### PR TITLE
Material Canvas: Fixing issues with node configuration editor and saving untitled documents

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicNode/DynamicNodeConfig.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicNode/DynamicNodeConfig.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AtomToolsFramework/DynamicNode/DynamicNodeSlotConfig.h>
+#include <AzCore/Serialization/EditContext.h>
 
 namespace AtomToolsFramework
 {
@@ -56,5 +57,8 @@ namespace AtomToolsFramework
         AZStd::vector<DynamicNodeSlotConfig> m_inputSlots;
         //! Output slots is a container of DynamicNodeSlotConfig for all outputs from a node 
         AZStd::vector<DynamicNodeSlotConfig> m_outputSlots;
+
+    private:
+        static const AZ::Edit::ElementData* GetDynamicEditData(const void* handlerPtr, const void* elementPtr, const AZ::Uuid& elementType);
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicNode/DynamicNodeManager.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicNode/DynamicNodeManager.h
@@ -36,6 +36,8 @@ namespace AtomToolsFramework
         DynamicNodeConfig GetConfigById(const AZ::Uuid& configId) const override;
         void Clear() override;
         GraphCanvas::GraphCanvasTreeItem* CreateNodePaletteTree() const override;
+        void RegisterEditDataForSetting(const AZStd::string& settingName, const AZ::Edit::ElementData& editData) override;
+        const AZ::Edit::ElementData* GetEditDataForSetting(const AZStd::string& settingName) const override;
 
     private:
         bool ValidateSlotConfig(const AZ::Uuid& configId, const DynamicNodeSlotConfig& slotConfig) const;
@@ -44,5 +46,6 @@ namespace AtomToolsFramework
         const AZ::Crc32 m_toolId = {};
         GraphModel::DataTypeList m_registeredDataTypes;
         AZStd::unordered_map<AZ::Uuid, DynamicNodeConfig> m_nodeConfigMap;
+        AZStd::unordered_map<AZStd::string, AZ::Edit::ElementData> m_editDataForSettingName;
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicNode/DynamicNodeManagerRequestBus.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicNode/DynamicNodeManagerRequestBus.h
@@ -10,6 +10,7 @@
 
 #include <AtomToolsFramework/DynamicNode/DynamicNodeConfig.h>
 #include <AzCore/EBus/EBus.h>
+#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/std/string/string.h>
 #include <GraphCanvas/Widgets/NodePalette/TreeItems/NodePaletteTreeItem.h>
 #include <GraphModel/Model/DataType.h>
@@ -51,6 +52,14 @@ namespace AtomToolsFramework
 
         //! Generate the node palette tree from registered DynamicNodeConfig
         virtual GraphCanvas::GraphCanvasTreeItem* CreateNodePaletteTree() const = 0;
+
+        //! Register dynamic edit data for dynamic node settings so that the edit context handler and attribute can be overridden for a
+        //! particular settings group.
+        virtual void RegisterEditDataForSetting(const AZStd::string& settingName, const AZ::Edit::ElementData& editData) = 0;
+
+        //! Get the pointer value of the dynamic edit data registered for a dynamic node configuration setting. Edit data pointer must
+        //! remain valid for as long as configurations can be edited.
+        virtual const AZ::Edit::ElementData* GetEditDataForSetting(const AZStd::string& settingName) const = 0;
     };
 
     using DynamicNodeManagerRequestBus = AZ::EBus<DynamicNodeManagerRequests>;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicNode/DynamicNodeSlotConfig.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicNode/DynamicNodeSlotConfig.h
@@ -11,6 +11,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/RTTI/ReflectContext.h>
+#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/std/any.h>
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/containers/vector.h>
@@ -52,5 +53,13 @@ namespace AtomToolsFramework
         DynamicNodeSettingsMap m_settings;
         //! Specifies whether or not UI will be displayed for editing the slot value on the node
         bool m_supportsEditingOnNode = true;
+
+    private:
+        AZ::Crc32 SelectDefaultValue();
+        AZ::Crc32 ClearDefaultValue();
+        AZ::Crc32 ClearDefaultValueIfInvalid();
+        AZStd::vector<AZStd::string> GetSelectedDataTypesVec() const;
+
+        static const AZ::Edit::ElementData* GetDynamicEditData(const void* handlerPtr, const void* elementPtr, const AZ::Uuid& elementType);
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicNode/DynamicNodeUtil.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicNode/DynamicNodeUtil.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AtomToolsFramework/DynamicNode/DynamicNodeConfig.h>
+#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/std/containers/set.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/string/string.h>
@@ -32,4 +33,17 @@ namespace AtomToolsFramework
     // Build an accumulated list of settings found on a node or slot configuration.
     void CollectDynamicNodeSettings(
         const DynamicNodeSettingsMap& settings, const AZStd::string& settingName, AZStd::vector<AZStd::string>& container);
+
+    // Convenience function to get a list of all currently registered slot data type names.
+    AZStd::vector<AZStd::string> GetRegisteredDataTypeNames();
+
+    // Search the settings map and the dynamic node manager for dynamic edit data for the setting mapped to elementPtr
+    const AZ::Edit::ElementData* FindDynamicEditDataForSetting(const DynamicNodeSettingsMap& settings, const void* elementPtr);
+
+    // Add a new attribute to dynamic edit data for dynamic node settings
+    template<typename AttributeValueType>
+    void AddEditDataAttribute(AZ::Edit::ElementData& editData, const AZ::Crc32& crc, const AttributeValueType& attribute)
+    {
+        editData.m_attributes.push_back(AZ::Edit::AttributePair(crc, aznew AZ::AttributeContainerType<AttributeValueType>(attribute)));
+    }
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -60,13 +60,15 @@ namespace AtomToolsFramework
     //! @param initialPath File path initially selected in the dialog
     //! @param title Description of the filetype being opened that's displayed at the top of the dialog
     //! @returns Absolute path of the selected file, or an empty string if nothing was selected
-    AZStd::string GetSaveFilePath(const AZStd::string& initialPath, const AZStd::string& title = "Document");
+    AZStd::string GetSaveFilePathFromDialog(const AZStd::string& initialPath, const AZStd::string& title = "Document");
 
     //! Opens a dialog to prompt the user to select one or more files to open 
     //! @param filter A regular expression filter to determine which files are selectable and displayed in the dialog 
     //! @param title Description of the filetype being opened that's displayed at the top of the dialog
+    //! @param multiSelect If true, the file picker will allow selecting multiple files
     //! @returns Container of selected files matching the filter 
-    AZStd::vector<AZStd::string> GetOpenFilePaths(const QRegExp& filter, const AZStd::string& title = "Document");
+    AZStd::vector<AZStd::string> GetOpenFilePathsFromDialog(
+        const QRegExp& filter, const AZStd::string& title = "Document", const bool multiSelect = true);
 
     //! Converts an input file path to a unique file path by appending a unique number
     //! @param initialPath The starting path that will be compared to other existing files and modified until it is unique
@@ -76,12 +78,7 @@ namespace AtomToolsFramework
     //! Generates a unique, untitled file path in the project asset folder
     //! @param Extension Extension of the file path to be generated
     //! @returns Absolute file path with a unique filename
-    AZStd::string GetUniqueDefaultSaveFilePath(const AZStd::string& extension);
-
-    //! Opens a dialog to prompt the user to select a file path where the initial file will be duplicated 
-    //! @param initialPath File path to be duplicated, will be used to generate a unique filename for the new file 
-    //! @returns Absolute path of the selected file, or an empty string if nothing was selected
-    AZStd::string GetUniqueDuplicateFilePath(const AZStd::string& initialPath);
+    AZStd::string GetUniqueUntitledFilePath(const AZStd::string& extension);
 
     //! Verifies that an input file path is not empty, is not relative, can be normalized, and is a valid source file path accessible by the project
     //! @param path File path to be validated and normalized

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -56,10 +56,10 @@ namespace AtomToolsFramework
     //! @returns the display name generated from the file path
     AZStd::string GetDisplayNameFromPath(const AZStd::string& path);
 
-    //! Prompts the user to select one more strings from a dialogue with a list widget.
+    //! Prompts the user to select one more strings from a dialog with a list widget.
     //! @param selectedStrings Input for the currently selected set of strings. Output for the newly selected strings.
-    //! @param availableStrings List of strings that will populate the dialogue with available choices.
-    //! @param title Text that will be displayed at the top of the dialogue.
+    //! @param availableStrings List of strings that will populate the dialog with available choices.
+    //! @param title Text that will be displayed at the top of the dialog.
     //! @param multiSelect Flag that determines whether the user will be able to select one or multiple strings.
     //! @returns True if the user accepted the selected strings. Otherwise false.
     bool GetStringListFromDialog(

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -56,6 +56,18 @@ namespace AtomToolsFramework
     //! @returns the display name generated from the file path
     AZStd::string GetDisplayNameFromPath(const AZStd::string& path);
 
+    //! Prompts the user to select one more strings from a dialogue with a list widget.
+    //! @param selectedStrings Input for the currently selected set of strings. Output for the newly selected strings.
+    //! @param availableStrings List of strings that will populate the dialogue with available choices.
+    //! @param title Text that will be displayed at the top of the dialogue.
+    //! @param multiSelect Flag that determines whether the user will be able to select one or multiple strings.
+    //! @returns True if the user accepted the selected strings. Otherwise false.
+    bool GetStringListFromDialog(
+        AZStd::vector<AZStd::string>& selectedStrings,
+        const AZStd::vector<AZStd::string>& availableStrings,
+        const AZStd::string& title = "Select Values",
+        const bool multiSelect = false);
+
     //! Opens a dialog to prompt the user to select a save file path
     //! @param initialPath File path initially selected in the dialog
     //! @param title Description of the filetype being opened that's displayed at the top of the dialog

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -68,19 +68,44 @@ namespace AtomToolsFramework
         const AZStd::string& title = "Select Values",
         const bool multiSelect = false);
 
+    //! Build a file dialog filter string by combining all of the entries in the supported extensions table. .
+    //! @param supportedExtensions Table of descriptions and extensions use to configure file filters.
+    //! @returns The generated string that can be fed directly into a file dialog filter.
+    AZStd::string GetFileFilterFromSupportedExtensions(const AZStd::vector<AZStd::pair<AZStd::string, AZStd::string>>& supportedExtensions);
+
+    //! Returns the first non empty string found in a container of supported extensions.
+    //! @param supportedExtensions Table of descriptions and extensions use to configure file filters.
+    //! @returns The first non empty extension founded in container
+    AZStd::string GetFirstValidSupportedExtension(const AZStd::vector<AZStd::pair<AZStd::string, AZStd::string>>& supportedExtensions);
+
+    //! Returns the first extension matching a path.
+    //! @param supportedExtensions Table of descriptions and extensions use to configure file filters.
+    //! @param path Path or file name that will be compared against supported extensions.
+    //! @returns The first occurrence of an extension matching the path.
+    AZStd::string GetFirstMatchingSupportedExtension(
+        const AZStd::vector<AZStd::pair<AZStd::string, AZStd::string>>& supportedExtensions, const AZStd::string& path);
+
     //! Opens a dialog to prompt the user to select a save file path
     //! @param initialPath File path initially selected in the dialog
+    //! @param supportedExtensions Table of descriptions and extensions use to configure file filters.
     //! @param title Description of the filetype being opened that's displayed at the top of the dialog
     //! @returns Absolute path of the selected file, or an empty string if nothing was selected
-    AZStd::string GetSaveFilePathFromDialog(const AZStd::string& initialPath, const AZStd::string& title = "Document");
+    AZStd::string GetSaveFilePathFromDialog(
+        const AZStd::string& initialPath,
+        const AZStd::vector<AZStd::pair<AZStd::string, AZStd::string>>& supportedExtensions,
+        const AZStd::string& title);
 
     //! Opens a dialog to prompt the user to select one or more files to open 
-    //! @param filter A regular expression filter to determine which files are selectable and displayed in the dialog 
+    //! @param selectedFilePaths A list of file paths that will be selected in the dialog
+    //! @param supportedExtensions Table of descriptions and extensions use to configure file filters.
     //! @param title Description of the filetype being opened that's displayed at the top of the dialog
     //! @param multiSelect If true, the file picker will allow selecting multiple files
     //! @returns Container of selected files matching the filter 
     AZStd::vector<AZStd::string> GetOpenFilePathsFromDialog(
-        const QRegExp& filter, const AZStd::string& title = "Document", const bool multiSelect = true);
+        const AZStd::vector<AZStd::string>& selectedFilePaths,
+        const AZStd::vector<AZStd::pair<AZStd::string, AZStd::string>>& supportedExtensions,
+        const AZStd::string& title,
+        const bool multiSelect);
 
     //! Converts an input file path to a unique file path by appending a unique number
     //! @param initialPath The starting path that will be compared to other existing files and modified until it is unique

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AtomToolsFrameworkSystemComponent.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AtomToolsFrameworkSystemComponent.cpp
@@ -19,6 +19,7 @@
 #include <AtomToolsFramework/EntityPreviewViewport/EntityPreviewViewportSettingsSystem.h>
 #include <AtomToolsFramework/Inspector/InspectorWidget.h>
 #include <AtomToolsFrameworkSystemComponent.h>
+#include <Inspector/PropertyWidgets/PropertyStringBrowseEditCtrl.h>
 
 namespace AtomToolsFramework
 {
@@ -79,6 +80,7 @@ namespace AtomToolsFramework
 
     void AtomToolsFrameworkSystemComponent::Activate()
     {
+        RegisterStringBrowseEditHandler();
     }
 
     void AtomToolsFrameworkSystemComponent::Deactivate()

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentApplication.cpp
@@ -74,8 +74,8 @@ namespace AtomToolsFramework
                             : QObject::tr("Create %1...").arg(documentType.m_documentTypeName.c_str());
 
                         menu->addAction(createActionName, [entries, documentType, this]() {
-                            const auto& defaultPath = GetUniqueUntitledFilePath(documentType.GetDefaultExtensionToSave().c_str());
-                            const auto& savePath = GetSaveFilePathFromDialog(defaultPath);
+                            const auto& savePath = GetSaveFilePathFromDialog(
+                                {}, documentType.m_supportedExtensionsToSave, documentType.m_documentTypeName);
                             if (!savePath.empty())
                             {
                                 AtomToolsDocumentSystemRequestBus::Event(

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentApplication.cpp
@@ -74,8 +74,8 @@ namespace AtomToolsFramework
                             : QObject::tr("Create %1...").arg(documentType.m_documentTypeName.c_str());
 
                         menu->addAction(createActionName, [entries, documentType, this]() {
-                            const auto& defaultPath = GetUniqueDefaultSaveFilePath(documentType.GetDefaultExtensionToSave().c_str());
-                            const auto& savePath = GetSaveFilePath(defaultPath);
+                            const auto& defaultPath = GetUniqueUntitledFilePath(documentType.GetDefaultExtensionToSave().c_str());
+                            const auto& savePath = GetSaveFilePathFromDialog(defaultPath);
                             if (!savePath.empty())
                             {
                                 AtomToolsDocumentSystemRequestBus::Event(

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
@@ -339,28 +339,18 @@ namespace AtomToolsFramework
         bool isFirstDocumentTypeAdded = true;
         for (const auto& documentType : documentTypes)
         {
-            // Build a list of all extensions supported by this document type so they can be combined into a file dialog filter
-            QStringList extensionList;
-            for (const auto& extensionInfo : documentType.m_supportedExtensionsToOpen)
+            if (!documentType.m_supportedExtensionsToOpen.empty())
             {
-                extensionList.append(extensionInfo.second.c_str());
-            }
-
-            if (!extensionList.empty())
-            {
-                // Generate a regular expression that combines all of the supported extensions to use as a filter for the asset picker
-                const QString expression = QString("[\\w\\-.]+\\.(%1)").arg(extensionList.join("|"));
-
                 // Create a menu action for each document type instead of one action for all document types to reduce the number of
-                // extensions displayed in the get open file path dialog
+                // extensions displayed in the dialog
                 const QString name = tr("Open %1 Document...").arg(documentType.m_documentTypeName.c_str());
-                const QString title = tr("%1 Document").arg(documentType.m_documentTypeName.c_str());
-                CreateActionAtPosition(parentMenu, insertPostion, name, [expression, title, toolId = m_toolId]() {
-                    // Open all files selected in the get open file path dialog
-                    for (const auto& path : GetOpenFilePathsFromDialog(QRegExp(expression, Qt::CaseInsensitive), title.toUtf8().constData()))
+                CreateActionAtPosition(parentMenu, insertPostion, name, [documentType, toolId = m_toolId]() {
+                    // Open all files selected in the dialog
+                    const auto& paths =
+                        GetOpenFilePathsFromDialog({}, documentType.m_supportedExtensionsToOpen, documentType.m_documentTypeName, true);
+                    for (const auto& path : paths)
                     {
-                        AtomToolsDocumentSystemRequestBus::Event(
-                            toolId, &AtomToolsDocumentSystemRequestBus::Events::OpenDocument, path);
+                        AtomToolsDocumentSystemRequestBus::Event(toolId, &AtomToolsDocumentSystemRequestBus::Events::OpenDocument, path);
                     }
                 }, isFirstDocumentTypeAdded ? QKeySequence::Open : QKeySequence());
                 isFirstDocumentTypeAdded = false;
@@ -587,20 +577,10 @@ namespace AtomToolsFramework
 
     AZStd::string AtomToolsDocumentMainWindow::GetSaveDocumentParams(const AZStd::string& initialPath) const
     {
-        if (initialPath.empty())
-        {
-            // If the initial path is empty attempt to determine one using the document type info supported save extensions. This should be
-            // extended so that the save dialog lists out all of the available save extensions for documents that support more than one.
-            DocumentTypeInfo documentTypeInfo;
-            AtomToolsDocumentRequestBus::EventResult(
-                documentTypeInfo, GetCurrentDocumentId(), &AtomToolsDocumentRequestBus::Events::GetDocumentTypeInfo);
-            if (!documentTypeInfo.m_supportedExtensionsToSave.empty())
-            {
-                return GetSaveFilePathFromDialog(GetUniqueUntitledFilePath(documentTypeInfo.m_supportedExtensionsToSave.front().second));
-            }
-        }
-
-        return GetSaveFilePathFromDialog(GetUniqueFilePath(initialPath));
+        DocumentTypeInfo documentType;
+        AtomToolsDocumentRequestBus::EventResult(
+            documentType, GetCurrentDocumentId(), &AtomToolsDocumentRequestBus::Events::GetDocumentTypeInfo);
+        return GetSaveFilePathFromDialog(initialPath, documentType.m_supportedExtensionsToSave, documentType.m_documentTypeName);
     }
 
     void AtomToolsDocumentMainWindow::OnDocumentOpened(const AZ::Uuid& documentId)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeConfig.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeConfig.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AtomToolsFramework/DynamicNode/DynamicNodeConfig.h>
+#include <AtomToolsFramework/DynamicNode/DynamicNodeUtil.h>
 #include <AtomToolsFramework/Util/Util.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
@@ -36,13 +37,13 @@ namespace AtomToolsFramework
                 editContext->Class<DynamicNodeConfig>("DynamicNodeConfig", "Configuration settings defining the slots and UI of a dynamic node.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->SetDynamicEditDataProvider(&DynamicNodeConfig::GetDynamicEditData)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeConfig::m_id, "Id", "UUID for identifying this node configuration regardless of file location.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeConfig::m_category, "Category", "Name of the category where this node will appear in the node palette.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeConfig::m_title, "Title", "Title that will appear at the top of the node UI in a graph.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeConfig::m_subTitle, "Sub Title", "Secondary title that will appear below the main title on the node UI in a graph.")
+                    ->DataElement(AZ_CRC_CE("MultiLineString"), &DynamicNodeConfig::m_category, "Category", "Name of the category where this node will appear in the node palette.")
+                    ->DataElement(AZ_CRC_CE("MultiLineString"), &DynamicNodeConfig::m_title, "Title", "Title that will appear at the top of the node UI in a graph.")
+                    ->DataElement(AZ_CRC_CE("MultiLineString"), &DynamicNodeConfig::m_subTitle, "Sub Title", "Secondary title that will appear below the main title on the node UI in a graph.")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeConfig::m_settings, "Settings", "Table of strings that can be used for any context specific or user defined data for each node.")
-                        ->ElementAttribute(AZ::Edit::Attributes::Handler, AZ::Edit::UIHandlers::MultiLineEdit)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeConfig::m_inputSlots, "Input Slots", "Container of dynamic node input slot configurations.")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeConfig::m_outputSlots, "Output Slots", "Container of dynamic node output slot configurations.")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeConfig::m_propertySlots, "Property Slots", "Container hub dynamic node property slot configurations.")
@@ -117,5 +118,17 @@ namespace AtomToolsFramework
 
         *this = AZStd::any_cast<DynamicNodeConfig>(loadResult.GetValue());
         return true;
+    }
+
+
+    const AZ::Edit::ElementData* DynamicNodeConfig::GetDynamicEditData(
+        const void* handlerPtr, const void* elementPtr, const AZ::Uuid& elementType)
+    {
+        const DynamicNodeConfig* owner = reinterpret_cast<const DynamicNodeConfig*>(handlerPtr);
+        if (elementType == azrtti_typeid<AZStd::string>())
+        {
+            return FindDynamicEditDataForSetting(owner->m_settings, elementPtr);
+        }
+        return nullptr;
     }
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeManager.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeManager.cpp
@@ -120,6 +120,23 @@ namespace AtomToolsFramework
         return rootItem;
     }
 
+    void DynamicNodeManager::RegisterEditDataForSetting(const AZStd::string& settingName, const AZ::Edit::ElementData& editData)
+    {
+        m_editDataForSettingName[settingName] = editData;
+    }
+
+    const AZ::Edit::ElementData* DynamicNodeManager::GetEditDataForSetting(const AZStd::string& settingName) const
+    {
+        for (const auto& editDataPair : m_editDataForSettingName)
+        {
+            if (AZ::StringFunc::Equal(editDataPair.first, settingName))
+            {
+                return &editDataPair.second;
+            }
+        }
+        return nullptr;
+    }
+
     bool DynamicNodeManager::ValidateSlotConfig(
         [[maybe_unused]] const AZ::Uuid& configId, const DynamicNodeSlotConfig& slotConfig) const
     {

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodePaletteItem.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodePaletteItem.cpp
@@ -26,8 +26,7 @@ namespace AtomToolsFramework
         }
     }
 
-    CreateDynamicNodeMimeEvent::CreateDynamicNodeMimeEvent(
-        const AZ::Crc32& toolId, const AZ::Uuid& configId)
+    CreateDynamicNodeMimeEvent::CreateDynamicNodeMimeEvent(const AZ::Crc32& toolId, const AZ::Uuid& configId)
         : m_toolId(toolId)
         , m_configId(configId)
     {
@@ -39,10 +38,10 @@ namespace AtomToolsFramework
         GraphModel::GraphPtr graph;
         GraphModelIntegration::GraphManagerRequestBus::BroadcastResult(
             graph, &GraphModelIntegration::GraphManagerRequests::GetGraph, graphCanvasSceneId);
+
         if (graph)
         {
-            AZStd::shared_ptr<GraphModel::Node> node = AZStd::make_shared<DynamicNode>(graph, m_toolId, m_configId);
-            if (node)
+            if (auto node = AZStd::make_shared<DynamicNode>(graph, m_toolId, m_configId))
             {
                 GraphModelIntegration::GraphControllerRequestBus::Event(
                     graphCanvasSceneId, &GraphModelIntegration::GraphControllerRequests::AddNode, node, dropPosition);
@@ -53,8 +52,7 @@ namespace AtomToolsFramework
         return false;
     }
 
-    DynamicNodePaletteItem::DynamicNodePaletteItem(
-        const AZ::Crc32& toolId, const DynamicNodeConfig& config)
+    DynamicNodePaletteItem::DynamicNodePaletteItem(const AZ::Crc32& toolId, const DynamicNodeConfig& config)
         : DraggableNodePaletteTreeItem(config.m_title.c_str(), toolId)
         , m_toolId(toolId)
         , m_configId(config.m_id)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeSlotConfig.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeSlotConfig.cpp
@@ -6,7 +6,10 @@
  *
  */
 
+#include <AtomToolsFramework/DynamicNode/DynamicNodeManagerRequestBus.h>
 #include <AtomToolsFramework/DynamicNode/DynamicNodeSlotConfig.h>
+#include <AtomToolsFramework/DynamicNode/DynamicNodeUtil.h>
+#include <AtomToolsFramework/Util/Util.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>
@@ -24,9 +27,9 @@ namespace AtomToolsFramework
                 ->Field("name", &DynamicNodeSlotConfig::m_name)
                 ->Field("displayName", &DynamicNodeSlotConfig::m_displayName)
                 ->Field("description", &DynamicNodeSlotConfig::m_description)
-                ->Field("supportsEditingOnNode", &DynamicNodeSlotConfig::m_supportsEditingOnNode)
                 ->Field("supportedDataTypes", &DynamicNodeSlotConfig::m_supportedDataTypes)
                 ->Field("defaultValue", &DynamicNodeSlotConfig::m_defaultValue)
+                ->Field("supportsEditingOnNode", &DynamicNodeSlotConfig::m_supportsEditingOnNode)
                 ->Field("settings", &DynamicNodeSlotConfig::m_settings)
                 ;
 
@@ -35,15 +38,27 @@ namespace AtomToolsFramework
                 editContext->Class<DynamicNodeSlotConfig>("DynamicNodeSlotConfig", "Configuration settings for individual slots on a dynamic node.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeSlotConfig::m_name, "Name", "Unique name used to identify individual slots on a node.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeSlotConfig::m_displayName, "Display Name", "User friendly title of the slot that will appear on the node UI.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeSlotConfig::m_description, "Description", "Detailed description of the node, its purpose, and behavior that will appear in tooltips and other UI.")
-                        ->Attribute(AZ::Edit::Attributes::Handler, AZ::Edit::UIHandlers::MultiLineEdit)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeSlotConfig::m_supportsEditingOnNode, "Supports Editing On Node", "Enable this to allow editing the the slot value directly in the node UI.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeSlotConfig::m_supportedDataTypes, "Supported Data Types", "Container of names of data types that can be assigned to this slot. Output and property slots will be created using the first recognized data type in the container.")
+                    ->SetDynamicEditDataProvider(&DynamicNodeSlotConfig::GetDynamicEditData)
+                    ->DataElement(AZ_CRC_CE("MultiLineString"), &DynamicNodeSlotConfig::m_name, "Name", "Unique name used to identify individual slots on a node.")
+                    ->DataElement(AZ_CRC_CE("MultiLineString"), &DynamicNodeSlotConfig::m_displayName, "Display Name", "User friendly title of the slot that will appear on the node UI.")
+                    ->DataElement(AZ_CRC_CE("MultiLineString"), &DynamicNodeSlotConfig::m_description, "Description", "Detailed description of the node, its purpose, and behavior that will appear in tooltips and other UI.")
+                    ->DataElement(AZ_CRC_CE("MultiSelectStringVector"), &DynamicNodeSlotConfig::m_supportedDataTypes, "Data Types", "Container of names of data types that can be assigned to this slot. Output and property slots will be created using the first recognized data type in the container.")
+                        ->Attribute(AZ_CRC_CE("MultiSelectOptions"), &GetRegisteredDataTypeNames)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &DynamicNodeSlotConfig::ClearDefaultValueIfInvalid)
+                        ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::HideChildren)
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, false)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeSlotConfig::m_defaultValue, "Default Value", "The initial value of an input or property slot that has no incoming connection.")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                        ->ElementAttribute(AZ::Edit::Attributes::NameLabelOverride, "Default Value")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeSlotConfig::m_supportsEditingOnNode, "Display On Node", "Enable this to allow editing the the slot value directly in the node UI.")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &DynamicNodeSlotConfig::m_settings, "Settings", "Table of strings that can be used for any context specific or user defined data for each slot.")
-                        ->ElementAttribute(AZ::Edit::Attributes::Handler, AZ::Edit::UIHandlers::MultiLineEdit)
+                    ->UIElement(AZ::Edit::UIHandlers::Button, "", "Select Default Value")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &DynamicNodeSlotConfig::SelectDefaultValue)
+                        ->Attribute(AZ::Edit::Attributes::ButtonText, "Select Default Value")
+                    ->UIElement(AZ::Edit::UIHandlers::Button, "", "Clear Default Value")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &DynamicNodeSlotConfig::ClearDefaultValue)
+                        ->Attribute(AZ::Edit::Attributes::ButtonText, "Clear Default Value")
                     ;
             }
         }
@@ -81,5 +96,76 @@ namespace AtomToolsFramework
         , m_supportedDataTypes(supportedDataTypes)
         , m_settings(settings)
     {
+    }
+
+    AZ::Crc32 DynamicNodeSlotConfig::SelectDefaultValue()
+    {
+        AZStd::vector<AZStd::string> selections;
+        if (GetStringListFromDialog(selections, m_supportedDataTypes, "Select Default Value", false))
+        {
+            m_defaultValue.clear();
+
+            GraphModel::DataTypeList registeredDataTypes;
+            DynamicNodeManagerRequestBus::BroadcastResult(
+                registeredDataTypes, &DynamicNodeManagerRequestBus::Events::GetRegisteredDataTypes);
+
+            for (const auto& dataType : registeredDataTypes)
+            {
+                for (const auto& selection : selections)
+                {
+                    if (dataType->GetDisplayName() == selection)
+                    {
+                        m_defaultValue = dataType->GetDefaultValue();
+                        return AZ::Edit::PropertyRefreshLevels::EntireTree;
+                    }
+                }
+            }
+
+            return AZ::Edit::PropertyRefreshLevels::EntireTree;
+        }
+
+        return AZ::Edit::PropertyRefreshLevels::AttributesAndValues;
+    }
+
+    AZ::Crc32 DynamicNodeSlotConfig::ClearDefaultValue()
+    {
+        m_defaultValue.clear();
+        return AZ::Edit::PropertyRefreshLevels::EntireTree;
+    }
+
+    AZ::Crc32 DynamicNodeSlotConfig::ClearDefaultValueIfInvalid()
+    {
+        GraphModel::DataTypeList registeredDataTypes;
+        DynamicNodeManagerRequestBus::BroadcastResult(registeredDataTypes, &DynamicNodeManagerRequestBus::Events::GetRegisteredDataTypes);
+
+        for (const auto& dataType : registeredDataTypes)
+        {
+            for (const auto& selection : m_supportedDataTypes)
+            {
+                if (dataType->GetDisplayName() == selection && dataType->GetTypeUuid() == m_defaultValue.type())
+                {
+                    return AZ::Edit::PropertyRefreshLevels::EntireTree;
+                }
+            }
+        }
+
+        ClearDefaultValue();
+        return AZ::Edit::PropertyRefreshLevels::EntireTree;
+    }
+
+    AZStd::vector<AZStd::string> DynamicNodeSlotConfig::GetSelectedDataTypesVec() const
+    {
+        return m_supportedDataTypes;
+    }
+
+    const AZ::Edit::ElementData* DynamicNodeSlotConfig::GetDynamicEditData(
+        const void* handlerPtr, const void* elementPtr, const AZ::Uuid& elementType)
+    {
+        const DynamicNodeSlotConfig* owner = reinterpret_cast<const DynamicNodeSlotConfig*>(handlerPtr);
+        if (elementType == azrtti_typeid<AZStd::string>())
+        {
+            return FindDynamicEditDataForSetting(owner->m_settings, elementPtr);
+        }
+        return nullptr;
     }
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeUtil.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodeUtil.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AtomToolsFramework/DynamicNode/DynamicNodeManagerRequestBus.h>
 #include <AtomToolsFramework/DynamicNode/DynamicNodeUtil.h>
 
 namespace AtomToolsFramework
@@ -56,5 +57,37 @@ namespace AtomToolsFramework
         {
             container.insert(container.end(), settingsItr->second.begin(), settingsItr->second.end());
         }
+    }
+
+    AZStd::vector<AZStd::string> GetRegisteredDataTypeNames()
+    {
+        GraphModel::DataTypeList registeredDataTypes;
+        DynamicNodeManagerRequestBus::BroadcastResult(registeredDataTypes, &DynamicNodeManagerRequestBus::Events::GetRegisteredDataTypes);
+
+        AZStd::vector<AZStd::string> names;
+        names.reserve(registeredDataTypes.size());
+        for (const auto& dataType : registeredDataTypes)
+        {
+            names.push_back(dataType->GetDisplayName());
+        }
+        return names;
+    }
+
+    const AZ::Edit::ElementData* FindDynamicEditDataForSetting(const DynamicNodeSettingsMap& settings, const void* elementPtr)
+    {
+        for (const auto& settingsGroup : settings)
+        {
+            for (const auto& setting : settingsGroup.second)
+            {
+                if (elementPtr == &setting)
+                {
+                    const AZ::Edit::ElementData* registeredEditData = nullptr;
+                    DynamicNodeManagerRequestBus::BroadcastResult(
+                        registeredEditData, &DynamicNodeManagerRequestBus::Events::GetEditDataForSetting, settingsGroup.first);
+                    return registeredEditData;
+                }
+            }
+        }
+        return nullptr;
     }
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettingsInspector.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettingsInspector.cpp
@@ -99,8 +99,8 @@ namespace AtomToolsFramework
 
     void EntityPreviewViewportSettingsInspector::CreateModelPreset()
     {
-        const AZStd::string defaultPath = GetUniqueDefaultSaveFilePath(AZ::Render::ModelPreset::Extension);
-        const AZStd::string savePath = GetSaveFilePath(defaultPath);
+        const AZStd::string defaultPath = GetUniqueUntitledFilePath(AZ::Render::ModelPreset::Extension);
+        const AZStd::string savePath = GetSaveFilePathFromDialog(defaultPath);
         if (!savePath.empty())
         {
             EntityPreviewViewportSettingsRequestBus::Event(
@@ -155,10 +155,10 @@ namespace AtomToolsFramework
 
         if (defaultPath.empty())
         {
-            defaultPath = GetUniqueDefaultSaveFilePath(AZ::Render::ModelPreset::Extension);
+            defaultPath = GetUniqueUntitledFilePath(AZ::Render::ModelPreset::Extension);
         }
 
-        const AZStd::string savePath = GetSaveFilePath(defaultPath);
+        const AZStd::string savePath = GetSaveFilePathFromDialog(defaultPath);
         if (!savePath.empty())
         {
             EntityPreviewViewportSettingsRequestBus::Event(m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::SetModelPreset, m_modelPreset);
@@ -200,8 +200,8 @@ namespace AtomToolsFramework
 
     void EntityPreviewViewportSettingsInspector::CreateLightingPreset()
     {
-        const AZStd::string defaultPath = GetUniqueDefaultSaveFilePath(AZ::Render::LightingPreset::Extension);
-        const AZStd::string savePath = GetSaveFilePath(defaultPath);
+        const AZStd::string defaultPath = GetUniqueUntitledFilePath(AZ::Render::LightingPreset::Extension);
+        const AZStd::string savePath = GetSaveFilePathFromDialog(defaultPath);
         if (!savePath.empty())
         {
             EntityPreviewViewportSettingsRequestBus::Event(
@@ -256,10 +256,10 @@ namespace AtomToolsFramework
 
         if (defaultPath.empty())
         {
-            defaultPath = GetUniqueDefaultSaveFilePath(AZ::Render::LightingPreset::Extension);
+            defaultPath = GetUniqueUntitledFilePath(AZ::Render::LightingPreset::Extension);
         }
 
-        const AZStd::string savePath = GetSaveFilePath(defaultPath);
+        const AZStd::string savePath = GetSaveFilePathFromDialog(defaultPath);
         if (!savePath.empty())
         {
             EntityPreviewViewportSettingsRequestBus::Event(m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::SetLightingPreset, m_lightingPreset);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettingsInspector.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettingsInspector.cpp
@@ -99,8 +99,8 @@ namespace AtomToolsFramework
 
     void EntityPreviewViewportSettingsInspector::CreateModelPreset()
     {
-        const AZStd::string defaultPath = GetUniqueUntitledFilePath(AZ::Render::ModelPreset::Extension);
-        const AZStd::string savePath = GetSaveFilePathFromDialog(defaultPath);
+        const AZStd::string savePath =
+            GetSaveFilePathFromDialog({}, { { "Model Preset", AZ::Render::ModelPreset::Extension } }, "Model Preset");
         if (!savePath.empty())
         {
             EntityPreviewViewportSettingsRequestBus::Event(
@@ -153,12 +153,8 @@ namespace AtomToolsFramework
         EntityPreviewViewportSettingsRequestBus::EventResult(
             defaultPath, m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::GetLastModelPresetPath);
 
-        if (defaultPath.empty())
-        {
-            defaultPath = GetUniqueUntitledFilePath(AZ::Render::ModelPreset::Extension);
-        }
-
-        const AZStd::string savePath = GetSaveFilePathFromDialog(defaultPath);
+        const AZStd::string savePath =
+            GetSaveFilePathFromDialog(defaultPath, { { "Model Preset", AZ::Render::ModelPreset::Extension } }, "Model Preset");
         if (!savePath.empty())
         {
             EntityPreviewViewportSettingsRequestBus::Event(m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::SetModelPreset, m_modelPreset);
@@ -200,8 +196,8 @@ namespace AtomToolsFramework
 
     void EntityPreviewViewportSettingsInspector::CreateLightingPreset()
     {
-        const AZStd::string defaultPath = GetUniqueUntitledFilePath(AZ::Render::LightingPreset::Extension);
-        const AZStd::string savePath = GetSaveFilePathFromDialog(defaultPath);
+        const AZStd::string savePath =
+            GetSaveFilePathFromDialog({}, { { "Lighting Preset", AZ::Render::LightingPreset::Extension } }, "Lighting Preset");
         if (!savePath.empty())
         {
             EntityPreviewViewportSettingsRequestBus::Event(
@@ -254,12 +250,8 @@ namespace AtomToolsFramework
         EntityPreviewViewportSettingsRequestBus::EventResult(
             defaultPath, m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::GetLastLightingPresetPath);
 
-        if (defaultPath.empty())
-        {
-            defaultPath = GetUniqueUntitledFilePath(AZ::Render::LightingPreset::Extension);
-        }
-
-        const AZStd::string savePath = GetSaveFilePathFromDialog(defaultPath);
+        const AZStd::string savePath =
+            GetSaveFilePathFromDialog(defaultPath, { { "Lighting Preset", AZ::Render::LightingPreset::Extension } }, "Lighting Preset");
         if (!savePath.empty())
         {
             EntityPreviewViewportSettingsRequestBus::Event(m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::SetLightingPreset, m_lightingPreset);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/PropertyWidgets/PropertyStringBrowseEditCtrl.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/PropertyWidgets/PropertyStringBrowseEditCtrl.cpp
@@ -194,6 +194,7 @@ namespace AtomToolsFramework
         : PropertyStringBrowseEditCtrl(parent)
     {
         m_browseEdit->setLineEditReadOnly(true);
+        m_browseEdit->setAttachedButtonIcon(QIcon(":/stylesheet/img/UI20/browse-edit.svg"));
         SetEditButtonVisible(true);
         SetEditButtonEnabled(true);
     }
@@ -292,10 +293,11 @@ namespace AtomToolsFramework
         return false;
     }
 
-   PropertyMultiLineStringCtrl::PropertyMultiLineStringCtrl(QWidget* parent)
+    PropertyMultiLineStringCtrl::PropertyMultiLineStringCtrl(QWidget* parent)
         : PropertyStringBrowseEditCtrl(parent)
     {
         m_browseEdit->setLineEditReadOnly(false);
+        m_browseEdit->setAttachedButtonIcon(QIcon(":/stylesheet/img/UI20/open-in-internal-app.svg"));
         SetEditButtonVisible(true);
         SetEditButtonEnabled(true);
     }
@@ -371,6 +373,7 @@ namespace AtomToolsFramework
         : PropertyStringBrowseEditCtrl(parent)
     {
         m_browseEdit->setLineEditReadOnly(true);
+        m_browseEdit->setAttachedButtonIcon(QIcon(":/stylesheet/img/UI20/open-in-internal-app.svg"));
         SetEditButtonVisible(true);
         SetEditButtonEnabled(true);
     }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/PropertyWidgets/PropertyStringBrowseEditCtrl.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/PropertyWidgets/PropertyStringBrowseEditCtrl.cpp
@@ -1,0 +1,571 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AtomToolsFramework/Util/Util.h>
+#include <AzCore/Utils/Utils.h>
+#include <AzQtComponents/Components/Widgets/BrowseEdit.h>
+#include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
+#include <Inspector/PropertyWidgets/PropertyStringBrowseEditCtrl.h>
+
+AZ_PUSH_DISABLE_WARNING(4244 4251, "-Wunknown-warning-option")
+#include <QHBoxLayout>
+#include <QInputDialog>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QToolButton>
+#include <QVBoxLayout>
+AZ_POP_DISABLE_WARNING
+
+namespace AtomToolsFramework
+{
+    PropertyStringBrowseEditCtrl::PropertyStringBrowseEditCtrl(QWidget* parent)
+        : QWidget(parent)
+    {
+        setLayout(new QHBoxLayout(this));
+
+        m_browseEdit = new AzQtComponents::BrowseEdit(this);
+        m_browseEdit->lineEdit()->setFocusPolicy(Qt::StrongFocus);
+        m_browseEdit->setLineEditReadOnly(false);
+        m_browseEdit->setClearButtonEnabled(true);
+        m_browseEdit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+        m_browseEdit->setAttachedButtonIcon(QIcon(":/stylesheet/img/UI20/browse-edit.svg"));
+        QObject::connect(m_browseEdit, &AzQtComponents::BrowseEdit::attachedButtonTriggered, this, &PropertyStringBrowseEditCtrl::Edit);
+        QObject::connect(m_browseEdit, &AzQtComponents::BrowseEdit::editingFinished, this, &PropertyStringBrowseEditCtrl::ValueChanged);
+
+        SetEditButtonVisible(false);
+        SetEditButtonEnabled(false);
+
+        // Locate the clear button embedded inside the browse edit control to connect to its clicked signal
+        if (auto clearButton = AzQtComponents::LineEdit::getClearButton(m_browseEdit->lineEdit()))
+        {
+            clearButton->setVisible(true);
+            clearButton->setEnabled(true);
+            QObject::connect(clearButton, &QToolButton::clicked, this, &PropertyStringBrowseEditCtrl::Clear);
+        }
+
+        layout()->setContentsMargins(0, 0, 0, 0);
+        layout()->addWidget(m_browseEdit);
+
+        setFocusProxy(m_browseEdit->lineEdit());
+        setFocusPolicy(m_browseEdit->lineEdit()->focusPolicy());
+    }
+
+    void PropertyStringBrowseEditCtrl::ConsumeAttribute(AZ::u32 attrib, AzToolsFramework::PropertyAttributeReader* attrValue)
+    {
+        if (attrib == AZ_CRC_CE("LineEditReadOnly"))
+        {
+            if (bool value = true; attrValue->Read<bool>(value))
+            {
+                m_browseEdit->setLineEditReadOnly(value);
+            }
+            return;
+        }
+
+        if (attrib == AZ_CRC_CE("ClearButtonEnabled"))
+        {
+            if (bool value = true; attrValue->Read<bool>(value))
+            {
+                m_browseEdit->setClearButtonEnabled(value);
+            }
+            return;
+        }
+
+        if (attrib == AZ_CRC_CE("EditButtonIcon"))
+        {
+            if (AZStd::string value; attrValue->Read<AZStd::string>(value))
+            {
+                m_browseEdit->setAttachedButtonIcon(QIcon(value.c_str()));
+            }
+            return;
+        }
+
+        if (attrib == AZ_CRC_CE("EditButtonVisible"))
+        {
+            if (bool value = true; attrValue->Read<bool>(value))
+            {
+                SetEditButtonVisible(value);
+            }
+            return;
+        }
+
+        if (attrib == AZ_CRC_CE("EditButtonEnabled"))
+        {
+            if (bool value = true; attrValue->Read<bool>(value))
+            {
+                SetEditButtonEnabled(value);
+            }
+            return;
+        }
+    }
+
+    void PropertyStringBrowseEditCtrl::Edit()
+    {
+        Q_EMIT ValueChanged();
+    }
+
+    void PropertyStringBrowseEditCtrl::Clear()
+    {
+        m_browseEdit->setText("");
+        m_browseEdit->lineEdit()->clearFocus();
+        Q_EMIT ValueChanged();
+    }
+
+    void PropertyStringBrowseEditCtrl::SetValue(const AZStd::string& value)
+    {
+        m_browseEdit->setText(value.c_str());
+        Q_EMIT ValueChanged();
+    }
+
+    AZStd::string PropertyStringBrowseEditCtrl::GetValue() const
+    {
+        return m_browseEdit->text().toUtf8().constData();
+    }
+
+    void PropertyStringBrowseEditCtrl::SetEditButtonEnabled(bool value)
+    {
+        if (auto editButton = m_browseEdit->findChild<QPushButton*>())
+        {
+            editButton->setEnabled(value);
+        }
+    }
+
+    void PropertyStringBrowseEditCtrl::SetEditButtonVisible(bool value)
+    {
+        if (auto editButton = m_browseEdit->findChild<QPushButton*>())
+        {
+            editButton->setVisible(value);
+        }
+    }
+
+    QWidget* PropertyStringBrowseEditHandler::CreateGUI(QWidget* parent)
+    {
+        PropertyStringBrowseEditCtrl* newCtrl = aznew PropertyStringBrowseEditCtrl(parent);
+
+        QObject::connect(
+            newCtrl,
+            &PropertyStringBrowseEditCtrl::ValueChanged,
+            this,
+            [newCtrl]()
+            {
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                    &AzToolsFramework::PropertyEditorGUIMessages::RequestWrite, newCtrl);
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                    &AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
+            });
+
+        return newCtrl;
+    }
+
+    void PropertyStringBrowseEditHandler::ConsumeAttribute(
+        [[maybe_unused]] PropertyStringBrowseEditCtrl* GUI,
+        [[maybe_unused]] AZ::u32 attrib,
+        [[maybe_unused]] AzToolsFramework::PropertyAttributeReader* attrValue,
+        [[maybe_unused]] const char* debugName)
+    {
+        GUI->ConsumeAttribute(attrib, attrValue);
+    }
+
+    void PropertyStringBrowseEditHandler::WriteGUIValuesIntoProperty(
+        [[maybe_unused]] size_t index,
+        [[maybe_unused]] PropertyStringBrowseEditCtrl* GUI,
+        [[maybe_unused]] property_t& instance,
+        [[maybe_unused]] AzToolsFramework::InstanceDataNode* node)
+    {
+        instance = GUI->GetValue();
+    }
+
+    bool PropertyStringBrowseEditHandler::ReadValuesIntoGUI(
+        [[maybe_unused]] size_t index,
+        [[maybe_unused]] PropertyStringBrowseEditCtrl* GUI,
+        [[maybe_unused]] const property_t& instance,
+        [[maybe_unused]] AzToolsFramework::InstanceDataNode* node)
+    {
+        QSignalBlocker blocker(GUI);
+        GUI->SetValue(instance);
+        return false;
+    }
+
+    PropertyFilePathStringCtrl::PropertyFilePathStringCtrl(QWidget* parent)
+        : PropertyStringBrowseEditCtrl(parent)
+    {
+        m_browseEdit->setLineEditReadOnly(true);
+        SetEditButtonVisible(true);
+        SetEditButtonEnabled(true);
+    }
+
+    void PropertyFilePathStringCtrl::ConsumeAttribute(AZ::u32 attrib, AzToolsFramework::PropertyAttributeReader* attrValue)
+    {
+        PropertyStringBrowseEditCtrl::ConsumeAttribute(attrib, attrValue);
+
+        if (attrib == AZ_CRC_CE("Title"))
+        {
+            if (AZStd::string value; attrValue->Read<AZStd::string>(value))
+            {
+                m_title = value;
+            }
+            return;
+        }
+
+        if (attrib == AZ_CRC_CE("Extensions") || attrib == AZ_CRC_CE("Extension"))
+        {
+            if (AZStd::string value; attrValue->Read<AZStd::string>(value))
+            {
+                AZ::StringFunc::Tokenize(value, m_extensions, ";:, \t\r\n\\/|");
+                return;
+            }
+
+            if (AZStd::vector<AZStd::string> value; attrValue->Read<AZStd::vector<AZStd::string>>(value))
+            {
+                m_extensions = value;
+                return;
+            }
+            return;
+        }
+    }
+
+    void PropertyFilePathStringCtrl::Edit()
+    {
+        QStringList extensionList;
+        for (const auto& extension : m_extensions)
+        {
+            extensionList.append(extension.c_str());
+        }
+
+        const QString expression = QString("[\\w\\-.]+\\.(%1)").arg(extensionList.join("|"));
+        const auto& paths = GetOpenFilePathsFromDialog(QRegExp(expression, Qt::CaseInsensitive), m_title, false);
+        if (!paths.empty())
+        {
+            SetValue(GetPathWithAlias(paths.front()));
+        }
+    }
+
+    QWidget* PropertyFilePathStringHandler::CreateGUI(QWidget* parent)
+    {
+        PropertyFilePathStringCtrl* newCtrl = aznew PropertyFilePathStringCtrl(parent);
+
+        QObject::connect(
+            newCtrl,
+            &PropertyFilePathStringCtrl::ValueChanged,
+            this,
+            [newCtrl]()
+            {
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                    &AzToolsFramework::PropertyEditorGUIMessages::RequestWrite, newCtrl);
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                    &AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
+            });
+
+        return newCtrl;
+    }
+
+    void PropertyFilePathStringHandler::ConsumeAttribute(
+        [[maybe_unused]] PropertyFilePathStringCtrl* GUI,
+        [[maybe_unused]] AZ::u32 attrib,
+        [[maybe_unused]] AzToolsFramework::PropertyAttributeReader* attrValue,
+        [[maybe_unused]] const char* debugName)
+    {
+        GUI->ConsumeAttribute(attrib, attrValue);
+    }
+
+    void PropertyFilePathStringHandler::WriteGUIValuesIntoProperty(
+        [[maybe_unused]] size_t index,
+        [[maybe_unused]] PropertyFilePathStringCtrl* GUI,
+        [[maybe_unused]] property_t& instance,
+        [[maybe_unused]] AzToolsFramework::InstanceDataNode* node)
+    {
+        instance = GUI->GetValue();
+    }
+
+    bool PropertyFilePathStringHandler::ReadValuesIntoGUI(
+        [[maybe_unused]] size_t index,
+        [[maybe_unused]] PropertyFilePathStringCtrl* GUI,
+        [[maybe_unused]] const property_t& instance,
+        [[maybe_unused]] AzToolsFramework::InstanceDataNode* node)
+    {
+        QSignalBlocker blocker(GUI);
+        GUI->SetValue(instance);
+        return false;
+    }
+
+   PropertyMultiLineStringCtrl::PropertyMultiLineStringCtrl(QWidget* parent)
+        : PropertyStringBrowseEditCtrl(parent)
+    {
+        m_browseEdit->setLineEditReadOnly(false);
+        SetEditButtonVisible(true);
+        SetEditButtonEnabled(true);
+    }
+
+    void PropertyMultiLineStringCtrl::ConsumeAttribute(AZ::u32 attrib, AzToolsFramework::PropertyAttributeReader* attrValue)
+    {
+        PropertyStringBrowseEditCtrl::ConsumeAttribute(attrib, attrValue);
+    }
+
+    void PropertyMultiLineStringCtrl::Edit()
+    {
+        QInputDialog dialog(GetToolMainWindow());
+        dialog.setOptions(QInputDialog::UsePlainTextEditForTextInput);
+        dialog.setWindowTitle(tr("Edit String Value"));
+        dialog.setLabelText(tr("Edit String Value"));
+        dialog.setTextValue(GetValue().c_str());
+
+        if (dialog.exec())
+        {
+            SetValue(dialog.textValue().toUtf8().constData());
+        }
+    }
+
+    QWidget* PropertyMultiLineStringHandler::CreateGUI(QWidget* parent)
+    {
+        PropertyMultiLineStringCtrl* newCtrl = aznew PropertyMultiLineStringCtrl(parent);
+
+        QObject::connect(
+            newCtrl,
+            &PropertyMultiLineStringCtrl::ValueChanged,
+            this,
+            [newCtrl]()
+            {
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                    &AzToolsFramework::PropertyEditorGUIMessages::RequestWrite, newCtrl);
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                    &AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
+            });
+
+        return newCtrl;
+    }
+
+    void PropertyMultiLineStringHandler::ConsumeAttribute(
+        [[maybe_unused]] PropertyMultiLineStringCtrl* GUI,
+        [[maybe_unused]] AZ::u32 attrib,
+        [[maybe_unused]] AzToolsFramework::PropertyAttributeReader* attrValue,
+        [[maybe_unused]] const char* debugName)
+    {
+        GUI->ConsumeAttribute(attrib, attrValue);
+    }
+
+    void PropertyMultiLineStringHandler::WriteGUIValuesIntoProperty(
+      [[maybe_unused]] size_t index,
+        [[maybe_unused]] PropertyMultiLineStringCtrl* GUI,
+        [[maybe_unused]] property_t& instance,
+        [[maybe_unused]] AzToolsFramework::InstanceDataNode* node)
+    {
+        instance = GUI->GetValue();
+    }
+
+    bool PropertyMultiLineStringHandler::ReadValuesIntoGUI(
+        [[maybe_unused]] size_t index,
+        [[maybe_unused]] PropertyMultiLineStringCtrl* GUI,
+        [[maybe_unused]] const property_t& instance,
+        [[maybe_unused]] AzToolsFramework::InstanceDataNode* node)
+    {
+        QSignalBlocker blocker(GUI);
+        GUI->SetValue(instance);
+        return false;
+    }
+
+    PropertyMultiSelectSplitStringCtrl::PropertyMultiSelectSplitStringCtrl(QWidget* parent)
+        : PropertyStringBrowseEditCtrl(parent)
+    {
+        m_browseEdit->setLineEditReadOnly(true);
+        SetEditButtonVisible(true);
+        SetEditButtonEnabled(true);
+    }
+
+    void PropertyMultiSelectSplitStringCtrl::ConsumeAttribute(AZ::u32 attrib, AzToolsFramework::PropertyAttributeReader* attrValue)
+    {
+        PropertyStringBrowseEditCtrl::ConsumeAttribute(attrib, attrValue);
+
+        if (attrib == AZ_CRC_CE("MultiSelectOptions"))
+        {
+            if (AZStd::string value; attrValue->Read<AZStd::string>(value))
+            {
+                SetOptions(value);
+                return;
+            }
+
+            if (AZStd::vector<AZStd::string> value; attrValue->Read<AZStd::vector<AZStd::string>>(value))
+            {
+                SetOptionsVec(value);
+                return;
+            }
+        }
+    }
+
+    void PropertyMultiSelectSplitStringCtrl::Edit()
+    {
+        AZStd::vector<AZStd::string> selections = GetValuesVec();
+        if (GetStringListFromDialog(selections, GetOptionsVec(), "Select Options", true))
+        {
+            SetValuesVec(selections);
+        }
+    }
+
+    void PropertyMultiSelectSplitStringCtrl::SetValues(const AZStd::string& values)
+    {
+        SetValue(values);
+    }
+
+    AZStd::string PropertyMultiSelectSplitStringCtrl::GetValues() const
+    {
+        return GetValue();
+    }
+
+    void PropertyMultiSelectSplitStringCtrl::SetValuesVec(const AZStd::vector<AZStd::string>& values)
+    {
+        AZStd::string value;
+        AZ::StringFunc::Join(value, values, ", ");
+        SetValues(value);
+    }
+
+    AZStd::vector<AZStd::string> PropertyMultiSelectSplitStringCtrl::GetValuesVec() const
+    {
+        AZStd::vector<AZStd::string> values;
+        AZ::StringFunc::Tokenize(GetValues(), values, ";:, \t\r\n\\/|");
+        return values;
+    }
+
+    void PropertyMultiSelectSplitStringCtrl::SetOptions(const AZStd::string& options)
+    {
+        m_options = options;
+    }
+
+    AZStd::string PropertyMultiSelectSplitStringCtrl::GetOptions() const
+    {
+        return m_options;
+    }
+
+    void PropertyMultiSelectSplitStringCtrl::SetOptionsVec(const AZStd::vector<AZStd::string>& options)
+    {
+        AZStd::string option;
+        AZ::StringFunc::Join(option, options, ", ");
+        SetOptions(option);
+    }
+
+    AZStd::vector<AZStd::string> PropertyMultiSelectSplitStringCtrl::GetOptionsVec() const
+    {
+        AZStd::vector<AZStd::string> options;
+        AZ::StringFunc::Tokenize(GetOptions(), options, ";:, \t\r\n\\/|");
+        return options;
+    }
+
+    QWidget* PropertyMultiSelectSplitStringHandler::CreateGUI(QWidget* parent)
+    {
+        PropertyMultiSelectSplitStringCtrl* newCtrl = aznew PropertyMultiSelectSplitStringCtrl(parent);
+
+        QObject::connect(
+            newCtrl,
+            &PropertyMultiSelectSplitStringCtrl::ValueChanged,
+            this,
+            [newCtrl]()
+            {
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                    &AzToolsFramework::PropertyEditorGUIMessages::RequestWrite, newCtrl);
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                    &AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
+            });
+
+        return newCtrl;
+    }
+
+    void PropertyMultiSelectSplitStringHandler::ConsumeAttribute(
+        [[maybe_unused]] PropertyMultiSelectSplitStringCtrl* GUI,
+        [[maybe_unused]] AZ::u32 attrib,
+        [[maybe_unused]] AzToolsFramework::PropertyAttributeReader* attrValue,
+        [[maybe_unused]] const char* debugName)
+    {
+        GUI->ConsumeAttribute(attrib, attrValue);
+    }
+
+    void PropertyMultiSelectSplitStringHandler::WriteGUIValuesIntoProperty(
+        [[maybe_unused]] size_t index,
+        [[maybe_unused]] PropertyMultiSelectSplitStringCtrl* GUI,
+        [[maybe_unused]] property_t& instance,
+        [[maybe_unused]] AzToolsFramework::InstanceDataNode* node)
+    {
+        instance = GUI->GetValue();
+    }
+
+    bool PropertyMultiSelectSplitStringHandler::ReadValuesIntoGUI(
+        [[maybe_unused]] size_t index,
+        [[maybe_unused]] PropertyMultiSelectSplitStringCtrl* GUI,
+        [[maybe_unused]] const property_t& instance,
+        [[maybe_unused]] AzToolsFramework::InstanceDataNode* node)
+    {
+        QSignalBlocker blocker(GUI);
+        GUI->SetValue(instance);
+        return false;
+    }
+
+    QWidget* PropertyMultiSelectStringVectorHandler::CreateGUI(QWidget* parent)
+    {
+        PropertyMultiSelectSplitStringCtrl* newCtrl = aznew PropertyMultiSelectSplitStringCtrl(parent);
+
+        QObject::connect(
+            newCtrl,
+            &PropertyMultiSelectSplitStringCtrl::ValueChanged,
+            this,
+            [newCtrl]()
+            {
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                    &AzToolsFramework::PropertyEditorGUIMessages::RequestWrite, newCtrl);
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                    &AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
+            });
+
+        return newCtrl;
+    }
+
+    void PropertyMultiSelectStringVectorHandler::ConsumeAttribute(
+        [[maybe_unused]] PropertyMultiSelectSplitStringCtrl* GUI,
+        [[maybe_unused]] AZ::u32 attrib,
+        [[maybe_unused]] AzToolsFramework::PropertyAttributeReader* attrValue,
+        [[maybe_unused]] const char* debugName)
+    {
+        GUI->ConsumeAttribute(attrib, attrValue);
+    }
+
+    void PropertyMultiSelectStringVectorHandler::WriteGUIValuesIntoProperty(
+        [[maybe_unused]] size_t index,
+        [[maybe_unused]] PropertyMultiSelectSplitStringCtrl* GUI,
+        [[maybe_unused]] property_t& instance,
+        [[maybe_unused]] AzToolsFramework::InstanceDataNode* node)
+    {
+        instance = GUI->GetValuesVec();
+    }
+
+    bool PropertyMultiSelectStringVectorHandler::ReadValuesIntoGUI(
+        [[maybe_unused]] size_t index,
+        [[maybe_unused]] PropertyMultiSelectSplitStringCtrl* GUI,
+        [[maybe_unused]] const property_t& instance,
+        [[maybe_unused]] AzToolsFramework::InstanceDataNode* node)
+    {
+        QSignalBlocker blocker(GUI);
+        GUI->SetValuesVec(instance);
+        return false;
+    }
+
+    void RegisterStringBrowseEditHandler()
+    {
+        AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &AzToolsFramework::PropertyTypeRegistrationMessages::RegisterPropertyType,
+            aznew PropertyStringBrowseEditHandler());
+        AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &AzToolsFramework::PropertyTypeRegistrationMessages::RegisterPropertyType,
+            aznew PropertyFilePathStringHandler());
+        AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &AzToolsFramework::PropertyTypeRegistrationMessages::RegisterPropertyType,
+            aznew PropertyMultiLineStringHandler());
+        AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &AzToolsFramework::PropertyTypeRegistrationMessages::RegisterPropertyType,
+            aznew PropertyMultiSelectSplitStringHandler());
+        AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &AzToolsFramework::PropertyTypeRegistrationMessages::RegisterPropertyType,
+            aznew PropertyMultiSelectStringVectorHandler());
+    }
+} // namespace AtomToolsFramework
+
+#include "Inspector/PropertyWidgets/moc_PropertyStringBrowseEditCtrl.cpp"

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/PropertyWidgets/PropertyStringBrowseEditCtrl.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/PropertyWidgets/PropertyStringBrowseEditCtrl.h
@@ -23,7 +23,7 @@ namespace AzQtComponents
 namespace AtomToolsFramework
 {
     // Custom property widget for editing strings using a browse edit control. This allows the strings to be cleared using the browse
-    // controls clear button. It also allows for custom dialogues and editors to be opened using the browse edit button.
+    // controls clear button. It also allows for custom dialogs and editors to be opened using the browse edit button.
     class PropertyStringBrowseEditCtrl : public QWidget
     {
         Q_OBJECT

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/PropertyWidgets/PropertyStringBrowseEditCtrl.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/PropertyWidgets/PropertyStringBrowseEditCtrl.h
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#if !defined(Q_MOC_RUN)
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/std/string/string.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
+#include <QWidget>
+#endif
+
+namespace AzQtComponents
+{
+    class BrowseEdit;
+}
+
+namespace AtomToolsFramework
+{
+    // Custom property widget for editing strings using a browse edit control. This allows the strings to be cleared using the browse
+    // controls clear button. It also allows for custom dialogues and editors to be opened using the browse edit button.
+    class PropertyStringBrowseEditCtrl : public QWidget
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(PropertyStringBrowseEditCtrl, AZ::SystemAllocator, 0);
+
+        PropertyStringBrowseEditCtrl(QWidget* parent = nullptr);
+        virtual void ConsumeAttribute(AZ::u32 attrib, AzToolsFramework::PropertyAttributeReader* attrValue);
+        virtual void Edit();
+        virtual void Clear();
+        virtual void SetValue(const AZStd::string& value);
+        virtual AZStd::string GetValue() const;
+
+    Q_SIGNALS:
+        void ValueChanged();
+
+    protected:
+        void SetEditButtonEnabled(bool value);
+        void SetEditButtonVisible(bool value);
+        AzQtComponents::BrowseEdit* m_browseEdit = nullptr;
+    };
+
+    // Generic handler for manipulating strings using the PropertyStringBrowseEditCtrl
+    class PropertyStringBrowseEditHandler
+        : public QObject
+        , public AzToolsFramework::PropertyHandler<AZStd::string, PropertyStringBrowseEditCtrl>
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(PropertyStringBrowseEditHandler, AZ::SystemAllocator, 0);
+
+        AZ::u32 GetHandlerName() const override { return AZ_CRC_CE("StringBrowseEdit"); }
+
+        bool IsDefaultHandler() const override { return false; }
+
+        QWidget* CreateGUI(QWidget* parent) override;
+
+        void ConsumeAttribute(
+            PropertyStringBrowseEditCtrl* GUI,
+            AZ::u32 attrib,
+            AzToolsFramework::PropertyAttributeReader* attrValue,
+            const char* debugName) override;
+
+        void WriteGUIValuesIntoProperty(
+            size_t index,
+            PropertyStringBrowseEditCtrl* GUI,
+            property_t& instance,
+            AzToolsFramework::InstanceDataNode* node) override;
+
+        bool ReadValuesIntoGUI(
+            size_t index,
+            PropertyStringBrowseEditCtrl* GUI,
+            const property_t& instance,
+            AzToolsFramework::InstanceDataNode* node) override;
+    };
+
+    // Property widget that interprets string data as file paths and opens a custom source file browser.
+    class PropertyFilePathStringCtrl : public PropertyStringBrowseEditCtrl
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(PropertyFilePathStringCtrl, AZ::SystemAllocator, 0);
+
+        PropertyFilePathStringCtrl(QWidget* parent = nullptr);
+        void ConsumeAttribute(AZ::u32 attrib, AzToolsFramework::PropertyAttributeReader* attrValue) override;
+        void Edit() override;
+
+    private:
+        AZStd::string m_title = "File";
+        AZStd::vector<AZStd::string> m_extensions;
+    };
+
+    // Property handler for PropertyFilePathStringCtrl
+    class PropertyFilePathStringHandler
+        : public QObject
+        , public AzToolsFramework::PropertyHandler<AZStd::string, PropertyFilePathStringCtrl>
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(PropertyFilePathStringHandler, AZ::SystemAllocator, 0);
+
+        AZ::u32 GetHandlerName() const override { return AZ_CRC_CE("FilePathString"); }
+
+        bool IsDefaultHandler() const override { return false; }
+
+        QWidget* CreateGUI(QWidget* parent) override;
+
+        void ConsumeAttribute(
+            PropertyFilePathStringCtrl* GUI,
+            AZ::u32 attrib,
+            AzToolsFramework::PropertyAttributeReader* attrValue,
+            const char* debugName) override;
+
+        void WriteGUIValuesIntoProperty(
+            size_t index,
+            PropertyFilePathStringCtrl* GUI,
+            property_t& instance,
+            AzToolsFramework::InstanceDataNode* node) override;
+
+        bool ReadValuesIntoGUI(
+            size_t index,
+            PropertyFilePathStringCtrl* GUI,
+            const property_t& instance,
+            AzToolsFramework::InstanceDataNode* node) override;
+    };
+
+    // Property widget that opens a separate dialog for extended editing of large strings.
+    class PropertyMultiLineStringCtrl : public PropertyStringBrowseEditCtrl
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(PropertyMultiLineStringCtrl, AZ::SystemAllocator, 0);
+
+        PropertyMultiLineStringCtrl(QWidget* parent = nullptr);
+        void ConsumeAttribute(AZ::u32 attrib, AzToolsFramework::PropertyAttributeReader* attrValue) override;
+        void Edit() override;
+    };
+
+    // Property handler for PropertyMultiLineStringCtrl
+    class PropertyMultiLineStringHandler
+        : public QObject
+        , public AzToolsFramework::PropertyHandler<AZStd::string, PropertyMultiLineStringCtrl>
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(PropertyMultiLineStringHandler, AZ::SystemAllocator, 0);
+
+        AZ::u32 GetHandlerName() const override { return AZ_CRC_CE("MultiLineString"); }
+
+        bool IsDefaultHandler() const override { return false; }
+
+        QWidget* CreateGUI(QWidget* parent) override;
+
+        void ConsumeAttribute(
+            PropertyMultiLineStringCtrl* GUI,
+            AZ::u32 attrib,
+            AzToolsFramework::PropertyAttributeReader* attrValue,
+            const char* debugName) override;
+
+        void WriteGUIValuesIntoProperty(
+            size_t index, PropertyMultiLineStringCtrl* GUI,
+            property_t& instance,
+            AzToolsFramework::InstanceDataNode* node) override;
+
+        bool ReadValuesIntoGUI(
+            size_t index,
+            PropertyMultiLineStringCtrl* GUI,
+            const property_t& instance,
+            AzToolsFramework::InstanceDataNode* node) override;
+    };
+
+    // Property widget that splits an incoming stream into multiple values and allows selecting those values from another list of
+    // available strings.
+    class PropertyMultiSelectSplitStringCtrl : public PropertyStringBrowseEditCtrl
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(PropertyMultiSelectSplitStringCtrl, AZ::SystemAllocator, 0);
+
+        PropertyMultiSelectSplitStringCtrl(QWidget* parent = nullptr);
+        void ConsumeAttribute(AZ::u32 attrib, AzToolsFramework::PropertyAttributeReader* attrValue) override;
+        void Edit() override;
+
+        void SetValues(const AZStd::string& values);
+        AZStd::string GetValues() const;
+
+        void SetValuesVec(const AZStd::vector<AZStd::string>& values);
+        AZStd::vector<AZStd::string> GetValuesVec() const;
+
+        void SetOptions(const AZStd::string& options);
+        AZStd::string GetOptions() const;
+
+        void SetOptionsVec(const AZStd::vector<AZStd::string>& options);
+        AZStd::vector<AZStd::string> GetOptionsVec() const;
+
+    private:
+        AZStd::string m_options;
+    };
+
+    // PropertyMultiSelectSplitStringCtrl handler that tokenizes strings into a list of selected and available options
+    class PropertyMultiSelectSplitStringHandler
+        : public QObject
+        , public AzToolsFramework::PropertyHandler<AZStd::string, PropertyMultiSelectSplitStringCtrl>
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(PropertyMultiSelectSplitStringHandler, AZ::SystemAllocator, 0);
+
+        AZ::u32 GetHandlerName() const override { return AZ_CRC_CE("MultiSelectSplitString"); }
+
+        bool IsDefaultHandler() const override { return false; }
+
+        QWidget* CreateGUI(QWidget* parent) override;
+
+        void ConsumeAttribute(
+            PropertyMultiSelectSplitStringCtrl* GUI,
+            AZ::u32 attrib,
+            AzToolsFramework::PropertyAttributeReader* attrValue,
+            const char* debugName) override;
+
+        void WriteGUIValuesIntoProperty(
+            size_t index,
+            PropertyMultiSelectSplitStringCtrl* GUI,
+            property_t& instance,
+            AzToolsFramework::InstanceDataNode* node) override;
+
+        bool ReadValuesIntoGUI(
+            size_t index,
+            PropertyMultiSelectSplitStringCtrl* GUI,
+            const property_t& instance,
+            AzToolsFramework::InstanceDataNode* node) override;
+    };
+
+    // PropertyMultiSelectSplitStringCtrl handler that works directly with vectors to get the list of selected and available strains
+    class PropertyMultiSelectStringVectorHandler
+        : public QObject
+        , public AzToolsFramework::PropertyHandler<AZStd::vector<AZStd::string>, PropertyMultiSelectSplitStringCtrl>
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(PropertyMultiSelectStringVectorHandler, AZ::SystemAllocator, 0);
+
+        AZ::u32 GetHandlerName() const override { return AZ_CRC_CE("MultiSelectStringVector"); }
+
+        bool IsDefaultHandler() const override { return false; }
+
+        QWidget* CreateGUI(QWidget* parent) override;
+
+        void ConsumeAttribute(
+            PropertyMultiSelectSplitStringCtrl* GUI,
+            AZ::u32 attrib,
+            AzToolsFramework::PropertyAttributeReader* attrValue,
+            const char* debugName) override;
+
+        void WriteGUIValuesIntoProperty(
+            size_t index,
+            PropertyMultiSelectSplitStringCtrl* GUI,
+            property_t& instance,
+            AzToolsFramework::InstanceDataNode* node) override;
+
+        bool ReadValuesIntoGUI(
+            size_t index,
+            PropertyMultiSelectSplitStringCtrl* GUI,
+            const property_t& instance,
+            AzToolsFramework::InstanceDataNode* node) override;
+    };
+
+    void RegisterStringBrowseEditHandler();
+} // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/PropertyWidgets/PropertyStringBrowseEditCtrl.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/PropertyWidgets/PropertyStringBrowseEditCtrl.h
@@ -93,7 +93,7 @@ namespace AtomToolsFramework
 
     private:
         AZStd::string m_title = "File";
-        AZStd::vector<AZStd::string> m_extensions;
+        AZStd::vector<AZStd::pair<AZStd::string, AZStd::string>> m_extensions;
     };
 
     // Property handler for PropertyFilePathStringCtrl

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -127,10 +127,14 @@ namespace AtomToolsFramework
 
         // Fill the list widget with all of the available strings for the user to select.
         QListWidget listWidget(&dialog);
+        listWidget.setSelectionMode(multiSelect ? QAbstractItemView::ExtendedSelection : QAbstractItemView::SingleSelection);
+
         for (const auto& availableString : availableStrings)
         {
             listWidget.addItem(availableString.c_str());
         }
+
+        listWidget.sortItems();
 
         // The selected strings vector already has items then attempt to select those in the list.
         for (const auto& selection : selectedStrings)
@@ -141,8 +145,6 @@ namespace AtomToolsFramework
             }
         }
 
-        listWidget.setSelectionMode(multiSelect ? QAbstractItemView::ExtendedSelection : QAbstractItemView::SingleSelection);
-        listWidget.sortItems();
 
         // Create the button box that will provide default dialog buttons to allow the user to accept or reject their selections.
         QDialogButtonBox buttonBox(&dialog);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -110,7 +110,7 @@ namespace AtomToolsFramework
         return GetDisplayNameFromText(fileInfo.baseName().toUtf8().constData());
     }
 
-    AZStd::string GetSaveFilePath(const AZStd::string& initialPath, const AZStd::string& title)
+    AZStd::string GetSaveFilePathFromDialog(const AZStd::string& initialPath, const AZStd::string& title)
     {
         const QFileInfo initialFileInfo(initialPath.c_str());
         const QString initialExt(initialFileInfo.completeSuffix());
@@ -139,11 +139,11 @@ namespace AtomToolsFramework
             .absoluteFilePath().toUtf8().constData();
     }
 
-    AZStd::vector<AZStd::string> GetOpenFilePaths(const QRegExp& filter, const AZStd::string& title)
+    AZStd::vector<AZStd::string> GetOpenFilePathsFromDialog(const QRegExp& filter, const AZStd::string& title, const bool multiSelect)
     {
         auto selection = AzToolsFramework::AssetBrowser::AssetSelectionModel::SourceAssetTypeSelection(filter);
         selection.SetTitle(title.c_str());
-        selection.SetMultiselect(true);
+        selection.SetMultiselect(multiSelect);
 
         AzToolsFramework::AssetBrowser::AssetBrowserComponentRequestBus::Broadcast(
             &AzToolsFramework::AssetBrowser::AssetBrowserComponentRequests::PickAssets, selection, GetToolMainWindow());
@@ -170,14 +170,9 @@ namespace AtomToolsFramework
         return fileInfo.absoluteFilePath().toUtf8().constData();
     }
 
-    AZStd::string GetUniqueDefaultSaveFilePath(const AZStd::string& extension)
+    AZStd::string GetUniqueUntitledFilePath(const AZStd::string& extension)
     {
         return GetUniqueFilePath(AZStd::string::format("%s/Assets/untitled.%s", AZ::Utils::GetProjectPath().c_str(), extension.c_str()));
-    }
-
-    AZStd::string GetUniqueDuplicateFilePath(const AZStd::string& initialPath)
-    {
-        return GetSaveFilePath(GetUniqueFilePath(initialPath), "Duplicate File");
     }
 
     bool ValidateDocumentPath(AZStd::string& path)
@@ -540,10 +535,9 @@ namespace AtomToolsFramework
             addUtilFunc(behaviorContext->Method("GetSymbolNameFromText", GetSymbolNameFromText, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetDisplayNameFromText", GetDisplayNameFromText, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetDisplayNameFromPath", GetDisplayNameFromPath, nullptr, ""));
-            addUtilFunc(behaviorContext->Method("GetSaveFilePath", GetSaveFilePath, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetSaveFilePathFromDialog", GetSaveFilePathFromDialog, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetUniqueFilePath", GetUniqueFilePath, nullptr, ""));
-            addUtilFunc(behaviorContext->Method("GetUniqueDefaultSaveFilePath", GetUniqueDefaultSaveFilePath, nullptr, ""));
-            addUtilFunc(behaviorContext->Method("GetUniqueDuplicateFilePath", GetUniqueDuplicateFilePath, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetUniqueUntitledFilePath", GetUniqueUntitledFilePath, nullptr, ""));
             addUtilFunc(behaviorContext->Method("ValidateDocumentPath", ValidateDocumentPath, nullptr, ""));
             addUtilFunc(behaviorContext->Method("IsDocumentPathInSupportedFolder", IsDocumentPathInSupportedFolder, nullptr, ""));
             addUtilFunc(behaviorContext->Method("IsDocumentPathEditable", IsDocumentPathEditable, nullptr, ""));

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -145,7 +145,6 @@ namespace AtomToolsFramework
             }
         }
 
-
         // Create the button box that will provide default dialog buttons to allow the user to accept or reject their selections.
         QDialogButtonBox buttonBox(&dialog);
         buttonBox.setStandardButtons(QDialogButtonBox::Cancel | QDialogButtonBox::Ok);
@@ -155,6 +154,12 @@ namespace AtomToolsFramework
         // Add the list widget and button box to the layout so they appear and the dialog.
         dialog.layout()->addWidget(&listWidget);
         dialog.layout()->addWidget(&buttonBox);
+
+        // Temporarily forcing a fixed size before showing it to compensate for window management centering and resizing the dialog.
+        dialog.setFixedSize(400, 200);
+        dialog.show();
+        dialog.setMinimumSize(0, 0);
+        dialog.setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
 
         // If the user accepts their selections then the selected strings director will be cleared and refilled with them.
         if (dialog.exec() == QDialog::Accepted)
@@ -169,44 +174,154 @@ namespace AtomToolsFramework
         return false;
     }
 
-    AZStd::string GetSaveFilePathFromDialog(const AZStd::string& initialPath, const AZStd::string& title)
+    AZStd::string GetFileFilterFromSupportedExtensions(const AZStd::vector<AZStd::pair<AZStd::string, AZStd::string>>& supportedExtensions)
     {
-        const QFileInfo initialFileInfo(initialPath.c_str());
-        const QString initialExt(initialFileInfo.completeSuffix());
+        // Build an ordered table of all of the supported extensions and their display names. This will be transformed into the file filter
+        // that is displayed in the dialog.
+        AZStd::map<AZStd::string, AZStd::set<AZStd::string>> orderedExtensions;
+        for (const auto& extensionPair : supportedExtensions)
+        {
+            if (!extensionPair.second.empty())
+            {
+                // Sift all of the extensions into display name groups. If no display name was provided then we will use a default one.
+                const auto& group = !extensionPair.first.empty() ? extensionPair.first : "Supported";
 
+                // Convert the extension into a wild card.
+                orderedExtensions[group].insert("*." + extensionPair.second);
+            }
+        }
+
+        // Transform each of the ordered extension groups into individual file dialog filters that represent one or more extensions.
+        AZStd::vector<AZStd::string> individualFilters;
+        for (const auto& orderedExtensionPair : orderedExtensions)
+        {
+            AZStd::string combinedExtensions;
+            AZ::StringFunc::Join(combinedExtensions, orderedExtensionPair.second, " ");
+            individualFilters.push_back(orderedExtensionPair.first + " (" + combinedExtensions + ")");
+        }
+
+        // Combine all of the individual filters into a single expression that can be used directly with the file dialog.
+        AZStd::string combinedFilters;
+        AZ::StringFunc::Join(combinedFilters, individualFilters, ";;");
+        return combinedFilters;
+    }
+
+    AZStd::string GetFirstValidSupportedExtension(const AZStd::vector<AZStd::pair<AZStd::string, AZStd::string>>& supportedExtensions)
+    {
+        for (const auto& extensionPair : supportedExtensions)
+        {
+            if (!extensionPair.second.empty())
+            {
+                return extensionPair.second;
+            }
+        }
+
+        return AZStd::string();
+    }
+
+    AZStd::string GetFirstMatchingSupportedExtension(
+        const AZStd::vector<AZStd::pair<AZStd::string, AZStd::string>>& supportedExtensions, const AZStd::string& path)
+    {
+        for (const auto& extensionPair : supportedExtensions)
+        {
+            if (!extensionPair.second.empty() && AZ::StringFunc::EndsWith(path, extensionPair.second))
+            {
+                return extensionPair.second;
+            }
+        }
+
+        return AZStd::string();
+    }
+
+    AZStd::string GetSaveFilePathFromDialog(
+        const AZStd::string& initialPath,
+        const AZStd::vector<AZStd::pair<AZStd::string, AZStd::string>>& supportedExtensions,
+        const AZStd::string& title)
+    {
+        // Build the file dialog filter from all of the supported extensions.
+        const auto& combinedFilters = GetFileFilterFromSupportedExtensions(supportedExtensions);
+
+        // If no valid extensions were provided then return immediately.
+        if (combinedFilters.empty())
+        {
+            QMessageBox::critical(GetToolMainWindow(), "Error", QString("No supported extensions were specified."));
+            return AZStd::string();
+        }
+
+        // Remove any aliasing from the initial path to feed to the file dialog.
+        AZStd::string displayedPath = GetPathWithoutAlias(initialPath);
+
+        // If the display name is empty or invalid then build a unique default display name using the first supported extension. 
+        if (displayedPath.empty())
+        {
+            displayedPath = GetUniqueUntitledFilePath(GetFirstValidSupportedExtension(supportedExtensions));
+        }
+
+        // Prompt the user to select a save file name using the input path and the list of filtered extensions.
         const QFileInfo selectedFileInfo(AzQtComponents::FileDialog::GetSaveFileName(
-            GetToolMainWindow(),
-            QObject::tr("Save %1").arg(title.c_str()),
-            initialFileInfo.absoluteFilePath(),
-            QString("Files (*.%1)").arg(initialExt)));
+            GetToolMainWindow(), QObject::tr("Save %1").arg(title.c_str()), displayedPath.c_str(), combinedFilters.c_str()));
 
+        // If the returned path is empty this means that the user cancelled or escaped from the dialog and is canceling the operation.
         if (selectedFileInfo.absoluteFilePath().isEmpty())
         {
-            // Cancelled operation
             return AZStd::string();
         }
 
-        if (!selectedFileInfo.absoluteFilePath().endsWith(initialExt))
+        // Find the supported extension corresponding to the user selection.
+        const auto& selectedExtension =
+            GetFirstMatchingSupportedExtension(supportedExtensions, selectedFileInfo.absoluteFilePath().toUtf8().constData());
+
+        // If the selected path does not match any of the supported extensions consider it invalid and return. 
+        if (selectedExtension.empty())
         {
-            QMessageBox::critical(GetToolMainWindow(), "Error", QString("File name must have .%1 extension.").arg(initialExt));
+            QMessageBox::critical(GetToolMainWindow(), "Error", QString("File name does not match supported extension."));
             return AZStd::string();
         }
 
-        // Reconstructing the file info from the absolute path and expected extension to compensate for an issue with the save file
-        // dialog adding the extension multiple times if it contains "." like *.lightingpreset.azasset
-        return QFileInfo(QString("%1/%2.%3").arg(selectedFileInfo.absolutePath()).arg(selectedFileInfo.baseName()).arg(initialExt))
+        // Reconstruct the path to compensate for known problems with the file dialog and complex extensions containing multiple "." like
+        // *.lightingpreset.azasset
+        return QFileInfo(QString("%1/%2.%3").arg(selectedFileInfo.absolutePath()).arg(selectedFileInfo.baseName()).arg(selectedExtension.c_str()))
             .absoluteFilePath().toUtf8().constData();
     }
 
-    AZStd::vector<AZStd::string> GetOpenFilePathsFromDialog(const QRegExp& filter, const AZStd::string& title, const bool multiSelect)
+    AZStd::vector<AZStd::string> GetOpenFilePathsFromDialog(
+        const AZStd::vector<AZStd::string>& selectedFilePaths,
+        const AZStd::vector<AZStd::pair<AZStd::string, AZStd::string>>& supportedExtensions,
+        const AZStd::string& title,
+        const bool multiSelect)
     {
+        // Removing aliases from all incoming paths because the asset selection model does not recognize them.
+        AZStd::vector<AZStd::string> selectedFilePathsWithoutAliases = selectedFilePaths;
+        for (auto& path : selectedFilePathsWithoutAliases)
+        {
+            path = GetPathWithoutAlias(path);
+        }
+
+        // Build a string list from the supported extensions container that will be used in a regular expression wild card for the asset
+        // selection model.
+        QStringList extensionList;
+        for (const auto& extensionPair : supportedExtensions)
+        {
+            if (!extensionPair.second.empty())
+            {
+                extensionList.append(extensionPair.second.c_str());
+            }
+        }
+
+        // This expression so the selection model only matches files that match any of the valid extensions.
+        const QString expression = QString("[\\w\\-.]+\\.(%1)").arg(extensionList.join("|"));
+        const QRegExp filter(expression, Qt::CaseInsensitive);
+
+        // Create the selection models of the asset picture only displays files matching the filter.
         auto selection = AzToolsFramework::AssetBrowser::AssetSelectionModel::SourceAssetTypeSelection(filter);
         selection.SetTitle(title.c_str());
         selection.SetMultiselect(multiSelect);
+        selection.SetSelectedFilePaths(selectedFilePathsWithoutAliases);
 
         AzToolsFramework::AssetBrowser::AssetBrowserComponentRequestBus::Broadcast(
             &AzToolsFramework::AssetBrowser::AssetBrowserComponentRequests::PickAssets, selection, GetToolMainWindow());
 
+        // Return absolute paths for all results.
         AZStd::vector<AZStd::string> results;
         results.reserve(selection.GetResults().size());
         for (const auto& result : selection.GetResults())
@@ -595,7 +710,11 @@ namespace AtomToolsFramework
             addUtilFunc(behaviorContext->Method("GetDisplayNameFromText", GetDisplayNameFromText, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetDisplayNameFromPath", GetDisplayNameFromPath, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetStringListFromDialog", GetStringListFromDialog, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetFileFilterFromSupportedExtensions", GetFileFilterFromSupportedExtensions, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetFirstValidSupportedExtension", GetFirstValidSupportedExtension, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetFirstMatchingSupportedExtension", GetFirstMatchingSupportedExtension, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetSaveFilePathFromDialog", GetSaveFilePathFromDialog, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetOpenFilePathsFromDialog", GetOpenFilePathsFromDialog, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetUniqueFilePath", GetUniqueFilePath, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetUniqueUntitledFilePath", GetUniqueUntitledFilePath, nullptr, ""));
             addUtilFunc(behaviorContext->Method("ValidateDocumentPath", ValidateDocumentPath, nullptr, ""));

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/atomtoolsframework_files.cmake
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/atomtoolsframework_files.cmake
@@ -111,6 +111,8 @@ set(FILES
     Source/Inspector/InspectorWidget.cpp
     Source/Inspector/InspectorWidget.qrc
     Source/Inspector/InspectorWidget.ui
+    Source/Inspector/PropertyWidgets/PropertyStringBrowseEditCtrl.cpp
+    Source/Inspector/PropertyWidgets/PropertyStringBrowseEditCtrl.h
 
     Include/AtomToolsFramework/PerformanceMonitor/PerformanceMetrics.h
     Include/AtomToolsFramework/PerformanceMonitor/PerformanceMonitorRequestBus.h

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
@@ -53,9 +53,10 @@ namespace MaterialCanvas
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                 ->Attribute(AZ::Script::Attributes::Category, "Editor")
                 ->Attribute(AZ::Script::Attributes::Module, "materialcanvas")
+                ->Event("GetGraph", &MaterialCanvasDocumentRequests::GetGraph)
                 ->Event("GetGraphId", &MaterialCanvasDocumentRequests::GetGraphId)
-                ->Event("GetGeneratedFilePaths", &MaterialCanvasDocumentRequests::GetGeneratedFilePaths)
                 ->Event("GetGraphName", &MaterialCanvasDocumentRequests::GetGraphName)
+                ->Event("GetGeneratedFilePaths", &MaterialCanvasDocumentRequests::GetGeneratedFilePaths)
                 ->Event("CompileGraph", &MaterialCanvasDocumentRequests::CompileGraph)
                 ->Event("QueueCompileGraph", &MaterialCanvasDocumentRequests::QueueCompileGraph)
                 ->Event("IsCompileGraphQueued", &MaterialCanvasDocumentRequests::IsCompileGraphQueued);
@@ -305,9 +306,23 @@ namespace MaterialCanvas
         return true;
     }
 
+    GraphModel::GraphPtr MaterialCanvasDocument::GetGraph() const
+    {
+        return m_graph;
+    }
+
     GraphCanvas::GraphId MaterialCanvasDocument::GetGraphId() const
     {
         return m_graphId;
+    }
+
+    AZStd::string MaterialCanvasDocument::GetGraphName() const
+    {
+        // Sanitize the document name to remove any illegal characters that could not be used as symbols in generated code
+        AZStd::string documentName;
+        AZ::StringFunc::Path::GetFullFileName(m_absolutePath.c_str(), documentName);
+        AZ::StringFunc::Replace(documentName, ".materialcanvas.azasset", "");
+        return AtomToolsFramework::GetSymbolNameFromText(documentName);
     }
 
     const AZStd::vector<AZStd::string>& MaterialCanvasDocument::GetGeneratedFilePaths() const
@@ -507,15 +522,6 @@ namespace MaterialCanvas
                 m_groups.emplace_back(group);
             }
         }
-    }
-
-    AZStd::string MaterialCanvasDocument::GetGraphName() const
-    {
-        // Sanitize the document name to remove any illegal characters that could not be used as symbols in generated code
-        AZStd::string documentName;
-        AZ::StringFunc::Path::GetFullFileName(m_absolutePath.c_str(), documentName);
-        AZ::StringFunc::Replace(documentName, ".materialcanvas.azasset", "");
-        return AtomToolsFramework::GetSymbolNameFromText(documentName);
     }
 
     AZStd::string MaterialCanvasDocument::GetOutputPathFromTemplatePath(const AZStd::string& templateInputPath) const

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.h
@@ -56,9 +56,10 @@ namespace MaterialCanvas
         bool EndEdit() override;
 
         // MaterialCanvasDocumentRequestBus::Handler overrides...
+        GraphModel::GraphPtr GetGraph() const override;
         GraphCanvas::GraphId GetGraphId() const override;
-        const AZStd::vector<AZStd::string>& GetGeneratedFilePaths() const override;
         AZStd::string GetGraphName() const override;
+        const AZStd::vector<AZStd::string>& GetGeneratedFilePaths() const override;
         bool CompileGraph() const override;
         void QueueCompileGraph() const override;
         bool IsCompileGraphQueued() const override;

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocumentRequestBus.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocumentRequestBus.h
@@ -10,6 +10,7 @@
 
 #include <AzCore/EBus/EBus.h>
 #include <GraphCanvas/Editor/EditorTypes.h>
+#include <GraphModel/Model/DataType.h>
 
 namespace MaterialCanvas
 {
@@ -20,14 +21,17 @@ namespace MaterialCanvas
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
         typedef AZ::Uuid BusIdType;
 
+        // Get the graph model graph pointer for this document.
+        virtual GraphModel::GraphPtr GetGraph() const = 0;
+
         // Get the graph canvas scene ID for this document.
         virtual GraphCanvas::GraphId GetGraphId() const = 0;
 
-        // Get a list of all of the generated files from the last time this graph was compiled.
-        virtual const AZStd::vector<AZStd::string>& GetGeneratedFilePaths() const = 0;
-
         // Convert the document file name into one that can be used as a symbol in graph template files.
         virtual AZStd::string GetGraphName() const = 0;
+
+        // Get a list of all of the generated files from the last time this graph was compiled.
+        virtual const AZStd::vector<AZStd::string>& GetGeneratedFilePaths() const = 0;
 
         // Evaluate the graph nodes, slots, values, and settings to generate and export shaders, material types, and materials.
         virtual bool CompileGraph() const = 0;

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
@@ -110,12 +110,14 @@ namespace MaterialCanvas
 
         editData = {};
         editData.m_elementId = AZ_CRC_CE("FilePathString");
+        AtomToolsFramework::AddEditDataAttribute(editData, AZ_CRC_CE("Title"), AZStd::string("Template File"));
         AtomToolsFramework::AddEditDataAttribute(editData, AZ_CRC_CE("Extensions"),
             AZStd::vector<AZStd::string>{ "azsl.template", "azsli.template", "material.template", "materialtype.template", "shader.template" });
         m_dynamicNodeManager->RegisterEditDataForSetting("templatePaths", editData);
 
         editData = {};
         editData.m_elementId = AZ_CRC_CE("FilePathString");
+        AtomToolsFramework::AddEditDataAttribute(editData, AZ_CRC_CE("Title"), AZStd::string("Include File"));
         AtomToolsFramework::AddEditDataAttribute(editData, AZ_CRC_CE("Extensions"), AZStd::vector<AZStd::string>{ "azsli" });
         m_dynamicNodeManager->RegisterEditDataForSetting("includePaths", editData);
 

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
@@ -10,6 +10,8 @@
 #include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
 #include <AtomToolsFramework/Document/AtomToolsAnyDocument.h>
 #include <AtomToolsFramework/Document/AtomToolsDocumentSystemRequestBus.h>
+#include <AtomToolsFramework/DynamicNode/DynamicNodeUtil.h>
+#include <AtomToolsFramework/Util/Util.h>
 #include <AzCore/Math/Color.h>
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector3.h>
@@ -97,6 +99,25 @@ namespace MaterialCanvas
             AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("string"), AZStd::string{}, "string"),
             AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("image"), AZ::Data::Asset<AZ::RPI::StreamingImageAsset>{}, "image"),
         });
+
+        // Registering custom property handlers for dynamic node configuration settings. The settings are just a map of string data.
+        // Recognized settings will need special controls for selecting files or editing large blocks of text without taking up much real
+        // estate in the property editor.
+        AZ::Edit::ElementData editData;
+        editData.m_elementId = AZ_CRC_CE("MultiLineString");
+        m_dynamicNodeManager->RegisterEditDataForSetting("instructions", editData);
+        m_dynamicNodeManager->RegisterEditDataForSetting("materialInputs", editData);
+
+        editData = {};
+        editData.m_elementId = AZ_CRC_CE("FilePathString");
+        AtomToolsFramework::AddEditDataAttribute(editData, AZ_CRC_CE("Extensions"),
+            AZStd::vector<AZStd::string>{ "azsl.template", "azsli.template", "material.template", "materialtype.template", "shader.template" });
+        m_dynamicNodeManager->RegisterEditDataForSetting("templatePaths", editData);
+
+        editData = {};
+        editData.m_elementId = AZ_CRC_CE("FilePathString");
+        AtomToolsFramework::AddEditDataAttribute(editData, AZ_CRC_CE("Extensions"), AZStd::vector<AZStd::string>{ "azsli" });
+        m_dynamicNodeManager->RegisterEditDataForSetting("includePaths", editData);
 
         // Search the project and gems for dynamic node configurations and register them with the manager
         m_dynamicNodeManager->LoadConfigFiles("materialcanvasnode");

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
@@ -703,7 +703,8 @@ namespace AZ
 
             bool MaterialPropertyInspector::SaveMaterial(const AZStd::string& path) const
             {
-                const auto& saveFilePath = AtomToolsFramework::GetSaveFilePathFromDialog(path);
+                const AZStd::string saveFilePath = AtomToolsFramework::GetSaveFilePathFromDialog(
+                    path, { { "Material", AZ::RPI::MaterialSourceData::Extension } }, "Material");
                 if (saveFilePath.empty())
                 {
                     return false;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
@@ -703,7 +703,7 @@ namespace AZ
 
             bool MaterialPropertyInspector::SaveMaterial(const AZStd::string& path) const
             {
-                const auto& saveFilePath = AtomToolsFramework::GetSaveFilePath(path);
+                const auto& saveFilePath = AtomToolsFramework::GetSaveFilePathFromDialog(path);
                 if (saveFilePath.empty())
                 {
                     return false;


### PR DESCRIPTION
## What does this PR do?

- This change addresses issues with the node configuration editor and edit contexts.
- The included property controls prevent files outside of scan folders and invalid files and values from being selected within the editor.
- This fixes problems with editing shader code snippets that were previously limited to confined space in the inspector. Properties with large text blocks like shader code snippets and descriptions can now be opened and edited in a model, resizable dialog.
- Default values will be cleared if incompatible type selections are made.
- Fixed other bugs related to create a new, untitled documents and saving them without a file name. Instead, if no file name has been specified the user will be prompted to select a path, defaulting to an untitled path with the first supported extension.

## How was this PR tested?

Manually testing node configuration editor in material canvas.
Opening, closing, editing note configuration documents. Undo, redo, opening property editor dialogs to change values.
Continuing to test.

![image](https://user-images.githubusercontent.com/82461473/191727994-91222534-7e9e-4ad3-956b-d012234ba688.png)
![image](https://user-images.githubusercontent.com/82461473/191728411-de909764-8a6c-4a90-8703-31da28d2a333.png)
![image](https://user-images.githubusercontent.com/82461473/191728668-eec9132c-38d1-4fc8-8cb9-dc3565450bc2.png)
![image](https://user-images.githubusercontent.com/82461473/191728817-28da130f-07f4-43d5-b6a6-41a532e33cfd.png)
![image](https://user-images.githubusercontent.com/82461473/191729145-62c0605f-be06-4bac-86aa-39ad845ba12e.png)
