### PR TITLE
[LYN-15573] Asset Processor - Fix dependencies on non-asset files being ignored

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -5168,7 +5168,6 @@ namespace AssetProcessor
             explicit PathOrUuid(AZStd::string path)
                 : m_path(AZStd::move(path))
             {
-
             }
 
             bool IsUuid() const
@@ -5210,7 +5209,7 @@ namespace AssetProcessor
         struct Hasher
         {
             size_t operator()(const PathOrUuid& obj) const
-                {
+            {
                 size_t seed = 0;
 
                 if (obj.IsUuid())

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -5158,14 +5158,79 @@ namespace AssetProcessor
 
     void AssetProcessorManager::QueryAbsolutePathDependenciesRecursive(AZ::Uuid sourceUuid, SourceFilesForFingerprintingContainer& finalDependencyList, AzToolsFramework::AssetDatabase::SourceFileDependencyEntry::TypeOfDependency dependencyType)
     {
+        struct PathOrUuid
+        {
+            explicit PathOrUuid(AZ::Uuid uuid)
+                : m_uuid(uuid)
+            {
+            }
+
+            explicit PathOrUuid(AZStd::string path) : m_path(AZStd::move(path))
+            {
+
+            }
+
+            bool IsUuid() const
+            {
+                return !m_uuid.IsNull();
+            }
+
+            AZStd::string GetPath() const
+            {
+                return m_path;
+            }
+
+            AZ::Uuid GetUuid() const
+            {
+                return m_uuid;
+            }
+
+            AZStd::string ToString() const
+            {
+                if (IsUuid())
+                {
+                    return m_uuid.ToString<AZStd::string>(false, false);
+                }
+                else
+                {
+                    return m_path;
+                }
+            }
+
+            bool operator==(const PathOrUuid& rhs) const
+            {
+                return rhs.m_path == m_path && rhs.m_uuid == m_uuid;
+            }
+
+            AZStd::string m_path;
+            AZ::Uuid m_uuid;
+        };
+
+        struct Hasher
+        {
+            size_t operator()(const PathOrUuid& obj) const
+                {
+                size_t seed = 0;
+
+                if (obj.IsUuid())
+                {
+                    AZStd::hash_combine(seed, obj.GetUuid());
+                    return seed;
+                }
+
+                AZStd::hash_combine(seed, obj.GetPath());
+                return seed;
+            }
+        };
+
         // then we add database dependencies.  We have to query this recursively so that we get dependencies of dependencies:
-        AZStd::unordered_set<AZ::Uuid> results;
-        AZStd::queue<AZ::Uuid> queryQueue;
-        queryQueue.push(sourceUuid);
+        AZStd::unordered_set<PathOrUuid, Hasher> results;
+        AZStd::queue<PathOrUuid> queryQueue;
+        queryQueue.push(PathOrUuid(sourceUuid));
 
         while (!queryQueue.empty())
         {
-            AZ::Uuid toSearch = queryQueue.front();
+            PathOrUuid toSearch = queryQueue.front();
             queryQueue.pop();
 
             // if we've already queried it, dont do it again (breaks recursion)
@@ -5173,7 +5238,23 @@ namespace AssetProcessor
             {
                 continue;
             }
+
             results.insert(toSearch);
+
+            AZ::Uuid searchUuid;
+
+            if (!toSearch.IsUuid())
+            {
+                // If the dependency is a path, try to get a UUID for it
+                // If the dependency is an asset, this will resolve to a valid UUID
+                // If the dependency is not an asset, this will resolve to an invalid UUID which will simply return no results for our
+                // search
+                searchUuid = AssetUtilities::CreateSafeSourceUUIDFromName(toSearch.GetPath().c_str());
+            }
+            else
+            {
+                searchUuid = toSearch.GetUuid();
+            }
 
             auto callbackFunction = [&queryQueue](AzToolsFramework::AssetDatabase::SourceFileDependencyEntry& entry)
             {
@@ -5189,31 +5270,47 @@ namespace AssetProcessor
 
                 if(uuid.IsNull())
                 {
-                    uuid = AssetUtilities::CreateSafeSourceUUIDFromName(entry.m_dependsOnSource.c_str());
+                    queryQueue.push(PathOrUuid(dependsOnSource));
+                }
+                else
+                {
+                    queryQueue.push(PathOrUuid(uuid));
                 }
 
-                queryQueue.push(uuid);
                 return true;
             };
 
-            m_stateData->QueryDependsOnSourceBySourceDependency(toSearch, nullptr, dependencyType, callbackFunction);
+            m_stateData->QueryDependsOnSourceBySourceDependency(searchUuid, nullptr, dependencyType, callbackFunction);
         }
 
-        for (AZ::Uuid dep : results)
+        for (const PathOrUuid& dep : results)
         {
-            SourceInfo info;
+            QString absolutePath;
 
-            if (!SearchSourceInfoBySourceUUID(dep, info))
+            if (dep.IsUuid())
             {
-                continue;
+                SourceInfo info;
+
+                if (!SearchSourceInfoBySourceUUID(dep.GetUuid(), info))
+                {
+                    continue;
+                }
+
+                absolutePath = QDir(info.m_watchFolder).absoluteFilePath(info.m_sourceRelativeToWatchFolder);
+            }
+            else
+            {
+                absolutePath = m_platformConfig->FindFirstMatchingFile(dep.GetPath().c_str());
+
+                if (absolutePath.isEmpty())
+                {
+                    continue;
+                }
             }
 
-            QString absolutePath = QDir(info.m_watchFolder).absoluteFilePath(info.m_sourceRelativeToWatchFolder);
-
-            finalDependencyList.insert(AZStd::make_pair(absolutePath.toUtf8().constData(), dep.ToFixedString().c_str()));
+            finalDependencyList.insert(AZStd::make_pair(absolutePath.toUtf8().constData(), dep.ToString().c_str()));
         }
     }
-
     bool AssetProcessorManager::AreBuildersUnchanged(AZStd::string_view builderEntries, int& numBuildersEmittingSourceDependencies)
     {
         // each entry here is of the format "builderID~builderFingerprint"

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -5165,7 +5165,8 @@ namespace AssetProcessor
             {
             }
 
-            explicit PathOrUuid(AZStd::string path) : m_path(AZStd::move(path))
+            explicit PathOrUuid(AZStd::string path)
+                : m_path(AZStd::move(path))
             {
 
             }

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -991,6 +991,55 @@ TEST_F(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_Missing
     EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
 }
 
+// Test to make sure dependencies on non-asset files are included
+TEST_F(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_DependenciesOnNonAssetsIncluded)
+{
+    using SourceFileDependencyEntry = AzToolsFramework::AssetDatabase::SourceFileDependencyEntry;
+
+    //  A depends on B, which depends on both C and D
+
+    QDir tempPath(m_tempDir.path());
+
+    // Delete b and c from the database, making them "non asset" files
+    AzToolsFramework::AssetDatabase::SourceDatabaseEntry entry;
+    m_assetProcessorManager->m_stateData->GetSourceBySourceGuid(m_bUuid, entry);
+    m_assetProcessorManager->m_stateData->RemoveSource(entry.m_sourceID);
+
+    m_assetProcessorManager->m_stateData->GetSourceBySourceGuid(m_cUuid, entry);
+    m_assetProcessorManager->m_stateData->RemoveSource(entry.m_sourceID);
+
+    SourceFileDependencyEntry newEntry1; // a depends on B
+    newEntry1.m_sourceDependencyID = AzToolsFramework::AssetDatabase::InvalidEntryId;
+    newEntry1.m_builderGuid = AZ::Uuid::CreateRandom();
+    newEntry1.m_sourceGuid = m_aUuid;
+    newEntry1.m_dependsOnSource = "b.txt";
+
+    SourceFileDependencyEntry newEntry2; // b depends on C
+    newEntry2.m_sourceDependencyID = AzToolsFramework::AssetDatabase::InvalidEntryId;
+    newEntry2.m_builderGuid = AZ::Uuid::CreateRandom();
+    newEntry2.m_sourceGuid = m_bUuid;
+    newEntry2.m_dependsOnSource = "c.txt";
+
+    SourceFileDependencyEntry newEntry3; // b also depends on D
+    newEntry3.m_sourceDependencyID = AzToolsFramework::AssetDatabase::InvalidEntryId;
+    newEntry3.m_builderGuid = AZ::Uuid::CreateRandom();
+    newEntry3.m_sourceGuid = m_bUuid;
+    newEntry3.m_dependsOnSource = "d.txt";
+
+    ASSERT_TRUE(m_assetProcessorManager->m_stateData->SetSourceFileDependency(newEntry1));
+    ASSERT_TRUE(m_assetProcessorManager->m_stateData->SetSourceFileDependency(newEntry2));
+    ASSERT_TRUE(m_assetProcessorManager->m_stateData->SetSourceFileDependency(newEntry3));
+
+    AssetProcessor::SourceFilesForFingerprintingContainer dependencies;
+    m_assetProcessorManager->QueryAbsolutePathDependenciesRecursive(m_aUuid, dependencies, SourceFileDependencyEntry::DEP_SourceToSource);
+    EXPECT_EQ(dependencies.size(), 4);
+
+    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/a.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/b.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/c.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
+}
+
 TEST_F(AssetProcessorManagerTest, BuilderSDK_API_CreateJobs_HasValidParameters_WithNoOutputFolder)
 {
     QDir tempPath(m_tempDir.path());

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -839,10 +839,10 @@ TEST_F(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_BasicTe
     EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
 
     // make sure the corresponding values in the map are also correct
-    EXPECT_STREQ(dependencies[tempPath.absoluteFilePath("subfolder1/a.txt").toUtf8().constData()].c_str(), m_aUuid.ToFixedString().c_str());
-    EXPECT_STREQ(dependencies[tempPath.absoluteFilePath("subfolder1/b.txt").toUtf8().constData()].c_str(), m_bUuid.ToFixedString().c_str());
-    EXPECT_STREQ(dependencies[tempPath.absoluteFilePath("subfolder1/c.txt").toUtf8().constData()].c_str(), m_cUuid.ToFixedString().c_str());
-    EXPECT_STREQ(dependencies[tempPath.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()].c_str(), m_dUuid.ToFixedString().c_str());
+    EXPECT_STREQ(dependencies[tempPath.absoluteFilePath("subfolder1/a.txt").toUtf8().constData()].c_str(), m_aUuid.ToFixedString(false, false).c_str());
+    EXPECT_STREQ(dependencies[tempPath.absoluteFilePath("subfolder1/b.txt").toUtf8().constData()].c_str(), "b.txt");
+    EXPECT_STREQ(dependencies[tempPath.absoluteFilePath("subfolder1/c.txt").toUtf8().constData()].c_str(), "c.txt");
+    EXPECT_STREQ(dependencies[tempPath.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()].c_str(), "d.txt");
 
     dependencies.clear();
     m_assetProcessorManager->QueryAbsolutePathDependenciesRecursive(m_bUuid, dependencies, SourceFileDependencyEntry::DEP_SourceToSource);
@@ -936,9 +936,9 @@ TEST_F(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_Missing
 
     QDir tempPath(m_tempDir.path());
 
-    UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("subfolder1/a.txt"), QString("tempdata\n"));
-    UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("subfolder1/d.txt"), QString("tempdata\n"));
-    // note that we don't actually create b and c here, they are missing.
+    // Remove b and c files
+    AZ::IO::SystemFile::Delete(tempPath.absoluteFilePath("subfolder1/b.txt").toUtf8().constData());
+    AZ::IO::SystemFile::Delete(tempPath.absoluteFilePath("subfolder1/c.txt").toUtf8().constData());
 
     AzToolsFramework::AssetDatabase::SourceDatabaseEntry entry;
     m_assetProcessorManager->m_stateData->GetSourceBySourceGuid(m_bUuid, entry);

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.h
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.h
@@ -58,6 +58,7 @@ public:
     friend class GTEST_TEST_CLASS_NAME_(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_Reverse_BasicTest);
     friend class GTEST_TEST_CLASS_NAME_(
         AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_MissingFiles_ReturnsNoPathWithPlaceholders);
+    friend class GTEST_TEST_CLASS_NAME_(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_DependenciesOnNonAssetsIncluded);
 
     friend class GTEST_TEST_CLASS_NAME_(AssetProcessorManagerTest, BuilderDirtiness_BeforeComputingDirtiness_AllDirty);
     friend class GTEST_TEST_CLASS_NAME_(AssetProcessorManagerTest, BuilderDirtiness_EmptyDatabase_AllDirty);


### PR DESCRIPTION
## What does this PR do?

Trying to assign a UUID to a non-asset file and look up the file by UUID failed because non-asset files cannot be looked up by UUID. Switched to storing results from db as they are so lookups can be done separately for UUID vs path.

Note that the PathOrUuid class is placed in-line temporarily.  There is another, larger PR that further reworks dependencies which already includes this class.  That PR will be updated to include this fix and remove the PathOrUuid class.

## How was this PR tested?

Manually + added and ran unit test
