### PR TITLE
Prefab Fix | Set parent of direct entities to null in create-prefab

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -140,7 +140,8 @@ namespace AzToolsFramework
                 AZ::Quaternion containerEntityRotation(AZ::Quaternion::CreateZero());
                 GenerateContainerEntityTransform(topLevelEntities, containerEntityTranslation, containerEntityRotation);
 
-                // set parents of top level entities to null.
+                // Set the parent of top level entities to null, so the parent entity's child entity order array does not include the entities.
+                // This is needed before doing serialization on the parent entity to avoid referring to the detached entities.
                 for (AZ::Entity* topLevelEntity : topLevelEntities)
                 {
                     AZ::TransformBus::Event(topLevelEntity->GetId(), &AZ::TransformBus::Events::SetParent, AZ::EntityId());

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
@@ -109,19 +109,20 @@ namespace AzToolsFramework
             void DuplicateNestedInstancesInInstance(Instance& commonOwningInstance,
                 const AZStd::vector<Instance*>& instances, PrefabDom& domToAddDuplicatedInstancesUnder,
                 EntityIdList& duplicatedEntityIds, AZStd::unordered_map<InstanceAlias, Instance*>& newInstanceAliasToOldInstanceMap);
-            
+
             /**
-             * Applies the correct transform changes to the container entity based on the parent and child entities provided, and returns an appropriate patch.
-             * The container will be parented to parentId, moved to the average transform of the future direct children and its cache will be updated.
-             * This helper function won't support undo/redo, update the templates or create any links. All that needs to be done by the caller.
-             * 
+             * Applies the correct transform to the container entity, and returns an appropriate patch.
+             * This helper function won't support undo/redo, update the templates or create any links.
+             * All that needs to be done by the caller.
+             *
              * \param containerEntityId The container to apply the changes to.
              * \param parentEntityId The id of the entity the container should be parented to.
-             * \param childEntities A list of entities that will subsequently be parented to this container.
+             * \param translation New translation for the container entity.
+             * \param rotation New rotation for the container entity.
              * \return The PrefabDom containing the patches that should be stored in the parent link.
              */
-            PrefabDom ApplyContainerTransformAndGeneratePatch(
-                AZ::EntityId containerEntityId, AZ::EntityId parentEntityId, const EntityList& childEntities);
+            PrefabDom ApplyContainerTransformAndGeneratePatch(AZ::EntityId containerEntityId, AZ::EntityId parentEntityId,
+                const AZ::Vector3& translation, const AZ::Quaternion& rotation);
 
             /**
              * Creates a link between the templates of an instance and its parent.
@@ -187,6 +188,12 @@ namespace AzToolsFramework
 
             static Instance* GetParentInstance(Instance* instance);
             static Instance* GetAncestorOfInstanceThatIsChildOfRoot(const Instance* ancestor, Instance* descendant);
+
+            //! Generates the transform based on the input list of entities.
+            //! The transform will be based on the average transform of the direct children.
+            //! \param topLevelEntities The direct children entities provided to calculate the average transform.
+            //! \param[out] translation The output translation.
+            //! \param[out] rotation The output rotation.
             static void GenerateContainerEntityTransform(const EntityList& topLevelEntities, AZ::Vector3& translation, AZ::Quaternion& rotation);
 
             InstanceEntityMapperInterface* m_instanceEntityMapperInterface = nullptr;


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

Try to fix: #11748 (warning: entity id has no registered owning instance)

This PR fixes the warning "Entity Id has no registered owning instance". The root cause is described in the issue. It happens in instance object serialization where child entity object is detached but their parent container entity object still links to the child.

This can be fixed by breaking the relation before getting into serialization. To do that, we also need to move transform calculation forward before breaking.

A follow-up PR is replace UpdatePrefabInstance with RemoveEntities and UpdateEntity undo nodes, which is based on some changes in this PR.

## How was this PR tested?

- [x] Manual testing for create-prefab on entities and nested prefabs. Undo/Redo is also tested. Not seeing the warning anymore.
- [x] Passed auto tests and unit tests.