### PR TITLE
Fixed Wwise compile error

### DIFF
--- a/Gems/AudioEngineWwise/Code/Source/Engine/FileIOHandler_wwise.cpp
+++ b/Gems/AudioEngineWwise/Code/Source/Engine/FileIOHandler_wwise.cpp
@@ -299,7 +299,8 @@ namespace Audio
         auto offset = aznumeric_cast<size_t>(transferInfo.uFilePosition);
         auto readSize = aznumeric_cast<size_t>(transferInfo.uRequestedSize);
         auto bufferSize = aznumeric_cast<size_t>(transferInfo.uBufferSize);
-        AZStd::chrono::microseconds deadline = AZStd::chrono::duration<float, AZStd::milli>(heuristics.fDeadline);
+        auto deadline =
+            AZStd::chrono::duration_cast<AZ::IO::IStreamerTypes::Deadline>(AZStd::chrono::duration<float, AZStd::milli>(heuristics.fDeadline));
 
         auto streamer = AZ::Interface<AZ::IO::IStreamer>::Get();
         AZ::IO::FileRequestPtr request = streamer->Read(*filename, transferInfo.pBuffer, bufferSize, readSize, deadline, priority, offset);


### PR DESCRIPTION
## What does this PR do?

Fixed compile issue with Wwise enabled on latest development:

```
19>------ Build started: Project: EditorLib, Configuration: profile x64 ------
9>D:/github/o3de/Gems/AudioEngineWwise/Code/Source/Engine/FileIOHandler_wwise.cpp(302,114): error C2440: 'initializing': cannot convert from 'std::chrono::duration<float,std::milli>' to 'std::chrono::duration<__int64,std::micro>'
9>        AZStd::chrono::microseconds deadline = AZStd::chrono::duration<float, AZStd::milli>(heuristics.fDeadline);
9>                                                                                                                 ^
9>D:/github/o3de/Gems/AudioEngineWwise/Code/Source/Engine/FileIOHandler_wwise.cpp(302,46): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
9>        AZStd::chrono::microseconds deadline = AZStd::chrono::duration<float, AZStd::milli>(heuristics.fDeadline);
9>                                             ^
9>Done building project "AudioEngineWwise.Static.vcxproj" -- FAILED.
```

Updated the line in question to use a `duration_cast` and use the streamer deadline type.

## How was this PR tested?

Built/ran the Editor on a project with Wwise enabled and verified sound in the project works.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>