### PR TITLE
Add tests for entity edit overrides

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Main.py
@@ -74,3 +74,9 @@ class TestAutomationNoAutoTestMode(EditorTestSuite):
 
     class test_PrefabNotifications_RootPrefabLoadedNotificationsReceived(EditorSharedTest):
         from .tests.prefab_notifications import PrefabNotifications_RootPrefabLoadedNotificationsReceived as test_module
+
+    class test_EditEntity_UnderImmediateInstance(EditorSharedTest):
+        from .tests.overrides import EditEntity_UnderImmediateInstance as test_module
+
+    class test_EditEntity_UnderNestedInstance(EditorSharedTest):
+        from .tests.overrides import EditEntity_UnderNestedInstance as test_module

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/EditEntity_UnderImmediateInstance.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/EditEntity_UnderImmediateInstance.py
@@ -1,0 +1,73 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+def EditEntity_UnderImmediateInstance():
+
+    from editor_python_test_tools.editor_entity_utils import EditorEntity, EditorComponent
+    from editor_python_test_tools.prefab_utils import Prefab
+    from editor_python_test_tools.wait_utils import PrefabWaiter
+    import azlmbr.legacy.general as general
+    import Prefab.tests.PrefabTestUtils as prefab_test_utils
+    import azlmbr.bus as bus
+    import azlmbr.editor as editor
+    import azlmbr.globals as globals
+    import editor_python_test_tools.hydra_editor_utils as hydra
+
+    CAR_PREFAB_FILE_NAME = Path(__file__).stem + 'car_prefab'
+    CREATION_POSITION = azlmbr.math.Vector3(0.0, 0.0, 0.0)
+    UPDATED_POSITION = azlmbr.math.Vector3(10.0, 0.0, 0.0)
+
+    prefab_test_utils.open_base_tests_level()
+
+    # Create a new entity at the root level
+    car_entity = EditorEntity.create_editor_entity_at(CREATION_POSITION, "Car_Entity")
+    car_prefab_entities = [car_entity]
+
+    # Create a prefab from the new entity. Also creates first instance
+    car_prefab, car_instance_1 = Prefab.create_prefab(car_prefab_entities, CAR_PREFAB_FILE_NAME)
+
+    # Create a second instance
+    car_instance_2 = car_prefab.instantiate()
+    assert car_instance_2.is_valid(), "Failed to instantiate prefab"
+
+    # Edit the second instance by changing the transform of the entity it owns
+    car_entity_of_instance_2 = car_instance_2.get_direct_child_entities()[0]
+
+    # Move the car entity to a new postion.
+    get_transform_component_outcome = editor.EditorComponentAPIBus(
+        bus.Broadcast, "GetComponentOfType", car_entity_of_instance_2.id, globals.property.EditorTransformComponentTypeId
+    )
+    car_transform_component = EditorComponent(globals.property.EditorTransformComponentTypeId)
+    car_transform_component.id = get_transform_component_outcome.GetValue()
+    hydra.set_component_property_value(car_transform_component.id, "Values|Translate", UPDATED_POSITION)
+
+    PrefabWaiter.wait_for_propagation()
+
+    # Validate that only the second prefab instance has changed
+    car_entity_of_instance_1 = car_instance_1.get_direct_child_entities()[0]
+    car_entity_of_instance_1.validate_world_translate_position(CREATION_POSITION)
+    car_entity_of_instance_2.validate_world_translate_position(UPDATED_POSITION)
+
+    # Undo the override
+    general.undo()
+    PrefabWaiter.wait_for_propagation()
+
+    # Validate the undo
+    car_entity_of_instance_1.validate_world_translate_position(CREATION_POSITION)
+    car_entity_of_instance_2.validate_world_translate_position(CREATION_POSITION)
+
+    # Redo the override
+    general.redo()
+    PrefabWaiter.wait_for_propagation()
+
+    # Validate the redo
+    car_entity_of_instance_1.validate_world_translate_position(CREATION_POSITION)
+    car_entity_of_instance_2.validate_world_translate_position(UPDATED_POSITION)
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(EditEntity_UnderImmediateInstance)

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/EditEntity_UnderImmediateInstance.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/EditEntity_UnderImmediateInstance.py
@@ -6,6 +6,20 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
 def EditEntity_UnderImmediateInstance():
+    """
+    Test description:
+    - Creates a "Car" prefab containing one entity called "Car_Entity".
+    - Instantiates the "Car" prefab twice under the level prefab.
+    - Edits the "Car_Entity" of the second "Car" instance.
+    - Checks that after propagation, the "Car_Entity" of the second "Car" instance contains the correct edits.
+    - Checks that after propagation, the "Car_Entity" of the first "Car" instance does not contain any edits.
+
+    - Level (Focused prefab)
+    -- Car (first instance)
+    --- Car_Entity
+    -- Car (second instance)
+    --- Car_Entity <-- edit this entity's transform
+    """
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity, EditorComponent
     from editor_python_test_tools.prefab_utils import Prefab

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/EditEntity_UnderNestedInstance.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/EditEntity_UnderNestedInstance.py
@@ -1,0 +1,82 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+def EditEntity_UnderNestedInstance():
+
+    from editor_python_test_tools.editor_entity_utils import EditorEntity, EditorComponent
+    from editor_python_test_tools.prefab_utils import Prefab
+    from editor_python_test_tools.wait_utils import PrefabWaiter
+    from pathlib import Path
+    import azlmbr.legacy.general as general
+    import Prefab.tests.PrefabTestUtils as prefab_test_utils
+    import azlmbr.bus as bus
+    import azlmbr.editor as editor
+    import azlmbr.globals as globals
+    import editor_python_test_tools.hydra_editor_utils as hydra
+
+    prefab_test_utils.open_base_tests_level()
+
+    NESTED_PREFABS_FILE_NAME_PREFIX = Path(__file__).stem + '_' + 'nested_prefabs_'
+    NESTED_PREFABS_NAME_PREFIX = 'NestedPrefabs_Prefab_'
+    NESTED_PREFABS_TEST_ENTITY_NAME = 'TestEntity'
+    CREATION_POSITION = azlmbr.math.Vector3(0.0, 0.0, 0.0)
+    UPDATED_POSITION = azlmbr.math.Vector3(10.0, 0.0, 0.0)
+    NUM_NESTED_PREFABS_LEVELS = 3
+
+    # Create nested prefabs at the root level. Also creates first instance
+    entity = EditorEntity.create_editor_entity_at(CREATION_POSITION, name=NESTED_PREFABS_TEST_ENTITY_NAME)
+    assert entity.id.IsValid(), "Couldn't create TestEntity"
+    nested_prefabs, nested_prefab_instances = prefab_test_utils.create_linear_nested_prefabs(
+        [entity], NESTED_PREFABS_FILE_NAME_PREFIX, NESTED_PREFABS_NAME_PREFIX, NUM_NESTED_PREFABS_LEVELS)
+    prefab_test_utils.validate_linear_nested_prefab_instances_hierarchy(nested_prefab_instances)
+
+    # Create a second instance
+    nested_prefab_root = nested_prefabs[0]
+    nested_prefab_instance_root_2 = nested_prefab_root.instantiate()
+    assert nested_prefab_instance_root_2.is_valid(), "Failed to instantiate prefab"
+
+    # Edit transform of the entity owned by the deepest nested instance of the first instance
+    deepest_nested_prefab_instance_1 = nested_prefab_instances[NUM_NESTED_PREFABS_LEVELS-1]
+    entity_of_deepest_nested_instance_1 = deepest_nested_prefab_instance_1.get_direct_child_entities()[0]
+    get_transform_component_outcome = editor.EditorComponentAPIBus(
+        bus.Broadcast, "GetComponentOfType", entity_of_deepest_nested_instance_1.id, globals.property.EditorTransformComponentTypeId
+    )
+    entity_transform_component = EditorComponent(globals.property.EditorTransformComponentTypeId)
+    entity_transform_component.id = get_transform_component_outcome.GetValue()
+    hydra.set_component_property_value(entity_transform_component.id, "Values|Translate", UPDATED_POSITION)
+
+    PrefabWaiter.wait_for_propagation()
+
+    # Find the entity owned by the deepest nested instance of the second instance
+    children = nested_prefab_instance_root_2.get_direct_child_entities()
+    while children:
+        entity_of_deepest_nested_instance_2 = children[0]
+        children = entity_of_deepest_nested_instance_2.get_children()
+
+    # Validate that only the first prefab instance has changed
+    entity_of_deepest_nested_instance_1.validate_world_translate_position(UPDATED_POSITION)
+    entity_of_deepest_nested_instance_2.validate_world_translate_position(CREATION_POSITION)
+
+    # Undo the override
+    general.undo()
+    PrefabWaiter.wait_for_propagation()
+
+    # Validate the undo
+    entity_of_deepest_nested_instance_1.validate_world_translate_position(CREATION_POSITION)
+    entity_of_deepest_nested_instance_2.validate_world_translate_position(CREATION_POSITION)
+
+    # Redo the override
+    general.redo()
+    PrefabWaiter.wait_for_propagation()
+
+    # Validate the redo
+    entity_of_deepest_nested_instance_1.validate_world_translate_position(UPDATED_POSITION)
+    entity_of_deepest_nested_instance_2.validate_world_translate_position(CREATION_POSITION)
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(EditEntity_UnderNestedInstance)

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/EditEntity_UnderNestedInstance.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/EditEntity_UnderNestedInstance.py
@@ -6,6 +6,26 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
 def EditEntity_UnderNestedInstance():
+    """
+    Test description:
+    - Creates a "NestedPrefabs_Prefab_3" prefab containing one entity called "Test_Entity".
+    - Creates a "NestedPrefabs_Prefab_2" prefab containing "NestedPrefabs_Prefab_3" instance.
+    - Creates a "NestedPrefabs_Prefab_1" prefab containing "NestedPrefabs_Prefab_2" instance.
+    - Instantiates the "NestedPrefabs_Prefab_1" prefab twice under the level prefab.
+    - Edits the "Test_Entity" of the first "NestedPrefabs_Prefab_3" instance.
+    - Checks that after propagation, the "Test_Entity" of the first "NestedPrefabs_Prefab_3" instance contains the correct edits.
+    - Checks that after propagation, the "Test_Entity" of the second "NestedPrefabs_Prefab_3" instance does not contain any edits.
+
+    - Level (Focused prefab)
+    -- NestedPrefabs_Prefab_1 (first instance)
+    --- NestedPrefabs_Prefab_2
+    ---- NestedPrefabs_Prefab_3
+    ----- Test_Entity <-- edit this entity's transform
+    -- NestedPrefabs_Prefab_1 (second instance)
+    --- NestedPrefabs_Prefab_2
+    ---- NestedPrefabs_Prefab_3
+    ----- Test_Entity
+    """
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity, EditorComponent
     from editor_python_test_tools.prefab_utils import Prefab
@@ -22,7 +42,7 @@ def EditEntity_UnderNestedInstance():
 
     NESTED_PREFABS_FILE_NAME_PREFIX = Path(__file__).stem + '_' + 'nested_prefabs_'
     NESTED_PREFABS_NAME_PREFIX = 'NestedPrefabs_Prefab_'
-    NESTED_PREFABS_TEST_ENTITY_NAME = 'TestEntity'
+    NESTED_PREFABS_TEST_ENTITY_NAME = 'Test_Entity'
     CREATION_POSITION = azlmbr.math.Vector3(0.0, 0.0, 0.0)
     UPDATED_POSITION = azlmbr.math.Vector3(10.0, 0.0, 0.0)
     NUM_NESTED_PREFABS_LEVELS = 3


### PR DESCRIPTION
Signed-off-by: michabr <82236305+michabr@users.noreply.github.com>

## What does this PR do?

This PR adds two automated tests for verifying prefab instance overrides. It creates two instances from the same prefab, edits an entity in one of the instances and verifies that after propagation, only one of the two entities of the two instances was modified, and the other remained the same.
- Editing entity of an instance that's owned by the level
- Editing an entity of a nested instance

## How was this PR tested?

Ran Prefab automated tests and checked that they passed.
