### PR TITLE
Move shader asset builder tests to periodic suite from sandbox suite.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/Atom/CMakeLists.txt
@@ -126,4 +126,17 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         COMPONENT
             Atom
     )
+    ly_add_pytest(
+        NAME AutomatedTesting::Atom_Periodic_Null_Render_01
+        TEST_SUITE periodic
+        TEST_SERIAL
+        TIMEOUT 1200
+        PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite_Periodic_Null_Render_01.py
+        RUNTIME_DEPENDENCIES
+            AssetProcessor
+            AutomatedTesting.Assets
+            MaterialEditor
+        COMPONENT
+            Atom
+    )
 endif()

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Periodic_Null_Render_01.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Periodic_Null_Render_01.py
@@ -1,0 +1,17 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+import pytest
+
+from ly_test_tools.o3de.editor_test import EditorBatchedTest, EditorTestSuite
+
+
+@pytest.mark.parametrize("project", ["AutomatedTesting"])
+@pytest.mark.parametrize("launcher_platform", ['windows_editor'])
+class TestAtomPeriodic(EditorTestSuite):
+
+    class ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges(EditorBatchedTest):
+        from Atom.tests import hydra_ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges as test_module

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Sandbox.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Sandbox.py
@@ -31,9 +31,6 @@ class TestAutomation(EditorTestSuite):
     class AtomLevelLoadTest_Editor_Sandbox(EditorSharedTest):
         from Atom.tests import hydra_Atom_LevelLoadTest_Sandbox as test_module
 
-    class ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges(EditorSharedTest):
-        from Atom.tests import hydra_ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges as test_module
-
 
 @pytest.mark.parametrize("project", ["AutomatedTesting"])
 @pytest.mark.parametrize("launcher_platform", ['windows_generic'])


### PR DESCRIPTION
## What does this PR do?
Re-adds the shader asset builder test to the periodic suite out from the sandbox suite (it passes now).

## How was this PR tested?
Tested using command `C:\git\o3de\python\runtime\python-3.10.5-rev1-windows\python\python.exe -m pytest -vv -s --build-directory="C:\git\o3de\build\bin\profile" C:\git\o3de\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Periodic_Null_Render_01.py`
Results:
```
PASSED
AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Periodic_Null_Render_01.py::TestAtomPeriodic::ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges[windows-windows_editor-AutomatedTesting] <- tools\lytesttools\ly_test_tools\o3de\multi_test_framework.py Checking for tmp path C:\Users\jromnoa\AppData\Local\Temp\tmptzylh3ko
Found existing tmp path, deleting
Creating tmp path
Configuring Artifact Manager with path C:\git\o3de\build\bin\profile\Testing\LyTestTools\pytest_results\2022-09-22T16-56-52-847869
Test ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges:
Test Passed
------------
|  Output  |
------------
Starting test ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges...
Test ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges finished.
Report:
[SUCCESS] Success: azshader was removed
[SUCCESS] Success: azshader was compiled
[SUCCESS] Success: azshader was removed
[SUCCESS] Success: azshader was compiled
[SUCCESS] Success: azshader was removed
[SUCCESS] Success: azshader was compiled
[SUCCESS] Success: No errors detected
Test result:  SUCCESS
JSON_START({"name": "hydra_ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges", "success": true, "exception": null, "output": "Test ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges finished.\nReport:\n[SUCCESS] Success: azshader was removed\n[SUCCESS] Success: azshader was compiled\n[SUCCESS] Success: azshader was removed\n[SUCCESS] Success: azshader was compiled\n[SUCCESS] Success: azshader was removed\n[SUCCESS] Success: azshader was compiled\n[SUCCESS] Success: No errors detected\nTest result:  SUCCESS"})JSON_END


PASSED
```