### PR TITLE
Fix cancel button not showing while building

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectButtonWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectButtonWidget.cpp
@@ -680,6 +680,7 @@ namespace O3DE::ProjectManager
         if (isBuilding)
         {
             SetLaunchingEnabled(false);
+            m_projectImageLabel->GetActionCancelButton()->show();
         }
 
         buildingAnimation->movie()->setPaused(!isBuilding);


### PR DESCRIPTION
Cancel button was hidden while building, re-adding the button for this state.

![BuildCancel](https://user-images.githubusercontent.com/70403342/191858037-5f1cf4a5-3467-456d-a0f8-4f9dd2e21969.PNG)

Signed-off-by: AMZN-Phil <pconroy@amazon.com>