### PR TITLE
Added AreSlotsConnected API to GraphModel

### DIFF
--- a/Gems/GraphModel/Code/Include/GraphModel/GraphModelBus.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/GraphModelBus.h
@@ -126,6 +126,13 @@ namespace GraphModelIntegration
             GraphModel::NodePtr targetNode,
             GraphModel::SlotId targetSlotId) = 0;
 
+        //! Check if there is a connection between the specified source and target specified slots
+        virtual bool AreSlotsConnected(
+            GraphModel::NodePtr sourceNode,
+            GraphModel::SlotId sourceSlotId,
+            GraphModel::NodePtr targetNode,
+            GraphModel::SlotId targetSlotId) const = 0;
+
         //! Remove the specified connection
         virtual bool RemoveConnection(GraphModel::ConnectionPtr connection) = 0;
 

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/GraphController.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/GraphController.h
@@ -67,6 +67,11 @@ namespace GraphModelIntegration
 
         GraphModel::ConnectionPtr AddConnection(GraphModel::SlotPtr sourceSlot, GraphModel::SlotPtr targetSlot) override;
         GraphModel::ConnectionPtr AddConnectionBySlotId(GraphModel::NodePtr sourceNode, GraphModel::SlotId sourceSlotId, GraphModel::NodePtr targetNode, GraphModel::SlotId targetSlotId) override;
+        bool AreSlotsConnected(
+            GraphModel::NodePtr sourceNode,
+            GraphModel::SlotId sourceSlotId,
+            GraphModel::NodePtr targetNode,
+            GraphModel::SlotId targetSlotId) const override;
         bool RemoveConnection(GraphModel::ConnectionPtr connection) override;
         GraphModel::SlotId ExtendSlot(GraphModel::NodePtr node, GraphModel::SlotName slotName) override;
 

--- a/Gems/GraphModel/Code/Source/GraphModelSystemComponent.cpp
+++ b/Gems/GraphModel/Code/Source/GraphModelSystemComponent.cpp
@@ -87,6 +87,7 @@ namespace GraphModel
                 ->Event("WrapNode", &GraphModelIntegration::GraphControllerRequests::WrapNode)
                 ->Event("AddConnection", &GraphModelIntegration::GraphControllerRequests::AddConnection)
                 ->Event("AddConnectionBySlotId", &GraphModelIntegration::GraphControllerRequests::AddConnectionBySlotId)
+                ->Event("AreSlotsConnected", &GraphModelIntegration::GraphControllerRequests::AreSlotsConnected)
                 ->Event("RemoveConnection", &GraphModelIntegration::GraphControllerRequests::RemoveConnection)
                 ->Event("ExtendSlot", &GraphModelIntegration::GraphControllerRequests::ExtendSlot)
                 ;

--- a/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
@@ -648,6 +648,32 @@ namespace GraphModelIntegration
         return AddConnection(sourceSlot, targetSlot);
     }
 
+    bool GraphController::AreSlotsConnected(
+        GraphModel::NodePtr sourceNode, GraphModel::SlotId sourceSlotId, GraphModel::NodePtr targetNode, GraphModel::SlotId targetSlotId) const
+    {
+        if (!sourceNode || !targetNode)
+        {
+            return false;
+        }
+
+        GraphModel::SlotPtr sourceSlot = sourceNode->GetSlot(sourceSlotId);
+        if (!sourceSlot)
+        {
+            return false;
+        }
+
+        // Check all connections on the source slot to see if they match the target node and slot
+        for (const auto& connection : sourceSlot->GetConnections())
+        {
+            if (connection->GetTargetNode() == targetNode && connection->GetTargetSlot()->GetSlotId() == targetSlotId)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     bool GraphController::RemoveConnection(GraphModel::ConnectionPtr connection)
     {
         AZ::EntityId connectionUiId = m_elementMap.Find(connection);


### PR DESCRIPTION
## What does this PR do?

Fixes #12155 

Added API to query if specified source and target slots are connected in a graph.

## How was this PR tested?

Tested with the following script that creates two nodes and connects their slots and verifies before/after if they are connected using the new API. After executing the script I also manually disconnected them in the graph and then queried the API again to verify they are disconnected.

```
import azlmbr
import azlmbr.bus as bus
import azlmbr.editor as editor
import azlmbr.editor.graph as graph
import azlmbr.landscapecanvas as landscapecanvas
import azlmbr.math as math

editor_id = azlmbr.globals.property.LANDSCAPE_CANVAS_EDITOR_ID

# Create a new Landscape Canvas graph
new_graph_id = graph.AssetEditorRequestBus(bus.Event, 'CreateNewGraph', editor_id)
new_graph = graph.GraphManagerRequestBus(bus.Broadcast, 'GetGraph', new_graph_id)

# Create box and random noise nodes
box_shape_node = landscapecanvas.LandscapeCanvasNodeFactoryRequestBus(bus.Broadcast, 'CreateNodeForTypeName', new_graph, 'BoxShapeNode')
graph.GraphControllerRequestBus(bus.Event, 'AddNode', new_graph_id, box_shape_node, math.Vector2(0.0, 0.0))

random_noise_node = landscapecanvas.LandscapeCanvasNodeFactoryRequestBus(bus.Broadcast, 'CreateNodeForTypeName', new_graph, 'RandomNoiseGradientNode')
graph.GraphControllerRequestBus(bus.Event, 'AddNode', new_graph_id, random_noise_node, math.Vector2(300.0, 0.0))

bounds_slot_id = graph.GraphModelSlotId('Bounds')
preview_bounds_slot_id = graph.GraphModelSlotId('PreviewBounds')

# Check if the output bounds from the box shape is connected to the input preview bounds on the random noise gradient
connected = graph.GraphControllerRequestBus(bus.Event, 'AreSlotsConnected', new_graph_id, box_shape_node, bounds_slot_id,
                                    random_noise_node, preview_bounds_slot_id)
print(connected)
# connected = False

# Connect the slots
graph.GraphControllerRequestBus(bus.Event, 'AddConnectionBySlotId', new_graph_id, box_shape_node, bounds_slot_id,
                                    random_noise_node, preview_bounds_slot_id)

# Check again now that they've been connected
connected = graph.GraphControllerRequestBus(bus.Event, 'AreSlotsConnected', new_graph_id, box_shape_node, bounds_slot_id,
                                    random_noise_node, preview_bounds_slot_id)
print(connected)
# connected = True
```

![AreSlotsConnectedAPI](https://user-images.githubusercontent.com/7519264/191858998-96004a75-e6fc-4a36-9fdb-64056ed9e5bd.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>