### PR TITLE
Enable ray query and shader int64 atomics Vulkan device features

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -97,6 +97,7 @@ namespace AZ
             m_enabledDeviceFeatures.multiDrawIndirect = deviceFeatures.multiDrawIndirect;
             m_enabledDeviceFeatures.sampleRateShading = deviceFeatures.sampleRateShading;
             m_enabledDeviceFeatures.shaderImageGatherExtended = deviceFeatures.shaderImageGatherExtended;
+            m_enabledDeviceFeatures.shaderInt64 = deviceFeatures.shaderInt64;
 
             if (deviceFeatures.geometryShader)
             {
@@ -182,9 +183,21 @@ namespace AZ
             robustness2.nullDescriptor = physicalDevice.GetPhysicalDeviceRobutness2Features().nullDescriptor;
             depthClipEnabled.pNext = &robustness2;
 
+            VkPhysicalDeviceRayQueryFeaturesKHR rayQueryFeatures = {};
+            rayQueryFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR;
+            rayQueryFeatures.rayQuery = physicalDevice.GetRayQueryFeatures().rayQuery;
+            robustness2.pNext = &rayQueryFeatures;
+
+            VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT shaderImageAtomicInt64 = {};
+            shaderImageAtomicInt64.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT;
+            shaderImageAtomicInt64.shaderImageInt64Atomics = physicalDevice.GetShaderImageAtomicInt64Features().shaderImageInt64Atomics;
+            shaderImageAtomicInt64.sparseImageInt64Atomics = physicalDevice.GetShaderImageAtomicInt64Features().sparseImageInt64Atomics;
+            rayQueryFeatures.pNext = &shaderImageAtomicInt64;
+
             VkPhysicalDeviceVulkan12Features vulkan12Features = {};
             VkPhysicalDeviceShaderFloat16Int8FeaturesKHR float16Int8 = {};
             VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR separateDepthStencil = {};
+            VkPhysicalDeviceShaderAtomicInt64Features shaderAtomicInt64 = {};
 
             VkDeviceCreateInfo deviceInfo = {};
             deviceInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
@@ -204,7 +217,9 @@ namespace AZ
                 vulkan12Features.bufferDeviceAddress = physicalDevice.GetPhysicalDeviceVulkan12Features().bufferDeviceAddress;
                 vulkan12Features.bufferDeviceAddressMultiDevice = physicalDevice.GetPhysicalDeviceVulkan12Features().bufferDeviceAddressMultiDevice;
                 vulkan12Features.runtimeDescriptorArray = physicalDevice.GetPhysicalDeviceVulkan12Features().runtimeDescriptorArray;
-                robustness2.pNext = &vulkan12Features;
+                vulkan12Features.shaderSharedInt64Atomics = physicalDevice.GetPhysicalDeviceVulkan12Features().shaderSharedInt64Atomics;
+                vulkan12Features.shaderBufferInt64Atomics = physicalDevice.GetPhysicalDeviceVulkan12Features().shaderBufferInt64Atomics;
+                shaderImageAtomicInt64.pNext = &vulkan12Features;
                 deviceInfo.pNext = &depthClipEnabled;
             }
             else
@@ -216,7 +231,12 @@ namespace AZ
                 separateDepthStencil.separateDepthStencilLayouts = physicalDevice.GetPhysicalDeviceSeparateDepthStencilFeatures().separateDepthStencilLayouts;
                 float16Int8.pNext = &separateDepthStencil;
 
-                robustness2.pNext = &float16Int8;
+                shaderAtomicInt64.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES;
+                shaderAtomicInt64.shaderBufferInt64Atomics = physicalDevice.GetShaderAtomicInt64Features().shaderBufferInt64Atomics;
+                shaderAtomicInt64.shaderSharedInt64Atomics = physicalDevice.GetShaderAtomicInt64Features().shaderSharedInt64Atomics;
+                separateDepthStencil.pNext = &shaderAtomicInt64;
+
+                shaderImageAtomicInt64.pNext = &float16Int8;
                 deviceInfo.pNext = &descriptorIndexingFeatures;
             }
 
@@ -249,6 +269,7 @@ namespace AZ
 
                 rayTracingPipelineFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR;
                 rayTracingPipelineFeatures.rayTracingPipeline = physicalDevice.GetPhysicalDeviceRayTracingPipelineFeatures().rayTracingPipeline;
+                rayTracingPipelineFeatures.rayTracingPipelineTraceRaysIndirect = physicalDevice.GetPhysicalDeviceRayTracingPipelineFeatures().rayTracingPipelineTraceRaysIndirect;
                 accelerationStructureFeatures.pNext = &rayTracingPipelineFeatures;
             }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
@@ -107,6 +107,16 @@ namespace AZ
             return m_separateDepthStencilFeatures;
         }
 
+        const VkPhysicalDeviceShaderAtomicInt64Features& PhysicalDevice::GetShaderAtomicInt64Features() const
+        {
+            return m_shaderAtomicInt64Features;
+        }
+
+        const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT& PhysicalDevice::GetShaderImageAtomicInt64Features() const
+        {
+            return m_shaderImageAtomicInt64Features;
+        }
+
         const VkPhysicalDeviceAccelerationStructurePropertiesKHR& PhysicalDevice::GetPhysicalDeviceAccelerationStructureProperties() const
         {
             return m_accelerationStructureProperties;
@@ -125,6 +135,11 @@ namespace AZ
         const VkPhysicalDeviceRayTracingPipelineFeaturesKHR& PhysicalDevice::GetPhysicalDeviceRayTracingPipelineFeatures() const
         {
             return m_rayTracingPipelineFeatures;
+        }
+
+        const VkPhysicalDeviceRayQueryFeaturesKHR& PhysicalDevice::GetRayQueryFeatures() const
+        {
+            return m_rayQueryFeatures;
         }
 
         const VkPhysicalDeviceShaderFloat16Int8FeaturesKHR& PhysicalDevice::GetPhysicalDeviceFloat16Int8Features() const
@@ -264,10 +279,13 @@ namespace AZ
                 VK_KHR_RELAXED_BLOCK_LAYOUT_EXTENSION_NAME,
                 VK_EXT_ROBUSTNESS_2_EXTENSION_NAME,
                 VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME,
+                VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME,
+                VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME,
 
                 // ray tracing extensions
                 VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
                 VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME,
+                VK_KHR_RAY_QUERY_EXTENSION_NAME,
                 VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME,
                 VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME,
                 VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME,
@@ -346,10 +364,25 @@ namespace AZ
                 dephClipEnableFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT;
                 bufferDeviceAddressFeatures.pNext = &dephClipEnableFeatures;
 
+                VkPhysicalDeviceShaderAtomicInt64Features& shaderAtomicInt64Features = m_shaderAtomicInt64Features;
+                shaderAtomicInt64Features = {};
+                shaderAtomicInt64Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES;
+                dephClipEnableFeatures.pNext = &shaderAtomicInt64Features;
+
+                VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT& shaderImageAtomicInt64Features = m_shaderImageAtomicInt64Features;
+                shaderImageAtomicInt64Features = {};
+                shaderImageAtomicInt64Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT;
+                shaderAtomicInt64Features.pNext = &shaderImageAtomicInt64Features;
+
+                VkPhysicalDeviceRayQueryFeaturesKHR& rayQueryFeatures = m_rayQueryFeatures;
+                rayQueryFeatures = {};
+                rayQueryFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR;
+                shaderImageAtomicInt64Features.pNext = &rayQueryFeatures;
+
                 VkPhysicalDeviceRobustness2FeaturesEXT& robustness2Feature = m_robutness2Features;
                 robustness2Feature = {};
                 robustness2Feature.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT;
-                dephClipEnableFeatures.pNext = &robustness2Feature;
+                rayQueryFeatures.pNext = &robustness2Feature;
 
                 VkPhysicalDeviceShaderFloat16Int8FeaturesKHR& float16Int8Features = m_float16Int8Features;
                 float16Int8Features = {};

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.h
@@ -47,8 +47,11 @@ namespace AZ
             RelaxedBlockLayout,
             Robustness2,
             ShaderFloat16Int8,
+            ShaderAtomicInt64,
+            ShaderImageAtomicInt64,
             AccelerationStructure,
             RayTracingPipeline,
+            RayQuery,
             BufferDeviceAddress,
             DeferredHostOperations,
             DescriptorIndexing,
@@ -84,10 +87,13 @@ namespace AZ
             const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT& GetPhysicalDeviceBufferDeviceAddressFeatures() const;
             const VkPhysicalDeviceVulkan12Features& GetPhysicalDeviceVulkan12Features() const;
             const VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR& GetPhysicalDeviceSeparateDepthStencilFeatures() const;
+            const VkPhysicalDeviceShaderAtomicInt64Features& GetShaderAtomicInt64Features() const;
+            const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT& GetShaderImageAtomicInt64Features() const;
             const VkPhysicalDeviceAccelerationStructurePropertiesKHR& GetPhysicalDeviceAccelerationStructureProperties() const;
             const VkPhysicalDeviceAccelerationStructureFeaturesKHR& GetPhysicalDeviceAccelerationStructureFeatures() const;
             const VkPhysicalDeviceRayTracingPipelinePropertiesKHR& GetPhysicalDeviceRayTracingPipelineProperties() const;
             const VkPhysicalDeviceRayTracingPipelineFeaturesKHR& GetPhysicalDeviceRayTracingPipelineFeatures() const;
+            const VkPhysicalDeviceRayQueryFeaturesKHR& GetRayQueryFeatures() const;
             VkFormatProperties GetFormatProperties(RHI::Format format, bool raiseAsserts = true) const;
             StringList GetDeviceLayerNames() const;
             StringList GetDeviceExtensionNames(const char* layerName = nullptr) const;
@@ -119,10 +125,13 @@ namespace AZ
             VkPhysicalDeviceDescriptorIndexingFeaturesEXT m_descriptorIndexingFeatures{};
             VkPhysicalDeviceBufferDeviceAddressFeaturesEXT m_bufferDeviceAddressFeatures{};
             VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR m_separateDepthStencilFeatures{};
+            VkPhysicalDeviceShaderAtomicInt64Features m_shaderAtomicInt64Features{};
+            VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT m_shaderImageAtomicInt64Features{};
             VkPhysicalDeviceAccelerationStructurePropertiesKHR m_accelerationStructureProperties{};
             VkPhysicalDeviceAccelerationStructureFeaturesKHR m_accelerationStructureFeatures{};
             VkPhysicalDeviceRayTracingPipelinePropertiesKHR m_rayTracingPipelineProperties{};
             VkPhysicalDeviceRayTracingPipelineFeaturesKHR m_rayTracingPipelineFeatures{};
+            VkPhysicalDeviceRayQueryFeaturesKHR m_rayQueryFeatures{};
             VkPhysicalDeviceVulkan12Features m_vulkan12Features{};
         };
     }


### PR DESCRIPTION
## What does this PR do?

This PR enables the Vulkan device extensions
* `VK_KHR_ray_query`
* `VK_KHR_SHADER_ATOMIC_INT64`
* `VK_EXT_SHADER_IMAGE_ATOMIC_INT64`

and enables the following device features if they are supported:
* `rayQuery`
* `shaderInt64`
* `shaderImageInt64Atomics`
* `sparseImageInt64Atomics`
* `shaderBufferInt64Atomics`
* `shaderSharedInt64Atomics`
* `shaderBufferInt64Atomics`

## How was this PR tested?

I ran the AtomSampleViewer with Vulkan RHI and almost all tests pass (the hot-reload tests fail, which they also did before changing anything; and three other tests fail for being slightly above the error threshold, but this is very unlikely to be caused by these changed)
