### PR TITLE
Fixed issue when adding wrapped nodes via API creating new entities

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/LayerExtenderNodes_ComponentEntitySync.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/LayerExtenderNodes_ComponentEntitySync.py
@@ -137,7 +137,6 @@ def LayerExtenderNodes_ComponentEntitySync():
             extenderNode = landscapecanvas.LandscapeCanvasNodeFactoryRequestBus(bus.Broadcast,
                                                                                 'CreateNodeForTypeName', newGraph,
                                                                                 extenderName)
-            graph.GraphControllerRequestBus(bus.Event, 'AddNode', newGraphId, extenderNode, nodePosition)
             graph.GraphControllerRequestBus(bus.Event, 'WrapNode', newGraphId, areaNode, extenderNode)
 
             # Check that the appropriate Component was added when the extender node was added

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/TerrainExtenderNodes_ComponentEntitySync.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/TerrainExtenderNodes_ComponentEntitySync.py
@@ -125,7 +125,6 @@ def TerrainExtenderNodes_ComponentEntitySync():
             extenderNode = landscapecanvas.LandscapeCanvasNodeFactoryRequestBus(bus.Broadcast,
                                                                                 'CreateNodeForTypeName', newGraph,
                                                                                 extenderName)
-            graph.GraphControllerRequestBus(bus.Event, 'AddNode', newGraphId, extenderNode, nodePosition)
             graph.GraphControllerRequestBus(bus.Event, 'WrapNode', newGraphId, areaNode, extenderNode)
 
             # Check that the appropriate Component(s) were added when the extender node was added

--- a/Gems/GraphModel/Code/Include/GraphModel/GraphModelBus.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/GraphModelBus.h
@@ -221,6 +221,9 @@ namespace GraphModelIntegration
         //! A connection has been removed from the scene.
         virtual void OnGraphModelConnectionRemoved(GraphModel::ConnectionPtr /*connection*/){};
 
+        //! The specified node is about to be wrapped (embedded) onto the wrapperNode
+        virtual void PreOnGraphModelNodeWrapped([[maybe_unused]] GraphModel::NodePtr wrapperNode, [[maybe_unused]] GraphModel::NodePtr node) {};
+
         //! The specified node has been wrapped (embedded) onto the wrapperNode
         virtual void OnGraphModelNodeWrapped(GraphModel::NodePtr /*wrapperNode*/, GraphModel::NodePtr /*node*/){};
 

--- a/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
@@ -551,6 +551,9 @@ namespace GraphModelIntegration
             return;
         }
 
+        GraphControllerNotificationBus::Event(
+            m_graphCanvasSceneId, &GraphControllerNotifications::PreOnGraphModelNodeWrapped, wrapperNode, node);
+
         AZ::EntityId nodeUiId = m_elementMap.Find(node);
         if (!nodeUiId.IsValid())
         {

--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.h
@@ -112,6 +112,7 @@ namespace LandscapeCanvasEditor
         void PreOnGraphModelNodeRemoved(GraphModel::NodePtr node) override;
         void OnGraphModelConnectionAdded(GraphModel::ConnectionPtr connection) override;
         void OnGraphModelConnectionRemoved(GraphModel::ConnectionPtr connection) override;
+        void PreOnGraphModelNodeWrapped(GraphModel::NodePtr wrapperNode, GraphModel::NodePtr node) override;
         void OnGraphModelNodeWrapped(GraphModel::NodePtr wrapperNode, GraphModel::NodePtr node) override;
         void OnGraphModelGraphModified(GraphModel::NodePtr node) override;
         ////////////////////////////////////////////////////////////////////////
@@ -278,6 +279,7 @@ namespace LandscapeCanvasEditor
 
         using DeletedNodePositionsMap = AZStd::unordered_map<AZ::EntityComponentIdPair, AZ::Vector2>;
         AZStd::unordered_map<GraphCanvas::GraphId, DeletedNodePositionsMap> m_deletedNodePositions;
+        GraphModel::NodePtrList m_addedWrappedNodes;
         GraphModel::NodePtrList m_deletedWrappedNodes;
         AzToolsFramework::EntityIdList m_queuedEntityDeletes;
 


### PR DESCRIPTION
## What does this PR do?

Fixes #12079 

Prevented issue where adding wrapped nodes programmatically via API (e.g. in automated tests) was creating new entities for the components instead of just adding the component to the entity corresponding to the wrapper node.
-  Added `PreOnGraphModelNodeWrapped` event that corresponds to the existing `OnGraphModelNodeWrapped` so that Landscape Canvas could listen for when a node was about to be wrapped
- GraphModel already had logic that when you call `WrapNode` it would also add it to the graph if that node hadn't been added to the graph already
- This wasn't an issue before because Landscape Canvas had a check in `HandleNodeCreated` to ignore wrapped nodes by checking their type, but this was removed because Landscape Canvas now supports nodes being able to be both wrapped and free-floating, so instead there was a check added that would prevent the new entity creation logic when a user added a new wrapped node through the UI, but this didn't properly handle if a wrapped node was added via API directly
- Updated automated tests that were previously calling both `AddNode` and `WrapNode` since the add was superfluous

## How was this PR tested?

Ran all Landscape Canvas automated tests and verified they pass. Also tested manually to verify extra entities are no longer created when adding wrapped nodes via API in python script.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>