### PR TITLE
Added possibility to turn on and off PhysX joints' limits

### DIFF
--- a/Gems/PhysX/Code/Editor/Source/ComponentModes/Joints/JointsComponentModeCommon.cpp
+++ b/Gems/PhysX/Code/Editor/Source/ComponentModes/Joints/JointsComponentModeCommon.cpp
@@ -24,4 +24,6 @@ namespace PhysX::JointsComponentModeCommon
     const AZStd::string_view ParamaterNames::ComponentMode = "Component Mode";
     const AZStd::string_view ParamaterNames::LeadEntity = "Lead Entity";
     const AZStd::string_view ParamaterNames::LinearLimits = "Linear Limits";
+    const AZStd::string_view ParamaterNames::EnableLimits = "Enable Limits";
+    const AZStd::string_view ParamaterNames::EnableSoftLimits = "Enable SoftLimits";
 } // namespace PhysX::JointsComponentModeCommon

--- a/Gems/PhysX/Code/Editor/Source/ComponentModes/Joints/JointsComponentModeCommon.h
+++ b/Gems/PhysX/Code/Editor/Source/ComponentModes/Joints/JointsComponentModeCommon.h
@@ -60,6 +60,8 @@ namespace PhysX::JointsComponentModeCommon
         static const AZStd::string_view ComponentMode;
         static const AZStd::string_view LeadEntity;
         static const AZStd::string_view LinearLimits;
+        static const AZStd::string_view EnableLimits;
+        static const AZStd::string_view EnableSoftLimits;
     };
 
     //! A pairing of Sub component Names, and Id.

--- a/Gems/PhysX/Code/Source/EditorHingeJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorHingeJointComponent.cpp
@@ -173,6 +173,14 @@ namespace PhysX
                 &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay
                 , AzToolsFramework::Refresh_EntireTree);
         }
+        else if (parameterName == PhysX::JointsComponentModeCommon::ParamaterNames::EnableLimits)
+        {
+            m_angularLimit.m_standardLimitConfig.m_isLimited = value;
+        }
+        else if (parameterName == PhysX::JointsComponentModeCommon::ParamaterNames::EnableSoftLimits)
+        {
+            m_angularLimit.m_standardLimitConfig.m_isSoftLimit = value;
+        }
     }
 
     void EditorHingeJointComponent::SetLinearValue(const AZStd::string& parameterName, float value)

--- a/Gems/PhysX/Code/Source/EditorPrismaticJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorPrismaticJointComponent.cpp
@@ -126,8 +126,16 @@ namespace PhysX
         return {};
     }
 
-    void EditorPrismaticJointComponent::SetBoolValue([[maybe_unused]] const AZStd::string& parameterName, [[maybe_unused]] bool value)
+    void EditorPrismaticJointComponent::SetBoolValue(const AZStd::string& parameterName, bool value)
     {
+        if (parameterName == PhysX::JointsComponentModeCommon::ParamaterNames::EnableLimits)
+        {
+            m_linearLimit.m_standardLimitConfig.m_isLimited = value;
+        }
+        else if (parameterName == PhysX::JointsComponentModeCommon::ParamaterNames::EnableSoftLimits)
+        {
+            m_linearLimit.m_standardLimitConfig.m_isSoftLimit = value;
+        }
     }
 
     void EditorPrismaticJointComponent::SetLinearValue(const AZStd::string& parameterName, float value)


### PR DESCRIPTION
Signed-off-by: Michał Pełka <michalpelka@gmail.com>

## What does this PR do?
This PR is needed by a Gem that we are currently developing.  The API for manipulating joint limits lacks a way to activate and deactivate it by communicating with PhysX `EditorHingeJointComponent` and `EditorPrismaticJointComponent` via `EditorJointRequestBus`. Here is a snippet for sample usage:
````
PhysX::EditorJointRequestBus::Event(
    AZ::EntityComponentIdPair(followColliderEntityId, jointComponent->GetId()),
    &PhysX::EditorJointRequests::SetBoolValue,
    PhysX::JointsComponentModeCommon::ParamaterNames::EnableSoftLimits,false);
````
It allows to turn off Limits and Soft Limits for  `EditorHingeJointComponent` and `EditorPrismaticJointComponent`
## How was this PR tested?
It was manually tested against the developed codebase of our Gem.