### PR TITLE
Add SetVisibleInGame request to EditorShapeComponentRequests

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Shape/EditorBaseShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorBaseShapeComponent.cpp
@@ -90,6 +90,11 @@ namespace LmbrCentral
         m_visibleInEditor = visible;
     }
 
+    void EditorBaseShapeComponent::SetVisibleInGame(bool visible)
+    {
+        m_visibleInGameView = visible;
+    }
+
     void EditorBaseShapeComponent::SetShapeColor(const AZ::Color& shapeColor)
     {
         m_shapeColor = shapeColor;

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorBaseShapeComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorBaseShapeComponent.h
@@ -46,6 +46,7 @@ namespace LmbrCentral
         void SetShapeColor(const AZ::Color& solidColor) override;
         void SetShapeWireframeColor(const AZ::Color& wireColor) override;
         void SetVisibleInEditor(bool visible) override;
+        void SetVisibleInGame(bool visible) override;
         void SetShapeColorIsEditable(bool editable) override;
         bool GetShapeColorIsEditable() override;
 

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/EditorShapeComponentBus.h
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/EditorShapeComponentBus.h
@@ -42,6 +42,10 @@ namespace LmbrCentral
 
         //! @brief Returns true if the shape color can be set by the user in the editor.
         virtual bool GetShapeColorIsEditable() = 0;
+
+        //! @brief Sets if the shape is visible in game view
+        //! @param visible true for shape to be visible
+        virtual void SetVisibleInGame(bool visible) = 0;
     };
 
     // Bus to service the Shape component requests event group


### PR DESCRIPTION
Signed-off-by: Michał Pełka <michalpelka@gmail.com>

## What does this PR do?
This PR is needed by the Gem we are developing. API does not allow current to modify this property of `EditorShapeComponent`.
After merging this PR we will be able to set visibility of `EditorShapeComponent` added to an entity with the request.
## How was this PR tested?

Manually tested against developed Gem.
