### PR TITLE
Fix prefab collapsing after deleting entities within

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerTreeView.cpp
@@ -77,6 +77,7 @@ namespace AzToolsFramework
                 if (modelRow.isValid())
                 {
                     CheckExpandedState(modelRow);
+                    RecursiveCheckExpandedStates(modelRow);
                 }
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
@@ -276,7 +276,7 @@ namespace AzToolsFramework
         painter->setRenderHint(QPainter::Antialiasing, true);
         painter->setPen(borderLinePen);
 
-        if (IsLastVisibleChild(index, descendantIndex))
+        if (IsLastVisibleChild(index, descendantIndex, outlinerTreeView))
         {
             // This is the last visible entity in the prefab, so close the container
 
@@ -401,9 +401,9 @@ namespace AzToolsFramework
         painter->restore();
     }
 
-    bool PrefabUiHandler::IsLastVisibleChild(const QModelIndex& parent, const QModelIndex& child)
+    bool PrefabUiHandler::IsLastVisibleChild(const QModelIndex& parent, const QModelIndex& child, const QTreeView* outlinerTreeView)
     {
-        QModelIndex lastVisibleItemIndex = GetLastVisibleChild(parent);
+        QModelIndex lastVisibleItemIndex = GetLastVisibleChild(parent, outlinerTreeView);
         QModelIndex index = child;
 
         // GetLastVisibleChild returns an index set to the ColumnName column
@@ -415,7 +415,7 @@ namespace AzToolsFramework
         return index == lastVisibleItemIndex;
     }
 
-    QModelIndex PrefabUiHandler::GetLastVisibleChild(const QModelIndex& parent)
+    QModelIndex PrefabUiHandler::GetLastVisibleChild(const QModelIndex& parent, const QTreeView* outlinerTreeView)
     {
         auto model = parent.model();
         QModelIndex index = parent;
@@ -426,12 +426,14 @@ namespace AzToolsFramework
             index = index.siblingAtColumn(EntityOutlinerListModel::ColumnName);
         }
 
-        return Internal_GetLastVisibleChild(model, index);
+        return Internal_GetLastVisibleChild(model, index, outlinerTreeView);
     }
 
-    QModelIndex PrefabUiHandler::Internal_GetLastVisibleChild(const QAbstractItemModel* model, const QModelIndex& index)
+    QModelIndex PrefabUiHandler::Internal_GetLastVisibleChild(
+        const QAbstractItemModel* model, const QModelIndex& index, const QTreeView* outlinerTreeView)
     {
-        if (!model->hasChildren(index) || !index.data(EntityOutlinerListModel::ExpandedRole).value<bool>())
+
+        if (!model->hasChildren(index) || !outlinerTreeView->isExpanded(index))
         {
             return index;
         }
@@ -439,7 +441,7 @@ namespace AzToolsFramework
         int childCount = index.data(EntityOutlinerListModel::ChildCountRole).value<int>();
         QModelIndex lastChild = model->index(childCount - 1, EntityOutlinerListModel::ColumnName, index);
 
-        return Internal_GetLastVisibleChild(model, lastChild);
+        return Internal_GetLastVisibleChild(model, lastChild, outlinerTreeView);
     }
 
     bool PrefabUiHandler::OnOutlinerItemClick(const QPoint& position, const QStyleOptionViewItem& option, const QModelIndex& index) const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.h
@@ -57,9 +57,10 @@ namespace AzToolsFramework
         Prefab::PrefabFocusPublicInterface* m_prefabFocusPublicInterface = nullptr;
         Prefab::PrefabPublicInterface* m_prefabPublicInterface = nullptr;
 
-        static bool IsLastVisibleChild(const QModelIndex& parent, const QModelIndex& child);
-        static QModelIndex GetLastVisibleChild(const QModelIndex& parent);
-        static QModelIndex Internal_GetLastVisibleChild(const QAbstractItemModel* model, const QModelIndex& index);
+        static bool IsLastVisibleChild(const QModelIndex& parent, const QModelIndex& child, const QTreeView* outlinerTreeView);
+        static QModelIndex GetLastVisibleChild(const QModelIndex& parent, const QTreeView* outlinerTreeView);
+        static QModelIndex Internal_GetLastVisibleChild(
+            const QAbstractItemModel* model, const QModelIndex& index, const QTreeView* outlinerTreeView);
 
         void PaintDescendantBorder(
             QPainter* painter,


### PR DESCRIPTION
Signed-off-by: srikappa-amzn <82230713+srikappa-amzn@users.noreply.github.com>

## What does this PR do?

This PR does 2 things:
1. It doesn't let the prefab hierarchy get collapsed
2. In some edge cases, the prefab blue border is not getting drawn correctly because we are querying the model instead of the view

Note: This is obviously not the best or most optimal way to solve this problem as it walks through the same tree multiple times for each dataChanged call on any row, which can have perf implications. But this can go in as a short term fix until editor team can recommend a better long term fix. I've also tried this fix on a level with 10 layers of nesting and 1000 entities in the leaf prefab. Didn't find any significant slowness other than the usual blip it takes.

## How was this PR tested?

Manually. (Context menus don't show up in the recording. Sorry about that. I'm basically doing delete, undo and redo in the below operations)

Before:

https://user-images.githubusercontent.com/82230713/192031784-3daf08b2-c538-40d2-8436-aadc31b3fc6a.mp4


After:


https://user-images.githubusercontent.com/82230713/192031820-37343f37-5141-4198-8ef5-aff97f824f95.mp4

