### PR TITLE
Fixed StringFunc ReplaceExtension for extension removal

### DIFF
--- a/Code/Framework/AzCore/AzCore/StringFunc/StringFunc.cpp
+++ b/Code/Framework/AzCore/AzCore/StringFunc/StringFunc.cpp
@@ -2299,10 +2299,9 @@ namespace AZ::StringFunc
 
         void ReplaceExtension(AZStd::string& inout, const char* newExtension /* = nullptr*/)
         {
-            //treat this as a strip
-            if (!newExtension || newExtension[0] == '\0')
+            if (!newExtension)
             {
-                return;
+                newExtension = "";
             }
             AZ::IO::Path path(AZStd::move(inout));
             path.ReplaceExtension(newExtension);

--- a/Code/Framework/AzCore/Tests/StringFunc.cpp
+++ b/Code/Framework/AzCore/Tests/StringFunc.cpp
@@ -966,6 +966,34 @@ namespace AZ
 #endif
     }
 
+    TEST_F(StringFuncPathTest, ReplaceExtension_WithoutDot)
+    {
+        AZStd::string s = "D:\\p4\\some.file";
+        AZ::StringFunc::Path::ReplaceExtension(s, "xml");
+        EXPECT_STREQ("D:\\p4\\some.xml", s.c_str());
+    }
+
+    TEST_F(StringFuncPathTest, ReplaceExtension_WithDot)
+    {
+        AZStd::string s = "D:\\p4\\some.file";
+        AZ::StringFunc::Path::ReplaceExtension(s, ".xml");
+        EXPECT_STREQ("D:\\p4\\some.xml", s.c_str());
+    }
+
+    TEST_F(StringFuncPathTest, ReplaceExtension_Empty)
+    {
+        AZStd::string s = "D:\\p4\\some.file";
+        AZ::StringFunc::Path::ReplaceExtension(s, "");
+        EXPECT_STREQ("D:\\p4\\some", s.c_str());
+    }
+
+    TEST_F(StringFuncPathTest, ReplaceExtension_Null)
+    {
+        AZStd::string s = "D:\\p4\\some.file";
+        AZ::StringFunc::Path::ReplaceExtension(s, nullptr);
+        EXPECT_STREQ("D:\\p4\\some", s.c_str());
+    }
+
     class TestPathStringArgs
     {
     public:
@@ -1000,7 +1028,6 @@ namespace AZ
         EXPECT_TRUE(result);
         EXPECT_STREQ(input.c_str(), expected.c_str());
     }
-
 
 #if AZ_TRAIT_OS_USE_WINDOWS_FILE_PATHS
 


### PR DESCRIPTION
## What does this PR do?
The code was not working according to the API documentation. I fixed it so that empty or null extension means remove the extension, as described in StringFunc.h.

## How was this PR tested?
Ran the AzCore unit tests.
Tested with local changes (https://github.com/o3de/o3de/pull/12111) where use of this function was failing before.
