### PR TITLE
Multiple "Create Gem" fixes

### DIFF
--- a/Code/Tools/ProjectManager/Resources/ProjectManager.qss
+++ b/Code/Tools/ProjectManager/Resources/ProjectManager.qss
@@ -235,6 +235,10 @@ QTabBar::tab:focus {
     margin-left: 50px;
 }
 
+#createAGemBody #formErrorLabel {
+    margin-left: 0px;
+}
+
 #addRemoteProjectDialog #formErrorLabel {
     margin-left: 0px;
 }

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
@@ -328,6 +328,9 @@ namespace O3DE::ProjectManager
 
     bool CreateGem::ValidateGemPath()
     {
+        // This first isEmpty check is to check that the input field is not empty. If it is QDir will use the current
+        // directory as the gem location, so that if that folder is also empty it will pass the chosenGemLocation.isEmpty()
+        // check and place the created gem there, which is likely unintended behavior for a GUI app such as Project Manager.
         if (m_gemLocation->lineEdit()->text().isEmpty())
         {
             return false;

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
@@ -245,10 +245,10 @@ namespace O3DE::ProjectManager
         gemDetailsLayout->addWidget(m_licenseURL);
 
         m_userDefinedGemTags = new FormLineEditWidget(tr("User-defined Gem Tags (Comma separated list)"), "");
-        m_userDefinedGemTags->lineEdit()->setValidator(new QRegularExpressionValidator(QRegularExpression("(,|\\w)+"), this));
+        m_userDefinedGemTags->lineEdit()->setValidator(new QRegularExpressionValidator(QRegularExpression("(\\w+)(,\\s?\\w*)*"), this));
         gemDetailsLayout->addWidget(m_userDefinedGemTags);
 
-        m_gemLocation = new FormFolderBrowseEditWidget(tr("Gem Location"), "", tr("The path that the gem will be created at."), tr("The chosen directory must be empty."));
+        m_gemLocation = new FormFolderBrowseEditWidget(tr("Gem Location"), "", tr("The path that the gem will be created at."), tr("The chosen directory must either not exist or be empty."));
         gemDetailsLayout->addWidget(m_gemLocation);
         
         m_gemIconPath = new FormLineEditWidget(tr("Gem Icon Path"), "default.png", tr("Select Gem icon path"), "");

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
@@ -35,7 +35,7 @@ namespace O3DE::ProjectManager
         ~CreateGem() = default;
 
     signals:
-        void CreateButtonPressed(const GemInfo& gemInfo);
+        void GemCreated(const GemInfo& gemInfo);
 
     private slots:
         void HandleBackButton();
@@ -50,6 +50,7 @@ namespace O3DE::ProjectManager
         bool ValidateGemTemplateLocation();
         bool ValidateGemDisplayName();
         bool ValidateGemName();
+        bool ValidateGemPath();
         bool ValidateFormNotEmpty(FormLineEditWidget* form);
         bool ValidateRepositoryURL();
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -74,13 +74,13 @@ namespace O3DE::ProjectManager
         connect(m_headerWidget, &GemCatalogHeaderWidget::UpdateGemCart, this, &GemCatalogScreen::UpdateAndShowGemCart);
         connect(m_downloadController, &DownloadController::Done, this, &GemCatalogScreen::OnGemDownloadResult);
 
-        ScreensCtrl* screensControl = dynamic_cast<ScreensCtrl*>(parent);
+        ScreensCtrl* screensControl = qobject_cast<ScreensCtrl*>(parent);
         if (screensControl)
         {
             ScreenWidget* createGemScreen = screensControl->FindScreen(ProjectManagerScreen::CreateGem);
             if (createGemScreen)
             {
-                connect(reinterpret_cast<CreateGem*>(createGemScreen), &CreateGem::GemCreated, this, &GemCatalogScreen::HandleGemCreated);
+                connect(static_cast<CreateGem*>(createGemScreen), &CreateGem::GemCreated, this, &GemCatalogScreen::HandleGemCreated);
             }
         }
 
@@ -714,7 +714,7 @@ namespace O3DE::ProjectManager
         AddToGemModel(gemInfo);
 
         // create Toast Notification for project gem catalog
-        QString notification = gemInfo.m_displayName + tr(" has been created.");
+        QString notification = tr("%1 has been created.").arg(gemInfo.m_displayName);
         ShowStandardToastNotification(notification);
     }
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -21,6 +21,8 @@
 #include <DownloadController.h>
 #include <ProjectUtils.h>
 #include <AdjustableHeaderWidget.h>
+#include <ScreensCtrl.h>
+#include <CreateAGemScreen.h>
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -71,6 +73,16 @@ namespace O3DE::ProjectManager
         connect(m_headerWidget, &GemCatalogHeaderWidget::AddGem, this, &GemCatalogScreen::OnAddGemClicked);
         connect(m_headerWidget, &GemCatalogHeaderWidget::UpdateGemCart, this, &GemCatalogScreen::UpdateAndShowGemCart);
         connect(m_downloadController, &DownloadController::Done, this, &GemCatalogScreen::OnGemDownloadResult);
+
+        ScreensCtrl* screensControl = dynamic_cast<ScreensCtrl*>(parent);
+        if (screensControl)
+        {
+            ScreenWidget* createGemScreen = screensControl->FindScreen(ProjectManagerScreen::CreateGem);
+            if (createGemScreen)
+            {
+                connect(reinterpret_cast<CreateGem*>(createGemScreen), &CreateGem::GemCreated, this, &GemCatalogScreen::HandleGemCreated);
+            }
+        }
 
         QHBoxLayout* hLayout = new QHBoxLayout();
         hLayout->setMargin(0);
@@ -692,6 +704,18 @@ namespace O3DE::ProjectManager
                 GemModel::SetDownloadStatus(*m_gemModel, index, GemInfo::DownloadFailed);
             }
         }
+    }
+
+    void GemCatalogScreen::HandleGemCreated(const GemInfo& gemInfo)
+    {
+        // This signal occurs only upon successful completion of creating a gem. As such, the gemInfo data is assumed to be valid.
+
+        // make sure the project gem catalog model is updated
+        AddToGemModel(gemInfo);
+
+        // create Toast Notification for project gem catalog
+        QString notification = gemInfo.m_displayName + tr(" has been created.");
+        ShowStandardToastNotification(notification);
     }
 
     ProjectManagerScreen GemCatalogScreen::GetScreenEnum()

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
@@ -60,6 +60,7 @@ namespace O3DE::ProjectManager
         void Refresh();
         void UpdateGem(const QModelIndex& modelIndex);
         void UninstallGem(const QModelIndex& modelIndex);
+        void HandleGemCreated(const GemInfo& gemInfo);
 
     protected:
         void hideEvent(QHideEvent* event) override;

--- a/Code/Tools/ProjectManager/Source/ProjectManagerWindow.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectManagerWindow.cpp
@@ -34,6 +34,7 @@ namespace O3DE::ProjectManager
         QVector<ProjectManagerScreen> screenEnums =
         {
             ProjectManagerScreen::Projects,
+            ProjectManagerScreen::CreateGem,
             ProjectManagerScreen::GemCatalog,
             ProjectManagerScreen::Engine,
             ProjectManagerScreen::CreateProject,

--- a/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
+++ b/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
@@ -44,11 +44,9 @@ namespace O3DE::ProjectManager
         m_updateSettingsScreen = new UpdateProjectSettingsScreen();
         m_projectGemCatalogScreen = new ProjectGemCatalogScreen(downloadController);
         m_gemRepoScreen = new GemRepoScreen(this);
-        m_createGem = new CreateGem();
 
         connect(m_projectGemCatalogScreen, &ScreenWidget::ChangeScreenRequest, this, &UpdateProjectCtrl::OnChangeScreenRequest);
         connect(m_gemRepoScreen, &GemRepoScreen::OnRefresh, m_projectGemCatalogScreen, &ProjectGemCatalogScreen::Refresh);
-        connect(m_createGem, &CreateGem::CreateButtonPressed, this, &UpdateProjectCtrl::HandleCreateGemButtonPressed);
 
         m_stack = new QStackedWidget(this);
         m_stack->setObjectName("body");
@@ -76,7 +74,6 @@ namespace O3DE::ProjectManager
         m_stack->addWidget(topBarFrameWidget);
         m_stack->addWidget(m_projectGemCatalogScreen);
         m_stack->addWidget(m_gemRepoScreen);
-        m_stack->addWidget(m_createGem);
 
         QDialogButtonBox* backNextButtons = new QDialogButtonBox();
         backNextButtons->setObjectName("footer");
@@ -137,11 +134,6 @@ namespace O3DE::ProjectManager
             m_stack->setCurrentWidget(m_updateSettingsScreen);
             Update();
         }
-        else if (screen == ProjectManagerScreen::CreateGem)
-        {
-            m_stack->setCurrentWidget(m_createGem);
-            Update();
-        }
         else
         {
             emit ChangeScreenRequest(screen);
@@ -172,26 +164,6 @@ namespace O3DE::ProjectManager
                 emit GoToPreviousScreenRequest();
             }
         }
-    }
-
-    void UpdateProjectCtrl::HandleCreateGemButtonPressed(const GemInfo& gemInfo)
-    {
-        /*
-            Note: by the time this function is called, the signal CreateButtonPressed was already emitted.
-
-            This signal occurs only upon successful completion of creating a gem. As such, the gemInfo data is assumed to be valid.
-        */
-
-        //make sure the project gem catalog model is updated
-        m_projectGemCatalogScreen->AddToGemModel(gemInfo);
-
-        //create Toast Notification for project gem catalog
-        QString notification = gemInfo.m_displayName + tr(" has been created.");
-        m_projectGemCatalogScreen->ShowStandardToastNotification(notification);
-
-        //because we access the gem creation workflow from the catalog screen, we will forcibly return there
-        m_stack->setCurrentIndex(ScreenOrder::Gems);
-        Update();
     }
 
     void UpdateProjectCtrl::HandleNextButton()

--- a/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.h
+++ b/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.h
@@ -44,7 +44,6 @@ namespace O3DE::ProjectManager
         void HandleBackButton();
         void HandleNextButton();
         void HandleGemsButton();
-        void HandleCreateGemButtonPressed(const GemInfo& gemInfo);
         void OnChangeScreenRequest(ProjectManagerScreen screen);
         void UpdateCurrentProject(const QString& projectPath);
 
@@ -65,7 +64,6 @@ namespace O3DE::ProjectManager
         UpdateProjectSettingsScreen* m_updateSettingsScreen = nullptr;
         ProjectGemCatalogScreen* m_projectGemCatalogScreen = nullptr;
         GemRepoScreen* m_gemRepoScreen = nullptr;
-        CreateGem* m_createGem = nullptr;
 
         QPushButton* m_backButton = nullptr;
         QPushButton* m_nextButton = nullptr;

--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -2045,9 +2045,7 @@ def create_gem(gem_path: pathlib.Path,
         logger.error(f'Gem path {gem_path} already exists.')
         return 1
     else:
-        # We can also use an pre-existing folder if it is empty
-        folder_is_empty = gem_path.is_dir() and (len(list(gem_path.iterdir())) == 0)
-        os.makedirs(gem_path, exist_ok=(force or folder_is_empty))
+        os.makedirs(gem_path, exist_ok=True)
 
     # Default to the gem path basename component if gem_name has not been supplied
     if not gem_name:

--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -2045,7 +2045,9 @@ def create_gem(gem_path: pathlib.Path,
         logger.error(f'Gem path {gem_path} already exists.')
         return 1
     else:
-        os.makedirs(gem_path, exist_ok=force)
+        # We can also use an pre-existing folder if it is empty
+        folder_is_empty = gem_path.is_dir() and (len(list(gem_path.iterdir())) == 0)
+        os.makedirs(gem_path, exist_ok=(force or folder_is_empty))
 
     # Default to the gem path basename component if gem_name has not been supplied
     if not gem_name:
@@ -2112,7 +2114,8 @@ def create_gem(gem_path: pathlib.Path,
     
     tags = [gem_name]
     if user_tags:
-        new_tags = user_tags.split() if isinstance(user_tags, str) else user_tags
+        # Allow commas or spaces as tag separators
+        new_tags = user_tags.replace(',', ' ').split() if isinstance(user_tags, str) else user_tags
         tags.extend(new_tags)
     tags_quoted = ','.join(f'"{word.strip()}"' for word in set(tags))
     # remove the first and last quote because those already exist in gem.json


### PR DESCRIPTION
Set of fixes for Create Gem:
- Allow creating a gem from a template to use a folder that already exists if it is empty
- Error message in Project Manager UI if a folder is chosen that is not empty
- Allow commas as well as spaces for tag separation in engine_template.py
- Align form error messages to the left of the fields
- Do not allow spaces in user tag field (these would generate new tags and given instructions are to use commas)
- Fix the entry points to Create Gem, and reducing code duplication. This also fixes the back button to go back to an expected page.

![CreateGemScreen](https://user-images.githubusercontent.com/70403342/192068609-eeeac0e8-05b8-4818-8d87-3d7c9a815af9.PNG)

![CreateGemFolderError](https://user-images.githubusercontent.com/70403342/192068615-8445e042-d666-4198-984a-8ef9953ca40b.PNG)

![CreateGemBack](https://user-images.githubusercontent.com/70403342/192068618-ff593239-200a-46f6-b528-7abb8e81aa16.gif)

Signed-off-by: AMZN-Phil <pconroy@amazon.com>