### PR TITLE
PropertyEditor | Issues when ChangeValidate attribute is set on an Asset<> property

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
@@ -512,7 +512,15 @@ namespace AzToolsFramework
 
             const AZ::Uuid& desiredUUID = GetHandledType();
 
-            PropertyType* actualCast = static_cast<PropertyType*>(serializeContext->DownCast(tempValue, propertyType, desiredUUID));
+            PropertyType* actualCast;
+            if (serializeContext->CanDowncast(propertyType, desiredUUID))
+            {
+                actualCast = static_cast<PropertyType*>(serializeContext->DownCast(tempValue, propertyType, desiredUUID));
+            }
+            else
+            {
+                actualCast = serializeContext->Cast<PropertyType*>(tempValue, desiredUUID);
+            }
             AZ_Assert(actualCast, "Could not cast from the existing type ID to the actual typeid required by the editor.");
             WriteGUIValuesIntoProperty(0, wid, *actualCast, nullptr);
         }


### PR DESCRIPTION
## What does this PR do?

Fixes issue with the PropertyEditor class handling of the ChangeValidate Edit Context attribute.
The current implementation of the validation code will create a temporary instance of the class to pass to the validation call provided by the attribute. In doing so, it will call `WriteGUIValuesIntoTempProperty_Internal` which will try to DownCast the Asset<> class to the handled type for the property; in the case of all Asset<> classes, this will fail and result in a nullptr being returned, and then dereferenced causing a crash.

This change introduce a check that ensure that the type can be downclassed before attempting it, else tries a direct cast. This seems to fix the issue in #11239 ; after a quick test with Mesh and Spawnable properties, I was able to set a validation function and get the correct inputs.

I am not knowledgeable in the asset system and corresponding classes reflection, so I'm looping in reviewers from those areas. If there are any specific quirks with Asset<> classes, we could potentially add an edge case; I liked this implementation though cause it leaves the base case unvaried.

## How was this PR tested?

Manual testing. I could not find a unit test suite for this class; I will try to add a backlog task. In the meantime, I would recommend automation tests for usages of the ChangeValidate attribute for Asset<> properties whenever the first use case shows up.