### PR TITLE
bugfix(Script Canvas): fix crash when highlighting a variable

### DIFF
--- a/Gems/GraphCanvas/Code/Source/Components/SceneComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/SceneComponent.cpp
@@ -3995,6 +3995,9 @@ namespace GraphCanvas
         {
             GraphicsEffectRequestBus::Event(effectId, &GraphicsEffectRequests::OnGraphicsEffectCancelled);
             RemoveItemFromScene(graphicsItem);
+            // https://stackoverflow.com/questions/38458830/crash-after-qgraphicssceneremoveitem-with-custom-item-class
+            // Scene Index does not correctly update causing a crash when the index tree is queried. 
+            GraphicsEffectRequestBus::Event(effectId, &GraphicsEffectRequests::PrepareGeometryChange);
             delete graphicsItem;
         }
 

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/GraphicsItems/GraphicsEffect.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/GraphicsItems/GraphicsEffect.h
@@ -72,6 +72,11 @@ namespace GraphCanvas
         {
             return this;
         }
+
+        virtual void PrepareGeometryChange() 
+        {
+            GraphicsClass::prepareGeometryChange();
+        }
         
         virtual void OnGraphicsEffectCancelled()
         {            

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/GraphicsItems/GraphicsEffectBus.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/GraphicsItems/GraphicsEffectBus.h
@@ -20,6 +20,8 @@ namespace GraphCanvas
         using BusIdType = GraphicsEffectId;
         
         virtual QGraphicsItem* AsQGraphicsItem() = 0;
+
+        virtual void PrepareGeometryChange() = 0;
         
         virtual void OnGraphicsEffectCancelled() = 0;
 


### PR DESCRIPTION

Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

fixes a crash when highlighting a component and clicking away in the graph canvas. 

## How was this PR tested?

follow the referenced issue. its pretty hard to reproduce.

ref: https://github.com/o3de/o3de/issues/11639