### PR TITLE
bugfix(Script Canvas): improve dragging behavior for spinbox for script canvas

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/SpinBox.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/SpinBox.cpp
@@ -17,12 +17,12 @@
 #include <QApplication>
 #include <QDoubleSpinBox>
 #include <QEvent>
+#include <QGuiApplication>
 #include <QLineEdit>
 #include <QMouseEvent>
 #include <QObject>
 #include <QPainter>
 #include <QScreen>
-#include <QGuiApplication>
 #include <QSettings>
 #include <QStyle>
 #include <QStyleOptionSpinBox>
@@ -599,7 +599,7 @@ bool SpinBoxWatcher::handleMouseDragStepping(QAbstractSpinBox* spinBox, QEvent* 
             if (((mouseEvent->button() & Qt::LeftButton) && (m_state == Inactive) && !buttonDownPressed && !buttonUpPressed) ||
                 (mouseEvent->button() & Qt::MiddleButton))
             {
-                m_xPos = mouseEvent->screenPos().x();
+                m_xPos = mouseEvent->x();
                 emitValueChangeBegan(spinBox);
                 m_state = Dragging;
                 m_activeScreen = QGuiApplication::screenAt(mouseEvent->globalPos());


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

This fixes a problem where the user is unable to drag the the scale for a property in the scriptcanvas using the spinbox. another widget in the chain is consuming the mouse move event so this change will grab the mouse so events are handled exclusively for the active spinbox. I added some more logic to work on the screen where the mouse started to the wrapping logic. found that it only worked on the first screen in my multi-monitor setup.


https://user-images.githubusercontent.com/854359/192167997-dfc94c1c-c67e-47ad-8594-84315337e660.mp4


## How was this PR tested?

- open script canvas and create a heartbeat node. 