### PR TITLE
bugfix(Script Canvas): better handle focus for ComboBox

### DIFF
--- a/Gems/GraphCanvas/Code/Source/Widgets/GraphCanvasComboBox.cpp
+++ b/Gems/GraphCanvas/Code/Source/Widgets/GraphCanvasComboBox.cpp
@@ -114,6 +114,9 @@ namespace GraphCanvas
         escapeAction->setShortcut(Qt::Key_Escape);
 
         addAction(escapeAction);
+        connect(this, &QDialog::finished, this, [&]() {
+            Q_EMIT OnFocusOut();
+        });
 
         QObject::connect(escapeAction, &QAction::triggered, this, &GraphCanvasComboBoxMenu::CancelMenu);
     }
@@ -335,8 +338,6 @@ namespace GraphCanvas
         m_closeConnection = QObject::connect(&m_closeTimer, &QTimer::timeout, this, &QDialog::reject);
 
         m_closeTimer.start();
-
-        emit OnFocusOut();
     }
 
     ////////////////////////


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

This is a tweak where the dialog finished is used to determine when the the control loses focus. observed in the linked ticket that the control does not correctly lose focus. we don't hide the dialog/set the visibility to false so finished should be handled when the dialog is closed.

I did observe that it was possible to still get the control in a stuck state where the menu dialog does not correctly open. I don't think this change would cause that problem. 

If this fix does work I think it would be kind of temporary. I think I would like to rework this control a bit but this should be good enough to just address the problem. I think some of the logic to handle focus/unfocus could be simplified not sure how at the moment would need to have a closer look. 

ref: https://github.com/o3de/o3de/issues/11521

## How was this PR tested?

repeat the steps in the listed ticket, note this is hard to correctly reproduce. I tried this for quite a bit of time and was unable to reproduce the original issue. 
