### PR TITLE
Fix for RenderDebug disabling direct lighting in CubeMap captures

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Debug/RenderDebugFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Debug/RenderDebugFeatureProcessor.cpp
@@ -104,7 +104,7 @@ namespace AZ::Render
 
         for (const RPI::ViewPtr& view : packet.m_views)
         {
-            if (view->GetUsageFlags() & RPI::View::UsageFlags::UsageCamera)
+            if (view->GetUsageFlags() & (RPI::View::UsageFlags::UsageCamera | RPI::View::UsageFlags::UsageReflectiveCubeMap))
             {
                 Data::Instance<RPI::ShaderResourceGroup> viewSrg = view->GetShaderResourceGroup();
 


### PR DESCRIPTION
Added check for the ReflectiveCubeMap view usage flag

Tested baking ReflectionProbes in the Editor
Tested AtomSampleViewer

Signed-off-by: dmcdiarmid-ly <63674186+dmcdiarmid-ly@users.noreply.github.com>
