### PR TITLE
AutoGen a valid copy constructor for SC nodes

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Header.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Header.jinja
@@ -78,7 +78,7 @@ public: \
     static const char* GetDescription() { return "{{ macros.GetAttributeAsString(Class.attrib, 'Description') }}"; } \
     ScriptCanvas::NodePropertyInterface* GetPropertyInterface(AZ::Crc32 propertyId) override; \
     bool IsActive() const override { return false; } \
-{{ nodemacro.PopulateMemberVariables(Class) }}{{ nodemacro.ExecutionInDeclarations(Class) }}{{ nodemacro.ExecutionOutDeclarations(Class) }}/* end #define SCRIPTCANVAS_NODE_{{className}} */
+{{ nodemacro.PopulateMemberVariables(Class) }}{{ nodemacro.ExecutionInDeclarations(Class) }}{{ nodemacro.ExecutionOutDeclarations(Class) }}{{ nodemacro.CopyConstructor(Class) }}/* end #define SCRIPTCANVAS_NODE_{{className}} */
 
 {% if className is defined -%}
 {% set nodeableNodeName = nodeableClassName + 'Node' %}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvas_Nodeable_Macros.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvas_Nodeable_Macros.jinja
@@ -99,6 +99,28 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 {%+ endfor -%}
 {%- endmacro -%}
 
+
+{# Copy Constructor #}
+{# Produces the memberwise copy ctor  #}
+{%- macro CopyConstructor(Class) -%}
+{%- if Class.findall('Property')|length() > 0 or Class.findall('Parameter')|length() > 0 -%}
+{{ Class.attrib['Name'] }}([[maybe_unused]] const {{ Class.attrib['Name'] }}& rhs) { \
+{%+ for field in Class.findall('Property') %}
+{%-     set propertyName = CleanName(field.attrib['Name']) -%}
+{{ propertyName }} = rhs.{{ propertyName }}; \
+{%+ endfor -%}
+
+{%+ for field in Class.findall('Parameter') %}
+{%-         set propertyName = CleanName(field.attrib['Name']) -%}
+{{ propertyName }} = rhs.{{ propertyName }}; \
+{%- endfor -%}
+}
+{% endif %}
+{%- endmacro -%}
+{# ---------------- #}
+
+
+
 {%- macro DataSlotDefaultValue(defaultValue) -%}
 {%- if "\\\"" in defaultValue -%}
 {{defaultValue|replace("\\\"", '')}}
@@ -303,7 +325,7 @@ AZStd::tuple<{{returns|join(", ")}}>
 {%      for executionOut in Class.findall('Output') %}
                 {{ ExecutionOutDeclaration(Class, executionOut) }}
 {%-     endfor %}
-size_t GetRequiredOutCount() const override; 
+size_t GetRequiredOutCount() const override; \
 {% endmacro %}
 
 {% macro ExecutionBranchDefinition(Class, qualifiedName, executionOut, outIndexBranch) %}

--- a/Gems/StartingPointInput/Code/Source/InputHandlerNodeable.h
+++ b/Gems/StartingPointInput/Code/Source/InputHandlerNodeable.h
@@ -28,7 +28,6 @@ namespace StartingPointInput
     public:
         InputHandlerNodeable() = default;
         virtual ~InputHandlerNodeable();
-        InputHandlerNodeable(const InputHandlerNodeable&) = default;
         InputHandlerNodeable& operator=(const InputHandlerNodeable&) = default;
 
     protected:

--- a/Gems/StartingPointInput/Code/Source/InputHandlerNodeable.h
+++ b/Gems/StartingPointInput/Code/Source/InputHandlerNodeable.h
@@ -26,9 +26,7 @@ namespace StartingPointInput
         SCRIPTCANVAS_NODE(InputHandlerNodeable)
 
     public:
-        InputHandlerNodeable() = default;
-        virtual ~InputHandlerNodeable();
-        InputHandlerNodeable& operator=(const InputHandlerNodeable&) = default;
+        ~InputHandlerNodeable() override;
 
     protected:
         void OnDeactivate() override;


### PR DESCRIPTION
Signed-off-by: Luis Sempé <58790905+lsemp3d@users.noreply.github.com>

## What does this PR do?

I noticed some gems & features (StartingPointInput, spawnables) were providing a default copy ctor to get around some issues compiling when using Script Canvas nodes. I added a memberwise copy ctor for nodeables for any properties that become member variables.

One concern I have is what if a user adds custom non-serialized members may want to add their own copy ctor, I'll add a tag to opt out of this behavior in an upcoming commit