### PR TITLE
[SceneCore] Work around memory leak in GetNodeContext behavior reflection

### DIFF
--- a/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.cpp
@@ -188,6 +188,7 @@ namespace AZ
                         ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                         ->Attribute(AZ::Script::Attributes::Module, "scene.graph")
                         ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
+                        ->Constructor<>()
                         ->Method("CastWithTypeName", &GraphObjectProxy::CastWithTypeName)
                         ->Method("Invoke", &GraphObjectProxy::Invoke)
                         ->Method("Fetch", &GraphObjectProxy::Fetch)

--- a/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.h
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.h
@@ -38,6 +38,7 @@ namespace AZ
 
                 static void Reflect(AZ::ReflectContext* context);
 
+                GraphObjectProxy() = default;
                 GraphObjectProxy(AZStd::shared_ptr<const DataTypes::IGraphObject> graphObject);
                 ~GraphObjectProxy();
 

--- a/Code/Tools/SceneAPI/SceneCore/Containers/SceneGraph.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/SceneGraph.cpp
@@ -89,15 +89,14 @@ namespace AZ
                         {
                             return self.Find(root, path);
                         })
-                        ->Method("GetNodeContent", [](const SceneGraph& self, NodeIndex node) -> GraphObjectProxy*
+                        ->Method("GetNodeContent", [](const SceneGraph& self, NodeIndex node) -> GraphObjectProxy
                         {
                             auto graphObject = self.GetNodeContent(node);
                             if (graphObject)
                             {
-                                GraphObjectProxy* proxy = aznew GraphObjectProxy(graphObject);
-                                return proxy;
+                                return {graphObject};
                             }
-                            return aznew GraphObjectProxy(nullptr);
+                            return {nullptr};
                         });
                 }
             }


### PR DESCRIPTION
This method used to allocate and return a pointer to a `GraphObjectProxy` object. The trouble is, BehaviorContext has no way to express that this object should be owned by the script, and deallocated when the script's variable goes out of scope.

This works around that problem by returning this type by value. The script always owns value types returned from methods.

To allow for this, the `GraphObjectProxy` must have a default constructor. This is because the script context implements by-value return types by allocating space for the return type before the call is made, default constructing the resulting memory, then using copy assignment from the return value after the call is made. If the default constructor is not present, the copy assignment method may fail, since it is being run on an uninitialized object.

Fixes #11827

Signed-off-by: Chris Burel <burelc@amazon.com>
