### PR TITLE
Material Canvas: Fixing graph canvas and graph model data interfaces to send notifications after values are edited

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
@@ -341,6 +341,17 @@ namespace MaterialCanvas
         AtomToolsFramework::AtomToolsDocument::Clear();
     }
 
+    void MaterialCanvasDocument::OnGraphModelGraphModified([[maybe_unused]] GraphModel::NodePtr node)
+    {
+        m_modified = true;
+        BuildEditablePropertyGroups();
+        AtomToolsFramework::AtomToolsDocumentNotificationBus::Event(
+            m_toolId, &AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentObjectInfoInvalidated, m_id);
+        AtomToolsFramework::AtomToolsDocumentNotificationBus::Event(
+            m_toolId, &AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentModified, m_id);
+        QueueCompileGraph();
+    }
+
     void MaterialCanvasDocument::OnGraphModelRequestUndoPoint()
     {
         // Undo and redo is being handled differently for edits received directly from graph model and graph canvas. By the time this is

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.h
@@ -69,7 +69,7 @@ namespace MaterialCanvas
         void Clear() override;
 
         // GraphModelIntegration::GraphControllerNotificationBus::Handler overrides...
-        void OnGraphModelGraphModified(GraphModel::NodePtr node) override;
+        void OnGraphModelSlotModified(GraphModel::SlotPtr slot) override;
         void OnGraphModelRequestUndoPoint() override;
         void OnGraphModelTriggerUndo() override;
         void OnGraphModelTriggerRedo() override;

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.h
@@ -69,6 +69,7 @@ namespace MaterialCanvas
         void Clear() override;
 
         // GraphModelIntegration::GraphControllerNotificationBus::Handler overrides...
+        void OnGraphModelGraphModified(GraphModel::NodePtr node) override;
         void OnGraphModelRequestUndoPoint() override;
         void OnGraphModelTriggerUndo() override;
         void OnGraphModelTriggerRedo() override;

--- a/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/AssetIdNodePropertyDisplay.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/AssetIdNodePropertyDisplay.cpp
@@ -101,7 +101,6 @@ namespace GraphCanvas
     void AssetIdNodePropertyDisplay::EditStart()
     {
         NodePropertiesRequestBus::Event(GetNodeId(), &NodePropertiesRequests::LockEditState, this);
-
         TryAndSelectNode();
     }
 
@@ -132,11 +131,10 @@ namespace GraphCanvas
             m_propertyAssetCtrl = aznew AzToolsFramework::PropertyAssetCtrl(nullptr, m_dataInterface->GetStringFilter().c_str());
             m_propertyAssetCtrl->setProperty("HasNoWindowDecorations", true);
             m_propertyAssetCtrl->setProperty("DisableFocusWindowFix", true);
-            
-            QObject::connect(m_propertyAssetCtrl, &AzToolsFramework::PropertyAssetCtrl::OnAssetIDChanged, [this]() { this->SubmitValue(); });
-
             m_propertyAssetCtrl->SetCurrentAssetType(m_dataInterface->GetAssetType());
             m_propertyAssetCtrl->SetDefaultAssetID(AZ::Data::AssetId());
+            
+            QObject::connect(m_propertyAssetCtrl, &AzToolsFramework::PropertyAssetCtrl::OnAssetIDChanged, [this]() { SubmitValue(); });
 
             m_proxyWidget->setWidget(m_propertyAssetCtrl);
 

--- a/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/ComboBoxNodePropertyDisplay.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/ComboBoxNodePropertyDisplay.cpp
@@ -310,15 +310,12 @@ namespace GraphCanvas
             m_comboBox = aznew GraphCanvasComboBox(m_dataInterface->GetItemInterface());
             m_comboBox->setContextMenuPolicy(Qt::CustomContextMenu);
 
-            QObject::connect(m_comboBox, &AzToolsFramework::PropertyEntityIdCtrl::customContextMenuRequested, [this](const QPoint& pos) { this->ShowContextMenu(pos); });
-
-            QObject::connect(m_comboBox, &GraphCanvasComboBox::SelectedIndexChanged, [this](const QModelIndex& /*index*/) { this->m_valueDirty = true; });
-
-            QObject::connect(m_comboBox, &GraphCanvasComboBox::OnFocusIn, [this]() { this->EditStart();  });
-            QObject::connect(m_comboBox, &GraphCanvasComboBox::OnFocusOut, [this]() { this->EditFinished();  });
-            QObject::connect(m_comboBox, &GraphCanvasComboBox::OnMenuAboutToDisplay, [this]() { this->OnMenuAboutToDisplay(); });
-
-            QObject::connect(m_comboBox, &GraphCanvasComboBox::OnUserActionComplete, [this]() { this->SubmitValue();  });
+            QObject::connect(m_comboBox, &AzToolsFramework::PropertyEntityIdCtrl::customContextMenuRequested, [this](const QPoint& pos) { ShowContextMenu(pos); });
+            QObject::connect(m_comboBox, &GraphCanvasComboBox::SelectedIndexChanged, [this](const QModelIndex& /*index*/) { m_valueDirty = true; });
+            QObject::connect(m_comboBox, &GraphCanvasComboBox::OnFocusIn, [this]() { EditStart(); });
+            QObject::connect(m_comboBox, &GraphCanvasComboBox::OnFocusOut, [this]() { EditFinished(); });
+            QObject::connect(m_comboBox, &GraphCanvasComboBox::OnUserActionComplete, [this]() { SubmitValue(); });
+            QObject::connect(m_comboBox, &GraphCanvasComboBox::OnMenuAboutToDisplay, [this]() { OnMenuAboutToDisplay(); });
 
             m_proxyWidget->setWidget(m_comboBox);
 

--- a/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/EntityIdNodePropertyDisplay.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/EntityIdNodePropertyDisplay.cpp
@@ -186,9 +186,9 @@ namespace GraphCanvas
             m_propertyEntityIdCtrl->setContextMenuPolicy(Qt::CustomContextMenu);
             QObject::connect(m_propertyEntityIdCtrl, &AzToolsFramework::PropertyEntityIdCtrl::customContextMenuRequested, [this](const QPoint& pos) { this->ShowContextMenu(pos); });
 
-            QObject::connect(m_propertyEntityIdCtrl, &AzToolsFramework::PropertyEntityIdCtrl::OnPickStart, [this]() { this->EditStart(); });
-            QObject::connect(m_propertyEntityIdCtrl, &AzToolsFramework::PropertyEntityIdCtrl::OnPickComplete, [this]() { this->EditFinished(); });
-            QObject::connect(m_propertyEntityIdCtrl, &AzToolsFramework::PropertyEntityIdCtrl::OnEntityIdChanged, [this]() { this->SubmitValue(); });
+            QObject::connect(m_propertyEntityIdCtrl, &AzToolsFramework::PropertyEntityIdCtrl::OnPickStart, [this]() { EditStart(); });
+            QObject::connect(m_propertyEntityIdCtrl, &AzToolsFramework::PropertyEntityIdCtrl::OnPickComplete, [this]() { EditFinished(); });
+            QObject::connect(m_propertyEntityIdCtrl, &AzToolsFramework::PropertyEntityIdCtrl::OnEntityIdChanged, [this]() { SubmitValue(); });
 
             m_proxyWidget->setWidget(m_propertyEntityIdCtrl);
 

--- a/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/NumericNodePropertyDisplay.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/NumericNodePropertyDisplay.cpp
@@ -103,7 +103,6 @@ namespace GraphCanvas
     void NumericNodePropertyDisplay::EditStart()
     {
         NodePropertiesRequestBus::Event(GetNodeId(), &NodePropertiesRequests::LockEditState, this);
-
         TryAndSelectNode();
     }
     
@@ -143,9 +142,9 @@ namespace GraphCanvas
             m_spinBox = aznew Internal::FocusableDoubleSpinBox();
             m_spinBox->setProperty("HasNoWindowDecorations", true);
 
-            QObject::connect(m_spinBox, &Internal::FocusableDoubleSpinBox::OnFocusIn, [this]() { this->EditStart(); });
-            QObject::connect(m_spinBox, &Internal::FocusableDoubleSpinBox::OnFocusOut, [this]() { this->EditFinished(); });
-            QObject::connect(m_spinBox, &QDoubleSpinBox::editingFinished, [this]() { this->SubmitValue(); });
+            QObject::connect(m_spinBox, &Internal::FocusableDoubleSpinBox::OnFocusIn, [this]() { EditStart(); });
+            QObject::connect(m_spinBox, &Internal::FocusableDoubleSpinBox::OnFocusIn, [this]() { EditFinished(); });
+            QObject::connect(m_spinBox, &QDoubleSpinBox::editingFinished, [this]() { SubmitValue(); });
 
             m_spinBox->setMinimum(m_dataInterface->GetMin());
             m_spinBox->setMaximum(m_dataInterface->GetMax());

--- a/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/NumericNodePropertyDisplay.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/NumericNodePropertyDisplay.cpp
@@ -143,7 +143,7 @@ namespace GraphCanvas
             m_spinBox->setProperty("HasNoWindowDecorations", true);
 
             QObject::connect(m_spinBox, &Internal::FocusableDoubleSpinBox::OnFocusIn, [this]() { EditStart(); });
-            QObject::connect(m_spinBox, &Internal::FocusableDoubleSpinBox::OnFocusIn, [this]() { EditFinished(); });
+            QObject::connect(m_spinBox, &Internal::FocusableDoubleSpinBox::OnFocusOut, [this]() { EditFinished(); });
             QObject::connect(m_spinBox, &QDoubleSpinBox::editingFinished, [this]() { SubmitValue(); });
 
             m_spinBox->setMinimum(m_dataInterface->GetMin());

--- a/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/StringNodePropertyDisplay.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/StringNodePropertyDisplay.cpp
@@ -26,7 +26,6 @@ namespace GraphCanvas
         , m_displayLabel(nullptr)
         , m_lineEdit(nullptr)
         , m_proxyWidget(nullptr)        
-        , m_valueDirty(false)
         , m_isNudging(false)
     {
         m_dataInterface->RegisterDisplay(this);        
@@ -134,15 +133,8 @@ namespace GraphCanvas
 
     void StringNodePropertyDisplay::SubmitValue()
     {
-        if (!m_valueDirty)
-        {
-            return;
-        }
-
         if (m_lineEdit)
         {
-            m_valueDirty = false;
-
             AZStd::string value = m_lineEdit->text().toUtf8().data();
             m_dataInterface->SetString(value);
 
@@ -185,25 +177,10 @@ namespace GraphCanvas
             m_lineEdit->setProperty("HasNoWindowDecorations", true);
             m_lineEdit->setEnabled(true);
 
-            QObject::connect(m_lineEdit, &QLineEdit::textChanged, [this]() {
-                this->m_valueDirty = true;
-                this->ResizeToContents();
-            });
-
-            QObject::connect(m_lineEdit, &Internal::FocusableLineEdit::OnFocusIn, [this]() { 
-                this->m_valueDirty = false;
-                this->EditStart();
-            });
-
-            QObject::connect(m_lineEdit, &Internal::FocusableLineEdit::OnFocusOut, [this]()
-            {
-                this->OnFocusOut();
-            });
-
-            QObject::connect(m_lineEdit, &QLineEdit::returnPressed, [this]()
-            {
-                this->SubmitValue();
-            });            
+            QObject::connect(m_lineEdit, &QLineEdit::textChanged, [this]() { ResizeToContents(); });
+            QObject::connect(m_lineEdit, &Internal::FocusableLineEdit::OnFocusIn, [this]() { EditStart(); });
+            QObject::connect(m_lineEdit, &Internal::FocusableLineEdit::OnFocusOut, [this]() { EditFinished(); });
+            QObject::connect(m_lineEdit, &QLineEdit::editingFinished, [this]() { SubmitValue(); });
 
             m_proxyWidget->setWidget(m_lineEdit);
             UpdateDisplay();

--- a/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/StringNodePropertyDisplay.h
+++ b/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/StringNodePropertyDisplay.h
@@ -102,7 +102,6 @@ namespace GraphCanvas
         Internal::FocusableLineEdit*    m_lineEdit;
         QGraphicsProxyWidget*           m_proxyWidget;
 
-        bool m_valueDirty;
         bool m_isNudging;
     };
 }

--- a/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/VectorNodePropertyDisplay.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/VectorNodePropertyDisplay.cpp
@@ -281,10 +281,10 @@ namespace GraphCanvas
     void VectorNodePropertyDisplay::SubmitValue()
     {
         AzQtComponents::VectorElement** elements = m_propertyVectorCtrl->getElements();
-        const int elementCount = m_dataInterface->GetElementCount();
+        const int elementCount = m_propertyVectorCtrl->getSize();
         for (int i = 0; i < elementCount; ++i)
         {
-            AzQtComponents::VectorElement* element = elements[i];
+            const AzQtComponents::VectorElement* element = elements[i];
             m_dataInterface->SetValue(i, element->getValue());
         }
         UpdateDisplay();

--- a/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/VectorNodePropertyDisplay.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/VectorNodePropertyDisplay.cpp
@@ -37,10 +37,10 @@ namespace GraphCanvas
         switch (event->type())
         {
         case QEvent::FocusIn:
-            m_owner->OnFocusIn();
+            m_owner->EditStart();
             break;
         case QEvent::FocusOut:
-            m_owner->OnFocusOut();
+            m_owner->EditFinished();
             break;
         default:
             break;
@@ -272,20 +272,27 @@ namespace GraphCanvas
         }
     }
     
-    void VectorNodePropertyDisplay::OnFocusIn()
+    void VectorNodePropertyDisplay::EditStart()
     {
         NodePropertiesRequestBus::Event(GetNodeId(), &NodePropertiesRequests::LockEditState, this);
         TryAndSelectNode();
     }
     
-    void VectorNodePropertyDisplay::SubmitValue(int elementIndex, double newValue)
+    void VectorNodePropertyDisplay::SubmitValue()
     {
-        m_dataInterface->SetValue(elementIndex, newValue);
+        AzQtComponents::VectorElement** elements = m_propertyVectorCtrl->getElements();
+        const int elementCount = m_dataInterface->GetElementCount();
+        for (int i = 0; i < elementCount; ++i)
+        {
+            AzQtComponents::VectorElement* element = elements[i];
+            m_dataInterface->SetValue(i, element->getValue());
+        }
         UpdateDisplay();
     }
 
-    void VectorNodePropertyDisplay::OnFocusOut()
+    void VectorNodePropertyDisplay::EditFinished()
     {
+        SubmitValue();
         NodePropertiesRequestBus::Event(GetNodeId(), &NodePropertiesRequests::UnlockEditState, this);
     }
 
@@ -299,28 +306,22 @@ namespace GraphCanvas
             m_proxyWidget->setFocusPolicy(Qt::StrongFocus);
             m_proxyWidget->setAcceptDrops(false);
 
-            int elementCount = m_dataInterface->GetElementCount();
+            const int elementCount = m_dataInterface->GetElementCount();
             m_propertyVectorCtrl = new AzQtComponents::VectorInput(nullptr, elementCount);
             m_propertyVectorCtrl->setProperty("HasNoWindowDecorations", true);
 
-            AzQtComponents::VectorElement** elements = m_propertyVectorCtrl->getElements();
-
             for (int i = 0; i < elementCount; ++i)
             {
-                AzQtComponents::VectorElement* element = elements[i];
-
                 m_propertyVectorCtrl->setLabel(i, m_dataInterface->GetLabel(i));
                 m_propertyVectorCtrl->setMinimum(m_dataInterface->GetMinimum(i));
                 m_propertyVectorCtrl->setMaximum(m_dataInterface->GetMaximum(i));
                 m_propertyVectorCtrl->setDecimals(m_dataInterface->GetDecimalPlaces(i));
                 m_propertyVectorCtrl->setDisplayDecimals(m_dataInterface->GetDisplayDecimalPlaces(i));
                 m_propertyVectorCtrl->setSuffix(m_dataInterface->GetSuffix(i));
-
-                element->getSpinBox()->installEventFilter(aznew VectorEventFilter(this));
             }
 
             m_propertyVectorCtrl->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-            QObject::connect(m_propertyVectorCtrl, &AzQtComponents::VectorInput::valueAtIndexChanged, [this](int elementIndex, double newValue) { SubmitValue(elementIndex, newValue); });
+            QObject::connect(m_propertyVectorCtrl, &AzQtComponents::VectorInput::editingFinished, [this]() { SubmitValue(); });
 
             m_proxyWidget->setWidget(m_propertyVectorCtrl);
             UpdateDisplay();

--- a/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/VectorNodePropertyDisplay.h
+++ b/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/VectorNodePropertyDisplay.h
@@ -100,12 +100,12 @@ namespace GraphCanvas
     
     private:
 
-        void OnFocusIn();
-        void OnFocusOut();
+        void EditStart();
+        void EditFinished();
         void SetupProxyWidget();
         void CleanupProxyWidget();
         
-        void SubmitValue(int elementIndex, double newValue);
+        void SubmitValue();
     
         Styling::StyleHelper m_styleHelper;
         VectorDataInterface*  m_dataInterface;

--- a/Gems/GraphModel/Code/Include/GraphModel/GraphModelBus.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/GraphModelBus.h
@@ -220,6 +220,10 @@ namespace GraphModelIntegration
         //! The specified node has been unwrapped (removed) from the wrapperNode
         virtual void OnGraphModelNodeUnwrapped(GraphModel::NodePtr /*wrapperNode*/, GraphModel::NodePtr /*node*/){};
 
+        //! Sent whenever a graph model slot value changes
+        //! \param slot The slot that was modified in the graph.
+        virtual void OnGraphModelSlotModified(GraphModel::SlotPtr slot){};
+
         //! Something in the graph has been modified
         //! \param node The node that was modified in the graph.  If this is nullptr, some metadata on the graph itself was modified
         virtual void OnGraphModelGraphModified(GraphModel::NodePtr node){};

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/GraphController.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/GraphController.h
@@ -168,7 +168,6 @@ namespace GraphModelIntegration
         AZStd::string GetDataTypeString(const AZ::Uuid& typeId) override;
 
         //! This is where we find all of the graph metadata (like node positions, comments, etc) and store it in the node graph for serialization
-        // CJS TODO: Use this instead of the above undo functions
         void OnSaveDataDirtied(const AZ::EntityId& savedElement) override;
 
         void OnRemoveUnusedNodes() override {}

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/VectorDataInterface.inl
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/VectorDataInterface.inl
@@ -19,8 +19,7 @@
 namespace GraphModelIntegration
 {
     template<class Type, int ElementCount>
-    class VectorDataInterface
-        : public GraphCanvas::VectorDataInterface
+    class VectorDataInterface : public GraphCanvas::VectorDataInterface
     {
     public:
         AZ_CLASS_ALLOCATOR(VectorDataInterface, AZ::SystemAllocator, 0);
@@ -33,23 +32,17 @@ namespace GraphModelIntegration
 
         const char* GetLabel(int index) const override
         {
-            if (index == 0)
+            switch (index)
             {
+            case 0:
                 return "X";
-            }
-            else if (index == 1)
-            {
+            case 1:
                 return "Y";
-            }
-            else if (index == 2)
-            {
+            case 2:
                 return "Z";
-            }
-            else if (index == 3)
-            {
+            case 3:
                 return "W";
             }
-
             return "???";
         }
         AZStd::string GetStyle() const override
@@ -69,27 +62,30 @@ namespace GraphModelIntegration
         {
             if (GraphModel::SlotPtr slot = m_slot.lock())
             {
-                return slot->GetValue<Type>().GetElement(index);
+                if (index < ElementCount)
+                {
+                    return slot->GetValue<Type>().GetElement(index);
+                }
             }
-            else
-            {
-                return 0.0;
-            }
+            return 0.0;
         }
         void SetValue(int index, double value) override
         {
             if (GraphModel::SlotPtr slot = m_slot.lock())
             {
-                Type vector = slot->GetValue<Type>();
-                if (value != vector.GetElement(index))
+                if (index < ElementCount)
                 {
-                    const GraphCanvas::GraphId graphCanvasSceneId = GetDisplay()->GetSceneId();
-                    GraphCanvas::ScopedGraphUndoBatch undoBatch(graphCanvasSceneId);
+                    Type vector = slot->GetValue<Type>();
+                    if (value != vector.GetElement(index))
+                    {
+                        const GraphCanvas::GraphId graphCanvasSceneId = GetDisplay()->GetSceneId();
+                        GraphCanvas::ScopedGraphUndoBatch undoBatch(graphCanvasSceneId);
 
-                    vector.SetElement(index, aznumeric_cast<float>(value));
-                    slot->SetValue(vector);
-                    GraphControllerNotificationBus::Event(
-                        graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
+                        vector.SetElement(index, aznumeric_cast<float>(value));
+                        slot->SetValue(vector);
+                        GraphControllerNotificationBus::Event(
+                            graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
+                    }
                 }
             }
         }

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/VectorDataInterface.inl
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/VectorDataInterface.inl
@@ -12,6 +12,7 @@
 #include <GraphCanvas/Components/NodePropertyDisplay/VectorDataInterface.h>
 
 // Graph Model
+#include <GraphModel/GraphModelBus.h>
 #include <GraphModel/Integration/IntegrationBus.h>
 #include <GraphModel/Model/Slot.h>
 
@@ -82,12 +83,13 @@ namespace GraphModelIntegration
                 Type vector = slot->GetValue<Type>();
                 if (value != vector.GetElement(index))
                 {
-                    GraphCanvas::GraphId graphCanvasSceneId;
-                    IntegrationBus::BroadcastResult(graphCanvasSceneId, &IntegrationBusInterface::GetActiveGraphCanvasSceneId);
+                    const GraphCanvas::GraphId graphCanvasSceneId = GetDisplay()->GetSceneId();
                     GraphCanvas::ScopedGraphUndoBatch undoBatch(graphCanvasSceneId);
 
                     vector.SetElement(index, aznumeric_cast<float>(value));
                     slot->SetValue(vector);
+                    GraphControllerNotificationBus::Event(
+                        graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
                 }
             }
         }

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/VectorDataInterface.inl
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/VectorDataInterface.inl
@@ -84,6 +84,8 @@ namespace GraphModelIntegration
                         vector.SetElement(index, aznumeric_cast<float>(value));
                         slot->SetValue(vector);
                         GraphControllerNotificationBus::Event(
+                            graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelSlotModified, slot);
+                        GraphControllerNotificationBus::Event(
                             graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
                     }
                 }

--- a/Gems/GraphModel/Code/Source/Integration/BooleanDataInterface.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/BooleanDataInterface.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <GraphModel/GraphModelBus.h>
 #include <GraphModel/Integration/BooleanDataInterface.h>
 #include <GraphModel/Integration/IntegrationBus.h>
 
@@ -34,11 +35,12 @@ namespace GraphModelIntegration
         {
             if (enabled != slot->GetValue<bool>())
             {
-                GraphCanvas::GraphId graphCanvasSceneId;
-                IntegrationBus::BroadcastResult(graphCanvasSceneId, &IntegrationBusInterface::GetActiveGraphCanvasSceneId);
+                const GraphCanvas::GraphId graphCanvasSceneId = GetDisplay()->GetSceneId();
                 GraphCanvas::ScopedGraphUndoBatch undoBatch(graphCanvasSceneId);
 
                 slot->SetValue(enabled);
+                GraphControllerNotificationBus::Event(
+                    graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
             }
         }
     }

--- a/Gems/GraphModel/Code/Source/Integration/BooleanDataInterface.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/BooleanDataInterface.cpp
@@ -40,6 +40,8 @@ namespace GraphModelIntegration
 
                 slot->SetValue(enabled);
                 GraphControllerNotificationBus::Event(
+                    graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelSlotModified, slot);
+                GraphControllerNotificationBus::Event(
                     graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
             }
         }

--- a/Gems/GraphModel/Code/Source/Integration/FloatDataInterface.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/FloatDataInterface.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <GraphModel/GraphModelBus.h>
 #include <GraphModel/Integration/FloatDataInterface.h>
 #include <GraphModel/Integration/IntegrationBus.h>
 
@@ -33,11 +34,12 @@ namespace GraphModelIntegration
         {
             if (static_cast<float>(value) != slot->GetValue<float>())
             {
-                GraphCanvas::GraphId graphCanvasSceneId;
-                IntegrationBus::BroadcastResult(graphCanvasSceneId, &IntegrationBusInterface::GetActiveGraphCanvasSceneId);
+                const GraphCanvas::GraphId graphCanvasSceneId = GetDisplay()->GetSceneId();
                 GraphCanvas::ScopedGraphUndoBatch undoBatch(graphCanvasSceneId);
 
                 slot->SetValue(static_cast<float>(value));
+                GraphControllerNotificationBus::Event(
+                    graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
             }
         }
     }

--- a/Gems/GraphModel/Code/Source/Integration/FloatDataInterface.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/FloatDataInterface.cpp
@@ -39,6 +39,8 @@ namespace GraphModelIntegration
 
                 slot->SetValue(static_cast<float>(value));
                 GraphControllerNotificationBus::Event(
+                    graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelSlotModified, slot);
+                GraphControllerNotificationBus::Event(
                     graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
             }
         }

--- a/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
@@ -832,22 +832,17 @@ namespace GraphModelIntegration
 
     void GraphController::OnNodeAdded(const AZ::EntityId& nodeUiId, bool)
     {
-        const GraphModel::NodePtr node = m_elementMap.Find<GraphModel::Node>(nodeUiId);
-        if (node)
+        if (const GraphModel::NodePtr node = m_elementMap.Find<GraphModel::Node>(nodeUiId))
         {
-            GraphCanvas::ScopedGraphUndoBatch undoBatch(m_graphCanvasSceneId);
             GraphControllerNotificationBus::Event(m_graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelNodeAdded, node);
         }
     }
 
     void GraphController::OnNodeRemoved(const AZ::EntityId& nodeUiId)
     {
-        const GraphModel::NodePtr node = m_elementMap.Find<GraphModel::Node>(nodeUiId);
-        if (node)
+        if (const GraphModel::NodePtr node = m_elementMap.Find<GraphModel::Node>(nodeUiId))
         {
             GraphControllerNotificationBus::Event(m_graphCanvasSceneId, &GraphControllerNotifications::PreOnGraphModelNodeRemoved, node);
-
-            GraphCanvas::ScopedGraphUndoBatch undoBatch(m_graphCanvasSceneId);
 
             // Remove any thumbnail reference for this node when it is removed from the graph
             // The ThumbnailItem will be deleted by the Node layout itself
@@ -869,10 +864,8 @@ namespace GraphModelIntegration
 
     void GraphController::OnConnectionRemoved(const AZ::EntityId& connectionUiId)
     {
-        const GraphModel::ConnectionPtr connection = m_elementMap.Find<GraphModel::Connection>(connectionUiId);
-        if (connection)
+        if (const GraphModel::ConnectionPtr connection = m_elementMap.Find<GraphModel::Connection>(connectionUiId))
         {
-            GraphCanvas::ScopedGraphUndoBatch undoBatch(m_graphCanvasSceneId);
             m_graph->RemoveConnection(connection);
             m_elementMap.Remove(connection);
 
@@ -1360,9 +1353,7 @@ namespace GraphModelIntegration
 
     void GraphController::ResetSlotToDefaultValue(const GraphCanvas::Endpoint& endpoint)
     {
-        auto slot = m_elementMap.Find<GraphModel::Slot>(endpoint.GetSlotId());
-
-        if (slot)
+        if (auto slot = m_elementMap.Find<GraphModel::Slot>(endpoint.GetSlotId()))
         {
             GraphCanvas::ScopedGraphUndoBatch undoBatch(m_graphCanvasSceneId);
             slot->SetValue(slot->GetDefaultValue());
@@ -1406,8 +1397,7 @@ namespace GraphModelIntegration
         GraphCanvas::ScopedGraphUndoBatch undoBatch(m_graphCanvasSceneId);
         GraphCanvas::SlotId graphCanvasSlotId;
 
-        GraphModel::NodePtr node = m_elementMap.Find<GraphModel::Node>(nodeId);
-        if (node)
+        if (GraphModel::NodePtr node = m_elementMap.Find<GraphModel::Node>(nodeId))
         {
             auto it = m_nodeExtenderIds.find(nodeId);
             if (it == m_nodeExtenderIds.end())
@@ -1426,8 +1416,7 @@ namespace GraphModelIntegration
             // Node has overriden the extension handling and rejected the new slot
             const GraphModel::SlotName& slotName = extenderIt->second;
             GraphModel::SlotId newSlotId = ExtendSlot(node, slotName);
-            GraphModel::SlotPtr newSlot = node->GetSlot(newSlotId);
-            if (newSlot)
+            if (GraphModel::SlotPtr newSlot = node->GetSlot(newSlotId))
             {
                 graphCanvasSlotId = m_elementMap.Find(newSlot);
             }

--- a/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
@@ -1187,9 +1187,9 @@ namespace GraphModelIntegration
     template<typename DataInterfaceType, typename CreateDisplayFunctionType>
     GraphCanvas::NodePropertyDisplay* CreatePropertyDisplay(GraphModel::SlotPtr inputSlot, CreateDisplayFunctionType createDisplayFunction)
     {
+        GraphCanvas::NodePropertyDisplay* dataDisplay = nullptr;
         if (inputSlot)
         {
-            GraphCanvas::NodePropertyDisplay* dataDisplay = nullptr;
             GraphCanvas::DataInterface* dataInterface = aznew DataInterfaceType(inputSlot);
             GraphCanvas::GraphCanvasRequestBus::BroadcastResult(
                 dataDisplay, createDisplayFunction, static_cast<DataInterfaceType*>(dataInterface));
@@ -1197,12 +1197,8 @@ namespace GraphModelIntegration
             {
                 delete dataInterface;
             }
-            return dataDisplay;
         }
-        else
-        {
-            return nullptr;
-        }
+        return dataDisplay;
     }
 
     GraphCanvas::NodePropertyDisplay* GraphController::CreatePropertySlotPropertyDisplay(
@@ -1214,8 +1210,13 @@ namespace GraphModelIntegration
         // expects a non-const NodePropertyDisplay*. We need non-const version of m_elementMap in order to create a non-const
         // NodePropertyDisplay
         GraphModel::SlotPtr inputSlot = const_cast<GraphController*>(this)->m_elementMap.Find<GraphModel::Slot>(slotUiId);
-
-        return CreateSlotPropertyDisplay(inputSlot);
+        GraphCanvas::NodePropertyDisplay* display = CreateSlotPropertyDisplay(inputSlot);
+        if (display)
+        {
+            display->SetNodeId(nodeUiId);
+            display->SetSlotId(slotUiId);
+        }
+        return display;
     }
 
     GraphCanvas::NodePropertyDisplay* GraphController::CreateDataSlotPropertyDisplay(
@@ -1237,8 +1238,13 @@ namespace GraphModelIntegration
         // expects a non-const NodePropertyDisplay*. We need non-const version of m_elementMap in order to create a non-const
         // NodePropertyDisplay
         GraphModel::SlotPtr inputSlot = const_cast<GraphController*>(this)->m_elementMap.Find<GraphModel::Slot>(slotUiId);
-
-        return CreateSlotPropertyDisplay(inputSlot);
+        GraphCanvas::NodePropertyDisplay* display = CreateSlotPropertyDisplay(inputSlot);
+        if (display)
+        {
+            display->SetNodeId(nodeUiId);
+            display->SetSlotId(slotUiId);
+        }
+        return display;
     }
 
     GraphCanvas::NodePropertyDisplay* GraphController::CreateSlotPropertyDisplay(GraphModel::SlotPtr inputSlot) const
@@ -1251,46 +1257,45 @@ namespace GraphModelIntegration
         AZ_Assert(
             inputSlot->GetSlotDirection() == GraphModel::SlotDirection::Input, "Property value displays are only meant for input slots");
 
-        GraphCanvas::NodePropertyDisplay* dataDisplay = nullptr;
-        AZ::Uuid dataTypeUuid = inputSlot->GetDataType()->GetTypeUuid();
+        const AZ::Uuid dataTypeUuid = inputSlot->GetDataType()->GetTypeUuid();
 
         if (dataTypeUuid == azrtti_typeid<bool>())
         {
-            dataDisplay =
-                CreatePropertyDisplay<BooleanDataInterface>(inputSlot, &GraphCanvas::GraphCanvasRequests::CreateBooleanNodePropertyDisplay);
+            return CreatePropertyDisplay<BooleanDataInterface>(
+                inputSlot, &GraphCanvas::GraphCanvasRequests::CreateBooleanNodePropertyDisplay);
         }
-        else if (dataTypeUuid == azrtti_typeid<int>())
+        if (dataTypeUuid == azrtti_typeid<int>())
         {
-            dataDisplay =
-                CreatePropertyDisplay<IntegerDataInterface>(inputSlot, &GraphCanvas::GraphCanvasRequests::CreateNumericNodePropertyDisplay);
+            return CreatePropertyDisplay<IntegerDataInterface>(
+                inputSlot, &GraphCanvas::GraphCanvasRequests::CreateNumericNodePropertyDisplay);
         }
-        else if (dataTypeUuid == azrtti_typeid<float>())
+        if (dataTypeUuid == azrtti_typeid<float>())
         {
-            dataDisplay =
-                CreatePropertyDisplay<FloatDataInterface>(inputSlot, &GraphCanvas::GraphCanvasRequests::CreateNumericNodePropertyDisplay);
+            return CreatePropertyDisplay<FloatDataInterface>(
+                inputSlot, &GraphCanvas::GraphCanvasRequests::CreateNumericNodePropertyDisplay);
         }
-        else if (dataTypeUuid == azrtti_typeid<AZ::Vector2>())
+        if (dataTypeUuid == azrtti_typeid<AZ::Vector2>())
         {
-            dataDisplay = CreatePropertyDisplay<VectorDataInterface<AZ::Vector2, 2>>(
+            return CreatePropertyDisplay<VectorDataInterface<AZ::Vector2, 2>>(
                 inputSlot, &GraphCanvas::GraphCanvasRequests::CreateVectorNodePropertyDisplay);
         }
-        else if (dataTypeUuid == azrtti_typeid<AZ::Vector3>())
+        if (dataTypeUuid == azrtti_typeid<AZ::Vector3>())
         {
-            dataDisplay = CreatePropertyDisplay<VectorDataInterface<AZ::Vector3, 3>>(
+            return CreatePropertyDisplay<VectorDataInterface<AZ::Vector3, 3>>(
                 inputSlot, &GraphCanvas::GraphCanvasRequests::CreateVectorNodePropertyDisplay);
         }
-        else if (dataTypeUuid == azrtti_typeid<AZ::Vector4>())
+        if (dataTypeUuid == azrtti_typeid<AZ::Vector4>())
         {
-            dataDisplay = CreatePropertyDisplay<VectorDataInterface<AZ::Vector4, 4>>(
+            return CreatePropertyDisplay<VectorDataInterface<AZ::Vector4, 4>>(
                 inputSlot, &GraphCanvas::GraphCanvasRequests::CreateVectorNodePropertyDisplay);
         }
-        else if (dataTypeUuid == azrtti_typeid<AZStd::string>())
+        if (dataTypeUuid == azrtti_typeid<AZStd::string>())
         {
-            dataDisplay =
-                CreatePropertyDisplay<StringDataInterface>(inputSlot, &GraphCanvas::GraphCanvasRequests::CreateStringNodePropertyDisplay);
+            return CreatePropertyDisplay<StringDataInterface>(
+                inputSlot, &GraphCanvas::GraphCanvasRequests::CreateStringNodePropertyDisplay);
         }
 
-        return dataDisplay;
+        return nullptr;
     }
 
     void GraphController::RequestUndoPoint()

--- a/Gems/GraphModel/Code/Source/Integration/IntegerDataInterface.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/IntegerDataInterface.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <GraphModel/GraphModelBus.h>
 #include <GraphModel/Integration/IntegerDataInterface.h>
 #include <GraphModel/Integration/IntegrationBus.h>
 
@@ -33,11 +34,12 @@ namespace GraphModelIntegration
         {
             if (static_cast<int>(value) != slot->GetValue<int>())
             {
-                GraphCanvas::GraphId graphCanvasSceneId;
-                IntegrationBus::BroadcastResult(graphCanvasSceneId, &IntegrationBusInterface::GetActiveGraphCanvasSceneId);
+                const GraphCanvas::GraphId graphCanvasSceneId = GetDisplay()->GetSceneId();
                 GraphCanvas::ScopedGraphUndoBatch undoBatch(graphCanvasSceneId);
 
                 slot->SetValue(static_cast<int>(value));
+                GraphControllerNotificationBus::Event(
+                    graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
             }
         }
     }

--- a/Gems/GraphModel/Code/Source/Integration/IntegerDataInterface.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/IntegerDataInterface.cpp
@@ -39,6 +39,8 @@ namespace GraphModelIntegration
 
                 slot->SetValue(static_cast<int>(value));
                 GraphControllerNotificationBus::Event(
+                    graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelSlotModified, slot);
+                GraphControllerNotificationBus::Event(
                     graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
             }
         }

--- a/Gems/GraphModel/Code/Source/Integration/ReadOnlyDataInterface.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/ReadOnlyDataInterface.cpp
@@ -23,9 +23,6 @@ namespace GraphModelIntegration
         {
             return slot->GetValue<AZStd::string>();
         }
-        else
-        {
-            return "";
-        }
+        return "";
     }
 }

--- a/Gems/GraphModel/Code/Source/Integration/StringDataInterface.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/StringDataInterface.cpp
@@ -10,8 +10,9 @@
 #include <AzFramework/StringFunc/StringFunc.h>
 
 // Graph Model
-#include <GraphModel/Integration/StringDataInterface.h>
+#include <GraphModel/GraphModelBus.h>
 #include <GraphModel/Integration/IntegrationBus.h>
+#include <GraphModel/Integration/StringDataInterface.h>
 
 namespace GraphModelIntegration
 {
@@ -40,11 +41,12 @@ namespace GraphModelIntegration
 
             if (trimValue != slot->GetValue<AZStd::string>())
             {
-                GraphCanvas::GraphId graphCanvasSceneId;
-                IntegrationBus::BroadcastResult(graphCanvasSceneId, &IntegrationBusInterface::GetActiveGraphCanvasSceneId);
+                const GraphCanvas::GraphId graphCanvasSceneId = GetDisplay()->GetSceneId();
                 GraphCanvas::ScopedGraphUndoBatch undoBatch(graphCanvasSceneId);
 
                 slot->SetValue(trimValue);
+                GraphControllerNotificationBus::Event(
+                    graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
             }
         }
     }

--- a/Gems/GraphModel/Code/Source/Integration/StringDataInterface.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/StringDataInterface.cpp
@@ -46,6 +46,8 @@ namespace GraphModelIntegration
 
                 slot->SetValue(trimValue);
                 GraphControllerNotificationBus::Event(
+                    graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelSlotModified, slot);
+                GraphControllerNotificationBus::Event(
                     graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
             }
         }


### PR DESCRIPTION
## What does this PR do?

This change allows material canvas to consistently receive and process slot data changes whenever the user is done editing. Changes will be sent whenever the user is done editing, whenever focus changes, and other widget specific conditions. Material canvas will now correctly trigger regeneration of shaders, materials, material types after slot values are modified.

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Currently testing changes in material canvas, modifying vector, numeric, and asset properties. Will continue to test changes in landscape canvas and script canvas to make sure those update as expected.