### PR TITLE
TrackView | Fix issue on sequence creation

### DIFF
--- a/Code/Editor/TrackView/TrackViewSequenceManager.cpp
+++ b/Code/Editor/TrackView/TrackViewSequenceManager.cpp
@@ -165,7 +165,7 @@ void CTrackViewSequenceManager::CreateSequence(QString name, [[maybe_unused]] Se
         // add the SequenceComponent. The SequenceComponent's Init() method will call OnCreateSequenceObject() which will actually create
         // the sequence and connect it
         // #TODO LY-21846: Use "SequenceService" to find component, rather than specific component-type.
-        AzToolsFramework::EntityCompositionRequestBus::Broadcast(&AzToolsFramework::EntityCompositionRequests::AddComponentsToEntities, AzToolsFramework::EntityIdList{ newEntityId }, AZ::ComponentTypeList{ "{C02DC0E2-D0F3-488B-B9EE-98E28077EC56}" });
+        AzToolsFramework::EntityCompositionRequestBus::Broadcast(&AzToolsFramework::EntityCompositionRequests::AddComponentsToEntities, AzToolsFramework::EntityIdList{ newEntityId }, AZ::ComponentTypeList{ AZ::TypeId("{C02DC0E2-D0F3-488B-B9EE-98E28077EC56}") });
 
         // restore the Editor selection
         AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(&AzToolsFramework::ToolsApplicationRequests::Bus::Events::SetSelectedEntities, selectedEntities);


### PR DESCRIPTION
Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>

## What does this PR do?

Fixes issue that would prevent sequences to be created correctly in TrackView.
Fixes #12209 

The issue was related to this line
```
AzToolsFramework::EntityCompositionRequestBus::Broadcast(
    &AzToolsFramework::EntityCompositionRequests::AddComponentsToEntities, 
    AzToolsFramework::EntityIdList{ newEntityId }, 
    AZ::ComponentTypeList{ "{C02DC0E2-D0F3-488B-B9EE-98E28077EC56}" }
);
```

While this used to work correctly, the implicit conversion from string to AZ::Uuid/AZ::TypeId in `AZ::ComponentTypeList{ "{C02DC0E2-D0F3-488B-B9EE-98E28077EC56}" })` no longer works and `AddComponentsToEntities` would receive an empty vector, causing it to early out with a success (hence the lack of errors).

While I didn't pinpoint the root cause exactly, my suspicion is that this issue was due to this line relying on implicit conversions that used to work, but no longer does after this change: https://github.com/o3de/o3de/pull/11810

## How was this PR tested?

Verified the previous behavior is restored.
