### PR TITLE
use aznew with AtomRenderPlugin

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.h
@@ -52,7 +52,7 @@ namespace EMStudio
         bool GetIsFloatable() const override;
         bool GetIsVertical() const override;
         bool Init() override;
-        EMStudioPlugin* Clone() const { return new AtomRenderPlugin(); }
+        EMStudioPlugin* Clone() const { return aznew AtomRenderPlugin(); }
         EMStudioPlugin::EPluginType GetPluginType() const override;
         QWidget* GetInnerWidget();
 


### PR DESCRIPTION
## What does this PR do?
Fixes a warning related to using new instead of aznew with AtomRenderPlugin. Partial fix for #11408 (fixes warning but not assert).

## How was this PR tested?
Manually opened and closed animation editor and verified warning did not appear in console.
