### PR TITLE
Add world-space transform to RayTracingSceneSrg::MeshInfo

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingSceneSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingSceneSrg.azsli
@@ -159,6 +159,7 @@ ShaderResourceGroup RayTracingSceneSrg : SRG_RayTracingScene
 
         float4   m_irradianceColor;
         float3x4 m_worldInvTranspose;
+        float3x4 m_world;
     };
 
     // hit shaders can retrieve the MeshInfo for a mesh hit using: RayTracingSceneSrg::m_meshInfo[InstanceIndex()]    

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -188,6 +188,8 @@ namespace AZ
             AZ::Matrix3x3 rotationMatrix = Matrix3x3::CreateFromTransform(noScaleTransform);
             rotationMatrix = rotationMatrix.GetInverseFull().GetTranspose();
             Matrix3x4 worldInvTranspose3x4 = Matrix3x4::CreateFromMatrix3x3(rotationMatrix);
+            Matrix3x4 world3x4 = Matrix3x4::CreateFromTransform(mesh.m_transform);
+            world3x4.MultiplyByScale(mesh.m_nonUniformScale);
 
             // store the mesh buffers and material textures in the resource lists
             for (uint32_t subMeshIndex : mesh.m_subMeshIndices)
@@ -198,6 +200,7 @@ namespace AZ
 
                 subMesh.m_irradianceColor.StoreToFloat4(meshInfo.m_irradianceColor.data());
                 worldInvTranspose3x4.StoreToRowMajorFloat12(meshInfo.m_worldInvTranspose.data());
+                world3x4.StoreToRowMajorFloat12(meshInfo.m_world.data());
                 meshInfo.m_bufferFlags = subMesh.m_bufferFlags;
 
                 // add mesh buffers
@@ -359,12 +362,15 @@ namespace AZ
                 AZ::Matrix3x3 rotationMatrix = Matrix3x3::CreateFromTransform(noScaleTransform);
                 rotationMatrix = rotationMatrix.GetInverseFull().GetTranspose();
                 Matrix3x4 worldInvTranspose3x4 = Matrix3x4::CreateFromMatrix3x3(rotationMatrix);
+                Matrix3x4 world3x4 = Matrix3x4::CreateFromTransform(mesh.m_transform);
+                world3x4.MultiplyByScale(mesh.m_nonUniformScale);
 
                 // update all MeshInfos for this Mesh with the new transform
                 for (const auto& subMeshIndex : mesh.m_subMeshIndices)
                 {
                     MeshInfo& meshInfo = m_meshInfos[subMeshIndex];
                     worldInvTranspose3x4.StoreToRowMajorFloat12(meshInfo.m_worldInvTranspose.data());
+                    world3x4.StoreToRowMajorFloat12(meshInfo.m_world.data());
                 }
             }
 

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -272,6 +272,7 @@ namespace AZ
 
                 AZStd::array<float, 4> m_irradianceColor;    // float4
                 AZStd::array<float, 12> m_worldInvTranspose; // float3x4
+                AZStd::array<float, 12> m_world;             // float3x4
             };
 
             // vector of MeshInfo, transferred to the meshInfoGpuBuffer


### PR DESCRIPTION
## What does this PR do?

This PR adds the world-space transformation of a mesh to the `MeshInfo` struct of the `RayTracingSceneSrg`. This struct already contains `m_worldInvTranspose`, which only consists of the transpose-inverse of the 3x3 rotation matrix of the mesh.
The new field `m_world` is useful if a transformation from the model-space from a given `MeshInfo`-struct instance to world-space is required.

## How was this PR tested?

Internal testing shows that this code works, but since the `MeshInfo` struct is not used in public code (in O3DE or AtomSampleViewer), there is no test coverage other than that.