### PR TITLE
Fix for GHI12221: WhiteBox component crashes with Editor Mode Visual Feedback

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
@@ -615,6 +615,7 @@ namespace AZ::Render
 
         const Data::Instance<RPI::Model> model = m_meshFeatureProcessor->GetModel(*m_meshHandle);
         MeshComponentNotificationBus::Event(m_entityId, &MeshComponentNotificationBus::Events::OnModelReady, GetModelAsset(), model);
+        MeshHandleStateNotificationBus::Event(m_entityId, &MeshHandleStateNotificationBus::Events::OnMeshHandleSet, &(*m_meshHandle));
 
         m_meshFeatureProcessor->SetVisible(*m_meshHandle, IsVisible());
     }

--- a/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxAtomRenderMesh.cpp
+++ b/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxAtomRenderMesh.cpp
@@ -32,7 +32,7 @@ namespace WhiteBox
 
     AtomRenderMesh::~AtomRenderMesh()
     {
-        if (m_meshHandle.IsValid())
+        if (m_meshHandle.IsValid() && m_meshFeatureProcessor)
         {
             m_meshFeatureProcessor->ReleaseMesh(m_meshHandle);
             AZ::Render::MeshHandleStateNotificationBus::Event(

--- a/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxAtomRenderMesh.cpp
+++ b/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxAtomRenderMesh.cpp
@@ -32,6 +32,13 @@ namespace WhiteBox
 
     AtomRenderMesh::~AtomRenderMesh()
     {
+        if (m_meshHandle.IsValid())
+        {
+            m_meshFeatureProcessor->ReleaseMesh(m_meshHandle);
+            AZ::Render::MeshHandleStateNotificationBus::Event(
+                m_entityId, &AZ::Render::MeshHandleStateNotificationBus::Events::OnMeshHandleSet, &m_meshHandle);
+        }
+        
         AZ::Render::MeshHandleStateRequestBus::Handler::BusDisconnect();
         AZ::TickBus::Handler::BusDisconnect();
     }


### PR DESCRIPTION
## What does this PR do?

This PR fixes the crashing issue between `WhiteBox` and Editor Mode Visual Feedback by having the `WhiteBox` component correctly unregister its mesh handle when it goes out of scope.

Additionally, this PR adds the mesh handle registration to the Actor component for completeness (this was previously being obtained implicitly when the `DrawableMeshEntity` components connect to the `MeshHandleStateNotificationBus`, now the handles are registered explicitly by the `Actor` component).

## How was this PR tested?

Manually in the editor.