### PR TITLE
Fix issue with actor reloading using old ModelAsset

### DIFF
--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
@@ -575,9 +575,7 @@ namespace EMotionFX
                 return;
             }
 
-            auto&& dependencies = result.GetValue();
-
-            for (auto&& dependency : dependencies)
+            for (const auto& dependency : result.GetValue())
             {
                 auto dependencyAsset =
                     AZ::Data::AssetManager::Instance().FindAsset(dependency.m_assetId, AZ::Data::AssetLoadBehavior::Default);

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
@@ -584,6 +584,12 @@ namespace EMotionFX
 
                 if (dependencyAsset && dependencyAsset.GetType() == azrtti_typeid<AZ::RPI::ModelAsset>())
                 {
+                    m_modelReloadedEventHandler = AZ::Render::ModelReloadedEvent::Handler(
+                        [this](AZ::Data::Asset<AZ::RPI::ModelAsset> modelAsset)
+                        {
+                            m_actorAsset.QueueLoad();
+                        });
+
                     // Now that the ModelAsset has been found, request a reload.
                     // When this finishes, the callback will trigger a QueueLoad on m_actorAsset.
                     AZ::Render::ModelReloaderSystemInterface::Get()->ReloadModel(dependencyAsset, m_modelReloadedEventHandler);

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
@@ -542,7 +542,7 @@ namespace EMotionFX
             CheckActorCreation();
         }
 
-        void EditorActorComponent::OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset)
+        void EditorActorComponent::OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData>)
         {
             // Release the asset so everything can get unloaded.
             // The Actor asset holds a reference to a ModelAsset which can only be reloaded with a manual call.

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.h
@@ -25,6 +25,8 @@
 #include <LmbrCentral/Rendering/MaterialAsset.h>
 
 #include <EMotionFX/Source/ActorBus.h>
+#include <Atom/Feature/Mesh/MeshFeatureProcessor.h>
+#include <Atom/Feature/Mesh/MeshFeatureProcessor.h>
 
 namespace EMotionFX
 {
@@ -80,6 +82,7 @@ namespace EMotionFX
             // AZ::Data::AssetBus overrides ...
             void OnAssetReady(AZ::Data::Asset<AZ::Data::AssetData> asset) override;
             void OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset) override;
+            void OnAssetUnloaded(AZ::Data::AssetId assetId, AZ::Data::AssetType assetType) override;
 
             // BoundsRequestBus overrides ...
             AZ::Aabb GetWorldBounds() override;
@@ -174,7 +177,7 @@ namespace EMotionFX
             size_t                              m_lodLevel;
             ActorComponent::BoundingBoxConfiguration m_bboxConfig;
             bool                                m_forceUpdateJointsOOV = false;
-            ActorRenderFlags                    m_renderFlags;              ///< Actor render flag               
+            ActorRenderFlags                    m_renderFlags;              ///< Actor render flag
             // \todo attachmentTarget node nr
 
             // Note: LOD work in progress. For now we use one material instead of a list of material, because we don't have the support for LOD with multiple scene files.
@@ -185,6 +188,13 @@ namespace EMotionFX
 
             ActorAsset::ActorInstancePtr        m_actorInstance;            ///< Live actor instance.
             AZStd::unique_ptr<RenderActorInstance> m_renderActorInstance;
+
+            AZ::Render::ModelReloadedEvent::Handler m_modelReloadedEventHandler{ [this](AZ::Data::Asset<AZ::RPI::ModelAsset> modelAsset)
+                                                                                 {
+                                                                                     m_actorAsset.QueueLoad();
+                                                                                 } };
+
+            bool m_reloading = false;
         };
     } // namespace Integration
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.h
@@ -26,7 +26,6 @@
 
 #include <EMotionFX/Source/ActorBus.h>
 #include <Atom/Feature/Mesh/MeshFeatureProcessor.h>
-#include <Atom/Feature/Mesh/MeshFeatureProcessor.h>
 
 namespace EMotionFX
 {

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.h
@@ -188,10 +188,7 @@ namespace EMotionFX
             ActorAsset::ActorInstancePtr        m_actorInstance;            ///< Live actor instance.
             AZStd::unique_ptr<RenderActorInstance> m_renderActorInstance;
 
-            AZ::Render::ModelReloadedEvent::Handler m_modelReloadedEventHandler{ [this](AZ::Data::Asset<AZ::RPI::ModelAsset> modelAsset)
-                                                                                 {
-                                                                                     m_actorAsset.QueueLoad();
-                                                                                 } };
+            AZ::Render::ModelReloadedEvent::Handler m_modelReloadedEventHandler;
 
             bool m_reloading = false;
         };


### PR DESCRIPTION
## What does this PR do?

ModelAssets are set to not auto-reload and when used by Actor assets, they are assigned a unique ID which means the custom reloading system does not handle autoreload either. This fix unloads the actor first to remove all old references, requests a reload of the ModelAsset, and then loads the actor again when that is complete

This fixes https://github.com/o3de/o3de/issues/9764

## How was this PR tested?

Manually following repro steps at the end of here: https://github.com/o3de/o3de/issues/9764