### PR TITLE
Corrected ranges::contain_subrange to return true for an empty subrange

### DIFF
--- a/Code/Framework/AzCore/AzCore/std/ranges/ranges_algorithm.h
+++ b/Code/Framework/AzCore/AzCore/std/ranges/ranges_algorithm.h
@@ -1891,7 +1891,7 @@ namespace AZStd::ranges
             constexpr bool operator()(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
                 Proj1 proj1 = {}, Proj2 proj2 = {}) const
             {
-                return first1 == last2 || !ranges::search(AZStd::move(first1), AZStd::move(last1),
+                return first2 == last2 || !ranges::search(AZStd::move(first1), AZStd::move(last1),
                     AZStd::move(first2), AZStd::move(last2),
                     AZStd::move(pred), AZStd::move(proj1), AZStd::move(proj2)).empty();
             }

--- a/Code/Framework/AzCore/Tests/AZStd/RangesAlgorithmTests.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/RangesAlgorithmTests.cpp
@@ -530,7 +530,7 @@ namespace UnitTest
             searchRange.begin(), searchRange.end()));
         EXPECT_FALSE(AZStd::ranges::contains_subrange(testVector, AZStd::array{735, 32}));
         constexpr AZStd::array<int, 0> emptyRange{};
-        EXPECT_FALSE(AZStd::ranges::contains_subrange(testVector, emptyRange));
+        EXPECT_TRUE(AZStd::ranges::contains_subrange(testVector, emptyRange));
     }
 
     TEST_F(RangesAlgorithmTestFixture, RangesStartsWith_FindsSubrangeAtStart)


### PR DESCRIPTION
Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## What does this PR do?

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_

_Please add links to any issues, RFCs or other items that are relevant to this PR._

## How was this PR tested?

Fixed the `ranges::contains_subrange` unit test to expect true to be returned for an empty subrange(https://en.cppreference.com/w/cpp/algorithm/ranges/contains#Return_value).
