### PR TITLE
Check for nullptr in ClientTransceiver::DisconnectFromTarget()

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/ClientTransceiver.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/ClientTransceiver.cpp
@@ -276,7 +276,10 @@ namespace ScriptCanvas
 
         void ClientTransceiver::DisconnectFromTarget()
         {
-            RemoteToolsInterface::Get()->SendRemoteToolsMessage(m_currentTarget, Message::DisconnectRequest());
+            if (AzFramework::IRemoteTools* remoteTools = RemoteToolsInterface::Get())
+            {
+                remoteTools->SendRemoteToolsMessage(m_currentTarget, Message::DisconnectRequest());
+            }
         }
 
         void ClientTransceiver::CleanupConnection()


### PR DESCRIPTION
Signed-off-by: guillaume-haerinck <guillaume.haerinck@outlook.com>

## What does this PR do?

fix https://github.com/o3de/o3de/issues/11584 by checking that RemoteToolsInterface is not nullptr.
It is the case if the "Remote Tools Connection" gem is not enabled.

The check is done with a syntax similar to the rest of the file.

## How was this PR tested?

Simply run the script canvas debugger and exit it
