### PR TITLE
Group members inherit ChangeNotify

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -355,8 +355,19 @@ namespace AZ::Reflection
                         }
                     }
                 }
-
                 CacheAttributes();
+
+                // Inherit the change notify attribute from our parent
+                const Name changeNotify = Name("ChangeNotify");
+                Dom::Value changeNotifyValue = Find(changeNotify);
+                if (changeNotifyValue.IsNull())
+                {
+                    changeNotifyValue = Find(Name(), changeNotify, parentData);
+                    if (!changeNotifyValue.IsNull())
+                    {
+                        nodeData->m_cachedAttributes.push_back({ Name(), changeNotify, changeNotifyValue });
+                    }
+                }
 
                 const auto& EnumTypeAttribute = DocumentPropertyEditor::Nodes::PropertyEditor::EnumUnderlyingType;
                 Dom::Value enumTypeValue = Find(EnumTypeAttribute.GetName());
@@ -704,6 +715,18 @@ namespace AZ::Reflection
             {
                 const StackEntry& nodeData = m_stack.back();
                 for (auto it = nodeData.m_cachedAttributes.begin(); it != nodeData.m_cachedAttributes.end(); ++it)
+                {
+                    if (it->m_group == group && it->m_name == name)
+                    {
+                        return it->m_value;
+                    }
+                }
+                return Dom::Value();
+            }
+
+            AttributeDataType Find(Name group, Name name, StackEntry& parentData) const
+            {
+                for (auto it = parentData.m_cachedAttributes.begin(); it != parentData.m_cachedAttributes.end(); ++it)
                 {
                     if (it->m_group == group && it->m_name == name)
                     {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.h
@@ -20,6 +20,7 @@ namespace AZ::DocumentPropertyEditor
         : public ReflectionAdapter
         , private AzToolsFramework::PropertyEditorEntityChangeNotificationBus::MultiHandler
         , private AzToolsFramework::ToolsApplicationEvents::Bus::Handler
+        , private AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler
     {
     public:
         //! Creates an uninitialized (empty) ComponentAdapter.
@@ -31,6 +32,8 @@ namespace AZ::DocumentPropertyEditor
         void OnEntityComponentPropertyChanged(AZ::ComponentId componentId) override;
 
         void InvalidatePropertyDisplay(AzToolsFramework::PropertyModificationRefreshLevel level) override;
+
+        void RequestRefresh(AzToolsFramework::PropertyModificationRefreshLevel level) override;
 
         //! Sets the component, connects the appropriate Bus Handlers and sets the reflect data for this instance
         void SetComponent(AZ::Component* componentInstance);


### PR DESCRIPTION
## What does this PR do?

The DPE does not recognize a ChangeNotify attribute on group members that are not individually given the attribute. This PR fixes that by having each member of a group inherit the ChangeNotify of the group parent, so the DPE can broadcast messages properly.

This PR also fixes a crash introduced in #12130, because the entity instance was being deleted in the ComponentAdapter destructor. Also added another bus that listens for the same refresh value that the RPE uses to refresh the inspector.

## How was this PR tested?

Locally with the inspector.

Signed-off-by: Daniel Tamkin <jotamkin@amazon.com>