### PR TITLE
Enabled the RemoteTools Gem in AutomatedTesting.

### DIFF
--- a/AutomatedTesting/Gem/Code/enabled_gems.cmake
+++ b/AutomatedTesting/Gem/Code/enabled_gems.cmake
@@ -66,4 +66,5 @@ set(ENABLED_GEMS
     ScriptAutomation
     DiffuseProbeGrid
     PythonCoverage
+    RemoteTools
 )


### PR DESCRIPTION
This is important to be able to debug Lua scripts
with Lua Editor (aka LuaIDE.exe).

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>

## What does this PR do?

Enabled the RemoteTools Gem in AutomatedTesting. Without this, you can not debug Lua scripts.

## How was this PR tested?
Made sure the LuaIDE can connect to the Editor and was able to debug lua code.  
This picture shows that the Editor Target appears in the LuaIDE.

![image](https://user-images.githubusercontent.com/66021303/192890479-8c52b0b5-6b6f-42eb-9c51-d4ad6ee6a955.png)
