### PR TITLE
Added new flag to clear the asset database if the version of the on-disk database is a future version.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.cpp
@@ -1731,7 +1731,7 @@ namespace AzToolsFramework
             return databaseLocation;
         }
 
-        bool AssetDatabaseConnection::OpenDatabase()
+        bool AssetDatabaseConnection::OpenDatabase(bool ignoreFutureAssetDBVersionError)
         {
             AZ_Assert(!m_databaseConnection, "Already open!");
             AZStd::string assetDatabaseLocation = GetAssetDatabaseFilePath();
@@ -1768,7 +1768,7 @@ namespace AzToolsFramework
             m_validatedTables.clear();
             CreateStatements();
 
-            if (!PostOpenDatabase())
+            if (!PostOpenDatabase(ignoreFutureAssetDBVersionError))
             {
                 CloseDatabase();
                 return false;
@@ -1777,8 +1777,9 @@ namespace AzToolsFramework
             return true;
         }
 
-        bool AssetDatabaseConnection::PostOpenDatabase()
+        bool AssetDatabaseConnection::PostOpenDatabase(bool /*ignoreFutureAssetDBVersionError*/)
         {
+            // AssetDatabase.cpp handles the upgrading and version info, so ignoreFutureAssetDBVersionError isn't checked here.
             if (QueryDatabaseVersion() != CurrentDatabaseVersion())
             {
                 AZ_Error(LOG_NAME, false, "Unable to open database - invalid version - database has %i and we want %i\n", QueryDatabaseVersion(), CurrentDatabaseVersion());

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.h
@@ -461,7 +461,7 @@ namespace AzToolsFramework
             virtual ~AssetDatabaseConnection();
 
             //Open / Close the database
-            bool OpenDatabase();
+            bool OpenDatabase(bool ignoreFutureAssetDBVersionError = false);
             void CloseDatabase();
 
             //These only need to be overridden by derived class if write access is needed, such as by the
@@ -470,7 +470,7 @@ namespace AzToolsFramework
             {
                 return true;
             }
-            virtual bool PostOpenDatabase(); // used by Asset Processor to upgrade the database
+            virtual bool PostOpenDatabase(bool ignoreFutureAssetDBVersionError); // used by Asset Processor to upgrade the database
 
             //returns the current version of the code used for reading the database
             //this is how we know we have to upgrade old databases to the new ones

--- a/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.cpp
@@ -859,7 +859,7 @@ namespace AssetProcessor
     }
 
 
-    bool AssetDatabaseConnection::PostOpenDatabase()
+    bool AssetDatabaseConnection::PostOpenDatabase(bool ignoreFutureAssetDBVersionError)
     {
         DatabaseVersion foundVersion = DatabaseVersion::DatabaseDoesNotExist;
 
@@ -872,10 +872,31 @@ namespace AssetProcessor
         // if its a future version, we don't want to drop tables and blow up, we'd rather just inform the user, and move on:
         if (foundVersion > CurrentDatabaseVersion())
         {
-            AZ_Error(AssetProcessor::ConsoleChannel, false,
-                "The database in the Cache folder appears to be from a NEWER version of Asset Processor than this one.\n"
-                "To prevent loss of data in the cache for the newer version, this Asset Processor will close.\n");
-            return false;
+            if (!ignoreFutureAssetDBVersionError)
+            {
+                AZ_Error(
+                    AssetProcessor::ConsoleChannel,
+                    false,
+                    "The database in the Cache folder appears to be from a NEWER version of Asset Processor than this one.\n"
+                    "To prevent loss of data in the cache for the newer version, this Asset Processor will close.\n");
+                return false;
+            }
+            else
+            {
+                // This will erase the Asset Database. A future version can't be fully resolved,
+                // so if the flag is set to ignore the error, this will erase the Asset Database and create a new one at the current version.
+                // This flag should only be used with automated builds that use the same asset cache across builds of different branches.
+                // This should not be used for individual builds. If an individual finds themselves running into this issue often, the team should
+                // examine their workflows to determine why that individual frequently encounters future Asset Database versions.
+                AZ_TracePrintf(
+                    AssetProcessor::ConsoleChannel,
+                    "The Asset Database in the Cache folder (%i) is from a newer version of the Asset Processor than this one (expected: %i).\n"
+                    "The newer Asset Database will be deleted and a new Asset Database will be constructed.\n",
+                    foundVersion,
+                    CurrentDatabaseVersion()
+                    );
+                dropAllTables = true;
+            }
         }
 
         if (foundVersion == DatabaseVersion::AddedOutputPrefixToScanFolders)
@@ -1182,7 +1203,7 @@ namespace AssetProcessor
         // now that the database matches the schema, update it:
         SetDatabaseVersion(CurrentDatabaseVersion());
 
-        return AzToolsFramework::AssetDatabase::AssetDatabaseConnection::PostOpenDatabase();
+        return AzToolsFramework::AssetDatabase::AssetDatabaseConnection::PostOpenDatabase(ignoreFutureAssetDBVersionError);
     }
 
 

--- a/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.h
+++ b/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.h
@@ -46,7 +46,7 @@ namespace AssetProcessor
 
     protected:
         void CreateStatements() override;
-        bool PostOpenDatabase() override;
+        bool PostOpenDatabase(bool ignoreFutureAssetDBVersionError) override;
         //////////////////////////////////////////////////////////////////////////
 
     public:

--- a/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
@@ -123,7 +123,9 @@ namespace AssetProcessorMessagesTests
             ASSERT_EQ(status, ApplicationManager::BeforeRunStatus::Status_Success);
 
             m_batchApplicationManager->m_platformConfiguration = new PlatformConfiguration();
-            m_batchApplicationManager->InitAssetProcessorManager();
+            
+            AZStd::vector<ApplicationManagerBase::APCommandLineSwitch> commandLineInfo;
+            m_batchApplicationManager->InitAssetProcessorManager(commandLineInfo);
 
             m_assetCatalog = AZStd::make_unique<MockAssetCatalog>(nullptr, m_batchApplicationManager->m_platformConfiguration);
 

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -132,7 +132,7 @@ ApplicationServer* ApplicationManagerBase::GetApplicationServer() const
     return m_applicationServer;
 }
 
-void ApplicationManagerBase::InitAssetProcessorManager()
+void ApplicationManagerBase::InitAssetProcessorManager(AZStd::vector<ApplicationManagerBase::APCommandLineSwitch>& commandLineInfo)
 {
     AssetProcessor::ThreadController<AssetProcessor::AssetProcessorManager>* assetProcessorHelper = new AssetProcessor::ThreadController<AssetProcessor::AssetProcessorManager>();
 
@@ -151,34 +151,20 @@ void ApplicationManagerBase::InitAssetProcessorManager()
     const AzFramework::CommandLine* commandLine = nullptr;
     AzFramework::ApplicationRequests::Bus::BroadcastResult(commandLine, &AzFramework::ApplicationRequests::GetCommandLine);
 
-    struct APCommandLineSwitch
-    {
-        APCommandLineSwitch(const char* switchTitle, const char* helpText)
-            : m_switch(switchTitle)
-            , m_helpText(helpText)
-        {
-
-        }
-        const char* m_switch;
-        const char* m_helpText;
-    };
-
-    const APCommandLineSwitch Command_waitOnLaunch("waitOnLaunch", "Briefly pauses Asset Processor during initializiation. Useful if you want to attach a debugger.");
-    const APCommandLineSwitch Command_zeroAnalysisMode("zeroAnalysisMode", "Enables using file modification time when examining source assets for processing.");
-    const APCommandLineSwitch Command_enableQueryLogging("enableQueryLogging", "Enables logging database queries.");
-    const APCommandLineSwitch Command_dependencyScanPattern("dependencyScanPattern", "Scans assets that match the given pattern for missing product dependencies.");
-    const APCommandLineSwitch Command_dsp("dsp", Command_dependencyScanPattern.m_helpText);
-    const APCommandLineSwitch Command_fileDependencyScanPattern("fileDependencyScanPattern", "Used with dependencyScanPattern to farther filter the scan.");
-    const APCommandLineSwitch Command_fdsp("fdsp", Command_fileDependencyScanPattern.m_helpText);
-    const APCommandLineSwitch Command_additionalScanFolders("additionalScanFolders", "Used with dependencyScanPattern to farther filter the scan.");
-    const APCommandLineSwitch Command_dependencyScanMaxIteration("dependencyScanMaxIteration", "Used to limit the number of recursive searches per line when running dependencyScanPattern.");
-    const APCommandLineSwitch Command_warningLevel("warningLevel", "Configure the error and warning reporting level for AssetProcessor. Pass in 1 for fatal errors, 2 for fatal errors and warnings.");
-    const APCommandLineSwitch Command_acceptInput("acceptInput", "Enable external control messaging via the ControlRequestHandler, used with automated tests.");
-    const APCommandLineSwitch Command_debugOutput("debugOutput", "When enabled, builders that support it will output debug information as product assets. Used primarily with scene files.");
-    const APCommandLineSwitch Command_truncatefingerprint("truncatefingerprint", "Truncates the fingerprint used for processed assets. Useful if you plan to compress product assets to share on another machine because some compression formats like zip will truncate file mod timestamps.");
-    const APCommandLineSwitch Command_reprocessFileList("reprocessFileList", "Reprocesses files in the passed in newline separated text file.");
-    const APCommandLineSwitch Command_help("help", "Displays this message.");
-    const APCommandLineSwitch Command_h("h", Command_help.m_helpText);
+    const APCommandLineSwitch Command_waitOnLaunch(commandLineInfo, "waitOnLaunch", "Briefly pauses Asset Processor during initializiation. Useful if you want to attach a debugger.");
+    const APCommandLineSwitch Command_zeroAnalysisMode(commandLineInfo, "zeroAnalysisMode", "Enables using file modification time when examining source assets for processing.");
+    const APCommandLineSwitch Command_enableQueryLogging(commandLineInfo, "enableQueryLogging", "Enables logging database queries.");
+    const APCommandLineSwitch Command_dependencyScanPattern(commandLineInfo, "dependencyScanPattern", "Scans assets that match the given pattern for missing product dependencies.");
+    const APCommandLineSwitch Command_dsp(commandLineInfo, "dsp", Command_dependencyScanPattern.m_helpText);
+    const APCommandLineSwitch Command_fileDependencyScanPattern(commandLineInfo, "fileDependencyScanPattern", "Used with dependencyScanPattern to farther filter the scan.");
+    const APCommandLineSwitch Command_fdsp(commandLineInfo, "fdsp", Command_fileDependencyScanPattern.m_helpText);
+    const APCommandLineSwitch Command_additionalScanFolders(commandLineInfo, "additionalScanFolders", "Used with dependencyScanPattern to farther filter the scan.");
+    const APCommandLineSwitch Command_dependencyScanMaxIteration(commandLineInfo, "dependencyScanMaxIteration", "Used to limit the number of recursive searches per line when running dependencyScanPattern.");
+    const APCommandLineSwitch Command_warningLevel(commandLineInfo, "warningLevel", "Configure the error and warning reporting level for AssetProcessor. Pass in 1 for fatal errors, 2 for fatal errors and warnings.");
+    const APCommandLineSwitch Command_acceptInput(commandLineInfo, "acceptInput", "Enable external control messaging via the ControlRequestHandler, used with automated tests.");
+    const APCommandLineSwitch Command_debugOutput(commandLineInfo, "debugOutput", "When enabled, builders that support it will output debug information as product assets. Used primarily with scene files.");
+    const APCommandLineSwitch Command_truncatefingerprint(commandLineInfo, "truncatefingerprint", "Truncates the fingerprint used for processed assets. Useful if you plan to compress product assets to share on another machine because some compression formats like zip will truncate file mod timestamps.");
+    const APCommandLineSwitch Command_reprocessFileList(commandLineInfo, "reprocessFileList", "Reprocesses files in the passed in newline separated text file.");
 
     if (commandLine->HasSwitch(Command_waitOnLaunch.m_switch))
     {
@@ -281,6 +267,25 @@ void ApplicationManagerBase::InitAssetProcessorManager()
 
         AssetUtilities::SetTruncateFingerprintTimestamp(precision);
     }
+}
+
+void ApplicationManagerBase::HandleCommandLineHelp(AZStd::vector<ApplicationManagerBase::APCommandLineSwitch>& commandLineInfo)
+{
+    const AzFramework::CommandLine* commandLine = nullptr;
+    AzFramework::ApplicationRequests::Bus::BroadcastResult(commandLine, &AzFramework::ApplicationRequests::GetCommandLine);
+    if (!commandLine)
+    {
+        AZ_TracePrintf(
+            "AssetProcessor",
+            "Asset Processor Command Line information not available, help cannot be printed. This is an application initialization problem "
+            "and should be resolved in code.\n");
+        return;
+    }
+    const APCommandLineSwitch Command_help(commandLineInfo, "help", "Displays this message.");
+    const APCommandLineSwitch Command_h(commandLineInfo, "h", Command_help.m_helpText);
+
+    // The regset command line flag is checked elsewhere, but handled here to make the help text complete.
+    const APCommandLineSwitch Command_regset(commandLineInfo, "regset", "Set the given registry key to the given value.");
 
     if (commandLine->HasSwitch(Command_help.m_switch) || commandLine->HasSwitch(Command_h.m_switch))
     {
@@ -288,23 +293,10 @@ void ApplicationManagerBase::InitAssetProcessorManager()
         // that includes help output, but right now the AssetProcessor just checks strings
         // via HasSwitch. This means this help output has to be updated manually.
         AZ_TracePrintf("AssetProcessor", "Asset Processor Command Line Flags:\n");
-        AZ_TracePrintf("AssetProcessor", "\t%s : %s\n", Command_waitOnLaunch.m_switch, Command_waitOnLaunch.m_helpText);
-        AZ_TracePrintf("AssetProcessor", "\t%s : %s\n", Command_zeroAnalysisMode.m_switch, Command_zeroAnalysisMode.m_helpText);
-        AZ_TracePrintf("AssetProcessor", "\t%s : %s\n", Command_enableQueryLogging.m_switch, Command_enableQueryLogging.m_helpText);
-        AZ_TracePrintf("AssetProcessor", "\t%s : %s\n", Command_dependencyScanPattern.m_switch, Command_dependencyScanPattern.m_helpText);
-        AZ_TracePrintf("AssetProcessor", "\t%s : %s\n", Command_dsp.m_switch, Command_dsp.m_helpText);
-        AZ_TracePrintf("AssetProcessor", "\t%s : %s\n", Command_fileDependencyScanPattern.m_switch, Command_fileDependencyScanPattern.m_helpText);
-        AZ_TracePrintf("AssetProcessor", "\t%s : %s\n", Command_fdsp.m_switch, Command_fdsp.m_helpText);
-        AZ_TracePrintf("AssetProcessor", "\t%s : %s\n", Command_additionalScanFolders.m_switch, Command_additionalScanFolders.m_helpText);
-        AZ_TracePrintf("AssetProcessor", "\t%s : %s\n", Command_dependencyScanMaxIteration.m_switch, Command_dependencyScanMaxIteration.m_helpText);
-        AZ_TracePrintf("AssetProcessor", "\t%s : %s\n", Command_warningLevel.m_switch, Command_warningLevel.m_helpText);
-        AZ_TracePrintf("AssetProcessor", "\t%s : %s\n", Command_acceptInput.m_switch, Command_acceptInput.m_helpText);
-        AZ_TracePrintf("AssetProcessor", "\t%s : %s\n", Command_debugOutput.m_switch, Command_debugOutput.m_helpText);
-        AZ_TracePrintf("AssetProcessor", "\t%s : %s\n", Command_truncatefingerprint.m_switch, Command_truncatefingerprint.m_helpText);
-        AZ_TracePrintf("AssetProcessor", "\t%s : %s\n", Command_reprocessFileList.m_switch, Command_reprocessFileList.m_helpText);
-        AZ_TracePrintf("AssetProcessor", "\t%s : %s\n", Command_help.m_switch, Command_help.m_helpText);
-        AZ_TracePrintf("AssetProcessor", "\t%s : %s\n", Command_h.m_switch, Command_h.m_helpText);
-        AZ_TracePrintf("AssetProcessor", "\tregset : set the given registry key to the given value.\n");
+        for (const auto& command : commandLineInfo)
+        {
+            AZ_TracePrintf("AssetProcessor", "\t%s : %s\n", command.m_switch, command.m_helpText);
+        }
     }
 }
 
@@ -1281,14 +1273,14 @@ void ApplicationManagerBase::ShutdownBuilderManager()
     }
 }
 
-bool ApplicationManagerBase::InitAssetDatabase()
+bool ApplicationManagerBase::InitAssetDatabase(bool ignoreFutureAssetDBVersionError)
 {
     AzToolsFramework::AssetDatabase::AssetDatabaseRequests::Bus::Handler::BusConnect();
 
     // create or upgrade the asset database here, so that it is already good for the rest of the application and the rest
     // of the application does not have to worry about a failure to upgrade or create it.
     AssetProcessor::AssetDatabaseConnection database;
-    if (!database.OpenDatabase())
+    if (!database.OpenDatabase(ignoreFutureAssetDBVersionError))
     {
         return false;
     }
@@ -1415,7 +1407,16 @@ bool ApplicationManagerBase::Activate()
         return false;
     }
 
-    if (!InitAssetDatabase())
+    const AzFramework::CommandLine* commandLine = nullptr;
+    AzFramework::ApplicationRequests::Bus::BroadcastResult(commandLine, &AzFramework::ApplicationRequests::GetCommandLine);
+
+    AZStd::vector<APCommandLineSwitch> commandLineInfo;
+    const APCommandLineSwitch Command_ignoreFutureDBError(commandLineInfo, "ignoreFutureAssetDatabaseVersionError", "When not set, if the Asset Processor encounters an Asset Database "
+        "with a future version, it will emit an error and shut down. When set, instead it will print the error as a log and erase the Asset Database, then it will proceed to initialize. "
+        "This is intended for use with automated builds, and shouldn't be used by individuals. If an individual finds they want to use this flag frequently, the team should "
+        "examine their workflows to determine why some team members encounter issues with future versioned Asset Databases.");
+
+    if (!InitAssetDatabase(commandLine->HasSwitch(Command_ignoreFutureDBError.m_switch)))
     {
         // AssetDatabaseConnection::OpenDatabase reports any errors it encounters.
         return false;
@@ -1436,7 +1437,8 @@ bool ApplicationManagerBase::Activate()
     InitBuilderConfiguration();
     PopulateApplicationDependencies();
 
-    InitAssetProcessorManager();
+    InitAssetProcessorManager(commandLineInfo);
+    HandleCommandLineHelp(commandLineInfo);
     AssetBuilderSDK::InitializeSerializationContext();
     AssetBuilderSDK::InitializeBehaviorContext();
     AssetBuilder::InitializeSerializationContext();

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.h
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.h
@@ -119,6 +119,20 @@ public:
 
     bool IsAssetProcessorManagerIdle() const override;
     bool CheckFullIdle();
+
+    // Used to track AP command line checks, so the help can be easily printed.
+    struct APCommandLineSwitch
+    {
+        APCommandLineSwitch(AZStd::vector<APCommandLineSwitch>& commandLineInfo, const char* switchTitle, const char* helpText)
+            : m_switch(switchTitle)
+            , m_helpText(helpText)
+        {
+            commandLineInfo.push_back(*this);
+        }
+        const char* m_switch;
+        const char* m_helpText;
+    };
+
 Q_SIGNALS:
     void CheckAssetProcessorManagerIdleState();
     void ConnectionStatusMsg(QString message);
@@ -130,7 +144,7 @@ public Q_SLOTS:
     void OnAssetProcessorManagerIdleState(bool isIdle);
 
 protected:
-    virtual void InitAssetProcessorManager();//Deletion of assetProcessor Manager will be handled by the ThreadController
+    virtual void InitAssetProcessorManager(AZStd::vector<APCommandLineSwitch>& commandLineInfo);//Deletion of assetProcessor Manager will be handled by the ThreadController
     virtual void InitAssetCatalog();//Deletion of AssetCatalog will be handled when the ThreadController is deleted by the base ApplicationManager
     virtual void InitRCController();
     virtual void DestroyRCController();
@@ -154,7 +168,7 @@ protected:
     bool InitializeInternalBuilders();
     void InitBuilderManager();
     void ShutdownBuilderManager();
-    bool InitAssetDatabase();
+    bool InitAssetDatabase(bool ignoreFutureAssetDBVersionError);
     void ShutDownAssetDatabase();
     void InitAssetServerHandler();
     void DestroyAssetServerHandler();
@@ -163,6 +177,8 @@ protected:
     virtual void InitSourceControl() = 0;
     void InitInputThread();
     void InputThread();
+
+    void HandleCommandLineHelp(AZStd::vector<APCommandLineSwitch>& commandLineInfo);
 
     // Give an opportunity to derived classes to make connections before the application server starts listening
     virtual void MakeActivationConnections() {}


### PR DESCRIPTION
Added new flag to clear the asset database if the version of the on-disk database is a future version.
This is to be used with Jenkins builds, to make it easier to share the cache across builds.

Signed-off-by: AMZN-stankowi <4838196+AMZN-stankowi@users.noreply.github.com>

## What does this PR do?

Added new flag to clear the asset database if the version of the on-disk database is a future version.
This is to be used with Jenkins builds, to make it easier to share the cache across builds.

## How was this PR tested?

Manual testing so far, there is going to be a separate PR to make use of this on Jenkins.

![image](https://user-images.githubusercontent.com/4838196/192894370-a4b1078e-f25e-4914-ba4a-63339ca0f6a3.png)
![image](https://user-images.githubusercontent.com/4838196/192894383-a2f1fe92-a8f2-4097-ac26-909203b82d51.png)

