### PR TITLE
AzCore and AzCore.Tests GCC build fixes

### DIFF
--- a/Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h
@@ -516,8 +516,6 @@ namespace AZ
     {
     private:
         typedef typename AZStd::RemoveEnum<T>::type UnderlyingType;
-        // Used to provide a reference to a Uuid with a null value = {00000000-0000-0000-0000-000000000000}
-        inline static constexpr AZ::TypeId s_nullTypeId_v;
     public:
         static constexpr const char* Name()
         {
@@ -532,7 +530,7 @@ namespace AZ
         }
 
         template<typename TypeIdResolverTag = CanonicalTypeIdTag>
-        static constexpr AZ::TypeId Uuid() { return s_nullTypeId_v; }
+        static constexpr AZ::TypeId Uuid() { return AZ::TypeId{}; }
         static constexpr TypeTraits GetTypeTraits()
         {
             TypeTraits typeTraits{};

--- a/Code/Framework/AzCore/AzCore/std/chrono/chrono.h
+++ b/Code/Framework/AzCore/AzCore/std/chrono/chrono.h
@@ -94,7 +94,7 @@ namespace AZStd::chrono
 #else
     template<class Duration>
     using sys_time = time_point<system_clock, Duration>;
-    using sys_seconds = sys_time<seconds>;
+    using sys_seconds = sys_time<std::chrono::seconds>;
     using sys_days = sys_time<days>;
 #endif
 
@@ -119,12 +119,12 @@ namespace AZStd::chrono
         {
             return m_leap_second_date;
         }
-        constexpr seconds value() const noexcept
+        constexpr std::chrono::seconds value() const noexcept
         {
             return m_value;
         }
 
-        constexpr leap_second(sys_seconds leap_second_date, seconds value)
+        constexpr leap_second(sys_seconds leap_second_date, std::chrono::seconds value)
             : m_leap_second_date(leap_second_date)
             , m_value(value)
         {
@@ -132,7 +132,7 @@ namespace AZStd::chrono
 
     private:
         sys_seconds m_leap_second_date;
-        seconds m_value;
+        std::chrono::seconds m_value;
     };
 
     constexpr bool operator==(const leap_second& x, const leap_second& y) noexcept
@@ -228,27 +228,27 @@ namespace AZStd::chrono
         // http://eel.is/c++draft/time#zone.leap
         // https://www.ietf.org/timezones/data/leap-seconds.list
         static constexpr auto LeapSecondTable = to_array<leap_second>({
-            { sys_seconds{ seconds{ 78796800 } }, seconds{ 1 } },   { sys_seconds{ seconds{ 94694400 } }, seconds{ 1 } },
-            { sys_seconds{ seconds{ 126230400 } }, seconds{ 1 } },  { sys_seconds{ seconds{ 157766400 } }, seconds{ 1 } },
-            { sys_seconds{ seconds{ 189302400 } }, seconds{ 1 } },  { sys_seconds{ seconds{ 220924800 } }, seconds{ 1 } },
-            { sys_seconds{ seconds{ 252460800 } }, seconds{ 1 } },  { sys_seconds{ seconds{ 283996800 } }, seconds{ 1 } },
-            { sys_seconds{ seconds{ 315532800 } }, seconds{ 1 } },  { sys_seconds{ seconds{ 362793600 } }, seconds{ 1 } },
-            { sys_seconds{ seconds{ 394329600 } }, seconds{ 1 } },  { sys_seconds{ seconds{ 425865600 } }, seconds{ 1 } },
-            { sys_seconds{ seconds{ 489024000 } }, seconds{ 1 } },  { sys_seconds{ seconds{ 567993600 } }, seconds{ 1 } },
-            { sys_seconds{ seconds{ 631152000 } }, seconds{ 1 } },  { sys_seconds{ seconds{ 662688000 } }, seconds{ 1 } },
-            { sys_seconds{ seconds{ 709948800 } }, seconds{ 1 } },  { sys_seconds{ seconds{ 741484800 } }, seconds{ 1 } },
-            { sys_seconds{ seconds{ 773020800 } }, seconds{ 1 } },  { sys_seconds{ seconds{ 820454400 } }, seconds{ 1 } },
-            { sys_seconds{ seconds{ 867715200 } }, seconds{ 1 } },  { sys_seconds{ seconds{ 915148800 } }, seconds{ 1 } },
-            { sys_seconds{ seconds{ 1136073600 } }, seconds{ 1 } }, { sys_seconds{ seconds{ 1230768000 } }, seconds{ 1 } },
-            { sys_seconds{ seconds{ 1341100800 } }, seconds{ 1 } }, { sys_seconds{ seconds{ 1435708800 } }, seconds{ 1 } },
-            { sys_seconds{ seconds{ 1483228800 } }, seconds{ 1 } },
+            { sys_seconds{ std::chrono::seconds{ 78796800 } }, std::chrono::seconds{ 1 } },   { sys_seconds{ std::chrono::seconds{ 94694400 } }, std::chrono::seconds{ 1 } },
+            { sys_seconds{ std::chrono::seconds{ 126230400 } }, std::chrono::seconds{ 1 } },  { sys_seconds{ std::chrono::seconds{ 157766400 } }, std::chrono::seconds{ 1 } },
+            { sys_seconds{ std::chrono::seconds{ 189302400 } }, std::chrono::seconds{ 1 } },  { sys_seconds{ std::chrono::seconds{ 220924800 } }, std::chrono::seconds{ 1 } },
+            { sys_seconds{ std::chrono::seconds{ 252460800 } }, std::chrono::seconds{ 1 } },  { sys_seconds{ std::chrono::seconds{ 283996800 } }, std::chrono::seconds{ 1 } },
+            { sys_seconds{ std::chrono::seconds{ 315532800 } }, std::chrono::seconds{ 1 } },  { sys_seconds{ std::chrono::seconds{ 362793600 } }, std::chrono::seconds{ 1 } },
+            { sys_seconds{ std::chrono::seconds{ 394329600 } }, std::chrono::seconds{ 1 } },  { sys_seconds{ std::chrono::seconds{ 425865600 } }, std::chrono::seconds{ 1 } },
+            { sys_seconds{ std::chrono::seconds{ 489024000 } }, std::chrono::seconds{ 1 } },  { sys_seconds{ std::chrono::seconds{ 567993600 } }, std::chrono::seconds{ 1 } },
+            { sys_seconds{ std::chrono::seconds{ 631152000 } }, std::chrono::seconds{ 1 } },  { sys_seconds{ std::chrono::seconds{ 662688000 } }, std::chrono::seconds{ 1 } },
+            { sys_seconds{ std::chrono::seconds{ 709948800 } }, std::chrono::seconds{ 1 } },  { sys_seconds{ std::chrono::seconds{ 741484800 } }, std::chrono::seconds{ 1 } },
+            { sys_seconds{ std::chrono::seconds{ 773020800 } }, std::chrono::seconds{ 1 } },  { sys_seconds{ std::chrono::seconds{ 820454400 } }, std::chrono::seconds{ 1 } },
+            { sys_seconds{ std::chrono::seconds{ 867715200 } }, std::chrono::seconds{ 1 } },  { sys_seconds{ std::chrono::seconds{ 915148800 } }, std::chrono::seconds{ 1 } },
+            { sys_seconds{ std::chrono::seconds{ 1136073600 } }, std::chrono::seconds{ 1 } }, { sys_seconds{ std::chrono::seconds{ 1230768000 } }, std::chrono::seconds{ 1 } },
+            { sys_seconds{ std::chrono::seconds{ 1341100800 } }, std::chrono::seconds{ 1 } }, { sys_seconds{ std::chrono::seconds{ 1435708800 } }, std::chrono::seconds{ 1 } },
+            { sys_seconds{ std::chrono::seconds{ 1483228800 } }, std::chrono::seconds{ 1 } },
         });
     } // namespace Internal
 
     struct leap_second_info
     {
         bool is_leap_second{};
-        seconds elapsed{};
+        std::chrono::seconds elapsed{};
     };
 
     //! utc_clock and its associated time_point utc_time utc_time,
@@ -258,7 +258,7 @@ namespace AZStd::chrono
 
     template<class Duration>
     using utc_time = time_point<utc_clock, Duration>;
-    using utc_seconds = utc_time<seconds>;
+    using utc_seconds = utc_time<std::chrono::seconds>;
 
     class utc_clock
     {
@@ -266,8 +266,8 @@ namespace AZStd::chrono
         // Re-use the system_clock representation and tick period type
         using rep = system_clock::rep;
         using period = system_clock::period;
-        using duration = duration<rep, period>;
-        using time_point = time_point<utc_clock>;
+        using duration = chrono::duration<rep, period>;
+        using time_point = chrono::time_point<utc_clock>;
         static constexpr bool is_steady = system_clock::is_steady;
 
         static time_point now()
@@ -276,27 +276,27 @@ namespace AZStd::chrono
         }
 
         template<class Duration>
-        static sys_time<common_type_t<Duration, seconds>> to_sys(const utc_time<Duration>& t)
+        static sys_time<common_type_t<Duration, std::chrono::seconds>> to_sys(const utc_time<Duration>& t)
         {
-            using common_type = common_type_t<Duration, seconds>;
+            using common_type = common_type_t<Duration, std::chrono::seconds>;
             leap_second_info lsi = get_leap_second_info(t);
             common_type ticks;
             if (lsi.is_leap_second)
             {
                 // the leap second that is being inserted is not included in the sys_time
                 // and last representable value before the insertion of the leap second is returned
-                auto elapsedSeconds = floor<seconds>(t.time_since_epoch()) - lsi.elapsed;
+                auto elapsedSeconds = floor<std::chrono::seconds>(t.time_since_epoch()) - lsi.elapsed;
                 if constexpr (is_integral_v<typename duration::rep>)
                 {
                     // increment the last representable value for the common_type that is less than a second
-                    ticks = elapsedSeconds + seconds(1) - common_type(1);
+                    ticks = elapsedSeconds + std::chrono::seconds(1) - common_type(1);
                 }
                 else
                 {
                     // Find the next floating point value in the direction of 0.0
                     // This returns a value the last representable value for the common type that is
                     // round_to_next_lowest_representable_float_value(elapsedSeconds + 1)
-                    ticks = common_type{ nextafter(ceil<common_type>(elapsedSeconds + seconds(1)).count(), typename common_type::rep{ 0 }) };
+                    ticks = common_type{ nextafter(ceil<common_type>(elapsedSeconds + std::chrono::seconds(1)).count(), typename common_type::rep{ 0 }) };
                 }
             }
             else
@@ -306,10 +306,10 @@ namespace AZStd::chrono
             return sys_time<common_type>{ ticks };
         }
         template<class Duration>
-        static utc_time<common_type_t<Duration, seconds>> from_sys(const sys_time<Duration>& t)
+        static utc_time<common_type_t<Duration, std::chrono::seconds>> from_sys(const sys_time<Duration>& t)
         {
             // count the number of elapsed leap seconds
-            seconds elapsed{};
+            std::chrono::seconds elapsed{};
             for (size_t i = 0; i < Internal::LeapSecondTable.size(); ++i, ++elapsed)
             {
                 const leap_second& leapSecond = Internal::LeapSecondTable[i];
@@ -318,7 +318,7 @@ namespace AZStd::chrono
                     break;
                 }
             }
-            return utc_time<common_type_t<Duration, seconds>>{ t.time_since_epoch() + elapsed };
+            return utc_time<common_type_t<Duration, std::chrono::seconds>>{ t.time_since_epoch() + elapsed };
         }
     };
 
@@ -387,7 +387,7 @@ namespace AZStd::chrono
     };
     template<class Duration>
     using local_time = time_point<local_t, Duration>;
-    using local_seconds = local_time<seconds>;
+    using local_seconds = local_time<std::chrono::seconds>;
     using local_days = local_time<days>;
 #endif
     // [time.clock.cast](http://eel.is/c++draft/time#clock.cast), time_­point conversions
@@ -2309,7 +2309,7 @@ namespace AZStd::chrono
             return decimalExp == MaxExp ? 6 : decimalExp;
         }();
 
-        using precision = duration<common_type_t<typename Duration::rep, typename seconds::rep>, ratio<1, pow_10_exponentiate(fractional_width)>>;
+        using precision = duration<common_type_t<typename Duration::rep, typename std::chrono::seconds::rep>, ratio<1, pow_10_exponentiate(fractional_width)>>;
 
         hh_mm_ss() noexcept
             : hh_mm_ss(Duration::zero())
@@ -2320,7 +2320,7 @@ namespace AZStd::chrono
             : m_is_negative{ d < Duration::zero() }
             , m_hours{ duration_cast<chrono::hours>(abs(d)) }
             , m_minutes{ duration_cast<chrono::minutes>(abs(d) - m_hours) }
-            , m_seconds{ duration_cast<chrono::seconds>(abs(d) - m_hours - m_minutes) }
+            , m_seconds{ duration_cast<std::chrono::seconds>(abs(d) - m_hours - m_minutes) }
             , m_subseconds{ precision::zero() }
         {
             if constexpr (treat_as_floating_point_v<typename precision::rep>)
@@ -2346,7 +2346,7 @@ namespace AZStd::chrono
         {
             return m_minutes;
         }
-        constexpr chrono::seconds seconds() const noexcept
+        constexpr std::chrono::seconds seconds() const noexcept
         {
             return m_seconds;
         }
@@ -2370,7 +2370,7 @@ namespace AZStd::chrono
         bool m_is_negative{};
         chrono::hours m_hours;
         chrono::minutes m_minutes;
-        chrono::seconds m_seconds;
+        std::chrono::seconds m_seconds;
         precision m_subseconds;
     };
 #endif

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -361,7 +361,7 @@ namespace AzToolsFramework
 
         if (pAssetType)
         {
-            (*pAssetType) = {};
+            (*pAssetType) = AZ::Data::AssetType{};
         }
 
         if (!pData)
@@ -535,7 +535,7 @@ namespace AzToolsFramework
             m_errorButton = nullptr;
         }
     }
-    
+
     void PropertyAssetCtrl::UpdateErrorButton()
     {
         if (m_errorButton)
@@ -600,11 +600,11 @@ namespace AzToolsFramework
             logDialog->show();
         });
     }
-    
+
     void PropertyAssetCtrl::UpdateErrorButtonWithMessage(const AZStd::string& message)
     {
         UpdateErrorButton();
-        
+
         connect(m_errorButton, &QPushButton::clicked, this, [this, message]() {
             QMessageBox::critical(nullptr, "Error", message.c_str());
 

--- a/Code/Tools/LuaIDE/Source/LUA/WatchesPanel.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/WatchesPanel.cpp
@@ -364,7 +364,7 @@ void WatchesDataModel::AddWatch(AZStd::string newName)
     dv.m_name = newName;
     dv.m_value = "<invalid>";
     dv.m_type = LUA_TNONE;
-    dv.m_typeId = {};
+    dv.m_typeId = AZ::ScriptTypeId{};
     dv.m_flags = 0;
 
     AddWatch(dv);

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ReflectionProbe/ReflectionProbeComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ReflectionProbe/ReflectionProbeComponentController.cpp
@@ -168,7 +168,7 @@ namespace AZ
             if (m_featureProcessor)
             {
                 m_featureProcessor->RemoveReflectionProbe(m_handle);
-                m_handle = {};
+                m_handle = ReflectionProbeHandle{};
             }
 
             LmbrCentral::ShapeComponentNotificationsBus::Handler::BusDisconnect();

--- a/Gems/LandscapeCanvas/Code/Source/Editor/Core/Core.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/Core/Core.h
@@ -17,60 +17,60 @@
 
 namespace LandscapeCanvas
 {
-    static const GraphCanvas::EditorId LANDSCAPE_CANVAS_EDITOR_ID = AZ_CRC("LandscapeCanvasEditor", 0x57f5535f);
+    inline const GraphCanvas::EditorId LANDSCAPE_CANVAS_EDITOR_ID = AZ_CRC("LandscapeCanvasEditor", 0x57f5535f);
 
-    static constexpr const char* SYSTEM_NAME = "Landscape Canvas";
-    static constexpr const char* MODULE_FILE_EXTENSION = ".landscapecanvas";
-    static constexpr const char* MIME_EVENT_TYPE = "landscapecanvas/node-palette-mime-event";
-    static constexpr const char* SAVE_IDENTIFIER = "LandscapeCanvas";
-    static constexpr const char* CONTEXT_MENU_SAVE_IDENTIFIER = "LandscapeCanvas_ContextMenu";
+    inline constexpr const char* SYSTEM_NAME = "Landscape Canvas";
+    inline constexpr const char* MODULE_FILE_EXTENSION = ".landscapecanvas";
+    inline constexpr const char* MIME_EVENT_TYPE = "landscapecanvas/node-palette-mime-event";
+    inline constexpr const char* SAVE_IDENTIFIER = "LandscapeCanvas";
+    inline constexpr const char* CONTEXT_MENU_SAVE_IDENTIFIER = "LandscapeCanvas_ContextMenu";
 
     // Connection slot names (not translated, only used internally)
-    static constexpr const char* PREVIEW_BOUNDS_SLOT_ID = "PreviewBounds";
-    static constexpr const char* PLACEMENT_BOUNDS_SLOT_ID = "PlacementBounds";
-    static constexpr const char* INBOUND_GRADIENT_SLOT_ID = "InboundGradient";
-    static constexpr const char* OUTBOUND_GRADIENT_SLOT_ID = "OutboundGradient";
-    static constexpr const char* INBOUND_AREA_SLOT_ID = "InboundArea";
-    static constexpr const char* OUTBOUND_AREA_SLOT_ID = "OutboundArea";
-    static constexpr const char* INBOUND_SHAPE_SLOT_ID = "InboundShape";
-    static constexpr const char* INPUT_BOUNDS_SLOT_ID = "InputBounds";
-    static constexpr const char* PIN_TO_SHAPE_SLOT_ID = "PinToShape";
-    static constexpr const char* ENTITY_NAME_SLOT_ID = "EntityName";
-    static constexpr const char* IMAGE_ASSET_SLOT_ID = "ImageAsset";
-    static constexpr const char* OUTPUT_IMAGE_SLOT_ID = "OutputImage";
+    inline constexpr const char* PREVIEW_BOUNDS_SLOT_ID = "PreviewBounds";
+    inline constexpr const char* PLACEMENT_BOUNDS_SLOT_ID = "PlacementBounds";
+    inline constexpr const char* INBOUND_GRADIENT_SLOT_ID = "InboundGradient";
+    inline constexpr const char* OUTBOUND_GRADIENT_SLOT_ID = "OutboundGradient";
+    inline constexpr const char* INBOUND_AREA_SLOT_ID = "InboundArea";
+    inline constexpr const char* OUTBOUND_AREA_SLOT_ID = "OutboundArea";
+    inline constexpr const char* INBOUND_SHAPE_SLOT_ID = "InboundShape";
+    inline constexpr const char* INPUT_BOUNDS_SLOT_ID = "InputBounds";
+    inline constexpr const char* PIN_TO_SHAPE_SLOT_ID = "PinToShape";
+    inline constexpr const char* ENTITY_NAME_SLOT_ID = "EntityName";
+    inline constexpr const char* IMAGE_ASSET_SLOT_ID = "ImageAsset";
+    inline constexpr const char* OUTPUT_IMAGE_SLOT_ID = "OutputImage";
 
     // Category title labels
-    static const char* GRADIENT_TITLE = "Gradient";
-    static const char* GRADIENT_GENERATOR_TITLE = "Gradient";
-    static const char* GRADIENT_MODIFIER_TITLE = "Gradient Modifier";
-    static const char* VEGETATION_AREA_TITLE = "Vegetation Area";
-    static const char* TERRAIN_TITLE = "Terrain";
+    inline constexpr const char* GRADIENT_TITLE = "Gradient";
+    inline constexpr const char* GRADIENT_GENERATOR_TITLE = "Gradient";
+    inline constexpr const char* GRADIENT_MODIFIER_TITLE = "Gradient Modifier";
+    inline constexpr const char* VEGETATION_AREA_TITLE = "Vegetation Area";
+    inline constexpr const char* TERRAIN_TITLE = "Terrain";
 
     // Connection slot labels
-    static const QString PREVIEW_BOUNDS_SLOT_LABEL = QObject::tr("Preview Bounds");
-    static const QString PLACEMENT_BOUNDS_SLOT_LABEL = QObject::tr("Placement Bounds");
-    static const QString INBOUND_GRADIENT_SLOT_LABEL = QObject::tr("Inbound Gradient");
-    static const QString OUTBOUND_GRADIENT_SLOT_LABEL = QObject::tr("Outbound Gradient");
-    static const QString INBOUND_AREA_SLOT_LABEL = QObject::tr("Inbound Area");
-    static const QString OUTBOUND_AREA_SLOT_LABEL = QObject::tr("Outbound Area");
-    static const QString INBOUND_SHAPE_SLOT_LABEL = QObject::tr("Inbound Shape");
-    static const QString INPUT_BOUNDS_SLOT_LABEL = QObject::tr("Input Bounds");
-    static const QString PIN_TO_SHAPE_SLOT_LABEL = QObject::tr("Pin To Shape");
-    static const QString ENTITY_NAME_SLOT_LABEL = QObject::tr("Entity Name");
-    static const QString IMAGE_ASSET_SLOT_LABEL = QObject::tr("Image Asset");
-    static const QString OUTPUT_IMAGE_SLOT_LABEL = QObject::tr("Output Image");
+    inline const QString PREVIEW_BOUNDS_SLOT_LABEL = QObject::tr("Preview Bounds");
+    inline const QString PLACEMENT_BOUNDS_SLOT_LABEL = QObject::tr("Placement Bounds");
+    inline const QString INBOUND_GRADIENT_SLOT_LABEL = QObject::tr("Inbound Gradient");
+    inline const QString OUTBOUND_GRADIENT_SLOT_LABEL = QObject::tr("Outbound Gradient");
+    inline const QString INBOUND_AREA_SLOT_LABEL = QObject::tr("Inbound Area");
+    inline const QString OUTBOUND_AREA_SLOT_LABEL = QObject::tr("Outbound Area");
+    inline const QString INBOUND_SHAPE_SLOT_LABEL = QObject::tr("Inbound Shape");
+    inline const QString INPUT_BOUNDS_SLOT_LABEL = QObject::tr("Input Bounds");
+    inline const QString PIN_TO_SHAPE_SLOT_LABEL = QObject::tr("Pin To Shape");
+    inline const QString ENTITY_NAME_SLOT_LABEL = QObject::tr("Entity Name");
+    inline const QString IMAGE_ASSET_SLOT_LABEL = QObject::tr("Image Asset");
+    inline const QString OUTPUT_IMAGE_SLOT_LABEL = QObject::tr("Output Image");
 
     // Connection slot descriptions
-    static const QString PREVIEW_BOUNDS_INPUT_SLOT_DESCRIPTION = QObject::tr("Preview Bounds input slot");
-    static const QString PLACEMENT_BOUNDS_INPUT_SLOT_DESCRIPTION = QObject::tr("Placement Bounds input slot");
-    static const QString INBOUND_GRADIENT_INPUT_SLOT_DESCRIPTION = QObject::tr("Inbound Gradient input slot");
-    static const QString OUTBOUND_GRADIENT_OUTPUT_SLOT_DESCRIPTION = QObject::tr("Outbound Gradient output slot");
-    static const QString INBOUND_AREA_INPUT_SLOT_DESCRIPTION = QObject::tr("Inbound Area input slot");
-    static const QString OUTBOUND_AREA_OUTPUT_SLOT_DESCRIPTION = QObject::tr("Outbound Area output slot");
-    static const QString INBOUND_SHAPE_INPUT_SLOT_DESCRIPTION = QObject::tr("Inbound Shape input slot");
-    static const QString INPUT_BOUNDS_INPUT_SLOT_DESCRIPTION = QObject::tr("Input Bounds input slot");
-    static const QString PIN_TO_SHAPE_INPUT_SLOT_DESCRIPTION = QObject::tr("Pin To Shape input slot");
-    static const QString ENTITY_NAME_SLOT_DESCRIPTION = QObject::tr("Vegetation entity name");
-    static const QString IMAGE_ASSET_SLOT_DESCRIPTION = QObject::tr("Path to input Image Asset");
-    static const QString OUTPUT_IMAGE_SLOT_DESCRIPTION = QObject::tr("Output path to Image Asset");
+    inline const QString PREVIEW_BOUNDS_INPUT_SLOT_DESCRIPTION = QObject::tr("Preview Bounds input slot");
+    inline const QString PLACEMENT_BOUNDS_INPUT_SLOT_DESCRIPTION = QObject::tr("Placement Bounds input slot");
+    inline const QString INBOUND_GRADIENT_INPUT_SLOT_DESCRIPTION = QObject::tr("Inbound Gradient input slot");
+    inline const QString OUTBOUND_GRADIENT_OUTPUT_SLOT_DESCRIPTION = QObject::tr("Outbound Gradient output slot");
+    inline const QString INBOUND_AREA_INPUT_SLOT_DESCRIPTION = QObject::tr("Inbound Area input slot");
+    inline const QString OUTBOUND_AREA_OUTPUT_SLOT_DESCRIPTION = QObject::tr("Outbound Area output slot");
+    inline const QString INBOUND_SHAPE_INPUT_SLOT_DESCRIPTION = QObject::tr("Inbound Shape input slot");
+    inline const QString INPUT_BOUNDS_INPUT_SLOT_DESCRIPTION = QObject::tr("Input Bounds input slot");
+    inline const QString PIN_TO_SHAPE_INPUT_SLOT_DESCRIPTION = QObject::tr("Pin To Shape input slot");
+    inline const QString ENTITY_NAME_SLOT_DESCRIPTION = QObject::tr("Vegetation entity name");
+    inline const QString IMAGE_ASSET_SLOT_DESCRIPTION = QObject::tr("Path to input Image Asset");
+    inline const QString OUTPUT_IMAGE_SLOT_DESCRIPTION = QObject::tr("Output path to Image Asset");
 }


### PR DESCRIPTION
Removed unneeded `s_nullTypeId_v` constant. This was triggering the following error
```
[2022-09-28T05:14:53.562Z] /data/workspace/o3de/Code/Framework/AzCore/./AzCore/RTTI/TypeInfo.h:520:44: error: 'constexpr static data member 's_nullTypeId_v' must have an initializer

[2022-09-28T05:14:53.562Z]   520 |         inline static constexpr AZ::TypeId s_nullTypeId_v;
```

Updated the chrono.h header to explicitly use the chrono namespace to distinguish between type names and function names. This was triggering errors such as
```
[2022-09-28T05:14:53.563Z] /data/workspace/o3de/Code/Framework/AzCore/./AzCore/std/chrono/chrono.h:2349:35: error: declaration of 'constexpr std::chrono::seconds AZStd::chrono::hh_mm_ss<Duration>::seconds() const' changes meaning of 'seconds' [-fpermissive]

[2022-09-28T05:14:53.563Z]  2349 |         constexpr chrono::seconds seconds() const noexcept

```

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>
