### PR TITLE
Added optimization to ranges::copy/copy_n/copy_backward

### DIFF
--- a/Code/Framework/AzCore/Tests/AZStd/RangesAlgorithmBenchmarks.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/RangesAlgorithmBenchmarks.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/std/containers/array.h>
+#include <AzCore/std/ranges/ranges_algorithm.h>
+
+
+#if defined(HAVE_BENCHMARK)
+namespace Benchmark
+{
+    class RangesAlgorithmBenchmarkFixture
+        : public UnitTest::AllocatorsBenchmarkFixture
+    {};
+
+    // Benchmarks for ranges copy when using trivally copyable types with contiguous iterators
+    // memcpy or memmove should be used under the hood
+    BENCHMARK_F(RangesAlgorithmBenchmarkFixture, BM_RangesCopy_TriviallyCopyableType_DirectCall)(benchmark::State& state)
+    {
+        AZStd::array test1 = AZStd::to_array<const char>("The brown quick wolf jumped over the hyperactive cat");
+        [[maybe_unused]] AZStd::array<char, test1.size()> result;
+        for ([[maybe_unused]] auto _ : state)
+        {
+            // In profile configuration the AZStd::ranges::copy call triggers
+            // the overlapping range assert, most likely due to optimizations with result not being used
+            // Using DoNotOptimize resolves the issue
+            benchmark::DoNotOptimize(AZStd::ranges::copy(test1, result.begin()));
+        }
+    }
+
+    BENCHMARK_F(RangesAlgorithmBenchmarkFixture, BM_RangesCopyN_TriviallyCopyableType_DirectCall)(benchmark::State& state)
+    {
+        AZStd::array test1 = AZStd::to_array<const char>("The brown quick wolf jumped over the hyperactive cat");
+        [[maybe_unused]] AZStd::array<char, test1.size()> result;
+        for ([[maybe_unused]] auto _ : state)
+        {
+            benchmark::DoNotOptimize(AZStd::ranges::copy_n(test1.begin(), test1.size(), result.begin()));
+        }
+    }
+
+    BENCHMARK_F(RangesAlgorithmBenchmarkFixture, BM_RangesCopyBackward_TriviallyCopyableType_DirectCall)(benchmark::State& state)
+    {
+        AZStd::array test1 = AZStd::to_array<const char>("The brown quick wolf jumped over the hyperactive cat");
+        [[maybe_unused]] AZStd::array<char, test1.size()> result;
+        for ([[maybe_unused]] auto _ : state)
+        {
+            // copy_backward requires past the end of range sentinel and iterates backwards
+            benchmark::DoNotOptimize(AZStd::ranges::copy_backward(test1, result.end()));
+        }
+    }
+
+    BENCHMARK_F(RangesAlgorithmBenchmarkFixture, BM_RangesCopy_TriviallyCopyableType_CompileTime_DirectCall)(benchmark::State& state)
+    {
+        constexpr auto copyArray = []() constexpr
+        {
+            constexpr AZStd::array test1 = AZStd::to_array<const char>("The brown quick wolf jumped over the hyperactive cat");
+            AZStd::array<char, test1.size()> resultArray{};
+            AZStd::ranges::copy(test1, resultArray.begin());
+            return resultArray;
+        };
+
+        auto invokeAtCompileTime = [copyArray]()
+        {
+            [[maybe_unused]] constexpr auto result = copyArray();
+            return true;
+        };
+        for ([[maybe_unused]] auto _ : state)
+        {
+            benchmark::DoNotOptimize(invokeAtCompileTime());
+        }
+    }
+
+    BENCHMARK_F(RangesAlgorithmBenchmarkFixture, BM_RangesCopyN_TriviallyCopyableType_CompileTime_DirectCall)(benchmark::State& state)
+    {
+        constexpr auto copyArray = []() constexpr
+        {
+            constexpr AZStd::array test1 = AZStd::to_array<const char>("The brown quick wolf jumped over the hyperactive cat");
+            AZStd::array<char, test1.size()> resultArray{};
+            AZStd::ranges::copy_n(test1.begin(), test1.size(), resultArray.begin());
+            return resultArray;
+        };
+        auto invokeAtCompileTime = [copyArray]()
+        {
+            [[maybe_unused]] constexpr auto result = copyArray();
+            return true;
+        };
+
+        for ([[maybe_unused]] auto _ : state)
+        {
+            benchmark::DoNotOptimize(invokeAtCompileTime());
+        }
+    }
+
+    BENCHMARK_F(RangesAlgorithmBenchmarkFixture, BM_RangesCopyBackward_TriviallyCopyableType_CompileTime_DirectCall)(benchmark::State& state)
+    {
+        constexpr auto copyArray = []() constexpr
+        {
+            constexpr AZStd::array test1 = AZStd::to_array<const char>("The brown quick wolf jumped over the hyperactive cat");
+            AZStd::array<char, test1.size()> resultArray{};
+            AZStd::ranges::copy_backward(test1, resultArray.end());
+            return resultArray;
+        };
+        auto invokeAtCompileTime = [copyArray]()
+        {
+            [[maybe_unused]] constexpr auto result = copyArray();
+            return true;
+        };
+
+        for ([[maybe_unused]] auto _ : state)
+        {
+            benchmark::DoNotOptimize(invokeAtCompileTime());
+        }
+    }
+
+    BENCHMARK_F(RangesAlgorithmBenchmarkFixture, BM_RangesCopy_TriviallyCopyableType_MemcpyCall)(benchmark::State& state)
+    {
+        AZStd::array test1 = AZStd::to_array<const char>("The brown quick wolf jumped over the hyperactive cat");
+        [[maybe_unused]] AZStd::array<char, test1.size()> result;
+        for ([[maybe_unused]] auto _ : state)
+        {
+            benchmark::DoNotOptimize(memcpy(result.data(), test1.data(), test1.size() * sizeof(char)));
+        }
+    }
+
+    BENCHMARK_F(RangesAlgorithmBenchmarkFixture, BM_RangesCopy_TriviallyCopyableType_MemmoveCall)(benchmark::State& state)
+    {
+        AZStd::array test1 = AZStd::to_array<const char>("The brown quick wolf jumped over the hyperactive cat");
+        [[maybe_unused]] AZStd::array<char, test1.size()> result;
+        for ([[maybe_unused]] auto _ : state)
+        {
+            benchmark::DoNotOptimize(memmove(result.data(), test1.data(), test1.size() * sizeof(char)));
+        }
+    }
+
+    BENCHMARK_F(RangesAlgorithmBenchmarkFixture, BM_RangesCopy_TriviallyCopyableType_ForLoopImplementation)(benchmark::State& state)
+    {
+        AZStd::array test1 = AZStd::to_array<const char>("The brown quick wolf jumped over the hyperactive cat");
+        [[maybe_unused]] AZStd::array<char, test1.size()> resultArray;
+        auto forLoopCopy = [&test1, &resultArray]() constexpr
+        {
+            auto first = test1.begin();
+            auto last = test1.end();
+            auto result = resultArray.begin();
+            for (; first != last; ++first, ++result)
+            {
+                *result = *first;
+            }
+
+            return true;
+        };
+
+        for ([[maybe_unused]] auto _ : state)
+        {
+            bool ranLoop = forLoopCopy();
+            benchmark::DoNotOptimize(ranLoop);
+        }
+    }
+} // Benchmark
+#endif

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -223,6 +223,7 @@ set(FILES
     AZStd/Optional.cpp
     AZStd/Pair.cpp
     AZStd/Parallel.cpp
+    AZStd/RangesAlgorithmBenchmarks.cpp
     AZStd/RangesAlgorithmTests.cpp
     AZStd/RangesTests.cpp
     AZStd/RangesUtilityTests.cpp


### PR DESCRIPTION
The `ranges::copy` and `ranges::copy_n` functions will use memcpy if the output type is trivially copyable and both iterators are contiguous.

The `ranges::copy_backward` function will use memmove if the output iterator value type is trivially copyable and both iterators are contiguous.

Also added memcpy/memmove to `ranges::move` and `ranges::move_backward` as well.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Verified that the existing [ranges copy](https://github.com/o3de/o3de/blob/development/Code/Framework/AzCore/Tests/AZStd/RangesAlgorithmTests.cpp#L367) test succeed.

Added Benchmark Test to verify the optimizations

```
OKAY Library loaded: D:/o3de/o3de/build/windows/bin/profile/AzCore.Tests.dll
OKAY Symbol found: AzRunBenchmarks
09/30/22 20:20:00
Running D:/o3de/o3de/build/windows/bin/profile/AzTestRunner.exe
Run on (64 X 3700 MHz CPU s)
CPU Caches:
  L1 Data 32K (x32)
  L1 Instruction 32K (x32)
  L2 Unified 524K (x32)
  L3 Unified 16777K (x8)
---------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                                   Time             CPU   Iterations
---------------------------------------------------------------------------------------------------------------------------------------------
RangesAlgorithmBenchmarkFixture/BM_RangesCopy_TriviallyCopyableType_DirectCall                           2.34 ns         2.35 ns    298666667
RangesAlgorithmBenchmarkFixture/BM_RangesCopyN_TriviallyCopyableType_DirectCall                          2.09 ns         2.05 ns    320000000
RangesAlgorithmBenchmarkFixture/BM_RangesCopyBackward_TriviallyCopyableType_DirectCall                   2.09 ns         2.09 ns    344615385
RangesAlgorithmBenchmarkFixture/BM_RangesCopy_TriviallyCopyableType_CompileTime_DirectCall               1.31 ns         1.29 ns    448000000
RangesAlgorithmBenchmarkFixture/BM_RangesCopyN_TriviallyCopyableType_CompileTime_DirectCall              1.23 ns         1.23 ns    407272727
RangesAlgorithmBenchmarkFixture/BM_RangesCopyBackward_TriviallyCopyableType_CompileTime_DirectCall       1.27 ns         1.27 ns    640000000
RangesAlgorithmBenchmarkFixture/BM_RangesCopy_TriviallyCopyableType_MemcpyCall                           2.09 ns         2.09 ns    344615385
RangesAlgorithmBenchmarkFixture/BM_RangesCopy_TriviallyCopyableType_MemmoveCall                          2.07 ns         2.09 ns    344615385
RangesAlgorithmBenchmarkFixture/BM_RangesCopy_TriviallyCopyableType_ForLoopImplementation                20.4 ns         20.4 ns     34461538
OKAY AzRunBenchmarks() returned 0
Returning code: 0
```