### PR TITLE
Use job system instead of task graph for CPU skinning.

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/DualQuatSkinDeformer.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/DualQuatSkinDeformer.cpp
@@ -27,7 +27,6 @@ namespace EMotionFX
     DualQuatSkinDeformer::DualQuatSkinDeformer(Mesh* mesh)
         : MeshDeformer(mesh)
     {
-        AZ::TaskGraphActiveInterface* taskGraphActiveInterface = AZ::Interface<AZ::TaskGraphActiveInterface>::Get();
         m_useTaskGraph = false;
     }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Source/DualQuatSkinDeformer.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/DualQuatSkinDeformer.cpp
@@ -28,7 +28,7 @@ namespace EMotionFX
         : MeshDeformer(mesh)
     {
         AZ::TaskGraphActiveInterface* taskGraphActiveInterface = AZ::Interface<AZ::TaskGraphActiveInterface>::Get();
-        m_useTaskGraph = taskGraphActiveInterface && taskGraphActiveInterface->IsTaskGraphActive();
+        m_useTaskGraph = false;
     }
 
     DualQuatSkinDeformer::~DualQuatSkinDeformer()

--- a/Gems/EMotionFX/Code/EMotionFX/Source/DualQuatSkinDeformer.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/DualQuatSkinDeformer.h
@@ -140,7 +140,7 @@ namespace EMotionFX
         //! Number of vertices per batch/job used for multi-threaded software skinning.
         static constexpr AZ::u32 s_numVerticesPerBatch = 10000;
         AZ::TaskGraph m_taskGraph{ "DualQuatSkinDeformer" };
-        bool m_useTaskGraph = true;
+        bool m_useTaskGraph = false;
 
         /**
          * Default constructor.


### PR DESCRIPTION
Signed-off-by: amzn-tommy <waltont@amazon.com>

## What does this PR do?

Switch to the job system instead of the task graph for CPU skinning. There are two deadlocks caused by using the taskgraph improperly that this fixes.

## How was this PR tested?

Tested in the editor using vertex-based bounding box calculations and loading a level with an actor in it - the two scenarios that were leading to a deadlock.
