### PR TITLE
Fixed Landscape Canvas duplicate support

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/TestSuite_Main.py
@@ -28,7 +28,6 @@ class TestAutomation(EditorTestSuite):
     class test_LandscapeCanvas_ComponentUpdates_UpdateGraph(EditorSharedTest):
         from .EditorScripts import ComponentUpdates_UpdateGraph as test_module
 
-    @pytest.mark.skip(reason="https://github.com/o3de/o3de/issues/10126")
     class test_LandscapeCanvas_Edit_DisabledNodeDuplication(EditorSharedTest):
         from .EditorScripts import Edit_DisabledNodeDuplication as test_module
 

--- a/Gems/LandscapeCanvas/Code/Include/LandscapeCanvas/LandscapeCanvasBus.h
+++ b/Gems/LandscapeCanvas/Code/Include/LandscapeCanvas/LandscapeCanvasBus.h
@@ -23,11 +23,6 @@ namespace LandscapeCanvas
     {
         AZ_TYPE_INFO(LandscapeCanvasSerialization, "{263F0CE3-5F3D-4297-B2DC-0B81F30BEC3E}");
 
-        //! Mapping of the original EntityId to a clone of the Entity that was serialized
-        //! These Entities correspond to nodes that have been serialized that will need
-        //! to also copy the Entity they represent.
-        AZStd::unordered_map<AZ::EntityId, AZ::Entity*> m_serializedNodeEntities;
-
         //! Mapping of the original EntityId to the EntityId of the Entity that has been
         //! copied as part of the deserialization (paste/duplicate)
         AZStd::unordered_map<AZ::EntityId, AZ::EntityId> m_deserializedEntities;
@@ -47,7 +42,6 @@ namespace LandscapeCanvas
         //! Get/set our serialized mappings of the Landscape Canvas Entities that correspond to
         //! GraphModel nodes that have been serialized
         virtual const LandscapeCanvasSerialization& GetSerializedMappings() = 0;
-        virtual void SetSerializedNodeEntities(const AZStd::unordered_map<AZ::EntityId, AZ::Entity*>& nodeEntities) = 0;
         virtual void SetDeserializedEntities(const AZStd::unordered_map<AZ::EntityId, AZ::EntityId>& entities) = 0;
     };
 

--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
@@ -24,6 +24,7 @@
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <AzToolsFramework/Entity/ReadOnly/ReadOnlyEntityInterface.h>
 #include <AzToolsFramework/Prefab/PrefabFocusPublicInterface.h>
+#include <AzToolsFramework/Prefab/PrefabPublicInterface.h>
 #include <AzToolsFramework/PropertyTreeEditor/PropertyTreeEditor.h>
 #include <AzToolsFramework/ToolsComponents/EditorDisabledCompositionBus.h>
 #include <AzToolsFramework/ToolsComponents/EditorPendingCompositionBus.h>
@@ -262,30 +263,6 @@ namespace LandscapeCanvasEditor
         return componentPair->second->m_typeId;
     }
 
-    AZ::Entity* CloneSingleEntity(AZ::Entity* entity)
-    {
-        // Helper method for cloning a single Entity.  This Entity won't be registered with the Editor context
-        // since we are just going to save it for copy/paste purposes.
-        AZ::SliceComponent::EntityIdToEntityIdMap cloneEntityIdMap;
-        AZ::EntityUtils::SerializableEntityContainer sourceObjects;
-        sourceObjects.m_entities.push_back(entity);
-
-        AZ::EntityUtils::SerializableEntityContainer* clonedObjects = AZ::IdUtils::Remapper<AZ::EntityId>::CloneObjectAndGenerateNewIdsAndFixRefs(&sourceObjects, cloneEntityIdMap);
-        if (!clonedObjects)
-        {
-            AZ_Error("EditorEntityContext", false, "Failed to clone source entities.");
-            return nullptr;
-        }
-
-        AzToolsFramework::EntityList clonedEntities = clonedObjects->m_entities;
-
-        // We need to clean this up ourselves because CloneObjectAndGenerateNewIdsAndFixRefs assumes the caller takes ownership
-        delete clonedObjects;
-
-        AZ_Assert(clonedEntities.size() == 1, "Expected to only clone a single Entity");
-        return clonedEntities[0];
-    }
-
     CustomEntityPropertyEditor::CustomEntityPropertyEditor(QWidget* parent)
         : AzToolsFramework::EntityPropertyEditor(parent)
     {
@@ -499,6 +476,9 @@ namespace LandscapeCanvasEditor
 
         m_prefabFocusPublicInterface = AZ::Interface<AzToolsFramework::Prefab::PrefabFocusPublicInterface>::Get();
         AZ_Assert(m_prefabFocusPublicInterface, "LandscapeCanvas - could not get PrefabFocusPublicInterface on construction.");
+
+        m_prefabPublicInterface = AZ::Interface<AzToolsFramework::Prefab::PrefabPublicInterface>::Get();
+        AZ_Assert(m_prefabPublicInterface, "LandscapeCanvas - could not get PrefabPublicInterface on construction.");
 
         m_readOnlyEntityPublicInterface = AZ::Interface<AzToolsFramework::ReadOnlyEntityPublicInterface>::Get();
         AZ_Assert(m_readOnlyEntityPublicInterface, "LandscapeCanvas - could not get ReadOnlyEntityPublicInterface on construction.");
@@ -756,20 +736,28 @@ namespace LandscapeCanvasEditor
         });
     }
 
-    void MainWindow::OnEntitiesSerialized(GraphCanvas::GraphSerialization& serializationTarget)
+    void MainWindow::OnEntitiesDeserialized(const GraphCanvas::GraphSerialization& serializationTarget)
     {
-        LandscapeCanvas::LandscapeCanvasSerialization serialization;
+        using namespace AzToolsFramework;
+        using namespace LandscapeCanvas;
+
+        m_ignoreGraphUpdates = true;
 
         GraphCanvas::GraphId graphId = GetActiveGraphCanvasGraphId();
 
-        // Look for any nodes being serialized for which we also need to serialize the Editor Entity
+        LandscapeCanvasSerialization serialization;
+        LandscapeCanvasSerializationRequestBus::BroadcastResult(serialization, &LandscapeCanvasSerializationRequests::GetSerializedMappings);
+
+        EntityIdList entitiesToDuplicate;
+
+        // Look for any nodes being serialized for which we want to duplicate the Entity
         // corresponding to our Landscape Canvas node
         for (AZ::Entity* nodeEntity : serializationTarget.GetGraphData().m_nodes)
         {
             GraphCanvas::NodeId nodeUiId = nodeEntity->GetId();
 
             // Ignore any nodes serialized by GraphCanvas that aren't GraphModel nodes (e.g. comments/node groups), since they
-            // don't have an actual Entity/Component tied to them that we'll need to copy
+            // don't have an actual Entity/Component tied to them that we'll need to duplicate
             GraphModel::NodePtr node;
             GraphModelIntegration::GraphControllerRequestBus::EventResult(node, graphId, &GraphModelIntegration::GraphControllerRequests::GetNodeById, nodeUiId);
             if (!node)
@@ -780,82 +768,38 @@ namespace LandscapeCanvasEditor
             auto baseNodePtr = static_cast<LandscapeCanvas::BaseNode*>(node.get());
             AZ::EntityId entityId = baseNodePtr->GetVegetationEntityId();
 
-            // There could be multiple nodes being serialized that are tied to the same Entity.
-            // We only need to serialize the Entity once since all its components will be serialized as well.
-            auto it = serialization.m_serializedNodeEntities.find(entityId);
-            if (it != serialization.m_serializedNodeEntities.end())
+            entitiesToDuplicate.push_back(entityId);
+        }
+
+        // Duplicate the corresponding entities
+        auto outcome = m_prefabPublicInterface->DuplicateEntitiesInInstance(entitiesToDuplicate);
+        if (!outcome.IsSuccess())
+        {
+            AZ_Error("LandscapeCanvas", false, outcome.GetError().c_str());
+            return;
+        }
+
+        auto duplicatedEntities = outcome.GetValue();
+
+        // Create a mapping of the original EntityId's corresponding to the
+        // new EntityId's that were duplicated.
+        int i = 0;
+        const size_t numDuplicatedEntities = duplicatedEntities.size();
+        for (const auto& originalEntityId : entitiesToDuplicate)
+        {
+            // An EntityId might already exist in the mapping for the case where a single node (Entity)
+            // has multiple wrapped nodes on it, corresponding to multiple components on a single Entity
+            if (serialization.m_deserializedEntities.contains(originalEntityId))
             {
                 continue;
             }
 
-            AZ::Entity* entity = nullptr;
-            AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationRequests::FindEntity, entityId);
-            AZ_Assert(entity, "Entity corresponding to node is not registered with the application");
-
-            // Clone the Entity and save it with the mapping of its original EntityId since the copied node
-            // will stil have a reference to the original EntityId.  We have to clone the Entity instead of
-            // just saving the EntityId and making a copy later because if this serialization was caused by
-            // a Cut operation, then the Entity will actually be deleted when the node is deleted
-            AZ::Entity* clonedEntity = CloneSingleEntity(entity);
-            serialization.m_serializedNodeEntities[entityId] = clonedEntity;
-        }
-
-        LandscapeCanvas::LandscapeCanvasSerializationRequestBus::Broadcast(&LandscapeCanvas::LandscapeCanvasSerializationRequests::SetSerializedNodeEntities, serialization.m_serializedNodeEntities);
-    }
-
-    void MainWindow::OnEntitiesDeserialized(const GraphCanvas::GraphSerialization&)
-    {
-        using namespace AzToolsFramework;
-        using namespace LandscapeCanvas;
-
-        // We need to ignore the graph updates here because adding the cloned Entity to the EditorContext
-        // will trigger OnEditorEntityCreated
-        m_ignoreGraphUpdates = true;
-
-        ScopedUndoBatch undoBatch("Entities Deserialized");
-
-        LandscapeCanvasSerialization serialization;
-        LandscapeCanvasSerializationRequestBus::BroadcastResult(serialization, &LandscapeCanvasSerializationRequests::GetSerializedMappings);
-
-        for (auto it : serialization.m_serializedNodeEntities)
-        {
-            AZ::EntityId originalSerializedEntityId = it.first;
-            AZ::Entity* serializedEntity = it.second;
-
-            // Even though we cloned the original serialized Entity when we saved it in m_serializedNodeEntities,
-            // we need to clone it again when we actually deserialize, because the user could paste/duplicate
-            // multiple times, and each one will need a unique new Entity
-            AZ::Entity* clonedEntity = CloneSingleEntity(serializedEntity);
-            AZ::EntityId clonedEntityId = clonedEntity->GetId();
-            serialization.m_deserializedEntities[originalSerializedEntityId] = clonedEntityId;
-
-            // Register this new Entity with the Editor context
-            EditorEntityContextRequestBus::Broadcast(&EditorEntityContextRequests::AddEditorEntities, EntityList{ clonedEntity });
-
-            // If this node was copied from a different graph, then we will need
-            // to re-parent the cloned Entity so that it lives within the root Entity
-            // of our active graph, otherwise it won't know the node(Entity) belongs to
-            // this graph the next time it is loaded.
-            AZ::EntityId clonedEntityParentId;
-            AZ::TransformBus::EventResult(clonedEntityParentId, clonedEntityId, &AZ::TransformBus::Events::GetParentId);
-            GraphCanvas::GraphId clonedEntityGraphId = FindGraphContainingEntity(clonedEntityParentId);
-            GraphCanvas::GraphId activeGraphId = GetActiveGraphCanvasGraphId();
-            if (clonedEntityGraphId != activeGraphId)
+            if (i >= numDuplicatedEntities)
             {
-                AZ::EntityId rootEntityId = GetRootEntityIdForGraphId(activeGraphId);
-                if (rootEntityId.IsValid())
-                {
-                    AZ::TransformBus::Event(clonedEntityId, &AZ::TransformBus::Events::SetParent, rootEntityId);
-                }
+                break;
             }
 
-            // Make sure all cloned entities are contained within the currently active undo batch command
-            // We have to use a EntityCreateCommand instead of just marking the Entity as dirty within
-            // the undo batch because of how it is cloned as opposed to being created from scratch
-            EntityCreateCommand* command = aznew EntityCreateCommand(
-                static_cast<UndoSystem::URCommandID>(clonedEntityId));
-            command->Capture(clonedEntity);
-            command->SetParent(undoBatch.GetUndoBatch());
+            serialization.m_deserializedEntities[originalEntityId] = duplicatedEntities[i++];
         }
 
         LandscapeCanvas::LandscapeCanvasSerializationRequestBus::Broadcast(&LandscapeCanvas::LandscapeCanvasSerializationRequests::SetDeserializedEntities, serialization.m_deserializedEntities);
@@ -1066,6 +1010,24 @@ namespace LandscapeCanvasEditor
         }
 
         return menu;
+    }
+
+    QAction* MainWindow::AddEditCutAction([[maybe_unused]] QMenu* menu)
+    {
+        // Disabled until we can leverage prefab API to cut/copy/paste
+        return nullptr;
+    }
+
+    QAction* MainWindow::AddEditCopyAction([[maybe_unused]] QMenu* menu)
+    {
+        // Disabled until we can leverage prefab API to cut/copy/paste
+        return nullptr;
+    }
+
+    QAction* MainWindow::AddEditPasteAction([[maybe_unused]] QMenu* menu)
+    {
+        // Disabled until we can leverage prefab API to cut/paste
+        return nullptr;
     }
 
     void MainWindow::HandleWrapperNodeActionWidgetClicked(GraphModel::NodePtr wrapperNode, [[maybe_unused]] const QRect& actionWidgetBoundingRect, const QPointF& scenePoint, const QPoint& screenPoint)
@@ -2769,6 +2731,10 @@ namespace LandscapeCanvasEditor
             CloseEditor(dockWidgetId);
         }
 
+        // Handle any nodes that might've been created by duplicated/pasted entities
+        // once the prefab propagation has finished
+        HandleDeserializedNodes();
+
         // Handle any queued entities that we need to refresh by calling
         // HandleEditorEntityCreated, which will handle if there is anything
         // out of sync in the graph based on the corresponding entity.
@@ -2986,71 +2952,13 @@ namespace LandscapeCanvasEditor
         m_ignoreGraphUpdates = true;
 
         // If the new node already has a valid EntityId, then it means the node was copy/pasted, so we need
-        // to find the corresponding deserialized Entity and fix-up the references
+        // to find the corresponding deserialized Entity and fix-up the references.
+        // However, the new deserialized entities/components won't be available until the propagation is
+        // complete, so we'll need to keep track of the deserialized nodes and then handle the fix-up after.
         AZ::EntityId existingEntityId = baseNodePtr->GetVegetationEntityId();
         if (existingEntityId.IsValid())
         {
-            LandscapeCanvasSerialization serialization;
-            LandscapeCanvasSerializationRequestBus::BroadcastResult(serialization, &LandscapeCanvasSerializationRequests::GetSerializedMappings);
-
-            auto it = serialization.m_deserializedEntities.find(existingEntityId);
-            if (it != serialization.m_deserializedEntities.end())
-            {
-                AZ::EntityId newEntityId = it->second;
-
-                AZ::TypeId componentTypeId;
-                LandscapeCanvasNodeFactoryRequestBus::BroadcastResult(componentTypeId, &LandscapeCanvasNodeFactoryRequests::GetComponentTypeId, baseNodePtr->RTTI_GetType());
-                if (!componentTypeId.IsNull())
-                {
-                    AZ::Entity* newEntity = nullptr;
-                    AZ::ComponentApplicationBus::BroadcastResult(newEntity, &AZ::ComponentApplicationRequests::FindEntity, newEntityId);
-                    AZ_Assert(newEntity, "Unable to find deserialized Entity");
-
-                    // Find the component on the Entity that corresponds to this node
-                    AZ::Component* newComponent = newEntity->FindComponent(componentTypeId);
-                    if (!newComponent)
-                    {
-                        // The FindComponent won't find a component if its disabled, so if it failed
-                        // then look through the disabled components on this Entity
-                        AZ::Entity::ComponentArrayType disabledComponents;
-                        AzToolsFramework::EditorDisabledCompositionRequestBus::Event(newEntityId, &AzToolsFramework::EditorDisabledCompositionRequests::GetDisabledComponents, disabledComponents);
-                        for (auto disabledComponent : disabledComponents)
-                        {
-                            if (disabledComponent->RTTI_GetType() == componentTypeId)
-                            {
-                                newComponent = disabledComponent;
-                                break;
-                            }
-                        }
-
-                        // Look through the pending components next if we didn't find it in the disabled components,
-                        // since it may be put in the pending bucket if a dependent component is actually deleted
-                        // instead of just being disabled
-                        if (!newComponent)
-                        {
-                            AZ::Entity::ComponentArrayType pendingComponents;
-                            AzToolsFramework::EditorPendingCompositionRequestBus::Event(newEntityId, &AzToolsFramework::EditorPendingCompositionRequests::GetPendingComponents, pendingComponents);
-                            for (AZ::Component* pendingComponent : pendingComponents)
-                            {
-                                if (pendingComponent->RTTI_GetType() == componentTypeId)
-                                {
-                                    newComponent = pendingComponent;
-                                    break;
-                                }
-                            }
-                        }
-
-                        // If the component for this node is disabled, then the node needs to be disabled as well
-                        GraphModelIntegration::GraphControllerRequestBus::Event(graphId, &GraphModelIntegration::GraphControllerRequests::DisableNode, node);
-                    }
-
-                    AZ_Assert(newComponent, "Deserialized Entity missing component matching node");
-
-                    // Fix-up the references on the new node to the deserialized Entity/Component
-                    baseNodePtr->SetVegetationEntityId(newEntityId);
-                    baseNodePtr->SetComponentId(newComponent->GetId());
-                }
-            }
+            m_deserializedNodes.push_back(node);
         }
         // Otherwise, this new node was created by the user from the node palette or right-click menu,
         // so create a fresh Entity/Component for the node, except we need to ignore area extender
@@ -3481,6 +3389,105 @@ namespace LandscapeCanvasEditor
                 }
             }
         }
+    }
+
+    void MainWindow::HandleDeserializedNodes()
+    {
+        if (m_deserializedNodes.empty())
+        {
+            return;
+        }
+
+        m_ignoreGraphUpdates = true;
+
+        LandscapeCanvas::LandscapeCanvasSerialization serialization;
+        LandscapeCanvas::LandscapeCanvasSerializationRequestBus::BroadcastResult(serialization, &LandscapeCanvas::LandscapeCanvasSerializationRequests::GetSerializedMappings);
+
+        GraphCanvas::GraphId graphId = GetActiveGraphCanvasGraphId();
+
+        // The deserialized nodes already have a valid EntityId, so we need
+        // to find the corresponding deserialized Entity and fix-up the references
+        for (auto node : m_deserializedNodes)
+        {
+            auto* baseNodePtr = static_cast<LandscapeCanvas::BaseNode*>(node.get());
+            if (!baseNodePtr)
+            {
+                continue;
+            }
+
+            AZ::EntityId existingEntityId = baseNodePtr->GetVegetationEntityId();
+            if (!existingEntityId.IsValid())
+            {
+                continue;
+            }
+
+            auto it = serialization.m_deserializedEntities.find(existingEntityId);
+            if (it == serialization.m_deserializedEntities.end())
+            {
+                continue;
+            }
+
+            AZ::EntityId newEntityId = it->second;
+
+            AZ::TypeId componentTypeId;
+            LandscapeCanvas::LandscapeCanvasNodeFactoryRequestBus::BroadcastResult(componentTypeId, &LandscapeCanvas::LandscapeCanvasNodeFactoryRequests::GetComponentTypeId, baseNodePtr->RTTI_GetType());
+            if (componentTypeId.IsNull())
+            {
+                continue;
+            }
+
+            AZ::Entity* newEntity = nullptr;
+            AZ::ComponentApplicationBus::BroadcastResult(newEntity, &AZ::ComponentApplicationRequests::FindEntity, newEntityId);
+            AZ_Assert(newEntity, "Unable to find deserialized Entity");
+
+            // Find the component on the Entity that corresponds to this node
+            AZ::Component* newComponent = newEntity->FindComponent(componentTypeId);
+            if (!newComponent)
+            {
+                // The FindComponent won't find a component if its disabled, so if it failed
+                // then look through the disabled components on this Entity
+                AZ::Entity::ComponentArrayType disabledComponents;
+                AzToolsFramework::EditorDisabledCompositionRequestBus::Event(newEntityId, &AzToolsFramework::EditorDisabledCompositionRequests::GetDisabledComponents, disabledComponents);
+                for (auto disabledComponent : disabledComponents)
+                {
+                    if (disabledComponent->RTTI_GetType() == componentTypeId)
+                    {
+                        newComponent = disabledComponent;
+                        break;
+                    }
+                }
+
+                // Look through the pending components next if we didn't find it in the disabled components,
+                // since it may be put in the pending bucket if a dependent component is actually deleted
+                // instead of just being disabled
+                if (!newComponent)
+                {
+                    AZ::Entity::ComponentArrayType pendingComponents;
+                    AzToolsFramework::EditorPendingCompositionRequestBus::Event(newEntityId, &AzToolsFramework::EditorPendingCompositionRequests::GetPendingComponents, pendingComponents);
+                    for (AZ::Component* pendingComponent : pendingComponents)
+                    {
+                        if (pendingComponent->RTTI_GetType() == componentTypeId)
+                        {
+                            newComponent = pendingComponent;
+                            break;
+                        }
+                    }
+                }
+
+                // If the component for this node is disabled, then the node needs to be disabled as well
+                GraphModelIntegration::GraphControllerRequestBus::Event(graphId, &GraphModelIntegration::GraphControllerRequests::DisableNode, node);
+            }
+
+            AZ_Assert(newComponent, "Deserialized Entity missing component matching node");
+
+            // Fix-up the references on the new node to the deserialized Entity/Component
+            baseNodePtr->SetVegetationEntityId(newEntityId);
+            baseNodePtr->SetComponentId(newComponent->GetId());
+        }
+
+        m_deserializedNodes.clear();
+
+        m_ignoreGraphUpdates = false;
     }
 
     int MainWindow::GetInboundDataSlotIndex(GraphModel::NodePtr node, GraphModel::DataTypePtr dataType, GraphModel::SlotPtr targetSlot)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.h
@@ -39,6 +39,7 @@ namespace AzToolsFramework
     namespace Prefab
     {
         class PrefabFocusPublicInterface;
+        class PrefabPublicInterface;
     }
 }
 
@@ -125,11 +126,13 @@ namespace LandscapeCanvasEditor
         QAction* AddFileSaveAction(QMenu* menu) override;
         QAction* AddFileSaveAsAction(QMenu* menu) override;
         QMenu* AddEditMenu() override;
+        QAction* AddEditCutAction(QMenu* menu) override;
+        QAction* AddEditCopyAction(QMenu* menu) override;
+        QAction* AddEditPasteAction(QMenu* menu) override;
         void HandleWrapperNodeActionWidgetClicked(GraphModel::NodePtr wrapperNode, const QRect& actionWidgetBoundingRect, const QPointF& scenePoint, const QPoint& screenPoint) override;
         GraphCanvas::Endpoint CreateNodeForProposal(const AZ::EntityId& connectionId, const GraphCanvas::Endpoint& endpoint, const QPointF& scenePoint, const QPoint& screenPoint) override;
         void OnSelectionChanged() override;
-        void OnEntitiesSerialized(GraphCanvas::GraphSerialization& serializationTarget) override;
-        void OnEntitiesDeserialized(const GraphCanvas::GraphSerialization&) override;
+        void OnEntitiesDeserialized(const GraphCanvas::GraphSerialization& serializationTarget) override;
         ////////////////////////////////////////////////////////////////////////
 
         ////////////////////////////////////////////////////////////////////////
@@ -253,6 +256,7 @@ namespace LandscapeCanvasEditor
         void PlaceNewNode(GraphCanvas::GraphId graphId, LandscapeCanvas::BaseNode::BaseNodePtr node);
         int GetInboundDataSlotIndex(GraphModel::NodePtr node, GraphModel::DataTypePtr dataType, GraphModel::SlotPtr targetSlot);
         void HandleImageAssetSlot(GraphModel::NodePtr targetNode, const EntityIdNodeMap& gradientNodeMap, ConnectionsList& connections);
+        void HandleDeserializedNodes();
 
         //! Determines whether or not we should allow the user to interact with the graph
         //! This should be disabled when there is no level currently loaded
@@ -267,6 +271,7 @@ namespace LandscapeCanvasEditor
 
         static AzFramework::EntityContextId s_editorEntityContextId;
         AzToolsFramework::Prefab::PrefabFocusPublicInterface* m_prefabFocusPublicInterface = nullptr;
+        AzToolsFramework::Prefab::PrefabPublicInterface* m_prefabPublicInterface = nullptr;
         AzToolsFramework::ReadOnlyEntityPublicInterface* m_readOnlyEntityPublicInterface = nullptr;
 
         bool m_ignoreGraphUpdates = false;
@@ -276,6 +281,7 @@ namespace LandscapeCanvasEditor
         using DeletedNodePositionsMap = AZStd::unordered_map<AZ::EntityComponentIdPair, AZ::Vector2>;
         AZStd::unordered_map<GraphCanvas::GraphId, DeletedNodePositionsMap> m_deletedNodePositions;
         GraphModel::NodePtrList m_deletedWrappedNodes;
+        GraphModel::NodePtrList m_deserializedNodes;
         AzToolsFramework::EntityIdList m_queuedEntityDeletes;
         AzToolsFramework::EntityIdList m_queuedEntityRefresh;
 

--- a/Gems/LandscapeCanvas/Code/Source/LandscapeCanvasSystemComponent.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/LandscapeCanvasSystemComponent.cpp
@@ -376,17 +376,6 @@ namespace LandscapeCanvas
         return m_serialization;
     }
 
-    void LandscapeCanvasSystemComponent::SetSerializedNodeEntities(const AZStd::unordered_map<AZ::EntityId, AZ::Entity*>& nodeEntities)
-    {
-        // Delete any entities we had previously serialized before updating our mappings
-        for (auto it : m_serialization.m_serializedNodeEntities)
-        {
-            delete it.second;
-        }
-
-        m_serialization.m_serializedNodeEntities = nodeEntities;
-    }
-
     void LandscapeCanvasSystemComponent::SetDeserializedEntities(const AZStd::unordered_map<AZ::EntityId, AZ::EntityId>& entities)
     {
         m_serialization.m_deserializedEntities = entities;

--- a/Gems/LandscapeCanvas/Code/Source/LandscapeCanvasSystemComponent.h
+++ b/Gems/LandscapeCanvas/Code/Source/LandscapeCanvasSystemComponent.h
@@ -61,7 +61,6 @@ namespace LandscapeCanvas
         ////////////////////////////////////////////////////////////////////////
         // LandscapeCanvas::LandscapeCanvasSerializationRequestBus::Handler overrides
         const LandscapeCanvasSerialization& GetSerializedMappings() override;
-        void SetSerializedNodeEntities(const AZStd::unordered_map<AZ::EntityId, AZ::Entity*>& nodeEntities) override;
         void SetDeserializedEntities(const AZStd::unordered_map<AZ::EntityId, AZ::EntityId>& entities) override;
         ////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
## What does this PR do?

Fixes #10746, #8207, #3922 and #10126

Added proper support for duplicating nodes in Landscape Canvas. The root of this change is that when duplicating nodes in Landscape Canvas, this means under the hood we need to duplicate their corresponding entities/components. When Landscape Canvas was originally written, we were still using slices, so the duplicate logic revolved around cloning an `AZ::Entity` and then serializing/deserializing the cloned entity (or entities). This needed to be completely replaced to work with prefabs instead.
- Updated to use the prefab duplicate API directly, rather than trying to clone the entities ourselves
- Removed all slice/cloning specific logic that is now unneeded
- Hid Cut/Copy/Paste actions. This is consistent with the currently supported prefab workflow which only allows the user to duplicate entities currently.
- Moved/refactored logic for fixing up the duplicated entities references in the nodes to be after the prefab propagation has completed
- Updated `test_LandscapeCanvas_Edit_DisabledNodeDuplication` to no longer be skipped since the duplicate action has been fixed

![LCDuplicate](https://user-images.githubusercontent.com/7519264/193120319-866d3f57-03ed-4807-8f0e-718463c00452.gif)

## How was this PR tested?

Tested and verified all Landscape Canvas automated tests pass. Also did manual testing of duplicating single and multiple nodes at a time, and verifying the duplicate action works with undo/redo.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>