### PR TITLE
Improved Color Picker Clarity

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker.cpp
@@ -668,16 +668,22 @@ ColorPicker::ColorPicker(ColorPicker::Configuration configuration, const QString
 
     // Alternate color space info
 
-    m_alternateColorSpaceInfoLayout = new QGridLayout();
-    containerLayout->addLayout(m_alternateColorSpaceInfoLayout);
-
-    // These widgets will be updated and added to m_alternateColorSpaceInfoLayout as needed in setAlternateColorspace* functions
-    m_alternateColorSpaceIntLabel = new QLabel("Alternate Int");
-    m_alternateColorSpaceFloatLabel = new QLabel("Alternate Float");
-    m_alternateColorSpaceIntValue = new QLineEdit("Unspecified");
-    m_alternateColorSpaceFloatValue = new QLineEdit("Unspecified");
+    // These widgets will be updated as needed in setAlternateColorspace* functions
+    m_alternateColorSpaceIntLabel = new QLabel(QObject::tr("Alternate Int"), this);
+    m_alternateColorSpaceFloatLabel = new QLabel(QObject::tr("Alternate Float"), this);
+    m_alternateColorSpaceIntValue = new QLineEdit(QObject::tr("Unspecified"), this);
+    m_alternateColorSpaceFloatValue = new QLineEdit(QObject::tr("Unspecified"), this);
     m_alternateColorSpaceIntValue->setDisabled(true);
     m_alternateColorSpaceFloatValue->setDisabled(true);
+
+    m_alternateColorSpaceInfoLayout = new QGridLayout();
+    m_alternateColorSpaceInfoLayout->addWidget(m_alternateColorSpaceIntLabel, 0, 0);
+    m_alternateColorSpaceInfoLayout->addWidget(m_alternateColorSpaceFloatLabel, 1, 0);
+    m_alternateColorSpaceInfoLayout->addWidget(m_alternateColorSpaceIntValue, 0, 1);
+    m_alternateColorSpaceInfoLayout->addWidget(m_alternateColorSpaceFloatValue, 1, 1);
+    containerLayout->addLayout(m_alternateColorSpaceInfoLayout);
+
+    setAlternateColorspaceEnabled(false);
 
     // buttons
 
@@ -728,21 +734,10 @@ void ColorPicker::setComment(QString comment)
 
 void ColorPicker::setAlternateColorspaceEnabled(bool enabled)
 {
-    if (enabled && m_alternateColorSpaceInfoLayout->isEmpty())
-    {
-        m_alternateColorSpaceInfoLayout->addWidget(m_alternateColorSpaceIntLabel, 0, 0);
-        m_alternateColorSpaceInfoLayout->addWidget(m_alternateColorSpaceFloatLabel, 1, 0);
-        m_alternateColorSpaceInfoLayout->addWidget(m_alternateColorSpaceIntValue, 0, 1);
-        m_alternateColorSpaceInfoLayout->addWidget(m_alternateColorSpaceFloatValue, 1, 1);
-    }
-
-    if (!enabled && !m_alternateColorSpaceInfoLayout->isEmpty())
-    {
-        m_alternateColorSpaceInfoLayout->removeWidget(m_alternateColorSpaceIntLabel);
-        m_alternateColorSpaceInfoLayout->removeWidget(m_alternateColorSpaceFloatLabel);
-        m_alternateColorSpaceInfoLayout->removeWidget(m_alternateColorSpaceIntValue);
-        m_alternateColorSpaceInfoLayout->removeWidget(m_alternateColorSpaceFloatValue);
-    }
+    m_alternateColorSpaceIntLabel->setVisible(enabled);
+    m_alternateColorSpaceFloatLabel->setVisible(enabled);
+    m_alternateColorSpaceIntValue->setVisible(enabled);
+    m_alternateColorSpaceFloatValue->setVisible(enabled);
 }
 
 void ColorPicker::setAlternateColorspaceName(const QString& name)

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker.h
@@ -33,6 +33,7 @@ class QSettings;
 class QToolButton;
 class QUndoStack;
 class QLabel;
+class QLineEdit;
 
 namespace AzQtComponents
 {
@@ -128,6 +129,11 @@ namespace AzQtComponents
 
         //! Sets a comment string that will be included in the UI as a custom message that may provide some context for the user
         void setComment(QString comment);
+
+        //! Sets up some read-only output for displaying color values in an alternate color space.
+        void setAlternateColorspaceEnabled(bool enabled);
+        void setAlternateColorspaceName(const QString& name);
+        void setAlternateColorspaceValue(const AZ::Color& color);
 
         //! Populates the palette list with the palettes stored at the folder path provided.
         void importPalettesFromFolder(const QString& path);
@@ -282,8 +288,16 @@ namespace AzQtComponents
         qreal m_defaultVForHsMode = 0.0f;
         qreal m_defaultLForHsMode = 0.0f;
 
+        QWidget* m_floatEditSeparator = nullptr;
+
         QWidget* m_commentSeparator = nullptr;
         QLabel* m_commentLabel = nullptr;
+
+        QGridLayout* m_alternateColorSpaceInfoLayout = nullptr;
+        QLabel* m_alternateColorSpaceIntLabel = nullptr;
+        QLabel* m_alternateColorSpaceFloatLabel = nullptr;
+        QLineEdit* m_alternateColorSpaceIntValue = nullptr;
+        QLineEdit* m_alternateColorSpaceFloatValue = nullptr;
 
         QString m_lastSaveDirectory;
         QVector<QWidget*> m_separators;

--- a/Code/Framework/AzQtComponents/AzQtComponents/Utilities/ColorUtilities.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Utilities/ColorUtilities.cpp
@@ -60,6 +60,35 @@ namespace AzQtComponents
         return left.IsClose(right, tolerance);
     }
 
+
+    QString MakePropertyDisplayStringInts(const QColor& color, bool includeAlphaChannel)
+    {
+        int R, G, B, A;
+        color.getRgb(&R, &G, &B, &A);
+        auto colorStr =
+            includeAlphaChannel
+            ? QStringLiteral("%1,%2,%3,%4").arg(R).arg(G).arg(B).arg(A)
+            : QStringLiteral("%1,%2,%3").arg(R).arg(G).arg(B)
+            ;
+        return colorStr;
+    }
+
+    QString MakePropertyDisplayStringFloats(const QColor& color, bool includeAlphaChannel)
+    {
+        static const int FieldWidth = 0;
+        static const char Format = 'f';
+        static const int Precision = 3;
+
+        qreal R, G, B, A;
+        color.getRgbF(&R, &G, &B, &A);
+        auto colorStr =
+            includeAlphaChannel
+            ? QStringLiteral("%1, %2, %3, %4").arg(R, FieldWidth, Format, Precision).arg(G, FieldWidth, Format, Precision).arg(B, FieldWidth, Format, Precision).arg(A, FieldWidth, Format, Precision)
+            : QStringLiteral("%1, %2, %3").arg(R, FieldWidth, Format, Precision).arg(G, FieldWidth, Format, Precision).arg(B, FieldWidth, Format, Precision)
+            ;
+        return colorStr;
+    }
+
 } // namespace AzQtComponents
 
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Utilities/ColorUtilities.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Utilities/ColorUtilities.h
@@ -28,6 +28,9 @@ namespace AzQtComponents
     AZ_QT_COMPONENTS_API QBrush MakeAlphaBrush(const AZ::Color& color, float gamma = 1.0f);
 
     AZ_QT_COMPONENTS_API bool AreClose(const AZ::Color& left, const AZ::Color& right);
+
+    AZ_QT_COMPONENTS_API QString MakePropertyDisplayStringInts(const QColor& color, bool includeAlphaChannel);
+    AZ_QT_COMPONENTS_API QString MakePropertyDisplayStringFloats(const QColor& color, bool includeAlphaChannel);
 };
 
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
@@ -9,6 +9,7 @@
 #include "PropertyQTConstants.h"
 #include <AzQtComponents/Components/Widgets/ColorPicker.h>
 #include <AzQtComponents/Utilities/Conversions.h>
+#include <AzQtComponents/Utilities/ColorUtilities.h>
 #include <QtWidgets/QSlider>
 #include <QtWidgets/QLineEdit>
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option")
@@ -128,13 +129,7 @@ namespace AzToolsFramework
                 m_pColorDialog->setCurrentColor(azColor);
             }
 
-            int R, G, B, A;
-            m_color.getRgb(&R, &G, &B, &A);
-            auto colorStr =
-                m_alphaChannelEnabled
-                ? QStringLiteral("%1,%2,%3,%4").arg(R).arg(G).arg(B).arg(A)
-                : QStringLiteral("%1,%2,%3").arg(R).arg(G).arg(B)
-                ;
+            auto colorStr = AzQtComponents::MakePropertyDisplayStringInts(m_color, m_alphaChannelEnabled);
             m_colorEdit->setText(colorStr);
         }
     }
@@ -196,6 +191,8 @@ namespace AzToolsFramework
 
         if (m_config.m_propertyColorSpaceId != m_config.m_colorPickerDialogColorSpaceId)
         {
+            m_pColorDialog->setAlternateColorspaceEnabled(true);
+
             AZStd::string propertyColorSpaceName = m_config.m_colorSpaceNames[m_config.m_propertyColorSpaceId];
             AZStd::string dialogColorSpaceName = m_config.m_colorSpaceNames[m_config.m_colorPickerDialogColorSpaceId];
             if (!propertyColorSpaceName.empty() && !dialogColorSpaceName.empty())
@@ -203,12 +200,22 @@ namespace AzToolsFramework
                 QString comment = AZStd::string::format("Mixing space: %s | Final space: %s", dialogColorSpaceName.c_str(), propertyColorSpaceName.c_str()).c_str();
                 m_pColorDialog->setComment(comment);
             }
+
+            if (!propertyColorSpaceName.empty())
+            {
+                m_pColorDialog->setAlternateColorspaceName(propertyColorSpaceName.c_str());
+            }
+            else
+            {
+                m_pColorDialog->setAlternateColorspaceName("Output");
+            }
         }
 
         connect(m_pColorDialog, &AzQtComponents::ColorPicker::currentColorChanged, this, 
             [=](AZ::Color color)
         {
             color = TransformColor(color, m_config.m_colorPickerDialogColorSpaceId, m_config.m_propertyColorSpaceId);
+            m_pColorDialog->setAlternateColorspaceValue(color);
             onSelected(AzQtComponents::toQColor(color));
         });
 

--- a/Gems/Atom/Feature/Common/Code/Source/Utils/EditorLightingPreset.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Utils/EditorLightingPreset.cpp
@@ -72,7 +72,7 @@ namespace AZ
                             ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &LightConfig::m_direction, "Direction", "")
                         ->DataElement(Edit::UIHandlers::Color, &LightConfig::m_color, "Color", "Color of the light")
-                            ->Attribute("ColorEditorConfiguration", AZ::RPI::ColorUtils::GetRgbEditorConfig())
+                            ->Attribute("ColorEditorConfiguration", AZ::RPI::ColorUtils::GetLinearRgbEditorConfig())
                         ->DataElement(Edit::UIHandlers::Default, &LightConfig::m_intensity, "Intensity", "Intensity of the light in the set photometric unit.")
 
                         ->ClassElement(AZ::Edit::ClassElements::Group, "Shadow")

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicProperty/DynamicProperty.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicProperty/DynamicProperty.cpp
@@ -140,7 +140,7 @@ namespace AtomToolsFramework
             // Moving the attributes outside of the switch statement for specific types because the dynamic property is moving away from
             // using the enum. Even though these attributes only apply to specific property types, they can safely be applied to all
             // property types because each property control will only process attributes they recognize.
-            AddEditDataAttribute(AZ_CRC_CE("ColorEditorConfiguration"), AZ::RPI::ColorUtils::GetRgbEditorConfig());
+            AddEditDataAttribute(AZ_CRC_CE("ColorEditorConfiguration"), AZ::RPI::ColorUtils::GetLinearRgbEditorConfig());
             AddEditDataAttribute(AZ_CRC_CE("Thumbnail"), m_config.m_showThumbnail);
             AddEditDataAttribute(AZ_CRC_CE("SupportedAssetTypes"), m_config.m_supportedAssetTypes);
             AddEditDataAttribute(AZ::Edit::Attributes::ShowProductAssetFileName, false);

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
@@ -75,7 +75,7 @@ namespace AZ
                         ->DataElement(Edit::UIHandlers::Color, &AreaLightComponentConfig::m_color, "Color", "Color of the light")
                             ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
                             ->Attribute(Edit::Attributes::Visibility, &AreaLightComponentConfig::LightTypeIsSelected)
-                            ->Attribute("ColorEditorConfiguration", RPI::ColorUtils::GetRgbEditorConfig())
+                            ->Attribute("ColorEditorConfiguration", RPI::ColorUtils::GetLinearRgbEditorConfig())
                         ->DataElement(Edit::UIHandlers::ComboBox, &AreaLightComponentConfig::m_intensityMode, "Intensity mode", "Allows specifying which photometric unit to work in.")
                             ->Attribute(AZ::Edit::Attributes::EnumValues, &AreaLightComponentConfig::GetValidPhotometricUnits)
                             ->Attribute(Edit::Attributes::Visibility, &AreaLightComponentConfig::LightTypeIsSelected)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorDirectionalLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorDirectionalLightComponent.cpp
@@ -59,7 +59,7 @@ namespace AZ
                         ->ClassElement(Edit::ClassElements::EditorData, "")
                         ->DataElement(Edit::UIHandlers::Color, &DirectionalLightComponentConfig::m_color, "Color", "Color of the light")
                             ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
-                            ->Attribute("ColorEditorConfiguration", AZ::RPI::ColorUtils::GetRgbEditorConfig())
+                            ->Attribute("ColorEditorConfiguration", AZ::RPI::ColorUtils::GetLinearRgbEditorConfig())
                         ->DataElement(Edit::UIHandlers::ComboBox, &DirectionalLightComponentConfig::m_intensityMode, "Intensity mode", "Allows specifying light values in lux or Ev100")
                             ->EnumAttribute(PhotometricUnit::Lux, "Lux")
                             ->EnumAttribute(PhotometricUnit::Ev100Illuminance, "Ev100")


### PR DESCRIPTION
## What does this PR do?

Since the Color Picker operates in sRGB and the property being edited is Linear sRGB, the numbers do not match between Color Picker and the Property Inspector. This is intentional, but admittedly confusing as seen in these issues: 
- https://github.com/o3de/o3de/issues/4210
- https://github.com/o3de/o3de/issues/2980
- https://github.com/o3de/o3de/issues/3736

So I'm adding some alternate read-only fields to the Color Picker that will display the final output value in the destination color space. These values will match the value shown in the Property Inspector.

In the screenshot below...
- Most importantly, the "Linear sRGB Int" output **(3)** exactly matches the value shown in the Property Inspector **(5)**.
- The float edit fields **(1)** are moved up above the Quick Palette, closer to the main RGB sliders. I think this grouping makes more sense, especially now that the output color space has corresponding Int **(3)** and Float **(4)** fields next to each other.
- The colorspace comment text **(2)** is now located together with the alternate colorspace read-only fields, to provide some explanation of what's going on there. The actual content of the message is unchanged.
- The comment text **(2)** used to also serve as a label for the float edit boxes, now it is purely a colorspace comment.

![image](https://user-images.githubusercontent.com/55155825/193124847-b9b72e43-d0c0-4663-874b-83e5d96d8724.png)

The alternate colorspace fields are optional, they are only shown when the Color Picker is using a different colorspace from the property being edited. Here is what it looks like when there is no transformation needed:

![image](https://user-images.githubusercontent.com/55155825/193126238-d66ef60e-7cfd-49a1-88c7-94eedc207c2f.png)

The implementation in ColorPicker isn't ideal, because the client code is responsible for doing the conversion and populating these values every time the main color changes, using the currentColorChanged callback. It would be better for ColorPicker to manage the color conversion internally. But that level of change is out of scope for the upcoming release. There has been talk of wanting to make a more significant investment in ColorPicker, to enable it to operate in any color space of the artists choosing. Making those changes will naturally address this concern as it too will require making ColorPicker do the conversions internally.

This change is a followup to https://github.com/o3de/o3de/pull/12278

## How was this PR tested?

- Tested within the Material Editor, making sure the displayed alternate colorspace value exactly matches the value in the property inspector. 
- Locally changed the code to use GetRgbEditorConfig() instead of GetLinearRgbEditorConfig() to test the dialog in a non-transformation mode.
- Locally changed the code to make the ColorPicker run in RGBA mode to make sure the new fields can properly show four channels instead of three.
