### PR TITLE
Fix manually adding a local gem

### DIFF
--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -240,7 +240,10 @@ namespace O3DE::ProjectManager
                 AZ::Outcome<GemInfo, void> gemInfoResult = PythonBindingsInterface::Get()->GetGemInfo(directory);
                 if (gemInfoResult)
                 {
-                    AddToGemModel(gemInfoResult.GetValue<GemInfo>());
+                    // We added this local gem so set it's status to downloaded
+                    GemInfo& addedGemInfo = gemInfoResult.GetValue<GemInfo>();
+                    addedGemInfo.m_downloadStatus = GemInfo::DownloadStatus::Downloaded;
+                    AddToGemModel(addedGemInfo);
                 }
             }
         }


### PR DESCRIPTION
Manually adding a local gem then getting GemInfo was not setting the downloaded flag as it would when getting all gem infos, this was causing a gem added manually to report as not being downloaded causing issues creating a project using that gem.

Signed-off-by: AMZN-Phil <pconroy@amazon.com>