### PR TITLE
disabling atom tests which add axis aligned box shape

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Component_01.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Component_01.py
@@ -33,6 +33,7 @@ class TestAutomation(EditorTestSuite):
     class AtomEditorComponents_DepthOfFieldAdded(EditorBatchedTest):
         from Atom.tests import hydra_AtomEditorComponents_DepthOfFieldAdded as test_module
 
+    @pytest.mark.skip(reason="GHI# 12253 Failing in undo/redo intermittently")
     @pytest.mark.test_case_id("C36525659")
     class AtomEditorComponents_DiffuseProbeGridAdded(EditorBatchedTest):
         from Atom.tests import hydra_AtomEditorComponents_DiffuseProbeGridAdded as test_module

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Component_03.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Component_03.py
@@ -30,6 +30,7 @@ class TestAutomation(EditorTestSuite):
         from Atom.tests import (
             hydra_AtomEditorComponents_PostFXRadiusWeightModifierAdded as test_module)
 
+    @pytest.mark.skip(reason="GHI# 12253 Failing in undo/redo intermittently")
     @pytest.mark.test_case_id("C36525665")
     class AtomEditorComponents_PostFXShapeWeightModifierAdded(EditorBatchedTest):
         from Atom.tests import hydra_AtomEditorComponents_PostFxShapeWeightModifierAdded as test_module


### PR DESCRIPTION
Signed-off-by: Scott Murray <scottmur@amazon.com>

## What does this PR do?
disables postfx shapeweight modifier and diffuse probe which are also causing failures

## How was this PR tested?
