### PR TITLE
Fixed LC preview bounds not being parsed properly

### DIFF
--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
@@ -121,7 +121,7 @@ namespace LandscapeCanvasEditor
     static const int NODE_OFFSET_X_PIXELS = 350;
     static const int NODE_OFFSET_Y_PIXELS = 450;
     static constexpr int InvalidSlotIndex = -1;
-    static const char* PreviewEntityElementName = "PreviewEntity";
+    static const char* PreviewEntityElementName = "BoundsEntity";
     static const char* GradientIdElementName = "GradientId";
     static const char* GradientEntityIdElementName = "Gradient Entity";
     static const char* ShapeEntityIdElementName = "ShapeEntityId";


### PR DESCRIPTION
## What does this PR do?

Fixes #12301

Fixes issue with the preview bounds not being parsed properly in Landscape Canvas due to the field property name changing. This resulted in connections to the preview bounds being lost anytime the nodes connections were refreshed.

## How was this PR tested?

Tested steps from the linked issue.

BEFORE:
![PreviewBounds_BEFORE](https://user-images.githubusercontent.com/7519264/193149002-6233f270-64dd-4e6d-be34-8e80297aeb6f.gif)

AFTER:
![PreviewBounds_AFTER](https://user-images.githubusercontent.com/7519264/193149021-c52b38ad-5104-4a8c-bda9-9c24c50ad591.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>