### PR TITLE
Apply patch to fix crash in ProjectBuilderWorker on MacOS

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectBuilderWorker.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectBuilderWorker.cpp
@@ -123,7 +123,7 @@ namespace O3DE::ProjectManager
         }
 
         auto cmakeGenerateArguments = cmakeGenerateArgumentsResult.GetValue();
-        logStream << cmakeGenerateArguments.join(' ') << '\n'; 
+        logStream << cmakeGenerateArguments.join(' ') << '\n';
 
         m_configProjectProcess->start(cmakeGenerateArguments.front(), cmakeGenerateArguments.mid(1));
         if (!m_configProjectProcess->waitForStarted())
@@ -195,7 +195,11 @@ namespace O3DE::ProjectManager
             logStream.flush();
 
             // Show last line of output
-            UpdateProgress(buildOutput.split('\n', Qt::SkipEmptyParts).last());
+            if (QStringList strs = buildOutput.split('\n', Qt::SkipEmptyParts);
+                !strs.empty())
+            {
+                UpdateProgress(strs.last());
+            }
 
             if (QThread::currentThread()->isInterruptionRequested())
             {


### PR DESCRIPTION
The split command of the progress dialog causes an out of bounds access when the build output does not have a newline yet.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Used Project Manager on MacOS
