### PR TITLE
DPE: Enable enum comboboxes

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -175,6 +175,11 @@ namespace AZ::DocumentPropertyEditor
 
         AZStd::shared_ptr<AZ::Attribute> DomValueToLegacyAttribute(const AZ::Dom::Value& value) const override
         {
+            // We aren't currently hitting the right case here, but that's because our AttributeDefinition is of type Dom::Value
+            // The difficulties surrounding solving that problem are commented in PropertyEditorNodes.h
+            // If we must leave the attr definition as Dom::Value, then we need at least one more case here for pulling the
+            // data out of the AZStd::any and stuffing it in an AttributeData
+            // Getting the data out of the AZStd::any requires knowing its type, afaik, which is also a sticking point
             if constexpr (AZStd::is_same_v<AttributeType, AZ::Dom::Value>)
             {
                 return AZ::Reflection::WriteDomValueToGenericAttribute(value);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -58,6 +58,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumType);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumUnderlyingType);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumValue);
+        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumValues);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::ChangeNotify);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::AddNotify);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::RemoveNotify);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -129,7 +129,13 @@ namespace AZ::DocumentPropertyEditor::Nodes
 
         static constexpr auto EnumType = TypeIdAttributeDefinition("EnumType");
         static constexpr auto EnumUnderlyingType = TypeIdAttributeDefinition("EnumUnderlyingType");
+        // Should these be Dom::Value? StingList has its explicit type, and these function similar to StringList
+        // Problem with explicit parameterization here is that the desired type, at least in the case of EnumValues, is akin to
+        //          AZStd::vector<AZ:Edit::EnumConstant<OneOfManyEnunTypes>>
+        // I don't know of a way to scry our type here
+        // Could be a void*, but will this always be a ptr? And then we're just kicking the "what type is this?" can down the road
         static constexpr auto EnumValue = AttributeDefinition<Dom::Value>("EnumValue");
+        static constexpr auto EnumValues = AttributeDefinition<Dom::Value>("EnumValues");
         static constexpr auto ChangeNotify = CallbackAttributeDefinition<PropertyRefreshLevel()>("ChangeNotify");
         static constexpr auto RequestTreeUpdate = CallbackAttributeDefinition<void(PropertyRefreshLevel)>("RequestTreeUpdate");
 


### PR DESCRIPTION
**DRAFT**

My inexperience is starting to get in the way here, so any help is appreciated!

Gist of this draft:
- Enum comboboxes are currently empty with the DPE enabled
- We've found what seems to be the problem, but are running into some problems finding the right fix or any reasonable fix really
- There are some comments in the diff describing the problems

Description of problem space:
- We call `RpePropertyHandlerWrapper::SetValueFromDom` when creating the widget for our enum comboboxes and pass in our `Dom::Value` node
- `SetValueFromDom` then requests creation of an `AttributeData` containing our `EnumValues` data from `AttributeDefinion::DomValueToLegacyAttribute`
- We stuff that `AttributeData` into our `InstanceDataNode` m_proxyNode and hand the node off to the handler code for attribute consumption
- While consuming attributes inside of `GenericEnumPropertyComboBoxHandler`, we hit the `AZ::Edit::Attributes::EnumValues` case but fail to extract anything useful from our attributes because they contain a `Dom::Value` instead of an `AZStd::vector<AZ::Edit::EnumConstant<ValueType>>`

Solution vectors (and their problems):
- Make the AttributeDefinition type explicit like `AttributeDefinition<AZStd::vector<AZ::Edit::EnumConstant<ValueType>>>`
  - Problem: we have no idea what `ValueType` will be at compile time (is there a way to just use 'enum' as a type here?
- Make the AttributeDefinition type something that's more easily derived from inside `AttributeDefinion::DomValueToLegacyAttribute`
  - Problem: not sure what data type could contain any type and allow relatively easy typed retrieval of the wrapped data without the programmer specifying the wrapped type (words :/)
- Create a parameterized version of `AttributeDefinion::DomValueToLegacyAttribute` that could infer or somehow be given the type of our AZStd::any wrapped data (from inside the Dom::Value node)
  - Problem: this is starting to sound kind of crazy, and we're still stuck trying to pull the type of our Opaque value out of something unknown in such a way that the C++ compiler will be satisfied with the argument list