### PR TITLE
Use default templates folder for starting path for template location

### DIFF
--- a/Code/Tools/ProjectManager/Source/DownloadRemoteTemplateDialog.cpp
+++ b/Code/Tools/ProjectManager/Source/DownloadRemoteTemplateDialog.cpp
@@ -61,7 +61,7 @@ namespace O3DE::ProjectManager
         m_installPath = new FormFolderBrowseEditWidget(tr("Local template directory"));
         m_installPath->setMinimumSize(QSize(600, 0));
         m_installPath->lineEdit()->setText(
-            QDir::toNativeSeparators(ProjectUtils::GetDefaultProjectPath() + "/" + projectTemplate.m_name));
+            QDir::toNativeSeparators(ProjectUtils::GetDefaultTemplatePath() + "/" + projectTemplate.m_name));
         vLayout->addWidget(m_installPath);
 
         vLayout->addSpacing(20);

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
@@ -674,20 +674,35 @@ namespace O3DE::ProjectManager
             return AZ::Success(QString(projectBuildPath.c_str()));
         }
 
-    QString GetDefaultProjectPath()
-    {
-        QString defaultPath = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
-        AZ::Outcome<EngineInfo> engineInfoResult = PythonBindingsInterface::Get()->GetEngineInfo();
-        if (engineInfoResult.IsSuccess())
+        QString GetDefaultProjectPath()
         {
-            QDir path(QDir::toNativeSeparators(engineInfoResult.GetValue().m_defaultProjectsFolder));
-            if (path.exists())
+            QString defaultPath = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+            AZ::Outcome<EngineInfo> engineInfoResult = PythonBindingsInterface::Get()->GetEngineInfo();
+            if (engineInfoResult.IsSuccess())
             {
-                defaultPath = path.absolutePath();
+                QDir path(QDir::toNativeSeparators(engineInfoResult.GetValue().m_defaultProjectsFolder));
+                if (path.exists())
+                {
+                    defaultPath = path.absolutePath();
+                }
             }
+            return defaultPath;
         }
-        return defaultPath;
-    }
+
+        QString GetDefaultTemplatePath()
+        {
+            QString defaultPath = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+            AZ::Outcome<EngineInfo> engineInfoResult = PythonBindingsInterface::Get()->GetEngineInfo();
+            if (engineInfoResult.IsSuccess())
+            {
+                QDir path(QDir::toNativeSeparators(engineInfoResult.GetValue().m_defaultTemplatesFolder));
+                if (path.exists())
+                {
+                    defaultPath = path.absolutePath();
+                }
+            }
+            return defaultPath;
+        }
 
         void DisplayDetailedError(const QString& title, const AZ::Outcome<void, AZStd::pair<AZStd::string, AZStd::string>>& outcome, QWidget* parent)
         {

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.h
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.h
@@ -74,6 +74,7 @@ namespace O3DE::ProjectManager
         AZ::Outcome<QString, QString> RunGetPythonScript(const QString& enginePath);
 
         QString GetDefaultProjectPath();
+        QString GetDefaultTemplatePath();
 
         /**
          * Create a desktop shortcut.


### PR DESCRIPTION
Change to use the default template location for downloading templates.
Fixes indentation on GetDefaultProjectPath

Signed-off-by: AMZN-Phil <pconroy@amazon.com>