### PR TITLE
Reduce manual steps required to rename a gem

### DIFF
--- a/Templates/AssetGem/Template/CMakeLists.txt
+++ b/Templates/AssetGem/Template/CMakeLists.txt
@@ -6,10 +6,17 @@
 #
 # {END_LICENSE}
 
+# Query the gem name from the gem.json file if possible
+# otherwise fallback to using ${Name}
+o3de_find_ancestor_gem_root(gem_root_path gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
+if (NOT gem_name)
+    set(gem_name "${Name}")
+endif()
+
 # This will export the path to the directory containing the gem.json
 # to the "SourcePaths" entry within the "cmake_dependencies.<project>.assetbuilder.setreg"
 # which is generated when cmake is run
 # This path is the gem root directory
 if(PAL_TRAIT_BUILD_HOST_TOOLS)
-    ly_create_alias(NAME ${Name}.Builders NAMESPACE Gem)
+    ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem)
 endif()

--- a/Templates/CppToolGem/Template/CMakeLists.txt
+++ b/Templates/CppToolGem/Template/CMakeLists.txt
@@ -6,12 +6,24 @@
 #
 # {END_LICENSE}
 
-set(gem_path ${CMAKE_CURRENT_LIST_DIR})
+# Query the gem name from the gem.json file if possible
+# otherwise fallback to using ${Name}
+o3de_find_ancestor_gem_root(gem_path gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
+if (NOT gem_name)
+    set(gem_name "${Name}")
+endif()
+
+# Fallback to using the current source CMakeLists.txt directory as the gem root path
+if (NOT gem_path)
+    set(gem_path ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
 set(gem_json ${gem_path}/gem.json)
+
 o3de_restricted_path(${gem_json} gem_restricted_path gem_parent_relative_path)
 
-o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_SOURCE_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 
-ly_add_external_target_path(${CMAKE_CURRENT_LIST_DIR}/3rdParty)
+ly_add_external_target_path(${CMAKE_CURRENT_SOURCE_DIR}/3rdParty)
 
 add_subdirectory(Code)

--- a/Templates/CppToolGem/Template/Code/CMakeLists.txt
+++ b/Templates/CppToolGem/Template/Code/CMakeLists.txt
@@ -19,9 +19,9 @@ o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${
 # is supported by this platform.
 include(${pal_dir}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
 
-# The ${Name}.API target declares the common interface that users of this gem should depend on in their targets
+# The ${gem_name}.API target declares the common interface that users of this gem should depend on in their targets
 ly_add_target(
-    NAME ${Name}.API INTERFACE
+    NAME ${gem_name}.API INTERFACE
     NAMESPACE Gem
     FILES_CMAKE
         ${NameLower}_api_files.cmake
@@ -34,10 +34,10 @@ ly_add_target(
            AZ::AzCore
 )
 
-# The ${Name}.Private.Object target is an internal target
+# The ${gem_name}.Private.Object target is an internal target
 # It should not be used outside of this Gems CMakeLists.txt
 ly_add_target(
-    NAME ${Name}.Private.Object STATIC
+    NAME ${gem_name}.Private.Object STATIC
     NAMESPACE Gem
     FILES_CMAKE
         ${NameLower}_private_files.cmake
@@ -54,9 +54,9 @@ ly_add_target(
             AZ::AzFramework
 )
 
-# Here add ${Name} target, it depends on the Private Object library and Public API interface
+# Here add ${gem_name} target, it depends on the Private Object library and Public API interface
 ly_add_target(
-    NAME ${Name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
+    NAME ${gem_name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
     NAMESPACE Gem
     FILES_CMAKE
         ${NameLower}_shared_files.cmake
@@ -68,26 +68,26 @@ ly_add_target(
             Source
     BUILD_DEPENDENCIES
         PUBLIC
-            Gem::${Name}.API
+            Gem::${gem_name}.API
         PRIVATE
-            Gem::${Name}.Private.Object
+            Gem::${gem_name}.Private.Object
 )
 
-# By default, we will specify that the above target ${Name} would be used by
+# By default, we will specify that the above target ${gem_name} would be used by
 # Client and Server type targets when this gem is enabled.  If you don't want it
 # active in Clients or Servers by default, delete one of both of the following lines:
-ly_create_alias(NAME ${Name}.Clients NAMESPACE Gem TARGETS Gem::${Name})
-ly_create_alias(NAME ${Name}.Servers NAMESPACE Gem TARGETS Gem::${Name})
+ly_create_alias(NAME ${gem_name}.Clients NAMESPACE Gem TARGETS Gem::${gem_name})
+ly_create_alias(NAME ${gem_name}.Servers NAMESPACE Gem TARGETS Gem::${gem_name})
 
-# For the Client and Server variants of ${Name} Gem, an alias to the ${Name}.API target will be made
-ly_create_alias(NAME ${Name}.Clients.API NAMESPACE Gem TARGETS Gem::${Name}.API)
-ly_create_alias(NAME ${Name}.Servers.API NAMESPACE Gem TARGETS Gem::${Name}.API)
+# For the Client and Server variants of ${gem_name} Gem, an alias to the ${gem_name}.API target will be made
+ly_create_alias(NAME ${gem_name}.Clients.API NAMESPACE Gem TARGETS Gem::${gem_name}.API)
+ly_create_alias(NAME ${gem_name}.Servers.API NAMESPACE Gem TARGETS Gem::${gem_name}.API)
 
-# If we are on a host platform, we want to add the host tools targets like the ${Name}.Editor MODULE target
+# If we are on a host platform, we want to add the host tools targets like the ${gem_name}.Editor MODULE target
 if(PAL_TRAIT_BUILD_HOST_TOOLS)
-    # The ${Name}.Editor.API target can be used by other gems that want to interact with the ${Name}.Editor module
+    # The ${gem_name}.Editor.API target can be used by other gems that want to interact with the ${gem_name}.Editor module
     ly_add_target(
-        NAME ${Name}.Editor.API INTERFACE
+        NAME ${gem_name}.Editor.API INTERFACE
         NAMESPACE Gem
         FILES_CMAKE
             ${NameLower}_editor_api_files.cmake
@@ -100,11 +100,11 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 AZ::AzToolsFramework
     )
 
-    # The ${Name}.Editor.Private.Object target is an internal target
+    # The ${gem_name}.Editor.Private.Object target is an internal target
     # which is only to be used by this gems CMakeLists.txt and any subdirectories
     # Other gems should not use this target
     ly_add_target(
-        NAME ${Name}.Editor.Private.Object STATIC
+        NAME ${gem_name}.Editor.Private.Object STATIC
         NAMESPACE Gem
         AUTOMOC
         AUTORCC
@@ -119,11 +119,11 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::${Name}.Private.Object>
+                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
     )
 
     ly_add_target(
-        NAME ${Name}.Editor GEM_MODULE
+        NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
         AUTOMOC
         FILES_CMAKE
@@ -135,20 +135,20 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Include
         BUILD_DEPENDENCIES
             PUBLIC
-                Gem::${Name}.Editor.API
+                Gem::${gem_name}.Editor.API
             PRIVATE
-                Gem::${Name}.Editor.Private.Object
+                Gem::${gem_name}.Editor.Private.Object
     )
 
-    # By default, we will specify that the above target ${Name} would be used by
+    # By default, we will specify that the above target ${gem_name} would be used by
     # Tool and Builder type targets when this gem is enabled.  If you don't want it
     # active in Tools or Builders by default, delete one of both of the following lines:
-    ly_create_alias(NAME ${Name}.Tools    NAMESPACE Gem TARGETS Gem::${Name}.Editor)
-    ly_create_alias(NAME ${Name}.Builders NAMESPACE Gem TARGETS Gem::${Name}.Editor)
+    ly_create_alias(NAME ${gem_name}.Tools    NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
+    ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
 
-    # For the Tools and Builders variants of ${Name} Gem, an alias to the ${Name}.Editor API target will be made
-    ly_create_alias(NAME ${Name}.Tools.API NAMESPACE Gem TARGETS Gem::${Name}.Editor.API)
-    ly_create_alias(NAME ${Name}.Builders.API NAMESPACE Gem TARGETS Gem::${Name}.Editor.API)
+    # For the Tools and Builders variants of ${gem_name} Gem, an alias to the ${gem_name}.Editor API target will be made
+    ly_create_alias(NAME ${gem_name}.Tools.API NAMESPACE Gem TARGETS Gem::${gem_name}.Editor.API)
+    ly_create_alias(NAME ${gem_name}.Builders.API NAMESPACE Gem TARGETS Gem::${gem_name}.Editor.API)
 
 endif()
 
@@ -157,11 +157,11 @@ endif()
 ################################################################################
 # See if globally, tests are supported
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
-    # We globally support tests, see if we support tests on this platform for ${Name}.Tests
+    # We globally support tests, see if we support tests on this platform for ${gem_name}.Tests
     if(PAL_TRAIT_${NameUpper}_TEST_SUPPORTED)
-        # We support ${Name}.Tests on this platform, add dependency on the Private Object target
+        # We support ${gem_name}.Tests on this platform, add dependency on the Private Object target
         ly_add_target(
-            NAME ${Name}.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
+            NAME ${gem_name}.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
             NAMESPACE Gem
             FILES_CMAKE
                 ${NameLower}_tests_files.cmake
@@ -173,12 +173,12 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 PRIVATE
                     AZ::AzTest
                     AZ::AzFramework
-                    Gem::${Name}.Private.Object
+                    Gem::${gem_name}.Private.Object
         )
 
-        # Add ${Name}.Tests to googletest
+        # Add ${gem_name}.Tests to googletest
         ly_add_googletest(
-            NAME Gem::${Name}.Tests
+            NAME Gem::${gem_name}.Tests
         )
     endif()
 
@@ -186,10 +186,10 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
     if(PAL_TRAIT_BUILD_HOST_TOOLS)
         # We are a host platform, see if Editor tests are supported on this platform
         if(PAL_TRAIT_${NameUpper}_EDITOR_TEST_SUPPORTED)
-            # We support ${Name}.Editor.Tests on this platform, add ${Name}.Editor.Tests target which depends on
-            # private ${Name}.Editor.Private.Object target
+            # We support ${gem_name}.Editor.Tests on this platform, add ${gem_name}.Editor.Tests target which depends on
+            # private ${gem_name}.Editor.Private.Object target
             ly_add_target(
-                NAME ${Name}.Editor.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
+                NAME ${gem_name}.Editor.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
                 NAMESPACE Gem
                 FILES_CMAKE
                     ${NameLower}_editor_tests_files.cmake
@@ -200,12 +200,12 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 BUILD_DEPENDENCIES
                     PRIVATE
                         AZ::AzTest
-                        Gem::${Name}.Private.Object
+                        Gem::${gem_name}.Private.Object
             )
 
-            # Add ${Name}.Editor.Tests to googletest
+            # Add ${gem_name}.Editor.Tests to googletest
             ly_add_googletest(
-                NAME Gem::${Name}.Editor.Tests
+                NAME Gem::${gem_name}.Editor.Tests
             )
         endif()
     endif()

--- a/Templates/DefaultGem/Template/CMakeLists.txt
+++ b/Templates/DefaultGem/Template/CMakeLists.txt
@@ -6,12 +6,24 @@
 #
 # {END_LICENSE}
 
-set(gem_path ${CMAKE_CURRENT_LIST_DIR})
+# Query the gem name from the gem.json file if possible
+# otherwise fallback to using ${Name}
+o3de_find_ancestor_gem_root(gempath gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
+if (NOT gem_name)
+    set(gem_name "${Name}")
+endif()
+
+# Fallback to using the current source CMakeLists.txt directory as the gem root path
+if (NOT gem_path)
+    set(gem_path ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
 set(gem_json ${gem_path}/gem.json)
+
 o3de_restricted_path(${gem_json} gem_restricted_path gem_parent_relative_path)
 
-o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_SOURCE_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 
-ly_add_external_target_path(${CMAKE_CURRENT_LIST_DIR}/3rdParty)
+ly_add_external_target_path(${CMAKE_CURRENT_SOURCE_DIR}/3rdParty)
 
 add_subdirectory(Code)

--- a/Templates/DefaultGem/Template/Code/CMakeLists.txt
+++ b/Templates/DefaultGem/Template/Code/CMakeLists.txt
@@ -19,9 +19,9 @@ o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${
 # is supported by this platform.
 include(${pal_dir}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
 
-# The ${Name}.API target declares the common interface that users of this gem should depend on in their targets
+# The ${gem_name}.API target declares the common interface that users of this gem should depend on in their targets
 ly_add_target(
-    NAME ${Name}.API INTERFACE
+    NAME ${gem_name}.API INTERFACE
     NAMESPACE Gem
     FILES_CMAKE
         ${NameLower}_api_files.cmake
@@ -34,10 +34,10 @@ ly_add_target(
            AZ::AzCore
 )
 
-# The ${Name}.Private.Object target is an internal target
+# The ${gem_name}.Private.Object target is an internal target
 # It should not be used outside of this Gems CMakeLists.txt
 ly_add_target(
-    NAME ${Name}.Private.Object STATIC
+    NAME ${gem_name}.Private.Object STATIC
     NAMESPACE Gem
     FILES_CMAKE
         ${NameLower}_private_files.cmake
@@ -54,9 +54,9 @@ ly_add_target(
             AZ::AzFramework
 )
 
-# Here add ${Name} target, it depends on the Private Object library and Public API interface
+# Here add ${gem_name} target, it depends on the Private Object library and Public API interface
 ly_add_target(
-    NAME ${Name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
+    NAME ${gem_name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
     NAMESPACE Gem
     FILES_CMAKE
         ${NameLower}_shared_files.cmake
@@ -68,26 +68,26 @@ ly_add_target(
             Source
     BUILD_DEPENDENCIES
         PUBLIC
-            Gem::${Name}.API
+            Gem::${gem_name}.API
         PRIVATE
-            Gem::${Name}.Private.Object
+            Gem::${gem_name}.Private.Object
 )
 
-# By default, we will specify that the above target ${Name} would be used by
+# By default, we will specify that the above target ${gem_name} would be used by
 # Client and Server type targets when this gem is enabled.  If you don't want it
 # active in Clients or Servers by default, delete one of both of the following lines:
-ly_create_alias(NAME ${Name}.Clients NAMESPACE Gem TARGETS Gem::${Name})
-ly_create_alias(NAME ${Name}.Servers NAMESPACE Gem TARGETS Gem::${Name})
+ly_create_alias(NAME ${gem_name}.Clients NAMESPACE Gem TARGETS Gem::${gem_name})
+ly_create_alias(NAME ${gem_name}.Servers NAMESPACE Gem TARGETS Gem::${gem_name})
 
-# For the Client and Server variants of ${Name} Gem, an alias to the ${Name}.API target will be made
-ly_create_alias(NAME ${Name}.Clients.API NAMESPACE Gem TARGETS Gem::${Name}.API)
-ly_create_alias(NAME ${Name}.Servers.API NAMESPACE Gem TARGETS Gem::${Name}.API)
+# For the Client and Server variants of ${gem_name} Gem, an alias to the ${gem_name}.API target will be made
+ly_create_alias(NAME ${gem_name}.Clients.API NAMESPACE Gem TARGETS Gem::${gem_name}.API)
+ly_create_alias(NAME ${gem_name}.Servers.API NAMESPACE Gem TARGETS Gem::${gem_name}.API)
 
-# If we are on a host platform, we want to add the host tools targets like the ${Name}.Editor MODULE target
+# If we are on a host platform, we want to add the host tools targets like the ${gem_name}.Editor MODULE target
 if(PAL_TRAIT_BUILD_HOST_TOOLS)
-    # The ${Name}.Editor.API target can be used by other gems that want to interact with the ${Name}.Editor module
+    # The ${gem_name}.Editor.API target can be used by other gems that want to interact with the ${gem_name}.Editor module
     ly_add_target(
-        NAME ${Name}.Editor.API INTERFACE
+        NAME ${gem_name}.Editor.API INTERFACE
         NAMESPACE Gem
         FILES_CMAKE
             ${NameLower}_editor_api_files.cmake
@@ -100,11 +100,11 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 AZ::AzToolsFramework
     )
 
-    # The ${Name}.Editor.Private.Object target is an internal target
+    # The ${gem_name}.Editor.Private.Object target is an internal target
     # which is only to be used by this gems CMakeLists.txt and any subdirectories
     # Other gems should not use this target
     ly_add_target(
-        NAME ${Name}.Editor.Private.Object STATIC
+        NAME ${gem_name}.Editor.Private.Object STATIC
         NAMESPACE Gem
         FILES_CMAKE
             ${NameLower}_editor_private_files.cmake
@@ -117,11 +117,11 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::${Name}.Private.Object>
+                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
     )
 
     ly_add_target(
-        NAME ${Name}.Editor GEM_MODULE
+        NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
         AUTOMOC
         FILES_CMAKE
@@ -133,20 +133,20 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Include
         BUILD_DEPENDENCIES
             PUBLIC
-                Gem::${Name}.Editor.API
+                Gem::${gem_name}.Editor.API
             PRIVATE
-                Gem::${Name}.Editor.Private.Object
+                Gem::${gem_name}.Editor.Private.Object
     )
 
-    # By default, we will specify that the above target ${Name} would be used by
+    # By default, we will specify that the above target ${gem_name} would be used by
     # Tool and Builder type targets when this gem is enabled.  If you don't want it
     # active in Tools or Builders by default, delete one of both of the following lines:
-    ly_create_alias(NAME ${Name}.Tools    NAMESPACE Gem TARGETS Gem::${Name}.Editor)
-    ly_create_alias(NAME ${Name}.Builders NAMESPACE Gem TARGETS Gem::${Name}.Editor)
+    ly_create_alias(NAME ${gem_name}.Tools    NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
+    ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
 
-    # For the Tools and Builders variants of ${Name} Gem, an alias to the ${Name}.Editor API target will be made
-    ly_create_alias(NAME ${Name}.Tools.API NAMESPACE Gem TARGETS Gem::${Name}.Editor.API)
-    ly_create_alias(NAME ${Name}.Builders.API NAMESPACE Gem TARGETS Gem::${Name}.Editor.API)
+    # For the Tools and Builders variants of ${gem_name} Gem, an alias to the ${gem_name}.Editor API target will be made
+    ly_create_alias(NAME ${gem_name}.Tools.API NAMESPACE Gem TARGETS Gem::${gem_name}.Editor.API)
+    ly_create_alias(NAME ${gem_name}.Builders.API NAMESPACE Gem TARGETS Gem::${gem_name}.Editor.API)
 
 endif()
 
@@ -155,11 +155,11 @@ endif()
 ################################################################################
 # See if globally, tests are supported
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
-    # We globally support tests, see if we support tests on this platform for ${Name}.Tests
+    # We globally support tests, see if we support tests on this platform for ${gem_name}.Tests
     if(PAL_TRAIT_${NameUpper}_TEST_SUPPORTED)
-        # We support ${Name}.Tests on this platform, add dependency on the Private Object target
+        # We support ${gem_name}.Tests on this platform, add dependency on the Private Object target
         ly_add_target(
-            NAME ${Name}.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
+            NAME ${gem_name}.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
             NAMESPACE Gem
             FILES_CMAKE
                 ${NameLower}_tests_files.cmake
@@ -171,12 +171,12 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 PRIVATE
                     AZ::AzTest
                     AZ::AzFramework
-                    Gem::${Name}.Private.Object
+                    Gem::${gem_name}.Private.Object
         )
 
-        # Add ${Name}.Tests to googletest
+        # Add ${gem_name}.Tests to googletest
         ly_add_googletest(
-            NAME Gem::${Name}.Tests
+            NAME Gem::${gem_name}.Tests
         )
     endif()
 
@@ -184,10 +184,10 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
     if(PAL_TRAIT_BUILD_HOST_TOOLS)
         # We are a host platform, see if Editor tests are supported on this platform
         if(PAL_TRAIT_${NameUpper}_EDITOR_TEST_SUPPORTED)
-            # We support ${Name}.Editor.Tests on this platform, add ${Name}.Editor.Tests target which depends on
-            # private ${Name}.Editor.Private.Object target
+            # We support ${gem_name}.Editor.Tests on this platform, add ${gem_name}.Editor.Tests target which depends on
+            # private ${gem_name}.Editor.Private.Object target
             ly_add_target(
-                NAME ${Name}.Editor.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
+                NAME ${gem_name}.Editor.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
                 NAMESPACE Gem
                 FILES_CMAKE
                     ${NameLower}_editor_tests_files.cmake
@@ -198,12 +198,12 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 BUILD_DEPENDENCIES
                     PRIVATE
                         AZ::AzTest
-                        Gem::${Name}.Private.Object
+                        Gem::${gem_name}.Private.Object
             )
 
-            # Add ${Name}.Editor.Tests to googletest
+            # Add ${gem_name}.Editor.Tests to googletest
             ly_add_googletest(
-                NAME Gem::${Name}.Editor.Tests
+                NAME Gem::${gem_name}.Editor.Tests
             )
         endif()
     endif()

--- a/Templates/DefaultProject/Template/Gem/CMakeLists.txt
+++ b/Templates/DefaultProject/Template/Gem/CMakeLists.txt
@@ -6,8 +6,20 @@
 #
 # {END_LICENSE}
 
-set(gem_path ${CMAKE_CURRENT_LIST_DIR})
+# Query the gem name from the gem.json file if possible
+# otherwise fallback to using ${Name}
+o3de_find_ancestor_gem_root(gempath gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
+if (NOT gem_name)
+    set(gem_name "${Name}")
+endif()
+
+# Fallback to using the current source CMakeLists.txt directory as the gem root path
+if (NOT gem_path)
+    set(gem_path ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
 set(gem_json ${gem_path}/gem.json)
+
 o3de_restricted_path(${gem_json} gem_restricted_path gem_parent_relative_path)
 
 # Currently we are in the ${Name}/Code folder: ${CMAKE_CURRENT_LIST_DIR}
@@ -16,7 +28,7 @@ o3de_restricted_path(${gem_json} gem_restricted_path gem_parent_relative_path)
 #       in which case it will see if that platform is present here or in the restricted folder.
 #       i.e. It could here : ${Name}/Code/Platform/<platform_name>  or
 #            <restricted_folder>/<platform_name>/${Name}/Code
-o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_SOURCE_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 
 # Now that we have the platform abstraction layer (PAL) folder for this folder, thats where we will find the
 # traits for this platform. Traits for a platform are defines for things like whether or not something in this project
@@ -29,11 +41,14 @@ if(NOT PAL_TRAIT_${NameUpper}_SUPPORTED)
     return()
 endif()
 
-# We are on a supported platform, so add the ${Name} target
+# We are on a supported platform, so add the ${gem_name} target
 # Note: We include the common files and the platform specific files which are set in ${NameLower}_files.cmake and
 # in ${pal_dir}/${NameLower}_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
+
+# The ${gem_name}.Private.Object target is an internal target
+# It should not be used outside of this CMakeLists.txt
 ly_add_target(
-    NAME ${Name}.Static STATIC
+    NAME ${gem_name}.Private.Object STATIC
     NAMESPACE Gem
     FILES_CMAKE
         ${NameLower}_files.cmake
@@ -48,7 +63,7 @@ ly_add_target(
 )
 
 ly_add_target(
-    NAME ${Name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
+    NAME ${gem_name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
     NAMESPACE Gem
     FILES_CMAKE
         ${NameLower}_shared_files.cmake
@@ -58,15 +73,15 @@ ly_add_target(
             Include
     BUILD_DEPENDENCIES
         PRIVATE
-            Gem::${Name}.Static
+            Gem::${gem_name}.Private.Object
             AZ::AzCore
 )
 
-# if enabled, ${Name} is used by all kinds of applications
-ly_create_alias(NAME ${Name}.Builders NAMESPACE Gem TARGETS Gem::${Name})
-ly_create_alias(NAME ${Name}.Tools    NAMESPACE Gem TARGETS Gem::${Name})
-ly_create_alias(NAME ${Name}.Clients  NAMESPACE Gem TARGETS Gem::${Name})
-ly_create_alias(NAME ${Name}.Servers  NAMESPACE Gem TARGETS Gem::${Name})
+# if enabled, ${gem_name} is used by all kinds of applications
+ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem TARGETS Gem::${gem_name})
+ly_create_alias(NAME ${gem_name}.Tools    NAMESPACE Gem TARGETS Gem::${gem_name})
+ly_create_alias(NAME ${gem_name}.Clients  NAMESPACE Gem TARGETS Gem::${gem_name})
+ly_create_alias(NAME ${gem_name}.Servers  NAMESPACE Gem TARGETS Gem::${gem_name})
 
 ################################################################################
 # Gem dependencies

--- a/Templates/MinimalProject/Template/Gem/CMakeLists.txt
+++ b/Templates/MinimalProject/Template/Gem/CMakeLists.txt
@@ -6,8 +6,20 @@
 #
 # {END_LICENSE}
 
-set(gem_path ${CMAKE_CURRENT_LIST_DIR})
+# Query the gem name from the gem.json file if possible
+# otherwise fallback to using ${Name}
+o3de_find_ancestor_gem_root(gempath gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
+if (NOT gem_name)
+    set(gem_name "${Name}")
+endif()
+
+# Fallback to using the current source CMakeLists.txt directory as the gem root path
+if (NOT gem_path)
+    set(gem_path ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
 set(gem_json ${gem_path}/gem.json)
+
 o3de_restricted_path(${gem_json} gem_restricted_path gem_parent_relative_path)
 
 # Currently we are in the ${Name}/Code folder: ${CMAKE_CURRENT_LIST_DIR}
@@ -16,7 +28,7 @@ o3de_restricted_path(${gem_json} gem_restricted_path gem_parent_relative_path)
 #       in which case it will see if that platform is present here or in the restricted folder.
 #       i.e. It could here : ${Name}/Code/Platform/<platform_name>  or
 #            <restricted_folder>/<platform_name>/${Name}/Code
-o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_SOURCE_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 
 # Now that we have the platform abstraction layer (PAL) folder for this folder, thats where we will find the
 # traits for this platform. Traits for a platform are defines for things like whether or not something in this project
@@ -29,11 +41,14 @@ if(NOT PAL_TRAIT_${NameUpper}_SUPPORTED)
     return()
 endif()
 
-# We are on a supported platform, so add the ${Name} target
+# We are on a supported platform, so add the ${gem_name} target
 # Note: We include the common files and the platform specific files which are set in ${NameLower}_files.cmake and
 # in ${pal_dir}/${NameLower}_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
+
+# The ${gem_name}.Private.Object target is an internal target
+# It should not be used outside of this CMakeLists.txt
 ly_add_target(
-    NAME ${Name}.Static STATIC
+    NAME ${gem_name}.Private.Object STATIC
     NAMESPACE Gem
     FILES_CMAKE
         ${NameLower}_files.cmake
@@ -48,7 +63,7 @@ ly_add_target(
 )
 
 ly_add_target(
-    NAME ${Name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
+    NAME ${gem_name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
     NAMESPACE Gem
     FILES_CMAKE
         ${NameLower}_shared_files.cmake
@@ -58,15 +73,15 @@ ly_add_target(
             Include
     BUILD_DEPENDENCIES
         PRIVATE
-            Gem::${Name}.Static
+            Gem::${gem_name}.Private.Object
             AZ::AzCore
 )
 
-# if enabled, ${Name} is used by all kinds of applications
-ly_create_alias(NAME ${Name}.Builders NAMESPACE Gem TARGETS Gem::${Name})
-ly_create_alias(NAME ${Name}.Tools    NAMESPACE Gem TARGETS Gem::${Name})
-ly_create_alias(NAME ${Name}.Clients  NAMESPACE Gem TARGETS Gem::${Name})
-ly_create_alias(NAME ${Name}.Servers  NAMESPACE Gem TARGETS Gem::${Name})
+# if enabled, ${gem_name} is used by all kinds of applications
+ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem TARGETS Gem::${gem_name})
+ly_create_alias(NAME ${gem_name}.Tools    NAMESPACE Gem TARGETS Gem::${gem_name})
+ly_create_alias(NAME ${gem_name}.Clients  NAMESPACE Gem TARGETS Gem::${gem_name})
+ly_create_alias(NAME ${gem_name}.Servers  NAMESPACE Gem TARGETS Gem::${gem_name})
 
 ################################################################################
 # Gem dependencies

--- a/Templates/PrebuiltGem/Template/CMakeLists.txt
+++ b/Templates/PrebuiltGem/Template/CMakeLists.txt
@@ -6,10 +6,22 @@
 #
 # {END_LICENSE}
 
-set(gem_path ${CMAKE_CURRENT_LIST_DIR})
+# Query the gem name from the gem.json file if possible
+# otherwise fallback to using ${Name}
+o3de_find_ancestor_gem_root(gempath gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
+if (NOT gem_name)
+    set(gem_name "${Name}")
+endif()
+
+# Fallback to using the current source CMakeLists.txt directory as the gem root path
+if (NOT gem_path)
+    set(gem_path ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
 set(gem_json ${gem_path}/gem.json)
+
 o3de_restricted_path(${gem_json} gem_restricted_path gem_parent_relative_path)
 
-ly_add_external_target_path(${CMAKE_CURRENT_LIST_DIR}/3rdParty)
+ly_add_external_target_path(${CMAKE_CURRENT_SOURCE_DIR}/3rdParty)
 
 add_subdirectory(Code)

--- a/Templates/PrebuiltGem/Template/Code/CMakeLists.txt
+++ b/Templates/PrebuiltGem/Template/Code/CMakeLists.txt
@@ -13,9 +13,9 @@
 # Get the platform specific folder ${pal_dir} for the current folder: ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME}
 o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 
-# The ${Name}.API target declares the common interface that users of this gem should depend on in their targets
+# The ${gem_name}.API target declares the common interface that users of this gem should depend on in their targets
 ly_add_target(
-    NAME ${Name}.API INTERFACE
+    NAME ${gem_name}.API INTERFACE
     NAMESPACE Gem
     FILES_CMAKE
         ${NameLower}_api_files.cmake
@@ -30,10 +30,10 @@ ly_add_target(
 )
 
 
-# The ${Name} target is a prebuilt module that should contain extern "C" functions to hook into the Gem system
+# The ${gem_name} target is a prebuilt module that should contain extern "C" functions to hook into the Gem system
 # The list of those functions are available at https://github.com/o3de/o3de/blob/development/Code/Framework/AzCore/AzCore/Module/DynamicModuleHandle.h#L101-L137
 ly_add_target(
-    NAME ${Name} IMPORTED ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
+    NAME ${gem_name} IMPORTED ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
     NAMESPACE Gem
     PLATFORM_INCLUDE_FILES
         ${pal_dir}/${LY_BUILD_PERMUTATION}/${NameLower}.cmake
@@ -47,21 +47,21 @@ ly_add_target(
     TARGET_PROPERTIES
 )
 
-# By default, we will specify that the above target ${Name} would be used by
+# By default, we will specify that the above target ${gem_name} would be used by
 # Client and Server type targets when this gem is enabled.  If you don't want it
 # active in Clients or Servers by default, delete one of both of the following lines:
-ly_create_alias(NAME ${Name}.Clients NAMESPACE Gem TARGETS Gem::${Name})
-ly_create_alias(NAME ${Name}.Servers NAMESPACE Gem TARGETS Gem::${Name})
+ly_create_alias(NAME ${gem_name}.Clients NAMESPACE Gem TARGETS Gem::${gem_name})
+ly_create_alias(NAME ${gem_name}.Servers NAMESPACE Gem TARGETS Gem::${gem_name})
 
-# For the Client and Server variants of ${Name} Gem, an alias to the ${Name}.API target will be made
-ly_create_alias(NAME ${Name}.Clients.API NAMESPACE Gem TARGETS Gem::${Name}.API)
-ly_create_alias(NAME ${Name}.Servers.API NAMESPACE Gem TARGETS Gem::${Name}.API)
+# For the Client and Server variants of ${gem_name} Gem, an alias to the ${gem_name}.API target will be made
+ly_create_alias(NAME ${gem_name}.Clients.API NAMESPACE Gem TARGETS Gem::${gem_name}.API)
+ly_create_alias(NAME ${gem_name}.Servers.API NAMESPACE Gem TARGETS Gem::${gem_name}.API)
 
-# If we are on a host platform, we want to add the host tools targets like the ${Name}.Tools and ${Name}.Builders
+# If we are on a host platform, we want to add the host tools targets like the ${gem_name}.Tools and ${gem_name}.Builders
 if (PAL_TRAIT_BUILD_HOST_TOOLS)
-    # The ${Name}.Tools.API target can be used by other gems that want to interact with the ${Name}.Tools module
+    # The ${gem_name}.Tools.API target can be used by other gems that want to interact with the ${gem_name}.Tools module
     ly_add_target(
-        NAME ${Name}.Tools.API INTERFACE
+        NAME ${gem_name}.Tools.API INTERFACE
         NAMESPACE Gem
         FILES_CMAKE
             ${NameLower}_tools_api_files.cmake
@@ -75,10 +75,10 @@ if (PAL_TRAIT_BUILD_HOST_TOOLS)
         TARGET_PROPERTIES
     )
 
-    # The ${Name}.Tools target is a prebuilt module that should contain extern "C" functions to hook into the Gem system
+    # The ${gem_name}.Tools target is a prebuilt module that should contain extern "C" functions to hook into the Gem system
     # The list of those functions are available at https://github.com/o3de/o3de/blob/development/Code/Framework/AzCore/AzCore/Module/DynamicModuleHandle.h#L101-L137
     ly_add_target(
-        NAME ${Name}.Tools IMPORTED GEM_MODULE
+        NAME ${gem_name}.Tools IMPORTED GEM_MODULE
         NAMESPACE Gem
         PLATFORM_INCLUDE_FILES
             ${pal_dir}/${LY_BUILD_PERMUTATION}/${NameLower}_tools.cmake
@@ -91,9 +91,9 @@ if (PAL_TRAIT_BUILD_HOST_TOOLS)
     )
 
     # The Builders moudles are loaded by the AssetProcessor, AssetBuilder and AssetBundler
-    # The ${Name}.Builders.API target can be used by other gems that want to interact with the ${Name}.Builders module
+    # The ${gem_name}.Builders.API target can be used by other gems that want to interact with the ${gem_name}.Builders module
     ly_add_target(
-        NAME ${Name}.Builders.API INTERFACE
+        NAME ${gem_name}.Builders.API INTERFACE
         NAMESPACE Gem
         FILES_CMAKE
             ${NameLower}_builders_api_files.cmake
@@ -107,10 +107,10 @@ if (PAL_TRAIT_BUILD_HOST_TOOLS)
         TARGET_PROPERTIES
     )
 
-    # The ${Name}.Tools target is a prebuilt module that should contain extern "C" functions to hook into the Gem system
+    # The ${gem_name}.Tools target is a prebuilt module that should contain extern "C" functions to hook into the Gem system
     # The list of those functions are available at https://github.com/o3de/o3de/blob/development/Code/Framework/AzCore/AzCore/Module/DynamicModuleHandle.h#L101-L137
     ly_add_target(
-        NAME ${Name}.Builders IMPORTED GEM_MODULE
+        NAME ${gem_name}.Builders IMPORTED GEM_MODULE
         NAMESPACE Gem
         PLATFORM_INCLUDE_FILES
             ${pal_dir}/${LY_BUILD_PERMUTATION}/${NameLower}_builders.cmake
@@ -131,7 +131,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
     # Check if test are supported on the current platform
     if(PAL_TRAIT_${NameUpper}_TEST_SUPPORTED)
         ly_add_target(
-            NAME ${Name}.Tests IMPORTED ${PAL_TRAIT_TEST_TARGET_TYPE}
+            NAME ${gem_name}.Tests IMPORTED ${PAL_TRAIT_TEST_TARGET_TYPE}
             NAMESPACE Gem
             PLATFORM_INCLUDE_FILES
                 ${pal_dir}/${LY_BUILD_PERMUTATION}/${NameLower}_tests.cmake
@@ -142,7 +142,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
             TARGET_PROPERTIES
         )
         ly_add_googletest(
-            NAME Gem::${Name}.Tests
+            NAME Gem::${gem_name}.Tests
     )
     endif()
 
@@ -151,7 +151,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         if(PAL_TRAIT_${NameUpper}_EDITOR_TEST_SUPPORTED)
             # Check if the tools test are supported on the current platform
             ly_add_target(
-                NAME ${Name}.Tools.Tests IMPORTED ${PAL_TRAIT_TEST_TARGET_TYPE}
+                NAME ${gem_name}.Tools.Tests IMPORTED ${PAL_TRAIT_TEST_TARGET_TYPE}
                 NAMESPACE Gem
                 PLATFORM_INCLUDE_FILES
                     ${pal_dir}/${LY_BUILD_PERMUTATION}/${NameLower}_tools_tests.cmake
@@ -163,7 +163,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
             )
 
             ly_add_googletest(
-                NAME Gem::${Name}.Tools.Tests
+                NAME Gem::${gem_name}.Tools.Tests
             )
         endif()
     endif()

--- a/Templates/PythonToolGem/Template/CMakeLists.txt
+++ b/Templates/PythonToolGem/Template/CMakeLists.txt
@@ -6,9 +6,20 @@
 #
 # {END_LICENSE}
 
-set(o3de_gem_path ${CMAKE_CURRENT_LIST_DIR})
-set(o3de_gem_json ${o3de_gem_path}/gem.json)
-o3de_read_json_key(o3de_gem_name ${o3de_gem_json} "gem_name")
-o3de_restricted_path(${o3de_gem_json} o3de_gem_restricted_path)
+# Query the gem name from the gem.json file if possible
+# otherwise fallback to using ${Name}
+o3de_find_ancestor_gem_root(gempath gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
+if (NOT gem_name)
+    set(gem_name "${Name}")
+endif()
+
+# Fallback to using the current source CMakeLists.txt directory as the gem root path
+if (NOT gem_path)
+    set(gem_path ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
+set(gem_json ${gem_path}/gem.json)
+
+o3de_restricted_path(${gem_json} o3de_gem_restricted_path)
 
 add_subdirectory(Code)

--- a/Templates/PythonToolGem/Template/Code/CMakeLists.txt
+++ b/Templates/PythonToolGem/Template/Code/CMakeLists.txt
@@ -20,12 +20,12 @@ o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${
 include(${pal_dir}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
 
 
-# If we are on a host platform, we want to add the host tools targets like the ${Name}.Editor target which
-# will also depend on ${Name}.Editor.API target
+# If we are on a host platform, we want to add the host tools targets like the ${gem_name}.Editor target which
+# will also depend on ${gem_name}.Editor.API target
 if(PAL_TRAIT_BUILD_HOST_TOOLS)
-     # The ${Name}.Editor.API target can be used by other gems that want to interact with the ${Name}.Editor module
+     # The ${gem_name}.Editor.API target can be used by other gems that want to interact with the ${gem_name}.Editor module
     ly_add_target(
-        NAME ${Name}.Editor.API INTERFACE
+        NAME ${gem_name}.Editor.API INTERFACE
         NAMESPACE Gem
         FILES_CMAKE
             ${NameLower}_editor_api_files.cmake
@@ -38,11 +38,11 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 AZ::AzToolsFramework
     )
 
-    # The ${Name}.Editor.Private.Object target is an internal target
+    # The ${gem_name}.Editor.Private.Object target is an internal target
     # which is only to be used by this gems CMakeLists.txt and any subdirectories
     # Other gems should not use this target
     ly_add_target(
-        NAME ${Name}.Editor.Private.Object STATIC
+        NAME ${gem_name}.Editor.Private.Object STATIC
         NAMESPACE Gem
         AUTORCC
         FILES_CMAKE
@@ -59,7 +59,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     )
 
     ly_add_target(
-        NAME ${Name}.Editor GEM_MODULE
+        NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
         AUTOMOC
         FILES_CMAKE
@@ -71,22 +71,22 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Include
         BUILD_DEPENDENCIES
             PUBLIC
-                Gem::${Name}.Editor.API
+                Gem::${gem_name}.Editor.API
             PRIVATE
-                Gem::${Name}.Editor.Private.Object
+                Gem::${gem_name}.Editor.Private.Object
         RUNTIME_DEPENDENCIES
             Gem::QtForPython.Editor
     )
 
-    # By default, we will specify that the above target ${Name} would be used by
+    # By default, we will specify that the above target ${gem_name} would be used by
     # Tool and Builder type targets when this gem is enabled.  If you don't want it
     # active in Tools or Builders by default, delete one of both of the following lines:
-    ly_create_alias(NAME ${Name}.Tools    NAMESPACE Gem TARGETS Gem::${Name}.Editor)
-    ly_create_alias(NAME ${Name}.Builders NAMESPACE Gem TARGETS Gem::${Name}.Editor)
+    ly_create_alias(NAME ${gem_name}.Tools    NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
+    ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
 
-    # For the Tools and Builders variants of ${Name} Gem, an alias to the ${Name}.Editor API target will be made
-    ly_create_alias(NAME ${Name}.Tools.API NAMESPACE Gem TARGETS Gem::${Name}.Editor.API)
-    ly_create_alias(NAME ${Name}.Builders.API NAMESPACE Gem TARGETS Gem::${Name}.Editor.API)
+    # For the Tools and Builders variants of ${gem_name} Gem, an alias to the ${gem_name}.Editor API target will be made
+    ly_create_alias(NAME ${gem_name}.Tools.API NAMESPACE Gem TARGETS Gem::${gem_name}.Editor.API)
+    ly_create_alias(NAME ${gem_name}.Builders.API NAMESPACE Gem TARGETS Gem::${gem_name}.Editor.API)
 
 endif()
 
@@ -95,7 +95,7 @@ endif()
 ################################################################################
 # See if globally, tests are supported
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
-    # We globally support tests, see if we support tests on this platform for ${Name}.Editor.Tests
+    # We globally support tests, see if we support tests on this platform for ${gem_name}.Editor.Tests
 
     # If we are a host platform we want to add tools test like editor tests here
     if(PAL_TRAIT_BUILD_HOST_TOOLS)

--- a/cmake/Gems.cmake
+++ b/cmake/Gems.cmake
@@ -14,6 +14,49 @@ define_property(TARGET PROPERTY LY_PROJECT_NAME
     only a project with that name can have it's enabled gem list added as a dependency to this target.
     If the __NOPROJECT__ placeholder is associated with a list enabled gems, then it applies to this target regardless of this property value")
 
+
+# o3de_find_ancestor_gem_root:Searches for the nearest gem root from input source_dir
+#
+# \arg:source_dir(FILEPATH) - Filepath to walk upwards from to locate a gem.json
+# \return:output_gem_module_root - The directory containing the nearest gem.json
+# \return:output_gem_name - The name of the gem read from the gem.json
+function(o3de_find_ancestor_gem_root output_gem_module_root output_gem_name source_dir)
+    unset(${output_gem_module_root} PARENT_SCOPE)
+
+    if(source_dir)
+        set(candidate_gem_path ${source_dir})
+        # Locate the root of the gem by finding the gem.json location
+        cmake_path(APPEND candidate_gem_path "gem.json" OUTPUT_VARIABLE candidate_gem_json_path)
+        while(NOT EXISTS "${candidate_gem_json_path}")
+            get_property(parent_path DIRECTORY ${candidate_gem_path} PROPERTY PARENT_DIRECTORY)
+
+            # If the parent directory is the same as the candidate path then the root path has been found
+            cmake_path(COMPARE "${candidate_gem_path}" EQUAL "${parent_path}" reached_root_dir)
+            if (reached_root_dir)
+                # The source directory is not under a gem path in this case
+                return()
+            endif()
+            set(candidate_gem_path ${parent_path})
+            cmake_path(APPEND candidate_gem_path "gem.json" OUTPUT_VARIABLE candidate_gem_json_path)
+        endwhile()
+    endif()
+
+    if (EXISTS ${candidate_gem_json_path})
+        # Update source_dir if the gem root path exists
+        set(source_dir ${candidate_gem_path})
+        o3de_read_json_key(gem_name ${candidate_gem_json_path} "gem_name")
+    endif()
+
+    # Set the gem module root output directory to the location with the gem.json file within it or
+    # the supplied gem_target SOURCE_DIR location if no gem.json file was found
+    set(${output_gem_module_root} ${source_dir} PARENT_SCOPE)
+
+    # Set the gem name output value to the name of the gem as in the gem.json file
+    if(gem_name)
+        set(${output_gem_name} ${gem_name} PARENT_SCOPE)
+    endif()
+endfunction()
+
 # ly_create_alias
 # given an alias to create, and a list of one or more targets,
 # this creates an alias that depends on all of the given targets.
@@ -64,7 +107,7 @@ function(ly_create_alias)
         endif()
         list(APPEND final_targets ${de_aliased_target_name})
     endforeach()
-    
+
     # add_dependencies must be called with at least one dependent target
     if(final_targets)
         ly_parse_third_party_dependencies("${final_targets}")
@@ -176,7 +219,7 @@ function(ly_enable_gems)
     if ((NOT ly_enable_gems_GEMS AND NOT ly_enable_gems_GEM_FILE) OR (ly_enable_gems_GEMS AND ly_enable_gems_GEM_FILE))
         message(FATAL_ERROR "Provide exactly one of either GEM_FILE (filename) or GEMS (list of gems) keywords.")
     endif()
-    
+
     if (ly_enable_gems_GEM_FILE)
         set(store_temp ${ENABLED_GEMS})
         include(${ly_enable_gems_GEM_FILE} RESULT_VARIABLE was_able_to_load_the_file)

--- a/cmake/SettingsRegistry.cmake
+++ b/cmake/SettingsRegistry.cmake
@@ -42,14 +42,14 @@ string(APPEND gem_name_template
 )
 
 #!ly_detect_cycle_through_visitation: Detects if there is a cycle based on a list of visited
-# items. If the passed item is in the list, then there is a cycle. 
+# items. If the passed item is in the list, then there is a cycle.
 # \arg:item - item being checked for the cycle
 # \arg:visited_items - list of visited items
 # \arg:visited_items_var - list of visited items variable, "item" will be added to the list
-# \arg:cycle(variable) - empty string if there is no cycle (an empty string in cmake evaluates 
+# \arg:cycle(variable) - empty string if there is no cycle (an empty string in cmake evaluates
 #     to false). If there is a cycle a cycle dependency string detailing the sequence of items
 #     that produce a cycle, e.g. A --> B --> C --> A
-# 
+#
 function(ly_detect_cycle_through_visitation item visited_items visited_items_var cycle)
     if(item IN_LIST visited_items)
         unset(dependency_cycle_loop)
@@ -80,7 +80,7 @@ function(ly_get_gem_load_dependencies ly_GEM_LOAD_DEPENDENCIES ly_TARGET)
     if(NOT TARGET ${ly_TARGET})
         return() # Nothing to do
     endif()
-    # Internally we use a third parameter to pass the list of targets that we have traversed. This is 
+    # Internally we use a third parameter to pass the list of targets that we have traversed. This is
     # used to detect runtime cycles
     if(ARGC EQUAL 3)
         set(ly_CYCLE_DETECTION_TARGETS ${ARGV2})
@@ -140,23 +140,9 @@ function(ly_get_gem_module_root output_gem_module_root output_gem_name gem_targe
     unset(${output_gem_module_root} PARENT_SCOPE)
     get_property(gem_source_dir TARGET ${gem_target} PROPERTY SOURCE_DIR)
 
-    if(gem_source_dir)
-        set(candidate_gem_dir ${gem_source_dir})
-        # Locate the root of the gem by finding the gem.json location
-        while(NOT EXISTS ${candidate_gem_dir}/gem.json)
-            get_filename_component(parent_dir ${candidate_gem_dir} DIRECTORY)
-            if (${parent_dir} STREQUAL ${candidate_gem_dir})
-                # "Did not find a gem.json while processing GEM_MODULE target ${gem_target}!"
-                return()
-            endif()
-            set(candidate_gem_dir ${parent_dir})
-        endwhile()
-    endif()
-
-    if (EXISTS ${candidate_gem_dir}/gem.json)
-        set(gem_source_dir ${candidate_gem_dir})
-        o3de_read_json_key(gem_name ${candidate_gem_dir}/gem.json "gem_name")
-    endif()
+    # the o3de_find_ancestor_gem_root looks up the nearest gem root path
+    # at or above the current directory visited by cmake
+    o3de_find_ancestor_gem_root(gem_source_dir gem_name "${gem_source_dir}")
 
     # Set the gem module root output directory to the location with the gem.json file within it or
     # the supplied gem_target SOURCE_DIR location if no gem.json file was found

--- a/scripts/o3de/o3de/get_registration.py
+++ b/scripts/o3de/o3de/get_registration.py
@@ -14,13 +14,16 @@ from o3de import manifest
 
 
 def _run_get_registered(args: argparse) -> int:
+    # If the --query-project-path option is provided,
+    # That is used to filter the query to a specific project
     registered_path = manifest.get_registered(args.engine_name,
                                               args.project_name,
                                               args.gem_name,
                                               args.template_name,
                                               args.default_folder,
                                               args.repo_name,
-                                              args.restricted_name)
+                                              args.restricted_name,
+                                              project_path=args.query_project_path)
     # If a path has been found return 0
     if registered_path:
         print(registered_path)
@@ -51,6 +54,10 @@ def add_parser_args(parser):
                        help='Repo name.')
     group.add_argument('-rsn', '--restricted-name', type=str, required=False,
                        help='Restricted name.')
+
+    project_group = parser.add_mutually_exclusive_group(required=False)
+    project_group.add_argument('-qpp', '--query-project-path', type=pathlib.Path,
+                       help='The path to a project. Can be used to query gems registered with a specific project')
 
     parser.set_defaults(func=_run_get_registered)
 

--- a/scripts/o3de/o3de/manifest.py
+++ b/scripts/o3de/o3de/manifest.py
@@ -681,7 +681,16 @@ def get_registered(engine_name: str = None,
                             return project_path
 
     elif isinstance(gem_name, str):
-        gems = get_all_gems(project_path)
+        gems = []
+        if project_path:
+            gems = get_all_gems(project_path)
+        else:
+            # If project_path is not supplied
+            # query all registered projects
+            for registered_project_path in get_all_projects():
+                gems.extend(get_all_gems(registered_project_path))
+            gems = list(dict.fromkeys(gems))
+
         for gem_path in gems:
             gem_path = pathlib.Path(gem_path).resolve()
             gem_json = gem_path / 'gem.json'
@@ -699,7 +708,16 @@ def get_registered(engine_name: str = None,
                             return gem_path
 
     elif isinstance(template_name, str):
-        templates = get_all_templates(project_path)
+        templates = []
+        if project_path:
+            templates = get_all_templates(project_path)
+        else:
+            # If project_path is not supplied
+            # query all registered projects
+            for registered_project_path in get_all_projects():
+                templates.extend(get_all_templates(registered_project_path))
+            templates = list(dict.fromkeys(templates))
+
         for template_path in templates:
             template_path = pathlib.Path(template_path).resolve()
             template_json = template_path / 'template.json'

--- a/scripts/o3de/o3de/print_registration.py
+++ b/scripts/o3de/o3de/print_registration.py
@@ -179,6 +179,16 @@ def print_project_templates(verbose: int, project_path: pathlib.Path, project_na
     return 0
 
 
+def print_project_engine_name(verbose: int, project_path: pathlib.Path, project_name: str) -> int:
+    project_path = get_project_path(project_path, project_name)
+    if not project_path:
+        return 1
+
+    project_json_data = manifest.get_project_json_data(project_path=project_path)
+    print(f'Engine Name:\n{project_json_data.get("engine", "")}')
+    return 0
+
+
 def print_all_projects(verbose: int) -> int:
     all_projects_data = manifest.get_all_projects()
     print(f'Project Paths:\n{json.dumps(all_projects_data, indent=4)}')

--- a/scripts/o3de/tests/test_print_registration.py
+++ b/scripts/o3de/tests/test_print_registration.py
@@ -376,3 +376,26 @@ class TestPrintRegistration:
                 patch('o3de.print_registration.get_project_path', return_value=project_path) as get_project_path_patch:
             result = print_registration._run_register_show(test_args)
             assert result == 0
+
+    # No --verbose for the -project-engine-name option doesn't produce more output.
+    @pytest.mark.parametrize("arg_option, project_path, expected_result", [
+        pytest.param("--project-engine-name", None, 1),
+        pytest.param("--project-engine-name", pathlib.Path("D:/MinimalProject"), 0),
+    ])
+    def test_print_external_subdirectories_registration(self, arg_option, project_path, expected_result):
+        parser = argparse.ArgumentParser()
+
+        # Register the registration script subparsers with the current argument parser
+        print_registration.add_parser_args(parser)
+        arg_list = [arg_option]
+        if project_path:
+            arg_list += ['--project-path', project_path.as_posix()]
+        test_args = parser.parse_args(arg_list)
+
+        with patch('o3de.manifest.load_o3de_manifest', side_effect=self.load_manifest_json) as load_manifest_patch, \
+                patch('o3de.manifest.save_o3de_manifest', return_value=True) as save_manifest_patch, \
+                patch('o3de.manifest.get_project_json_data',
+                      side_effect=self.get_project_json_data) as get_project_json_patch, \
+                patch('o3de.print_registration.get_project_path', return_value=project_path) as get_project_path_patch:
+            result = print_registration._run_register_show(test_args)
+            assert result == expected_result


### PR DESCRIPTION
## What does this PR do?

Updated to Gem CMake targets templates to reference the "gem_name" from the gem.json

This changes makes it easier to rename a gem via updating it's
"gem_name" field in the gem.json file.

Previously users would also need to update the CMakeLists.txt to update
the target names to match the gem name in order for CMake to find the
`<gem-name>.<variant>` target that it checks before adding the gem module
filename to the generated `cmake_dependencies.<target>.setreg` which
indicates that the gem is active.

closes https://github.com/o3de/o3de/issues/12309

Added missing print_project_engine_name function to print_registration.py

The register-show command `--print-engine-name` command would attempt to
invoke a method to print the "engine" field from a `project.json` file,
but that function was never implemented.

Updated the manifest.get_registered method to query gems/template registered with all projects when a project-path parameter was not supplied.

Previously if a project-path parameter was not supplied, it would only
search for a gem registered with the `o3de_manifest.json` or the
associated `engine.json`.

Updated the get_registered command to accept a --query-project-path
argument to allow querying gems associated with a specific project.

## How was this PR tested?

The `register-show` command was verified with a new pytest that validates the engine name is output when the `--print-engine-name` argument is supplied.

The Gem template changes were verified by instantiating each Project Template(`DefaultProject` and `MinimalProject` and the non-prebuilt Gem Templates(`AssetGem`, `CppToolGem`, `DefaultGem`, `PythonToolGem`) templates.

Afterwards the name of each gem was updated using the o3de.py `edit-gem-properties` command to rename the gems.
Next the gems were all registred with the instantiated "DefaultProject" project.
Next cmake configure was run with the `--log-level verbose` option to verify that each instantiated gem template `<gem-name>.<variant>` targets were picked up.

Finally a build of the DefaultProject and MinimalProject templates were performed.

Here are commands to reproduce the testing on Windows. That o3de engine path should be updated based on the user's engine location

```
D:\o3de>scripts\o3de.bat create-project -tn DefaultProject -pp D:\DefaultProject
D:\o3de>scripts\o3de.bat create-project -tn MinimalProject -pp D:\MinimalProject
D:\o3de>scripts\o3de.bat create-gem -tn AssetGem -pp D:\MinimalProject\Gems\AssetGem
D:\o3de>scripts\o3de.bat create-gem -tn CppToolGem -pp D:\MinimalProject\Gems\CppToolGem
D:\o3de>scripts\o3de.bat create-gem -tn DefaultGem -pp D:\MinimalProject\Gems\DefaultGem
D:\o3de>scripts\o3de.bat create-gem -tn PythonToolGem -pp D:\MinimalProject\Gems\PythonToolGem

# Updates the "gem_name" of each created gem
# This requires the `manifest.get_registered` changes in this PR
D:\o3de>scripts\o3de.bat edit-gem-properties -gn AssetGem -gnn PW-AssetGem
D:\o3de>scripts\o3de.bat edit-gem-properties -gn CppToolGem -gnn PW-CppToolGem
D:\o3de>scripts\o3de.bat edit-gem-properties -gn DefaultGem -gnn PW-DefaultGem
D:\o3de>scripts\o3de.bat edit-gem-properties -gn PythonToolGem -gnn PW-PythonToolGem

# Enable all the gems in the D:\DefaultProject\Gems directory
D:\o3de>scripts\o3de.bat enable-gem -agp D:\DefaultProject\Gems

# Switch to the DefaultProject directory and configure cmake
D:\DefaultProject>cmake -B build\windows -S. --log-level verbose
# Build the DefaultProject
D:\DefaultProject>cmake --build build\windows --target Editor --config profile -- /m:8 /p:CL_MPCount=8
```


Here is the text that should be search for in the verbose output to validate that the renamed gems are being picked up
```
-- Gem Target "PW-AssetGem.Builders" has load dependencies of:
-- Gem Target "PW-CppToolGem.Builders" has load dependencies of: PW-CppToolGem.Editor
-- Gem Target "PW-DefaultGem.Builders" has load dependencies of: PW-DefaultGem.Editor
-- Gem Target "PW-PythonToolGem.Builders" has load dependencies of: EditorPythonBindings.Editor;QtForPython.Editor;PW-PythonToolGem.Editor
```