### PR TITLE
 Cherry-pick linux mouse fix

### DIFF
--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
@@ -548,7 +548,13 @@ namespace AzFramework
                     }
 
                     m_focusWindow = focusInEvent->event;
-                    HandleCursorState(m_focusWindow, m_systemCursorState);
+
+                    // If the cursor state is Unknown, then calling HandleCursorState would hide the cursor, 
+                    // but we should only hide the cursor if m_systemCursorState is explicitly hidden.
+                    if(SystemCursorState::Unknown != m_systemCursorState) 
+                    {
+                        HandleCursorState(m_focusWindow, m_systemCursorState);
+                    }
                 }
 
                 auto* interface = AzFramework::XcbConnectionManagerInterface::Get();


### PR DESCRIPTION
## What does this PR do?

Cherry-pick linux mouse fix from dev to stabilization.
Fixed a bug on linux where the system mouse cursor would be permanently hidden.

See https://github.com/o3de/o3de-atom-sampleviewer/issues/509

## How was this PR tested?

_Please describe any testing performed._
