### PR TITLE
Prefabs | Refresh Prefab Focus Path widget on init

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabViewportFocusPathHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabViewportFocusPathHandler.cpp
@@ -70,6 +70,8 @@ namespace AzToolsFramework::Prefab
 
         // Currently hide this button until we can correctly disable/enable it based on context.
         m_backButton->hide();
+
+        Refresh();
     }
 
     void PrefabViewportFocusPathHandler::OnPrefabFocusChanged(
@@ -85,14 +87,18 @@ namespace AzToolsFramework::Prefab
 
     void PrefabViewportFocusPathHandler::Refresh()
     {
-        // Push new Path
-        m_breadcrumbsWidget->pushPath(m_prefabFocusPublicInterface->GetPrefabFocusPath(m_editorEntityContextId).c_str());
+        if (int prefabFocusPathLength = m_prefabFocusPublicInterface->GetPrefabFocusPathLength(m_editorEntityContextId);
+            prefabFocusPathLength > 0)
+        {
+            // Push new Path
+            m_breadcrumbsWidget->pushPath(m_prefabFocusPublicInterface->GetPrefabFocusPath(m_editorEntityContextId).c_str());
 
-        // Set root icon
-        m_breadcrumbsWidget->setIconAt(0, QString(":/Level/level.svg"));
+            // Set root icon
+            m_breadcrumbsWidget->setIconAt(0, QString(":/Level/level.svg"));
 
-        // If root instance is focused, disable the back button; else enable it.
-        m_backButton->setEnabled(m_prefabFocusPublicInterface->GetPrefabFocusPathLength(m_editorEntityContextId) > 1);
+            // If root instance is focused, disable the back button; else enable it.
+            m_backButton->setEnabled(prefabFocusPathLength > 1);
+        }
     }
 
 } // namespace AzToolsFramework::Prefab


### PR DESCRIPTION
## What does this PR do?

Refreshes the Prefab Focus Path widget on initialization. This fixes issues where the widget would look empty if initialized after the level has already been loaded, for example when restoring the default Editor layout.

Fixes #12090

## How was this PR tested?
Manual testing.
