### PR TITLE
Fix linux/debug linker errors in Linux/clang

### DIFF
--- a/Gems/NvCloth/Code/Source/Pipeline/SceneAPIExt/ClothRule.cpp
+++ b/Gems/NvCloth/Code/Source/Pipeline/SceneAPIExt/ClothRule.cpp
@@ -12,7 +12,6 @@
 
 #include <SceneAPI/SceneCore/DataTypes/GraphData/IMeshData.h>
 #include <SceneAPI/SceneCore/DataTypes/GraphData/IMeshVertexColorData.h>
-#include <SceneAPI/SceneData/Groups/MeshGroup.h>
 
 #include <Pipeline/SceneAPIExt/ClothRule.h>
 


### PR DESCRIPTION
## What does this PR do?

Remove unnecessary include from SceneData in NvCloth, causing undefined references in debug/clang builds

Fixes the following
```
Code && /usr/bin/cmake -P /home/github/o3de/cmake/Platform/Linux/ProcessDebugSymbols.cmake /usr/bin/strip /usr/bin/objcopy /home/github/o3de/build/linux/bin/debug/libNvCloth.Editor.Gem.so dbg MODULE_LIBRARY DETACH /usr/bin/ld: lib/debug/libNvCloth.Editor.Static.a(ClothRule.cpp.o):
(.data.rel.ro._ZTVN2AZ8SceneAPI9SceneData22SceneNodeSelectionListE[_ZTVN2AZ8SceneAPI9SceneData22SceneNodeSelectionListE]+0x50): undefined reference to `AZ::SceneAPI::SceneData::SceneNodeSelectionList::GetSelectedNodeCount() const' /usr/bin/ld: lib/debug/libNvCloth.Editor.Static.a(ClothRule.cpp.o):
(.data.rel.ro._ZTVN2AZ8SceneAPI9SceneData22SceneNodeSelectionListE[_ZTVN2AZ8SceneAPI9SceneData22SceneNodeSelectionListE]+0x58): undefined reference to `AZ::SceneAPI::SceneData::SceneNodeSelectionList::GetSelectedNode(unsigned long) const' /usr/bin/ld: lib/debug/libNvCloth.Editor.Static.a(ClothRule.cpp.o):
(.data.rel.ro._ZTVN2AZ8SceneAPI9SceneData22SceneNodeSelectionListE[_ZTVN2AZ8SceneAPI9SceneData22SceneNodeSelectionListE]+0x60): undefined reference to `AZ::SceneAPI::SceneData::SceneNodeSelectionList::AddSelectedNode(AZStd::basic_string<char, AZStd::char_traits<char>, AZStd::allocator> const&)' /usr/bin/ld: lib/debug/libNvCloth.Editor.Static.a(ClothRule.cpp.o):
(.data.rel.ro._ZTVN2AZ8SceneAPI9SceneData22SceneNodeSelectionListE[_ZTVN2AZ8SceneAPI9SceneData22SceneNodeSelectionListE]+0x68): undefined reference to `AZ::SceneAPI::SceneData::SceneNodeSelectionList::AddSelectedNode(AZStd::basic_string<char, AZStd::char_traits<char>, AZStd::allocator>&&)' /usr/bin/ld: lib/debug/libNvCloth.Editor.Static.a(ClothRule.cpp.o):
(.data.rel.ro._ZTVN2AZ8SceneAPI9SceneData22SceneNodeSelectionListE[_ZTVN2AZ8SceneAPI9SceneData22SceneNodeSelectionListE]+0x70): undefined reference to `AZ::SceneAPI::SceneData::SceneNodeSelectionList::RemoveSelectedNode(unsigned long)' /usr/bin/ld: lib/debug/libNvCloth.Editor.Static.a(ClothRule.cpp.o):
(.data.rel.ro._ZTVN2AZ8SceneAPI9SceneData22SceneNodeSelectionListE[_ZTVN2AZ8SceneAPI9SceneData22SceneNodeSelectionListE]+0x78): undefined reference to `AZ::SceneAPI::SceneData::SceneNodeSelectionList::RemoveSelectedNode(AZStd::basic_string<char, AZStd::char_traits<char>, AZStd::allocator> const&)' /usr/bin/ld: lib/debug/libNvCloth.Editor.Static.a(ClothRule.cpp.o):
(.data.rel.ro._ZTVN2AZ8SceneAPI9SceneData22SceneNodeSelectionListE[_ZTVN2AZ8SceneAPI9SceneData22SceneNodeSelectionListE]+0x80): undefined reference to `AZ::SceneAPI::SceneData::SceneNodeSelectionList::ClearSelectedNodes()' /usr/bin/ld: lib/debug/libNvCloth.Editor.Static.a(ClothRule.cpp.o):
(.data.rel.ro._ZTVN2AZ8SceneAPI9SceneData22SceneNodeSelectionListE[_ZTVN2AZ8SceneAPI9SceneData22SceneNodeSelectionListE]+0x88): undefined reference to `AZ::SceneAPI::SceneData::SceneNodeSelectionList::GetUnselectedNodeCount() const'
```

Fixes https://github.com/o3de/o3de/issues/12310 

## How was this PR tested?

Compiled successfully in debug. No impact on testing as this just removes an unnecessary include, no other changes involved.
