### PR TITLE
Fix for #11749 - LyShinePass ebus fix

### DIFF
--- a/Gems/LyShine/Code/Source/LyShinePass.cpp
+++ b/Gems/LyShine/Code/Source/LyShinePass.cpp
@@ -44,6 +44,8 @@ namespace LyShine
     {
         if (pipeline == nullptr)
         {
+            // The pipeline being set to null means this pass will soon be destroyed. Disconnect from the bus so if a
+            // new LyShinePass is being created to replace it, it will be able to connect.
             LyShinePassRequestBus::Handler::BusDisconnect();
         }
         ParentPass::SetRenderPipeline(pipeline);

--- a/Gems/LyShine/Code/Source/LyShinePass.cpp
+++ b/Gems/LyShine/Code/Source/LyShinePass.cpp
@@ -40,6 +40,15 @@ namespace LyShine
         Base::ResetInternal();
     }
 
+    void LyShinePass::SetRenderPipeline(AZ::RPI::RenderPipeline* pipeline)
+    {
+        if (pipeline == nullptr)
+        {
+            LyShinePassRequestBus::Handler::BusDisconnect();
+        }
+        ParentPass::SetRenderPipeline(pipeline);
+    }
+
     void LyShinePass::BuildInternal()
     {
         AZ::RPI::Scene* scene = GetScene();

--- a/Gems/LyShine/Code/Source/LyShinePass.h
+++ b/Gems/LyShine/Code/Source/LyShinePass.h
@@ -37,6 +37,7 @@ namespace LyShine
         void ResetInternal() override;
         void BuildInternal() override;
         void CreateChildPassesInternal() override;
+        void SetRenderPipeline(AZ::RPI::RenderPipeline* pipeline) override;
 
         // LyShinePassRequestBus overrides
         void RebuildRttChildren() override;


### PR DESCRIPTION
## What does this PR do?

When render pipelines are rebuilt the old pass hierarchy will stick around while the new one is being built. This means that for a brief moment, there will be two instances of the same pass on the same render pipeline. The LyShinePass connects to a single handler / multi address bus. This means when a new LyShinePass is created on render pipeline rebuild, it fails to connect to the bus because the old pass hasn't yet disconnected. The old pass then disconnects, and LyShine is left in a permanent zombie state where the pass bus isn't connected to anything.

#11749 refers to a specific case of this problem where adding a terrain world renderer component will break LyShine. This is because it adds a feature processor under the hood when the component activates, causing the pipeline to refresh at certain times (like entering game mode).

A few possible fixes were considered:
- Remove the LyShinePassRequestBus, and instead make direct queries on the LyShinePass. There are already tools available to find passes by class type on a render pipeline, so the pass could be accessed directly quite easily. However, the LyShinePassRequestBus provides several different functions and they would all need to be replaced - this would make the surface area of the change larger and increase the chance of unintended side effects.
- Make the LyShinePassRequestBus a multi handler. This fixes the problem, but seems conceptually wrong given that generally only a single instance of the pass should exist per scene. It also creates a possible future problem if the bus were ever accessed while the pass tree was being rebuild
- Disconnect from the bus in the old pass before the new pass connects to it. This also wasn't straightforward since there's no event propagated for "This pass is about to be deleted". However, the pipeline for the old pass is set to null before the new pass connects, so I decided this would suffice for now. There are currently no cases where a pass's pipeline would be set to null, then later set to something valid - it's always indicative of the pass being removed shortly.

## How was this PR tested?

Repro steps for the bug no longer cause the problem. In addition I checked to make sure the UI canvas tool continues to work, and also that you can render ui canvases to meshes when actual terrain is present (not just the terrain world renderer component)

Fixes #11749
