### PR TITLE
Prefab | Fix crash on escaping prefab edit mode

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
@@ -275,8 +275,12 @@ namespace AzToolsFramework::Prefab
 
         // Close all container entities in the old path.
         SetInstanceContainersOpenState(m_rootAliasFocusPath, false);
-        // Always close all nested instances in the old focus subtree.
-        SetInstanceContainersOpenStateOfAllDescendantContainers(GetInstanceReference(m_rootAliasFocusPath), false);
+
+        if (IsPrefabOverridesUxEnabled())
+        {
+            // Always close all nested instances in the old focus subtree.
+            SetInstanceContainersOpenStateOfAllDescendantContainers(GetInstanceReference(m_rootAliasFocusPath), false);
+        }
 
         const RootAliasPath previousContainerRootAliasPath = m_rootAliasFocusPath;
         const InstanceOptionalReference previousFocusedInstance = GetInstanceReference(previousContainerRootAliasPath);
@@ -326,9 +330,12 @@ namespace AzToolsFramework::Prefab
 
         // Open all container entities in the new path.
         SetInstanceContainersOpenState(m_rootAliasFocusPath, true);
-        // Set open state on all nested instances in the new focus subtree based on edit scope.
-        SetInstanceContainersOpenStateOfAllDescendantContainers(
-            GetInstanceReference(m_rootAliasFocusPath), m_prefabEditScope == PrefabEditScope::SHOW_NESTED_INSTANCES_CONTENT);
+
+        if (IsPrefabOverridesUxEnabled())
+        {
+            // Set open state on all nested instances in the new focus subtree based on edit scope.
+            SetInstanceContainersOpenStateOfAllDescendantContainers(GetInstanceReference(m_rootAliasFocusPath), true);
+        }
 
         AZ::EntityId previousFocusedInstanceContainerEntityId = previousFocusedInstance.has_value() ?
             previousFocusedInstance->get().GetContainerEntityId() : AZ::EntityId();


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

Fix: #11741

This PR fixes the crash when escaping prefab edit mode. See the issue for more details.

The changes were originally introduced from prefab overrides UX prototype #10943. The related two lines should be put under the overrides UX flag.

**Note: The flag is OFF by default and the two lines were added after the above PR. So the risk of merging this PR should be minimal.**

## How was this PR tested?

- [x] Manually tested in development. The crash does not occur any more when the flag is off or on.
- [x] Manually tested in stabilization/2210 branch