### PR TITLE
Add support for reading `EnumValues` to the DPE.

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/EditContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContext.h
@@ -821,7 +821,7 @@ namespace AZ
 
             EnumConstant() {}
             EnumConstant(EnumType first, AZStd::string_view description)
-                : m_value(aznumeric_cast<AZ::u64>(first))
+                : m_value(static_cast<AZ::u64>(first))
                 , m_description(description)
             {
             }

--- a/Code/Framework/AzCore/AzCore/Serialization/EditContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContext.h
@@ -819,16 +819,15 @@ namespace AZ
         {
             AZ_TYPE_INFO(EnumConstant, "{4CDFEE70-7271-4B27-833B-F8F72AA64C40}");
 
-            typedef typename AZStd::RemoveEnum<EnumType>::type UnderlyingType;
-
             EnumConstant() {}
-            EnumConstant(EnumType first, const char* description)
+            EnumConstant(EnumType first, AZStd::string_view description)
+                : m_value(aznumeric_cast<AZ::u64>(first))
+                , m_description(description)
             {
-                m_value = static_cast<UnderlyingType>(first);
-                m_description = description;
             }
 
-            UnderlyingType m_value;
+            // Store using a u64 under the hood so this can be safely cast to any valid enum-range value
+            AZ::u64 m_value;
             AZStd::string m_description;
         };
 

--- a/Code/Framework/AzCore/AzCore/Serialization/Utils.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/Utils.h
@@ -103,7 +103,7 @@ namespace AZ
                     if (reader.Read<AZ::Edit::EnumConstant<T>>(enumPair))
                     {
                         T* enumValue = reinterpret_cast<T*>(instance);
-                        if (enumPair.m_value == *enumValue)
+                        if (static_cast<T>(enumPair.m_value) == *enumValue)
                         {
                             value = enumPair.m_description;
                             return true;

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.cpp
@@ -114,7 +114,7 @@ namespace AZ::DocumentPropertyEditor
         {
             Dom::Value entryDom(Dom::Type::Object);
             entryDom[enumEntryDescription] = Dom::Value(entry.m_description, true);
-            entryDom[enumEntryValue] = Dom::Value(entry.m_value);
+            entryDom[enumEntryValue] = Dom::Value(static_cast<uint64_t>(entry.m_value));
             result.ArrayPushBack(AZStd::move(entryDom));
         }
         return result;
@@ -134,7 +134,7 @@ namespace AZ::DocumentPropertyEditor
             {
                 continue;
             }
-            result.emplace_back(entryDom[enumEntryValue].GetUint64(), entryDom[enumEntryDescription].GetString());
+            result.emplace_back(static_cast<AZ::u64>(entryDom[enumEntryValue].GetUint64()), entryDom[enumEntryDescription].GetString());
         }
 
         return result;

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.cpp
@@ -103,4 +103,40 @@ namespace AZ::DocumentPropertyEditor
 
         return Dom::Value(result.GetStringView(), false);
     }
+
+    static const AZ::Name enumEntryDescription = AZ_NAME_LITERAL("description");
+    static const AZ::Name enumEntryValue = AZ_NAME_LITERAL("value");
+
+    Dom::Value EnumValuesAttributeDefinition::ValueToDom(const EnumValuesContainer& attribute) const
+    {
+        Dom::Value result(Dom::Type::Array);
+        for (const auto& entry : attribute)
+        {
+            Dom::Value entryDom(Dom::Type::Object);
+            entryDom[enumEntryDescription] = Dom::Value(entry.m_description, true);
+            entryDom[enumEntryValue] = Dom::Value(entry.m_value);
+            result.ArrayPushBack(AZStd::move(entryDom));
+        }
+        return result;
+    }
+
+    AZStd::optional<EnumValuesContainer> EnumValuesAttributeDefinition::DomToValue(const Dom::Value& value) const
+    {
+        if (!value.IsArray())
+        {
+            return {};
+        }
+
+        EnumValuesContainer result;
+        for (const Dom::Value& entryDom : value.GetArray())
+        {
+            if (!entryDom.IsObject() || !entryDom.HasMember(enumEntryDescription) || !entryDom.HasMember(enumEntryValue))
+            {
+                continue;
+            }
+            result.emplace_back(entryDom[enumEntryValue].GetUint64(), entryDom[enumEntryDescription].GetString());
+        }
+
+        return result;
+    }
 } // namespace AZ::DocumentPropertyEditor

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.cpp
@@ -104,17 +104,14 @@ namespace AZ::DocumentPropertyEditor
         return Dom::Value(result.GetStringView(), false);
     }
 
-    static const AZ::Name enumEntryDescription = AZ_NAME_LITERAL("description");
-    static const AZ::Name enumEntryValue = AZ_NAME_LITERAL("value");
-
     Dom::Value EnumValuesAttributeDefinition::ValueToDom(const EnumValuesContainer& attribute) const
     {
         Dom::Value result(Dom::Type::Array);
         for (const auto& entry : attribute)
         {
             Dom::Value entryDom(Dom::Type::Object);
-            entryDom[enumEntryDescription] = Dom::Value(entry.m_description, true);
-            entryDom[enumEntryValue] = Dom::Value(static_cast<uint64_t>(entry.m_value));
+            entryDom[EntryDescriptionKey] = Dom::Value(entry.m_description, true);
+            entryDom[EntryValueKey] = Dom::Value(static_cast<uint64_t>(entry.m_value));
             result.ArrayPushBack(AZStd::move(entryDom));
         }
         return result;
@@ -130,11 +127,11 @@ namespace AZ::DocumentPropertyEditor
         EnumValuesContainer result;
         for (const Dom::Value& entryDom : value.GetArray())
         {
-            if (!entryDom.IsObject() || !entryDom.HasMember(enumEntryDescription) || !entryDom.HasMember(enumEntryValue))
+            if (!entryDom.IsObject() || !entryDom.HasMember(EntryDescriptionKey) || !entryDom.HasMember(EntryValueKey))
             {
                 continue;
             }
-            result.emplace_back(static_cast<AZ::u64>(entryDom[enumEntryValue].GetUint64()), entryDom[enumEntryDescription].GetString());
+            result.emplace_back(static_cast<AZ::u64>(entryDom[EntryValueKey].GetUint64()), entryDom[EntryDescriptionKey].GetString());
         }
 
         return result;

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -10,6 +10,7 @@
 
 #include <AzCore/DOM/DomUtils.h>
 #include <AzCore/DOM/DomValue.h>
+#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Name/Name.h>
 #include <AzCore/Name/NameDictionary.h>
 #include <AzCore/Outcome/Outcome.h>
@@ -181,7 +182,7 @@ namespace AZ::DocumentPropertyEditor
             }
             else
             {
-                AZStd::optional<AttributeType> attributeValue = AZ::Dom::Utils::ValueToType<AttributeType>(value);
+                AZStd::optional<AttributeType> attributeValue = DomToValue(value);
                 return attributeValue.has_value()
                     ? AZStd::make_shared<AZ::AttributeData<AttributeType>>(AZStd::move(attributeValue.value()))
                     : nullptr;
@@ -207,7 +208,7 @@ namespace AZ::DocumentPropertyEditor
                 {
                     return AZ::Dom::Value();
                 }
-                return AZ::Dom::Utils::ValueFromType(value);
+                return ValueToDom(value);
             }
         }
 
@@ -244,6 +245,20 @@ namespace AZ::DocumentPropertyEditor
         AZStd::optional<AZ::Name> DomToValue(const Dom::Value& value) const override;
         AZStd::shared_ptr<AZ::Attribute> DomValueToLegacyAttribute(const AZ::Dom::Value& value) const override;
         AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const override;
+    };
+
+    using EnumValuesContainer = AZStd::vector<AZ::Edit::EnumConstant<AZ::u64>>;
+
+    class EnumValuesAttributeDefinition final : public AttributeDefinition<EnumValuesContainer>
+    {
+    public:
+        explicit constexpr EnumValuesAttributeDefinition(AZStd::string_view name)
+            : AttributeDefinition<EnumValuesContainer>(name)
+        {
+        }
+
+        Dom::Value ValueToDom(const EnumValuesContainer& attribute) const override;
+        AZStd::optional<EnumValuesContainer> DomToValue(const Dom::Value& value) const override;
     };
 
     //! Defines a callback applicable to a Node.

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -252,6 +252,9 @@ namespace AZ::DocumentPropertyEditor
     class EnumValuesAttributeDefinition final : public AttributeDefinition<EnumValuesContainer>
     {
     public:
+        static constexpr const char* EntryDescriptionKey = "description";
+        static constexpr const char* EntryValueKey = "value";
+
         explicit constexpr EnumValuesAttributeDefinition(AZStd::string_view name)
             : AttributeDefinition<EnumValuesContainer>(name)
         {

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -58,6 +58,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumType);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumUnderlyingType);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumValue);
+        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumValues);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::ChangeNotify);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::AddNotify);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::RemoveNotify);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -130,6 +130,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr auto EnumType = TypeIdAttributeDefinition("EnumType");
         static constexpr auto EnumUnderlyingType = TypeIdAttributeDefinition("EnumUnderlyingType");
         static constexpr auto EnumValue = AttributeDefinition<Dom::Value>("EnumValue");
+        static constexpr auto EnumValues = EnumValuesAttributeDefinition("EnumValues");
         static constexpr auto ChangeNotify = CallbackAttributeDefinition<PropertyRefreshLevel()>("ChangeNotify");
         static constexpr auto RequestTreeUpdate = CallbackAttributeDefinition<void(PropertyRefreshLevel)>("RequestTreeUpdate");
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
@@ -62,11 +62,11 @@ namespace DPEDebugView
         AZ_TYPE_INFO(TestContainer, "{86586583-A58F-45FD-BB6E-C3E9C76DDA38}");
         AZ_CLASS_ALLOCATOR(TestContainer, AZ::SystemAllocator, 0);
 
-        enum class EnumType : AZ::u8
+        enum class EnumType : AZ::s16
         {
             Value1 = 1,
             Value2 = 2,
-            ValueZ = 10,
+            ValueZ = -10,
             NotReflected = 0xFF
         };
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
@@ -70,6 +70,16 @@ namespace DPEDebugView
             NotReflected = 0xFF
         };
 
+        AZStd::vector<AZ::Edit::EnumConstant<EnumType>> GetEnumValues() const
+        {
+            AZStd::vector<AZ::Edit::EnumConstant<EnumType>> values;
+            values.emplace_back(EnumType::Value1, "Value 1");
+            values.emplace_back(EnumType::Value2, "Value 2");
+            values.emplace_back(EnumType::ValueZ, "Value Z");
+            values.emplace_back(EnumType::NotReflected, "Not Reflected (set from EnumValues)");
+            return values;
+        }
+
         int m_simpleInt = 5;
         double m_doubleSlider = 3.25;
         AZStd::vector<AZStd::string> m_vector;
@@ -148,6 +158,7 @@ namespace DPEDebugView
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_entityIdMap, "unordered_map<EntityId, Number>", "")
                         ->ClassElement(AZ::Edit::ClassElements::Group, "")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_enumValue, "enum (no multi-edit)", "")
+                        ->Attribute(AZ::Edit::Attributes::EnumValues, &TestContainer::GetEnumValues)
                         ->Attribute(AZ::Edit::Attributes::AcceptsMultiEdit, false)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_entityId, "entityId", "")
                         ->UIElement(AZ::Edit::UIHandlers::Button, "")

--- a/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
@@ -122,11 +122,6 @@ namespace DPEDebugView
 
                 if (auto editContext = serializeContext->GetEditContext())
                 {
-                    editContext->Enum<EnumType>("EnumType", "")
-                        ->Value("Value1", EnumType::Value1)
-                        ->Value("Value2", EnumType::Value2)
-                        ->Value("ValueZ", EnumType::ValueZ);
-
                     editContext->Class<TestContainer>("TestContainer", "")
                         ->UIElement(AZ::Edit::UIHandlers::Button, "")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &Button1)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEnumComboBoxCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEnumComboBoxCtrl.hxx
@@ -110,7 +110,7 @@ namespace AzToolsFramework
                 AZ::Edit::EnumConstant<ValueType> enumConstant;
                 if (attrValue->Read<AZ::Edit::EnumConstant<ValueType>>(enumConstant))
                 {
-                    enumValue.first = enumConstant.m_value;
+                    enumValue.first = ValueType(enumConstant.m_value);
                     enumValue.second = enumConstant.m_description;
 
                     genericGUI->addElement(enumValue);
@@ -150,7 +150,7 @@ namespace AzToolsFramework
                 {
                     for (const AZ::Edit::EnumConstant<ValueType>& constantValue : enumConstantValues)
                     {
-                        enumValues.emplace_back(constantValue.m_value, constantValue.m_description);
+                        enumValues.emplace_back(static_cast<ValueType>(constantValue.m_value), constantValue.m_description);
                     }
                     genericGUI->setElements(enumValues);
                 }

--- a/Gems/LyShine/Code/Editor/PropertyHandlerEntityIdComboBox.cpp
+++ b/Gems/LyShine/Code/Editor/PropertyHandlerEntityIdComboBox.cpp
@@ -46,10 +46,10 @@ void PropertyHandlerEntityIdComboBox::ConsumeAttribute(PropertyEntityIdComboBoxC
     {
         AZStd::pair<AZ::EntityId, AZStd::string>  guiEnumValue;
         AZStd::pair<AZ::EntityId, AZStd::string>  enumValue;
-        AZ::Edit::EnumConstant<AZ::EntityId> enumConstant;
-        if (attrValue->Read<AZ::Edit::EnumConstant<AZ::EntityId>>(enumConstant))
+        AZ::Edit::EnumConstant<AZ::u64> enumConstant;
+        if (attrValue->Read<AZ::Edit::EnumConstant<AZ::u64>>(enumConstant))
         {
-            guiEnumValue.first = enumConstant.m_value;
+            guiEnumValue.first = AZ::EntityId(enumConstant.m_value);
             guiEnumValue.second = enumConstant.m_description;
             GUI->addEnumValue(guiEnumValue);
         }
@@ -81,13 +81,13 @@ void PropertyHandlerEntityIdComboBox::ConsumeAttribute(PropertyEntityIdComboBoxC
     {
         AZStd::vector<AZStd::pair<AZ::EntityId, AZStd::string>>  guiEnumValues;
         AZStd::vector<AZStd::pair<AZ::EntityId, AZStd::string> > enumValues;
-        AZStd::vector<AZ::Edit::EnumConstant<AZ::EntityId>> enumConstantValues;
-        if (attrValue->Read<AZStd::vector<AZ::Edit::EnumConstant<AZ::EntityId>>>(enumConstantValues))
+        AZStd::vector<AZ::Edit::EnumConstant<AZ::u64>> enumConstantValues;
+        if (attrValue->Read<AZStd::vector<AZ::Edit::EnumConstant<AZ::u64>>>(enumConstantValues))
         {
-            for (const AZ::Edit::EnumConstant<AZ::EntityId>& constantValue : enumConstantValues)
+            for (const AZ::Edit::EnumConstant<AZ::u64>& constantValue : enumConstantValues)
             {
                 auto& enumValue = guiEnumValues.emplace_back();
-                enumValue.first = constantValue.m_value;
+                enumValue.first = AZ::EntityId(constantValue.m_value);
                 enumValue.second = constantValue.m_description;
             }
 


### PR DESCRIPTION
## What does this PR do?

Adds support for the `EnumValues` attribute from `EditContext` to the DPE.

This is accomplished by way of ensuring the vector `EnumConstant`s contained by reflected `EnumValues` is guaranteed 64-bit, then adding an attribute handler to marshal the vector to and from the DOM.

There seems to be an issue in which `EnumValue` entries can be read and added when `EnumValues` is present, but I believe it to be unrelated to the attribute logic introduced here and I expect it should be straightforward to track down.

Created in response to discussion in https://github.com/o3de/o3de/pull/12306

## How was this PR tested?

Manually tested in the standalone DPE (with above noted issue). Unit testing would be wise, but I don't presently have the bandwidth to spec out a set of reflection adapter unit tests - happy to help anyone interested in doing so though!
