### PR TITLE
Fixing an issue where the DiffuseProbeGrid passes were not available

### DIFF
--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -332,8 +332,7 @@ namespace AZ
                 }
 
                 // Load the main default pipeline
-                bool applyMSAAState = true;
-                isPipelineAssetLoadSuccessfull &= LoadPipeline(scene, viewportContext, pipelineName, AZ::RPI::ViewType::Default, applyMSAAState);
+                isPipelineAssetLoadSuccessfull &= LoadPipeline(scene, viewportContext, pipelineName, AZ::RPI::ViewType::Default, true);
                 if (!isPipelineAssetLoadSuccessfull)
                 {
                     return false;

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -332,7 +332,8 @@ namespace AZ
                 }
 
                 // Load the main default pipeline
-                isPipelineAssetLoadSuccessfull &= LoadPipeline(scene, viewportContext, pipelineName, AZ::RPI::ViewType::Default);
+                bool applyMSAAState = true;
+                isPipelineAssetLoadSuccessfull &= LoadPipeline(scene, viewportContext, pipelineName, AZ::RPI::ViewType::Default, applyMSAAState);
                 if (!isPipelineAssetLoadSuccessfull)
                 {
                     return false;

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -326,17 +326,17 @@ namespace AZ
                         AZ::RPI::ViewType viewType = i == 0 ? AZ::RPI::ViewType::XrLeft : AZ::RPI::ViewType::XrRight;
                         AZStd::string pipelineAssetName =
                             i == 0 ? "passes/XRLeftRenderPipeline.azasset" : "passes/XRRightRenderPipeline.azasset";
-                        isPipelineAssetLoadSuccessfull &= LoadPipeline(scene, viewportContext, pipelineAssetName, viewType, multisampleState);
+                        bool applyMSAAState = false; //Use the sampling state from the default pipeline
+                        isPipelineAssetLoadSuccessfull &= LoadPipeline(scene, viewportContext, pipelineAssetName, viewType, applyMSAAState);
                     }
                 }
 
                 // Load the main default pipeline
-                isPipelineAssetLoadSuccessfull &= LoadPipeline(scene, viewportContext, pipelineName, AZ::RPI::ViewType::Default, multisampleState);
+                isPipelineAssetLoadSuccessfull &= LoadPipeline(scene, viewportContext, pipelineName, AZ::RPI::ViewType::Default);
                 if (!isPipelineAssetLoadSuccessfull)
                 {
                     return false;
                 }
-                AZ::RPI::RPISystemInterface::Get()->SetApplicationMultisampleState(multisampleState);
 
                 // As part of our initialization we need to create the BRDF texture generation pipeline
                 AZ::RPI::RenderPipelineDescriptor pipelineDesc;
@@ -378,7 +378,7 @@ namespace AZ
             }
 
             bool BootstrapSystemComponent::LoadPipeline( AZ::RPI::ScenePtr scene, AZ::RPI::ViewportContextPtr viewportContext,
-                                                    AZStd::string_view pipelineName, AZ::RPI::ViewType viewType, RHI::MultisampleState& outMultisampleState)
+                                                    AZStd::string_view pipelineName, AZ::RPI::ViewType viewType, bool applyMSAAState)
             {
                 AzFramework::AssetSystem::AssetStatus status = AzFramework::AssetSystem::AssetStatus_Unknown;
                 AzFramework::AssetSystemRequestBus::BroadcastResult(
@@ -396,7 +396,12 @@ namespace AZ
                         *RPI::GetDataFromAnyAsset<RPI::RenderPipelineDescriptor>(pipelineAsset);
                     renderPipelineDescriptor.m_name =
                         AZStd::string::format("%s_%i", renderPipelineDescriptor.m_name.c_str(), viewportContext->GetId());
-                    outMultisampleState = renderPipelineDescriptor.m_renderSettings.m_multisampleState;
+
+                    if (applyMSAAState)
+                    {
+                        AZ::RPI::RPISystemInterface::Get()->SetApplicationMultisampleState(
+                            renderPipelineDescriptor.m_renderSettings.m_multisampleState);
+                    }
 
                     if (!scene->GetRenderPipeline(AZ::Name(renderPipelineDescriptor.m_name)))
                     {

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -316,7 +316,6 @@ namespace AZ
                     pipelineName = "passes/LowEndRenderPipeline.azasset";
                 }
 
-                RHI::MultisampleState multisampleState;
                 bool isPipelineAssetLoadSuccessfull = true;
                 // Load XR pipelines if applicable
                 if (xrSystem)

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.h
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.h
@@ -95,7 +95,7 @@ namespace AZ
 
                 //! Load a render pipeline from disk and add it to the scene
                 bool LoadPipeline(const AZ::RPI::ScenePtr scene, const AZ::RPI::ViewportContextPtr viewportContext, AZStd::string_view xrPipelineName,
-                                    AZ::RPI::ViewType viewType, RHI::MultisampleState& outMultisampleState);
+                                    AZ::RPI::ViewType viewType, bool applyMSAAState = true);
 
                 AzFramework::Scene::RemovalEvent::Handler m_sceneRemovalHandler;
 

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.h
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.h
@@ -95,7 +95,7 @@ namespace AZ
 
                 //! Load a render pipeline from disk and add it to the scene
                 bool LoadPipeline(const AZ::RPI::ScenePtr scene, const AZ::RPI::ViewportContextPtr viewportContext, AZStd::string_view xrPipelineName,
-                                    AZ::RPI::ViewType viewType, bool applyMSAAState = true);
+                                    AZ::RPI::ViewType viewType, bool applyMSAAState);
 
                 AzFramework::Scene::RemovalEvent::Handler m_sceneRemovalHandler;
 


### PR DESCRIPTION

Signed-off-by: moudgils <47460854+moudgils@users.noreply.github.com>

## What does this PR do?

Fixing an issue where the DiffuseProbeGrid passes were getting removed because we were seting MSAA state after adding the pipeline to the scene

## How was this PR tested?

Ran Editor and ensured that DiffuseProbeGrid passes are still present
