### PR TITLE
Added Spawnable support to Script Events & Containers

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.cpp
@@ -26,10 +26,6 @@ namespace AzFramework::Scripts
                 ->Field("asset", &SpawnableScriptAssetRef::m_asset)
             ;
 
-            serializeContext->RegisterGenericType<AZStd::vector<SpawnableScriptAssetRef>>();
-            serializeContext->RegisterGenericType<AZStd::unordered_map<AZStd::string, SpawnableScriptAssetRef>>();
-            serializeContext->RegisterGenericType<AZStd::unordered_map<double, SpawnableScriptAssetRef>>(); // required to support Map<Number, SpawnableScriptAssetRef> in Script Canvas
-
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
                 editContext
@@ -49,6 +45,7 @@ namespace AzFramework::Scripts
         {
             behaviorContext->Class<SpawnableScriptAssetRef>("SpawnableScriptAssetRef")
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::EnableAsScriptEventParamType, true)
                 ->Attribute(AZ::Script::Attributes::Category, "Prefab/Spawning")
                 ->Attribute(AZ::Script::Attributes::Module, "prefabs")
                 ->Constructor()

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.h
@@ -32,6 +32,11 @@ namespace AzFramework::Scripts
         SpawnableScriptAssetRef& operator=(const SpawnableScriptAssetRef& rhs);
         SpawnableScriptAssetRef& operator=(SpawnableScriptAssetRef&& rhs);
 
+        bool operator == (const SpawnableScriptAssetRef& rhs) const
+        {
+            return m_asset == rhs.GetAsset();
+        }
+
         void SetAsset(const AZ::Data::Asset<Spawnable>& asset);
         AZ::Data::Asset<Spawnable> GetAsset() const;
 
@@ -50,5 +55,22 @@ namespace AzFramework::Scripts
         void OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset) override;
 
         AZ::Data::Asset<Spawnable> m_asset;
+    };
+}
+
+namespace AZStd
+{
+    template<>
+    struct hash<AzFramework::Scripts::SpawnableScriptAssetRef>
+    {
+        using argument_type = AzFramework::Scripts::SpawnableScriptAssetRef;
+        using result_type = size_t;
+
+        result_type operator() (const argument_type& ticket) const
+        {
+            size_t h = 0;
+            hash_combine(h, ticket.GetAsset().GetId());
+            return h;
+        }
     };
 }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataTrait.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataTrait.h
@@ -11,8 +11,7 @@
 #include <Data/BehaviorContextObjectPtr.h>
 #include <Data/Data.h>
 
-//#include <AzFramework/Entity/EntityContextBus.h>
-//#include <AzFramework/Slice/SliceInstantiationTicket.h>
+#include <AzFramework/Spawnable/Script/SpawnableScriptAssetRef.h>
 
 namespace ScriptCanvas
 {
@@ -393,21 +392,21 @@ namespace ScriptCanvas
             static bool IsDefault(const Type& value, const Data::Type& = {}) { return value == GetDefault(); }
         };
 
-        /*template<>
-        struct Traits<AzFramework::SliceInstantiationTicket> : public TraitsBase<AzFramework::SliceInstantiationTicket>
+        template<>
+        struct Traits<AzFramework::Scripts::SpawnableScriptAssetRef> : public TraitsBase<AzFramework::Scripts::SpawnableScriptAssetRef>
         {
-            using Type = AzFramework::SliceInstantiationTicket;
+            using Type = AzFramework::Scripts::SpawnableScriptAssetRef;
             static const bool s_isAutoBoxed = true;
             static const bool s_isNative = false;
             static const bool s_isKey = true;
             static const eType s_type = eType::BehaviorContextObject;
 
-            static AZ::Uuid GetAZType(const Data::Type& = {}) { return azrtti_typeid<AzFramework::SliceInstantiationTicket>(); }
-            static Data::Type GetSCType(const AZ::TypeId& = AZ::TypeId::CreateNull()) { return Data::Type::BehaviorContextObject(AzFramework::SliceInstantiationTicket::TYPEINFO_Uuid()); }
-            static AZStd::string GetName(const Data::Type& = {}) { return "SliceInstantiationTicket"; }
-            static Type GetDefault(const Data::Type& = {}) { return AzFramework::SliceInstantiationTicket(); }
+            static AZ::Uuid GetAZType(const Data::Type& = {}) { return azrtti_typeid<AzFramework::Scripts::SpawnableScriptAssetRef>(); }
+            static Data::Type GetSCType(const AZ::TypeId& = AZ::TypeId::CreateNull()) { return Data::Type::BehaviorContextObject(AzFramework::Scripts::SpawnableScriptAssetRef::TYPEINFO_Uuid()); }
+            static AZStd::string GetName(const Data::Type& = {}) { return "SpawnableScriptAssetRef"; }
+            static Type GetDefault(const Data::Type& = {}) { return AzFramework::Scripts::SpawnableScriptAssetRef(); }
             static bool IsDefault(const Type& value, const Data::Type& = {}) { return value == GetDefault(); }
-        };*/
+        };
 
         /**
         * Special Case Traits specialization for the string_view type


### PR DESCRIPTION
Signed-off-by: Luis Sempé <58790905+lsemp3d@users.noreply.github.com>

## What does this PR do?

Added SpawnableAssetRef as a possible Script Event parameter and as a supported type in Script Canvas containers. This enables the option of creating complex mechanisms for spawning prefabs

Minor: Removed some commented out Slice code

## How was this PR tested?

- Created Script Events that pass a SpawnAssetRef in order to spawn them in a different script.
- Created a map of <Number,SpawnAssetRef> to created a weighted randomized spawning mechanism

Both cases worked correctly
