### PR TITLE
Deprecated AzCore/math default constructors that create unitinialized components and replaced them with CreateUnitialized methods

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-    "version": 4,
+    "version": 3,
     "cmakeMinimumRequired": {
         "major": 3,
         "minor": 23,

--- a/Code/Framework/AzCore/AzCore/Math/Aabb.h
+++ b/Code/Framework/AzCore/AzCore/Math/Aabb.h
@@ -32,6 +32,10 @@ namespace AZ
         //! This is an invalid AABB which has no size, but is useful as adding a point to it will make it valid
         static Aabb CreateNull();
 
+        //! Returns an axis aligned bounding box with uninitialized data members.
+        //! Many of the member functions are not safe to call until the data members have been initialized.
+        static Aabb CreateUninitialized();
+
         static Aabb CreateFromPoint(const Vector3& p);
 
         static Aabb CreateFromMinMax(const Vector3& min, const Vector3& max);
@@ -51,7 +55,7 @@ namespace AZ
         //! Creates an AABB which contains the specified OBB.
         static Aabb CreateFromObb(const Obb& obb);
 
-        Aabb() = default;
+        AZ_DEPRECATED(Aabb() = default, "The Aabb Default Constructor has been deprecated. Please use Aabb::CreateUninitialized() instead.");
 
         const Vector3& GetMin() const;
 

--- a/Code/Framework/AzCore/AzCore/Math/Aabb.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Aabb.inl
@@ -10,6 +10,11 @@
 
 namespace AZ
 {
+    AZ_MATH_INLINE Aabb Aabb::CreateUninitialized()
+    {
+        return Aabb();
+    }
+
     AZ_MATH_INLINE Aabb Aabb::CreateNull()
     {
         Aabb result;

--- a/Code/Framework/AzCore/AzCore/Math/Color.h
+++ b/Code/Framework/AzCore/AzCore/Math/Color.h
@@ -26,8 +26,12 @@ namespace AZ
         static void Reflect(ReflectContext* context);
 
         //! Default constructor, components are uninitialized.
-        Color() = default;
+        AZ_DEPRECATED(Color() = default, "The Color Default Constructor has been deprecated. Please use Color::CreateUnitialized() instead.");
         Color(const Vector4& v)   { m_color = v; }
+
+        //! Returns a color with uninitialized data members.
+        //! Many of the member functions are not safe to call until the data members have been initialized.
+        static Color CreateUninitialized();
 
         explicit Color(const Vector2& source);
 

--- a/Code/Framework/AzCore/AzCore/Math/Color.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Color.inl
@@ -9,6 +9,10 @@
 
 namespace AZ
 {
+    AZ_MATH_INLINE Color Color::CreateUninitialized()
+    {
+        return Color();
+    }
 
     AZ_MATH_INLINE Color::Color(const Vector2& source)
     {

--- a/Code/Framework/AzCore/AzCore/Math/Frustum.h
+++ b/Code/Framework/AzCore/AzCore/Math/Frustum.h
@@ -84,7 +84,11 @@ namespace AZ
         static void Reflect(ReflectContext* context);
 
         //! Default constructor, leaves members uninitialized for speed.
-        Frustum();
+        AZ_DEPRECATED(Frustum(), "The Frustum Default Constructor has been deprecated. Please use Frustum::CreateUnitialized() instead.");
+
+        //! Returns a frustum with uninitialized data members.
+        //! Many of the member functions are not safe to call until the data members have been initialized.
+        static Frustum CreateUninitialized();
 
         //! Construct a view frustum from ViewFrustumAttributes.
         //! 

--- a/Code/Framework/AzCore/AzCore/Math/Frustum.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Frustum.inl
@@ -16,6 +16,11 @@ namespace AZ
         return planeId;
     }
 
+    AZ_MATH_INLINE Frustum Frustum::CreateUninitialized()
+    {
+        return Frustum();
+    }
+
     AZ_MATH_INLINE Frustum::Frustum()
     {
 #ifdef AZ_DEBUG_BUILD

--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x3.h
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x3.h
@@ -36,7 +36,11 @@ namespace AZ
         static void Reflect(ReflectContext* context);
 
         //! Default constructor does not initialize the matrix.
-        Matrix3x3() = default;
+        AZ_DEPRECATED(Matrix3x3() = default, "The Matrix3x3 Default Constructor has been deprecated. Please use Matrix3x3::CreateUnitialized() instead.");
+
+        //! Returns a 3x3 matrix with uninitialized data members.
+        //! Many of the member functions are not safe to call until the data members have been initialized.
+        static Matrix3x3 CreateUninitialized();
 
         explicit Matrix3x3(const Quaternion& quaternion);
 

--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x3.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x3.inl
@@ -13,6 +13,11 @@
 
 namespace AZ
 {
+    AZ_MATH_INLINE Matrix3x3 Matrix3x3::CreateUninitialized()
+    {
+        return Matrix3x3();
+    }
+
     AZ_MATH_INLINE Matrix3x3::Matrix3x3(const Matrix3x3& rhs)
     {
 #if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR

--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x4.h
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x4.h
@@ -39,7 +39,11 @@ namespace AZ
         using Axis = Constants::Axis;
 
         //! Default constructor, which does not initialize the matrix.
-        Matrix3x4() = default;
+        AZ_DEPRECATED(Matrix3x4() = default, "The Matrix3x4 Default Constructor has been deprecated. Please use Matrix3x4::CreateUnitialized() instead.");
+
+        //! Returns a 3x4 matrix with uninitialized data members.
+        //! Many of the member functions are not safe to call until the data members have been initialized.
+        static Matrix3x4 CreateUninitialized();
 
         Matrix3x4(const Matrix3x4& rhs);
         Matrix3x4(Simd::Vec4::FloatArgType row0, Simd::Vec4::FloatArgType row1, Simd::Vec4::FloatArgType row2);

--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x4.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x4.inl
@@ -14,6 +14,11 @@
 
 namespace AZ
 {
+    AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateUninitialized()
+    {
+        return Matrix3x4();
+    }
+
     AZ_MATH_INLINE void ConvertTo4x4(const Simd::Vec4::FloatType* in3x4, Simd::Vec4::FloatType* out4x4)
     {
         out4x4[0] = in3x4[0];

--- a/Code/Framework/AzCore/AzCore/Math/Matrix4x4.h
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix4x4.h
@@ -41,7 +41,11 @@ namespace AZ
         static void Reflect(ReflectContext* context);
 
         //! Default constructor does not initialize the matrix.
-        Matrix4x4() = default;
+        AZ_DEPRECATED(Matrix4x4() = default, "The Matrix4x4 Default Constructor has been deprecated. Please use Matrix4x4::CreateUnitialized() instead.");
+
+        //! Returns a 4x4 matrix with uninitialized data members.
+        //! Many of the member functions are not safe to call until the data members have been initialized.
+        static Matrix4x4 CreateUninitialized();
 
         Matrix4x4(const Matrix4x4& rhs);
         Matrix4x4(Simd::Vec4::FloatArgType row0, Simd::Vec4::FloatArgType row1, Simd::Vec4::FloatArgType row2, Simd::Vec4::FloatArgType row3);

--- a/Code/Framework/AzCore/AzCore/Math/Matrix4x4.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix4x4.inl
@@ -13,6 +13,11 @@
 
 namespace AZ
 {
+    AZ_MATH_INLINE Matrix4x4 Matrix4x4::CreateUninitialized()
+    {
+        return Matrix4x4();
+    }
+
     AZ_MATH_INLINE Matrix4x4::Matrix4x4(const Matrix4x4& rhs)
     {
 #if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR

--- a/Code/Framework/AzCore/AzCore/Math/Obb.h
+++ b/Code/Framework/AzCore/AzCore/Math/Obb.h
@@ -33,7 +33,11 @@ namespace AZ
         //! @param context reflection context
         static void Reflect(ReflectContext* context);
 
-        Obb() = default;
+        AZ_DEPRECATED(Obb() = default, "The Obb Default Constructor has been deprecated. Please use Obb::CreateUnitialized() instead.");
+
+        //! Returns an oriented bounding box with uninitialized data members.
+        //! Many of the member functions are not safe to call until the data members have been initialized.
+        static Obb CreateUninitialized();
 
         static Obb CreateFromPositionRotationAndHalfLengths(
             const Vector3& position, const Quaternion& rotation, const Vector3& halfLengths);

--- a/Code/Framework/AzCore/AzCore/Math/Obb.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Obb.inl
@@ -10,6 +10,11 @@
 
 namespace AZ
 {
+    AZ_MATH_INLINE Obb Obb::CreateUninitialized()
+    {
+        return Obb();
+    }
+
     AZ_MATH_INLINE const Vector3& Obb::GetPosition() const
     {
         return m_position;

--- a/Code/Framework/AzCore/AzCore/Math/Plane.h
+++ b/Code/Framework/AzCore/AzCore/Math/Plane.h
@@ -38,7 +38,11 @@ namespace AZ
         static void Reflect(ReflectContext* context);
 
         //! Default construction, no initialization.
-        Plane() = default;
+        AZ_DEPRECATED(Plane() = default, "The Plane Default Constructor has been deprecated. Please use Plane::CreateUnitialized() instead.");
+
+        //! Returns a plane with uninitialized data members.
+        //! Many of the member functions are not safe to call until the data members have been initialized.
+        static Plane CreateUninitialized();
 
         //! Construct from a simd vector representing a plane.
         explicit Plane(Simd::Vec4::FloatArgType plane);

--- a/Code/Framework/AzCore/AzCore/Math/Plane.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Plane.inl
@@ -10,6 +10,11 @@
 
 namespace AZ
 {
+    AZ_MATH_INLINE Plane Plane::CreateUninitialized()
+    {
+        return Plane();
+    }
+
     AZ_MATH_INLINE Plane::Plane(Simd::Vec4::FloatArgType plane)
         : m_plane(plane)
     {

--- a/Code/Framework/AzCore/AzCore/Math/PolygonPrism.h
+++ b/Code/Framework/AzCore/AzCore/Math/PolygonPrism.h
@@ -28,8 +28,12 @@ namespace AZ
         AZ_RTTI(PolygonPrism, "{F01C8BDD-6F24-4344-8945-521A8750B30B}")
         AZ_CLASS_ALLOCATOR_DECL
 
-        PolygonPrism() = default;
+        AZ_DEPRECATED(PolygonPrism() = default, "The PolygonPrism Default Constructor has been deprecated. Please use PolygonPrism::CreateUnitialized() instead.");
         virtual ~PolygonPrism() = default;
+
+        //! Returns a polygon prism with uninitialized data members.
+        //! Many of the member functions are not safe to call until the data members have been initialized.
+        static PolygonPrism CreateUninitialized();
 
         //! Set the height of the polygon prism.
         void SetHeight(float height);
@@ -78,3 +82,5 @@ namespace AZ
     using PolygonPrismPtr = AZStd::shared_ptr<PolygonPrism>;
     using ConstPolygonPrismPtr = AZStd::shared_ptr<const PolygonPrism>;
 }
+
+#include <AzCore/Math/PolygonPrism.inl>

--- a/Code/Framework/AzCore/AzCore/Math/PolygonPrism.inl
+++ b/Code/Framework/AzCore/AzCore/Math/PolygonPrism.inl
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+namespace AZ
+{
+    AZ_MATH_INLINE PolygonPrism PolygonPrism::CreateUninitialized()
+    {
+        return PolygonPrism();
+    }
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.h
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.h
@@ -23,7 +23,11 @@ namespace AZ
         static void Reflect(ReflectContext* context);
 
         //! Default constructor, components are uninitialized.
-        Quaternion() = default;
+        AZ_DEPRECATED(Quaternion() = default, "The Quaternion Default Constructor has been deprecated. Please use Quaternion::CreateUnitialized() instead.");
+
+        //! Returns a quaternion with uninitialized data members.
+        //! Many of the member functions are not safe to call until the data members have been initialized.
+        static Quaternion CreateUninitialized();
 
         //! Copy constructor, clones the provided quaternion.
         Quaternion(const Quaternion& q);

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.inl
@@ -8,6 +8,11 @@
 
 namespace AZ
 {
+    AZ_MATH_INLINE Quaternion Quaternion::CreateUninitialized()
+    {
+        return Quaternion();
+    }
+
     AZ_MATH_INLINE Quaternion::Quaternion(const Quaternion& q)
         : m_value(q.m_value)
     {

--- a/Code/Framework/AzCore/AzCore/Math/Sphere.h
+++ b/Code/Framework/AzCore/AzCore/Math/Sphere.h
@@ -20,8 +20,12 @@ namespace AZ
     public:
         AZ_TYPE_INFO(Sphere, "{34BB6527-81AE-4854-99ED-D1A319DCD0A9}");
 
-        Sphere() = default;
+        AZ_DEPRECATED(Sphere() = default, "The Sphere Default Constructor has been deprecated. Please use Sphere::CreateUnitialized() instead.");
         Sphere(const Vector3& center, float radius);
+
+        //! Returns a sphere with uninitialized data members.
+        //! Many of the member functions are not safe to call until the data members have been initialized.
+        static Sphere CreateUninitialized();
 
         static Sphere CreateUnitSphere();
         static Sphere CreateFromAabb(const Aabb& aabb);

--- a/Code/Framework/AzCore/AzCore/Math/Sphere.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Sphere.inl
@@ -10,6 +10,12 @@
 
 namespace AZ
 {
+    AZ_MATH_INLINE Sphere Sphere::CreateUninitialized()
+    {
+        return Sphere();
+    }
+
+
     AZ_MATH_INLINE Sphere::Sphere(const Vector3& center, float radius)
     {
         m_center = center;

--- a/Code/Framework/AzCore/AzCore/Math/Transform.h
+++ b/Code/Framework/AzCore/AzCore/Math/Transform.h
@@ -38,7 +38,11 @@ namespace AZ
         static void Reflect(ReflectContext* context);
 
         //! Default constructor does not initialize the matrix.
-        Transform() = default;
+        AZ_DEPRECATED(Transform() = default, "The Transform Default Constructor has been deprecated. Please use Transform::CreateUnitialized() instead.");
+
+        //! Returns a transform with uninitialized data members.
+        //! Many of the member functions are not safe to call until the data members have been initialized.
+        static Transform CreateUninitialized();
 
         //! Construct a transform from components.
         Transform(const Vector3& translation, const Quaternion& rotation, float scale);

--- a/Code/Framework/AzCore/AzCore/Math/Transform.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Transform.inl
@@ -8,6 +8,11 @@
 
 namespace AZ
 {
+    AZ_MATH_INLINE Transform Transform::CreateUninitialized()
+    {
+        return Transform();
+    }
+
     AZ_MATH_INLINE Transform::Transform(const Vector3& translation, const Quaternion& rotation, float scale)
         : m_translation(translation)
         , m_rotation(rotation)

--- a/Code/Framework/AzCore/AzCore/Math/Uuid.h
+++ b/Code/Framework/AzCore/AzCore/Math/Uuid.h
@@ -47,7 +47,13 @@ namespace AZ
         static constexpr int ValidUuidStringLength = 32; /// Number of characters (data only, no extra formatting) in a valid UUID string
         static constexpr size_t MaxStringBuffer = 39; /// 32 Uuid + 4 dashes + 2 brackets + 1 terminate
         using FixedString = AZStd::fixed_string<MaxStringBuffer>;
-        constexpr Uuid() = default;
+
+        AZ_DEPRECATED(constexpr Uuid() = default, "The Uuid Default Constructor has been deprecated. Please use Uuid::CreateUnitialized() instead.");
+
+        //! Returns a uuid with uninitialized data members.
+        //! Many of the member functions are not safe to call until the data members have been initialized.
+        inline constexpr Uuid CreateUninitialized();
+
         constexpr explicit Uuid(AZStd::string_view uuidString);
         constexpr Uuid(const char* string, size_t stringLength);
 

--- a/Code/Framework/AzCore/AzCore/Math/Uuid.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Uuid.inl
@@ -35,6 +35,11 @@ namespace AZ::UuidInternal
 
 namespace AZ
 {
+    inline constexpr Uuid Uuid::CreateUninitialized()
+    {
+        return Uuid();
+    }
+
     constexpr Uuid::Uuid(AZStd::string_view uuidString)
     {
         operator=(CreateString(uuidString));

--- a/Code/Framework/AzCore/AzCore/Math/Vector2.h
+++ b/Code/Framework/AzCore/AzCore/Math/Vector2.h
@@ -28,9 +28,13 @@ namespace AZ
         //! @param context reflection context
         static void Reflect(ReflectContext* context);
 
-        Vector2() = default;
+        AZ_DEPRECATED(Vector2() = default, "The Vector2 Default Constructor has been deprecated. Please use Vector2::CreateUnitialized() instead.");
 
         Vector2(const Vector2& v) = default;
+
+        //! Returns a vector with uninitialized data members.
+        //! Many of the member functions are not safe to call until the data members have been initialized.
+        static Vector2 CreateUninitialized();
 
         //! Constructs vector with all components set to the same specified value.
         explicit Vector2(float x);

--- a/Code/Framework/AzCore/AzCore/Math/Vector2.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Vector2.inl
@@ -12,6 +12,11 @@
 
 namespace AZ
 {
+    AZ_MATH_INLINE Vector2 Vector2::CreateUninitialized()
+    {
+        return Vector2();
+    }
+
     AZ_MATH_INLINE Vector2::Vector2(float x)
         : m_value(Simd::Vec2::Splat(x))
     {

--- a/Code/Framework/AzCore/AzCore/Math/Vector3.h
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.h
@@ -34,8 +34,12 @@ namespace AZ
         static void Reflect(ReflectContext* context);
 
         //! Default constructor, components are uninitialized.
-        Vector3() = default;
+        AZ_DEPRECATED(Vector3() = default, "The Vector3 Default Constructor has been deprecated. Please use Vector3::CreateUnitialized() instead.");
         Vector3(const Vector3& v);
+
+        //! Returns a vector with uninitialized data members.
+        //! Many of the member functions are not safe to call until the data members have been initialized.
+        static Vector3 CreateUninitialized();
 
         //! Constructs vector with all components set to the same specified value.
         explicit Vector3(float x);

--- a/Code/Framework/AzCore/AzCore/Math/Vector3.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.inl
@@ -12,6 +12,11 @@
 
 namespace AZ
 {
+    AZ_MATH_INLINE Vector3 Vector3::CreateUninitialized()
+    {
+        return Vector3();
+    }
+
     AZ_MATH_INLINE Vector3::Vector3(float x)
         : m_value(Simd::Vec3::Splat(x))
     {

--- a/Code/Framework/AzCore/AzCore/Math/Vector4.h
+++ b/Code/Framework/AzCore/AzCore/Math/Vector4.h
@@ -30,8 +30,12 @@ namespace AZ
         static void Reflect(ReflectContext* context);
 
         //! Default constructor, components are uninitialized.
-        Vector4() = default;
+        AZ_DEPRECATED(Vector4() = default, "The Vector4 Default Constructor has been deprecated. Please use Vector4::CreateUnitialized() instead.");
         Vector4(const Vector4& v);
+
+        //! Returns a vector with uninitialized data members.
+        //! Many of the member functions are not safe to call until the data members have been initialized.
+        static Vector4 CreateUninitialized();
 
         //! Constructs vector with all components set to the same specified value.
         explicit Vector4(float x);

--- a/Code/Framework/AzCore/AzCore/Math/Vector4.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Vector4.inl
@@ -11,6 +11,11 @@
 
 namespace AZ
 {
+    AZ_MATH_INLINE Vector4 Vector4::CreateUninitialized()
+    {
+        return Vector4();
+    }
+
     AZ_MATH_INLINE Vector4::Vector4(const Vector4& v)
         : m_value(v.m_value)
     {


### PR DESCRIPTION
## What does this PR do?

Attempt to fix issue [#10146](https://github.com/o3de/o3de/issues/10146)

This PR deprecates default constructors that create uninitialized components to avoid users attempting to access non-existent data.
The deprecated constructors were replaced with a CreateUninitialized method, and the constructors should be moved from public to private after a deprecation period.

## How was this PR tested?

Manually tested in development. Was able to create instances of math objects using CreateUninitialized method.
