### PR TITLE
Disable Component Mode Switcher in Automated Testing project

### DIFF
--- a/AutomatedTesting/Registry/editorpreferences.setreg
+++ b/AutomatedTesting/Registry/editorpreferences.setreg
@@ -1,7 +1,10 @@
 {
     "Amazon": {
         "Preferences": {
-            "EnablePrefabSystem": true
+            "EnablePrefabSystem": true,
+            "Editor": {
+                "ComponentSwitcherEnabled": false
+            }
         }
     },
     "O3DE": {


### PR DESCRIPTION
## What does this PR do?

Temporarily disables the Component Mode Switcher in the Automated Testing project.

To help resolve #12253 

## How was this PR tested?

Running AR to detect if this resolves the issue above
