### PR TITLE
Fix crash when EMVF mask asset is not ready.

### DIFF
--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMaskRenderer.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMaskRenderer.cpp
@@ -10,13 +10,13 @@
 
 namespace AZ::Render
 {
-    EditorStateMaskRenderer::EditorStateMaskRenderer(const Name& name, Data::Instance<RPI::Material> maskMaterial)
+    EditorStateMaskRenderer::EditorStateMaskRenderer(const Name& name)
         : m_drawTag(name)
-        , m_maskMaterial(maskMaterial)
     {
     }
 
-    void EditorStateMaskRenderer::RenderMaskEntities(const AzToolsFramework::EntityIdSet& entityIds)
+    void EditorStateMaskRenderer::RenderMaskEntities(
+        Data::Instance<RPI::Material> maskMaterial, const AzToolsFramework::EntityIdSet& entityIds)
     {
         if (entityIds.empty())
         {
@@ -34,7 +34,7 @@ namespace AZ::Render
             {
                 m_drawableEntities.emplace(
                     AZStd::piecewise_construct, AZStd::forward_as_tuple(entityId),
-                    AZStd::forward_as_tuple(entityId, m_maskMaterial, m_drawTag));
+                    AZStd::forward_as_tuple(entityId, maskMaterial, m_drawTag));
             }
         }
 

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMaskRenderer.h
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMaskRenderer.h
@@ -20,16 +20,15 @@ namespace AZ::Render
     {
     public:
         //! Constructs the mask renderer for the specified draw tag.
-        EditorStateMaskRenderer(const Name& name, Data::Instance<RPI::Material> maskMaterial);
+        EditorStateMaskRenderer(const Name& name);
 
         //! Renders the specified entities to this mask.
-        void RenderMaskEntities(const AzToolsFramework::EntityIdSet& entityIds);
+        void RenderMaskEntities(Data::Instance<RPI::Material> maskMaterial, const AzToolsFramework::EntityIdSet& entityIds);
     private:
 
         //! The drawable components of the entities tagged for rendering to this mask.
         AZStd::unordered_map<EntityId, DrawableMeshEntity> m_drawableEntities;
 
         Name m_drawTag; //!< The draw tag for this mask.
-        Data::Instance<RPI::Material> m_maskMaterial = nullptr; //!< The material for this mask.
     };
 } // namespace AZ::Render

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/EditorModeFeedbackFeatureProcessor.h
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/EditorModeFeedbackFeatureProcessor.h
@@ -23,7 +23,7 @@ namespace AZ
         //! Feature processor for Editor Mode Feedback visual effect system.
         class EditorModeFeatureProcessor
             : public RPI::FeatureProcessor
-            , public AZ::TickBus::Handler
+            , private AZ::TickBus::Handler
         {
         public:
             AZ_RTTI(AZ::Render::EditorModeFeatureProcessor, "{78D40D57-F564-4ECD-B9F5-D8C9784B15D0}", AZ::RPI::FeatureProcessor);

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/EditorModeFeedbackFeatureProcessor.h
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/EditorModeFeedbackFeatureProcessor.h
@@ -13,6 +13,7 @@
 
 #include <Atom/RPI.Public/FeatureProcessor.h>
 #include <Atom/RPI.Reflect/System/AnyAsset.h>
+#include <AzCore/Component/TickBus.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 
 namespace AZ
@@ -22,6 +23,7 @@ namespace AZ
         //! Feature processor for Editor Mode Feedback visual effect system.
         class EditorModeFeatureProcessor
             : public RPI::FeatureProcessor
+            , public AZ::TickBus::Handler
         {
         public:
             AZ_RTTI(AZ::Render::EditorModeFeatureProcessor, "{78D40D57-F564-4ECD-B9F5-D8C9784B15D0}", AZ::RPI::FeatureProcessor);
@@ -39,6 +41,9 @@ namespace AZ
             void OnRenderPipelineAdded(RPI::RenderPipelinePtr pipeline) override;
             void OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline) override;
             void OnRenderPipelineRemoved(RPI::RenderPipeline* pipeline) override;
+
+            // AZ::TickBus overrides ...
+            void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
 
         private:
             //! The pass system for the editor state feedback effects.


### PR DESCRIPTION
## What does this PR do?

This PR defers the usage of the EMVF mask material until the asset is successfully loaded. Previously, the attempt to load this asset occurred only once when the EMVF system component was activated. Under certain conditions, this asset was not ready and thus the attempt would fail, causing consumers of that material to dereference a null pointer.

Fixes https://github.com/o3de/o3de/issues/12221

## How was this PR tested?

Manual testing in the editor by myself and Lionbridge testers.
