### PR TITLE
Prism/CreateGemLHSTabs

### DIFF
--- a/Code/Tools/ProjectManager/Resources/ProjectManager.qss
+++ b/Code/Tools/ProjectManager/Resources/ProjectManager.qss
@@ -35,21 +35,30 @@ QTabBar::tab:text {
     text-align:left;
 }
 
-/*#createGemTab QTabBar::tab {
-    background-color: #444444;
-    font-size:16px;
-    min-height:230px;
-    margin: 0px;
-    text-align:left;
+QRadioButton#createAGemLHSTab::indicator{
+    image: url(:/nothing.png);
 }
 
-QTabWidget#createGemTab::tab-bar {
-    left: 0px;
+QRadioButton#createAGemLHSTab{
+    font-size: 16px;
+    height: 40px;
+    min-width: 180px;
+    spacing: 10px;
+    color: #6b6b6b;
 }
 
-QTabBar#createGemTab::tab:text {
-    text-align:left;
-}*/
+
+QRadioButton#createAGemLHSTab:enabled{
+    color: #aaaaaa;
+}
+
+
+QRadioButton#createAGemLHSTab:checked{
+    background-color: #333333;
+    spacing: 30px;
+    color: #FFFFFF;
+}
+
 
 QStackedWidget#createAGemRHS{
     background-color: #333333;
@@ -152,10 +161,6 @@ QTabBar::tab:focus {
 }
 
 #createAGem #formFrame {
-    margin-left: 0px;
-}
-
-#createAGemFormLineEdit #formFrame {
     margin-left: 0px;
 }
 
@@ -269,7 +274,6 @@ QTabBar::tab:focus {
 
 #rightPaneDetailsHeader {
     font-size:21px;
-    /* qproperty-indent: 0; */
 }
 
 #rightPaneSubheader {

--- a/Code/Tools/ProjectManager/Resources/ProjectManager.qss
+++ b/Code/Tools/ProjectManager/Resources/ProjectManager.qss
@@ -35,7 +35,7 @@ QTabBar::tab:text {
     text-align:left;
 }
 
-#createGemTab QTabBar::tab {
+/*#createGemTab QTabBar::tab {
     background-color: #444444;
     font-size:16px;
     min-height:230px;
@@ -48,6 +48,11 @@ QTabWidget#createGemTab::tab-bar {
 }
 
 QTabBar#createGemTab::tab:text {
+    text-align:left;
+}*/
+
+QStackedWidget#createAGemRHS{
+    background-color: #333333;
     text-align:left;
 }
 
@@ -147,6 +152,10 @@ QTabBar::tab:focus {
 }
 
 #createAGem #formFrame {
+    margin-left: 0px;
+}
+
+#createAGemFormLineEdit #formFrame {
     margin-left: 0px;
 }
 
@@ -258,6 +267,11 @@ QTabBar::tab:focus {
     qproperty-indent: 0;
 }
 
+#rightPaneDetailsHeader {
+    font-size:21px;
+    /* qproperty-indent: 0; */
+}
+
 #rightPaneSubheader {
     font-size:14px;
     qproperty-indent: 0;
@@ -279,6 +293,10 @@ QTabBar::tab:focus {
     padding-bottom: 20px;
     padding-left: 23px;
     font-size: 12;
+}
+
+#createAGemRadioButtonSubFormField #formFrame{
+    margin-left: 23px;
 }
 
 /************** General (Modal windows) **************/

--- a/Code/Tools/ProjectManager/Resources/ProjectManager.qss
+++ b/Code/Tools/ProjectManager/Resources/ProjectManager.qss
@@ -35,11 +35,7 @@ QTabBar::tab:text {
     text-align:left;
 }
 
-QRadioButton#createAGemLHSTab::indicator{
-    image: url(:/nothing.png);
-}
-
-QRadioButton#createAGemLHSTab{
+#createAGemLHS QRadioButton{
     font-size: 16px;
     height: 40px;
     min-width: 180px;
@@ -47,22 +43,27 @@ QRadioButton#createAGemLHSTab{
     color: #6b6b6b;
 }
 
-
-QRadioButton#createAGemLHSTab:enabled{
+#createAGemLHS QRadioButton:enabled{
     color: #aaaaaa;
 }
 
-
-QRadioButton#createAGemLHSTab:checked{
+#createAGemLHS QRadioButton:checked{
     background-color: #333333;
     spacing: 30px;
     color: #FFFFFF;
 }
 
+#createAGemLHS QRadioButton::indicator{
+    image: url(:/nothing.png);
+}
 
 QStackedWidget#createAGemRHS{
     background-color: #333333;
     text-align:left;
+}
+
+#createAGemRHS #formFrame{
+    margin-left: 0px;
 }
 
 QTabWidget::pane {

--- a/Code/Tools/ProjectManager/Resources/nothing.png
+++ b/Code/Tools/ProjectManager/Resources/nothing.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b52b8cf497186550366c876c7503f999d7949987b6f0d268960caad341ab1ebe
+size 139

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
@@ -33,11 +33,11 @@ namespace O3DE::ProjectManager
         : ScreenWidget(parent)
     {
 
-        QVBoxLayout* screenLayout = new QVBoxLayout(this);
+        QVBoxLayout* screenLayout = new QVBoxLayout();
         screenLayout->setSpacing(0);
         screenLayout->setContentsMargins(0, 0, 0, 0);
 
-        ScreenHeader* m_header = new ScreenHeader(this);
+        ScreenHeader* m_header = new ScreenHeader();
         m_header->setSubTitle(tr("Create a new gem"));
         connect(
             m_header->backButton(),
@@ -50,23 +50,23 @@ namespace O3DE::ProjectManager
         screenLayout->addWidget(m_header);
 
         
-        QHBoxLayout* hLayout = new QHBoxLayout(this);
+        QHBoxLayout* hLayout = new QHBoxLayout();
         hLayout->setSpacing(0);
         hLayout->setContentsMargins(0, 0, 0, 0);
 
-        QFrame* lhsFrame = CreateLHSTabs();
-        hLayout->addWidget(lhsFrame);
+        QFrame* tabButtonsFrame = CreateTabButtonsFrame();
+        hLayout->addWidget(tabButtonsFrame);
 
-        QFrame* rhsFrame = CreateRHSPane();
-        hLayout->addWidget(rhsFrame);
+        QFrame* tabPaneFrame = CreateTabPaneFrame();
+        hLayout->addWidget(tabPaneFrame);
         
-        QFrame* createGemFrame = new QFrame(this);
+        QFrame* createGemFrame = new QFrame();
         createGemFrame->setLayout(hLayout);
         screenLayout->addWidget(createGemFrame);
         
-        QFrame* footerFrame = new QFrame(this);
+        QFrame* footerFrame = new QFrame();
         footerFrame->setObjectName("createAGemFooter");
-        m_backNextButtons = new QDialogButtonBox(this);
+        m_backNextButtons = new QDialogButtonBox();
         m_backNextButtons->setObjectName("footer");
         QVBoxLayout* footerLayout = new QVBoxLayout();
         footerLayout->setContentsMargins(0, 0, 0, 0);
@@ -85,12 +85,12 @@ namespace O3DE::ProjectManager
         setLayout(screenLayout);
     }
 
-    QFrame* CreateGem::CreateLHSTabs()
+    QFrame* CreateGem::CreateTabButtonsFrame()
     {
-        QFrame* lhsFrame = new QFrame(this);
-        lhsFrame->setObjectName("createAGemLHS");
+        QFrame* tabButtonsFrame = new QFrame();
+        tabButtonsFrame->setObjectName("createAGemLHS");
 
-        QVBoxLayout* vLayout = new QVBoxLayout(this);
+        QVBoxLayout* vLayout = new QVBoxLayout();
         vLayout->setSpacing(0);
         vLayout->setContentsMargins(0, 0, 0, 0);
 
@@ -98,13 +98,8 @@ namespace O3DE::ProjectManager
         m_gemDetailsTab =           new QRadioButton(tr("2.  Gem Details"));
         m_gemCreatorDetailsTab =    new QRadioButton(tr("3.  Creator Details"));
 
-        m_gemTemplateSelectionTab->setObjectName("createAGemLHSTab");
         m_gemTemplateSelectionTab->setChecked(true);
-
-        m_gemDetailsTab->setObjectName("createAGemLHSTab");
         m_gemDetailsTab->setEnabled(false);
-
-        m_gemCreatorDetailsTab->setObjectName("createAGemLHSTab");
         m_gemCreatorDetailsTab->setEnabled(false);
 
         connect(m_gemTemplateSelectionTab,  &QPushButton::clicked, this, &CreateGem::HandleGemTemplateSelectionTab);
@@ -119,52 +114,52 @@ namespace O3DE::ProjectManager
         vLayout->addWidget(m_gemCreatorDetailsTab);
         vLayout->addStretch();
 
-        lhsFrame->setLayout(vLayout);
+        tabButtonsFrame->setLayout(vLayout);
 
-        return lhsFrame;
+        return tabButtonsFrame;
     }
 
     void CreateGem::HandleGemTemplateSelectionTab()
     {
-        m_stackWidget->setCurrentIndex(gemTemplateSelectionScreen);
+        m_stackWidget->setCurrentIndex(GemTemplateSelectionScreen);
         m_nextButton->setText(tr("Next"));
         m_backButton->setVisible(false);
     }
 
     void CreateGem::HandleGemDetailsTab()
     {
-        m_stackWidget->setCurrentIndex(gemDetailsScreen);
+        m_stackWidget->setCurrentIndex(GemDetailsScreen);
         m_nextButton->setText(tr("Next"));
         m_backButton->setVisible(true);
     }
 
     void CreateGem::HandleGemCreatorDetailsTab()
     {
-        m_stackWidget->setCurrentIndex(gemCreatorDetailsScreen);
+        m_stackWidget->setCurrentIndex(GemCreatorDetailsScreen);
         m_nextButton->setText(tr("Create"));
         m_backButton->setVisible(true);
     }
 
-    QFrame* CreateGem::CreateRHSPane()
+    QFrame* CreateGem::CreateTabPaneFrame()
     {
-        QFrame* rhsFrame = new QFrame(this);
+        QFrame* tabPaneFrame = new QFrame();
 
-        QVBoxLayout* vLayout = new QVBoxLayout(this);
+        QVBoxLayout* vLayout = new QVBoxLayout();
         vLayout->setSpacing(0);
         vLayout->setContentsMargins(0, 0, 0, 0);
 
-        m_stackWidget = new QStackedWidget(this);
+        m_stackWidget = new QStackedWidget();
         m_stackWidget->setContentsMargins(0, 0, 0, 0);
         
         m_stackWidget->setObjectName("createAGemRHS");
-        m_stackWidget->addWidget(CreateGemSetupScrollArea());  //tr("1. Gem Setup");
-        m_stackWidget->addWidget(CreateGemDetailsScrollArea());//tr("2. Gem Details");
-        m_stackWidget->addWidget(CreateGemCreatorScrollArea());//tr("3. Creator Details");
+        m_stackWidget->addWidget(CreateGemSetupScrollArea());
+        m_stackWidget->addWidget(CreateGemDetailsScrollArea());
+        m_stackWidget->addWidget(CreateGemCreatorScrollArea());
         vLayout->addWidget(m_stackWidget);
 
-        rhsFrame->setLayout(vLayout);
+        tabPaneFrame->setLayout(vLayout);
 
-        return rhsFrame;
+        return tabPaneFrame;
     }
 
 
@@ -254,48 +249,38 @@ namespace O3DE::ProjectManager
             tr("The unique name for your gem consisting of only alphanumeric characters, '-' and '_'."),
             tr("A gem system name is required."));
         m_gemName->lineEdit()->setValidator(new QRegularExpressionValidator(QRegularExpression("[a-zA-Z]+[a-zA-Z0-9\\-\\_]*"), this));
-        m_gemName->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_gemName);
 
         m_gemDisplayName = new FormLineEditWidget(
             tr("Gem Display name*"), "", tr("The name displayed in the Gem Catalog"), tr("A gem display name is required."));
         m_gemDisplayName->lineEdit()->setValidator(new QRegularExpressionValidator(QRegularExpression("( |\\w)+"), this));
-        m_gemDisplayName->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_gemDisplayName);
 
         m_gemSummary = new FormLineEditWidget(tr("Gem Summary"), "", tr("A short description of your Gem"), "");
-        m_gemSummary->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_gemSummary);
 
         m_requirements = new FormLineEditWidget(tr("Requirements"), "", tr("Notice of any requirements your Gem. i.e. This requires X other gem"), "");
-        m_requirements->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_requirements);
 
         m_license = new FormLineEditWidget(
             tr("License*"), "", tr("License uses goes here: i.e. Apache-2.0 or MIT"), tr("License details are required."));
-        m_license->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_license);
 
         m_licenseURL = new FormLineEditWidget(tr("License URL"), "", tr("Link to the license web site i.e. https://opensource.org/licenses/Apache-2.0"), "");
-        m_licenseURL->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_licenseURL);
 
         m_userDefinedGemTags = new FormLineEditWidget(tr("User-defined Gem Tags (Comma separated list)"), "");
         m_userDefinedGemTags->lineEdit()->setValidator(new QRegularExpressionValidator(QRegularExpression("(\\w+)(,\\s?\\w*)*"), this));
-        m_userDefinedGemTags->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_userDefinedGemTags);
 
         m_gemLocation = new FormFolderBrowseEditWidget(tr("Gem Location"), "", tr("The path that the gem will be created at."), tr("The chosen directory must either not exist or be empty."));
-        m_gemLocation->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_gemLocation);
         
         m_gemIconPath = new FormLineEditWidget(tr("Gem Icon Path"), "default.png", tr("Select Gem icon path"), "");
-        m_gemIconPath->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_gemIconPath);
 
         m_documentationURL = new FormLineEditWidget(
             tr("Documentation URL"), "", tr("Link to any documentation of your Gem i.e. https://o3de.org/docs/user-guide/gems/..."), "");
-        m_documentationURL->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_documentationURL);
 
         return gemDetailsScrollArea;
@@ -322,15 +307,12 @@ namespace O3DE::ProjectManager
 
         m_origin =
             new FormLineEditWidget(tr("Creator Name*"), "", tr("The name of the gem creator or originator goes here. i.e. O3DE"), tr("You must provide a creator name."));
-        m_origin->setObjectName("createAGem");
         gemCreatorLayout->addWidget(m_origin);
 
         m_originURL = new FormLineEditWidget(tr("Origin URL"), "", tr("The primary website for your Gem. i.e. http://o3de.org"), "");
-        m_originURL->setObjectName("createAGem");
         gemCreatorLayout->addWidget(m_originURL);
 
         m_repositoryURL = new FormLineEditWidget(tr("Repository URL"), "", tr("Optional URL of the repository for this gem."), "");
-        m_repositoryURL->setObjectName("createAGem");
         gemCreatorLayout->addWidget(m_repositoryURL);
 
         return gemCreatorScrollArea;
@@ -408,22 +390,22 @@ namespace O3DE::ProjectManager
 
     void CreateGem::HandleBackButton()
     {
-        if (m_stackWidget->currentIndex() > gemTemplateSelectionScreen)
+        if (m_stackWidget->currentIndex() > 0)
         {
-            m_stackWidget->setCurrentIndex(m_stackWidget->currentIndex() - 1);
+            const int newIndex = m_stackWidget->currentIndex() - 1;
+            m_stackWidget->setCurrentIndex(newIndex);
 
-            int newIndex = m_stackWidget->currentIndex();
-            if (newIndex == gemDetailsScreen)
+            if (newIndex == GemDetailsScreen)
             {
                 m_gemDetailsTab->setChecked(true);
             }
-            else if (newIndex == gemTemplateSelectionScreen)
+            else if (newIndex == GemTemplateSelectionScreen)
             {
                 m_gemTemplateSelectionTab->setChecked(true);
             }
         }
 
-        if (m_stackWidget->currentIndex() == gemTemplateSelectionScreen)
+        if (m_stackWidget->currentIndex() == 0)
         {
             m_backButton->setVisible(false);
         }
@@ -433,14 +415,14 @@ namespace O3DE::ProjectManager
 
     void CreateGem::HandleNextButton()
     {
-        if (m_stackWidget->currentIndex() == gemTemplateSelectionScreen && ValidateGemTemplateLocation())
+        if (m_stackWidget->currentIndex() == GemTemplateSelectionScreen && ValidateGemTemplateLocation())
         {
             m_backButton->setVisible(true);
-            m_stackWidget->setCurrentIndex(gemDetailsScreen);
+            m_stackWidget->setCurrentIndex(GemDetailsScreen);
             m_gemDetailsTab->setEnabled(true);
             m_gemDetailsTab->setChecked(true);
         }
-        else if (m_stackWidget->currentIndex() == gemDetailsScreen)
+        else if (m_stackWidget->currentIndex() == GemDetailsScreen)
         {
             bool gemNameValid = ValidateGemName();
             bool gemDisplayNameValid = ValidateGemDisplayName();
@@ -458,13 +440,13 @@ namespace O3DE::ProjectManager
                 m_createGemInfo.m_path = m_gemLocation->lineEdit()->text();
                 m_createGemInfo.m_features = m_userDefinedGemTags->lineEdit()->text().split(',');
 
-                m_stackWidget->setCurrentIndex(gemCreatorDetailsScreen);
+                m_stackWidget->setCurrentIndex(GemCreatorDetailsScreen);
                 m_nextButton->setText(tr("Create"));
                 m_gemCreatorDetailsTab->setEnabled(true);
                 m_gemCreatorDetailsTab->setChecked(true);
             }
         }
-        else if (m_stackWidget->currentIndex() == gemCreatorDetailsScreen)
+        else if (m_stackWidget->currentIndex() == GemCreatorDetailsScreen)
         {
             bool originIsValid = ValidateFormNotEmpty(m_origin);
             bool repoURLIsValid = ValidateRepositoryURL();

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
@@ -32,9 +32,10 @@ namespace O3DE::ProjectManager
     CreateGem::CreateGem(QWidget* parent)
         : ScreenWidget(parent)
     {
-        QVBoxLayout* vLayout = new QVBoxLayout(this);
-        vLayout->setSpacing(0);
-        vLayout->setContentsMargins(0, 0, 0, 0);
+
+        QVBoxLayout* screenLayout = new QVBoxLayout(this);
+        screenLayout->setSpacing(0);
+        screenLayout->setContentsMargins(0, 0, 0, 0);
 
         ScreenHeader* m_header = new ScreenHeader(this);
         m_header->setSubTitle(tr("Create a new gem"));
@@ -46,7 +47,111 @@ namespace O3DE::ProjectManager
             {
                 emit GoToPreviousScreenRequest();
             });
-        vLayout->addWidget(m_header);
+        screenLayout->addWidget(m_header);
+
+        
+        QHBoxLayout* hLayout = new QHBoxLayout(this);
+        hLayout->setSpacing(0);
+        hLayout->setContentsMargins(0, 0, 0, 0);
+
+        QFrame* lhsFrame = CreateLHSTabs();
+        hLayout->addWidget(lhsFrame);
+
+        QFrame* rhsFrame = CreateRHSPane();
+        hLayout->addWidget(rhsFrame);
+        
+        QFrame* createGemFrame = new QFrame(this);
+        createGemFrame->setLayout(hLayout);
+        screenLayout->addWidget(createGemFrame);
+        
+        QFrame* footerFrame = new QFrame(this);
+        footerFrame->setObjectName("createAGemFooter");
+        m_backNextButtons = new QDialogButtonBox(this);
+        m_backNextButtons->setObjectName("footer");
+        QVBoxLayout* footerLayout = new QVBoxLayout();
+        footerLayout->setContentsMargins(0, 0, 0, 0);
+        footerFrame->setLayout(footerLayout);
+        footerLayout->addWidget(m_backNextButtons);
+        screenLayout->addWidget(footerFrame);
+
+        m_backButton = m_backNextButtons->addButton(tr("Back"), QDialogButtonBox::RejectRole);
+        m_backButton->setProperty("secondary", true);
+        m_nextButton = m_backNextButtons->addButton(tr("Next"), QDialogButtonBox::ApplyRole);
+
+        connect(m_backButton, &QPushButton::clicked, this, &CreateGem::HandleBackButton);
+        connect(m_nextButton, &QPushButton::clicked, this, &CreateGem::HandleNextButton);
+
+        setObjectName("createAGemBody");
+        setLayout(screenLayout);
+    }
+
+    QFrame* CreateGem::CreateLHSTabs()
+    {
+        QFrame* lhsFrame = new QFrame(this);
+        lhsFrame->setObjectName("createAGemLHS");
+
+        QVBoxLayout* vLayout = new QVBoxLayout(this);
+        vLayout->setSpacing(0);
+        vLayout->setContentsMargins(0, 0, 0, 0);
+
+        m_gemTemplateSelectionTab = new QRadioButton(tr("1.  Gem Setup"));
+        m_gemDetailsTab =           new QRadioButton(tr("2.  Gem Details"));
+        m_gemCreatorDetailsTab =    new QRadioButton(tr("3.  Creator Details"));
+
+        m_gemTemplateSelectionTab->setObjectName("createAGemLHSTab");
+        m_gemTemplateSelectionTab->setChecked(true);
+
+        m_gemDetailsTab->setObjectName("createAGemLHSTab");
+        m_gemDetailsTab->setEnabled(false);
+
+        m_gemCreatorDetailsTab->setObjectName("createAGemLHSTab");
+        m_gemCreatorDetailsTab->setEnabled(false);
+
+        connect(m_gemTemplateSelectionTab,  &QPushButton::clicked, this, &CreateGem::HandleGemTemplateSelectionTab);
+        connect(m_gemDetailsTab,            &QPushButton::clicked, this, &CreateGem::HandleGemDetailsTab);
+        connect(m_gemCreatorDetailsTab,     &QPushButton::clicked, this, &CreateGem::HandleGemCreatorDetailsTab);
+
+        vLayout->addSpacing(46);
+        vLayout->addWidget(m_gemTemplateSelectionTab);
+        vLayout->addSpacing(12);
+        vLayout->addWidget(m_gemDetailsTab);
+        vLayout->addSpacing(12);
+        vLayout->addWidget(m_gemCreatorDetailsTab);
+        vLayout->addStretch();
+
+        lhsFrame->setLayout(vLayout);
+
+        return lhsFrame;
+    }
+
+    void CreateGem::HandleGemTemplateSelectionTab()
+    {
+        m_stackWidget->setCurrentIndex(gemTemplateSelectionScreen);
+        m_nextButton->setText(tr("Next"));
+        m_backButton->setVisible(false);
+    }
+
+    void CreateGem::HandleGemDetailsTab()
+    {
+        m_stackWidget->setCurrentIndex(gemDetailsScreen);
+        m_nextButton->setText(tr("Next"));
+        m_backButton->setVisible(true);
+    }
+
+    void CreateGem::HandleGemCreatorDetailsTab()
+    {
+        m_stackWidget->setCurrentIndex(gemCreatorDetailsScreen);
+        m_nextButton->setText(tr("Create"));
+        m_backButton->setVisible(true);
+    }
+
+    QFrame* CreateGem::CreateRHSPane()
+    {
+        QFrame* rhsFrame = new QFrame(this);
+
+        QVBoxLayout* vLayout = new QVBoxLayout(this);
+        vLayout->setSpacing(0);
+        vLayout->setContentsMargins(0, 0, 0, 0);
 
         m_stackWidget = new QStackedWidget(this);
         m_stackWidget->setContentsMargins(0, 0, 0, 0);
@@ -57,27 +162,10 @@ namespace O3DE::ProjectManager
         m_stackWidget->addWidget(CreateGemCreatorScrollArea());//tr("3. Creator Details");
         vLayout->addWidget(m_stackWidget);
 
-        QFrame* footerFrame = new QFrame(this);
-        footerFrame->setObjectName("createAGemFooter");
-        m_backNextButtons = new QDialogButtonBox(this);
-        m_backNextButtons->setObjectName("footer");
-        QVBoxLayout* footerLayout = new QVBoxLayout();
-        footerLayout->setContentsMargins(0, 0, 0, 0);
-        footerFrame->setLayout(footerLayout);
-        footerLayout->addWidget(m_backNextButtons);
-        vLayout->addWidget(footerFrame);
+        rhsFrame->setLayout(vLayout);
 
-        m_backButton = m_backNextButtons->addButton(tr("Back"), QDialogButtonBox::RejectRole);
-        m_backButton->setProperty("secondary", true);
-        m_nextButton = m_backNextButtons->addButton(tr("Next"), QDialogButtonBox::ApplyRole);
-
-        connect(m_backButton, &QPushButton::clicked, this, &CreateGem::HandleBackButton);
-        connect(m_nextButton, &QPushButton::clicked, this, &CreateGem::HandleNextButton);
-
-        setObjectName("createAGemBody");
-        setLayout(vLayout);
+        return rhsFrame;
     }
-
 
 
     void CreateGem::LoadButtonsFromGemTemplatePaths(QVBoxLayout* gemSetupLayout)
@@ -166,7 +254,7 @@ namespace O3DE::ProjectManager
             tr("The unique name for your gem consisting of only alphanumeric characters, '-' and '_'."),
             tr("A gem system name is required."));
         m_gemName->lineEdit()->setValidator(new QRegularExpressionValidator(QRegularExpression("[a-zA-Z]+[a-zA-Z0-9\\-\\_]*"), this));
-        m_gemName->setObjectName("createAGemFormLineEdit");
+        m_gemName->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_gemName);
 
         m_gemDisplayName = new FormLineEditWidget(
@@ -320,12 +408,22 @@ namespace O3DE::ProjectManager
 
     void CreateGem::HandleBackButton()
     {
-        if (m_stackWidget->currentIndex() > 0)
+        if (m_stackWidget->currentIndex() > gemTemplateSelectionScreen)
         {
             m_stackWidget->setCurrentIndex(m_stackWidget->currentIndex() - 1);
+
+            int newIndex = m_stackWidget->currentIndex();
+            if (newIndex == gemDetailsScreen)
+            {
+                m_gemDetailsTab->setChecked(true);
+            }
+            else if (newIndex == gemTemplateSelectionScreen)
+            {
+                m_gemTemplateSelectionTab->setChecked(true);
+            }
         }
 
-        if (m_stackWidget->currentIndex() == 0)
+        if (m_stackWidget->currentIndex() == gemTemplateSelectionScreen)
         {
             m_backButton->setVisible(false);
         }
@@ -339,6 +437,8 @@ namespace O3DE::ProjectManager
         {
             m_backButton->setVisible(true);
             m_stackWidget->setCurrentIndex(gemDetailsScreen);
+            m_gemDetailsTab->setEnabled(true);
+            m_gemDetailsTab->setChecked(true);
         }
         else if (m_stackWidget->currentIndex() == gemDetailsScreen)
         {
@@ -360,6 +460,8 @@ namespace O3DE::ProjectManager
 
                 m_stackWidget->setCurrentIndex(gemCreatorDetailsScreen);
                 m_nextButton->setText(tr("Create"));
+                m_gemCreatorDetailsTab->setEnabled(true);
+                m_gemCreatorDetailsTab->setChecked(true);
             }
         }
         else if (m_stackWidget->currentIndex() == gemCreatorDetailsScreen)
@@ -395,18 +497,6 @@ namespace O3DE::ProjectManager
                         tr("The gem failed to be created"));
                 }
             }
-        }
-    }
-
-    void CreateGem::UpdateNextButtonToCreate()
-    {
-        if (m_stackWidget->currentIndex() == gemCreatorDetailsScreen)
-        {
-            m_nextButton->setText(tr("Create"));
-        }
-        else
-        {
-            m_nextButton->setText(tr("Next"));
         }
     }
 

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
@@ -23,69 +23,11 @@
 #include <QRadioButton>
 #include <QScrollArea>
 #include <QStackedWidget>
-#include <QStyleOptionTab>
-#include <QStylePainter>
-#include <QTabBar>
-#include <QTabWidget>
 #include <QVBoxLayout>
 
 
 namespace O3DE::ProjectManager
 {
-    class TabBar : public QTabBar
-    {
-    public:
-        QSize tabSizeHint(int index) const
-        {
-            QSize s = QTabBar::tabSizeHint(index);
-            s.transpose();
-            return s;
-        }
-
-    protected:
-        void paintEvent(QPaintEvent*)
-        {
-            QStylePainter painter(this);
-            QStyleOptionTab opt;
-
-            QPoint currentTopPosition(115, 175);
-
-            QStringList strs = { "1. Gem Setup", "2. Gem Details", "3. Creator Details" };
-            for (int i = 0; i < count(); i++)
-            {
-                initStyleOption(&opt, i);
-                painter.drawControl(QStyle::CE_TabBarTabShape, opt);
-                painter.save();
-                QSize s = opt.rect.size();
-                s.transpose();
-                s.setWidth(130);
-                QRect r(QPoint(), s);
-                r.moveCenter(opt.rect.center());
-                opt.rect = r;
-                QPoint c = tabRect(i).center();
-                QPoint leftJustify(currentTopPosition);
-                leftJustify.setX(30 + (int)(0.5 * opt.rect.width()));
-                painter.translate(leftJustify);
-                currentTopPosition.setY(currentTopPosition.y() + 55);
-                painter.setFont(QFont("Open Sans", 12));
-                painter.translate(-c);
-                painter.drawItemText(r, Qt::AlignLeft, QApplication::palette(), true, strs.at(i));
-                painter.restore();
-            }
-        }
-    };
-
-    class TabWidget : public QTabWidget
-    {
-    public:
-        TabWidget(QWidget* parent = nullptr)
-            : QTabWidget(parent)
-        {
-            setTabBar(new TabBar());
-            setTabPosition(QTabWidget::West);
-            setTabShape(QTabWidget::TabShape::Rounded);
-        }
-    };
 
     CreateGem::CreateGem(QWidget* parent)
         : ScreenWidget(parent)
@@ -106,15 +48,14 @@ namespace O3DE::ProjectManager
             });
         vLayout->addWidget(m_header);
 
-        m_tabWidget = new TabWidget(this);
-        m_tabWidget->setContentsMargins(0, 0, 0, 0);
+        m_stackWidget = new QStackedWidget(this);
+        m_stackWidget->setContentsMargins(0, 0, 0, 0);
         
-        m_tabWidget->setObjectName("createGemTab");
-        m_tabWidget->addTab(CreateGemSetupScrollArea(), tr("1. Gem Setup"));
-        m_tabWidget->addTab(CreateGemDetailsScrollArea(), tr("2. Gem Details"));
-        m_tabWidget->addTab(CreateGemCreatorScrollArea(), tr("3. Creator Details"));
-        m_tabWidget->tabBar()->setEnabled(false);
-        vLayout->addWidget(m_tabWidget);
+        m_stackWidget->setObjectName("createAGemRHS");
+        m_stackWidget->addWidget(CreateGemSetupScrollArea());  //tr("1. Gem Setup");
+        m_stackWidget->addWidget(CreateGemDetailsScrollArea());//tr("2. Gem Details");
+        m_stackWidget->addWidget(CreateGemCreatorScrollArea());//tr("3. Creator Details");
+        vLayout->addWidget(m_stackWidget);
 
         QFrame* footerFrame = new QFrame(this);
         footerFrame->setObjectName("createAGemFooter");
@@ -130,13 +71,14 @@ namespace O3DE::ProjectManager
         m_backButton->setProperty("secondary", true);
         m_nextButton = m_backNextButtons->addButton(tr("Next"), QDialogButtonBox::ApplyRole);
 
-        connect(m_tabWidget, &TabWidget::currentChanged, this, &CreateGem::UpdateNextButtonToCreate);
         connect(m_backButton, &QPushButton::clicked, this, &CreateGem::HandleBackButton);
         connect(m_nextButton, &QPushButton::clicked, this, &CreateGem::HandleNextButton);
 
         setObjectName("createAGemBody");
         setLayout(vLayout);
     }
+
+
 
     void CreateGem::LoadButtonsFromGemTemplatePaths(QVBoxLayout* gemSetupLayout)
     {
@@ -192,7 +134,7 @@ namespace O3DE::ProjectManager
         m_radioButtonGroup->addButton(m_formFolderRadioButton);
 
         m_gemTemplateLocation = new FormFolderBrowseEditWidget(tr("Gem Template Location*"), "", "", tr("A path must be provided."));
-
+        m_gemTemplateLocation->setObjectName("createAGemRadioButtonSubFormField");
         gemSetupLayout->addWidget(m_formFolderRadioButton);
         gemSetupLayout->addWidget(m_gemTemplateLocation);
 
@@ -215,7 +157,7 @@ namespace O3DE::ProjectManager
         gemDetailsScrollWidget->setLayout(gemDetailsLayout);
 
         QLabel* secondRightPaneHeader = new QLabel(tr("Enter Gem Details"));
-        secondRightPaneHeader->setObjectName("rightPaneHeader");
+        secondRightPaneHeader->setObjectName("rightPaneDetailsHeader");
         gemDetailsLayout->addWidget(secondRightPaneHeader);
 
         m_gemName = new FormLineEditWidget(
@@ -224,38 +166,48 @@ namespace O3DE::ProjectManager
             tr("The unique name for your gem consisting of only alphanumeric characters, '-' and '_'."),
             tr("A gem system name is required."));
         m_gemName->lineEdit()->setValidator(new QRegularExpressionValidator(QRegularExpression("[a-zA-Z]+[a-zA-Z0-9\\-\\_]*"), this));
+        m_gemName->setObjectName("createAGemFormLineEdit");
         gemDetailsLayout->addWidget(m_gemName);
 
         m_gemDisplayName = new FormLineEditWidget(
             tr("Gem Display name*"), "", tr("The name displayed in the Gem Catalog"), tr("A gem display name is required."));
         m_gemDisplayName->lineEdit()->setValidator(new QRegularExpressionValidator(QRegularExpression("( |\\w)+"), this));
+        m_gemDisplayName->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_gemDisplayName);
 
         m_gemSummary = new FormLineEditWidget(tr("Gem Summary"), "", tr("A short description of your Gem"), "");
+        m_gemSummary->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_gemSummary);
 
         m_requirements = new FormLineEditWidget(tr("Requirements"), "", tr("Notice of any requirements your Gem. i.e. This requires X other gem"), "");
+        m_requirements->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_requirements);
 
         m_license = new FormLineEditWidget(
             tr("License*"), "", tr("License uses goes here: i.e. Apache-2.0 or MIT"), tr("License details are required."));
+        m_license->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_license);
 
         m_licenseURL = new FormLineEditWidget(tr("License URL"), "", tr("Link to the license web site i.e. https://opensource.org/licenses/Apache-2.0"), "");
+        m_licenseURL->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_licenseURL);
 
         m_userDefinedGemTags = new FormLineEditWidget(tr("User-defined Gem Tags (Comma separated list)"), "");
         m_userDefinedGemTags->lineEdit()->setValidator(new QRegularExpressionValidator(QRegularExpression("(\\w+)(,\\s?\\w*)*"), this));
+        m_userDefinedGemTags->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_userDefinedGemTags);
 
         m_gemLocation = new FormFolderBrowseEditWidget(tr("Gem Location"), "", tr("The path that the gem will be created at."), tr("The chosen directory must either not exist or be empty."));
+        m_gemLocation->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_gemLocation);
         
         m_gemIconPath = new FormLineEditWidget(tr("Gem Icon Path"), "default.png", tr("Select Gem icon path"), "");
+        m_gemIconPath->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_gemIconPath);
 
         m_documentationURL = new FormLineEditWidget(
             tr("Documentation URL"), "", tr("Link to any documentation of your Gem i.e. https://o3de.org/docs/user-guide/gems/..."), "");
+        m_documentationURL->setObjectName("createAGem");
         gemDetailsLayout->addWidget(m_documentationURL);
 
         return gemDetailsScrollArea;
@@ -277,17 +229,20 @@ namespace O3DE::ProjectManager
         gemCreatorScrollWidget->setLayout(gemCreatorLayout);
 
         QLabel* thirdRightPaneHeader = new QLabel(tr("Enter your Details"));
-        thirdRightPaneHeader->setObjectName("rightPaneHeader");
+        thirdRightPaneHeader->setObjectName("rightPaneDetailsHeader");
         gemCreatorLayout->addWidget(thirdRightPaneHeader);
 
         m_origin =
             new FormLineEditWidget(tr("Creator Name*"), "", tr("The name of the gem creator or originator goes here. i.e. O3DE"), tr("You must provide a creator name."));
+        m_origin->setObjectName("createAGem");
         gemCreatorLayout->addWidget(m_origin);
 
         m_originURL = new FormLineEditWidget(tr("Origin URL"), "", tr("The primary website for your Gem. i.e. http://o3de.org"), "");
+        m_originURL->setObjectName("createAGem");
         gemCreatorLayout->addWidget(m_originURL);
 
         m_repositoryURL = new FormLineEditWidget(tr("Repository URL"), "", tr("Optional URL of the repository for this gem."), "");
+        m_repositoryURL->setObjectName("createAGem");
         gemCreatorLayout->addWidget(m_repositoryURL);
 
         return gemCreatorScrollArea;
@@ -365,12 +320,12 @@ namespace O3DE::ProjectManager
 
     void CreateGem::HandleBackButton()
     {
-        if (m_tabWidget->currentIndex() > 0)
+        if (m_stackWidget->currentIndex() > 0)
         {
-            m_tabWidget->setCurrentIndex(m_tabWidget->currentIndex() - 1);
+            m_stackWidget->setCurrentIndex(m_stackWidget->currentIndex() - 1);
         }
 
-        if (m_tabWidget->currentIndex() == 0)
+        if (m_stackWidget->currentIndex() == 0)
         {
             m_backButton->setVisible(false);
         }
@@ -380,16 +335,12 @@ namespace O3DE::ProjectManager
 
     void CreateGem::HandleNextButton()
     {
-        const int gemTemplateSelectionScreen = 0;
-        const int gemDetailsScreen = 1;
-        const int gemCreatorDetailsScreen = 2;
-
-        if (m_tabWidget->currentIndex() == gemTemplateSelectionScreen && ValidateGemTemplateLocation())
+        if (m_stackWidget->currentIndex() == gemTemplateSelectionScreen && ValidateGemTemplateLocation())
         {
             m_backButton->setVisible(true);
-            m_tabWidget->setCurrentIndex(gemDetailsScreen);
+            m_stackWidget->setCurrentIndex(gemDetailsScreen);
         }
-        else if (m_tabWidget->currentIndex() == gemDetailsScreen)
+        else if (m_stackWidget->currentIndex() == gemDetailsScreen)
         {
             bool gemNameValid = ValidateGemName();
             bool gemDisplayNameValid = ValidateGemDisplayName();
@@ -407,11 +358,11 @@ namespace O3DE::ProjectManager
                 m_createGemInfo.m_path = m_gemLocation->lineEdit()->text();
                 m_createGemInfo.m_features = m_userDefinedGemTags->lineEdit()->text().split(',');
 
-                m_tabWidget->setCurrentIndex(gemCreatorDetailsScreen);
+                m_stackWidget->setCurrentIndex(gemCreatorDetailsScreen);
                 m_nextButton->setText(tr("Create"));
             }
         }
-        else if (m_tabWidget->currentIndex() == gemCreatorDetailsScreen)
+        else if (m_stackWidget->currentIndex() == gemCreatorDetailsScreen)
         {
             bool originIsValid = ValidateFormNotEmpty(m_origin);
             bool repoURLIsValid = ValidateRepositoryURL();
@@ -449,7 +400,7 @@ namespace O3DE::ProjectManager
 
     void CreateGem::UpdateNextButtonToCreate()
     {
-        if (m_tabWidget->currentIndex() == 2)
+        if (m_stackWidget->currentIndex() == gemCreatorDetailsScreen)
         {
             m_nextButton->setText(tr("Create"));
         }

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
@@ -22,11 +22,10 @@ class QDialogButtonBox;
 class QRadioButton;
 class QScrollArea;
 class QVBoxLayout;
+class QStackedWidget;
 
 namespace O3DE::ProjectManager
 {
-    class TabWidget;
-
     class CreateGem : public ScreenWidget
     {
         Q_OBJECT
@@ -77,13 +76,17 @@ namespace O3DE::ProjectManager
         FormLineEditWidget* m_originURL = nullptr;
         FormLineEditWidget* m_repositoryURL = nullptr;
 
-        TabWidget* m_tabWidget;
+        QStackedWidget* m_stackWidget = nullptr;
 
         QDialogButtonBox* m_backNextButtons = nullptr;
         QPushButton* m_backButton = nullptr;
         QPushButton* m_nextButton = nullptr;
 
         GemInfo m_createGemInfo;
+
+        const int gemTemplateSelectionScreen = 0;
+        const int gemDetailsScreen = 1;
+        const int gemCreatorDetailsScreen = 2;
     };
 
 

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
@@ -17,12 +17,12 @@
 #include <PythonBindings.h>
 #endif
 
-class QButtonGroup;
-class QDialogButtonBox;
-class QRadioButton;
-class QScrollArea;
-class QVBoxLayout;
-class QStackedWidget;
+QT_FORWARD_DECLARE_CLASS(QButtonGroup)
+QT_FORWARD_DECLARE_CLASS(QDialogButtonBox)
+QT_FORWARD_DECLARE_CLASS(QRadioButton)
+QT_FORWARD_DECLARE_CLASS(QScrollArea)
+QT_FORWARD_DECLARE_CLASS(QVBoxLayout)
+QT_FORWARD_DECLARE_CLASS(QStackedWidget)
 
 namespace O3DE::ProjectManager
 {
@@ -48,8 +48,8 @@ namespace O3DE::ProjectManager
         QScrollArea* CreateGemSetupScrollArea();
         QScrollArea* CreateGemDetailsScrollArea();
         QScrollArea* CreateGemCreatorScrollArea();
-        QFrame* CreateLHSTabs();
-        QFrame* CreateRHSPane();
+        QFrame* CreateTabButtonsFrame();
+        QFrame* CreateTabPaneFrame();
         bool ValidateGemTemplateLocation();
         bool ValidateGemDisplayName();
         bool ValidateGemName();
@@ -93,9 +93,9 @@ namespace O3DE::ProjectManager
 
         GemInfo m_createGemInfo;
 
-        const int gemTemplateSelectionScreen = 0;
-        const int gemDetailsScreen = 1;
-        const int gemCreatorDetailsScreen = 2;
+        static constexpr int GemTemplateSelectionScreen = 0;
+        static constexpr int GemDetailsScreen = 1;
+        static constexpr int GemCreatorDetailsScreen = 2;
     };
 
 

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
@@ -39,13 +39,17 @@ namespace O3DE::ProjectManager
     private slots:
         void HandleBackButton();
         void HandleNextButton();
-        void UpdateNextButtonToCreate();
+        void HandleGemTemplateSelectionTab();
+        void HandleGemDetailsTab();
+        void HandleGemCreatorDetailsTab();
 
     private:
         void LoadButtonsFromGemTemplatePaths(QVBoxLayout* gemSetupLayout);
         QScrollArea* CreateGemSetupScrollArea();
         QScrollArea* CreateGemDetailsScrollArea();
         QScrollArea* CreateGemCreatorScrollArea();
+        QFrame* CreateLHSTabs();
+        QFrame* CreateRHSPane();
         bool ValidateGemTemplateLocation();
         bool ValidateGemDisplayName();
         bool ValidateGemName();
@@ -81,6 +85,11 @@ namespace O3DE::ProjectManager
         QDialogButtonBox* m_backNextButtons = nullptr;
         QPushButton* m_backButton = nullptr;
         QPushButton* m_nextButton = nullptr;
+
+        
+        QRadioButton* m_gemTemplateSelectionTab = nullptr;
+        QRadioButton* m_gemDetailsTab = nullptr;
+        QRadioButton* m_gemCreatorDetailsTab = nullptr;
 
         GemInfo m_createGemInfo;
 


### PR DESCRIPTION
## What does this PR do?

This PR implements a UI feature for the create a gem workflow. It introduces Left hand side tabs for ease of browsing during the gem creation process, allowing the user to backtrack quickly to previously edited fields.

This is what we had before the changes were introduced:
![GemCatalogBeforeLHSTabChanges](https://user-images.githubusercontent.com/112996779/193636710-13754037-c1c6-41af-a17c-a20dedc389e0.gif)

The main issues were as follows:
- LHS is completely static, devoid of any interaction
- No highlighting to determine where the user is at in the process.
- Browsing using just Next and Back buttons can prove tedious over time.

There was also an architectural issue with `CreateAGem`, where we used `TabWidget` code with custom QPainter logic. This proved extremely cumbersome to work with, and made integrating tab like features nigh impossible (AMZN-Phil cited that the setup prevented proper mouse hit detection due to the math involved with transposing the tabs over to column form instead of row form, which blocked efforts of integrating actual tabs).

My changes get rid of the TabWidget logic, and replace it with a straightforward layout implementation (a horizontal layout with an LHS pane for tabs, and RHS for the primary body of the workflow). The RHS pane uses a `QStackedWidget` instead of the tab widget, and I implement the tabs as a series of `QRadioButton`s with styling over in the LHS pane. All changes and subsequent wiring follow this basic architectural update.

This is what the PR introduces:
![GemCatalogAfterLHSTabChanges](https://user-images.githubusercontent.com/112996779/193638224-b5ebb5f1-595b-4bb2-86a5-d154ededb037.gif)


## How was this PR tested?

All testing was performed manually, by interacting with the project manager for the gem tab process. I have tested for the following scenarios:

- Clicking on tabs ahead of the user's current page in the workflow.
- Navigating the workflow using various combinations of the next and back buttons with the tabs
- Clicking through the accessible tabs in various orderings (ascending, descending, semi-random)
