### PR TITLE
TIAF pipeline

### DIFF
--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -29,6 +29,16 @@
       "test_impact_analysis_profile_python"
     ]
   },
+  "profile_pipe_tiaf": {
+    "TAGS": [
+      "tiaf-testing"
+    ],
+    "steps": [
+      "profile",
+      "asset_profile",
+      "test_impact_analysis_profile_python"
+    ]
+  },
   "scrubbing": {
     "TAGS": [],
     "COMMAND": "python_windows.cmd",

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -36,6 +36,7 @@
     "steps": [
       "profile",
       "asset_profile",
+      "test_impact_analysis_profile_native",
       "test_impact_analysis_profile_python"
     ]
   },


### PR DESCRIPTION
## What does this PR do?

This PR creates a separate pipeline for the Test Impact Analysis Framework (TIAF). This allows the team to test running the TIAF separately before it's merged in the main AR pipeline. 

This config swaps out `test_cpu_profile` with `test_impact_analysis_profile_native`.

## How was this PR tested?

This was tested in a branch. Running this separate tiaf pipeline will not affect the outcome of the AR on pull requests. 
