### PR TITLE
Fixed active actors to handle transform sync events outside of the scene lock

### DIFF
--- a/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
+++ b/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
@@ -586,20 +586,23 @@ namespace PhysX
         {
             AZ_PROFILE_SCOPE(Physics, "PhysXScene::ActiveActors");
 
-            PHYSX_SCENE_READ_LOCK(m_pxScene);
-
-            physx::PxU32 numActiveActors = 0;
-            physx::PxActor** activeActors = m_pxScene->getActiveActors(numActiveActors);
             AzPhysics::SimulatedBodyHandleList activeBodyHandles;
-            activeBodyHandles.reserve(numActiveActors);
-            for (physx::PxU32 i = 0; i < numActiveActors; ++i)
+
             {
-                if (ActorData* actorData = Utils::GetUserData(activeActors[i]))
+                PHYSX_SCENE_READ_LOCK(m_pxScene);
+                physx::PxU32 numActiveActors = 0;
+                physx::PxActor** activeActors = m_pxScene->getActiveActors(numActiveActors);
+                activeBodyHandles.reserve(numActiveActors);
+                for (physx::PxU32 i = 0; i < numActiveActors; ++i)
                 {
-                    activeBodyHandles.emplace_back(actorData->GetBodyHandle());
+                    if (ActorData* actorData = Utils::GetUserData(activeActors[i]))
+                    {
+                        activeBodyHandles.emplace_back(actorData->GetBodyHandle());
+                    }
                 }
             }
 
+            // Keep the event signal outside of the scene lock since there may be handlers that want to lock the scene for write
             m_sceneActiveSimulatedBodies.Signal(m_sceneHandle, activeBodyHandles, m_currentDeltaTime);
 
             SyncActiveBodyTransform(activeBodyHandles);


### PR DESCRIPTION
Fixed active actors to handle transform sync events outside of the scene lock

Signed-off-by: Sergey Pereslavtsev <pereslav@amazon.com>

## What does this PR do?

There are active actors and transform sync handlers that may lock the scene for write. We need to make sure we signal the events outside of the scene read lock

## How was this PR tested?

Unit tests. Manual tests in a test level reproducing the issue