### PR TITLE
Update the LFS pointer checking for autofail jobs

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -633,11 +633,6 @@ namespace AssetProcessor
 
         UpdateAnalysisTrackerForFile(jobEntry, AnalysisTrackerUpdateType::JobFailed);
 
-        // if its a fake "autofail job" or other reason for it not to exist in the DB, don't do anything here.
-        if (!jobEntry.m_addToDatabase)
-        {
-            return;
-        }
 
         QString absolutePathToFile = jobEntry.GetAbsoluteSourcePath();
 
@@ -657,6 +652,12 @@ namespace AssetProcessor
         }
 
         AssetProcessor::SetThreadLocalJobId(0);
+
+        // if its a fake "autofail job" or other reason for it not to exist in the DB, don't do anything here.
+        if (!jobEntry.m_addToDatabase)
+        {
+            return;
+        }
 
         // wipe the times so that it will try again next time.
         // note:  Leave the prior successful products where they are, though.

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -3658,13 +3658,62 @@ TEST_F(AssetProcessorManagerTest, SourceFileProcessFailure_ValidLfsPointerFile_R
 
     for(const auto& processResult : processResults)
     {
-        AssetBuilderSDK::ProcessJobResponse response;
-        response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
-
         m_assetProcessorManager->AssetFailed(processResult.m_jobEntry);
     }
 
     ASSERT_TRUE(BlockUntilIdle(idleWaitTime));
+
+    // An error message should be thrown for the valid LFS pointer file.
+    ASSERT_EQ(m_errorAbsorber->m_numErrorsAbsorbed, 1);
+
+    // Revert the project and engine root directories in the setting registry.
+    settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder, engineRoot);
+    settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath, projectRoot);
+}
+
+TEST_F(AssetProcessorManagerTest, SourceFileProcessFailure_AutoFailedLfsPointerFile_ReceiveLFSPointerFileError)
+{
+    // Override the project and engine root directories in the setting registry to create a custom .gitattributes file for testing.
+    auto settingsRegistry = AZ::SettingsRegistry::Get();
+    ASSERT_TRUE(settingsRegistry);
+    AZ::IO::FixedMaxPathString engineRoot, projectRoot;
+    settingsRegistry->Get(engineRoot, AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
+    settingsRegistry->Get(projectRoot, AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath);
+    settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder, m_tempDir.path().toUtf8().data());
+    settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath, m_tempDir.path().toUtf8().data());
+
+    QDir tempPath(m_tempDir.path());
+    QString gitAttributesPath = tempPath.absoluteFilePath(".gitattributes");
+    ASSERT_TRUE(UnitTestUtils::CreateDummyFile(gitAttributesPath, QString(
+        "#\n"
+        "# Git LFS(see https ://git-lfs.github.com/)\n"
+        "#\n"
+        "*.txt filter=lfs diff=lfs merge=lfs -text\n")));
+
+    QString sourcePath = tempPath.absoluteFilePath("subfolder1/test.txt");
+    ASSERT_TRUE(UnitTestUtils::CreateDummyFile(sourcePath, QString(
+        "version https://git-lfs.github.com/spec/v1\n"
+        "oid sha256:ee4799379bfcfa99e95afd6494da51fbeda95f21ea71d267ae7102f048edec85\n"
+        "size 63872\n")));
+
+    constexpr int idleWaitTime = 5000;
+    using namespace AzToolsFramework::AssetDatabase;
+
+    QList<AssetProcessor::JobDetails> processResults;
+    auto assetConnection = QObject::connect(m_assetProcessorManager.get(), &AssetProcessorManager::AssetToProcess, [&processResults](JobDetails details)
+        {
+            details.m_jobEntry.m_addToDatabase = false;
+            processResults.push_back(AZStd::move(details));
+        });
+
+    // Add the test file and signal a failed event
+    m_assetProcessorManager.get()->AssessAddedFile(sourcePath);
+    ASSERT_TRUE(BlockUntilIdle(idleWaitTime));
+
+    for(const auto& processResult : processResults)
+    {
+        m_assetProcessorManager->AssetFailed(processResult.m_jobEntry);
+    }
 
     // An error message should be thrown for the valid LFS pointer file.
     ASSERT_EQ(m_errorAbsorber->m_numErrorsAbsorbed, 1);


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?
Check LFS pointer files for autofail jobs, so that files which failed at the CreateJobs phase will also be validated.

## How was this PR tested?
Tested manually in AP and unit tests passed.
![image](https://user-images.githubusercontent.com/68558268/193689194-21b0685e-d540-42f8-babd-f7e75dc1322b.png)

```
[ RUN      ] AssetProcessorManagerTest.SourceFileProcessFailure_AutoFailedLfsPointerFile_ReceiveLFSPointerFileError
[       OK ] AssetProcessorManagerTest.SourceFileProcessFailure_AutoFailedLfsPointerFile_ReceiveLFSPointerFileError (134 ms)
```
