### PR TITLE
Material Canvas: Fix include paths broken after shader refactor

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialTemplates/ExperimentalPBR/MaterialGraphName_ForwardPass.azsl.template
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialTemplates/ExperimentalPBR/MaterialGraphName_ForwardPass.azsl.template
@@ -7,9 +7,10 @@
  */
 
 #include <viewsrg.srgi>
+#include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
-#include <Atom/Features/PBR/ForwardPassSrg.azsli>
-#include <Atom/Features/PBR/ForwardPassOutput.azsli>
+#include <Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli>
+#include <Atom/Features/Pipeline/Forward/ForwardPassOutput.azsli>
 #include <Atom/Features/PBR/AlphaUtils.azsli>
 #include <Atom/Features/SrgSemantics.azsli>
 #include <Atom/Features/ColorManagement/TransformColor.azsli>


### PR DESCRIPTION
## What does this PR do?

Updated material canvas experimental shader templates referencing include paths that have changed since the shader refactor.

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Materials and shaders generated from the experimental template were failing in the asset processor. After this change, the generated code and assets compiled successfully and appeared in the report.