### PR TITLE
Material Canvas: Fix warnings caused by missing translation files

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/Translation/materialcanvas_en_us.ts
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/Translation/materialcanvas_en_us.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>PlaceholderDialog</name>
+    <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished">Translated placeholder text</translation>
+    </message>
+</context>
+</TS>

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
@@ -133,7 +133,7 @@ namespace MaterialCanvas
 
         // This configuration data is passed through the main window and graph views to setup translation data, styling, and node palettes
         AtomToolsFramework::GraphViewConfig graphViewConfig;
-        graphViewConfig.m_translationPath = "@products@/translation/materialcanvas_en_us.qm";
+        graphViewConfig.m_translationPath = "@products@/materialcanvas/translation/materialcanvas_en_us.qm";
         graphViewConfig.m_styleManagerPath = "MaterialCanvas/StyleSheet/materialcanvas_style.json";
         graphViewConfig.m_nodeMimeType = "MaterialCanvas/node-palette-mime-event";
         graphViewConfig.m_nodeSaveIdentifier = "MaterialCanvas/ContextMenu";

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
@@ -84,20 +84,19 @@ namespace MaterialCanvas
         m_nodePalette = aznew GraphCanvas::NodePaletteDockWidget(this, "Node Palette", nodePaletteConfig);
         AddDockWidget("Node Palette", m_nodePalette, Qt::LeftDockWidgetArea);
 
-        AZStd::array<char, AZ::IO::MaxPathLength> unresolvedPath;
-        AZ::IO::FileIOBase::GetInstance()->ResolvePath(m_graphViewConfig.m_translationPath.c_str(), unresolvedPath.data(), unresolvedPath.size());
-
-        QString translationFilePath(unresolvedPath.data());
-        if (m_translator.load(QLocale::Language::English, translationFilePath))
+        AZ::IO::FixedMaxPath resolvedPath;
+        AZ::IO::FileIOBase::GetInstance()->ReplaceAlias(resolvedPath, m_graphViewConfig.m_translationPath.c_str());
+        const AZ::IO::FixedMaxPathString translationFilePath = resolvedPath.LexicallyNormal().FixedMaxPathString();
+        if (m_translator.load(QLocale::Language::English, translationFilePath.c_str()))
         {
             if (!qApp->installTranslator(&m_translator))
             {
-                AZ_Warning("MaterialCanvas", false, "Error installing translation %s!", unresolvedPath.data());
+                AZ_Warning("MaterialCanvas", false, "Error installing translation %s!", translationFilePath.c_str());
             }
         }
         else
         {
-            AZ_Warning("MaterialCanvas", false, "Error loading translation file %s", unresolvedPath.data());
+            AZ_Warning("MaterialCanvas", false, "Error loading translation file %s", translationFilePath.c_str());
         }
 
         OnDocumentOpened(AZ::Uuid::CreateNull());


### PR DESCRIPTION
## What does this PR do?

Creating a placeholder Qt translation file to silence startup warnings and eventually update with proper translations unless it is possible to use the graph canvas translation system generically.

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Launched material canvas to see that warning no longer appears on startup