### PR TITLE
Material Canvas: Update sorting logic to force positioning of input and output nodes

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -28,6 +28,45 @@ class QMenu;
 class QMimeData;
 class QWidget;
 
+// Macros for printing information to the console if a condition is met.
+#if defined(AZ_ENABLE_TRACING)
+#define AZ_TracePrintf_IfTrue(window, expression, ...)\
+    AZ_PUSH_DISABLE_WARNING(4127, "-Wunknown-warning-option")\
+    if (expression)\
+    {\
+        AZ_TraceFmtCompileTimeCheck(\
+            expression,\
+            AZ_VA_HAS_ARGS(__VA_ARGS__),\
+            "String used in place of boolean expression for AZ_TracePrintf_IfTrue.",\
+            "Did you mean AZ_TracePrintf_IfTrue(" #window ", false, \"%s\", " #expression "); ?",\
+            "Did you mean AZ_TracePrintf_IfTrue(" #window ", false, " #expression ", " #__VA_ARGS__ "); ?");\
+        AZ::Debug::Trace::Instance().Printf(window, __VA_ARGS__);\
+    }\
+    AZ_POP_DISABLE_WARNING
+
+#define AZ_TracePrintfOnce_IfTrue(window, expression, ...)\
+    AZ_PUSH_DISABLE_WARNING(4127, "-Wunknown-warning-option")\
+    if (expression)\
+    {\
+        AZ_TraceFmtCompileTimeCheck(\
+            expression,\
+            AZ_VA_HAS_ARGS(__VA_ARGS__),\
+            "String used in place of boolean expression for AZ_TracePrintfOnce_IfTrue.",\
+            "Did you mean AZ_TracePrintfOnce_IfTrue(" #window ", false, \"%s\", " #expression "); ?",\
+            "Did you mean AZ_TracePrintfOnce_IfTrue(" #window ", false, " #expression ", " #__VA_ARGS__ "); ?");\
+        static bool AZ_CONCAT_VAR_NAME(azTraceDisplayed, __LINE__) = false;\
+        if (!AZ_CONCAT_VAR_NAME(azTraceDisplayed, __LINE__))\
+        {\
+            AZ::Debug::Trace::Instance().Printf(window, __VA_ARGS__);\
+            AZ_CONCAT_VAR_NAME(azTraceDisplayed, __LINE__) = true;\
+        }\
+    }\
+    AZ_POP_DISABLE_WARNING
+#else // !AZ_ENABLE_TRACING
+#define AZ_TracePrintf_IfTrue(...)
+#define AZ_TracePrintfOnce_IfTrue(...)
+#endif
+
 namespace AtomToolsFramework
 {
     using LoadImageAsyncCallback = AZStd::function<void(const QImage&)>;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodePaletteItem.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodePaletteItem.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzFramework/StringFunc/StringFunc.h>
+#include <GraphCanvas/Utils/GraphUtils.h>
 #include <GraphModel/GraphModelBus.h>
 #include <GraphModel/Model/Common.h>
 
@@ -43,6 +44,9 @@ namespace AtomToolsFramework
         {
             if (auto node = AZStd::make_shared<DynamicNode>(graph, m_toolId, m_configId))
             {
+                // Handle undo/redo adding a single node. This will need to be done at a higher level for multiple nodes.
+                GraphCanvas::ScopedGraphUndoBatch undoBatch(graphCanvasSceneId);
+
                 GraphModelIntegration::GraphControllerRequestBus::Event(
                     graphCanvasSceneId, &GraphModelIntegration::GraphControllerRequests::AddNode, node, dropPosition);
                 return true;

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
@@ -444,26 +444,31 @@ namespace MaterialCanvas
 
     void MaterialCanvasDocument::BuildEditablePropertyGroups()
     {
-        // Get a list of currently selected nodes that will be used to populate the inspector
-        GraphModel::NodePtrList selectedNodes;
-        GraphModelIntegration::GraphControllerRequestBus::EventResult(
-            selectedNodes, m_graphId, &GraphModelIntegration::GraphControllerRequests::GetSelectedNodes);
-
-        // Sort all the nodes according to their connection so they appear in a consistent order in the inspector
-        AZStd::sort(
-            selectedNodes.begin(),
-            selectedNodes.end(),
-            [](GraphModel::ConstNodePtr nodeA, GraphModel::ConstNodePtr nodeB)
+        // Sort nodes according to their connection so they appear in a consistent order in the inspector
+        AZStd::vector<GraphModel::NodePtr> nodes;
+        if (m_graph)
+        {
+            // Retrieve nodes and sort them in the same order used for code generation.
+            nodes.reserve(m_graph->GetNodes().size());
+            for (auto& nodePair : m_graph->GetNodes())
             {
-                if (!nodeA->HasConnections() && nodeB->HasConnections())
-                {
-                    return true;
-                }
-                return nodeA != nodeB && nodeA->HasOutputConnectionToNode(nodeB);
+                nodes.push_back(nodePair.second);
+            }
+
+            SortNodesInExecutionOrder(nodes);
+
+            // Remove non selected nodes from the list that will be displayed in the inspector.
+            GraphModel::NodePtrList selectedNodes;
+            GraphModelIntegration::GraphControllerRequestBus::EventResult(
+                selectedNodes, m_graphId, &GraphModelIntegration::GraphControllerRequests::GetSelectedNodes);
+
+            AZStd::erase_if(nodes, [&](const auto& node) {
+                return AZStd::find(selectedNodes.begin(), selectedNodes.end(), node) == selectedNodes.end();
             });
+        }
 
         m_groups.clear();
-        for (auto currentNode : selectedNodes)
+        for (auto currentNode : nodes)
         {
             auto dynamicNode = azrtti_cast<const AtomToolsFramework::DynamicNode*>(currentNode.get());
             if (!dynamicNode)
@@ -655,32 +660,61 @@ namespace MaterialCanvas
         return false;
     }
 
+    template<typename NodeContainer>
+    void MaterialCanvasDocument::SortNodesInExecutionOrder(NodeContainer& nodes) const
+    {
+        // Perform an initial sort, arranging all of the nodes in the order they should execute based on their connections. This pass is
+        // mostly reliable but there are issues. A single output slot can connect to multiple input slots which will make their ordering
+        // nondeterministic. Some nodes with multiple connections or no connections can be shuffled multiple times throughout the short.
+        // Because of this, a secondary pass will be done to move those nodes to the front or back of the container.
+        AZStd::stable_sort(
+            nodes.begin(),
+            nodes.end(),
+            [&](const auto& nodeA, const auto& nodeB)
+            {
+                return nodeA->HasOutputConnectionToNode(nodeB);
+            });
+
+        // Perform a secondary sort, moving all of the constant nodes, material input nodes, and disconnected nodes to the front of the
+        // container while output nodes go to the end. This forces nodes that act as graph inputs to be processed first and appear at the
+        // top of the inspector.
+        AZStd::stable_sort(
+            nodes.begin(),
+            nodes.end(),
+            [&](const auto& nodeA, const auto& nodeB)
+            {
+                auto dynamicNodeA = azrtti_cast<const AtomToolsFramework::DynamicNode*>(nodeA.get());
+                auto dynamicNodeB = azrtti_cast<const AtomToolsFramework::DynamicNode*>(nodeB.get());
+                return AZStd::make_tuple(
+                           !dynamicNodeA->GetConfig().m_inputSlots.empty(),
+                           dynamicNodeA->HasConnections(),
+                           dynamicNodeA->GetConfig().m_outputSlots.empty()) <
+                    AZStd::make_tuple(
+                           !dynamicNodeB->GetConfig().m_inputSlots.empty(),
+                           dynamicNodeB->HasConnections(),
+                           dynamicNodeB->GetConfig().m_outputSlots.empty());
+            });
+    }
+
     AZStd::vector<GraphModel::ConstNodePtr> MaterialCanvasDocument::GetInstructionNodesInExecutionOrder(
         GraphModel::ConstNodePtr outputNode, const AZStd::vector<AZStd::string>& inputSlotNames) const
     {
         AZ_Assert(m_graph, "Attempting to generate data from invalid graph object.");
 
-        AZStd::vector<GraphModel::ConstNodePtr> sortedNodes;
-        sortedNodes.reserve(m_graph->GetNodes().size());
+        AZStd::vector<GraphModel::ConstNodePtr> nodes;
+        nodes.reserve(m_graph->GetNodes().size());
 
         for (const auto& nodePair : m_graph->GetNodes())
         {
             const auto& inputNode = nodePair.second;
             if (ShouldUseInstructionsFromInputNode(outputNode, inputNode, inputSlotNames))
             {
-                sortedNodes.push_back(inputNode);
+                nodes.push_back(inputNode);
             }
         }
 
-        AZStd::sort(
-            sortedNodes.begin(),
-            sortedNodes.end(),
-            [](GraphModel::ConstNodePtr nodeA, GraphModel::ConstNodePtr nodeB)
-            {
-                return nodeA != nodeB && nodeA->HasOutputConnectionToNode(nodeB);
-            });
-
-        return sortedNodes;
+        SortNodesInExecutionOrder(nodes);
+        return nodes;
     }
 
     AZStd::vector<AZStd::string> MaterialCanvasDocument::GetInstructionsFromConnectedNodes(
@@ -822,6 +856,9 @@ namespace MaterialCanvas
         const LineGenerationFn& lineGenerationFn,
         AZStd::vector<AZStd::string>& templateLines) const
     {
+        const bool reportAllCompileStatus =
+            AtomToolsFramework::GetSettingsValue("/O3DE/Atom/MaterialCanvasDocument/ReportAllCompileStatus", false);
+
         auto blockBeginItr = AZStd::find_if(
             templateLines.begin(),
             templateLines.end(),
@@ -832,7 +869,7 @@ namespace MaterialCanvas
 
         while (blockBeginItr != templateLines.end())
         {
-            AZ_TracePrintf("MaterialCanvasDocument", "*blockBegin: %s\n", (*blockBeginItr).c_str());
+            AZ_TracePrintf_IfTrue("MaterialCanvasDocument", reportAllCompileStatus, "*blockBegin: %s\n", (*blockBeginItr).c_str());
 
             // We have to insert one line at a time because AZStd::vector does not include a standard
             // range insert that returns an iterator
@@ -841,12 +878,13 @@ namespace MaterialCanvas
             {
                 ++blockBeginItr;
                 blockBeginItr = templateLines.insert(blockBeginItr, lineToInsert);
-                AZ_TracePrintf("MaterialCanvasDocument", "lineToInsert: %s\n", lineToInsert.c_str());
+
+                AZ_TracePrintf_IfTrue("MaterialCanvasDocument", reportAllCompileStatus, "lineToInsert: %s\n", lineToInsert.c_str());
             }
 
             if (linesToInsert.empty())
             {
-                AZ_TracePrintf("MaterialCanvasDocument", "Nothing was generated. This block will remain unmodified.\n");
+                AZ_TracePrintf_IfTrue("MaterialCanvasDocument", reportAllCompileStatus, "Nothing was generated. This block will remain unmodified.\n");
             }
 
             ++blockBeginItr;
@@ -860,7 +898,7 @@ namespace MaterialCanvas
                     return AZ::StringFunc::Contains(line, blockEndToken);
                 });
 
-            AZ_TracePrintf("MaterialCanvasDocument", "*blockEnd: %s\n", (*blockEndItr).c_str());
+            AZ_TracePrintf_IfTrue("MaterialCanvasDocument", reportAllCompileStatus, "*blockEnd: %s\n", (*blockEndItr).c_str());
 
             if (!linesToInsert.empty())
             {
@@ -1001,7 +1039,10 @@ namespace MaterialCanvas
         AZStd::vector<AZStd::string> functionDefinitions;
         AZStd::vector<AZStd::string> inputDefinitions;
 
-        AZ_TracePrintf("MaterialCanvasDocument", "Dumping data scraped from traversing material graph.\n");
+        const bool reportAllCompileStatus =
+            AtomToolsFramework::GetSettingsValue("/O3DE/Atom/MaterialCanvasDocument/ReportAllCompileStatus", false);
+
+        AZ_TracePrintf_IfTrue("MaterialCanvasDocument", reportAllCompileStatus, "Dumping data scraped from traversing material graph.\n");
 
         // Traverse all graph nodes and slots to collect global settings like include files and class definitions
         for (const auto& nodePair : m_graph->GetNodes())
@@ -1053,7 +1094,7 @@ namespace MaterialCanvas
                     continue;
                 }
 
-                AZ_TracePrintf("MaterialCanvasDocument", "templatePath: %s\n", templatePath.c_str());
+                AZ_TracePrintf_IfTrue("MaterialCanvasDocument", reportAllCompileStatus, "templatePath: %s\n", templatePath.c_str());
 
                 // Attempt to load the template file to do symbol substitution and inject any code or data
                 if (auto result = AZ::Utils::ReadFile(templateInputPath))
@@ -1145,7 +1186,7 @@ namespace MaterialCanvas
                     continue;
                 }
 
-                AZ_TracePrintf("MaterialCanvasDocument", "templatePath: %s\n", templatePath.c_str());
+                AZ_TracePrintf_IfTrue("MaterialCanvasDocument", reportAllCompileStatus, "templatePath: %s\n", templatePath.c_str());
 
                 if (!BuildMaterialTypeFromTemplate(currentNode, instructionNodesForAllBlocks, templateInputPath, templateOutputPath))
                 {

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.h
@@ -108,6 +108,10 @@ namespace MaterialCanvas
             GraphModel::ConstNodePtr inputNode,
             const AZStd::vector<AZStd::string>& inputSlotNames) const;
 
+        // Sort a container of nodes based on connections between nodes so they execute and appear in the inspector in the expected order.
+        template<typename NodeContainer>
+        void SortNodesInExecutionOrder(NodeContainer& nodes) const;
+
         // Get a list of all of the graph nodes sorted in execution order based on input connections.
         AZStd::vector<GraphModel::ConstNodePtr> GetInstructionNodesInExecutionOrder(
             GraphModel::ConstNodePtr outputNode, const AZStd::vector<AZStd::string>& inputSlotNames) const;

--- a/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
@@ -716,6 +716,8 @@ namespace GraphModelIntegration
     GraphModel::NodePtrList GraphController::GetNodesFromGraphNodeIds(const AZStd::vector<GraphCanvas::NodeId>& nodeIds)
     {
         GraphModel::NodePtrList nodeList;
+        nodeList.reserve(nodeIds.size());
+
         for (auto nodeId : nodeIds)
         {
             if (GraphModel::NodePtr nodePtr = m_elementMap.Find<GraphModel::Node>(nodeId))

--- a/Gems/GraphModel/Code/Source/Model/Node.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Node.cpp
@@ -280,7 +280,7 @@ namespace GraphModel
 
     bool Node::HasInputConnectionFromNode(ConstNodePtr node) const
     {
-        if (node)
+        if (node && node.get() != this)
         {
             for (const auto& slotPair : GetSlots())
             {
@@ -302,7 +302,7 @@ namespace GraphModel
 
     bool Node::HasOutputConnectionToNode(ConstNodePtr node) const
     {
-        if (node)
+        if (node && node.get() != this)
         {
             for (const auto& slotPair : GetSlots())
             {


### PR DESCRIPTION
## What does this PR do?

Inspector and code generation now use the same sorting logic that forces input nodes to the beginning and output nodes to the end of the container. This resolves problems where disconnected nodes and slots with multiple connections can result in nondeterministic ordering.

Also implemented custom trace print functions that only printed the condition is true to help reduce repeated checks and blocks. We’ll discuss if these are worth moving with the rest of the core trace functions in macros.

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Loaded existing and created new graphs with several nodes, disconnected nodes, multiple inputs and outputs, confirming that the order of the nodes appear in the inspector corresponds to the order of the generated code and that undoing and redoing multiple times does not break the generated code. Undoing and redoing can result in the relative order of groups of nodes changing in the case that one slot has multiple outputs because that ordering will be nondeterministic. This is either because the node IDs change after reloading or because node mappings are stored in an unordered map.