### PR TITLE
Fix for the warning we see from AZ::Events about handler mismatches during multiplayer

### DIFF
--- a/Code/Framework/AzCore/AzCore/EBus/EventSchedulerSystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/EBus/EventSchedulerSystemComponent.cpp
@@ -109,7 +109,7 @@ namespace AZ
             timedEvent->m_handle = AllocateHandle();
         }
         const bool ownsScheduledEvent = false;
-        *(timedEvent->m_handle) = ScheduledEventHandle(TimeMs(currentMilliseconds + durationMs), durationMs, timedEvent, ownsScheduledEvent);
+        timedEvent->m_handle = new (timedEvent->m_handle) ScheduledEventHandle(TimeMs(currentMilliseconds + durationMs), durationMs, timedEvent, ownsScheduledEvent);
         timedEvent->m_timeInserted = currentMilliseconds;
         m_queue.push(timedEvent->m_handle);
         return timedEvent->m_handle;
@@ -125,7 +125,7 @@ namespace AZ
         TimeMs currentMilliseconds = AZ::GetElapsedTimeMs();
         ScheduledEvent* timedEvent = AllocateManagedEvent(callback, eventName);
         const bool ownsScheduledEvent = true;
-        *(timedEvent->m_handle) = ScheduledEventHandle(TimeMs(currentMilliseconds + durationMs), durationMs, timedEvent, ownsScheduledEvent);
+        timedEvent->m_handle = new (timedEvent->m_handle) ScheduledEventHandle(TimeMs(currentMilliseconds + durationMs), durationMs, timedEvent, ownsScheduledEvent);
         timedEvent->m_timeInserted = currentMilliseconds;
         m_queue.push(timedEvent->m_handle);
     }

--- a/Code/Framework/AzCore/AzCore/EBus/ScheduledEvent.cpp
+++ b/Code/Framework/AzCore/AzCore/EBus/ScheduledEvent.cpp
@@ -115,6 +115,10 @@ namespace AZ
 
     void ScheduledEvent::ClearHandle()
     {
+        if (m_handle)
+        {
+            m_handle->Clear();
+        }
         m_handle = nullptr;
     }
 }

--- a/Code/Framework/AzCore/AzCore/EBus/ScheduledEventHandle.cpp
+++ b/Code/Framework/AzCore/AzCore/EBus/ScheduledEventHandle.cpp
@@ -75,4 +75,13 @@ namespace AZ
     {
         return m_event;
     }
+
+    void ScheduledEventHandle::Clear()
+    {
+        // We can nullptr events we don't own, but events that we do own need to go back into the free pool
+        if (!m_ownsScheduledEvent)
+        {
+            m_event = nullptr;
+        }
+    }
 }

--- a/Code/Framework/AzCore/AzCore/EBus/ScheduledEventHandle.h
+++ b/Code/Framework/AzCore/AzCore/EBus/ScheduledEventHandle.h
@@ -55,6 +55,9 @@ namespace AZ
         //! @return the scheduled event instance bound to this event handle
         ScheduledEvent* GetScheduledEvent() const;
 
+        //! Used internally to clear the event associated with this handle.
+        void Clear();
+
     private:
 
         TimeMs m_executeTimeMs = TimeMs{ 0 }; //< execution time of the scheduled event


### PR DESCRIPTION
Fix for the warning we see from AZ::Events about handler mismatches during multiplayer matches

Signed-off-by: kberg-amzn <karlberg@amazon.com>