### PR TITLE
Updated the `LocalFileIO::ReplaceAlias` to substitute inplace

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/IO/LocalFileIO.cpp
+++ b/Code/Framework/AzFramework/AzFramework/IO/LocalFileIO.cpp
@@ -829,8 +829,21 @@ namespace AZ
                     {
                         return false;
                     }
-                    replacedAliasPath.Native() = AZ::IO::FixedMaxPathString(AZStd::string_view{ aliasValue });
-                    replacedAliasPath.Native() += postAliasView;
+
+                    // Check if the path is input path does not overlap the output path
+                    if (postAliasView.data() < replacedAliasPath.Native().data()
+                        || postAliasView.data() >= replacedAliasPath.Native().data() + replacedAliasPath.Native().size())
+                    {
+                        replacedAliasPath.Native() = AZ::IO::FixedMaxPathString(AZStd::string_view{ aliasValue });
+                        replacedAliasPath.Native() += postAliasView;
+                    }
+                    else
+                    {
+                        // inplace case, copy the postAliasView to a temporary fixed string buffer
+                        AZ::IO::FixedMaxPathString postAliasCopy(postAliasView);
+                        replacedAliasPath.Native() = AZ::IO::FixedMaxPathString(AZStd::string_view{ aliasValue });
+                        replacedAliasPath.Native() += postAliasCopy;
+                    }
                     return true;
                 }
             }

--- a/Code/Framework/AzFramework/AzFramework/IO/LocalFileIO.cpp
+++ b/Code/Framework/AzFramework/AzFramework/IO/LocalFileIO.cpp
@@ -830,7 +830,7 @@ namespace AZ
                         return false;
                     }
 
-                    // Check if the path is input path does not overlap the output path
+                    // Check if the input path does not overlap the output path
                     if (postAliasView.data() < replacedAliasPath.Native().data()
                         || postAliasView.data() >= replacedAliasPath.Native().data() + replacedAliasPath.Native().size())
                     {

--- a/Code/Framework/AzFramework/Tests/FileIO.cpp
+++ b/Code/Framework/AzFramework/Tests/FileIO.cpp
@@ -190,7 +190,7 @@ namespace UnitTest
                 m_file02Name = m_fileRoot / "file02.asdf";
                 m_file03Name = m_fileRoot / "test123.wha";
             }
-        
+
             void TearDown() override
             {
             }
@@ -422,7 +422,7 @@ namespace UnitTest
             void run()
             {
                 LocalFileIO local;
-                
+
                 AZ_TEST_ASSERT(local.CreatePath(m_fileRoot.c_str()));
                 AZ_TEST_ASSERT(local.IsDirectory(m_fileRoot.c_str()));
                 {
@@ -797,6 +797,32 @@ namespace UnitTest
             AZ_TEST_STOP_TRACE_SUPPRESSION(1);
         }
 
+        TEST_F(AliasTest, ReplaceAlias_CanReplaceAliasInplace_Succeeds)
+        {
+            AZ::IO::LocalFileIO local;
+            AZ::IO::FixedMaxPathString aliasFolder;
+            auto CreateTestAbsPath = [&local](char* ptr, size_t size) -> size_t
+            {
+                // If the path was successfully converted to an absolute path
+                // then take the string length of it to figure out where to resize
+                // the fixed_string downwards
+                return local.ConvertToAbsolutePath("/temp", ptr, size) ?
+                    AZStd::char_traits<char>::length(ptr) : 0;
+            };
+            aliasFolder.resize_and_overwrite(aliasFolder.max_size(), CreateTestAbsPath);
+            local.SetAlias("@test@", aliasFolder.c_str());
+
+            // First replace the alias into a new FixedMaxPath
+            const AZ::IO::FixedMaxPath testValue = "@test@/Assets/Materials/Types/MaterialInputs/BaseColorPropertyGroup.json";
+            AZ::IO::FixedMaxPath expectedResolvedValue;
+            EXPECT_TRUE(local.ReplaceAlias(expectedResolvedValue, testValue));
+
+            // Make a copy of the testValue into a FixedMaxPath and resolve it inplace
+            AZ::IO::FixedMaxPath testPath = testValue;
+            EXPECT_TRUE(local.ReplaceAlias(testPath, testPath));
+            EXPECT_EQ(expectedResolvedValue, testPath);
+        }
+
         TEST_F(AliasTest, GetAlias_LogsError_WhenAccessingDeprecatedAlias_Succeeds)
         {
             AZ::IO::LocalFileIO local;
@@ -897,7 +923,7 @@ namespace UnitTest
                 testString[0] = '\0';
                 localFileIO.Read(fileHandle1, testString, testStringLen);
 
-                // try swapping files when the destination file is open for read only, 
+                // try swapping files when the destination file is open for read only,
                 // since window is unable to move files that are open for read, this will fail.
                 AZ_TEST_ASSERT(!AZ::IO::SmartMove(m_file01Name.c_str(), m_file02Name.c_str()));
                 localFileIO.Close(fileHandle1);


### PR DESCRIPTION
Also added support to the JSONImporter to replace any aliases in the import path before appending it to the import path stack

This allows the `ResolveImports` function to be used with a path that
starts with a path that has the form of
`@gemroot:<gem-name>@/rest/of/path` and smartly update the import path
based on whether it the import filepath resolves to an absolute path in
which case it replaces the path importAbsPath value. Or if the import
path doesn't contain a fileio alias and is relative, it is appended to
the importAbsPath value.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Added Unittest to validate inplace replacement of a FileIO alias at the beginning of a path
