### PR TITLE
Material Canvas: Register crash function Python binding for automated testing failure cases

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Application/AtomToolsApplication.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Application/AtomToolsApplication.h
@@ -95,6 +95,7 @@ namespace AtomToolsFramework
 
         static void PyIdleWaitFrames(uint32_t frames);
         static void PyExit();
+        static void PyCrash();
         static void PyTestOutput(const AZStd::string& output);
 
         // Adding static instance access for static Python methods

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
@@ -123,6 +123,9 @@ namespace AtomToolsFramework
                 "exit", &AtomToolsApplication::PyExit, nullptr,
                 "Exit application. Primarily used for auto-testing."));
             addGeneral(behaviorContext->Method(
+                "crash", &AtomToolsApplication::PyCrash, nullptr,
+                "Crashes the application, useful for testing crash reporting and other automation tools."));
+            addGeneral(behaviorContext->Method(
                 "test_output", &AtomToolsApplication::PyTestOutput, nullptr,
                 "Report test information."));
         }
@@ -683,6 +686,11 @@ namespace AtomToolsFramework
     void AtomToolsApplication::PyExit()
     {
         AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::ExitMainLoop);
+    }
+
+    void AtomToolsApplication::PyCrash()
+    {
+        AZ_Crash();
     }
 
     void AtomToolsApplication::PyTestOutput(const AZStd::string& output)


### PR DESCRIPTION
## What does this PR do?

Registering crash function with behavior context to create failure cases. Some of the duplicate bindings should be moved to a common, lower-level location to be shared between the editor and other tools.

Resolves https://github.com/o3de/o3de/issues/12396

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Duplicated from main editor and compiling to facilitate other tests that are being written separately.