### PR TITLE
Added an PostFrame function to XR Render API

### DIFF
--- a/Code/Framework/AzCore/Platform/Android/AzCore/Android/AndroidEnv.h
+++ b/Code/Framework/AzCore/Platform/Android/AzCore/Android/AndroidEnv.h
@@ -85,9 +85,6 @@ namespace AZ
             //! \return A pointer to the JNIEnv on the current thread.
             JNIEnv* GetJniEnv() const;
 
-            //! Request the global reference to the activity java virtual machine
-            JavaVM* GetActivityJavaVM() const { return m_jvm; }
-
             //! Request the global reference to the activity class
             jclass GetActivityClassRef() const { return m_activityClass; }
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/XRRenderingInterface.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/XRRenderingInterface.h
@@ -101,10 +101,16 @@ namespace AZ::RHI
         virtual AZ::RHI::ResultCode CreateSwapChain() = 0;
 
         //! Rendering api to signal the beginning of a frame.
+        //! @note This function is called from the thread related to the presentation queue.
         virtual void BeginFrame() = 0;
 
         //! Rendering api to signal the end of a frame.
+        //! @note This function is called from the thread related to the presentation queue.
         virtual void EndFrame() = 0;
+
+        //! Rendering api to signal after EndFrame has been executed.
+        //! @note This function is called from the main thread.
+        virtual void PostFrame() = 0;
 
         //! Rendering api to get the native swapchain image to write into.
         virtual AZ::RHI::ResultCode GetSwapChainImage(AZ::RHI::XRSwapChainDescriptor* swapchainDescriptor) const = 0;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -645,6 +645,8 @@ namespace AZ
 
                 presentationQueue.QueueCommand(AZStd::move(presentCommand));
                 presentationQueue.FlushCommands();
+
+                xrSystem->PostFrame();
             }
 
             m_commandQueueContext.End();


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

This fixes the following issue when running OpenXR on Quest 2:
` I/JniUtils: Creating temporary JNIEnv. This is a heavy operation and should be infrequent. To optimize, use JNI AttachCurrentThread on calling thread`

This PR goes in conjunction with this PR: https://github.com/o3de/o3de-extras/pull/38

- Added `PostFrame` function to XR rendering interface called from the main thread. This is necessary to add a point for XR system to restore the JNI Environment back to the main thread when running on Android.
- Removed `GetActivityJavaVM` function, which was added to use it when initializing the loader of OpenXR, but that's not the right way to query the JavaVM (the correct way is to use `GetJNIEnv()->GetJavaVM()`), so removing the getter.

## How was this PR tested?

Run ASV "RHI/OpenXR" sample on Quest2. 
