### PR TITLE
Add colored icons next to items in EMotionFX context menu

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.cpp
@@ -72,10 +72,24 @@ namespace EMStudio
         return m_namePrefix;
     }
 
-    BlendGraphNodePaletteTreeItem::BlendGraphNodePaletteTreeItem(AZStd::string_view name, const QString& typeString,
-        GraphCanvas::EditorId editorId)
-        : GraphCanvas::IconDecoratedNodePaletteTreeItem(name, editorId), m_typeString(typeString)
+    BlendGraphNodePaletteTreeItem::BlendGraphNodePaletteTreeItem(
+        AZStd::string_view name, const QString& typeString, GraphCanvas::EditorId editorId, const AZ::Color& color)
+        : GraphCanvas::IconDecoratedNodePaletteTreeItem(name, editorId)
+        , m_typeString(typeString)
     {
+        // Draw a pixmap with the provided color to use as an icon adjacent to the name text
+        QSize pixmapSize(20, 20);
+        QPixmap pixmap(pixmapSize);
+        // Fill with transparency for the padding around the solid color
+        pixmap.fill(Qt::transparent);
+
+        QPainter painter(&pixmap);
+        painter.fillRect(
+            // leave some padding
+            QRect(QPoint(8, 4), QSize(pixmapSize.width() - 8, pixmapSize.height() - 8)),
+            AzQtComponents::toQColor(color));
+
+        m_colorPixmap = pixmap;
     }
 
     void BlendGraphNodePaletteTreeItem::SetTypeString(const QString& typeString)
@@ -86,6 +100,16 @@ namespace EMStudio
     QString BlendGraphNodePaletteTreeItem::GetTypeString() const
     {
         return m_typeString;
+    }
+
+    QVariant BlendGraphNodePaletteTreeItem::OnData(const QModelIndex& index, int role) const
+    {
+        // Show a square of the color adjacent to the name text
+        if (role == Qt::DecorationRole && index.column() == Column::Name)
+        {
+            return QVariant(m_colorPixmap);
+        }
+        return NodePaletteTreeItem::OnData(index, role);
     }
 
     BlendGraphMimeEvent* BlendGraphNodePaletteTreeItem::CreateMimeEvent() const

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.h
@@ -50,13 +50,18 @@ namespace EMStudio
     class BlendGraphNodePaletteTreeItem : public GraphCanvas::IconDecoratedNodePaletteTreeItem
     {
     public:
-        BlendGraphNodePaletteTreeItem(AZStd::string_view name, const QString& typeString, GraphCanvas::EditorId editorId);
+        BlendGraphNodePaletteTreeItem(AZStd::string_view name, const QString& typeString, GraphCanvas::EditorId editorId, const AZ::Color& color);
         BlendGraphMimeEvent* CreateMimeEvent() const override;
 
         void SetTypeString(const QString& typeString);
         QString GetTypeString() const;
+
+    protected:
+        QVariant OnData(const QModelIndex& index, int role) const override;
+
     private:
         QString m_typeString;
+        QPixmap m_colorPixmap;
     };
 
     class BlendGraphWidget

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ContextMenu.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ContextMenu.cpp
@@ -56,7 +56,8 @@ namespace EMStudio
             const EMotionFX::AnimGraphNode* nodePrototype = static_cast<const EMotionFX::AnimGraphNode*>(objectPrototype);
 
             const QString typeString = azrtti_typeid(nodePrototype).ToString<QString>();
-            auto* node = categoryNode->CreateChildNode<BlendGraphNodePaletteTreeItem>(nodePrototype->GetPaletteName(), typeString, AnimGraphEditorId);
+            auto* node = categoryNode->CreateChildNode<BlendGraphNodePaletteTreeItem>(
+                nodePrototype->GetPaletteName(), typeString, AnimGraphEditorId, nodePrototype->GetVisualColor());
             node->SetEnabled(active);
         }
         categoryNode->SetEnabled(categoryEnabled);


### PR DESCRIPTION
## What does this PR do?
Add colored icons next to items EMotionFX context menu. These icons correspond to the colors of the nodes they create when selected.

Fixes https://github.com/o3de/o3de/issues/11689

## How was this PR tested?

manually
![context-menu-colors](https://user-images.githubusercontent.com/9455094/193945809-4ce97d8a-3c43-4cfc-a544-f49fdc30654b.png)

