### PR TITLE
re-enables pytest sanity tests to run in serial

### DIFF
--- a/scripts/ctest/CMakeLists.txt
+++ b/scripts/ctest/CMakeLists.txt
@@ -19,31 +19,33 @@ endif()
 
 if(PAL_TRAIT_TEST_PYTEST_SUPPORTED)
     # Disabled due to intermittent XML error in https://github.com/o3de/o3de/issues/11667
-    # foreach(suite_name ${LY_TEST_GLOBAL_KNOWN_SUITE_NAMES})
-    #     ly_add_pytest(
-    #         NAME pytest_sanity_${suite_name}_no_gpu
-    #         PATH ${CMAKE_CURRENT_LIST_DIR}/sanity_test.py
-    #         TEST_SUITE ${suite_name}
-    #     )
+     foreach(suite_name ${LY_TEST_GLOBAL_KNOWN_SUITE_NAMES})
+         ly_add_pytest(
+             NAME pytest_sanity_${suite_name}_no_gpu
+             PATH ${CMAKE_CURRENT_LIST_DIR}/sanity_test.py
+             TEST_SUITE ${suite_name}
+             TEST_SERIAL
+         )
 
-    #     ly_add_pytest(
-    #         NAME pytest_sanity_${suite_name}_requires_gpu
-    #         PATH ${CMAKE_CURRENT_LIST_DIR}/sanity_test.py
-    #         TEST_SUITE ${suite_name}
-    #         TEST_REQUIRES gpu
-    #     )
-    # endforeach()
+         ly_add_pytest(
+             NAME pytest_sanity_${suite_name}_requires_gpu
+             PATH ${CMAKE_CURRENT_LIST_DIR}/sanity_test.py
+             TEST_SUITE ${suite_name}
+             TEST_REQUIRES gpu
+             TEST_SERIAL
+         )
+     endforeach()
 
     # Disabled due to dependency on the test above
-    # # add a custom test which makes sure that the test filtering works!
-    # ly_add_test(
-    #     NAME cli_test_driver
-    #     EXCLUDE_TEST_RUN_TARGET_FROM_IDE
-    #     TEST_COMMAND ${LY_PYTHON_CMD} ${CMAKE_CURRENT_LIST_DIR}/ctest_driver_test.py
-    #         -x ${CMAKE_CTEST_COMMAND} 
-    #         --build-path ${CMAKE_BINARY_DIR}
-    #         --config $<CONFIG>
-    #     TEST_LIBRARY pytest
-    # )
+     # add a custom test which makes sure that the test filtering works!
+     ly_add_test(
+         NAME cli_test_driver
+         EXCLUDE_TEST_RUN_TARGET_FROM_IDE
+         TEST_COMMAND ${LY_PYTHON_CMD} ${CMAKE_CURRENT_LIST_DIR}/ctest_driver_test.py
+             -x ${CMAKE_CTEST_COMMAND} 
+             --build-path ${CMAKE_BINARY_DIR}
+             --config $<CONFIG>
+         TEST_LIBRARY pytest
+     )
 
 endif()


### PR DESCRIPTION
Signed-off-by: evanchia-ly-sdets <evanchia@amazon.com>

## What does this PR do?
Re-enables the pytest sanity tests to run in serial to prevent xml race condition.

https://github.com/o3de/o3de/issues/11667 

## How was this PR tested?
Ran tests locally. By running in serial, this adds slightly under 9 seconds of additional test time.