### PR TITLE
Material Canvas: Adding style sheet to fix node palette search highlighting

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/GraphView/GraphView.qrc
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/GraphView/GraphView.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/GraphView">
+        <file>GraphView.qss</file>
+    </qresource>
+</RCC>

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/GraphView/GraphView.qss
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/GraphView/GraphView.qss
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+GraphCanvas--NodePaletteTreeView
+{
+    selection-background-color: rgba(255, 255, 255, 41);
+}

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/atomtoolsframework_files.cmake
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/atomtoolsframework_files.cmake
@@ -98,6 +98,8 @@ set(FILES
     Include/AtomToolsFramework/GraphView/GraphView.h
     Include/AtomToolsFramework/GraphView/GraphViewConfig.h
     Source/GraphView/GraphView.cpp
+    Source/GraphView/GraphView.qrc
+    Source/GraphView/GraphView.qss
 
     Include/AtomToolsFramework/Inspector/InspectorGroupHeaderWidget.h
     Include/AtomToolsFramework/Inspector/InspectorGroupWidget.h

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
@@ -34,6 +34,7 @@ void InitMaterialCanvasResources()
     Q_INIT_RESOURCE(MaterialCanvas);
     Q_INIT_RESOURCE(InspectorWidget);
     Q_INIT_RESOURCE(AtomToolsAssetBrowser);
+    Q_INIT_RESOURCE(GraphView);
 }
 
 namespace MaterialCanvas

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
@@ -8,6 +8,7 @@
 
 #include <AtomToolsFramework/SettingsDialog/SettingsDialog.h>
 #include <AzCore/IO/FileIO.h>
+#include <AzQtComponents/Components/StyleManager.h>
 #include <GraphCanvas/Widgets/NodePalette/TreeItems/NodePaletteTreeItem.h>
 #include <Window/MaterialCanvasMainWindow.h>
 #include <Window/MaterialCanvasViewportContent.h>
@@ -99,6 +100,9 @@ namespace MaterialCanvas
         {
             AZ_Warning("MaterialCanvas", false, "Error loading translation file %s", unresolvedPath.data());
         }
+
+        // Set up style sheet to fix highlighting in the node palette
+        AzQtComponents::StyleManager::setStyleSheet(this, QStringLiteral(":/GraphView/GraphView.qss"));
 
         OnDocumentOpened(AZ::Uuid::CreateNull());
     }


### PR DESCRIPTION
## What does this PR do?

This change introduces a style sheet to make the node palette search text highlighting transparent so that it does not obscure the text from the user.

Resolves https://github.com/o3de/o3de/issues/10905

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Verify that using a text filter in the node palette highlight the filter text in each node palette entry without obscuring the name of the node.