### PR TITLE
Check if EMVF passs templates are already created before creating. 

### DIFF
--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/EditorStatePassSystem.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/EditorStatePassSystem.cpp
@@ -51,6 +51,7 @@ namespace AZ::Render
         const auto templateName = Name(MainPassParentTemplateName);
         if (RPI::PassSystemInterface::Get()->GetPassTemplate(templateName))
         {
+            // Template was created by another pipeline, do not to create again
             return;
         }
 

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/EditorStatePassSystem.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/EditorStatePassSystem.cpp
@@ -48,8 +48,14 @@ namespace AZ::Render
 
     void EditorStatePassSystem::AddPassesToRenderPipeline(RPI::RenderPipeline* renderPipeline)
     {
+        const auto templateName = Name(MainPassParentTemplateName);
+        if (RPI::PassSystemInterface::Get()->GetPassTemplate(templateName))
+        {
+            return;
+        }
+
         auto mainParentPassTemplate = AZStd::make_shared<RPI::PassTemplate>();
-        mainParentPassTemplate->m_name = Name(MainPassParentTemplateName);
+        mainParentPassTemplate->m_name = templateName;
         mainParentPassTemplate->m_passClass = Name(MainPassParentTemplatePassClassName);
         
         // Input depth slot

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/EditorStatePassSystemUtils.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/EditorStatePassSystemUtils.cpp
@@ -38,8 +38,14 @@ namespace AZ::Render
 
     void CreateAndAddStateParentPassTemplate(const EditorStateBase& state)
     {
+        const auto templateName = state.GetPassTemplateName();
+        if (RPI::PassSystemInterface::Get()->GetPassTemplate(templateName))
+        {
+            return;
+        }
+
         auto stateParentPassTemplate = AZStd::make_shared<RPI::PassTemplate>();
-        stateParentPassTemplate->m_name = state.GetPassTemplateName();
+        stateParentPassTemplate->m_name = templateName;
         stateParentPassTemplate->m_passClass = StatePassTemplatePassClassName;
 
          // Input depth slot
@@ -142,8 +148,14 @@ namespace AZ::Render
 
     void CreateAndAddBufferCopyPassTemplate(const EditorStateBase& state)
     {
+        const auto templateName = GetBufferCopyPassTemplateName(state);
+        if (RPI::PassSystemInterface::Get()->GetPassTemplate(templateName))
+        {
+            return;
+        }
+
         auto passTemplate = AZStd::make_shared<RPI::PassTemplate>();
-        passTemplate->m_name = GetBufferCopyPassTemplateName(state);
+        passTemplate->m_name = templateName;
         passTemplate->m_passClass = BufferCopyStatePassTemplatePassClassName;
     
         // Input color slot
@@ -207,8 +219,14 @@ namespace AZ::Render
 
     void CreateAndAddMaskPassTemplate(const Name& drawList)
     {
+        const auto templateName = GetMaskPassTemplateNameForDrawList(drawList);
+        if (RPI::PassSystemInterface::Get()->GetPassTemplate(templateName))
+        {
+            return;
+        }
+
         auto maskPassTemplate = AZStd::make_shared<RPI::PassTemplate>();
-        maskPassTemplate->m_name = GetMaskPassTemplateNameForDrawList(drawList);
+        maskPassTemplate->m_name = templateName;
         maskPassTemplate->m_passClass = Name("RasterPass");
 
         // Input depth slot

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/EditorStatePassSystemUtils.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/EditorStatePassSystemUtils.cpp
@@ -41,6 +41,7 @@ namespace AZ::Render
         const auto templateName = state.GetPassTemplateName();
         if (RPI::PassSystemInterface::Get()->GetPassTemplate(templateName))
         {
+            // Template was created by another pipeline, do not to create again
             return;
         }
 
@@ -151,6 +152,7 @@ namespace AZ::Render
         const auto templateName = GetBufferCopyPassTemplateName(state);
         if (RPI::PassSystemInterface::Get()->GetPassTemplate(templateName))
         {
+            // Template was created by another pipeline, do not to create again
             return;
         }
 
@@ -222,6 +224,7 @@ namespace AZ::Render
         const auto templateName = GetMaskPassTemplateNameForDrawList(drawList);
         if (RPI::PassSystemInterface::Get()->GetPassTemplate(templateName))
         {
+            // Template was created by another pipeline, do not to create again
             return;
         }
 


### PR DESCRIPTION
Signed-off-by: John <jonawals@amazon.com>

## What does this PR do?

This PR adds checks to ensure that an already created pass template for EMVF is not created and attempted to register more than once. Although his shouldn't functionally change any behavior as the warning emitted by the Atom pass system early exits if it detects a duplicate creation for a given template, this fix will unclutter the editor logs with this warning and reduce misdirection when debugging viewport render related behavior.

## How was this PR tested?

This fix was tested manually in the editor.
