### PR TITLE
Fix UI anim curve editor issues

### DIFF
--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewDialog.cpp
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewDialog.cpp
@@ -188,7 +188,6 @@ CUiAnimViewDialog::CUiAnimViewDialog(QWidget* pParent /*=NULL*/)
 
 CUiAnimViewDialog::~CUiAnimViewDialog()
 {
-    SaveLayouts();
     SaveMiscSettings();
     SaveTrackColors();
 
@@ -214,10 +213,6 @@ CUiAnimViewDialog::~CUiAnimViewDialog()
     CUiAnimViewSequenceManager::GetSequenceManager()->RemoveListener(this);
     m_animationContext->RemoveListener(this);
     GetIEditor()->UnregisterNotifyListener(this);
-
-    // UI_ANIMATION_REVISIT it seems something should be deleting these
-    delete m_wndCurveEditor;
-    delete m_wndCurveEditorDock;
 
     UiEditorAnimationStateBus::Handler::BusDisconnect();
     UiEditorAnimListenerBus::Handler::BusDisconnect();
@@ -262,11 +257,11 @@ BOOL CUiAnimViewDialog::OnInitDialog()
     setCentralWidget(w);
 
     m_wndKeyProperties = new CUiAnimViewKeyPropertiesDlg(this);
-    QDockWidget* dw = new AzQtComponents::StyledDockWidget(this);
-    dw->setObjectName("m_wndKeyProperties");
-    dw->setWindowTitle("Key");
-    dw->setWidget(m_wndKeyProperties);
-    addDockWidget(Qt::RightDockWidgetArea, dw);
+    m_wndKeyPropertiesDock = new AzQtComponents::StyledDockWidget(this);
+    m_wndKeyPropertiesDock->setObjectName("m_wndKeyProperties");
+    m_wndKeyPropertiesDock->setWindowTitle("Key");
+    m_wndKeyPropertiesDock->setWidget(m_wndKeyProperties);
+    addDockWidget(Qt::RightDockWidgetArea, m_wndKeyPropertiesDock);
     m_wndKeyProperties->PopulateVariables();
     m_wndKeyProperties->SetKeysCtrl(m_wndDopeSheet);
 
@@ -279,10 +274,6 @@ BOOL CUiAnimViewDialog::OnInitDialog()
     m_wndCurveEditor->SetPlayCallback([this] { OnPlay();
         });
 
-    // Close/hide by default to avoid the pane to show up as a standalone, white window when not displayed in a layout.
-    m_wndCurveEditorDock->setVisible(false);
-    m_wndCurveEditorDock->setEnabled(false);
-
     // In order to prevent the track editor view from collapsing and becoming invisible, we use the
     // minimum size of the curve editor for the track editor as well. Since both editors use the same
     // view widget in the UI animation editor when not in 'Both' mode, the sizes can be identical.
@@ -292,6 +283,7 @@ BOOL CUiAnimViewDialog::OnInitDialog()
 
     m_lazyInitDone = false;
 
+    SetViewMode(ViewMode::TrackView);
     QTimer::singleShot(0, this, SLOT(ReadLayouts()));
     //  ReadLayouts();
     ReadMiscSettings();
@@ -1386,6 +1378,22 @@ void CUiAnimViewDialog::keyPressEvent(QKeyEvent* event)
 }
 
 //////////////////////////////////////////////////////////////////////////
+void CUiAnimViewDialog::closeEvent([[maybe_unused]] QCloseEvent* event)
+{
+    m_wndKeyPropertiesDock->hide();
+    m_wndCurveEditorDock->hide();
+}
+
+void CUiAnimViewDialog::showEvent([[maybe_unused]] QShowEvent* event)
+{
+    m_wndKeyPropertiesDock->show();
+    if (m_lastMode == ViewMode::Both)
+    {
+        m_wndCurveEditorDock->show();
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////
 void CUiAnimViewDialog::OnModeDopeSheet()
 {
     auto sizes = m_wndSplitter->sizes();
@@ -1400,6 +1408,7 @@ void CUiAnimViewDialog::OnModeDopeSheet()
     m_actions[ID_TV_MODE_DOPESHEET]->setChecked(true);
     m_actions[ID_TV_MODE_CURVEEDITOR]->setChecked(false);
     m_wndCurveEditor->OnSequenceChanged(m_animationContext->GetSequence());
+    m_lastMode = ViewMode::TrackView;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1417,6 +1426,7 @@ void CUiAnimViewDialog::OnModeCurveEditor()
     m_actions[ID_TV_MODE_DOPESHEET]->setChecked(false);
     m_actions[ID_TV_MODE_CURVEEDITOR]->setChecked(true);
     m_wndCurveEditor->OnSequenceChanged(m_animationContext->GetSequence());
+    m_lastMode = ViewMode::CurveEditor;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1428,6 +1438,7 @@ void CUiAnimViewDialog::OnOpenCurveEditor()
     m_actions[ID_TV_MODE_DOPESHEET]->setChecked(true);
     m_actions[ID_TV_MODE_CURVEEDITOR]->setChecked(true);
     m_wndCurveEditor->OnSequenceChanged(m_animationContext->GetSequence());
+    m_lastMode = ViewMode::Both;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1551,6 +1562,7 @@ void CUiAnimViewDialog::SaveLayouts()
     settings.beginGroup("UiAnimView");
     QByteArray stateData = this->saveState();
     settings.setValue("layout", stateData);
+    settings.setValue("lastViewMode", static_cast<int>(m_lastMode));
     QStringList sl;
     foreach(int i, m_wndSplitter->sizes())
     sl << QString::number(i);
@@ -1576,12 +1588,34 @@ void CUiAnimViewDialog::ReadLayouts()
     {
         QStringList sl = settings.value("splitter").toString().split(",");
         QList<int> szl;
-        foreach(QString s, sl)
-        szl << s.toInt();
+        foreach (QString s, sl)
+        {
+            szl << s.toInt();
+        }
         if (!sl.isEmpty())
         {
             m_wndSplitter->setSizes(szl);
         }
+    }
+
+    QVariant defaultMode(static_cast<int>(m_lastMode));
+    SetViewMode(static_cast<ViewMode>(settings.value("lastViewMode", defaultMode).toInt()));
+}
+
+//////////////////////////////////////////////////////////////////////////
+void CUiAnimViewDialog::SetViewMode(ViewMode mode)
+{
+    switch (mode)
+    {
+    case ViewMode::TrackView:
+        OnModeDopeSheet();
+        break;
+    case ViewMode::CurveEditor:
+        OnModeCurveEditor();
+        break;
+    case ViewMode::Both:
+        OnOpenCurveEditor();
+        break;
     }
 }
 
@@ -1741,6 +1775,14 @@ void CUiAnimViewDialog::UpdateDopeSheetTime(CUiAnimViewSequence* pSequence)
     m_wndDopeSheet->SetStartMarker(timeRange.start);
     m_wndDopeSheet->SetEndMarker(timeRange.end);
     m_wndDopeSheet->SetTimeScale(m_wndDopeSheet->GetTimeScale(), 0);
+}
+
+//////////////////////////////////////////////////////////////////////////
+void CUiAnimViewDialog::EditorAboutToClose()
+{
+    m_wndCurveEditorDock->setFloating(false);
+    m_wndKeyPropertiesDock->setFloating(false);
+    SaveLayouts();
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewDialog.h
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewDialog.h
@@ -82,6 +82,8 @@ public:
 
     const CUiAnimViewDopeSheetBase& GetUiAnimViewDopeSheet() const { return *m_wndDopeSheet; }
 
+    void EditorAboutToClose();
+
 public slots:
     void OnPlay();
 
@@ -136,11 +138,22 @@ protected slots:
 
 protected:
     void keyPressEvent(QKeyEvent* event) override;
+    void closeEvent(QCloseEvent* event) override;
+    void showEvent(QShowEvent* event) override;
 
 private slots:
     void ReadLayouts();
 
 private:
+
+    enum class ViewMode
+    {
+        TrackView = 1,
+        CurveEditor = 2,
+        Both = 3
+    };
+
+    void SetViewMode(ViewMode);
     void UpdateActions();
     void ReloadSequencesComboBox();
 
@@ -187,6 +200,7 @@ private:
     CUiAnimViewDopeSheetBase*   m_wndDopeSheet;
     QDockWidget* m_wndCurveEditorDock;
     UiAnimViewCurveEditorDialog*    m_wndCurveEditor;
+    QDockWidget* m_wndKeyPropertiesDock = nullptr; 
     CUiAnimViewKeyPropertiesDlg* m_wndKeyProperties;
     CUiAnimViewFindDlg* m_findDlg;
     QToolBar* m_mainToolBar;
@@ -220,4 +234,5 @@ private:
     std::vector<CUiAnimParamType> m_toolBarParamTypes;
 
     QHash<int, QAction*> m_actions;
+    ViewMode m_lastMode = ViewMode::TrackView;
 };

--- a/Gems/LyShine/Code/Editor/EditorWindow.cpp
+++ b/Gems/LyShine/Code/Editor/EditorWindow.cpp
@@ -47,6 +47,7 @@
 void initUiCanvasEditorResources()
 {
     Q_INIT_RESOURCE(UiCanvasEditor);
+    Q_INIT_RESOURCE(UiAnimViewDialog);
 }
 
 namespace

--- a/Gems/LyShine/Code/Editor/EditorWindow.cpp
+++ b/Gems/LyShine/Code/Editor/EditorWindow.cpp
@@ -2196,6 +2196,8 @@ void EditorWindow::closeEvent(QCloseEvent* closeEvent)
     // Save the current window state
     SaveEditorWindowSettings();
 
+    m_animationWidget->EditorAboutToClose();
+
 #if defined(AZ_PLATFORM_LINUX)
     // Work-around for issue on Linux where closing (and destroying) the window an re-opening causes the Editor
     // to hang or crash. So instead of closing this window, replicate the action of unchecking UI Editor from the


### PR DESCRIPTION
## What does this PR do?

- Fixes curve editor icons not being found
- The curve editor docking widget does not draw when the layout is saved/restored when the curve editor is undocked. This issue seems to be related to UI Editor not using the fancy docking system, so a longer term fix would be to convert UI Editor to use fancy docking. The current workaround in this PR is to dock the sub-panes back up before saving the layout.

The new ViewMode related code was taken from TrackView.

Fixes #11616

## How was this PR tested?

Manual testing closing and re-opening curve widget, UI editor, main editor.

https://user-images.githubusercontent.com/82236305/194137274-78b76731-584a-415a-9158-ac96a8f1b8b0.mp4

https://user-images.githubusercontent.com/82236305/194137294-20bc9b29-d8b8-4369-97d9-176453c945b2.mp4