### PR TITLE
Material Canvas: Follow up fixing search text highlighting in context menu

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/GraphView/GraphView.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/GraphView/GraphView.cpp
@@ -9,6 +9,7 @@
 #include <AtomToolsFramework/GraphView/GraphView.h>
 #include <AtomToolsFramework/Util/Util.h>
 #include <AzCore/IO/FileIO.h>
+#include <AzQtComponents/Components/StyleManager.h>
 #include <GraphCanvas/Components/Connections/ConnectionBus.h>
 #include <GraphCanvas/Components/MimeDataHandlerBus.h>
 #include <GraphCanvas/Components/Nodes/NodeBus.h>
@@ -90,6 +91,10 @@ namespace AtomToolsFramework
         nodePaletteConfig.m_rootTreeItem = m_graphViewConfig.m_createNodeTreeItemsFn(m_toolId);
         m_sceneContextMenu = aznew GraphCanvas::SceneContextMenu(m_toolId, this);
         m_sceneContextMenu->AddNodePaletteMenuAction(nodePaletteConfig);
+
+        // Set up style sheet to fix highlighting in the node palette
+        AzQtComponents::StyleManager::setStyleSheet(
+            const_cast<GraphCanvas::NodePaletteWidget*>(m_sceneContextMenu->GetNodePalette()), QStringLiteral(":/GraphView/GraphView.qss"));
 
         // Setup the context menu with node palette for proposing a new node
         // when dropping a connection in an empty space in the graph


### PR DESCRIPTION
## What does this PR do?

The node palettes embedded in context menus override their styling after construction. This forces you to use the same style sheet as the docked version.

Resolves https://github.com/o3de/o3de/issues/10905

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Verified highlighting appears correctly in context menu

![image](https://user-images.githubusercontent.com/82461473/194124936-ea136973-b293-4454-973e-e1a644c1ec18.png)
