### PR TITLE
DPE: Add support for ReadOnly attributes

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -52,6 +52,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
 
         system->RegisterNode<PropertyEditor, NodeWithVisiblityControl>();
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::OnChanged);
+        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::SetDisabled);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::Type);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::Value);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::ValueType);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -52,7 +52,6 @@ namespace AZ::DocumentPropertyEditor::Nodes
 
         system->RegisterNode<PropertyEditor, NodeWithVisiblityControl>();
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::OnChanged);
-        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::SetDisabled);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::Type);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::Value);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::ValueType);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -107,7 +107,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr auto ValueHashed = AttributeDefinition<AZ::Uuid>("ValueHashed");
 
         //! In some cases, a node may need to know that it is descended from a disabled ancestor. For example, disabled
-        //! elements of a disabled container might requrie different treatment than disabled elements of an enabled container.
+        //! elements of a disabled container might require different treatment than disabled elements of an enabled container.
         static constexpr auto AncestorDisabled = AttributeDefinition<bool>("AncestorDisabled");
 
         //! If set to true, specifies that this PropertyEditor shouldn't be allocated its own column, but instead appended

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -36,6 +36,11 @@ namespace AZ::DocumentPropertyEditor::Nodes
     {
         static constexpr AZStd::string_view Name = "NodeWithVisiblityControl";
         static constexpr auto Visibility = AttributeDefinition<PropertyVisibility>("Visibility");
+
+        static constexpr auto Disabled = AttributeDefinition<bool>("Disabled");
+        //! In some cases, a node may need to know that it is descended from a disabled ancestor. For example, disabled
+        //! elements of a disabled container might require different treatment than disabled elements of an enabled container.
+        static constexpr auto AncestorDisabled = AttributeDefinition<bool>("AncestorDisabled");
     };
 
     //! Adapter: The top-level tag for a DocumentAdapter that may contain any number of Rows.
@@ -45,6 +50,10 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr auto QueryKey = CallbackAttributeDefinition<void(DocumentAdapterPtr*, AZ::Dom::Path)>("QueryKey");
         static constexpr auto AddContainerKey = CallbackAttributeDefinition<void(DocumentAdapterPtr*, AZ::Dom::Path)>("AddContainerKey");
         static constexpr auto RejectContainerKey = CallbackAttributeDefinition<void(DocumentAdapterPtr*, AZ::Dom::Path)>("RejectContainerKey");
+
+        //! Use this callback attribute if there is need to enable/disable an adapter's nodes at runtime.
+        static constexpr auto SetNodeDisabled =
+            CallbackAttributeDefinition<void(bool shouldDisable, Dom::Path targetNode)>("SetDisabled");
 
         static bool CanAddToParentNode(const Dom::Value& parentNode);
         static bool CanBeParentToValue(const Dom::Value& value);
@@ -104,13 +113,6 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr auto Value = AttributeDefinition<AZ::Dom::Value>("Value");
         static constexpr auto ValueType = TypeIdAttributeDefinition("ValueType");
         static constexpr auto ValueHashed = AttributeDefinition<AZ::Uuid>("ValueHashed");
-
-        //! Use this callback attribute if there is need to enable/disable property editors at runtime.
-        static constexpr auto SetDisabled = CallbackAttributeDefinition<void(bool shouldDisable)>("SetDisabled");
-        static constexpr auto Disabled = AttributeDefinition<bool>("Disabled");
-        //! In some cases, a node may need to know that it is descended from a disabled ancestor. For example, disabled
-        //! elements of a disabled container might require different treatment than disabled elements of an enabled container.
-        static constexpr auto AncestorDisabled = AttributeDefinition<bool>("AncestorDisabled");
 
         //! If set to true, specifies that this PropertyEditor shouldn't be allocated its own column, but instead appended
         //! to the previous column in the layout, creating a SharedColumn that can hold many PropertyEditors.

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -103,9 +103,11 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr auto OnChanged = CallbackAttributeDefinition<void(const Dom::Value&, ValueChangeType)>("OnChanged");
         static constexpr auto Value = AttributeDefinition<AZ::Dom::Value>("Value");
         static constexpr auto ValueType = TypeIdAttributeDefinition("ValueType");
-        static constexpr auto Disabled = AttributeDefinition<bool>("Disabled");
         static constexpr auto ValueHashed = AttributeDefinition<AZ::Uuid>("ValueHashed");
 
+        //! Use this callback attribute if there is need to enable/disable property editors at runtime.
+        static constexpr auto SetDisabled = CallbackAttributeDefinition<void(bool shouldDisable)>("SetDisabled");
+        static constexpr auto Disabled = AttributeDefinition<bool>("Disabled");
         //! In some cases, a node may need to know that it is descended from a disabled ancestor. For example, disabled
         //! elements of a disabled container might require different treatment than disabled elements of an enabled container.
         static constexpr auto AncestorDisabled = AttributeDefinition<bool>("AncestorDisabled");
@@ -186,7 +188,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
     {
         AddElement,
         RemoveElement,
-        Clear,
+        Clear
     };
 
     struct ContainerActionButton : PropertyEditorDefinition

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -106,6 +106,10 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr auto Disabled = AttributeDefinition<bool>("Disabled");
         static constexpr auto ValueHashed = AttributeDefinition<AZ::Uuid>("ValueHashed");
 
+        //! In some cases, a node may need to know that it is descended from a disabled ancestor. For example, disabled
+        //! elements of a disabled container might requrie different treatment than disabled elements of an enabled container.
+        static constexpr auto AncestorDisabled = AttributeDefinition<bool>("AncestorDisabled");
+
         //! If set to true, specifies that this PropertyEditor shouldn't be allocated its own column, but instead appended
         //! to the previous column in the layout, creating a SharedColumn that can hold many PropertyEditors.
         //! Useful for things like the "add container entry" button.

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -159,6 +159,7 @@ namespace AZ::Reflection
                 bool m_skipLabel = false;
                 AZStd::string m_labelOverride;
                 bool m_disableEditor = false;
+                bool m_isAncestorDisabled = false;
 
                 // extra data necessary to support Containers composed of pair<> children (like maps!)
                 bool m_extractKeyedPair = false;
@@ -263,6 +264,22 @@ namespace AZ::Reflection
                 StackEntry* nodeData = &m_stack.back();
                 nodeData->m_path = AZStd::move(path);
 
+                // If our parent node is disabled then we should inherit its Disabled attribute and make note of the inheritance
+                if (parentData.m_disableEditor)
+                {
+                    nodeData->m_disableEditor = true;
+                    nodeData->m_isAncestorDisabled = true;
+                }
+                else if (classElement && classElement->m_editData)
+                {
+                    // If this node is ReadOnly then we want to add a Disabled attribute
+                    if (auto readOnlyAttribute = classElement->m_editData->FindAttribute(AZ::Crc32("ReadOnly")); readOnlyAttribute)
+                    {
+                        Dom::Value readOnlyValue = readOnlyAttribute->GetAsDomValue(instance);
+                        nodeData->m_disableEditor |= readOnlyValue.GetBool();
+                    }
+                }
+
                 if (parentAssociativeInterface)
                 {
                     if (nodeData->m_instance ==
@@ -353,16 +370,6 @@ namespace AZ::Reflection
                             nodeData->m_entryClosed = true;
                             return true;
                         }
-                    }
-                }
-
-                // If the node has a ReadOnly attribute then we want to store it as a Disabled attribute for the DPE
-                if (classElement && classElement->m_editData)
-                {
-                    if (auto readOnlyAttribute = classElement->m_editData->FindAttribute(AZ::Crc32("ReadOnly")); readOnlyAttribute)
-                    {
-                        Dom::Value readOnlyValue = readOnlyAttribute->GetAsDomValue(instance);
-                        nodeData->m_disableEditor |= readOnlyValue.GetBool();
                     }
                 }
 
@@ -693,6 +700,12 @@ namespace AZ::Reflection
                 {
                     nodeData.m_cachedAttributes.push_back(
                         { group, AZ::DocumentPropertyEditor::Nodes::PropertyEditor::Disabled.GetName(), Dom::Value(true) });
+                }
+
+                if (nodeData.m_isAncestorDisabled)
+                {
+                    nodeData.m_cachedAttributes.push_back(
+                        { group, AZ::DocumentPropertyEditor::Nodes::PropertyEditor::AncestorDisabled.GetName(), Dom::Value(true) });
                 }
 
                 if (nodeData.m_classData->m_container)

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -355,6 +355,17 @@ namespace AZ::Reflection
                         }
                     }
                 }
+
+                // If the node has a ReadOnly attribute then we want to store it as a Disabled attribute for the DPE
+                if (classElement && classElement->m_editData)
+                {
+                    if (auto readOnlyAttribute = classElement->m_editData->FindAttribute(AZ::Crc32("ReadOnly")); readOnlyAttribute)
+                    {
+                        Dom::Value readOnlyValue = readOnlyAttribute->GetAsDomValue(instance);
+                        nodeData->m_disableEditor |= readOnlyValue.GetBool();
+                    }
+                }
+
                 CacheAttributes();
 
                 // Inherit the change notify attribute from our parent

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -264,15 +264,13 @@ namespace AZ::Reflection
                 StackEntry* nodeData = &m_stack.back();
                 nodeData->m_path = AZStd::move(path);
 
-                // If our parent node is disabled then we should inherit its Disabled attribute and make note of the inheritance
-                if (parentData.m_disableEditor)
+                // If our parent node is disabled then we should inherit its disabled state
+                if (parentData.m_disableEditor || parentData.m_isAncestorDisabled)
                 {
-                    nodeData->m_disableEditor = true;
                     nodeData->m_isAncestorDisabled = true;
                 }
                 else if (classElement && classElement->m_editData)
                 {
-                    // If this node is ReadOnly then we want to add a Disabled attribute
                     if (auto readOnlyAttribute = classElement->m_editData->FindAttribute(AZ::Crc32("ReadOnly")); readOnlyAttribute)
                     {
                         Dom::Value readOnlyValue = readOnlyAttribute->GetAsDomValue(instance);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -347,6 +347,11 @@ namespace AZ::DocumentPropertyEditor
                     m_builder.Attribute(Nodes::PropertyEditor::UseMinimumWidth, true);
                     m_builder.Attribute(Nodes::PropertyEditor::Alignment, Nodes::PropertyEditor::Align::AlignRight);
                     m_builder.Attribute(Nodes::ContainerActionButton::Action, Nodes::ContainerAction::RemoveElement);
+                    auto disabledValue = attributes.Find(DocumentPropertyEditor::Nodes::PropertyEditor::AncestorDisabled.GetName());
+                    if (disabledValue.GetBool())
+                    {
+                        m_builder.Attribute(Nodes::PropertyEditor::Disabled, true);
+                    }
                     m_builder.AddMessageHandler(m_adapter, Nodes::ContainerActionButton::OnActivate.GetName());
                     m_builder.EndPropertyEditor();
                 }
@@ -423,9 +428,15 @@ namespace AZ::DocumentPropertyEditor
 
                     if (!container->IsFixedSize())
                     {
+                        bool isDisabled = attributes.Find(DocumentPropertyEditor::Nodes::PropertyEditor::Disabled.GetName()).GetBool();
+
                         m_builder.BeginPropertyEditor<Nodes::ContainerActionButton>();
                         m_builder.Attribute(Nodes::ContainerActionButton::Action, Nodes::ContainerAction::AddElement);
                         m_builder.Attribute(Nodes::PropertyEditor::UseMinimumWidth, true);
+                        if (isDisabled)
+                        {
+                            m_builder.Attribute(Nodes::PropertyEditor::Disabled, true);
+                        }
                         m_builder.AddMessageHandler(m_adapter, Nodes::ContainerActionButton::OnActivate.GetName());
                         m_builder.EndPropertyEditor();
 
@@ -434,6 +445,10 @@ namespace AZ::DocumentPropertyEditor
                         m_builder.Attribute(Nodes::PropertyEditor::UseMinimumWidth, true);
                         m_builder.Attribute(Nodes::PropertyEditor::Alignment, Nodes::PropertyEditor::Align::AlignRight);
                         m_builder.Attribute(Nodes::ContainerActionButton::Action, Nodes::ContainerAction::Clear);
+                        if (isDisabled)
+                        {
+                            m_builder.Attribute(Nodes::PropertyEditor::Disabled, true);
+                        }
                         m_builder.AddMessageHandler(m_adapter, Nodes::ContainerActionButton::OnActivate.GetName());
                         m_builder.EndPropertyEditor();
                     }

--- a/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
@@ -85,6 +85,7 @@ namespace DPEDebugView
         double m_doubleSlider = 3.25;
         AZStd::vector<AZStd::string> m_vector;
         AZStd::map<AZStd::string, float> m_map;
+        AZStd::map<AZStd::string, float> m_readOnlyMap;
         AZStd::unordered_map<AZStd::pair<int, double>, int> m_unorderedMap;
         AZStd::unordered_map<EnumType, int> m_simpleEnum;
         AZStd::unordered_map<EnumType, double> m_immutableEnum;
@@ -106,6 +107,7 @@ namespace DPEDebugView
                     ->Field("doubleSlider", &TestContainer::m_doubleSlider)
                     ->Field("vector", &TestContainer::m_vector)
                     ->Field("map", &TestContainer::m_map)
+                    ->Field("map", &TestContainer::m_readOnlyMap)
                     ->Field("unorderedMap", &TestContainer::m_unorderedMap)
                     ->Field("simpleEnum", &TestContainer::m_simpleEnum)
                     ->Field("immutableEnum", &TestContainer::m_immutableEnum)
@@ -164,6 +166,9 @@ namespace DPEDebugView
                         ->Attribute(AZ::Edit::Attributes::AcceptsMultiEdit, true)
                         ->ClassElement(AZ::Edit::ClassElements::Group, "ReadOnly")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_readOnlyInt, "readonly int", "")
+                        ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_readOnlyMap, "readonly map<string, float>", "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->Attribute(AZ::Edit::Attributes::ReadOnly, true);
                 }
             }
@@ -223,6 +228,10 @@ int main(int argc, char** argv)
     testContainer.m_map["One"] = 1.f;
     testContainer.m_map["Two"] = 2.f;
     testContainer.m_map["million"] = 1000000.f;
+
+    testContainer.m_readOnlyMap["A"] = 1.f;
+    testContainer.m_readOnlyMap["B"] = 2.f;
+    testContainer.m_readOnlyMap["C"] = 3.f;
 
     testContainer.m_unorderedMap[{1, 2.}] = 3;
     testContainer.m_unorderedMap[{ 4, 5. }] = 6;

--- a/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
@@ -81,6 +81,7 @@ namespace DPEDebugView
         }
 
         int m_simpleInt = 5;
+        int m_readOnlyInt = 33;
         double m_doubleSlider = 3.25;
         AZStd::vector<AZStd::string> m_vector;
         AZStd::map<AZStd::string, float> m_map;
@@ -101,6 +102,7 @@ namespace DPEDebugView
             {
                 serializeContext->Class<TestContainer>()
                     ->Field("simpleInt", &TestContainer::m_simpleInt)
+                    ->Field("readonlyInt", &TestContainer::m_readOnlyInt)
                     ->Field("doubleSlider", &TestContainer::m_doubleSlider)
                     ->Field("vector", &TestContainer::m_vector)
                     ->Field("map", &TestContainer::m_map)
@@ -159,7 +161,10 @@ namespace DPEDebugView
                         ->UIElement(AZ::Edit::UIHandlers::Button, "")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &Button2)
                         ->Attribute(AZ::Edit::Attributes::ButtonText, "Button 2 (should be at bottom)")
-                        ->Attribute(AZ::Edit::Attributes::AcceptsMultiEdit, true);
+                        ->Attribute(AZ::Edit::Attributes::AcceptsMultiEdit, true)
+                        ->ClassElement(AZ::Edit::ClassElements::Group, "ReadOnly")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_readOnlyInt, "readonly int", "")
+                        ->Attribute(AZ::Edit::Attributes::ReadOnly, true);
                 }
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -664,165 +664,76 @@ namespace AzToolsFramework
 
     void DPERowWidget::SetPropertyEditorAttributes(size_t domIndex, const AZ::Dom::Value& domArray, QWidget* childWidget)
     {
-        // Extract all attributes from dom value
-        auto alignment = AZ::Dpe::Nodes::PropertyEditor::Alignment.ExtractFromDomNode(domArray).value_or(
-            AZ::Dpe::Nodes::PropertyEditor::Align::UseDefaultAlignment);
-        auto sharePrior = AZ::Dpe::Nodes::PropertyEditor::SharePriorColumn.ExtractFromDomNode(domArray).value_or(false);
-        auto minimumWidth = AZ::Dpe::Nodes::PropertyEditor::UseMinimumWidth.ExtractFromDomNode(domArray).value_or(false);
-        auto descriptionString = AZ::Dpe::Nodes::PropertyEditor::Description.ExtractFromDomNode(domArray).value_or("");
-        auto shouldDisable = AZ::Dpe::Nodes::PropertyEditor::Disabled.ExtractFromDomNode(domArray).value_or(false);
+        AttributeInfo updatedInfo;
 
-        // Check for a widget in the previous column
-        int priorColumnIndex = -1;
-        for (int searchIndex = static_cast<int>(domIndex) - 1; (priorColumnIndex == -1 && searchIndex >= 0); --searchIndex)
+        // Extract all attributes from dom value
+        updatedInfo.m_alignment = AZ::Dpe::Nodes::PropertyEditor::Alignment.ExtractFromDomNode(domArray).value_or(
+            AZ::Dpe::Nodes::PropertyEditor::Align::UseDefaultAlignment);
+        updatedInfo.m_sharePriorColumn = AZ::Dpe::Nodes::PropertyEditor::SharePriorColumn.ExtractFromDomNode(domArray).value_or(false);
+        updatedInfo.m_minimumWidth = AZ::Dpe::Nodes::PropertyEditor::UseMinimumWidth.ExtractFromDomNode(domArray).value_or(false);
+        updatedInfo.m_descriptionString = AZ::Dpe::Nodes::PropertyEditor::Description.ExtractFromDomNode(domArray).value_or("");
+        updatedInfo.m_isDisabled = AZ::Dpe::Nodes::PropertyEditor::Disabled.ExtractFromDomNode(domArray).value_or(false) ||
+            AZ::Dpe::Nodes::PropertyEditor::AncestorDisabled.ExtractFromDomNode(domArray).value_or(false);
+
+        AttributeInfo currentInfo;
+        auto attributeIter = m_domOrderToAttributeInfo.find(domIndex);
+        if (attributeIter != m_domOrderToAttributeInfo.end())
         {
-            priorColumnIndex = m_columnLayout->indexOf(m_domOrderedChildren[searchIndex]);
+            currentInfo = m_domOrderToAttributeInfo[domIndex];
         }
 
-        auto foundEntry = m_domOrderToAttributeInfo.find(domIndex);
-
-        // If there is no existing attribute entry in the map, try to create a new one
-        if (foundEntry == m_domOrderToAttributeInfo.end())
+        if (updatedInfo.m_sharePriorColumn != currentInfo.m_sharePriorColumn)
         {
-            bool validAttribute = false;
-            AttributeInfo* newAttribute = new AttributeInfo;
-
-            // Check Alignment
-            if (alignment != AZ::Dpe::Nodes::PropertyEditor::Align::UseDefaultAlignment)
+            if (updatedInfo.m_sharePriorColumn)
             {
-                newAttribute->m_alignment = alignment;
-                validAttribute = true;
-            }
+                // Check for a widget in the previous column
+                int priorColumnIndex = -1;
+                for (int searchIndex = static_cast<int>(domIndex) - 1; (priorColumnIndex == -1 && searchIndex >= 0); --searchIndex)
+                {
+                    priorColumnIndex = m_columnLayout->indexOf(m_domOrderedChildren[searchIndex]);
+                }
 
-            // Check SharePrior
-            if (sharePrior)
-            {
                 AZ_Assert(priorColumnIndex != -1, "Tried to share column with an out of bounds index!");
                 if (priorColumnIndex != -1)
                 {
                     m_columnLayout->AddSharePriorColumn(priorColumnIndex, domIndex);
-                    newAttribute->m_sharePriorColumn = true;
-                    validAttribute = true;
                 }
             }
-            // Check MinimumWidth
-            if (minimumWidth)
+            else
             {
-                newAttribute->m_minimumWidth = true;
-                validAttribute = true;
-            }
-
-            // Check DescriptionString
-            if (!descriptionString.empty())
-            {
-                if (toolTip().isEmpty())
-                {
-                    setToolTip(QString::fromUtf8(descriptionString.data(), aznumeric_cast<int>(descriptionString.size())));
-                }
-                if (childWidget->toolTip().isEmpty())
-                {
-                    setToolTip(QString::fromUtf8(descriptionString.data(), aznumeric_cast<int>(descriptionString.size())));
-                }
-                newAttribute->m_descriptionString = descriptionString;
-                validAttribute = true;
-            }
-
-            // Check Disabled
-            if (shouldDisable)
-            {
-                childWidget->setEnabled(false);
-                validAttribute = true;
-            }
-
-            // If there are any valid attributes, add the new entry to the map
-            if (validAttribute)
-            {
-                m_domOrderToAttributeInfo[domIndex] = newAttribute;
+                m_columnLayout->RemoveSharePriorColumn(domIndex);
             }
         }
 
-        // If an attribute entry already exists at this index, either update it or remove it
-        else if (foundEntry != m_domOrderToAttributeInfo.end())
+        if (updatedInfo.m_descriptionString != currentInfo.m_descriptionString)
         {
-            // If none of the extracted attributes are valid, delete the attribute entry at this index
-            if (alignment == AZ::Dpe::Nodes::PropertyEditor::Align::UseDefaultAlignment && !sharePrior && !minimumWidth &&
-                descriptionString.empty() && !shouldDisable)
-            {
-                m_columnLayout->RemoveSharePriorColumn(domIndex);
-                m_domOrderToAttributeInfo.erase(foundEntry);
-            }
-            // At least one attribute is valid, check if we need to update the existing attribute entry
-            else
-            {
-                // Check Alignment
-                if (alignment != foundEntry->second->m_alignment)
-                {
-                    foundEntry->second->m_alignment = alignment;
-                }
+            setToolTip(QString::fromUtf8(updatedInfo.m_descriptionString.data(),
+                aznumeric_cast<int>(updatedInfo.m_descriptionString.size())));
+            childWidget->setToolTip(QString::fromUtf8(updatedInfo.m_descriptionString.data(),
+                aznumeric_cast<int>(updatedInfo.m_descriptionString.size())));
+        }
 
-                // Check SharePrior
-                if (sharePrior && !foundEntry->second->m_sharePriorColumn)
-                {
-                    AZ_Assert(priorColumnIndex != -1, "Tried to share column with an out of bounds index!");
-                    if (priorColumnIndex != -1)
-                    {
-                        m_columnLayout->AddSharePriorColumn(priorColumnIndex, domIndex);
-                        foundEntry->second->m_sharePriorColumn = true;
-                    }
-                }
-                else if (!sharePrior && foundEntry->second->m_sharePriorColumn)
-                {
-                    m_columnLayout->RemoveSharePriorColumn(domIndex);
-                    foundEntry->second->m_sharePriorColumn = false;
-                }
+        if (updatedInfo.m_isDisabled != currentInfo.m_isDisabled)
+        {
+            childWidget->setEnabled(!updatedInfo.m_isDisabled);
+        }
 
-                // Check MinimumWidth
-                if (minimumWidth != foundEntry->second->m_minimumWidth)
-                {
-                    foundEntry->second->m_minimumWidth = minimumWidth;
-                }
-
-                // Check DescriptionString
-                if (descriptionString.empty() && !foundEntry->second->m_descriptionString.empty())
-                {
-                    if (!toolTip().isEmpty())
-                    {
-                        setToolTip(QString());
-                    }
-                    if (!childWidget->toolTip().isEmpty())
-                    {
-                        childWidget->setToolTip(QString());
-                    }
-                    foundEntry->second->m_descriptionString = "";
-                }
-                else if (!descriptionString.empty() && foundEntry->second->m_descriptionString.empty())
-                {
-                    if (toolTip().isEmpty())
-                    {
-                        setToolTip(QString::fromUtf8(descriptionString.data(), aznumeric_cast<int>(descriptionString.size())));
-                    }
-                    if (childWidget->toolTip().isEmpty())
-                    {
-                        childWidget->setToolTip(QString::fromUtf8(descriptionString.data(), aznumeric_cast<int>(descriptionString.size())));
-                    }
-                    foundEntry->second->m_descriptionString = descriptionString;
-                }
-
-                // Check Disabled
-                if (shouldDisable != foundEntry->second->m_shouldDisable)
-                {
-                    foundEntry->second->m_shouldDisable = shouldDisable;
-                }
-            }
+        if (attributeIter != m_domOrderToAttributeInfo.end() && updatedInfo.IsDefault())
+        {
+            m_domOrderToAttributeInfo.erase(attributeIter);
+        }
+        else
+        {
+            m_domOrderToAttributeInfo[domIndex] = updatedInfo;
         }
     }
 
-    AzToolsFramework::DPERowWidget::AttributeInfo* DPERowWidget::GetAttributes(size_t domIndex)
+    DPERowWidget::AttributeInfo* DPERowWidget::GetAttributes(size_t domIndex)
     {
         auto foundEntry = m_domOrderToAttributeInfo.find(domIndex);
         if (foundEntry != m_domOrderToAttributeInfo.end())
         {
-            return foundEntry->second;
+            return &foundEntry->second;
         }
         else
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -676,10 +676,10 @@ namespace AzToolsFramework
             AZ::Dpe::Nodes::PropertyEditor::AncestorDisabled.ExtractFromDomNode(domArray).value_or(false);
 
         AttributeInfo currentInfo;
-        auto attributeIter = m_domOrderToAttributeInfo.find(domIndex);
-        if (attributeIter != m_domOrderToAttributeInfo.end())
+        auto attributeIter = m_childIndexToAttributeInfo.find(domIndex);
+        if (attributeIter != m_childIndexToAttributeInfo.end())
         {
-            currentInfo = m_domOrderToAttributeInfo[domIndex];
+            currentInfo = m_childIndexToAttributeInfo[domIndex];
         }
 
         if (updatedInfo.m_sharePriorColumn != currentInfo.m_sharePriorColumn)
@@ -718,20 +718,20 @@ namespace AzToolsFramework
             childWidget->setEnabled(!updatedInfo.m_isDisabled);
         }
 
-        if (attributeIter != m_domOrderToAttributeInfo.end() && updatedInfo.IsDefault())
+        if (attributeIter != m_childIndexToAttributeInfo.end() && updatedInfo.IsDefault())
         {
-            m_domOrderToAttributeInfo.erase(attributeIter);
+            m_childIndexToAttributeInfo.erase(attributeIter);
         }
         else
         {
-            m_domOrderToAttributeInfo[domIndex] = updatedInfo;
+            m_childIndexToAttributeInfo[domIndex] = updatedInfo;
         }
     }
 
     DPERowWidget::AttributeInfo* DPERowWidget::GetAttributes(size_t domIndex)
     {
-        auto foundEntry = m_domOrderToAttributeInfo.find(domIndex);
-        if (foundEntry != m_domOrderToAttributeInfo.end())
+        auto foundEntry = m_childIndexToAttributeInfo.find(domIndex);
+        if (foundEntry != m_childIndexToAttributeInfo.end())
         {
             return &foundEntry->second;
         }
@@ -743,17 +743,17 @@ namespace AzToolsFramework
 
     void DPERowWidget::RemoveAttributes(size_t domIndex)
     {
-        auto foundEntry = m_domOrderToAttributeInfo.find(domIndex);
-        if (foundEntry != m_domOrderToAttributeInfo.end())
+        auto foundEntry = m_childIndexToAttributeInfo.find(domIndex);
+        if (foundEntry != m_childIndexToAttributeInfo.end())
         {
-            m_domOrderToAttributeInfo.erase(foundEntry);
+            m_childIndexToAttributeInfo.erase(foundEntry);
             m_columnLayout->RemoveSharePriorColumn(domIndex);
         }
     }
 
     void DPERowWidget::ClearAttributes()
     {
-        m_domOrderToAttributeInfo.clear();
+        m_childIndexToAttributeInfo.clear();
         for (AZStd::vector<size_t> sharedGroup : m_columnLayout->m_sharePriorColumn)
         {
             sharedGroup.clear();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -164,7 +164,7 @@ namespace AzToolsFramework
                     !m_isDisabled;
             }
         };
-        AZStd::unordered_map<size_t, AttributeInfo> m_domOrderToAttributeInfo;
+        AZStd::unordered_map<size_t, AttributeInfo> m_childIndexToAttributeInfo;
         AttributeInfo* GetAttributes(size_t domIndex);
 
         // row attributes extracted from the DOM

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -152,10 +152,19 @@ namespace AzToolsFramework
             AZ::Dpe::Nodes::PropertyEditor::Align m_alignment = AZ::Dpe::Nodes::PropertyEditor::Align::UseDefaultAlignment;
             bool m_sharePriorColumn = false;
             bool m_minimumWidth = false;
-            AZStd::string_view m_descriptionString = "";
-            bool m_shouldDisable = false;
+            AZStd::string_view m_descriptionString = {};
+            bool m_isDisabled = false;
+
+            bool IsDefault() const
+            {
+                return m_alignment == AZ::Dpe::Nodes::PropertyEditor::Align::UseDefaultAlignment &&
+                    !m_sharePriorColumn &&
+                    !m_minimumWidth &&
+                    m_descriptionString.empty() &&
+                    !m_isDisabled;
+            }
         };
-        AZStd::unordered_map<size_t, AttributeInfo*> m_domOrderToAttributeInfo;
+        AZStd::unordered_map<size_t, AttributeInfo> m_domOrderToAttributeInfo;
         AttributeInfo* GetAttributes(size_t domIndex);
 
         // row attributes extracted from the DOM


### PR DESCRIPTION
**Description**
This PR adds support to the DPE for the `AZ::Edit::Attributes::Readonly` attribute. Nodes with this attribute set will be disabled when their property handler widget is created in `DPERowWidget::CreateWidgetForHandler`.

Any existing ReadOnly attribute will be detected per node and its value stored in the node's disabled flag prior to caching attributes in the LegacyReflectionBridge. When caching attributes, we already check if the node should be disabled (as is the case with set data structures) hence we roll the legacy ReadOnly attribute into our DPE Disabled attribute. Also, child nodes of disabled parents will inherit the Disabled attribute and elements of ReadOnly containers will disable their container action buttons.

Box 1 in the image below shows that non-readonly set elements are unaffected by this change. Box 2 shows that the legacy ReadOnly attribute can be applied to simple property editor nodes and to entire containers:


![dpe_disabledEditors](https://user-images.githubusercontent.com/104796591/194473713-373c7036-3396-4510-a0be-a9c551cc0f4c.jpg)

**Updates since originally approved**
- Added support for applying/removing the Disabled and AncestorDisabled attributes at runtime
  - There is now a `CallbackAttributeDefinition` called `SetDisabled` that is added to property editors built in the `ReflectionAdapter`
  - There is also a handler for that callback attribute in `ReflectionAdapter::HandleMessage`, in the lambda `handlePropertyEditorDisabledChanged`, that handles the three main cases we run into:
    - disabling a node and propagating to its descendants
    - enabling a node and removing the ancestor disabled state of its descendants
    - disabling an element of a container
- Refactored the attribute updating code inside of `DPERowWidget::SetPropertyEditorAttributes` in order to fix some troubles with refreshing re-enabled nodes in the view

Here you can see the state changes propagating in the view and their respective DOM changes (expand to view properly):
![dpeReadOnlyRuntimeInheritance](https://user-images.githubusercontent.com/104796591/199871132-af1a307f-9ebf-42d9-9934-2fb433717b4c.gif)

**Testing**
- Added some ReadOnly nodes to the standalone debug DPE app and verified that they are non-editable
- Verified that non-ReadOnly set containers functionality is unchanged by this PR
- Created a temp button that toggled the disabled state of a node and verified that the two disabled states are propagated correctly and interact with each other correctly (a disabled node should remain so when its parent becomes enabled, etc.)
- Verified there were no unexpected errors/assertions in a debug build of the standalone debug DPE

Signed-off-by: Ryan <ryanto@amazon.com>