### PR TITLE
Asset Processor - Fix crash on editor startup due to missing assets

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
@@ -318,7 +318,7 @@ namespace AzFramework
 
         return AZ::Success(itr->second);
     }
-    
+
     AZ::Outcome<AZStd::vector<AZ::Data::ProductDependency>, AZStd::string> AssetCatalog::GetAllProductDependencies(const AZ::Data::AssetId& id)
     {
         return GetAllProductDependenciesFilter(id, {}, {});
@@ -405,7 +405,7 @@ namespace AzFramework
         return AZStd::wildcard_match(wildcardPattern, relativePath);
     }
 
-    bool AssetCatalog::DoesAssetIdMatchWildcardPattern(const AZ::Data::AssetId& assetId, const AZStd::string& wildcardPattern) 
+    bool AssetCatalog::DoesAssetIdMatchWildcardPattern(const AZ::Data::AssetId& assetId, const AZStd::string& wildcardPattern)
     {
         return DoesAssetIdMatchWildcardPatternInternal(assetId, wildcardPattern);
     }
@@ -542,7 +542,7 @@ namespace AzFramework
     {
         bool shouldBroadcast = false;
         {
-            // this scope controls the below lock guard, do not remove this scope.  
+            // this scope controls the below lock guard, do not remove this scope.
             // the lock must expire before we send out notifications to other systems.
             AZStd::lock_guard<AZStd::recursive_mutex> lock(m_registryMutex);
 
@@ -808,96 +808,118 @@ namespace AzFramework
     // note that this function is called from within a network job thread in order to update
     // the catalog as soon as new data is available, before other systems try to reach in and query
     // the results.  For this reason, it is a direct call and protects its structures with a lock.
-    void AssetCatalog::AssetChanged(AzFramework::AssetSystem::AssetNotificationMessage message)
+    void AssetCatalog::AssetChanged(const AZStd::vector<AzFramework::AssetSystem::AssetNotificationMessage>& messages, bool isCatalogInitialize)
     {
-        AZStd::string relativePath = message.m_data;
-        EBUS_EVENT(AzFramework::ApplicationRequests::Bus, MakePathAssetRootRelative, relativePath);
-
-        AZ::Data::AssetId assetId = message.m_assetId;
-
-        AZStd::string extension;
-        AzFramework::StringFunc::Path::GetExtension(relativePath.c_str(), extension, false);
-        if (assetId.IsValid())
+        for (const auto& message : messages)
         {
-            bool isNewAsset = false;
+            AZStd::string relativePath = message.m_data;
+            EBUS_EVENT(AzFramework::ApplicationRequests::Bus, MakePathAssetRootRelative, relativePath);
+
+            AZ::Data::AssetId assetId = message.m_assetId;
+
+            AZStd::string extension;
+            AzFramework::StringFunc::Path::GetExtension(relativePath.c_str(), extension, false);
+            if (assetId.IsValid())
             {
-                // this scope controls the below lock guard, do not remove this scope.  
-                // the lock must expire before we send out notifications to other systems.
-                AZStd::lock_guard<AZStd::recursive_mutex> lock(m_registryMutex);
-
-                // is it an add or a change?
-                auto assetInfoPair = m_registry->m_assetIdToInfo.find(assetId);
-                isNewAsset = (assetInfoPair == m_registry->m_assetIdToInfo.end());
-
-    #if defined(AZ_ENABLE_TRACING)
-                if (message.m_assetType == AZ::Data::s_invalidAssetType)
+                bool isNewAsset = false;
                 {
-                    AZ_TracePrintf("AssetCatalog", "Registering asset \"%s\" via AssetSystem message, but type is not set.\n", relativePath.c_str());
-                }
-    #endif
+                    // this scope controls the below lock guard, do not remove this scope.
+                    // the lock must expire before we send out notifications to other systems.
+                    AZStd::lock_guard<AZStd::recursive_mutex> lock(m_registryMutex);
 
-                const AZ::Data::AssetType& assetType = isNewAsset ? message.m_assetType : assetInfoPair->second.m_assetType;
+                    // is it an add or a change?
+                    auto assetInfoPair = m_registry->m_assetIdToInfo.find(assetId);
+                    isNewAsset = (assetInfoPair == m_registry->m_assetIdToInfo.end());
 
-                AZ::Data::AssetInfo newData;
-                newData.m_assetId = assetId;
-                newData.m_assetType = assetType;
-                newData.m_relativePath = message.m_data;
-                newData.m_sizeBytes = message.m_sizeBytes;
-
-                m_registry->RegisterAsset(assetId, newData);
-                m_registry->SetAssetDependencies(assetId, message.m_dependencies);
-
-                for (const auto& mapping : message.m_legacyAssetIds)
-                {
-                    m_registry->RegisterLegacyAssetMapping(mapping, assetId);
-                }
-            }
-            if (!isNewAsset)
-            {
-                // the following deliveries must happen on the main thread of the application:
-                AZ::SystemTickBus::QueueFunction([assetId]() 
-                {
-                    AzFramework::AssetCatalogEventBus::Broadcast(&AzFramework::AssetCatalogEventBus::Events::OnCatalogAssetChanged, assetId);
-                });
-
-                // in case someone has an ancient reference, notify on that too.
-                for (const auto& mapping : message.m_legacyAssetIds)
-                {
-                    AZ::SystemTickBus::QueueFunction([mapping]()
+                    if (!isNewAsset && isCatalogInitialize)
                     {
-                        AzFramework::AssetCatalogEventBus::Broadcast(&AzFramework::AssetCatalogEventBus::Events::OnCatalogAssetChanged, mapping);
-                    });
-                    
+                        // Nothing to do here - catalog initialize messages are intended to sync with the AP catalog.
+                        // Since this asset is already known, just stop processing to avoid triggering reloads.
+                        return;
+                    }
+
+#if defined(AZ_ENABLE_TRACING)
+                    if (message.m_assetType == AZ::Data::s_invalidAssetType)
+                    {
+                        AZ_TracePrintf(
+                            "AssetCatalog",
+                            "Registering asset \"%s\" via AssetSystem message, but type is not set.\n",
+                            relativePath.c_str());
+                    }
+#endif
+
+                    const AZ::Data::AssetType& assetType = isNewAsset ? message.m_assetType : assetInfoPair->second.m_assetType;
+
+                    AZ::Data::AssetInfo newData;
+                    newData.m_assetId = assetId;
+                    newData.m_assetType = assetType;
+                    newData.m_relativePath = message.m_data;
+                    newData.m_sizeBytes = message.m_sizeBytes;
+
+                    m_registry->RegisterAsset(assetId, newData);
+                    m_registry->SetAssetDependencies(assetId, message.m_dependencies);
+
+                    for (const auto& mapping : message.m_legacyAssetIds)
+                    {
+                        m_registry->RegisterLegacyAssetMapping(mapping, assetId);
+                    }
+                }
+                if (!isNewAsset)
+                {
+                    // the following deliveries must happen on the main thread of the application:
+                    AZ::SystemTickBus::QueueFunction(
+                        [assetId]()
+                        {
+                            AzFramework::AssetCatalogEventBus::Broadcast(
+                                &AzFramework::AssetCatalogEventBus::Events::OnCatalogAssetChanged, assetId);
+                        });
+
+                    // in case someone has an ancient reference, notify on that too.
+                    for (const auto& mapping : message.m_legacyAssetIds)
+                    {
+                        AZ::SystemTickBus::QueueFunction(
+                            [mapping]()
+                            {
+                                AzFramework::AssetCatalogEventBus::Broadcast(
+                                    &AzFramework::AssetCatalogEventBus::Events::OnCatalogAssetChanged, mapping);
+                            });
+                    }
+                }
+                else
+                {
+                    AZ::SystemTickBus::QueueFunction(
+                        [assetId]()
+                        {
+                            AzFramework::AssetCatalogEventBus::Broadcast(
+                                &AzFramework::AssetCatalogEventBus::Events::OnCatalogAssetAdded, assetId);
+                        });
+                    for (const auto& mapping : message.m_legacyAssetIds)
+                    {
+                        AZ::SystemTickBus::QueueFunction(
+                            [mapping]()
+                            {
+                                AzFramework::AssetCatalogEventBus::Broadcast(
+                                    &AzFramework::AssetCatalogEventBus::Events::OnCatalogAssetAdded, mapping);
+                            });
+                    }
+                }
+
+                AzFramework::LegacyAssetEventBus::QueueEvent(
+                    AZ::Crc32(extension.c_str()), &AzFramework::LegacyAssetEventBus::Events::OnFileChanged, relativePath);
+
+                if (AZ::Data::AssetManager::IsReady())
+                {
+                    AZ::SystemTickBus::QueueFunction(
+                        [assetId]()
+                        {
+                            AZ::Data::AssetManager::Instance().ReloadAsset(assetId, AZ::Data::AssetLoadBehavior::Default, true);
+                        });
                 }
             }
             else
             {
-                AZ::SystemTickBus::QueueFunction([assetId]()
-                {
-                    AzFramework::AssetCatalogEventBus::Broadcast(&AzFramework::AssetCatalogEventBus::Events::OnCatalogAssetAdded, assetId);
-                });
-                for (const auto& mapping : message.m_legacyAssetIds)
-                {
-                    AZ::SystemTickBus::QueueFunction([mapping]()
-                    {
-                        AzFramework::AssetCatalogEventBus::Broadcast(&AzFramework::AssetCatalogEventBus::Events::OnCatalogAssetAdded, mapping);
-                    });
-                }
+                AZ_TracePrintf("AssetCatalog", "AssetChanged: invalid asset id: %s\n", assetId.ToString<AZStd::string>().c_str());
             }
-
-            AzFramework::LegacyAssetEventBus::QueueEvent(AZ::Crc32(extension.c_str()), &AzFramework::LegacyAssetEventBus::Events::OnFileChanged, relativePath);
-            
-            if (AZ::Data::AssetManager::IsReady())
-            {
-                AZ::SystemTickBus::QueueFunction([assetId]()
-                {
-                    AZ::Data::AssetManager::Instance().ReloadAsset(assetId, AZ::Data::AssetLoadBehavior::Default, true);
-                });
-            }
-        }
-        else
-        {
-            AZ_TracePrintf("AssetCatalog", "AssetChanged: invalid asset id: %s\n", assetId.ToString<AZStd::string>().c_str());
         }
     }
 
@@ -907,30 +929,35 @@ namespace AzFramework
     // note that this function is called from within a network job thread in order to update
     // the catalog as soon as new data is available, before other systems try to reach in and query
     // the results.  For this reason, it is a direct call and protects its structures with a lock.
-    void AssetCatalog::AssetRemoved(AzFramework::AssetSystem::AssetNotificationMessage message)
+    void AssetCatalog::AssetRemoved(const AZStd::vector<AzFramework::AssetSystem::AssetNotificationMessage>& messages)
     {
-        AZStd::string relativePath = message.m_data;
-        AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::Bus::Events::MakePathAssetRootRelative, relativePath);
+        for (const auto& message : messages)
+        {
+            AZStd::string relativePath = message.m_data;
+            AzFramework::ApplicationRequests::Bus::Broadcast(
+                &AzFramework::ApplicationRequests::Bus::Events::MakePathAssetRootRelative, relativePath);
 
-        const AZ::Data::AssetId assetId = message.m_assetId;
-        if (assetId.IsValid())
-        {
-            AZStd::string extension;
-            AzFramework::StringFunc::Path::GetExtension(relativePath.c_str(), extension, false);
-            UnregisterAsset(assetId);
+            const AZ::Data::AssetId assetId = message.m_assetId;
+            if (assetId.IsValid())
             {
-                AZStd::lock_guard<AZStd::recursive_mutex> lock(m_registryMutex);
-                for (const auto& mapping : message.m_legacyAssetIds)
+                AZStd::string extension;
+                AzFramework::StringFunc::Path::GetExtension(relativePath.c_str(), extension, false);
+                UnregisterAsset(assetId);
                 {
-                    m_registry->UnregisterLegacyAssetMapping(mapping);
+                    AZStd::lock_guard<AZStd::recursive_mutex> lock(m_registryMutex);
+                    for (const auto& mapping : message.m_legacyAssetIds)
+                    {
+                        m_registry->UnregisterLegacyAssetMapping(mapping);
+                    }
                 }
+                // queue this for later delivery, since we are not on the main thread:
+                AzFramework::LegacyAssetEventBus::QueueEvent(
+                    AZ::Crc32(extension.c_str()), &AzFramework::LegacyAssetEventBus::Events::OnFileRemoved, relativePath);
             }
-            // queue this for later delivery, since we are not on the main thread:
-            AzFramework::LegacyAssetEventBus::QueueEvent(AZ::Crc32(extension.c_str()), &AzFramework::LegacyAssetEventBus::Events::OnFileRemoved, relativePath);
-        }
-        else
-        {
-            AZ_TracePrintf("AssetCatalog", "AssetRemoved: invalid asset id: %s\n", assetId.ToString<AZStd::string>().c_str());
+            else
+            {
+                AZ_TracePrintf("AssetCatalog", "AssetRemoved: invalid asset id: %s\n", assetId.ToString<AZStd::string>().c_str());
+            }
         }
     }
 
@@ -974,7 +1001,7 @@ namespace AzFramework
     //=========================================================================
     bool AssetCatalog::LoadCatalog(const char* catalogRegistryFile)
     {
-        // right before we load the catalog, make sure you are listening for update events, so that you don't miss any in the gap 
+        // right before we load the catalog, make sure you are listening for update events, so that you don't miss any in the gap
         // that happens AFTER the catalog is saved but BEFORE you start monitoring them:
         StartMonitoringAssets();
         {
@@ -988,7 +1015,7 @@ namespace AzFramework
     // ClearCatalog
     //=========================================================================
     void AssetCatalog::ClearCatalog()
-    {   
+    {
         {
             AZStd::lock_guard<AZStd::recursive_mutex> lock(m_deltaCatalogMutex);
             m_deltaCatalogList.clear();
@@ -1050,7 +1077,7 @@ namespace AzFramework
         m_deltaCatalogList.insert(m_deltaCatalogList.begin() + catalogIndex, deltaCatalog);
     }
 
-    AZStd::shared_ptr<AzFramework::AssetRegistry> AssetCatalog::LoadCatalogFromFile(const char* catalogFile) 
+    AZStd::shared_ptr<AzFramework::AssetRegistry> AssetCatalog::LoadCatalogFromFile(const char* catalogFile)
     {
         AZStd::shared_ptr<AzFramework::AssetRegistry> deltaCatalog;
         deltaCatalog.reset(AZ::Utils::LoadObjectFromFile<AzFramework::AssetRegistry>(catalogFile));
@@ -1081,7 +1108,7 @@ namespace AzFramework
     // InsertDeltaCatalog
     //=========================================================================
     bool AssetCatalog::InsertDeltaCatalogBefore(AZStd::shared_ptr<AzFramework::AssetRegistry> deltaCatalog, AZStd::shared_ptr<AzFramework::AssetRegistry> nextCatalog)
-    { 
+    {
         if (!nextCatalog)
         {
             AddDeltaCatalog(deltaCatalog);
@@ -1275,7 +1302,7 @@ namespace AzFramework
             for (const AZ::Data::ProductDependency& dependency : dependencyResult.GetValue())
             {
                 deltaRegistry.RegisterAssetDependency(asset, dependency);
-            }            
+            }
         }
         for (auto legacyToRealPair : m_registry->GetLegacyMappingSubsetFromRealIds(deltaPakAssetIds))
         {

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.h
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.h
@@ -27,7 +27,7 @@ namespace AzFramework
     /*
      * An asset catalog keeps a registry of asset data information (file name, size, type, etc)
      */
-    class AssetCatalog 
+    class AssetCatalog
         : public AZ::Data::AssetCatalog
         , public AZ::Data::AssetCatalogRequestBus::Handler
         , private AssetSystem::NetworkAssetUpdateInterface
@@ -98,8 +98,8 @@ namespace AzFramework
 
         //////////////////////////////////////////////////////////////////////////
         // NetworkAssetUpdateInterface
-        void AssetChanged(AzFramework::AssetSystem::AssetNotificationMessage message) override;
-        void AssetRemoved(AzFramework::AssetSystem::AssetNotificationMessage message) override;
+        void AssetChanged(const AZStd::vector<AzFramework::AssetSystem::AssetNotificationMessage>& messages, bool isCatalogInitialize = false) override;
+        void AssetRemoved(const AZStd::vector<AzFramework::AssetSystem::AssetNotificationMessage>& messages) override;
         //////////////////////////////////////////////////////////////////////////
 
         static AZStd::shared_ptr<AzFramework::AssetRegistry> LoadCatalogFromFile(const char* catalogFile);

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetProcessorMessages.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetProcessorMessages.cpp
@@ -148,7 +148,7 @@ namespace AzFramework
             : BaseAssetProcessorMessage(true)
             , m_assetUuid(assetUuid)
         {
-            
+
         }
 
         // these share the same message type since they're request and response.
@@ -620,7 +620,7 @@ namespace AzFramework
         }
 
         //---------------------------------------------------------------------
-        
+
         unsigned int ShowAssetInAssetProcessorRequest::GetMessageType() const
         {
             return MessageType;
@@ -1547,6 +1547,24 @@ namespace AzFramework
                     ->Field("legacyAssetIds", &AssetNotificationMessage::m_legacyAssetIds)
                     ->Field("dependencies", &AssetNotificationMessage::m_dependencies)
                     ->Field("platform", &AssetNotificationMessage::m_platform);
+            }
+        }
+
+        //----------------------------------------------------------------------------
+        unsigned int BulkAssetNotificationMessage::GetMessageType() const
+        {
+            return MessageType;
+        }
+
+        void BulkAssetNotificationMessage::Reflect(AZ::ReflectContext* context)
+        {
+            auto serialize = azrtti_cast<AZ::SerializeContext*>(context);
+            if (serialize)
+            {
+                serialize->Class<BulkAssetNotificationMessage, BaseAssetProcessorMessage>()
+                    ->Version(1)
+                    ->Field("Type", &BulkAssetNotificationMessage::m_type)
+                    ->Field("Messages", &BulkAssetNotificationMessage::m_messages);
             }
         }
 

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetProcessorMessages.h
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetProcessorMessages.h
@@ -643,7 +643,6 @@ namespace AzFramework
             unsigned int GetMessageType() const override;
 
             AssetNotificationMessage::NotificationType m_type;
-            AZStd::unordered_map<AZ::Data::AssetId, AZ::Data::AssetId> m_legacyAssetIdMap;
             AZStd::vector<AssetNotificationMessage> m_messages;
         };
 

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetProcessorMessages.h
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetProcessorMessages.h
@@ -41,10 +41,10 @@ namespace AzFramework
         bool UnpackMessage(const Buffer& buffer, Message& message)
         {
             AZ::IO::ByteContainerStream<const Buffer> byteStream(&buffer);
-            
+
             // load object from stream but note here that we do not allow any errors to occur since this is a message that is supposed
             // to be sent between matching server/client versions.
-            
+
             return AZ::Utils::LoadObjectFromStreamInPlace(byteStream, nullptr, message.RTTI_GetType(), &message, AZ::ObjectStream::FilterDescriptor(&AZ::Data::AssetFilterNoAssetLoading, AZ::ObjectStream::FILTERFLAG_STRICT));
         }
 
@@ -58,7 +58,7 @@ namespace AzFramework
             virtual unsigned int GetMessageType() const = 0;
             static void Reflect(AZ::ReflectContext* context);
             //! Some asset messages might require that the requests be evaluated by the asset processor only after the OS has send it a file notification regarding that asset,
-            //! Otherwise there could be a race condition and the asset request could be processed before the asset processor gets the file notification.To prevent this we create a fence file 
+            //! Otherwise there could be a race condition and the asset request could be processed before the asset processor gets the file notification.To prevent this we create a fence file
             //! and only evaluate the request after the asset processor picks up that fence file.We call this fencing.
             bool RequireFencing() const;
         private:
@@ -110,7 +110,7 @@ namespace AzFramework
             ResponsePing() = default;
             unsigned int GetMessageType() const override;
         };
-       
+
         //////////////////////////////////////////////////////////////////////////
         //!  Request the status of an asset or force one to compile
         class RequestAssetStatus
@@ -133,11 +133,11 @@ namespace AzFramework
             unsigned int GetMessageType() const override;
 
             AZ::OSString m_searchTerm; // some generic search term - can be parts of a name, or full name, of source file or product
-            AZ::Data::AssetId m_assetId; 
+            AZ::Data::AssetId m_assetId;
             bool m_isStatusRequest = false; // if this is true, it will only query status.  if false it will actually compile it.
             int m_searchType{ SearchType::Default };
         };
-        
+
         //! this will be sent in response to the RequestAssetStatus request
         class ResponseAssetStatus
             : public BaseAssetProcessorMessage
@@ -209,7 +209,7 @@ namespace AzFramework
             int m_numberOfPendingJobs; // number of copy jobs that are still pending
             bool m_isAssetProcessorReady = false;
         };
-        
+
         //////////////////////////////////////////////////////////////////////////
         struct GetUnresolvedDependencyCountsRequest
             : BaseAssetProcessorMessage
@@ -333,7 +333,7 @@ namespace AzFramework
             static void Reflect(AZ::ReflectContext* context);
 
             static constexpr unsigned int MessageType = AZ_CRC("AssetSystem::GetFullSourcePathFromRelativeProductPath", 0x08057afe);
-            
+
             GetFullSourcePathFromRelativeProductPathRequest() = default;
             GetFullSourcePathFromRelativeProductPathRequest(const AZ::OSString& relativeProductPath);
             unsigned int GetMessageType() const override;
@@ -376,7 +376,7 @@ namespace AzFramework
             * @param assetType This parameter is optional but could help detect problems with incorrect asset types being assigned to products.
             */
             explicit SourceAssetInfoRequest(const AZ::Data::AssetId& assetId, const AZ::Data::AssetType& assetType = AZ::Data::s_invalidAssetType);
-            
+
             //! You can also make a request with the relative or absolute path to the asset instead.  This always returns the source path.
             explicit SourceAssetInfoRequest(const char* assetPath);
 
@@ -626,6 +626,25 @@ namespace AzFramework
             AZStd::vector<AZ::Data::AssetId> m_legacyAssetIds; // if this asset was referred to by other legacy assetIds in the past, then they will be included here.
             AZ::Data::AssetType m_assetType = AZ::Data::s_invalidAssetType;
             AZStd::vector<AZ::Data::ProductDependency> m_dependencies;
+        };
+
+        // Bulk message for sending updates for multiple assets all at once.
+        // All updates must be of the same type and for the same platform.  The only supported types are AssetChanged and AssetRemoved.
+        class BulkAssetNotificationMessage
+            : public BaseAssetProcessorMessage
+        {
+        public:
+            AZ_CLASS_ALLOCATOR(BulkAssetNotificationMessage, AZ::OSAllocator, 0);
+            AZ_RTTI(BulkAssetNotificationMessage, "{D0BDFFA1-2E5A-4F37-A38D-26521ECAF812}", BaseAssetProcessorMessage);
+            static void Reflect(AZ::ReflectContext* context);
+            static constexpr unsigned int MessageType = AZ_CRC_CE("AssetProcessorManager::BulkAssetNotification"); // 1942440592U 0x73C74A90
+
+            BulkAssetNotificationMessage() = default;
+            unsigned int GetMessageType() const override;
+
+            AssetNotificationMessage::NotificationType m_type;
+            AZStd::unordered_map<AZ::Data::AssetId, AZ::Data::AssetId> m_legacyAssetIdMap;
+            AZStd::vector<AssetNotificationMessage> m_messages;
         };
 
         // SaveAssetCatalogRequest

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetRegistry.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetRegistry.cpp
@@ -107,7 +107,7 @@ namespace AzFramework
         // to achieve this we have two maps
         // one map which maps from [asset relative path] -> [Asset ID]
         // one map which maps from [Asset ID] -> [AssetInfo struct]
-        
+
         // whats important to note is that the [asset relative path] map, for performance and memory purposes, uses the
         // SHA1 hash of the [asset relative path] instead of storing strings.
         // this makes it take a fixed amount of space and a fixed amount of time to do a lookup
@@ -119,7 +119,7 @@ namespace AzFramework
         // because either way, there is an asset there, so it has to be added to both maps.  there will just be two entries
         // in the [Asset ID] -> [AssetInfo struct] that points at the same output file.  Notifying the user that this has occurred
         // should happen at a much higher level.
-        
+
         SetAssetIdByPath(assetInfo.m_relativePath.c_str(), id);
         m_assetIdToInfo.insert_key(id).first->second = assetInfo;
     }
@@ -138,7 +138,7 @@ namespace AzFramework
         {
             m_assetPathToId.erase(CreateUUIDForName(existingAsset->second.m_relativePath.c_str()));
         }
-        
+
         m_assetIdToInfo.erase(id);
         m_assetDependencies.erase(id);
     }
@@ -163,9 +163,16 @@ namespace AzFramework
         m_assetDependencies[id].push_back(dependency);
     }
 
-    AZStd::vector<AZ::Data::ProductDependency> AssetRegistry::GetAssetDependencies(const AZ::Data::AssetId& id)
+    AZStd::vector<AZ::Data::ProductDependency> AssetRegistry::GetAssetDependencies(const AZ::Data::AssetId& id) const
     {
-        return m_assetDependencies[id];
+        auto itr = m_assetDependencies.find(id);
+
+        if(itr == m_assetDependencies.end())
+        {
+            return {};
+        }
+
+        return itr->second;
     }
 
     AZ::Data::AssetId AssetRegistry::GetAssetIdByLegacyAssetId(const AZ::Data::AssetId& legacyAssetId) const
@@ -198,7 +205,7 @@ namespace AzFramework
         if ((!assetPath) || (assetPath[0] == 0))
         {
             // the empty path has no asset ID.
-            return AZ::Data::AssetId(); 
+            return AZ::Data::AssetId();
         }
 
         auto entry = m_assetPathToId.find(CreateUUIDForName(assetPath));
@@ -217,7 +224,7 @@ namespace AzFramework
         {
             return;
         }
-        
+
         m_assetPathToId.insert_key(CreateUUIDForName(assetPath)).first->second = AZStd::move(id);
     }
 
@@ -227,7 +234,7 @@ namespace AzFramework
         {
             m_assetIdToInfo[element.first] = element.second;
             // remove dependency info that exists for this asset, as the change could have removed any dependenices this asset had.
-            m_assetDependencies.erase(element.first);   
+            m_assetDependencies.erase(element.first);
         }
         for (const auto& element : assetRegistry->m_assetDependencies)
         {

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetRegistry.h
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetRegistry.h
@@ -38,9 +38,9 @@ namespace AzFramework
 
         void SetAssetDependencies(const AZ::Data::AssetId& id, const AZStd::vector<AZ::Data::ProductDependency>& dependencies);
         void RegisterAssetDependency(const AZ::Data::AssetId& id, const AZ::Data::ProductDependency& dependency);
-        AZStd::vector<AZ::Data::ProductDependency> GetAssetDependencies(const AZ::Data::AssetId& id);
+        AZStd::vector<AZ::Data::ProductDependency> GetAssetDependencies(const AZ::Data::AssetId& id) const;
 
-        //! LEGACY - do not use in new code unless interfacing with legacy systems.  
+        //! LEGACY - do not use in new code unless interfacing with legacy systems.
         //! All new systems should be referring to assets by ID/Type only and should not need to look up by path/
         AZ::Data::AssetId GetAssetIdByPath(const char* assetPath) const;
 
@@ -65,10 +65,10 @@ namespace AzFramework
 
         // use these only through the legacy getters/setters above.
         using AssetPathToIdMap = AZStd::unordered_map < AZ::Uuid, AZ::Data::AssetId >;
-        
+
         AssetPathToIdMap m_assetPathToId; // for legacy lookups only
         LegacyAssetIdToRealAssetIdMap m_legacyAssetIdToRealAssetId; // for when we change the UUID-creation scheme
-        
+
         //! LEGACY - do not use in new code unless interfacing with legacy systems.
         //! given an assetPath and AssetID, this stores it in the registry to use with the above GetAssetIdByPath function.
         //! Called automatically by RegisterAsset.

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponent.cpp
@@ -84,7 +84,7 @@ namespace AzFramework
                 AzFramework::AssetSystem::NetworkAssetUpdateInterface* notificationInterface = AZ::Interface<AzFramework::AssetSystem::NetworkAssetUpdateInterface>::Get();
                 if (notificationInterface)
                 {
-                    notificationInterface->AssetChanged(message);
+                    notificationInterface->AssetChanged({ message });
                 }
             }
             break;
@@ -98,7 +98,7 @@ namespace AzFramework
                 AzFramework::AssetSystem::NetworkAssetUpdateInterface* notificationInterface = AZ::Interface<AzFramework::AssetSystem::NetworkAssetUpdateInterface>::Get();
                 if (notificationInterface)
                 {
-                    notificationInterface->AssetRemoved(message);
+                    notificationInterface->AssetRemoved({ message });
                 }
             }
             break;
@@ -158,7 +158,7 @@ namespace AzFramework
 
             EnableSocketConnection();
 
-            m_cbHandle = m_socketConn->AddMessageHandler(AZ_CRC("AssetProcessorManager::AssetNotification", 0xd6191df5),
+            m_cbHandle = m_socketConn->AddMessageHandler(AssetNotificationMessage::MessageType,
                 [context](unsigned int typeId, unsigned int /*serial*/, const void* data, unsigned int dataLength)
             {
                 if (dataLength)
@@ -166,6 +166,58 @@ namespace AzFramework
                     OnAssetSystemMessage(typeId, data, dataLength, context);
                 }
             });
+
+            m_bulkMessageHandle = m_socketConn->AddMessageHandler(
+                BulkAssetNotificationMessage::MessageType,
+                [context](unsigned int /*typeId*/, unsigned int /*serial*/, const void* data, unsigned int dataLength)
+                {
+                    if (dataLength)
+                    {
+                        BulkAssetNotificationMessage bulkMessage;
+
+                        // note that we forbid asset loading and we set STRICT mode.  These messages are all the kind of message that is
+                        // supposed to be transmitted between the same version of software, and are created at runtime, not loaded from
+                        // disk, so they should not contain errors - if they do, it requires investigation.
+                        if (!AZ::Utils::LoadObjectFromBufferInPlace(
+                                data,
+                                dataLength,
+                                bulkMessage,
+                                context,
+                                AZ::ObjectStream::FilterDescriptor(
+                                    &AZ::Data::AssetFilterNoAssetLoading, AZ::ObjectStream::FILTERFLAG_STRICT)))
+                        {
+                            AZ_WarningOnce(
+                                "AssetSystem",
+                                false,
+                                "BulkAssetNotificationMessage received but unable to deserialize it.  Is AssetProcessor.exe up to date?");
+                            return;
+                        }
+
+                        AzFramework::AssetSystem::NetworkAssetUpdateInterface* notificationInterface =
+                            AZ::Interface<AzFramework::AssetSystem::NetworkAssetUpdateInterface>::Get();
+
+                        if (!notificationInterface)
+                        {
+                            return;
+                        }
+
+                        switch(bulkMessage.m_type)
+                        {
+                        case AssetNotificationMessage::AssetChanged:
+                            notificationInterface->AssetChanged(bulkMessage.m_messages, true);
+                            break;
+                        case AssetNotificationMessage::AssetRemoved:
+                            notificationInterface->AssetRemoved(bulkMessage.m_messages);
+                            break;
+                        default:
+                            AZ_Warning(
+                                "AssetSystem",
+                                false,
+                                "BulkAssetNotificationMessage received with invalid/unsupported type %d",
+                                int(bulkMessage.m_type));
+                        }
+                    }
+                });
 
             AssetSystemRequestBus::Handler::BusConnect();
             AZ::SystemTickBus::Handler::BusConnect();
@@ -179,7 +231,8 @@ namespace AzFramework
 
             AZ::SystemTickBus::Handler::BusDisconnect();
             AssetSystemRequestBus::Handler::BusDisconnect();
-            m_socketConn->RemoveMessageHandler(AZ_CRC("AssetProcessorManager::AssetNotification", 0xd6191df5), m_cbHandle);
+            m_socketConn->RemoveMessageHandler(AssetNotificationMessage::MessageType, m_cbHandle);
+            m_socketConn->RemoveMessageHandler(BulkAssetNotificationMessage::MessageType, m_bulkMessageHandle);
             m_socketConn->Disconnect(true);
 
             DisableSocketConnection();
@@ -263,6 +316,7 @@ namespace AzFramework
             SaveAssetCatalogResponse::Reflect(context);
 
             AssetNotificationMessage::Reflect(context);
+            BulkAssetNotificationMessage::Reflect(context);
             AssetSeedListReflector::Reflect(context);
             SeedInfo::Reflect(context);
             AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context);

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponent.h
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponent.h
@@ -58,7 +58,7 @@ namespace AzFramework
             static void Reflect(AZ::ReflectContext* context);
             static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
             static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
-            
+
         private:
             AssetSystemComponent(const AssetSystemComponent&) = delete;
             void EnableSocketConnection();
@@ -128,7 +128,7 @@ namespace AzFramework
             //! in the calling code.
             //! returns true if successfully connected, false if not
             bool ConnectFromAssetProcessor(const ConnectionSettings& connectionSettings);
-            
+
             AssetStatus CompileAssetSync(const AZStd::string& assetPath) override;
             AssetStatus CompileAssetSync_FlushIO(const AZStd::string& assetPath) override;
 
@@ -160,6 +160,7 @@ namespace AzFramework
 
             AZStd::unique_ptr<SocketConnection> m_socketConn = nullptr;
             SocketConnection::TMessageCallbackHandle m_cbHandle = 0;
+            SocketConnection::TMessageCallbackHandle m_bulkMessageHandle = 0;
             AZStd::string m_assetProcessorBranchToken;
             AZStd::string m_assetProcessorProjectName;
             AZStd::string m_assetProcessorPlatform;

--- a/Code/Framework/AzFramework/AzFramework/Asset/NetworkAssetNotification_private.h
+++ b/Code/Framework/AzFramework/AzFramework/Asset/NetworkAssetNotification_private.h
@@ -32,9 +32,9 @@ namespace AzFramework
             NetworkAssetUpdateInterface& operator=(NetworkAssetUpdateInterface&&) = delete;
 
             //! Called by the AssetProcessor when an asset in the cache has been modified.
-            virtual void AssetChanged(AzFramework::AssetSystem::AssetNotificationMessage /*message*/) = 0;
+            virtual void AssetChanged([[maybe_unused]] const AZStd::vector<AzFramework::AssetSystem::AssetNotificationMessage>& message, [[maybe_unused]] bool isCatalogInitialize = false) = 0;
             //! Called by the AssetProcessor when an asset in the cache has been removed.
-            virtual void AssetRemoved(AzFramework::AssetSystem::AssetNotificationMessage /*message*/) = 0;
+            virtual void AssetRemoved([[maybe_unused]] const AZStd::vector<AzFramework::AssetSystem::AssetNotificationMessage>& message) = 0;
 
             //! If we want to hear about assets for multiple platforms or something other than the asset platform defined at startup
             virtual AZStd::string GetSupportedPlatforms() { return {}; }

--- a/Code/Framework/AzFramework/Tests/AssetCatalog.cpp
+++ b/Code/Framework/AzFramework/Tests/AssetCatalog.cpp
@@ -114,7 +114,7 @@ namespace UnitTest
                 AzFramework::AssetSystem::AssetNotificationMessage message("test", AzFramework::AssetSystem::AssetNotificationMessage::AssetChanged, AZ::Uuid::CreateRandom(), "");
                 message.m_assetId = asset1;
                 message.m_dependencies.emplace_back(asset2, 0);
-                notificationInterface->AssetChanged(message);
+                notificationInterface->AssetChanged({ message });
             }
 
             {
@@ -123,7 +123,7 @@ namespace UnitTest
                 message.m_assetId = asset2;
                 message.m_dependencies.emplace_back(asset3, 0);
                 message.m_dependencies.emplace_back(asset4, 0);
-                notificationInterface->AssetChanged(message);
+                notificationInterface->AssetChanged({ message });
             }
 
             {
@@ -131,21 +131,21 @@ namespace UnitTest
                 AzFramework::AssetSystem::AssetNotificationMessage message("test", AzFramework::AssetSystem::AssetNotificationMessage::AssetChanged, AZ::Uuid::CreateRandom(), "");
                 message.m_assetId = asset3;
                 message.m_dependencies.emplace_back(asset5, 0);
-                notificationInterface->AssetChanged(message);
+                notificationInterface->AssetChanged({ message });
             }
 
             {
                 m_assetCatalog->RegisterAsset(asset4, info4);
                 AzFramework::AssetSystem::AssetNotificationMessage message("test", AzFramework::AssetSystem::AssetNotificationMessage::AssetChanged, AZ::Uuid::CreateRandom(), "");
                 message.m_assetId = asset4;
-                notificationInterface->AssetChanged(message);
+                notificationInterface->AssetChanged({ message });
             }
 
             {
                 m_assetCatalog->RegisterAsset(asset5, info5);
                 AzFramework::AssetSystem::AssetNotificationMessage message("test", AzFramework::AssetSystem::AssetNotificationMessage::AssetChanged, AZ::Uuid::CreateRandom(), "");
                 message.m_assetId = asset5;
-                notificationInterface->AssetChanged(message);
+                notificationInterface->AssetChanged({ message });
             }
 
         }
@@ -302,7 +302,7 @@ namespace UnitTest
             m_app.reset(aznew AzFramework::Application());
             AZ::ComponentApplication::Descriptor desc;
             desc.m_useExistingAllocator = true;
-            
+
             AZ::SettingsRegistryInterface* registry = AZ::SettingsRegistry::Get();
             auto projectPathKey =
                 AZ::SettingsRegistryInterface::FixedValueString(AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey) + "/project_path";
@@ -316,7 +316,7 @@ namespace UnitTest
             m_app->Start(desc, startupParameters);
 
             // Without this, the user settings component would attempt to save on finalize/shutdown. Since the file is
-            // shared across the whole engine, if multiple tests are run in parallel, the saving could cause a crash 
+            // shared across the whole engine, if multiple tests are run in parallel, the saving could cause a crash
             // in the unit tests.
             AZ::UserSettingsComponentRequestBus::Broadcast(&AZ::UserSettingsComponentRequests::DisableSaveOnFinalize);
 
@@ -358,7 +358,7 @@ namespace UnitTest
                 AzFramework::AssetSystem::AssetNotificationMessage message(path3, AzFramework::AssetSystem::AssetNotificationMessage::AssetChanged, AZ::Uuid::CreateRandom(), "");
                 message.m_assetId = asset1;
                 message.m_dependencies.push_back(AZ::Data::ProductDependency(asset2, 0));
-                notificationInterface->AssetChanged(message);
+                notificationInterface->AssetChanged({ message });
             }
             AssetCatalogRequestBus::Broadcast(&AssetCatalogRequestBus::Events::StopMonitoringAssets);
             // sourcecatalog1 - asset1 path3 (depends on asset 2), asset2 path2, asset4 path4
@@ -378,7 +378,7 @@ namespace UnitTest
                 AzFramework::AssetSystem::AssetNotificationMessage message(path5, AzFramework::AssetSystem::AssetNotificationMessage::AssetChanged, AZ::Uuid::CreateRandom(), "");
                 message.m_assetId = asset5;
                 message.m_dependencies.push_back(AZ::Data::ProductDependency(asset2, 0));
-                notificationInterface->AssetChanged(message);
+                notificationInterface->AssetChanged({ message });
             }
             AssetCatalogRequestBus::Broadcast(&AssetCatalogRequestBus::Events::StopMonitoringAssets);
             // sourcecatalog2 - asset1 path3 (depends on asset 2), asset2 path2, asset4 path4, asset5 path5 (depends on asset 2)
@@ -389,7 +389,7 @@ namespace UnitTest
             // deltacatalog2 - asset5 path5 (depends on asset 2)
             deltaCatalogFiles2.push_back(path5);
             AssetCatalogRequestBus::Broadcast(&AssetCatalogRequestBus::Events::SaveCatalog, deltaCatalogPath2);
-            
+
             AssetCatalogRequestBus::Broadcast(&AssetCatalogRequestBus::Events::RegisterAsset, asset1, info6);
             AssetCatalogRequestBus::Broadcast(&AssetCatalogRequestBus::Events::RegisterAsset, asset2, info2);
             AssetCatalogRequestBus::Broadcast(&AssetCatalogRequestBus::Events::RegisterAsset, asset5, info4);
@@ -398,7 +398,7 @@ namespace UnitTest
                 AzFramework::AssetSystem::AssetNotificationMessage message(path4, AzFramework::AssetSystem::AssetNotificationMessage::AssetChanged, AZ::Uuid::CreateRandom(), "");
                 message.m_assetId = asset5;
                 message.m_dependencies.push_back(AZ::Data::ProductDependency(asset2, 0));
-                notificationInterface->AssetChanged(message);
+                notificationInterface->AssetChanged({ message });
             }
             AssetCatalogRequestBus::Broadcast(&AssetCatalogRequestBus::Events::StopMonitoringAssets);
             //sourcecatalog3 - asset1 path6, asset2 path2, asset5 path4 (depends on asset 2)
@@ -466,7 +466,7 @@ namespace UnitTest
             AzFramework::AssetSystem::AssetNotificationMessage message("test", AzFramework::AssetSystem::AssetNotificationMessage::AssetChanged, AZ::Uuid::CreateRandom(), "");
             message.m_assetId = updatedAsset;
             message.m_dependencies.emplace_back(asset2, 0);
-            notificationInterface->AssetChanged(message);
+            notificationInterface->AssetChanged({ message });
         }
 
         AZ::Data::AssetInfo assetInfo;
@@ -779,7 +779,7 @@ namespace UnitTest
     TEST_F(AssetCatalogDeltaTest, DeltaCatalogCreationTest)
     {
         bool result = false;
-        AZStd::string assetPath;        
+        AZStd::string assetPath;
 
         // load source catalog 1
         AssetCatalogRequestBus::Broadcast(&AssetCatalogRequestBus::Events::ClearCatalog);
@@ -1061,7 +1061,7 @@ namespace UnitTest
 
         char* m_data;
     };
-    
+
     class AssetType2
         : public AssetData
     {
@@ -1210,7 +1210,7 @@ namespace UnitTest
         handler->Unregister();
         delete handler;
     }
-    
+
     TEST_F(AssetCatalogDisplayNameTest, GetAssetTypeByDisplayName_NoRegisteredType)
     {
         // Get the Asset Type from a Display Name we did not register

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetCatalog/PlatformAddressedAssetCatalogManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetCatalog/PlatformAddressedAssetCatalogManager.cpp
@@ -93,26 +93,38 @@ namespace AzToolsFramework
         return AZStd::string_view(AzFramework::PlatformHelper::GetCommaSeparatedPlatformList(platformFlags));
     }
 
-    void PlatformAddressedAssetCatalogManager::AssetChanged(AzFramework::AssetSystem::AssetNotificationMessage message)
+    void PlatformAddressedAssetCatalogManager::AssetChanged(const AZStd::vector<AzFramework::AssetSystem::AssetNotificationMessage>& messages, bool isCatalogInitialize)
     {
-        int platformId = AzFramework::PlatformHelper::GetPlatformIndexFromName(message.m_platform.c_str());
+        if(messages.empty())
+        {
+            return;
+        }
+
+        // All messages are required to be for the same platform, so just check the first
+        int platformId = AzFramework::PlatformHelper::GetPlatformIndexFromName(messages[0].m_platform.c_str());
         for (const auto& thisCatalog : m_assetCatalogList)
         {
             if (thisCatalog->GetPlatformId() == platformId)
             {
-                thisCatalog->AssetChanged(message);
+                thisCatalog->AssetChanged(messages, isCatalogInitialize);
             }
         }
     }
 
-    void PlatformAddressedAssetCatalogManager::AssetRemoved(AzFramework::AssetSystem::AssetNotificationMessage message)
+    void PlatformAddressedAssetCatalogManager::AssetRemoved(const AZStd::vector<AzFramework::AssetSystem::AssetNotificationMessage>& messages)
     {
-        int platformId = AzFramework::PlatformHelper::GetPlatformIndexFromName(message.m_platform.c_str());
+        if (messages.empty())
+        {
+            return;
+        }
+
+        // All messages are required to be for the same platform, so just check the first
+        int platformId = AzFramework::PlatformHelper::GetPlatformIndexFromName(messages[0].m_platform.c_str());
         for (const auto& thisCatalog : m_assetCatalogList)
         {
             if (thisCatalog->GetPlatformId() == platformId)
             {
-                thisCatalog->AssetRemoved(message);
+                thisCatalog->AssetRemoved(messages);
             }
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetCatalog/PlatformAddressedAssetCatalogManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetCatalog/PlatformAddressedAssetCatalogManager.h
@@ -34,8 +34,8 @@ namespace AzToolsFramework
         void TakeSingleCatalog(AZStd::unique_ptr<AzToolsFramework::PlatformAddressedAssetCatalog>&& newCatalog);
         //////////////////////////////////////////////////////////////////////////
         // NetworkAssetUpdateInterface
-        void AssetChanged(AzFramework::AssetSystem::AssetNotificationMessage message) override;
-        void AssetRemoved(AzFramework::AssetSystem::AssetNotificationMessage message) override;
+        void AssetChanged(const AZStd::vector<AzFramework::AssetSystem::AssetNotificationMessage>& messages, bool isCatalogInitialize = false) override;
+        void AssetRemoved(const AZStd::vector<AzFramework::AssetSystem::AssetNotificationMessage>& messages) override;
         AZStd::string GetSupportedPlatforms() override;
         //////////////////////////////////////////////////////////////////////////
 

--- a/Code/Framework/AzToolsFramework/Tests/PlatformAddressedAssetCatalogTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/PlatformAddressedAssetCatalogTests.cpp
@@ -165,8 +165,8 @@ namespace UnitTest
         {
 
         }
-        MOCK_METHOD1(AssetChanged, void(AzFramework::AssetSystem::AssetNotificationMessage message));
-        MOCK_METHOD1(AssetRemoved, void(AzFramework::AssetSystem::AssetNotificationMessage message));
+        MOCK_METHOD2(AssetChanged, void(const AZStd::vector<AzFramework::AssetSystem::AssetNotificationMessage>& message, bool isCatalogInitialize));
+        MOCK_METHOD1(AssetRemoved, void(const AZStd::vector<AzFramework::AssetSystem::AssetNotificationMessage>& message));
     };
 
     class PlatformAddressedAssetCatalogManagerMessageTest : public AzToolsFramework::PlatformAddressedAssetCatalogManager
@@ -221,23 +221,23 @@ namespace UnitTest
         catalogHolder.reset(mockCatalog);
 
         m_platformAddressedAssetCatalogManager->TakeSingleCatalog(AZStd::move(catalogHolder));
-        EXPECT_CALL(*mockCatalog, AssetChanged(testing::_)).Times(0);
-        notificationInterface->AssetChanged(testMessage);
+        EXPECT_CALL(*mockCatalog, AssetChanged(testing::_, false)).Times(0);
+        notificationInterface->AssetChanged({ testMessage });
 
         testMessage.m_platform = "android";
-        EXPECT_CALL(*mockCatalog, AssetChanged(testing::_)).Times(1);
-        notificationInterface->AssetChanged(testMessage);
+        EXPECT_CALL(*mockCatalog, AssetChanged(testing::_, false)).Times(1);
+        notificationInterface->AssetChanged({ testMessage });
 
         testMessage.m_platform = "pc";
-        EXPECT_CALL(*mockCatalog, AssetChanged(testing::_)).Times(0);
-        notificationInterface->AssetChanged(testMessage);
+        EXPECT_CALL(*mockCatalog, AssetChanged(testing::_, false)).Times(0);
+        notificationInterface->AssetChanged({ testMessage });
 
         EXPECT_CALL(*mockCatalog, AssetRemoved(testing::_)).Times(0);
-        notificationInterface->AssetRemoved(testMessage);
+        notificationInterface->AssetRemoved({ testMessage });
 
         testMessage.m_platform = "android";
         EXPECT_CALL(*mockCatalog, AssetRemoved(testing::_)).Times(1);
-        notificationInterface->AssetRemoved(testMessage);
+        notificationInterface->AssetRemoved({ testMessage });
     }
 
 }

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
@@ -605,6 +605,11 @@ namespace AssetProcessor
 
             const auto& currentRegistry = *itr;
 
+            AzFramework::AssetSystem::BulkAssetNotificationMessage bulkMessage;
+
+            bulkMessage.m_messages.reserve(currentRegistry.m_assetIdToInfo.size());
+            bulkMessage.m_type = AzFramework::AssetSystem::AssetNotificationMessage::AssetChanged;
+
             for (const auto& assetInfo : currentRegistry.m_assetIdToInfo)
             {
                 AzFramework::AssetSystem::AssetNotificationMessage message(
@@ -615,7 +620,6 @@ namespace AssetProcessor
 
                 message.m_assetId = assetInfo.second.m_assetId;
                 message.m_sizeBytes = assetInfo.second.m_sizeBytes;
-
                 message.m_dependencies = AZStd::move(currentRegistry.GetAssetDependencies(assetInfo.second.m_assetId));
 
                 const auto& legacyIds =
@@ -626,8 +630,10 @@ namespace AssetProcessor
                     message.m_legacyAssetIds.emplace_back(legacyId.first);
                 }
 
-                AssetProcessor::ConnectionBus::Event(connectionId, &AssetProcessor::ConnectionBus::Events::Send, 0, message);
+                bulkMessage.m_messages.push_back(AZStd::move(message));
             }
+
+            AssetProcessor::ConnectionBus::Event(connectionId, &AssetProcessor::ConnectionBus::Events::Send, 0, bulkMessage);
         }
     }
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
@@ -589,16 +589,11 @@ namespace AssetProcessor
         m_catalogIsDirty = true;
     }
 
-    void AssetCatalog::OnConnect(unsigned int connectionId, ::Connection* connection)
+    void AssetCatalog::OnConnect(unsigned int connectionId, QStringList platforms)
     {
-        if(!connection || connection->Status() != ::Connection::ConnectionStatus::Connected)
-        {
-            return;
-        }
-
         // Send out a message for each asset to make sure the connected tools are aware of the existence of all previously built assets
         // since the assetcatalog might not have been written out to disk previously.
-        for (QString platform : connection->AssetPlatforms())
+        for (QString platform : platforms)
         {
             QMutexLocker locker(&m_registriesMutex);
             auto itr = m_registries.find(platform);

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
@@ -589,6 +589,47 @@ namespace AssetProcessor
         m_catalogIsDirty = true;
     }
 
+    void AssetCatalog::OnConnect(unsigned int /*connectionId*/, ::Connection* connection)
+    {
+        // Send out a message for each asset to make sure the connected tools are aware of the existence of all previously built assets
+        // since the assetcatalog might not have been written out to disk previously.
+        for (QString platform : connection->AssetPlatforms())
+        {
+            auto itr = m_registries.find(platform);
+
+            if(itr == m_registries.end())
+            {
+                continue;
+            }
+
+            const auto& currentRegistry = *itr;
+
+            for (const auto& assetInfo : currentRegistry.m_assetIdToInfo)
+            {
+                AzFramework::AssetSystem::AssetNotificationMessage message(
+                    assetInfo.second.m_relativePath.c_str(),
+                    AzFramework::AssetSystem::AssetNotificationMessage::AssetChanged,
+                    assetInfo.second.m_assetType,
+                    platform.toUtf8().constData());
+
+                message.m_assetId = assetInfo.second.m_assetId;
+                message.m_sizeBytes = assetInfo.second.m_sizeBytes;
+
+                message.m_dependencies = AZStd::move(currentRegistry.GetAssetDependencies(assetInfo.second.m_assetId));
+
+                const auto& legacyIds =
+                    m_registries[platform].GetLegacyMappingSubsetFromRealIds(AZStd::vector<AZ::Data::AssetId>{ assetInfo.second.m_assetId });
+
+                for (auto& legacyId : legacyIds)
+                {
+                    message.m_legacyAssetIds.emplace_back(legacyId.first);
+                }
+
+                connection->Send(0, message);
+            }
+        }
+    }
+
     void AssetCatalog::OnSourceQueued(AZ::Uuid sourceUuid, AZ::Uuid legacyUuid, QString rootPath, QString relativeFilePath)
     {
         AZStd::lock_guard<AZStd::mutex> lock(m_sourceUUIDToSourceNameMapMutex);

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.h
@@ -68,7 +68,7 @@ namespace AssetProcessor
         // incoming message from the AP
         void OnAssetMessage(AzFramework::AssetSystem::AssetNotificationMessage message);
         void OnDependencyResolved(const AZ::Data::AssetId& assetId, const AzToolsFramework::AssetDatabase::ProductDependencyDatabaseEntry& entry);
-        void OnConnect(unsigned int connectionId, ::Connection* connection);
+        void OnConnect(unsigned int connectionId, QStringList platforms);
 
         void SaveRegistry_Impl();
         virtual AzFramework::AssetSystem::GetUnresolvedDependencyCountsResponse HandleGetUnresolvedDependencyCountsRequest(MessageData<AzFramework::AssetSystem::GetUnresolvedDependencyCountsRequest> messageData);

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.h
@@ -26,6 +26,7 @@
 #include <QMultiMap>
 #include <AzCore/IO/SystemFile.h>
 #include <AzToolsFramework/ToolsComponents/ToolsAssetCatalogBus.h>
+#include <native/connection/connection.h>
 #endif
 
 #include "AssetRequestHandler.h"
@@ -67,6 +68,7 @@ namespace AssetProcessor
         // incoming message from the AP
         void OnAssetMessage(AzFramework::AssetSystem::AssetNotificationMessage message);
         void OnDependencyResolved(const AZ::Data::AssetId& assetId, const AzToolsFramework::AssetDatabase::ProductDependencyDatabaseEntry& entry);
+        void OnConnect(unsigned int connectionId, ::Connection* connection);
 
         void SaveRegistry_Impl();
         virtual AzFramework::AssetSystem::GetUnresolvedDependencyCountsResponse HandleGetUnresolvedDependencyCountsRequest(MessageData<AzFramework::AssetSystem::GetUnresolvedDependencyCountsRequest> messageData);

--- a/Code/Tools/AssetProcessor/native/connection/connection.cpp
+++ b/Code/Tools/AssetProcessor/native/connection/connection.cpp
@@ -319,7 +319,7 @@ void Connection::OnConnectionDisconnect()
     // For user created connections, the id is user generated (either because they've manually entered some text
     // this session, or because the id was loaded from a session previously saved where the user entered it).
     // As such, when a connection disconnects, we only want to clear the id when the connection was triggered
-    // from something other than the user (i.e. like when an automatic connection from Editor or a job worker 
+    // from something other than the user (i.e. like when an automatic connection from Editor or a job worker
     // disconnects).
     if (!m_userCreatedConnection)
     {
@@ -363,6 +363,8 @@ void Connection::OnConnectionEstablished(QString ipAddress, quint16 port)
     SetIpAddress(ipAddress);
     SetPort(port);
     SetStatus(Connected);
+
+    Q_EMIT ConnectionReady(ConnectionId(), this);
 }
 
 void Connection::ReceiveMessage(unsigned int type, unsigned int serial, QByteArray payload)
@@ -849,7 +851,7 @@ AZ::u32 Connection::GetNextSerial()
     static AZStd::atomic_uint serial(AzFramework::AssetSystem::DEFAULT_SERIAL);
 
     AZ::u32 nextSerial = ++serial;
-    
+
     // Avoid special-case serials
     return (nextSerial & AzFramework::AssetSystem::RESPONSE_SERIAL_FLAG
         || nextSerial == AzFramework::AssetSystem::DEFAULT_SERIAL

--- a/Code/Tools/AssetProcessor/native/connection/connection.cpp
+++ b/Code/Tools/AssetProcessor/native/connection/connection.cpp
@@ -364,7 +364,7 @@ void Connection::OnConnectionEstablished(QString ipAddress, quint16 port)
     SetPort(port);
     SetStatus(Connected);
 
-    Q_EMIT ConnectionReady(ConnectionId(), this);
+    Q_EMIT ConnectionReady(ConnectionId(), AssetPlatforms());
 }
 
 void Connection::ReceiveMessage(unsigned int type, unsigned int serial, QByteArray payload)

--- a/Code/Tools/AssetProcessor/native/connection/connection.h
+++ b/Code/Tools/AssetProcessor/native/connection/connection.h
@@ -187,6 +187,7 @@ Q_SIGNALS:
     void DisplayNameChanged();
     void ElapsedChanged();
     void NormalConnectionRequested(QString IpAddress, quint16 Port);
+    void ConnectionReady(unsigned int connId, Connection* connection);
 
     void connectionEnded();
     void TerminateConnection();

--- a/Code/Tools/AssetProcessor/native/connection/connection.h
+++ b/Code/Tools/AssetProcessor/native/connection/connection.h
@@ -187,7 +187,7 @@ Q_SIGNALS:
     void DisplayNameChanged();
     void ElapsedChanged();
     void NormalConnectionRequested(QString IpAddress, quint16 Port);
-    void ConnectionReady(unsigned int connId, Connection* connection);
+    void ConnectionReady(unsigned int connId, QStringList platforms);
 
     void connectionEnded();
     void TerminateConnection();

--- a/Code/Tools/AssetProcessor/native/connection/connectionManager.cpp
+++ b/Code/Tools/AssetProcessor/native/connection/connectionManager.cpp
@@ -126,6 +126,7 @@ unsigned int ConnectionManager::internalAddConnection(bool isUserConnection, qin
     connect(connection, SIGNAL(DisconnectConnection(unsigned int)), this, SIGNAL(ConnectionDisconnected(unsigned int)));
     connect(connection, SIGNAL(ConnectionDestroyed(unsigned int)), this, SLOT(RemoveConnectionFromMap(unsigned int)));
     connect(connection, SIGNAL(Error(unsigned int, QString)), this, SIGNAL(ConnectionError(unsigned int, QString)));
+    connect(connection, &Connection::ConnectionReady, this, &ConnectionManager::ConnectionReady);
 
     m_connectionMap.insert(connectionId, connection);
     Q_EMIT connectionAdded(connectionId, connection);

--- a/Code/Tools/AssetProcessor/native/connection/connectionManager.h
+++ b/Code/Tools/AssetProcessor/native/connection/connectionManager.h
@@ -103,7 +103,7 @@ Q_SIGNALS:
 
     void ConnectionError(unsigned int connId, QString error);
 
-    void ConnectionReady(unsigned int connectionId, Connection* connection);
+    void ConnectionReady(unsigned int connectionId, QStringList platforms);
 
     void ReadyToQuit(QObject* source);
 

--- a/Code/Tools/AssetProcessor/native/connection/connectionManager.h
+++ b/Code/Tools/AssetProcessor/native/connection/connectionManager.h
@@ -71,11 +71,11 @@ public:
     // Singleton pattern:
     static ConnectionManager* Get();
     Q_INVOKABLE int getCount() const;
-    Q_INVOKABLE Connection* getConnection(unsigned int connectionId);    
-    Q_INVOKABLE ConnectionMap& getConnectionMap();    
-    Q_INVOKABLE unsigned int addConnection(qintptr socketDescriptor = -1);    
+    Q_INVOKABLE Connection* getConnection(unsigned int connectionId);
+    Q_INVOKABLE ConnectionMap& getConnectionMap();
+    Q_INVOKABLE unsigned int addConnection(qintptr socketDescriptor = -1);
     Q_INVOKABLE unsigned int addUserConnection();
-    Q_INVOKABLE void removeConnection(unsigned int connectionId);    
+    Q_INVOKABLE void removeConnection(unsigned int connectionId);
     unsigned int GetConnectionId(QString ipaddress, int port);
     void SaveConnections(QString settingPrefix = ""); // settingPrefix allowed for testing purposes.
     void LoadConnections(QString settingPrefix = ""); // settingPrefix allowed for testing purposes.
@@ -95,13 +95,15 @@ public:
     void removeConnection(const QModelIndex& index);
 
 Q_SIGNALS:
-    void connectionAdded(unsigned int connectionId, Connection* connection);    
-    void beforeConnectionRemoved(unsigned int connectionId);    
+    void connectionAdded(unsigned int connectionId, Connection* connection);
+    void beforeConnectionRemoved(unsigned int connectionId);
 
     void ConnectionDisconnected(unsigned int connectionId);
     void ConnectionRemoved(unsigned int connectionId);
 
     void ConnectionError(unsigned int connId, QString error);
+
+    void ConnectionReady(unsigned int connectionId, Connection* connection);
 
     void ReadyToQuit(QObject* source);
 
@@ -118,7 +120,7 @@ public Q_SLOTS:
     void RemoveConnectionFromMap(unsigned int connectionId);
     void MakeSureConnectionMapEmpty();
     void NewConnection(qintptr socketDescriptor);
-    
+
     void AllowedListingEnabled(bool enabled);
     void IsAddressInAllowedList(QHostAddress hostAddress, void* token);
     void AddAddressToAllowedList(QString address);
@@ -180,7 +182,7 @@ public Q_SLOTS:
     void UpdateConnectionMetrics();
 
     void OnStatusChanged(unsigned int connId);
-    
+
     void UpdateAllowedListFromBootStrap();
 
 private:
@@ -204,7 +206,7 @@ private:
     //allowed listing
     bool m_allowedListingEnabled = true;
 
-    //these lists are just caches, only used for updating    
+    //these lists are just caches, only used for updating
     QStringList m_allowedListAddresses;
     QStringList m_rejectedAddresses;
 };

--- a/Code/Tools/AssetProcessor/native/tests/AssetCatalog/AssetCatalogUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/AssetCatalog/AssetCatalogUnitTests.cpp
@@ -541,11 +541,12 @@ namespace AssetProcessor
 
         virtual size_t Send([[maybe_unused]] unsigned int serial, const AzFramework::AssetSystem::BaseAssetProcessorMessage& message)
         {
-            auto* a = azrtti_cast<const AssetNotificationMessage*>(&message);
+            auto* bulkMessage = azrtti_cast<const BulkAssetNotificationMessage*>(&message);
 
-            EXPECT_TRUE(a);
-            EXPECT_EQ(a->m_type, AssetNotificationMessage::AssetChanged);
-            ++m_messages;
+            EXPECT_TRUE(bulkMessage);
+            EXPECT_EQ(bulkMessage->m_type, AssetNotificationMessage::AssetChanged);
+            EXPECT_GT(bulkMessage->m_messages.size(), 0);
+            m_messages += bulkMessage->m_messages.size();
 
             return sizeof(message);
         }
@@ -583,7 +584,7 @@ namespace AssetProcessor
             GTEST_NONFATAL_FAILURE_("Not supported");
         }
 
-        int m_messages = 0;
+        size_t m_messages = 0;
     };
 
     TEST_F(AssetCatalogTestWithProducts, SendAssetUpdateOnConnect)

--- a/Code/Tools/AssetProcessor/native/tests/AssetCatalog/AssetCatalogUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/AssetCatalog/AssetCatalogUnitTests.cpp
@@ -527,6 +527,103 @@ namespace AssetProcessor
         ASSERT_TRUE(TestGetRelativeProductPath(fileToCheck, true, { "aaa/basefile.txt" }));
     }
 
+    struct MockConnection : AssetProcessor::ConnectionBus::Handler
+    {
+        MockConnection(int connectionId)
+        {
+            BusConnect(connectionId);
+        }
+
+        ~MockConnection()
+        {
+            BusDisconnect();
+        }
+
+        virtual size_t Send([[maybe_unused]] unsigned int serial, const AzFramework::AssetSystem::BaseAssetProcessorMessage& message)
+        {
+            auto* a = azrtti_cast<const AssetNotificationMessage*>(&message);
+
+            EXPECT_TRUE(a);
+            EXPECT_EQ(a->m_type, AssetNotificationMessage::AssetChanged);
+            ++m_messages;
+
+            return sizeof(message);
+        }
+        virtual size_t SendRaw(unsigned int /*type*/, unsigned int /*serial*/, const QByteArray& /*data*/)
+        {
+            GTEST_NONFATAL_FAILURE_("Not supported");
+            return 0;
+        }
+        virtual size_t SendPerPlatform(
+            unsigned int /*serial*/, const AzFramework::AssetSystem::BaseAssetProcessorMessage& /*message*/, const QString& /*platform*/)
+        {
+            GTEST_NONFATAL_FAILURE_("Not supported");
+            return 0;
+        }
+        virtual size_t SendRawPerPlatform(
+            unsigned int /*type*/, unsigned int /*serial*/, const QByteArray& /*data*/, const QString& /*platform*/)
+        {
+            GTEST_NONFATAL_FAILURE_("Not supported");
+            return 0;
+        }
+
+        virtual unsigned int SendRequest(
+            const AzFramework::AssetSystem::BaseAssetProcessorMessage& /*message*/, const ResponseCallback& /*callback*/)
+        {
+            GTEST_NONFATAL_FAILURE_("Not supported");
+            return 0;
+        }
+        virtual size_t SendResponse(unsigned int /*serial*/, const AzFramework::AssetSystem::BaseAssetProcessorMessage& /*message*/)
+        {
+            GTEST_NONFATAL_FAILURE_("Not supported");
+            return 0;
+        }
+        virtual void RemoveResponseHandler(unsigned int /*serial*/)
+        {
+            GTEST_NONFATAL_FAILURE_("Not supported");
+        }
+
+        int m_messages = 0;
+    };
+
+    TEST_F(AssetCatalogTestWithProducts, SendAssetUpdateOnConnect)
+    {
+        static constexpr int ConnId = 1;
+
+        AssetNotificationMessage message;
+        message.m_type = AssetNotificationMessage::AssetChanged;
+        message.m_data = "filea.png";
+        message.m_assetId = AZ::Data::AssetId("{4DBBC5A7-ACEE-4084-A435-9CA8AA05B01B}");
+        message.m_assetType = AZ::Data::AssetType("{01E432B8-4252-40F5-86CC-4CB554004C49}");
+        message.m_platform = "pc";
+        message.m_sizeBytes = 10;
+
+        // Add 2 assets to the catalog
+        m_data->m_assetCatalog->OnAssetMessage(message);
+
+        message.m_data = "fileb.png";
+        message.m_assetId = AZ::Data::AssetId("{29AA7E27-4A80-4443-8DFD-6FC459833BD2}");
+
+        m_data->m_assetCatalog->OnAssetMessage(message);
+
+        // Simulate a connection afterwards
+        MockConnection mockConnection(ConnId);
+        MockConnection android(ConnId + 1);
+
+        EXPECT_EQ(mockConnection.m_messages, 0);
+        EXPECT_EQ(android.m_messages, 0);
+
+        m_data->m_assetCatalog->OnConnect(ConnId, { "pc" });
+
+        // Should recieve both asset messages
+        EXPECT_EQ(mockConnection.m_messages, 2);
+
+        m_data->m_assetCatalog->OnConnect(ConnId + 1, { "android" });
+
+        EXPECT_EQ(android.m_messages, 0); // No assets for the android platform
+        EXPECT_EQ(mockConnection.m_messages, 2); // No extra messages for the pc platform
+    }
+
     class AssetCatalogTestRelativeSourcePath : public AssetCatalogTest
     {
     public:

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -571,6 +571,9 @@ void ApplicationManagerBase::InitConnectionManager()
     [[maybe_unused]] bool result = QObject::connect(GetAssetCatalog(), &AssetProcessor::AssetCatalog::SendAssetMessage, connectionAndChangeMessagesThreadContext, forwardMessageFunction, Qt::QueuedConnection);
     AZ_Assert(result, "Failed to connect to AssetCatalog signal");
 
+    result = QObject::connect(m_connectionManager, &ConnectionManager::ConnectionReady, GetAssetCatalog(), &AssetProcessor::AssetCatalog::OnConnect, Qt::QueuedConnection);
+    AZ_Assert(result, "Failed to connect to AssetCatalog signal");
+
     //Application manager related stuff
 
     // The AssetCatalog has to be rebuilt on connection, so we force the incoming connection messages to be serialized as they connect to the ApplicationManagerBase

--- a/Gems/AssetValidation/Code/Source/AssetSystemTestCommands.cpp
+++ b/Gems/AssetValidation/Code/Source/AssetSystemTestCommands.cpp
@@ -150,7 +150,7 @@ namespace AssetValidation
                         if (randomizer.GetRandom() % 100 < changePercent)
                         {
                             ++thisChangeCount;
-                            notificationInterface->AssetChanged(thisElement.second);
+                            notificationInterface->AssetChanged({ thisElement.second });
                         }
                     }
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Asset/AssetUtils.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Asset/AssetUtils.h
@@ -46,7 +46,7 @@ namespace AZ
             //! @return a null asset if the asset could not be found or loaded.
             template<typename AssetDataT>
             Data::Asset<AssetDataT> LoadAssetById(Data::AssetId assetId, TraceLevel reporting = TraceLevel::Warning);
-            
+
             //! Loads a critial asset using a file path (both source and product path should be same), on the current thread.
             //! If the asset wasn't compiled, wait until the asset is compiled.
             //! @return a null asset if the asset could not be compiled or loaded.
@@ -141,7 +141,7 @@ namespace AZ
                     AzFramework::AssetSystem::AssetStatus status = AzFramework::AssetSystem::AssetStatus_Unknown;
                     AzFramework::AssetSystemRequestBus::BroadcastResult(
                         status, &AzFramework::AssetSystemRequestBus::Events::CompileAssetSync, assetFilePath);
-                    if (status != AzFramework::AssetSystem::AssetStatus_Compiled)
+                    if (status != AzFramework::AssetSystem::AssetStatus_Compiled && status != AzFramework::AssetSystem::AssetStatus_Unknown)
                     {
                         AssetUtilsInternal::ReportIssue(reporting, AZStd::string::format("Could not compile asset '%s'", assetFilePath.c_str()).c_str());
                         return {};

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
@@ -268,7 +268,7 @@ namespace AtomToolsFramework
 
     void AtomToolsApplication::RunMainLoop()
     {
-        // Start initial command line processing and application update as part of the Qt event loop 
+        // Start initial command line processing and application update as part of the Qt event loop
         QTimer::singleShot(0, this, [this]() { OnIdle(); ProcessCommandLine(m_commandLine); });
         exec();
     }
@@ -350,7 +350,7 @@ namespace AtomToolsFramework
             AzFramework::AssetSystem::AssetStatus status = AzFramework::AssetSystem::AssetStatus_Unknown;
             AzFramework::AssetSystemRequestBus::BroadcastResult(
                 status, &AzFramework::AssetSystemRequestBus::Events::CompileAssetSync, assetFilters);
-            if (status != AzFramework::AssetSystem::AssetStatus_Compiled)
+            if (status != AzFramework::AssetSystem::AssetStatus_Compiled && status != AzFramework::AssetSystem::AssetStatus_Unknown)
             {
                 failedAssets.append(assetFilters.c_str());
             }


### PR DESCRIPTION
## What does this PR do?

When starting editor from a cache that does not contain an assetcatalog.xml, editor relies on network messages from the AP to build its in-memory catalog.  If the asset processor/editor are restarted before the first time starutp has completed, AP will resume where it was in the processing without resending the previously completed assets to the editor.

This fixes AP to send out all the existing assets in the catalog when a new connection is established. Also fixed issue in a few usages of CompileAssetSync where the Unknown return case was not being handled, which can occur when an asset has already been compiled.

Fixes https://github.com/o3de/o3de/issues/11926

## How was this PR tested?

Manually following repro steps in above linked issue
Added and ran automated test


### Release Exception Tracking

- [x] 1. (sig-content, @lsemp3d ) Owning SIG requests the exception, by a Sig Representative (Chair/co-chair) adding the PR to the exception requests queue board.
- [x] 2. Owning SIG comments on the PR explaining impact if this code does not go into stabilization.  (editor crash - see related issue)
- [x] 3.  (sig-core, @lumberyard-employee-dm ) Unrelated SIG representative (chair/cochair) approves the exception, adding a comment indicating approval and the SIG they represent.
- [x] 4. UX SIG representative (chair/cochair) approves the exception, adding a comment indicating approval and the SIG they represent.
- [x] 5. Testing SIG representative (chair/cochair) approves the exception, adding a comment indicating approval and the SIG they represent.
- [x] (Must occur at some point before SIG-Release approval) Code has been approved for merging by maintainers
- [x] 6. (sig-release, @tonybalandiuk - release manager) SIG-Release Release Manager or co-Release Manager approves the exception, adding a comment indicating approval and the SIG they represent. 
- [x] 7. If all approvals are accepted, then the exception PR may be merged
- [ ] 8. Merged PR is verified successful via testing. If Merged PR verification testing failed, consult reps from step 3-5 and discussion occurs on fixing the failure vs backing out change
- [ ] 9. Exception is complete

(CC @tonybalandiuk )