### PR TITLE
Fix Asset Processor test failures caused by the future database version

### DIFF
--- a/Code/Tools/AssetProcessor/assetprocessor_test_files.cmake
+++ b/Code/Tools/AssetProcessor/assetprocessor_test_files.cmake
@@ -68,6 +68,7 @@ set(FILES
     native/tests/ApplicationManagerTests.h
     native/tests/BuilderManagerTests.cpp
     native/tests/BuilderManagerTests.h
+    native/tests/MockAssetDatabaseRequestsHandler.h
     native/unittests/AssetCacheServerUnitTests.cpp
     native/unittests/AssetProcessingStateDataUnitTests.cpp
     native/unittests/AssetProcessingStateDataUnitTests.h

--- a/Code/Tools/AssetProcessor/native/tests/ApplicationManagerTests.h
+++ b/Code/Tools/AssetProcessor/native/tests/ApplicationManagerTests.h
@@ -10,6 +10,7 @@
 
 #include <utilities/BatchApplicationManager.h>
 #include <AzCore/UnitTest/TestTypes.h>
+#include <native/tests/MockAssetDatabaseRequestsHandler.h>
 #include "assetmanager/MockAssetProcessorManager.h"
 #include "assetmanager/MockFileProcessor.h"
 
@@ -25,31 +26,13 @@ namespace UnitTests
         using BatchApplicationManager::BatchApplicationManager;
     };
 
-    class DatabaseLocationListener : public AzToolsFramework::AssetDatabase::AssetDatabaseRequests::Bus::Handler
-    {
-    public:
-        DatabaseLocationListener()
-        {
-            BusConnect();
-        }
-        ~DatabaseLocationListener() override
-        {
-            BusDisconnect();
-        }
-
-        bool GetAssetDatabaseLocation(AZStd::string& location) override;
-
-        AZStd::string m_databaseLocation;
-    };
-
     struct ApplicationManagerTest : ::UnitTest::ScopedAllocatorSetupFixture
     {
     protected:
         void SetUp() override;
         void TearDown() override;
 
-        AZ::Test::ScopedAutoTempDirectory m_tempDir;
-        DatabaseLocationListener m_databaseLocationListener;
+        AssetProcessor::MockAssetDatabaseRequestsHandler m_databaseLocationListener;
 
         AZStd::unique_ptr<QCoreApplication> m_coreApplication;
         AZStd::unique_ptr<MockBatchApplicationManager> m_applicationManager;

--- a/Code/Tools/AssetProcessor/native/tests/AssetCatalog/AssetCatalogUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/AssetCatalog/AssetCatalogUnitTests.cpp
@@ -14,6 +14,7 @@
 #include <QCoreApplication>
 
 #include <native/unittests/UnitTestRunner.h> // for UnitTestUtils like CreateDummyFile / AssertAbsorber.
+#include <native/tests/MockAssetDatabaseRequestsHandler.h>
 #include <native/resourcecompiler/RCBuilder.h>
 
 #include "AssetManager/FileStateCache.h"
@@ -23,18 +24,11 @@ namespace AssetProcessor
     using namespace AZ;
     using namespace AZ::Data;
     using namespace testing;
-    using ::testing::NiceMock;
     using namespace UnitTestUtils;
     using namespace UnitTest;
     using namespace AzFramework::AssetSystem;
     using namespace AzToolsFramework::AssetSystem;
     using namespace AzToolsFramework::AssetDatabase;
-
-    class AssetCatalogUnitTestsMockDatabaseLocationListener : public AzToolsFramework::AssetDatabase::AssetDatabaseRequests::Bus::Handler
-    {
-    public:
-        MOCK_METHOD1(GetAssetDatabaseLocation, bool(AZStd::string&));
-    };
 
     class AssetCatalogForUnitTest : public AssetProcessor::AssetCatalog
     {
@@ -69,10 +63,9 @@ namespace AssetProcessor
         // store all data we create here so that it can be destroyed on shutdown before we remove allocators
         struct DataMembers
         {
-            NiceMock<AssetCatalogUnitTestsMockDatabaseLocationListener> m_databaseLocationListener;
+            MockAssetDatabaseRequestsHandler m_databaseLocationListener;
             FileStatePassthrough m_fileStateCache;
-            QTemporaryDir m_temporaryDir;
-            QDir m_temporarySourceDir;
+            QDir m_assetRootSourceDir;
             QDir m_priorAssetRoot;
             AssetDatabaseConnection m_dbConn;
             UnitTestUtils::ScopedDir m_scopedDir;
@@ -109,23 +102,18 @@ namespace AssetProcessor
             AssetUtilities::ComputeAssetRoot(m_data->m_priorAssetRoot);
             AssetUtilities::ResetAssetRoot();
 
-            // the canonicalization of the path here is to get around the fact that on some platforms
-            // the "temporary" folder location could be junctioned into some other folder and getting "QDir::current()"
-            // and other similar functions may actually return a different string but still be referring to the same folder
-            m_data->m_temporarySourceDir = QDir(m_data->m_temporaryDir.path());
-            QString canonicalTempDirPath = AssetUtilities::NormalizeDirectoryPath(m_data->m_temporarySourceDir.canonicalPath());
-            m_data->m_temporarySourceDir = QDir(canonicalTempDirPath);
-            m_data->m_scopedDir.Setup(m_data->m_temporarySourceDir.path());
+            m_data->m_assetRootSourceDir = QDir(m_data->m_databaseLocationListener.GetAssetRootDir().c_str());
+            m_data->m_scopedDir.Setup(m_data->m_assetRootSourceDir.path());
             m_data->m_gameName = AssetUtilities::ComputeProjectName("AutomatedTesting"); // uses the above file.
 
             AssetUtilities::ResetAssetRoot();
             QDir newRoot; // throwaway dummy var - we just want to invoke the below function
-            AssetUtilities::ComputeAssetRoot(newRoot, &m_data->m_temporarySourceDir);
+            AssetUtilities::ComputeAssetRoot(newRoot, &m_data->m_assetRootSourceDir);
 
             auto settingsRegistry = AZ::SettingsRegistry::Get();
             auto cacheRootKey =
                 AZ::SettingsRegistryInterface::FixedValueString(AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey) + "/project_cache_path";
-            settingsRegistry->Set(cacheRootKey, m_data->m_temporarySourceDir.absoluteFilePath("Cache").toUtf8().constData());
+            settingsRegistry->Set(cacheRootKey, m_data->m_assetRootSourceDir.absoluteFilePath("Cache").toUtf8().constData());
             auto projectPathKey =
                 AZ::SettingsRegistryInterface::FixedValueString(AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey) + "/project_path";
             AZ::IO::FixedMaxPath enginePath;
@@ -139,57 +127,44 @@ namespace AssetProcessor
             // create the files we'll use for this test:
             QSet<QString> expectedFiles;
             // set up some interesting files:
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("rootfile2.txt");
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("subfolder1/rootfile1.txt"); // note:  Must override the actual root file
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("subfolder1/basefile.txt");
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("subfolder2/basefile.txt");
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("subfolder2/aaa/basefile.txt");
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("subfolder2/aaa/bbb/basefile.txt");
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("subfolder2/aaa/bbb/ccc/basefile.txt");
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("subfolder2/aaa/bbb/ccc/ddd/basefile.txt");
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("subfolder3/BaseFile.txt"); // note the case upper here
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("subfolder8/a/b/c/test.txt");
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("rootfile2.txt");
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("subfolder1/rootfile1.txt"); // note:  Must override the actual root file
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("subfolder1/basefile.txt");
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("subfolder2/basefile.txt");
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("subfolder2/aaa/basefile.txt");
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("subfolder2/aaa/bbb/basefile.txt");
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("subfolder2/aaa/bbb/ccc/basefile.txt");
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("subfolder2/aaa/bbb/ccc/ddd/basefile.txt");
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("subfolder3/BaseFile.txt"); // note the case upper here
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("subfolder8/a/b/c/test.txt");
 
             // subfolder3 is not recursive so none of these should show up in any scan or override check
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("subfolder3/aaa/basefile.txt");
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("subfolder3/aaa/bbb/basefile.txt");
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("subfolder3/aaa/bbb/ccc/basefile.txt");
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("subfolder3/aaa/basefile.txt");
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("subfolder3/aaa/bbb/basefile.txt");
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("subfolder3/aaa/bbb/ccc/basefile.txt");
 
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("subfolder3/uniquefile.txt"); // only exists in subfolder3
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("subfolder3/uniquefile.ignore"); // only exists in subfolder3
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("subfolder3/uniquefile.txt"); // only exists in subfolder3
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("subfolder3/uniquefile.ignore"); // only exists in subfolder3
 
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("subfolder3/rootfile3.txt"); // must override rootfile3 in root
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("rootfile1.txt");
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("rootfile3.txt");
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("unrecognised.file"); // a file that should not be recognised
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("unrecognised2.file"); // a file that should not be recognised
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("subfolder1/test/test.format"); // a file that should be recognised
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("test.format"); // a file that should NOT be recognised
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("subfolder3/somefile.xxx");
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("subfolder3/savebackup/test.txt");//file that should be excluded
-            expectedFiles << m_data->m_temporarySourceDir.absoluteFilePath("subfolder3/somerandomfile.random");
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("subfolder3/rootfile3.txt"); // must override rootfile3 in root
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("rootfile1.txt");
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("rootfile3.txt");
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("unrecognised.file"); // a file that should not be recognised
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("unrecognised2.file"); // a file that should not be recognised
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("subfolder1/test/test.format"); // a file that should be recognised
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("test.format"); // a file that should NOT be recognised
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("subfolder3/somefile.xxx");
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("subfolder3/savebackup/test.txt");//file that should be excluded
+            expectedFiles << m_data->m_assetRootSourceDir.absoluteFilePath("subfolder3/somerandomfile.random");
 
             for (const QString& expect : expectedFiles)
             {
                 CreateDummyFile(expect);
             }
 
-            // in other unit tests we may open the database called ":memory:" to use an in-memory database instead of one on disk.
-            // in this test, however, we use a real database, because the catalog shares it and opens its own connection to it.
-            // ":memory:" databases are one-instance-only, and even if another connection is opened to ":memory:" it would
-            // not share with others created using ":memory:" and get a unique database instead.
-            m_data->m_databaseLocation = m_data->m_temporarySourceDir.absoluteFilePath("test_database.sqlite").toUtf8().constData();
-
-            ON_CALL(m_data->m_databaseLocationListener, GetAssetDatabaseLocation(_))
-                .WillByDefault(
-                    DoAll( // set the 0th argument ref (string) to the database location and return true.
-                        SetArgReferee<0>(m_data->m_databaseLocation.c_str()),
-                        Return(true)));
-
-            m_data->m_databaseLocationListener.BusConnect();
             m_data->m_dbConn.OpenDatabase();
 
-            BuildConfig(m_data->m_temporarySourceDir, &(m_data->m_dbConn), m_data->m_config);
+            BuildConfig(m_data->m_assetRootSourceDir, &(m_data->m_dbConn), m_data->m_config);
             m_data->m_assetCatalog.reset(new AssetCatalogForUnitTest(nullptr, &(m_data->m_config)));
         }
 
@@ -425,7 +400,7 @@ namespace AssetProcessor
         m_data->m_absorber.Clear();
 
         ASSERT_TRUE(TestGetRelativeProductPath("", false, { "" }));
-        ASSERT_TRUE(TestGetFullSourcePath("", m_data->m_temporarySourceDir, false, ""));
+        ASSERT_TRUE(TestGetFullSourcePath("", m_data->m_assetRootSourceDir, false, ""));
     }
 
     TEST_F(AssetCatalogTestWithProducts, GetRelativePath_GivenRootPath_ReturnsFailure)
@@ -515,7 +490,7 @@ namespace AssetProcessor
 
     TEST_F(AssetCatalogTestWithProducts, GetRelativeProductPathFromFullSourceOrProductPath_RelativePathToSourceFile_ReturnsProductFilePath)
     {
-        QString fileToCheck = m_data->m_temporarySourceDir.absoluteFilePath("subfolder3/BaseFile.txt");
+        QString fileToCheck = m_data->m_assetRootSourceDir.absoluteFilePath("subfolder3/BaseFile.txt");
         ASSERT_TRUE(TestGetRelativeProductPath(fileToCheck, true, { "basefilez.arc2", "basefileaz.azm2",
             "basefile.arc2", "basefile.azm2" }));
     }
@@ -523,7 +498,7 @@ namespace AssetProcessor
     TEST_F(AssetCatalogTestWithProducts, GetRelativeProductPathFromFullSourceOrProductPath_RelativePathToSourceFile_BadCasing_ReturnsProductFilePath)
     {
         // note that the casing of the source file is not correct.  It must still work.
-        QString fileToCheck = m_data->m_temporarySourceDir.absoluteFilePath("subfolder2/aaa/basefile.txt");
+        QString fileToCheck = m_data->m_assetRootSourceDir.absoluteFilePath("subfolder2/aaa/basefile.txt");
         ASSERT_TRUE(TestGetRelativeProductPath(fileToCheck, true, { "aaa/basefile.txt" }));
     }
 
@@ -730,70 +705,70 @@ namespace AssetProcessor
     {
         // feed it an relative product, and expect a full, absolute source file path in return.
         QString fileToCheck = "subfolder3/randomfileoutput.random1";
-        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_temporarySourceDir, true, "subfolder3/somerandomfile.random"));
+        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_assetRootSourceDir, true, "subfolder3/somerandomfile.random"));
     }
 
     TEST_F(AssetCatalogTest_GetFullSourcePath, SecondProduct_ReturnsAbsolutePathToSource)
     {
         // feed it another relative product from the same source file, expect the same source.
         QString fileToCheck = "subfolder3/randomfileoutput.random2";
-        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_temporarySourceDir, true, "subfolder3/somerandomfile.random"));
+        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_assetRootSourceDir, true, "subfolder3/somerandomfile.random"));
     }
 
     TEST_F(AssetCatalogTest_GetFullSourcePath, IncorrectSeperators_ReturnsAbsolutePathToSource)
     {
         //feed it the same relative product with different separators
         QString fileToCheck = "subfolder3\\randomfileoutput.random2";
-        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_temporarySourceDir, true, "subfolder3/somerandomfile.random"));
+        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_assetRootSourceDir, true, "subfolder3/somerandomfile.random"));
     }
 
     TEST_F(AssetCatalogTest_GetFullSourcePath, SourcePath_ReturnsSourcePath)
     {
         // feed it a full path to a source file, we expect that path back
-        QString fileToCheck = m_data->m_temporarySourceDir.filePath("somefolder/somefile.txt");
-        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_temporarySourceDir, true, "somefolder/somefile.txt"));
+        QString fileToCheck = m_data->m_assetRootSourceDir.filePath("somefolder/somefile.txt");
+        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_assetRootSourceDir, true, "somefolder/somefile.txt"));
     }
 
     TEST_F(AssetCatalogTest_GetFullSourcePath, AliasedCachePath_ReturnsAbsolutePathToSource)
     {
         //feed it a path with alias and asset id
         QString fileToCheck = "@products@/subfolder3/randomfileoutput.random1";
-        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_temporarySourceDir, true, "subfolder3/somerandomfile.random"));
+        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_assetRootSourceDir, true, "subfolder3/somerandomfile.random"));
     }
 
     TEST_F(AssetCatalogTest_GetFullSourcePath, InvalidAlias_ReturnsAbsolutePathToSource)
     {
         //feed it a path with some random alias and asset id
         QString fileToCheck = "@somerandomalias@/subfolder3/randomfileoutput.random1";
-        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_temporarySourceDir, true, "subfolder3/somerandomfile.random"));
+        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_assetRootSourceDir, true, "subfolder3/somerandomfile.random"));
     }
 
     TEST_F(AssetCatalogTest_GetFullSourcePath, InvalidAliasMissingSeperator_ReturnsAbsolutePathToSource)
     {
         //feed it a path with some random alias and asset id but no separator
         QString fileToCheck = "@somerandomalias@subfolder3/randomfileoutput.random1";
-        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_temporarySourceDir, true, "subfolder3/somerandomfile.random"));
+        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_assetRootSourceDir, true, "subfolder3/somerandomfile.random"));
     }
 
     TEST_F(AssetCatalogTest_GetFullSourcePath, InvalidSourcePathContainingCacheAlias_ReturnsAbsolutePathToSource)
     {
         //feed it a path with alias and input name
         QString fileToCheck = "@products@/somerandomfile.random";
-        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_temporarySourceDir, true, "subfolder3/somerandomfile.random"));
+        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_assetRootSourceDir, true, "subfolder3/somerandomfile.random"));
     }
 
     TEST_F(AssetCatalogTest_GetFullSourcePath, AbsolutePathToCache_ReturnsAbsolutePathToSource)
     {
         //feed it an absolute path with cacheroot
         QString fileToCheck = m_data->m_cacheRootDir.filePath(QString("pc") + "/subfolder3/randomfileoutput.random1");
-        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_temporarySourceDir, true, "subfolder3/somerandomfile.random"));
+        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_assetRootSourceDir, true, "subfolder3/somerandomfile.random"));
     }
 
     TEST_F(AssetCatalogTest_GetFullSourcePath, ProductNameIncludingPlatformAndGameName_ReturnsAbsolutePathToSource)
     {
         //feed it a productName directly
         QString fileToCheck = QString("pc") + "/subfolder3/randomfileoutput.random1";
-        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_temporarySourceDir, true, "subfolder3/somerandomfile.random"));
+        EXPECT_TRUE(TestGetFullSourcePath(fileToCheck, m_data->m_assetRootSourceDir, true, "subfolder3/somerandomfile.random"));
     }
 
     class AssetCatalogTest_AssetInfo
@@ -822,7 +797,7 @@ namespace AssetProcessor
         {
             AssetCatalogTest::SetUp();
             m_customDataMembers = azcreate(AssetCatalogTest_AssetInfo_DataMembers, ());
-            m_customDataMembers->m_subfolder1AbsolutePath = m_data->m_temporarySourceDir.absoluteFilePath("subfolder1").toStdString().c_str();
+            m_customDataMembers->m_subfolder1AbsolutePath = m_data->m_assetRootSourceDir.absoluteFilePath("subfolder1").toStdString().c_str();
 
             AzFramework::StringFunc::Path::Join(m_customDataMembers->m_subfolder1AbsolutePath.c_str(), m_customDataMembers->m_assetASourceRelPath.c_str(), m_customDataMembers->m_assetAFullPath);
             CreateDummyFile(QString::fromUtf8(m_customDataMembers->m_assetAFullPath.c_str()), m_customDataMembers->m_assetTestString.c_str());

--- a/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
@@ -15,13 +15,12 @@
 #include <AzCore/Utils/Utils.h>
 #include <connection/connectionManager.h>
 #include <QCoreApplication>
-#include <QTemporaryDir>
 #include <AzFramework/Network/AssetProcessorConnection.h>
+#include <native/tests/MockAssetDatabaseRequestsHandler.h>
 
 namespace AssetProcessorMessagesTests
 {
     using namespace testing;
-    using ::testing::NiceMock;
 
     using namespace AssetProcessor;
     using namespace AssetBuilderSDK;
@@ -40,12 +39,6 @@ namespace AssetProcessorMessagesTests
         }
 
         friend class AssetProcessorMessages;
-    };
-
-    class AssetProcessorMessagesTestsMockDatabaseLocationListener : public AzToolsFramework::AssetDatabase::AssetDatabaseRequests::Bus::Handler
-    {
-    public:
-        MOCK_METHOD1(GetAssetDatabaseLocation, bool(AZStd::string&));
     };
 
     struct MockAssetCatalog : AssetProcessor::AssetCatalog
@@ -84,17 +77,6 @@ namespace AssetProcessorMessagesTests
         void SetUp() override
         {
             AssetUtilities::ResetGameName();
-
-            m_temporarySourceDir = QDir(m_temporaryDir.path());
-            m_databaseLocation = m_temporarySourceDir.absoluteFilePath("test_database.sqlite").toUtf8().constData();
-
-            ON_CALL(m_databaseLocationListener, GetAssetDatabaseLocation(_))
-                .WillByDefault(
-                    DoAll( // set the 0th argument ref (string) to the database location and return true.
-                        SetArgReferee<0>(m_databaseLocation.c_str()),
-                        Return(true)));
-
-            m_databaseLocationListener.BusConnect();
 
             m_dbConn.OpenDatabase();
 
@@ -228,12 +210,10 @@ namespace AssetProcessorMessagesTests
     protected:
 
         MockAssetRequestHandler* m_assetRequestHandler{}; // Not owned, AP will delete this pointer
-        QTemporaryDir m_temporaryDir;
         AZStd::unique_ptr<UnitTestBatchApplicationManager> m_batchApplicationManager;
         AZStd::unique_ptr<AzFramework::AssetSystem::AssetSystemComponent> m_assetSystemComponent;
-        NiceMock<AssetProcessorMessagesTestsMockDatabaseLocationListener> m_databaseLocationListener;
+        AssetProcessor::MockAssetDatabaseRequestsHandler m_databaseLocationListener;
         AZStd::unique_ptr<MockAssetCatalog> m_assetCatalog = nullptr;
-        QDir m_temporarySourceDir;
         AZStd::string m_databaseLocation;
         AssetDatabaseConnection m_dbConn;
     };

--- a/Code/Tools/AssetProcessor/native/tests/FileProcessor/FileProcessorTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/FileProcessor/FileProcessorTests.cpp
@@ -19,20 +19,7 @@ namespace UnitTests
 
         m_databaseLocationListener.BusConnect();
 
-        m_temporarySourceDir = QDir(m_temporaryDir.path());
-
-        // in other unit tests we may open the database called ":memory:" to use an in-memory database instead of one on disk.
-        // in this test, however, we use a real database, because the file processor shares it and opens its own connection to it.
-        // ":memory:" databases are one-instance-only, and even if another connection is opened to ":memory:" it would
-        // not share with others created using ":memory:" and get a unique database instead.
-        m_databaseLocation = m_temporarySourceDir.absoluteFilePath("test_database.sqlite").toUtf8().constData();
-
-
-        ON_CALL(m_databaseLocationListener, GetAssetDatabaseLocation(::testing::_))
-            .WillByDefault(
-                DoAll( // set the 0th argument ref (string) to the database location and return true.
-                    ::testing::SetArgReferee<0>(m_databaseLocation),
-                    ::testing::Return(true)));
+        m_assetRootSourceDir = QDir(m_databaseLocationListener.GetAssetRootDir().c_str());
 
         // Initialize the database:
         m_connection.ClearData(); // this is expected to reset/clear/reopen
@@ -42,8 +29,8 @@ namespace UnitTests
 
         m_fileProcessor = AZStd::make_unique<FileProcessor>(m_config.get());
 
-        m_scanFolder = { m_temporarySourceDir.absoluteFilePath("dev").toUtf8().constData(), "dev", "rootportkey" };
-        m_scanFolder2 = { m_temporarySourceDir.absoluteFilePath("dev2").toUtf8().constData(), "dev2", "dev2" };
+        m_scanFolder = { m_assetRootSourceDir.absoluteFilePath("dev").toUtf8().constData(), "dev", "rootportkey" };
+        m_scanFolder2 = { m_assetRootSourceDir.absoluteFilePath("dev2").toUtf8().constData(), "dev2", "dev2" };
         ASSERT_TRUE(m_connection.SetScanFolder(m_scanFolder));
         ASSERT_TRUE(m_connection.SetScanFolder(m_scanFolder2));
 

--- a/Code/Tools/AssetProcessor/native/tests/FileProcessor/FileProcessorTests.h
+++ b/Code/Tools/AssetProcessor/native/tests/FileProcessor/FileProcessorTests.h
@@ -10,7 +10,8 @@
 
 #include <AzTest/AzTest.h>
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
-#include "native/tests/AssetProcessorTest.h"
+#include <native/tests/AssetProcessorTest.h>
+#include <native/tests/MockAssetDatabaseRequestsHandler.h>
 #include "AzToolsFramework/API/AssetDatabaseBus.h"
 #include "AssetDatabase/AssetDatabase.h"
 #include "FileProcessor/FileProcessor.h"
@@ -20,7 +21,6 @@
 
 namespace UnitTests
 {
-    using ::testing::NiceMock;
     using namespace AssetProcessor;
 
     using AzToolsFramework::AssetDatabase::ProductDatabaseEntry;
@@ -35,12 +35,6 @@ namespace UnitTests
     using AzToolsFramework::AssetDatabase::AssetDatabaseConnection;
     using AzToolsFramework::AssetDatabase::FileDatabaseEntry;
     using AzToolsFramework::AssetDatabase::FileDatabaseEntryContainer;
-
-    class FileProcessorTestsMockDatabaseLocationListener : public AzToolsFramework::AssetDatabase::AssetDatabaseRequests::Bus::Handler
-    {
-    public:
-        MOCK_METHOD1(GetAssetDatabaseLocation, bool(AZStd::string&));
-    };
 
     class FileProcessorTests
         : public AssetProcessorTest,
@@ -78,11 +72,10 @@ namespace UnitTests
         void RemoveResponseHandler([[maybe_unused]] unsigned int serial) override {};
 
     protected:
-        QTemporaryDir m_temporaryDir;
-        QDir m_temporarySourceDir;
+        QDir m_assetRootSourceDir;
 
         AZStd::string m_databaseLocation;
-        NiceMock<FileProcessorTestsMockDatabaseLocationListener> m_databaseLocationListener;
+        AssetProcessor::MockAssetDatabaseRequestsHandler m_databaseLocationListener;
         AssetProcessor::AssetDatabaseConnection m_connection;
 
         AZStd::unique_ptr<AssetProcessor::PlatformConfiguration> m_config;

--- a/Code/Tools/AssetProcessor/native/tests/MockAssetDatabaseRequestsHandler.h
+++ b/Code/Tools/AssetProcessor/native/tests/MockAssetDatabaseRequestsHandler.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <QDir>
+#include <QTemporaryDir>
+#include <AzToolsFramework/API/AssetDatabaseBus.h>
+#include <native/utilities/assetUtils.h>
+
+namespace AssetProcessor
+{
+    // Mock the AssetDatabaseRequests handler for retrieving the asset database location in unit tests
+    class MockAssetDatabaseRequestsHandler
+        : public AzToolsFramework::AssetDatabase::AssetDatabaseRequests::Bus::Handler
+    {
+    public:
+        MockAssetDatabaseRequestsHandler()
+        {
+            // the canonicalization of the path here is to get around the fact that on some platforms
+            // the "temporary" folder location could be junctioned into some other folder and getting "QDir::current()"
+            // and other similar functions may actually return a different string but still be referring to the same folder
+            QString canonicalTempDirPath = AssetUtilities::NormalizeDirectoryPath(QDir(m_temporaryDir.path()).canonicalPath());
+            m_assetDatabasePath = QDir(canonicalTempDirPath).absoluteFilePath("test_database.sqlite").toUtf8().data();
+
+            BusConnect();
+        }
+
+        ~MockAssetDatabaseRequestsHandler()
+        {
+            BusDisconnect();
+        }
+
+        bool GetAssetDatabaseLocation(AZStd::string& location) override
+        {
+            location = m_assetDatabasePath;
+
+            return true;
+        }
+
+        AZStd::string GetAssetRootDir()
+        {
+            return QFileInfo(m_assetDatabasePath.c_str()).dir().path().toUtf8().data();
+        }
+
+        AZStd::string m_assetDatabasePath;
+
+    private:
+        QTemporaryDir m_temporaryDir;
+    };
+}

--- a/Code/Tools/AssetProcessor/native/tests/assetdatabase/AssetDatabaseTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetdatabase/AssetDatabaseTest.cpp
@@ -11,13 +11,13 @@
 #include <AzCore/std/sort.h>
 
 #include <native/tests/AssetProcessorTest.h>
+#include <native/tests/MockAssetDatabaseRequestsHandler.h>
 #include <native/AssetDatabase/AssetDatabase.h>
 #include <AzToolsFramework/AssetDatabase/PathOrUuid.h>
 
 namespace UnitTests
 {
     using namespace testing;
-    using ::testing::NiceMock;
     using namespace AssetProcessor;
     using namespace AzToolsFramework::AssetDatabase;
 
@@ -36,12 +36,6 @@ namespace UnitTests
     using AzToolsFramework::AssetDatabase::StatDatabaseEntryContainer;
 
 
-    class AssetDatabaseTestMockDatabaseLocationListener : public AzToolsFramework::AssetDatabase::AssetDatabaseRequests::Bus::Handler
-    {
-    public:
-        MOCK_METHOD1(GetAssetDatabaseLocation, bool(AZStd::string&));
-    };
-
     class AssetDatabaseTest : public AssetProcessorTest
     {
     public:
@@ -49,22 +43,13 @@ namespace UnitTests
         {
             AssetProcessorTest::SetUp();
             m_data.reset(new StaticData());
-            m_data->m_databaseLocation = ":memory:"; // this special string causes SQLITE to open the database in memory and not touch disk at all.
-            m_data->m_databaseLocationListener.BusConnect();
-
-            ON_CALL(m_data->m_databaseLocationListener, GetAssetDatabaseLocation(_))
-                .WillByDefault(
-                    DoAll( // set the 0th argument ref (string) to the database location and return true.
-                        SetArgReferee<0>(":memory:"),
-                        Return(true)));
-
+            m_data->m_databaseLocationListener.m_assetDatabasePath = ":memory:"; // this special string causes SQLITE to open the database in memory and not touch disk at all.
             // Initialize the database:
             m_data->m_connection.ClearData(); // this is expected to reset/clear/reopen
         }
 
         void TearDown() override
         {
-            m_data->m_databaseLocationListener.BusDisconnect();
             m_data.reset();
             AssetProcessorTest::TearDown();
         }
@@ -144,7 +129,7 @@ namespace UnitTests
         {
             // these variables are created during SetUp() and destroyed during TearDown() and thus are always available during tests using this fixture:
             AZStd::string m_databaseLocation;
-            NiceMock<AssetDatabaseTestMockDatabaseLocationListener> m_databaseLocationListener;
+            AssetProcessor::MockAssetDatabaseRequestsHandler m_databaseLocationListener;
             AssetProcessor::AssetDatabaseConnection m_connection;
 
             // The following database entry variables are initialized only when you call coverage test data CreateCoverageTestData().

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetManagerTestingBase.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetManagerTestingBase.cpp
@@ -20,12 +20,6 @@
 
 namespace UnitTests
 {
-    bool TestingDatabaseLocationListener::GetAssetDatabaseLocation(AZStd::string& location)
-    {
-        location = m_databaseLocation;
-        return true;
-    }
-
     void TestingAssetProcessorManager::CheckActiveFiles(int count)
     {
         ASSERT_EQ(m_activeFiles.size(), count);
@@ -53,8 +47,7 @@ namespace UnitTests
         }
 
         // Specify the database lives in the temp directory
-        AZ::IO::Path tempDir(m_tempDir.GetDirectory());
-        m_databaseLocationListener.m_databaseLocation = (tempDir / "test_database.sqlite").Native();
+        AZ::IO::Path assetRootDir(m_databaseLocationListener.GetAssetRootDir());
 
         // We need a settings registry in order for APM to figure out the cache path
         m_settingsRegistry = AZStd::make_unique<AZ::SettingsRegistryImpl>();
@@ -62,7 +55,7 @@ namespace UnitTests
 
         auto projectPathKey =
             AZ::SettingsRegistryInterface::FixedValueString(AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey) + "/project_path";
-        m_settingsRegistry->Set(projectPathKey, m_tempDir.GetDirectory());
+        m_settingsRegistry->Set(projectPathKey, m_databaseLocationListener.GetAssetRootDir().c_str());
         AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_AddRuntimeFilePaths(*m_settingsRegistry);
 
         // We need a QCoreApplication set up in order for QCoreApplication::processEvents to function
@@ -83,7 +76,7 @@ namespace UnitTests
         m_platformConfig->PopulatePlatformsForScanFolder(platforms);
 
         m_platformConfig->AddScanFolder(
-            AssetProcessor::ScanFolderInfo{ (tempDir / "folder").c_str(), "folder", "folder", false, true, platforms });
+            AssetProcessor::ScanFolderInfo{ (assetRootDir / "folder").c_str(), "folder", "folder", false, true, platforms });
 
         m_platformConfig->AddIntermediateScanFolder();
 

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetManagerTestingBase.h
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetManagerTestingBase.h
@@ -14,6 +14,7 @@
 #include <AzCore/std/parallel/binary_semaphore.h>
 #include <Tests/Utils/Utils.h>
 #include <native/AssetManager/assetProcessorManager.h>
+#include <native/tests/MockAssetDatabaseRequestsHandler.h>
 #include <resourcecompiler/rccontroller.h>
 #include <tests/UnitTestUtilities.h>
 #include <QCoreApplication>
@@ -29,23 +30,6 @@ namespace UnitTests
     {
     public:
         MOCK_METHOD2(CheckSufficientDiskSpace, bool(qint64, bool));
-    };
-
-    class TestingDatabaseLocationListener : public AzToolsFramework::AssetDatabase::AssetDatabaseRequests::Bus::Handler
-    {
-    public:
-        TestingDatabaseLocationListener()
-        {
-            BusConnect();
-        }
-        ~TestingDatabaseLocationListener() override
-        {
-            BusDisconnect();
-        }
-
-        bool GetAssetDatabaseLocation(AZStd::string& location) override;
-
-        AZStd::string m_databaseLocation;
     };
 
     class JobSignalReceiver : AZ::Interface<AssetProcessor::IRCJobSignal>::Registrar
@@ -108,8 +92,7 @@ namespace UnitTests
         AZStd::unique_ptr<AZ::SettingsRegistryImpl> m_settingsRegistry;
         AZStd::shared_ptr<AssetProcessor::AssetDatabaseConnection> m_stateData;
         AZStd::unique_ptr<::testing::NiceMock<MockDiskSpaceResponder>> m_diskSpaceResponder;
-        AZ::Test::ScopedAutoTempDirectory m_tempDir;
-        TestingDatabaseLocationListener m_databaseLocationListener;
+        AssetProcessor::MockAssetDatabaseRequestsHandler m_databaseLocationListener;
         AzToolsFramework::AssetDatabase::ScanFolderDatabaseEntry m_scanfolder;
         MockMultiBuilderInfoHandler m_builderInfoHandler;
         AZ::IO::LocalFileIO* m_localFileIo;

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -100,14 +100,14 @@ void AssetProcessorManagerTest::SetUp()
 
     AssetUtilities::ResetAssetRoot();
 
+    m_assetRootDir = QDir(m_data->m_databaseLocationListener.GetAssetRootDir().c_str());
     m_scopeDir = AZStd::make_unique<UnitTestUtils::ScopedDir>();
-    m_scopeDir->Setup(m_tempDir.path());
-    QDir tempPath(m_tempDir.path());
+    m_scopeDir->Setup(m_assetRootDir.path());
 
     auto registry = AZ::SettingsRegistry::Get();
     auto cacheRootKey =
         AZ::SettingsRegistryInterface::FixedValueString(AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey) + "/project_cache_path";
-    registry->Set(cacheRootKey, tempPath.absoluteFilePath("Cache").toUtf8().constData());
+    registry->Set(cacheRootKey, m_assetRootDir.absoluteFilePath("Cache").toUtf8().constData());
     auto projectPathKey =
         AZ::SettingsRegistryInterface::FixedValueString(AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey) + "/project_path";
     AZ::IO::FixedMaxPath enginePath;
@@ -115,25 +115,11 @@ void AssetProcessorManagerTest::SetUp()
     registry->Set(projectPathKey, (enginePath / "AutomatedTesting").Native());
     AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_AddRuntimeFilePaths(*registry);
 
-    m_data->m_databaseLocationListener.BusConnect();
-
-    // in other unit tests we may open the database called ":memory:" to use an in-memory database instead of one on disk.
-    // in this test, however, we use a real database, because the file processor shares it and opens its own connection to it.
-    // ":memory:" databases are one-instance-only, and even if another connection is opened to ":memory:" it would
-    // not share with others created using ":memory:" and get a unique database instead.
-    m_data->m_databaseLocation = tempPath.absoluteFilePath("test_database.sqlite").toUtf8().constData();
-
-    ON_CALL(m_data->m_databaseLocationListener, GetAssetDatabaseLocation(_))
-        .WillByDefault(
-            DoAll( // set the 0th argument ref (string) to the database location and return true.
-                SetArgReferee<0>(m_data->m_databaseLocation),
-                Return(true)));
-
     m_gameName = AssetUtilities::ComputeProjectName("AutomatedTesting", true);
 
     AssetUtilities::ResetAssetRoot();
     QDir newRoot;
-    AssetUtilities::ComputeEngineRoot(newRoot, &tempPath);
+    AssetUtilities::ComputeEngineRoot(newRoot, &m_assetRootDir);
 
     QDir cacheRoot;
     AssetUtilities::ComputeProjectCacheRoot(cacheRoot);
@@ -141,14 +127,14 @@ void AssetProcessorManagerTest::SetUp()
 
     m_normalizedCacheRootDir.setPath(normalizedCacheRoot);
 
-    UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("subfolder1/assetProcessorManagerTest.txt"));
+    UnitTestUtils::CreateDummyFile(m_assetRootDir.absoluteFilePath("subfolder1/assetProcessorManagerTest.txt"));
 
     m_config->EnablePlatform({ "pc", { "host", "renderer", "desktop" } }, true);
 
-    m_config->AddScanFolder(ScanFolderInfo(tempPath.filePath("subfolder1"), "subfolder1", "subfolder1", false, true, m_config->GetEnabledPlatforms(), 1));
-    m_config->AddScanFolder(ScanFolderInfo(tempPath.filePath("subfolder2"), "subfolder2", "subfolder2", false, true, m_config->GetEnabledPlatforms()));
-    m_config->AddScanFolder(ScanFolderInfo(tempPath.filePath("subfolder3"), "subfolder3", "subfolder3", false, true, m_config->GetEnabledPlatforms(), 1));
-    m_config->AddScanFolder(ScanFolderInfo(tempPath.filePath("subfolder4"), "subfolder4", "subfolder4", false, true, m_config->GetEnabledPlatforms(), 1));
+    m_config->AddScanFolder(ScanFolderInfo(m_assetRootDir.filePath("subfolder1"), "subfolder1", "subfolder1", false, true, m_config->GetEnabledPlatforms(), 1));
+    m_config->AddScanFolder(ScanFolderInfo(m_assetRootDir.filePath("subfolder2"), "subfolder2", "subfolder2", false, true, m_config->GetEnabledPlatforms()));
+    m_config->AddScanFolder(ScanFolderInfo(m_assetRootDir.filePath("subfolder3"), "subfolder3", "subfolder3", false, true, m_config->GetEnabledPlatforms(), 1));
+    m_config->AddScanFolder(ScanFolderInfo(m_assetRootDir.filePath("subfolder4"), "subfolder4", "subfolder4", false, true, m_config->GetEnabledPlatforms(), 1));
     m_config->AddMetaDataType("assetinfo", "");
     m_config->AddIntermediateScanFolder();
 
@@ -203,9 +189,7 @@ void AssetProcessorManagerTest::TearDown()
 
 void AssetProcessorManagerTest::CreateSourceAndFile(const char* tempFolderRelativePath)
 {
-    QDir tempPath(m_tempDir.path());
-
-    auto absolutePath = tempPath.absoluteFilePath(tempFolderRelativePath);
+    auto absolutePath = m_assetRootDir.absoluteFilePath(tempFolderRelativePath);
 
     auto scanFolder = m_config->GetScanFolderForFile(absolutePath);
 
@@ -224,10 +208,8 @@ void AssetProcessorManagerTest::PopulateDatabase()
 {
     using namespace AzToolsFramework::AssetDatabase;
 
-    QDir tempPath(m_tempDir.path());
-
     AzToolsFramework::AssetDatabase::ScanFolderDatabaseEntry scanFolder(
-        tempPath.absoluteFilePath("subfolder1").toUtf8().constData(), "temp path", "temp path");
+        m_assetRootDir.absoluteFilePath("subfolder1").toUtf8().constData(), "temp path", "temp path");
     ASSERT_TRUE(m_assetProcessorManager->m_stateData->SetScanFolder(scanFolder));
 
     CreateSourceAndFile("subfolder1/a.txt");
@@ -244,11 +226,9 @@ TEST_F(AssetProcessorManagerTest, UnitTestForGettingJobInfoBySourceUUIDSuccess)
     using namespace AzToolsFramework::AssetSystem;
     using namespace AssetProcessor;
 
-    QDir tempPath(m_tempDir.path());
-
     QString relFileName("assetProcessorManagerTest.txt");
-    QString absPath(tempPath.absoluteFilePath("subfolder1/assetProcessorManagerTest.txt"));
-    QString watchFolder = tempPath.absoluteFilePath("subfolder1");
+    QString absPath(m_assetRootDir.absoluteFilePath("subfolder1/assetProcessorManagerTest.txt"));
+    QString watchFolder = m_assetRootDir.absoluteFilePath("subfolder1");
 
     JobEntry entry;
     entry.m_watchFolderPath = watchFolder;
@@ -294,7 +274,7 @@ TEST_F(AssetProcessorManagerTest, UnitTestForGettingJobInfoBySourceUUIDSuccess)
 
     EXPECT_EQ(JobStatus::Queued, response.m_jobList[0].m_status);
     EXPECT_STRCASEEQ(relFileName.toUtf8().data(), response.m_jobList[0].m_sourceFile.c_str());
-    EXPECT_STRCASEEQ(tempPath.filePath("subfolder1").toUtf8().data(), response.m_jobList[0].m_watchFolder.c_str());
+    EXPECT_STRCASEEQ(m_assetRootDir.filePath("subfolder1").toUtf8().data(), response.m_jobList[0].m_watchFolder.c_str());
 
     ASSERT_EQ(m_errorAbsorber->m_numWarningsAbsorbed, 0);
     ASSERT_EQ(m_errorAbsorber->m_numErrorsAbsorbed, 0);
@@ -308,11 +288,9 @@ TEST_F(AssetProcessorManagerTest, WarningsAndErrorsReported_SuccessfullySavedToD
     using namespace AzToolsFramework::AssetSystem;
     using namespace AssetProcessor;
 
-    QDir tempPath(m_tempDir.path());
-
     QString relFileName("assetProcessorManagerTest.txt");
-    QString absPath(tempPath.absoluteFilePath("subfolder1/assetProcessorManagerTest.txt"));
-    QString watchFolder = tempPath.absoluteFilePath("subfolder1");
+    QString absPath(m_assetRootDir.absoluteFilePath("subfolder1/assetProcessorManagerTest.txt"));
+    QString watchFolder = m_assetRootDir.absoluteFilePath("subfolder1");
 
     JobEntry entry;
     entry.m_watchFolderPath = watchFolder;
@@ -359,14 +337,13 @@ TEST_F(AssetProcessorManagerTest, WarningsAndErrorsReported_SuccessfullySavedToD
 TEST_F(AssetProcessorManagerTest, DeleteFolder_SignalsDeleteOfContainedFiles)
 {
     using namespace AssetProcessor;
-    QDir tempPath(m_tempDir.path());
 
     static constexpr char folderPathNoScanfolder[] = "folder/folder/foldertest.txt";
     static constexpr char folderPath[] = "subfolder1/folder/folder/foldertest.txt";
 
-    UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath(folderPath));
+    UnitTestUtils::CreateDummyFile(m_assetRootDir.absoluteFilePath(folderPath));
 
-    auto scanFolderInfo = m_config->GetScanFolderByPath(tempPath.absoluteFilePath("subfolder1"));
+    auto scanFolderInfo = m_config->GetScanFolderByPath(m_assetRootDir.absoluteFilePath("subfolder1"));
     ASSERT_TRUE(scanFolderInfo != nullptr);
 
     AzToolsFramework::AssetDatabase::SourceDatabaseEntry sourceEntry(
@@ -387,14 +364,14 @@ TEST_F(AssetProcessorManagerTest, DeleteFolder_SignalsDeleteOfContainedFiles)
 
     m_isIdling = false;
     // tell the APM about the files:
-    m_assetProcessorManager->AssessAddedFile(tempPath.absoluteFilePath(folderPath));
+    m_assetProcessorManager->AssessAddedFile(m_assetRootDir.absoluteFilePath(folderPath));
 
     ASSERT_TRUE(BlockUntilIdle(5000));
 
-    EXPECT_TRUE(QDir(tempPath.absoluteFilePath("subfolder1/folder")).removeRecursively());
+    EXPECT_TRUE(QDir(m_assetRootDir.absoluteFilePath("subfolder1/folder")).removeRecursively());
 
     m_isIdling = false;
-    m_assetProcessorManager->AssessDeletedFile(tempPath.absoluteFilePath("subfolder1/folder"));
+    m_assetProcessorManager->AssessDeletedFile(m_assetRootDir.absoluteFilePath("subfolder1/folder"));
     ASSERT_TRUE(BlockUntilIdle(5000));
 
     EXPECT_EQ(1, count);
@@ -423,12 +400,11 @@ TEST_F(AssetProcessorManagerTest, UnitTestForCancelledJob)
     using namespace AzToolsFramework::AssetSystem;
     using namespace AssetProcessor;
 
-    QDir tempPath(m_tempDir.path());
     QString relFileName("assetProcessorManagerTest.txt");
-    QString absPath(tempPath.absoluteFilePath("subfolder1/assetProcessorManagerTest.txt"));
+    QString absPath(m_assetRootDir.absoluteFilePath("subfolder1/assetProcessorManagerTest.txt"));
     JobEntry entry;
 
-    entry.m_watchFolderPath = tempPath.absolutePath();
+    entry.m_watchFolderPath = m_assetRootDir.absolutePath();
     entry.m_databaseSourceName = entry.m_pathRelativeToWatchFolder = relFileName;
 
     entry.m_jobKey = "txt";
@@ -800,12 +776,10 @@ TEST_F(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_BasicTe
 
     //  A depends on B, which depends on both C and D
 
-    QDir tempPath(m_tempDir.path());
-
-    UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("subfolder1/a.txt"), QString("tempdata\n"));
-    UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("subfolder1/b.txt"), QString("tempdata\n"));
-    UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("subfolder1/c.txt"), QString("tempdata\n"));
-    UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("subfolder1/d.txt"), QString("tempdata\n"));
+    UnitTestUtils::CreateDummyFile(m_assetRootDir.absoluteFilePath("subfolder1/a.txt"), QString("tempdata\n"));
+    UnitTestUtils::CreateDummyFile(m_assetRootDir.absoluteFilePath("subfolder1/b.txt"), QString("tempdata\n"));
+    UnitTestUtils::CreateDummyFile(m_assetRootDir.absoluteFilePath("subfolder1/c.txt"), QString("tempdata\n"));
+    UnitTestUtils::CreateDummyFile(m_assetRootDir.absoluteFilePath("subfolder1/d.txt"), QString("tempdata\n"));
 
     SourceFileDependencyEntry newEntry1;  // a depends on B
     newEntry1.m_sourceDependencyID = AzToolsFramework::AssetDatabase::InvalidEntryId;
@@ -833,23 +807,23 @@ TEST_F(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_BasicTe
     m_assetProcessorManager->QueryAbsolutePathDependenciesRecursive(m_aUuid, dependencies, SourceFileDependencyEntry::DEP_SourceToSource );
     EXPECT_EQ(dependencies.size(), 4); // a depends on b, c, and d - with the latter two being indirect.
 
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/a.txt").toUtf8().constData()), dependencies.end());
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/b.txt").toUtf8().constData()), dependencies.end());
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/c.txt").toUtf8().constData()), dependencies.end());
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/a.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/b.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/c.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
 
     // make sure the corresponding values in the map are also correct
-    EXPECT_STREQ(dependencies[tempPath.absoluteFilePath("subfolder1/a.txt").toUtf8().constData()].c_str(), m_aUuid.ToFixedString(false, false).c_str());
-    EXPECT_STREQ(dependencies[tempPath.absoluteFilePath("subfolder1/b.txt").toUtf8().constData()].c_str(), m_bUuid.ToFixedString(false, false).c_str());
-    EXPECT_STREQ(dependencies[tempPath.absoluteFilePath("subfolder1/c.txt").toUtf8().constData()].c_str(), "c.txt");
-    EXPECT_STREQ(dependencies[tempPath.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()].c_str(), "d.txt");
+    EXPECT_STREQ(dependencies[m_assetRootDir.absoluteFilePath("subfolder1/a.txt").toUtf8().constData()].c_str(), m_aUuid.ToFixedString(false, false).c_str());
+    EXPECT_STREQ(dependencies[m_assetRootDir.absoluteFilePath("subfolder1/b.txt").toUtf8().constData()].c_str(), m_bUuid.ToFixedString(false, false).c_str());
+    EXPECT_STREQ(dependencies[m_assetRootDir.absoluteFilePath("subfolder1/c.txt").toUtf8().constData()].c_str(), "c.txt");
+    EXPECT_STREQ(dependencies[m_assetRootDir.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()].c_str(), "d.txt");
 
     dependencies.clear();
     m_assetProcessorManager->QueryAbsolutePathDependenciesRecursive(m_bUuid, dependencies, SourceFileDependencyEntry::DEP_SourceToSource);
     EXPECT_EQ(dependencies.size(), 3); // b  depends on c, and d
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/b.txt").toUtf8().constData()), dependencies.end());
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/c.txt").toUtf8().constData()), dependencies.end());
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/b.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/c.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
 
     // eliminate b --> c
     ASSERT_TRUE(m_assetProcessorManager->m_stateData->RemoveSourceFileDependency(newEntry2.m_sourceDependencyID));
@@ -857,9 +831,9 @@ TEST_F(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_BasicTe
     dependencies.clear();
     m_assetProcessorManager->QueryAbsolutePathDependenciesRecursive(m_aUuid, dependencies, SourceFileDependencyEntry::DEP_SourceToSource);
     EXPECT_EQ(dependencies.size(), 3); // a depends on b and d, but no longer c
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/a.txt").toUtf8().constData()), dependencies.end());
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/b.txt").toUtf8().constData()), dependencies.end());
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/a.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/b.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
 }
 
 TEST_F(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_WithDifferentTypes_BasicTest)
@@ -867,12 +841,10 @@ TEST_F(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_WithDif
     // test to make sure that different TYPES of dependencies work as expected.
     using namespace AzToolsFramework::AssetDatabase;
 
-    QDir tempPath(m_tempDir.path());
-
-    UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("subfolder1/a.txt"), QString("tempdata\n"));
-    UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("subfolder1/b.txt"), QString("tempdata\n"));
-    UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("subfolder1/c.txt"), QString("tempdata\n"));
-    UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("subfolder1/d.txt"), QString("tempdata\n"));
+    UnitTestUtils::CreateDummyFile(m_assetRootDir.absoluteFilePath("subfolder1/a.txt"), QString("tempdata\n"));
+    UnitTestUtils::CreateDummyFile(m_assetRootDir.absoluteFilePath("subfolder1/b.txt"), QString("tempdata\n"));
+    UnitTestUtils::CreateDummyFile(m_assetRootDir.absoluteFilePath("subfolder1/c.txt"), QString("tempdata\n"));
+    UnitTestUtils::CreateDummyFile(m_assetRootDir.absoluteFilePath("subfolder1/d.txt"), QString("tempdata\n"));
 
     SourceFileDependencyEntry newEntry1;  // a depends on B as a SOURCE dependency.
     newEntry1.m_sourceDependencyID = AzToolsFramework::AssetDatabase::InvalidEntryId;
@@ -905,25 +877,25 @@ TEST_F(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_WithDif
     // however, since b's dependency on C is via JOB, and we're asking for SOURCE only, we should not see C.
     EXPECT_EQ(dependencies.size(), 3);
 
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/a.txt").toUtf8().constData()), dependencies.end());
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/b.txt").toUtf8().constData()), dependencies.end());
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/a.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/b.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
 
     dependencies.clear();
     m_assetProcessorManager->QueryAbsolutePathDependenciesRecursive(m_bUuid, dependencies, SourceFileDependencyEntry::DEP_JobToJob);
     // b  depends on c, and d  - but we're asking for job dependencies only, so we should not get anything except C and B
     EXPECT_EQ(dependencies.size(), 2);
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/b.txt").toUtf8().constData()), dependencies.end());
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/c.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/b.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/c.txt").toUtf8().constData()), dependencies.end());
 
     // now ask for ALL kinds and you should get the full tree.
     dependencies.clear();
     m_assetProcessorManager->QueryAbsolutePathDependenciesRecursive(m_aUuid, dependencies, SourceFileDependencyEntry::DEP_Any);
     EXPECT_EQ(dependencies.size(), 4);
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/a.txt").toUtf8().constData()), dependencies.end());
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/b.txt").toUtf8().constData()), dependencies.end());
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/c.txt").toUtf8().constData()), dependencies.end());
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/a.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/b.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/c.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
 }
 
 // since we need these files to still produce a 0-based fingerprint, we need them to
@@ -934,11 +906,9 @@ TEST_F(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_Missing
 
     //  A depends on B, which depends on both C and D
 
-    QDir tempPath(m_tempDir.path());
-
     // Remove b and c files
-    AZ::IO::SystemFile::Delete(tempPath.absoluteFilePath("subfolder1/b.txt").toUtf8().constData());
-    AZ::IO::SystemFile::Delete(tempPath.absoluteFilePath("subfolder1/c.txt").toUtf8().constData());
+    AZ::IO::SystemFile::Delete(m_assetRootDir.absoluteFilePath("subfolder1/b.txt").toUtf8().constData());
+    AZ::IO::SystemFile::Delete(m_assetRootDir.absoluteFilePath("subfolder1/c.txt").toUtf8().constData());
 
     AzToolsFramework::AssetDatabase::SourceDatabaseEntry entry;
     m_assetProcessorManager->m_stateData->GetSourceBySourceGuid(m_bUuid, entry);
@@ -973,13 +943,13 @@ TEST_F(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_Missing
     m_assetProcessorManager->QueryAbsolutePathDependenciesRecursive(m_aUuid, dependencies, SourceFileDependencyEntry::DEP_SourceToSource);
     EXPECT_EQ(dependencies.size(), 2); // b and c don't exist, so only expect a and d
 
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/a.txt").toUtf8().constData()), dependencies.end());
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/a.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
 
     dependencies.clear();
     m_assetProcessorManager->QueryAbsolutePathDependenciesRecursive(m_bUuid, dependencies, SourceFileDependencyEntry::DEP_SourceToSource);
     EXPECT_EQ(dependencies.size(), 1); // c doesn't exist, so only expect d
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
 
     // eliminate b --> c
     ASSERT_TRUE(m_assetProcessorManager->m_stateData->RemoveSourceFileDependency(newEntry2.m_sourceDependencyID));
@@ -987,8 +957,8 @@ TEST_F(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_Missing
     dependencies.clear();
     m_assetProcessorManager->QueryAbsolutePathDependenciesRecursive(m_aUuid, dependencies, SourceFileDependencyEntry::DEP_SourceToSource);
     EXPECT_EQ(dependencies.size(), 2); // a depends on b and d, but no longer c
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/a.txt").toUtf8().constData()), dependencies.end());
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/a.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
 }
 
 // Test to make sure dependencies on non-asset files are included
@@ -997,8 +967,6 @@ TEST_F(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_Depende
     using namespace AzToolsFramework::AssetDatabase;
 
     //  A depends on B, which depends on both C and D
-
-    QDir tempPath(m_tempDir.path());
 
     // Delete b and c from the database, making them "non asset" files
     AzToolsFramework::AssetDatabase::SourceDatabaseEntry entry;
@@ -1034,17 +1002,16 @@ TEST_F(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_Depende
     m_assetProcessorManager->QueryAbsolutePathDependenciesRecursive(m_aUuid, dependencies, SourceFileDependencyEntry::DEP_SourceToSource);
     EXPECT_EQ(dependencies.size(), 4);
 
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/a.txt").toUtf8().constData()), dependencies.end());
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/b.txt").toUtf8().constData()), dependencies.end());
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/c.txt").toUtf8().constData()), dependencies.end());
-    EXPECT_NE(dependencies.find(tempPath.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/a.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/b.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/c.txt").toUtf8().constData()), dependencies.end());
+    EXPECT_NE(dependencies.find(m_assetRootDir.absoluteFilePath("subfolder1/d.txt").toUtf8().constData()), dependencies.end());
 }
 
 TEST_F(AssetProcessorManagerTest, BuilderSDK_API_CreateJobs_HasValidParameters_WithNoOutputFolder)
 {
-    QDir tempPath(m_tempDir.path());
     // here we push a file change through APM and make sure that "CreateJobs" has correct parameters, with no output redirection
-    QString absPath(tempPath.absoluteFilePath("subfolder1/test_text.txt"));
+    QString absPath(m_assetRootDir.absoluteFilePath("subfolder1/test_text.txt"));
     UnitTestUtils::CreateDummyFile(absPath);
 
     m_mockApplicationManager->ResetMockBuilderCreateJobCalls();
@@ -1062,7 +1029,7 @@ TEST_F(AssetProcessorManagerTest, BuilderSDK_API_CreateJobs_HasValidParameters_W
 
     const AssetBuilderSDK::CreateJobsRequest &req = builderTxtBuilder->GetLastCreateJobRequest();
 
-    EXPECT_STREQ(req.m_watchFolder.c_str(), tempPath.absoluteFilePath("subfolder1").toUtf8().constData());
+    EXPECT_STREQ(req.m_watchFolder.c_str(), m_assetRootDir.absoluteFilePath("subfolder1").toUtf8().constData());
     EXPECT_STREQ(req.m_sourceFile.c_str(), "test_text.txt"); // only the name should be there, no output prefix.
 
     EXPECT_NE(req.m_sourceFileUUID, AZ::Uuid::CreateNull());
@@ -1073,9 +1040,8 @@ TEST_F(AssetProcessorManagerTest, BuilderSDK_API_CreateJobs_HasValidParameters_W
 
 TEST_F(AssetProcessorManagerTest, BuilderSDK_API_CreateJobs_HasValidParameters_WithOutputRedirectedFolder)
 {
-    QDir tempPath(m_tempDir.path());
     // here we push a file change through APM and make sure that "CreateJobs" has correct parameters, with no output redirection
-    QString absPath(tempPath.absoluteFilePath("subfolder2/test_text.txt"));
+    QString absPath(m_assetRootDir.absoluteFilePath("subfolder2/test_text.txt"));
     UnitTestUtils::CreateDummyFile(absPath);
 
     m_mockApplicationManager->ResetMockBuilderCreateJobCalls();
@@ -1096,7 +1062,7 @@ TEST_F(AssetProcessorManagerTest, BuilderSDK_API_CreateJobs_HasValidParameters_W
     // subfolder2 has its output redirected in the cache
     // this test makes sure that the CreateJobs API is completely unaffected by that and none of the internal database stuff
     // is reflected by the API.
-    EXPECT_STREQ(req.m_watchFolder.c_str(), tempPath.absoluteFilePath("subfolder2").toUtf8().constData());
+    EXPECT_STREQ(req.m_watchFolder.c_str(), m_assetRootDir.absoluteFilePath("subfolder2").toUtf8().constData());
     EXPECT_STREQ(req.m_sourceFile.c_str(), "test_text.txt"); // only the name should be there, no output prefix.
 
     EXPECT_NE(req.m_sourceFileUUID, AZ::Uuid::CreateNull());
@@ -1109,8 +1075,7 @@ void AbsolutePathProductDependencyTest::SetUp()
     using namespace AzToolsFramework::AssetDatabase;
     AssetProcessorManagerTest::SetUp();
 
-    QDir tempPath(m_tempDir.path());
-    m_scanFolderInfo = m_config->GetScanFolderByPath(tempPath.absoluteFilePath("subfolder4"));
+    m_scanFolderInfo = m_config->GetScanFolderByPath(m_assetRootDir.absoluteFilePath("subfolder4"));
     ASSERT_TRUE(m_scanFolderInfo != nullptr);
 
     SourceDatabaseEntry sourceEntry(
@@ -1292,8 +1257,7 @@ void PathDependencyTest::CaptureJobs(AZStd::vector<AssetProcessor::JobDetails>& 
 {
     using namespace AssetProcessor;
     using namespace AssetBuilderSDK;
-    QDir tempPath(m_tempDir.path());
-    QString absPath(tempPath.absoluteFilePath(sourceFilePath));
+    QString absPath(m_assetRootDir.absoluteFilePath(sourceFilePath));
     UnitTestUtils::CreateDummyFile(absPath, QString::number(QDateTime::currentMSecsSinceEpoch()));
 
     // prepare to capture the job details as the APM inspects the file.
@@ -1445,8 +1409,7 @@ TEST_F(DuplicateProcessTest, SameAssetProcessedTwice_DependenciesResolveWithoutE
     AZStd::vector<JobDetails> jobDetailsList;
     ProductPathDependencySet dependencies = { {"dep1.txt", ProductPathDependencyType::SourceFile}, {"DEP2.asset2", ProductPathDependencyType::ProductFile}, {"Dep2.asset3", ProductPathDependencyType::ProductFile} };
 
-    QDir tempPath(m_tempDir.path());
-    QString absPath(tempPath.absoluteFilePath(sourceFilePath));
+    QString absPath(m_assetRootDir.absoluteFilePath(sourceFilePath));
     UnitTestUtils::CreateDummyFile(absPath);
 
     // prepare to capture the job details as the APM inspects the file.
@@ -1527,8 +1490,7 @@ TEST_F(PathDependencyTest, NoLongerProcessedFile_IsRemoved)
             details = message;
         });
 
-    QDir tempPath(m_tempDir.path());
-    QString absPath(tempPath.absoluteFilePath("subfolder1/test1.txt"));
+    QString absPath(m_assetRootDir.absoluteFilePath("subfolder1/test1.txt"));
 
     TestAsset testAsset("test1");
 
@@ -2219,8 +2181,7 @@ TEST_F(PathDependencyTest, AbsoluteDependencies_Existing_ResolveCorrectly)
     using namespace AssetProcessor;
     using namespace AssetBuilderSDK;
 
-    QDir tempPath(m_tempDir.path());
-    QString absPath(tempPath.absoluteFilePath("subfolder1/dep1.txt"));
+    QString absPath(m_assetRootDir.absoluteFilePath("subfolder1/dep1.txt"));
 
     // create dependees
     TestAsset dep1("dep1");
@@ -2250,16 +2211,15 @@ TEST_F(PathDependencyTest, AbsoluteDependencies_Deferred_ResolveCorrectly)
     using namespace AssetProcessor;
     using namespace AssetBuilderSDK;
 
-    QDir tempPath(m_tempDir.path());
     AZStd::string relativePathDep1("dep1.txt");
-    QString absPathDep1(tempPath.absoluteFilePath(QString("subfolder4%1%2").arg(QDir::separator()).arg(relativePathDep1.c_str())));
+    QString absPathDep1(m_assetRootDir.absoluteFilePath(QString("subfolder4%1%2").arg(QDir::separator()).arg(relativePathDep1.c_str())));
 
     auto scanfolder4 = m_config->GetScanFolderForFile(absPathDep1);
     // When an absolute path matches a scan folder, the portion of the path matching that scan folder
     // is replaced with the scan folder's ID.
     AZStd::string absPathDep1WithScanfolder(AZStd::string::format("$%" PRId64 "$%s", aznumeric_cast<int64_t>(scanfolder4->ScanFolderID()), relativePathDep1.c_str()));
-    QString absPathDep2(tempPath.absoluteFilePath("subfolder2/redirected/dep2.txt"));
-    QString absPathDep3(tempPath.absoluteFilePath("subfolder1/dep3.txt"));
+    QString absPathDep2(m_assetRootDir.absoluteFilePath("subfolder2/redirected/dep2.txt"));
+    QString absPathDep3(m_assetRootDir.absoluteFilePath("subfolder1/dep3.txt"));
 
     // -------- Make main test asset, with dependencies on products that don't exist yet -----
     TestAsset primaryFile("test_text");
@@ -2301,8 +2261,7 @@ TEST_F(PathDependencyTest, ChangeDependencies_Existing_ResolveCorrectly)
     using namespace AssetProcessor;
     using namespace AssetBuilderSDK;
 
-    QDir tempPath(m_tempDir.path());
-    QString absPath(tempPath.absoluteFilePath("subfolder1/dep1.txt"));
+    QString absPath(m_assetRootDir.absoluteFilePath("subfolder1/dep1.txt"));
 
     // create dependees
     TestAsset dep1("dep1");
@@ -2353,8 +2312,7 @@ TEST_F(PathDependencyTest, MixedPathDependencies_Existing_ResolveCorrectly)
     TestAsset dep4("dep4");
     TestAsset dep5("dep5");
 
-    QDir tempPath(m_tempDir.path());
-    QString absPath(tempPath.absoluteFilePath("subfolder1/folderA/folderB/dep5.txt"));
+    QString absPath(m_assetRootDir.absoluteFilePath("subfolder1/folderA/folderB/dep5.txt"));
 
     ASSERT_TRUE(ProcessAsset(dep1, { {".asset1"}, {".asset2"} }, {}, "subfolder1/folderA/folderB/"));
     ASSERT_TRUE(ProcessAsset(dep2, { {".asset1", ".asset2"}, {".asset3"} }, {}, "subfolder1/folderA/folderB/"));
@@ -2402,8 +2360,7 @@ TEST_F(PathDependencyTest, MixedPathDependencies_Deferred_ResolveCorrectly)
     TestAsset dep4("dep4");
     TestAsset dep5("dep5");
 
-    QDir tempPath(m_tempDir.path());
-    QString absPath(tempPath.absoluteFilePath("subfolder1/folderA\\folderB/dep5.txt"));
+    QString absPath(m_assetRootDir.absoluteFilePath("subfolder1/folderA\\folderB/dep5.txt"));
 
     // -------- Make main test asset, with dependencies on products that don't exist yet -----
     TestAsset primaryFile("test_text");
@@ -2446,11 +2403,10 @@ void MultiplatformPathDependencyTest::SetUp()
     m_config.reset(new AssetProcessor::PlatformConfiguration());
     m_config->EnablePlatform({ "pc", { "host", "renderer", "desktop" } }, true);
     m_config->EnablePlatform({ "provo",{ "console" } }, true);
-    QDir tempPath(m_tempDir.path());
 
-    m_config->AddScanFolder(ScanFolderInfo(tempPath.filePath("subfolder1"), "subfolder1", "subfolder1", false, true, m_config->GetEnabledPlatforms()));
-    m_config->AddScanFolder(ScanFolderInfo(tempPath.filePath("subfolder2"), "subfolder2", "subfolder2", false, true, m_config->GetEnabledPlatforms()));
-    m_config->AddScanFolder(ScanFolderInfo(tempPath.filePath("subfolder3"), "subfolder3", "subfolder3", false, true, m_config->GetEnabledPlatforms()));
+    m_config->AddScanFolder(ScanFolderInfo(m_assetRootDir.filePath("subfolder1"), "subfolder1", "subfolder1", false, true, m_config->GetEnabledPlatforms()));
+    m_config->AddScanFolder(ScanFolderInfo(m_assetRootDir.filePath("subfolder2"), "subfolder2", "subfolder2", false, true, m_config->GetEnabledPlatforms()));
+    m_config->AddScanFolder(ScanFolderInfo(m_assetRootDir.filePath("subfolder3"), "subfolder3", "subfolder3", false, true, m_config->GetEnabledPlatforms()));
     m_config->AddIntermediateScanFolder();
 
     m_assetProcessorManager = nullptr; // we need to destroy the previous instance before creating a new one
@@ -2634,8 +2590,7 @@ TEST_F(AssetProcessorManagerTest, AssetProcessedImpl_DifferentProductDependencie
     /// --------------------- SETUP PHASE - make an asset exist in the database -------------------
 
     // Create the source file.
-    QDir tempPath(m_tempDir.path());
-    QString absPath(tempPath.absoluteFilePath("subfolder1/test_text.txt"));
+    QString absPath(m_assetRootDir.absoluteFilePath("subfolder1/test_text.txt"));
     UnitTestUtils::CreateDummyFile(absPath);
 
     // prepare to capture the job details as the APM inspects the file.
@@ -2741,8 +2696,7 @@ TEST_F(AssetProcessorManagerTest, AssessDeletedFile_OnJobInFlight_IsIgnored)
     // The asset needs multiple job products.
 
     // Create the source file.
-    QDir tempPath(m_tempDir.path());
-    QString absPath(tempPath.absoluteFilePath("subfolder1/test_text.txt"));
+    QString absPath(m_assetRootDir.absoluteFilePath("subfolder1/test_text.txt"));
     UnitTestUtils::CreateDummyFile(absPath);
 
     // prepare to capture the job details as the APM inspects the file.
@@ -2900,18 +2854,17 @@ void SourceFileDependenciesTest::SetupData(
 {
     // make sure that if we publish some dependencies, they appear:
     m_dummyBuilderUuid = AZ::Uuid::CreateRandom();
-    QDir tempPath(m_tempDir.path());
     QString relFileName("assetProcessorManagerTest.txt");
-    m_absPath = tempPath.absoluteFilePath("subfolder1/assetProcessorManagerTest.txt");
-    m_watchFolderPath = tempPath.absoluteFilePath("subfolder1");
+    m_absPath = m_assetRootDir.absoluteFilePath("subfolder1/assetProcessorManagerTest.txt");
+    m_watchFolderPath = m_assetRootDir.absoluteFilePath("subfolder1");
     m_scanFolder = m_config->GetScanFolderByPath(m_watchFolderPath);
     ASSERT_NE(m_scanFolder, nullptr);
 
     // the above file (assetProcessorManagerTest.txt) will depend on these four files:
-    m_dependsOnFile1_Source = tempPath.absoluteFilePath("subfolder1/a.txt");
-    m_dependsOnFile2_Source = tempPath.absoluteFilePath("subfolder1/b.txt");
-    m_dependsOnFile1_Job = tempPath.absoluteFilePath("subfolder1/c.txt");
-    m_dependsOnFile2_Job = tempPath.absoluteFilePath("subfolder1/d.txt");
+    m_dependsOnFile1_Source = m_assetRootDir.absoluteFilePath("subfolder1/a.txt");
+    m_dependsOnFile2_Source = m_assetRootDir.absoluteFilePath("subfolder1/b.txt");
+    m_dependsOnFile1_Job = m_assetRootDir.absoluteFilePath("subfolder1/c.txt");
+    m_dependsOnFile2_Job = m_assetRootDir.absoluteFilePath("subfolder1/d.txt");
 
     if (createFile1Dummies)
     {
@@ -2961,10 +2914,8 @@ void SourceFileDependenciesTest::PopulateDatabase()
 {
     using namespace AzToolsFramework::AssetDatabase;
 
-    QDir tempPath(m_tempDir.path());
-
     AzToolsFramework::AssetDatabase::ScanFolderDatabaseEntry scanFolder(
-        tempPath.absoluteFilePath("subfolder1").toUtf8().constData(), "temp path", "temp path");
+        m_assetRootDir.absoluteFilePath("subfolder1").toUtf8().constData(), "temp path", "temp path");
     ASSERT_TRUE(m_assetProcessorManager->m_stateData->SetScanFolder(scanFolder));
 
     CreateSourceAndFile("subFolder1/assetProcessorManagerTest.txt");
@@ -3348,14 +3299,13 @@ TEST_F(AssetProcessorManagerTest, JobDependencyOrderOnce_MultipleJobs_EmitOK)
     using namespace AssetProcessor;
     using namespace AssetBuilderSDK;
 
-    QDir tempPath(m_tempDir.path());
-    QString watchFolderPath = tempPath.absoluteFilePath("subfolder1");
+    QString watchFolderPath = m_assetRootDir.absoluteFilePath("subfolder1");
     const ScanFolderInfo* scanFolder = m_config->GetScanFolderByPath(watchFolderPath);
     ASSERT_NE(scanFolder, nullptr);
     const char relSourceFileName[] = "a.dummy";
     const char secondRelSourceFile[] = "b.dummy";
-    QString sourceFileName = tempPath.absoluteFilePath("subfolder1/a.dummy");
-    QString secondSourceFile = tempPath.absoluteFilePath("subfolder1/b.dummy");
+    QString sourceFileName = m_assetRootDir.absoluteFilePath("subfolder1/a.dummy");
+    QString secondSourceFile = m_assetRootDir.absoluteFilePath("subfolder1/b.dummy");
     ASSERT_TRUE(UnitTestUtils::CreateDummyFile(sourceFileName, QString("tempdata\n")));
     ASSERT_TRUE(UnitTestUtils::CreateDummyFile(secondSourceFile, QString("tempdata\n")));
 
@@ -3506,12 +3456,11 @@ TEST_F(AssetProcessorManagerTest, SourceFile_With_NonASCII_Characters_Fail_Job_O
         failedjobDetails = jobDetails;
     });
 
-    QDir tempPath(m_tempDir.path());
-    QString watchFolderPath = tempPath.absoluteFilePath("subfolder1");
+    QString watchFolderPath = m_assetRootDir.absoluteFilePath("subfolder1");
     const ScanFolderInfo* scanFolder = m_config->GetScanFolderByPath(watchFolderPath);
     ASSERT_NE(scanFolder, nullptr);
 
-    QString folderPath(tempPath.absoluteFilePath("subfolder1/Test\xD0"));
+    QString folderPath(m_assetRootDir.absoluteFilePath("subfolder1/Test\xD0"));
     QDir folderPathDir(folderPath);
     QString absPath(folderPathDir.absoluteFilePath("Test.txt"));
     ASSERT_TRUE(UnitTestUtils::CreateDummyFile(absPath, QString("test\n")));
@@ -3542,12 +3491,10 @@ TEST_F(AssetProcessorManagerTest, SourceFileProcessFailure_ClearsFingerprint)
         processResults.push_back(AZStd::move(details));
     });
 
-    QDir tempPath(m_tempDir.path());
-
-    const ScanFolderInfo* scanFolder = m_config->GetScanFolderByPath(tempPath.absoluteFilePath("subfolder1"));
+    const ScanFolderInfo* scanFolder = m_config->GetScanFolderByPath(m_assetRootDir.absoluteFilePath("subfolder1"));
     ASSERT_NE(scanFolder, nullptr);
 
-    QString absPath = tempPath.absoluteFilePath("subfolder1/test.txt");
+    QString absPath = m_assetRootDir.absoluteFilePath("subfolder1/test.txt");
     ASSERT_TRUE(UnitTestUtils::CreateDummyFile(absPath, QString("test\n")));
 
     //////////////////////////////////////////////////////////////////////////
@@ -3626,18 +3573,17 @@ TEST_F(AssetProcessorManagerTest, SourceFileProcessFailure_ValidLfsPointerFile_R
     AZ::IO::FixedMaxPathString engineRoot, projectRoot;
     settingsRegistry->Get(engineRoot, AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
     settingsRegistry->Get(projectRoot, AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath);
-    settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder, m_tempDir.path().toUtf8().data());
-    settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath, m_tempDir.path().toUtf8().data());
+    settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder, m_assetRootDir.path().toUtf8().data());
+    settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath, m_assetRootDir.path().toUtf8().data());
 
-    QDir tempPath(m_tempDir.path());
-    QString gitAttributesPath = tempPath.absoluteFilePath(".gitattributes");
+    QString gitAttributesPath = m_assetRootDir.absoluteFilePath(".gitattributes");
     ASSERT_TRUE(UnitTestUtils::CreateDummyFile(gitAttributesPath, QString(
         "#\n"
         "# Git LFS(see https ://git-lfs.github.com/)\n"
         "#\n"
         "*.txt filter=lfs diff=lfs merge=lfs -text\n")));
 
-    QString sourcePath = tempPath.absoluteFilePath("subfolder1/test.txt");
+    QString sourcePath = m_assetRootDir.absoluteFilePath("subfolder1/test.txt");
     ASSERT_TRUE(UnitTestUtils::CreateDummyFile(sourcePath, QString(
         "version https://git-lfs.github.com/spec/v1\n"
         "oid sha256:ee4799379bfcfa99e95afd6494da51fbeda95f21ea71d267ae7102f048edec85\n"
@@ -3747,21 +3693,20 @@ TEST_F(AssetProcessorManagerTest, UpdateSourceFileDependenciesDatabase_WildcardM
     // And recognize matching files as dependencies
 
     AZ::Uuid dummyBuilderUUID = AZ::Uuid::CreateRandom();
-    QDir tempPath(m_tempDir.path());
-    UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("subfolder1/wildcardTest.txt"));
+    UnitTestUtils::CreateDummyFile(m_assetRootDir.absoluteFilePath("subfolder1/wildcardTest.txt"));
     QString relFileName("wildcardTest.txt");
-    QString absPath(tempPath.absoluteFilePath("subfolder1/wildcardTest.txt"));
-    QString watchFolderPath = tempPath.absoluteFilePath("subfolder1");
+    QString absPath(m_assetRootDir.absoluteFilePath("subfolder1/wildcardTest.txt"));
+    QString watchFolderPath = m_assetRootDir.absoluteFilePath("subfolder1");
     const ScanFolderInfo* scanFolder = m_config->GetScanFolderByPath(watchFolderPath);
     ASSERT_NE(scanFolder, nullptr);
 
     // the above file (assetProcessorManagerTest.txt) will depend on these four files:
-    QString dependsOnFilea_Source = tempPath.absoluteFilePath("subfolder1/a.txt");
-    QString dependsOnFileb_Source = tempPath.absoluteFilePath("subfolder1/b.txt");
-    QString dependsOnFileb1_Source = tempPath.absoluteFilePath("subfolder1/b1.txt");
-    QString dependsOnFilec_Job = tempPath.absoluteFilePath("subfolder1/c.txt");
-    QString dependsOnFilec1_Job = tempPath.absoluteFilePath("subfolder1/c1.txt");
-    QString dependsOnFiled_Job = tempPath.absoluteFilePath("subfolder1/d.txt");
+    QString dependsOnFilea_Source = m_assetRootDir.absoluteFilePath("subfolder1/a.txt");
+    QString dependsOnFileb_Source = m_assetRootDir.absoluteFilePath("subfolder1/b.txt");
+    QString dependsOnFileb1_Source = m_assetRootDir.absoluteFilePath("subfolder1/b1.txt");
+    QString dependsOnFilec_Job = m_assetRootDir.absoluteFilePath("subfolder1/c.txt");
+    QString dependsOnFilec1_Job = m_assetRootDir.absoluteFilePath("subfolder1/c1.txt");
+    QString dependsOnFiled_Job = m_assetRootDir.absoluteFilePath("subfolder1/d.txt");
 
     // in this case, we are only creating file b, and d, which are addressed by UUID.
     ASSERT_TRUE(UnitTestUtils::CreateDummyFile(dependsOnFileb_Source, QString("tempdata\n")));
@@ -3854,7 +3799,6 @@ TEST_F(AssetProcessorManagerTest, RemoveSource_RemoveCacheFolderIfEmpty_Ok)
     using namespace AssetProcessor;
     using namespace AssetBuilderSDK;
 
-    QDir tempPath(m_tempDir.path());
     QStringList sourceFiles;
     QStringList productFiles;
 
@@ -3869,7 +3813,7 @@ TEST_F(AssetProcessorManagerTest, RemoveSource_RemoveCacheFolderIfEmpty_Ok)
 
     for (int idx = 0; idx < NumOfSourceFiles; idx++)
     {
-        sourceFiles.append(tempPath.absoluteFilePath("subfolder1/subfolder2/source_test%1.txt").arg(idx));
+        sourceFiles.append(m_assetRootDir.absoluteFilePath("subfolder1/subfolder2/source_test%1.txt").arg(idx));
         UnitTestUtils::CreateDummyFile(sourceFiles[idx], "source");
         // Tell the APM about the file:
         m_isIdling = false;
@@ -3999,12 +3943,11 @@ TEST_F(DuplicateProductsTest, SameSource_MultipleBuilder_DuplicateProductJobs_Em
     using namespace AssetBuilderSDK;
 
     QString productFile;
-    QDir tempPath(m_tempDir.path());
     QString sourceFile;
     AZStd::vector<JobDetails> jobDetails;
 
     ProcessJobResponse response;
-    SetupDuplicateProductsTest(sourceFile, tempPath, productFile, jobDetails, response, false, "txt");
+    SetupDuplicateProductsTest(sourceFile, m_assetRootDir, productFile, jobDetails, response, false, "txt");
 
     // ----------------------------- TEST BEGINS HERE -----------------------------
     // We will process another job with the same source file outputting the same product
@@ -4024,12 +3967,11 @@ TEST_F(DuplicateProductsTest, SameSource_SameBuilder_DuplicateProductJobs_EmitAu
     using namespace AssetBuilderSDK;
 
     QString productFile;
-    QDir tempPath(m_tempDir.path());
     QString sourceFile;
     AZStd::vector<JobDetails> jobDetails;
 
     ProcessJobResponse response;
-    SetupDuplicateProductsTest(sourceFile, tempPath, productFile, jobDetails, response, true, "png");
+    SetupDuplicateProductsTest(sourceFile, m_assetRootDir, productFile, jobDetails, response, true, "png");
 
     // ----------------------------- TEST BEGINS HERE -----------------------------
     // We will process another job with the same source file outputting the same product
@@ -4048,14 +3990,13 @@ TEST_F(DuplicateProductsTest, SameSource_MultipleBuilder_NoDuplicateProductJob_N
     using namespace AssetProcessor;
     using namespace AssetBuilderSDK;
 
-    QDir tempPath(m_tempDir.path());
     QString sourceFile;
     QString productFile;
 
     // Capture the job details as the APM inspects the file.
     AZStd::vector<JobDetails> jobDetails;
     ProcessJobResponse response;
-    SetupDuplicateProductsTest(sourceFile, tempPath, productFile, jobDetails, response, false, "txt");
+    SetupDuplicateProductsTest(sourceFile, m_assetRootDir, productFile, jobDetails, response, false, "txt");
 
     // ----------------------------- TEST BEGINS HERE -----------------------------
     // We will process another job with the same source file outputting a different product file
@@ -4092,9 +4033,7 @@ void JobDependencyTest::SetUp()
     m_data->m_mockBuilderInfoHandler.CreateBuilderDescInfoRef("test builder", m_data->m_builderUuid.ToString<QString>(), { AssetBuilderSDK::AssetBuilderPattern("*.txt", AssetBuilderSDK::AssetBuilderPattern::Wildcard) }, m_data->m_assetBuilderConfig);
     m_data->m_mockBuilderInfoHandler.BusConnect();
 
-    QDir tempPath(m_tempDir.path());
-
-    QString watchFolderPath = tempPath.absoluteFilePath("subfolder1");
+    QString watchFolderPath = m_assetRootDir.absoluteFilePath("subfolder1");
     const ScanFolderInfo* scanFolder = m_config->GetScanFolderByPath(watchFolderPath);
 
     // Create a dummy file and put entries in the db to simulate a previous successful AP run for this file (source, job, and product entries)
@@ -4305,11 +4244,9 @@ TEST_F(MetadataFileTest, MetadataFile_SourceFileExtensionDifferentCase)
     using namespace AzToolsFramework::AssetSystem;
     using namespace AssetProcessor;
 
-    QDir tempPath(m_tempDir.path());
-
     QString relFileName("Dummy.TXT");
-    QString absPath(tempPath.absoluteFilePath("subfolder1/Dummy.TXT"));
-    QString watchFolder = tempPath.absoluteFilePath("subfolder1");
+    QString absPath(m_assetRootDir.absoluteFilePath("subfolder1/Dummy.TXT"));
+    QString watchFolder = m_assetRootDir.absoluteFilePath("subfolder1");
     UnitTestUtils::CreateDummyFile(absPath, "dummy");
 
     JobEntry entry;
@@ -4334,7 +4271,7 @@ TEST_F(MetadataFileTest, MetadataFile_SourceFileExtensionDifferentCase)
     // Creating a metadata file for the source assets
     // APM should process the source asset if a metadafile is detected
     // We are intentionally having a source file with a different file extension casing than the one specified in the metadata rule.
-    QString metadataFile(tempPath.absoluteFilePath("subfolder1/Dummy.foo"));
+    QString metadataFile(m_assetRootDir.absoluteFilePath("subfolder1/Dummy.foo"));
     UnitTestUtils::CreateDummyFile(metadataFile, "dummy");
 
     // Capture the job details as the APM inspects the file.
@@ -4344,7 +4281,7 @@ TEST_F(MetadataFileTest, MetadataFile_SourceFileExtensionDifferentCase)
             jobDetails = job;
         });
 
-    m_assetProcessorManager->AssessAddedFile(tempPath.absoluteFilePath(metadataFile));
+    m_assetProcessorManager->AssessAddedFile(m_assetRootDir.absoluteFilePath(metadataFile));
 
     ASSERT_TRUE(BlockUntilIdle(5000));
     ASSERT_EQ(jobDetails.m_jobEntry.m_pathRelativeToWatchFolder, relFileName);
@@ -4388,10 +4325,8 @@ void WildcardSourceDependencyTest::SetUp()
 
     AssetProcessorManagerTest::SetUp();
 
-    QDir tempPath(m_tempDir.path());
-
     // Add a non-recursive scan folder.  Only files directly inside of this folder should be picked up, subfolders are ignored
-    m_config->AddScanFolder(ScanFolderInfo(tempPath.filePath("no_recurse"), "no_recurse",
+    m_config->AddScanFolder(ScanFolderInfo(m_assetRootDir.filePath("no_recurse"), "no_recurse",
         "no_recurse", false, false, m_config->GetEnabledPlatforms(), 1));
 
     {
@@ -4418,16 +4353,16 @@ void WildcardSourceDependencyTest::SetUp()
     CreateSourceAndFile("subfolder2/folder/one/d.foo");
 
     // Add a file that is not in a scanfolder.  Should always be ignored
-    UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("not/a/scanfolder/e.foo"));
+    UnitTestUtils::CreateDummyFile(m_assetRootDir.absoluteFilePath("not/a/scanfolder/e.foo"));
 
     // Add a file in the non-recursive scanfolder.  Since its not directly in the scan folder, it should always be ignored
-    UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("no_recurse/one/two/three/f.foo"));
+    UnitTestUtils::CreateDummyFile(m_assetRootDir.absoluteFilePath("no_recurse/one/two/three/f.foo"));
 
     // Add a file to an ignored folder
-    UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("subfolder2/folder/ignored/g.foo"));
+    UnitTestUtils::CreateDummyFile(m_assetRootDir.absoluteFilePath("subfolder2/folder/ignored/g.foo"));
 
     // Add an ignored file
-    UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("subfolder2/folder/one/z.foo"));
+    UnitTestUtils::CreateDummyFile(m_assetRootDir.absoluteFilePath("subfolder2/folder/one/z.foo"));
 
     // Add a file in the cache
     AZStd::string projectCacheRootValue;
@@ -4449,7 +4384,7 @@ void WildcardSourceDependencyTest::SetUp()
 
     // Absolute path wildcard dependency
     dependencies.push_back(AzToolsFramework::AssetDatabase::SourceFileDependencyEntry(
-        AZ::Uuid::CreateRandom(), bUuid, PathOrUuid(tempPath.absoluteFilePath("%b.foo").toUtf8().constData()),
+        AZ::Uuid::CreateRandom(), bUuid, PathOrUuid(m_assetRootDir.absoluteFilePath("%b.foo").toUtf8().constData()),
         AzToolsFramework::AssetDatabase::SourceFileDependencyEntry::DEP_SourceLikeMatch, 0, ""));
 
     // Test what happens when we have 2 dependencies on the same file
@@ -4458,16 +4393,16 @@ void WildcardSourceDependencyTest::SetUp()
         AzToolsFramework::AssetDatabase::SourceFileDependencyEntry::DEP_SourceLikeMatch, 0, ""));
 
     dependencies.push_back(AzToolsFramework::AssetDatabase::SourceFileDependencyEntry(
-        AZ::Uuid::CreateRandom(), dUuid, PathOrUuid(tempPath.absoluteFilePath("%c.foo").toUtf8().constData()),
+        AZ::Uuid::CreateRandom(), dUuid, PathOrUuid(m_assetRootDir.absoluteFilePath("%c.foo").toUtf8().constData()),
         AzToolsFramework::AssetDatabase::SourceFileDependencyEntry::DEP_SourceLikeMatch, 0, ""));
 
 #ifdef AZ_PLATFORM_WINDOWS
     // Test to make sure a relative wildcard dependency doesn't match an absolute path
     // For example, if the input is C:/project/subfolder1/a.foo
     // This should not match a wildcard of c%.foo
-    // Take the first character of the tempPath and append %.foo onto it for this test, which should produce something like c%.foo
+    // Take the first character of the m_assetRootDir and append %.foo onto it for this test, which should produce something like c%.foo
     // This only applies to windows because on other OSes if the dependency starts with /, then its an abs path dependency
-    auto test = (tempPath.absolutePath().left(1) + "%.foo");
+    auto test = (m_assetRootDir.absolutePath().left(1) + "%.foo");
     dependencies.push_back(AzToolsFramework::AssetDatabase::SourceFileDependencyEntry(
         AZ::Uuid::CreateRandom(), dUuid,
         PathOrUuid(test.toUtf8().constData()),
@@ -4508,9 +4443,8 @@ TEST_F(WildcardSourceDependencyTest, Absolute_WithFolder)
 {
     // Make sure we can use absolute paths to filter to files under a folder
     AZStd::vector<AZStd::string> resolvedPaths;
-    QDir tempPath(m_tempDir.path());
 
-    ASSERT_TRUE(Test(tempPath.absoluteFilePath("subfolder2/*.foo").toUtf8().constData(), resolvedPaths));
+    ASSERT_TRUE(Test(m_assetRootDir.absoluteFilePath("subfolder2/*.foo").toUtf8().constData(), resolvedPaths));
     ASSERT_THAT(resolvedPaths, ::testing::UnorderedElementsAre("a.foo", "b.foo", "folder/one/c.foo", "folder/one/d.foo"));
 }
 
@@ -4518,9 +4452,8 @@ TEST_F(WildcardSourceDependencyTest, Absolute_NotInScanfolder)
 {
     // Files outside a scanfolder should not be returned even with an absolute path
     AZStd::vector<AZStd::string> resolvedPaths;
-    QDir tempPath(m_tempDir.path());
 
-    ASSERT_TRUE(Test(tempPath.absoluteFilePath("not/a/scanfolder/*.foo").toUtf8().constData(), resolvedPaths));
+    ASSERT_TRUE(Test(m_assetRootDir.absoluteFilePath("not/a/scanfolder/*.foo").toUtf8().constData(), resolvedPaths));
     ASSERT_THAT(resolvedPaths, ::testing::UnorderedElementsAre());
 }
 
@@ -4528,7 +4461,6 @@ TEST_F(WildcardSourceDependencyTest, Relative_NotInScanfolder)
 {
     // Files outside a scanfolder should not be returned
     AZStd::vector<AZStd::string> resolvedPaths;
-    QDir tempPath(m_tempDir.path());
 
     ASSERT_TRUE(Test("*/e.foo", resolvedPaths));
     ASSERT_THAT(resolvedPaths, ::testing::UnorderedElementsAre());
@@ -4538,7 +4470,6 @@ TEST_F(WildcardSourceDependencyTest, Relative_InNonRecursiveScanfolder)
 {
     // Files deep inside non-recursive scanfolders should not be returned
     AZStd::vector<AZStd::string> resolvedPaths;
-    QDir tempPath(m_tempDir.path());
 
     ASSERT_TRUE(Test("*/f.foo", resolvedPaths));
     ASSERT_THAT(resolvedPaths, ::testing::UnorderedElementsAre());
@@ -4548,9 +4479,8 @@ TEST_F(WildcardSourceDependencyTest, Absolute_InNonRecursiveScanfolder)
 {
     // Absolute paths to files deep inside non-recursive scanfolders should not be returned
     AZStd::vector<AZStd::string> resolvedPaths;
-    QDir tempPath(m_tempDir.path());
 
-    ASSERT_TRUE(Test(tempPath.absoluteFilePath("one/two/three/*.foo").toUtf8().constData(), resolvedPaths));
+    ASSERT_TRUE(Test(m_assetRootDir.absoluteFilePath("one/two/three/*.foo").toUtf8().constData(), resolvedPaths));
     ASSERT_THAT(resolvedPaths, ::testing::UnorderedElementsAre());
 }
 
@@ -4558,7 +4488,6 @@ TEST_F(WildcardSourceDependencyTest, Relative_NoWildcard)
 {
     // No wildcard results in a failure
     AZStd::vector<AZStd::string> resolvedPaths;
-    QDir tempPath(m_tempDir.path());
 
     ASSERT_FALSE(Test("subfolder1/1a.foo", resolvedPaths));
     ASSERT_THAT(resolvedPaths, ::testing::UnorderedElementsAre());
@@ -4568,9 +4497,8 @@ TEST_F(WildcardSourceDependencyTest, Absolute_NoWildcard)
 {
     // No wildcard results in a failure
     AZStd::vector<AZStd::string> resolvedPaths;
-    QDir tempPath(m_tempDir.path());
 
-    ASSERT_FALSE(Test(tempPath.absoluteFilePath("subfolder1/1a.foo").toUtf8().constData(), resolvedPaths));
+    ASSERT_FALSE(Test(m_assetRootDir.absoluteFilePath("subfolder1/1a.foo").toUtf8().constData(), resolvedPaths));
     ASSERT_THAT(resolvedPaths, ::testing::UnorderedElementsAre());
 }
 
@@ -4585,9 +4513,8 @@ TEST_F(WildcardSourceDependencyTest, Relative_IgnoredFolder)
 TEST_F(WildcardSourceDependencyTest, Absolute_IgnoredFolder)
 {
     AZStd::vector<AZStd::string> resolvedPaths;
-    QDir tempPath(m_tempDir.path());
 
-    ASSERT_TRUE(Test(tempPath.absoluteFilePath("*g.foo").toUtf8().constData(), resolvedPaths));
+    ASSERT_TRUE(Test(m_assetRootDir.absoluteFilePath("*g.foo").toUtf8().constData(), resolvedPaths));
     ASSERT_THAT(resolvedPaths, ::testing::UnorderedElementsAre());
 }
 
@@ -4602,16 +4529,14 @@ TEST_F(WildcardSourceDependencyTest, Relative_IgnoredFile)
 TEST_F(WildcardSourceDependencyTest, Absolute_IgnoredFile)
 {
     AZStd::vector<AZStd::string> resolvedPaths;
-    QDir tempPath(m_tempDir.path());
 
-    ASSERT_TRUE(Test(tempPath.absoluteFilePath("*z.foo").toUtf8().constData(), resolvedPaths));
+    ASSERT_TRUE(Test(m_assetRootDir.absoluteFilePath("*z.foo").toUtf8().constData(), resolvedPaths));
     ASSERT_THAT(resolvedPaths, ::testing::UnorderedElementsAre());
 }
 
 TEST_F(WildcardSourceDependencyTest, Relative_CacheFolder)
 {
     AZStd::vector<AZStd::string> resolvedPaths;
-    QDir tempPath(m_tempDir.path());
 
     ASSERT_TRUE(Test("*cache.foo", resolvedPaths));
     ASSERT_THAT(resolvedPaths, ::testing::UnorderedElementsAre());
@@ -4620,7 +4545,6 @@ TEST_F(WildcardSourceDependencyTest, Relative_CacheFolder)
 TEST_F(WildcardSourceDependencyTest, FilesAddedAfterInitialCache)
 {
     AZStd::vector<AZStd::string> resolvedPaths;
-    QDir tempPath(m_tempDir.path());
 
     auto excludedFolderCacheInterface = AZ::Interface<ExcludedFolderCacheInterface>::Get();
 
@@ -4633,7 +4557,7 @@ TEST_F(WildcardSourceDependencyTest, FilesAddedAfterInitialCache)
     }
 
     // Add a file to a new ignored folder
-    QString newFilePath = tempPath.absoluteFilePath("subfolder2/folder/two/ignored/three/new.foo");
+    QString newFilePath = m_assetRootDir.absoluteFilePath("subfolder2/folder/two/ignored/three/new.foo");
     UnitTestUtils::CreateDummyFile(newFilePath);
 
     excludedFolderCacheInterface->FileAdded(newFilePath);
@@ -4641,16 +4565,15 @@ TEST_F(WildcardSourceDependencyTest, FilesAddedAfterInitialCache)
     const auto& excludedFolders = excludedFolderCacheInterface->GetExcludedFolders();
 
     ASSERT_EQ(excludedFolders.size(), 3);
-    ASSERT_THAT(excludedFolders, ::testing::Contains(AZStd::string(tempPath.absoluteFilePath("subfolder2/folder/two/ignored").toUtf8().constData())));
+    ASSERT_THAT(excludedFolders, ::testing::Contains(AZStd::string(m_assetRootDir.absoluteFilePath("subfolder2/folder/two/ignored").toUtf8().constData())));
 }
 
 TEST_F(WildcardSourceDependencyTest, FilesRemovedAfterInitialCache)
 {
     AZStd::vector<AZStd::string> resolvedPaths;
-    QDir tempPath(m_tempDir.path());
 
     // Add a file to a new ignored folder
-    QString newFilePath = tempPath.absoluteFilePath("subfolder2/folder/two/ignored/three/new.foo");
+    QString newFilePath = m_assetRootDir.absoluteFilePath("subfolder2/folder/two/ignored/three/new.foo");
     UnitTestUtils::CreateDummyFile(newFilePath);
 
     auto excludedFolderCacheInterface = AZ::Interface<ExcludedFolderCacheInterface>::Get();
@@ -4663,7 +4586,7 @@ TEST_F(WildcardSourceDependencyTest, FilesRemovedAfterInitialCache)
         ASSERT_EQ(excludedFolders.size(), 3);
     }
 
-    m_fileStateCache->SignalDeleteEvent(tempPath.absoluteFilePath("subfolder2/folder/two/ignored"));
+    m_fileStateCache->SignalDeleteEvent(m_assetRootDir.absoluteFilePath("subfolder2/folder/two/ignored"));
 
     const auto& excludedFolders = excludedFolderCacheInterface->GetExcludedFolders();
 
@@ -4672,27 +4595,21 @@ TEST_F(WildcardSourceDependencyTest, FilesRemovedAfterInitialCache)
 
 TEST_F(WildcardSourceDependencyTest, NewFile_MatchesSavedRelativeDependency)
 {
-    QDir tempPath(m_tempDir.path());
+    auto matches = FileAddedTest(m_assetRootDir.absoluteFilePath("subfolder1/1a.foo"));
 
-    auto matches = FileAddedTest(tempPath.absoluteFilePath("subfolder1/1a.foo"));
-
-    ASSERT_THAT(matches, ::testing::UnorderedElementsAre(tempPath.absoluteFilePath("subfolder2/a.foo").toUtf8().constData()));
+    ASSERT_THAT(matches, ::testing::UnorderedElementsAre(m_assetRootDir.absoluteFilePath("subfolder2/a.foo").toUtf8().constData()));
 }
 
 TEST_F(WildcardSourceDependencyTest, NewFile_MatchesSavedAbsoluteDependency)
 {
-    QDir tempPath(m_tempDir.path());
+    auto matches = FileAddedTest(m_assetRootDir.absoluteFilePath("subfolder1/1b.foo"));
 
-    auto matches = FileAddedTest(tempPath.absoluteFilePath("subfolder1/1b.foo"));
-
-    ASSERT_THAT(matches, ::testing::UnorderedElementsAre(tempPath.absoluteFilePath("subfolder2/b.foo").toUtf8().constData()));
+    ASSERT_THAT(matches, ::testing::UnorderedElementsAre(m_assetRootDir.absoluteFilePath("subfolder2/b.foo").toUtf8().constData()));
 }
 
 TEST_F(WildcardSourceDependencyTest, NewFile_MatchesDuplicatedDependenciesOnce)
 {
-    QDir tempPath(m_tempDir.path());
+    auto matches = FileAddedTest(m_assetRootDir.absoluteFilePath("subfolder2/folder/one/c.foo"));
 
-    auto matches = FileAddedTest(tempPath.absoluteFilePath("subfolder2/folder/one/c.foo"));
-
-    ASSERT_THAT(matches, ::testing::UnorderedElementsAre(tempPath.absoluteFilePath("subfolder2/folder/one/d.foo").toUtf8().constData()));
+    ASSERT_THAT(matches, ::testing::UnorderedElementsAre(m_assetRootDir.absoluteFilePath("subfolder2/folder/one/d.foo").toUtf8().constData()));
 }

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.h
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.h
@@ -11,7 +11,8 @@
 #include <AzTest/AzTest.h>
 #include <AzCore/std/parallel/atomic.h>
 #include <qcoreapplication.h>
-#include "native/tests/AssetProcessorTest.h"
+#include <native/tests/AssetProcessorTest.h>
+#include <native/tests/MockAssetDatabaseRequestsHandler.h>
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
 #include "native/assetprocessor.h"
 #include "native/unittests/UnitTestRunner.h"
@@ -21,7 +22,6 @@
 #include <AssetManager/FileStateCache.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 
-#include <QTemporaryDir>
 #include <QMetaObject>
 #include <AzCore/Jobs/JobContext.h>
 #include <AzCore/Jobs/JobManager.h>
@@ -32,12 +32,6 @@
 #include "resourcecompiler/rccontroller.h"
 
 class AssetProcessorManager_Test;
-
-class MockDatabaseLocationListener : public AzToolsFramework::AssetDatabase::AssetDatabaseRequests::Bus::Handler
-{
-public:
-    MOCK_METHOD1(GetAssetDatabaseLocation, bool(AZStd::string&));
-};
 
 class AssetProcessorManager_Test : public AssetProcessor::AssetProcessorManager
 {
@@ -172,7 +166,7 @@ protected:
     virtual void CreateSourceAndFile(const char* tempFolderRelativePath);
     virtual void PopulateDatabase();
 
-    QTemporaryDir m_tempDir;
+    QDir m_assetRootDir;
 
     AZStd::unique_ptr<AssetProcessorManager_Test> m_assetProcessorManager;
     AZStd::unique_ptr<AssetProcessor::MockApplicationManager> m_mockApplicationManager;
@@ -190,7 +184,7 @@ protected:
     struct StaticData
     {
         AZStd::string m_databaseLocation;
-        ::testing::NiceMock<MockDatabaseLocationListener> m_databaseLocationListener;
+        AssetProcessor::MockAssetDatabaseRequestsHandler m_databaseLocationListener;
         AZ::Entity* m_jobManagerEntity{};
         AZ::ComponentDescriptor* m_descriptor{};
         AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/IntermediateAssetTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/IntermediateAssetTests.cpp
@@ -123,7 +123,7 @@ namespace UnitTests
                 m_processJobResponse = response;
             });
 
-        m_localFileIo->SetAlias("@log@", (AZ::IO::Path(m_tempDir.GetDirectory()) / "logs").c_str());
+        m_localFileIo->SetAlias("@log@", (AZ::IO::Path(m_databaseLocationListener.GetAssetRootDir()) / "logs").c_str());
     }
 
     void IntermediateAssetTests::TearDown()
@@ -185,7 +185,7 @@ namespace UnitTests
 
     AZStd::string IntermediateAssetTests::MakePath(const char* filename, bool intermediate)
     {
-        auto cacheDir = AZ::IO::Path(m_tempDir.GetDirectory()) / "Cache";
+        auto cacheDir = AZ::IO::Path(m_databaseLocationListener.GetAssetRootDir()) / "Cache";
 
         if (intermediate)
         {
@@ -241,7 +241,7 @@ namespace UnitTests
     void IntermediateAssetTests::ProcessFileMultiStage(
         int endStage, bool doProductOutputCheck, const char* file, int startStage, bool expectAutofail, bool hasExtraFile)
     {
-        auto cacheDir = AZ::IO::Path(m_tempDir.GetDirectory()) / "Cache";
+        auto cacheDir = AZ::IO::Path(m_databaseLocationListener.GetAssetRootDir()) / "Cache";
         auto intermediatesDir = AssetUtilities::GetIntermediateAssetsFolder(cacheDir);
 
         if (file == nullptr)
@@ -384,7 +384,7 @@ namespace UnitTests
 
         ProcessFileMultiStage(1, false);
 
-        auto expectedProduct = AZ::IO::Path(m_tempDir.GetDirectory()) / "Cache" / "pc" / "test.stage1";
+        auto expectedProduct = AZ::IO::Path(m_databaseLocationListener.GetAssetRootDir()) / "Cache" / "pc" / "test.stage1";
 
         EXPECT_EQ(m_jobDetailsList.size(), 1);
         EXPECT_TRUE(AZ::IO::SystemFile::Exists(expectedProduct.c_str())) << expectedProduct.c_str();

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/JobDependencySubIdTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/JobDependencySubIdTests.cpp
@@ -16,8 +16,6 @@ namespace UnitTests
     {
         using namespace AzToolsFramework::AssetDatabase;
 
-        AZ::IO::Path tempDir(m_tempDir.GetDirectory());
-
         SourceDatabaseEntry source1{ m_scanfolder.m_scanFolderID, "parent.txt", AZ::Uuid::CreateRandom(), "fingerprint" };
         SourceDatabaseEntry source2{ m_scanfolder.m_scanFolderID, "child.txt", AZ::Uuid::CreateRandom(), "fingerprint" };
 
@@ -55,7 +53,7 @@ namespace UnitTests
 
     void JobDependencySubIdTest::RunTest(bool firstProductChanged, bool secondProductChanged)
     {
-        AZ::IO::Path cacheDir(m_tempDir.GetDirectory());
+        AZ::IO::Path cacheDir(m_databaseLocationListener.GetAssetRootDir());
         cacheDir /= "Cache";
         cacheDir /= "pc";
 

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/ModtimeScanningTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/ModtimeScanningTests.cpp
@@ -265,7 +265,6 @@ namespace UnitTests
         AssetUtilities::SetUseFileHashOverride(true, true);
 
         // Enable android platform after the initial SetUp has already processed the files for pc
-        QDir tempPath(m_tempDir.path());
         AssetBuilderSDK::PlatformInfo androidPlatform("android", { "host", "renderer" });
         m_config->EnablePlatform(androidPlatform, true);
 
@@ -629,9 +628,9 @@ namespace UnitTests
         };
 
         // Create test files
-        QDir tempPath(m_tempDir.path());
-        const auto* scanFolder1 = m_config->GetScanFolderByPath(tempPath.absoluteFilePath("subfolder1"));
-        const auto* scanFolder4 = m_config->GetScanFolderByPath(tempPath.absoluteFilePath("subfolder4"));
+        QDir assetRootPath(m_assetRootDir);
+        const auto* scanFolder1 = m_config->GetScanFolderByPath(assetRootPath.absoluteFilePath("subfolder1"));
+        const auto* scanFolder4 = m_config->GetScanFolderByPath(assetRootPath.absoluteFilePath("subfolder4"));
 
         createFileAndAddToDatabaseFunc(scanFolder1, QString("textures/a.txt"));
         createFileAndAddToDatabaseFunc(scanFolder4, QString("textures/b.txt"));
@@ -672,8 +671,8 @@ namespace UnitTests
         ExpectNoWork();
 
         // Delete one of the folders
-        QDir tempPath(m_tempDir.path());
-        QString absPath(tempPath.absoluteFilePath("subfolder1/textures"));
+        QDir assetRootPath(m_assetRootDir);
+        QString absPath(assetRootPath.absoluteFilePath("subfolder1/textures"));
         QDir(absPath).removeRecursively();
 
         AZStd::vector<AZStd::string> deletedFolders;

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/Validators/LfsPointerFileValidatorTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/Validators/LfsPointerFileValidatorTests.cpp
@@ -15,20 +15,20 @@ namespace UnitTests
     {
         AssetManagerTestingBase::SetUp();
 
-        m_tempFolder = m_tempDir.GetDirectory();
-        CreateTestFile((m_tempFolder / ".gitattributes").Native(),
+        m_assetRootDir = m_databaseLocationListener.GetAssetRootDir();
+        CreateTestFile((m_assetRootDir / ".gitattributes").Native(),
             "#\n"
             "# Git LFS(see https ://git-lfs.github.com/)\n"
             "#\n"
             "*.test filter=lfs diff=lfs merge=lfs -text\n"
         );
 
-        m_validator = AssetProcessor::LfsPointerFileValidator({ m_tempDir.GetDirectory() });
+        m_validator = AssetProcessor::LfsPointerFileValidator({ m_assetRootDir.c_str() });
     }
 
     void LfsPointerFileValidatorTests::TearDown()
     {
-        RemoveTestFile((m_tempFolder / ".gitattributes").Native());
+        RemoveTestFile((m_assetRootDir / ".gitattributes").Native());
         AssetManagerTestingBase::TearDown();
     }
 
@@ -64,7 +64,7 @@ namespace UnitTests
 
     TEST_F(LfsPointerFileValidatorTests, IsLfsPointerFile_ValidLfsPointerFile_CheckSucceed)
     {
-        AZStd::string testFilePath = (m_tempFolder / "file.test").Native();
+        AZStd::string testFilePath = (m_assetRootDir / "file.test").Native();
         CreateTestFile(testFilePath,
             "version https://git-lfs.github.com/spec/v1\n"
             "oid sha256:ee4799379bfcfa99e95afd6494da51fbeda95f21ea71d267ae7102f048edec85\n"
@@ -77,7 +77,7 @@ namespace UnitTests
 
     TEST_F(LfsPointerFileValidatorTests, IsLfsPointerFile_NonLfsPointerFileType_CheckFail)
     {
-        AZStd::string testFilePath = (m_tempFolder / "file.test1").Native();
+        AZStd::string testFilePath = (m_assetRootDir / "file.test1").Native();
         CreateTestFile(testFilePath,
             "version https://git-lfs.github.com/spec/v1\n"
             "oid sha256:ee4799379bfcfa99e95afd6494da51fbeda95f21ea71d267ae7102f048edec85\n"
@@ -90,7 +90,7 @@ namespace UnitTests
 
     TEST_F(LfsPointerFileValidatorTests, IsLfsPointerFile_InvalidFirstKey_CheckFail)
     {
-        AZStd::string testFilePath = (m_tempFolder / "file.test").Native();
+        AZStd::string testFilePath = (m_assetRootDir / "file.test").Native();
         CreateTestFile(testFilePath,
             "oid sha256:ee4799379bfcfa99e95afd6494da51fbeda95f21ea71d267ae7102f048edec85\n"
             "size 63872\n"
@@ -103,7 +103,7 @@ namespace UnitTests
 
     TEST_F(LfsPointerFileValidatorTests, IsLfsPointerFile_InvalidKeyCharacter_CheckFail)
     {
-        AZStd::string testFilePath = (m_tempFolder / "file.test").Native();
+        AZStd::string testFilePath = (m_assetRootDir / "file.test").Native();
         CreateTestFile(testFilePath,
             "version https://git-lfs.github.com/spec/v1\n"
             "oid+ sha256:ee4799379bfcfa99e95afd6494da51fbeda95f21ea71d267ae7102f048edec85\n"
@@ -116,7 +116,7 @@ namespace UnitTests
 
     TEST_F(LfsPointerFileValidatorTests, IsLfsPointerFile_UnorderedKeys_CheckFail)
     {
-        AZStd::string testFilePath = (m_tempFolder / "file.test").Native();
+        AZStd::string testFilePath = (m_assetRootDir / "file.test").Native();
         CreateTestFile(testFilePath,
             "version https://git-lfs.github.com/spec/v1\n"
             "size 63872\n"
@@ -129,7 +129,7 @@ namespace UnitTests
 
     TEST_F(LfsPointerFileValidatorTests, IsLfsPointerFile_MissingRequiredKey_CheckFail)
     {
-        AZStd::string testFilePath = (m_tempFolder / "file.test").Native();
+        AZStd::string testFilePath = (m_assetRootDir / "file.test").Native();
         CreateTestFile(testFilePath,
             "version https://git-lfs.github.com/spec/v1\n"
             "bla 63872\n"

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/Validators/LfsPointerFileValidatorTests.h
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/Validators/LfsPointerFileValidatorTests.h
@@ -22,7 +22,7 @@ namespace UnitTests
         bool CreateTestFile(const AZStd::string& filePath, const AZStd::string& content);
         bool RemoveTestFile(const AZStd::string& filePath);
 
-        AZ::IO::Path m_tempFolder;
+        AZ::IO::Path m_assetRootDir;
         AssetProcessor::LfsPointerFileValidator m_validator;
     };
 }

--- a/Code/Tools/AssetProcessor/native/tests/utilities/JobModelTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/utilities/JobModelTest.cpp
@@ -167,20 +167,6 @@ void JobModelUnitTests::SetUp()
         using namespace testing;
         m_data.reset(new StaticData());
 
-        //! Setup temporary database
-        m_data->m_temporaryDatabaseDir = QDir(m_data->m_temporaryDir.path());
-        QString canonicalTempDirPath = AssetUtilities::NormalizeDirectoryPath(m_data->m_temporaryDatabaseDir.canonicalPath());
-        m_data->m_temporaryDatabaseDir = QDir(canonicalTempDirPath);
-        m_data->m_temporaryDatabasePath = m_data->m_temporaryDatabaseDir.absoluteFilePath("test_database.sqlite").toUtf8().data();
-
-        //! Setup Asset Database connection.
-        //! There will be two database connection: one for CreateDatabaseTestData, and one inside UnitTestJobModel::PopulateJobsFromDatabase.
-        //! In-memory databases can have only a single connection, so we need a file-backed SQLite database to serve the needs.
-        m_data->m_databaseLocationListener.BusConnect();
-        ON_CALL(m_data->m_databaseLocationListener, GetAssetDatabaseLocation(_))
-            .WillByDefault(DoAll(
-                SetArgReferee<0>(m_data->m_temporaryDatabasePath.c_str()),
-                Return(true)));
         m_data->m_connection.ClearData();
     }
 

--- a/Code/Tools/AssetProcessor/native/tests/utilities/JobModelTest.h
+++ b/Code/Tools/AssetProcessor/native/tests/utilities/JobModelTest.h
@@ -10,6 +10,7 @@
 
 #include <native/resourcecompiler/JobsModel.h>
 #include <native/tests/AssetProcessorTest.h>
+#include <native/tests/MockAssetDatabaseRequestsHandler.h>
 #include <AzToolsFramework/API/AssetDatabaseBus.h>
 #include <QCoreApplication>
 
@@ -35,12 +36,6 @@ public:
     friend class JobModelUnitTests;
 };
 
-class JobModelTestMockDatabaseLocationListener : public AzToolsFramework::AssetDatabase::AssetDatabaseRequests::Bus::Handler
-{
-public:
-    MOCK_METHOD1(GetAssetDatabaseLocation, bool(AZStd::string&));
-};
-
 class JobModelUnitTests
     : public AssetProcessor::AssetProcessorTest
 {
@@ -55,11 +50,7 @@ public:
 protected:
     struct StaticData
     {
-        QTemporaryDir m_temporaryDir;
-        QDir m_temporaryDatabaseDir;
-        AZStd::string m_temporaryDatabasePath;
-
-        testing::NiceMock<JobModelTestMockDatabaseLocationListener> m_databaseLocationListener;
+        AssetProcessor::MockAssetDatabaseRequestsHandler m_databaseLocationListener;
         AssetProcessor::AssetDatabaseConnection m_connection;
 
         const AZStd::string m_sourceName{ "theFile.fbx" };

--- a/Code/Tools/AssetProcessor/native/tests/utilities/StatsCaptureTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/utilities/StatsCaptureTest.cpp
@@ -25,268 +25,288 @@
 
 namespace AssetProcessor
 {
-// Its okay to talk to this system when unintialized, you can gain some perf
-// by not intializing it at all
-TEST_F(AssetProcessorTest, StatsCaptureTest_UninitializedSystemDoesNotAssert)
-{
-    AssetProcessor::StatsCapture::BeginCaptureStat("Test");
-    AssetProcessor::StatsCapture::EndCaptureStat("Test");
-    AssetProcessor::StatsCapture::Dump();
-    AssetProcessor::StatsCapture::Shutdown();
-}
-
-// Double-intiailize is an error
-TEST_F(AssetProcessorTest, StatsCaptureTest_DoubleInitializeIsAnAssert)
-{
-    m_errorAbsorber->Clear();
-    
-    AssetProcessor::StatsCapture::Initialize();
-    AssetProcessor::StatsCapture::Initialize();
-    
-    EXPECT_EQ(m_errorAbsorber->m_numErrorsAbsorbed, 0);
-    EXPECT_EQ(m_errorAbsorber->m_numAssertsAbsorbed, 1); // not allowed to assert on this
-
-    AssetProcessor::StatsCapture::BeginCaptureStat("Test");
-    AssetProcessor::StatsCapture::Shutdown();
-}
-
-class StatsCaptureMockDatabaseLocationListener : public AzToolsFramework::AssetDatabase::AssetDatabaseRequests::Bus::Handler
-{
-public:
-    MOCK_METHOD1(GetAssetDatabaseLocation, bool(AZStd::string&));
-};
-
-class StatsCaptureOutputTest : public AssetProcessorTest, public AZ::Debug::TraceMessageBus::Handler
-{
-private:
-    //! These private members establish the connection to a temporary asset database, which StatsCapture may persist stat entries to.
-    QTemporaryDir m_temporaryDir;
-    AZStd::string m_temporaryDatabasePath;
-    testing::NiceMock<StatsCaptureMockDatabaseLocationListener> m_databaseLocationListener;
-    AssetDatabaseConnection m_dbConnection;
-    friend class GTEST_TEST_CLASS_NAME_(StatsCaptureOutputTest, StatsCaptureTest_PersistToDb);
-
-public:
-    void SetUp() override
+    class StatsCaptureMockDatabaseLocationListener
+        : public AzToolsFramework::AssetDatabase::AssetDatabaseRequests::Bus::Handler
     {
-        AssetProcessorTest::SetUp();
+    public:
+        MOCK_METHOD1(GetAssetDatabaseLocation, bool(AZStd::string&));
+    };
 
-        //! Create a temporary directory to save temporary asset database.
-        //! Setup listener so AseetDatabaseConnection will connect to that temporary database.
+    class StatsCaptureTest
+        : public AssetProcessorTest
+    {
+    private:
+        //! These private members establish the connection to a temporary asset database, which StatsCapture may persist stat entries to.
+        QTemporaryDir m_temporaryDir;
+        AZStd::string m_temporaryDatabasePath;
+        testing::NiceMock<StatsCaptureMockDatabaseLocationListener> m_databaseLocationListener;
+
+    public:
+        void SetUp() override
         {
-            using namespace testing;
+            AssetProcessorTest::SetUp();
 
-            QString canonicalTempDirPath = AssetUtilities::NormalizeDirectoryPath(QDir(m_temporaryDir.path()).canonicalPath());
-            m_temporaryDatabasePath = QDir(canonicalTempDirPath).absoluteFilePath("test_database.sqlite").toUtf8().data();
+            //! Create a temporary directory to save temporary asset database.
+            //! Setup listener so AseetDatabaseConnection will connect to that temporary database.
+            {
+                using namespace testing;
 
-            m_databaseLocationListener.BusConnect();
-            ON_CALL(m_databaseLocationListener, GetAssetDatabaseLocation(_))
-                .WillByDefault(DoAll(SetArgReferee<0>(m_temporaryDatabasePath.c_str()), Return(true)));
+                QString canonicalTempDirPath = AssetUtilities::NormalizeDirectoryPath(QDir(m_temporaryDir.path()).canonicalPath());
+                m_temporaryDatabasePath = QDir(canonicalTempDirPath).absoluteFilePath("test_database.sqlite").toUtf8().data();
 
+                m_databaseLocationListener.BusConnect();
+                ON_CALL(m_databaseLocationListener, GetAssetDatabaseLocation(_))
+                    .WillByDefault(DoAll(SetArgReferee<0>(m_temporaryDatabasePath.c_str()), Return(true)));
+            }
         }
 
-        m_dbConnection.OpenDatabase();
-        AssetProcessor::StatsCapture::Initialize();
-    }
-    
-    // dump but also capture the dump as a vector of lines:
-    void Dump()
+        void TearDown() override
+        {
+            m_databaseLocationListener.BusDisconnect();
+
+            AssetProcessorTest::TearDown();
+        }
+    };
+
+    // Its okay to talk to this system when unintialized, you can gain some perf
+    // by not intializing it at all
+    TEST_F(StatsCaptureTest, StatsCaptureTest_UninitializedSystemDoesNotAssert)
     {
-        AZ::Debug::TraceMessageBus::Handler::BusConnect();
+        AssetProcessor::StatsCapture::BeginCaptureStat("Test");
+        AssetProcessor::StatsCapture::EndCaptureStat("Test");
         AssetProcessor::StatsCapture::Dump();
-        AZ::Debug::TraceMessageBus::Handler::BusDisconnect();
-    }
-    
-    virtual bool OnPrintf(const char* /*window*/, const char* message)
-    {
-        m_gatheredMessages.emplace_back(message);
-        AZ::StringFunc::TrimWhiteSpace(m_gatheredMessages.back(), true, true);
-        return false;
-    }
-    
-    void TearDown() override
-    {
-        m_gatheredMessages = {};
-        
         AssetProcessor::StatsCapture::Shutdown();
-        m_databaseLocationListener.BusDisconnect();
-        AssetProcessorTest::TearDown();
     }
-    
-    AZStd::vector<AZStd::string> m_gatheredMessages;
-};
 
-// turning off machine and human readable mode, should not dump anything.
-TEST_F(StatsCaptureOutputTest, StatsCaptureTest_DisabledByRegset_DumpsNothing)
-{
-    auto registry = AZ::SettingsRegistry::Get();
-    ASSERT_NE(registry, nullptr);
-    registry->Set("/Amazon/AssetProcessor/Settings/Stats/HumanReadable", false);
-    registry->Set("/Amazon/AssetProcessor/Settings/Stats/MachineReadable", false);
-    AssetProcessor::StatsCapture::BeginCaptureStat("Test");
-    AssetProcessor::StatsCapture::EndCaptureStat("Test");
-    Dump();
-    EXPECT_EQ(m_gatheredMessages.size(), 0);
-}
-
-// turning on Human Readable, turn off Machine Readable, should not output any machine readable stats.
-TEST_F(StatsCaptureOutputTest, StatsCaptureTest_HumanReadableOnly_DumpsNoMachineReadable)
-{
-    auto registry = AZ::SettingsRegistry::Get();
-    ASSERT_NE(registry, nullptr);
-    registry->Set("/Amazon/AssetProcessor/Settings/Stats/HumanReadable", true);
-    registry->Set("/Amazon/AssetProcessor/Settings/Stats/MachineReadable", false);
-    AssetProcessor::StatsCapture::BeginCaptureStat("Test");
-    AssetProcessor::StatsCapture::EndCaptureStat("Test");
-    Dump();
-    EXPECT_GT(m_gatheredMessages.size(), 0);
-    for (const auto& message : m_gatheredMessages)
+    // Double-intiailize is an error
+    TEST_F(StatsCaptureTest, StatsCaptureTest_DoubleInitializeIsAnAssert)
     {
-        // we expect to see ZERO "Machine Readable" lines
-        EXPECT_FALSE(message.contains("MachineReadableStat:")) << "Found unexpected line in output: " << message.c_str();
+        m_errorAbsorber->Clear();
+    
+        AssetProcessor::StatsCapture::Initialize();
+        AssetProcessor::StatsCapture::Initialize();
+    
+        EXPECT_EQ(m_errorAbsorber->m_numErrorsAbsorbed, 0);
+        EXPECT_EQ(m_errorAbsorber->m_numAssertsAbsorbed, 1); // not allowed to assert on this
+
+        AssetProcessor::StatsCapture::BeginCaptureStat("Test");
+        AssetProcessor::StatsCapture::Shutdown();
     }
-}
 
-// Turn on Machine Readable, Turn off Human Readable, ensure only Machine Readable stats emitted.
-TEST_F(StatsCaptureOutputTest, StatsCaptureTest_MachineReadableOnly_DumpsNoHumanReadable)
-{
-    auto registry = AZ::SettingsRegistry::Get();
-    ASSERT_NE(registry, nullptr);
-    registry->Set("/Amazon/AssetProcessor/Settings/Stats/HumanReadable", false);
-    registry->Set("/Amazon/AssetProcessor/Settings/Stats/MachineReadable", true);
-    AssetProcessor::StatsCapture::BeginCaptureStat("Test");
-    AssetProcessor::StatsCapture::EndCaptureStat("Test");
-    Dump();
-    for (const auto& message : m_gatheredMessages)
+    class StatsCaptureOutputTest
+        : public StatsCaptureTest
+        , public AZ::Debug::TraceMessageBus::Handler
     {
-        // we expect to see ONLY "Machine Readable" lines
-        EXPECT_TRUE(message.contains("MachineReadableStat:")) << "Found unexpected line in output: " << message.c_str();
-    }
-    EXPECT_GT(m_gatheredMessages.size(), 0);
-}
+    private:
+        //! These private members establish the connection to a temporary asset database, which StatsCapture may persist stat entries to.
+        AssetDatabaseConnection m_dbConnection;
+        friend class GTEST_TEST_CLASS_NAME_(StatsCaptureOutputTest, StatsCaptureTest_PersistToDb);
 
-
-// The interface for StatsCapture just captures and then dumps.  
-// For us to test this, we thus have to capture and parse the dump output.
-TEST_F(StatsCaptureOutputTest, StatsCaptureTest_Sanity)
-{
-    auto registry = AZ::SettingsRegistry::Get();
-    ASSERT_NE(registry, nullptr);
-    
-    // Make it output in "machine raadable" format so that it is simpler to parse.
-    registry->Set("/Amazon/AssetProcessor/Settings/Stats/HumanReadable", false);
-    registry->Set("/Amazon/AssetProcessor/Settings/Stats/MachineReadable", true);
-    AssetProcessor::StatsCapture::BeginCaptureStat("CreateJobs,foo,mybuilder");
-    AssetProcessor::StatsCapture::EndCaptureStat("CreateJobs,foo,mybuilder");
-    
-    // Intentionally not using sleeps in this test.  It means that the 
-    // captured duration will be likely 0 but its not worth it to slow down tests.
-    // If the durations end up 0 its going to be extremely noticable in day-to-day use.
-    AssetProcessor::StatsCapture::BeginCaptureStat("CreateJobs,foo,mybuilder");
-    AssetProcessor::StatsCapture::EndCaptureStat("CreateJobs,foo,mybuilder");
-    
-    // for the second stat, we'll double capture and double end, in order to test debounce
-    AssetProcessor::StatsCapture::BeginCaptureStat("CreateJobs,foo2,mybuilder");
-    AssetProcessor::StatsCapture::BeginCaptureStat("CreateJobs,foo2,mybuilder");
-    AssetProcessor::StatsCapture::EndCaptureStat("CreateJobs,foo2,mybuilder2");
-    AssetProcessor::StatsCapture::EndCaptureStat("CreateJobs,foo2,mybuilder2");
-    
-    m_gatheredMessages.clear();
-    Dump();
-    EXPECT_GT(m_gatheredMessages.size(), 0);
-
-    // We'll parse the machine readable stat lines here and make sure that the following is true
-    // mybuilder appears
-    // mybuilder appears only once but count is 2
-    bool foundFoo = false;
-    bool foundFoo2 = false;
-    
-    for (const auto& stat : m_gatheredMessages)
-    {
-        if (stat.contains("MachineReadableStat:"))
+    public:
+        void SetUp() override
         {
-            AZStd::vector<AZStd::string> tokens;
-            AZ::StringFunc::Tokenize(stat, tokens, ":", false, false);
-            ASSERT_EQ(tokens.size(), 5); // should be "MachineReadableStat:time:count:average:name)
-            const auto& countData = tokens[2];
-            const auto& nameData = tokens[4];
-            
-            if (AZ::StringFunc::Equal(nameData, "CreateJobs,foo,mybuilder"))
-            {
-                EXPECT_FALSE(foundFoo); // should only find one of these
-                foundFoo = true;
-                EXPECT_STREQ(countData.c_str(), "2");
-            }
-            
-            if (AZ::StringFunc::Equal(nameData, "CreateJobs,foo2,mybuilder2"))
-            {
-                EXPECT_FALSE(foundFoo2); // should only find one of these
-                foundFoo2 = true;
-                EXPECT_STREQ(countData.c_str(), "1");
-            }
+            StatsCaptureTest::SetUp();
+
+            m_dbConnection.OpenDatabase();
+            AssetProcessor::StatsCapture::Initialize();
+        }
+    
+        // dump but also capture the dump as a vector of lines:
+        void Dump()
+        {
+            AZ::Debug::TraceMessageBus::Handler::BusConnect();
+            AssetProcessor::StatsCapture::Dump();
+            AZ::Debug::TraceMessageBus::Handler::BusDisconnect();
+        }
+    
+        virtual bool OnPrintf(const char* /*window*/, const char* message)
+        {
+            m_gatheredMessages.emplace_back(message);
+            AZ::StringFunc::TrimWhiteSpace(m_gatheredMessages.back(), true, true);
+            return false;
+        }
+    
+        void TearDown() override
+        {
+            m_gatheredMessages = {};     
+            AssetProcessor::StatsCapture::Shutdown();
+
+            StatsCaptureTest::TearDown();
+        }
+    
+        AZStd::vector<AZStd::string> m_gatheredMessages;
+    };
+
+    // turning off machine and human readable mode, should not dump anything.
+    TEST_F(StatsCaptureOutputTest, StatsCaptureTest_DisabledByRegset_DumpsNothing)
+    {
+        auto registry = AZ::SettingsRegistry::Get();
+        ASSERT_NE(registry, nullptr);
+        registry->Set("/Amazon/AssetProcessor/Settings/Stats/HumanReadable", false);
+        registry->Set("/Amazon/AssetProcessor/Settings/Stats/MachineReadable", false);
+        AssetProcessor::StatsCapture::BeginCaptureStat("Test");
+        AssetProcessor::StatsCapture::EndCaptureStat("Test");
+        Dump();
+        EXPECT_EQ(m_gatheredMessages.size(), 0);
+    }
+
+    // turning on Human Readable, turn off Machine Readable, should not output any machine readable stats.
+    TEST_F(StatsCaptureOutputTest, StatsCaptureTest_HumanReadableOnly_DumpsNoMachineReadable)
+    {
+        auto registry = AZ::SettingsRegistry::Get();
+        ASSERT_NE(registry, nullptr);
+        registry->Set("/Amazon/AssetProcessor/Settings/Stats/HumanReadable", true);
+        registry->Set("/Amazon/AssetProcessor/Settings/Stats/MachineReadable", false);
+        AssetProcessor::StatsCapture::BeginCaptureStat("Test");
+        AssetProcessor::StatsCapture::EndCaptureStat("Test");
+        Dump();
+        EXPECT_GT(m_gatheredMessages.size(), 0);
+        for (const auto& message : m_gatheredMessages)
+        {
+            // we expect to see ZERO "Machine Readable" lines
+            EXPECT_FALSE(message.contains("MachineReadableStat:")) << "Found unexpected line in output: " << message.c_str();
         }
     }
+
+    // Turn on Machine Readable, Turn off Human Readable, ensure only Machine Readable stats emitted.
+    TEST_F(StatsCaptureOutputTest, StatsCaptureTest_MachineReadableOnly_DumpsNoHumanReadable)
+    {
+        auto registry = AZ::SettingsRegistry::Get();
+        ASSERT_NE(registry, nullptr);
+        registry->Set("/Amazon/AssetProcessor/Settings/Stats/HumanReadable", false);
+        registry->Set("/Amazon/AssetProcessor/Settings/Stats/MachineReadable", true);
+        AssetProcessor::StatsCapture::BeginCaptureStat("Test");
+        AssetProcessor::StatsCapture::EndCaptureStat("Test");
+        Dump();
+        for (const auto& message : m_gatheredMessages)
+        {
+            // we expect to see ONLY "Machine Readable" lines
+            EXPECT_TRUE(message.contains("MachineReadableStat:")) << "Found unexpected line in output: " << message.c_str();
+        }
+        EXPECT_GT(m_gatheredMessages.size(), 0);
+    }
+
+
+    // The interface for StatsCapture just captures and then dumps.  
+    // For us to test this, we thus have to capture and parse the dump output.
+    TEST_F(StatsCaptureOutputTest, StatsCaptureTest_Sanity)
+    {
+        auto registry = AZ::SettingsRegistry::Get();
+        ASSERT_NE(registry, nullptr);
     
-    EXPECT_TRUE(foundFoo) << "The expected token CreateJobs,foo,mybuilder did not appear in the output.";
-    EXPECT_TRUE(foundFoo2) << "The expected CreateJobs.foo2.mybuilder2 did not appear in the output";
-}
+        // Make it output in "machine raadable" format so that it is simpler to parse.
+        registry->Set("/Amazon/AssetProcessor/Settings/Stats/HumanReadable", false);
+        registry->Set("/Amazon/AssetProcessor/Settings/Stats/MachineReadable", true);
+        AssetProcessor::StatsCapture::BeginCaptureStat("CreateJobs,foo,mybuilder");
+        AssetProcessor::StatsCapture::EndCaptureStat("CreateJobs,foo,mybuilder");
+    
+        // Intentionally not using sleeps in this test.  It means that the 
+        // captured duration will be likely 0 but its not worth it to slow down tests.
+        // If the durations end up 0 its going to be extremely noticable in day-to-day use.
+        AssetProcessor::StatsCapture::BeginCaptureStat("CreateJobs,foo,mybuilder");
+        AssetProcessor::StatsCapture::EndCaptureStat("CreateJobs,foo,mybuilder");
+    
+        // for the second stat, we'll double capture and double end, in order to test debounce
+        AssetProcessor::StatsCapture::BeginCaptureStat("CreateJobs,foo2,mybuilder");
+        AssetProcessor::StatsCapture::BeginCaptureStat("CreateJobs,foo2,mybuilder");
+        AssetProcessor::StatsCapture::EndCaptureStat("CreateJobs,foo2,mybuilder2");
+        AssetProcessor::StatsCapture::EndCaptureStat("CreateJobs,foo2,mybuilder2");
+    
+        m_gatheredMessages.clear();
+        Dump();
+        EXPECT_GT(m_gatheredMessages.size(), 0);
 
-// If BeginCaptureStat was called for a certain statName, EndCaptureStat returns with a AZStd::optional containing just-measured duration as
-// its value. If BeginCaptureStat was not called for a certain statName, EndCaptureStat returns with a AZStd::optional without a value.
-TEST_F(StatsCaptureOutputTest, StatsCaptureTest_ReturnsLastDuration)
-{
-    AssetProcessor::StatsCapture::BeginCaptureStat("O3");
-    auto o3Result = AssetProcessor::StatsCapture::EndCaptureStat("O3");
-    auto deResult = AssetProcessor::StatsCapture::EndCaptureStat("DE");
-    EXPECT_TRUE(o3Result.has_value());
-    EXPECT_FALSE(deResult.has_value());
-}
+        // We'll parse the machine readable stat lines here and make sure that the following is true
+        // mybuilder appears
+        // mybuilder appears only once but count is 2
+        bool foundFoo = false;
+        bool foundFoo2 = false;
+    
+        for (const auto& stat : m_gatheredMessages)
+        {
+            if (stat.contains("MachineReadableStat:"))
+            {
+                AZStd::vector<AZStd::string> tokens;
+                AZ::StringFunc::Tokenize(stat, tokens, ":", false, false);
+                ASSERT_EQ(tokens.size(), 5); // should be "MachineReadableStat:time:count:average:name)
+                const auto& countData = tokens[2];
+                const auto& nameData = tokens[4];
+            
+                if (AZ::StringFunc::Equal(nameData, "CreateJobs,foo,mybuilder"))
+                {
+                    EXPECT_FALSE(foundFoo); // should only find one of these
+                    foundFoo = true;
+                    EXPECT_STREQ(countData.c_str(), "2");
+                }
+            
+                if (AZ::StringFunc::Equal(nameData, "CreateJobs,foo2,mybuilder2"))
+                {
+                    EXPECT_FALSE(foundFoo2); // should only find one of these
+                    foundFoo2 = true;
+                    EXPECT_STREQ(countData.c_str(), "1");
+                }
+            }
+        }
+    
+        EXPECT_TRUE(foundFoo) << "The expected token CreateJobs,foo,mybuilder did not appear in the output.";
+        EXPECT_TRUE(foundFoo2) << "The expected CreateJobs.foo2.mybuilder2 did not appear in the output";
+    }
 
-// Stat does not exist in asset database if EndCaptureStat's persistToDb argument is not specified or is false, and exist in asset database if
-// persistToDb is true.
-TEST_F(StatsCaptureOutputTest, StatsCaptureTest_PersistToDb)
-{
-    AZ::u32 statEntryCount{ 0 };
-    auto countQueriedStatEntry = [&statEntryCount]([[maybe_unused]] AzToolsFramework::AssetDatabase::StatDatabaseEntry& entry)
+    // If BeginCaptureStat was called for a certain statName, EndCaptureStat returns with a AZStd::optional containing just-measured duration as
+    // its value. If BeginCaptureStat was not called for a certain statName, EndCaptureStat returns with a AZStd::optional without a value.
+    TEST_F(StatsCaptureOutputTest, StatsCaptureTest_ReturnsLastDuration)
     {
-        ++statEntryCount;
-        return true;
-    };
+        AssetProcessor::StatsCapture::BeginCaptureStat("O3");
+        auto o3Result = AssetProcessor::StatsCapture::EndCaptureStat("O3");
+        auto deResult = AssetProcessor::StatsCapture::EndCaptureStat("DE");
+        EXPECT_TRUE(o3Result.has_value());
+        EXPECT_FALSE(deResult.has_value());
+    }
 
-    AZStd::vector<AzToolsFramework::AssetDatabase::StatDatabaseEntry> statEntryContainer;
-    auto getQueriedStatEntry = [&statEntryContainer]([[maybe_unused]] AzToolsFramework::AssetDatabase::StatDatabaseEntry& entry)
+    // Stat does not exist in asset database if EndCaptureStat's persistToDb argument is not specified or is false, and exist in asset database if
+    // persistToDb is true.
+    TEST_F(StatsCaptureOutputTest, StatsCaptureTest_PersistToDb)
     {
-        statEntryContainer.emplace_back() = AZStd::move(entry);
-        return true;
-    };
+        AZ::u32 statEntryCount{ 0 };
+        auto countQueriedStatEntry = [&statEntryCount]([[maybe_unused]] AzToolsFramework::AssetDatabase::StatDatabaseEntry& entry)
+        {
+            ++statEntryCount;
+            return true;
+        };
 
-    // persistToDb argument is not specified
-    AssetProcessor::StatsCapture::BeginCaptureStat("Open");
-    AssetProcessor::StatsCapture::EndCaptureStat("Open");
+        AZStd::vector<AzToolsFramework::AssetDatabase::StatDatabaseEntry> statEntryContainer;
+        auto getQueriedStatEntry = [&statEntryContainer]([[maybe_unused]] AzToolsFramework::AssetDatabase::StatDatabaseEntry& entry)
+        {
+            statEntryContainer.emplace_back() = AZStd::move(entry);
+            return true;
+        };
 
-    statEntryCount = 0;
-    m_dbConnection.QueryStatsTable(countQueriedStatEntry);
-    EXPECT_EQ(statEntryCount, 0);
+        // persistToDb argument is not specified
+        AssetProcessor::StatsCapture::BeginCaptureStat("Open");
+        AssetProcessor::StatsCapture::EndCaptureStat("Open");
 
-    // persistToDb argument is false
-    AssetProcessor::StatsCapture::BeginCaptureStat("3D");
-    AssetProcessor::StatsCapture::EndCaptureStat("3D", false);
-    statEntryCount = 0;
+        statEntryCount = 0;
+        m_dbConnection.QueryStatsTable(countQueriedStatEntry);
+        EXPECT_EQ(statEntryCount, 0);
 
-    m_dbConnection.QueryStatsTable(countQueriedStatEntry);
-    EXPECT_EQ(statEntryCount, 0);
+        // persistToDb argument is false
+        AssetProcessor::StatsCapture::BeginCaptureStat("3D");
+        AssetProcessor::StatsCapture::EndCaptureStat("3D", false);
+        statEntryCount = 0;
 
-    // persistToDb argument is true
-    AssetProcessor::StatsCapture::BeginCaptureStat("Engine");
-    auto statResult = AssetProcessor::StatsCapture::EndCaptureStat("Engine", true);
-    ASSERT_TRUE(statResult.has_value());
+        m_dbConnection.QueryStatsTable(countQueriedStatEntry);
+        EXPECT_EQ(statEntryCount, 0);
 
-    statEntryContainer.clear();
-    m_dbConnection.QueryStatsTable(getQueriedStatEntry);
-    ASSERT_EQ(statEntryContainer.size(), 1);
+        // persistToDb argument is true
+        AssetProcessor::StatsCapture::BeginCaptureStat("Engine");
+        auto statResult = AssetProcessor::StatsCapture::EndCaptureStat("Engine", true);
+        ASSERT_TRUE(statResult.has_value());
 
-    EXPECT_EQ(statEntryContainer.at(0).m_statValue, aznumeric_cast<AZ::s64>(statResult.value()));
-}
+        statEntryContainer.clear();
+        m_dbConnection.QueryStatsTable(getQueriedStatEntry);
+        ASSERT_EQ(statEntryContainer.size(), 1);
 
+        EXPECT_EQ(statEntryContainer.at(0).m_statValue, aznumeric_cast<AZ::s64>(statResult.value()));
+    }
 } // namespace AssetProcessor
 

--- a/Code/Tools/AssetProcessor/native/unittests/AssetProcessingStateDataUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetProcessingStateDataUnitTests.cpp
@@ -9,40 +9,6 @@
 #include <AzToolsFramework/API/AssetDatabaseBus.h>
 #include "native/AssetDatabase/AssetDatabase.h"
 
-namespace AssetProcessingStateDataUnitTestInternal
-{
-    // a utility class to redirect the location the database is stored to a different location so that we don't
-    // touch real data during unit tests.
-    class FakeDatabaseLocationListener
-        : protected AzToolsFramework::AssetDatabase::AssetDatabaseRequests::Bus::Handler
-    {
-    public:
-        FakeDatabaseLocationListener(const char* desiredLocation, const char* assetPath)
-            : m_location(desiredLocation)
-            , m_assetPath(assetPath)
-        {
-            AzToolsFramework::AssetDatabase::AssetDatabaseRequests::Bus::Handler::BusConnect();
-        }
-        ~FakeDatabaseLocationListener()
-        {
-            AzToolsFramework::AssetDatabase::AssetDatabaseRequests::Bus::Handler::BusDisconnect();
-        }
-    protected:
-        // IMPLEMENTATION OF -------------- AzToolsFramework::AssetDatabase::AssetDatabaseRequests::Bus::Listener
-        bool GetAssetDatabaseLocation(AZStd::string& location) override
-        {
-            location = m_location;
-            return true;
-        }
-
-        // ------------------------------------------------------------
-
-    private:
-        AZStd::string m_location;
-        AZStd::string m_assetPath;
-    };
-}
-
 // perform some operations on the state data given.  (Does not perform save and load tests)
 void AssetProcessingStateDataUnitTest::DataTest(AssetProcessor::AssetDatabaseConnection* stateData)
 {
@@ -1294,9 +1260,9 @@ void AssetProcessingStateDataUnitTest::DataTest(AssetProcessor::AssetDatabaseCon
 
 void AssetProcessingStateDataUnitTest::ExistenceTest(AssetProcessor::AssetDatabaseConnection* stateData)
 {
-    UNIT_TEST_EXPECT_FALSE(stateData->DataExists());
-    stateData->ClearData(); // this is expected to initialize a database.
+    // The asset database has already been created when the application manager was activated.
     UNIT_TEST_EXPECT_TRUE(stateData->DataExists());
+    UNIT_TEST_EXPECT_TRUE(stateData->OpenDatabase());
 }
 
 // test is broken out into its own function so as to be more compatible with a future GTEST-like API.
@@ -1487,58 +1453,44 @@ void AssetProcessingStateDataUnitTest::SourceFingerprintTest(AssetProcessor::Ass
 
 void AssetProcessingStateDataUnitTest::AssetProcessingStateDataTest()
 {
-    using namespace AssetProcessingStateDataUnitTestInternal;
     using namespace AzToolsFramework::AssetDatabase;
 
-    QDir dirPath;
-
-    // intentional scope to contain QTemporaryDir since it cleans up on destruction!
+    bool testsFailed = false;
+    connect(this, &UnitTestRun::UnitTestFailed, this, [&testsFailed]()
     {
-        QTemporaryDir tempDir;
-        ProductDatabaseEntryContainer products;
-        dirPath = QDir(tempDir.path());
+        testsFailed = true;
+    }, Qt::DirectConnection);
 
-        bool testsFailed = false;
-        connect(this, &UnitTestRun::UnitTestFailed, this, [&testsFailed]()
-        {
-            testsFailed = true;
-        }, Qt::DirectConnection);
-
+    {
         // now test the SQLite version of the database on its own.
+        AssetProcessor::AssetDatabaseConnection connection;
+
+        ExistenceTest(&connection);
+        if (testsFailed)
         {
-            FakeDatabaseLocationListener listener(dirPath.filePath("statedatabase.sqlite").toUtf8().constData(), "displayString");
-            AssetProcessor::AssetDatabaseConnection connection;
-
-            ExistenceTest(&connection);
-            if (testsFailed)
-            {
-                return;
-            }
-
-            DataTest(&connection);
-            if (testsFailed)
-            {
-                return;
-            }
-
-            BuilderInfoTest(&connection);
-            if (testsFailed)
-            {
-                return;
-            }
-
-            SourceFingerprintTest(&connection);
-            if (testsFailed)
-            {
-                return;
-            }
-
-            SourceDependencyTest(&connection);
+            return;
         }
+
+        DataTest(&connection);
+        if (testsFailed)
+        {
+            return;
+        }
+
+        BuilderInfoTest(&connection);
+        if (testsFailed)
+        {
+            return;
+        }
+
+        SourceFingerprintTest(&connection);
+        if (testsFailed)
+        {
+            return;
+        }
+
+        SourceDependencyTest(&connection);
     }
-    // scope ending for the QTempDir
-    // if this fails it means someone left a handle to the database open.
-    UNIT_TEST_EXPECT_FALSE(dirPath.exists());
 
     Q_EMIT UnitTestPassed();
 }


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?
Currently, the failed tests read database.sqlite from the current working directory and create one if the file doesn't exist. However, the tests don't clean up the database file during the tear down process. This becomes a problem when the current asset database version doesn't match the database version on disk/Jenkins since the tests keep reading the outdated database information on disk/Jenkins.

PR changes:
- Make sure that database.sqlite is only written to a temp folder and cleaned each time after the tests finish. 
- Refactor test code to remove the duplicate AzToolsFramework::AssetDatabase::AssetDatabaseRequests::Bus::Handler implementations. 
- Fix an issue in https://github.com/o3de/o3de/blob/development/Code/Tools/AssetProcessor/native/utilities/StatsCapture.cpp which can cause a crash if the database is not opened successfully during initialization.

## How was this PR tested?
- Automation tests passed locally.
- Set break points in the test code and verified that the database file is written to the temp folder and cleaned up after running the test.
