### PR TITLE
Fix uninitialized member variable in AWSCore test

### DIFF
--- a/Gems/AWSCore/Code/Tests/Credential/AWSDefaultCredentialHandlerTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Credential/AWSDefaultCredentialHandlerTest.cpp
@@ -101,7 +101,7 @@ public:
     std::shared_ptr<InstanceProfileCredentialsProviderMock> m_instanceProfileCredentialsProviderMock;
     AZStd::unique_ptr<AWSDefaultCredentialHandlerMock> m_credentialHandler;
     AZStd::string m_profileName;
-    bool m_allowAWSMetadataCredentials;
+    bool m_allowAWSMetadataCredentials{ false };
 };
 
 TEST_F(AWSDefaultCredentialHandlerTest, GetCredentialsProvider_EnvironmentCredentialProviderReturnsNonEmptyCredentials_GetExpectedCredentialProvider)


### PR DESCRIPTION
Signed-off-by: allisaurus <34254888+allisaurus@users.noreply.github.com>

## What does this PR do?

Fixes https://jenkins.build.o3de.org/blue/organizations/jenkins/O3DE/detail/development/3224/pipeline/   

## How was this PR tested?

unit tests pass (and the reverse of this change, initialize to `true`, causes it to fail like above CI error)
