### PR TITLE
Add MutexType to EditorEntityContextRequests

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextBus.h
@@ -34,7 +34,6 @@ namespace AzToolsFramework
         : public AZ::EBusTraits
     {
     public:
-
         using MutexType = AZStd::recursive_mutex;
 
         virtual ~EditorEntityContextRequests() {}

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextBus.h
@@ -34,6 +34,8 @@ namespace AzToolsFramework
         : public AZ::EBusTraits
     {
     public:
+        // This bus itself is thread safe, and function like GetEditorEntityContextId() is thread safe. But be careful
+        // with function like AddEntity, DestroyEntity - those might not be thread safe due the implementation.
         static constexpr bool LocklessDispatch = true;
 
         virtual ~EditorEntityContextRequests() {}

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextBus.h
@@ -34,7 +34,7 @@ namespace AzToolsFramework
         : public AZ::EBusTraits
     {
     public:
-        using MutexType = AZStd::recursive_mutex;
+        static const bool LocklessDispatch = true;
 
         virtual ~EditorEntityContextRequests() {}
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextBus.h
@@ -34,7 +34,7 @@ namespace AzToolsFramework
         : public AZ::EBusTraits
     {
     public:
-        static const bool LocklessDispatch = true;
+        static constexpr bool LocklessDispatch = true;
 
         virtual ~EditorEntityContextRequests() {}
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextBus.h
@@ -35,6 +35,8 @@ namespace AzToolsFramework
     {
     public:
 
+        using MutexType = AZStd::recursive_mutex;
+
         virtual ~EditorEntityContextRequests() {}
 
         //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes https://github.com/o3de/o3de/issues/12414
It was discovered that making call to EditorEntityContextRequests is not thread safe. Not sure why it would only be triggered in the repro steps in 12414, but I think it's a reasonable request to add the mutex type to EditorEntityContextRequests Bus.
