### PR TITLE
Fix crash in curve editor on double click

### DIFF
--- a/Gems/LyShine/Code/Editor/Animation/Controls/UiSplineCtrlEx.cpp
+++ b/Gems/LyShine/Code/Editor/Animation/Controls/UiSplineCtrlEx.cpp
@@ -1280,6 +1280,13 @@ void SplineWidget::mouseDoubleClickEvent(QMouseEvent* event)
     break;
     case HIT_KEY:
     {
+        // End recording that was started at the beginning of the double click sequence
+        if (UiAnimUndo::IsRecording())
+        {
+            UiAnimUndoManager::Get()->Cancel();
+            m_pCurrentUndo = nullptr;
+        }
+
         RemoveKey(m_pHitSpline, m_nHitKeyIndex);
     }
     break;


### PR DESCRIPTION
Signed-off-by: michabr <82236305+michabr@users.noreply.github.com>

Fix a crash caused by double clicking on a key in the curve editor to delete the key. The issue was that the undo system wasn't in the correct state when the delete command was added.

Fixes #12219.

## How was this PR tested?

Manual testing by repeating steps in ticket multiple times, and also doing undo/redo.
