### PR TITLE
Added option to set rhi-device-validation in settings registry

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ValidationLayer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ValidationLayer.h
@@ -25,7 +25,7 @@ namespace AZ
         };
 
         // Read the RHI validation mode considering configurations,
-        // cvars, comman line options and registry settings.
+        // cvars, command line options and registry settings.
         ValidationMode ReadValidationMode();
     }
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ValidationLayer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ValidationLayer.h
@@ -24,8 +24,8 @@ namespace AZ
             GPU
         };
 
-        // Read the RHI validation mode from the command line arguments.
-        // If not present in the arguments, return nullopt.
-        AZStd::optional<ValidationMode> ReadValidationModeFromCommandArgs();
+        // Read the RHI validation mode considering configurations,
+        // cvars, comman line options and registry settings.
+        ValidationMode ReadValidationMode();
     }
 }

--- a/Gems/Atom/RHI/Code/Source/RHI.Private/FactoryManagerSystemComponent.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Private/FactoryManagerSystemComponent.cpp
@@ -201,14 +201,7 @@ namespace AZ
 
         void FactoryManagerSystemComponent::UpdateValidationModeFromCommandline()
         {
-#if defined(_RELEASE)
-            m_validationMode = ValidationMode::Disabled;
-#else
-            if (auto commandLineValidation = AZ::RHI::ReadValidationModeFromCommandArgs())
-            {
-                m_validationMode = *commandLineValidation;
-            }
-#endif        
+            m_validationMode = AZ::RHI::ReadValidationMode();
         }
 
     } // namespace RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/ValidationLayer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ValidationLayer.cpp
@@ -25,28 +25,43 @@ namespace AZ
             "Use this cvar to override device validation for debug builds.");
 
         static const char* ValidationCommandLineOption = "rhi-device-validation";
+        static const char* ValidationSetting = "/O3DE/Atom/rhi-device-validation";
 
-        AZStd::optional<ValidationMode> ReadValidationModeFromCommandArgs()
+        ValidationMode ReadValidationMode()
         {
+#if defined(AZ_RELEASE_BUILD)
+            // Always disabled in Release configuration.
+            return ValidationMode::Disabled;
+#else
             ValidationMode mode = ValidationMode::Disabled;
-            bool debugBuildDeviceValidationOverride = true;
-            if (auto* console = Interface<IConsole>::Get())
+
+            // Always enabled in Debug configuration by default, unless overriden by cvar, command line or setting registry.
+            if constexpr (AZ::RHI::BuildOptions::IsDebugBuild)
             {
-                console->GetCvarValue("r_debugBuildDeviceValidationOverride", debugBuildDeviceValidationOverride);
+                mode = r_debugBuildDeviceValidationOverride ? ValidationMode::Enabled : ValidationMode::Disabled;
             }
 
-            bool isDebugBuild = AZ::RHI::BuildOptions::IsDebugBuild;
-            if (isDebugBuild && debugBuildDeviceValidationOverride)
-            {
-                mode = ValidationMode::Enabled;
-            }
+            AZStd::string validationValue;
 
+            // Check command line option first.
             const AzFramework::CommandLine* commandLine = nullptr;
             AzFramework::ApplicationRequests::Bus::BroadcastResult(commandLine, &AzFramework::ApplicationRequests::GetApplicationCommandLine);
             if (commandLine)
             {
-                AZStd::string validationValue = RHI::GetCommandLineValue(ValidationCommandLineOption);
-                
+                validationValue = RHI::GetCommandLineValue(ValidationCommandLineOption);
+            }
+
+            // Check settings registry next.
+            if (validationValue.empty())
+            {
+                if (AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get())
+                {
+                    settingsRegistry->Get(validationValue, ValidationSetting);
+                }
+            }
+
+            if (!validationValue.empty())
+            {
                 if (AzFramework::StringFunc::Equal(validationValue.c_str(), "disable"))
                 {
                     mode = ValidationMode::Disabled;
@@ -63,12 +78,10 @@ namespace AZ
                 {
                     mode = ValidationMode::GPU;
                 }
-                return AZStd::optional<ValidationMode>(mode);
             }
-            else
-            {
-                return AZStd::optional<ValidationMode>();
-            }
+
+            return mode;
+#endif // defined(AZ_RELEASE_BUILD)
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

Now it's possible to specify the rhi device validation by both command line and setting registry by having this in a .setget file.

````
{
    "O3DE": {
        "Atom": {
            "rhi-device-validation": "enable"
        }
    }
}
````

This is very useful for android platform since it's not possible at the moment to pass the validation by command line.

Also unified the logic into one function so it's simpler to read and follow.

## How was this PR tested?

Tested setting the validation using cvar, command line and setting registry.
