### PR TITLE
Allow using the default sv_port value when hosting through the IMultiplayer interface, and adds some safety guards

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/IMultiplayer.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/IMultiplayer.h
@@ -105,7 +105,8 @@ namespace Multiplayer
         //! @param port The port to listen for connection on, 0 means use the currently configured port value of sv_port
         //! @param isDedicated Whether the server is dedicated or client hosted
         //! @return if the application successfully started hosting
-        virtual bool StartHosting(uint16_t port = 0, bool isDedicated = true) = 0;
+        static const uint16_t UseDefaultHostPort = 0;
+        virtual bool StartHosting(uint16_t port = UseDefaultHostPort, bool isDedicated = true) = 0;
 
         //! Connects to the specified IP as a Client.
         //! @param remoteAddress The domain or IP to connect to

--- a/Gems/Multiplayer/Code/Include/Multiplayer/IMultiplayer.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/IMultiplayer.h
@@ -102,10 +102,10 @@ namespace Multiplayer
         virtual void InitializeMultiplayer(MultiplayerAgentType state) = 0;
 
         //! Starts hosting a server.
-        //! @param port The port to listen for connection on
+        //! @param port The port to listen for connection on, 0 means use the currently configured port value of sv_port
         //! @param isDedicated Whether the server is dedicated or client hosted
         //! @return if the application successfully started hosting
-        virtual bool StartHosting(uint16_t port, bool isDedicated = true) = 0;
+        virtual bool StartHosting(uint16_t port = 0, bool isDedicated = true) = 0;
 
         //! Connects to the specified IP as a Client.
         //! @param remoteAddress The domain or IP to connect to

--- a/Gems/Multiplayer/Code/Source/Components/MultiplayerComponentRegistry.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/MultiplayerComponentRegistry.cpp
@@ -20,7 +20,11 @@ namespace Multiplayer
     AZStd::unique_ptr<IMultiplayerComponentInput> MultiplayerComponentRegistry::AllocateComponentInput(NetComponentId netComponentId)
     {
         const ComponentData& componentData = GetMultiplayerComponentData(netComponentId);
-        return AZStd::move(componentData.m_allocComponentInputFunction());
+        if (componentData.m_allocComponentInputFunction)
+        {
+            return AZStd::move(componentData.m_allocComponentInputFunction());
+        }
+        return nullptr;
     }
 
     const char* MultiplayerComponentRegistry::GetComponentGemName(NetComponentId netComponentId) const
@@ -38,13 +42,21 @@ namespace Multiplayer
     const char* MultiplayerComponentRegistry::GetComponentPropertyName(NetComponentId netComponentId, PropertyIndex propertyIndex) const
     {
         const ComponentData& componentData = GetMultiplayerComponentData(netComponentId);
-        return componentData.m_componentPropertyNameLookupFunction(propertyIndex);
+        if (componentData.m_componentPropertyNameLookupFunction)
+        {
+            return componentData.m_componentPropertyNameLookupFunction(propertyIndex);
+        }
+        return "Unknown component";
     }
 
     const char* MultiplayerComponentRegistry::GetComponentRpcName(NetComponentId netComponentId, RpcIndex rpcIndex) const
     {
         const ComponentData& componentData = GetMultiplayerComponentData(netComponentId);
-        return componentData.m_componentRpcNameLookupFunction(rpcIndex);
+        if (componentData.m_componentRpcNameLookupFunction)
+        {
+            return componentData.m_componentRpcNameLookupFunction(rpcIndex);
+        }
+        return "Unknown component";
     }
 
     const MultiplayerComponentRegistry::ComponentData& MultiplayerComponentRegistry::GetMultiplayerComponentData(NetComponentId netComponentId) const

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -265,6 +265,11 @@ namespace Multiplayer
 
     bool MultiplayerSystemComponent::StartHosting(uint16_t port, bool isDedicated)
     {
+        if (port == 0)
+        {
+            port = sv_port;
+        }
+
         if (port != sv_port)
         {
             sv_port = port;

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -265,7 +265,7 @@ namespace Multiplayer
 
     bool MultiplayerSystemComponent::StartHosting(uint16_t port, bool isDedicated)
     {
-        if (port == 0)
+        if (port == UseDefaultHostPort)
         {
             port = sv_port;
         }

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
@@ -111,7 +111,7 @@ namespace Multiplayer
         //! @{
         MultiplayerAgentType GetAgentType() const override;
         void InitializeMultiplayer(MultiplayerAgentType state) override;
-        bool StartHosting(uint16_t port = 0, bool isDedicated = true) override;
+        bool StartHosting(uint16_t port = UseDefaultHostPort, bool isDedicated = true) override;
         bool Connect(const AZStd::string& remoteAddress, uint16_t port) override;
         void Terminate(AzNetworking::DisconnectReason reason) override;
         void AddClientMigrationStartEventHandler(ClientMigrationStartEvent::Handler& handler) override;

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
@@ -111,7 +111,7 @@ namespace Multiplayer
         //! @{
         MultiplayerAgentType GetAgentType() const override;
         void InitializeMultiplayer(MultiplayerAgentType state) override;
-        bool StartHosting(uint16_t port, bool isDedicated = true) override;
+        bool StartHosting(uint16_t port = 0, bool isDedicated = true) override;
         bool Connect(const AZStd::string& remoteAddress, uint16_t port) override;
         void Terminate(AzNetworking::DisconnectReason reason) override;
         void AddClientMigrationStartEventHandler(ClientMigrationStartEvent::Handler& handler) override;

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
@@ -276,6 +276,7 @@ namespace Multiplayer
     {
         if (alwaysRelevant)
         {
+            AZ_Assert(entityHandle.GetNetBindComponent()->IsNetEntityRoleAuthority(), "Marking an entity always relevant can only be done on an authoritative entity");
             m_alwaysRelevantToClients.emplace(entityHandle);
         }
         else
@@ -288,6 +289,7 @@ namespace Multiplayer
     {
         if (alwaysRelevant)
         {
+            AZ_Assert(entityHandle.GetNetBindComponent()->IsNetEntityRoleAuthority(), "Marking an entity always relevant can only be done on an authoritative entity");
             m_alwaysRelevantToServers.emplace(entityHandle);
         }
         else

--- a/Gems/Multiplayer/Code/Source/ReplicationWindows/ServerToClientReplicationWindow.cpp
+++ b/Gems/Multiplayer/Code/Source/ReplicationWindows/ServerToClientReplicationWindow.cpp
@@ -170,6 +170,7 @@ namespace Multiplayer
         {
             if (entityHandle.Exists())
             {
+                AZ_Assert(entityHandle.GetNetBindComponent()->IsNetEntityRoleAuthority(), "Encountered forced relevant entity that is not in an authority role");
                 m_replicationSet[entityHandle] = { NetEntityRole::Client, 1.0f }; // Always replicate entities with forced relevancy
             }
         }


### PR DESCRIPTION
Allow using the default sv_port value when hosting through the IMultiplayer interface, adds some safety guards to the component registry and some asserts to the mark always relevent methods to guarantee we don't create replicators in a bad state, and validate that all replicators marked relevent are in the correct role for replication

Signed-off-by: kberg-amzn <karlberg@amazon.com>