### PR TITLE
adding new naming conventions for splatmaps

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/ImageBuilder.settings
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/ImageBuilder.settings
@@ -109,6 +109,9 @@
             // Gradient
             "_grad": [ "Gradient" ],
             "_gradient": [ "Gradient" ],
+			"_sm": [ "Gradient" ],
+			"_splat": [ "Gradient" ],
+			"_splatmap": [ "Gradient" ],
             
             // Greyscale
             "_grey": [ "Greyscale" ],
@@ -202,9 +205,6 @@
 			"_SpecularReflectance": [ "Reflectance" ],
 			"_thickness": [ "Reflectance" ],
 			"_linear": [ "Reflectance" ],
-			"_sm": [ "Reflectance" ],
-			"_splat": [ "Reflectance" ],
-			"_splatmap": [ "Reflectance" ],
             
             
             // Skybox

--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/ImageBuilder.settings
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/ImageBuilder.settings
@@ -201,6 +201,11 @@
             "_specular": [ "Reflectance" ],
 			"_SpecularReflectance": [ "Reflectance" ],
 			"_thickness": [ "Reflectance" ],
+			"_linear": [ "Reflectance" ],
+			"_sm": [ "Reflectance" ],
+			"_splat": [ "Reflectance" ],
+			"_splatmap": [ "Reflectance" ],
+            
             
             // Skybox
             "_skyboxcm": [ "Skybox" ],


### PR DESCRIPTION
## What does this PR do?
Adds naming convention support for _linear and _splatmaps to the image builder profiles.

## How was this PR tested?
Locally created images using conventions, cooked and then utilized in the engine.

