### PR TITLE
Prefab - Fix memory issue in create entity operation

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -693,21 +693,6 @@ namespace AzToolsFramework
             m_prefabUndoCache.UpdateCache(entityId);
             m_prefabUndoCache.UpdateCache(parentId);
 
-            // Get the alias of the parent entity in the owning template's DOM.
-            AZStd::string parentEntityAliasPath = m_instanceToTemplateInterface->GenerateEntityAliasPath(parentId);
-            PrefabDomPath entityPathInOwningTemplate(parentEntityAliasPath.c_str());
-            
-            PrefabDom& owningTemplateDom =
-                m_prefabSystemComponentInterface->FindTemplateDom(owningInstanceOfParentEntity->get().GetTemplateId());
-            const PrefabDomValue* parentEntityDomInOwningTemplate = entityPathInOwningTemplate.Get(owningTemplateDom);
-            if (!parentEntityDomInOwningTemplate)
-            {
-                return AZ::Failure<AZStd::string>("Could not load entity DOM from the owning template's DOM.");
-            }
-
-            const PrefabDomValue& parentEntityDomBeforeAddingEntity = *parentEntityDomInOwningTemplate;
-
-            PrefabDom parentEntityDomAfterAddingEntity;
             AZ::Entity* parentEntity = GetEntityById(parentId);
 
             if (!parentEntity)
@@ -715,7 +700,30 @@ namespace AzToolsFramework
                 return AZ::Failure<AZStd::string>("Parent entity cannot be found while adding an entity.");
             }
 
-            m_instanceToTemplateInterface->GenerateDomForEntity(parentEntityDomAfterAddingEntity, *parentEntity);
+            // Get the alias of the parent entity in the owning template's DOM.
+            AZStd::string parentEntityAliasPath = m_instanceToTemplateInterface->GenerateEntityAliasPath(parentId);
+            PrefabDomPath entityPathInOwningTemplate(parentEntityAliasPath.c_str());
+            
+            PrefabDom& owningTemplateDom =
+                m_prefabSystemComponentInterface->FindTemplateDom(owningInstanceOfParentEntity->get().GetTemplateId());
+
+            {
+                // DOM value pointers can't be relied upon if the original DOM gets modified after pointer creation.
+                // This scope is added to limit their usage and ensure DOM is not modified when it is being used.
+                const PrefabDomValue* parentEntityDomInOwningTemplate = entityPathInOwningTemplate.Get(owningTemplateDom);
+                if (!parentEntityDomInOwningTemplate)
+                {
+                    return AZ::Failure<AZStd::string>("Could not load entity DOM from the owning template's DOM.");
+                }
+
+                PrefabDom parentEntityDomAfterAddingEntity;
+                m_instanceToTemplateInterface->GenerateDomForEntity(parentEntityDomAfterAddingEntity, *parentEntity);
+
+                // Create undo node to account for changes to parent entity due to adding a new entity under it. Currently only the
+                // EditorEntitySortComponent get modified on the parent but more things can change in the future too.
+                PrefabUndoHelpers::UpdateEntity(
+                    *parentEntityDomInOwningTemplate, parentEntityDomAfterAddingEntity, parentId, undoBatch.GetUndoBatch());
+            }
 
             // Select the new entity (and deselect others).
             AzToolsFramework::EntityIdList selection = {entityId};
@@ -725,15 +733,11 @@ namespace AzToolsFramework
 
             ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::SetSelectedEntities, selection);
 
+            // Add entity DOM in owning template.
             PrefabDom newEntityDom;
             m_instanceToTemplateInterface->GenerateDomForEntity(newEntityDom, *entity);
 
             PrefabUndoHelpers::AddEntity(newEntityDom, entityId, entityOwningInstance.GetTemplateId(), undoBatch.GetUndoBatch());
-
-            // Create undo node to account for changes to parent entity due to adding a new entity under it. Currently only the
-            // EditorEntitySortComponent get modified on the parent but more things can change in the future too.
-            PrefabUndoHelpers::UpdateEntity(parentEntityDomBeforeAddingEntity, parentEntityDomAfterAddingEntity, parentId,
-                undoBatch.GetUndoBatch());
                 
             AzToolsFramework::ToolsApplicationRequestBus::Broadcast(
                 &AzToolsFramework::ToolsApplicationRequestBus::Events::ClearDirtyEntities);


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

This PR fixes a potential memory issue in create-entity workflow. The issue was observed when turning on CRT allocation for RapidJSON usage. PrefabUndoHelpers::AddEntity modifies the DOM that UpdateEntity relies on.

Change:
- Moved PrefabUndoHelpers::UpdateEntity call before AddEntity call
- Put DOM value pointers under limited scope

## How was this PR tested?

It was tested that it could resolve the memory issue in the branch in this PR https://github.com/o3de/o3de/pull/11860.

- [x] Manually tested create-entity workflow
- [x] Pass AR on a separate branch with changes in this PR and CRT turned on
