### PR TITLE
Asset Processor - Add registry reverse lookup for real id -> legacy id

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetRegistry.h
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetRegistry.h
@@ -69,6 +69,9 @@ namespace AzFramework
         AssetPathToIdMap m_assetPathToId; // for legacy lookups only
         LegacyAssetIdToRealAssetIdMap m_legacyAssetIdToRealAssetId; // for when we change the UUID-creation scheme
         
+        // for reverse look-ups of the above, provides a list of legacy AssetIds for a given real AssetId
+        AZStd::unordered_multimap<AZ::Data::AssetId, AZ::Data::AssetId> m_realAssetIdToLegacyAssetIdMap;
+
         //! LEGACY - do not use in new code unless interfacing with legacy systems.
         //! given an assetPath and AssetID, this stores it in the registry to use with the above GetAssetIdByPath function.
         //! Called automatically by RegisterAsset.

--- a/Code/Framework/AzFramework/Tests/AssetRegistry.cpp
+++ b/Code/Framework/AzFramework/Tests/AssetRegistry.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzFramework/Asset/AssetRegistry.h>
+
+namespace UnitTest
+{
+    using AssetRegistry = AllocatorsFixture;
+
+    TEST_F(AssetRegistry, LegacyIdMappingTest)
+    {
+        using namespace ::testing;
+
+        AzFramework::AssetRegistry registry;
+
+        AZ::Data::AssetId realId("{914F8E72-5EBB-461E-A029-90B07DD7D0E4}", 1);
+        AZ::Data::AssetId legacyId1("{C94A4B65-5F1E-48C6-9704-42BB6CF61E11}", 2);
+        AZ::Data::AssetId legacyId2("{9CF3C5F2-62AF-4B87-A26E-F8714AB91D38}", 3);
+        AZ::Data::AssetId realId2("{8735EA11-CB48-41D5-8D63-2A5AFB269952}", 4);
+        AZ::Data::AssetId legacyId3("{153CC980-91FC-4766-92CE-67222DF91F3C}", 5);
+
+        registry.RegisterLegacyAssetMapping(legacyId1, realId);
+        registry.RegisterLegacyAssetMapping(legacyId2, realId);
+        registry.RegisterLegacyAssetMapping(legacyId3, realId2);
+
+        auto fullSet = registry.GetLegacyMappingSubsetFromRealIds({ realId, realId2 });
+
+        EXPECT_THAT(fullSet, ::testing::UnorderedElementsAre(Pair(legacyId1, realId), Pair(legacyId2, realId), Pair(legacyId3, realId2)));
+
+        auto id1Set = registry.GetLegacyMappingSubsetFromRealIds({ realId });
+
+        EXPECT_THAT(id1Set, ::testing::UnorderedElementsAre(Pair(legacyId1, realId), Pair(legacyId2, realId)));
+
+        auto id2Set = registry.GetLegacyMappingSubsetFromRealIds({ realId2 });
+
+        EXPECT_THAT(id2Set, ::testing::UnorderedElementsAre(Pair(legacyId3, realId2)));
+
+        registry.UnregisterLegacyAssetMapping(legacyId2);
+        id1Set = registry.GetLegacyMappingSubsetFromRealIds({ realId });
+
+        EXPECT_THAT(id1Set, ::testing::UnorderedElementsAre(Pair(legacyId1, realId)));
+
+        registry.UnregisterLegacyAssetMapping(legacyId3);
+        id2Set = registry.GetLegacyMappingSubsetFromRealIds({ realId2 });
+
+        EXPECT_THAT(id2Set, ::testing::UnorderedElementsAre());
+    }
+}

--- a/Code/Framework/AzFramework/Tests/frameworktests_files.cmake
+++ b/Code/Framework/AzFramework/Tests/frameworktests_files.cmake
@@ -26,6 +26,7 @@ set(FILES
     OctreePerformanceTests.cpp
     OctreeTests.cpp
     AssetCatalog.cpp
+    AssetRegistry.cpp
     AssetProcessorConnection.cpp
     NativeWindow.cpp
     ProcessLaunchParseTests.cpp


### PR DESCRIPTION
## What does this PR do?

This greatly speeds up the GetLegacyMappingSubsetFromRealIds call which was previously looping over every entry to find the subset of legacy ids that belong to the provided real id.

This will address the performance impact from https://github.com/o3de/o3de/pull/12445, reducing time taken from about 4000ms to about 150ms.

## How was this PR tested?

Tested with above PR for speed improvement.
Added and ran unit test
