### PR TITLE
Expand sig-content ownership for AzFramework Asset folders

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,19 +40,21 @@
 /engine.json @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 
 # SIG-Content general ownership area
-/Code/Framework/AzToolsFramework/ @o3de/sig-content-maintainers
-/Code/Tools/ @o3de/sig-content-maintainers
+/Code/Framework/AzToolsFramework/ @o3de/sig-content-maintainers @o3de/sig-content-reviewers
+/Code/Tools/ @o3de/sig-content-maintainers  @o3de/sig-content-reviewers
 
 # SIG-Content Asset Pipeline ownership area
-/AutomatedTesting/Gem/PythonTests/assetpipeline/ap_fixtures/ @o3de/sig-content-maintainers
-/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/ @o3de/sig-content-maintainers
-/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/ @o3de/sig-content-maintainers
-/AutomatedTesting/Gem/PythonTests/PythonAssetBuilder/ @o3de/sig-content-maintainers
-/Gems/SceneProcessing/ @o3de/sig-content-maintainers
-/Code/Framework/AzCore/AzCore/Asset/ @o3de/sig-content-maintainers
-/Code/Framework/AzCore/Tests/Asset/ @o3de/sig-content-maintainers
-/Code/Framework/AzCore/Tests/AssetManager.cpp @o3de/sig-content-maintainers
-/Code/Framework/AzCore/Tests/TestCatalog.h @o3de/sig-content-maintainers
+/AutomatedTesting/Gem/PythonTests/assetpipeline/ap_fixtures/ @o3de/sig-content-maintainers @o3de/sig-content-reviewers
+/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/ @o3de/sig-content-maintainers @o3de/sig-content-reviewers
+/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/ @o3de/sig-content-maintainers @o3de/sig-content-reviewers
+/AutomatedTesting/Gem/PythonTests/PythonAssetBuilder/ @o3de/sig-content-maintainers @o3de/sig-content-reviewers
+/Gems/SceneProcessing/ @o3de/sig-content-maintainers @o3de/sig-content-reviewers
+/Code/Framework/AzCore/AzCore/Asset/ @o3de/sig-content-maintainers @o3de/sig-content-reviewers
+/Code/Framework/AzCore/Tests/Asset/ @o3de/sig-content-maintainers @o3de/sig-content-reviewers
+/Code/Framework/AzCore/Tests/AssetManager.cpp @o3de/sig-content-maintainers @o3de/sig-content-reviewers
+/Code/Framework/AzCore/Tests/TestCatalog.h @o3de/sig-content-maintainers @o3de/sig-content-reviewers
+/Code/Framework/AzFramework/AzFramework/Asset @o3de/sig-content-maintainers @o3de/sig-content-reviewers
+/Code/Framework/AzFramework/Tests/Asset* @o3de/sig-content-maintainers @o3de/sig-content-reviewers
 
 # SIG-Content Viewport ownership area
 /Code/Framework/AzFramework/AzFramework/Viewport/ @o3de/sig-content-maintainers


### PR DESCRIPTION
## What does this PR do?

Expand sig-content ownership for AzFramework Asset folders and include reviewers group

## How was this PR tested?

No testing done
