### PR TITLE
Adding GetProjectUserPath utility function

### DIFF
--- a/Code/Framework/AzCore/AzCore/Utils/Utils.cpp
+++ b/Code/Framework/AzCore/AzCore/Utils/Utils.cpp
@@ -199,6 +199,25 @@ namespace AZ::Utils
         return {};
     }
 
+    AZ::IO::FixedMaxPathString GetProjectUserPath(AZ::SettingsRegistryInterface* settingsRegistry)
+    {
+        if (settingsRegistry == nullptr)
+        {
+            settingsRegistry = AZ::SettingsRegistry::Get();
+        }
+
+
+        if (settingsRegistry != nullptr)
+        {
+            if (AZ::IO::FixedMaxPathString settingsValue;
+                settingsRegistry->Get(settingsValue, AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectUserPath))
+            {
+                return settingsValue;
+            }
+        }
+        return {};
+    }
+
     AZ::Outcome<void, AZStd::string> WriteFile(AZStd::string_view content, AZStd::string_view filePath)
     {
         return WriteFile(AZStd::span(reinterpret_cast<const AZStd::byte*>(content.data()), content.size()), filePath);

--- a/Code/Framework/AzCore/AzCore/Utils/Utils.h
+++ b/Code/Framework/AzCore/AzCore/Utils/Utils.h
@@ -81,6 +81,12 @@ namespace AZ
         //! If nullptr, the AZ::Interface instance of the SettingsRegistry is used
         AZ::IO::FixedMaxPathString GetProjectPath(AZ::SettingsRegistryInterface* settingsRegistry = nullptr);
 
+        //! Retrieves the full path to the project user path from the settings registry
+        //! This path defaults to <project-path>/user, but can be overridden via the --project-user-path option
+        //! @param settingsRegistry pointer to the SettingsRegistry to use for lookup
+        //! If nullptr, the AZ::Interface instance of the SettingsRegistry is used
+        AZ::IO::FixedMaxPathString GetProjectUserPath(AZ::SettingsRegistryInterface* settingsRegistry = nullptr);
+
         //! Retrieves the project name from the settings registry
         //! @param settingsRegistry pointer to the SettingsRegistry to use for lookup
         //! If nullptr, the AZ::Interface instance of the SettingsRegistry is used


### PR DESCRIPTION
The GetProjectUserPath function queries the Settings Registry the `/O3DE/Runtime/FilePaths/SourceProjectUserPath` setting which stores the path the project user path which defaults to `<project-root>/user`

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>
