### PR TITLE
Fixed error deploying assets to android after the first deploy

### DIFF
--- a/cmake/Tools/Platform/Android/android_deployment.py
+++ b/cmake/Tools/Platform/Android/android_deployment.py
@@ -439,7 +439,7 @@ class AndroidDeployment(object):
 
     def path_exists_on_device(self, path, device_id):
         try:
-            result, output = self.adb_ls(path=path,
+            result, _ = self.adb_ls(path=path,
                                         args=None,
                                         device_id=device_id)
             return result

--- a/cmake/Tools/Platform/Android/android_deployment.py
+++ b/cmake/Tools/Platform/Android/android_deployment.py
@@ -437,18 +437,18 @@ class AndroidDeployment(object):
         self.adb_call(arg_list=['install', '-t', '-r', str(self.apk_path.resolve())],
                       device_id=target_device)
 
-    def path_exists_on_device(self, path, target_device):
+    def path_exists_on_device(self, path, device_id):
         try:
             result, output = self.adb_ls(path=path,
                                         args=None,
-                                        device_id=target_device)
+                                        device_id=device_id)
             return result
         except (common.LmbrCmdError, AttributeError):
             return False
 
-    def create_path_on_device(self, path, target_device):
-        if not self.path_exists_on_device(path, target_device):
-            self.adb_shell(command=f'mkdir {path}', device_id=target_device)
+    def create_path_on_device(self, path, device_id):
+        if not self.path_exists_on_device(path, device_id):
+            self.adb_shell(command=f'mkdir {path}', device_id=device_id)
 
     def install_assets_to_device(self, detected_storage, target_device):
         """


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

Second attempt to deploy assets to an android device was failing because `mkdir` command fails since the folder already exists. Added function to create a path on device that checks if it exists first.

## How was this PR tested?

Deployed assets to android device from scratch, made a change to one asset and deployed again. Both deploys work now.
