### PR TITLE
Fix View Directory Label Link with proper directory link after gem creation

### DIFF
--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -878,8 +878,8 @@ namespace O3DE::ProjectManager
         }
         else
         {
-            //For Windows paths, need to normalize directory link to forward slashes
-            gemInfoResult.m_directoryLink.replace("\\", "/");
+            //Make sure directory link is a normalized path that can be rendered in "View Directory" dialog
+            gemInfoResult.m_directoryLink = QDir::cleanPath(gemInfoResult.m_directoryLink);
             return AZ::Success(AZStd::move(gemInfoResult));
         }
     }

--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -878,6 +878,8 @@ namespace O3DE::ProjectManager
         }
         else
         {
+            //For Windows paths, need to normalize directory link to forward slashes
+            gemInfoResult.m_directoryLink.replace("\\", "/");
             return AZ::Success(AZStd::move(gemInfoResult));
         }
     }


### PR DESCRIPTION
## What does this PR do?
There was a weird issue discovered where shortly after a gem is created via Create a Gem workflow, trying to "View Directory" of said gem in the catalog produced a malformed directory link, leaving us unable to access the folder unless you close the program and restart.

This is the issue before the proposed fix:
![CreateGemViewDirectoryWeirdPath](https://user-images.githubusercontent.com/112996779/194684604-cb88f741-2210-484b-998f-6ddd949728b0.gif)

After the fix:
![CreateGemViewDirectoryWorkingPath](https://user-images.githubusercontent.com/112996779/194684630-a413e963-1f67-4278-ae99-801407bd8894.gif)

The main issue was shown in the first gif. The rendered URL in the View Directory dialog uses %5C as the separator. This is an URL encoding for backward slash, which means the links were being rendered as windows paths instead of unix paths (which are compatible with URL links). The main fix was to update the CreateGem function in the PythonBindings to make sure to replace '\\' with '/' in the directory link field of the output `GemInfo` before returning the result.
