### PR TITLE
chore: remove legacy safe frame

### DIFF
--- a/Code/Editor/EditorPreferencesPageViewportGeneral.cpp
+++ b/Code/Editor/EditorPreferencesPageViewportGeneral.cpp
@@ -31,7 +31,6 @@ void CEditorPreferencesPage_ViewportGeneral::Reflect(AZ::SerializeContext& seria
 
     serialize.Class<Display>()
         ->Version(1)
-        ->Field("ShowSafeFrame", &Display::m_showSafeFrame)
         ->Field("HighlightSelGeom", &Display::m_highlightSelGeom)
         ->Field("HighlightSelVegetation", &Display::m_highlightSelVegetation)
         ->Field("HighlightOnMouseOver", &Display::m_highlightOnMouseOver)
@@ -97,8 +96,6 @@ void CEditorPreferencesPage_ViewportGeneral::Reflect(AZ::SerializeContext& seria
             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &General::m_stickySelectEnabled, "Enable Sticky Select", "Enable Sticky Select");
 
         editContext->Class<Display>("Viewport Display Settings", "")
-            ->DataElement(
-                AZ::Edit::UIHandlers::CheckBox, &Display::m_showSafeFrame, "Show 4:3 Aspect Ratio Frame", "Show 4:3 Aspect Ratio Frame")
             ->DataElement(
                 AZ::Edit::UIHandlers::CheckBox, &Display::m_highlightSelGeom, "Highlight Selected Geometry", "Highlight Selected Geometry")
             ->DataElement(
@@ -225,7 +222,6 @@ void CEditorPreferencesPage_ViewportGeneral::OnApply()
     SandboxEditor::SetCameraDefaultNearPlaneDistance(m_general.m_defaultNearPlane);
     SandboxEditor::SetCameraDefaultFarPlaneDistance(m_general.m_defaultFarPlane);
 
-    gSettings.viewports.bShowSafeFrame = m_display.m_showSafeFrame;
     gSettings.viewports.bHighlightSelectedGeometry = m_display.m_highlightSelGeom;
     gSettings.viewports.bHighlightSelectedVegetation = m_display.m_highlightSelVegetation;
     gSettings.viewports.bHighlightMouseOverGeometry = m_display.m_highlightOnMouseOver;
@@ -289,7 +285,6 @@ void CEditorPreferencesPage_ViewportGeneral::InitializeSettings()
     m_general.m_sync2DViews = gSettings.viewports.bSync2DViews;
     m_general.m_stickySelectEnabled = SandboxEditor::StickySelectEnabled();
 
-    m_display.m_showSafeFrame = gSettings.viewports.bShowSafeFrame;
     m_display.m_highlightSelGeom = gSettings.viewports.bHighlightSelectedGeometry;
     m_display.m_highlightSelVegetation = gSettings.viewports.bHighlightSelectedVegetation;
     m_display.m_highlightOnMouseOver = gSettings.viewports.bHighlightMouseOverGeometry;

--- a/Code/Editor/EditorPreferencesPageViewportGeneral.h
+++ b/Code/Editor/EditorPreferencesPageViewportGeneral.h
@@ -52,7 +52,6 @@ private:
     {
         AZ_TYPE_INFO(Display, "{F0376933-FA0B-4B58-9DD9-6F6EBC7386CA}")
 
-        bool m_showSafeFrame;
         bool m_highlightSelGeom;
         bool m_highlightSelVegetation;
         bool m_highlightOnMouseOver;

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -648,12 +648,6 @@ void EditorViewportWidget::OnBeginPrepareRender()
     auto prevState = m_debugDisplay->GetState();
     m_debugDisplay->SetState(e_Mode3D | e_AlphaBlended | e_FillModeSolid | e_CullModeBack | e_DepthWriteOn | e_DepthTestOn);
 
-    if (gSettings.viewports.bShowSafeFrame)
-    {
-        UpdateSafeFrame();
-        RenderSafeFrame();
-    }
-
     AzFramework::ViewportDebugDisplayEventBus::Event(
         AzToolsFramework::GetEntityContextId(), &AzFramework::ViewportDebugDisplayEvents::DisplayViewport2d,
         AzFramework::ViewportInfo{ GetViewportId() }, *m_debugDisplay);
@@ -692,79 +686,6 @@ void EditorViewportWidget::RenderAll()
                 AztfVi::MouseButtons(AztfVi::TranslateMouseButtons(QGuiApplication::mouseButtons())), keyboardModifiers,
                 BuildMousePick(WidgetToViewport(mapFromGlobal(QCursor::pos())))));
         m_debugDisplay->DepthTestOn();
-    }
-}
-
-//////////////////////////////////////////////////////////////////////////
-
-//////////////////////////////////////////////////////////////////////////
-void EditorViewportWidget::UpdateSafeFrame()
-{
-    m_safeFrame = m_rcClient;
-
-    if (m_safeFrame.height() == 0)
-    {
-        return;
-    }
-
-    const bool allowSafeFrameBiggerThanViewport = false;
-
-    float safeFrameAspectRatio = float(m_safeFrame.width()) / m_safeFrame.height();
-    float targetAspectRatio = GetAspectRatio();
-    bool viewportIsWiderThanSafeFrame = (targetAspectRatio <= safeFrameAspectRatio);
-    if (viewportIsWiderThanSafeFrame || allowSafeFrameBiggerThanViewport)
-    {
-        float maxSafeFrameWidth = m_safeFrame.height() * targetAspectRatio;
-        float widthDifference = m_safeFrame.width() - maxSafeFrameWidth;
-
-        m_safeFrame.setLeft(static_cast<int>(m_safeFrame.left() + widthDifference * 0.5f));
-        m_safeFrame.setRight(static_cast<int>(m_safeFrame.right() - widthDifference * 0.5f));
-    }
-    else
-    {
-        float maxSafeFrameHeight = m_safeFrame.width() / targetAspectRatio;
-        float heightDifference = m_safeFrame.height() - maxSafeFrameHeight;
-
-        m_safeFrame.setTop(static_cast<int>(m_safeFrame.top() + heightDifference * 0.5f));
-        m_safeFrame.setBottom(static_cast<int>(m_safeFrame.bottom() - heightDifference * 0.5f));
-    }
-
-    m_safeFrame.adjust(0, 0, -1, -1); // <-- aesthetic improvement.
-
-    const float SAFE_ACTION_SCALE_FACTOR = 0.05f;
-    m_safeAction = m_safeFrame;
-    m_safeAction.adjust(
-        static_cast<int>(m_safeFrame.width() * SAFE_ACTION_SCALE_FACTOR), static_cast<int>(m_safeFrame.height() * SAFE_ACTION_SCALE_FACTOR),
-        static_cast<int>(-m_safeFrame.width() * SAFE_ACTION_SCALE_FACTOR),
-        static_cast<int>(-m_safeFrame.height() * SAFE_ACTION_SCALE_FACTOR));
-
-    const float SAFE_TITLE_SCALE_FACTOR = 0.1f;
-    m_safeTitle = m_safeFrame;
-    m_safeTitle.adjust(
-        static_cast<int>(m_safeFrame.width() * SAFE_TITLE_SCALE_FACTOR), static_cast<int>(m_safeFrame.height() * SAFE_TITLE_SCALE_FACTOR),
-        static_cast<int>(-m_safeFrame.width() * SAFE_TITLE_SCALE_FACTOR),
-        static_cast<int>(-m_safeFrame.height() * SAFE_TITLE_SCALE_FACTOR));
-}
-
-//////////////////////////////////////////////////////////////////////////
-void EditorViewportWidget::RenderSafeFrame()
-{
-    RenderSafeFrame(m_safeFrame, 0.75f, 0.75f, 0, 0.8f);
-    RenderSafeFrame(m_safeAction, 0, 0.85f, 0.80f, 0.8f);
-    RenderSafeFrame(m_safeTitle, 0.80f, 0.60f, 0, 0.8f);
-}
-
-//////////////////////////////////////////////////////////////////////////
-void EditorViewportWidget::RenderSafeFrame(const QRect& frame, float r, float g, float b, float a)
-{
-    m_debugDisplay->SetColor(AZ::Color(r, g, b, a));
-
-    const int LINE_WIDTH = 2;
-    for (int i = 0; i < LINE_WIDTH; i++)
-    {
-        AZ::Vector3 topLeft(static_cast<float>(frame.left() + i), static_cast<float>(frame.top() + i), 0.0f);
-        AZ::Vector3 bottomRight(static_cast<float>(frame.right() - i), static_cast<float>(frame.bottom() - i), 0.0f);
-        m_debugDisplay->DrawWireBox(topLeft, bottomRight);
     }
 }
 
@@ -1055,7 +976,6 @@ void EditorViewportWidget::OnTitleMenu(QMenu* menu)
     action->setCheckable(true);
     action->setChecked(bDisplayLabels);
 
-    AZ::ViewportHelpers::AddCheckbox(menu, tr("Show Safe Frame"), &gSettings.viewports.bShowSafeFrame);
     AZ::ViewportHelpers::AddCheckbox(menu, tr("Show Construction Plane"), &gSettings.snap.constructPlaneDisplay);
     AZ::ViewportHelpers::AddCheckbox(menu, tr("Show Trigger Bounds"), &gSettings.viewports.bShowTriggerBounds);
     AZ::ViewportHelpers::AddCheckbox(menu, tr("Show Helpers of Frozen Objects"), &gSettings.viewports.nShowFrozenHelpers);

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -253,16 +253,6 @@ private:
     void RenderSnapMarker();
     void RenderAll();
 
-    // Update the safe frame, safe action, safe title, and borders rectangles based on
-    // viewport size and target aspect ratio.
-    void UpdateSafeFrame();
-
-    // Draw safe frame, safe action, safe title rectangles and borders.
-    void RenderSafeFrame();
-
-    // Draw one of the safe frame rectangles with the desired color.
-    void RenderSafeFrame(const QRect& frame, float r, float g, float b, float a);
-
     // Draw a selected region if it has been selected
     void RenderSelectedRegion();
 
@@ -386,11 +376,6 @@ private:
 
     // Reentrancy guard for on paint events
     bool m_isOnPaint = false;
-
-    // Shapes of various safe frame helpers which can be displayed in the editor
-    QRect m_safeFrame;
-    QRect m_safeAction;
-    QRect m_safeTitle;
 
     // Aspect ratios available in the title bar
     CPredefinedAspectRatios m_predefinedAspectRatios;

--- a/Code/Editor/Settings.cpp
+++ b/Code/Editor/Settings.cpp
@@ -131,7 +131,6 @@ SEditorSettings::SEditorSettings()
     viewports.bSync2DViews = false;
     viewports.fDefaultAspectRatio = 800.0f / 600.0f;
     
-    viewports.bShowSafeFrame = false;
     viewports.bHighlightSelectedGeometry = false;
     viewports.bHighlightSelectedVegetation = true;
     viewports.bHighlightMouseOverGeometry = true;
@@ -472,7 +471,6 @@ void SEditorSettings::Save(bool isEditorClosing)
     SaveValue("Settings", "AlwaysShowRadiuses", viewports.bAlwaysShowRadiuses);
     SaveValue("Settings", "Sync2DViews", viewports.bSync2DViews);
     SaveValue("Settings", "AspectRatio", viewports.fDefaultAspectRatio);
-    SaveValue("Settings", "ShowSafeFrame", viewports.bShowSafeFrame);
     SaveValue("Settings", "HighlightSelectedGeometry", viewports.bHighlightSelectedGeometry);
     SaveValue("Settings", "HighlightSelectedVegetation", viewports.bHighlightSelectedVegetation);
     SaveValue("Settings", "HighlightMouseOverGeometry", viewports.bHighlightMouseOverGeometry);
@@ -667,7 +665,6 @@ void SEditorSettings::Load()
     LoadValue("Settings", "AlwaysShowRadiuses", viewports.bAlwaysShowRadiuses);
     LoadValue("Settings", "Sync2DViews", viewports.bSync2DViews);
     LoadValue("Settings", "AspectRatio", viewports.fDefaultAspectRatio);
-    LoadValue("Settings", "ShowSafeFrame", viewports.bShowSafeFrame);
     LoadValue("Settings", "HighlightSelectedGeometry", viewports.bHighlightSelectedGeometry);
     LoadValue("Settings", "HighlightSelectedVegetation", viewports.bHighlightSelectedVegetation);
     LoadValue("Settings", "HighlightMouseOverGeometry", viewports.bHighlightMouseOverGeometry);

--- a/Code/Editor/Settings.h
+++ b/Code/Editor/Settings.h
@@ -118,8 +118,6 @@ struct SViewportsSettings
     bool bSync2DViews;
     //! Camera Aspect Ratio for perspective View.
     float fDefaultAspectRatio;
-    //! Show safe frame.
-    bool bShowSafeFrame;
     //! To highlight selected geometry.
     bool bHighlightSelectedGeometry;
     //! To highlight selected vegetation.


### PR DESCRIPTION
ref: https://github.com/o3de/o3de/issues/12347
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

This removes the safe frame logic from the viewport. this is planning to get handled through LyShine. 

@hultonha  do we want to hold off until a replacement is made?