### PR TITLE
Fix for delete key shortcut operating when outliner context menu is o…

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
@@ -342,6 +342,13 @@ namespace AzToolsFramework
     //  Currently, the first behavior is implemented.
     void EntityOutlinerWidget::OnSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected)
     {
+        // If we have an open context menu when the selection changes, it is no longer relevant and needs closing.
+        QMenu* menu = qobject_cast<QMenu*>(QApplication::activePopupWidget());
+        if (menu && menu->parentWidget() == this)
+        {
+            menu->close();
+        }
+
         if (m_selectionChangeInProgress || !m_enableSelectionUpdates
             || (selected.empty() && deselected.empty()))
         {


### PR DESCRIPTION
…pen.

Signed-off-by: sphrose <82213493+sphrose@users.noreply.github.com>

## What does this PR do?

This pr fixes https://github.com/o3de/o3de/issues/11411. The problem is caused by the menu being synchronous, but the delete hotkey still being available during its lifetime. This could result in the selected entity being deleted whilst the menu is still active.

## How was this PR tested?

Tested in the editor as described, ensured menu otherwise operates correctly and ensures other context menus were not affected.
