### PR TITLE
#12147 Fixed crash when cylinder sizes are set to zero

### DIFF
--- a/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
@@ -1538,19 +1538,22 @@ namespace PhysX
         const float height = m_shapeConfiguration.m_cylinder.m_height;
         const float radius = m_shapeConfiguration.m_cylinder.m_radius;
 
-        if (height > 0.0f && radius > 0.0f)
+        if (height <= 0.0f)
         {
-            Utils::Geometry::PointList samplePoints = Utils::CreatePointsAtFrustumExtents(height, radius, radius, subdivisionCount).value();
+            AZ_Error("PhysX", false, "Cylinder height must be greater than zero. Entity: %s", GetEntity()->GetName().c_str());
+            return;
+        }
 
-            const AZ::Vector3 scale = m_shapeConfiguration.m_cylinder.m_configuration.m_scale;
-            m_shapeConfiguration.m_cylinder.m_configuration = Utils::CreatePxCookedMeshConfiguration(samplePoints, scale).value();
-        }
-        else
+        if (radius <= 0.0f)
         {
-            AZ_Error("PhysX", false, "Cylinder radius and height must be greater than zero. Entity: %s",
-                GetEntity()->GetName().c_str());
-            m_shapeConfiguration.m_cylinder.m_configuration = {};
+            AZ_Error("PhysX", false, "Cylinder radius must be greater than zero. Entity: %s", GetEntity()->GetName().c_str());
+            return;
         }
+
+        Utils::Geometry::PointList samplePoints = Utils::CreatePointsAtFrustumExtents(height, radius, radius, subdivisionCount).value();
+
+        const AZ::Vector3 scale = m_shapeConfiguration.m_cylinder.m_configuration.m_scale;
+        m_shapeConfiguration.m_cylinder.m_configuration = Utils::CreatePxCookedMeshConfiguration(samplePoints, scale).value();
     }
 
     void EditorColliderComponentDescriptor::Reflect(AZ::ReflectContext* reflection) const

--- a/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
@@ -1464,9 +1464,16 @@ namespace PhysX
 
     void EditorColliderComponent::SetCylinderRadius(float radius)
     {
-        m_shapeConfiguration.m_cylinder.m_radius = radius;
-        UpdateCylinderCookedMesh();
-        CreateStaticEditorCollider();
+        if (radius > 0.0f)
+        {
+            m_shapeConfiguration.m_cylinder.m_radius = radius;
+            UpdateCylinderCookedMesh();
+            CreateStaticEditorCollider();
+        }
+        else
+        {
+            AZ_Error("PhysX", false, "SetCylinderRadius: radius must be greater than zero.");
+        }
     }
 
     float EditorColliderComponent::GetCylinderRadius() const
@@ -1476,9 +1483,16 @@ namespace PhysX
 
     void EditorColliderComponent::SetCylinderHeight(float height)
     {
-        m_shapeConfiguration.m_cylinder.m_height = height;
-        UpdateCylinderCookedMesh();
-        CreateStaticEditorCollider();
+        if (height > 0.0f)
+        {
+            m_shapeConfiguration.m_cylinder.m_height = height;
+            UpdateCylinderCookedMesh();
+            CreateStaticEditorCollider();
+        }
+        else
+        {
+            AZ_Error("PhysX", false, "SetCylinderHeight: height must be greater than zero.");
+        }
     }
 
     float EditorColliderComponent::GetCylinderHeight() const
@@ -1525,11 +1539,20 @@ namespace PhysX
         const AZ::u8 subdivisionCount = m_shapeConfiguration.m_cylinder.m_subdivisionCount;
         const float height = m_shapeConfiguration.m_cylinder.m_height;
         const float radius = m_shapeConfiguration.m_cylinder.m_radius;
-        Utils::Geometry::PointList samplePoints = Utils::CreatePointsAtFrustumExtents(height, radius, radius, subdivisionCount).value();
 
-        const AZ::Vector3 scale = m_shapeConfiguration.m_cylinder.m_configuration.m_scale;
-        m_shapeConfiguration.m_cylinder.m_configuration
-            = Utils::CreatePxCookedMeshConfiguration(samplePoints, scale).value();
+        if (height > 0.0f && radius > 0.0f)
+        {
+            Utils::Geometry::PointList samplePoints = Utils::CreatePointsAtFrustumExtents(height, radius, radius, subdivisionCount).value();
+
+            const AZ::Vector3 scale = m_shapeConfiguration.m_cylinder.m_configuration.m_scale;
+            m_shapeConfiguration.m_cylinder.m_configuration = Utils::CreatePxCookedMeshConfiguration(samplePoints, scale).value();
+        }
+        else
+        {
+            AZ_Error("PhysX", false, "Cylinder radius and height must be greater than zero. Entity: %s",
+                GetEntity()->GetName().c_str());
+            m_shapeConfiguration.m_cylinder.m_configuration = {};
+        }
     }
 
     void EditorColliderComponentDescriptor::Reflect(AZ::ReflectContext* reflection) const

--- a/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
@@ -1464,16 +1464,15 @@ namespace PhysX
 
     void EditorColliderComponent::SetCylinderRadius(float radius)
     {
-        if (radius > 0.0f)
-        {
-            m_shapeConfiguration.m_cylinder.m_radius = radius;
-            UpdateCylinderCookedMesh();
-            CreateStaticEditorCollider();
-        }
-        else
+        if (radius <= 0.0f)
         {
             AZ_Error("PhysX", false, "SetCylinderRadius: radius must be greater than zero.");
+            return;
         }
+
+        m_shapeConfiguration.m_cylinder.m_radius = radius;
+        UpdateCylinderCookedMesh();
+        CreateStaticEditorCollider();
     }
 
     float EditorColliderComponent::GetCylinderRadius() const
@@ -1483,16 +1482,15 @@ namespace PhysX
 
     void EditorColliderComponent::SetCylinderHeight(float height)
     {
-        if (height > 0.0f)
-        {
-            m_shapeConfiguration.m_cylinder.m_height = height;
-            UpdateCylinderCookedMesh();
-            CreateStaticEditorCollider();
-        }
-        else
+        if (height <= 0.0f)
         {
             AZ_Error("PhysX", false, "SetCylinderHeight: height must be greater than zero.");
+            return;
         }
+
+        m_shapeConfiguration.m_cylinder.m_height = height;
+        UpdateCylinderCookedMesh();
+        CreateStaticEditorCollider();
     }
 
     float EditorColliderComponent::GetCylinderHeight() const

--- a/Gems/PhysX/Code/Tests/RigidBodyComponentTests.cpp
+++ b/Gems/PhysX/Code/Tests/RigidBodyComponentTests.cpp
@@ -141,51 +141,64 @@ namespace PhysXEditorTests
         EXPECT_EQ(pxShape->getGeometryType(), physx::PxGeometryType::eCONVEXMESH);
     }
 
-    TEST_F(PhysXEditorFixture, EditorRigidBodyComponent_CylinderColliderZeroSize_NoColliderCreated)
+    TEST_F(PhysXEditorFixture, EditorRigidBodyComponent_CylinderColliderZeroRadius_NoColliderCreated)
     {
         // Create editor entities
-        EntityPtr editorEntities[2] = { CreateInactiveEditorEntity("ZeroRadius"), CreateInactiveEditorEntity("ZeroHeight") };
+        EntityPtr editorEntity = CreateInactiveEditorEntity("ZeroRadius");
 
-        constexpr const char* expectedErrors[2] = { "SetCylinderRadius: radius must be greater than zero.",
-                                                     "SetCylinderHeight: height must be greater than zero."};
+        UnitTest::ErrorHandler expectedError("SetCylinderRadius: radius must be greater than zero.");
 
-        for (int i = 0; i < 2; ++i)
-        {
-            UnitTest::ErrorHandler expectedError(expectedErrors[i]);
-            EntityPtr& editorEntity = editorEntities[i];
+        const auto* rigidBodyComponent = editorEntity->CreateComponent<PhysX::EditorRigidBodyComponent>();
+        const auto* colliderComponent = editorEntity->CreateComponent<PhysX::EditorColliderComponent>();
 
-            const auto* rigidBodyComponent = editorEntity->CreateComponent<PhysX::EditorRigidBodyComponent>();
-            const auto* colliderComponent = editorEntity->CreateComponent<PhysX::EditorColliderComponent>();
+        editorEntity->Activate();
 
-            editorEntity->Activate();
+        AZ::EntityComponentIdPair idPair(editorEntity->GetId(), colliderComponent->GetId());
 
-            AZ::EntityComponentIdPair idPair(editorEntity->GetId(), colliderComponent->GetId());
+        // Set collider to be a cylinder
+        const Physics::ShapeType shapeType = Physics::ShapeType::Cylinder;
+        PhysX::EditorColliderComponentRequestBus::Event(idPair, &PhysX::EditorColliderComponentRequests::SetShapeType, shapeType);
 
-            // Set collider to be a cylinder
-            const Physics::ShapeType shapeType = Physics::ShapeType::Cylinder;
-            PhysX::EditorColliderComponentRequestBus::Event(idPair, &PhysX::EditorColliderComponentRequests::SetShapeType, shapeType);
+        // Set collider cylinder radius to zero
+        PhysX::EditorColliderComponentRequestBus::Event(idPair, &PhysX::EditorColliderComponentRequests::SetCylinderRadius, 0.0f);
 
-            // Set collider cylinder radius and height
-            if (i == 0)
-            {
-                PhysX::EditorColliderComponentRequestBus::Event(
-                    idPair, &PhysX::EditorColliderComponentRequests::SetCylinderRadius, 0.0f);
-            }
-            else
-            {
-                PhysX::EditorColliderComponentRequestBus::Event(
-                    idPair, &PhysX::EditorColliderComponentRequests::SetCylinderHeight, 0.0f);
-            }
+        // Notify listeners that collider has changed
+        Physics::ColliderComponentEventBus::Event(editorEntity->GetId(), &Physics::ColliderComponentEvents::OnColliderChanged);
 
-            // Notify listeners that collider has changed
-            Physics::ColliderComponentEventBus::Event(editorEntity->GetId(), &Physics::ColliderComponentEvents::OnColliderChanged);
-
-            // Verify no shapes are created and there's an expected error
-            const AzPhysics::RigidBody* rigidBody = rigidBodyComponent->GetRigidBody();
-            EXPECT_EQ(rigidBody->GetShapeCount(), 0);
-            EXPECT_EQ(expectedError.GetErrorCount(), 1);
-        }
+        // Verify no shapes are created and there's an expected error
+        const AzPhysics::RigidBody* rigidBody = rigidBodyComponent->GetRigidBody();
+        EXPECT_EQ(rigidBody->GetShapeCount(), 0);
+        EXPECT_EQ(expectedError.GetErrorCount(), 1);
     }
 
+    TEST_F(PhysXEditorFixture, EditorRigidBodyComponent_CylinderColliderZeroHeight_NoColliderCreated)
+    {
+        // Create editor entities
+        EntityPtr editorEntity =  CreateInactiveEditorEntity("ZeroHeight");
+
+        UnitTest::ErrorHandler expectedError("SetCylinderHeight: height must be greater than zero.");
+
+        const auto* rigidBodyComponent = editorEntity->CreateComponent<PhysX::EditorRigidBodyComponent>();
+        const auto* colliderComponent = editorEntity->CreateComponent<PhysX::EditorColliderComponent>();
+
+        editorEntity->Activate();
+
+        AZ::EntityComponentIdPair idPair(editorEntity->GetId(), colliderComponent->GetId());
+
+        // Set collider to be a cylinder
+        const Physics::ShapeType shapeType = Physics::ShapeType::Cylinder;
+        PhysX::EditorColliderComponentRequestBus::Event(idPair, &PhysX::EditorColliderComponentRequests::SetShapeType, shapeType);
+
+        // Set collider cylinder height to zero
+        PhysX::EditorColliderComponentRequestBus::Event(idPair, &PhysX::EditorColliderComponentRequests::SetCylinderHeight, 0.0f);
+
+        // Notify listeners that collider has changed
+        Physics::ColliderComponentEventBus::Event(editorEntity->GetId(), &Physics::ColliderComponentEvents::OnColliderChanged);
+
+        // Verify no shapes are created and there's an expected error
+        const AzPhysics::RigidBody* rigidBody = rigidBodyComponent->GetRigidBody();
+        EXPECT_EQ(rigidBody->GetShapeCount(), 0);
+        EXPECT_EQ(expectedError.GetErrorCount(), 1);
+    }
 
 } // namespace PhysXEditorTests


### PR DESCRIPTION
Signed-off-by: Sergey Pereslavtsev <pereslav@amazon.com>

## What does this PR do?

Fixes a crash when either radius or height of the cylinder collider is set to zero.
Issue #12147

## How was this PR tested?

Unit tests, manual testing in the Editor