### PR TITLE
Fix test build failures caused by the AP LFS pointer tests

### DIFF
--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -3625,10 +3625,10 @@ TEST_F(AssetProcessorManagerTest, SourceFileProcessFailure_AutoFailedLfsPointerF
     AZ::IO::FixedMaxPathString engineRoot, projectRoot;
     settingsRegistry->Get(engineRoot, AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
     settingsRegistry->Get(projectRoot, AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath);
-    settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder, m_tempDir.path().toUtf8().data());
-    settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath, m_tempDir.path().toUtf8().data());
+    settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder, m_assetRootDir.path().toUtf8().data());
+    settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath, m_assetRootDir.path().toUtf8().data());
 
-    QDir tempPath(m_tempDir.path());
+    QDir tempPath(m_assetRootDir.path());
     QString gitAttributesPath = tempPath.absoluteFilePath(".gitattributes");
     ASSERT_TRUE(UnitTestUtils::CreateDummyFile(gitAttributesPath, QString(
         "#\n"

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -3628,15 +3628,15 @@ TEST_F(AssetProcessorManagerTest, SourceFileProcessFailure_AutoFailedLfsPointerF
     settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder, m_assetRootDir.path().toUtf8().data());
     settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath, m_assetRootDir.path().toUtf8().data());
 
-    QDir tempPath(m_assetRootDir.path());
-    QString gitAttributesPath = tempPath.absoluteFilePath(".gitattributes");
+    QDir assetRootDir(m_assetRootDir.path());
+    QString gitAttributesPath = assetRootDir.absoluteFilePath(".gitattributes");
     ASSERT_TRUE(UnitTestUtils::CreateDummyFile(gitAttributesPath, QString(
         "#\n"
         "# Git LFS(see https ://git-lfs.github.com/)\n"
         "#\n"
         "*.txt filter=lfs diff=lfs merge=lfs -text\n")));
 
-    QString sourcePath = tempPath.absoluteFilePath("subfolder1/test.txt");
+    QString sourcePath = assetRootDir.absoluteFilePath("subfolder1/test.txt");
     ASSERT_TRUE(UnitTestUtils::CreateDummyFile(sourcePath, QString(
         "version https://git-lfs.github.com/spec/v1\n"
         "oid sha256:ee4799379bfcfa99e95afd6494da51fbeda95f21ea71d267ae7102f048edec85\n"


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?

Fix the issue for building AP automation tests. This is caused by the following two conflict PRs merged into dev together:

- https://github.com/o3de/o3de/pull/12446
- https://github.com/o3de/o3de/pull/12401

## How was this PR tested?
Built and ran the test locally.
