### PR TITLE
bugfix: fix SourceFileProcessFailure_AutoFailedLfsPointerFile_ReceiveLFSPointerFileError Test

### DIFF
--- a/Code/Tools/AssetProcessor/native/tests/AssetProcessorTest.h
+++ b/Code/Tools/AssetProcessor/native/tests/AssetProcessorTest.h
@@ -27,6 +27,7 @@ namespace AssetProcessor
         : public ::UnitTest::ScopedAllocatorSetupFixture
     {
     protected:
+        AZ::Test::ScopedAutoTempDirectory m_tempDir;
         AZStd::unique_ptr<UnitTestUtils::AssertAbsorber> m_errorAbsorber{};
         AZStd::unique_ptr<FileStatePassthrough> m_fileStateCache{};
 

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -3625,10 +3625,10 @@ TEST_F(AssetProcessorManagerTest, SourceFileProcessFailure_AutoFailedLfsPointerF
     AZ::IO::FixedMaxPathString engineRoot, projectRoot;
     settingsRegistry->Get(engineRoot, AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
     settingsRegistry->Get(projectRoot, AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath);
-    settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder, m_tempDir.path().toUtf8().data());
-    settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath, m_tempDir.path().toUtf8().data());
+    settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder, m_tempDir.GetDirectory());
+    settingsRegistry->Set(AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath, m_tempDir.GetDirectory());
 
-    QDir tempPath(m_tempDir.path());
+    QDir tempPath(m_tempDir.GetDirectory());
     QString gitAttributesPath = tempPath.absoluteFilePath(".gitattributes");
     ASSERT_TRUE(UnitTestUtils::CreateDummyFile(gitAttributesPath, QString(
         "#\n"


### PR DESCRIPTION

ref: https://github.com/o3de/o3de/pull/11920
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

not sure how this test passed AR this is failing to build on linux. any clue where m_tempDir is defined for windows? This just adds ScopedAutoTempDirectory and tweaks the unit test. 

wasn't able to verify this on my system hopefully this should pass AR. 

