### PR TITLE
Made SpawnableScriptAssetRef usable in ScriptEvents

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.cpp
@@ -49,6 +49,7 @@ namespace AzFramework::Scripts
         {
             behaviorContext->Class<SpawnableScriptAssetRef>("SpawnableScriptAssetRef")
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::EnableAsScriptEventParamType, true)
                 ->Attribute(AZ::Script::Attributes::Category, "Prefab/Spawning")
                 ->Attribute(AZ::Script::Attributes::Module, "prefabs")
                 ->Constructor()


### PR DESCRIPTION
Signed-off-by: Luis Sempé <58790905+lsemp3d@users.noreply.github.com>

Enables SpawnableScriptAssetRef to be used in Script Events, this is useful to pass information about what prefabs to spawn as a result of an event. Required for O3DCon workshop
