### PR TITLE
The new AzCore/Debug/PerformanceCollector

### DIFF
--- a/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.cpp
+++ b/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.cpp
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/IO/OpenMode.h>
+#include <AzCore/IO/GenericStreams.h>
+#include <AzCore/IO/ByteContainerStream.h>
+#include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+
+#include "PerformanceCollector.h"
+
+
+namespace AZ::Debug
+{
+    PerformanceCollector::PerformanceCollector(const AZStd::string_view logCategory, AZStd::span<const AZStd::string_view> m_metricNames, OnBatchCompleteCallback onBatchCompleteCallback)
+        : m_logCategory(logCategory), m_onBatchCompleteCallback(onBatchCompleteCallback)
+    {
+        for (const auto& metricName : m_metricNames)
+        {
+            [[maybe_unused]] const auto statisticPtr = m_statisticsManager.AddStatistic(metricName, metricName, "us");
+            AZ_Assert(statisticPtr, "Failed to add metric with name <%.*s>. Maybe already added?", AZ_STRING_ARG(metricName));
+        }
+        RestartPeriodicEventStamps();
+    }
+
+    PerformanceCollector::~PerformanceCollector()
+    {
+
+    }
+
+    bool PerformanceCollector::IsWaitingBeforeCapture()
+    {
+        return !m_numberOfCaptureBatches || m_isWaitingBeforeNextBatch;
+    }
+
+    void PerformanceCollector::FrameTick()
+    {
+        if (!m_numberOfCaptureBatches)
+        {
+            return;
+        }
+
+        if (m_isWaitingBeforeNextBatch)
+        {
+            if (m_waitTimeBeforeEachBatch.count() > 0)
+            {
+                AZStd::chrono::steady_clock::time_point now = AZStd::chrono::steady_clock::now();
+                if (m_startWaitTime.time_since_epoch().count() == 0)
+                {
+                    AZ_TracePrintf(LogName, "Will Wait %lld seconds before starting batch %u...", m_waitTimeBeforeEachBatch.count(), m_numberOfCaptureBatches);
+                    m_startWaitTime = now;
+                }
+                auto duration = AZStd::chrono::duration_cast<AZStd::chrono::seconds>(now - m_startWaitTime);
+                if (duration < m_waitTimeBeforeEachBatch)
+                {
+                    return; // Do nothing. Keep waiting.
+                }
+            }
+            AZ_TracePrintf(LogName, "Waited %lld seconds. Will start collecting performance numbers for %u frames at batch %u...", m_waitTimeBeforeEachBatch.count(), m_frameCountPerCaptureBatch, m_numberOfCaptureBatches);
+            m_isWaitingBeforeNextBatch = false;
+        }
+
+        m_frameCountInCurrentBatch++;
+        if (m_frameCountInCurrentBatch <= m_frameCountPerCaptureBatch)
+        {
+            // All good nothing to do.
+            return;
+        }
+
+        // Current batch is complete.
+        m_numberOfCaptureBatches--;
+        m_isWaitingBeforeNextBatch = true;
+        m_frameCountInCurrentBatch = 0;
+        m_startWaitTime = {};
+
+        if (m_dataLogType == DataLogType::LogStatistics)
+        {
+            //It is time to write the statistical summaries to the Log file.
+            RecordStatistics();
+            m_statisticsManager.ResetAllStatistics();
+        }
+        RestartPeriodicEventStamps();
+
+        m_onBatchCompleteCallback(m_numberOfCaptureBatches);
+        if (!m_numberOfCaptureBatches)
+        {
+            // This will close the file that contains performance results for all batches.
+            m_eventLogger.ResetStream(nullptr);
+            AZ_TracePrintf(LogName, "Performance data output file <%s> is ready", m_outputFilePath.c_str());
+        }
+
+    }
+
+    void PerformanceCollector::RecordSample(AZStd::string_view metricName, AZStd::chrono::microseconds microSeconds)
+    {
+        if (m_dataLogType == DataLogType::LogStatistics)
+        {
+            m_statisticsManager.PushSampleForStatistic(metricName, aznumeric_caster(microSeconds.count()));
+        }
+        else
+        {
+            Metrics::CompleteArgs completeArgs;
+            completeArgs.m_name = metricName;
+            completeArgs.m_cat = m_logCategory;
+            completeArgs.m_dur = microSeconds;
+            m_eventLogger.RecordCompleteEvent(completeArgs);
+        }
+    }
+
+    void PerformanceCollector::RecordPeriodicEvent(AZStd::string_view metricName)
+    {
+        auto prevStamp = m_periodicEventStamps[metricName];
+        AZStd::chrono::steady_clock::time_point now = AZStd::chrono::steady_clock::now();
+        m_periodicEventStamps[metricName] = now;
+        if (prevStamp.time_since_epoch().count() == 0)
+        {
+            return;
+        }
+        auto duration = AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(now - prevStamp);
+        RecordSample(metricName, duration);
+    }
+
+    void PerformanceCollector::RecordStatistics()
+    {
+        AZStd::vector<Statistics::NamedRunningStatistic*> statistics;
+        m_statisticsManager.GetAllStatistics(statistics);
+        AZ_Warning(LogName, !statistics.empty(), "There are no statistics to report");
+        for (const auto statistic : statistics)
+        {
+            using EventObjectStorage = AZStd::fixed_vector<AZ::Metrics::EventField, 8>;
+            EventObjectStorage statisticalParams;
+            statisticalParams.emplace_back(AVG, statistic->GetAverage());
+            statisticalParams.emplace_back(MIN, statistic->GetMinimum());
+            statisticalParams.emplace_back(MAX, statistic->GetMaximum());
+            statisticalParams.emplace_back(SAMPLE_COUNT, statistic->GetNumSamples());
+            statisticalParams.emplace_back(UNITS, statistic->GetUnits());
+            statisticalParams.emplace_back(VARIANCE, statistic->GetVariance());
+            statisticalParams.emplace_back(STDEV, statistic->GetStdev());
+            statisticalParams.emplace_back(MOST_RECENT_SAMPLE, statistic->GetMostRecentSample());
+
+            Metrics::CompleteArgs completeArgs;
+            completeArgs.m_name = statistic->GetName();
+            completeArgs.m_cat = m_logCategory;
+            completeArgs.m_dur = AZStd::chrono::microseconds(aznumeric_cast<long long>(statistic->GetAverage()));
+            completeArgs.m_args = statisticalParams;
+            m_eventLogger.RecordCompleteEvent(completeArgs);
+        }
+    }
+
+    void PerformanceCollector::RestartPeriodicEventStamps()
+    {
+        AZStd::vector<Statistics::NamedRunningStatistic*> statistics;
+        m_statisticsManager.GetAllStatistics(statistics);
+        m_periodicEventStamps.clear();
+        for (auto statistic : statistics)
+        {
+            m_periodicEventStamps[statistic->GetName()] = {};
+        }
+    }
+
+    void PerformanceCollector::UpdateDataLogType(DataLogType newValue)
+    {
+        if (m_dataLogType == newValue)
+        {
+            return;
+        }
+
+        if (m_numberOfCaptureBatches > 0)
+        {
+            AZ_Warning(LogName, false, "%s changes to control params are rejected while data is being captured", __FUNCTION__);
+            return;
+        }
+
+        m_dataLogType = newValue;
+    }
+
+    void PerformanceCollector::UpdateFrameCountPerCaptureBatch(AZ::u32 newValue)
+    {
+        if (m_frameCountPerCaptureBatch == newValue)
+        {
+            return;
+        }
+
+        if (m_numberOfCaptureBatches > 0)
+        {
+            AZ_Warning(LogName, false, "%s changes to control params are rejected while data is being captured", __FUNCTION__);
+            return;
+        }
+
+        m_frameCountPerCaptureBatch = newValue;
+    }
+
+    void PerformanceCollector::UpdateWaitTimeBeforeEachBatch(AZStd::chrono::seconds seconds)
+    {
+        if (m_waitTimeBeforeEachBatch.count() == seconds.count())
+        {
+            return;
+        }
+
+        if (m_numberOfCaptureBatches > 0)
+        {
+            AZ_Warning(LogName, false, "%s changes to control params are rejected while data is being captured", __FUNCTION__);
+            return;
+        }
+
+        m_waitTimeBeforeEachBatch = seconds;
+    }
+
+    void PerformanceCollector::UpdateNumberOfCaptureBatches(AZ::u32 newValue)
+    {
+        if (m_numberOfCaptureBatches == newValue)
+        {
+            return;
+        }
+        if (m_numberOfCaptureBatches == 0)
+        {
+            CreateOutputJsonFile();
+        }
+        m_numberOfCaptureBatches = newValue;
+        AZ_TracePrintf(LogName, "%s updated value to %u", __FUNCTION__, m_numberOfCaptureBatches);
+    }
+
+    void PerformanceCollector::CreateOutputJsonFile()
+    {
+        AZStd::chrono::steady_clock::time_point now = AZStd::chrono::steady_clock::now();
+
+        m_outputFilePath.clear();
+        m_outputDataBuffer.clear();
+
+        AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get();
+        if (!settingsRegistry)
+        {
+            // Most likely running under unit test.
+            auto bufferStream = AZStd::make_unique<AZ::IO::ByteContainerStream<AZStd::string>>(&m_outputDataBuffer);
+            m_eventLogger.ResetStream(AZStd::move(bufferStream));
+        }
+        else
+        {
+            settingsRegistry->Get(m_outputFilePath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectUserPath);
+            m_outputFilePath /= AZStd::string::format("Performance_%s_%lld.json", m_logCategory.c_str(), now.time_since_epoch().count());
+
+            constexpr AZ::IO::OpenMode openMode = AZ::IO::OpenMode::ModeWrite;
+            auto stream = AZStd::make_unique<AZ::IO::SystemFileStream>(m_outputFilePath.c_str(), openMode);
+            m_eventLogger.ResetStream(AZStd::move(stream));
+        }
+    }
+
+} //namespace AZ::Debug

--- a/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.cpp
+++ b/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.cpp
@@ -115,6 +115,10 @@ namespace AZ::Debug
 
     void PerformanceCollector::RecordPeriodicEvent(AZStd::string_view metricName)
     {
+        if (IsWaitingBeforeCapture())
+        {
+            return;
+        }
         auto prevStamp = m_periodicEventStamps[metricName];
         AZStd::chrono::steady_clock::time_point now = AZStd::chrono::steady_clock::now();
         m_periodicEventStamps[metricName] = now;

--- a/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.cpp
+++ b/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.cpp
@@ -247,9 +247,9 @@ namespace AZ::Debug
         else
         {
             settingsRegistry->Get(m_outputFilePath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectUserPath);
-            auto now = AZStd::chrono::utc_clock::now();
+            //auto now = AZStd::chrono::utc_clock::now();
             AZ::Date::Iso8601TimestampString utcTimestamp;
-            AZ::Date::GetFilenameCompatibleFormatWithMicroseconds(utcTimestamp, now);
+            AZ::Date::GetFilenameCompatibleFormatNowWithMicroseconds(utcTimestamp);// , now);
             m_outputFilePath /= AZStd::string::format("Performance_%s_%s.json", m_logCategory.c_str(), utcTimestamp.c_str());
 
             constexpr AZ::IO::OpenMode openMode = AZ::IO::OpenMode::ModeWrite;

--- a/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.cpp
+++ b/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.cpp
@@ -29,11 +29,6 @@ namespace AZ::Debug
         RestartPeriodicEventStamps();
     }
 
-    PerformanceCollector::~PerformanceCollector()
-    {
-
-    }
-
     bool PerformanceCollector::IsWaitingBeforeCapture()
     {
         return !m_numberOfCaptureBatches || m_isWaitingBeforeNextBatch;
@@ -53,7 +48,7 @@ namespace AZ::Debug
                 AZStd::chrono::steady_clock::time_point now = AZStd::chrono::steady_clock::now();
                 if (m_startWaitTime.time_since_epoch().count() == 0)
                 {
-                    AZ_TracePrintf(LogName, "Will Wait %lld seconds before starting batch %u...", m_waitTimeBeforeEachBatch.count(), m_numberOfCaptureBatches);
+                    AZ_TracePrintf(LogName, "Will Wait %lld seconds before starting batch %u...\n", m_waitTimeBeforeEachBatch.count(), m_numberOfCaptureBatches);
                     m_startWaitTime = now;
                 }
                 auto duration = AZStd::chrono::duration_cast<AZStd::chrono::seconds>(now - m_startWaitTime);
@@ -62,7 +57,7 @@ namespace AZ::Debug
                     return; // Do nothing. Keep waiting.
                 }
             }
-            AZ_TracePrintf(LogName, "Waited %lld seconds. Will start collecting performance numbers for %u frames at batch %u...", m_waitTimeBeforeEachBatch.count(), m_frameCountPerCaptureBatch, m_numberOfCaptureBatches);
+            AZ_TracePrintf(LogName, "Waited %lld seconds. Will start collecting performance numbers for %u frames at batch %u...\n", m_waitTimeBeforeEachBatch.count(), m_frameCountPerCaptureBatch, m_numberOfCaptureBatches);
             m_isWaitingBeforeNextBatch = false;
         }
 
@@ -92,7 +87,7 @@ namespace AZ::Debug
         {
             // This will close the file that contains performance results for all batches.
             m_eventLogger.ResetStream(nullptr);
-            AZ_TracePrintf(LogName, "Performance data output file <%s> is ready", m_outputFilePath.c_str());
+            AZ_TracePrintf(LogName, "Performance data output file <%s> is ready\n", m_outputFilePath.c_str());
         }
 
     }
@@ -134,7 +129,7 @@ namespace AZ::Debug
     {
         AZStd::vector<Statistics::NamedRunningStatistic*> statistics;
         m_statisticsManager.GetAllStatistics(statistics);
-        AZ_Warning(LogName, !statistics.empty(), "There are no statistics to report");
+        AZ_Warning(LogName, !statistics.empty(), "There are no statistics to report.");
         for (const auto statistic : statistics)
         {
             using EventObjectStorage = AZStd::fixed_vector<AZ::Metrics::EventField, 8>;
@@ -177,7 +172,7 @@ namespace AZ::Debug
 
         if (m_numberOfCaptureBatches > 0)
         {
-            AZ_Warning(LogName, false, "%s changes to control params are rejected while data is being captured", __FUNCTION__);
+            AZ_Warning(LogName, false, "%s changes to control params are rejected while data is being captured.", __FUNCTION__);
             return;
         }
 
@@ -193,7 +188,7 @@ namespace AZ::Debug
 
         if (m_numberOfCaptureBatches > 0)
         {
-            AZ_Warning(LogName, false, "%s changes to control params are rejected while data is being captured", __FUNCTION__);
+            AZ_Warning(LogName, false, "%s changes to control params are rejected while data is being captured.", __FUNCTION__);
             return;
         }
 
@@ -209,7 +204,7 @@ namespace AZ::Debug
 
         if (m_numberOfCaptureBatches > 0)
         {
-            AZ_Warning(LogName, false, "%s changes to control params are rejected while data is being captured", __FUNCTION__);
+            AZ_Warning(LogName, false, "%s changes to control params are rejected while data is being captured.", __FUNCTION__);
             return;
         }
 
@@ -227,7 +222,7 @@ namespace AZ::Debug
             CreateOutputJsonFile();
         }
         m_numberOfCaptureBatches = newValue;
-        AZ_TracePrintf(LogName, "%s updated value to %u", __FUNCTION__, m_numberOfCaptureBatches);
+        AZ_TracePrintf(LogName, "%s updated value to %u\n", __FUNCTION__, m_numberOfCaptureBatches);
     }
 
     void PerformanceCollector::CreateOutputJsonFile()

--- a/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.cpp
+++ b/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.cpp
@@ -247,9 +247,8 @@ namespace AZ::Debug
         else
         {
             settingsRegistry->Get(m_outputFilePath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectUserPath);
-            //auto now = AZStd::chrono::utc_clock::now();
             AZ::Date::Iso8601TimestampString utcTimestamp;
-            AZ::Date::GetFilenameCompatibleFormatNowWithMicroseconds(utcTimestamp);// , now);
+            AZ::Date::GetFilenameCompatibleFormatNowWithMicroseconds(utcTimestamp);
             m_outputFilePath /= AZStd::string::format("Performance_%s_%s.json", m_logCategory.c_str(), utcTimestamp.c_str());
 
             constexpr AZ::IO::OpenMode openMode = AZ::IO::OpenMode::ModeWrite;

--- a/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.h
+++ b/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.h
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Metrics/JsonTraceEventLogger.h>
+#include <AzCore/Statistics/StatisticsManager.h>
+#include <AzCore/std/chrono/chrono.h>
+
+namespace AZ::Debug
+{
+    //! A helper class that facilitates collecting performance metrics as part of blocks
+    //! of code, or measuring time lapses of periodically called functions.
+    //! The metrics can be recorded as raw events (DataLogType::LogAllSamples)
+    //! or aggregated as statistical summaries (DataLogType::LogStatistics).
+    //! Performance is captured in batches of frames.
+    class PerformanceCollector final
+    {
+    public:
+        PerformanceCollector() = delete;
+
+        //! Common properties found in the "args" dictionary of each Google Trace Json Row:
+        static constexpr AZStd::string_view AVG = "avg";
+        static constexpr AZStd::string_view MIN = "min";
+        static constexpr AZStd::string_view MAX = "max";
+        static constexpr AZStd::string_view SAMPLE_COUNT = "sampleCount";
+        static constexpr AZStd::string_view UNITS = "units";
+        static constexpr AZStd::string_view VARIANCE = "variance";
+        static constexpr AZStd::string_view STDEV = "stdev";
+        static constexpr AZStd::string_view MOST_RECENT_SAMPLE = "mostRecentSampleValue";
+
+        //! Function signature for the notification callback that will be dispatched
+        //! each time a batch of frames are measured.
+        using OnBatchCompleteCallback = AZStd::function<void(AZ::u32 pendingBatchCount)>;
+
+        //! All metrics that will ever be recorded must be declared at construction time
+        //! of the performance collector.
+        //! @param logCategory Category name that will be used in the Google Trace output json file.
+        //!                    Each output file will be named Performance_<Category>_<CreationTime>.json
+        //! @param m_metricNames List of all the metrics that will be recorded. All metrics will be measured in Microseconds.
+        //! @param onBatchCompleteCallback See comments above in OnBatchCompleteCallback declaration.
+        PerformanceCollector(const AZStd::string_view logCategory, AZStd::span<const AZStd::string_view> m_metricNames, OnBatchCompleteCallback onBatchCompleteCallback);
+        ~PerformanceCollector();
+
+        static constexpr char LogName[] = "PerformanceCollector";
+    
+        enum class DataLogType
+        {
+            LogStatistics, //! Aggregates each sampled data using the StatiscalProfiler API.
+                           //! When done, a single record with statistical summary is dumped in the output file using
+                           //! the IEventLogger API.
+            LogAllSamples, //! Each sample becomes a unique record in the output file using the IEventLogger API.
+        };
+    
+        //! Returns true if the user has disabled performance capture or
+        //! the performance collector is waiting for certain amount of time
+        //! before starting to measure performance.
+        bool IsWaitingBeforeCapture();
+    
+        //! Records a measured value according to the current CaptureType.
+        void RecordSample(AZStd::string_view metricName, AZStd::chrono::microseconds microSeconds);
+    
+        //! This is similar to RecordSample(). Captures the elapsed time between
+        //! two consecutive calls to this function for any given @metricName.
+        //! The time delta is recorded according to the current CaptureType.
+        void RecordPeriodicEvent(AZStd::string_view metricName);
+
+        //! The user of the API must call this function each frame. This is
+        //! where this class performs book keeping and decides when to flush
+        //! data into the output files, etc.
+        void FrameTick();
+
+        //! Updates the kind of data collection and reporting. See @DataLogType for details.
+        //! This function logs a warning and does nothing if a set of performance capture batches
+        //! is already in effect.
+        void UpdateDataLogType(DataLogType newValue);
+
+        //! Updates the number of frames that will be profiled per batch.
+        //! This function logs a warning and does nothing if a set of performance capture batches
+        //! is already in effect.
+        void UpdateFrameCountPerCaptureBatch(AZ::u32 newValue);
+
+        //! Updates the amount of time to wait, in seconds, before each batch starts.
+        //! This function logs a warning and does nothing if a set of performance capture batches
+        //! is already in effect.
+        void UpdateWaitTimeBeforeEachBatch(AZStd::chrono::seconds seconds);
+
+        //! Calling this one with newValue > 0 will trigger json file creation
+        //! and performance capture for as many batches.
+        void UpdateNumberOfCaptureBatches(AZ::u32 newValue);
+
+        const AZ::IO::Path& GetOutputFilePath() { return m_outputFilePath;  }
+
+        const AZStd::string& GetOutputDataBuffer() { return m_outputDataBuffer; }
+    
+    private:
+        //! A helper function that loops across all statistics in @m_statisticsManager
+        //! and reports each result into @m_eventLogger.
+        void RecordStatistics();
+
+        void RestartPeriodicEventStamps();
+
+        void CreateOutputJsonFile();
+
+        //! Main control parameters. Usually mirrored by CVARs. They can change at runtime.
+        AZ::u32 m_numberOfCaptureBatches = 0; // A number greater than 0 starts performance collection.
+        DataLogType m_dataLogType = DataLogType::LogStatistics; // Defines the data collection and report mode.
+        AZ::u32 m_frameCountPerCaptureBatch = 50; // How many frames of data will be capture per batch.
+        AZStd::chrono::seconds m_waitTimeBeforeEachBatch = AZStd::chrono::seconds(3); // How many seconds to wait before starting the next batch of data capture.
+
+        AZStd::string m_logCategory;
+        AZ::u32 m_frameCountInCurrentBatch = 0; // How many frames have been captured so far within the current batch.
+        AZStd::chrono::steady_clock::time_point m_startWaitTime;
+        bool m_isWaitingBeforeNextBatch = true;
+        OnBatchCompleteCallback m_onBatchCompleteCallback; // A notification will be sent each time a batch of frames is performance collected.
+   
+        //! Only used when @m_captureType == CaptureType::LogStatistics.
+        AZ::Statistics::StatisticsManager<AZStd::string> m_statisticsManager;
+    
+        //! Only used to store the previous value when RecordPeriodicEvent() is called
+        //! for any given metrics.
+        AZStd::unordered_map<AZStd::string, AZStd::chrono::steady_clock::time_point> m_periodicEventStamps;
+
+        //! In some circumstances, like running under UnitTests, an output file won't be created.
+        //! Instead the output data will be streamed into this buffer.
+        AZStd::string m_outputDataBuffer;
+
+        AZ::IO::Path m_outputFilePath; // We store here the file path of the most recently created output file.
+        Metrics::JsonTraceEventLogger m_eventLogger;
+    }; // class PerformanceCollector
+    
+    //! A Convenience class used to measure time performance of scopes of code
+    //! with constructor/destructor.
+    class ScopeDuration
+    {
+    public:
+        ScopeDuration() = delete;
+    
+        explicit ScopeDuration(PerformanceCollector* performanceCollector, const AZStd::string_view metricName)
+            : m_performanceCollector(performanceCollector)
+            , m_metricName(metricName)
+        {
+            if (!performanceCollector)
+            {
+                // This is normal. No need to assert.
+                return;
+            }
+            m_pushSample = !performanceCollector->IsWaitingBeforeCapture();
+            if (m_pushSample)
+            {
+                m_startTime = AZStd::chrono::steady_clock::now();
+            }
+        }
+    
+        ~ScopeDuration()
+        {
+            if (!m_performanceCollector || !m_pushSample)
+            {
+                // This is normal. No need to assert.
+                return;
+            }
+            AZStd::chrono::steady_clock::time_point stopTime = AZStd::chrono::steady_clock::now();
+            auto duration = AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(stopTime - m_startTime);
+            m_performanceCollector->RecordSample(m_metricName, duration);
+        }
+    
+    private:
+        bool m_pushSample;
+        PerformanceCollector* m_performanceCollector;
+        const AZStd::string_view m_metricName;
+        AZStd::chrono::steady_clock::time_point m_startTime;
+    }; // class ScopeDuration
+
+}; // namespace AZ::Debug

--- a/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.h
+++ b/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.h
@@ -140,7 +140,7 @@ namespace AZ::Debug
     public:
         ScopeDuration() = delete;
     
-        explicit ScopeDuration(PerformanceCollector* performanceCollector, const AZStd::string_view metricName)
+        ScopeDuration(PerformanceCollector* performanceCollector, const AZStd::string_view metricName)
             : m_performanceCollector(performanceCollector)
             , m_metricName(metricName)
         {

--- a/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.h
+++ b/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.h
@@ -44,7 +44,7 @@ namespace AZ::Debug
         //! @param m_metricNames List of all the metrics that will be recorded. All metrics will be measured in Microseconds.
         //! @param onBatchCompleteCallback See comments above in OnBatchCompleteCallback declaration.
         PerformanceCollector(const AZStd::string_view logCategory, AZStd::span<const AZStd::string_view> m_metricNames, OnBatchCompleteCallback onBatchCompleteCallback);
-        ~PerformanceCollector();
+        ~PerformanceCollector() = default;
 
         static constexpr char LogName[] = "PerformanceCollector";
     

--- a/Code/Framework/AzCore/AzCore/Metrics/JsonTraceEventLogger.cpp
+++ b/Code/Framework/AzCore/AzCore/Metrics/JsonTraceEventLogger.cpp
@@ -247,6 +247,7 @@ namespace AZ::Metrics
         {
             extraParams.emplace_back(ThreadDurationKey, EventValue{ AZStd::in_place_type<AZ::s64>, completeArgs.m_tdur->count() });
         }
+
         eventDesc.SetExtraParams(extraParams);
 
         if (FlushRequest(eventDesc))

--- a/Code/Framework/AzCore/AzCore/Metrics/JsonTraceEventLogger.cpp
+++ b/Code/Framework/AzCore/AzCore/Metrics/JsonTraceEventLogger.cpp
@@ -247,7 +247,6 @@ namespace AZ::Metrics
         {
             extraParams.emplace_back(ThreadDurationKey, EventValue{ AZStd::in_place_type<AZ::s64>, completeArgs.m_tdur->count() });
         }
-
         eventDesc.SetExtraParams(extraParams);
 
         if (FlushRequest(eventDesc))

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -82,6 +82,8 @@ set(FILES
     Debug/BudgetTracker.h
     Debug/BudgetTracker.cpp
     Debug/MemoryProfiler.h
+    Debug/PerformanceCollector.h
+    Debug/PerformanceCollector.cpp
     Debug/Profiler.cpp
     Debug/Profiler.inl
     Debug/Profiler.h

--- a/Code/Framework/AzCore/Tests/Debug/PerformanceCollectorTests.cpp
+++ b/Code/Framework/AzCore/Tests/Debug/PerformanceCollectorTests.cpp
@@ -55,14 +55,14 @@ namespace UnitTest
         const AZ::u32 EXCESS_FRAME_LOOP = 5;
         for (AZ::u32 frameLoop = 0; frameLoop < ((numberOfCaptureBatches*frameCountPerCaptureBatch) + EXCESS_FRAME_LOOP); frameLoop++)
         {
-            performanceCollector.FrameTick();
-            if (!performanceCollector.IsWaitingBeforeCapture())
-            {
-                performanceCollector.RecordPeriodicEvent(PerfParam1);
-            }
+            performanceCollector.FrameTick(); // Required Heart beat.
+
+            performanceCollector.RecordPeriodicEvent(PerfParam1);
+
             {
                 AZ::Debug::ScopeDuration param1Scope(&performanceCollector, PerfParam2);
             }
+
             {
                 AZ::Debug::ScopeDuration param1Scope(&performanceCollector, PerfParam3);
             }
@@ -152,14 +152,14 @@ namespace UnitTest
         const AZ::u32 EXCESS_FRAME_LOOP = 5;
         for (AZ::u32 frameLoop = 0; frameLoop < ((numberOfCaptureBatches*frameCountPerCaptureBatch) + EXCESS_FRAME_LOOP); frameLoop++)
         {
-            performanceCollector.FrameTick();
-            if (!performanceCollector.IsWaitingBeforeCapture())
-            {
-                performanceCollector.RecordPeriodicEvent(PerfParam1);
-            }
+            performanceCollector.FrameTick(); // Required Heart beat.
+
+            performanceCollector.RecordPeriodicEvent(PerfParam1);
+
             {
                 AZ::Debug::ScopeDuration param1Scope(&performanceCollector, PerfParam2);
             }
+
             {
                 AZ::Debug::ScopeDuration param1Scope(&performanceCollector, PerfParam3);
             }

--- a/Code/Framework/AzCore/Tests/Debug/PerformanceCollectorTests.cpp
+++ b/Code/Framework/AzCore/Tests/Debug/PerformanceCollectorTests.cpp
@@ -1,0 +1,215 @@
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: Apache-2.0 OR MIT
+*
+*/
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/UnitTest/UnitTest.h>
+#include <AzTest/AzTest.h>
+
+#include <AzCore/Debug/PerformanceCollector.h>
+#include <AzCore/JSON/document.h>
+
+using namespace AZ;
+using namespace Debug;
+
+namespace UnitTest
+{
+    class PerformanceCollectorTest
+        : public AllocatorsFixture
+    {
+    public:
+        PerformanceCollectorTest()
+        {
+        }
+
+        void SetUp() override
+        {
+            AllocatorsFixture::SetUp();
+        }
+
+        ~PerformanceCollectorTest() override
+        {
+        }
+
+        void TearDown() override
+        {
+            AllocatorsFixture::TearDown();
+        }
+    }; //class PerformanceCollectorTest
+
+    TEST_F(PerformanceCollectorTest, CreatePerformanceCollector_CollectPerformance_ValidateStatisticalOutput)
+    {
+        // In this test we use the PerformanceCollector to collect statistical data for three parameters.
+        // Statistical data summarizes the results across a single batch of sampled frames.
+        // In this test we run 3 batches, which means we expect 3 rows (aka json object) per measured
+        // parameter. Each json object will contain statistical summary of a batch made of 10 frames.
+
+        const AZStd::string LogCategory("PerformanceCollectorTest");
+        constexpr AZStd::string_view PerfParam1("param1");
+        constexpr AZStd::string_view PerfParam2("param2");
+        constexpr AZStd::string_view PerfParam3("param3");
+
+        // Define control arguments that will define how much data to collect.
+        // In real life these parameters are mirrored by CVARs.
+        const AZ::u32 numberOfCaptureBatches = 3;
+        const AZ::Debug::PerformanceCollector::DataLogType dataLogType = AZ::Debug::PerformanceCollector::DataLogType::LogStatistics;
+        const AZ::u32 waitTimePerCaptureBatch = 0; //0 seconds
+        const AZ::u32 frameCountPerCaptureBatch = 10;
+
+        AZ::u32 pendingBatchCount = numberOfCaptureBatches;
+        auto onCompleteCallback = [&](AZ::u32 batchCount) {
+            pendingBatchCount = batchCount;
+        };
+        AZStd::vector<AZStd::string_view> paramList = { PerfParam1, PerfParam2, PerfParam3 };
+        AZ::Debug::PerformanceCollector performanceCollector(LogCategory, paramList, onCompleteCallback);
+        performanceCollector.UpdateDataLogType(dataLogType);
+        performanceCollector.UpdateFrameCountPerCaptureBatch(frameCountPerCaptureBatch);
+        performanceCollector.UpdateWaitTimeBeforeEachBatch(AZStd::chrono::seconds(waitTimePerCaptureBatch));
+        performanceCollector.UpdateNumberOfCaptureBatches(numberOfCaptureBatches);
+
+        // We will loop more than is required to simulate OnSystemTick, but the amount of collected data should
+        // be limited to the specified control parameters.
+        const AZ::u32 EXCESS_FRAME_LOOP = 5;
+        for (AZ::u32 frameLoop = 0; frameLoop < ((numberOfCaptureBatches*frameCountPerCaptureBatch) + EXCESS_FRAME_LOOP); frameLoop++)
+        {
+            performanceCollector.FrameTick();
+            if (!performanceCollector.IsWaitingBeforeCapture())
+            {
+                performanceCollector.RecordPeriodicEvent(PerfParam1);
+            }
+            {
+                AZ::Debug::ScopeDuration param1Scope(&performanceCollector, PerfParam2);
+            }
+            {
+                AZ::Debug::ScopeDuration param1Scope(&performanceCollector, PerfParam3);
+            }
+        }
+
+        auto stringWithOutputData = performanceCollector.GetOutputDataBuffer();
+        EXPECT_FALSE(stringWithOutputData.empty());
+        EXPECT_EQ(pendingBatchCount, 0);
+
+        rapidjson::Document jsonDoc;
+        jsonDoc.Parse(stringWithOutputData.c_str());
+        ASSERT_TRUE(!jsonDoc.HasParseError());
+
+        // The root is an array of dictionaries.
+        ASSERT_TRUE(jsonDoc.IsArray());
+        // We have 3 paramaters and 3 capture batches. So we expect 9 arrays.
+        auto expectedArraySize = paramList.size() * numberOfCaptureBatches;
+        ASSERT_TRUE(jsonDoc.Size() == expectedArraySize);
+        for (rapidjson::SizeType i = 0; i < expectedArraySize; i += aznumeric_cast<rapidjson::SizeType>(paramList.size()))
+        {
+            AZStd::unordered_set<AZStd::string> validatedParams;
+            AZStd::string paramName = jsonDoc[i]["name"].GetString();
+            EXPECT_NE(AZStd::find(paramList.begin(), paramList.end(), paramName), paramList.end());
+            ASSERT_FALSE(paramName.empty());
+            ASSERT_FALSE(validatedParams.count(paramName) > 0);
+            validatedParams.emplace(paramName);
+            EXPECT_EQ(LogCategory, jsonDoc[i]["cat"].GetString());
+            auto argsObj = jsonDoc[i]["args"].GetObject();
+            ASSERT_TRUE(argsObj.HasMember(AZ::Debug::PerformanceCollector::AVG.data()));
+            ASSERT_TRUE(argsObj.HasMember(AZ::Debug::PerformanceCollector::MIN.data()));
+            ASSERT_TRUE(argsObj.HasMember(AZ::Debug::PerformanceCollector::MAX.data()));
+            ASSERT_TRUE(argsObj.HasMember(AZ::Debug::PerformanceCollector::STDEV.data()));
+            ASSERT_TRUE(argsObj.HasMember(AZ::Debug::PerformanceCollector::SAMPLE_COUNT.data()));
+
+            // Remark, here we call GetDouble() and later cast to unsigned int, because
+            // GetUint() returns weird numbers when reading a floating point value.
+            auto avgAsDouble = argsObj[AZ::Debug::PerformanceCollector::AVG.data()].GetDouble();
+            EXPECT_EQ(jsonDoc[i]["dur"].GetUint(), aznumeric_cast<unsigned int>(avgAsDouble));
+
+            auto sampleCount = argsObj[AZ::Debug::PerformanceCollector::SAMPLE_COUNT.data()].GetUint();
+            if (paramName == PerfParam1)
+            {
+                // Periodic events work in deltas. The first frame is just for collecting
+                // the Begin time, so there's no delta. For subsequent events there's
+                // now previous data to subtract from and that's why we check for (FrameCount - 1).
+                EXPECT_EQ(sampleCount, frameCountPerCaptureBatch - 1);
+            }
+            else
+            {
+                EXPECT_EQ(sampleCount, frameCountPerCaptureBatch);
+            }
+        }
+
+    }
+
+    TEST_F(PerformanceCollectorTest, CreatePerformanceCollector_CollectPerformance_ValidateAllSamplesOutput)
+    {
+        // In this test we use the PerformanceCollector to collect all data for three parameters.
+        // the data is NOT statistically summarize so each time RecordPeriodicEvent() or
+        // the AZ::Debug::ScopeDuration is used, a unique row (aka json object) will be added to the output json.
+
+        const AZStd::string LogCategory("PerformanceCollectorTest");
+        constexpr AZStd::string_view PerfParam1("param1");
+        constexpr AZStd::string_view PerfParam2("param2");
+        constexpr AZStd::string_view PerfParam3("param3");
+
+        // Define control arguments that will define how much data to collect.
+        // In real life these parameters are mirrored by CVARs.
+        const AZ::u32 numberOfCaptureBatches = 3;
+        const AZ::Debug::PerformanceCollector::DataLogType dataLogType = AZ::Debug::PerformanceCollector::DataLogType::LogAllSamples;
+        const AZ::u32 waitTimePerCaptureBatch = 0; //0 seconds
+        const AZ::u32 frameCountPerCaptureBatch = 10;
+
+        AZ::u32 pendingBatchCount = numberOfCaptureBatches;
+        auto onCompleteCallback = [&](AZ::u32 batchCount) {
+            pendingBatchCount = batchCount;
+        };
+        AZStd::vector<AZStd::string_view> paramList = { PerfParam1, PerfParam2, PerfParam3 };
+        AZ::Debug::PerformanceCollector performanceCollector(LogCategory, paramList, onCompleteCallback);
+        performanceCollector.UpdateDataLogType(dataLogType);
+        performanceCollector.UpdateFrameCountPerCaptureBatch(frameCountPerCaptureBatch);
+        performanceCollector.UpdateWaitTimeBeforeEachBatch(AZStd::chrono::seconds(waitTimePerCaptureBatch));
+        performanceCollector.UpdateNumberOfCaptureBatches(numberOfCaptureBatches);
+
+        // We will loop more than is required to simulate OnSystemTick, but the amount of collected data should
+        // be limited to the specified control parameters.
+        const AZ::u32 EXCESS_FRAME_LOOP = 5;
+        for (AZ::u32 frameLoop = 0; frameLoop < ((numberOfCaptureBatches*frameCountPerCaptureBatch) + EXCESS_FRAME_LOOP); frameLoop++)
+        {
+            performanceCollector.FrameTick();
+            if (!performanceCollector.IsWaitingBeforeCapture())
+            {
+                performanceCollector.RecordPeriodicEvent(PerfParam1);
+            }
+            {
+                AZ::Debug::ScopeDuration param1Scope(&performanceCollector, PerfParam2);
+            }
+            {
+                AZ::Debug::ScopeDuration param1Scope(&performanceCollector, PerfParam3);
+            }
+        }
+
+        auto stringWithOutputData = performanceCollector.GetOutputDataBuffer();
+        EXPECT_FALSE(stringWithOutputData.empty());
+        EXPECT_EQ(pendingBatchCount, 0);
+
+        rapidjson::Document jsonDoc;
+        jsonDoc.Parse(stringWithOutputData.c_str());
+        ASSERT_TRUE(!jsonDoc.HasParseError());
+
+        // The root is an array of dictionaries.
+        ASSERT_TRUE(jsonDoc.IsArray());
+
+        // When in DataLogType::LogAllSamples mode, each recorded data becomes a single dictionary in the
+        // output json file. But in this test the parameter PerfParam1 is recorded with RecordPeriodicEvent()
+        // which always skips the first frame because that frame is used to store the first previous value.
+        auto expectedArraySize = (paramList.size() - 1) * numberOfCaptureBatches * frameCountPerCaptureBatch;
+        expectedArraySize += numberOfCaptureBatches * (frameCountPerCaptureBatch - 1);
+        ASSERT_TRUE(jsonDoc.Size() == expectedArraySize);
+        for (rapidjson::SizeType i = 0; i < expectedArraySize; i++)
+        {
+            AZStd::string paramName = jsonDoc[i]["name"].GetString();
+            ASSERT_FALSE(paramName.empty());
+            EXPECT_NE(AZStd::find(paramList.begin(), paramList.end(), paramName), paramList.end());
+            EXPECT_EQ(LogCategory, jsonDoc[i]["cat"].GetString());
+            EXPECT_TRUE(jsonDoc[i].HasMember("dur"));
+        }
+    }
+
+}//namespace UnitTest

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -28,7 +28,7 @@ set(FILES
     AZStd/ConcurrentAllocators.cpp
     AZStd/ConcurrentContainers.cpp
     AZStd/ChronoTests.cpp
-    AZStd/DequeAndSimilar.cpp
+    AZStd/DequeAndSimilar.cppD
     AZStd/Examples.cpp
     AZStd/FunctionalBasic.cpp
     AZStd/FunctorsBind.cpp
@@ -74,6 +74,7 @@ set(FILES
     Console/LoggerSystemComponentTests.cpp
     Console/ConsoleTests.cpp
     Date/DateFormatTests.cpp
+    Debug/PerformanceCollectorTests.cpp
     Debug/Trace.cpp
     Debug.cpp
     DLL.cpp

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -28,7 +28,7 @@ set(FILES
     AZStd/ConcurrentAllocators.cpp
     AZStd/ConcurrentContainers.cpp
     AZStd/ChronoTests.cpp
-    AZStd/DequeAndSimilar.cppD
+    AZStd/DequeAndSimilar.cpp
     AZStd/Examples.cpp
     AZStd/FunctionalBasic.cpp
     AZStd/FunctorsBind.cpp

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/PerformanceCVarManager.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/PerformanceCVarManager.cpp
@@ -31,7 +31,7 @@ namespace AZ
 
             static void OnDataLogTypeChanged(const AZ::CVarFixedString& newCaptureType)
             {
-                AZ_TracePrintf(LogName, "%s cvar changed to %s", __FUNCTION__, newCaptureType.c_str());
+                AZ_TracePrintf(LogName, "%s cvar changed to %s.\n", __FUNCTION__, newCaptureType.c_str());
                 auto performanceCollectorOwner = PerformanceCollectorOwner::Get();
                 if (!performanceCollectorOwner)
                 {
@@ -47,7 +47,7 @@ namespace AZ
 
             static void OnNumberOfCaptureBatchesChanged(const AZ::u32& newValue)
             {
-                AZ_TracePrintf(LogName, "%s cvar changed to %u", __FUNCTION__, newValue);
+                AZ_TracePrintf(LogName, "%s cvar changed to %u.\n", __FUNCTION__, newValue);
                 auto performanceCollectorOwner = PerformanceCollectorOwner::Get();
                 if (!performanceCollectorOwner)
                 {
@@ -63,7 +63,7 @@ namespace AZ
 
             static void OnWaitTimePerCaptureBatchChanged(const AZ::u32& newValue)
             {
-                AZ_TracePrintf(LogName, "%s cvar changed to %u", __FUNCTION__, newValue);
+                AZ_TracePrintf(LogName, "%s cvar changed to %u.\n", __FUNCTION__, newValue);
                 auto performanceCollectorOwner = PerformanceCollectorOwner::Get();
                 if (!performanceCollectorOwner)
                 {
@@ -79,7 +79,7 @@ namespace AZ
 
             static void OnFrameCountPerCaptureBatchChanged(const AZ::u32& newValue)
             {
-                AZ_TracePrintf(LogName, "%s cvar changed to %u", __FUNCTION__, newValue);
+                AZ_TracePrintf(LogName, "%s cvar changed to %u.\n", __FUNCTION__, newValue);
                 auto performanceCollectorOwner = PerformanceCollectorOwner::Get();
                 if (!performanceCollectorOwner)
                 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/PerformanceCVarManager.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/PerformanceCVarManager.cpp
@@ -1,0 +1,122 @@
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: Apache-2.0 OR MIT
+*
+*/
+
+#include <AzCore/Debug/PerformanceCollector.h>
+
+#include "PerformanceCVarManager.h"
+
+namespace AZ
+{
+    namespace RPI
+    {
+
+        AZ::Debug::PerformanceCollector::DataLogType GetDataLogTypeFromCVar(const AZ::CVarFixedString& newCaptureType)
+        {
+            if (newCaptureType[0] == 'a' || newCaptureType[0] == 'A')
+            {
+                return AZ::Debug::PerformanceCollector::DataLogType::LogAllSamples;
+            }
+            return AZ::Debug::PerformanceCollector::DataLogType::LogStatistics;
+        }
+
+        class PerformanceCvarManager
+        {
+        public:
+            static constexpr char LogName[] = "RPIPerformanceCvarManager";
+
+            static void OnDataLogTypeChanged(const AZ::CVarFixedString& newCaptureType)
+            {
+                AZ_TracePrintf(LogName, "%s cvar changed to %s", __FUNCTION__, newCaptureType.c_str());
+                auto performanceCollectorOwner = PerformanceCollectorOwner::Get();
+                if (!performanceCollectorOwner)
+                {
+                    return;
+                }
+                auto performanceCollector = performanceCollectorOwner->GetPerformanceCollector();
+                if (!performanceCollector)
+                {
+                    return;
+                }
+                performanceCollector->UpdateDataLogType(GetDataLogTypeFromCVar(newCaptureType));
+            }
+
+            static void OnNumberOfCaptureBatchesChanged(const AZ::u32& newValue)
+            {
+                AZ_TracePrintf(LogName, "%s cvar changed to %u", __FUNCTION__, newValue);
+                auto performanceCollectorOwner = PerformanceCollectorOwner::Get();
+                if (!performanceCollectorOwner)
+                {
+                    return;
+                }
+                auto performanceCollector = performanceCollectorOwner->GetPerformanceCollector();
+                if (!performanceCollector)
+                {
+                    return;
+                }
+                performanceCollector->UpdateNumberOfCaptureBatches(newValue);
+            }
+
+            static void OnWaitTimePerCaptureBatchChanged(const AZ::u32& newValue)
+            {
+                AZ_TracePrintf(LogName, "%s cvar changed to %u", __FUNCTION__, newValue);
+                auto performanceCollectorOwner = PerformanceCollectorOwner::Get();
+                if (!performanceCollectorOwner)
+                {
+                    return;
+                }
+                auto performanceCollector = performanceCollectorOwner->GetPerformanceCollector();
+                if (!performanceCollector)
+                {
+                    return;
+                }
+                performanceCollector->UpdateWaitTimeBeforeEachBatch(AZStd::chrono::seconds(newValue));
+            }
+
+            static void OnFrameCountPerCaptureBatchChanged(const AZ::u32& newValue)
+            {
+                AZ_TracePrintf(LogName, "%s cvar changed to %u", __FUNCTION__, newValue);
+                auto performanceCollectorOwner = PerformanceCollectorOwner::Get();
+                if (!performanceCollectorOwner)
+                {
+                    return;
+                }
+                auto performanceCollector = performanceCollectorOwner->GetPerformanceCollector();
+                if (!performanceCollector)
+                {
+                    return;
+                }
+                performanceCollector->UpdateFrameCountPerCaptureBatch(newValue);
+            }
+        };
+
+        AZ_CVAR(AZ::u32, r_metricsNumberOfCaptureBatches,
+            0, // Starts at 0, which means "do not capture performance data". When this variable changes to >0 we'll start performance capture.
+            &PerformanceCvarManager::OnNumberOfCaptureBatchesChanged,
+            ConsoleFunctorFlags::DontReplicate,
+            "Collects and reports graphics performance in this number of batches.");
+
+        AZ_CVAR(AZ::CVarFixedString, r_metricsDataLogType,
+            "statistical", // (s)(S)tatistical Summary (average, min, max, stdev) / (a)(A)ll Samples. Default=s.
+            &PerformanceCvarManager::OnDataLogTypeChanged,
+            ConsoleFunctorFlags::DontReplicate,
+            "Defines the kind of data collection and logging. If starts with 's' it will log statistical summaries, if starts with 'a' will log each sample of data (high verbosity).");
+
+        AZ_CVAR(AZ::u32, r_metricsWaitTimePerCaptureBatch,
+            0, // Starts at 0, which means "do not capture performance data". When this variable changes to >0 we'll start performance capture.
+            &PerformanceCvarManager::OnWaitTimePerCaptureBatchChanged,
+            ConsoleFunctorFlags::DontReplicate,
+            "How many seconds to wait before each batch of performance capture.");
+
+        AZ_CVAR(AZ::u32, r_metricsFrameCountPerCaptureBatch,
+            1200, // Number of frames in which performance will be measured per batch.
+            &PerformanceCvarManager::OnFrameCountPerCaptureBatchChanged,
+            ConsoleFunctorFlags::DontReplicate,
+            "Number of frames in which performance will be measured per batch.");
+
+    } // namespace RPI
+} // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/PerformanceCVarManager.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/PerformanceCVarManager.h
@@ -1,0 +1,44 @@
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: Apache-2.0 OR MIT
+*
+*/
+
+#pragma once
+
+#include <AzCore/Console/IConsole.h>
+#include <AzCore/Interface/Interface.h>
+
+namespace AZ
+{
+    namespace Debug
+    {
+        class PerformanceCollector;
+    }
+
+    namespace RPI
+    {
+        // A simple helper function.
+        AZ::Debug::PerformanceCollector::DataLogType GetDataLogTypeFromCVar(const AZ::CVarFixedString& newCaptureType);
+
+        //! This is a simple interface to help get a reference to an AZ::Debug::PerformanceCollector
+        //! so we can feed CVar values into it.
+        class IPerformanceCollectorOwner
+        {
+        public:
+            AZ_CLASS_ALLOCATOR(IPerformanceCollectorOwner, AZ::SystemAllocator, 0);
+            AZ_RTTI(IPerformanceCollectorOwner, "{D157F48E-8D9C-4F4F-93CE-961860371965}");
+
+            IPerformanceCollectorOwner() = default;
+            virtual ~IPerformanceCollectorOwner() = default;
+
+        protected:
+            friend class PerformanceCvarManager;
+            virtual AZ::Debug::PerformanceCollector* GetPerformanceCollector() { return nullptr; }
+        };
+        using PerformanceCollectorOwner = AZ::Interface<IPerformanceCollectorOwner>;
+
+    } // namespace RPI
+} // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
@@ -192,15 +192,15 @@ namespace AZ
         void RPISystemComponent::InitializePerformanceCollector()
         {
             auto onBatchCompleteCallback = [](AZ::u32 pendingBatches) {
-                AZ_TracePrintf("RPISystem", "Completed a performance batch, still %llu batches are pending", pendingBatches);
+                AZ_TracePrintf("RPISystem", "Completed a performance batch, still %u batches are pending.\n", pendingBatches);
                 r_metricsNumberOfCaptureBatches = pendingBatches;
             };
 
-            AZStd::vector<AZStd::string_view> performanceMetrics = {
+            auto performanceMetrics = AZStd::to_array<AZStd::string_view>({
                 PerformanceSpecGraphicsSimulationTime,
                 PerformanceSpecGraphicsRenderTime,
                 PerformanceSpecEngineCpuTime,
-            };
+                });
             m_performanceCollector = AZStd::make_unique<AZ::Debug::PerformanceCollector>(
                 PerformanceLogCategory, performanceMetrics, onBatchCompleteCallback);
             //Feed the CVAR values.

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
@@ -136,10 +136,7 @@ namespace AZ
         {
             if (m_performanceCollector)
             {
-                if (!m_performanceCollector->IsWaitingBeforeCapture())
-                {
-                    m_performanceCollector->RecordPeriodicEvent(PerformanceSpecEngineCpuTime);
-                }
+                m_performanceCollector->RecordPeriodicEvent(PerformanceSpecEngineCpuTime);
                 m_performanceCollector->FrameTick();
             }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.h
@@ -14,10 +14,13 @@
 #pragma once
 
 #include <AzCore/Component/Component.h>
+#include <AzCore/Debug/PerformanceCollector.h>
 
 #include <Atom/RHI/RHISystemInterface.h>
 #include <Atom/RPI.Public/RPISystem.h>
 #include <Atom/RPI.Public/XR/XRRenderingInterface.h>
+
+#include "PerformanceCVarManager.h"
 
 namespace AZ
 {
@@ -37,6 +40,7 @@ namespace AZ
             , public AZ::SystemTickBus::Handler
             , public AZ::RHI::RHISystemNotificationBus::Handler
             , public XRRegisterInterface::Registrar
+            , public PerformanceCollectorOwner::Registrar
         {
         public:
             AZ_COMPONENT(RPISystemComponent, "{83E301F3-7A0C-4099-B530-9342B91B1BC0}");
@@ -66,6 +70,23 @@ namespace AZ
                         
             // RHISystemNotificationBus::Handler
             void OnDeviceRemoved(RHI::Device* device) override;
+
+            ///////////////////////////////////////////////////////////////////
+            // IPerformanceCollectorOwner overrides
+            AZ::Debug::PerformanceCollector* GetPerformanceCollector() override { return m_performanceCollector.get(); }
+            ///////////////////////////////////////////////////////////////////
+
+            ///////////////////////////////////////////////////////////////////
+            // Performance Collection
+            void InitializePerformanceCollector();
+
+            static constexpr AZStd::string_view PerformanceLogCategory = "Graphics";
+            static constexpr AZStd::string_view PerformanceSpecGraphicsSimulationTime = "Graphics Simulation Time";
+            static constexpr AZStd::string_view PerformanceSpecGraphicsRenderTime = "Graphics Render Time";
+            static constexpr AZStd::string_view PerformanceSpecEngineCpuTime = "Engine Cpu Time";
+
+            AZStd::unique_ptr<AZ::Debug::PerformanceCollector> m_performanceCollector;
+            ///////////////////////////////////////////////////////////////////
 
             RPISystem m_rpiSystem;
 

--- a/Gems/Atom/RPI/Code/atom_rpi_private_files.cmake
+++ b/Gems/Atom/RPI/Code/atom_rpi_private_files.cmake
@@ -11,4 +11,6 @@ set(FILES
     Source/RPI.Private/Module.h
     Source/RPI.Private/RPISystemComponent.cpp
     Source/RPI.Private/RPISystemComponent.h
+    Source/RPI.Private/PerformanceCVarManager.cpp
+    Source/RPI.Private/PerformanceCVarManager.h
 )


### PR DESCRIPTION
## What does this PR do?

Added a new class to AzCore/Debug called `PerformanceCollector`. It is a general purpose class that helps measure and record performance data. The output data is generated using AzCore/Metrics/JsonTraceEventLogger which produces JSON files in the Google Trace data format.

For details on how to use take a look at the file `AzCore/Tests/Debug/PerformanceCollectorTests`, but here is the gist of it:  
PerformanceCollector provides two mechanisms to measure code performance in `microseconds`:

1. Scope based:
Use the companion AZ::Debug::ScopeDuration class.  Let's say you want to measure the duration of a particular function:  
```cpp
void MyClass::MyFunction()
{
     ...  Some Code ...
}
```
Then you can do (Assuming MyClass owns or has access to a PerformanceCollector object.  
```cpp
void MyClass::MyFunction()
{
     AZ::Debug::ScopeDuration scope(m_performanceCollectorPtr, "MyParameter");
     ...  Some Code ...
}
```
In the code above, the duration of `MyClass::MyFunction()` will be recorded under the parameter named `MyParameter`.
Equivalently, You can use AZ::Debug::ScopeDuration to measure any other block of code.

2. Periodic events/functions:  
This option is useful to measure the time it takes between calls to periodic functions like OnSystemTick() or OnTick():  
```cpp
void RPISystemComponent::OnSystemTick()
{
    m_performanceCollector->RecordPeriodicEvent("MyCpuTime");
    ... code ...
}
```
In the code above, the time it takes in between calls to `RPISystemComponent::OnSystemTick()` will be recorded in the parameter named `MyCpuTime`.  

### About size of the output data.
The size of the output data will be drastically different depending on the output mode you choose when configuring the PerformanceCollector.  
1. `DataLogType::LogStatistics`:  This is the default mode of operation. Each measured parameter will produce a single json line for all the data collected under an arbitrary number of frames. Whether the data is collected across 1 frame or 10000000 frames, only one line of json data with a statistical summary will be produced. Example:  
`{"name":"Graphics Render Time","cat":"Graphics","ph":"X","ts":1665585433079433,"pid":7228,"tid":51260,"args":{"avg":14802.554166666678,"min":13290.0,"max":16197.0,"sampleCount":1200,"units":"us","variance":418435.9353454264,"stdev":646.866242236698,"mostRecentSampleValue":14840.0},"dur":14802},`  
2. `DataLogType::LogAllSamples`: This is the verbose alternative. For each frame/sample of recorded data a json object will be added to the output file. This means that if you choose to capture performance data for a single parameter across 10000000 frames, then 10000000 json objects will added to the output file. Use this mode judiciously.

### PerformanceCollector & RPISystemComponent.
In this PR the first customer of `PerformanceCollector ` class is the `RPISystemComponent`. The RPISystemComponent now exposes the following CVARs:  
- r_metricsDataLogType=statistical [  ]  
- r_metricsFrameCountPerCaptureBatch=1200 [  ]
- r_metricsNumberOfCaptureBatches=0 [  ]
- r_metricsWaitTimePerCaptureBatch=0[  ]
When the user changes r_metricsNumberOfCaptureBatches to be greater than 0, it will trigger performance collection for the following parameters: `Graphics Simulation Time`, `Graphics Render Time` and `Engine CPU Time`.

### Why? How does this compare to AzCore/Debug/Profiler and AZ_PROFILE_* macros?
AZ_PROFILE_* Macros are the de-facto and encouraged method to place profiling markers across the code base. It produces data files that can be used with PIX to debug and root cause performance issues. See this wiki for more details: [Profiling Tools](https://github.com/o3de/o3de/wiki/CPU-&-GPU-Debugging-and-Profiling-Tools).  
`PerformanceCollector`, on the other hand, is useful to keep track of key performance metrics, that can be collected regularly and help us spot regressions or improvements. It is easy to use at runtime without requiring special compilation flags. It leverages the Google Trace JSON format because it uses the JsonTraceEventLogger APIs.

## How was this PR tested?

Added a Unit Test at `AzCore/Tests/Debug/PerformanceCollectorTests.cpp` which passes on Both Linux & Windows.

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>
