### PR TITLE
Fix crash when running on Quest 2 with GPU detailed profiling mode enabled

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/Vulkan/XRVkDescriptors.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/Vulkan/XRVkDescriptors.h
@@ -84,6 +84,7 @@ namespace AZ::Vulkan
         struct
         {
             VkDevice m_xrVkDevice = VK_NULL_HANDLE;
+            GladVulkanContext m_context;
         } m_outputData;
     };
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -271,6 +271,7 @@ namespace AZ
                 AZ::RHI::ResultCode result = xrSystem->CreateDevice(&xrDevicDescriptor);
                 AZ_Assert(result == RHI::ResultCode::Success, "Xr Vk device creation was not successful");
                 m_nativeDevice = xrDevicDescriptor.m_outputData.m_xrVkDevice;
+                m_context = xrDevicDescriptor.m_outputData.m_context;
                 RETURN_RESULT_IF_UNSUCCESSFUL(result);
                 m_isXrNativeDevice = true;
             }
@@ -280,18 +281,18 @@ namespace AZ
                     instance.GetContext().CreateDevice(physicalDevice.GetNativePhysicalDevice(), &deviceInfo, nullptr, &m_nativeDevice);
                 AssertSuccess(vkResult);
                 RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(vkResult));
+
+                if (!instance.GetFunctionLoader().LoadProcAddresses(
+                        &m_context, instance.GetNativeInstance(), physicalDevice.GetNativePhysicalDevice(), m_nativeDevice))
+                {
+                    AZ_Warning("Vulkan", false, "Could not initialized function loader.");
+                    return RHI::ResultCode::Fail;
+                }
             }
 
             for (const VkDeviceQueueCreateInfo& queueInfo : queueCreationInfo)
             {
                 delete[] queueInfo.pQueuePriorities;
-            }
-
-            if (!instance.GetFunctionLoader().LoadProcAddresses(
-                    &m_context, instance.GetNativeInstance(), physicalDevice.GetNativePhysicalDevice(), m_nativeDevice))
-            {
-                AZ_Warning("Vulkan", false, "Could not initialized function loader.");
-                return RHI::ResultCode::Fail;
             }
 
             //Load device features now that we have loaded all extension info

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -285,7 +285,7 @@ namespace AZ
                 if (!instance.GetFunctionLoader().LoadProcAddresses(
                         &m_context, instance.GetNativeInstance(), physicalDevice.GetNativePhysicalDevice(), m_nativeDevice))
                 {
-                    AZ_Warning("Vulkan", false, "Could not initialized function loader.");
+                    AZ_Warning("Vulkan", false, "Could not initialize function loader.");
                     return RHI::ResultCode::Fail;
                 }
             }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
@@ -75,7 +75,7 @@ namespace AZ
             if (!m_functionLoader->Init() ||
                 !m_functionLoader->LoadProcAddresses(&m_context, VK_NULL_HANDLE, VK_NULL_HANDLE, VK_NULL_HANDLE))
             {
-                AZ_Warning("Vulkan", false, "Could not initialized function loader.");
+                AZ_Warning("Vulkan", false, "Could not initialize function loader.");
                 return false;
             }
 


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

ASV RHI and RPI samples crashed when running on Quest2 with GPU detailed profiling mode enabled (`'adb shell ovrgpuprofiler -e`), which allows the use of `GPU systrace` and `ovrgpuprofiler` tools.

There were 2 crashes when GPU detailed profiling mode is enabled:
1. XR pipeline calling `LoadProcAddresses` passing the physical device leads to vulkan extensions enabled when they are not supported in an XR environment. To fix this issue the RHI::Device just uses the glad context returned from XR, that way only XR's device is responsible to do `LoadProcAddresses`.
2. With an XR pipeline it crashes when creating the default swapchain. Since the default swapchain isn't used anyway in non-host platforms when there is an xr system, now it's not created, saving memory and avoiding the crash (which was a segfault happing in the vulkan internals when creating the swapchain).

This PR goes in conjunction with this PR in o3de-extras: https://github.com/o3de/o3de-extras/pull/43

## How was this PR tested?

Run ASV RHI and RPI samples on Quest 2 with GPU detailed profiling mode enabled and disabled.
Able to capture render stage metrics with both `GPU systrace` and `ovrgpuprofiler` tools.