### PR TITLE
Fixed misnamed `GetFilenameCompatibleFormatNowWithMicroseconds`

### DIFF
--- a/Code/Framework/AzCore/AzCore/Date/DateFormat.cpp
+++ b/Code/Framework/AzCore/AzCore/Date/DateFormat.cpp
@@ -50,7 +50,7 @@ namespace AZ::Date
         return GetFilenameCompatibleFormatWithMilliseconds(utcTimestamp, AZStd::chrono::utc_clock::now());
     }
 
-    bool GetFilenameCompatibleBasicFormatNowWithMicroseconds(Iso8601TimestampString& utcTimestamp)
+    bool GetFilenameCompatibleFormatNowWithMicroseconds(Iso8601TimestampString& utcTimestamp)
     {
         return GetFilenameCompatibleFormatWithMicroseconds(utcTimestamp, AZStd::chrono::utc_clock::now());
     }


### PR DESCRIPTION
The function was incorrectly named
`GetFilenameCompatibleBasicFormatNowWithMicroseconds`

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

