### PR TITLE
{lyn15599} updating asset cache server tab ordering

### DIFF
--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
@@ -831,7 +831,7 @@ void MainWindow::AddPatternRow(AZStd::string_view name, AssetBuilderSDK::AssetBu
     button->setStyleSheet("QPushButton { background-color: transparent; border: 0px }");
     ui->sharedCacheTable->setCellWidget(row, aznumeric_cast<int>(PatternColumns::Remove), button);
     ui->sharedCacheTable->setColumnWidth(aznumeric_cast<int>(PatternColumns::Remove), 16);
-    button->setToolTip(tr("Removes the pattern from to be considered for caching"));
+    button->setToolTip(tr("Removes the pattern to be considered for caching"));
     QObject::connect(button, &QPushButton::clicked, this,
         [this]()
         {

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
@@ -802,10 +802,12 @@ void MainWindow::AddPatternRow(AZStd::string_view name, AssetBuilderSDK::AssetBu
     QObject::connect(enableChackmark, &QCheckBox::stateChanged, ui->sharedCacheTable, updateStatus);
     ui->sharedCacheTable->setCellWidget(row, aznumeric_cast<int>(PatternColumns::Enabled), enableChackmark);
     ui->sharedCacheTable->setColumnWidth(aznumeric_cast<int>(PatternColumns::Enabled), 8);
+    enableChackmark->setToolTip(tr("Temporarily disable the pattern by unchecking this box"));
 
     // Name
     auto* nameWidgetItem = new QTableWidgetItem(name.data());
     ui->sharedCacheTable->setItem(row, aznumeric_cast<int>(PatternColumns::Name), nameWidgetItem);
+    nameWidgetItem->setToolTip(tr("Name of the pattern or title name of an asset builder"));
 
     // Type combo
     auto* combo = new QComboBox();
@@ -814,10 +816,12 @@ void MainWindow::AddPatternRow(AZStd::string_view name, AssetBuilderSDK::AssetBu
     combo->addItem("Regex", QVariant(AssetBuilderPattern::PatternType::Regex));
     combo->setCurrentIndex(aznumeric_cast<int>(type));
     ui->sharedCacheTable->setCellWidget(row, aznumeric_cast<int>(PatternColumns::Type), combo);
+    combo->setToolTip(tr("Wildcard is a file wild card pattern; Regex is a regular expression pattern"));
 
     // Pattern
     auto* patternWidgetItem = new QTableWidgetItem(pattern.data());
     ui->sharedCacheTable->setItem(row, aznumeric_cast<int>(PatternColumns::Pattern), patternWidgetItem);
+    patternWidgetItem->setToolTip(tr("String pattern to match source assets"));
 
     // Remove button
     auto* button = new QPushButton();
@@ -827,6 +831,7 @@ void MainWindow::AddPatternRow(AZStd::string_view name, AssetBuilderSDK::AssetBu
     button->setStyleSheet("QPushButton { background-color: transparent; border: 0px }");
     ui->sharedCacheTable->setCellWidget(row, aznumeric_cast<int>(PatternColumns::Remove), button);
     ui->sharedCacheTable->setColumnWidth(aznumeric_cast<int>(PatternColumns::Remove), 16);
+    button->setToolTip(tr("Removes the pattern from to be considered for caching"));
     QObject::connect(button, &QPushButton::clicked, this,
         [this]()
         {

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
@@ -1757,7 +1757,11 @@
               </widget>
              </item>
              <item row="5" column="0" colspan="4">
-              <widget class="QLineEdit" name="serverAddressLineEdit"/>
+              <widget class="QLineEdit" name="serverAddressLineEdit">
+               <property name="toolTip">
+                <string>Set the remote folder location for the shared cache</string>
+               </property>
+              </widget>
              </item>
              <item row="9" column="4">
               <widget class="QPushButton" name="sharedCacheDiscardButton">
@@ -1965,6 +1969,45 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>supportButton</tabstop>
+  <tabstop>sharedCacheSupport</tabstop>
+  <tabstop>serverCacheModeOptions</tabstop>
+  <tabstop>serverAddressLineEdit</tabstop>
+  <tabstop>serverAddressToolButton</tabstop>
+  <tabstop>sharedCacheAddPattern</tabstop>
+  <tabstop>sharedCacheTable</tabstop>
+  <tabstop>sharedCacheSubmitButton</tabstop>
+  <tabstop>sharedCacheDiscardButton</tabstop>
+  <tabstop>editConnectionButton</tabstop>
+  <tabstop>addConnectionButton</tabstop>
+  <tabstop>removeConnectionButton</tabstop>
+  <tabstop>connectionTreeView</tabstop>
+  <tabstop>allowedListEnableCheckBox</tabstop>
+  <tabstop>allowedListAddHostNameLineEdit</tabstop>
+  <tabstop>allowedListAddHostNameToolButton</tabstop>
+  <tabstop>allowedListAddIPLineEdit</tabstop>
+  <tabstop>allowedListAddIPToolButton</tabstop>
+  <tabstop>allowListAllowedListConnectionsListView</tabstop>
+  <tabstop>allowedListToAllowedListToolButton</tabstop>
+  <tabstop>allowedListToRejectedListToolButton</tabstop>
+  <tabstop>allowedListRejectedConnectionsListView</tabstop>
+  <tabstop>builderList</tabstop>
+  <tabstop>builderInfoTabWidget</tabstop>
+  <tabstop>builderInfoPatternsTableView</tabstop>
+  <tabstop>builderInfoMetricsTreeView</tabstop>
+  <tabstop>modtimeSkippingCheckBox</tabstop>
+  <tabstop>debugOutputCheckBox</tabstop>
+  <tabstop>fullScanButton</tabstop>
+  <tabstop>missingDependencyScanResults</tabstop>
+  <tabstop>assetsTabWidget</tabstop>
+  <tabstop>logButton</tabstop>
+  <tabstop>ProductAssetsTreeView</tabstop>
+  <tabstop>IntermediateAssetsTreeView</tabstop>
+  <tabstop>jobContextLogTableView</tabstop>
+  <tabstop>SourceAssetsTreeView</tabstop>
+  <tabstop>jobTreeView</tabstop>
+ </tabstops>
  <resources>
   <include location="style/AssetProcessor.qrc"/>
  </resources>


### PR DESCRIPTION
## What does this PR do?

* added tab stops for each input field for the asset cache server
* added tool tips for the input fields

## How was this PR tested?

Manually used the Asset Processor GUI tool in the Shared Cache tool.
