### PR TITLE
Fix early return when destroying entity and descendants

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
@@ -311,7 +311,7 @@ namespace AzFramework
                                     spawnableEntitiesInterface->DespawnEntity(currentEntity->GetId(), entitySpawnTicket);
                                 }
                             });
-                        return;
+                        continue;
                     }
                 }
 


### PR DESCRIPTION
Signed-off-by: michabr <82236305+michabr@users.noreply.github.com>

## What does this PR do?

In the function that destroys an entity and its descendants, it loops through all entities to be deleted. If an entity has a valid spawn ticket, it queues up a command to get the spawn ticket, and then returns. (Later when the spawn ticket is retrieved, a command to despawn the entity is queued, which ends up calling the same DestroyGameEntityInternal function, but this time the spawn ticket will be 0 and the entity will be deleted.)

This PR changes the "return" to a "continue" so that it can go through all entities to be deleted.

Fixes #12003

## How was this PR tested?

Tested using repro steps in the ticket. Also tested with nested children to make sure those get deleted as well.
