### PR TITLE
GraphCanvas node palette in EMotionFX node palette dock

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphPlugin.cpp
@@ -42,6 +42,7 @@
 #include <EMotionStudio/EMStudioSDK/Source/SaveChangedFilesManager.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphActionManager.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphModel.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NavigationHistory.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterEditor/ParameterEditorFactory.h>
 #include <MysticQt/Source/DialogStack.h>
@@ -338,6 +339,7 @@ namespace EMStudio
     void AnimGraphPlugin::Reflect(AZ::ReflectContext* context)
     {
         AnimGraphOptions::Reflect(context);
+        BlendGraphMimeEvent::Reflect(context);
         ParameterEditorFactory::ReflectParameterEditorTypes(context);
     }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.cpp
@@ -35,6 +35,7 @@
 #include <MysticQt/Source/KeyboardShortcutManager.h>
 #include <MCore/Source/LogManager.h>
 #include <GraphCanvas/Widgets/GraphCanvasTreeItem.h>
+#include <GraphCanvas/Widgets/GraphCanvasMimeContainer.h>
 #include <GraphCanvas/Widgets/NodePalette/TreeItems/NodePaletteTreeItem.h>
 // qt includes
 #include <QDropEvent>
@@ -46,8 +47,20 @@
 
 namespace EMStudio
 {
-    BlendGraphMimeEvent::BlendGraphMimeEvent(QString typeString, QString namePrefix)
-        : GraphCanvas::GraphCanvasMimeEvent(), m_typeString(typeString), m_namePrefix(namePrefix)
+    void BlendGraphMimeEvent::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<BlendGraphMimeEvent, GraphCanvas::GraphCanvasMimeEvent>()
+                ->Version(0)
+                ->Field("typeString", &BlendGraphMimeEvent::m_typeString)
+                ->Field("namePrefix", &BlendGraphMimeEvent::m_namePrefix);
+        }
+    }
+    BlendGraphMimeEvent::BlendGraphMimeEvent(AZStd::string_view typeString, AZStd::string_view namePrefix)
+        : GraphCanvas::GraphCanvasMimeEvent()
+        , m_typeString(typeString)
+        , m_namePrefix(namePrefix)
     {
     }
 
@@ -62,19 +75,19 @@ namespace EMStudio
         return false;
     }
 
-    QString BlendGraphMimeEvent::GetTypeString() const
+    AZStd::string BlendGraphMimeEvent::GetTypeString() const
     {
         return m_typeString;
     }
 
-    QString BlendGraphMimeEvent::GetNamePrefix() const
+    AZStd::string BlendGraphMimeEvent::GetNamePrefix() const
     {
         return m_namePrefix;
     }
 
     BlendGraphNodePaletteTreeItem::BlendGraphNodePaletteTreeItem(
-        AZStd::string_view name, const QString& typeString, GraphCanvas::EditorId editorId, const AZ::Color& color)
-        : GraphCanvas::IconDecoratedNodePaletteTreeItem(name, editorId)
+        const AZStd::string_view name, const QString& typeString, GraphCanvas::EditorId editorId, const AZ::Color& color)
+        : GraphCanvas::DraggableNodePaletteTreeItem(name, editorId)
         , m_typeString(typeString)
     {
         // Draw a pixmap with the provided color to use as an icon adjacent to the name text
@@ -109,12 +122,12 @@ namespace EMStudio
         {
             return QVariant(m_colorPixmap);
         }
-        return NodePaletteTreeItem::OnData(index, role);
+        return GraphCanvas::DraggableNodePaletteTreeItem::OnData(index, role);
     }
 
     BlendGraphMimeEvent* BlendGraphNodePaletteTreeItem::CreateMimeEvent() const
     {
-        return IsEnabled() ? new BlendGraphMimeEvent(m_typeString, GetName()) : nullptr;
+        return IsEnabled() ? new BlendGraphMimeEvent(FromQtString(m_typeString), FromQtString(GetName())) : nullptr;
     }
 
     // constructor
@@ -155,6 +168,30 @@ namespace EMStudio
             return;
         }
 
+        // calculate the drop position
+        QPoint localPos = LocalToGlobal(event->pos());
+
+        // Dragged from node palette
+        if (event->mimeData()->hasFormat(BlendGraphMimeEvent::BlendGraphMimeEventType))
+        {
+            GraphCanvas::GraphCanvasMimeContainer mimeContainer;
+            const QByteArray mimeDataBuffer = event->mimeData()->data(BlendGraphMimeEvent::BlendGraphMimeEventType);
+            mimeContainer.FromBuffer(mimeDataBuffer.constData(), mimeDataBuffer.size());
+
+            // When adding multiple nodes together, position them a bit differently
+            // so they don't end up on top of each other looking like only one was added
+            int offset = 0;
+            for (GraphCanvas::GraphCanvasMimeEvent* graphCanvasEvent : mimeContainer.m_mimeEvents)
+            {
+                if (auto* blendGraphEvent = azrtti_cast<BlendGraphMimeEvent*>(graphCanvasEvent))
+                {
+                    const QPoint nudgedPosition = { localPos.x(), localPos.y() + offset };
+                    offset += 10;
+                    CreateNodeFromMimeEvent(blendGraphEvent, nudgedPosition);
+                }
+            }
+        }
+
         // only accept copy actions
         if (event->dropAction() != Qt::CopyAction || event->mimeData()->hasText() == false)
         {
@@ -166,8 +203,6 @@ namespace EMStudio
         AZStd::string dropText = FromQtString(event->mimeData()->text());
         MCore::CommandLine commandLine(dropText.c_str());
 
-        // calculate the drop position
-        QPoint offset = LocalToGlobal(event->pos());
         QModelIndex targetModelIndex;
         if (GetActiveGraph())
         {
@@ -207,10 +242,10 @@ namespace EMStudio
                         if (targetModelIndex.isValid())
                         {
                             EMotionFX::AnimGraphNode* currentNode = targetModelIndex.data(AnimGraphModel::ROLE_NODE_POINTER).value<EMotionFX::AnimGraphNode*>();
-                            CommandSystem::CreateAnimGraphNode(&commandGroup, currentNode->GetAnimGraph(), AZ::Uuid::CreateName("BlendTreeMotionNode"), "Motion", currentNode, offset.x(), offset.y(), serializedMotionNode.GetValue());
+                            CommandSystem::CreateAnimGraphNode(&commandGroup, currentNode->GetAnimGraph(), AZ::Uuid::CreateName("BlendTreeMotionNode"), "Motion", currentNode, localPos.x(), localPos.y(), serializedMotionNode.GetValue());
 
                             // setup the offset for the next motion
-                            offset.setY(offset.y() + 60);
+                            localPos.setY(localPos.y() + 60);
                         }
                     }
                 }
@@ -278,10 +313,10 @@ namespace EMStudio
                         if (serializedContent.IsSuccess())
                         {
                             EMotionFX::AnimGraphNode* currentNode = targetModelIndex.data(AnimGraphModel::ROLE_NODE_POINTER).value<EMotionFX::AnimGraphNode*>();
-                            CommandSystem::CreateAnimGraphNode(&commandGroup, currentNode->GetAnimGraph(), azrtti_typeid<EMotionFX::AnimGraphMotionNode>(), "Motion", currentNode, offset.x(), offset.y(), serializedContent.GetValue());
+                            CommandSystem::CreateAnimGraphNode(&commandGroup, currentNode->GetAnimGraph(), azrtti_typeid<EMotionFX::AnimGraphMotionNode>(), "Motion", currentNode, localPos.x(), localPos.y(), serializedContent.GetValue());
 
                             // setup the offset for the next motion
-                            offset.setY(offset.y() + 60);
+                            localPos.setY(localPos.y() + 60);
                         }
                     }
                     else
@@ -316,43 +351,18 @@ namespace EMStudio
                         AZ::Outcome<AZStd::string> serializedMotionNode = MCore::ReflectionSerializer::Serialize(&tempMotionNode);
                         if (serializedMotionNode.IsSuccess())
                         {
-                            EMotionFX::AnimGraphNode* currentNode = targetModelIndex.data(AnimGraphModel::ROLE_NODE_POINTER).value<EMotionFX::AnimGraphNode*>();
-                            CommandSystem::CreateAnimGraphNode(&commandGroup, currentNode->GetAnimGraph(), azrtti_typeid<EMotionFX::AnimGraphMotionNode>(), "Motion", currentNode, offset.x(), offset.y(), serializedMotionNode.GetValue());
+                            EMotionFX::AnimGraphNode* currentNode = targetModelIndex.data(AnimGraphModel::ROLE_NODE_POINTER)
+                                .value<EMotionFX::AnimGraphNode*>();
+                            CommandSystem::CreateAnimGraphNode(&commandGroup, currentNode->GetAnimGraph(),
+                                azrtti_typeid<EMotionFX::AnimGraphMotionNode>(), "Motion", currentNode, localPos.x(), localPos.y(),
+                                serializedMotionNode.GetValue());
 
                             // setup the offset for the next motion
-                            offset.setY(offset.y() + 60);
+                            localPos.setY(localPos.y() + 60);
                         }
                     }
                 }
             }
-        }
-        // default handling, we're drag & dropping from the palette window
-        else
-        {
-            AZStd::vector<AZStd::string> parts;
-            AzFramework::StringFunc::Tokenize(dropText.c_str(), parts, ";", false, true);
-            if (parts.size() != 3)
-            {
-                MCore::LogError("BlendGraphWidget::dropEvent() - Incorrect syntax using drop data '%s'", FromQtString(event->mimeData()->text()).c_str());
-                event->ignore();
-                return;
-            }
-
-            AZStd::string commandString;
-            AZStd::string resultString;
-            EMotionFX::AnimGraphNode* currentNode = targetModelIndex.data(AnimGraphModel::ROLE_NODE_POINTER).value<EMotionFX::AnimGraphNode*>();
-            if (!currentNode)
-            {
-                event->ignore();
-                return;
-            }
-
-            // build the name prefix
-            AZStd::string& namePrefix = parts[2];
-            AzFramework::StringFunc::Strip(namePrefix, MCore::CharacterConstants::space, true /* case sensitive */);
-
-            const AZ::TypeId typeId = AZ::TypeId::CreateString(parts[1].c_str(), parts[1].size());
-            CommandSystem::CreateAnimGraphNode(&commandGroup, currentNode->GetAnimGraph(), typeId, namePrefix, currentNode, offset.x(), offset.y());
         }
 
         if (!commandGroup.IsEmpty())
@@ -368,8 +378,15 @@ namespace EMStudio
     }
 
 
-    bool BlendGraphWidget::OnEnterDropEvent(QDragEnterEvent* event, EMotionFX::AnimGraphNode* currentNode, NodeGraph* activeGraph)
+    bool BlendGraphWidget::OnEnterDropEvent(QDragEnterEvent* event, EMotionFX::AnimGraphNode* currentNode)
     {
+        if (event->mimeData()->hasFormat(BlendGraphMimeEvent::BlendGraphMimeEventType))
+        {
+            // If it's coming from node palette it should be legal to add because node palette
+            // filters for only the permitted ones
+            return true;
+        }
+
         if (event->mimeData()->hasText() == false)
         {
             return false;
@@ -395,69 +412,7 @@ namespace EMStudio
             {
                 return true;
             }
-
-            return false;
         }
-
-        AZStd::vector<AZStd::string> parts;
-        AzFramework::StringFunc::Tokenize(dropText.c_str(), parts, MCore::CharacterConstants::semiColon, true /* keep empty strings */, true /* keep space strings */);
-
-        if (parts.size() != 3)
-        {
-            //MCore::LogError("BlendGraphWidget::dropEvent() - Incorrect syntax using drop data '%s'", FromQtString(event->mimeData()->text()).AsChar());
-            return false;
-        }
-
-        if (parts[0].find("EMotionFX::AnimGraphNode") != 0)
-        {
-            return false;
-        }
-
-        // check if the dropped node is a state machine node
-        bool canActAsState = false;
-        const AZ::TypeId typeId = AZ::TypeId::CreateString(parts[1].c_str(), parts[1].size());
-        if (!typeId.IsNull())
-        {
-            EMotionFX::AnimGraphObject* registeredObject = EMotionFX::AnimGraphObjectFactory::Create(typeId);
-            MCORE_ASSERT(azrtti_istypeof<EMotionFX::AnimGraphNode>(registeredObject));
-
-            EMotionFX::AnimGraphNode* registeredNode = static_cast<EMotionFX::AnimGraphNode*>(registeredObject);
-            if (registeredNode->GetCanActAsState())
-            {
-                canActAsState = true;
-            }
-
-            delete registeredObject;
-        }
-
-        // in case the current node is nullptr and the active graph is a valid graph it means we are showing the root graph
-        if (currentNode == nullptr)
-        {
-            if (activeGraph)
-            {
-                // only state machine nodes are allowed in the root graph
-                if (canActAsState)
-                {
-                    return true;
-                }
-            }
-        }
-        else
-        {
-            // check if we need to prevent dropping of non-state machine nodes
-            if (azrtti_typeid(currentNode) == azrtti_typeid<EMotionFX::AnimGraphStateMachine>())
-            {
-                if (canActAsState)
-                {
-                    return true;
-                }
-            }
-            else
-            {
-                return true;
-            }
-        }
-
         return false;
     }
 
@@ -469,7 +424,7 @@ namespace EMStudio
         if (GetActiveGraph())
         {
             EMotionFX::AnimGraphNode* currentNode = GetActiveGraph()->GetModelIndex().data(AnimGraphModel::ROLE_NODE_POINTER).value<EMotionFX::AnimGraphNode*>();
-            bool acceptEnterEvent = OnEnterDropEvent(event, currentNode, GetActiveGraph());
+            bool acceptEnterEvent = OnEnterDropEvent(event, currentNode);
 
             if (acceptEnterEvent)
             {
@@ -498,27 +453,32 @@ namespace EMStudio
 
     void BlendGraphWidget::OnContextMenuCreateNode(const BlendGraphMimeEvent* event)
     {
+        // calculate the position
+        const QPoint offset = SnapLocalToGrid(LocalToGlobal(m_contextMenuEventMousePos));
+        CreateNodeFromMimeEvent(event, offset);
+    }
+
+    void BlendGraphWidget::CreateNodeFromMimeEvent(const BlendGraphMimeEvent* event, const QPoint& location )
+    {
         NodeGraph* nodeGraph = GetActiveGraph();
         if (!nodeGraph || !event)
         {
             return;
         }
 
-        // calculate the position
-        const QPoint offset = SnapLocalToGrid(LocalToGlobal(m_contextMenuEventMousePos));
-
-        const AZStd::string typeString = FromQtString(event->GetTypeString());
+        const AZStd::string typeString = event->GetTypeString();
         if(typeString.empty())
         {
             return;
         }
-        AZStd::string namePrefix = FromQtString(event->GetNamePrefix());
+        AZStd::string namePrefix = event->GetNamePrefix();
         AzFramework::StringFunc::Strip(namePrefix, MCore::CharacterConstants::space, true /* case sensitive */);
         const AZ::TypeId typeId = AZ::TypeId::CreateString(typeString.c_str(), typeString.size());
 
         const QModelIndex modelIndex = nodeGraph->GetModelIndex();
         EMotionFX::AnimGraphNode* currentNode = modelIndex.data(AnimGraphModel::ROLE_NODE_POINTER).value<EMotionFX::AnimGraphNode*>();
-        CommandSystem::CreateAnimGraphNode(/*commandGroup=*/nullptr, currentNode->GetAnimGraph(), typeId, namePrefix, currentNode, offset.x(), offset.y());
+        CommandSystem::CreateAnimGraphNode(
+            /*commandGroup=*/nullptr, currentNode->GetAnimGraph(), typeId, namePrefix, currentNode, location.x(), location.y());
     }
 
     bool BlendGraphWidget::CheckIfIsStateMachine()

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.h
@@ -14,7 +14,7 @@
 #include <EMotionStudio/Plugins/StandardPlugins/Source/StandardPluginsConfig.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphModel.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodeGraphWidget.h>
-#include <GraphCanvas/Widgets/NodePalette/TreeItems/IconDecoratedNodePaletteTreeItem.h>
+#include <GraphCanvas/Widgets/NodePalette/TreeItems/DraggableNodePaletteTreeItem.h>
 #include <GraphCanvas/Widgets/GraphCanvasMimeEvent.h>
 #include <MCore/Source/CommandGroup.h>
 #endif
@@ -37,20 +37,30 @@ namespace EMStudio
     class BlendGraphMimeEvent : public GraphCanvas::GraphCanvasMimeEvent
     {
     public:
-        explicit BlendGraphMimeEvent(QString typeString, QString namePrefix);
+        AZ_RTTI(BlendGraphMimeEvent, "{AA7C8960-C7BA-4F26-B52B-97CF4AC3CB39}", GraphCanvas::GraphCanvasMimeEvent);
+        AZ_CLASS_ALLOCATOR(BlendGraphMimeEvent, AZ::SystemAllocator, 0);
+        static void Reflect(AZ::ReflectContext* context);
+
+        BlendGraphMimeEvent() = default;
+        BlendGraphMimeEvent(AZStd::string_view typeString, AZStd::string_view namePrefix);
+
         bool ExecuteEvent(const AZ::Vector2& sceneMousePosition, AZ::Vector2& sceneDropPosition, const AZ::EntityId& sceneId) override;
 
-        QString GetTypeString() const;
-        QString GetNamePrefix() const;
+        AZStd::string GetTypeString() const;
+        AZStd::string GetNamePrefix() const;
+
+        static constexpr const char* BlendGraphMimeEventType = "animgraph/node-palette-mime-event";
+
     private:
-        QString m_typeString;
-        QString m_namePrefix;
+        AZStd::string m_typeString;
+        AZStd::string m_namePrefix;
     };
 
-    class BlendGraphNodePaletteTreeItem : public GraphCanvas::IconDecoratedNodePaletteTreeItem
+    class BlendGraphNodePaletteTreeItem : public GraphCanvas::DraggableNodePaletteTreeItem
     {
     public:
-        BlendGraphNodePaletteTreeItem(AZStd::string_view name, const QString& typeString, GraphCanvas::EditorId editorId, const AZ::Color& color);
+        BlendGraphNodePaletteTreeItem(
+            const AZStd::string_view name, const QString& typeString, GraphCanvas::EditorId editorId, const AZ::Color& color);
         BlendGraphMimeEvent* CreateMimeEvent() const override;
 
         void SetTypeString(const QString& typeString);
@@ -95,7 +105,7 @@ namespace EMStudio
 
         void DeleteSelectedItems(NodeGraph* nodeGraph);
 
-        static bool OnEnterDropEvent(QDragEnterEvent* event, EMotionFX::AnimGraphNode* currentNode, NodeGraph* activeGraph);
+        static bool OnEnterDropEvent(QDragEnterEvent* event, EMotionFX::AnimGraphNode* currentNode);
 
         // checks if the currently shown graph is a state machine
         bool CheckIfIsStateMachine();
@@ -103,8 +113,6 @@ namespace EMStudio
         // context menu shared function (definitions in ContextMenu.cpp)
         void AddNodeGroupSubmenu(QMenu* menu, EMotionFX::AnimGraph* animGraph, const AZStd::vector<EMotionFX::AnimGraphNode*>& selectedNodes);
         void AddPreviewMotionSubmenu(QMenu* menu, AnimGraphActionManager* actionManager, const EMotionFX::AnimGraphNode* selectedNode);
-        void AddAnimGraphObjectCategoryMenu(AnimGraphPlugin* plugin, QMenu* parentMenu,
-            EMotionFX::AnimGraphObject::ECategory category, EMotionFX::AnimGraphObject* focusedGraphObject);
         void AddCategoryToNodePalette(EMotionFX::AnimGraphNode::ECategory category, GraphCanvas::NodePaletteTreeItem* rootNode,
             EMotionFX::AnimGraphObject* focusedGraphObject);
 
@@ -137,6 +145,7 @@ namespace EMStudio
     public slots:
         void DeleteSelectedItems();
         void OnContextMenuCreateNode(const BlendGraphMimeEvent* event);
+        void CreateNodeFromMimeEvent(const BlendGraphMimeEvent* event, const QPoint& location);
         void OnNodeGroupSelected();
         void EnableSelectedTransitions()                    { SetSelectedTransitionsEnabled(true); }
         void DisableSelectedTransitions()                   { SetSelectedTransitionsEnabled(false); }

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ContextMenu.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ContextMenu.cpp
@@ -21,6 +21,7 @@
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphViewWidget.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodePaletteWidget.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodePaletteModelUpdater.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetsWindowPlugin.h>
 #include <GraphCanvas/Widgets/NodePalette/TreeItems/NodePaletteTreeItem.h>
 #include <GraphCanvas/Widgets/NodePalette/NodePaletteWidget.h>
@@ -30,39 +31,6 @@
 
 namespace EMStudio
 {
-    // Fill the node palette tree view with the anim graph objects that can be created inside the current given object and category.
-    void BlendGraphWidget::AddCategoryToNodePalette(EMotionFX::AnimGraphNode::ECategory category, GraphCanvas::NodePaletteTreeItem* rootNode,
-        EMotionFX::AnimGraphObject* focusedGraphObject)
-    {
-        const AZStd::vector<EMotionFX::AnimGraphObject*>& objectPrototypes = m_plugin->GetAnimGraphObjectFactory()->GetUiObjectPrototypes();
-        // If the category is empty, don't add a node for it
-        if (objectPrototypes.empty())
-        {
-            return;
-        }
-        const char* categoryName = EMotionFX::AnimGraphObject::GetCategoryName(category);
-
-        auto* categoryNode = rootNode->CreateChildNode<GraphCanvas::NodePaletteTreeItem>(categoryName, AnimGraphEditorId);
-        bool categoryEnabled = false;
-        for (const EMotionFX::AnimGraphObject* objectPrototype : objectPrototypes)
-        {
-            if (objectPrototype->GetPaletteCategory() != category)
-            {
-                continue;
-            }
-
-            bool active = m_plugin->CheckIfCanCreateObject(focusedGraphObject, objectPrototype, category);
-            categoryEnabled |= active;
-            const EMotionFX::AnimGraphNode* nodePrototype = static_cast<const EMotionFX::AnimGraphNode*>(objectPrototype);
-
-            const QString typeString = azrtti_typeid(nodePrototype).ToString<QString>();
-            auto* node = categoryNode->CreateChildNode<BlendGraphNodePaletteTreeItem>(
-                nodePrototype->GetPaletteName(), typeString, AnimGraphEditorId, nodePrototype->GetVisualColor());
-            node->SetEnabled(active);
-        }
-        categoryNode->SetEnabled(categoryEnabled);
-    }
-
     void BlendGraphWidget::AddNodeGroupSubmenu(QMenu* menu, EMotionFX::AnimGraph* animGraph, const AZStd::vector<EMotionFX::AnimGraphNode*>& selectedNodes)
     {
         // node group sub menu
@@ -185,34 +153,21 @@ namespace EMStudio
 
                 if (actionFilter.m_createNodes)
                 {
-                    const AZStd::vector<EMotionFX::AnimGraphNode::ECategory> categories =
-                    {
-                        EMotionFX::AnimGraphNode::CATEGORY_SOURCES,
-                        EMotionFX::AnimGraphNode::CATEGORY_BLENDING,
-                        EMotionFX::AnimGraphNode::CATEGORY_CONTROLLERS,
-                        EMotionFX::AnimGraphNode::CATEGORY_PHYSICS,
-                        EMotionFX::AnimGraphNode::CATEGORY_LOGIC,
-                        EMotionFX::AnimGraphNode::CATEGORY_MATH,
-                        EMotionFX::AnimGraphNode::CATEGORY_MISC
-                    };
-
                     // Create nodes in palette view for each of the categories that are possible to be added to the currently focused graph.
                     EMotionFX::AnimGraphNode* currentNode = nodeGraph->GetModelIndex().data(AnimGraphModel::ROLE_NODE_POINTER).value<EMotionFX::AnimGraphNode*>();
 
                     auto* action = new QWidgetAction(menu);
-                    auto* rootItem = new GraphCanvas::NodePaletteTreeItem("root", AnimGraphEditorId);
+
+                    NodePaletteModelUpdater modelUpdater{ plugin };
+                    modelUpdater.InitForNode(currentNode);
+
                     GraphCanvas::NodePaletteConfig config;
-                    config.m_rootTreeItem = rootItem;
+                    config.m_rootTreeItem = modelUpdater.GetRootItem();
                     config.m_isInContextMenu = true;
                     auto* paletteWidget = new GraphCanvas::NodePaletteWidget(nullptr);
                     paletteWidget->SetupNodePalette(config);
                     action->setDefaultWidget(paletteWidget);
                     menu->addAction(action);
-
-                    for (const EMotionFX::AnimGraphNode::ECategory category: categories)
-                    {
-                        AddCategoryToNodePalette(category, rootItem, currentNode);
-                    }
 
                     connect(menu, &QMenu::aboutToShow, paletteWidget, [=](){
                         paletteWidget->FocusOnSearchFilter();

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ContextMenu.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ContextMenu.cpp
@@ -144,6 +144,7 @@ namespace EMStudio
             if (graphNode == nullptr)
             {
                 QMenu* menu = new QMenu(parentWidget);
+                menu->setAttribute(Qt::WA_DeleteOnClose);
 
                 if (actionFilter.m_copyAndPaste && actionManager.GetIsReadyForPaste() && nodeGraph->GetModelIndex().isValid())
                 {
@@ -181,8 +182,6 @@ namespace EMStudio
                             }
                     });
                 }
-
-                connect(menu, &QMenu::triggered, menu, &QMenu::deleteLater);
 
                 if (!menu->isEmpty())
                 {

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodePaletteModelUpdater.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodePaletteModelUpdater.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "NodePaletteModelUpdater.h"
+#include <EMotionFX/Source/AnimGraphObjectFactory.h>
+#include <EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphPlugin.h>
+#include <EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.h>
+#include <GraphCanvas/Widgets/NodePalette/TreeItems/NodePaletteTreeItem.h>
+
+namespace EMStudio
+{
+    NodePaletteModelUpdater::NodePaletteModelUpdater(AnimGraphPlugin* plugin)
+        : m_rootItem(aznew GraphCanvas::NodePaletteTreeItem("root", AnimGraphEditorId))
+        , m_plugin(plugin)
+
+    {
+        static const EMotionFX::AnimGraphNode::ECategory categories[] = {
+            EMotionFX::AnimGraphNode::CATEGORY_SOURCES,     EMotionFX::AnimGraphNode::CATEGORY_BLENDING,
+            EMotionFX::AnimGraphNode::CATEGORY_CONTROLLERS, EMotionFX::AnimGraphNode::CATEGORY_PHYSICS,
+            EMotionFX::AnimGraphNode::CATEGORY_LOGIC,       EMotionFX::AnimGraphNode::CATEGORY_MATH,
+            EMotionFX::AnimGraphNode::CATEGORY_MISC
+        };
+
+        for (EMotionFX::AnimGraphNode::ECategory category : categories)
+        {
+            const char* categoryName = EMotionFX::AnimGraphObject::GetCategoryName(category);
+            auto* node = m_rootItem->CreateChildNode<GraphCanvas::NodePaletteTreeItem>(categoryName, AnimGraphEditorId);
+            m_categoryNodes.insert({ category, node });
+        }
+    }
+
+    GraphCanvas::NodePaletteTreeItem* NodePaletteModelUpdater::GetRootItem()
+    {
+        return m_rootItem;
+    }
+
+    void NodePaletteModelUpdater::InitForNode(EMotionFX::AnimGraphNode* focusNode)
+    {
+        for (auto& [category, categoryNode] : m_categoryNodes)
+        {
+            categoryNode->ClearChildren();
+            categoryNode->SetEnabled(false);
+        }
+
+        const AZStd::vector<EMotionFX::AnimGraphObject*>& objectPrototypes = m_plugin->GetAnimGraphObjectFactory()->GetUiObjectPrototypes();
+        for (const EMotionFX::AnimGraphObject* objectPrototype : objectPrototypes)
+        {
+            const EMotionFX::AnimGraphObject::ECategory objectCategory = objectPrototype->GetPaletteCategory();
+            const auto categoryNodeIt = m_categoryNodes.find(objectCategory);
+            if (categoryNodeIt != m_categoryNodes.end())
+            {
+                const EMotionFX::AnimGraphNode* nodePrototype = static_cast<const EMotionFX::AnimGraphNode*>(objectPrototype);
+                const auto typeString = azrtti_typeid(nodePrototype).ToString<QString>();
+                auto* node = categoryNodeIt->second->CreateChildNode<EMStudio::BlendGraphNodePaletteTreeItem>(
+                    nodePrototype->GetPaletteName(), typeString, AnimGraphEditorId, nodePrototype->GetVisualColor());
+
+                const bool nodeEnabled = focusNode && m_plugin->CheckIfCanCreateObject(focusNode, objectPrototype, categoryNodeIt->first);
+                node->SetEnabled(nodeEnabled);
+
+                if (nodeEnabled)
+                {
+                    categoryNodeIt->second->SetEnabled(true);
+                }
+            }
+        }
+    }
+
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodePaletteModelUpdater.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodePaletteModelUpdater.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <EMotionFX/Source/AnimGraphNode.h>
+
+namespace GraphCanvas
+{
+    class NodePaletteWidget;
+    class NodePaletteTreeItem;
+} // namespace GraphCanvas
+
+namespace EMStudio
+{
+    class AnimGraphPlugin;
+
+    //! NodePaletteModelUpdater
+    //!
+    //! This class builds a hierarchy of GraphCanvas::NodePaletteTreeItem nodes
+    //! that represent nodes that can be added to the anim graph when a given
+    //! node is focused. They will be grouped into EMotionFX node categories.
+    //!
+    //! On initialization and on every change of focused anim graph node you
+    //! need to call InitForNode. Without it, you'll get only empty category
+    //! nodes.
+    //!
+    //! Root node returned by GetRootItem() is typically passed in a config
+    //! for GraphCanvas::NodePaletteWidget setup. Object of this class should live
+    //! no longer than the widget because the widget takes the ownership of the
+    //! root node and the nodes in this class will become dangling pointers if the
+    //! wigdet is destroyed.
+    class NodePaletteModelUpdater
+    {
+    public:
+        explicit NodePaletteModelUpdater(AnimGraphPlugin* plugin);
+        GraphCanvas::NodePaletteTreeItem* GetRootItem();
+        /**
+         * Rebuild the list of available/enabled nodes when a given node is focused
+         */
+        void InitForNode(EMotionFX::AnimGraphNode* focusNode);
+
+    private:
+        AnimGraphPlugin* m_plugin;
+        GraphCanvas::NodePaletteTreeItem* m_rootItem;
+        AZStd::map<EMotionFX::AnimGraphNode::ECategory, GraphCanvas::NodePaletteTreeItem*> m_categoryNodes;
+    };
+
+} // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodePaletteModelUpdater.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodePaletteModelUpdater.h
@@ -40,9 +40,8 @@ namespace EMStudio
     public:
         explicit NodePaletteModelUpdater(AnimGraphPlugin* plugin);
         GraphCanvas::NodePaletteTreeItem* GetRootItem();
-        /**
-         * Rebuild the list of available/enabled nodes when a given node is focused
-         */
+
+        //! Rebuild the list of available/enabled nodes when a given node is focused
         void InitForNode(EMotionFX::AnimGraphNode* focusNode);
 
     private:

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodePaletteWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodePaletteWidget.cpp
@@ -15,6 +15,10 @@
 #include <EMotionFX/Source/AnimGraphNode.h>
 #include <EMotionFX/Source/AnimGraphStateTransition.h>
 #include <EMotionFX/Source/BlendTreeFinalNode.h>
+#include <EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.h>
+#include <GraphCanvas/Widgets/NodePalette/NodePaletteWidget.h>
+#include <GraphCanvas/Widgets/NodePalette/TreeItems/NodePaletteTreeItem.h>
+#include <AzQtComponents/Utilities/Conversions.h>
 #include "AnimGraphPlugin.h"
 #include <QVBoxLayout>
 #include <QIcon>
@@ -28,263 +32,6 @@
 namespace EMStudio
 {
     AZ_CLASS_ALLOCATOR_IMPL(NodePaletteWidget::EventHandler, EMotionFX::EventHandlerAllocator, 0)
-
-    class NodePaletteModel
-        : public QAbstractItemModel
-    {
-    public:
-        explicit NodePaletteModel(AnimGraphPlugin* plugin, QObject* parent = nullptr);
-
-        QModelIndex index(int row, int column, const QModelIndex& parent = {}) const override;
-        QModelIndex parent(const QModelIndex& index) const override;
-
-        int columnCount(const QModelIndex& parent = {}) const override;
-        int rowCount(const QModelIndex& parent = {}) const override;
-
-        QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
-
-        Qt::ItemFlags flags(const QModelIndex& index) const override;
-
-        QStringList mimeTypes() const override;
-        QMimeData* mimeData(const QModelIndexList& indexes) const override;
-
-        void setNode(EMotionFX::AnimGraphNode* node);
-
-        const auto& GetCategoryNames() const { return m_categoryNames; }
-
-    private:
-        void initializeGroups();
-
-        struct CategoryGroup
-        {
-            EMotionFX::AnimGraphNode::ECategory m_category;
-            AZStd::vector<AZStd::pair<EMotionFX::AnimGraphObject*, /*enabled=*/bool>> m_nodes;
-            bool m_enabled = true;
-        };
-
-        AnimGraphPlugin* m_plugin;
-        EMotionFX::AnimGraphNode* m_node = nullptr;
-        AZStd::vector<AZStd::unique_ptr<CategoryGroup>> m_groups;
-
-        // Registered categories and names for this model.
-        AZStd::unordered_map<EMotionFX::AnimGraphNode::ECategory, QString> m_categoryNames;
-    };
-
-    NodePaletteModel::NodePaletteModel(AnimGraphPlugin* plugin, QObject* parent)
-        : QAbstractItemModel(parent)
-        , m_plugin(plugin)
-    {
-        m_categoryNames.emplace(EMotionFX::AnimGraphNode::CATEGORY_SOURCES, NodePaletteWidget::tr("Sources"));
-        m_categoryNames.emplace(EMotionFX::AnimGraphNode::CATEGORY_BLENDING, NodePaletteWidget::tr("Blending"));
-        m_categoryNames.emplace(EMotionFX::AnimGraphNode::CATEGORY_CONTROLLERS, NodePaletteWidget::tr("Controllers"));
-        m_categoryNames.emplace(EMotionFX::AnimGraphNode::CATEGORY_PHYSICS, NodePaletteWidget::tr("Physics"));
-        m_categoryNames.emplace(EMotionFX::AnimGraphNode::CATEGORY_LOGIC, NodePaletteWidget::tr("Logic"));
-        m_categoryNames.emplace(EMotionFX::AnimGraphNode::CATEGORY_MATH, NodePaletteWidget::tr("Math"));
-        m_categoryNames.emplace(EMotionFX::AnimGraphNode::CATEGORY_MISC, NodePaletteWidget::tr("Misc"));
-    }
-
-    QModelIndex NodePaletteModel::index(int row, int column, const QModelIndex& parent) const
-    {
-        if (!parent.isValid())
-        {
-            if (row >= 0 && row < static_cast<int>(m_groups.size()))
-            {
-                return createIndex(row, column, nullptr);
-            }
-        }
-        else
-        {
-            if (parent.row() >= 0 && parent.row() < static_cast<int>(m_groups.size()))
-            {
-                const auto& group = m_groups[parent.row()];
-                if (row >= 0 && row < static_cast<int>(group->m_nodes.size()))
-                {
-                    return createIndex(row, column, const_cast<CategoryGroup*>(group.get()));
-                }
-            }
-        }
-        return {};
-    }
-
-    QModelIndex NodePaletteModel::parent(const QModelIndex& index) const
-    {
-        if (!index.isValid())
-        {
-            return {};
-        }
-        if (const auto* group = static_cast<CategoryGroup*>(index.internalPointer()))
-        {
-            auto it = std::find_if(m_groups.begin(), m_groups.end(),
-                    [category = group->m_category](const auto& group) { return group->m_category == category; });
-            if (it != m_groups.end())
-            {
-                return createIndex(aznumeric_cast<int>(std::distance(m_groups.begin(), it)), 0, nullptr);
-            }
-        }
-        return {};
-    }
-
-    int NodePaletteModel::columnCount(const QModelIndex&) const
-    {
-        return 1;
-    }
-
-    int NodePaletteModel::rowCount(const QModelIndex& parent) const
-    {
-        if (!parent.isValid())
-        {
-            return static_cast<int>(m_groups.size());
-        }
-        else if (parent.internalPointer() == nullptr && parent.row() >= 0 && parent.row() < static_cast<int>(m_groups.size()))
-        {
-            const auto& group = m_groups[parent.row()];
-            return static_cast<int>(group->m_nodes.size());
-        }
-        return 0;
-    }
-
-    QVariant NodePaletteModel::data(const QModelIndex& index, int role) const
-    {
-        if (!hasIndex(index.row(), index.column(), index.parent()))
-        {
-            return {};
-        }
-
-        if (const auto* group = static_cast<CategoryGroup*>(index.internalPointer()))
-        {
-            const auto& nodePair = group->m_nodes[index.row()];
-            EMotionFX::AnimGraphObject* node = nodePair.first;
-            switch (role)
-            {
-            case Qt::DisplayRole:
-            {
-                return node->GetPaletteName();
-            }
-            case Qt::DecorationRole:
-            {
-                return NodePaletteWidget::GetNodeIcon(static_cast<const EMotionFX::AnimGraphNode*>(node));
-            }
-            case Qt::UserRole:
-            {
-                return azrtti_typeid(node).ToString<AZStd::string>().c_str();
-            }
-            default:
-                break;
-            }
-        }
-        else
-        {
-            switch (role)
-            {
-            case Qt::DisplayRole:
-            {
-                const EMotionFX::AnimGraphNode::ECategory category = m_groups[index.row()]->m_category;
-
-                const auto& categoryNames = m_categoryNames;
-                auto it = categoryNames.find(category);
-                if (it != categoryNames.end())
-                {
-                    return it->second;
-                }
-                break;
-            }
-            default:
-                break;
-            }
-        }
-        return {};
-    }
-
-    Qt::ItemFlags NodePaletteModel::flags(const QModelIndex& index) const
-    {
-        Qt::ItemFlags flags = QAbstractItemModel::flags(index);
-
-        if (const auto* group = static_cast<CategoryGroup*>(index.internalPointer()))
-        {
-            const auto& nodePair = group->m_nodes[index.row()];
-
-            // Node item in the tree view is disabled.
-            if (!nodePair.second)
-            {
-                flags.setFlag(Qt::ItemIsEnabled, false);
-            }
-            // Node item in the tree view is enabled.
-            else
-            {
-                flags.setFlag(Qt::ItemIsDragEnabled, true);
-            }
-        }
-
-        return flags;
-    }
-
-    QStringList NodePaletteModel::mimeTypes() const
-    {
-        return {QStringLiteral("text/plain")};
-    }
-
-    QMimeData* NodePaletteModel::mimeData(const QModelIndexList& indexes) const
-    {
-        if (indexes.isEmpty())
-        {
-            return nullptr;
-        }
-
-        const auto& index = indexes.first();
-
-        auto* mimeData = new QMimeData;
-        QString textData = QStringLiteral("EMotionFX::AnimGraphNode;");
-        textData += index.data(Qt::UserRole).toString();
-        textData += ";" + index.data(Qt::DisplayRole).toString(); // add the palette name as generated name prefix (spaces will be removed from it
-        mimeData->setText(textData);
-
-        return mimeData;
-    }
-
-    void NodePaletteModel::setNode(EMotionFX::AnimGraphNode* node)
-    {
-        if (node == m_node)
-        {
-            return;
-        }
-
-        beginResetModel();
-
-        m_node = node;
-        initializeGroups();
-
-        endResetModel();
-    }
-
-    void NodePaletteModel::initializeGroups()
-    {
-        m_groups.clear();
-        m_groups.reserve(m_categoryNames.size());
-
-        const AZStd::vector<EMotionFX::AnimGraphObject*>& objectPrototypes = m_plugin->GetAnimGraphObjectFactory()->GetUiObjectPrototypes();
-        AZStd::vector<AZStd::pair<EMotionFX::AnimGraphObject*, bool>> nodes;
-        for (const auto& categoryName : m_categoryNames)
-        {
-            nodes.clear();
-            const EMotionFX::AnimGraphNode::ECategory category = categoryName.first;
-            for (EMotionFX::AnimGraphObject* objectPrototype : objectPrototypes)
-            {
-                if (objectPrototype->GetPaletteCategory() == categoryName.first)
-                {
-                    const bool isEnabled = m_plugin->CheckIfCanCreateObject(m_node, objectPrototype, category);
-                    nodes.emplace_back(objectPrototype, isEnabled);
-                }
-            }
-
-            if (!nodes.empty())
-            {
-                auto group = AZStd::make_unique<CategoryGroup>();
-                group->m_category = category;
-                group->m_nodes = AZStd::move(nodes);
-                m_groups.emplace_back(std::move(group));
-            }
-        }
-    }
 
     NodePaletteWidget::EventHandler::EventHandler(NodePaletteWidget* widget)
         : m_widget(widget)
@@ -312,7 +59,7 @@ namespace EMStudio
     NodePaletteWidget::NodePaletteWidget(AnimGraphPlugin* plugin)
         : QWidget()
         , m_plugin(plugin)
-        , m_model(new NodePaletteModel(plugin, this))
+        , m_modelUpdater(plugin)
     {
         m_node   = nullptr;
 
@@ -332,14 +79,15 @@ namespace EMStudio
         // add the initial text in the layout
         m_layout->addWidget(m_initialText);
 
-        // create the tree view
-        m_treeView = new QTreeView(this);
-        m_treeView->setHeaderHidden(true);
-        m_treeView->setModel(m_model);
-        m_treeView->setDragDropMode(QAbstractItemView::DragOnly);
-
-        // add the tree view in the layout
-        m_layout->addWidget(m_treeView);
+        GraphCanvas::NodePaletteConfig config;
+        config.m_editorId = AnimGraphEditorId;
+        config.m_rootTreeItem = m_modelUpdater.GetRootItem();
+        config.m_isInContextMenu = false;
+        config.m_mimeType = BlendGraphMimeEvent::BlendGraphMimeEventType;
+        m_palette = new GraphCanvas::NodePaletteWidget(this);
+        m_palette->SetupNodePalette(config);
+        m_palette->hide();
+        m_layout->addWidget(m_palette);
 
         // set the default layout
         setLayout(m_layout);
@@ -359,7 +107,6 @@ namespace EMStudio
         delete m_eventHandler;
     }
 
-
     // init everything for editing a blend tree
     void NodePaletteWidget::Init(EMotionFX::AnimGraph* animGraph, EMotionFX::AnimGraphNode* node)
     {
@@ -375,8 +122,8 @@ namespace EMStudio
             m_layout->setSpacing(0);
 
             // set the widget visible or not
-            m_initialText->setVisible(true);
-            m_treeView->setVisible(false);
+            m_initialText->show();
+            m_palette->hide();
         }
         else
         {
@@ -385,79 +132,11 @@ namespace EMStudio
             m_layout->setSpacing(2);
 
             // set the widget visible or not
-            m_initialText->setVisible(false);
-            m_treeView->setVisible(true);
+            m_initialText->hide();
+            m_palette->show();
         }
-
-        SaveExpandStates();
-        m_model->setNode(m_node);
-        RestoreExpandStates();
+        m_modelUpdater.InitForNode(node);
     }
-
-
-    void NodePaletteWidget::SaveExpandStates()
-    {
-        m_expandedCatagory.clear();
-        const auto& catagoryNames = m_model->GetCategoryNames();
-
-        // Save the expand state.
-        for (const auto& categoryName : catagoryNames)
-        {
-            const QString& str = categoryName.second;
-            const QModelIndexList items = m_model->match(m_model->index(0, 0), Qt::DisplayRole, QVariant::fromValue(str));
-            if (!items.isEmpty())
-            {
-                if (m_treeView->isExpanded(items.first()))
-                {
-                    m_expandedCatagory.emplace(categoryName.first);
-                }
-            }
-        }
-    }
-
-
-    void NodePaletteWidget::RestoreExpandStates()
-    {
-        const auto& catagoryNames = m_model->GetCategoryNames();
-
-        // Restore the expand state.
-        for (const auto& categoryName : catagoryNames)
-        {
-            const EMotionFX::AnimGraphNode::ECategory category = categoryName.first;
-            if (m_expandedCatagory.find(category) == m_expandedCatagory.end())
-            {
-                continue;
-            }
-
-            const QString& str = categoryName.second;
-            const QModelIndexList items = m_model->match(m_model->index(0, 0), Qt::DisplayRole, QVariant::fromValue(str));
-            if (!items.isEmpty())
-            {
-                m_treeView->setExpanded(items.first(), true);
-            }
-        }
-        m_expandedCatagory.clear();
-    }
-
-
-    QIcon NodePaletteWidget::GetNodeIcon(const EMotionFX::AnimGraphNode* node)
-    {
-        QPixmap pixmap(QSize(12, 8));
-        QColor nodeColor;
-        nodeColor.setRgbF(node->GetVisualColor().GetR(), node->GetVisualColor().GetG(), node->GetVisualColor().GetB(), 1.0f);
-        pixmap.fill(nodeColor);
-        QIcon icon(pixmap);
-        icon.addPixmap(pixmap, QIcon::Selected);
-
-        // Create a disabled state for the icon.
-        QPixmap disabledPixmap(QSize(12, 8));
-        QColor disabledNodeColor(51, 51, 51, 255);
-        disabledPixmap.fill(disabledNodeColor);
-        icon.addPixmap(disabledPixmap, QIcon::Disabled);
-
-        return icon;
-    }
-
 
     void NodePaletteWidget::OnFocusChanged(const QModelIndex& newFocusIndex, const QModelIndex& newFocusParent, const QModelIndex& oldFocusIndex, const QModelIndex& oldFocusParent)
     {

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodePaletteWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodePaletteWidget.h
@@ -13,6 +13,7 @@
 #include <EMotionFX/Source/AnimGraphNode.h>
 #include <EMotionFX/Source/EventHandler.h>
 #include "../StandardPluginsConfig.h"
+#include "NodePaletteModelUpdater.h"
 #include <QWidget>
 #endif
 
@@ -21,11 +22,14 @@ QT_FORWARD_DECLARE_CLASS(QLabel)
 QT_FORWARD_DECLARE_CLASS(QVBoxLayout)
 
 
+namespace GraphCanvas
+{
+    class NodePaletteWidget;
+}
+
 namespace EMStudio
 {
     class AnimGraphPlugin;
-    class NodePaletteModel;
-
 
     class NodePaletteWidget
         : public QWidget
@@ -56,22 +60,18 @@ namespace EMStudio
 
         void Init(EMotionFX::AnimGraph* animGraph, EMotionFX::AnimGraphNode* node);
 
-        static QIcon GetNodeIcon(const EMotionFX::AnimGraphNode* node);
-
     private slots:
         void OnFocusChanged(const QModelIndex& newFocusIndex, const QModelIndex& newFocusParent, const QModelIndex& oldFocusIndex, const QModelIndex& oldFocusParent);
 
     private:
-        void SaveExpandStates();
-        void RestoreExpandStates();
 
         AnimGraphPlugin*            m_plugin;
-        NodePaletteModel*           m_model;
-        QTreeView*                  m_treeView;
+        NodePaletteModelUpdater      m_modelUpdater;
         EMotionFX::AnimGraphNode*   m_node;
         EventHandler*               m_eventHandler;
         QVBoxLayout*                m_layout;
         QLabel*                     m_initialText;
+        GraphCanvas::NodePaletteWidget* m_palette;
 
         // Cache the expanded states.
         AZStd::unordered_set<EMotionFX::AnimGraphObject::ECategory> m_expandedCatagory;

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/standardplugins_files.cmake
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/standardplugins_files.cmake
@@ -68,6 +68,8 @@ set(FILES
     Source/AnimGraph/NodeGraphWidget.h
     Source/AnimGraph/NodeGroupWindow.cpp
     Source/AnimGraph/NodeGroupWindow.h
+    Source/AnimGraph/NodePaletteModelUpdater.h
+    Source/AnimGraph/NodePaletteModelUpdater.cpp
     Source/AnimGraph/NodePaletteWidget.cpp
     Source/AnimGraph/NodePaletteWidget.h
     Source/AnimGraph/ParameterCreateEditDialog.cpp

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.cpp
@@ -83,7 +83,7 @@ namespace GraphCanvas
     {
         if (signalAdd)
         {
-            beginInsertRows(QModelIndex(), aznumeric_cast<int>(m_availableItems.size() - 1), aznumeric_cast<int>(m_availableItems.size() - 1));
+            beginInsertRows(QModelIndex(), aznumeric_cast<int>(m_availableItems.size()), aznumeric_cast<int>(m_availableItems.size()));
         }
 
         m_availableItems.push_back(treeItem);

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/NodePaletteWidget.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/NodePaletteWidget.cpp
@@ -126,7 +126,6 @@ namespace GraphCanvas
         : QWidget(parent)        
         , m_ui(new Ui::NodePaletteWidget())
         , m_itemDelegate(nullptr)        
-        , m_contextMenuCreateEvent(nullptr)
         , m_model(nullptr)
         , m_isInContextMenu(false)
         , m_searchFieldSelectionChange(false)
@@ -136,7 +135,6 @@ namespace GraphCanvas
     NodePaletteWidget::~NodePaletteWidget()
     {
         GraphCanvasTreeModelRequestBus::Handler::BusDisconnect();
-        delete m_contextMenuCreateEvent;
     }
 
     void NodePaletteWidget::SetupNodePalette(const NodePaletteConfig& paletteConfig)
@@ -228,7 +226,6 @@ namespace GraphCanvas
 
     void NodePaletteWidget::ResetDisplay()
     {
-        delete m_contextMenuCreateEvent;
         m_contextMenuCreateEvent = nullptr;
 
         {
@@ -254,7 +251,7 @@ namespace GraphCanvas
 
     GraphCanvasMimeEvent* NodePaletteWidget::GetContextMenuEvent() const
     {
-        return m_contextMenuCreateEvent;
+        return m_contextMenuCreateEvent.get();
     }
 
     void NodePaletteWidget::ResetSourceSlotFilter()
@@ -745,7 +742,7 @@ namespace GraphCanvas
     {
         if (m_isInContextMenu && !m_searchFieldSelectionChange)
         {
-            m_contextMenuCreateEvent = treeItem->CreateMimeEvent();
+            m_contextMenuCreateEvent.reset(treeItem->CreateMimeEvent());
 
             if (m_contextMenuCreateEvent)
             {

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/NodePaletteWidget.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/NodePaletteWidget.h
@@ -168,7 +168,7 @@ namespace GraphCanvas
         NodePaletteTreeDelegate* m_itemDelegate;
 
         EditorId m_editorId;
-        GraphCanvasMimeEvent* m_contextMenuCreateEvent;
+        AZStd::unique_ptr<GraphCanvasMimeEvent> m_contextMenuCreateEvent;
 
         QTimer        m_filterTimer;
         NodePaletteSortFilterProxyModel* m_model;


### PR DESCRIPTION
## What does this PR do?

This PR migrates node palette dock (`EMStudio::NodePaletteWidget`) from custom solution to `GraphCanvas::NodePaletteWidget`.

Also, common code for building the tree model for the node palette in EMFX context menu and dock was extracted to a common helper class.

A bugfix for `GraphCanvas::NodePaletteAutoCompleteModel` also was discovered and fixed.

I encourage reviewing commit by commit.

Here's how it looks:
https://user-images.githubusercontent.com/104767/195676131-92acd1ab-137f-4fc2-bd71-50156a27e4f5.mp4
Note that my screen recorder didn't grab the nice pixmap that is following the cursor during the drag.

## Failing tests (Fixed)

~~I'm putting this PR as a draft because I don't know how to fix memory allocation errors related to the new code:~~
The tests are fixed now
```
[ RUN      ] UIFixture.CanAddAnimGraphNode
[  MEMORY  ] Allocation Name: "BlendGraphMimeEvent" Addr: 000000191461DE4D0 Size: 80 Alignment: 8
[  MEMORY  ]  C:\kdab\dev\amazon\code\o3de\Gems\GraphCanvas\Code\StaticLib\GraphCanvas\Widgets\NodePalette\NodePaletteWidget.cpp (748) : GraphCanvas::NodePaletteWidget::HandleSelectedItem
[  MEMORY  ]  C:\kdab\dev\amazon\code\o3de\Gems\GraphCanvas\Code\StaticLib\GraphCanvas\Widgets\NodePalette\NodePaletteWidget.cpp (598) : GraphCanvas::NodePaletteWidget::OnSelectionChanged
[  MEMORY  ]  00007FF9BDDE09AA (Qt5Core) : QObject::qt_static_metacall
[  MEMORY  ]  00007FF9BDD8EA81 (Qt5Core) : QItemSelectionModel::emitSelectionChanged
[  MEMORY  ]  00007FF9BDD93B36 (Qt5Core) : QItemSelectionModel::select
[  MEMORY  ] Allocation Name: "BlendGraphMimeEvent" Addr: 000000191461DE520 Size: 80 Alignment: 8
[  MEMORY  ]  C:\kdab\dev\amazon\code\o3de\Gems\GraphCanvas\Code\StaticLib\GraphCanvas\Widgets\NodePalette\NodePaletteWidget.cpp (748) : GraphCanvas::NodePaletteWidget::HandleSelectedItem
[  MEMORY  ]  C:\kdab\dev\amazon\code\o3de\Gems\GraphCanvas\Code\StaticLib\GraphCanvas\Widgets\NodePalette\NodePaletteWidget.cpp (598) : GraphCanvas::NodePaletteWidget::OnSelectionChanged
[  MEMORY  ]  00007FF9BDDE09AA (Qt5Core) : QObject::qt_static_metacall
[  MEMORY  ]  00007FF9BDD8EC20 (Qt5Core) : QItemSelectionModel::emitSelectionChanged
[  MEMORY  ]  00007FF9BDD93B36 (Qt5Core) : QItemSelectionModel::select
[  MEMORY  ] Allocation Name: "AZStd::allocator" Addr: 00000019147911540 Size: 48 Alignment: 1
[  MEMORY  ]  C:\kdab\dev\amazon\code\o3de\Code\Framework\AzCore\AzCore\std\string\string.h (396) : AZStd::basic_string<char,AZStd::char_traits<char>,AZStd::allocator>::assign
[  MEMORY  ]  C:\kdab\dev\amazon\code\o3de\Gems\EMotionFX\Code\EMotionFX\Tools\EMotionStudio\Plugins\StandardPlugins\Source\AnimGraph\BlendGraphWidget.cpp (130) : EMStudio::BlendGraphNodePaletteTreeItem::CreateMimeEvent
[  MEMORY  ]  C:\kdab\dev\amazon\code\o3de\Gems\GraphCanvas\Code\StaticLib\GraphCanvas\Widgets\NodePalette\NodePaletteWidget.cpp (748) : GraphCanvas::NodePaletteWidget::HandleSelectedItem
[  MEMORY  ]  C:\kdab\dev\amazon\code\o3de\Gems\GraphCanvas\Code\StaticLib\GraphCanvas\Widgets\NodePalette\NodePaletteWidget.cpp (598) : GraphCanvas::NodePaletteWidget::OnSelectionChanged
[  MEMORY  ]  00007FF9BDDE09AA (Qt5Core) : QObject::qt_static_metacall
[  MEMORY  ] Allocation Name: "AZStd::allocator" Addr: 00000019147911600 Size: 48 Alignment: 1
[  MEMORY  ]  C:\kdab\dev\amazon\code\o3de\Code\Framework\AzCore\AzCore\std\string\string.h (396) : AZStd::basic_string<char,AZStd::char_traits<char>,AZStd::allocator>::assign
[  MEMORY  ]  C:\kdab\dev\amazon\code\o3de\Gems\EMotionFX\Code\EMotionFX\Tools\EMotionStudio\Plugins\StandardPlugins\Source\AnimGraph\BlendGraphWidget.cpp (130) : EMStudio::BlendGraphNodePaletteTreeItem::CreateMimeEvent
[  MEMORY  ]  C:\kdab\dev\amazon\code\o3de\Gems\GraphCanvas\Code\StaticLib\GraphCanvas\Widgets\NodePalette\NodePaletteWidget.cpp (748) : GraphCanvas::NodePaletteWidget::HandleSelectedItem
[  MEMORY  ]  C:\kdab\dev\amazon\code\o3de\Gems\GraphCanvas\Code\StaticLib\GraphCanvas\Widgets\NodePalette\NodePaletteWidget.cpp (598) : GraphCanvas::NodePaletteWidget::OnSelectionChanged
[  MEMORY  ]  00007FF9BDDE09AA (Qt5Core) : QObject::qt_static_metacall
C:\kdab\dev\amazon\code\o3de\Code\Framework\AzCore\AzCore/UnitTest/UnitTest.h(175): error: We still have 4 allocations on record! They must be freed prior to destroy!

[  FAILED  ] UIFixture.CanAddAnimGraphNode (1032 ms)
````

As you can see, these tests complain about allocation of `BlendGraphMimeEvent` which happens only in `BlendGraphNodePaletteTreeItem::CreateMimeEvent`. I do it similar to other classes in the engine (e.g. `ScriptEventsHandlerEventPaletteTreeItem::CreateMimeEvent`). This method is called by the internals of `GraphCanvasTreeModel` and the result is serialized. I don't have control of it from the tree item side:

```cpp
    BlendGraphMimeEvent* BlendGraphNodePaletteTreeItem::CreateMimeEvent() const
    {
        return IsEnabled() ? new BlendGraphMimeEvent(FromQtString(m_typeString), FromQtString(GetName())) : nullptr;
    }
```
I couldn't find a working combination of `aznew` and `new` that would make the tests happy. Help appreciated.

## How was this PR tested?

I checked the functionality of the node palette and context menu manually, also, apart from failing memory management requirements, the unit tests run functionally correct.

Fixes #11691