### PR TITLE
Remove double-click-to-exit for component mode

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeDelegate.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeDelegate.cpp
@@ -307,19 +307,9 @@ namespace AzToolsFramework
         }
 
         bool ComponentModeDelegate::DetectLeaveComponentModeInteraction(
-            const ViewportInteraction::MouseInteractionEvent& mouseInteraction)
+            [[maybe_unused]] const ViewportInteraction::MouseInteractionEvent& mouseInteraction)
         {
-            if (ShouldDetectEnterLeaveComponentMode(mouseInteraction))
-            {
-                if (DoubleClickedComponent(mouseInteraction, m_handler) == DoubleClickOutcome::OffComponent)
-                {
-                    ComponentModeSystemRequestBus::Broadcast(
-                        &ComponentModeSystemRequests::EndComponentMode);
-
-                    return true;
-                }
-            }
-
+            // by default, we won't use mouse interactions to leave component mode, so we'll always return false.
             return false;
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/PaintBrushManipulator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/PaintBrushManipulator.cpp
@@ -163,16 +163,6 @@ namespace AzToolsFramework
                 return true;
             }
         }
-        else if (mouseInteraction.m_mouseEvent == AzToolsFramework::ViewportInteraction::MouseEvent::DoubleClick)
-        {
-            if (mouseInteraction.m_mouseInteraction.m_mouseButtons.Left())
-            {
-                // Swallow up double-click events so that the default component mode behavior doesn't detect it and try
-                // to leave component mode. It's too easy to double-click by accident when painting, so double-clicking
-                // to exit just doesn't work well.
-                return true;
-            }
-        }
 
         return false;
     }


### PR DESCRIPTION
## What does this PR do?

This removes the default behavior for component mode where double-clicking off of an entity would exit component mode. 

This was removed for the painting tool because double-clicking was too easy to do by mistake. After discussion on https://github.com/o3de/o3de/pull/12564 and with the UX team, it sounds like we should remove the default behavior as a whole, because other component modes (such as prefab editing) also don't want this behavior.

## How was this PR tested?

Went into component mode and verified that double-clicking didn't exit component mode.
