### PR TITLE
Fix for cmake configure loop when using SDK

### DIFF
--- a/cmake/Gems.cmake
+++ b/cmake/Gems.cmake
@@ -28,7 +28,7 @@ function(o3de_find_ancestor_gem_root output_gem_module_root output_gem_name sour
         # Locate the root of the gem by finding the gem.json location
         cmake_path(APPEND candidate_gem_path "gem.json" OUTPUT_VARIABLE candidate_gem_json_path)
         while(NOT EXISTS "${candidate_gem_json_path}")
-            get_property(parent_path DIRECTORY ${candidate_gem_path} PROPERTY PARENT_DIRECTORY)
+            cmake_path(GET candidate_gem_path PARENT_PATH parent_path)
 
             # If the parent directory is the same as the candidate path then the root path has been found
             cmake_path(COMPARE "${candidate_gem_path}" EQUAL "${parent_path}" reached_root_dir)


### PR DESCRIPTION
The `get_property` command doesn't update the output variable if the property name that is supplied is an empty string. This was causing the `o3de_find_ancestor_gem_root` function to be stuck in an infinite loop

fixes #12593

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Configured the AtomSampleViewer project using an SDK engine
