### PR TITLE
Improved CPU performance by almost 13ms (37.48ms -> 24.74ms) on the RosCon level

### DIFF
--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -469,6 +469,7 @@ void EditorViewportWidget::Update()
         }
     }
 
+    if(!m_hasUpdatedVisibility)
     {
         auto start = std::chrono::steady_clock::now();
 
@@ -480,6 +481,8 @@ void EditorViewportWidget::Update()
             std::chrono::duration<double> diff = stop - start;
             AZ_Printf("Visibility", "FindVisibleEntities (new) - Duration: %f", diff);
         }
+
+        m_hasUpdatedVisibility = true;
     }
 
     QtViewport::Update();
@@ -618,6 +621,10 @@ void EditorViewportWidget::OnEditorNotifyEvent(EEditorNotifyEvent event)
 
 void EditorViewportWidget::OnBeginPrepareRender()
 {
+    AZ_PROFILE_FUNCTION(Editor);
+
+    m_hasUpdatedVisibility = false;
+
     if (!m_debugDisplay)
     {
         AzFramework::DebugDisplayRequestBus::BusPtr debugDisplayBus;

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -377,6 +377,9 @@ private:
     // Reentrancy guard for on paint events
     bool m_isOnPaint = false;
 
+    // Guard against calling UpdateVisibility multiple times a frame
+    bool m_hasUpdatedVisibility = false;
+
     // Aspect ratios available in the title bar
     CPredefinedAspectRatios m_predefinedAspectRatios;
 

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraphSystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraphSystemComponent.cpp
@@ -15,8 +15,14 @@
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Threading/ThreadUtils.h>
 
+ // PERFORMANCE NOTE & TODO
+ // Profiling Ros Con demo, Task Graph was 2-3ms slower than Jobs
+ // Time for Jobs was ~5.5ms, maxing out at ~6.3ms
+ // Task Graph took ~7.7ms, maxing out at ~8.7ms
+ // Disabling cl_activateTaskGraph for performance reasons for the time being
+
 // Create a cvar as a central location for experimentation with switching from the Job system to TaskGraph system.
-AZ_CVAR(bool, cl_activateTaskGraph, true, nullptr, AZ::ConsoleFunctorFlags::Null, "Flag clients of TaskGraph to switch between jobs/taskgraph (Note does not disable task graph system)");
+AZ_CVAR(bool, cl_activateTaskGraph, false, nullptr, AZ::ConsoleFunctorFlags::Null, "Flag clients of TaskGraph to switch between jobs/taskgraph (Note does not disable task graph system)");
 AZ_CVAR(float, cl_taskGraphThreadsConcurrencyRatio, 1.0f, nullptr, AZ::ConsoleFunctorFlags::Null, "TaskGraph calculate the number of worker threads to spawn by scaling the number of hw threads, value is clamped between 0.0f and 1.0f");
 AZ_CVAR(uint32_t, cl_taskGraphThreadsNumReserved, 2, nullptr, AZ::ConsoleFunctorFlags::Null, "TaskGraph number of hardware threads that are reserved for O3DE system threads. Value is clamped between 0 and the number of logical cores in the system");
 AZ_CVAR(uint32_t, cl_taskGraphThreadsMinNumber, 2, nullptr, AZ::ConsoleFunctorFlags::Null, "TaskGraph minimum number of worker threads to create after scaling the number of hw threads");

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContext.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContext.h
@@ -82,6 +82,8 @@ namespace AZ
             void OnRenderPipelineRemoved(RenderPipeline* pipeline) override;
             //! OnBeginPrepareRender is forwarded to our RenderTick notification to allow subscribers to do rendering.
             void OnBeginPrepareRender() override;
+            //! OnEndPrepareRender is forwarded to our WaitForRender notification to wait for any pending work
+            void OnEndPrepareRender() override;
 
             // WindowNotificationBus interface overrides...
             //! Used to fire a notification when our window resizes.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContextBus.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContextBus.h
@@ -128,6 +128,8 @@ namespace AZ
             //! Called when the viewport is to be rendered.
             //! Add draws to this functions if they only need to be rendered to this viewport. 
             virtual void OnRenderTick(){};
+            //! Called as a sync point for any render jobs in flight
+            virtual void WaitForRender(){};
 
         protected:
             ~ViewportContextNotifications() = default;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
@@ -514,7 +514,6 @@ namespace AZ
 
             auto nodeVisitorLambda = [worklistData, &parentJob, &worklist](const AzFramework::IVisibilityScene::NodeData& nodeData) -> void
             {
-                AZ_PROFILE_SCOPE(RPI, "nodeVisitorLambda()");
                 AZ_Assert(nodeData.m_entries.size() > 0, "should not get called with 0 entries");
                 AZ_Assert(worklist.size() < worklist.capacity(), "we should always have room to push a node on the queue");
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -1302,7 +1302,6 @@ namespace AZ
 
         void Pass::FrameBegin(FramePrepareParams params)
         {
-            AZ_PROFILE_SCOPE(RPI, "Pass::FrameBegin() - %s", m_path.GetCStr());
             AZ_RPI_BREAK_ON_TARGET_PASS;
 
             bool earlyOut = !IsEnabled();
@@ -1335,10 +1334,7 @@ namespace AZ
 
             // FrameBeginInternal needs to be the last function be called in FrameBegin because its implementation expects 
             // all the attachments are imported to database (for example, ImageAttachmentPreview)
-            {
-                AZ_PROFILE_SCOPE(RPI, "Pass::FrameBeginInternal()");
-                FrameBeginInternal(params);
-            }
+            FrameBeginInternal(params);
             
             // readback attachment with output state
             UpdateReadbackAttachment(params, false);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassSystem.cpp
@@ -212,7 +212,7 @@ namespace AZ
 
         void PassSystem::FrameUpdate(RHI::FrameGraphBuilder& frameGraphBuilder)
         {
-            AZ_PROFILE_SCOPE(RPI, "PassSystem: FrameUpdate");
+            AZ_PROFILE_FUNCTION(RPI);
 
             ResetFrameStatistics();
             ProcessQueuedChanges();
@@ -229,7 +229,7 @@ namespace AZ
 
         void PassSystem::FrameEnd()
         {
-            AZ_PROFILE_SCOPE(RHI, "PassSystem: FrameEnd");
+            AZ_PROFILE_FUNCTION(RPI);
 
             m_state = PassSystemState::FrameEnd;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
@@ -146,7 +146,6 @@ namespace AZ
 
         void RasterPass::UpdateDrawList()
         {
-            AZ_PROFILE_SCOPE(RPI, "RasterPass::UpdateDrawList");
              // DrawLists from dynamic draw
             AZStd::vector<RHI::DrawListView> drawLists = DynamicDrawInterface::Get()->GetDrawListsForPass(this);
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -488,6 +488,7 @@ namespace AZ
 
         void RenderPipeline::PassSystemFrameBegin(Pass::FramePrepareParams params)
         {
+            AZ_PROFILE_FUNCTION(RPI);
             if (GetRenderMode() != RenderPipeline::RenderMode::NoRender)
             {
                 m_passTree.m_rootPass->FrameBegin(params);
@@ -496,6 +497,7 @@ namespace AZ
 
         void RenderPipeline::PassSystemFrameEnd()
         {
+            AZ_PROFILE_FUNCTION(RPI);
             if (GetRenderMode() != RenderPipeline::RenderMode::NoRender)
             {
                 m_passTree.m_rootPass->FrameEnd();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -485,12 +485,8 @@ namespace AZ
                 WaitAndCleanCompletionJob(m_simulationCompletion);
             }
 
-            // Profiling Ros Con demo, Task Graph was 2-3ms slower than Jobs
-            // Time for Jobs was ~5.5ms, maxing out at ~6.3ms
-            // Task Graph took ~7.7ms, maxing out at ~8.7ms
-            // Disabling task graph for performance reasons, to re-enable uncomment these two lines
-            // auto taskGraphActiveInterface = AZ::Interface<AZ::TaskGraphActiveInterface>::Get();
-            // m_taskGraphActive = taskGraphActiveInterface && taskGraphActiveInterface->IsTaskGraphActive();
+            auto taskGraphActiveInterface = AZ::Interface<AZ::TaskGraphActiveInterface>::Get();
+            m_taskGraphActive = taskGraphActiveInterface && taskGraphActiveInterface->IsTaskGraphActive();
 
             if (jobPolicy == RHI::JobPolicy::Serial)
             {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -485,8 +485,12 @@ namespace AZ
                 WaitAndCleanCompletionJob(m_simulationCompletion);
             }
 
-            auto taskGraphActiveInterface = AZ::Interface<AZ::TaskGraphActiveInterface>::Get();
-            m_taskGraphActive = taskGraphActiveInterface && taskGraphActiveInterface->IsTaskGraphActive();
+            // Profiling Ros Con demo, Task Graph was 2-3ms slower than Jobs
+            // Time for Jobs was ~5.5ms, maxing out at ~6.3ms
+            // Task Graph took ~7.7ms, maxing out at ~8.7ms
+            // Disabling task graph for performance reasons, to re-enable uncomment these two lines
+            // auto taskGraphActiveInterface = AZ::Interface<AZ::TaskGraphActiveInterface>::Get();
+            // m_taskGraphActive = taskGraphActiveInterface && taskGraphActiveInterface->IsTaskGraphActive();
 
             if (jobPolicy == RHI::JobPolicy::Serial)
             {
@@ -702,7 +706,10 @@ namespace AZ
                 WaitAndCleanCompletionJob(m_simulationCompletion);
             }
 
-            SceneNotificationBus::Event(GetId(), &SceneNotification::OnBeginPrepareRender);
+            {
+                AZ_PROFILE_SCOPE(RPI, "Scene: OnBeginPrepareRender");
+                SceneNotificationBus::Event(GetId(), &SceneNotification::OnBeginPrepareRender);
+            }
 
             // Get active pipelines which need to be rendered and notify them frame started
             AZStd::vector<RenderPipelinePtr> activePipelines;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContext.cpp
@@ -141,8 +141,16 @@ namespace AZ
 
         void ViewportContext::OnBeginPrepareRender()
         {
+            AZ_PROFILE_FUNCTION(RPI);
             ViewportContextNotificationBus::Event(GetName(), &ViewportContextNotificationBus::Events::OnRenderTick);
             ViewportContextIdNotificationBus::Event(GetId(), &ViewportContextIdNotificationBus::Events::OnRenderTick);
+        }
+
+        void ViewportContext::OnEndPrepareRender()
+        {
+            AZ_PROFILE_FUNCTION(RPI);
+            ViewportContextNotificationBus::Event(GetName(), &ViewportContextNotificationBus::Events::WaitForRender);
+            ViewportContextIdNotificationBus::Event(GetId(), &ViewportContextIdNotificationBus::Events::WaitForRender);
         }
 
         AZ::Name ViewportContext::GetName() const

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
@@ -79,6 +79,9 @@ namespace AtomToolsFramework
         m_view->SetViewToClipMatrix(viewToClipMatrix);
         m_renderPipeline->SetDefaultView(m_view);
 
+        // Don't render the pipeline until a capture request
+        m_renderPipeline->RemoveFromRenderTick();
+
         m_state.reset(new PreviewRendererIdleState(this));
 
         AZ::Interface<PreviewRendererInterface>::Register(this);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
@@ -80,7 +80,7 @@ namespace AtomToolsFramework
         m_renderPipeline->SetDefaultView(m_view);
 
         // Don't render the pipeline until a capture request
-        m_renderPipeline->RemoveFromRenderTick();
+        m_renderPipeline->AddToRenderTickOnce();
 
         m_state.reset(new PreviewRendererIdleState(this));
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
@@ -79,7 +79,11 @@ namespace AtomToolsFramework
         m_view->SetViewToClipMatrix(viewToClipMatrix);
         m_renderPipeline->SetDefaultView(m_view);
 
-        // Don't render the pipeline until a capture request
+        // Run the pipeline once for complete initialization, else capturing will fail
+        // Todo: Investigate why RemoveFromRenderTick doesn't work here and what initialization
+        // steps are missing in that case (could be the target image/texture doesn't get setup)
+        // Without this line, pipeline default to render every frame until a capture is triggered
+        // This resulted in a ~0.5ms performance hit every frame
         m_renderPipeline->AddToRenderTickOnce();
 
         m_state.reset(new PreviewRendererIdleState(this));

--- a/Gems/AtomLyIntegration/ImguiAtom/Code/Source/ImguiAtomSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/ImguiAtom/Code/Source/ImguiAtomSystemComponent.cpp
@@ -95,6 +95,13 @@ namespace AZ
 #endif
         }
 
+        void ImguiAtomSystemComponent::WaitForRender()
+        {
+#if defined(IMGUI_ENABLED)
+            ImGui::ImGuiManagerBus::Broadcast(&ImGui::IImGuiManager::WaitForRenderToFinish);
+#endif
+        }
+
         void ImguiAtomSystemComponent::OnViewportSizeChanged([[maybe_unused]] AzFramework::WindowSize size)
         {
 #if defined(IMGUI_ENABLED)

--- a/Gems/AtomLyIntegration/ImguiAtom/Code/Source/ImguiAtomSystemComponent.h
+++ b/Gems/AtomLyIntegration/ImguiAtom/Code/Source/ImguiAtomSystemComponent.h
@@ -51,6 +51,7 @@ namespace AZ
 
             // ViewportContextNotificationBus overrides...
             void OnRenderTick() override;
+            void WaitForRender() override;
             void OnViewportSizeChanged(AzFramework::WindowSize size) override;
             void OnViewportDpiScalingChanged(float dpiScale) override;
 

--- a/Gems/ImGui/Code/Include/ImGuiBus.h
+++ b/Gems/ImGui/Code/Include/ImGuiBus.h
@@ -95,6 +95,7 @@ namespace ImGui
         virtual void SetDpiScalingFactor(float dpiScalingFactor) = 0;
         virtual float GetDpiScalingFactor() const = 0;
         virtual void Render() = 0;
+        virtual void WaitForRenderToFinish() = 0;
 
         using ImGuiSetEnabledEvent = AZ::Event<bool>;
         ImGuiSetEnabledEvent m_setEnabledEvent;

--- a/Gems/ImGui/Code/Source/ImGuiManager.h
+++ b/Gems/ImGui/Code/Source/ImGuiManager.h
@@ -24,6 +24,8 @@
 #include <AzCore/Module/DynamicModuleHandle.h>
 #endif // defined(LOAD_IMGUI_LIB_DYNAMICALLY)  && !defined(AZ_MONOLITHIC_BUILD)
 
+namespace AZ { class JobCompletion; }
+
 namespace ImGui
 {
     enum class ImGuiStateBroadcast
@@ -73,6 +75,7 @@ namespace ImGui
         void SetDpiScalingFactor(float dpiScalingFactor) override;
         float GetDpiScalingFactor() const override;
         void Render() override;
+        void WaitForRenderToFinish() override;
         void ToggleThroughImGuiVisibleState() override;
         void ToggleToImGuiVisibleState(DisplayState state) override;
         // -- ImGuiManagerBus Interface -------------------------------------------------------------------
@@ -90,6 +93,8 @@ namespace ImGui
         void InitWindowSize();
 
     private:
+        void RenderJob();
+
         ImGuiContext* m_imguiContext = nullptr;
         DisplayState m_clientMenuBarState = DisplayState::Hidden;
         DisplayState m_editorWindowState = DisplayState::Hidden;
@@ -118,6 +123,8 @@ namespace ImGui
         bool m_simulateBackspaceKeyPressed = false;
 
         ImGuiBroadcastState m_imGuiBroadcastState;
+
+        AZ::JobCompletion* m_renderJobCompletion = nullptr;
 
 #if defined(LOAD_IMGUI_LIB_DYNAMICALLY)  && !defined(AZ_MONOLITHIC_BUILD)
         AZStd::unique_ptr<AZ::DynamicModuleHandle>  m_imgSharedLib;


### PR DESCRIPTION
Improved CPU performance with the following optimizations:
- Removed a redundant call to UpdateVisibility at the end of the frame (~3ms)
- Switched culling to use jobs instead of task graph (~2.5ms)
- Switch the tools render pipeline to be off when created since it gets manually turned on and then off when it needs to do a capture (~0.5ms)
- Switch ImGui update to be multithreaded (up to 5ms when CPU profiler is running)

Those were the big ones if I'm not forgetting any. Other changes here are small things like removing perf markers that are too small to show up in profiling, adding perf markers for tasks that are definitely big enough to profile, 
 