### PR TITLE
Cherry Pick fix for AP Connection warning spam on Linux

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponent.cpp
@@ -682,7 +682,12 @@ namespace AzFramework
                 AZStd::this_thread::yield();
             }
 
-            return ConnectedWithAssetProcessor();
+            bool connected = ConnectedWithAssetProcessor();
+            if ((!connected) && (m_socketConn->GetLastResult() != 0))
+            {
+                AZ_Warning("AssetProcessorConnection", false, "%s", m_socketConn->GetLastErrorMessage().c_str());
+            }
+            return connected;            
         }
 
         bool AssetSystemComponent::WaitUntilAssetProcessorReady(AZStd::chrono::duration<float> timeout)

--- a/Code/Framework/AzFramework/AzFramework/Network/AssetProcessorConnection.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Network/AssetProcessorConnection.cpp
@@ -67,8 +67,6 @@ namespace AzFramework
             , m_connectionState(EConnectionState::Disconnected)
             , m_port(0)
             , m_sendEventNotEmpty()
-            , m_lastErrorResult{ 0 }
-            , m_lastErrorMessage{}
         {
             m_requestSerial = 1;
             m_unitTesting = false;

--- a/Code/Framework/AzFramework/AzFramework/Network/AssetProcessorConnection.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Network/AssetProcessorConnection.cpp
@@ -67,6 +67,8 @@ namespace AzFramework
             , m_connectionState(EConnectionState::Disconnected)
             , m_port(0)
             , m_sendEventNotEmpty()
+            , m_lastErrorResult{ 0 }
+            , m_lastErrorMessage{}
         {
             m_requestSerial = 1;
             m_unitTesting = false;
@@ -229,7 +231,9 @@ namespace AzFramework
             AZ::s32 result = AZ::AzSock::Connect(m_socket, socketAddress);
             if (AZ::AzSock::SocketErrorOccured(result))
             {
-                AZ_Warning(ConnectThreadWindow, false, "Network connection attempt failure, Connect returned error %s", AZ::AzSock::GetStringForError(result));
+                m_lastErrorResult = result;
+                m_lastErrorMessage = AZStd::string::format("Network connection attempt failure, Connect returned error %s", AZ::AzSock::GetStringForError(result));
+                DebugMessage("%s", m_lastErrorMessage.c_str());
 
                 if (m_connectThread.m_join)
                 {
@@ -243,7 +247,9 @@ namespace AzFramework
             result = AZ::AzSock::EnableTCPNoDelay(m_socket, true);
             if (result)
             {
-                AZ_Warning(ConnectThreadWindow, false, "Network connection attempt failure, EnableTCPNoDelay returned an error %s", AZ::AzSock::GetStringForError(result));
+                m_lastErrorResult = result;
+                m_lastErrorMessage = AZStd::string::format("Network connection attempt failure, EnableTCPNoDelay returned an error %s", AZ::AzSock::GetStringForError(result));
+                DebugMessage("%s", m_lastErrorMessage.c_str());
                 if (m_connectThread.m_join)
                 {
                     return;
@@ -253,6 +259,9 @@ namespace AzFramework
             }
 
             DebugMessage("AssetProcessorConnection::ConnectThread - socket connected to %s:%u, Negotiate...", m_connectAddr.c_str(), m_port);
+
+            m_lastErrorResult = 0;
+            m_lastErrorMessage.clear();
 
             //we connected, start the send recv threads so we can negotiate
             StartSendRecvThreads();
@@ -1094,6 +1103,16 @@ namespace AzFramework
                 }
             }
             DebugMessage("AzSockConnection::RemoveMessageHandler - Tried to remove a type callback that didn't exist");
+        }
+
+        AZ::s32 AssetProcessorConnection::GetLastResult() const
+        {
+            return m_lastErrorResult;
+        }
+
+        AZStd::string AssetProcessorConnection::GetLastErrorMessage() const
+        {
+            return m_lastErrorMessage;
         }
 
         void AssetProcessorConnection::InvokeMessageHandler(AZ::u32 typeId, AZ::u32 serial, const void* dataBuffer, AZ::u32 dataLength)

--- a/Code/Framework/AzFramework/AzFramework/Network/AssetProcessorConnection.h
+++ b/Code/Framework/AzFramework/AzFramework/Network/AssetProcessorConnection.h
@@ -93,6 +93,8 @@ namespace AzFramework
             //! @return returns a value that can be passed to /ref RemoveMessageHandler .
             SocketConnection::TMessageCallbackHandle AddMessageHandler(AZ::u32 typeId, TMessageCallback callback) override;
             void RemoveMessageHandler(AZ::u32 typeId, TMessageCallbackHandle callbackHandle) override;
+            AZ::s32 GetLastResult() const override;
+            AZStd::string GetLastErrorMessage() const override;
             //////////////////////////////////////////////////////////////////////////
 
             bool NegotiationFailed() { return m_negotiationFailed; } //hold whether the last connection attempt failed negotiation or not
@@ -208,7 +210,8 @@ namespace AzFramework
             // has yet to finish cleaning everything up.
             AZStd::atomic_bool m_isBusyDisconnecting;
 
-            
+            AZ::s32 m_lastErrorResult;
+            AZStd::string m_lastErrorMessage;
         };
 
         typedef AZStd::vector<AZ::u8, AZ::OSStdAllocator> MessageBuffer;

--- a/Code/Framework/AzFramework/AzFramework/Network/AssetProcessorConnection.h
+++ b/Code/Framework/AzFramework/AzFramework/Network/AssetProcessorConnection.h
@@ -210,7 +210,7 @@ namespace AzFramework
             // has yet to finish cleaning everything up.
             AZStd::atomic_bool m_isBusyDisconnecting;
 
-            AZ::s32 m_lastErrorResult;
+            AZ::s32 m_lastErrorResult = 0;
             AZStd::string m_lastErrorMessage;
         };
 

--- a/Code/Framework/AzFramework/AzFramework/Network/SocketConnection.h
+++ b/Code/Framework/AzFramework/AzFramework/Network/SocketConnection.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/std/functional.h>
+#include <AzCore/std/string/string.h>
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/std/parallel/mutex.h>
@@ -77,6 +78,12 @@ namespace AzFramework
 
         //! Remove callback for specific typeId (allows multiple callbacks per id)
         virtual void RemoveMessageHandler(AZ::u32 typeId, TMessageCallbackHandle callbackHandle) = 0;
+
+        //! Get the last socket result code from any socket call 
+        virtual AZ::s32 GetLastResult() const { return 0; }
+
+        //! Get the last socket-related error from any socket call
+        virtual AZStd::string GetLastErrorMessage() const { return AZStd::string(); };        
     };
 
     class EngineConnectionEvents


### PR DESCRIPTION
## What does this PR do?

On Linux, the Editor spams the console with 'AP Connection Timeout' spam during the attempt/retry loop until the AP is started and accepts connections. This moves the logic to defer until either the connection is made or if there is an error


## How was this PR tested?

Tested with the ROSCon demo on Linux
