### PR TITLE
Removing Cry Dependency for Getting the Current Level Name

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/API/ApplicationAPI.h
+++ b/Code/Framework/AzFramework/AzFramework/API/ApplicationAPI.h
@@ -203,19 +203,22 @@ namespace AzFramework
     };
     using LevelLoadBlockerBus = AZ::EBus<LevelLoadBlockerRequests>;
 
-    class LevelSystemLifecycleRequests
-        : public AZ::EBusTraits
+    class ILevelSystemLifecycle
     {
     public:
-        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
-        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+        AZ_TYPE_INFO(ILevelSystemLifecycle, "{BDF3616A-4725-4B5D-AB71-34DFCDF9C5B0}");
+        virtual ~ILevelSystemLifecycle() = default;
 
         //! Returns the name of the currently loaded level.
         //! Note: for spawnable level system, this is the cache folder path to the level asset. Example: levels/mylevel/mylevel.spawnable
         //! @return Level name or empty string if no level loaded.
-        virtual AZStd::string GetCurrentLevelName() = 0;
+        virtual const char* GetCurrentLevelName() const = 0;
+
+        //! Checks if a level is loaded
+        //! @return true if a level is loaded; otherwise false.
+        virtual bool IsLevelLoaded() const = 0;
     };
-    using LevelSystemLifecycleRequestBus = AZ::EBus<LevelSystemLifecycleRequests>;
+    using LevelSystemLifecycleInterface = AZ::Interface<ILevelSystemLifecycle>;
 
     class LevelSystemLifecycleNotifications
         : public AZ::EBusTraits

--- a/Code/Framework/AzFramework/AzFramework/API/ApplicationAPI.h
+++ b/Code/Framework/AzFramework/AzFramework/API/ApplicationAPI.h
@@ -189,17 +189,31 @@ namespace AzFramework
         virtual void OnApplicationAboutToStop() {}
     };
 
+    class LevelLoadBlockerRequests
+        : public AZ::EBusTraits
+    {
+    public:
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+
+        //! Gives handlers the opportunity to block the loadlevel command.
+        //! There can be multiple handlers for this bus; if any one of them return true the loadlevel command will be stopped.
+        //! @return Return true to stop loading.
+        virtual bool ShouldBlockLevelLoading([[maybe_unused]]const char* levelName) { return false; }
+    };
+    using LevelLoadBlockerBus = AZ::EBus<LevelLoadBlockerRequests>;
+
     class LevelSystemLifecycleRequests
         : public AZ::EBusTraits
     {
     public:
-        // Bus Configuration
-        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
 
-        // Gives handlers the opportunity to block the loadlevel command.
-        // Return true to stop loading.
-        virtual bool ShouldBlockLevelLoading([[maybe_unused]]const char* levelName) { return false; }
+        //! Returns the name of the currently loaded level.
+        //! Note: for spawnable level system, this is the cache folder path to the level asset. Example: levels/mylevel/mylevel.spawnable
+        //! @return Level name or empty string if no level loaded.
+        virtual AZStd::string GetCurrentLevelName() = 0;
     };
     using LevelSystemLifecycleRequestBus = AZ::EBus<LevelSystemLifecycleRequests>;
 

--- a/Code/Legacy/CryCommon/ILevelSystem.h
+++ b/Code/Legacy/CryCommon/ILevelSystem.h
@@ -68,10 +68,12 @@ struct ILevelSystem
 
     //! Deprecated.
     //! @deprecated ILevelSystem is part of the legacy CryCommon module, please use AzFramework::LevelSystemLifecycleInterface::Get()->IsLevelLoaded instead.
+    //! O3DE_DEPRECATION_NOTICE(GHI-12715)
     virtual bool IsLevelLoaded() const = 0;
 
     //! Deprecated.
-    //! @deprecated ILevelSystem is part of the legacy CryCommon module, please use AzFramework::LevelSystemLifecycleInterface::Get()->GetCurrentLevelName instead.
+    //! @deprecated ILevelSystem is part of the legacy CryCommon module, please use AzFramework::LevelSystemLifecycleInterface::Get()->GetCurrentLevelName instead. O3DE_DEPRECATION_NOTICE(GHI-12715)
+    //! O3DE_DEPRECATION_NOTICE(GHI-12715)
     virtual const char* GetCurrentLevelName() const = 0;
 
     // If the level load failed then we need to have a different shutdown procedure vs when a level is naturally unloaded

--- a/Code/Legacy/CryCommon/ILevelSystem.h
+++ b/Code/Legacy/CryCommon/ILevelSystem.h
@@ -65,9 +65,11 @@ struct ILevelSystem
 
     virtual bool LoadLevel(const char* levelName) = 0;
     virtual void UnloadLevel() = 0;
-    virtual bool IsLevelLoaded() = 0;
 
-    // Deprecated. Use AzFramework::LevelSystemLifecycleRequests::GetCurrentLevelName instead.
+    // Deprecated. Use AzFramework::LevelSystemLifecycleInterface::Get()->IsLevelLoaded instead.
+    virtual bool IsLevelLoaded() const = 0;
+
+    // Deprecated. Use AzFramework::LevelSystemLifecycleInterface::Get()->GetCurrentLevelName instead.
     virtual const char* GetCurrentLevelName() const = 0;
 
     // If the level load failed then we need to have a different shutdown procedure vs when a level is naturally unloaded

--- a/Code/Legacy/CryCommon/ILevelSystem.h
+++ b/Code/Legacy/CryCommon/ILevelSystem.h
@@ -66,10 +66,12 @@ struct ILevelSystem
     virtual bool LoadLevel(const char* levelName) = 0;
     virtual void UnloadLevel() = 0;
 
-    // Deprecated. Use AzFramework::LevelSystemLifecycleInterface::Get()->IsLevelLoaded instead.
+    //! Deprecated.
+    //! @deprecated ILevelSystem is part of the legacy CryCommon module, please use AzFramework::LevelSystemLifecycleInterface::Get()->IsLevelLoaded instead.
     virtual bool IsLevelLoaded() const = 0;
 
-    // Deprecated. Use AzFramework::LevelSystemLifecycleInterface::Get()->GetCurrentLevelName instead.
+    //! Deprecated.
+    //! @deprecated ILevelSystem is part of the legacy CryCommon module, please use AzFramework::LevelSystemLifecycleInterface::Get()->GetCurrentLevelName instead.
     virtual const char* GetCurrentLevelName() const = 0;
 
     // If the level load failed then we need to have a different shutdown procedure vs when a level is naturally unloaded

--- a/Code/Legacy/CryCommon/ILevelSystem.h
+++ b/Code/Legacy/CryCommon/ILevelSystem.h
@@ -66,6 +66,8 @@ struct ILevelSystem
     virtual bool LoadLevel(const char* levelName) = 0;
     virtual void UnloadLevel() = 0;
     virtual bool IsLevelLoaded() = 0;
+
+    // Deprecated. Use AzFramework::LevelSystemLifecycleRequests::GetCurrentLevelName instead.
     virtual const char* GetCurrentLevelName() const = 0;
 
     // If the level load failed then we need to have a different shutdown procedure vs when a level is naturally unloaded

--- a/Code/Legacy/CryCommon/ILevelSystem.h
+++ b/Code/Legacy/CryCommon/ILevelSystem.h
@@ -72,7 +72,7 @@ struct ILevelSystem
     virtual bool IsLevelLoaded() const = 0;
 
     //! Deprecated.
-    //! @deprecated ILevelSystem is part of the legacy CryCommon module, please use AzFramework::LevelSystemLifecycleInterface::Get()->GetCurrentLevelName instead. O3DE_DEPRECATION_NOTICE(GHI-12715)
+    //! @deprecated ILevelSystem is part of the legacy CryCommon module, please use AzFramework::LevelSystemLifecycleInterface::Get()->GetCurrentLevelName instead.
     //! O3DE_DEPRECATION_NOTICE(GHI-12715)
     virtual const char* GetCurrentLevelName() const = 0;
 

--- a/Code/Legacy/CrySystem/LevelSystem/LevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/LevelSystem.cpp
@@ -200,11 +200,14 @@ CLevelSystem::CLevelSystem(ISystem* pSystem, const char* levelsFolder)
         });
         m_levelPackCloseHandler.Connect(*levelPakCloseEvent);
     }
+
+    AzFramework::LevelSystemLifecycleRequestBus::Handler::BusConnect();
 }
 
 //------------------------------------------------------------------------
 CLevelSystem::~CLevelSystem()
 {
+    AzFramework::LevelSystemLifecycleRequestBus::Handler::BusDisconnect();
     UnloadLevel();
 }
 

--- a/Code/Legacy/CrySystem/LevelSystem/LevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/LevelSystem.cpp
@@ -201,17 +201,14 @@ CLevelSystem::CLevelSystem(ISystem* pSystem, const char* levelsFolder)
         m_levelPackCloseHandler.Connect(*levelPakCloseEvent);
     }
 
-    auto registerOutcome = AzFramework::LevelSystemLifecycleInterface::Register(this);
-    AZ_Error("LevelSystem", registerOutcome,
-        "Failed to register the LevelSystem with the LevelSystemLifecycleInterface: %s",
-        registerOutcome.GetError().c_str());
+    AZ_Error("LevelSystem", AzFramework::LevelSystemLifecycleInterface::Get() == this,
+        "Failed to register the LevelSystem with the LevelSystemLifecycleInterface.");
 }
 
 //------------------------------------------------------------------------
 CLevelSystem::~CLevelSystem()
 {
     UnloadLevel();
-    AzFramework::LevelSystemLifecycleInterface::Unregister(this);
 }
 
 //------------------------------------------------------------------------

--- a/Code/Legacy/CrySystem/LevelSystem/LevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/LevelSystem.cpp
@@ -200,12 +200,18 @@ CLevelSystem::CLevelSystem(ISystem* pSystem, const char* levelsFolder)
         });
         m_levelPackCloseHandler.Connect(*levelPakCloseEvent);
     }
+
+    auto registerOutcome = AzFramework::LevelSystemLifecycleInterface::Register(this);
+    AZ_Error("LevelSystem", registerOutcome,
+        "Failed to register the LevelSystem with the LevelSystemLifecycleInterface: %s",
+        registerOutcome.GetError().c_str());
 }
 
 //------------------------------------------------------------------------
 CLevelSystem::~CLevelSystem()
 {
     UnloadLevel();
+    AzFramework::LevelSystemLifecycleInterface::Unregister(this);
 }
 
 //------------------------------------------------------------------------

--- a/Code/Legacy/CrySystem/LevelSystem/LevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/LevelSystem.cpp
@@ -200,14 +200,11 @@ CLevelSystem::CLevelSystem(ISystem* pSystem, const char* levelsFolder)
         });
         m_levelPackCloseHandler.Connect(*levelPakCloseEvent);
     }
-
-    AzFramework::LevelSystemLifecycleRequestBus::Handler::BusConnect();
 }
 
 //------------------------------------------------------------------------
 CLevelSystem::~CLevelSystem()
 {
-    AzFramework::LevelSystemLifecycleRequestBus::Handler::BusDisconnect();
     UnloadLevel();
 }
 

--- a/Code/Legacy/CrySystem/LevelSystem/LevelSystem.h
+++ b/Code/Legacy/CrySystem/LevelSystem/LevelSystem.h
@@ -74,7 +74,7 @@ private:
 
 class CLevelSystem
     : public ILevelSystem
-    , AZ::Interface<AzFramework::ILevelSystemLifecycle>::Registrar
+    , AzFramework::LevelSystemLifecycleInterface::Registrar
 {
 public:
     CLevelSystem(ISystem* pSystem, const char* levelsFolder);
@@ -94,7 +94,7 @@ public:
     bool LoadLevel(const char* levelName) override;
     void UnloadLevel() override;
 
-    //! AzFramework::LevelSystemLifecycleRequestBus overrides.
+    //! AzFramework::LevelSystemLifecycleInterface overrides.
     //! @{
     bool IsLevelLoaded() const override { return m_bLevelLoaded; }
 

--- a/Code/Legacy/CrySystem/LevelSystem/LevelSystem.h
+++ b/Code/Legacy/CrySystem/LevelSystem/LevelSystem.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "ILevelSystem.h"
+#include <AzFramework/API/ApplicationAPI.h>
 #include <AzFramework/Archive/IArchive.h>
 #include <CryCommon/TimeValue.h>
 
@@ -73,6 +74,7 @@ private:
 
 class CLevelSystem
     : public ILevelSystem
+    , AzFramework::LevelSystemLifecycleRequestBus::Handler
 {
 public:
     CLevelSystem(ISystem* pSystem, const char* levelsFolder);
@@ -92,6 +94,16 @@ public:
     bool LoadLevel(const char* levelName) override;
     void UnloadLevel() override;
     bool IsLevelLoaded() override { return m_bLevelLoaded; }
+
+    AZStd::string GetCurrentLevelName() override
+    {
+        if (m_pCurrentLevel && m_pCurrentLevel->GetLevelInfo())
+        {
+            return m_pCurrentLevel->GetLevelInfo()->GetName();
+        }
+        return "";
+    }
+
     const char* GetCurrentLevelName() const override
     {
         if (m_pCurrentLevel && m_pCurrentLevel->GetLevelInfo())

--- a/Code/Legacy/CrySystem/LevelSystem/LevelSystem.h
+++ b/Code/Legacy/CrySystem/LevelSystem/LevelSystem.h
@@ -74,7 +74,7 @@ private:
 
 class CLevelSystem
     : public ILevelSystem
-    , AzFramework::LevelSystemLifecycleInterface::Registrar
+    , AzFramework::ILevelSystemLifecycle
 {
 public:
     CLevelSystem(ISystem* pSystem, const char* levelsFolder);

--- a/Code/Legacy/CrySystem/LevelSystem/LevelSystem.h
+++ b/Code/Legacy/CrySystem/LevelSystem/LevelSystem.h
@@ -74,7 +74,7 @@ private:
 
 class CLevelSystem
     : public ILevelSystem
-    , AzFramework::LevelSystemLifecycleRequestBus::Handler
+    , AZ::Interface<AzFramework::ILevelSystemLifecycle>::Registrar
 {
 public:
     CLevelSystem(ISystem* pSystem, const char* levelsFolder);
@@ -93,16 +93,10 @@ public:
 
     bool LoadLevel(const char* levelName) override;
     void UnloadLevel() override;
-    bool IsLevelLoaded() override { return m_bLevelLoaded; }
 
-    AZStd::string GetCurrentLevelName() override
-    {
-        if (m_pCurrentLevel && m_pCurrentLevel->GetLevelInfo())
-        {
-            return m_pCurrentLevel->GetLevelInfo()->GetName();
-        }
-        return "";
-    }
+    //! AzFramework::LevelSystemLifecycleRequestBus overrides.
+    //! @{
+    bool IsLevelLoaded() const override { return m_bLevelLoaded; }
 
     const char* GetCurrentLevelName() const override
     {
@@ -112,6 +106,7 @@ public:
         }
         return "";
     }
+    //! @}
 
     // If the level load failed then we need to have a different shutdown procedure vs when a level is naturally unloaded
     void SetLevelLoadFailed(bool loadFailed) override { m_levelLoadFailed = loadFailed; }

--- a/Code/Legacy/CrySystem/LevelSystem/LevelSystem.h
+++ b/Code/Legacy/CrySystem/LevelSystem/LevelSystem.h
@@ -74,7 +74,7 @@ private:
 
 class CLevelSystem
     : public ILevelSystem
-    , AzFramework::ILevelSystemLifecycle
+    , AzFramework::LevelSystemLifecycleInterface::Registrar
 {
 public:
     CLevelSystem(ISystem* pSystem, const char* levelsFolder);

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
@@ -83,10 +83,8 @@ namespace LegacyLevelSystem
 
         AzFramework::RootSpawnableNotificationBus::Handler::BusConnect();
 
-        auto registerOutcome = AzFramework::LevelSystemLifecycleInterface::Register(this);
-        AZ_Error( "SpawnableLevelSystem", registerOutcome,
-            "Failed to register the SpawnableLevelSystem with the LevelSystemLifecycleInterface: %s",
-            registerOutcome.GetError().c_str());
+        AZ_Error("SpawnableLevelSystem", AzFramework::LevelSystemLifecycleInterface::Get() == this,
+            "Failed to register the SpawnableLevelSystem with the LevelSystemLifecycleInterface.");
 
         // If there were LoadLevel command invocations before the creation of the level system
         // then those invocations were queued.
@@ -110,7 +108,6 @@ namespace LegacyLevelSystem
     //------------------------------------------------------------------------
     SpawnableLevelSystem::~SpawnableLevelSystem()
     {
-        AzFramework::LevelSystemLifecycleInterface::Unregister(this);
         AzFramework::RootSpawnableNotificationBus::Handler::BusDisconnect();
     }
 

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
@@ -82,7 +82,6 @@ namespace LegacyLevelSystem
         }
 
         AzFramework::RootSpawnableNotificationBus::Handler::BusConnect();
-        AzFramework::LevelSystemLifecycleRequestBus::Handler::BusConnect();
 
         // If there were LoadLevel command invocations before the creation of the level system
         // then those invocations were queued.
@@ -106,7 +105,6 @@ namespace LegacyLevelSystem
     //------------------------------------------------------------------------
     SpawnableLevelSystem::~SpawnableLevelSystem()
     {
-        AzFramework::LevelSystemLifecycleRequestBus::Handler::BusDisconnect();
         AzFramework::RootSpawnableNotificationBus::Handler::BusDisconnect();
     }
 
@@ -115,14 +113,9 @@ namespace LegacyLevelSystem
         delete this;
     }
 
-    bool SpawnableLevelSystem::IsLevelLoaded()
+    bool SpawnableLevelSystem::IsLevelLoaded() const
     {
         return m_bLevelLoaded;
-    }
-
-    AZStd::string SpawnableLevelSystem::GetCurrentLevelName()
-    {
-        return m_bLevelLoaded ? m_lastLevelName : "";
     }
 
     const char* SpawnableLevelSystem::GetCurrentLevelName() const

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
@@ -82,6 +82,7 @@ namespace LegacyLevelSystem
         }
 
         AzFramework::RootSpawnableNotificationBus::Handler::BusConnect();
+        AzFramework::LevelSystemLifecycleRequestBus::Handler::BusConnect();
 
         // If there were LoadLevel command invocations before the creation of the level system
         // then those invocations were queued.
@@ -105,6 +106,7 @@ namespace LegacyLevelSystem
     //------------------------------------------------------------------------
     SpawnableLevelSystem::~SpawnableLevelSystem()
     {
+        AzFramework::LevelSystemLifecycleRequestBus::Handler::BusDisconnect();
         AzFramework::RootSpawnableNotificationBus::Handler::BusDisconnect();
     }
 
@@ -116,6 +118,11 @@ namespace LegacyLevelSystem
     bool SpawnableLevelSystem::IsLevelLoaded()
     {
         return m_bLevelLoaded;
+    }
+
+    AZStd::string SpawnableLevelSystem::GetCurrentLevelName()
+    {
+        return m_bLevelLoaded ? m_lastLevelName : "";
     }
 
     const char* SpawnableLevelSystem::GetCurrentLevelName() const
@@ -237,8 +244,8 @@ namespace LegacyLevelSystem
 
         // This is a valid level, find out if any systems need to stop level loading before proceeding
         bool blockLoading = false;
-        AzFramework::LevelSystemLifecycleRequestBus::EnumerateHandlers(
-            [&blockLoading, &validLevelName](AzFramework::LevelSystemLifecycleRequests* handler)->bool
+        AzFramework::LevelLoadBlockerBus::EnumerateHandlers(
+            [&blockLoading, &validLevelName](AzFramework::LevelLoadBlockerRequests* handler) -> bool
             {
                 if (handler->ShouldBlockLevelLoading(validLevelName.c_str()))
                 {

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
@@ -83,6 +83,11 @@ namespace LegacyLevelSystem
 
         AzFramework::RootSpawnableNotificationBus::Handler::BusConnect();
 
+        auto registerOutcome = AzFramework::LevelSystemLifecycleInterface::Register(this);
+        AZ_Error( "SpawnableLevelSystem", registerOutcome,
+            "Failed to register the SpawnableLevelSystem with the LevelSystemLifecycleInterface: %s",
+            registerOutcome.GetError().c_str());
+
         // If there were LoadLevel command invocations before the creation of the level system
         // then those invocations were queued.
         // load the last level in the queue, since only one level can be loaded at a time
@@ -105,6 +110,7 @@ namespace LegacyLevelSystem
     //------------------------------------------------------------------------
     SpawnableLevelSystem::~SpawnableLevelSystem()
     {
+        AzFramework::LevelSystemLifecycleInterface::Unregister(this);
         AzFramework::RootSpawnableNotificationBus::Handler::BusDisconnect();
     }
 

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
@@ -20,7 +20,7 @@ namespace LegacyLevelSystem
 class SpawnableLevelSystem
         : public ILevelSystem
         , public AzFramework::RootSpawnableNotificationBus::Handler
-        , AzFramework::LevelSystemLifecycleRequestBus::Handler
+        , AZ::Interface<AzFramework::ILevelSystemLifecycle>::Registrar
     {
     public:
         explicit SpawnableLevelSystem(ISystem* pSystem);
@@ -35,15 +35,11 @@ class SpawnableLevelSystem
 
         bool LoadLevel(const char* levelName) override;
         void UnloadLevel() override;
-        bool IsLevelLoaded() override;
 
         // If the level load failed then we need to have a different shutdown procedure vs when a level is naturally unloaded
         void SetLevelLoadFailed(bool loadFailed) override;
         bool GetLevelLoadFailed() override;
         AZ::Data::AssetType GetLevelAssetType() const override;
-
-        // Deprecated. Use AzFramework::LevelSystemLifecycleRequests::GetCurrentLevelName instead.
-        const char* GetCurrentLevelName() const override;
 
         // The following methods are deprecated from ILevelSystem and will be removed once slice support is removed.
         // [LYN-2376] Remove once legacy slice support is removed
@@ -55,7 +51,8 @@ class SpawnableLevelSystem
 
         //! AzFramework::LevelSystemLifecycleRequestBus overrides.
         //! @{
-        AZStd::string GetCurrentLevelName() override;
+        const char* GetCurrentLevelName() const override;
+        bool IsLevelLoaded() const override;
         //! @}
 
     private:

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
@@ -20,7 +20,7 @@ namespace LegacyLevelSystem
 class SpawnableLevelSystem
         : public ILevelSystem
         , public AzFramework::RootSpawnableNotificationBus::Handler
-        , AzFramework::ILevelSystemLifecycle
+        , AzFramework::LevelSystemLifecycleInterface::Registrar
     {
     public:
         explicit SpawnableLevelSystem(ISystem* pSystem);

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
@@ -9,8 +9,7 @@
 #pragma once
 
 #include "ILevelSystem.h"
-#include <AzCore/Console/IConsole.h>
-#include <AzFramework/Archive/IArchive.h>
+#include <AzFramework/API/ApplicationAPI.h>
 #include <AzFramework/Spawnable/RootSpawnableInterface.h>
 #include <CryCommon/TimeValue.h>
 

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
@@ -20,12 +20,14 @@ namespace LegacyLevelSystem
 class SpawnableLevelSystem
         : public ILevelSystem
         , public AzFramework::RootSpawnableNotificationBus::Handler
+        , AzFramework::LevelSystemLifecycleRequestBus::Handler
     {
     public:
         explicit SpawnableLevelSystem(ISystem* pSystem);
         ~SpawnableLevelSystem() override;
 
-        // ILevelSystem
+        //! ILevelSystem overrides.
+        //! @{
         void Release() override;
 
         void AddListener(ILevelSystemListener* pListener) override;
@@ -34,20 +36,27 @@ class SpawnableLevelSystem
         bool LoadLevel(const char* levelName) override;
         void UnloadLevel() override;
         bool IsLevelLoaded() override;
-        const char* GetCurrentLevelName() const override;
 
         // If the level load failed then we need to have a different shutdown procedure vs when a level is naturally unloaded
         void SetLevelLoadFailed(bool loadFailed) override;
         bool GetLevelLoadFailed() override;
         AZ::Data::AssetType GetLevelAssetType() const override;
 
-        // The following methods are deprecated from ILevelSystem and will be removed once slice support is removed.
+        // Deprecated. Use AzFramework::LevelSystemLifecycleRequests::GetCurrentLevelName instead.
+        const char* GetCurrentLevelName() const override;
 
+        // The following methods are deprecated from ILevelSystem and will be removed once slice support is removed.
         // [LYN-2376] Remove once legacy slice support is removed
         void Rescan([[maybe_unused]] const char* levelsFolder) override;
         int GetLevelCount() override;
         ILevelInfo* GetLevelInfo([[maybe_unused]] int level) override;
         ILevelInfo* GetLevelInfo([[maybe_unused]] const char* levelName) override;
+        //! @}
+
+        //! AzFramework::LevelSystemLifecycleRequestBus overrides.
+        //! @{
+        AZStd::string GetCurrentLevelName() override;
+        //! @}
 
     private:
         void OnRootSpawnableAssigned(AZ::Data::Asset<AzFramework::Spawnable> rootSpawnable, uint32_t generation) override;

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
@@ -20,7 +20,7 @@ namespace LegacyLevelSystem
 class SpawnableLevelSystem
         : public ILevelSystem
         , public AzFramework::RootSpawnableNotificationBus::Handler
-        , AzFramework::LevelSystemLifecycleInterface::Registrar
+        , AzFramework::ILevelSystemLifecycle
     {
     public:
         explicit SpawnableLevelSystem(ISystem* pSystem);

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
@@ -20,7 +20,7 @@ namespace LegacyLevelSystem
 class SpawnableLevelSystem
         : public ILevelSystem
         , public AzFramework::RootSpawnableNotificationBus::Handler
-        , AZ::Interface<AzFramework::ILevelSystemLifecycle>::Registrar
+        , AzFramework::LevelSystemLifecycleInterface::Registrar
     {
     public:
         explicit SpawnableLevelSystem(ISystem* pSystem);
@@ -49,7 +49,7 @@ class SpawnableLevelSystem
         ILevelInfo* GetLevelInfo([[maybe_unused]] const char* levelName) override;
         //! @}
 
-        //! AzFramework::LevelSystemLifecycleRequestBus overrides.
+        //! AzFramework::LevelSystemLifecycleInterface overrides.
         //! @{
         const char* GetCurrentLevelName() const override;
         bool IsLevelLoaded() const override;

--- a/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYCommonMenu.cpp
+++ b/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYCommonMenu.cpp
@@ -303,16 +303,16 @@ namespace ImGui
 
                 // View Maps ( pending valid ILevelSystem )
                 auto lvlSystem = (gEnv && gEnv->pSystem) ? gEnv->pSystem->GetILevelSystem() : nullptr;
-                if (lvlSystem && ImGui::BeginMenu("Levels"))
+                if (lvlSystem && LevelSystemLifecycleInterface::Get() && ImGui::BeginMenu("Levels"))
                 {
-                    if (AzFramework::LevelSystemLifecycleInterface::Get()->IsLevelLoaded())
+                    if (LevelSystemLifecycleInterface::Get()->IsLevelLoaded())
                     {
                         ImGui::TextColored(ImGui::Colors::s_PlainLabelColor, "Current Level: ");
                         ImGui::SameLine();
                         ImGui::TextColored(
                             ImGui::Colors::s_NiceLabelColor,
                             "%s",
-                            AzFramework::LevelSystemLifecycleInterface::Get()->GetCurrentLevelName());
+                            LevelSystemLifecycleInterface::Get()->GetCurrentLevelName());
                     }
 
                     bool usePrefabSystemForLevels = false;

--- a/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYCommonMenu.cpp
+++ b/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYCommonMenu.cpp
@@ -305,11 +305,15 @@ namespace ImGui
                 auto lvlSystem = (gEnv && gEnv->pSystem) ? gEnv->pSystem->GetILevelSystem() : nullptr;
                 if (lvlSystem && ImGui::BeginMenu("Levels"))
                 {
-                    if (lvlSystem->IsLevelLoaded())
+                    AZStd::string currentLevelName;
+                    AzFramework::LevelSystemLifecycleRequestBus::BroadcastResult(
+                        currentLevelName, &AzFramework::LevelSystemLifecycleRequests::GetCurrentLevelName);
+
+                    if (!currentLevelName.empty())
                     {
                         ImGui::TextColored(ImGui::Colors::s_PlainLabelColor, "Current Level: ");
                         ImGui::SameLine();
-                        ImGui::TextColored(ImGui::Colors::s_NiceLabelColor, "%s", lvlSystem->GetCurrentLevelName());
+                        ImGui::TextColored(ImGui::Colors::s_NiceLabelColor, "%s", currentLevelName.c_str());
                     }
 
                     bool usePrefabSystemForLevels = false;

--- a/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYCommonMenu.cpp
+++ b/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYCommonMenu.cpp
@@ -303,16 +303,16 @@ namespace ImGui
 
                 // View Maps ( pending valid ILevelSystem )
                 auto lvlSystem = (gEnv && gEnv->pSystem) ? gEnv->pSystem->GetILevelSystem() : nullptr;
-                if (lvlSystem && LevelSystemLifecycleInterface::Get() && ImGui::BeginMenu("Levels"))
+                if (lvlSystem && AzFramework::LevelSystemLifecycleInterface::Get() && ImGui::BeginMenu("Levels"))
                 {
-                    if (LevelSystemLifecycleInterface::Get()->IsLevelLoaded())
+                    if (AzFramework::LevelSystemLifecycleInterface::Get()->IsLevelLoaded())
                     {
                         ImGui::TextColored(ImGui::Colors::s_PlainLabelColor, "Current Level: ");
                         ImGui::SameLine();
                         ImGui::TextColored(
                             ImGui::Colors::s_NiceLabelColor,
                             "%s",
-                            LevelSystemLifecycleInterface::Get()->GetCurrentLevelName());
+                            AzFramework::LevelSystemLifecycleInterface::Get()->GetCurrentLevelName());
                     }
 
                     bool usePrefabSystemForLevels = false;

--- a/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYCommonMenu.cpp
+++ b/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYCommonMenu.cpp
@@ -305,15 +305,14 @@ namespace ImGui
                 auto lvlSystem = (gEnv && gEnv->pSystem) ? gEnv->pSystem->GetILevelSystem() : nullptr;
                 if (lvlSystem && ImGui::BeginMenu("Levels"))
                 {
-                    AZStd::string currentLevelName;
-                    AzFramework::LevelSystemLifecycleRequestBus::BroadcastResult(
-                        currentLevelName, &AzFramework::LevelSystemLifecycleRequests::GetCurrentLevelName);
-
-                    if (!currentLevelName.empty())
+                    if (AzFramework::LevelSystemLifecycleInterface::Get()->IsLevelLoaded())
                     {
                         ImGui::TextColored(ImGui::Colors::s_PlainLabelColor, "Current Level: ");
                         ImGui::SameLine();
-                        ImGui::TextColored(ImGui::Colors::s_NiceLabelColor, "%s", currentLevelName.c_str());
+                        ImGui::TextColored(
+                            ImGui::Colors::s_NiceLabelColor,
+                            "%s",
+                            AzFramework::LevelSystemLifecycleInterface::Get()->GetCurrentLevelName());
                     }
 
                     bool usePrefabSystemForLevels = false;

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -230,7 +230,7 @@ namespace Multiplayer
         AzFramework::RootSpawnableNotificationBus::Handler::BusConnect();
         AZ::TickBus::Handler::BusConnect();
         SessionNotificationBus::Handler::BusConnect();
-        AzFramework::LevelSystemLifecycleRequestBus::Handler::BusConnect();
+        AzFramework::LevelLoadBlockerBus::Handler::BusConnect();
         const AZ::Name interfaceName = AZ::Name(MpNetworkInterfaceName);
         m_networkInterface = AZ::Interface<INetworking>::Get()->CreateNetworkInterface(interfaceName, sv_protocol, TrustZone::ExternalClientToServer, *this);
 
@@ -256,7 +256,7 @@ namespace Multiplayer
         m_consoleCommandHandler.Disconnect();
         const AZ::Name interfaceName = AZ::Name(MpNetworkInterfaceName);
         AZ::Interface<INetworking>::Get()->DestroyNetworkInterface(interfaceName);
-        AzFramework::LevelSystemLifecycleRequestBus::Handler::BusDisconnect();
+        AzFramework::LevelLoadBlockerBus::Handler::BusDisconnect();
         SessionNotificationBus::Handler::BusDisconnect();
         AZ::TickBus::Handler::BusDisconnect();
         AzFramework::RootSpawnableNotificationBus::Handler::BusDisconnect();

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
@@ -45,7 +45,7 @@ namespace Multiplayer
         , public AzNetworking::IConnectionListener
         , public IMultiplayer
         , AzFramework::RootSpawnableNotificationBus::Handler
-        , AzFramework::LevelSystemLifecycleRequestBus::Handler
+        , AzFramework::LevelLoadBlockerBus::Handler
     {
     public:
         AZ_COMPONENT(MultiplayerSystemComponent, "{7C99C4C1-1103-43F9-AD62-8B91CF7C1981}");
@@ -148,7 +148,7 @@ namespace Multiplayer
         void OnRootSpawnableReady(AZ::Data::Asset<AzFramework::Spawnable> rootSpawnable, uint32_t generation) override;
         //! @}
 
-        //! AzFramework::LevelSystemLifecycleRequestBus::Handler overrides.
+        //! AzFramework::LevelLoadBlockerBus::Handler overrides.
         //! @{
         bool ShouldBlockLevelLoading(const char* levelName) override;
         //! @}


### PR DESCRIPTION
- Adding GetCurrentLevelName() method to AzFramework LevelSystem in order to remove Cry dependency. 
- Multiplayer will need to use this value in an upcoming PR
- Rename level blocking with its own EBus

Signed-off-by: Gene Walters <genewalt@amazon.com>

_Please add links to any issues, RFCs or other items that are relevant to this PR._
A piece of #9666 

## How was this PR tested?
Making sure the updated code that was using the old GetLevelName is still working.
