### PR TITLE
Removed unnecessary #include lines from terrain shader code.

### DIFF
--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainCommon.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainCommon.azsli
@@ -7,10 +7,6 @@
 
 #pragma once
 
-#include <../Materials/Types/MaterialInputs/RoughnessInput.azsli>
-#include <../Materials/Types/MaterialInputs/MetallicInput.azsli>
-#include <../Materials/Types/MaterialInputs/SpecularInput.azsli>
-#include <../Materials/Types/MaterialInputs/NormalInput.azsli>
 #include <TerrainSrg.azsli>
 #include <TerrainMaterialSrg.azsli>
 #include <Atom/Features/PBR/Lights/ReflectionProbeData.azsli>

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainMaterialSrg.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainMaterialSrg.azsli
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <Atom/Features/SrgSemantics.azsli>
-#include <../Materials/Types/MaterialInputs/BaseColorInput.azsli>
 
 ShaderResourceGroup TerrainMaterialSrg : SRG_PerMaterial
 {


### PR DESCRIPTION

## What does this PR do?

Removed unnecessary #include lines from terrain shader code.

These paths were not resolving to the intended files and were being reported as missing, but the compilation still passed because nothing in the shader code actually depended on these files. So I just deleted the offending #included statements. The errors were like D:/o3de/Gems/Terrain/Assets/Shaders/Terrain/TerrainCommon.azsli:11: error: Can't open include file "../Materials/Types/MaterialInputs/MetallicInput.azsli"

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>

## How was this PR tested?

The shader files reprocessed in the AP with no errors reported.
