### PR TITLE
Clean up AP tests to make sure that database connection is closed before destroy the temp testing folder

### DIFF
--- a/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
@@ -182,6 +182,10 @@ namespace AssetProcessorMessagesTests
                 m_assetSystemComponent->Deactivate();
             }
             m_batchApplicationManager->Destroy();
+
+            m_assetCatalog.reset();
+            m_assetSystemComponent.reset();
+            m_batchApplicationManager.reset();
         }
 
         void RunNetworkRequest(AZStd::function<void()> func) const

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetManagerTestingBase.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetManagerTestingBase.cpp
@@ -144,6 +144,9 @@ namespace UnitTests
         AZ::AllocatorInstance<AZ::ThreadPoolAllocator>::Destroy();
         AZ::AllocatorInstance<AZ::PoolAllocator>::Destroy();
 
+        m_stateData.reset();
+        m_assetProcessorManager.reset();
+
         ScopedAllocatorSetupFixture::TearDown();
     }
 

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -100,7 +100,7 @@ void AssetProcessorManagerTest::SetUp()
 
     AssetUtilities::ResetAssetRoot();
 
-    m_assetRootDir = QDir(m_data->m_databaseLocationListener.GetAssetRootDir().c_str());
+    m_assetRootDir = QDir(m_databaseLocationListener.GetAssetRootDir().c_str());
     m_scopeDir = AZStd::make_unique<UnitTestUtils::ScopedDir>();
     m_scopeDir->Setup(m_assetRootDir.path());
 

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.h
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.h
@@ -170,6 +170,7 @@ protected:
 
     AZStd::unique_ptr<AssetProcessorManager_Test> m_assetProcessorManager;
     AZStd::unique_ptr<AssetProcessor::MockApplicationManager> m_mockApplicationManager;
+    AssetProcessor::MockAssetDatabaseRequestsHandler m_databaseLocationListener;
     AZStd::unique_ptr<AssetProcessor::PlatformConfiguration> m_config;
     QString m_gameName;
     QDir m_normalizedCacheRootDir;
@@ -184,7 +185,6 @@ protected:
     struct StaticData
     {
         AZStd::string m_databaseLocation;
-        AssetProcessor::MockAssetDatabaseRequestsHandler m_databaseLocationListener;
         AZ::Entity* m_jobManagerEntity{};
         AZ::ComponentDescriptor* m_descriptor{};
         AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?

Clean up AP tests to make sure that database connection is closed before destroy the temp testing folder.

## How was this PR tested?

Run AP tests locally and don't see the error related to QTempFolder any more.
