### PR TITLE
Improved culling performance by 2.5ms (roughly 50%)

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Culling.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Culling.h
@@ -263,6 +263,12 @@ namespace AZ
             //! Will create child jobs under the parentJob to do the processing in parallel.
             //! Can be called in parallel (i.e. to perform culling on multiple views at the same time).
             void ProcessCullablesJobs(const Scene& scene, View& view, AZ::Job& parentJob);
+            //! Variation that accumulates visibility nodes from the octree into lists to hand off to jobs
+            void ProcessCullablesJobsNodes(const Scene& scene, View& view, AZ::Job& parentJob);
+            //! Variation that accumulates entries into lists to hand off to jobs. This yieldeds more
+            //! balanced jobs and thus better performance than the above Nodes variation.
+            //! Use the r_useEntryWorkListsForCulling CVAR to toggle between the two.
+            void ProcessCullablesJobsEntries(const Scene& scene, View& view, AZ::Job& parentJob);
 
             //! Performs render culling and lod selection for a View, then adds the visible renderpackets to that View.
             //! Must be called between BeginCulling() and EndCulling(), once for each active scene/view pair.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Culling.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Culling.h
@@ -260,21 +260,18 @@ namespace AZ
 
             //! Performs render culling and lod selection for a View, then adds the visible renderpackets to that View.
             //! Must be called between BeginCulling() and EndCulling(), once for each active scene/view pair.
-            //! Will create child jobs under the parentJob to do the processing in parallel.
             //! Can be called in parallel (i.e. to perform culling on multiple views at the same time).
-            void ProcessCullablesJobs(const Scene& scene, View& view, AZ::Job& parentJob);
-            //! Variation that accumulates visibility nodes from the octree into lists to hand off to jobs
-            void ProcessCullablesJobsNodes(const Scene& scene, View& view, AZ::Job& parentJob);
+            void ProcessCullables(const Scene& scene, View& view, AZ::Job* parentJob, AZ::TaskGraph* taskGraph = nullptr, AZ::TaskGraphEvent* processCullablesTGEvent = nullptr);
             //! Variation that accumulates entries into lists to hand off to jobs. This yieldeds more
             //! balanced jobs and thus better performance than the above Nodes variation.
             //! Use the r_useEntryWorkListsForCulling CVAR to toggle between the two.
-            void ProcessCullablesJobsEntries(const Scene& scene, View& view, AZ::Job& parentJob);
+            void ProcessCullablesJobsEntries(const Scene& scene, View& view, AZ::Job* parentJob);
 
-            //! Performs render culling and lod selection for a View, then adds the visible renderpackets to that View.
-            //! Must be called between BeginCulling() and EndCulling(), once for each active scene/view pair.
+            //! Will create child jobs under the parentJob to do the processing in parallel.
+            void ProcessCullablesJobs(const Scene& scene, View& view, AZ::Job& parentJob);
+
             //! Will create child task graphs that signal the TaskGraphEvent to do the processing in parallel.
-            //! Can be called in parallel (i.e. to perform culling on multiple views at the same time).
-            void ProcessCullablesTG(const Scene& scene, View& view, AZ::TaskGraph& taskGraph);
+            void ProcessCullablesTG(const Scene& scene, View& view, AZ::TaskGraph& taskGraph, AZ::TaskGraphEvent& processCullablesTGEvent);
 
             //! Adds a Cullable to the underlying visibility system(s).
             //! Must be called at least once on initialization and whenever a Cullable's position or bounds is changed.

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
@@ -166,7 +166,7 @@ namespace AZ
             {
                 if (m_debugCtx->m_debugDraw && (m_view->GetName() == m_debugCtx->m_currentViewSelectionName))
                 {
-                    AuxGeomFeatureProcessorInterface::GetDrawQueueForScene(worklistData->m_scene);
+                    AuxGeomFeatureProcessorInterface::GetDrawQueueForScene(m_scene);
                 }
                 return nullptr;
             }
@@ -290,7 +290,7 @@ namespace AZ
                             if (worklistData->m_debugCtx->m_drawBoundingBoxes)
                             {
                                 auxGeomPtr->DrawObb(c->m_cullData.m_boundingObb, Matrix3x4::Identity(),
-                                    nodeIsContainedInFrustum ? Colors::Lime : Colors::Yellow, AuxGeomDraw::DrawStyle::Line);
+                                    parentNodeContainedInFrustum ? Colors::Lime : Colors::Yellow, AuxGeomDraw::DrawStyle::Line);
                             }
 
                             if (worklistData->m_debugCtx->m_drawBoundingSpheres)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -470,8 +470,6 @@ namespace AZ
                 }
                 else if (pipelineViews.m_type == PipelineViewType::Persistent)
                 {
-                    // Reset persistent view: clean draw list mask and draw lists
-                    pipelineViews.m_views[0]->Reset();
                     pipelineViews.m_views[0]->SetPassesByDrawList(&pipelineViews.m_passesByDrawList);
                 }
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -582,7 +582,7 @@ namespace AZ
                     processCullablesTG.AddTask(processCullablesDescriptor, [this, &viewPtr, &processCullablesTGEvent]()
                         {
                             AZ::TaskGraph subTaskGraph{ "ProcessCullables Subgraph" };
-                            m_cullingScene->ProcessCullablesTG(*this, *viewPtr, subTaskGraph);
+                            m_cullingScene->ProcessCullablesTG(*this, *viewPtr, subTaskGraph, processCullablesTGEvent);
                             if (!subTaskGraph.IsEmpty())
                             {
                                 subTaskGraph.Detach();
@@ -595,7 +595,7 @@ namespace AZ
             {
                 for (ViewPtr& viewPtr : m_renderPacket.m_views)
                 {
-                    m_cullingScene->ProcessCullablesTG(*this, *viewPtr, processCullablesTG);
+                    m_cullingScene->ProcessCullablesTG(*this, *viewPtr, processCullablesTG, processCullablesTGEvent);
                 }
             }
             bool processCullablesHasWork = !processCullablesTG.IsEmpty();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
@@ -82,9 +82,12 @@ namespace AZ
 
         void View::SetDrawListMask(const RHI::DrawListMask& drawListMask)
         {
-            m_drawListMask = drawListMask;
-            m_drawListContext.Shutdown();
-            m_drawListContext.Init(m_drawListMask);
+            if (m_drawListMask != drawListMask)
+            {
+                m_drawListMask = drawListMask;
+                m_drawListContext.Shutdown();
+                m_drawListContext.Init(m_drawListMask);
+            }
         }
 
         void View::Reset()


### PR DESCRIPTION
Changes:

**Culling.cpp**: changed WorkListCapacity from 5 to 9. This increases performance quite a bit as it increases the size of the array of visibility nodes we fill before we spawn a job to process that list (so less job spawning, longer jobs, better performance)
The rest of Culling.cpp is just cosmetic changes

**RenderPipeline.cpp**: Removed unnecessary call to reset views. Resetting the view resets the DrawListContext, which kills all the array and so the array capacity during the next draw list context gather will be 0, resulting in array growing and memory allocations. This changes lets the arrays keep their capacity for better draw item insertion.

**View.cpp**: Don't reset the DrawListContext if the mask is the same (for the same reason as just stated)

Update:
Added a commit with the option to use entry lists instead of visibility node lists for job work. This creates more balanced jobs and results in better performance when tested. There is a CVAR to switch between this and the old node list method as well as a CVARs to control the amount of entities accumulated into the node list / entity list respectively before the lists are handed off to jobs.


Signed-off-by: antonmic <56370189+antonmic@users.noreply.github.com>
