### PR TITLE
bugfix(ToolsFramework): ensure TransformRowWidget widget deletes additional components 

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
@@ -170,6 +170,7 @@ namespace AzToolsFramework
         m_handler = nullptr;
         m_isMultiSizeContainer = false;
         m_isFixedSizeOrSmartPtrContainer = false;
+        m_custom = false;
         if (m_selectionEnabled) 
         {
             SetSelected(false);

--- a/Code/Tools/SceneAPI/SceneUI/RowWidgets/TransformRowWidget.cpp
+++ b/Code/Tools/SceneAPI/SceneUI/RowWidgets/TransformRowWidget.cpp
@@ -103,12 +103,12 @@ namespace AZ
             TransformRowWidget::TransformRowWidget(QWidget* parent)
                 : QWidget(parent)
             {
-                QWidget* hider = new QWidget();
+                m_containerWidget = new QWidget();
                 QGridLayout* layout = new QGridLayout();
                 layout->setMargin(0);
                 QGridLayout* layout2 = new QGridLayout();
                 setLayout(layout);
-                AzToolsFramework::PropertyRowWidget* parentWidget = reinterpret_cast<AzToolsFramework::PropertyRowWidget*>(parent);
+                AzToolsFramework::PropertyRowWidget* parentWidget = static_cast<AzToolsFramework::PropertyRowWidget*>(parent);
                 QToolButton* toolButton = parentWidget->GetIndicatorButton();
                 QVBoxLayout* layoutOriginal = parentWidget->GetLeftHandSideLayoutParent();
                 parentWidget->SetAsCustom(true);
@@ -146,22 +146,22 @@ namespace AZ
                 parentWidget->SetIndentSize(1);
                 toolButton->setVisible(true);
 
-                hider->setLayout(layout2);
-                layoutOriginal->addWidget(hider);
+                m_containerWidget->setLayout(layout2);
+                layoutOriginal->addWidget(m_containerWidget);
 
-                connect(toolButton, &QToolButton::clicked, this, [this, hider, toolButton]
+                connect(toolButton, &QToolButton::clicked, this, [&, toolButton]
                 {
                     m_expanded = !m_expanded;
                     if (m_expanded)
                     {
-                        this->show();
-                        hider->show();
+                        show();
+                        m_containerWidget->show();
                         toolButton->setArrowType(Qt::DownArrow);
                     }
                     else
                     {
-                        this->hide();
-                        hider->hide();
+                        hide();
+                        m_containerWidget->hide();
                         toolButton->setArrowType(Qt::RightArrow);
                     }
                 });
@@ -195,6 +195,14 @@ namespace AZ
                     m_transform.SetScale(scale);
                     AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&AzToolsFramework::PropertyEditorGUIMessages::RequestWrite, this);
                 });
+            }
+
+            TransformRowWidget::~TransformRowWidget()
+            {
+                if (m_containerWidget)
+                {
+                    m_containerWidget->deleteLater();
+                }
             }
 
             void TransformRowWidget::SetEnableEdit(bool enableEdit)

--- a/Code/Tools/SceneAPI/SceneUI/RowWidgets/TransformRowWidget.h
+++ b/Code/Tools/SceneAPI/SceneUI/RowWidgets/TransformRowWidget.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
+#include <QPointer>
 #include <QString>
 #include <QLineEdit>
 #include <AzCore/Math/Transform.h>
@@ -71,6 +72,7 @@ namespace AZ
                 AZ_CLASS_ALLOCATOR_DECL;
 
                 explicit TransformRowWidget(QWidget* parent = nullptr);
+                ~TransformRowWidget();
 
                 void SetEnableEdit(bool enableEdit);
 
@@ -87,6 +89,7 @@ namespace AZ
 
                 bool m_expanded = true;
 
+                QPointer<QWidget> m_containerWidget;
                 AzQtComponents::VectorInput* m_translationWidget;
                 AzQtComponents::VectorInput* m_rotationWidget;
                 AzToolsFramework::PropertyDoubleSpinCtrl* m_scaleWidget;


### PR DESCRIPTION
ref: https://github.com/o3de/o3de/issues/12602

Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

this just makes sure that the modifications that are introduced with the TransformwWidget is cleaned up with the component is deleted.  this is because PropertyRowWidget is recycled and reused so any change to the component will need to be undone when the widget is return to the pool

## How was this PR tested?

follow step in the referenced issue
