### PR TITLE
Updated the Editor TitleBar to use the Project Display Name

### DIFF
--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -679,7 +679,7 @@ void CCryEditApp::OnFileSave()
     }
 
     const QScopedValueRollback<bool> rollback(m_savingLevel, true);
-    
+
     bool usePrefabSystemForLevels = false;
     AzFramework::ApplicationRequests::Bus::BroadcastResult(
         usePrefabSystemForLevels, &AzFramework::ApplicationRequests::IsPrefabSystemEnabled);
@@ -1794,7 +1794,7 @@ bool CCryEditApp::InitInstance()
         }
     }
 
-    SetEditorWindowTitle(nullptr, AZ::Utils::GetProjectName().c_str(), nullptr);
+    SetEditorWindowTitle(nullptr, AZ::Utils::GetProjectDisplayName().c_str(), nullptr);
     if (!GetIEditor()->IsInMatEditMode())
     {
         m_pEditor->InitFinished();
@@ -1872,7 +1872,7 @@ void CCryEditApp::LoadFile(QString fileName)
 
     if (MainWindow::instance() || m_pConsoleDialog)
     {
-        SetEditorWindowTitle(nullptr, AZ::Utils::GetProjectName().c_str(), GetIEditor()->GetGameEngine()->GetLevelName());
+        SetEditorWindowTitle(nullptr, AZ::Utils::GetProjectDisplayName().c_str(), GetIEditor()->GetGameEngine()->GetLevelName());
     }
 
     GetIEditor()->SetModifiedFlag(false);

--- a/Code/Editor/MainWindow.cpp
+++ b/Code/Editor/MainWindow.cpp
@@ -418,7 +418,7 @@ MainWindow::~MainWindow()
         GetEntityContextId(), &ActionOverrideRequests::TeardownActionOverrideHandler);
 
     m_instance = nullptr;
-    
+
     if (!IsNewActionManagerEnabled())
     {
         delete m_levelEditorMenuHandler;
@@ -763,7 +763,7 @@ void MainWindow::InitActions()
                 EditorTransformComponentSelectionRequestBus::Event(
                     GetEntityContextId(), &EditorTransformComponentSelectionRequests::SetTransformMode,
                     EditorTransformComponentSelectionRequests::Mode::Translation);
-            });                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
+            });
     am->AddAction(AzToolsFramework::EditModeRotate, tr("Rotate"))
         .SetIcon(Style::icon("Translate"))
         .SetShortcut(tr("2"))
@@ -1434,7 +1434,7 @@ void MainWindow::OnEditorNotifyEvent(EEditorNotifyEvent ev)
         auto cryEdit = CCryEditApp::instance();
         if (cryEdit)
         {
-            cryEdit->SetEditorWindowTitle(nullptr, AZ::Utils::GetProjectName().c_str(), GetIEditor()->GetGameEngine()->GetLevelName());
+            cryEdit->SetEditorWindowTitle(nullptr, AZ::Utils::GetProjectDisplayName().c_str(), GetIEditor()->GetGameEngine()->GetLevelName());
         }
     }
     break;
@@ -1443,7 +1443,7 @@ void MainWindow::OnEditorNotifyEvent(EEditorNotifyEvent ev)
         auto cryEdit = CCryEditApp::instance();
         if (cryEdit)
         {
-            cryEdit->SetEditorWindowTitle(nullptr, AZ::Utils::GetProjectName().c_str(), nullptr);
+            cryEdit->SetEditorWindowTitle(nullptr, AZ::Utils::GetProjectDisplayName().c_str(), nullptr);
         }
     }
     break;

--- a/Code/Editor/WelcomeScreen/WelcomeScreenDialog.cpp
+++ b/Code/Editor/WelcomeScreen/WelcomeScreenDialog.cpp
@@ -78,7 +78,7 @@ WelcomeScreenDialog::WelcomeScreenDialog(QWidget* pParent)
     {
         projectPreviewPath = ":/WelcomeScreenDialog/DefaultProjectImage.png";
     }
-    
+
     ui->activeProjectIcon->setPixmap(
         AzQtComponents::ScalePixmapForScreenDpi(
             QPixmap(projectPreviewPath),
@@ -99,8 +99,8 @@ WelcomeScreenDialog::WelcomeScreenDialog(QWidget* pParent)
     ui->recentLevelTable->setIconSize(QSize(20, 20));
     installEventFilter(this);
 
-    auto projectName = AZ::Utils::GetProjectName();
-    ui->currentProjectName->setText(projectName.c_str());
+    auto projectDisplayName = AZ::Utils::GetProjectDisplayName();
+    ui->currentProjectName->setText(projectDisplayName.c_str());
 
     ui->newLevelButton->setDefault(true);
 

--- a/Code/Framework/AzCore/AzCore/Utils/Utils.cpp
+++ b/Code/Framework/AzCore/AzCore/Utils/Utils.cpp
@@ -177,6 +177,29 @@ namespace AZ::Utils
         return {};
     }
 
+    AZ::SettingsRegistryInterface::FixedValueString GetProjectDisplayName(AZ::SettingsRegistryInterface* settingsRegistry)
+    {
+        if (settingsRegistry == nullptr)
+        {
+            settingsRegistry = AZ::SettingsRegistry::Get();
+        }
+
+        if (settingsRegistry != nullptr)
+        {
+            using FixedValueString = AZ::SettingsRegistryInterface::FixedValueString;
+            FixedValueString projectNameKey{ AZ::SettingsRegistryMergeUtils::ProjectSettingsRootKey };
+            projectNameKey += "/display_name";
+
+            if (FixedValueString settingsValue;
+                settingsRegistry->Get(settingsValue, projectNameKey))
+            {
+                return settingsValue;
+            }
+        }
+        // fallback to querying the "project_name", if the "display_name" could not be read
+        return GetProjectName(settingsRegistry);
+    }
+
     AZ::IO::FixedMaxPathString GetGemPath(AZStd::string_view gemName, AZ::SettingsRegistryInterface* settingsRegistry)
     {
         if (settingsRegistry == nullptr)

--- a/Code/Framework/AzCore/AzCore/Utils/Utils.h
+++ b/Code/Framework/AzCore/AzCore/Utils/Utils.h
@@ -92,6 +92,13 @@ namespace AZ
         //! If nullptr, the AZ::Interface instance of the SettingsRegistry is used
         AZ::SettingsRegistryInterface::FixedValueString GetProjectName(AZ::SettingsRegistryInterface* settingsRegistry = nullptr);
 
+        //! Retrieves the project display name from the settings registry
+        //! First attempts to lookup the "display_name" field read from the project.json settings section of the
+        //! Settings Registry ! and if that is not available, the "project_name" field is read instead.
+        //! @param settingsRegistry pointer to the SettingsRegistry to use for lookup
+        //! If nullptr, the AZ::Interface instance of the SettingsRegistry is used
+        AZ::SettingsRegistryInterface::FixedValueString GetProjectDisplayName(AZ::SettingsRegistryInterface* settingsRegistry = nullptr);
+
         //! Lookups the full path for a gem, given it's name from the settings registry
         //! @param gemName path of the gem whose paths will be queried from within the settings registry
         //! @param settingsRegistry pointer to the SettingsRegistry to use for lookup

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -117,7 +117,7 @@ namespace AZ
                 {
                     // GFX TODO - investigate window creation being part of the GameApplication.
 
-                    auto projectTitle = AZ::Utils::GetProjectName();
+                    auto projectTitle = AZ::Utils::GetProjectDisplayName();
 
                     m_nativeWindow = AZStd::make_unique<AzFramework::NativeWindow>(projectTitle.c_str(), AzFramework::WindowGeometry(0, 0, 1920, 1080));
                     AZ_Assert(m_nativeWindow, "Failed to create the game window\n");
@@ -199,7 +199,7 @@ namespace AZ
                     AZ::NativeUI::NativeUIRequestBus::Broadcast(
                         &AZ::NativeUI::NativeUIRequestBus::Events::DisplayOkDialog, "O3DE Fatal Error", msgBoxMessage.c_str(), false);
                     AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::ExitMainLoop);
-                                        
+
                     return;
                 }
 
@@ -259,7 +259,7 @@ namespace AZ
                 // Listen to window notification so we can request exit application when window closes
                 AzFramework::WindowNotificationBus::Handler::BusConnect(GetDefaultWindowHandle());
             }
-            
+
             AZ::RPI::ScenePtr BootstrapSystemComponent::GetOrCreateAtomSceneFromAzScene(AzFramework::Scene* scene)
             {
                 // Get or create a weak pointer to our scene


### PR DESCRIPTION
The Editor Welcome Screen dialog and the GameLauncher window were also updated to use the Project Display Name.

Added a Utility function to read the project's display name from the Settings Registry.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>


## How was this PR tested?

Renamed the "display_name" in the AutomatedTesting project to "Automated Renamed Testing"
![image](https://user-images.githubusercontent.com/56135373/196082939-13ff5df9-6ce3-47eb-8ebb-1c6de6219bc7.png)
![image](https://user-images.githubusercontent.com/56135373/196082978-e231f15b-d8a9-4ed8-b439-36db391667f8.png)
