### PR TITLE
Add a template for deprecation notice

### DIFF
--- a/.github/ISSUE_TEMPLATE/deprecation_template.md
+++ b/.github/ISSUE_TEMPLATE/deprecation_template.md
@@ -6,18 +6,18 @@ labels: 'kind/deprecation'
 
 ---
 
-***The list of APIs to be deprecated***
+## Deprecated APIs
 List the fully qualified APIs/types. For example, `AZ::Quaternion::SetFromEulerRadians(const Vector3&)`
 
-***Describe alternatives for each of the APIs***
+## Alternatives APIs
 List new or updated APIs to replace deprecated API. 
 For example, use 
 `Quaternion AZ::Quaternionstatic CreateFromEulerRadiansXYZ(const Vector3&)` 
 to repleace 
 `void AZ::Quaternion::SetFromEulerRadians(const Vector3&)` and `Quaternion AZ::Quaternion::ConvertEulerRadiansToQuaternion(const Vector3&)`
 
-***Describe the last release version before this deprecation***
-For example: `stabilization/2210`
+## Last Release
+Describe the last release version before this deprecation. For example: `stabilization/2210`
 
-***Additional context***
+## Additional Context
 Add some information about the reasons for the deprecations

--- a/.github/ISSUE_TEMPLATE/deprecation_template.md
+++ b/.github/ISSUE_TEMPLATE/deprecation_template.md
@@ -12,7 +12,7 @@ List the fully qualified APIs/types. For example, `AZ::Quaternion::SetFromEulerR
 ## Alternatives APIs
 List new or updated APIs to replace deprecated API. 
 For example, use 
-`Quaternion AZ::Quaternionstatic CreateFromEulerRadiansXYZ(const Vector3&)` 
+`Quaternion AZ::Quaternion::CreateFromEulerRadiansXYZ(const Vector3&)` 
 to repleace 
 `void AZ::Quaternion::SetFromEulerRadians(const Vector3&)` and `Quaternion AZ::Quaternion::ConvertEulerRadiansToQuaternion(const Vector3&)`
 

--- a/.github/ISSUE_TEMPLATE/deprecation_template.md
+++ b/.github/ISSUE_TEMPLATE/deprecation_template.md
@@ -1,0 +1,23 @@
+---
+name: Deprecation Notice
+about: A notice for one or more feature or API deprecations
+title: 'Deprecation Notice'
+labels: 'kind/deprecation'
+
+---
+
+***The list of APIs to be deprecated***
+List the fully qualified APIs/types. For example, `AZ::Quaternion::SetFromEulerRadians(const Vector3&)`
+
+***Describe alternatives for each of the APIs***
+List new or updated APIs to replace deprecated API. 
+For example, use 
+`Quaternion AZ::Quaternionstatic CreateFromEulerRadiansXYZ(const Vector3&)` 
+to repleace 
+`void AZ::Quaternion::SetFromEulerRadians(const Vector3&)` and `Quaternion AZ::Quaternion::ConvertEulerRadiansToQuaternion(const Vector3&)`
+
+***Describe the last release version before this deprecation***
+For example: `stabilization/2210`
+
+***Additional context***
+Add some information about the reasons for the deprecations


### PR DESCRIPTION
## What does this PR do?

Add a template for deprecation notice. This template is used for create a github issue which is mentioned [here ](https://github.com/o3de/community/blob/main/guides/o3de-deprecation-guidelines.md#api-deprecation---initial-steps)

## How was this PR tested?

md file viewer

![image](https://user-images.githubusercontent.com/55564570/196484879-f7d98fdd-0473-4496-8a1e-6eaa967e23d5.png)
