### PR TITLE
Migrate the legacy AssetRequestHandlerUnitTests

### DIFF
--- a/Code/Tools/AssetProcessor/native/unittests/AssetRequestHandlerUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetRequestHandlerUnitTests.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <native/AssetManager/AssetrequestHandler.h>
+#include <native/AssetManager/AssetRequestHandler.h>
 
 #include <native/unittests/AssetRequestHandlerUnitTests.h>
 #include <native/unittests/MockConnectionHandler.h>
@@ -72,15 +72,6 @@ namespace AssetProcessor
             return m_deleteFenceFileResult;
         }
     };
-}
-
-AssetRequestHandlerUnitTests::AssetRequestHandlerUnitTests()
-    : UnitTest::AssetProcessorUnitTestBase()
-{
-}
-
-AssetRequestHandlerUnitTests::~AssetRequestHandlerUnitTests()
-{
 }
 
 void AssetRequestHandlerUnitTests::SetUp()

--- a/Code/Tools/AssetProcessor/native/unittests/AssetRequestHandlerUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetRequestHandlerUnitTests.cpp
@@ -5,21 +5,30 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include "AssetRequestHandlerUnitTests.h"
 
-#include "native/unittests/MockConnectionHandler.h"
+#include <native/AssetManager/AssetrequestHandler.h>
 
-#include "native/AssetManager/AssetRequestHandler.h"
+#include <native/unittests/AssetRequestHandlerUnitTests.h>
+
 #include <QCoreApplication>
 
 using namespace AssetProcessor;
 using namespace AzFramework::AssetSystem;
 using namespace UnitTestUtils;
 
-namespace
+namespace AssetProcessor
 {
+    namespace
+    {
+        constexpr const char* Platform = "pc";
+        constexpr const char* AssetName = "test.dds";
+        constexpr const char* FenceFileName = "foo.fence";
+        constexpr const NetworkRequestID RequestId = NetworkRequestID(1, 1234);
+    }
+
     //! Internal class to unit test AssetRequestHandler
-    class AssetRequestHandletUnitTest : public AssetRequestHandler 
+    class MockAssetRequestHandler
+        : public AssetRequestHandler
     {
     public:
         void Reset()
@@ -29,6 +38,7 @@ namespace
             m_requestReadyCount = 0;
             m_fencingFailed = false;
             m_fenceId = 0;
+            m_fenceFileName = FenceFileName;
             m_deleteFenceFileResult = true;
         }
 
@@ -45,8 +55,8 @@ namespace
         int  m_requestReadyCount = 0;
         bool m_fencingFailed = false;
         unsigned int m_fenceId = 0;
-        QString m_fenceFileName = QString();
-        bool m_deleteFenceFileResult = false;
+        QString m_fenceFileName = FenceFileName;
+        bool m_deleteFenceFileResult = true;
 
     protected:
         QString CreateFenceFile(unsigned int fenceId) override
@@ -63,257 +73,274 @@ namespace
     };
 }
 
-REGISTER_UNIT_TEST(AssetRequestHandlerUnitTests)
-
-AssetRequestHandlerUnitTests::AssetRequestHandlerUnitTests()
+void AssetRequestHandlerUnitTests::SetUp()
 {
+    UnitTest::AssetProcessorUnitTestBase::SetUp();
+
+    m_requestHandler = AZStd::make_unique<MockAssetRequestHandler>();
+
+    QObject::connect(m_requestHandler.get(), &AssetRequestHandler::RequestCompileGroup, this, [&](NetworkRequestID groupID, QString platform, QString searchTerm)
+        {
+            m_requestedCompileGroup = true;
+            m_platformSet = platform;
+            m_requestIdSet = groupID;
+            m_searchTermSet = searchTerm;
+        });
+
+    QObject::connect(m_requestHandler.get(), &AssetRequestHandler::RequestAssetExists, this, [&](NetworkRequestID groupID, QString platform, QString searchTerm)
+        {
+            m_requestedAssetExists = true;
+            m_platformSet = platform;
+            m_requestIdSet = groupID;
+            m_searchTermSet = searchTerm;
+        });
+
+    m_connection.BusConnect(1);
 }
 
-void AssetRequestHandlerUnitTests::StartTest()
+void AssetRequestHandlerUnitTests::TearDown()
 {
-    AssetRequestHandletUnitTest requestHandler;
+    m_connection.BusDisconnect(1);
 
-    bool requestedCompileGroup = false;
-    bool requestedAssetExists = false;
+    m_requestHandler.reset();
 
-    QString platformSet;
-    NetworkRequestID requestIdSet;
-    QString searchTermSet;
+    UnitTest::AssetProcessorUnitTestBase::TearDown();
+}
 
-    QObject::connect(&requestHandler, &AssetRequestHandler::RequestCompileGroup, this, [&](NetworkRequestID groupID, QString platform, QString searchTerm)
-        {
-            requestedCompileGroup = true;
-            platformSet = platform;
-            requestIdSet = groupID;
-            searchTermSet = searchTerm;
-        });
-
-    QObject::connect(&requestHandler, &AssetRequestHandler::RequestAssetExists, this, [&](NetworkRequestID groupID, QString platform, QString searchTerm)
-        {
-            requestedAssetExists = true;
-            platformSet = platform;
-            requestIdSet = groupID;
-            searchTermSet = searchTerm;
-        });
-
-    AssetProcessor::MockConnectionHandler connection;
-    connection.BusConnect(1);
-
-    // ------- FIRST TEST ----------------- create a request to process an asset that does not exist in db and also does not exist in queue:
+TEST_F(AssetRequestHandlerUnitTests, RequestToProcessAssetNotExistInDatabaseOrQueue_RequestSent_RequestHandled)
+{
     QByteArray buffer;
-    NetworkRequestID requestId(1, 1234);
-    AzFramework::AssetSystem::RequestAssetStatus request("test.dds", true, true);
+    AzFramework::AssetSystem::RequestAssetStatus request(AssetName, true, true);
     AssetProcessor::PackMessage(request, buffer);
-    requestHandler.m_fenceFileName = QString();
-    requestHandler.OnNewIncomingRequest(requestId.first, requestId.second, buffer, "pc");
-    QCoreApplication::processEvents(QEventLoop::AllEvents);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.m_requestReadyCount == 1);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.m_fencingFailed);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.m_numTimesCreateFenceFileCalled == g_RetriesForFenceFile);
-    UNIT_TEST_EXPECT_FALSE(requestHandler.m_numTimesDeleteFenceFileCalled);
 
-    requestHandler.Reset();
-    requestHandler.m_fenceFileName = "foo.fence";
-    requestHandler.m_deleteFenceFileResult = false;
-    QMetaObject::invokeMethod(&requestHandler, "OnNewIncomingRequest", Qt::DirectConnection, Q_ARG(unsigned int, requestId.first), Q_ARG(unsigned int, requestId.second), Q_ARG(QByteArray, buffer), Q_ARG(QString, "pc"));
+    m_requestHandler->m_fenceFileName = QString();
+    m_requestHandler->m_deleteFenceFileResult = false;
+    m_requestHandler->OnNewIncomingRequest(RequestId.first, RequestId.second, buffer, Platform);
+    QCoreApplication::processEvents(QEventLoop::AllEvents);
+    EXPECT_EQ(m_requestHandler->m_requestReadyCount, 1);
+    EXPECT_TRUE(m_requestHandler->m_fencingFailed);
+    EXPECT_EQ(m_requestHandler->m_numTimesCreateFenceFileCalled, g_RetriesForFenceFile);
+    EXPECT_FALSE(m_requestHandler->m_numTimesDeleteFenceFileCalled);
+
+    m_requestHandler->Reset();
+    m_requestHandler->m_deleteFenceFileResult = false;
+    QMetaObject::invokeMethod(m_requestHandler.get(), "OnNewIncomingRequest", Qt::DirectConnection, Q_ARG(unsigned int, RequestId.first), Q_ARG(unsigned int, RequestId.second), Q_ARG(QByteArray, buffer), Q_ARG(QString, Platform));
     // we will have to call processEvents here equal to the number of retries, because only after that will the requestReady event be added to the event queue  
-    while (requestHandler.m_numTimesDeleteFenceFileCalled <= g_RetriesForFenceFile && !requestHandler.m_requestReadyCount)
+    while (m_requestHandler->m_numTimesDeleteFenceFileCalled <= g_RetriesForFenceFile && !m_requestHandler->m_requestReadyCount)
     {
         QCoreApplication::processEvents(QEventLoop::AllEvents);
     }
-    UNIT_TEST_EXPECT_TRUE(requestHandler.m_requestReadyCount == 1);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.m_fencingFailed);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.m_numTimesCreateFenceFileCalled == 1);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.m_numTimesDeleteFenceFileCalled == g_RetriesForFenceFile);
+    EXPECT_EQ(m_requestHandler->m_requestReadyCount, 1);
+    EXPECT_TRUE(m_requestHandler->m_fencingFailed);
+    EXPECT_EQ(m_requestHandler->m_numTimesCreateFenceFileCalled, 1);
+    EXPECT_EQ(m_requestHandler->m_numTimesDeleteFenceFileCalled, g_RetriesForFenceFile);
 
-    requestHandler.Reset();
-    QMetaObject::invokeMethod(&requestHandler, "OnNewIncomingRequest", Qt::DirectConnection, Q_ARG(unsigned int, requestId.first), Q_ARG(unsigned int, requestId.second), Q_ARG(QByteArray, buffer), Q_ARG(QString, "pc"));
-    requestHandler.OnFenceFileDetected(requestHandler.m_fenceId);
+    m_requestHandler->Reset();
+    QMetaObject::invokeMethod(m_requestHandler.get(), "OnNewIncomingRequest", Qt::DirectConnection, Q_ARG(unsigned int, RequestId.first), Q_ARG(unsigned int, RequestId.second), Q_ARG(QByteArray, buffer), Q_ARG(QString, Platform));
+    m_requestHandler->OnFenceFileDetected(m_requestHandler->m_fenceId);
     QCoreApplication::processEvents(QEventLoop::AllEvents);
-    UNIT_TEST_EXPECT_TRUE(requestedCompileGroup);
-    UNIT_TEST_EXPECT_TRUE(!requestedAssetExists);
-    UNIT_TEST_EXPECT_TRUE(!connection.m_sent);
-    UNIT_TEST_EXPECT_TRUE(platformSet == "pc");
-    UNIT_TEST_EXPECT_TRUE(requestIdSet == NetworkRequestID(1, 1234));
-    UNIT_TEST_EXPECT_TRUE(searchTermSet == "test.dds");
-    UNIT_TEST_EXPECT_TRUE(requestHandler.GetNumOutstandingAssetRequests() == 1);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.m_numTimesCreateFenceFileCalled == 1);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.m_numTimesDeleteFenceFileCalled == 1);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.m_requestReadyCount == 1);
-    UNIT_TEST_EXPECT_FALSE(requestHandler.m_fencingFailed);
+    EXPECT_TRUE(m_requestedCompileGroup);
+    EXPECT_FALSE(m_requestedAssetExists);
+    EXPECT_FALSE(m_connection.m_sent);
+    EXPECT_EQ(m_platformSet, Platform);
+    EXPECT_EQ(m_requestIdSet, RequestId);
+    EXPECT_EQ(m_searchTermSet, AssetName);
+    EXPECT_EQ(m_requestHandler->GetNumOutstandingAssetRequests(), 1);
+    EXPECT_EQ(m_requestHandler->m_numTimesCreateFenceFileCalled, 1);
+    EXPECT_EQ(m_requestHandler->m_numTimesDeleteFenceFileCalled, 1);
+    EXPECT_EQ(m_requestHandler->m_requestReadyCount, 1);
+    EXPECT_FALSE(m_requestHandler->m_fencingFailed);
 
-    requestedCompileGroup = false;
-    requestedAssetExists = false;
-    connection.m_sent = false;
-
-    // it worked so far, now synthesize a response:
-    // it should result in it asking for asset exists
-    requestHandler.OnCompileGroupCreated(requestIdSet, AssetStatus_Unknown);
-
-    UNIT_TEST_EXPECT_TRUE(!requestedCompileGroup);
-    UNIT_TEST_EXPECT_TRUE(requestedAssetExists);
-    UNIT_TEST_EXPECT_TRUE(!connection.m_sent);
-    UNIT_TEST_EXPECT_TRUE(platformSet == "pc");
-    UNIT_TEST_EXPECT_TRUE(requestIdSet == NetworkRequestID(1, 1234));
-    UNIT_TEST_EXPECT_TRUE(searchTermSet == "test.dds");
-    requestedCompileGroup = false;
-    requestedAssetExists = false;
-    connection.m_sent = false;
-    UNIT_TEST_EXPECT_TRUE(requestHandler.GetNumOutstandingAssetRequests() == 1); // it should still be alive!
+    m_requestedCompileGroup = false;
+    m_requestedAssetExists = false;
+    m_connection.m_sent = false;
 
     // it worked so far, now synthesize a response:
     // it should result in it asking for asset exists
-    requestHandler.OnRequestAssetExistsResponse(requestIdSet,  false);
+    m_requestHandler->OnCompileGroupCreated(m_requestIdSet, AssetStatus_Unknown);
+
+    EXPECT_FALSE(m_requestedCompileGroup);
+    EXPECT_TRUE(m_requestedAssetExists);
+    EXPECT_FALSE(m_connection.m_sent);
+    EXPECT_EQ(m_platformSet, Platform);
+    EXPECT_EQ(m_requestIdSet, RequestId);
+    EXPECT_EQ(m_searchTermSet, AssetName);
+    m_requestedCompileGroup = false;
+    m_requestedAssetExists = false;
+    m_connection.m_sent = false;
+    EXPECT_EQ(m_requestHandler->GetNumOutstandingAssetRequests(), 1); // it should still be alive!
+
+    // it worked so far, now synthesize a response:
+    // it should result in it asking for asset exists
+    m_requestHandler->OnRequestAssetExistsResponse(m_requestIdSet, false);
 
     // this should result in it sending:
-    UNIT_TEST_EXPECT_TRUE(!requestedCompileGroup);
-    UNIT_TEST_EXPECT_TRUE(!requestedAssetExists);
-    UNIT_TEST_EXPECT_TRUE(connection.m_sent);
-    UNIT_TEST_EXPECT_TRUE(NetworkRequestID(1, connection.m_serial) == NetworkRequestID(1, 1234));
-    UNIT_TEST_EXPECT_TRUE(connection.m_type == RequestAssetStatus::MessageType);
-    requestedCompileGroup = false;
-    requestedAssetExists = false;
-    connection.m_sent = false;
-    UNIT_TEST_EXPECT_TRUE(requestHandler.GetNumOutstandingAssetRequests() == 0); // it should be gone now
+    EXPECT_FALSE(m_requestedCompileGroup);
+    EXPECT_FALSE(m_requestedAssetExists);
+    EXPECT_TRUE(m_connection.m_sent);
+    EXPECT_EQ(NetworkRequestID(1, m_connection.m_serial), RequestId);
+    EXPECT_EQ(m_connection.m_type, RequestAssetStatus::MessageType);
+    m_requestedCompileGroup = false;
+    m_requestedAssetExists = false;
+    m_connection.m_sent = false;
+    EXPECT_EQ(m_requestHandler->GetNumOutstandingAssetRequests(), 0); // it should be gone now
 
     // decode the buffer.
     ResponseAssetStatus resp;
+    EXPECT_TRUE(AZ::Utils::LoadObjectFromBufferInPlace(m_connection.m_payload.data(), m_connection.m_payload.size(), resp));
+    EXPECT_EQ(resp.m_assetStatus, AssetStatus_Missing);
+}
 
-    UNIT_TEST_EXPECT_TRUE(AZ::Utils::LoadObjectFromBufferInPlace(connection.m_payload.data(), connection.m_payload.size(), resp));
-    UNIT_TEST_EXPECT_TRUE(resp.m_assetStatus == AssetStatus_Missing);
+TEST_F(AssetRequestHandlerUnitTests, RequestToCreateCompileGroup_RequestSent_RequestHandled)
+{
+    // Test creating a request for a real compile group.
+    // We will mock the response as saying 'yes, I made a compile group':
+    QByteArray buffer;
+    AzFramework::AssetSystem::RequestAssetStatus request(AssetName, true, true);
+    AssetProcessor::PackMessage(request, buffer);
 
-    // ------ TEST ---------- Create a request for a real compile group.
-    // we will mock the response as saying 'yes, I made a compile group':
-    requestHandler.Reset();
-    QMetaObject::invokeMethod(&requestHandler, "OnNewIncomingRequest", Qt::DirectConnection, Q_ARG(unsigned int, requestId.first), Q_ARG(unsigned int, requestId.second), Q_ARG(QByteArray, buffer), Q_ARG(QString, "pc"));
-    requestHandler.OnFenceFileDetected(requestHandler.m_fenceId);
+    QMetaObject::invokeMethod(m_requestHandler.get(), "OnNewIncomingRequest", Qt::DirectConnection, Q_ARG(unsigned int, RequestId.first), Q_ARG(unsigned int, RequestId.second), Q_ARG(QByteArray, buffer), Q_ARG(QString, Platform));
+    m_requestHandler->OnFenceFileDetected(m_requestHandler->m_fenceId);
     QCoreApplication::processEvents(QEventLoop::AllEvents);
-    UNIT_TEST_EXPECT_TRUE(requestedCompileGroup);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.GetNumOutstandingAssetRequests() == 1);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.m_numTimesCreateFenceFileCalled == 1);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.m_numTimesDeleteFenceFileCalled == 1);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.m_requestReadyCount == 1);
-    UNIT_TEST_EXPECT_FALSE(requestHandler.m_fencingFailed);
+    EXPECT_TRUE(m_requestedCompileGroup);
+    EXPECT_EQ(m_requestHandler->GetNumOutstandingAssetRequests(), 1);
+    EXPECT_EQ(m_requestHandler->m_numTimesCreateFenceFileCalled, 1);
+    EXPECT_EQ(m_requestHandler->m_numTimesDeleteFenceFileCalled, 1);
+    EXPECT_EQ(m_requestHandler->m_requestReadyCount, 1);
+    EXPECT_FALSE(m_requestHandler->m_fencingFailed);
     // it worked so far, now synthesize a response:
     // it should result in it asking for asset exists
-    requestHandler.OnCompileGroupCreated(requestIdSet, AssetStatus_Queued);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.GetNumOutstandingAssetRequests() == 0); // for a STATUS request, its enough to know that its queued
+    m_requestHandler->OnCompileGroupCreated(m_requestIdSet, AssetStatus_Queued);
+    EXPECT_EQ(m_requestHandler->GetNumOutstandingAssetRequests(), 0); // for a STATUS request, its enough to know that its queued
 
     // no callbacks should be set:
-    requestedCompileGroup = false;
-    requestedAssetExists = false;
-    connection.m_sent = false;
+    m_requestedCompileGroup = false;
+    m_requestedAssetExists = false;
+    m_connection.m_sent = false;
 
-    UNIT_TEST_EXPECT_TRUE(!requestedCompileGroup);
-    UNIT_TEST_EXPECT_TRUE(!requestedAssetExists);
-    UNIT_TEST_EXPECT_TRUE(!connection.m_sent);
+    EXPECT_FALSE(m_requestedCompileGroup);
+    EXPECT_FALSE(m_requestedAssetExists);
+    EXPECT_FALSE(m_connection.m_sent);
 
     // test invalid group:
-    requestHandler.OnCompileGroupFinished(NetworkRequestID(0, 0), AssetStatus_Queued);
+    m_requestHandler->OnCompileGroupFinished(NetworkRequestID(0, 0), AssetStatus_Queued);
 
-    UNIT_TEST_EXPECT_TRUE(!requestedCompileGroup);
-    UNIT_TEST_EXPECT_TRUE(!requestedAssetExists);
-    UNIT_TEST_EXPECT_TRUE(!connection.m_sent);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.GetNumOutstandingAssetRequests() == 0);
+    EXPECT_FALSE(m_requestedCompileGroup);
+    EXPECT_FALSE(m_requestedAssetExists);
+    EXPECT_FALSE(m_connection.m_sent);
+    EXPECT_EQ(m_requestHandler->GetNumOutstandingAssetRequests(), 0);
 
-    requestHandler.OnCompileGroupFinished(requestIdSet, AssetStatus_Failed);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.GetNumOutstandingAssetRequests() == 0);
-    UNIT_TEST_EXPECT_TRUE(!connection.m_sent);
+    m_requestHandler->OnCompileGroupFinished(m_requestIdSet, AssetStatus_Failed);
+    EXPECT_EQ(m_requestHandler->GetNumOutstandingAssetRequests(), 0);
+    EXPECT_FALSE(m_connection.m_sent);
+}
 
-    // ------------ Test the success case, where its waiting for the actual compilation to be done. ---
-
-    request.m_isStatusRequest = false;
-    buffer.clear();
+TEST_F(AssetRequestHandlerUnitTests, RequestToCompileAsset_RequestSent_RequestHandled)
+{
+    // Test the success case, where its waiting for the actual compilation to be done.
+    QByteArray buffer;
+    AzFramework::AssetSystem::RequestAssetStatus request(AssetName, false, true);
     AssetProcessor::PackMessage(request, buffer);
-    requestHandler.Reset();
-    QMetaObject::invokeMethod(&requestHandler, "OnNewIncomingRequest", Qt::DirectConnection, Q_ARG(unsigned int, requestId.first), Q_ARG(unsigned int, requestId.second), Q_ARG(QByteArray, buffer), Q_ARG(QString, "pc"));
-    requestHandler.OnFenceFileDetected(requestHandler.m_fenceId);
+
+    QMetaObject::invokeMethod(m_requestHandler.get(), "OnNewIncomingRequest", Qt::DirectConnection, Q_ARG(unsigned int, RequestId.first), Q_ARG(unsigned int, RequestId.second), Q_ARG(QByteArray, buffer), Q_ARG(QString, Platform));
+    m_requestHandler->OnFenceFileDetected(m_requestHandler->m_fenceId);
     QCoreApplication::processEvents(QEventLoop::AllEvents);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.m_numTimesCreateFenceFileCalled == 1);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.m_numTimesDeleteFenceFileCalled == 1);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.m_requestReadyCount == 1);
-    UNIT_TEST_EXPECT_FALSE(requestHandler.m_fencingFailed);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.GetNumOutstandingAssetRequests() == 1);
-    requestHandler.OnCompileGroupCreated(requestIdSet, AssetStatus_Queued);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.GetNumOutstandingAssetRequests() == 1);
+    EXPECT_EQ(m_requestHandler->m_numTimesCreateFenceFileCalled, 1);
+    EXPECT_EQ(m_requestHandler->m_numTimesDeleteFenceFileCalled, 1);
+    EXPECT_EQ(m_requestHandler->m_requestReadyCount, 1);
+    EXPECT_FALSE(m_requestHandler->m_fencingFailed);
+    EXPECT_EQ(m_requestHandler->GetNumOutstandingAssetRequests(), 1);
+    m_requestHandler->OnCompileGroupCreated(m_requestIdSet, AssetStatus_Queued);
+    EXPECT_EQ(m_requestHandler->GetNumOutstandingAssetRequests(), 1);
     // no callbacks should be set:
 
-    requestedCompileGroup = false;
-    requestedAssetExists = false;
-    connection.m_sent = false;
+    m_requestedCompileGroup = false;
+    m_requestedAssetExists = false;
+    m_connection.m_sent = false;
 
-    requestHandler.OnCompileGroupFinished(requestIdSet, AssetStatus_Compiled);
+    m_requestHandler->OnCompileGroupFinished(m_requestIdSet, AssetStatus_Compiled);
+
+    // decode the buffer.
+    ResponseAssetStatus resp;
     // no callbacks should be set:
-    UNIT_TEST_EXPECT_TRUE(!requestedCompileGroup);
-    UNIT_TEST_EXPECT_TRUE(!requestedAssetExists);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.GetNumOutstandingAssetRequests() == 0);
-    UNIT_TEST_EXPECT_TRUE(connection.m_sent);
-    UNIT_TEST_EXPECT_TRUE(AZ::Utils::LoadObjectFromBufferInPlace(connection.m_payload.data(), connection.m_payload.size(), resp));
-    UNIT_TEST_EXPECT_TRUE(resp.m_assetStatus == AssetStatus_Compiled);
+    EXPECT_FALSE(m_requestedCompileGroup);
+    EXPECT_FALSE(m_requestedAssetExists);
+    EXPECT_EQ(m_requestHandler->GetNumOutstandingAssetRequests(), 0);
+    EXPECT_TRUE(m_connection.m_sent);
+    EXPECT_TRUE(AZ::Utils::LoadObjectFromBufferInPlace(m_connection.m_payload.data(), m_connection.m_payload.size(), resp));
+    EXPECT_EQ(resp.m_assetStatus, AssetStatus_Compiled);
+}
 
-    // -------------- Test the case where the file reports as being on disk just not in the queue ------------
-    request.m_isStatusRequest = true;
-    buffer.clear();
+TEST_F(AssetRequestHandlerUnitTests, RequestToProcessFileOnDiskButNotInQueue_RequestSent_RequestHandled)
+{
+    // Test the case where the file reports as being on disk just not in the queue
+    QByteArray buffer;
+    AzFramework::AssetSystem::RequestAssetStatus request(AssetName, true, true);
     AssetProcessor::PackMessage(request, buffer);
-    requestHandler.Reset();
-    QMetaObject::invokeMethod(&requestHandler, "OnNewIncomingRequest", Qt::DirectConnection, Q_ARG(unsigned int, requestId.first), Q_ARG(unsigned int, requestId.second), Q_ARG(QByteArray, buffer), Q_ARG(QString, "pc"));
-    requestHandler.OnFenceFileDetected(requestHandler.m_fenceId);
+
+    QMetaObject::invokeMethod(m_requestHandler.get(), "OnNewIncomingRequest", Qt::DirectConnection, Q_ARG(unsigned int, RequestId.first), Q_ARG(unsigned int, RequestId.second), Q_ARG(QByteArray, buffer), Q_ARG(QString, Platform));
+    m_requestHandler->OnFenceFileDetected(m_requestHandler->m_fenceId);
     QCoreApplication::processEvents(QEventLoop::AllEvents);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.GetNumOutstandingAssetRequests() == 1);
+    EXPECT_EQ(m_requestHandler->GetNumOutstandingAssetRequests(), 1);
 
-    requestedCompileGroup = false;
-    requestedAssetExists = false;
-    connection.m_sent = false;
+    m_requestedCompileGroup = false;
+    m_requestedAssetExists = false;
+    m_connection.m_sent = false;
 
-    requestHandler.OnCompileGroupCreated(requestIdSet, AssetStatus_Unknown);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.GetNumOutstandingAssetRequests() == 1);
-    UNIT_TEST_EXPECT_TRUE(!requestedCompileGroup);
-    UNIT_TEST_EXPECT_TRUE(requestedAssetExists);
-    UNIT_TEST_EXPECT_TRUE(!connection.m_sent);
+    m_requestHandler->OnCompileGroupCreated(m_requestIdSet, AssetStatus_Unknown);
+    EXPECT_EQ(m_requestHandler->GetNumOutstandingAssetRequests(), 1);
+    EXPECT_FALSE(m_requestedCompileGroup);
+    EXPECT_TRUE(m_requestedAssetExists);
+    EXPECT_FALSE(m_connection.m_sent);
 
-    requestedCompileGroup = false;
-    requestedAssetExists = false;
-    connection.m_sent = false;
-    requestHandler.OnRequestAssetExistsResponse(requestIdSet, true);
-    UNIT_TEST_EXPECT_TRUE(!requestedCompileGroup);
-    UNIT_TEST_EXPECT_TRUE(!requestedAssetExists);
-    UNIT_TEST_EXPECT_TRUE(connection.m_sent);
-    UNIT_TEST_EXPECT_TRUE(AZ::Utils::LoadObjectFromBufferInPlace(connection.m_payload.data(), connection.m_payload.size(), resp));
-    UNIT_TEST_EXPECT_TRUE(resp.m_assetStatus == AssetStatus_Compiled);
+    m_requestedCompileGroup = false;
+    m_requestedAssetExists = false;
+    m_connection.m_sent = false;
+    m_requestHandler->OnRequestAssetExistsResponse(m_requestIdSet, true);
+    EXPECT_FALSE(m_requestedCompileGroup);
+    EXPECT_FALSE(m_requestedAssetExists);
+    EXPECT_TRUE(m_connection.m_sent);
 
-    // ------------------ TEST MULTIPLE IN-FLIGHT REQUESTS ------------------
-    requestHandler.Reset();
-    QMetaObject::invokeMethod(&requestHandler, "OnNewIncomingRequest", Qt::DirectConnection, Q_ARG(unsigned int, requestId.first), Q_ARG(unsigned int, requestId.second), Q_ARG(QByteArray, buffer), Q_ARG(QString, "pc"));
-    requestHandler.OnFenceFileDetected(requestHandler.m_fenceId);
+    // decode the buffer.
+    ResponseAssetStatus resp;
+    EXPECT_TRUE(AZ::Utils::LoadObjectFromBufferInPlace(m_connection.m_payload.data(), m_connection.m_payload.size(), resp));
+    EXPECT_EQ(resp.m_assetStatus, AssetStatus_Compiled);
+}
+
+TEST_F(AssetRequestHandlerUnitTests, TestMultipleInFlightRequests_RequestsSent_RequestsHandled)
+{
+    QByteArray buffer;
+    NetworkRequestID requestId = RequestId;
+    AzFramework::AssetSystem::RequestAssetStatus request(AssetName, true, true);
+    AssetProcessor::PackMessage(request, buffer);
+
+    QMetaObject::invokeMethod(m_requestHandler.get(), "OnNewIncomingRequest", Qt::DirectConnection, Q_ARG(unsigned int, requestId.first), Q_ARG(unsigned int, requestId.second), Q_ARG(QByteArray, buffer), Q_ARG(QString, Platform));
+    m_requestHandler->OnFenceFileDetected(m_requestHandler->m_fenceId);
     QCoreApplication::processEvents(QEventLoop::AllEvents);
     requestId = NetworkRequestID(1, 1235);
-    requestHandler.Reset();
-    QMetaObject::invokeMethod(&requestHandler, "OnNewIncomingRequest", Qt::DirectConnection, Q_ARG(unsigned int, requestId.first), Q_ARG(unsigned int, requestId.second), Q_ARG(QByteArray, buffer), Q_ARG(QString, "pc"));
+    m_requestHandler->Reset();
+    QMetaObject::invokeMethod(m_requestHandler.get(), "OnNewIncomingRequest", Qt::DirectConnection, Q_ARG(unsigned int, requestId.first), Q_ARG(unsigned int, requestId.second), Q_ARG(QByteArray, buffer), Q_ARG(QString, Platform));
     // note, this last one is for a compile.
-    requestHandler.OnFenceFileDetected(requestHandler.m_fenceId);
+    m_requestHandler->OnFenceFileDetected(m_requestHandler->m_fenceId);
     QCoreApplication::processEvents(QEventLoop::AllEvents);
     request.m_isStatusRequest = false;
     buffer.clear();
     AssetProcessor::PackMessage(request, buffer);
     requestId = NetworkRequestID(1, 1236);
-    requestHandler.Reset();
-    QMetaObject::invokeMethod(&requestHandler, "OnNewIncomingRequest", Qt::DirectConnection, Q_ARG(unsigned int, requestId.first), Q_ARG(unsigned int, requestId.second), Q_ARG(QByteArray, buffer), Q_ARG(QString, "pc"));
-    requestHandler.OnFenceFileDetected(requestHandler.m_fenceId);
+    m_requestHandler->Reset();
+    QMetaObject::invokeMethod(m_requestHandler.get(), "OnNewIncomingRequest", Qt::DirectConnection, Q_ARG(unsigned int, requestId.first), Q_ARG(unsigned int, requestId.second), Q_ARG(QByteArray, buffer), Q_ARG(QString, Platform));
+    m_requestHandler->OnFenceFileDetected(m_requestHandler->m_fenceId);
     QCoreApplication::processEvents(QEventLoop::AllEvents);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.GetNumOutstandingAssetRequests() == 3);
+    EXPECT_EQ(m_requestHandler->GetNumOutstandingAssetRequests(), 3);
 
-    requestHandler.OnCompileGroupCreated(NetworkRequestID(1, 1234), AssetStatus_Queued);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.GetNumOutstandingAssetRequests() == 2);
-    requestHandler.OnCompileGroupCreated(NetworkRequestID(1, 1235), AssetStatus_Queued);
-    UNIT_TEST_EXPECT_TRUE(requestHandler.GetNumOutstandingAssetRequests() == 1);
-    requestHandler.OnCompileGroupCreated(NetworkRequestID(1, 1236), AssetStatus_Queued); // this one doesn't go away yet
-    UNIT_TEST_EXPECT_TRUE(requestHandler.GetNumOutstandingAssetRequests() == 1);
+    m_requestHandler->OnCompileGroupCreated(RequestId, AssetStatus_Queued);
+    EXPECT_EQ(m_requestHandler->GetNumOutstandingAssetRequests(), 2);
+    m_requestHandler->OnCompileGroupCreated(NetworkRequestID(1, 1235), AssetStatus_Queued);
+    EXPECT_EQ(m_requestHandler->GetNumOutstandingAssetRequests(), 1);
+    m_requestHandler->OnCompileGroupCreated(NetworkRequestID(1, 1236), AssetStatus_Queued); // this one doesn't go away yet
+    EXPECT_EQ(m_requestHandler->GetNumOutstandingAssetRequests(), 1);
 
-    requestHandler.OnCompileGroupFinished(NetworkRequestID(1, 1236), AssetStatus_Compiled); // this one doesn't go away yet
-    UNIT_TEST_EXPECT_TRUE(requestHandler.GetNumOutstandingAssetRequests() == 0);
-
-    connection.BusDisconnect(1);
-
-    Q_EMIT UnitTestPassed();
+    m_requestHandler->OnCompileGroupFinished(NetworkRequestID(1, 1236), AssetStatus_Compiled); // this one doesn't go away yet
+    EXPECT_EQ(m_requestHandler->GetNumOutstandingAssetRequests(), 0);
 }
 

--- a/Code/Tools/AssetProcessor/native/unittests/AssetRequestHandlerUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetRequestHandlerUnitTests.cpp
@@ -74,6 +74,10 @@ namespace AssetProcessor
     };
 }
 
+AssetRequestHandlerUnitTests::~AssetRequestHandlerUnitTests()
+{
+}
+
 void AssetRequestHandlerUnitTests::SetUp()
 {
     UnitTest::AssetProcessorUnitTestBase::SetUp();

--- a/Code/Tools/AssetProcessor/native/unittests/AssetRequestHandlerUnitTests.h
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetRequestHandlerUnitTests.h
@@ -21,7 +21,8 @@ namespace AssetProcessor
         , public UnitTest::AssetProcessorUnitTestBase
     {
         Q_OBJECT
-
+    public:
+        ~AssetRequestHandlerUnitTests();
     protected:
         void SetUp() override;
         void TearDown() override;

--- a/Code/Tools/AssetProcessor/native/unittests/AssetRequestHandlerUnitTests.h
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetRequestHandlerUnitTests.h
@@ -9,7 +9,6 @@
 
 #if !defined(Q_MOC_RUN)
 #include <native/unittests/AssetProcessorUnitTests.h>
-#include <native/unittests/MockConnectionHandler.h>
 #endif
 
 namespace AssetProcessor
@@ -24,12 +23,15 @@ namespace AssetProcessor
         Q_OBJECT
 
     protected:
+        AssetRequestHandlerUnitTests();
+        ~AssetRequestHandlerUnitTests();
+
         void SetUp() override;
         void TearDown() override;
 
         AZStd::unique_ptr<MockAssetRequestHandler> m_requestHandler;
 
-        AssetProcessor::MockConnectionHandler m_connection;
+        AZStd::unique_ptr<AssetProcessor::MockConnectionHandler> m_connection;
         bool m_requestedCompileGroup = false;
         bool m_requestedAssetExists = false;
         QString m_platformSet;

--- a/Code/Tools/AssetProcessor/native/unittests/AssetRequestHandlerUnitTests.h
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetRequestHandlerUnitTests.h
@@ -23,9 +23,6 @@ namespace AssetProcessor
         Q_OBJECT
 
     protected:
-        AssetRequestHandlerUnitTests();
-        ~AssetRequestHandlerUnitTests();
-
         void SetUp() override;
         void TearDown() override;
 

--- a/Code/Tools/AssetProcessor/native/unittests/AssetRequestHandlerUnitTests.h
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetRequestHandlerUnitTests.h
@@ -6,18 +6,34 @@
  *
  */
 #pragma once
+
 #if !defined(Q_MOC_RUN)
-#include "UnitTestRunner.h"
+#include <native/unittests/AssetProcessorUnitTests.h>
+#include <native/unittests/MockConnectionHandler.h>
 #endif
 
 namespace AssetProcessor
 {
+    class MockAssetRequestHandler;
+    class MockConnectionHandler;
+
     class AssetRequestHandlerUnitTests
-        : public UnitTestRun
+        : public QObject
+        , public UnitTest::AssetProcessorUnitTestBase
     {
         Q_OBJECT
-    public:
-        AssetRequestHandlerUnitTests();
-        virtual void StartTest() override;
+
+    protected:
+        void SetUp() override;
+        void TearDown() override;
+
+        AZStd::unique_ptr<MockAssetRequestHandler> m_requestHandler;
+
+        AssetProcessor::MockConnectionHandler m_connection;
+        bool m_requestedCompileGroup = false;
+        bool m_requestedAssetExists = false;
+        QString m_platformSet;
+        NetworkRequestID m_requestIdSet;
+        QString m_searchTermSet;
     };
 }


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?

Migrated the legacy AssetRequestHandlerUnitTests and broke it into multiple tests

## How was this PR tested?

```
[==========] Running 5 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 5 tests from AssetRequestHandlerUnitTests
[ RUN      ] AssetRequestHandlerUnitTests.RequestToProcessAssetNotExistInDatabaseOrQueue_RequestSent_RequestHandled
[       OK ] AssetRequestHandlerUnitTests.RequestToProcessAssetNotExistInDatabaseOrQueue_RequestSent_RequestHandled (720 ms)
[ RUN      ] AssetRequestHandlerUnitTests.RequestToCreateCompileGroup_RequestSent_RequestHandled
[       OK ] AssetRequestHandlerUnitTests.RequestToCreateCompileGroup_RequestSent_RequestHandled (303 ms)
[ RUN      ] AssetRequestHandlerUnitTests.RequestToCompileAsset_RequestSent_RequestHandled
[       OK ] AssetRequestHandlerUnitTests.RequestToCompileAsset_RequestSent_RequestHandled (315 ms)
[ RUN      ] AssetRequestHandlerUnitTests.RequestToProcessFileOnDiskButNotInQueue_RequestSent_RequestHandled
[       OK ] AssetRequestHandlerUnitTests.RequestToProcessFileOnDiskButNotInQueue_RequestSent_RequestHandled (318 ms)
[ RUN      ] AssetRequestHandlerUnitTests.TestMultipleInFlightRequests_RequestsSent_RequestsHandled
[       OK ] AssetRequestHandlerUnitTests.TestMultipleInFlightRequests_RequestsSent_RequestsHandled (315 ms)
[----------] 5 tests from AssetRequestHandlerUnitTests (1972 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test case ran. (1973 ms total)
[  PASSED  ] 5 tests.
```