### PR TITLE
Automatically set the matching Diffuse or Specular IBL image in the Editor

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
@@ -611,9 +611,9 @@ class AtomComponentProperties:
         """
         properties = {
             'name': 'Global Skylight (IBL)',
-            'Diffuse Image': 'Controller|Configuration|Diffuse Image',
-            'Specular Image': 'Controller|Configuration|Specular Image',
-            'Exposure': 'Controller|Configuration|Exposure',
+            'Diffuse Image': 'Diffuse Image',
+            'Specular Image': 'Specular Image',
+            'Exposure': 'Exposure',
         }
         return properties[property]
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ImageBasedLights/EditorImageBasedLightComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ImageBasedLights/EditorImageBasedLightComponent.h
@@ -30,6 +30,13 @@ namespace AZ
             EditorImageBasedLightComponent() = default;
             EditorImageBasedLightComponent(const ImageBasedLightComponentConfig& config);
 
+            AZ::u32 OnDiffuseImageAssetChanged();
+            AZ::u32 OnSpecularImageAssetChanged();
+
+        private:
+
+            bool UpdateImageAsset(Data::Asset<RPI::StreamingImageAsset>& asset1, const char* asset1Suffix, const char* asset1Name,
+                                  Data::Asset<RPI::StreamingImageAsset>& asset2, const char* asset2Suffix, const char* asset2Name);
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ImageBasedLights/EditorImageBasedLightComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ImageBasedLights/EditorImageBasedLightComponent.h
@@ -30,13 +30,21 @@ namespace AZ
             EditorImageBasedLightComponent() = default;
             EditorImageBasedLightComponent(const ImageBasedLightComponentConfig& config);
 
+            // AZ::Component overrides
+            void Activate() override;
+
             AZ::u32 OnDiffuseImageAssetChanged();
             AZ::u32 OnSpecularImageAssetChanged();
+            AZ::u32 OnExposureChanged();
 
         private:
 
             bool UpdateImageAsset(Data::Asset<RPI::StreamingImageAsset>& asset1, const char* asset1Suffix, const char* asset1Name,
                                   Data::Asset<RPI::StreamingImageAsset>& asset2, const char* asset2Suffix, const char* asset2Name);
+
+            Data::Asset<RPI::StreamingImageAsset> m_specularImageAsset;
+            Data::Asset<RPI::StreamingImageAsset> m_diffuseImageAsset;
+            float m_exposure = 0.0f;
         };
     } // namespace Render
 } // namespace AZ


### PR DESCRIPTION
This change will automatically set the matching Diffuse or Specular IBL image in the EditorImageBasedLightComponent.

Tested Editor DX12/Vulkan

Signed-off-by: dmcdiarmid-ly <63674186+dmcdiarmid-ly@users.noreply.github.com>
