### PR TITLE
refactor: fix crash for CFolderTreeCtrl and cleanup logic

### DIFF
--- a/Code/Editor/Controls/FolderTreeCtrl.cpp
+++ b/Code/Editor/Controls/FolderTreeCtrl.cpp
@@ -6,7 +6,6 @@
  *
  */
 
-
 #include "EditorDefs.h"
 
 #include "FolderTreeCtrl.h"
@@ -16,87 +15,76 @@
 #include <QSortFilterProxyModel>
 #include <QStandardItemModel>
 
+#include <AzCore/std/algorithm.h>
 // AzQtComponents
-#include <AzQtComponents/Utilities/DesktopUtilities.h>      // for AzQtComponents::ShowFileOnDesktop
-
-
-enum ETreeImage
-{
-    eTreeImage_Folder = 0,
-    eTreeImage_File = 2
-};
-
-enum CustomRoles
-{
-    IsFolderRole = Qt::UserRole
-};
+#include <AzQtComponents/Utilities/DesktopUtilities.h> // for AzQtComponents::ShowFileOnDesktop
 
 //////////////////////////////////////////////////////////////////////////
 // CFolderTreeCtrl
 //////////////////////////////////////////////////////////////////////////
-CFolderTreeCtrl::CFolderTreeCtrl(const QStringList& folders, const QString& fileNameSpec,
-    const QString& rootName, bool bDisableMonitor, bool bFlatTree, QWidget* parent)
-    : QTreeView(parent)
-    , m_rootTreeItem(nullptr)
-    , m_folders(folders)
-    , m_fileNameSpec(fileNameSpec)
-    , m_rootName(rootName)
-    , m_bDisableMonitor(bDisableMonitor)
-    , m_bFlatStyle(bFlatTree)
-{
-    init(folders, fileNameSpec, rootName, bDisableMonitor, bFlatTree);
-}
 
 CFolderTreeCtrl::CFolderTreeCtrl(QWidget* parent)
     : QTreeView(parent)
-    , m_rootTreeItem(nullptr)
-    , m_bDisableMonitor(false)
-    , m_bFlatStyle(true)
-
+    , m_folderIcon(":/TreeView/folder-icon.svg")
+    , m_fileIcon(":/TreeView/default-icon.svg")
+    , m_model(new QStandardItemModel(this))
+    , m_proxyModel(new QSortFilterProxyModel(this))
 {
-}
-
-
-void CFolderTreeCtrl::init(const QStringList& folders, const QString& fileNameSpec, const QString& rootName, bool bDisableMonitor /*= false*/, bool bFlatTree /*= true*/)
-{
-    m_model = new QStandardItemModel(this);
-    m_proxyModel = new QSortFilterProxyModel(this);
-    m_proxyModel->setRecursiveFilteringEnabled(true);
-
     m_proxyModel->setSourceModel(m_model);
+    m_proxyModel->setRecursiveFilteringEnabled(true);
     setModel(m_proxyModel);
 
-    m_folders = folders;
+    QObject::connect(this, &QTreeView::doubleClicked, this, &CFolderTreeCtrl::OnIndexDoubleClicked);
+}
+
+void CFolderTreeCtrl::Configure(
+    const AZStd::vector<QString>& folders, const QString& fileNameSpec, const QString& rootName, bool bDisableMonitor, bool bFlatTree)
+{
+    m_folders.clear();
+    AZStd::ranges::copy_if(
+        folders,
+        AZStd::back_inserter(m_folders),
+        [](const auto& path)
+        {
+            if (CFileUtil::PathExists(path) || Path::IsFolder(path.toLocal8Bit().constData()))
+            {
+                return true;
+            }
+            return false;
+        });
+    AZStd::transform(m_folders.begin(), m_folders.end(), m_folders.begin(), 
+        [](auto& item) {
+            return Path::RemoveBackslash(Path::ToUnixPath(item));
+        });
+
     m_fileNameSpec = fileNameSpec;
     m_rootName = rootName;
     m_bDisableMonitor = bDisableMonitor;
     m_bFlatStyle = bFlatTree;
-    m_fileIcon = QIcon(":/TreeView/default-icon.svg");
-    m_folderIcon = QIcon(":/TreeView/folder-icon.svg");
 
-    for (auto item = m_folders.begin(), end = m_folders.end(); item != end; ++item)
+    if (m_rootTreeItem)
     {
-        (*item) = Path::RemoveBackslash(Path::ToUnixPath((*item)));
-
-        if (CFileUtil::PathExists(*item))
-        {
-            m_foldersSegments.insert(std::make_pair((*item), Path::SplitIntoSegments((*item)).size()));
-        }
-        else if (Path::IsFolder((*item).toLocal8Bit().constData()))
-        {
-            m_foldersSegments.insert(std::make_pair((*item), Path::SplitIntoSegments((*item)).size()));
-        }
-        else
-        {
-            (*item).clear();
-        }
+        delete m_rootTreeItem;
+        m_rootTreeItem = nullptr;
     }
+
+    m_rootTreeItem = new CTreeItem(*this, nullptr, QString(), m_rootName, IconType::FolderIcon);
+    m_model->invisibleRootItem()->appendRow(m_rootTreeItem);
 
     setHeaderHidden(true);
 
-    QObject::connect(this, &QTreeView::doubleClicked, this, &CFolderTreeCtrl::OnIndexDoubleClicked);
+    for (auto& item: m_folders)
+    {
+        if (!item.isEmpty())
+        {
+            LoadTreeRec(item);
+        }
+    }
 
-    InitTree();
+    if (!m_bDisableMonitor)
+    {
+        CFileChangeMonitor::Instance()->Subscribe(this);
+    }
 
     setSortingEnabled(true);
 }
@@ -115,7 +103,7 @@ QString CFolderTreeCtrl::GetPath(QStandardItem* item) const
 
 bool CFolderTreeCtrl::IsFolder(QStandardItem* item) const
 {
-    return item->data(IsFolderRole).toBool();
+    return item->data(aznumeric_cast<int>(Roles::IsFolderRole)).toBool();
 }
 
 bool CFolderTreeCtrl::IsFile(QStandardItem* item) const
@@ -125,9 +113,6 @@ bool CFolderTreeCtrl::IsFile(QStandardItem* item) const
 
 CFolderTreeCtrl::~CFolderTreeCtrl()
 {
-    // Obliterate tree items before destroying the controls
-    m_rootTreeItem.reset(nullptr);
-
     // Unsubscribe from file change notifications
     if (!m_bDisableMonitor)
     {
@@ -137,11 +122,6 @@ CFolderTreeCtrl::~CFolderTreeCtrl()
 
 void CFolderTreeCtrl::OnIndexDoubleClicked(const QModelIndex& index)
 {
-    if (!m_proxyModel || !m_model)
-    {
-        return;
-    }
-
     QStandardItem* item = GetSourceItemByIndex(index);
     if (item)
     {
@@ -197,37 +177,16 @@ void CFolderTreeCtrl::contextMenuEvent(QContextMenuEvent* e)
 
     QMenu menu;
     QAction* editAction = menu.addAction(tr("Edit"));
-    connect(editAction, &QAction::triggered, this, [=]()
+    connect(editAction, &QAction::triggered, this, [&]()
         {
-            this->Edit(path);
+            Edit(path);
         });
     QAction* showInExplorerAction = menu.addAction(tr("Show In Explorer"));
-    connect(showInExplorerAction, &QAction::triggered, this, [=]()
+    connect(showInExplorerAction,&QAction::triggered,this,[&]()
         {
-            this->ShowInExplorer(path);
+            ShowInExplorer(path);
         });
     menu.exec(QCursor::pos());
-}
-
-void CFolderTreeCtrl::InitTree()
-{
-    m_rootTreeItem.reset(new CTreeItem(*this, m_rootName));
-
-    for (auto item = m_folders.begin(), end = m_folders.end(); item != end; ++item)
-    {
-        if (!(*item).isEmpty())
-        {
-            LoadTreeRec((*item));
-        }
-    }
-
-    if (!m_bDisableMonitor)
-    {
-        CFileChangeMonitor::Instance()->Subscribe(this);
-    }
-
-
-    expandAll();
 }
 
 void CFolderTreeCtrl::LoadTreeRec(const QString& currentFolder)
@@ -247,7 +206,7 @@ void CFolderTreeCtrl::LoadTreeRec(const QString& currentFolder)
         }
 
         // update the base folder name
-        QStringList parts =  Path::SplitIntoSegments(currentFolderSlash);
+        QStringList parts = Path::SplitIntoSegments(currentFolderSlash);
         if (parts.size() > 1)
         {
             parts.removeFirst();
@@ -255,8 +214,8 @@ void CFolderTreeCtrl::LoadTreeRec(const QString& currentFolder)
         }
     }
 
-    for (bool bFoundFile = fileEnum.StartEnumeration(targetFolder, "*", &fileData);
-         bFoundFile; bFoundFile = fileEnum.GetNextFile(&fileData))
+    for (bool bFoundFile = fileEnum.StartEnumeration(targetFolder, "*", &fileData); bFoundFile;
+         bFoundFile = fileEnum.GetNextFile(&fileData))
     {
         const QString fileName = fileData.fileName();
 
@@ -286,8 +245,13 @@ void CFolderTreeCtrl::AddItem(const QString& path)
     if (regex.exactMatch(path))
     {
         CTreeItem* folderTreeItem = CreateFolderItems(QString::fromUtf8(folder.c_str(), static_cast<int>(folder.Native().size())));
-        folderTreeItem->AddChild(QString::fromUtf8(fileNameWithoutExtension.c_str(),
-            static_cast<int>(fileNameWithoutExtension.Native().size())), path, eTreeImage_File);
+        if(folderTreeItem)
+        {
+            folderTreeItem->AddChild(
+                QString::fromUtf8(fileNameWithoutExtension.c_str(), static_cast<int>(fileNameWithoutExtension.Native().size())),
+                path,
+                IconType::FileIcon);
+        }
     }
 }
 
@@ -348,8 +312,13 @@ QString CFolderTreeCtrl::CalculateFolderFullPath(const QStringList& splittedFold
 
 CFolderTreeCtrl::CTreeItem* CFolderTreeCtrl::CreateFolderItems(const QString& folder)
 {
+    if(!m_rootTreeItem) 
+    {
+        return nullptr;
+    }
+
     QStringList splittedFolder = Path::SplitIntoSegments(folder);
-    CTreeItem* currentTreeItem = m_rootTreeItem.get();
+    CTreeItem* currentTreeItem = m_rootTreeItem;
 
     if (!m_bFlatStyle)
     {
@@ -364,7 +333,7 @@ CFolderTreeCtrl::CTreeItem* CFolderTreeCtrl::CreateFolderItems(const QString& fo
             CTreeItem* folderItem = GetItem(fullpath);
             if (!folderItem)
             {
-                currentTreeItem = currentTreeItem->AddChild(currentFolder, fullpath, eTreeImage_Folder);
+                currentTreeItem = currentTreeItem->AddChild(currentFolder, fullpath, IconType::FolderIcon);
             }
             else
             {
@@ -406,10 +375,8 @@ void CFolderTreeCtrl::ShowInExplorer(const QString& path)
 {
     QString absolutePath = QDir::currentPath();
 
-    CTreeItem* root = m_rootTreeItem.get();
     CTreeItem* item = GetItem(path);
-
-    if (item != root)
+    if (item != m_rootTreeItem)
     {
         absolutePath += QStringLiteral("/%1").arg(path);
     }
@@ -417,9 +384,9 @@ void CFolderTreeCtrl::ShowInExplorer(const QString& path)
     AzQtComponents::ShowFileOnDesktop(absolutePath);
 }
 
-QIcon CFolderTreeCtrl::GetItemIcon(int image) const
+QIcon CFolderTreeCtrl::GetItemIcon(IconType image) const
 {
-    return image == eTreeImage_File ? m_fileIcon : m_folderIcon;
+    return image == IconType::FolderIcon ? m_folderIcon : m_fileIcon;
 }
 
 QList<QStandardItem*> CFolderTreeCtrl::GetSelectedItems() const
@@ -446,31 +413,23 @@ void CFolderTreeCtrl::SetSearchFilter(const QString& searchText)
     }
 }
 
-
 //////////////////////////////////////////////////////////////////////////
 // CFolderTreeCtrl::CTreeItem
 //////////////////////////////////////////////////////////////////////////
-CFolderTreeCtrl::CTreeItem::CTreeItem(CFolderTreeCtrl& folderTreeCtrl, const QString& path)
-    : QStandardItem(folderTreeCtrl.GetItemIcon(eTreeImage_Folder), folderTreeCtrl.m_rootName)
+
+CFolderTreeCtrl::CTreeItem::CTreeItem(
+    CFolderTreeCtrl& folderTreeCtrl, CFolderTreeCtrl::CTreeItem* parent, const QString& name, const QString& path, IconType icon)
+    : QStandardItem(folderTreeCtrl.GetItemIcon(icon), name)
     , m_folderTreeCtrl(folderTreeCtrl)
     , m_path(path)
 {
-    setData(true, IsFolderRole);
+    if (parent)
+    {
+        parent->appendRow(this);
+    }
+    setData(icon == IconType::FolderIcon, aznumeric_cast<int>(Roles::IsFolderRole));
 
-    m_folderTreeCtrl.m_model->invisibleRootItem()->appendRow(this);
-    m_folderTreeCtrl.m_pathToTreeItem[ m_path ] = this;
-}
-
-CFolderTreeCtrl::CTreeItem::CTreeItem(CFolderTreeCtrl& folderTreeCtrl, CFolderTreeCtrl::CTreeItem* parent,
-    const QString& name, const QString& path, const int image)
-    : QStandardItem(folderTreeCtrl.GetItemIcon(image), name)
-    , m_folderTreeCtrl(folderTreeCtrl)
-    , m_path(path)
-{
-    parent->appendRow(this);
-    setData(image == eTreeImage_Folder, IsFolderRole);
-
-    m_folderTreeCtrl.m_pathToTreeItem[ m_path ] = this;
+    m_folderTreeCtrl.m_pathToTreeItem[m_path] = this;
 }
 
 CFolderTreeCtrl::CTreeItem::~CTreeItem()
@@ -495,8 +454,7 @@ void CFolderTreeCtrl::CTreeItem::Remove()
     }
 }
 
-CFolderTreeCtrl::CTreeItem* CFolderTreeCtrl::CTreeItem::AddChild(const QString& name, const QString& path, const int image)
+CFolderTreeCtrl::CTreeItem* CFolderTreeCtrl::CTreeItem::AddChild(const QString& name, const QString& path, IconType icon)
 {
-    CTreeItem* newItem = new CTreeItem(m_folderTreeCtrl, this, name, path, image);
-    return newItem;
+    return new CTreeItem(m_folderTreeCtrl, this, name, path, icon);
 }

--- a/Code/Editor/Controls/FolderTreeCtrl.h
+++ b/Code/Editor/Controls/FolderTreeCtrl.h
@@ -6,12 +6,13 @@
  *
  */
 
-
-#ifndef CRYINCLUDE_EDITOR_CONTROLS_FOLDERTREECTRL_H
-#define CRYINCLUDE_EDITOR_CONTROLS_FOLDERTREECTRL_H
 #pragma once
 
 #include "Util/FileChangeMonitor.h"
+
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/containers/map.h>
+
 #include <QList>
 #include <QStandardItem>
 #include <QTreeView>
@@ -20,39 +21,37 @@
 class QSortFilterProxyModel;
 class QStandardItemModel;
 
-//! Case insensetive less key for any type convertable to const char*.
-struct qstring_icmp
-{
-    bool operator()(const QString& left, const QString& right) const
-    {
-        return QString::compare(left, right, Qt::CaseInsensitive) < 0;
-    }
-};
-
 class CFolderTreeCtrl
     : public QTreeView
     , public CFileChangeMonitorListener
 {
-    Q_OBJECT // AUTOMOC
+    Q_OBJECT 
 
     friend class CTreeItem;
+
+    enum class IconType
+    {
+        FolderIcon = 0,
+        FileIcon = 2
+    };
+
+    enum class Roles : int
+    {
+        IsFolderRole = Qt::UserRole
+    };
 
     class CTreeItem
         : public QStandardItem
     {
-        // Only allow destruction through std::unique_ptr
-        friend struct std::default_delete<CTreeItem>;
-
     public:
-        explicit CTreeItem(CFolderTreeCtrl& folderTreeCtrl, const QString& path);
-        explicit CTreeItem(CFolderTreeCtrl& folderTreeCtrl, CTreeItem* parent,
-            const QString& name, const QString& path, const int image);
+        CTreeItem(CFolderTreeCtrl& folderTreeCtrl, CTreeItem* parent,
+            const QString& name, const QString& path, IconType image);
+        ~CTreeItem();
 
         void Remove();
-        CTreeItem* AddChild(const QString& name, const QString& path, const int image);
+        CTreeItem* AddChild(const QString& name, const QString& path, IconType image);
         QString GetPath() const { return m_path; }
     private:
-        ~CTreeItem();
 
         CFolderTreeCtrl& m_folderTreeCtrl;
         QString m_path;
@@ -60,18 +59,16 @@ class CFolderTreeCtrl
 
 public:
     CFolderTreeCtrl(QWidget* parent = 0);
-    CFolderTreeCtrl(const QStringList& folders, const QString& fileNameSpec,
-        const QString& rootName, bool bDisableMonitor = false, bool bFlatTree = true, QWidget* parent = 0);
     virtual ~CFolderTreeCtrl();
 
-    void init(const QStringList& folders, const QString& fileNameSpec,
+    void Configure(const AZStd::vector<QString>& folders, const QString& fileNameSpec,
         const QString& rootName, bool bDisableMonitor = false, bool bFlatTree = true);
 
     QString GetPath(QStandardItem* item) const;
     bool IsFolder(QStandardItem* item) const;
     bool IsFile(QStandardItem* item) const;
 
-    QIcon GetItemIcon(int image) const;
+    QIcon GetItemIcon(IconType image) const;
     QList<QStandardItem*> GetSelectedItems() const;
 
     void SetSearchFilter(const QString& searchText);
@@ -83,10 +80,18 @@ protected Q_SLOTS:
     void OnIndexDoubleClicked(const QModelIndex& index);
 
 protected:
+    struct CaseInsensitiveCompare
+    {
+        bool operator()(const QString& left, const QString& right) const
+        {
+            return QString::compare(left, right, Qt::CaseInsensitive) < 0;
+        }
+    };
+
+
     void OnFileMonitorChange(const SFileChangeInfo& rChange) override;
     void contextMenuEvent(QContextMenuEvent* e) override;
 
-    void InitTree();
     void LoadTreeRec(const QString& currentFolder);
 
     void AddItem(const QString& path);
@@ -102,19 +107,17 @@ protected:
     void Edit(const QString& path);
     void ShowInExplorer(const QString& path);
 
-    bool m_bDisableMonitor;
-    bool m_bFlatStyle;
-    std::unique_ptr< CTreeItem > m_rootTreeItem;
-    QString m_fileNameSpec;
-    QStringList m_folders;
-    QString m_rootName;
-    std::map<QString, unsigned int> m_foldersSegments;
+    bool m_bDisableMonitor = false;
+    bool m_bFlatStyle = false;
+    QString m_fileNameSpec = "";
+    AZStd::vector<QString> m_folders = {};
+    QString m_rootName = "";
+    AZStd::map< QString, CTreeItem*, CaseInsensitiveCompare > m_pathToTreeItem = {};
+    CTreeItem* m_rootTreeItem = nullptr;
+
     QIcon m_folderIcon;
     QIcon m_fileIcon;
+    QStandardItemModel* m_model;
+    QSortFilterProxyModel* m_proxyModel;
 
-    QSortFilterProxyModel* m_proxyModel = nullptr;
-    QStandardItemModel* m_model = nullptr;
-    std::map< QString, CTreeItem*, qstring_icmp > m_pathToTreeItem;
 };
-
-#endif // CRYINCLUDE_EDITOR_CONTROLS_FOLDERTREECTRL_H

--- a/Code/Editor/Controls/FolderTreeCtrl.h
+++ b/Code/Editor/Controls/FolderTreeCtrl.h
@@ -62,7 +62,7 @@ public:
     virtual ~CFolderTreeCtrl();
 
     void Configure(const AZStd::vector<QString>& folders, const QString& fileNameSpec,
-        const QString& rootName, bool bDisableMonitor = false, bool bFlatTree = true);
+        const QString& rootName, bool bEnabledMonitor = true, bool bFlatTree = true);
 
     QString GetPath(QStandardItem* item) const;
     bool IsFolder(QStandardItem* item) const;
@@ -107,7 +107,7 @@ protected:
     void Edit(const QString& path);
     void ShowInExplorer(const QString& path);
 
-    bool m_bDisableMonitor = false;
+    bool m_bEnableMonitor = false;
     bool m_bFlatStyle = false;
     QString m_fileNameSpec = "";
     AZStd::vector<QString> m_folders = {};

--- a/Code/Editor/Dialogs/PythonScriptsDialog.cpp
+++ b/Code/Editor/Dialogs/PythonScriptsDialog.cpp
@@ -66,7 +66,7 @@ CPythonScriptsDialog::CPythonScriptsDialog(QWidget* parent)
 
     AzQtComponents::LineEdit::applySearchStyle(ui->searchField);
 
-    QStringList scriptFolders;
+    AZStd::vector<QString> scriptFolders;
     auto engineScriptPath = AZ::IO::FixedMaxPath(AZ::Utils::GetEnginePath()) / "Assets" / "Editor" / "Scripts";
     scriptFolders.push_back(engineScriptPath.c_str());
 
@@ -90,14 +90,21 @@ CPythonScriptsDialog::CPythonScriptsDialog(QWidget* parent)
         }
     }
 
-    ui->treeView->init(scriptFolders, s_kPythonFileNameSpec, s_kRootElementName, false, false);
+    ui->treeView->Configure(scriptFolders, s_kPythonFileNameSpec, s_kRootElementName, false, false);
+    ui->treeView->expandAll();
     QObject::connect(ui->treeView, &CFolderTreeCtrl::ItemDoubleClicked, this, &CPythonScriptsDialog::OnExecute);
     QObject::connect(ui->executeButton, &QPushButton::clicked, this, &CPythonScriptsDialog::OnExecute);
-    QObject::connect(ui->searchField, &QLineEdit::textChanged, ui->treeView, &CFolderTreeCtrl::SetSearchFilter);
+    QObject::connect(ui->searchField, &QLineEdit::textChanged, this, [&](QString searchText){
+        ui->treeView->SetSearchFilter(searchText);
+        if(searchText.trimmed().isEmpty()) 
+        {
+            ui->treeView->expandAll();
+        }
+    });
 }
 
 //////////////////////////////////////////////////////////////////////////
-void CPythonScriptsDialog::ScanFolderForScripts(QString path, QStringList& scriptFolders) const
+void CPythonScriptsDialog::ScanFolderForScripts(QString path, AZStd::vector<QString>& scriptFolders) const
 {
     char resolvedPath[AZ_MAX_PATH_LEN] = { 0 };
     if (AZ::IO::FileIOBase::GetDirectInstance()->ResolvePath(path.toLocal8Bit().constData(), resolvedPath, AZ_MAX_PATH_LEN))
@@ -112,9 +119,6 @@ void CPythonScriptsDialog::ScanFolderForScripts(QString path, QStringList& scrip
 //////////////////////////////////////////////////////////////////////////
 CPythonScriptsDialog::~CPythonScriptsDialog()
 {
-    // Clear the filter before closing to workaround an issue with the QSortFilterProxyModel.
-    // It appears to delete any matching items itself, resulting in an attempt to delete an item twice.
-    ui->treeView->SetSearchFilter("");
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/Dialogs/PythonScriptsDialog.h
+++ b/Code/Editor/Dialogs/PythonScriptsDialog.h
@@ -5,14 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-
-
-#ifndef CRYINCLUDE_EDITOR_DIALOGS_PYTHONSCRIPTSDIALOG_H
-#define CRYINCLUDE_EDITOR_DIALOGS_PYTHONSCRIPTSDIALOG_H
 #pragma once
 
-
 #if !defined(Q_MOC_RUN)
+#include <AzCore/std/containers/vector.h>
+
 #include <QWidget>
 #include <QScopedPointer>
 #endif
@@ -45,11 +42,8 @@ private slots:
     void OnExecute();
 
 protected:
-    void ScanFolderForScripts(QString path, QStringList& scriptFolders) const;
+    void ScanFolderForScripts(QString path, AZStd::vector<QString>& scriptFolders) const;
 
 private:
     QScopedPointer<Ui::CPythonScriptsDialog> ui;
 };
-
-
-#endif // CRYINCLUDE_EDITOR_DIALOGS_PYTHONSCRIPTSDIALOG_H


### PR DESCRIPTION
ref: https://github.com/o3de/o3de/issues/12270

Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

this resolves the ownership problems with CFolderTreeCtrl. This should resolve the crash problem observed in the referenced ticket. I also migrated the logic from the standard library and removed a lot of additional methods. I think the logic should be more clear with these changes. 

## How was this PR tested?

follow the steps in the referenced ticket.
