### PR TITLE
Migrate the legacy FileWatcherUnitTests

### DIFF
--- a/Code/Tools/AssetProcessor/native/unittests/FileWatcherUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/FileWatcherUnitTests.cpp
@@ -5,155 +5,168 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include "FileWatcherUnitTests.h"
-#include "native/FileWatcher/FileWatcher.h"
-#include "native/AssetManager/assetProcessorManager.h"
-#include <AzTest/AzTest.h>
+
+#include <native/tests/MockAssetDatabaseRequestsHandler.h>
+#include <native/unittests/FileWatcherUnitTests.h>
+#include <native/unittests/UnitTestRunner.h>
+
 #include <QCoreApplication>
 
 using namespace AssetProcessor;
 
-void FileWatcherUnitTestRunner::StartTest()
+void FileWatcherUnitTest::SetUp()
 {
-    // QTemporaryDir returns a path that may have symbolic links in it. for macOS
-    // this fails because the file events use paths with no symbolic links. Use
-    // QDir's canonicalPath to remove the symbolic links.
-    QTemporaryDir tempDir;
-    QDir dir(tempDir.path());
-    QString tempPath = dir.canonicalPath();
+    UnitTest::AssetProcessorUnitTestBase::SetUp();
 
-    FileWatcher fileWatcher;
+    m_assetRootPath = QString(m_assetDatabaseRequestsHandler->GetAssetRootDir().c_str());
+    m_fileWatcher.AddFolderWatch(m_assetRootPath);
+    m_fileWatcher.StartWatching();
+}
 
-    fileWatcher.AddFolderWatch(tempPath);
-    fileWatcher.StartWatching();
+void FileWatcherUnitTest::TearDown()
+{
+    UnitTest::AssetProcessorUnitTestBase::TearDown();
+}
 
-    { // test a single file create/write
-        bool foundFile = false;
-        auto connection = QObject::connect(&fileWatcher, &FileWatcher::fileAdded, this, [&](QString filename)
+// File operations on Linux behave differently on Linux than Windows.
+// The system under test doesn't yet handle Linux's file operations, which surfaced as this test arbitrarily passing and failing.
+// This test is disabled on Linux until the system under test can handle Linux file system behavior correctly.
+#if !AZ_TRAIT_DISABLE_FAILED_ASSET_PROCESSOR_TESTS && !defined(AZ_PLATFORM_LINUX)
+
+TEST_F(FileWatcherUnitTest, WatchFileCreation_CreateSingleFile_FileChangeFound)
+{
+    // test a single file create/write
+    bool foundFile = false;
+    auto connection = QObject::connect(&m_fileWatcher, &FileWatcher::fileAdded, this, [&](QString filename)
         {
             AZ_TracePrintf(AssetProcessor::DebugChannel, "Single file test Found asset: %s.\n", filename.toUtf8().data());
             foundFile = true;
         });
 
-        // give the file watcher thread a moment to get started
-        QThread::msleep(50);
+    // give the file watcher thread a moment to get started
+    QThread::msleep(50);
 
-        QFile testTif(tempPath + "/test.tif");
-        bool open = testTif.open(QFile::WriteOnly);
+    QFile testTif(m_assetRootPath + "/test.tif");
+    bool open = testTif.open(QFile::WriteOnly);
 
-        UNIT_TEST_EXPECT_TRUE(open);
+    EXPECT_TRUE(open);
 
-        testTif.write("0");
-        testTif.close();
+    testTif.write("0");
+    testTif.close();
 
-        // Wait for file change to be found, timeout, and be delivered
-        unsigned int tries = 0;
-        while (!foundFile && tries++ < 10)
-        {
-            QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
-            QThread::msleep(10);
-        }
-
-        UNIT_TEST_EXPECT_TRUE(foundFile);
-        QObject::disconnect(connection);
+    // Wait for file change to be found, timeout, and be delivered
+    unsigned int tries = 0;
+    while (!foundFile && tries++ < 10)
+    {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
+        QThread::msleep(10);
     }
 
-    { // test a whole bunch of files created/written
-      // send enough files such that main thread is likely to be blocked:
-        const unsigned long maxFiles = 1000;
-        QSet<QString> outstandingFiles;
+    EXPECT_TRUE(foundFile);
 
-        auto connection = QObject::connect(&fileWatcher, &FileWatcher::fileAdded, this, [&](QString filename)
+    QObject::disconnect(connection);
+}
+
+TEST_F(FileWatcherUnitTest, WatchFileCreation_CreateMultipleFiles_FileChangesFound)
+{
+    // test a whole bunch of files created/written
+    // send enough files such that main thread is likely to be blocked:
+    const unsigned long maxFiles = 1000;
+    QSet<QString> outstandingFiles;
+
+    auto connection = QObject::connect(&m_fileWatcher, &FileWatcher::fileAdded, this, [&](QString filename)
         {
             outstandingFiles.remove(filename);
         });
-        AZ_TracePrintf(AssetProcessor::DebugChannel, "Performing multi-file test...\n");
+    AZ_TracePrintf(AssetProcessor::DebugChannel, "Performing multi-file test...\n");
 
-        // give the file watcher thread a moment to get started
-        QThread::msleep(50);
+    // give the file watcher thread a moment to get started
+    QThread::msleep(50);
 
-        for (unsigned long fileIndex = 0; fileIndex < maxFiles; ++fileIndex)
+    for (unsigned long fileIndex = 0; fileIndex < maxFiles; ++fileIndex)
+    {
+        if (fileIndex % 100 == 0)
         {
-            if (fileIndex % 100 == 0)
-            {
-                AZ_TracePrintf(AssetProcessor::DebugChannel, "Performing multi-file test... creating file  %d / %d\n", fileIndex, maxFiles);
-            }
-            QString filename = QString(tempPath + "/test%1.tif").arg(fileIndex);
-            filename = QDir::toNativeSeparators(filename);
-            outstandingFiles.insert(filename);
-            QFile testTif(filename);
-            bool open = testTif.open(QFile::WriteOnly);
-
-            UNIT_TEST_EXPECT_TRUE(open);
-
-            testTif.write("0");
-            testTif.close();
+            AZ_TracePrintf(AssetProcessor::DebugChannel, "Performing multi-file test... creating file  %d / %d\n", fileIndex, maxFiles);
         }
+        QString filename = QString(m_assetRootPath + "/test%1.tif").arg(fileIndex);
+        filename = QDir::toNativeSeparators(filename);
+        outstandingFiles.insert(filename);
+        QFile testTif(filename);
+        bool open = testTif.open(QFile::WriteOnly);
 
-        // Wait for file change to be found, timeout, and be delivered
-        unsigned int tries = 0;
-        while (outstandingFiles.count() > 0 && tries++ < 50) // 5 secs is more than enough for all remaining deliveries.
-        {
-            QCoreApplication::processEvents(QEventLoop::AllEvents);
-            QThread::msleep(100);
-            AZ_TracePrintf(AssetProcessor::DebugChannel, "Waiting for remaining notifications: %d \n", outstandingFiles.count());
-        }
+        EXPECT_TRUE(open);
 
-         if (outstandingFiles.count() > 0)
-        {
-#if defined(AZ_ENABLE_TRACING)
-            AZ_TracePrintf(AssetProcessor::DebugChannel, "Timed out waiting for file changes: %d / %d  missed\n", outstandingFiles.count(), maxFiles);
-            for (const QString& pending : outstandingFiles)
-            {
-                AZ_TracePrintf(AssetProcessor::DebugChannel, "Missed file: %s", pending.toUtf8().data());
-            }
-#endif
-            Q_EMIT UnitTestFailed("Missed files waiting for file changes");
-            return;
-        }
-
-        QObject::disconnect(connection);
+        testTif.write("0");
+        testTif.close();
     }
 
+    // Wait for file change to be found, timeout, and be delivered
+    unsigned int tries = 0;
+    while (outstandingFiles.count() > 0 && tries++ < 50) // 5 secs is more than enough for all remaining deliveries.
+    {
+        QCoreApplication::processEvents(QEventLoop::AllEvents);
+        QThread::msleep(100);
+        AZ_TracePrintf(AssetProcessor::DebugChannel, "Waiting for remaining notifications: %d \n", outstandingFiles.count());
+    }
 
-    AZ_TracePrintf(AssetProcessor::DebugChannel, "Deletion test ... \n");
+    bool filesMissed = outstandingFiles.count() > 0;
+    if (filesMissed)
+    {
+#if defined(AZ_ENABLE_TRACING)
+        AZ_TracePrintf(AssetProcessor::DebugChannel, "Timed out waiting for file changes: %d / %d  missed\n", outstandingFiles.count(), maxFiles);
+        for (const QString& pending : outstandingFiles)
+        {
+            AZ_TracePrintf(AssetProcessor::DebugChannel, "Missed file: %s", pending.toUtf8().data());
+        }
+#endif
+        ASSERT_FALSE(filesMissed) << "Missed files waiting for file changes";
+    }
 
-    { // test deletion
-        bool foundFile = false;
-        auto connection = QObject::connect(&fileWatcher, &FileWatcher::fileRemoved, this, [&](QString filename)
+    QObject::disconnect(connection);
+}
+
+TEST_F(FileWatcherUnitTest, WatchFileDeletion_RemoveTestAsset_FileChangeFound)
+{
+    bool foundFile = false;
+    auto connection = QObject::connect(&m_fileWatcher, &FileWatcher::fileRemoved, this, [&](QString filename)
         {
             AZ_TracePrintf(AssetProcessor::DebugChannel, "Deleted asset: %s...\n", filename.toUtf8().data());
             foundFile = true;
         });
 
-        // give the file watcher thread a moment to get started
-        QThread::msleep(50);
+    // give the file watcher thread a moment to get started
+    QThread::msleep(50);
 
-        QString filename(tempPath + "/test.tif");
-        bool removed = QFile::remove(filename);
+    QString fileName = m_assetRootPath + "/test.tif";
+    EXPECT_TRUE(UnitTestUtils::CreateDummyFile(fileName));
 
-        UNIT_TEST_EXPECT_TRUE(removed);
+    bool removed = QFile::remove(fileName);
 
-        // Wait for file change to be found, timeout, and be delivered
-        unsigned int tries = 0;
-        while (!foundFile && tries++ < 100)
-        {
-            QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
-            QThread::msleep(10);
-            AZ_TracePrintf(AssetProcessor::DebugChannel, "Deletion test ... waiting for deletion notification \n");
-        }
+    EXPECT_TRUE(removed);
 
-        UNIT_TEST_EXPECT_TRUE(foundFile);
-
-        QObject::disconnect(connection);
+    // Wait for file change to be found, timeout, and be delivered
+    unsigned int tries = 0;
+    while (!foundFile && tries++ < 100)
+    {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
+        QThread::msleep(10);
+        AZ_TracePrintf(AssetProcessor::DebugChannel, "Deletion test ... waiting for deletion notification \n");
     }
 
+    EXPECT_TRUE(foundFile);
+
+    QObject::disconnect(connection);
+}
+
+TEST_F(FileWatcherUnitTest, WatchFileRelocation_RenameTestAsset_FileChangeFound)
+{
     AZ_TracePrintf(AssetProcessor::DebugChannel, "rename/move test ...\n");
 
     {
         bool fileAddCalled = false;
         QString fileAddName;
-        auto connectionAdd = QObject::connect(&fileWatcher, &FileWatcher::fileAdded, this, [&](QString filename)
+        auto connectionAdd = QObject::connect(&m_fileWatcher, &FileWatcher::fileAdded, this, [&](QString filename)
         {
             fileAddCalled = true;
             fileAddName = filename;
@@ -161,7 +174,7 @@ void FileWatcherUnitTestRunner::StartTest()
 
         bool fileRemoveCalled = false;
         QString fileRemoveName;
-        auto connectionRemove = QObject::connect(&fileWatcher, &FileWatcher::fileRemoved, this, [&](QString filename)
+        auto connectionRemove = QObject::connect(&m_fileWatcher, &FileWatcher::fileRemoved, this, [&](QString filename)
         {
             fileRemoveCalled = true;
             fileRemoveName = filename;
@@ -169,7 +182,7 @@ void FileWatcherUnitTestRunner::StartTest()
 
         QStringList fileModifiedNames;
         bool fileModifiedCalled = false;
-        auto connectionModified = QObject::connect(&fileWatcher, &FileWatcher::fileModified, this, [&](QString filename)
+        auto connectionModified = QObject::connect(&m_fileWatcher, &FileWatcher::fileModified, this, [&](QString filename)
         {
             fileModifiedCalled = true;
             fileModifiedNames.append(filename);
@@ -178,7 +191,7 @@ void FileWatcherUnitTestRunner::StartTest()
         // give the file watcher thread a moment to get started
         QThread::msleep(50);
 
-        QDir tempDirPath(tempPath);
+        QDir tempDirPath(m_assetRootPath);
         tempDirPath.mkpath("dir1");
         tempDirPath.mkpath("dir2");
         tempDirPath.mkpath("dir3");
@@ -189,7 +202,7 @@ void FileWatcherUnitTestRunner::StartTest()
         QString newName3 = tempDirPath.absoluteFilePath("dir3/test3.tif"); // change name and dir.
 
 
-        UNIT_TEST_EXPECT_TRUE(UnitTestUtils::CreateDummyFile(originalName));
+        EXPECT_TRUE(UnitTestUtils::CreateDummyFile(originalName));
 
         int tries = 0;
         while (!(fileAddCalled && fileModifiedCalled) && tries++ < 100)
@@ -199,14 +212,14 @@ void FileWatcherUnitTestRunner::StartTest()
         }
 
 
-        UNIT_TEST_EXPECT_TRUE(fileAddCalled);
-        UNIT_TEST_EXPECT_FALSE(fileRemoveCalled);
+        EXPECT_TRUE(fileAddCalled);
+        EXPECT_FALSE(fileRemoveCalled);
         fileAddCalled = false;
         fileRemoveCalled = false;
         fileModifiedCalled = false;
 
         // okay, now rename it:
-        UNIT_TEST_EXPECT_TRUE(QFile::rename(originalName, newName1));
+        EXPECT_TRUE(QFile::rename(originalName, newName1));
 
         tries = 0;
         while (!(fileAddCalled || fileRemoveCalled || fileModifiedCalled) && tries++ < 100)
@@ -217,22 +230,22 @@ void FileWatcherUnitTestRunner::StartTest()
 
         // make sure both callbacks fired and that
         // the original was "removed" and the new was "added"
-        UNIT_TEST_EXPECT_TRUE(fileAddCalled);
-        UNIT_TEST_EXPECT_TRUE(fileRemoveCalled);
+        EXPECT_TRUE(fileAddCalled);
+        EXPECT_TRUE(fileRemoveCalled);
 
 #if defined(AZ_PLATFORM_WINDOWS)
-        UNIT_TEST_EXPECT_TRUE(fileModifiedCalled); // modified should be called on the folder that the file lives in (Only on Windows)
+        EXPECT_TRUE(fileModifiedCalled); // modified should be called on the folder that the file lives in (Only on Windows)
 #endif // AZ_PLATFORM_WINDOWS
 
-        UNIT_TEST_EXPECT_TRUE(QDir::toNativeSeparators(fileRemoveName).toLower() == QDir::toNativeSeparators(originalName).toLower());
-        UNIT_TEST_EXPECT_TRUE(QDir::toNativeSeparators(fileAddName).toLower() == QDir::toNativeSeparators(newName1).toLower());
+        EXPECT_EQ(QDir::toNativeSeparators(fileRemoveName).toLower(), QDir::toNativeSeparators(originalName).toLower());
+        EXPECT_EQ(QDir::toNativeSeparators(fileAddName).toLower(), QDir::toNativeSeparators(newName1).toLower());
 
         fileAddCalled = false;
         fileRemoveCalled = false;
         fileModifiedCalled = false;
 
         // okay, now rename it to the second folder.
-        UNIT_TEST_EXPECT_TRUE(QFile::rename(newName1, newName2));
+        EXPECT_TRUE(QFile::rename(newName1, newName2));
 
         tries = 0;
         while (!(fileAddCalled || fileRemoveCalled || fileModifiedCalled) && tries++ < 100)
@@ -243,17 +256,17 @@ void FileWatcherUnitTestRunner::StartTest()
 
         // make sure both callbacks fired and that
         // the new1 was "removed" and the new2 was "added"
-        UNIT_TEST_EXPECT_TRUE(fileAddCalled);
-        UNIT_TEST_EXPECT_TRUE(fileRemoveCalled);
+        EXPECT_TRUE(fileAddCalled);
+        EXPECT_TRUE(fileRemoveCalled);
 #if defined(AZ_PLATFORM_WINDOWS)
-        UNIT_TEST_EXPECT_TRUE(fileModifiedCalled); // modified should be called on the folder that the file lives in (Only on Windows)
+        EXPECT_TRUE(fileModifiedCalled); // modified should be called on the folder that the file lives in (Only on Windows)
 #endif // AZ_PLATFORM_WINDOWS
 
-        UNIT_TEST_EXPECT_TRUE(QDir::toNativeSeparators(fileRemoveName).toLower() == QDir::toNativeSeparators(newName1).toLower());
-        UNIT_TEST_EXPECT_TRUE(QDir::toNativeSeparators(fileAddName).toLower() == QDir::toNativeSeparators(newName2).toLower());
+        EXPECT_EQ(QDir::toNativeSeparators(fileRemoveName).toLower(), QDir::toNativeSeparators(newName1).toLower());
+        EXPECT_EQ(QDir::toNativeSeparators(fileAddName).toLower(), QDir::toNativeSeparators(newName2).toLower());
 
         // okay, now rename it to the 3rd folder.
-        UNIT_TEST_EXPECT_TRUE(QFile::rename(newName2, newName3));
+        EXPECT_TRUE(QFile::rename(newName2, newName3));
 
         fileAddCalled = false;
         fileRemoveCalled = false;
@@ -267,13 +280,13 @@ void FileWatcherUnitTestRunner::StartTest()
         }
         // make sure both callbacks fired and that
         // the new1 was "removed" and the new2 was "added"
-        UNIT_TEST_EXPECT_TRUE(fileAddCalled);
-        UNIT_TEST_EXPECT_TRUE(fileRemoveCalled);
+        EXPECT_TRUE(fileAddCalled);
+        EXPECT_TRUE(fileRemoveCalled);
 #if defined(AZ_PLATFORM_WINDOWS)
-        UNIT_TEST_EXPECT_TRUE(fileModifiedCalled); // modified should be called on the folder that the file lives in (Only on Windows)
+        EXPECT_TRUE(fileModifiedCalled); // modified should be called on the folder that the file lives in (Only on Windows)
 #endif // AZ_PLATFORM_WINDOWS
-        UNIT_TEST_EXPECT_TRUE(QDir::toNativeSeparators(fileRemoveName).toLower() == QDir::toNativeSeparators(newName2).toLower());
-        UNIT_TEST_EXPECT_TRUE(QDir::toNativeSeparators(fileAddName).toLower() == QDir::toNativeSeparators(newName3).toLower());
+        EXPECT_EQ(QDir::toNativeSeparators(fileRemoveName).toLower(), QDir::toNativeSeparators(newName2).toLower());
+        EXPECT_EQ(QDir::toNativeSeparators(fileAddName).toLower(), QDir::toNativeSeparators(newName3).toLower());
 
 #if !defined(AZ_PLATFORM_LINUX)
         // final test... make sure that renaming a DIRECTORY works too.
@@ -283,7 +296,7 @@ void FileWatcherUnitTestRunner::StartTest()
         fileRemoveCalled = false;
         fileModifiedCalled = false;
 
-        UNIT_TEST_EXPECT_TRUE(renamer.rename(tempDirPath.absoluteFilePath("dir3"), tempDirPath.absoluteFilePath("dir4")));
+        EXPECT_TRUE(renamer.rename(tempDirPath.absoluteFilePath("dir3"), tempDirPath.absoluteFilePath("dir4")));
 
         tries = 0;
         while (!(fileAddCalled && fileRemoveCalled) && tries++ < 100)
@@ -292,28 +305,19 @@ void FileWatcherUnitTestRunner::StartTest()
             QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
         }
 
-        UNIT_TEST_EXPECT_TRUE(fileAddCalled);
-        UNIT_TEST_EXPECT_TRUE(fileRemoveCalled);
+        EXPECT_TRUE(fileAddCalled);
+        EXPECT_TRUE(fileRemoveCalled);
 
         // note that when you rename a directory ONLY, its os-specific as to whether you get a modify callback.  Windows does not
         // but we don't specify or require or deny it in our API.
 
-        UNIT_TEST_EXPECT_TRUE(QDir::toNativeSeparators(fileRemoveName).toLower() == QDir::toNativeSeparators(tempDirPath.absoluteFilePath("dir3")).toLower());
-        UNIT_TEST_EXPECT_TRUE(QDir::toNativeSeparators(fileAddName).toLower() == QDir::toNativeSeparators(tempDirPath.absoluteFilePath("dir4")).toLower());
+        EXPECT_EQ(QDir::toNativeSeparators(fileRemoveName).toLower(), QDir::toNativeSeparators(tempDirPath.absoluteFilePath("dir3")).toLower());
+        EXPECT_EQ(QDir::toNativeSeparators(fileAddName).toLower(), QDir::toNativeSeparators(tempDirPath.absoluteFilePath("dir4")).toLower());
 #endif // AZ_PLATFORM_LINUX
 
         QObject::disconnect(connectionRemove);
         QObject::disconnect(connectionAdd);
         QObject::disconnect(connectionModified);
     }
-
-
-    Q_EMIT UnitTestPassed();
 }
-
-// File operations on Linux behave differently on Linux than Windows.
-// The system under test doesn't yet handle Linux's file operations, which surfaced as this test arbitrarily passing and failing.
-// This test is disabled on Linux until the system under test can handle Linux file system behavior correctly.
-#if !AZ_TRAIT_DISABLE_FAILED_ASSET_PROCESSOR_TESTS && !defined(AZ_PLATFORM_LINUX)
-REGISTER_UNIT_TEST(FileWatcherUnitTestRunner)
 #endif // !AZ_TRAIT_DISABLE_FAILED_ASSET_PROCESSOR_TESTS

--- a/Code/Tools/AssetProcessor/native/unittests/FileWatcherUnitTests.h
+++ b/Code/Tools/AssetProcessor/native/unittests/FileWatcherUnitTests.h
@@ -21,6 +21,6 @@ public:
     void TearDown() override;
 
 protected:
-    FileWatcher m_fileWatcher;
+    AZStd::unique_ptr<FileWatcher> m_fileWatcher;
     QString m_assetRootPath;
 };

--- a/Code/Tools/AssetProcessor/native/unittests/FileWatcherUnitTests.h
+++ b/Code/Tools/AssetProcessor/native/unittests/FileWatcherUnitTests.h
@@ -5,15 +5,22 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#ifndef FILEMONITORUNITTESTS_H
-#define FILEMONITORUNITTESTS_H
-#include "UnitTestRunner.h"
 
-class FileWatcherUnitTestRunner
-    : public UnitTestRun
+#pragma once
+
+#include <native/unittests/AssetProcessorUnitTests.h>
+
+class FileWatcherUnitTest
+    : public QObject
+    , public UnitTest::AssetProcessorUnitTestBase
 {
-public:
-    virtual void StartTest() override;
-};
+    Q_OBJECT
 
-#endif // FILEMONITORUNITTESTS_H
+public:
+    void SetUp() override;
+    void TearDown() override;
+
+protected:
+    FileWatcher m_fileWatcher;
+    QString m_assetRootPath;
+};


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?

Migrate the legacy FileWatcherUnitTests to the modern test framework.

The test has lots of hardcoded timeout. I'll create a separate task to investigate and get rid of them if possible.

## How was this PR tested?

```
[----------] 4 tests from FileWatcherUnitTest
[ RUN      ] FileWatcherUnitTest.WatchFileCreation_CreateSingleFile_FileChangeFound
[       OK ] FileWatcherUnitTest.WatchFileCreation_CreateSingleFile_FileChangeFound (405 ms)
[ RUN      ] FileWatcherUnitTest.WatchFileCreation_CreateMultipleFiles_FileChangesFound
[       OK ] FileWatcherUnitTest.WatchFileCreation_CreateMultipleFiles_FileChangesFound (1077 ms)
[ RUN      ] FileWatcherUnitTest.WatchFileDeletion_RemoveTestAsset_FileChangeFound
[       OK ] FileWatcherUnitTest.WatchFileDeletion_RemoveTestAsset_FileChangeFound (407 ms)
[ RUN      ] FileWatcherUnitTest.WatchFileRelocation_RenameTestAsset_FileChangeFound
[       OK ] FileWatcherUnitTest.WatchFileRelocation_RenameTestAsset_FileChangeFound (465 ms)
[----------] 4 tests from FileWatcherUnitTest (2357 ms total)
```
