### PR TITLE
Add undo/redo steps to existing MaterialEditor basic tests.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_tools_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_tools_utils.py
@@ -125,6 +125,14 @@ def redo(document_id: azlmbr.math.Uuid) -> bool:
     return azlmbr.atomtools.AtomToolsDocumentRequestBus(bus.Event, "Redo", document_id)
 
 
+def begin_edit(document_id: azlmbr.math.Uuid) -> bool:
+    return azlmbr.atomtools.AtomToolsDocumentRequestBus(azlmbr.bus.Event, "BeginEdit", document_id)
+
+
+def end_edit(document_id: azlmbr.math.Uuid) -> bool:
+    return azlmbr.atomtools.AtomToolsDocumentRequestBus(azlmbr.bus.Event, "EndEdit", document_id)
+
+
 def exit() -> None:
     """
     Closes the current Atom tools executable.

--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_tools_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_tools_utils.py
@@ -117,6 +117,14 @@ def select_model_config(asset_path: str) -> None:
     azlmbr.atomtools.EntityPreviewViewportSettingsRequestBus(azlmbr.bus.Broadcast, "LoadModelPresetByAssetId", asset_id)
 
 
+def undo(document_id: azlmbr.math.Uuid) -> bool:
+    return azlmbr.atomtools.AtomToolsDocumentRequestBus(bus.Event, "Undo", document_id)
+
+
+def redo(document_id: azlmbr.math.Uuid) -> bool:
+    return azlmbr.atomtools.AtomToolsDocumentRequestBus(bus.Event, "Redo", document_id)
+
+
 def exit() -> None:
     """
     Closes the current Atom tools executable.

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_BasicTests.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_BasicTests.py
@@ -26,8 +26,8 @@ class Tests:
         "Material asset color changed successfully.",
         "P0: Failed to change the color values of a material asset file.")
     undo_material_asset_color_change = (
-        "Material asset color reverted back to its initial color successfully.",
-        "P0: Failed to revert material asset color back to its initial color.")
+        "Material asset color change was reverted using undo.",
+        "P0: Failed to undo material asset color change.")
     redo_material_asset_color_change = (
         "Material asset color changed again successfully using redo.",
         "P0: Failed to change material asset color again using redo.")
@@ -115,7 +115,9 @@ def MaterialEditor_BasicFunctionalityChecks_AllChecksPass():
         document_id = atom_tools_utils.open_document(os.path.join(test_data_path, test_material_1))
         initial_color = material_editor_utils.get_property(document_id, base_color_property_name)
         expected_color = math.Color(0.25, 0.25, 0.25, 1.0)
+        atom_tools_utils.begin_edit(document_id)
         material_editor_utils.set_property(document_id, base_color_property_name, expected_color)
+        atom_tools_utils.end_edit(document_id)
         Report.result(
             Tests.changed_material_asset_color,
             material_editor_utils.get_property(document_id, base_color_property_name) == expected_color)


### PR DESCRIPTION
## What does this PR do?
Adds undo/redo functionality to the MaterialEditor basic tests.

## How was this PR tested?
Ran test command: `C:\git\o3de>C:\git\o3de\python\runtime\python-3.10.5-rev1-windows\python\python.exe -m pytest -vv -s --build-directory="C:\git\o3de\build\bin\profile" C:\git\o3de\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_Null_Render_MaterialEditor_01.py -k MaterialEditor_Atom_BasicTests`
Result:
```
Starting test MaterialEditor_BasicFunctionalityChecks_AllChecksPass...
Test MaterialEditor_BasicFunctionalityChecks_AllChecksPass finished.
Report:
[SUCCESS] Success: Existing material asset file opened successfully.
[SUCCESS] Success: Closed existing material asset file.
[SUCCESS] Success: Closed all currently opened asset document files.
[SUCCESS] Success: Closed all currently opened asset document files except for one file.
[SUCCESS] Success: Inspector pane is visible, MaterialEditor launch succeeded
[SUCCESS] Success: Material asset color changed successfully.
[SUCCESS] Success: Material asset color change was reverted using undo.
[SUCCESS] Success: Material asset color changed again successfully using redo.
Test result:  SUCCESS

=== 2 passed, 4 deselected in 30.77s ===
```