### PR TITLE
Re-enable disabled Atom Editor tests since GHI#12253 is fixed

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Component_01.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Component_01.py
@@ -33,7 +33,6 @@ class TestAutomation(EditorTestSuite):
     class AtomEditorComponents_DepthOfFieldAdded(EditorBatchedTest):
         from Atom.tests import hydra_AtomEditorComponents_DepthOfFieldAdded as test_module
 
-    @pytest.mark.skip(reason="GHI# 12253 Failing in undo/redo intermittently")
     @pytest.mark.test_case_id("C36525659")
     class AtomEditorComponents_DiffuseProbeGridAdded(EditorBatchedTest):
         from Atom.tests import hydra_AtomEditorComponents_DiffuseProbeGridAdded as test_module

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Component_03.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Component_03.py
@@ -30,12 +30,10 @@ class TestAutomation(EditorTestSuite):
         from Atom.tests import (
             hydra_AtomEditorComponents_PostFXRadiusWeightModifierAdded as test_module)
 
-    @pytest.mark.skip(reason="GHI# 12253 Failing in undo/redo intermittently")
     @pytest.mark.test_case_id("C36525665")
     class AtomEditorComponents_PostFXShapeWeightModifierAdded(EditorBatchedTest):
         from Atom.tests import hydra_AtomEditorComponents_PostFxShapeWeightModifierAdded as test_module
 
-    @pytest.mark.skip(reason="GHI# 12253 Failing in undo/redo intermittently")
     @pytest.mark.test_case_id("C32078128")
     class AtomEditorComponents_ReflectionProbeAdded(EditorBatchedTest):
         from Atom.tests import hydra_AtomEditorComponents_ReflectionProbeAdded as test_module


### PR DESCRIPTION
## What does this PR do?
This PR re-enables the tests that were disabled as part of GHI#12253: https://github.com/o3de/o3de/issues/12253 
The disabled test PRs are here:
- https://github.com/o3de/o3de/pull/12295 
- https://github.com/o3de/o3de/pull/12254

This ended up being the fix: https://github.com/o3de/o3de/pull/12367  

## How was this PR tested?
Tests were run on Linux and passed without issue.