### PR TITLE
Fix intermediate asset infinite loop

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -2842,7 +2842,7 @@ namespace AssetProcessor
                 QString overrider;
                 if (examineFile.m_isDelete)
                 {
-                    if (IsInIntermediateAssetsFolder(sourceAssetReference.AbsolutePath()))
+                    if (IsInIntermediateAssetsFolder(normalizedPath))
                     {
                         // This delete is likely the result of attempting to stop a source -> intermediate loop
                         // In any case, intermediate files don't participate in the override system, so ignore this file and move on

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -2842,6 +2842,13 @@ namespace AssetProcessor
                 QString overrider;
                 if (examineFile.m_isDelete)
                 {
+                    if (IsInIntermediateAssetsFolder(sourceAssetReference.AbsolutePath()))
+                    {
+                        // This delete is likely the result of attempting to stop a source -> intermediate loop
+                        // In any case, intermediate files don't participate in the override system, so ignore this file and move on
+                        continue;
+                    }
+
                     // if we delete it, check if its revealed by an underlying file:
                     overrider = m_platformConfig->FindFirstMatchingFile(databasePathToFile);
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -2842,37 +2842,35 @@ namespace AssetProcessor
                 QString overrider;
                 if (examineFile.m_isDelete)
                 {
-                    if (IsInIntermediateAssetsFolder(normalizedPath))
+                    // Only look for an override if this is not an intermediate asset
+                    // Intermediate assets don't participate in the override system, so just process as-is without looking for an override
+                    if (!IsInIntermediateAssetsFolder(normalizedPath))
                     {
-                        // This delete is likely the result of attempting to stop a source -> intermediate loop
-                        // In any case, intermediate files don't participate in the override system, so ignore this file and move on
-                        continue;
-                    }
+                        // if we delete it, check if its revealed by an underlying file:
+                        overrider = m_platformConfig->FindFirstMatchingFile(databasePathToFile);
 
-                    // if we delete it, check if its revealed by an underlying file:
-                    overrider = m_platformConfig->FindFirstMatchingFile(databasePathToFile);
-
-                    if (!overrider.isEmpty()) // override found!
-                    {
-                        if (overrider.compare(normalizedPath, Qt::CaseInsensitive) == 0)
+                        if (!overrider.isEmpty()) // override found!
                         {
-                            // if the overrider is the same file, it means that a file was deleted, then reappeared.
-                            // if that happened there will be a message in the notification queue for that file reappearing, there
-                            // is no need to add a double here.
-                            overrider.clear();
-                        }
-                        else
-                        {
-                            // on the other hand, if we found a file it means that a deleted file revealed a file that
-                            // was previously overridden by it.
-                            // Because the deleted file may have "revealed" a file with different case,
-                            // we have to actually correct its case here.  This is rare, so it should be reasonable
-                            // to call the expensive function to discover correct case.
-                            QString pathRelativeToScanFolder;
-                            QString scanFolderPath;
-                            m_platformConfig->ConvertToRelativePath(overrider, pathRelativeToScanFolder, scanFolderPath);
-                            AssetUtilities::UpdateToCorrectCase(scanFolderPath, pathRelativeToScanFolder);
-                            overrider = QDir(scanFolderPath).absoluteFilePath(pathRelativeToScanFolder);
+                            if (overrider.compare(normalizedPath, Qt::CaseInsensitive) == 0)
+                            {
+                                // if the overrider is the same file, it means that a file was deleted, then reappeared.
+                                // if that happened there will be a message in the notification queue for that file reappearing, there
+                                // is no need to add a double here.
+                                overrider.clear();
+                            }
+                            else
+                            {
+                                // on the other hand, if we found a file it means that a deleted file revealed a file that
+                                // was previously overridden by it.
+                                // Because the deleted file may have "revealed" a file with different case,
+                                // we have to actually correct its case here.  This is rare, so it should be reasonable
+                                // to call the expensive function to discover correct case.
+                                QString pathRelativeToScanFolder;
+                                QString scanFolderPath;
+                                m_platformConfig->ConvertToRelativePath(overrider, pathRelativeToScanFolder, scanFolderPath);
+                                AssetUtilities::UpdateToCorrectCase(scanFolderPath, pathRelativeToScanFolder);
+                                overrider = QDir(scanFolderPath).absoluteFilePath(pathRelativeToScanFolder);
+                            }
                         }
                     }
                 }

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/IntermediateAssetTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/IntermediateAssetTests.cpp
@@ -374,6 +374,13 @@ namespace UnitTests
         EXPECT_TRUE(m_jobDetailsList[1].m_autoFail);
 
         EXPECT_EQ(m_jobDetailsList[1].m_jobEntry.m_databaseSourceName, "test.stage1");
+
+        m_assetProcessorManager->AssessDeletedFile(MakePath("test.stage1", true).c_str());
+        RunFile(0);
+
+        m_assetProcessorManager->CheckFilesToExamine(0);
+        m_assetProcessorManager->CheckActiveFiles(0);
+        m_assetProcessorManager->CheckJobEntries(0);
     }
 
     TEST_F(IntermediateAssetTests, CopyJob_Works)


### PR DESCRIPTION

Signed-off-by: amzn-mike <80125227+amzn-mike@users.noreply.github.com>

## What does this PR do?

AP was detecting the loop case but the override system was causing AP to reprocess the source again, causing an infinite loop.

## How was this PR tested?

Manual testing plus updated the existing unit test to verify it catches this issue
