### PR TITLE
bugfix(EmotionFX): update Motion Event Inspector when event data has changed

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/Event.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Event.cpp
@@ -16,6 +16,17 @@ namespace EMotionFX
 {
     AZ_CLASS_ALLOCATOR_IMPL(Event, MotionEventAllocator, 0)
 
+    Event::Event(const Event& data)
+        : m_eventDatas(data.m_eventDatas)
+    {
+    }
+
+    Event::Event(Event&& event)
+        : m_eventDatas(AZStd::move(event.m_eventDatas)),
+          m_eventDatasChangeEvent(AZStd::move(event.m_eventDatasChangeEvent))
+    {
+    }
+
     Event::Event(EventDataPtr&& data)
         : m_eventDatas{ AZStd::move(data) }
     {
@@ -24,6 +35,18 @@ namespace EMotionFX
     Event::Event(EventDataSet&& datas)
         : m_eventDatas(AZStd::move(datas))
     {
+    }
+    
+    Event& Event::operator=(const Event& other) 
+    {
+        m_eventDatas = other.m_eventDatas;
+        return *this;
+    }
+
+    Event& Event::operator=(Event&& other) 
+    {
+        m_eventDatas = AZStd::move(other.m_eventDatas);
+        return *this;
     }
 
     void Event::Reflect(AZ::ReflectContext* context)
@@ -65,30 +88,30 @@ namespace EMotionFX
     void Event::AppendEventData(EventDataPtr&& newData)
     {
         m_eventDatas.emplace_back(AZStd::move(newData));
-        m_eventContainer.m_eventDatasChangeEvent.Signal();
+        m_eventDatasChangeEvent.Signal();
     }
 
     void Event::RemoveEventData(size_t index)
     {
         m_eventDatas.erase(AZStd::next(m_eventDatas.begin(), index));
-        m_eventContainer.m_eventDatasChangeEvent.Signal();
+        m_eventDatasChangeEvent.Signal();
     }
 
     void Event::SetEventData(size_t index, EventDataPtr&& newData)
     {
         m_eventDatas[index] = AZStd::move(newData);
-        m_eventContainer.m_eventDatasChangeEvent.Signal();
+        m_eventDatasChangeEvent.Signal();
     }
 
     void Event::InsertEventData(size_t index, EventDataPtr&& newData)
     {
         m_eventDatas.emplace(AZStd::next(m_eventDatas.begin(), index), AZStd::move(newData));
-        m_eventContainer.m_eventDatasChangeEvent.Signal();
+        m_eventDatasChangeEvent.Signal();
     }
 
     void Event::SetEventDataChangeEvent(Event::EventDataChangeEvent::Handler& handler)
     {
-        handler.Connect(m_eventContainer.m_eventDatasChangeEvent);
+        handler.Connect(m_eventDatasChangeEvent);
     }
 
 } // end namespace EMotionFX

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Event.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Event.cpp
@@ -65,21 +65,30 @@ namespace EMotionFX
     void Event::AppendEventData(EventDataPtr&& newData)
     {
         m_eventDatas.emplace_back(AZStd::move(newData));
+        m_eventContainer.m_eventDatasChangeEvent.Signal();
     }
 
     void Event::RemoveEventData(size_t index)
     {
         m_eventDatas.erase(AZStd::next(m_eventDatas.begin(), index));
+        m_eventContainer.m_eventDatasChangeEvent.Signal();
     }
 
     void Event::SetEventData(size_t index, EventDataPtr&& newData)
     {
         m_eventDatas[index] = AZStd::move(newData);
+        m_eventContainer.m_eventDatasChangeEvent.Signal();
     }
 
     void Event::InsertEventData(size_t index, EventDataPtr&& newData)
     {
         m_eventDatas.emplace(AZStd::next(m_eventDatas.begin(), index), AZStd::move(newData));
+        m_eventContainer.m_eventDatasChangeEvent.Signal();
+    }
+
+    void Event::SetEventDataChangeEvent(Event::EventDataChangeEvent::Handler& handler)
+    {
+        handler.Connect(m_eventContainer.m_eventDatasChangeEvent);
     }
 
 } // end namespace EMotionFX

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Event.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Event.cpp
@@ -45,6 +45,7 @@ namespace EMotionFX
 
     Event& Event::operator=(Event&& other) 
     {
+        m_eventDatasChangeEvent = AZStd::move(other.m_eventDatasChangeEvent);
         m_eventDatas = AZStd::move(other.m_eventDatas);
         return *this;
     }
@@ -109,7 +110,7 @@ namespace EMotionFX
         m_eventDatasChangeEvent.Signal();
     }
 
-    void Event::SetEventDataChangeEvent(Event::EventDataChangeEvent::Handler& handler)
+    void Event::RegisterEventDataChangeEvent(Event::EventDataChangeEvent::Handler& handler)
     {
         handler.Connect(m_eventDatasChangeEvent);
     }

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Event.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Event.h
@@ -11,6 +11,7 @@
 #include "EventData.h"
 
 #include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/EBus/Event.h>
 
 namespace AZ
 {
@@ -25,6 +26,8 @@ namespace EMotionFX
     class EMFX_API Event
     {
     public:
+        using EventDataChangeEvent = AZ::Event<>;
+
         AZ_RTTI(Event, "{67549E9F-8E3F-4336-BDB8-716AFCBD4985}");
         AZ_CLASS_ALLOCATOR_DECL
 
@@ -42,7 +45,21 @@ namespace EMotionFX
         void SetEventData(size_t index, EventDataPtr&& newData);
         void InsertEventData(size_t index, EventDataPtr&& newData);
 
+        void SetEventDataChangeEvent(Event::EventDataChangeEvent::Handler& handler);
     protected:
+        struct EventContainer {
+            EventContainer() = default;
+             
+            // event container is not copyable 
+            EventContainer(const EventContainer&) {}
+            EventContainer& operator=(const EventContainer&) {
+                return *this;
+            }
+
+            EventDataChangeEvent m_eventDatasChangeEvent;
+        };
+
         EventDataSet m_eventDatas;
+        EventContainer m_eventContainer;
     };
 } // end namespace EMotionFX

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Event.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Event.h
@@ -32,6 +32,9 @@ namespace EMotionFX
         AZ_CLASS_ALLOCATOR_DECL
 
         Event() = default;
+
+        Event(const Event& event);
+        Event(Event&& event);
         explicit Event(EventDataPtr&& data);
         explicit Event(EventDataSet&& datas);
         virtual ~Event() = default;
@@ -46,20 +49,14 @@ namespace EMotionFX
         void InsertEventData(size_t index, EventDataPtr&& newData);
 
         void SetEventDataChangeEvent(Event::EventDataChangeEvent::Handler& handler);
-    protected:
-        struct EventContainer {
-            EventContainer() = default;
-             
-            // event container is not copyable 
-            EventContainer(const EventContainer&) {}
-            EventContainer& operator=(const EventContainer&) {
-                return *this;
-            }
 
-            EventDataChangeEvent m_eventDatasChangeEvent;
-        };
+        Event& operator=(const Event& other);
+
+        Event& operator=(Event&& other);
+
+    protected:
 
         EventDataSet m_eventDatas;
-        EventContainer m_eventContainer;
+        EventDataChangeEvent m_eventDatasChangeEvent;
     };
 } // end namespace EMotionFX

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Event.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Event.h
@@ -39,6 +39,9 @@ namespace EMotionFX
         explicit Event(EventDataSet&& datas);
         virtual ~Event() = default;
 
+        Event& operator=(const Event& other);
+        Event& operator=(Event&& other);
+
         static void Reflect(AZ::ReflectContext* context);
 
         const EventDataSet& GetEventDatas() const;
@@ -48,11 +51,7 @@ namespace EMotionFX
         void SetEventData(size_t index, EventDataPtr&& newData);
         void InsertEventData(size_t index, EventDataPtr&& newData);
 
-        void SetEventDataChangeEvent(Event::EventDataChangeEvent::Handler& handler);
-
-        Event& operator=(const Event& other);
-
-        Event& operator=(Event&& other);
+        void RegisterEventDataChangeEvent(Event::EventDataChangeEvent::Handler& handler);
 
     protected:
 

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionEvent.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionEvent.cpp
@@ -39,7 +39,7 @@ namespace EMotionFX
 
     }
     MotionEvent::MotionEvent(MotionEvent&& event):
-        Event(event),
+        Event(AZStd::move(event)),
         m_startTime(event.m_startTime),
         m_endTime(event.m_endTime),
         m_isSyncEvent(event.m_isSyncEvent)
@@ -90,7 +90,7 @@ namespace EMotionFX
 
     MotionEvent& MotionEvent::operator=(MotionEvent&& other)
     {
-        Event::operator=(other);
+        Event::operator=(AZStd::move(other));
         m_startTime = other.m_startTime;
         m_endTime = other.m_endTime;
         m_isSyncEvent = other.m_isSyncEvent;

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionEvent.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionEvent.cpp
@@ -30,6 +30,23 @@ namespace EMotionFX
     {
     }
 
+    MotionEvent::MotionEvent(const MotionEvent& event):
+        Event(event),
+        m_startTime(event.m_startTime),
+        m_endTime(event.m_endTime),
+        m_isSyncEvent(event.m_isSyncEvent)
+    {
+
+    }
+    MotionEvent::MotionEvent(MotionEvent&& event):
+        Event(event),
+        m_startTime(event.m_startTime),
+        m_endTime(event.m_endTime),
+        m_isSyncEvent(event.m_isSyncEvent)
+    {
+        
+    }
+
     MotionEvent::MotionEvent(float timeValue, EventDataPtr&& data)
         : Event(AZStd::move(data))
         , m_startTime(timeValue)
@@ -60,6 +77,24 @@ namespace EMotionFX
         , m_endTime(endTimeValue)
         , m_isSyncEvent(false)
     {
+    }
+
+    MotionEvent& MotionEvent::operator=(const MotionEvent& other)
+    {
+        Event::operator=(other);
+        m_startTime = other.m_startTime;
+        m_endTime = other.m_endTime;
+        m_isSyncEvent = other.m_isSyncEvent;
+        return *this;
+    }
+
+    MotionEvent& MotionEvent::operator=(MotionEvent&& other)
+    {
+        Event::operator=(other);
+        m_startTime = other.m_startTime;
+        m_endTime = other.m_endTime;
+        m_isSyncEvent = other.m_isSyncEvent;
+        return *this;
     }
 
     void MotionEvent::Reflect(AZ::ReflectContext* context)

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionEvent.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionEvent.h
@@ -99,7 +99,7 @@ namespace EMotionFX
         MotionEvent(float startTimeValue, float endTimeValue, EventDataSet&& datas);
 
         MotionEvent& operator=(const MotionEvent& other);
-        
+
         MotionEvent& operator=(MotionEvent&& other);
 
         static void Reflect(AZ::ReflectContext* context);

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionEvent.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionEvent.h
@@ -59,6 +59,8 @@ namespace EMotionFX
         AZ_CLASS_ALLOCATOR_DECL
 
         MotionEvent();
+        MotionEvent(const MotionEvent& event);
+        MotionEvent(MotionEvent&& event);
 
         /**
          * Creates a tick event
@@ -95,6 +97,10 @@ namespace EMotionFX
          * @param data The list of values to emit when the event is triggered
          */
         MotionEvent(float startTimeValue, float endTimeValue, EventDataSet&& datas);
+
+        MotionEvent& operator=(const MotionEvent& other);
+        
+        MotionEvent& operator=(MotionEvent&& other);
 
         static void Reflect(AZ::ReflectContext* context);
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventWidget.cpp
@@ -9,6 +9,7 @@
 #include <Editor/InspectorBus.h>
 #include "MotionEventWidget.h"
 #include "MotionEventEditor.h"
+#include <EMotionFX/Source/MotionEvent.h>
 #include <QVBoxLayout>
 
 namespace EMStudio
@@ -19,6 +20,9 @@ namespace EMStudio
         : QWidget(parent)
         , m_editor(new MotionEventEditor())
     {
+        m_changeEventHandler = EMotionFX::Event::EventDataChangeEvent::Handler([&]() {
+            Q_EMIT eventDataChanged();
+        });
         Init();
         ReInit();
     }
@@ -36,9 +40,13 @@ namespace EMStudio
         layout->addWidget(m_editor, 0, Qt::AlignTop);
     }
 
-
     void MotionEventWidget::ReInit(EMotionFX::Motion* motion, EMotionFX::MotionEvent* motionEvent)
     {
+        m_changeEventHandler.Disconnect();
+        if (motionEvent)
+        {
+            motionEvent->SetEventDataChangeEvent(m_changeEventHandler);
+        }
         m_editor->SetMotionEvent(motion, motionEvent);
     }
 } // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventWidget.cpp
@@ -45,7 +45,7 @@ namespace EMStudio
         m_changeEventHandler.Disconnect();
         if (motionEvent)
         {
-            motionEvent->SetEventDataChangeEvent(m_changeEventHandler);
+            motionEvent->RegisterEventDataChangeEvent(m_changeEventHandler);
         }
         m_editor->SetMotionEvent(motion, motionEvent);
     }

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventWidget.h
@@ -11,6 +11,7 @@
 #if !defined(Q_MOC_RUN)
 #include "../StandardPluginsConfig.h"
 #include <QWidget>
+#include <EMotionFX/Source/Event.h>
 #endif
 
 namespace EMotionFX
@@ -37,10 +38,14 @@ namespace EMStudio
         void ReInit(EMotionFX::Motion* motion = nullptr, EMotionFX::MotionEvent* motionEvent = nullptr);
 
         static constexpr const char* s_headerIcon = ":/EMotionFX/ActorComponent.svg";
+    
+    Q_SIGNALS:
+        void eventDataChanged();
 
     private:
         void Init();
 
         MotionEventEditor* m_editor = nullptr;
+        EMotionFX::Event::EventDataChangeEvent::Handler m_changeEventHandler;
     };
 } // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TimeViewPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TimeViewPlugin.cpp
@@ -243,34 +243,38 @@ namespace EMStudio
         // Create the motion event properties widget.
         m_motionEventWidget = new MotionEventWidget();
         m_motionEventWidget->hide();
-        connect(this, &TimeViewPlugin::SelectionChanged, this, [=]
-            {
-                if (!m_motionEventWidget)
-                {
-                    return;
-                }
-
-                UpdateSelection();
-                if (GetNumSelectedEvents() != 1)
-                {
-                    m_motionEventWidget->ReInit();
-                    m_motionEventWidget->hide();
-                    EMStudio::InspectorRequestBus::Broadcast(&EMStudio::InspectorRequestBus::Events::Clear); // This also gets called when just switching a motion
-                }
-                else
-                {
-                    EventSelectionItem selectionItem = GetSelectedEvent(0);
-                    m_motionEventWidget->ReInit(selectionItem.m_motion, selectionItem.GetMotionEvent());
-                    EMStudio::InspectorRequestBus::Broadcast(&EMStudio::InspectorRequestBus::Events::UpdateWithHeader,
-                        "Motion Event",
-                        MotionEventWidget::s_headerIcon,
-                        m_motionEventWidget);
-                }
-            });
+        connect(m_motionEventWidget, &MotionEventWidget::eventDataChanged, this, &TimeViewPlugin::onRefreshSelection);
+        connect(this, &TimeViewPlugin::SelectionChanged, this, &TimeViewPlugin::onRefreshSelection);
 
         return true;
     }
 
+    void TimeViewPlugin::onRefreshSelection()
+    {
+        if (!m_motionEventWidget)
+        {
+            return;
+        }
+
+        UpdateSelection();
+        if (GetNumSelectedEvents() != 1)
+        {
+            m_motionEventWidget->ReInit();
+            m_motionEventWidget->hide();
+            EMStudio::InspectorRequestBus::Broadcast(
+                &EMStudio::InspectorRequestBus::Events::Clear); // This also gets called when just switching a motion
+        }
+        else
+        {
+            EventSelectionItem selectionItem = GetSelectedEvent(0);
+            m_motionEventWidget->ReInit(selectionItem.m_motion, selectionItem.GetMotionEvent());
+            EMStudio::InspectorRequestBus::Broadcast(
+                &EMStudio::InspectorRequestBus::Events::UpdateWithHeader,
+                "Motion Event",
+                MotionEventWidget::s_headerIcon,
+                m_motionEventWidget);
+        }
+    }
 
     // add a new track
     void TimeViewPlugin::AddTrack(TimeTrack* track)
@@ -278,7 +282,6 @@ namespace EMStudio
         m_tracks.emplace_back(track);
         SetRedrawFlag();
     }
-
 
     // delete all tracks
     void TimeViewPlugin::RemoveAllTracks()

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TimeViewPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TimeViewPlugin.cpp
@@ -243,13 +243,13 @@ namespace EMStudio
         // Create the motion event properties widget.
         m_motionEventWidget = new MotionEventWidget();
         m_motionEventWidget->hide();
-        connect(m_motionEventWidget, &MotionEventWidget::eventDataChanged, this, &TimeViewPlugin::onRefreshSelection);
-        connect(this, &TimeViewPlugin::SelectionChanged, this, &TimeViewPlugin::onRefreshSelection);
+        connect(m_motionEventWidget, &MotionEventWidget::eventDataChanged, this, &TimeViewPlugin::OnRefreshSelection);
+        connect(this, &TimeViewPlugin::SelectionChanged, this, &TimeViewPlugin::OnRefreshSelection);
 
         return true;
     }
 
-    void TimeViewPlugin::onRefreshSelection()
+    void TimeViewPlugin::OnRefreshSelection()
     {
         if (!m_motionEventWidget)
         {

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TimeViewPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TimeViewPlugin.h
@@ -182,7 +182,7 @@ namespace EMStudio
         void MotionEventTrackChanged(size_t eventNr, float startTime, float endTime, const char* oldTrackName, const char* newTrackName)            { UnselectAllElements(); CommandSystem::CommandHelperMotionEventTrackChanged(eventNr, startTime, endTime, oldTrackName, newTrackName); }
         void OnManualTimeChange(float timeValue);
         void toggleMotionEventPresetsPane();
-        void onRefreshSelection();
+        void OnRefreshSelection();
 
     signals:
         void SelectionChanged();

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TimeViewPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TimeViewPlugin.h
@@ -182,6 +182,7 @@ namespace EMStudio
         void MotionEventTrackChanged(size_t eventNr, float startTime, float endTime, const char* oldTrackName, const char* newTrackName)            { UnselectAllElements(); CommandSystem::CommandHelperMotionEventTrackChanged(eventNr, startTime, endTime, oldTrackName, newTrackName); }
         void OnManualTimeChange(float timeValue);
         void toggleMotionEventPresetsPane();
+        void onRefreshSelection();
 
     signals:
         void SelectionChanged();

--- a/Gems/EMotionFX/Code/Tests/EventManagerTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/EventManagerTests.cpp
@@ -14,7 +14,7 @@
 namespace EMotionFX
 {
 
-TEST_F(SystemComponentFixture, DISABLED_EventDataFactoryMakesUniqueData)
+TEST_F(SystemComponentFixture, EventDataFactoryMakesUniqueData)
 {
     MotionEventTrack* track = aznew MotionEventTrack();
     track->SetName("My name");
@@ -34,6 +34,42 @@ TEST_F(SystemComponentFixture, DISABLED_EventDataFactoryMakesUniqueData)
 
     delete track;
     delete loadedTrack;
+}
+
+
+TEST_F(SystemComponentFixture, EventDataMotionEventChangeEvent)
+{
+    AZ::u32 eventCount = 0;
+    Event::EventDataChangeEvent::Handler handler = Event::EventDataChangeEvent::Handler(
+        [&eventCount]()
+        {
+            eventCount++;
+        });
+    MotionEventTrack* track = aznew MotionEventTrack();
+    track->SetName("My name");
+    track->AddEvent(0.5, EventDataSet({}));
+    track->GetEvent(0).RegisterEventDataChangeEvent(handler);
+
+    track->GetEvent(0).AppendEventData(
+        EMotionFX::GetEventManager().FindOrCreateEventData<TwoStringEventData>("My subject", "My parameter"));
+
+    // event handler shouldn't be carried over to new track
+    MotionEventTrack* track2 = aznew MotionEventTrack();
+    track->CopyTo(track2);
+    track2->GetEvent(0).RemoveEventData(0);
+
+    track->GetEvent(0).AppendEventData(
+        EMotionFX::GetEventManager().FindOrCreateEventData<TwoStringEventData>("My subject", "My parameter"));
+    track->GetEvent(0).InsertEventData(
+        0, EMotionFX::GetEventManager().FindOrCreateEventData<TwoStringEventData>("My subject", "My parameter"));
+    track->GetEvent(0).RemoveEventData(0);
+
+    EXPECT_EQ(track->GetEvent(0).GetEventDatas().size(), 2);
+    EXPECT_EQ(track2->GetEvent(0).GetEventDatas().size(), 0);
+    EXPECT_EQ(eventCount, 4);
+
+    delete track;
+    delete track2;
 }
 
 } // end namespace EMotionFX

--- a/Gems/EMotionFX/Code/Tests/EventTest.cpp
+++ b/Gems/EMotionFX/Code/Tests/EventTest.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "EMotionFX/Source/MotionEvent.h"
+#include "SystemComponentFixture.h"
+#include <AzCore/Serialization/Utils.h>
+#include <EMotionFX/Source/MotionEventTrack.h>
+#include <EMotionFX/Source/TwoStringEventData.h>
+
+namespace EMotionFX
+{
+
+    TEST_F(SystemComponentFixture, EventMoveTestEventDataChangeEvent)
+    {
+        AZ::u32 eventCount = 0;
+        Event::EventDataChangeEvent::Handler handler = Event::EventDataChangeEvent::Handler(
+            [&eventCount]()
+            {
+                eventCount++;
+            });
+
+        MotionEvent event;
+        event.RegisterEventDataChangeEvent(handler);
+        event.AppendEventData(EMotionFX::GetEventManager().FindOrCreateEventData<TwoStringEventData>("My subject", "My parameter"));
+        EXPECT_EQ(event.GetEventDatas().size(), 1);
+
+        MotionEvent event2;
+        event2 = AZStd::move(event);
+        event2.AppendEventData(EMotionFX::GetEventManager().FindOrCreateEventData<TwoStringEventData>("My subject", "My parameter"));
+        EXPECT_EQ(event2.GetEventDatas().size(), 2);
+
+        MotionEvent event3(AZStd::move(event2));
+        event3.AppendEventData(EMotionFX::GetEventManager().FindOrCreateEventData<TwoStringEventData>("My subject", "My parameter"));
+        EXPECT_EQ(event3.GetEventDatas().size(), 3);
+
+        MotionEvent event4(event3);
+        event4.AppendEventData(EMotionFX::GetEventManager().FindOrCreateEventData<TwoStringEventData>("My subject", "My parameter"));
+        EXPECT_EQ(event4.GetEventDatas().size(), 4);
+
+        MotionEvent event5 = event3;
+        event5.AppendEventData(EMotionFX::GetEventManager().FindOrCreateEventData<TwoStringEventData>("My subject", "My parameter"));
+        EXPECT_EQ(event5.GetEventDatas().size(), 4);
+
+        EXPECT_EQ(eventCount, 3);
+    }
+} // namespace EMotionFX

--- a/Gems/EMotionFX/Code/emotionfx_tests_files.cmake
+++ b/Gems/EMotionFX/Code/emotionfx_tests_files.cmake
@@ -80,6 +80,7 @@ set(FILES
     Tests/ColliderCommandTests.cpp
     Tests/EMotionFXTest.cpp
     Tests/EmotionFXMathLibTests.cpp
+    Tests/EventTest.cpp
     Tests/EventManagerTests.cpp
     Tests/JackGraphFixture.h
     Tests/JackGraphFixture.cpp


### PR DESCRIPTION
ref: https://github.com/o3de/o3de/issues/12665
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

I added some logic to update the event data when its changed. not sure if this is the best way to approach this, but I think this should handle the case where an event is update remotely/deleted since this logic will just re-query the data from TimerViewerPlugin.cpp.

There is quite a lot here, I think can be refactored. This can be pretty hard to follow. 

## How was this PR tested?

follows steps in linked PR.
