### PR TITLE
10965 move animgraph parameter props to inspector

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditWidget.cpp
@@ -37,7 +37,7 @@ namespace EMStudio
         setObjectName("ParameterCreateEditWidget");
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Maximum);
 
-        m_createButton = new QPushButton("Create", this);
+        m_createButton = new QPushButton(tr("Create"), this);
         m_createButton->setObjectName("EMFX.ParameterCreateEditWidget.CreateApplyButton");
         QVBoxLayout* mainLayout = new QVBoxLayout(this);
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditWidget.cpp
@@ -35,7 +35,7 @@ namespace EMStudio
         , m_valueParameterEditor(nullptr)
     {
         setObjectName("ParameterCreateEditWidget");
-        setSizePolicy(QSizePolicy::Expanding, QSizePolicy::MinimumExpanding);
+        setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Maximum);
 
         m_createButton = new QPushButton("Create", this);
         m_createButton->setObjectName("EMFX.ParameterCreateEditWidget.CreateApplyButton");

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditWidget.h
@@ -12,7 +12,7 @@
 #include <AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/StandardPluginsConfig.h>
 #include <MCore/Source/StandardHeaders.h>
-#include <QDialog>
+#include <QWidget>
 #endif
 
 QT_FORWARD_DECLARE_CLASS(QComboBox)
@@ -28,12 +28,12 @@ namespace EMStudio
     class AnimGraphPlugin;
     class ValueParameterEditor;
 
-    class ParameterCreateEditDialog
-        : public QDialog
+    class ParameterCreateEditWidget
+        : public QWidget
         , private AzToolsFramework::IPropertyEditorNotify
     {
         Q_OBJECT
-        MCORE_MEMORYOBJECTCATEGORY(ParameterCreateEditDialog, EMFX_DEFAULT_ALIGNMENT, MEMCATEGORY_STANDARDPLUGINS_ANIMGRAPH);
+        MCORE_MEMORYOBJECTCATEGORY(ParameterCreateEditWidget, EMFX_DEFAULT_ALIGNMENT, MEMCATEGORY_STANDARDPLUGINS_ANIMGRAPH);
 
     public:
         enum
@@ -43,10 +43,10 @@ namespace EMStudio
             VALUE_MAXIMUM = 2
         };
 
-        ParameterCreateEditDialog(AnimGraphPlugin* plugin, QWidget* parent, const EMotionFX::Parameter* editParameter = nullptr);
-        ~ParameterCreateEditDialog();
+        ParameterCreateEditWidget(AnimGraphPlugin* plugin, QWidget* parent);
+        ~ParameterCreateEditWidget();
 
-        void Init();
+        void Reinit(const EMotionFX::Parameter* editParameter = nullptr);
 
         const AZStd::unique_ptr<EMotionFX::Parameter>& GetParameter() const { return m_parameter; }
 
@@ -55,6 +55,9 @@ namespace EMStudio
     protected slots:
         void OnValueTypeChange(int valueType);
         void OnValidate();
+
+    Q_SIGNALS:
+        void accept();
 
     private:
         void InitDynamicInterface(const AZ::TypeId& typeID);
@@ -68,6 +71,7 @@ namespace EMStudio
 
     private:
         AnimGraphPlugin*                    m_plugin;
+        QLabel*                             m_valueTypeLabel;
         QComboBox*                          m_valueTypeCombo;
         QFrame*                             m_previewFrame;
         AzToolsFramework::ReflectedPropertyEditor* m_previewWidget;
@@ -78,6 +82,6 @@ namespace EMStudio
         AZStd::unique_ptr<EMotionFX::Parameter> m_parameter;
         AZStd::string                       m_originalName;
 
-        static int                          s_parameterEditorMinWidth;
+        static const int                    s_parameterEditorMinWidth;
     };
 } // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterWindow.cpp
@@ -224,8 +224,9 @@ namespace EMStudio
         // set the focus policy
         setFocusPolicy(Qt::ClickFocus);
 
-        // create parameter create/edit widget
-        m_parameterCreateEditWidget = new ParameterCreateEditWidget(m_plugin, this);
+        // create parameter create/edit widget, no parent because we don't want to show
+        // it. Inspector will show this widget when instructed
+        m_parameterCreateEditWidget = new ParameterCreateEditWidget(m_plugin, nullptr);
 
         // Force reinitialize in case e.g. a parameter got added or removed.
         connect(&m_plugin->GetAnimGraphModel(), &AnimGraphModel::ParametersChanged, [this](EMotionFX::AnimGraph* animGraph)

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterWindow.cpp
@@ -638,6 +638,7 @@ namespace EMStudio
 
         m_lockSelection = false;
 
+        UpdateSelectionArrays();
         UpdateAttributesForParameterWidgets();
         UpdateInterface();
     }

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterWindow.cpp
@@ -9,6 +9,7 @@
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/StringFunc/StringFunc.h>
 #include <AzQtComponents/Components/FilteredSearchWidget.h>
+#include <Editor/InspectorBus.h>
 #include <EMotionFX/CommandSystem/Source/AnimGraphGroupParameterCommands.h>
 #include <EMotionFX/CommandSystem/Source/AnimGraphParameterCommands.h>
 #include <EMotionFX/CommandSystem/Source/SelectionList.h>
@@ -23,7 +24,7 @@
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendTreeVisualNode.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/GraphNode.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodeGraph.h>
-#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditDialog.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditWidget.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterEditor/ParameterEditorFactory.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterEditor/ValueParameterEditor.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterWindow.h>
@@ -164,11 +165,6 @@ namespace EMStudio
             m_addAction->setMenu(contextMenu);
         }
 
-        // add edit button
-        m_editAction = toolBar->addAction(QIcon(":/EMotionFX/Edit.svg"),
-            tr("Edit selected parameter"),
-            this, &ParameterWindow::OnEditButton);
-
         // add spacer widget
         QWidget* spacerWidget = new QWidget();
         spacerWidget->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
@@ -228,6 +224,9 @@ namespace EMStudio
         // set the focus policy
         setFocusPolicy(Qt::ClickFocus);
 
+        // create parameter create/edit widget
+        m_parameterCreateEditWidget = new ParameterCreateEditWidget(m_plugin, this);
+
         // Force reinitialize in case e.g. a parameter got added or removed.
         connect(&m_plugin->GetAnimGraphModel(), &AnimGraphModel::ParametersChanged, [this](EMotionFX::AnimGraph* animGraph)
         {
@@ -251,6 +250,7 @@ namespace EMStudio
     ParameterWindow::~ParameterWindow()
     {
         EMotionFX::AnimGraphNotificationBus::Handler::BusDisconnect();
+        delete m_parameterCreateEditWidget;
     }
 
     // check if the gamepad control mode is enabled for the given parameter and if its actually being controlled or not
@@ -446,10 +446,6 @@ namespace EMStudio
                     connect(makeDefaultAction, &QAction::triggered, this, &ParameterWindow::OnMakeDefaultValue);
                 }
             }
-
-            // edit action
-            QAction* editAction = menu->addAction("Edit");
-            connect(editAction, &QAction::triggered, this, &ParameterWindow::OnEditButton);
         }
         if (!m_selectedParameterNames.empty())
         {
@@ -750,18 +746,20 @@ namespace EMStudio
         if (!m_animGraph || EMotionFX::GetRecorder().GetIsInPlayMode() || EMotionFX::GetRecorder().GetIsRecording())
         {
             m_addAction->setEnabled(false);
-            m_editAction->setEnabled(false);
             return;
         }
 
         // always allow to add a parameter when there is a anim graph selected
         m_addAction->setEnabled(true);
 
-        // disable the remove and edit buttton if we dont have any parameter selected
-        m_editAction->setEnabled(true);
-        if (m_selectedParameterNames.empty())
+        // edit variable if only one is chosen, otherwise close parameter editor
+        if (m_selectedParameterNames.size() == 1)
         {
-            m_editAction->setEnabled(false);
+            OnEditSelected();
+        }
+        else if (m_parameterCreateEditWidget)
+        {
+            EMStudio::InspectorRequestBus::Broadcast(&EMStudio::InspectorRequestBus::Events::ClearIfShown, m_parameterCreateEditWidget);
         }
 
         // check if we can move up/down the currently single selected item
@@ -842,23 +840,20 @@ namespace EMStudio
             return;
         }
 
-        ParameterCreateEditDialog* createEditParameterDialog = new ParameterCreateEditDialog(m_plugin, this);
-        createEditParameterDialog->Init();
+        m_parameterCreateEditWidget->Reinit();
+        QObject::disconnect(m_parameterCreateEditWidget, &EMStudio::ParameterCreateEditWidget::accept, nullptr, nullptr);
 
-        EMStudio::ParameterCreateEditDialog::connect(createEditParameterDialog, &QDialog::finished, [=](int resultCode)
+        EMStudio::InspectorRequestBus::Broadcast(&EMStudio::InspectorRequestBus::Events::Update, m_parameterCreateEditWidget);
+        EMStudio::ParameterCreateEditWidget::connect(m_parameterCreateEditWidget, &EMStudio::ParameterCreateEditWidget::accept, [this]()
             {
-                if (resultCode == QDialog::Rejected)
-                {
-                    delete createEditParameterDialog;
-                    return;
-                }
+                EMStudio::InspectorRequestBus::Broadcast(&EMStudio::InspectorRequestBus::Events::ClearIfShown, m_parameterCreateEditWidget);
 
                 AZStd::string commandResult;
                 AZStd::string commandString;
                 MCore::CommandGroup commandGroup("Add parameter");
 
                 // Construct the create parameter command and add it to the command group.
-                const AZStd::unique_ptr<EMotionFX::Parameter>& parameter = createEditParameterDialog->GetParameter();
+                const AZStd::unique_ptr<EMotionFX::Parameter>& parameter = m_parameterCreateEditWidget->GetParameter();
 
                 CommandSystem::ConstructCreateParameterCommand(commandString, m_animGraph, parameter.get());
                 commandGroup.AddCommandString(commandString);
@@ -893,15 +888,12 @@ namespace EMStudio
                 {
                     AZ_Error("EMotionFX", false, result.c_str());
                 }
-                delete createEditParameterDialog;
             });
-
-        createEditParameterDialog->open();
     }
 
 
     // edit a new parameter
-    void ParameterWindow::OnEditButton()
+    void ParameterWindow::OnEditSelected()
     {
         if (!m_animGraph)
         {
@@ -917,20 +909,16 @@ namespace EMStudio
 
         const AZStd::string oldName = parameter->GetName();
 
-        // create and init the dialog
-        ParameterCreateEditDialog* dialog = new ParameterCreateEditDialog(m_plugin, this, parameter);
-        dialog->Init();
-        // We cannot use exec here as we need to access it from the tests
-        EMStudio::ParameterCreateEditDialog::connect(dialog, &QDialog::finished, [=](int resultCode)
+        m_parameterCreateEditWidget->Reinit(parameter);
+        QObject::disconnect(m_parameterCreateEditWidget, &EMStudio::ParameterCreateEditWidget::accept, nullptr, nullptr);
+
+        EMStudio::InspectorRequestBus::Broadcast(&EMStudio::InspectorRequestBus::Events::Update, m_parameterCreateEditWidget);
+        EMStudio::ParameterCreateEditWidget::connect(m_parameterCreateEditWidget, &EMStudio::ParameterCreateEditWidget::accept, [this, parameter, oldName]()
             {
-                dialog->deleteLater();
-                if (resultCode == QDialog::Rejected)
-                {
-                    return;
-                }
+                EMStudio::InspectorRequestBus::Broadcast(&EMStudio::InspectorRequestBus::Events::ClearIfShown, m_parameterCreateEditWidget);
 
                 // convert the interface type into a string
-                const AZStd::unique_ptr<EMotionFX::Parameter>& editedParameter = dialog->GetParameter();
+                const AZStd::unique_ptr<EMotionFX::Parameter>& editedParameter = m_parameterCreateEditWidget->GetParameter();
                 const AZStd::string contents = MCore::ReflectionSerializer::Serialize(editedParameter.get()).GetValue();
 
                 const bool isGroupParameter = (azrtti_typeid(parameter) == azrtti_typeid<EMotionFX::GroupParameter>());
@@ -1030,7 +1018,6 @@ namespace EMStudio
                     }
                 }
             });
-        dialog->open();
     }
 
 
@@ -1115,6 +1102,8 @@ namespace EMStudio
         {
             return;
         }
+
+        EMStudio::InspectorRequestBus::Broadcast(&EMStudio::InspectorRequestBus::Events::ClearIfShown, m_parameterCreateEditWidget);
 
         MCore::CommandGroup commandGroup("Remove parameters/groups");
 
@@ -1208,6 +1197,8 @@ namespace EMStudio
         {
             return;
         }
+
+        EMStudio::InspectorRequestBus::Broadcast(&EMStudio::InspectorRequestBus::Events::ClearIfShown, m_parameterCreateEditWidget);
 
         MCore::CommandGroup commandGroup("Clear parameters/groups");
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterWindow.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterWindow.h
@@ -51,6 +51,7 @@ namespace EMStudio
     class AnimGraphPlugin;
     class ValueParameterEditor;
     class ParameterWindowTreeWidget;
+    class ParameterCreateEditWidget;
 
     class ParameterCreateRenameWindow
         : public QDialog
@@ -125,7 +126,7 @@ namespace EMStudio
         void OnAddParameter();
         void OnAddGroup();
         void OnRemoveSelected();
-        void OnEditButton();
+        void OnEditSelected();
 
     private slots:
         void UpdateInterface();
@@ -194,7 +195,7 @@ namespace EMStudio
         QAction* m_addAction;
         static int s_contextMenuWidth;
 
-        QAction* m_editAction;
+        ParameterCreateEditWidget*      m_parameterCreateEditWidget = nullptr;
 
         AZStd::vector<AZStd::string>    m_selectedParameterNames;
         bool                            m_ensureVisibility;

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/standardplugins_files.cmake
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/standardplugins_files.cmake
@@ -70,8 +70,8 @@ set(FILES
     Source/AnimGraph/NodeGroupWindow.h
     Source/AnimGraph/NodePaletteWidget.cpp
     Source/AnimGraph/NodePaletteWidget.h
-    Source/AnimGraph/ParameterCreateEditDialog.cpp
-    Source/AnimGraph/ParameterCreateEditDialog.h
+    Source/AnimGraph/ParameterCreateEditWidget.cpp
+    Source/AnimGraph/ParameterCreateEditWidget.h
     Source/AnimGraph/ParameterSelectionWindow.cpp
     Source/AnimGraph/ParameterSelectionWindow.h
     Source/AnimGraph/ParameterWidget.cpp

--- a/Gems/EMotionFX/Code/Tests/ProvidesUI/AnimGraph/Parameters/AddParameter.cpp
+++ b/Gems/EMotionFX/Code/Tests/ProvidesUI/AnimGraph/Parameters/AddParameter.cpp
@@ -14,7 +14,7 @@
 #include <EMotionFX/Source/AnimGraphManager.h>
 #include <EMotionFX/Source/Parameter/ParameterFactory.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphPlugin.h>
-#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditDialog.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditWidget.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterWindow.h>
 #include <QApplication>
 #include <QComboBox>
@@ -69,12 +69,12 @@ namespace EMotionFX
         parameterWindow->OnAddParameter();
 
         // Create parameter window.
-        QWidget* parameterCreateWidget = FindTopLevelWidget("ParameterCreateEditDialog");
-        ASSERT_NE(parameterCreateWidget, nullptr) << "Cannot find anim graph parameter create/edit dialog. Is the anim graph selected?";
-        auto parameterCreateDialog = qobject_cast<EMStudio::ParameterCreateEditDialog*>(parameterCreateWidget);
+        QWidget* parameterCreate = FindTopLevelWidget("ParameterCreateEditWidget");
+        ASSERT_NE(parameterCreate, nullptr) << "Cannot find anim graph parameter create/edit widget. Is the anim graph selected?";
+        auto parameterCreateWidget = qobject_cast<EMStudio::ParameterCreateEditWidget*>(parameterCreate);
 
         // Set the parameter type using the combo box.
-        QComboBox* valueTypeComboBox = parameterCreateDialog->GetValueTypeComboBox();
+        QComboBox* valueTypeComboBox = parameterCreateWidget->GetValueTypeComboBox();
         const int row = GetParam();
         valueTypeComboBox->setCurrentIndex(row);
         EXPECT_EQ(row, valueTypeComboBox->currentIndex()) << "Changing the value type failed. Out of bounds?";
@@ -87,7 +87,7 @@ namespace EMotionFX
             << "The parameter type id from the combo box do not match the type ids from the parameter factory.";
 
         // Accept the dialog (this creates the actual parameter object in the anim graph).
-        parameterCreateDialog->accept();
+        parameterCreateWidget->accept();
         
         // Verify the parameter in the anim graph.
         EXPECT_EQ(m_animGraph->GetNumParameters(), 1) << "Parameter creation failed. We should end up with exactly one parameter.";

--- a/Gems/EMotionFX/Code/Tests/ProvidesUI/AnimGraph/Parameters/ParameterGroupEdit.cpp
+++ b/Gems/EMotionFX/Code/Tests/ProvidesUI/AnimGraph/Parameters/ParameterGroupEdit.cpp
@@ -19,7 +19,7 @@
 #include <QApplication>
 #include <QComboBox>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodeGroupWindow.h>
-#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditDialog.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditWidget.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterEditor/ParameterEditorFactory.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterEditor/ValueParameterEditor.h>
 #include <EMotionFX/Source/AnimGraphNodeGroup.h>
@@ -99,11 +99,11 @@ namespace EMotionFX
         ASSERT_TRUE(parameterWindow) << "Anim graph parameter window is invalid.";
 
         parameterWindow->SelectParameters({ "Group0" });
-        parameterWindow->OnEditButton();
+        parameterWindow->OnEditSelected();
 
-        auto groupEditWidget = static_cast<EMStudio::ParameterCreateEditDialog*>(FindTopLevelWidget("ParameterCreateEditDialog"));
+        auto groupEditWidget = static_cast<EMStudio::ParameterCreateEditWidget*>(FindTopLevelWidget("ParameterCreateEditWidget"));
         ASSERT_NE(groupEditWidget, nullptr) << "Cannot find anim graph group edit dialog";
-        auto propertyEditor = groupEditWidget->findChild<AzToolsFramework::ReflectedPropertyEditor*>("EMFX.ParameterCreateEditDialog.ReflectedPropertyEditor.ParameterEditorWidget");
+        auto propertyEditor = groupEditWidget->findChild<AzToolsFramework::ReflectedPropertyEditor*>("EMFX.ParameterCreateEditWidget.ReflectedPropertyEditor.ParameterEditorWidget");
 
         // Get list of all PropertyRowWidgets (and their InstanceDataNodes)
         const WidgetMap& list = propertyEditor->GetWidgets();

--- a/Gems/EMotionFX/Code/Tests/UI/CanEditParameters.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanEditParameters.cpp
@@ -21,7 +21,7 @@
 #include <EMotionStudio/EMStudioSDK/Source/EMStudioManager.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphPlugin.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphViewWidget.h>
-#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditDialog.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditWidget.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterWindow.h>
 #include <Tests/UI/UIFixture.h>
 
@@ -63,11 +63,11 @@ namespace EMotionFX
         parameterWindow->OnAddParameter();
 
         // Find parameter window.
-        EMStudio::ParameterCreateEditDialog* parameterCreateDialog = qobject_cast<EMStudio::ParameterCreateEditDialog*>(FindTopLevelWidget("ParameterCreateEditDialog"));
-        ASSERT_NE(parameterCreateDialog, nullptr) << "Cannot find anim graph parameter create/edit dialog. Is the anim graph selected?";
+        EMStudio::ParameterCreateEditWidget* parameterCreateWidget = qobject_cast<EMStudio::ParameterCreateEditWidget*>(FindTopLevelWidget("ParameterCreateEditWidget"));
+        ASSERT_NE(parameterCreateWidget, nullptr) << "Cannot find anim graph parameter create/edit widget. Is the anim graph selected?";
 
         // Find the Create button
-        QPushButton* createButton = parameterCreateDialog->findChild<QPushButton*>("EMFX.ParameterCreateEditDialog.CreateApplyButton");
+        QPushButton* createButton = parameterCreateWidget->findChild<QPushButton*>("EMFX.ParameterCreateEditWidget.CreateApplyButton");
         EXPECT_TRUE(createButton)<< "Cannot find Create Button";
 
         // Send the left button click directly to the button
@@ -90,25 +90,16 @@ namespace EMotionFX
 
         parameterNodeItem->setSelected(true);
 
-        const QRect rect = treeWidget->visualItemRect(parameterNodeItem);
-        BringUpContextMenu(treeWidget, rect);
-
-        QMenu* contextMenu = parameterWindow->findChild<QMenu*>("EMFX.ParameterWindow.ContextMenu");
-        EXPECT_TRUE(contextMenu) << "No context menu available";
-        QAction* editAction;
-        EXPECT_TRUE(UIFixture::GetActionFromContextMenu(editAction, contextMenu, "Edit")) << "Cannot find the Edit action";
-        editAction->trigger();
-
         // Check that the values we are interested are set to their initial value
         EXPECT_TRUE(parameter->GetHasMinValue()) << "MinValue should be true";
         EXPECT_TRUE(parameter->GetHasMaxValue()) << "MaxValue should be true";
 
-        // Find parameter window.
-        parameterCreateDialog = qobject_cast<EMStudio::ParameterCreateEditDialog*>(FindTopLevelWidget("ParameterCreateEditDialog"));
-        ASSERT_NE(parameterCreateDialog, nullptr) << "Cannot find anim graph parameter create/edit dialog. Is the anim graph selected?";
+        // Find parameter widget.
+        parameterCreateWidget = qobject_cast<EMStudio::ParameterCreateEditWidget*>(FindTopLevelWidget("ParameterCreateEditWidget"));
+        ASSERT_NE(parameterCreateWidget, nullptr) << "Cannot find anim graph parameter create/edit widget. Is the anim graph selected?";
         
         // Get the parameter widget that holds ReflectedPropertyEditor
-        AzToolsFramework::ReflectedPropertyEditor * parameterWidget = parameterCreateDialog->findChild<AzToolsFramework::ReflectedPropertyEditor*>("EMFX.ParameterCreateEditDialog.ReflectedPropertyEditor.ParameterEditorWidget");
+        AzToolsFramework::ReflectedPropertyEditor * parameterWidget = parameterCreateWidget->findChild<AzToolsFramework::ReflectedPropertyEditor*>("EMFX.ParameterCreateEditWidget.ReflectedPropertyEditor.ParameterEditorWidget");
         ASSERT_TRUE(parameterWidget) << "Cannot find the parameterWidget";
 
         AzToolsFramework::PropertyRowWidget* minimumWidget = reinterpret_cast<AzToolsFramework::PropertyRowWidget*>(GetNamedPropertyRowWidgetFromReflectedPropertyEditor(parameterWidget, "Has minimum"));
@@ -130,7 +121,7 @@ namespace EMotionFX
         checkBox->click();
 
         // Find the Apply button, until the changes are applied the values will not be updated
-        QPushButton* applyButton = parameterCreateDialog->findChild<QPushButton*>("EMFX.ParameterCreateEditDialog.CreateApplyButton");
+        QPushButton* applyButton = parameterCreateWidget->findChild<QPushButton*>("EMFX.ParameterCreateEditWidget.CreateApplyButton");
         EXPECT_TRUE(applyButton) << "Cannot find Apply Button";
 
         // Send the left button click directly to the button
@@ -175,19 +166,10 @@ namespace EMotionFX
         ASSERT_NE(parameterNodeItem, nullptr) << "Cannot select parameter group.";
         parameterNodeItem->setSelected(true);
 
-        // Navigate to and execute the edit parameter action.
-        const QRect rect = treeWidget->visualItemRect(parameterNodeItem);
-        BringUpContextMenu(treeWidget, rect);
-        QMenu* contextMenu = parameterWindow->findChild<QMenu*>("EMFX.ParameterWindow.ContextMenu");
-        ASSERT_NE(contextMenu, nullptr) << "No context menu available.";
-        QAction* editAction = nullptr;
-        ASSERT_TRUE(UIFixture::GetActionFromContextMenu(editAction, contextMenu, "Edit")) << "Cannot find the Edit action.";
-        editAction->trigger();
-
         // Find edit parameter window and the line edit control for the name.
-        EMStudio::ParameterCreateEditDialog* parameterCreateDialog = qobject_cast<EMStudio::ParameterCreateEditDialog*>(FindTopLevelWidget("ParameterCreateEditDialog"));
-        ASSERT_NE(parameterCreateDialog, nullptr) << "Cannot find the edit parameter window.";
-        AzToolsFramework::ReflectedPropertyEditor* parameterWidget = parameterCreateDialog->findChild<AzToolsFramework::ReflectedPropertyEditor*>("EMFX.ParameterCreateEditDialog.ReflectedPropertyEditor.ParameterEditorWidget");
+        EMStudio::ParameterCreateEditWidget* parameterCreateWidget = qobject_cast<EMStudio::ParameterCreateEditWidget*>(FindTopLevelWidget("ParameterCreateEditWidget"));
+        ASSERT_NE(parameterCreateWidget, nullptr) << "Cannot find the edit parameter window.";
+        AzToolsFramework::ReflectedPropertyEditor* parameterWidget = parameterCreateWidget->findChild<AzToolsFramework::ReflectedPropertyEditor*>("EMFX.ParameterCreateEditWidget.ReflectedPropertyEditor.ParameterEditorWidget");
         ASSERT_NE(parameterWidget, nullptr) << "Cannot find the reflected property editor.";
         AzToolsFramework::PropertyRowWidget* nameWidget = reinterpret_cast<AzToolsFramework::PropertyRowWidget*>(GetNamedPropertyRowWidgetFromReflectedPropertyEditor(parameterWidget, "Name"));
         ASSERT_NE(nameWidget, nullptr) << "Name widget not found";
@@ -201,7 +183,7 @@ namespace EMotionFX
         lineEdit->setText(changedGroupName.c_str());
 
         // Find and click the apply button.
-        QPushButton* applyButton = parameterCreateDialog->findChild<QPushButton*>("EMFX.ParameterCreateEditDialog.CreateApplyButton");
+        QPushButton* applyButton = parameterCreateWidget->findChild<QPushButton*>("EMFX.ParameterCreateEditWidget.CreateApplyButton");
         EXPECT_NE(applyButton, nullptr) << "Cannot find Apply button.";
         QTest::mouseClick(applyButton, Qt::LeftButton);
 

--- a/Gems/EMotionFX/Code/Tests/UI/CanOpenWorkspace.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanOpenWorkspace.cpp
@@ -22,7 +22,7 @@
 #include <EMotionStudio/EMStudioSDK/Source/ResetSettingsDialog.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphPlugin.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterWindow.h>
-#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditDialog.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditWidget.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphViewWidget.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetsWindowPlugin.h>
 

--- a/Gems/EMotionFX/Code/Tests/UI/UIFixture.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/UIFixture.cpp
@@ -19,7 +19,7 @@
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphPlugin.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterWindow.h>
-#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditDialog.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditWidget.h>
 
 #include <AzCore/IO/Path/Path.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
@@ -432,14 +432,14 @@ namespace EMotionFX
         EMStudio::ParameterWindow* parameterWindow = m_animGraphPlugin->GetParameterWindow();
         parameterWindow->OnAddParameter();
 
-        EMStudio::ParameterCreateEditDialog* paramDialog = parameterWindow->findChild< EMStudio::ParameterCreateEditDialog*>();
-        ASSERT_TRUE(paramDialog);
+        auto paramWidget = qobject_cast<EMStudio::ParameterCreateEditWidget*>(FindTopLevelWidget("ParameterCreateEditWidget"));
+        ASSERT_TRUE(paramWidget);
 
-        const AZStd::unique_ptr<EMotionFX::Parameter>& param = paramDialog->GetParameter();
+        const AZStd::unique_ptr<EMotionFX::Parameter>& param = paramWidget->GetParameter();
         param->SetName(name);
         const size_t numParams = m_animGraphPlugin->GetActiveAnimGraph()->GetNumParameters();
 
-        QPushButton* createButton = paramDialog->findChild<QPushButton*>("EMFX.ParameterCreateEditDialog.CreateApplyButton");
+        QPushButton* createButton = paramWidget->findChild<QPushButton*>("EMFX.ParameterCreateEditWidget.CreateApplyButton");
         QTest::mouseClick(createButton, Qt::LeftButton);
 
         ASSERT_EQ(m_animGraphPlugin->GetActiveAnimGraph()->GetNumParameters(), numParams + 1);


### PR DESCRIPTION
## What does this PR do?

This moves the parameter properties edit/creation window into the inspector.
I's a re-submission of PR [!11702](https://github.com/o3de/o3de/pull/11702) that I had to take over. See that PR for technical discussion. I only added two commits that fixed minor issues and rebased the commit on top of the `development` branch tip because otherwise, the PR was accepted.

https://user-images.githubusercontent.com/104767/196743764-10518a2a-2058-45d2-91f1-c063b144edf3.mp4

## How was this PR tested?

Manually according to requirements. Also EMotionFX unit test suite was updated to test the functionality.

Fixes #10965
