### PR TITLE
GHI-12687 AZ::RPI::RenderPipeline related notification APIs

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/AuxGeom/AuxGeomFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/AuxGeom/AuxGeomFeatureProcessor.h
@@ -47,8 +47,7 @@ namespace AZ
             void ReleaseDrawQueueForView(const RPI::View* view) override;
 
             // RPI::SceneNotificationBus::Handler overrides...
-            void OnRenderPipelineAdded(RPI::RenderPipelinePtr pipeline) override;
-            void OnRenderPipelineRemoved(RPI::RenderPipeline* pipeline) override;
+            void OnRenderPipelineChanged(AZ::RPI::RenderPipeline* pipeline, RPI::SceneNotification::RenderPipelineChangeType changeType) override;
 
         private: // functions
 

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
@@ -198,8 +198,7 @@ namespace AZ
             MeshFeatureProcessor(const MeshFeatureProcessor&) = delete;
 
             // RPI::SceneNotificationBus::Handler overrides...
-            void OnRenderPipelineAdded(RPI::RenderPipelinePtr pipeline) override;
-            void OnRenderPipelineRemoved(RPI::RenderPipeline* pipeline) override;
+            void OnRenderPipelineChanged(AZ::RPI::RenderPipeline* pipeline, RPI::SceneNotification::RenderPipelineChangeType changeType) override;
                         
             AZStd::concurrency_checker m_meshDataChecker;
             StableDynamicArray<ModelDataInstance> m_modelData;

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomFeatureProcessor.cpp
@@ -157,7 +157,8 @@ namespace AZ
             m_fixedShapeProcessor->SetUpdatePipelineStates();
         }
 
-        void AuxGeomFeatureProcessor::OnRenderPipelineChanged(RPI::RenderPipeline*, RPI::SceneNotification::RenderPipelineChangeType)
+        void AuxGeomFeatureProcessor::OnRenderPipelineChanged([[maybe_unused]] RPI::RenderPipeline* pipeline,
+            [[maybe_unused]] RPI::SceneNotification::RenderPipelineChangeType changeType)
         {
             OnSceneRenderPipelinesChanged();
         }

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomFeatureProcessor.cpp
@@ -157,15 +157,9 @@ namespace AZ
             m_fixedShapeProcessor->SetUpdatePipelineStates();
         }
 
-        void AuxGeomFeatureProcessor::OnRenderPipelineAdded(RPI::RenderPipelinePtr pipeline)
+        void AuxGeomFeatureProcessor::OnRenderPipelineChanged(RPI::RenderPipeline*, RPI::SceneNotification::RenderPipelineChangeType)
         {
             OnSceneRenderPipelinesChanged();
         }
-
-        void AuxGeomFeatureProcessor::OnRenderPipelineRemoved([[maybe_unused]] RPI::RenderPipeline* pipeline)
-        {
-            OnSceneRenderPipelinesChanged();
-        }
-
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -646,23 +646,22 @@ namespace AZ
             m_lightBufferNeedsUpdate = true;
         }
 
-        void DirectionalLightFeatureProcessor::OnRenderPipelineAdded(RPI::RenderPipelinePtr pipeline)
+        void DirectionalLightFeatureProcessor::OnRenderPipelineChanged([[maybe_unused]] RPI::RenderPipeline* pipeline,
+            RPI::SceneNotification::RenderPipelineChangeType changeType)
         {
-            PrepareForChangingRenderPipelineAndCameraView();
-        }
-
-        void DirectionalLightFeatureProcessor::OnRenderPipelineRemoved(RPI::RenderPipeline* pipeline)
-        {
-            if (m_cascadedShadowmapsPasses.find(pipeline->GetId()) != m_cascadedShadowmapsPasses.end() ||
-                m_esmShadowmapsPasses.find(pipeline->GetId()) != m_esmShadowmapsPasses.end())
+            if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Added
+                || changeType == RPI::SceneNotification::RenderPipelineChangeType::PassChanged)
             {
                 PrepareForChangingRenderPipelineAndCameraView();
             }
-        }
-
-        void DirectionalLightFeatureProcessor::OnRenderPipelinePassesChanged(RPI::RenderPipeline*)
-        {
-            PrepareForChangingRenderPipelineAndCameraView();
+            else if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Removed)
+            {
+                if (m_cascadedShadowmapsPasses.find(pipeline->GetId()) != m_cascadedShadowmapsPasses.end()
+                    || m_esmShadowmapsPasses.find(pipeline->GetId()) != m_esmShadowmapsPasses.end())
+                {
+                    PrepareForChangingRenderPipelineAndCameraView();
+                }
+            }
         }
 
         void DirectionalLightFeatureProcessor::OnRenderPipelinePersistentViewChanged(RPI::RenderPipeline* pipeline, RPI::PipelineViewTag, RPI::ViewPtr, RPI::ViewPtr)

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
@@ -254,9 +254,7 @@ namespace AZ
 
         private:
             // RPI::SceneNotificationBus::Handler overrides...
-            void OnRenderPipelineAdded(RPI::RenderPipelinePtr pipeline) override;
-            void OnRenderPipelineRemoved(RPI::RenderPipeline* pipeline) override;
-            void OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline) override;
+            void OnRenderPipelineChanged(AZ::RPI::RenderPipeline* pipeline, RPI::SceneNotification::RenderPipelineChangeType changeType) override;
             void OnRenderPipelinePersistentViewChanged(RPI::RenderPipeline* renderPipeline, RPI::PipelineViewTag viewTag, RPI::ViewPtr newView, RPI::ViewPtr previousView) override;
 
             //! This prepare for change of render pipelines and camera views.

--- a/Gems/Atom/Feature/Common/Code/Source/CubeMapCapture/CubeMapCaptureFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CubeMapCapture/CubeMapCaptureFeatureProcessor.cpp
@@ -123,11 +123,15 @@ namespace AZ
             cubeMapCapture->SetRelativePath(relativePath);
         }
 
-        void CubeMapCaptureFeatureProcessor::OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline)
+        void CubeMapCaptureFeatureProcessor::OnRenderPipelineChanged(RPI::RenderPipeline* renderPipeline,
+                RPI::SceneNotification::RenderPipelineChangeType changeType)
         {
-            for (auto& cubeMapCapture : m_cubeMapCaptures)
+            if (changeType == RPI::SceneNotification::RenderPipelineChangeType::PassChanged)
             {
-                cubeMapCapture->OnRenderPipelinePassesChanged(renderPipeline);
+                for (auto& cubeMapCapture : m_cubeMapCaptures)
+                {
+                    cubeMapCapture->OnRenderPipelinePassesChanged(renderPipeline);
+                }
             }
         }
     } // namespace Render

--- a/Gems/Atom/Feature/Common/Code/Source/CubeMapCapture/CubeMapCaptureFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CubeMapCapture/CubeMapCaptureFeatureProcessor.h
@@ -45,7 +45,7 @@ namespace AZ
             AZ_DISABLE_COPY_MOVE(CubeMapCaptureFeatureProcessor);
 
             // RPI::SceneNotificationBus::Handler overrides
-            void OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline) override;
+            void OnRenderPipelineChanged(RPI::RenderPipeline* renderPipeline, RPI::SceneNotification::RenderPipelineChangeType changeType) override;
 
             // list of CubeMapCaptures
             using CubeMapCaptureVector = AZStd::vector<AZStd::shared_ptr<CubeMapCapture>>;

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -518,12 +518,8 @@ namespace AZ
             m_forceRebuildDrawPackets = true;
         }
 
-        void MeshFeatureProcessor::OnRenderPipelineAdded(RPI::RenderPipelinePtr pipeline)
-        {
-            m_forceRebuildDrawPackets = true;;
-        }
-
-        void MeshFeatureProcessor::OnRenderPipelineRemoved([[maybe_unused]] RPI::RenderPipeline* pipeline)
+        void MeshFeatureProcessor::OnRenderPipelineChanged([[maybe_unused]] RPI::RenderPipeline* pipeline,
+            [[maybe_unused]] RPI::SceneNotification::RenderPipelineChangeType changeType)
         {
             m_forceRebuildDrawPackets = true;
         }

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.cpp
@@ -679,22 +679,16 @@ namespace AZ
             AZ_Error("ReflectionProbeFeatureProcessor", srgLayout != nullptr, "Failed to find ObjectSrg layout from shader [%s]", filePath);
         }
 
-        void ReflectionProbeFeatureProcessor::OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline)
+        void ReflectionProbeFeatureProcessor::OnRenderPipelineChanged(RPI::RenderPipeline* renderPipeline,
+            RPI::SceneNotification::RenderPipelineChangeType changeType)
         {
-            for (auto& reflectionProbe : m_reflectionProbes)
+            if (changeType == RPI::SceneNotification::RenderPipelineChangeType::PassChanged)
             {
-                reflectionProbe->OnRenderPipelinePassesChanged(renderPipeline);
+                for (auto& reflectionProbe : m_reflectionProbes)
+                {
+                    reflectionProbe->OnRenderPipelinePassesChanged(renderPipeline);
+                }
             }
-            m_needUpdatePipelineStates = true;
-        }
-
-        void ReflectionProbeFeatureProcessor::OnRenderPipelineAdded(RPI::RenderPipelinePtr pipeline)
-        {
-            m_needUpdatePipelineStates = true;
-        }
-
-        void ReflectionProbeFeatureProcessor::OnRenderPipelineRemoved([[maybe_unused]] RPI::RenderPipeline* pipeline)
-        {
             m_needUpdatePipelineStates = true;
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.h
@@ -81,9 +81,7 @@ namespace AZ
                 RHI::Ptr<RHI::ShaderResourceGroupLayout>& srgLayout, RHI::DrawListTag& drawListTag);
 
             // RPI::SceneNotificationBus::Handler overrides
-            void OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline) override;
-            void OnRenderPipelineAdded(RPI::RenderPipelinePtr pipeline) override;
-            void OnRenderPipelineRemoved(RPI::RenderPipeline* pipeline) override;
+            void OnRenderPipelineChanged(AZ::RPI::RenderPipeline* pipeline, RPI::SceneNotification::RenderPipelineChangeType changeType) override;
 
             void UpdatePipelineStates();
 

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
@@ -301,8 +301,8 @@ namespace AZ::Render
         UpdateShadowView(shadowProperty);
     }
         
-    void ProjectedShadowFeatureProcessor::OnRenderPipelineChanged(RPI::RenderPipeline* /*renderPipeline*/,
-            RPI::SceneNotification::RenderPipelineChangeType /*changeType*/)
+    void ProjectedShadowFeatureProcessor::OnRenderPipelineChanged([[maybe_unused]] RPI::RenderPipeline* renderPipeline,
+            [[maybe_unused]] RPI::SceneNotification::RenderPipelineChangeType changeType)
     {
         CachePasses();
     }

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
@@ -300,18 +300,9 @@ namespace AZ::Render
 
         UpdateShadowView(shadowProperty);
     }
-
-    void ProjectedShadowFeatureProcessor::OnRenderPipelinePassesChanged(RPI::RenderPipeline* /*renderPipeline*/)
-    {
-        CachePasses();
-    }
-
-    void ProjectedShadowFeatureProcessor::OnRenderPipelineAdded(RPI::RenderPipelinePtr /*renderPipeline*/)
-    {
-        CachePasses();
-    }
-
-    void ProjectedShadowFeatureProcessor::OnRenderPipelineRemoved( RPI::RenderPipeline* /*renderPipeline*/)
+        
+    void ProjectedShadowFeatureProcessor::OnRenderPipelineChanged(RPI::RenderPipeline* /*renderPipeline*/,
+            RPI::SceneNotification::RenderPipelineChangeType /*changeType*/)
     {
         CachePasses();
     }

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.h
@@ -86,9 +86,7 @@ namespace AZ::Render
         static constexpr float MinimumFieldOfView = 0.001f;
 
         // RPI::SceneNotificationBus::Handler overrides...
-        void OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline) override;
-        void OnRenderPipelineAdded(RPI::RenderPipelinePtr pipeline) override;
-        void OnRenderPipelineRemoved(RPI::RenderPipeline* pipeline) override;
+        void OnRenderPipelineChanged(AZ::RPI::RenderPipeline* pipeline, RPI::SceneNotification::RenderPipelineChangeType changeType) override;
         
         // Shadow specific functions
         void UpdateShadowView(ShadowProperty& shadowProperty);

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.cpp
@@ -283,14 +283,14 @@ namespace AZ
 #endif
         }
 
-        void SkinnedMeshFeatureProcessor::OnRenderPipelineAdded(RPI::RenderPipelinePtr pipeline)
+        void SkinnedMeshFeatureProcessor::OnRenderPipelineChanged(RPI::RenderPipeline* renderPipeline,
+            RPI::SceneNotification::RenderPipelineChangeType changeType)
         {
-            InitSkinningAndMorphPass(pipeline.get());
-        }
-
-        void SkinnedMeshFeatureProcessor::OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline)
-        {
-            InitSkinningAndMorphPass(renderPipeline);
+            if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Added
+                || changeType == RPI::SceneNotification::RenderPipelineChangeType::PassChanged)
+            {
+                InitSkinningAndMorphPass(renderPipeline);
+            }
         }
 
         void SkinnedMeshFeatureProcessor::OnBeginPrepareRender()

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.h
@@ -51,8 +51,7 @@ namespace AZ
             void OnRenderEnd() override;
 
             // RPI::SceneNotificationBus overrides ...
-            void OnRenderPipelineAdded(RPI::RenderPipelinePtr pipeline) override;
-            void OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline) override;
+            void OnRenderPipelineChanged(RPI::RenderPipeline* renderPipeline, RPI::SceneNotification::RenderPipelineChangeType changeType) override;
             void OnBeginPrepareRender() override;
 
             // SkinnedMeshFeatureProcessorInterface overrides ...

--- a/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmosphereFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmosphereFeatureProcessor.cpp
@@ -97,7 +97,7 @@ namespace AZ::Render
         }
     }
 
-    void SkyAtmosphereFeatureProcessor::OnRenderPipelineChanged(RPI::RenderPipeline* /*pipeline*/,
+    void SkyAtmosphereFeatureProcessor::OnRenderPipelineChanged([[maybe_unused]] RPI::RenderPipeline* pipeline,
         RPI::SceneNotification::RenderPipelineChangeType changeType)
     {
         CachePasses();

--- a/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmosphereFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmosphereFeatureProcessor.cpp
@@ -97,21 +97,15 @@ namespace AZ::Render
         }
     }
 
-    void SkyAtmosphereFeatureProcessor::OnRenderPipelinePassesChanged([[maybe_unused]]RPI::RenderPipeline* renderPipeline)
+    void SkyAtmosphereFeatureProcessor::OnRenderPipelineChanged(RPI::RenderPipeline* /*pipeline*/,
+        RPI::SceneNotification::RenderPipelineChangeType changeType)
     {
         CachePasses();
-        UpdateBackgroundClearColor();
-    }
-
-    void SkyAtmosphereFeatureProcessor::OnRenderPipelineAdded([[maybe_unused]]RPI::RenderPipelinePtr renderPipeline)
-    {
-        CachePasses();
-        UpdateBackgroundClearColor();
-    }
-
-    void SkyAtmosphereFeatureProcessor::OnRenderPipelineRemoved([[maybe_unused]] RPI::RenderPipeline* renderPipeline)
-    {
-        CachePasses();
+        if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Added
+            || changeType == RPI::SceneNotification::RenderPipelineChangeType::PassChanged)
+        {
+            UpdateBackgroundClearColor();
+        }
     }
     
     void SkyAtmosphereFeatureProcessor::CachePasses()

--- a/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmosphereFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmosphereFeatureProcessor.h
@@ -42,9 +42,7 @@ namespace AZ::Render
     private:
 
         //! RPI::SceneNotificationBus::Handler
-        void OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline) override;
-        void OnRenderPipelineAdded(RPI::RenderPipelinePtr pipeline) override;
-        void OnRenderPipelineRemoved(RPI::RenderPipeline* pipeline) override;
+        void OnRenderPipelineChanged(AZ::RPI::RenderPipeline* pipeline, RPI::SceneNotification::RenderPipelineChangeType changeType) override;
         
         void InitializeAtmosphere(AtmosphereId id);
         void UpdateBackgroundClearColor();

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/FeatureProcessor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/FeatureProcessor.h
@@ -88,9 +88,16 @@ namespace AZ
 
             //! Perform any necessary deactivation.
             virtual void Deactivate() {}
-
+            
+            //! O3DE_DEPRECATION_NOTICE(GHI-12687)
+            //! @deprecated use AddRenderPasses(RenderPipeline*)
             //! Apply changes and add additional render passes to the render pipeline from the feature processors
             virtual void ApplyRenderPipelineChange(RenderPipeline* ) {}
+
+            //! Add additional render passes to the render pipeline before it's finalized
+            //! The render pipeline must have m_allowModification set to true (see Scene::TryApplyRenderPipelineChanges() function)
+            //! This function is called when the render pipeline is added or rebuilt
+            virtual void AddRenderPasses(RenderPipeline* ) {}
 
             //! Allows the feature processor to expose supporting views based on
             //! the main views passed in. Main views (persistent views) are views that must be 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/FeatureProcessor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/FeatureProcessor.h
@@ -92,12 +92,12 @@ namespace AZ
             //! O3DE_DEPRECATION_NOTICE(GHI-12687)
             //! @deprecated use AddRenderPasses(RenderPipeline*)
             //! Apply changes and add additional render passes to the render pipeline from the feature processors
-            virtual void ApplyRenderPipelineChange(RenderPipeline* ) {}
+            virtual void ApplyRenderPipelineChange([[maybe_unused]] RenderPipeline* pipeline) {}
 
             //! Add additional render passes to the render pipeline before it's finalized
             //! The render pipeline must have m_allowModification set to true (see Scene::TryApplyRenderPipelineChanges() function)
             //! This function is called when the render pipeline is added or rebuilt
-            virtual void AddRenderPasses(RenderPipeline* ) {}
+            virtual void AddRenderPasses([[maybe_unused]] RenderPipeline* pipeline) {}
 
             //! Allows the feature processor to expose supporting views based on
             //! the main views passed in. Main views (persistent views) are views that must be 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/SceneBus.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/SceneBus.h
@@ -39,14 +39,37 @@ namespace AZ
             template<typename Bus>
             using ConnectionPolicy = SceneConnectionPolicy<Bus>;
             //////////////////////////////////////////////////////////////////////////
+
+            enum class RenderPipelineChangeType
+            {
+                Added,              //The render pipeline was added to this scene
+                PassChanged,      //Any passes of this render pipeline are modified before a render tick
+                Removed             //The render pipeline was removed from this scene
+            };
                         
+            //! O3DE_DEPRECATION_NOTICE(GHI-12687)
+            //! @deprecated use OnRenderPipelineChanged(RenderPipeline*, RenderPipelineChangeType::Added)
             //! Notifies when a render pipeline is added to this scene. 
             //! @param pipeline The render pipeline which was added
             virtual void OnRenderPipelineAdded(RenderPipelinePtr pipeline) {};
+                        
+            //! O3DE_DEPRECATION_NOTICE(GHI-12687)
+            //! @deprecated use OnRenderPipelineChanged(RenderPipeline*, RenderPipelineChangeType::PassChanged)
+            //! Notifies when any passes of this render pipeline are modified before a render tick
+            //! This includes adding a pass, removing a pass, or if pass data changed (such as attachments, draw list tags, etc.)
+            //! Feature processors may need to use it to update their cached pipeline states
+            //! @param pipeline The render pipeline which was modified
+            virtual void OnRenderPipelinePassesChanged([[maybe_unused]] RenderPipeline* renderPipeline) {}
 
+            //! O3DE_DEPRECATION_NOTICE(GHI-12687)
+            //! @deprecated use OnRenderPipelineChanged(RenderPipeline*, RenderPipelineChangeType::Removed)
             //! Notifies when a render pipeline is removed from this scene.
             //! @param pipeline The render pipeline which was removed
             virtual void OnRenderPipelineRemoved([[maybe_unused]] RenderPipeline* pipeline) {};
+
+            //! Notifies when a render pipeline was added, removed or changed
+            //! @param pipeline The render pipeline which was added
+            virtual void OnRenderPipelineChanged(RenderPipeline* , RenderPipelineChangeType) {};
             
             //! Notifies when a persistent view is set/changed (for a particular RenderPipeline + ViewTag)
             //! @param pipeline The render pipeline which was modified
@@ -54,12 +77,6 @@ namespace AZ
             //! @param newView The view which was set to the render pipeline's view tag
             //! @param previousView The previous view associates to render pipeline's view tag before the new view was set
             virtual void OnRenderPipelinePersistentViewChanged([[maybe_unused]] RenderPipeline* renderPipeline, PipelineViewTag viewTag, ViewPtr newView, ViewPtr previousView) {}
-
-            //! Notifies when any passes of this render pipeline are modified before a render tick
-            //! This includes adding a pass, removing a pass, or if pass data changed (such as attachments, draw list tags, etc.)
-            //! Feature processors may need to use it to update their cached pipeline states
-            //! @param pipeline The render pipeline which was modified
-            virtual void OnRenderPipelinePassesChanged([[maybe_unused]] RenderPipeline* renderPipeline) {}
 
             //! Notifies when the PrepareRender phase is beginning
             //! This phase is when data is read from the FeatureProcessors and written to the draw lists.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContext.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContext.h
@@ -77,9 +77,7 @@ namespace AZ
 
             // SceneNotificationBus interface overrides...
             //! Ensures our default view remains set when our scene's render pipelines are modified.
-            void OnRenderPipelineAdded(RenderPipelinePtr pipeline) override;
-            //! Ensures our default view remains set when our scene's render pipelines are modified.
-            void OnRenderPipelineRemoved(RenderPipeline* pipeline) override;
+            void OnRenderPipelineChanged(RenderPipeline* pipeline, SceneNotification::RenderPipelineChangeType changeType) override;
             //! OnBeginPrepareRender is forwarded to our RenderTick notification to allow subscribers to do rendering.
             void OnBeginPrepareRender() override;
             //! OnEndPrepareRender is forwarded to our WaitForRender notification to wait for any pending work

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -424,6 +424,8 @@ namespace AZ
                 if (m_scene)
                 {
                     SceneNotificationBus::Event(m_scene->GetId(), &SceneNotification::OnRenderPipelinePassesChanged, this);
+                    SceneNotificationBus::Event(m_scene->GetId(), &SceneNotification::OnRenderPipelineChanged, this,
+                        SceneNotification::RenderPipelineChangeType::PassChanged);
 
                     // Pipeline state lookup
                     if (PipelineStateLookupNeedsRebuild(m_pipelinePassChanges))

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -323,7 +323,7 @@ namespace AZ
 
         void Scene::TryApplyRenderPipelineChanges(RenderPipeline* pipeline)
         {
-            // return directly if the pipeline doesn't allow modification or it was already modifed by scene
+            // return directly if the pipeline doesn't allow modification or it was already modified by scene
             if (!pipeline->m_descriptor.m_allowModification || pipeline->m_wasModifiedByScene)
             {
                 return;
@@ -332,6 +332,7 @@ namespace AZ
             pipeline->m_wasModifiedByScene = true;
             for (auto& fp : m_featureProcessors)
             {
+                fp->AddRenderPasses(pipeline);
                 fp->ApplyRenderPipelineChange(pipeline);
             }
             pipeline->ProcessQueuedPassChanges();
@@ -373,6 +374,7 @@ namespace AZ
             RebuildPipelineStatesLookup();
 
             SceneNotificationBus::Event(m_id, &SceneNotification::OnRenderPipelineAdded, pipeline);
+            SceneNotificationBus::Event(m_id, &SceneNotification::OnRenderPipelineChanged, pipeline.get(), SceneNotification::RenderPipelineChangeType::Added);
         }
         
         void Scene::RemoveRenderPipeline(const RenderPipelineId& pipelineId)
@@ -395,6 +397,11 @@ namespace AZ
                     m_pipelines.erase(it);
                     
                     SceneNotificationBus::Event(m_id, &SceneNotification::OnRenderPipelineRemoved, pipelineToRemove.get());
+                    SceneNotificationBus::Event(
+                        m_id,
+                        &SceneNotification::OnRenderPipelineChanged,
+                        pipelineToRemove.get(),
+                        SceneNotification::RenderPipelineChangeType::Removed);
 
                     // If the default pipeline was removed, set to the first one in the list
                     if (m_defaultPipeline == nullptr && m_pipelines.size() > 0)
@@ -907,6 +914,7 @@ namespace AZ
             for (auto renderPipeline : m_pipelines)
             {
                 handler->OnRenderPipelineAdded(renderPipeline);
+                handler->OnRenderPipelineChanged(renderPipeline.get(), SceneNotification::RenderPipelineChangeType::Added);
                 const RenderPipeline::PipelineViewMap& viewsInfo = renderPipeline->GetPipelineViews();
                 for (RenderPipeline::PipelineViewMap::const_iterator itr = viewsInfo.begin(); itr != viewsInfo.end(); itr++)
                 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContext.cpp
@@ -309,26 +309,29 @@ namespace AZ
             return m_currentPipelines[DefaultViewType];
         }
 
-        void ViewportContext::OnRenderPipelineAdded([[maybe_unused]]RenderPipelinePtr pipeline)
+        void ViewportContext::OnRenderPipelineChanged(RenderPipeline* pipeline,
+            SceneNotification::RenderPipelineChangeType changeType)
         {
-            // If the pipeline is registered to our window, reset our current pipeline and do a lookup
-            // Currently, Scene just stores pipelines sequentially in a vector, but we'll attempt to be safe
-            // in the event prioritization is added later
-            if (pipeline->GetWindowHandle() == m_windowContext->GetWindowHandle())
+            if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Added)
             {
-                uint32_t viewIndex = static_cast<uint32_t>(pipeline->GetViewType());
-                m_currentPipelines[viewIndex].reset();
-                UpdatePipelineView(viewIndex);
+                // If the pipeline is registered to our window, reset our current pipeline and do a lookup
+                // Currently, Scene just stores pipelines sequentially in a vector, but we'll attempt to be safe
+                // in the event prioritization is added later
+                if (pipeline->GetWindowHandle() == m_windowContext->GetWindowHandle())
+                {
+                    uint32_t viewIndex = static_cast<uint32_t>(pipeline->GetViewType());
+                    m_currentPipelines[viewIndex].reset();
+                    UpdatePipelineView(viewIndex);
+                }
             }
-        }
-
-        void ViewportContext::OnRenderPipelineRemoved(RenderPipeline* pipeline)
-        {
-            uint32_t viewIndex = static_cast<uint32_t>(pipeline->GetViewType());
-            if (m_currentPipelines[viewIndex].get() == pipeline)
+            else if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Removed)
             {
-                m_currentPipelines[viewIndex].reset();
-                UpdatePipelineView(viewIndex);
+                 uint32_t viewIndex = static_cast<uint32_t>(pipeline->GetViewType());
+                if (m_currentPipelines[viewIndex].get() == pipeline)
+                {
+                    m_currentPipelines[viewIndex].reset();
+                    UpdatePipelineView(viewIndex);
+                }
             }
         }
 

--- a/Gems/Atom/RPI/Code/Tests/Common/TestFeatureProcessors.h
+++ b/Gems/Atom/RPI/Code/Tests/Common/TestFeatureProcessors.h
@@ -47,30 +47,28 @@ namespace UnitTest
         void Render(const RenderPacket&)  override {};
 
         // Overrides for scene notification bus handler
-        void OnRenderPipelineAdded(AZ::RPI::RenderPipelinePtr pipeline) override
-        {
-            m_pipelineCount++;
-            m_lastPipeline = pipeline.get();
-        }
-
-        void OnRenderPipelineRemoved(AZ::RPI::RenderPipeline* pipeline) override
-        {
-            m_pipelineCount--;
-            m_lastPipeline = pipeline;
-        }
-
         void OnRenderPipelinePersistentViewChanged(AZ::RPI::RenderPipeline* renderPipeline, AZ::RPI::PipelineViewTag viewTag, AZ::RPI::ViewPtr newView, AZ::RPI::ViewPtr previousView) override
         {
             m_viewSetCount++;
             m_lastPipeline = renderPipeline;
         }
 
-        void OnRenderPipelinePassesChanged(AZ::RPI::RenderPipeline* renderPipeline) override
+        void OnRenderPipelineChanged(AZ::RPI::RenderPipeline* pipeline, AZ::RPI::SceneNotification::RenderPipelineChangeType changeType) override
         {
-            m_pipelineChangedCount++;
-            m_lastPipeline = renderPipeline;
+            if (changeType == AZ::RPI::SceneNotification::RenderPipelineChangeType::Added)
+            {            
+                m_pipelineCount++;
+            }
+            else if (changeType == AZ::RPI::SceneNotification::RenderPipelineChangeType::Removed)
+            {
+                m_pipelineCount--;
+            }
+            else if (changeType == AZ::RPI::SceneNotification::RenderPipelineChangeType::PassChanged)
+            {
+                m_pipelineChangedCount++;
+            }
+            m_lastPipeline = pipeline;
         }
-
     }; 
     
     class TestFeatureProcessor2 final

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/EditorModeFeedbackFeatureProcessor.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/EditorModeFeedbackFeatureProcessor.cpp
@@ -61,37 +61,26 @@ namespace AZ
             DisableSceneNotification();
         }
 
-        void EditorModeFeatureProcessor::OnRenderPipelineRemoved(RPI::RenderPipeline* pipeline)
+        void EditorModeFeatureProcessor::OnRenderPipelineChanged(RPI::RenderPipeline* renderPipeline,
+            RPI::SceneNotification::RenderPipelineChangeType changeType)
         {
             if (!m_editorStatePassSystem)
             {
                 return;
             }
 
-            m_editorStatePassSystem->RemoveStatePassesForPipeline(pipeline);
-        }
-
-        void EditorModeFeatureProcessor::OnRenderPipelineAdded(RPI::RenderPipelinePtr pipeline)
-        {
-            if (!m_editorStatePassSystem)
+            if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Added
+                || changeType == RPI::SceneNotification::RenderPipelineChangeType::PassChanged)
             {
-                return;
+                m_editorStatePassSystem->ConfigureStatePassesForPipeline(renderPipeline);
             }
-
-            m_editorStatePassSystem->ConfigureStatePassesForPipeline(pipeline.get());
-        }
-
-        void EditorModeFeatureProcessor::OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline)
-        {
-            if (!m_editorStatePassSystem)
+            else if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Removed)
             {
-                return;
+                m_editorStatePassSystem->RemoveStatePassesForPipeline(renderPipeline);
             }
-
-            m_editorStatePassSystem->ConfigureStatePassesForPipeline(renderPipeline);
         }
 
-        void EditorModeFeatureProcessor::ApplyRenderPipelineChange(RPI::RenderPipeline* renderPipeline)
+        void EditorModeFeatureProcessor::AddRenderPasses(RPI::RenderPipeline* renderPipeline)
         {
             if (!m_editorStatePassSystem)
             {

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/EditorModeFeedbackFeatureProcessor.h
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/EditorModeFeedbackFeatureProcessor.h
@@ -33,14 +33,12 @@ namespace AZ
             // FeatureProcessor overrides ...
             void Activate() override;
             void Deactivate() override;
-            void ApplyRenderPipelineChange(RPI::RenderPipeline* renderPipeline) override;
+            void AddRenderPasses(RPI::RenderPipeline* renderPipeline) override;
             void Render(const RenderPacket& packet) override;
             void Simulate(const SimulatePacket& packet) override;
 
             // RPI::SceneNotificationBus overrides ...
-            void OnRenderPipelineAdded(RPI::RenderPipelinePtr pipeline) override;
-            void OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline) override;
-            void OnRenderPipelineRemoved(RPI::RenderPipeline* pipeline) override;
+            void OnRenderPipelineChanged(AZ::RPI::RenderPipeline* pipeline, AZ::RPI::SceneNotification::RenderPipelineChangeType changeType) override;
 
             // AZ::TickBus overrides ...
             void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
@@ -372,15 +372,15 @@ namespace AZ
             void HairFeatureProcessor::OnRenderPipelineChanged(RPI::RenderPipeline* renderPipeline,
                 RPI::SceneNotification::RenderPipelineChangeType changeType)
             {
+                // Proceed only if this is the main pipeline that contains the parent pass
+                if (!HasHairParentPass(renderPipeline))
+                {
+                    return;
+                }
+
                 if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Added
                     || changeType == RPI::SceneNotification::RenderPipelineChangeType::PassChanged)
                 {
-                    // Proceed only if this is the main pipeline that contains the parent pass
-                    if (!HasHairParentPass(renderPipeline))
-                    {
-                        return;
-                    }
-
                     Init(renderPipeline);
 
                     // Mark for all passes to evacuate their render data and recreate it.
@@ -388,12 +388,6 @@ namespace AZ
                 }
                 else if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Removed)
                 {
-                    // Proceed only if this is the main pipeline that contains the parent pass
-                    if (!HasHairParentPass(renderPipeline))
-                    {
-                        return;
-                    }
-
                     m_renderPipeline = nullptr;
                     ClearPasses();
                 }

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
@@ -106,7 +106,7 @@ namespace AZ
                 HairGlobalSettingsRequestBus::Handler::BusDisconnect();
             }
 
-            void HairFeatureProcessor::ApplyRenderPipelineChange(RPI::RenderPipeline* renderPipeline)
+            void HairFeatureProcessor::AddRenderPasses(RPI::RenderPipeline* renderPipeline)
             {
                 AddHairParentPass(renderPipeline);
             }
@@ -369,44 +369,34 @@ namespace AZ
                 return success;
             }
 
-            void HairFeatureProcessor::OnRenderPipelineAdded(RPI::RenderPipelinePtr renderPipeline)
+            void HairFeatureProcessor::OnRenderPipelineChanged(RPI::RenderPipeline* renderPipeline,
+                RPI::SceneNotification::RenderPipelineChangeType changeType)
             {
-                // Proceed only if this is the main pipeline that contains the parent pass
-                if (!HasHairParentPass(renderPipeline.get()))
+                if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Added
+                    || changeType == RPI::SceneNotification::RenderPipelineChangeType::PassChanged)
                 {
-                    return;
+                    // Proceed only if this is the main pipeline that contains the parent pass
+                    if (!HasHairParentPass(renderPipeline))
+                    {
+                        return;
+                    }
+
+                    Init(renderPipeline);
+
+                    // Mark for all passes to evacuate their render data and recreate it.
+                    m_forceRebuildRenderData = true;
                 }
-
-                Init(renderPipeline.get());
-
-                // Mark for all passes to evacuate their render data and recreate it.
-                m_forceRebuildRenderData = true;
-            }
-
-            void HairFeatureProcessor::OnRenderPipelineRemoved([[maybe_unused]] RPI::RenderPipeline* renderPipeline)
-            {
-                // Proceed only if this is the main pipeline that contains the parent pass
-                if (!HasHairParentPass(renderPipeline))
+                else if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Removed)
                 {
-                    return;
+                    // Proceed only if this is the main pipeline that contains the parent pass
+                    if (!HasHairParentPass(renderPipeline))
+                    {
+                        return;
+                    }
+
+                    m_renderPipeline = nullptr;
+                    ClearPasses();
                 }
-
-                m_renderPipeline = nullptr;
-                ClearPasses();
-            }
-
-            void HairFeatureProcessor::OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline)
-            {
-                // Proceed only if this is the main pipeline that contains the parent pass
-                if (!HasHairParentPass(renderPipeline))
-                {
-                    return;
-                }
-
-                Init(renderPipeline);
-
-                // Mark for all passes to evacuate their render data and recreate it.
-                m_forceRebuildRenderData = true;
             }
 
             bool HairFeatureProcessor::Init(RPI::RenderPipeline* renderPipeline)

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.h
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.h
@@ -113,7 +113,7 @@ namespace AZ
                 // FeatureProcessor overrides ...
                 void Activate() override;
                 void Deactivate() override;
-                void ApplyRenderPipelineChange(RPI::RenderPipeline* renderPipeline) override;
+                void AddRenderPasses(RPI::RenderPipeline* renderPipeline) override;
                 void Simulate(const FeatureProcessor::SimulatePacket& packet) override;
                 void Render(const FeatureProcessor::RenderPacket& packet) override;
 
@@ -125,9 +125,7 @@ namespace AZ
                 bool RemoveHairRenderObject(Data::Instance<HairRenderObject> renderObject);
 
                 // RPI::SceneNotificationBus overrides ...
-                void OnRenderPipelineAdded(RPI::RenderPipelinePtr renderPipeline) override;
-                void OnRenderPipelineRemoved(RPI::RenderPipeline* renderPipeline) override;
-                void OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline) override;
+                void OnRenderPipelineChanged(AZ::RPI::RenderPipeline* pipeline, AZ::RPI::SceneNotification::RenderPipelineChangeType changeType) override;
 
                 Data::Instance<HairSkinningComputePass> GetHairSkinningComputegPass();
                 Data::Instance<HairPPLLRasterPass> GetHairPPLLRasterPass();

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseGlobalIlluminationFeatureProcessor.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseGlobalIlluminationFeatureProcessor.cpp
@@ -51,14 +51,14 @@ namespace AZ
             UpdatePasses();
         }
 
-        void DiffuseGlobalIlluminationFeatureProcessor::OnRenderPipelinePassesChanged([[maybe_unused]] RPI::RenderPipeline* renderPipeline)
+        void DiffuseGlobalIlluminationFeatureProcessor::OnRenderPipelineChanged([[maybe_unused]] RPI::RenderPipeline* renderPipeline,
+                RPI::SceneNotification::RenderPipelineChangeType changeType)
         {
-            UpdatePasses();
-        }
-
-        void DiffuseGlobalIlluminationFeatureProcessor::OnRenderPipelineAdded([[maybe_unused]] RPI::RenderPipelinePtr pipeline)
-        {
-            UpdatePasses();
+            if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Added
+                || changeType == RPI::SceneNotification::RenderPipelineChangeType::PassChanged)
+            {
+                UpdatePasses();
+            }
         }
 
         void DiffuseGlobalIlluminationFeatureProcessor::UpdatePasses()

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseGlobalIlluminationFeatureProcessor.h
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseGlobalIlluminationFeatureProcessor.h
@@ -37,8 +37,7 @@ namespace AZ
             AZ_DISABLE_COPY_MOVE(DiffuseGlobalIlluminationFeatureProcessor);
 
             // RPI::SceneNotificationBus::Handler overrides
-            void OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline) override;
-            void OnRenderPipelineAdded(RPI::RenderPipelinePtr pipeline) override;
+            void OnRenderPipelineChanged(AZ::RPI::RenderPipeline* pipeline, AZ::RPI::SceneNotification::RenderPipelineChangeType changeType) override;
 
             void UpdatePasses();
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
@@ -720,33 +720,37 @@ namespace AZ
 
             AZ::RHI::ValidateStreamBufferViews(m_boxStreamLayout, m_probeGridRenderData.m_boxPositionBufferView);
         }
-
-        void DiffuseProbeGridFeatureProcessor::OnRenderPipelinePassesChanged([[maybe_unused]] RPI::RenderPipeline* renderPipeline)
+        
+        void DiffuseProbeGridFeatureProcessor::OnRenderPipelineChanged(RPI::RenderPipeline* renderPipeline,
+                RPI::SceneNotification::RenderPipelineChangeType changeType)
         {
-            // change the attachment on the AuxGeom pass to use the output of the visualization pass
-            RPI::PassFilter auxGeomPassFilter = RPI::PassFilter::CreateWithPassName(AZ::Name("AuxGeomPass"), renderPipeline);
-            RPI::Pass* auxGeomPass = RPI::PassSystemInterface::Get()->FindFirstPass(auxGeomPassFilter);
-            RPI::PassFilter visualizationPassFilter = RPI::PassFilter::CreateWithPassName(AZ::Name("DiffuseProbeGridVisualizationPass"), renderPipeline);
-            RPI::Pass* visualizationPass = RPI::PassSystemInterface::Get()->FindFirstPass(visualizationPassFilter);
-
-            if (auxGeomPass && visualizationPass && visualizationPass->GetInputOutputCount())
+            if (changeType == RPI::SceneNotification::RenderPipelineChangeType::PassChanged)
             {
-                RPI::PassAttachmentBinding& visualizationBinding = visualizationPass->GetInputOutputBinding(0);
-                RPI::PassAttachmentBinding* auxGeomBinding = auxGeomPass->FindAttachmentBinding(AZ::Name("ColorInputOutput"));
-                if (auxGeomBinding)
-                {
-                    auxGeomBinding->SetAttachment(visualizationBinding.GetAttachment());
-                }
-            }
+                // change the attachment on the AuxGeom pass to use the output of the visualization pass
+                RPI::PassFilter auxGeomPassFilter = RPI::PassFilter::CreateWithPassName(AZ::Name("AuxGeomPass"), renderPipeline);
+                RPI::Pass* auxGeomPass = RPI::PassSystemInterface::Get()->FindFirstPass(auxGeomPassFilter);
+                RPI::PassFilter visualizationPassFilter = RPI::PassFilter::CreateWithPassName(AZ::Name("DiffuseProbeGridVisualizationPass"), renderPipeline);
+                RPI::Pass* visualizationPass = RPI::PassSystemInterface::Get()->FindFirstPass(visualizationPassFilter);
 
-            UpdatePasses();
+                if (auxGeomPass && visualizationPass && visualizationPass->GetInputOutputCount())
+                {
+                    RPI::PassAttachmentBinding& visualizationBinding = visualizationPass->GetInputOutputBinding(0);
+                    RPI::PassAttachmentBinding* auxGeomBinding = auxGeomPass->FindAttachmentBinding(AZ::Name("ColorInputOutput"));
+                    if (auxGeomBinding)
+                    {
+                        auxGeomBinding->SetAttachment(visualizationBinding.GetAttachment());
+                    }
+                }
+
+                UpdatePasses();
+            }
             m_needUpdatePipelineStates = true;
         }
-
-        void DiffuseProbeGridFeatureProcessor::OnRenderPipelineAdded([[maybe_unused]] RPI::RenderPipelinePtr renderPipeline)
+                
+        void DiffuseProbeGridFeatureProcessor::AddRenderPasses(AZ::RPI::RenderPipeline* renderPipeline)
         {
             // only add to this pipeline if it contains the DiffuseGlobalFullscreen pass
-            RPI::PassFilter diffuseGlobalFullscreenPassFilter = RPI::PassFilter::CreateWithPassName(AZ::Name("DiffuseGlobalFullscreenPass"), renderPipeline.get());
+            RPI::PassFilter diffuseGlobalFullscreenPassFilter = RPI::PassFilter::CreateWithPassName(AZ::Name("DiffuseGlobalFullscreenPass"), renderPipeline);
             RPI::Pass* diffuseGlobalFullscreenPass = RPI::PassSystemInterface::Get()->FindFirstPass(diffuseGlobalFullscreenPassFilter);
             if (!diffuseGlobalFullscreenPass)
             {
@@ -754,20 +758,20 @@ namespace AZ
             }
 
             // check to see if the DiffuseProbeGrid passes were already added
-            RPI::PassFilter diffuseProbeGridUpdatePassFilter = RPI::PassFilter::CreateWithPassName(AZ::Name("DiffuseProbeGridUpdatePass"), renderPipeline.get());
+            RPI::PassFilter diffuseProbeGridUpdatePassFilter = RPI::PassFilter::CreateWithPassName(AZ::Name("DiffuseProbeGridUpdatePass"), renderPipeline);
             RPI::Pass* diffuseProbeGridUpdatePass = RPI::PassSystemInterface::Get()->FindFirstPass(diffuseProbeGridUpdatePassFilter);
 
             if (!diffuseProbeGridUpdatePass)
             {
-                AddPassRequest(renderPipeline.get(), "Passes/DiffuseProbeGridUpdatePassRequest.azasset", "DepthPrePass");
-                AddPassRequest(renderPipeline.get(), "Passes/DiffuseProbeGridRenderPassRequest.azasset", "ForwardSubsurface");
+                AddPassRequest(renderPipeline, "Passes/DiffuseProbeGridUpdatePassRequest.azasset", "DepthPrePass");
+                AddPassRequest(renderPipeline, "Passes/DiffuseProbeGridRenderPassRequest.azasset", "ForwardSubsurface");
 
                 // only add the visualization pass if there's an AuxGeom pass in the pipeline
-                RPI::PassFilter auxGeomPassFilter = RPI::PassFilter::CreateWithPassName(AZ::Name("AuxGeomPass"), renderPipeline.get());
+                RPI::PassFilter auxGeomPassFilter = RPI::PassFilter::CreateWithPassName(AZ::Name("AuxGeomPass"), renderPipeline);
                 RPI::Pass* auxGeomPass = RPI::PassSystemInterface::Get()->FindFirstPass(auxGeomPassFilter);
                 if (auxGeomPass)
                 {
-                    AddPassRequest(renderPipeline.get(), "Passes/DiffuseProbeGridVisualizationPassRequest.azasset", "PostProcessPass");
+                    AddPassRequest(renderPipeline, "Passes/DiffuseProbeGridVisualizationPassRequest.azasset", "PostProcessPass");
                 }
 
                 // disable the DiffuseGlobalFullscreenPass if it exists, since it is replaced with a DiffuseProbeGrid composite pass
@@ -777,12 +781,7 @@ namespace AZ
             UpdatePasses();
             m_needUpdatePipelineStates = true;
         }
-
-        void DiffuseProbeGridFeatureProcessor::OnRenderPipelineRemoved([[maybe_unused]] RPI::RenderPipeline* pipeline)
-        {
-            m_needUpdatePipelineStates = true;
-        }
-
+        
         void DiffuseProbeGridFeatureProcessor::AddPassRequest(RPI::RenderPipeline* renderPipeline, const char* passRequestAssetFilePath, const char* insertionPointPassName)
         {
             auto passRequestAsset = RPI::AssetUtils::LoadAssetByProductPath<RPI::AnyAsset>(passRequestAssetFilePath, RPI::AssetUtils::TraceLevel::Warning);

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.h
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.h
@@ -133,9 +133,10 @@ namespace AZ
             // RPI::SceneNotificationBus::Handler overrides
             void OnBeginPrepareRender() override;
             void OnEndPrepareRender() override;
-            void OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline) override;
-            void OnRenderPipelineAdded(RPI::RenderPipelinePtr renderPipeline) override;
-            void OnRenderPipelineRemoved(RPI::RenderPipeline* renderPipeline) override;
+            void OnRenderPipelineChanged(RPI::RenderPipeline* pipeline, RPI::SceneNotification::RenderPipelineChangeType changeType) override;
+            
+            // FeatureProcessor overrides
+            void AddRenderPasses(RPI::RenderPipeline* renderPipeline) override;
 
             void AddPassRequest(RPI::RenderPipeline* renderPipeline, const char* passRequestAssetFilePath, const char* insertionPointPassName);
             void UpdatePipelineStates();

--- a/Gems/LyShine/Code/Source/LyShineFeatureProcessor.cpp
+++ b/Gems/LyShine/Code/Source/LyShineFeatureProcessor.cpp
@@ -27,21 +27,7 @@ namespace LyShine
         }
     }
 
-    void LyShineFeatureProcessor::Activate()
-    {
-        EnableSceneNotification();
-    }
-
-    void LyShineFeatureProcessor::Deactivate()
-    {        
-        DisableSceneNotification();
-    }
-
-    void LyShineFeatureProcessor::OnRenderPipelinePassesChanged([[maybe_unused]] AZ::RPI::RenderPipeline* renderPipeline)
-    {
-    }
-
-    void LyShineFeatureProcessor::ApplyRenderPipelineChange(AZ::RPI::RenderPipeline* renderPipeline)
+    void LyShineFeatureProcessor::AddRenderPasses(AZ::RPI::RenderPipeline* renderPipeline)
     {
         // Get the pass request to create LyShine parent pass from the asset
         const char* passRequestAssetFilePath = "Passes/LyShinePassRequest.azasset";

--- a/Gems/LyShine/Code/Source/LyShineFeatureProcessor.h
+++ b/Gems/LyShine/Code/Source/LyShineFeatureProcessor.h
@@ -26,16 +26,8 @@ namespace LyShine
         LyShineFeatureProcessor() = default;
         ~LyShineFeatureProcessor() = default;
 
+    private:        
         // AZ::RPI::FeatureProcessor overrides...
-        void Activate() override;
-        void Deactivate() override;
-
-    private:
-
-        // AZ::RPI::SceneNotificationBus overrides...
-        void OnRenderPipelinePassesChanged(AZ::RPI::RenderPipeline* renderPipeline) override;
-        
-        // AZ::RPI::FeatureProcessor overrides...
-        void ApplyRenderPipelineChange(AZ::RPI::RenderPipeline* renderPipeline) override;
+        void AddRenderPasses(AZ::RPI::RenderPipeline* renderPipeline) override;
     };
 }

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsFeatureProcessor.cpp
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsFeatureProcessor.cpp
@@ -209,7 +209,7 @@ namespace AZ
 
         // This method will be called by the scene to establish all required injections
         // to the pass pipeline
-        void MeshletsFeatureProcessor::ApplyRenderPipelineChange(RPI::RenderPipeline* renderPipeline)
+        void MeshletsFeatureProcessor::AddRenderPasses(RPI::RenderPipeline* renderPipeline)
         {
             AddMeshletsPassesToPipeline(renderPipeline);
         }
@@ -408,39 +408,24 @@ namespace AZ
             m_renderPass->AddDrawPackets(drawPackets);
         }
 
-        void MeshletsFeatureProcessor::OnRenderPipelinePassesChanged([[maybe_unused]] RPI::RenderPipeline* renderPipeline)
+        void MeshletsFeatureProcessor::OnRenderPipelineChanged(RPI::RenderPipeline* renderPipeline, RPI::SceneNotification::RenderPipelineChangeType changeType)
         {
             if (!HasMeshletPasses(renderPipeline))
             {   // This pipeline is not relevant - exist without changing anything.
                 return;
             }
 
-            m_renderPipeline = renderPipeline;
-            CreateResources();
-            Init(m_renderPipeline);
-        }
-
-        void MeshletsFeatureProcessor::OnRenderPipelineAdded([[maybe_unused]] RPI::RenderPipelinePtr renderPipeline)
-        {
-            if (!HasMeshletPasses(renderPipeline.get()))
-            {   // This pipeline is not relevant - exist without changing anything.
-                return;
+            if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Added
+                || changeType == RPI::SceneNotification::RenderPipelineChangeType::PassChanged)
+            {
+                m_renderPipeline = renderPipeline;
+                CreateResources();
+                Init(m_renderPipeline);
             }
-
-            m_renderPipeline = renderPipeline.get();
-            CreateResources();
-            Init(m_renderPipeline);
-        }
-
-        void MeshletsFeatureProcessor::OnRenderPipelineRemoved([[maybe_unused]] RPI::RenderPipeline* renderPipeline)
-        {
-            if (!HasMeshletPasses(renderPipeline))
-            {   // This pipeline is not relevant - exist without changing anything.
-                return;
+            else if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Removed)
+            {
+                m_renderPipeline = nullptr;
             }
-
-            m_renderPipeline = nullptr;
         }
-
     } // namespace AtomSceneStream
 } // namespace AZ

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsFeatureProcessor.h
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsFeatureProcessor.h
@@ -63,7 +63,7 @@ namespace AZ
             // FeatureProcessor overrides ...
             void Activate() override;
             void Deactivate() override;
-            void ApplyRenderPipelineChange(RPI::RenderPipeline* renderPipeline) override;
+            void AddRenderPasses(RPI::RenderPipeline* renderPipeline) override;
             void Simulate(const FeatureProcessor::SimulatePacket& packet) override;
             void Render(const FeatureProcessor::RenderPacket& packet) override;
 
@@ -73,11 +73,6 @@ namespace AZ
             // AZ::TickBus::Handler overrides
             void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
             int GetTickOrder() override;
-
-            // RPI::SceneNotificationBus overrides ...
-            void OnRenderPipelineAdded(RPI::RenderPipelinePtr renderPipeline) override;
-            void OnRenderPipelineRemoved(RPI::RenderPipeline* renderPipeline) override;
-            void OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline) override;
 
             void SetTransform(
                 const Render::TransformServiceFeatureProcessorInterface::ObjectId objectId,
@@ -90,6 +85,9 @@ namespace AZ
             Data::Instance<RPI::Shader> GetRenderShader() { return m_renderShader; }
 
         protected:
+            // RPI::SceneNotificationBus overrides ...
+            void OnRenderPipelineChanged(RPI::RenderPipeline* pipeline, RPI::SceneNotification::RenderPipelineChangeType changeType) override;
+
             bool BuildDrawPacket(
                 ModelLodDataArray& lodRenderDataArray,
                 Render::TransformServiceFeatureProcessorInterface::ObjectId objectId);

--- a/Gems/Stars/Code/Source/StarsFeatureProcessor.cpp
+++ b/Gems/Stars/Code/Source/StarsFeatureProcessor.cpp
@@ -195,39 +195,42 @@ namespace AZ::Render
         m_updateShaderConstants = true;
     }
 
-    void StarsFeatureProcessor::OnRenderPipelineAdded([[maybe_unused]] RPI::RenderPipelinePtr renderPipeline)
+    void StarsFeatureProcessor::OnRenderPipelineChanged([[maybe_unused]] AZ::RPI::RenderPipeline* renderPipeline,
+        AZ::RPI::SceneNotification::RenderPipelineChangeType changeType)
     {
-        if(!m_meshPipelineState)
+        if (changeType == AZ::RPI::SceneNotification::RenderPipelineChangeType::Added)
         {
-            m_meshPipelineState = aznew RPI::PipelineStateForDraw;
-            m_meshPipelineState->Init(m_shader);
+            if(!m_meshPipelineState)
+            {
+                m_meshPipelineState = aznew RPI::PipelineStateForDraw;
+                m_meshPipelineState->Init(m_shader);
 
 
-            RHI::InputStreamLayoutBuilder layoutBuilder;
-            layoutBuilder.AddBuffer()
-                ->Channel("POSITION", RHI::Format::R32G32B32_FLOAT)
-                ->Channel("COLOR", RHI::Format::R8G8B8A8_UNORM);
-            layoutBuilder.SetTopology(RHI::PrimitiveTopology::TriangleList);
-            auto inputStreamLayout = layoutBuilder.End();
+                RHI::InputStreamLayoutBuilder layoutBuilder;
+                layoutBuilder.AddBuffer()
+                    ->Channel("POSITION", RHI::Format::R32G32B32_FLOAT)
+                    ->Channel("COLOR", RHI::Format::R8G8B8A8_UNORM);
+                layoutBuilder.SetTopology(RHI::PrimitiveTopology::TriangleList);
+                auto inputStreamLayout = layoutBuilder.End();
 
-            m_meshPipelineState->SetInputStreamLayout(inputStreamLayout);
-            m_meshPipelineState->SetOutputFromScene(GetParentScene());
-            m_meshPipelineState->Finalize();
+                m_meshPipelineState->SetInputStreamLayout(inputStreamLayout);
+                m_meshPipelineState->SetOutputFromScene(GetParentScene());
+                m_meshPipelineState->Finalize();
 
-            UpdateDrawPacket();
-            UpdateBackgroundClearColor();
+                UpdateDrawPacket();
+                UpdateBackgroundClearColor();
+            }
         }
-    }
-
-    void StarsFeatureProcessor::OnRenderPipelinePassesChanged([[maybe_unused]] RPI::RenderPipeline* renderPipeline)
-    {
-        if(m_meshPipelineState)
+        else if (changeType == AZ::RPI::SceneNotification::RenderPipelineChangeType::PassChanged)
         {
-            m_meshPipelineState->SetOutputFromScene(GetParentScene());
-            m_meshPipelineState->Finalize();
+            if(m_meshPipelineState)
+            {
+                m_meshPipelineState->SetOutputFromScene(GetParentScene());
+                m_meshPipelineState->Finalize();
 
-            UpdateDrawPacket();
-            UpdateBackgroundClearColor();
+                UpdateDrawPacket();
+                UpdateBackgroundClearColor();
+            }
         }
     }
 

--- a/Gems/Stars/Code/Source/StarsFeatureProcessor.h
+++ b/Gems/Stars/Code/Source/StarsFeatureProcessor.h
@@ -48,8 +48,7 @@ namespace AZ::Render
 
     protected:
         //! RPI::SceneNotificationBus
-        void OnRenderPipelineAdded(RPI::RenderPipelinePtr renderPipeline) override;
-        void OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline) override;
+        void OnRenderPipelineChanged(RPI::RenderPipeline* pipeline, RPI::SceneNotification::RenderPipelineChangeType changeType) override;
 
         //! RPI::ViewportContextIdNotificationBus
         void OnViewportSizeChanged(AzFramework::WindowSize size) override;

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.cpp
@@ -130,14 +130,14 @@ namespace Terrain
         }
     }
 
-    void TerrainFeatureProcessor::OnRenderPipelineAdded([[maybe_unused]] AZ::RPI::RenderPipelinePtr pipeline)
+    void TerrainFeatureProcessor::OnRenderPipelineChanged([[maybe_unused]] AZ::RPI::RenderPipeline* renderPipeline,
+        AZ::RPI::SceneNotification::RenderPipelineChangeType changeType)
     {
-        CachePasses();
-    }
-
-    void TerrainFeatureProcessor::OnRenderPipelinePassesChanged([[maybe_unused]] AZ::RPI::RenderPipeline* renderPipeline)
-    {
-        CachePasses();
+        if (changeType == AZ::RPI::SceneNotification::RenderPipelineChangeType::Added
+            || changeType == AZ::RPI::SceneNotification::RenderPipelineChangeType::PassChanged)
+        {
+            CachePasses();
+        }
     }
 
     void AddPassRequestToRenderPipeline(
@@ -192,7 +192,7 @@ namespace Terrain
         }
     }
 
-    void TerrainFeatureProcessor::ApplyRenderPipelineChange(AZ::RPI::RenderPipeline* renderPipeline)
+    void TerrainFeatureProcessor::AddRenderPasses(AZ::RPI::RenderPipeline* renderPipeline)
     {
         // Get the pass requests to create passes from the asset
         AddPassRequestToRenderPipeline(renderPipeline, "Passes/TerrainPassRequest.azasset", "DepthPrePass", true);

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.h
@@ -81,11 +81,10 @@ namespace Terrain
         void OnTerrainDataChanged(const AZ::Aabb& dirtyRegion, TerrainDataChangedMask dataChangedMask) override;
 
         // AZ::RPI::SceneNotificationBus overrides...
-        void OnRenderPipelineAdded(AZ::RPI::RenderPipelinePtr pipeline) override;
-        void OnRenderPipelinePassesChanged(AZ::RPI::RenderPipeline* renderPipeline) override;
+        void OnRenderPipelineChanged(AZ::RPI::RenderPipeline* pipeline, AZ::RPI::SceneNotification::RenderPipelineChangeType changeType) override;
         
         // AZ::RPI::FeatureProcessor overrides...
-        void ApplyRenderPipelineChange(AZ::RPI::RenderPipeline* renderPipeline) override;
+        void AddRenderPasses(AZ::RPI::RenderPipeline* renderPipeline) override;
 
         void Initialize();
 

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
@@ -157,14 +157,12 @@ namespace Terrain
         m_rebuildSectors = true;
     }
 
-    void TerrainMeshManager::OnRenderPipelineAdded([[maybe_unused]] AZ::RPI::RenderPipelinePtr pipeline)
+    void TerrainMeshManager::OnRenderPipelineChanged([[maybe_unused]] AZ::RPI::RenderPipeline* pipeline, AZ::RPI::SceneNotification::RenderPipelineChangeType changeType)
     {
-        m_rebuildDrawPackets = true;
-    }
-
-    void TerrainMeshManager::OnRenderPipelinePassesChanged([[maybe_unused]] AZ::RPI::RenderPipeline* renderPipeline)
-    {
-        m_rebuildDrawPackets = true;
+        if (changeType == RenderPipelineChangeType::Added || changeType == RenderPipelineChangeType::PassChanged)
+        {
+            m_rebuildDrawPackets = true;
+        }
     }
 
     void TerrainMeshManager::Update(const AZ::RPI::ViewPtr mainView, AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>& terrainSrg)

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.h
@@ -210,8 +210,7 @@ namespace Terrain
         };
 
         // AZ::RPI::SceneNotificationBus overrides...
-        void OnRenderPipelineAdded(AZ::RPI::RenderPipelinePtr pipeline) override;
-        void OnRenderPipelinePassesChanged(AZ::RPI::RenderPipeline* renderPipeline) override;
+        void OnRenderPipelineChanged(AZ::RPI::RenderPipeline* pipeline, AZ::RPI::SceneNotification::RenderPipelineChangeType changeType) override;
 
         // AzFramework::Terrain::TerrainDataNotificationBus overrides...
         void OnTerrainDataCreateEnd() override;


### PR DESCRIPTION
## What does this PR do?
This is to simplify the render pipeline change notification to one function because the operation inside each are often the same.
It also rename AZ::RPI::FeatureProcessor::ApplyRenderPipelineChange() to AZ::RPI::FeatureProcessor::AddRenderPasses() to clarify the intention of this function.
(https://github.com/o3de/o3de/issues/12687)

## How was this PR tested?
O3DE editor
ASV Screenshot tests.
