### PR TITLE
fix for crash on invalid cylinder collider subdivision count

### DIFF
--- a/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
@@ -62,6 +62,8 @@ namespace PhysX
                         ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &EditorProxyCylinderShapeConfig::m_subdivisionCount,
                         "Subdivision", "Cylinder subdivision count.")
+                        ->Attribute(AZ::Edit::Attributes::Min, Utils::MinFrustumSubdivisions)
+                        ->Attribute(AZ::Edit::Attributes::Max, Utils::MaxFrustumSubdivisions)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &EditorProxyCylinderShapeConfig::m_height, "Height", "Cylinder height.")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &EditorProxyCylinderShapeConfig::m_radius, "Radius", "Cylinder radius.")
                     ;
@@ -1500,7 +1502,16 @@ namespace PhysX
 
     void EditorColliderComponent::SetCylinderSubdivisionCount(AZ::u8 subdivisionCount)
     {
-        m_shapeConfiguration.m_cylinder.m_subdivisionCount = subdivisionCount;
+        const AZ::u8 clampedSubdivisionCount = AZ::GetClamp(subdivisionCount, Utils::MinFrustumSubdivisions, Utils::MaxFrustumSubdivisions);
+        AZ_Warning(
+            "PhysX",
+            clampedSubdivisionCount == subdivisionCount,
+            "Requested cylinder subdivision count %d clamped into allowed range (%d - %d). Entity: %s",
+            subdivisionCount,
+            Utils::MinFrustumSubdivisions,
+            Utils::MaxFrustumSubdivisions,
+            GetEntity()->GetName().c_str());
+        m_shapeConfiguration.m_cylinder.m_subdivisionCount = clampedSubdivisionCount;
         UpdateCylinderCookedMesh();
         CreateStaticEditorCollider();
     }

--- a/Gems/PhysX/Code/Tests/RigidBodyComponentTests.cpp
+++ b/Gems/PhysX/Code/Tests/RigidBodyComponentTests.cpp
@@ -201,4 +201,31 @@ namespace PhysXEditorTests
         EXPECT_EQ(expectedError.GetErrorCount(), 1);
     }
 
+    TEST_F(PhysXEditorFixture, EditorRigidBodyComponent_CylinderColliderSetInvalidSubdivisions_WarningIssued)
+    {
+        // Create editor entities
+        EntityPtr editorEntity = CreateInactiveEditorEntity("InvalidSubdivisions");
+
+        UnitTest::ErrorHandler expectedError("clamped into allowed range");
+
+        editorEntity->CreateComponent<PhysX::EditorRigidBodyComponent>();
+        const auto* colliderComponent = editorEntity->CreateComponent<PhysX::EditorColliderComponent>();
+
+        editorEntity->Activate();
+
+        AZ::EntityComponentIdPair idPair(editorEntity->GetId(), colliderComponent->GetId());
+
+        // Set collider to be a cylinder
+        const Physics::ShapeType shapeType = Physics::ShapeType::Cylinder;
+        PhysX::EditorColliderComponentRequestBus::Event(idPair, &PhysX::EditorColliderComponentRequests::SetShapeType, shapeType);
+
+        // Set collider subdivision values outside the allowed range
+        const AZ::u8 subdivisionsTooSmall = PhysX::Utils::MinFrustumSubdivisions - 1;
+        PhysX::EditorColliderComponentRequestBus::Event(idPair, &PhysX::EditorColliderComponentRequests::SetCylinderSubdivisionCount, subdivisionsTooSmall);
+        EXPECT_EQ(expectedError.GetWarningCount(), 1);
+
+        const AZ::u8 subdivisionsTooLarge = PhysX::Utils::MaxFrustumSubdivisions + 1;
+        PhysX::EditorColliderComponentRequestBus::Event(idPair, &PhysX::EditorColliderComponentRequests::SetCylinderSubdivisionCount, subdivisionsTooLarge);
+        EXPECT_EQ(expectedError.GetWarningCount(), 2);
+    }
 } // namespace PhysXEditorTests


### PR DESCRIPTION
Signed-off-by: greerdv <greerdv@amazon.com>

## What does this PR do?
Fixes crash when setting cylinder collider subdivision count to invalid value (fixes #12608)

## How was this PR tested?
Unit test plus manual testing in editor.
