### PR TITLE
Fixed casing issue for Linux for automated UDP test

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/PythonAssetBuilder/TestSuite_Periodic.py
+++ b/AutomatedTesting/Gem/PythonTests/PythonAssetBuilder/TestSuite_Periodic.py
@@ -49,7 +49,8 @@ class TestAutomation(EditorTestSuite):
 
             # compute the file name to the .dbgsg file
             root, _ = os.path.splitext(instance.default_mat_file)
-            dbgsg_path = os.path.join(cache_folder, root + ".dbgsg").lower()
+            # The full path to the Asset Cache on Linux is not all lowercase
+            dbgsg_path = os.path.join(cache_folder, root + ".dbgsg")
             if os.path.isfile(dbgsg_path) == False:
                 raise Exception(f"Missing file {dbgsg_path}")
 


### PR DESCRIPTION
## What does this PR do?

This test was looking for this path on Jenkins:
/data/workspace/o3de/automatedtesting/cache/linux/assets/ap_test_assets/default_mat_5455996710058.dbgsg

But the file was at this path:
/data/workspace/o3de/AutomatedTesting/Cache/linux/assets/ap_test_assets/default_mat_5455996710058.dbgsg

## How was this PR tested?

Tested on Windows locally, will wait for weekly periodic job to run to validate on Jenkins.
