### PR TITLE
Added quit option for performance collection.

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Private/PerformanceCVarManager.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/PerformanceCVarManager.cpp
@@ -118,5 +118,11 @@ namespace AZ
             ConsoleFunctorFlags::DontReplicate,
             "Number of frames in which performance will be measured per batch.");
 
+        AZ_CVAR(bool, r_metricsQuitUponCompletion,
+            false, // If true the application will quit when Number Of Capture Batches reaches 0.
+            nullptr,
+            ConsoleFunctorFlags::DontReplicate,
+            "If true the application will quit when Number Of Capture Batches reaches 0.");
+
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
@@ -20,9 +20,11 @@
 #include <AzCore/NativeUI/NativeUIRequests.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/PlatformId/PlatformId.h>
 
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzFramework/CommandLine/CommandLine.h>
+#include <AzFramework/Components/ConsoleBus.h>
 
 #ifdef RPI_EDITOR
 #include <Atom/RPI.Edit/Material/MaterialFunctorSourceDataRegistration.h>
@@ -185,12 +187,26 @@ namespace AZ
         AZ_CVAR_EXTERNED(AZ::CVarFixedString, r_metricsDataLogType);
         AZ_CVAR_EXTERNED(AZ::u32, r_metricsWaitTimePerCaptureBatch);
         AZ_CVAR_EXTERNED(AZ::u32, r_metricsFrameCountPerCaptureBatch);
+        AZ_CVAR_EXTERNED(bool, r_metricsQuitUponCompletion);
+
+        AZStd::string RPISystemComponent::GetLogCategory()
+        {
+            AZStd::string platformName = AZ::GetPlatformName(AZ::g_currentPlatform);
+            AZ::Name apiName = AZ::RHI::Factory::Get().GetName();
+            auto logCategory = AZStd::string::format("%.*s-%s-%s", AZ_STRING_ARG(PerformanceLogCategory), platformName.c_str(), apiName.GetCStr());
+            return logCategory;
+        }
 
         void RPISystemComponent::InitializePerformanceCollector()
         {
             auto onBatchCompleteCallback = [](AZ::u32 pendingBatches) {
                 AZ_TracePrintf("RPISystem", "Completed a performance batch, still %u batches are pending.\n", pendingBatches);
                 r_metricsNumberOfCaptureBatches = pendingBatches;
+                if (r_metricsQuitUponCompletion && (pendingBatches == 0))
+                {
+                    AzFramework::ConsoleRequestBus::Broadcast(
+                        &AzFramework::ConsoleRequests::ExecuteConsoleCommand, "quit");
+                }
             };
 
             auto performanceMetrics = AZStd::to_array<AZStd::string_view>({
@@ -198,8 +214,9 @@ namespace AZ
                 PerformanceSpecGraphicsRenderTime,
                 PerformanceSpecEngineCpuTime,
                 });
+            AZStd::string logCategory = GetLogCategory();
             m_performanceCollector = AZStd::make_unique<AZ::Debug::PerformanceCollector>(
-                PerformanceLogCategory, performanceMetrics, onBatchCompleteCallback);
+                logCategory, performanceMetrics, onBatchCompleteCallback);
             //Feed the CVAR values.
             m_performanceCollector->UpdateDataLogType(GetDataLogTypeFromCVar(r_metricsDataLogType));
             m_performanceCollector->UpdateFrameCountPerCaptureBatch(r_metricsFrameCountPerCaptureBatch);

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.h
@@ -78,6 +78,11 @@ namespace AZ
 
             ///////////////////////////////////////////////////////////////////
             // Performance Collection
+
+            //! Returns "Graphics-<OS>-<RHI>" string, which will be part of the output filename.
+            //! It will make it easy to keep vulkan and dx12 results side by side.
+            AZStd::string GetLogCategory();
+
             void InitializePerformanceCollector();
 
             static constexpr AZStd::string_view PerformanceLogCategory = "Graphics";


### PR DESCRIPTION
## What does this PR do?
Added new CVAR named `r_metricsQuitUponCompletion`, defaults to false. When true the application will quit when all frame batches have been measured for performance.

Added OS name and RHI name to the Log Category name: `Graphics-<OS>-<RHI>`. It will make it easy to keep vulkan and dx12 results side by side and easy to identify.

## How was this PR tested?

This is a cosmetic change but I made sure the GameLauncher  quits when all frames have been measured for performance.
Also made sure the output json file has the new name format: "Performance_Graphics-OS-RHI_DATE.json".

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>
