### PR TITLE
Bugfix for switcher defaulting back to Transform.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeCollection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeCollection.cpp
@@ -213,7 +213,7 @@ namespace AzToolsFramework
         void ComponentModeCollection::BeginComponentMode()
         {
             m_selectedComponentModeIndex = 0;
-            m_componentMode = true;
+            m_componentModeState = ComponentModeState::Active;
             m_adding = false;
 
             // notify listeners the editor has entered ComponentMode - listeners may
@@ -287,6 +287,10 @@ namespace AzToolsFramework
                 componentModeCommand.release();
             }
 
+            // Change our state from "Active" to "Stopping", so that any code that executes during deactivation that checks to see
+            // if component mode is active will see that it is not.
+            m_componentModeState = ComponentModeState::Stopping;
+
             // notify listeners the editor has left ComponentMode - listeners may
             // wish to modify state to indicate this (e.g. appearance, functionality etc.)
             m_viewportEditorModeTracker->DeactivateMode({ GetEntityContextId() }, ViewportEditorMode::Component);
@@ -305,8 +309,10 @@ namespace AzToolsFramework
             m_activeComponentTypes.clear();
             m_viewportUiHandlers.clear();
 
-            m_componentMode = false;
             m_selectedComponentModeIndex = 0;
+
+            // Finished stopping component mode, so transition to a "Stopped" state.
+            m_componentModeState = ComponentModeState::Stopped;
         }
 
         void ComponentModeCollection::Refresh(const AZ::EntityComponentIdPair& entityComponentIdPair)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeCollection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeCollection.h
@@ -57,7 +57,7 @@ namespace AzToolsFramework
             void AddOtherSelectedEntityModes();
 
             /// Return is the Editor-wide ComponentMode state active.
-            bool InComponentMode() const { return m_componentMode; }
+            bool InComponentMode() const { return m_componentModeState == ComponentModeState::Active; }
             /// Are ComponentModes in the process of being added.
             /// Used to determine if other selected entities with the same Component type should also be added.
             bool ModesAdded() const { return m_adding; }
@@ -95,6 +95,13 @@ namespace AzToolsFramework
             AZStd::vector<AZ::Uuid> GetComponentTypes() const override;
 
         private:
+            enum class ComponentModeState : uint8_t
+            {
+                Active,
+                Stopping,
+                Stopped
+            };
+
             // Internal helper used by Select[|Prev|Next]ActiveComponentMode
             bool ActiveComponentModeChanged(const AZ::Uuid& previousComponentType);
 
@@ -106,7 +113,8 @@ namespace AzToolsFramework
 
             size_t m_selectedComponentModeIndex = 0; ///< Index into the array of active ComponentModes, current index is 'selected' ComponentMode.
             bool m_adding = false; ///< Are we currently adding individual ComponentModes to the Editor wide ComponentMode.
-            bool m_componentMode = false; ///< Editor (global) ComponentMode flag - is ComponentMode active or not.
+            /// Editor (global) ComponentMode state - is ComponentMode active or not.
+            ComponentModeState m_componentModeState = ComponentModeState::Stopped; 
             ViewportEditorModeTrackerInterface* m_viewportEditorModeTracker = nullptr; //!< Tracker for activating/deactivating viewport editor modes.
         };
     } // namespace ComponentModeFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
@@ -285,28 +285,20 @@ namespace AzToolsFramework::ComponentModeFramework
         if (mode == ViewportEditorMode::Component)
         {
             // when component mode ends, change the active button to transform
-            // this waits one frame in case component mode is switching to another component
-            // instead of ending
             m_activeSwitcherComponent = nullptr;
 
-            QTimer::singleShot(
-                1,
-                nullptr,
-                [this]()
-                {
-                    bool inComponentMode = false;
-                    AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequestBus::BroadcastResult(
-                        inComponentMode, &ComponentModeSystemRequests::InComponentMode);
+            bool inComponentMode = false;
+            AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequestBus::BroadcastResult(
+                inComponentMode, &ComponentModeSystemRequests::InComponentMode);
 
-                    if (!inComponentMode)
-                    {
-                        ViewportUi::ViewportUiRequestBus::Event(
-                            ViewportUi::DefaultViewportId,
-                            &ViewportUi::ViewportUiRequestBus::Events::SetSwitcherActiveButton,
-                            m_switcherId,
-                            m_transformButtonId);
-                    }
-                });
+            if (!inComponentMode)
+            {
+                ViewportUi::ViewportUiRequestBus::Event(
+                    ViewportUi::DefaultViewportId,
+                    &ViewportUi::ViewportUiRequestBus::Events::SetSwitcherActiveButton,
+                    m_switcherId,
+                    m_transformButtonId);
+            }
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

The Image Gradient Component Mode wasn't defaulting back to Transform on exit. This was happening because in its exit code, it ran multiple event ticks while showing a progress bar during image asset saving, and the component switcher was using a timer to defer some logic to switch to Transform after the Component Mode ended. Since the mode hadn't fully ended at the point the timer triggered, the switch never occurred.

This change adds more information to make it clear that the component mode has begun ending, so the switcher no longer needs to defer its logic and it can handle things immediately.

## How was this PR tested?

Manually switched between Tube, Spline, Image Gradient, and Transform multiple times successfully.
