### PR TITLE
Extern the AZStd::fixed_string<1024> template instantiation

### DIFF
--- a/Code/Framework/AzCore/AzCore/std/azstd_files.cmake
+++ b/Code/Framework/AzCore/AzCore/std/azstd_files.cmake
@@ -169,6 +169,7 @@ set(FILES
     string/alphanum.cpp
     string/alphanum.h
     string/conversions.h
+    string/fixed_string.cpp
     string/fixed_string.h
     string/fixed_string.inl
     string/memorytoascii.h

--- a/Code/Framework/AzCore/AzCore/std/string/fixed_string.cpp
+++ b/Code/Framework/AzCore/AzCore/std/string/fixed_string.cpp
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <AzCore/std/string/fixed_string.h>
+
+namespace AZStd
+{
+    template class basic_fixed_string<char, 1024>;
+} // namespace AZStd

--- a/Code/Framework/AzCore/AzCore/std/string/fixed_string.h
+++ b/Code/Framework/AzCore/AzCore/std/string/fixed_string.h
@@ -489,6 +489,9 @@ namespace AZStd
     template<class Element, size_t MaxElementCount, class Traits>
     struct hash<basic_fixed_string<Element, MaxElementCount, Traits>>;
 
+    // Extern common fixed_string types
+    extern template class basic_fixed_string<char, 1024>;
+
 } // namespace AZStd
 
 #include <AzCore/std/string/fixed_string.inl>

--- a/Code/Framework/AzCore/AzCore/std/string/fixed_string.inl
+++ b/Code/Framework/AzCore/AzCore/std/string/fixed_string.inl
@@ -655,9 +655,9 @@ namespace AZStd
     {   // insert count * elem at insertPos
         const_pointer insertPosPtr = insertPos;
 
-        pointer data = m_buffer;
         size_type offset = insertPosPtr - data();
-        return insert(offset, count, ch);
+        insert(offset, count, ch);
+        return data() + offset;
     }
 
     template<class Element, size_t MaxElementCount, class Traits>


### PR DESCRIPTION
This reduces the number of template instantiations down to 1.

Externing the fixed_string<1024> class exposed a compiler error in the insert function, which is the other change

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Built the and ran the AzCore.Tests

