### PR TITLE
Prism/edit gem workflow

### DIFF
--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
@@ -483,4 +483,26 @@ namespace O3DE::ProjectManager
         }
     }
 
+    void CreateGem::ResetWorkflow(const GemInfo& oldGemInfo)
+    {
+        //details page
+        m_gemDisplayName->lineEdit()->setText(oldGemInfo.m_displayName);
+        m_gemName->lineEdit()->setText(oldGemInfo.m_name);
+        m_gemSummary->lineEdit()->setText(oldGemInfo.m_summary);
+        m_requirements->lineEdit()->setText(oldGemInfo.m_requirement);
+        m_license->lineEdit()->setText(oldGemInfo.m_licenseText);
+        m_licenseURL->lineEdit()->setText(oldGemInfo.m_licenseLink);
+        m_documentationURL->lineEdit()->setText(oldGemInfo.m_documentationLink);
+        m_gemLocation->lineEdit()->setText(oldGemInfo.m_path);
+        m_gemIconPath->lineEdit()->setText(oldGemInfo.m_iconPath);
+        m_userDefinedGemTags->setTags(oldGemInfo.m_features);
+
+        //creator details page
+        m_origin->lineEdit()->setText(oldGemInfo.m_origin);
+        m_originURL->lineEdit()->setText(oldGemInfo.m_originURL);
+        m_repositoryURL->lineEdit()->setText(oldGemInfo.m_repoUri);
+
+        //this will be ported over to a new EditGem class. There are a lot of subtle details, like removing the template selection, pre-filling gem values like type, and disabling folder editing, that are better handled on a separate class.
+    }
+
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
@@ -642,7 +642,8 @@ namespace O3DE::ProjectManager
 
         m_gemIconPath->lineEdit()->setText(oldGemInfo.m_iconPath);
 
-        //before settings the tags field, find a tag that includes the gem name, and remove it
+        //Gem name is included in tags. Since the user can override this by setting the name field
+        //we should remove it from the tag list to prevent unintended consequences
         QStringList tagsToEdit = oldGemInfo.m_features;
         tagsToEdit.removeAll(oldGemInfo.m_name);
         m_userDefinedGemTags->setTags(tagsToEdit);

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
@@ -39,14 +39,6 @@ namespace O3DE::ProjectManager
 
         m_header = new ScreenHeader();
         m_header->setSubTitle(tr("Create a new gem"));
-        connect(
-            m_header->backButton(),
-            &QPushButton::clicked,
-            this,
-            [&]()
-            {
-                emit GoToPreviousScreenRequest();
-            });
         screenLayout->addWidget(m_header);
         
         QHBoxLayout* hLayout = new QHBoxLayout();
@@ -77,14 +69,26 @@ namespace O3DE::ProjectManager
         m_backButton->setProperty("secondary", true);
         m_nextButton = m_backNextButtons->addButton(tr("Next"), QDialogButtonBox::ApplyRole);
 
-        connect(m_backButton, &QPushButton::clicked, this, &CreateGem::HandleBackButton);
-        connect(m_nextButton, &QPushButton::clicked, this, &CreateGem::HandleNextButton);
-
         setObjectName("createAGemBody");
         setLayout(screenLayout);
 
         m_gemActionString = tr("Create");
         m_indexBackLimit = GemTemplateSelectionScreen;
+    }
+
+    void CreateGem::HookConnections()
+    {
+        connect(
+            m_header->backButton(),
+            &QPushButton::clicked,
+            this,
+            [&]()
+            {
+                emit GoToPreviousScreenRequest();
+            });
+        
+        connect(m_backButton, &QPushButton::clicked, this, &CreateGem::HandleBackButton);
+        connect(m_nextButton, &QPushButton::clicked, this, &CreateGem::HandleNextButton);
     }
 
     QFrame* CreateGem::CreateTabButtonsFrame()
@@ -354,6 +358,11 @@ namespace O3DE::ProjectManager
         return gemSystemNameIsValid;
     }
 
+    bool CreateGem::ValidateGemLocation(const QDir& chosenGemLocation) const
+    {
+        return !chosenGemLocation.exists() || chosenGemLocation.isEmpty();
+    }
+
     bool CreateGem::ValidateGemPath()
     {
         // This first isEmpty check is to check that the input field is not empty. If it is QDir will use the current
@@ -435,15 +444,15 @@ namespace O3DE::ProjectManager
         
         if (canProceedToDetailsPage)
         {
-            m_focalGemInfo.m_displayName = m_gemDisplayName->lineEdit()->text();
-            m_focalGemInfo.m_name = m_gemName->lineEdit()->text();
-            m_focalGemInfo.m_summary = m_gemSummary->lineEdit()->text();
-            m_focalGemInfo.m_requirement = m_requirements->lineEdit()->text();
-            m_focalGemInfo.m_licenseText = m_license->lineEdit()->text();
-            m_focalGemInfo.m_licenseLink = m_licenseURL->lineEdit()->text();
-            m_focalGemInfo.m_documentationLink = m_documentationURL->lineEdit()->text();
-            m_focalGemInfo.m_path = m_gemLocation->lineEdit()->text();
-            m_focalGemInfo.m_features = m_userDefinedGemTags->getTags();
+            m_gemInfo.m_displayName = m_gemDisplayName->lineEdit()->text();
+            m_gemInfo.m_name = m_gemName->lineEdit()->text();
+            m_gemInfo.m_summary = m_gemSummary->lineEdit()->text();
+            m_gemInfo.m_requirement = m_requirements->lineEdit()->text();
+            m_gemInfo.m_licenseText = m_license->lineEdit()->text();
+            m_gemInfo.m_licenseLink = m_licenseURL->lineEdit()->text();
+            m_gemInfo.m_documentationLink = m_documentationURL->lineEdit()->text();
+            m_gemInfo.m_path = m_gemLocation->lineEdit()->text();
+            m_gemInfo.m_features = m_userDefinedGemTags->getTags();
 
             m_stackWidget->setCurrentIndex(GemCreatorDetailsScreen);
             
@@ -466,11 +475,11 @@ namespace O3DE::ProjectManager
         }
         else
         {
-            int templateID = m_radioButtonGroup->checkedId();
+            const int templateID = m_radioButtonGroup->checkedId();
             templateLocation = m_gemTemplates[templateID].m_path;
         }
 
-        auto result = PythonBindingsInterface::Get()->CreateGem(templateLocation, m_focalGemInfo);
+        auto result = PythonBindingsInterface::Get()->CreateGem(templateLocation, m_gemInfo);
         if (result.IsSuccess())
         {
             ClearFields();
@@ -493,9 +502,9 @@ namespace O3DE::ProjectManager
         bool repoURLIsValid = ValidateRepositoryURL();
         if (originIsValid && repoURLIsValid)
         {
-            m_focalGemInfo.m_origin = m_origin->lineEdit()->text();
-            m_focalGemInfo.m_originURL = m_originURL->lineEdit()->text();
-            m_focalGemInfo.m_repoUri = m_repositoryURL->lineEdit()->text();
+            m_gemInfo.m_origin = m_origin->lineEdit()->text();
+            m_gemInfo.m_originURL = m_originURL->lineEdit()->text();
+            m_gemInfo.m_repoUri = m_repositoryURL->lineEdit()->text();
             
 
             GemAction();

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
@@ -76,8 +76,9 @@ namespace O3DE::ProjectManager
         m_indexBackLimit = GemTemplateSelectionScreen;
     }
 
-    void CreateGem::HookConnections()
+    void CreateGem::Init()
     {
+        //hookup connections
         connect(
             m_header->backButton(),
             &QPushButton::clicked,

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
@@ -41,6 +41,7 @@ namespace O3DE::ProjectManager
 
     signals:
         void GemCreated(const GemInfo& gemInfo);
+        void GemEdited(const GemInfo& newGemInfo);
 
     private slots:
         void HandleBackButton();
@@ -69,6 +70,7 @@ namespace O3DE::ProjectManager
 
         //Edit Gem workflow
         bool m_isEditGem = false;
+        GemInfo m_oldGemInfo;
 
         //Gem Setup
         QVector<TemplateInfo> m_gemTemplates;

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
@@ -41,7 +41,7 @@ namespace O3DE::ProjectManager
             return ProjectManagerScreen::CreateGem;
         }
 
-        void HookConnections() override;
+        void Init() override;
 
     signals:
         void GemCreated(const GemInfo& gemInfo);

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
@@ -17,8 +17,6 @@
 #include <GemCatalog/GemInfo.h>
 #include <PythonBindings.h>
 #include <ScreenHeaderWidget.h>
-#include <ScreenDefs.h>
-#include <QDir>
 #endif
 
 QT_FORWARD_DECLARE_CLASS(QButtonGroup)
@@ -38,12 +36,12 @@ namespace O3DE::ProjectManager
         explicit CreateGem(QWidget* parent = nullptr);
         ~CreateGem() = default;
 
-        void ClearFields();
-
         ProjectManagerScreen GetScreenEnum() override
         {
             return ProjectManagerScreen::CreateGem;
         }
+
+        void HookConnections() override;
 
     signals:
         void GemCreated(const GemInfo& gemInfo);
@@ -59,24 +57,11 @@ namespace O3DE::ProjectManager
         void HandleGemCreatorDetailsTab();
 
     protected:
-        bool ValidateGemTemplateLocation();
-        bool ValidateGemDisplayName();
-        bool ValidateGemName();
-        bool ValidateGemPath();
-        bool ValidateFormNotEmpty(FormLineEditWidget* form);
-        bool ValidateRepositoryURL();
-        
-        void ProceedToGemDetailsPage();
-        void ProceedToGemCreatorDetailsPage();
-        void ProceedToGemAction();
+        void ClearFields();
 
         virtual void GemAction();
 
-        virtual bool ValidateGemLocation(QDir chosenGemLocation)
-        {
-            return !chosenGemLocation.exists() || chosenGemLocation.isEmpty();
-        }
-
+        virtual bool ValidateGemLocation(const QDir& chosenGemLocation) const;
 
         //Gem Setup
         QVector<TemplateInfo> m_gemTemplates;
@@ -114,7 +99,7 @@ namespace O3DE::ProjectManager
         QRadioButton* m_gemDetailsTab = nullptr;
         QRadioButton* m_gemCreatorDetailsTab = nullptr;
 
-        GemInfo m_focalGemInfo;
+        GemInfo m_gemInfo;
 
         static constexpr int GemTemplateSelectionScreen = 0;
         static constexpr int GemDetailsScreen = 1;
@@ -132,6 +117,16 @@ namespace O3DE::ProjectManager
         QFrame* CreateTabButtonsFrame();
         QFrame* CreateTabPaneFrame();
         void SetupCreateWorkflow();
-        
+
+        void ProceedToGemDetailsPage();
+        void ProceedToGemCreatorDetailsPage();
+        void ProceedToGemAction();
+
+        bool ValidateGemTemplateLocation();
+        bool ValidateGemDisplayName();
+        bool ValidateGemName();
+        bool ValidateGemPath();
+        bool ValidateFormNotEmpty(FormLineEditWidget* form);
+        bool ValidateRepositoryURL();
     };
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
@@ -16,6 +16,8 @@
 #include <FormComboBoxWidget.h>
 #include <GemCatalog/GemInfo.h>
 #include <PythonBindings.h>
+#include <ScreenHeaderWidget.h>
+
 #endif
 
 QT_FORWARD_DECLARE_CLASS(QButtonGroup)
@@ -34,7 +36,8 @@ namespace O3DE::ProjectManager
         explicit CreateGem(QWidget* parent = nullptr);
         ~CreateGem() = default;
 
-        void ResetWorkflow(const GemInfo& oldGemInfo);
+        void ClearWorkflow();
+        void ResetWorkflow(const GemInfo& oldGemInfo, bool isEditWorkflow);
 
     signals:
         void GemCreated(const GemInfo& gemInfo);
@@ -60,11 +63,20 @@ namespace O3DE::ProjectManager
         bool ValidateFormNotEmpty(FormLineEditWidget* form);
         bool ValidateRepositoryURL();
 
+        //workflow management
+        void ChangeToEditWorkflow();
+        void ChangeToCreateWorkflow();
+
+        //Edit Gem workflow
+        bool m_isEditGem = false;
+
         //Gem Setup
         QVector<TemplateInfo> m_gemTemplates;
         QButtonGroup* m_radioButtonGroup = nullptr;
         QRadioButton* m_formFolderRadioButton = nullptr;
         FormFolderBrowseEditWidget* m_gemTemplateLocation = nullptr;
+
+        ScreenHeader* m_header = nullptr;
 
         //Gem Details
         FormLineEditWidget* m_gemDisplayName = nullptr;

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
@@ -34,6 +34,8 @@ namespace O3DE::ProjectManager
         explicit CreateGem(QWidget* parent = nullptr);
         ~CreateGem() = default;
 
+        void ResetWorkflow(const GemInfo& oldGemInfo);
+
     signals:
         void GemCreated(const GemInfo& gemInfo);
 

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.h
@@ -17,7 +17,8 @@
 #include <GemCatalog/GemInfo.h>
 #include <PythonBindings.h>
 #include <ScreenHeaderWidget.h>
-
+#include <ScreenDefs.h>
+#include <QDir>
 #endif
 
 QT_FORWARD_DECLARE_CLASS(QButtonGroup)
@@ -26,6 +27,7 @@ QT_FORWARD_DECLARE_CLASS(QRadioButton)
 QT_FORWARD_DECLARE_CLASS(QScrollArea)
 QT_FORWARD_DECLARE_CLASS(QVBoxLayout)
 QT_FORWARD_DECLARE_CLASS(QStackedWidget)
+QT_FORWARD_DECLARE_CLASS(QDir)
 
 namespace O3DE::ProjectManager
 {
@@ -36,41 +38,45 @@ namespace O3DE::ProjectManager
         explicit CreateGem(QWidget* parent = nullptr);
         ~CreateGem() = default;
 
-        void ClearWorkflow();
-        void ResetWorkflow(const GemInfo& oldGemInfo, bool isEditWorkflow);
+        void ClearFields();
+
+        ProjectManagerScreen GetScreenEnum() override
+        {
+            return ProjectManagerScreen::CreateGem;
+        }
 
     signals:
         void GemCreated(const GemInfo& gemInfo);
-        void GemEdited(const GemInfo& newGemInfo);
 
-    private slots:
+    protected slots:
         void HandleBackButton();
         void HandleNextButton();
+        
+
+    private slots:
         void HandleGemTemplateSelectionTab();
         void HandleGemDetailsTab();
         void HandleGemCreatorDetailsTab();
 
-    private:
-        void LoadButtonsFromGemTemplatePaths(QVBoxLayout* gemSetupLayout);
-        QScrollArea* CreateGemSetupScrollArea();
-        QScrollArea* CreateGemDetailsScrollArea();
-        QScrollArea* CreateGemCreatorScrollArea();
-        QFrame* CreateTabButtonsFrame();
-        QFrame* CreateTabPaneFrame();
+    protected:
         bool ValidateGemTemplateLocation();
         bool ValidateGemDisplayName();
         bool ValidateGemName();
         bool ValidateGemPath();
         bool ValidateFormNotEmpty(FormLineEditWidget* form);
         bool ValidateRepositoryURL();
+        
+        void ProceedToGemDetailsPage();
+        void ProceedToGemCreatorDetailsPage();
+        void ProceedToGemAction();
 
-        //workflow management
-        void ChangeToEditWorkflow();
-        void ChangeToCreateWorkflow();
+        virtual void GemAction();
 
-        //Edit Gem workflow
-        bool m_isEditGem = false;
-        GemInfo m_oldGemInfo;
+        virtual bool ValidateGemLocation(QDir chosenGemLocation)
+        {
+            return !chosenGemLocation.exists() || chosenGemLocation.isEmpty();
+        }
+
 
         //Gem Setup
         QVector<TemplateInfo> m_gemTemplates;
@@ -108,12 +114,24 @@ namespace O3DE::ProjectManager
         QRadioButton* m_gemDetailsTab = nullptr;
         QRadioButton* m_gemCreatorDetailsTab = nullptr;
 
-        GemInfo m_createGemInfo;
+        GemInfo m_focalGemInfo;
 
         static constexpr int GemTemplateSelectionScreen = 0;
         static constexpr int GemDetailsScreen = 1;
         static constexpr int GemCreatorDetailsScreen = 2;
+
+        int m_indexBackLimit = 0;
+
+        QString m_gemActionString;
+
+    private:
+        void LoadButtonsFromGemTemplatePaths(QVBoxLayout* gemSetupLayout);
+        QScrollArea* CreateGemSetupScrollArea();
+        QScrollArea* CreateGemDetailsScrollArea();
+        QScrollArea* CreateGemCreatorScrollArea();
+        QFrame* CreateTabButtonsFrame();
+        QFrame* CreateTabPaneFrame();
+        void SetupCreateWorkflow();
+        
     };
-
-
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/EditAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/EditAGemScreen.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <GemCatalog/GemCatalogHeaderWidget.h>
+#include <ProjectUtils.h>
+#include <PythonBindingsInterface.h>
+#include <ScreenHeaderWidget.h>
+#include <EditAGemScreen.h>
+
+#include <QApplication>
+#include <QButtonGroup>
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QDir>
+#include <QLabel>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QRadioButton>
+#include <QScrollArea>
+#include <QStackedWidget>
+#include <QVBoxLayout>
+
+
+namespace O3DE::ProjectManager
+{
+
+    EditGem::EditGem(QWidget* parent)
+        : CreateGem(parent)
+    {
+        //undo the connections of the parent class
+        m_header->backButton()->disconnect();
+        m_backButton->disconnect();
+        m_nextButton->disconnect();
+
+        m_header->setSubTitle(tr("Edit gem"));
+        
+        connect(
+            m_header->backButton(),
+            &QPushButton::clicked,
+            this,
+            [&]()
+            {
+                //if previously editing a gem, cancel the operation and revert to old creation workflow
+                //this way we prevent accidental stale data for an already existing gem.
+                ClearFields();
+                emit GoToPreviousScreenRequest();
+            });
+        
+        connect(m_backButton, &QPushButton::clicked, this, &EditGem::HandleBackButton);
+        connect(m_nextButton, &QPushButton::clicked, this, &EditGem::HandleNextButton);
+
+        
+        //we will only have two pages: details page and creator details page
+        m_gemTemplateSelectionTab->setChecked(false);
+        m_gemTemplateSelectionTab->setVisible(false);
+
+        m_gemDetailsTab->setEnabled(true);
+        m_gemDetailsTab->setChecked(true);
+
+        m_gemCreatorDetailsTab->setEnabled(true);
+
+        m_gemDetailsTab->setText(tr("1.  Gem Details"));
+        m_gemCreatorDetailsTab->setText(tr("2.  Creator Details"));
+
+        m_stackWidget->setCurrentIndex(GemDetailsScreen);
+
+        m_gemLocation->setEnabled(false);
+
+        m_nextButton->setText(tr("Next"));
+
+        m_gemActionString = tr("Edit");
+        m_indexBackLimit = GemDetailsScreen;
+    }
+
+    void EditGem::ResetWorkflow(const GemInfo& oldGemInfo)
+    {
+        //details page
+        m_gemDisplayName->lineEdit()->setText(oldGemInfo.m_displayName);
+        m_gemDisplayName->setErrorLabelVisible(false);
+
+        m_gemName->lineEdit()->setText(oldGemInfo.m_name);
+        m_gemName->setErrorLabelVisible(false);
+
+        m_gemSummary->lineEdit()->setText(oldGemInfo.m_summary);
+        m_requirements->lineEdit()->setText(oldGemInfo.m_requirement);
+        
+        m_license->lineEdit()->setText(oldGemInfo.m_licenseText);
+        m_license->setErrorLabelVisible(false);
+
+        m_licenseURL->lineEdit()->setText(oldGemInfo.m_licenseLink);
+        m_documentationURL->lineEdit()->setText(oldGemInfo.m_documentationLink);
+        
+        m_gemLocation->lineEdit()->setText(oldGemInfo.m_path);
+        m_gemLocation->setErrorLabelVisible(false);
+
+        m_gemIconPath->lineEdit()->setText(oldGemInfo.m_iconPath);
+
+        //Gem name is included in tags. Since the user can override this by setting the name field
+        //we should remove it from the tag list to prevent unintended consequences
+        QStringList tagsToEdit = oldGemInfo.m_features;
+        tagsToEdit.removeAll(oldGemInfo.m_name);
+        m_userDefinedGemTags->setTags(tagsToEdit);
+
+        //creator details page
+        m_origin->lineEdit()->setText(oldGemInfo.m_origin);
+        m_origin->setErrorLabelVisible(false);
+
+        m_originURL->lineEdit()->setText(oldGemInfo.m_originURL);
+        m_repositoryURL->lineEdit()->setText(oldGemInfo.m_repoUri);
+
+        m_oldGemInfo = oldGemInfo;
+    }
+
+
+    //here we handle the actual edit gem logic
+    void EditGem::GemAction()
+    {
+        //during editing, we remove the gem name tag to prevent the user accidentally altering it
+        //so add it back here before submission
+        if(!m_focalGemInfo.m_features.contains(m_focalGemInfo.m_name))
+        {
+            m_focalGemInfo.m_features << m_focalGemInfo.m_name;
+        }
+
+        auto result = PythonBindingsInterface::Get()->EditGem(m_oldGemInfo.m_name, m_focalGemInfo);
+        if(result.IsSuccess())
+        {
+            ClearFields();
+            emit GemEdited(result.GetValue<GemInfo>());
+            emit GoToPreviousScreenRequest();
+        }
+        else
+        {
+            QMessageBox::critical(
+                this,
+                tr("Failed to edit gem"),
+                tr("The gem failed to be edited"));
+        }
+    }
+
+} // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/EditAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/EditAGemScreen.cpp
@@ -6,25 +6,7 @@
  *
  */
 
-#include <GemCatalog/GemCatalogHeaderWidget.h>
-#include <ProjectUtils.h>
-#include <PythonBindingsInterface.h>
-#include <ScreenHeaderWidget.h>
 #include <EditAGemScreen.h>
-
-#include <QApplication>
-#include <QButtonGroup>
-#include <QComboBox>
-#include <QDialogButtonBox>
-#include <QDir>
-#include <QLabel>
-#include <QMessageBox>
-#include <QPushButton>
-#include <QRadioButton>
-#include <QScrollArea>
-#include <QStackedWidget>
-#include <QVBoxLayout>
-
 
 namespace O3DE::ProjectManager
 {

--- a/Code/Tools/ProjectManager/Source/EditAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/EditAGemScreen.cpp
@@ -7,7 +7,13 @@
  */
 
 #include <EditAGemScreen.h>
+
 #include <QDir>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QRadioButton>
+#include <QStackedWidget>
+
 
 namespace O3DE::ProjectManager
 {

--- a/Code/Tools/ProjectManager/Source/EditAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/EditAGemScreen.cpp
@@ -45,8 +45,9 @@ namespace O3DE::ProjectManager
         m_indexBackLimit = GemDetailsScreen;
     }
 
-    void EditGem::HookConnections()
+    void EditGem::Init()
     {
+        //hookup connections
         connect(
             m_header->backButton(),
             &QPushButton::clicked,

--- a/Code/Tools/ProjectManager/Source/EditAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/EditAGemScreen.cpp
@@ -13,7 +13,7 @@
 #include <QPushButton>
 #include <QRadioButton>
 #include <QStackedWidget>
-
+#include <QMessageBox>
 
 namespace O3DE::ProjectManager
 {

--- a/Code/Tools/ProjectManager/Source/EditAGemScreen.h
+++ b/Code/Tools/ProjectManager/Source/EditAGemScreen.h
@@ -10,6 +10,8 @@
 
 #if !defined(Q_MOC_RUN)
 #include <CreateAGemScreen.h>
+
+QT_FORWARD_DECLARE_CLASS(QDir)
 #endif
 
 namespace O3DE::ProjectManager
@@ -28,20 +30,17 @@ namespace O3DE::ProjectManager
             return ProjectManagerScreen::EditGem;
         }
 
+        void HookConnections() override;
+
     signals:
         void GemEdited(const GemInfo& newGemInfo);
         
     private: 
         void GemAction() override;
 
-        bool ValidateGemLocation(QDir chosenGemLocation) override
-        {
-            return chosenGemLocation.exists();
-        }
+        bool ValidateGemLocation(const QDir& chosenGemLocation) const override;
 
-        //Edit Gem workflow
-        bool m_isEditGem = false;
-        GemInfo m_oldGemInfo;
+        QString m_oldGemName;
 
     };
 

--- a/Code/Tools/ProjectManager/Source/EditAGemScreen.h
+++ b/Code/Tools/ProjectManager/Source/EditAGemScreen.h
@@ -9,26 +9,8 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
-#include <ScreenWidget.h>
-#include <FormFolderBrowseEditWidget.h>
-#include <FormLineEditWidget.h>
-#include <FormLineEditTagsWidget.h>
-#include <FormComboBoxWidget.h>
-#include <GemCatalog/GemInfo.h>
 #include <CreateAGemScreen.h>
-#include <PythonBindings.h>
-#include <ScreenHeaderWidget.h>
-#include <ScreenDefs.h>
-
 #endif
-
-QT_FORWARD_DECLARE_CLASS(QButtonGroup)
-QT_FORWARD_DECLARE_CLASS(QDialogButtonBox)
-QT_FORWARD_DECLARE_CLASS(QRadioButton)
-QT_FORWARD_DECLARE_CLASS(QScrollArea)
-QT_FORWARD_DECLARE_CLASS(QVBoxLayout)
-QT_FORWARD_DECLARE_CLASS(QStackedWidget)
-QT_FORWARD_DECLARE_CLASS(QDir)
 
 namespace O3DE::ProjectManager
 {

--- a/Code/Tools/ProjectManager/Source/EditAGemScreen.h
+++ b/Code/Tools/ProjectManager/Source/EditAGemScreen.h
@@ -30,7 +30,7 @@ namespace O3DE::ProjectManager
             return ProjectManagerScreen::EditGem;
         }
 
-        void HookConnections() override;
+        void Init() override;
 
     signals:
         void GemEdited(const GemInfo& newGemInfo);

--- a/Code/Tools/ProjectManager/Source/EditAGemScreen.h
+++ b/Code/Tools/ProjectManager/Source/EditAGemScreen.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#if !defined(Q_MOC_RUN)
+#include <ScreenWidget.h>
+#include <FormFolderBrowseEditWidget.h>
+#include <FormLineEditWidget.h>
+#include <FormLineEditTagsWidget.h>
+#include <FormComboBoxWidget.h>
+#include <GemCatalog/GemInfo.h>
+#include <CreateAGemScreen.h>
+#include <PythonBindings.h>
+#include <ScreenHeaderWidget.h>
+#include <ScreenDefs.h>
+
+#endif
+
+QT_FORWARD_DECLARE_CLASS(QButtonGroup)
+QT_FORWARD_DECLARE_CLASS(QDialogButtonBox)
+QT_FORWARD_DECLARE_CLASS(QRadioButton)
+QT_FORWARD_DECLARE_CLASS(QScrollArea)
+QT_FORWARD_DECLARE_CLASS(QVBoxLayout)
+QT_FORWARD_DECLARE_CLASS(QStackedWidget)
+QT_FORWARD_DECLARE_CLASS(QDir)
+
+namespace O3DE::ProjectManager
+{
+    class EditGem : public CreateGem
+    {
+        Q_OBJECT
+    public:
+        explicit EditGem(QWidget* parent = nullptr);
+        ~EditGem() = default;
+
+        void ResetWorkflow(const GemInfo& oldGemInfo);
+
+        ProjectManagerScreen GetScreenEnum() override
+        {
+            return ProjectManagerScreen::EditGem;
+        }
+
+    signals:
+        void GemEdited(const GemInfo& newGemInfo);
+        
+    private: 
+        void GemAction() override;
+
+        bool ValidateGemLocation(QDir chosenGemLocation) override
+        {
+            return chosenGemLocation.exists();
+        }
+
+        //Edit Gem workflow
+        bool m_isEditGem = false;
+        GemInfo m_oldGemInfo;
+
+    };
+
+
+} // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/FormLineEditTagsWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/FormLineEditTagsWidget.cpp
@@ -121,6 +121,13 @@ namespace O3DE::ProjectManager
         refreshTagFrame();
     }
 
+    void FormLineEditTagsWidget::clear()
+    {
+        m_lineEdit->clear();
+        m_tags.clear();
+        refreshTagFrame();
+    }
+
     void FormLineEditTagsWidget::refreshTagFrame()
     {
         // cleanup the tag frame widget and re-add the tag list

--- a/Code/Tools/ProjectManager/Source/FormLineEditTagsWidget.h
+++ b/Code/Tools/ProjectManager/Source/FormLineEditTagsWidget.h
@@ -59,6 +59,12 @@ namespace O3DE::ProjectManager
             return m_tags;
         }
 
+        void setTags(const QStringList& tagList)
+        {
+            m_tags = tagList;
+            refreshTagFrame();
+        }
+
     protected:
         //! The button that is placed on the right side of the line edit. Used to show the auto-completion menu.
         QPushButton* m_dropdownButton = nullptr;

--- a/Code/Tools/ProjectManager/Source/FormLineEditTagsWidget.h
+++ b/Code/Tools/ProjectManager/Source/FormLineEditTagsWidget.h
@@ -65,6 +65,8 @@ namespace O3DE::ProjectManager
             refreshTagFrame();
         }
 
+        void clear();
+
     protected:
         //! The button that is placed on the right side of the line edit. Used to show the auto-completion menu.
         QPushButton* m_dropdownButton = nullptr;

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -80,7 +80,9 @@ namespace O3DE::ProjectManager
             ScreenWidget* createGemScreen = m_screensControl->FindScreen(ProjectManagerScreen::CreateGem);
             if (createGemScreen)
             {
-                connect(static_cast<CreateGem*>(createGemScreen), &CreateGem::GemCreated, this, &GemCatalogScreen::HandleGemCreated);
+                CreateGem* createGem = static_cast<CreateGem*>(createGemScreen);
+                connect(createGem, &CreateGem::GemCreated, this, &GemCatalogScreen::HandleGemCreated);
+                connect(createGem, &CreateGem::GemEdited, this, &GemCatalogScreen::HandleGemEdited);
             }
         }
 
@@ -735,6 +737,21 @@ namespace O3DE::ProjectManager
 
         // create Toast Notification for project gem catalog
         QString notification = tr("%1 has been created.").arg(gemInfo.m_displayName);
+        ShowStandardToastNotification(notification);
+    }
+
+    void GemCatalogScreen::HandleGemEdited(const GemInfo& newGemInfo)
+    {
+        // This signal only occurs upon successful completion of editing a gem. As such, the gemInfo is assumed to be valid
+
+        // make sure to update the current model index in the gem catalog model
+        m_gemModel->RemoveGem(m_gemInspector->GetCurrentModelIndex());
+        m_gemModel->AddGem(newGemInfo);
+
+        //gem inspector needs to have its selection updated to the newly added gem
+        SelectGem(newGemInfo.m_name);
+
+        QString notification = tr("%1 was edited.").arg(newGemInfo.m_displayName);
         ShowStandardToastNotification(notification);
     }
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -74,10 +74,10 @@ namespace O3DE::ProjectManager
         connect(m_headerWidget, &GemCatalogHeaderWidget::UpdateGemCart, this, &GemCatalogScreen::UpdateAndShowGemCart);
         connect(m_downloadController, &DownloadController::Done, this, &GemCatalogScreen::OnGemDownloadResult);
 
-        ScreensCtrl* screensControl = qobject_cast<ScreensCtrl*>(parent);
-        if (screensControl)
+        m_screensControl = qobject_cast<ScreensCtrl*>(parent);
+        if (m_screensControl)
         {
-            ScreenWidget* createGemScreen = screensControl->FindScreen(ProjectManagerScreen::CreateGem);
+            ScreenWidget* createGemScreen = m_screensControl->FindScreen(ProjectManagerScreen::CreateGem);
             if (createGemScreen)
             {
                 connect(static_cast<CreateGem*>(createGemScreen), &CreateGem::GemCreated, this, &GemCatalogScreen::HandleGemCreated);
@@ -96,7 +96,7 @@ namespace O3DE::ProjectManager
         connect(m_gemInspector, &GemInspector::TagClicked, [=](const Tag& tag) { SelectGem(tag.id); });
         connect(m_gemInspector, &GemInspector::UpdateGem, this, &GemCatalogScreen::UpdateGem);
         connect(m_gemInspector, &GemInspector::UninstallGem, this, &GemCatalogScreen::UninstallGem);
-        connect(m_gemInspector, &GemInspector::EditGem, this, &GemCatalogScreen::HandleCreateGem);
+        connect(m_gemInspector, &GemInspector::EditGem, this, &GemCatalogScreen::HandleEditGem);
 
         QWidget* filterWidget = new QWidget(this);
         filterWidget->setFixedWidth(sidePanelWidth);
@@ -639,6 +639,21 @@ namespace O3DE::ProjectManager
     void GemCatalogScreen::HandleCreateGem()
     {
         emit ChangeScreenRequest(ProjectManagerScreen::CreateGem);
+    }
+
+    void GemCatalogScreen::HandleEditGem()
+    {
+        if (m_screensControl)
+        {
+            ScreenWidget* createGemScreen = m_screensControl->FindScreen(ProjectManagerScreen::CreateGem);
+            if (createGemScreen)
+            {
+                auto createGem = qobject_cast<CreateGem*>(createGemScreen);
+                createGem->ResetWorkflow(m_gemModel->GetGemInfo(m_gemInspector->GetCurrentModelIndex()));
+                emit ChangeScreenRequest(ProjectManagerScreen::CreateGem);
+            }
+        }
+        
     }
 
     void GemCatalogScreen::UpdateAndShowGemCart(QWidget* cartWidget)

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -654,16 +654,14 @@ namespace O3DE::ProjectManager
     {
         if (m_screensControl)
         {
-            ScreenWidget* editGemScreen = m_screensControl->FindScreen(ProjectManagerScreen::EditGem);
+            auto editGemScreen = qobject_cast<EditGem*>(m_screensControl->FindScreen(ProjectManagerScreen::EditGem));
             if (editGemScreen)
             {
-                auto editGem = qobject_cast<EditGem*>(editGemScreen);
                 m_curEditedIndex = currentModelIndex;
-                editGem->ResetWorkflow(m_gemModel->GetGemInfo(currentModelIndex));
+                editGemScreen->ResetWorkflow(m_gemModel->GetGemInfo(currentModelIndex));
                 emit ChangeScreenRequest(ProjectManagerScreen::EditGem);
             }
         }
-        
     }
 
     void GemCatalogScreen::UpdateAndShowGemCart(QWidget* cartWidget)

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -96,6 +96,7 @@ namespace O3DE::ProjectManager
         connect(m_gemInspector, &GemInspector::TagClicked, [=](const Tag& tag) { SelectGem(tag.id); });
         connect(m_gemInspector, &GemInspector::UpdateGem, this, &GemCatalogScreen::UpdateGem);
         connect(m_gemInspector, &GemInspector::UninstallGem, this, &GemCatalogScreen::UninstallGem);
+        connect(m_gemInspector, &GemInspector::EditGem, this, &GemCatalogScreen::HandleCreateGem);
 
         QWidget* filterWidget = new QWidget(this);
         filterWidget->setFixedWidth(sidePanelWidth);

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -649,7 +649,8 @@ namespace O3DE::ProjectManager
             if (createGemScreen)
             {
                 auto createGem = qobject_cast<CreateGem*>(createGemScreen);
-                createGem->ResetWorkflow(m_gemModel->GetGemInfo(m_gemInspector->GetCurrentModelIndex()));
+                createGem->ResetWorkflow(m_gemModel->GetGemInfo(m_gemInspector->GetCurrentModelIndex()),
+                                        /*isEditWorkflow = */true);
                 emit ChangeScreenRequest(ProjectManagerScreen::CreateGem);
             }
         }

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
@@ -76,7 +76,7 @@ namespace O3DE::ProjectManager
     private slots:
         void HandleOpenGemRepo();
         void HandleCreateGem();
-        void HandleEditGem();
+        void HandleEditGem(const QModelIndex& currentModelIndex);
         void UpdateAndShowGemCart(QWidget* cartWidget);
         void ShowInspector();
 
@@ -102,5 +102,8 @@ namespace O3DE::ProjectManager
         bool m_notificationsEnabled = true;
         QString m_projectPath;
         bool m_readOnly;
+
+        QModelIndex m_curEditedIndex;
+
     };
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
@@ -62,6 +62,7 @@ namespace O3DE::ProjectManager
         void UpdateGem(const QModelIndex& modelIndex);
         void UninstallGem(const QModelIndex& modelIndex);
         void HandleGemCreated(const GemInfo& gemInfo);
+        void HandleGemEdited(const GemInfo& newGemInfo);
 
     protected:
         void hideEvent(QHideEvent* event) override;

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
@@ -10,6 +10,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <ScreenWidget.h>
+#include <ScreensCtrl.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzToolsFramework/UI/Notifications/ToastNotificationsView.h>
 #include <GemCatalog/GemInfo.h>
@@ -74,6 +75,7 @@ namespace O3DE::ProjectManager
     private slots:
         void HandleOpenGemRepo();
         void HandleCreateGem();
+        void HandleEditGem();
         void UpdateAndShowGemCart(QWidget* cartWidget);
         void ShowInspector();
 
@@ -95,6 +97,7 @@ namespace O3DE::ProjectManager
         QVBoxLayout* m_filterWidgetLayout = nullptr;
         GemFilterWidget* m_filterWidget = nullptr;
         DownloadController* m_downloadController = nullptr;
+        ScreensCtrl* m_screensControl = nullptr;
         bool m_notificationsEnabled = true;
         QString m_projectPath;
         bool m_readOnly;

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.cpp
@@ -275,6 +275,13 @@ namespace O3DE::ProjectManager
 
         m_mainLayout->addSpacing(10);
 
+        m_editGemButton = new QPushButton(tr("Edit Gem"));
+        m_editGemButton->setObjectName("gemCatalogUpdateGemButton");
+        m_mainLayout->addWidget(m_editGemButton);
+        connect(m_editGemButton, &QPushButton::clicked, this , [this]{ emit EditGem(); });
+
+        m_mainLayout->addSpacing(10);
+
         m_uninstallGemButton = new QPushButton(tr("Uninstall Gem"));
         m_uninstallGemButton->setObjectName("gemCatalogUninstallGemButton");
         m_mainLayout->addWidget(m_uninstallGemButton);

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.cpp
@@ -278,7 +278,7 @@ namespace O3DE::ProjectManager
         m_editGemButton = new QPushButton(tr("Edit Gem"));
         m_editGemButton->setObjectName("gemCatalogUpdateGemButton");
         m_mainLayout->addWidget(m_editGemButton);
-        connect(m_editGemButton, &QPushButton::clicked, this , [this]{ emit EditGem(); });
+        connect(m_editGemButton, &QPushButton::clicked, this , [this]{ emit EditGem(m_curModelIndex); });
 
         m_mainLayout->addSpacing(10);
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.h
@@ -48,6 +48,7 @@ namespace O3DE::ProjectManager
         void TagClicked(const Tag& tag);
         void UpdateGem(const QModelIndex& modelIndex);
         void UninstallGem(const QModelIndex& modelIndex);
+        void EditGem();
 
     private slots:
         void OnSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
@@ -85,6 +86,7 @@ namespace O3DE::ProjectManager
         QLabel* m_binarySizeLabel = nullptr;
 
         QPushButton* m_updateGemButton = nullptr;
+        QPushButton* m_editGemButton = nullptr;
         QPushButton* m_uninstallGemButton = nullptr;
     };
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.h
@@ -44,16 +44,11 @@ namespace O3DE::ProjectManager
         inline constexpr static const char* s_headerColor = "#FFFFFF";
         inline constexpr static const char* s_textColor = "#DDDDDD";
 
-        QModelIndex GetCurrentModelIndex()
-        {
-            return m_curModelIndex;
-        }
-
     signals:
         void TagClicked(const Tag& tag);
         void UpdateGem(const QModelIndex& modelIndex);
         void UninstallGem(const QModelIndex& modelIndex);
-        void EditGem();
+        void EditGem(const QModelIndex& modelIndex);
 
     private slots:
         void OnSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.h
@@ -44,6 +44,11 @@ namespace O3DE::ProjectManager
         inline constexpr static const char* s_headerColor = "#FFFFFF";
         inline constexpr static const char* s_textColor = "#DDDDDD";
 
+        QModelIndex GetCurrentModelIndex()
+        {
+            return m_curModelIndex;
+        }
+
     signals:
         void TagClicked(const Tag& tag);
         void UpdateGem(const QModelIndex& modelIndex);

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.cpp
@@ -125,6 +125,34 @@ namespace O3DE::ProjectManager
         }
     }
 
+    const GemInfo GemModel::GetGemInfo(const QModelIndex& modelIndex)
+    {
+        GemInfo gemInfo;
+        gemInfo.m_name = modelIndex.data(RoleName).toString();
+        gemInfo.m_displayName = modelIndex.data(RoleDisplayName).toString();
+        gemInfo.m_origin = modelIndex.data(RoleCreator).toString();
+        gemInfo.m_gemOrigin = static_cast<GemInfo::GemOrigin>(modelIndex.data(RoleGemOrigin).toInt());
+        gemInfo.m_platforms = static_cast<GemInfo::Platforms>(modelIndex.data(RolePlatforms).toInt());
+        gemInfo.m_types = static_cast<GemInfo::Type>(modelIndex.data(RoleTypes).toInt());
+        gemInfo.m_summary = modelIndex.data(RoleSummary).toString();
+        gemInfo.m_isAdded = modelIndex.data(RoleIsAdded).toBool();
+        gemInfo.m_directoryLink = modelIndex.data(RoleDirectoryLink).toString();
+        gemInfo.m_documentationLink = modelIndex.data(RoleDocLink).toString();
+        gemInfo.m_dependencies = modelIndex.data(RoleDependingGems).toStringList();
+        gemInfo.m_version = modelIndex.data(RoleVersion).toString();
+        gemInfo.m_lastUpdatedDate = modelIndex.data(RoleLastUpdated).toString();
+        gemInfo.m_binarySizeInKB = modelIndex.data(RoleBinarySize).toInt();
+        gemInfo.m_features = modelIndex.data(RoleFeatures).toStringList();
+        gemInfo.m_path = modelIndex.data(RolePath).toString();
+        gemInfo.m_requirement = modelIndex.data(RoleRequirement).toString();
+        gemInfo.m_downloadStatus = static_cast<GemInfo::DownloadStatus>(modelIndex.data(RoleDownloadStatus).toInt());
+        gemInfo.m_licenseText = modelIndex.data(RoleLicenseText).toString();
+        gemInfo.m_licenseLink = modelIndex.data(RoleLicenseLink).toString();
+        gemInfo.m_repoUri = modelIndex.data(RoleRepoUri).toString();
+
+        return gemInfo;
+    }
+
     QString GemModel::GetName(const QModelIndex& modelIndex)
     {
         return modelIndex.data(RoleName).toString();

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.h
@@ -65,6 +65,7 @@ namespace O3DE::ProjectManager
         QVector<Tag> GetDependingGemTags(const QModelIndex& modelIndex);
         bool HasDependentGems(const QModelIndex& modelIndex) const;
 
+        static const GemInfo GetGemInfo(const QModelIndex& modelIndex);
         static QString GetName(const QModelIndex& modelIndex);
         static QString GetDisplayName(const QModelIndex& modelIndex);
         static QString GetCreator(const QModelIndex& modelIndex);

--- a/Code/Tools/ProjectManager/Source/ProjectManagerWindow.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectManagerWindow.cpp
@@ -35,6 +35,7 @@ namespace O3DE::ProjectManager
         {
             ProjectManagerScreen::Projects,
             ProjectManagerScreen::CreateGem,
+            ProjectManagerScreen::EditGem,
             ProjectManagerScreen::GemCatalog,
             ProjectManagerScreen::Engine,
             ProjectManagerScreen::CreateProject,

--- a/Code/Tools/ProjectManager/Source/PythonBindings.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.h
@@ -45,7 +45,7 @@ namespace O3DE::ProjectManager
 
         // Gem
         AZ::Outcome<GemInfo> CreateGem(const QString& templatePath, const GemInfo& gemInfo, bool registerGem = true) override;
-        AZ::Outcome<GemInfo> EditGem(const GemInfo& oldGemInfo, const GemInfo& newGemInfo) override;
+        AZ::Outcome<GemInfo> EditGem(const QString& oldGemName, const GemInfo& newGemInfo) override;
         AZ::Outcome<GemInfo> GetGemInfo(const QString& path, const QString& projectPath = {}) override;
         AZ::Outcome<QVector<GemInfo>, AZStd::string> GetEngineGemInfos() override;
         AZ::Outcome<QVector<GemInfo>, AZStd::string> GetAllGemInfos(const QString& projectPath) override;

--- a/Code/Tools/ProjectManager/Source/PythonBindings.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.h
@@ -45,6 +45,7 @@ namespace O3DE::ProjectManager
 
         // Gem
         AZ::Outcome<GemInfo> CreateGem(const QString& templatePath, const GemInfo& gemInfo, bool registerGem = true) override;
+        AZ::Outcome<GemInfo> EditGem(const GemInfo& oldGemInfo, const GemInfo& newGemInfo) override;
         AZ::Outcome<GemInfo> GetGemInfo(const QString& path, const QString& projectPath = {}) override;
         AZ::Outcome<QVector<GemInfo>, AZStd::string> GetEngineGemInfos() override;
         AZ::Outcome<QVector<GemInfo>, AZStd::string> GetAllGemInfos(const QString& projectPath) override;
@@ -114,6 +115,7 @@ namespace O3DE::ProjectManager
         AZ::IO::FixedMaxPath m_enginePath;
         mutable AZStd::recursive_mutex m_lock;
 
+        pybind11::handle m_gemProperties;
         pybind11::handle m_engineTemplate;
         pybind11::handle m_engineProperties;
         pybind11::handle m_cmake;

--- a/Code/Tools/ProjectManager/Source/PythonBindingsInterface.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindingsInterface.h
@@ -110,11 +110,11 @@ namespace O3DE::ProjectManager
 
         /**
          * Edit a Gem from the Edit Gem Wizard
-         * @param oldGemInfo the gem info that existed prior to the update request
+         * @param oldGemName the gem name that existed prior to the update request
          * @param newGemInfo the gem updates that the user is requesting
          * @return an outcome with GemInfo on success
          */
-         virtual AZ::Outcome<GemInfo> EditGem(const GemInfo& oldGemInfo, const GemInfo& newGemInfo) = 0;
+         virtual AZ::Outcome<GemInfo> EditGem(const QString& oldGemName, const GemInfo& newGemInfo) = 0;
 
         /**
          * Get info about a Gem.

--- a/Code/Tools/ProjectManager/Source/PythonBindingsInterface.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindingsInterface.h
@@ -109,6 +109,14 @@ namespace O3DE::ProjectManager
         virtual AZ::Outcome<GemInfo> CreateGem(const QString& templatePath, const GemInfo& gemInfo, bool registerGem = true) = 0;
 
         /**
+         * Edit a Gem from the Edit Gem Wizard
+         * @param oldGemInfo the gem info that existed prior to the update request
+         * @param newGemInfo the gem updates that the user is requesting
+         * @return an outcome with GemInfo on success
+         */
+         virtual AZ::Outcome<GemInfo> EditGem(const GemInfo& oldGemInfo, const GemInfo& newGemInfo) = 0;
+
+        /**
          * Get info about a Gem.
          * @param path The absolute path to the Gem
          * @param projectPath (Optional) The absolute path to the Gem project

--- a/Code/Tools/ProjectManager/Source/ScreenDefs.h
+++ b/Code/Tools/ProjectManager/Source/ScreenDefs.h
@@ -28,7 +28,8 @@ namespace O3DE::ProjectManager
         EngineSettings,
         GemRepos,
         GemsGemRepos,
-        CreateGem
+        CreateGem,
+        EditGem
     };
 
     static QHash<QString, ProjectManagerScreen> s_ProjectManagerStringNames = {
@@ -44,7 +45,8 @@ namespace O3DE::ProjectManager
         { "EngineSettings", ProjectManagerScreen::EngineSettings},
         { "GemRepos", ProjectManagerScreen::GemRepos},
         { "GemsGemRepos", ProjectManagerScreen::GemsGemRepos},
-        { "CreateGem", ProjectManagerScreen::CreateGem }
+        { "CreateGem", ProjectManagerScreen::CreateGem },
+        { "EditGem", ProjectManagerScreen::EditGem }
     };
 
     // need to define qHash for ProjectManagerScreen when using scoped enums

--- a/Code/Tools/ProjectManager/Source/ScreenFactory.cpp
+++ b/Code/Tools/ProjectManager/Source/ScreenFactory.cpp
@@ -75,7 +75,7 @@ namespace O3DE::ProjectManager
         }
 
         //handle any code that needs to run after construction but before startup 
-        newScreen->HookConnections();
+        newScreen->Init();
 
         return newScreen;
     }

--- a/Code/Tools/ProjectManager/Source/ScreenFactory.cpp
+++ b/Code/Tools/ProjectManager/Source/ScreenFactory.cpp
@@ -19,6 +19,7 @@
 #include <EngineSettingsScreen.h>
 #include <GemRepo/GemRepoScreen.h>
 #include <CreateAGemScreen.h>
+#include <EditAGemScreen.h>
 #include <DownloadController.h>
 
 namespace O3DE::ProjectManager
@@ -64,6 +65,9 @@ namespace O3DE::ProjectManager
             break;
         case (ProjectManagerScreen::CreateGem):
             newScreen = new CreateGem(parent);
+            break;
+        case (ProjectManagerScreen::EditGem):
+            newScreen = new EditGem(parent);
             break;
         case (ProjectManagerScreen::Empty):
         default:

--- a/Code/Tools/ProjectManager/Source/ScreenFactory.cpp
+++ b/Code/Tools/ProjectManager/Source/ScreenFactory.cpp
@@ -74,6 +74,9 @@ namespace O3DE::ProjectManager
             newScreen = new ScreenWidget(parent);
         }
 
+        //handle any code that needs to run after construction but before startup 
+        newScreen->HookConnections();
+
         return newScreen;
     }
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/ScreenWidget.h
+++ b/Code/Tools/ProjectManager/Source/ScreenWidget.h
@@ -54,7 +54,7 @@ namespace O3DE::ProjectManager
         virtual void GoToScreen([[maybe_unused]] ProjectManagerScreen screen)
         {
         }
-        virtual void HookConnections()
+        virtual void Init()
         {
         }
         //! Notify this screen it is the current screen 

--- a/Code/Tools/ProjectManager/Source/ScreenWidget.h
+++ b/Code/Tools/ProjectManager/Source/ScreenWidget.h
@@ -54,7 +54,9 @@ namespace O3DE::ProjectManager
         virtual void GoToScreen([[maybe_unused]] ProjectManagerScreen screen)
         {
         }
-
+        virtual void HookConnections()
+        {
+        }
         //! Notify this screen it is the current screen 
         virtual void NotifyCurrentScreen()
         {

--- a/Code/Tools/ProjectManager/project_manager_files.cmake
+++ b/Code/Tools/ProjectManager/project_manager_files.cmake
@@ -102,6 +102,8 @@ set(FILES
     Source/TextOverflowWidget.cpp
     Source/CreateAGemScreen.h
     Source/CreateAGemScreen.cpp
+    Source/EditAGemScreen.h
+    Source/EditAGemScreen.cpp
     Source/GemCatalog/GemCatalogHeaderWidget.h
     Source/GemCatalog/GemCatalogHeaderWidget.cpp
     Source/GemCatalog/GemCatalogScreen.h


### PR DESCRIPTION
## What does this PR do?

A new feature is implemented to edit existing gem information from the Project Manager.

![EditGemWorkflow](https://user-images.githubusercontent.com/112996779/197106407-655beb7b-3760-4922-9298-4143f2653f6f.gif)

Primary changes are focused around the existing `CreateAGemScreen` class. A new edit workflow is introduced, and entry points are modified to change the existing workflow UI and actions depending on the type of workflow initiated (whether edit or creation based).

## How was this PR tested?

Tests were done manually for the following:
* Initiating the edit workflow from multiple gems (including backtracking, and picking a new gem). In each case, the intended gem information selected by the user is correctly loaded into the workflow for editing and publishing.
* Verifying existing UI interactions such as tabs, next and back buttons, and form fields.
* Successive operations of editing gems and creating new gems (in various combinations). In each case the application behaved as expected.
* Adding and removing tags. This also factors in the gem name change which is implicitly included with gem tags in the JSON files.

After discussing with @AMZN-Phil, I plan to create a follow up Github issue for implementing unit tests for the newly created `PythonBindings::EditGem` function. This will most likely be lumped in with a larger effort to improve unit testing for `PythonBindings` overall.
