### PR TITLE
EMotionFX: Don't use magic numbers for snapping

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.cpp
@@ -186,7 +186,7 @@ namespace EMStudio
                 if (auto* blendGraphEvent = azrtti_cast<BlendGraphMimeEvent*>(graphCanvasEvent))
                 {
                     const QPoint nudgedPosition = { localPos.x(), localPos.y() + offset };
-                    offset += 10;
+                    offset += s_snapCellSize;
                     CreateNodeFromMimeEvent(blendGraphEvent, nudgedPosition);
                 }
             }

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodeGraphWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodeGraphWidget.cpp
@@ -346,13 +346,11 @@ namespace EMStudio
     }
 
 
-    QPoint NodeGraphWidget::SnapLocalToGrid(const QPoint& inPoint, uint32 cellSize) const
+    QPoint NodeGraphWidget::SnapLocalToGrid(const QPoint& inPoint) const
     {
-        MCORE_UNUSED(cellSize);
-
         QPoint snapped;
-        snapped.setX(inPoint.x() - aznumeric_cast<int>(MCore::Math::FMod(aznumeric_cast<float>(inPoint.x()), 10.0f)));
-        snapped.setY(inPoint.y() - aznumeric_cast<int>(MCore::Math::FMod(aznumeric_cast<float>(inPoint.y()), 10.0f)));
+        snapped.setX(inPoint.x() - inPoint.x() % s_snapCellSize);
+        snapped.setY(inPoint.y() - inPoint.y() % s_snapCellSize);
         return snapped;
     }
 
@@ -373,7 +371,7 @@ namespace EMStudio
             QPoint oldTopRight = m_moveNode->GetRect().topRight();
             QPoint scaledMouseDelta = (mousePos - m_mouseLastPos) * (1.0f / m_activeGraph->GetScale());
             QPoint unSnappedTopRight = oldTopRight + scaledMouseDelta;
-            QPoint snappedTopRight = SnapLocalToGrid(unSnappedTopRight, 10);
+            QPoint snappedTopRight = SnapLocalToGrid(unSnappedTopRight);
             snapDelta = snappedTopRight - unSnappedTopRight;
         }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodeGraphWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodeGraphWidget.h
@@ -60,7 +60,9 @@ namespace EMStudio
 
         QPoint LocalToGlobal(const QPoint& inPoint) const;
         QPoint GlobalToLocal(const QPoint& inPoint) const;
-        QPoint SnapLocalToGrid(const QPoint& inPoint, uint32 cellSize = 10) const;
+
+        static constexpr uint32 s_snapCellSize = 10;
+        QPoint SnapLocalToGrid(const QPoint& inPoint) const;
 
         void CalcSelectRect(QRect& outRect);
 


### PR DESCRIPTION
Since the cellSize parameter was not used anyway, let's get rid of it.

Signed-off-by: Miłosz Kosobucki <milosz@kosobucki.pl>

## What does this PR do?

It's a small code cleanup.

## How was this PR tested?

EMotionFX unit tests were executed and snapping in node graph was tested manually for regressions.