### PR TITLE
Add optional whitespace capture to AP regex in root cause analysis config

### DIFF
--- a/scripts/build/build_failure_rca/rca_patterns/Asset-Processing.json
+++ b/scripts/build/build_failure_rca/rca_patterns/Asset-Processing.json
@@ -7,7 +7,7 @@
         "single_line": true,
         "find_all": true,
         "log_patterns": [
-          "^.*AssetProcessor: Failed.*\\.\\.\\.$",
+          "^.*AssetProcessor: Failed.*\\.\\.\\.\\s*$",
           "^.*?AssetProcessor: Createjobs Failed:.*$"
         ],
         "log_testcases": [


### PR DESCRIPTION
## What does this PR do?

Added optional whitespace capture at end of regex to deal with a space at the end of the message

## How was this PR tested?

Untested since this runs on Jenkins
