### PR TITLE
Image suffix support

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.cpp
@@ -91,9 +91,14 @@ namespace AzToolsFramework
             // Set the entity* for each disabled component
             for (auto disabledComponent : m_disabledComponents)
             {
-                auto editorComponentBaseComponent = azrtti_cast<Components::EditorComponentBase*>(disabledComponent);
-                AZ_Assert(editorComponentBaseComponent, "Editor component does not derive from EditorComponentBase");
-                editorComponentBaseComponent->SetEntity(GetEntity());
+                // It's possible to get null components in the list if errors occur during serialization.
+                // Guard against that case so that the code won't crash.
+                if (disabledComponent)
+                {
+                    auto editorComponentBaseComponent = azrtti_cast<Components::EditorComponentBase*>(disabledComponent);
+                    AZ_Assert(editorComponentBaseComponent, "Editor component does not derive from EditorComponentBase");
+                    editorComponentBaseComponent->SetEntity(GetEntity());
+                }
             }
         }
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.cpp
@@ -601,20 +601,17 @@ namespace ImageProcessingAtom
         AZStd::string fileName;
         QString lowerFileName = imageFilePath.data();
         lowerFileName = lowerFileName.toLower();
-        AzFramework::StringFunc::Path::GetFileName(lowerFileName.toUtf8().constData(), fileName);
+
+        // If the complete file name contains multiple extension separators ('.'), only use the base name before the first separator
+        // for the file mask. For example, 'name_filemask.something.extension' will only use 'name_filemask', producing a result
+        // of '_filemask' that is returned from this method.
+        fileName = QFileInfo(lowerFileName).baseName().toUtf8();
 
         //get the substring from last '_'
         size_t lastUnderScore = fileName.find_last_of(FileMaskDelimiter);
         if (lastUnderScore != AZStd::string::npos)
         {
-            // If the complete file name contains multiple extension separators ('.'), the GetFileName() call above will
-            // return all of the extensions except the last as the file name, and only the last is stripped off as the extension.
-            // For example, 'name_filemask.something.extension' will have the '.extension' removed, leaving us
-            // with 'name_filemask.something'. We would like to ignore *all* extensions when comparing file masks, so look for
-            // the extension separator and only use the portion of the name from the underscore to the period.
-            // i.e. use '_filemask', and ignore '.something'.
-            size_t firstExtensionChar = fileName.find(AZ_FILESYSTEM_EXTENSION_SEPARATOR, lastUnderScore);
-            return fileName.substr(lastUnderScore, firstExtensionChar - lastUnderScore);
+            return fileName.substr(lastUnderScore);
         }
 
         return AZStd::string();

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.cpp
@@ -598,14 +598,13 @@ namespace ImageProcessingAtom
     AZStd::string BuilderSettingManager::GetFileMask(AZStd::string_view imageFilePath) const
     {
         //get file name
-        AZStd::string fileName;
         QString lowerFileName = imageFilePath.data();
         lowerFileName = lowerFileName.toLower();
 
         // If the complete file name contains multiple extension separators ('.'), only use the base name before the first separator
         // for the file mask. For example, 'name_filemask.something.extension' will only use 'name_filemask', producing a result
         // of '_filemask' that is returned from this method.
-        fileName = QFileInfo(lowerFileName).baseName().toUtf8();
+        AZStd::string fileName(QFileInfo(lowerFileName).baseName().toUtf8());
 
         //get the substring from last '_'
         size_t lastUnderScore = fileName.find_last_of(FileMaskDelimiter);


### PR DESCRIPTION
## What does this PR do?

The Atom Image Builder uses a set of user-definable file name suffixes to select the correct image settings for processing the image. These suffixes take the form “_albedo”, “_gsi”, etc. See https://www.o3de.org/docs/user-guide/assets/texture-settings/texture-presets/ for more details. The change that’s being made is that an additional condition is being added to the suffix check so they will only compare the filename between the last underscore and the first period. For example, the name “image_gsi.0000.tif” used to try comparing “_gsi.0000” to the image suffixes. Now it will compare “_gsi” and ignore the “.0000”.

There's also a small mostly-unrelated null crash fix in this PR that I found while debugging the builder code in the Asset Processor. I wasn't making it to the image builder because some other malformed assets on my drive were crashing the EditorDisabledComponent. This crash fix prevents malformed assets from crashing. :) 

## How was this PR tested?

Verified that assets following the pattern "image_gsi.0000.tif" were getting processed as GSI files.
Verified that assets following regular patterns ("chair_normal.tif" etc) were getting processed as normals, etc.