### PR TITLE
LyShine shutdown assert/crash fix

### DIFF
--- a/Gems/LyShine/Code/Source/Sprite.cpp
+++ b/Gems/LyShine/Code/Source/Sprite.cpp
@@ -197,7 +197,10 @@ CSprite::CSprite()
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 CSprite::~CSprite()
 {
-    s_loadedSprites->erase(m_pathname);
+    if (s_loadedSprites)
+    {
+        s_loadedSprites->erase(m_pathname);
+    }
     TextureAtlasNamespace::TextureAtlasNotificationBus::Handler::BusDisconnect();
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes a debugger assert/crash when closing a game launcher with LyShine assets on the level.

## How was this PR tested?

Game launcher under a debugger with o3de-multiplayersample
