### PR TITLE
Makes sure the initial value of vsync_interval

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
@@ -15,6 +15,7 @@
 #include <AzFramework/Viewport/ViewportScreen.h>
 #include <AzToolsFramework/Viewport/ViewportTypes.h>
 #include <AzCore/Math/MathUtils.h>
+#include <AzCore/Console/IConsole.h>
 #include <Atom/RHI/RHISystemInterface.h>
 #include <Atom/Bootstrap/BootstrapRequestBus.h>
 
@@ -455,7 +456,12 @@ namespace AtomToolsFramework
 
     uint32_t RenderViewportWidget::GetSyncInterval() const
     {
-        return 1;
+        uint32_t vsyncInterval = 1;
+        if (auto* console = AZ::Interface<AZ::IConsole>::Get(); console != nullptr)
+        {
+            console->GetCvarValue("vsync_interval", vsyncInterval);
+        }
+        return vsyncInterval;
     }
 
     // Editor ignores requests to change the sync interval


### PR DESCRIPTION
## What does this PR do?
Makes sure the initial value of vsync_interval
CVar is used when initializing the swapchain.

Fixes the 2nd problem mentioned here: https://github.com/o3de/o3de/issues/12748

## How was this PR tested?

On windows set the `--vsync_interval=0` in the command line when starting Editor.exe. The FPS started almost at 200fps.
On windows set the `--vsync_interval=1` in the command line when starting Editor.exe. The FPS started almost at 60fps.

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>
