### PR TITLE
Refactor and break the AP state data unit tests

### DIFF
--- a/Code/Tools/AssetProcessor/native/unittests/AssetProcessingStateDataUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetProcessingStateDataUnitTests.cpp
@@ -1570,7 +1570,6 @@ namespace AssetProcessor
     TEST_F(AssetProcessingStateDataUnitTest, TestSourceFingerprint_QuerySourceAnalysisFingerprint_Succeeds)
     {
         using SourceDatabaseEntry = AzToolsFramework::AssetDatabase::SourceDatabaseEntry;
-        using ScanFolderDatabaseEntry = AzToolsFramework::AssetDatabase::ScanFolderDatabaseEntry;
 
         AddDefaultSource();
         // Add another source

--- a/Code/Tools/AssetProcessor/native/unittests/AssetProcessingStateDataUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetProcessingStateDataUnitTests.cpp
@@ -14,7 +14,7 @@ using namespace AzToolsFramework::AssetDatabase;
 
 namespace AssetProcessor
 {
-    namespace
+    namespace Internal
     {
         auto ScanFoldersContainScanFolderID = [](const ScanFolderDatabaseEntryContainer& scanFolders, AZ::s64 scanFolderID) -> bool
         {
@@ -426,10 +426,10 @@ namespace AssetProcessor
         scanFolders.clear();
         EXPECT_TRUE(m_connection.GetScanFolders(scanFolders));
         EXPECT_EQ(scanFolders.size(), 1);
-        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/dev"));
-        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, m_defaultScanFolder.m_scanFolderID));
-        EXPECT_TRUE(ScanFoldersContainPortableKey(scanFolders, m_defaultScanFolder.m_portableKey.c_str()));
-        EXPECT_TRUE(ScanFoldersContainPortableKey(scanFolders, "rootportkey"));
+        EXPECT_TRUE(Internal::ScanFoldersContainScanPath(scanFolders, "c:/O3DE/dev"));
+        EXPECT_TRUE(Internal::ScanFoldersContainScanFolderID(scanFolders, m_defaultScanFolder.m_scanFolderID));
+        EXPECT_TRUE(Internal::ScanFoldersContainPortableKey(scanFolders, m_defaultScanFolder.m_portableKey.c_str()));
+        EXPECT_TRUE(Internal::ScanFoldersContainPortableKey(scanFolders, "rootportkey"));
     }
 
     TEST_F(AssetProcessingStateDataUnitTest, TestScanFolder_AddDuplicateScanFolder_GetsSameId)
@@ -450,10 +450,10 @@ namespace AssetProcessor
         ScanFolderDatabaseEntryContainer scanFolders;
         EXPECT_TRUE(m_connection.GetScanFolders(scanFolders));
         EXPECT_EQ(scanFolders.size(), 1);
-        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/dev1"));
-        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, m_defaultScanFolder.m_scanFolderID));
-        EXPECT_TRUE(ScanFoldersContainPortableKey(scanFolders, m_defaultScanFolder.m_portableKey.c_str()));
-        EXPECT_TRUE(ScanFoldersContainPortableKey(scanFolders, "rootportkey"));
+        EXPECT_TRUE(Internal::ScanFoldersContainScanPath(scanFolders, "c:/O3DE/dev1"));
+        EXPECT_TRUE(Internal::ScanFoldersContainScanFolderID(scanFolders, m_defaultScanFolder.m_scanFolderID));
+        EXPECT_TRUE(Internal::ScanFoldersContainPortableKey(scanFolders, m_defaultScanFolder.m_portableKey.c_str()));
+        EXPECT_TRUE(Internal::ScanFoldersContainPortableKey(scanFolders, "rootportkey"));
     }
 
     TEST_F(AssetProcessingStateDataUnitTest, TestScanFolder_RetrieveScanFolderById_Succeeds)
@@ -490,10 +490,10 @@ namespace AssetProcessor
         ScanFolderDatabaseEntryContainer scanFolders;
         EXPECT_TRUE(m_connection.GetScanFolders(scanFolders));
         EXPECT_EQ(scanFolders.size(), 2);
-        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/dev"));
-        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/game"));
-        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, m_defaultScanFolder.m_scanFolderID));
-        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, gameScanFolderEntry.m_scanFolderID));
+        EXPECT_TRUE(Internal::ScanFoldersContainScanPath(scanFolders, "c:/O3DE/dev"));
+        EXPECT_TRUE(Internal::ScanFoldersContainScanPath(scanFolders, "c:/O3DE/game"));
+        EXPECT_TRUE(Internal::ScanFoldersContainScanFolderID(scanFolders, m_defaultScanFolder.m_scanFolderID));
+        EXPECT_TRUE(Internal::ScanFoldersContainScanFolderID(scanFolders, gameScanFolderEntry.m_scanFolderID));
 
         // Remove the game scan folder
         EXPECT_TRUE(m_connection.RemoveScanFolder(848475));//should return true even if it doesn't exist, false only means SQL failed
@@ -503,8 +503,8 @@ namespace AssetProcessor
         scanFolders.clear();
         EXPECT_TRUE(m_connection.GetScanFolders(scanFolders));
         EXPECT_EQ(scanFolders.size(), 1);
-        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/dev"));
-        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, m_defaultScanFolder.m_scanFolderID));
+        EXPECT_TRUE(Internal::ScanFoldersContainScanPath(scanFolders, "c:/O3DE/dev"));
+        EXPECT_TRUE(Internal::ScanFoldersContainScanFolderID(scanFolders, m_defaultScanFolder.m_scanFolderID));
     }
 
     TEST_F(AssetProcessingStateDataUnitTest, TestScanFolder_RemoveScanFolderByContainer_Succeeds)
@@ -519,10 +519,10 @@ namespace AssetProcessor
         ScanFolderDatabaseEntryContainer scanFolders;
         EXPECT_TRUE(m_connection.GetScanFolders(scanFolders));
         EXPECT_EQ(scanFolders.size(), 2);
-        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/dev"));
-        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/game"));
-        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, m_defaultScanFolder.m_scanFolderID));
-        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, gameScanFolderEntry.m_scanFolderID));
+        EXPECT_TRUE(Internal::ScanFoldersContainScanPath(scanFolders, "c:/O3DE/dev"));
+        EXPECT_TRUE(Internal::ScanFoldersContainScanPath(scanFolders, "c:/O3DE/game"));
+        EXPECT_TRUE(Internal::ScanFoldersContainScanFolderID(scanFolders, m_defaultScanFolder.m_scanFolderID));
+        EXPECT_TRUE(Internal::ScanFoldersContainScanFolderID(scanFolders, gameScanFolderEntry.m_scanFolderID));
 
         // Remove scan folder by using a container
         ScanFolderDatabaseEntryContainer tempScanFolderDatabaseEntryContainer; // note that on clang, its illegal to call a non-const function with a temp variable container as the param
@@ -561,9 +561,9 @@ namespace AssetProcessor
         EXPECT_TRUE(m_connection.GetSources(sources));
         EXPECT_EQ(sources.size(), 1);
         EXPECT_EQ(sources[0].m_analysisFingerprint, "12345");
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        EXPECT_TRUE(Internal::SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(Internal::SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(Internal::SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
     }
 
     TEST_F(AssetProcessingStateDataUnitTest, TestSources_AddDuplicateSource_GetsSameId)
@@ -581,9 +581,9 @@ namespace AssetProcessor
         EXPECT_TRUE(m_connection.GetSources(sources));
         EXPECT_EQ(sources.size(), 1);
         EXPECT_EQ(sources[0].m_analysisFingerprint, "12345");
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        EXPECT_TRUE(Internal::SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(Internal::SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(Internal::SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
     }
 
     TEST_F(AssetProcessingStateDataUnitTest, TestSources_ChangeSourceField_Succeeds)
@@ -600,9 +600,9 @@ namespace AssetProcessor
         EXPECT_TRUE(m_connection.GetSources(sources));
         EXPECT_EQ(sources.size(), 1);
         EXPECT_EQ(sources[0].m_analysisFingerprint, "otherFingerprint");
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        EXPECT_TRUE(Internal::SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(Internal::SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(Internal::SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
     }
 
     TEST_F(AssetProcessingStateDataUnitTest, TestSources_ChangeScanFolder_Succeeds)
@@ -625,9 +625,9 @@ namespace AssetProcessor
         EXPECT_TRUE(m_connection.GetSources(sources));
         EXPECT_EQ(sources.size(), 1);
         EXPECT_EQ(sources[0].m_analysisFingerprint, "new different fingerprint"); // verify that this column IS updated.
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        EXPECT_TRUE(Internal::SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(Internal::SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(Internal::SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
 
         // Add the same source again, but change the scan folder back. This should NOT add a new source - this time we do know what the source ID is!
         SourceDatabaseEntry dupeSource(m_defaultSource);
@@ -639,18 +639,18 @@ namespace AssetProcessor
         sources.clear();
         EXPECT_TRUE(m_connection.GetSources(sources));
         EXPECT_EQ(sources.size(), 1);
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        EXPECT_TRUE(Internal::SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(Internal::SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(Internal::SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
 
         // Remove the extra scan folder, make sure it doesn't drop the source since it should now be bound to the original scan folder agian
         EXPECT_TRUE(m_connection.RemoveScanFolder(scanfolder.m_scanFolderID));
         sources.clear();
         EXPECT_TRUE(m_connection.GetSources(sources));
         EXPECT_EQ(sources.size(), 1);
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        EXPECT_TRUE(Internal::SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(Internal::SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(Internal::SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
     }
 
     TEST_F(AssetProcessingStateDataUnitTest, TestSources_RetrieveSourceBySourceId_Succeeds)
@@ -692,39 +692,39 @@ namespace AssetProcessor
         sources.clear();
         EXPECT_TRUE(m_connection.GetSourcesLikeSourceName("SomeSource%", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Raw, sources));
         EXPECT_EQ(sources.size(), 1);
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        EXPECT_TRUE(Internal::SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(Internal::SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(Internal::SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
         sources.clear();
         EXPECT_TRUE(m_connection.GetSourcesLikeSourceName("%SomeSource%", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Raw, sources));
         EXPECT_EQ(sources.size(), 1);
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        EXPECT_TRUE(Internal::SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(Internal::SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(Internal::SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
         sources.clear();
         EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("Source", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::StartsWith, sources));
         sources.clear();
         EXPECT_TRUE(m_connection.GetSourcesLikeSourceName("Some", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::StartsWith, sources));
         EXPECT_EQ(sources.size(), 1);
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        EXPECT_TRUE(Internal::SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(Internal::SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(Internal::SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
         sources.clear();
         EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("SomeSource", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::EndsWith, sources));
         sources.clear();
         EXPECT_TRUE(m_connection.GetSourcesLikeSourceName(".tif", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::EndsWith, sources));
         EXPECT_EQ(sources.size(), 1);
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        EXPECT_TRUE(Internal::SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(Internal::SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(Internal::SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
         sources.clear();
         EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("blah", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Matches, sources));
         sources.clear();
         EXPECT_TRUE(m_connection.GetSourcesLikeSourceName("meSour", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Matches, sources));
         EXPECT_EQ(sources.size(), 1);
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        EXPECT_TRUE(Internal::SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(Internal::SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(Internal::SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
     }
 
     TEST_F(AssetProcessingStateDataUnitTest, TestSources_RemoveSourceById_Succeeds)
@@ -736,9 +736,9 @@ namespace AssetProcessor
         EXPECT_TRUE(m_connection.GetSources(sources));
         EXPECT_EQ(sources.size(), 1);
         EXPECT_EQ(sources[0].m_analysisFingerprint, "12345");
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        EXPECT_TRUE(Internal::SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(Internal::SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(Internal::SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
 
         // Remove a source
         EXPECT_TRUE(m_connection.RemoveSource(432234));//should return true even if it doesn't exist, false only if SQL failed
@@ -761,12 +761,12 @@ namespace AssetProcessor
         SourceDatabaseEntryContainer sources;
         EXPECT_TRUE(m_connection.GetSources(sources));
         EXPECT_EQ(sources.size(), 2);
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource1.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
-        EXPECT_TRUE(SourcesContainSourceID(sources, source.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, source.m_sourceGuid));
+        EXPECT_TRUE(Internal::SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(Internal::SourcesContainSourceName(sources, "SomeSource1.tif"));
+        EXPECT_TRUE(Internal::SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(Internal::SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        EXPECT_TRUE(Internal::SourcesContainSourceID(sources, source.m_sourceID));
+        EXPECT_TRUE(Internal::SourcesContainSourceGuid(sources, source.m_sourceGuid));
 
         // Remove source via container
         SourceDatabaseEntryContainer tempSourceDatabaseEntryContainer;
@@ -790,12 +790,12 @@ namespace AssetProcessor
         SourceDatabaseEntryContainer sources;
         EXPECT_TRUE(m_connection.GetSources(sources));
         EXPECT_EQ(sources.size(), 2);
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource1.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
-        EXPECT_TRUE(SourcesContainSourceID(sources, source.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, source.m_sourceGuid));
+        EXPECT_TRUE(Internal::SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(Internal::SourcesContainSourceName(sources, "SomeSource1.tif"));
+        EXPECT_TRUE(Internal::SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(Internal::SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        EXPECT_TRUE(Internal::SourcesContainSourceID(sources, source.m_sourceID));
+        EXPECT_TRUE(Internal::SourcesContainSourceGuid(sources, source.m_sourceGuid));
 
         // Remove the scan folder for these sources, the sources should cascade delete
         EXPECT_TRUE(m_connection.RemoveScanFolder(m_defaultScanFolder.m_scanFolderID));
@@ -842,13 +842,13 @@ namespace AssetProcessor
         jobs.clear();
         EXPECT_TRUE(m_connection.GetJobs(jobs));
         EXPECT_EQ(jobs.size(), 1);
-        EXPECT_TRUE(JobsContainJobID(jobs, m_defaultJob.m_jobID));
-        EXPECT_TRUE(JobsContainJobKey(jobs, m_defaultJob.m_jobKey.c_str()));
-        EXPECT_TRUE(JobsContainFingerprint(jobs, m_defaultJob.m_fingerprint));
-        EXPECT_TRUE(JobsContainPlatform(jobs, m_defaultJob.m_platform.c_str()));
-        EXPECT_TRUE(JobsContainBuilderGuid(jobs, m_defaultJob.m_builderGuid));
-        EXPECT_TRUE(JobsContainStatus(jobs, m_defaultJob.m_status));
-        EXPECT_TRUE(JobsContainRunKey(jobs, m_defaultJob.m_jobRunKey));
+        EXPECT_TRUE(Internal::JobsContainJobID(jobs, m_defaultJob.m_jobID));
+        EXPECT_TRUE(Internal::JobsContainJobKey(jobs, m_defaultJob.m_jobKey.c_str()));
+        EXPECT_TRUE(Internal::JobsContainFingerprint(jobs, m_defaultJob.m_fingerprint));
+        EXPECT_TRUE(Internal::JobsContainPlatform(jobs, m_defaultJob.m_platform.c_str()));
+        EXPECT_TRUE(Internal::JobsContainBuilderGuid(jobs, m_defaultJob.m_builderGuid));
+        EXPECT_TRUE(Internal::JobsContainStatus(jobs, m_defaultJob.m_status));
+        EXPECT_TRUE(Internal::JobsContainRunKey(jobs, m_defaultJob.m_jobRunKey));
     }
 
     TEST_F(AssetProcessingStateDataUnitTest, TestJobs_AddDuplicateJob_GetsSameId)
@@ -865,12 +865,12 @@ namespace AssetProcessor
         JobDatabaseEntryContainer jobs;
         EXPECT_TRUE(m_connection.GetJobs(jobs));
         EXPECT_EQ(jobs.size(), 1);
-        EXPECT_TRUE(JobsContainJobID(jobs, m_defaultJob.m_jobID));
-        EXPECT_TRUE(JobsContainJobKey(jobs, m_defaultJob.m_jobKey.c_str()));
-        EXPECT_TRUE(JobsContainFingerprint(jobs, m_defaultJob.m_fingerprint));
-        EXPECT_TRUE(JobsContainPlatform(jobs, m_defaultJob.m_platform.c_str()));
-        EXPECT_TRUE(JobsContainBuilderGuid(jobs, m_defaultJob.m_builderGuid));
-        EXPECT_TRUE(JobsContainStatus(jobs, m_defaultJob.m_status));
+        EXPECT_TRUE(Internal::JobsContainJobID(jobs, m_defaultJob.m_jobID));
+        EXPECT_TRUE(Internal::JobsContainJobKey(jobs, m_defaultJob.m_jobKey.c_str()));
+        EXPECT_TRUE(Internal::JobsContainFingerprint(jobs, m_defaultJob.m_fingerprint));
+        EXPECT_TRUE(Internal::JobsContainPlatform(jobs, m_defaultJob.m_platform.c_str()));
+        EXPECT_TRUE(Internal::JobsContainBuilderGuid(jobs, m_defaultJob.m_builderGuid));
+        EXPECT_TRUE(Internal::JobsContainStatus(jobs, m_defaultJob.m_status));
     }
 
     TEST_F(AssetProcessingStateDataUnitTest, TestJobs_RetrieveJobByJobId_Succeeds)
@@ -885,12 +885,12 @@ namespace AssetProcessor
         JobDatabaseEntryContainer jobs;
         EXPECT_TRUE(m_connection.GetJobsBySourceID(m_defaultSource.m_sourceID, jobs));
         EXPECT_EQ(jobs.size(), 1);
-        EXPECT_TRUE(JobsContainJobID(jobs, m_defaultJob.m_jobID));
-        EXPECT_TRUE(JobsContainJobKey(jobs, m_defaultJob.m_jobKey.c_str()));
-        EXPECT_TRUE(JobsContainFingerprint(jobs, m_defaultJob.m_fingerprint));
-        EXPECT_TRUE(JobsContainPlatform(jobs, m_defaultJob.m_platform.c_str()));
-        EXPECT_TRUE(JobsContainBuilderGuid(jobs, m_defaultJob.m_builderGuid));
-        EXPECT_TRUE(JobsContainStatus(jobs, m_defaultJob.m_status));
+        EXPECT_TRUE(Internal::JobsContainJobID(jobs, m_defaultJob.m_jobID));
+        EXPECT_TRUE(Internal::JobsContainJobKey(jobs, m_defaultJob.m_jobKey.c_str()));
+        EXPECT_TRUE(Internal::JobsContainFingerprint(jobs, m_defaultJob.m_fingerprint));
+        EXPECT_TRUE(Internal::JobsContainPlatform(jobs, m_defaultJob.m_platform.c_str()));
+        EXPECT_TRUE(Internal::JobsContainBuilderGuid(jobs, m_defaultJob.m_builderGuid));
+        EXPECT_TRUE(Internal::JobsContainStatus(jobs, m_defaultJob.m_status));
     }
 
     TEST_F(AssetProcessingStateDataUnitTest, TestJobs_RetrieveJobBySourceName_Succeeds)
@@ -907,12 +907,12 @@ namespace AssetProcessor
         EXPECT_TRUE(m_connection.GetJobsBySourceName(AssetProcessor::SourceAssetReference(
             m_defaultSource.m_scanFolderPK, m_defaultSource.m_sourceName.c_str()), jobs));
         EXPECT_EQ(jobs.size(), 1);
-        EXPECT_TRUE(JobsContainJobID(jobs, m_defaultJob.m_jobID));
-        EXPECT_TRUE(JobsContainJobKey(jobs, m_defaultJob.m_jobKey.c_str()));
-        EXPECT_TRUE(JobsContainFingerprint(jobs, m_defaultJob.m_fingerprint));
-        EXPECT_TRUE(JobsContainPlatform(jobs, m_defaultJob.m_platform.c_str()));
-        EXPECT_TRUE(JobsContainBuilderGuid(jobs, m_defaultJob.m_builderGuid));
-        EXPECT_TRUE(JobsContainStatus(jobs, m_defaultJob.m_status));
+        EXPECT_TRUE(Internal::JobsContainJobID(jobs, m_defaultJob.m_jobID));
+        EXPECT_TRUE(Internal::JobsContainJobKey(jobs, m_defaultJob.m_jobKey.c_str()));
+        EXPECT_TRUE(Internal::JobsContainFingerprint(jobs, m_defaultJob.m_fingerprint));
+        EXPECT_TRUE(Internal::JobsContainPlatform(jobs, m_defaultJob.m_platform.c_str()));
+        EXPECT_TRUE(Internal::JobsContainBuilderGuid(jobs, m_defaultJob.m_builderGuid));
+        EXPECT_TRUE(Internal::JobsContainStatus(jobs, m_defaultJob.m_status));
     }
 
     TEST_F(AssetProcessingStateDataUnitTest, TestJobs_RemoveJobByJobId_Succeeds)
@@ -947,18 +947,18 @@ namespace AssetProcessor
         JobDatabaseEntryContainer jobs;
         EXPECT_TRUE(m_connection.GetJobs(jobs));
         EXPECT_EQ(jobs.size(), 2);
-        EXPECT_TRUE(JobsContainJobID(jobs, m_defaultJob.m_jobID));
-        EXPECT_TRUE(JobsContainJobKey(jobs, m_defaultJob.m_jobKey.c_str()));
-        EXPECT_TRUE(JobsContainFingerprint(jobs, m_defaultJob.m_fingerprint));
-        EXPECT_TRUE(JobsContainPlatform(jobs, m_defaultJob.m_platform.c_str()));
-        EXPECT_TRUE(JobsContainBuilderGuid(jobs, m_defaultJob.m_builderGuid));
-        EXPECT_TRUE(JobsContainStatus(jobs, m_defaultJob.m_status));
-        EXPECT_TRUE(JobsContainJobID(jobs, job.m_jobID));
-        EXPECT_TRUE(JobsContainJobKey(jobs, job.m_jobKey.c_str()));
-        EXPECT_TRUE(JobsContainFingerprint(jobs, job.m_fingerprint));
-        EXPECT_TRUE(JobsContainPlatform(jobs, job.m_platform.c_str()));
-        EXPECT_TRUE(JobsContainBuilderGuid(jobs, job.m_builderGuid));
-        EXPECT_TRUE(JobsContainStatus(jobs, job.m_status));
+        EXPECT_TRUE(Internal::JobsContainJobID(jobs, m_defaultJob.m_jobID));
+        EXPECT_TRUE(Internal::JobsContainJobKey(jobs, m_defaultJob.m_jobKey.c_str()));
+        EXPECT_TRUE(Internal::JobsContainFingerprint(jobs, m_defaultJob.m_fingerprint));
+        EXPECT_TRUE(Internal::JobsContainPlatform(jobs, m_defaultJob.m_platform.c_str()));
+        EXPECT_TRUE(Internal::JobsContainBuilderGuid(jobs, m_defaultJob.m_builderGuid));
+        EXPECT_TRUE(Internal::JobsContainStatus(jobs, m_defaultJob.m_status));
+        EXPECT_TRUE(Internal::JobsContainJobID(jobs, job.m_jobID));
+        EXPECT_TRUE(Internal::JobsContainJobKey(jobs, job.m_jobKey.c_str()));
+        EXPECT_TRUE(Internal::JobsContainFingerprint(jobs, job.m_fingerprint));
+        EXPECT_TRUE(Internal::JobsContainPlatform(jobs, job.m_platform.c_str()));
+        EXPECT_TRUE(Internal::JobsContainBuilderGuid(jobs, job.m_builderGuid));
+        EXPECT_TRUE(Internal::JobsContainStatus(jobs, job.m_status));
 
         //Remove job via container
         JobDatabaseEntryContainer tempJobDatabaseEntryContainer;
@@ -985,18 +985,18 @@ namespace AssetProcessor
         JobDatabaseEntryContainer jobs;
         EXPECT_TRUE(m_connection.GetJobs(jobs));
         EXPECT_EQ(jobs.size(), 2);
-        EXPECT_TRUE(JobsContainJobID(jobs, m_defaultJob.m_jobID));
-        EXPECT_TRUE(JobsContainJobKey(jobs, m_defaultJob.m_jobKey.c_str()));
-        EXPECT_TRUE(JobsContainFingerprint(jobs, m_defaultJob.m_fingerprint));
-        EXPECT_TRUE(JobsContainPlatform(jobs, m_defaultJob.m_platform.c_str()));
-        EXPECT_TRUE(JobsContainBuilderGuid(jobs, m_defaultJob.m_builderGuid));
-        EXPECT_TRUE(JobsContainStatus(jobs, m_defaultJob.m_status));
-        EXPECT_TRUE(JobsContainJobID(jobs, job.m_jobID));
-        EXPECT_TRUE(JobsContainJobKey(jobs, job.m_jobKey.c_str()));
-        EXPECT_TRUE(JobsContainFingerprint(jobs, job.m_fingerprint));
-        EXPECT_TRUE(JobsContainPlatform(jobs, job.m_platform.c_str()));
-        EXPECT_TRUE(JobsContainBuilderGuid(jobs, job.m_builderGuid));
-        EXPECT_TRUE(JobsContainStatus(jobs, job.m_status));
+        EXPECT_TRUE(Internal::JobsContainJobID(jobs, m_defaultJob.m_jobID));
+        EXPECT_TRUE(Internal::JobsContainJobKey(jobs, m_defaultJob.m_jobKey.c_str()));
+        EXPECT_TRUE(Internal::JobsContainFingerprint(jobs, m_defaultJob.m_fingerprint));
+        EXPECT_TRUE(Internal::JobsContainPlatform(jobs, m_defaultJob.m_platform.c_str()));
+        EXPECT_TRUE(Internal::JobsContainBuilderGuid(jobs, m_defaultJob.m_builderGuid));
+        EXPECT_TRUE(Internal::JobsContainStatus(jobs, m_defaultJob.m_status));
+        EXPECT_TRUE(Internal::JobsContainJobID(jobs, job.m_jobID));
+        EXPECT_TRUE(Internal::JobsContainJobKey(jobs, job.m_jobKey.c_str()));
+        EXPECT_TRUE(Internal::JobsContainFingerprint(jobs, job.m_fingerprint));
+        EXPECT_TRUE(Internal::JobsContainPlatform(jobs, job.m_platform.c_str()));
+        EXPECT_TRUE(Internal::JobsContainBuilderGuid(jobs, job.m_builderGuid));
+        EXPECT_TRUE(Internal::JobsContainStatus(jobs, job.m_status));
 
         // Remove the source for these jobs, the jobs should cascade delete
         EXPECT_TRUE(m_connection.RemoveSource(m_defaultSource.m_sourceID));
@@ -1248,11 +1248,11 @@ namespace AssetProcessor
         EXPECT_TRUE(m_connection.GetProductDependencies(productDependencies));
         EXPECT_EQ(productDependencies.size(), 1);
 
-        EXPECT_TRUE(ProductDependenciesContainProductDependencyID(productDependencies, productDependency.m_productDependencyID));
-        EXPECT_TRUE(ProductDependenciesContainProductID(productDependencies, productDependency.m_productPK));
-        EXPECT_TRUE(ProductDependenciesContainDependencySoureGuid(productDependencies, productDependency.m_dependencySourceGuid));
-        EXPECT_TRUE(ProductDependenciesContainDependencySubID(productDependencies, productDependency.m_dependencySubID));
-        EXPECT_TRUE(ProductDependenciesContainDependencyFlags(productDependencies, productDependency.m_dependencyFlags));
+        EXPECT_TRUE(Internal::ProductDependenciesContainProductDependencyID(productDependencies, productDependency.m_productDependencyID));
+        EXPECT_TRUE(Internal::ProductDependenciesContainProductID(productDependencies, productDependency.m_productPK));
+        EXPECT_TRUE(Internal::ProductDependenciesContainDependencySoureGuid(productDependencies, productDependency.m_dependencySourceGuid));
+        EXPECT_TRUE(Internal::ProductDependenciesContainDependencySubID(productDependencies, productDependency.m_dependencySubID));
+        EXPECT_TRUE(Internal::ProductDependenciesContainDependencyFlags(productDependencies, productDependency.m_dependencyFlags));
 
         // Add the same product again, should not add another because it already exists, so we should get the same id
         ProductDependencyDatabaseEntry dupeProductDependency(productDependency);
@@ -1265,11 +1265,11 @@ namespace AssetProcessor
         productDependencies.clear();
         EXPECT_TRUE(m_connection.GetProductDependencies(productDependencies));
         EXPECT_EQ(productDependencies.size(), 1);
-        EXPECT_TRUE(ProductDependenciesContainProductDependencyID(productDependencies, productDependency.m_productDependencyID));
-        EXPECT_TRUE(ProductDependenciesContainProductID(productDependencies, productDependency.m_productPK));
-        EXPECT_TRUE(ProductDependenciesContainDependencySoureGuid(productDependencies, productDependency.m_dependencySourceGuid));
-        EXPECT_TRUE(ProductDependenciesContainDependencySubID(productDependencies, productDependency.m_dependencySubID));
-        EXPECT_TRUE(ProductDependenciesContainDependencyFlags(productDependencies, productDependency.m_dependencyFlags));
+        EXPECT_TRUE(Internal::ProductDependenciesContainProductDependencyID(productDependencies, productDependency.m_productDependencyID));
+        EXPECT_TRUE(Internal::ProductDependenciesContainProductID(productDependencies, productDependency.m_productPK));
+        EXPECT_TRUE(Internal::ProductDependenciesContainDependencySoureGuid(productDependencies, productDependency.m_dependencySourceGuid));
+        EXPECT_TRUE(Internal::ProductDependenciesContainDependencySubID(productDependencies, productDependency.m_dependencySubID));
+        EXPECT_TRUE(Internal::ProductDependenciesContainDependencyFlags(productDependencies, productDependency.m_dependencyFlags));
     }
 
     TEST_F(AssetProcessingStateDataUnitTest, TestProductDependency_VerifyProductDependency_Succeeds)
@@ -1288,20 +1288,20 @@ namespace AssetProcessor
         ProductDatabaseEntryContainer dependentProducts;
         EXPECT_TRUE(m_connection.GetDirectProductDependencies(products[0].m_productID, dependentProducts));
         EXPECT_EQ(dependentProducts.size(), 1);
-        EXPECT_TRUE(ProductsContainProductID(products, products[1].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(products, products[1].m_productID));
 
         // products[1] -> products[2], products[3]
         dependentProducts.clear();
         EXPECT_TRUE(m_connection.GetDirectProductDependencies(products[1].m_productID, dependentProducts));
         EXPECT_EQ(dependentProducts.size(), 2);
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[2].m_productID));
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[3].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[2].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[3].m_productID));
 
         // products[2] -> products[4]
         dependentProducts.clear();
         EXPECT_TRUE(m_connection.GetDirectProductDependencies(products[2].m_productID, dependentProducts));
         EXPECT_EQ(dependentProducts.size(), 1);
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[4].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[4].m_productID));
 
         // products[3] ->
         dependentProducts.clear();
@@ -1312,7 +1312,7 @@ namespace AssetProcessor
         dependentProducts.clear();
         EXPECT_TRUE(m_connection.GetDirectProductDependencies(products[4].m_productID, dependentProducts));
         EXPECT_EQ(dependentProducts.size(), 1);
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[5].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[5].m_productID));
 
         // products[5] ->
         dependentProducts.clear();
@@ -1324,27 +1324,27 @@ namespace AssetProcessor
         dependentProducts.clear();
         EXPECT_TRUE(m_connection.GetAllProductDependencies(products[0].m_productID, dependentProducts));
         EXPECT_EQ(dependentProducts.size(), 5);
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[1].m_productID));
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[2].m_productID));
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[3].m_productID));
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[4].m_productID));
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[5].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[1].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[2].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[3].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[4].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[5].m_productID));
 
         // products[1] -> products[2], products[3], products[4], products[5]
         dependentProducts.clear();
         EXPECT_TRUE(m_connection.GetAllProductDependencies(products[1].m_productID, dependentProducts));
         EXPECT_EQ(dependentProducts.size(), 4);
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[2].m_productID));
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[3].m_productID));
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[4].m_productID));
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[5].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[2].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[3].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[4].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[5].m_productID));
 
         // products[2] -> products[4], products[5]
         dependentProducts.clear();
         EXPECT_TRUE(m_connection.GetAllProductDependencies(products[2].m_productID, dependentProducts));
         EXPECT_EQ(dependentProducts.size(), 2);
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[4].m_productID));
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[5].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[4].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[5].m_productID));
 
         // products[3] ->
         dependentProducts.clear();
@@ -1355,7 +1355,7 @@ namespace AssetProcessor
         dependentProducts.clear();
         EXPECT_TRUE(m_connection.GetAllProductDependencies(products[4].m_productID, dependentProducts));
         EXPECT_EQ(dependentProducts.size(), 1);
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[5].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[5].m_productID));
 
         // products[5] ->
         dependentProducts.clear();
@@ -1384,17 +1384,17 @@ namespace AssetProcessor
         ProductDatabaseEntryContainer dependentProducts;
         EXPECT_TRUE(m_connection.GetDirectProductDependencies(products[5].m_productID, dependentProducts));
         EXPECT_EQ(dependentProducts.size(), 1);
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[0].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[0].m_productID));
 
         // products[2] -> products[4], products[5], products[0], products[1], products[3]
         dependentProducts.clear();
         EXPECT_TRUE(m_connection.GetAllProductDependencies(products[2].m_productID, dependentProducts));
         EXPECT_EQ(dependentProducts.size(), 5);
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[4].m_productID));
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[5].m_productID));
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[0].m_productID));
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[1].m_productID));
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[3].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[4].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[5].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[0].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[1].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[3].m_productID));
 
         m_connection.RemoveProductDependencyByProductId(products[4].m_productID);
 
@@ -1402,9 +1402,9 @@ namespace AssetProcessor
         dependentProducts.clear();
         EXPECT_TRUE(m_connection.GetAllProductDependencies(products[1].m_productID, dependentProducts));
         EXPECT_EQ(dependentProducts.size(), 3);
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[2].m_productID));
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[3].m_productID));
-        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[4].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[2].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[3].m_productID));
+        EXPECT_TRUE(Internal::ProductsContainProductID(dependentProducts, products[4].m_productID));
     }
 
     TEST_F(AssetProcessingStateDataUnitTest, TestProductDependency_RemoveProductDependency_Succeeds)

--- a/Code/Tools/AssetProcessor/native/unittests/AssetProcessingStateDataUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetProcessingStateDataUnitTests.cpp
@@ -10,86 +10,12 @@
 #include <native/unittests/AssetProcessorUnitTests.h>
 #include <native/unittests/UnitTestRunner.h> // for the assert absorber.
 
+using namespace AzToolsFramework::AssetDatabase;
+
 namespace AssetProcessor
 {
-    class AssetProcessingStateDataUnitTest
-        : public UnitTest::AssetProcessorUnitTestBase
+    namespace
     {
-    protected:
-        void SetUp() override
-        {
-            UnitTest::AssetProcessorUnitTestBase::SetUp();
-
-            EXPECT_TRUE(m_connection.DataExists());
-            EXPECT_TRUE(m_connection.OpenDatabase());
-
-        }
-
-        void TearDown() override
-        {
-            m_connection.CloseDatabase();
-
-            UnitTest::AssetProcessorUnitTestBase::TearDown();
-        }
-
-        AssetProcessor::AssetDatabaseConnection m_connection;
-    };
-
-    TEST_F(AssetProcessingStateDataUnitTest, DataTest_ValidDatabaseConnectionProvided_OperationsSucceed)
-    {
-        using namespace AzToolsFramework::AssetDatabase;
-
-        ScanFolderDatabaseEntry scanFolder;
-        SourceDatabaseEntry source;
-        JobDatabaseEntry job;
-        ProductDatabaseEntry product;
-        ProductDependencyDatabaseEntry productDependency;
-
-        ScanFolderDatabaseEntryContainer scanFolders;
-        SourceDatabaseEntryContainer sources;
-        JobDatabaseEntryContainer jobs;
-        ProductDatabaseEntryContainer products;
-        ProductDependencyDatabaseEntryContainer productDependencies;
-        MissingProductDependencyDatabaseEntryContainer missingDependencies;
-
-        QString outName;
-        QString outPlat;
-        QString outJobDescription;
-
-        AZ::Uuid validSourceGuid1 = AZ::Uuid::CreateRandom();
-        AZ::Uuid validSourceGuid2 = AZ::Uuid::CreateRandom();
-        AZ::Uuid validSourceGuid3 = AZ::Uuid::CreateRandom();
-        AZ::Uuid validSourceGuid4 = AZ::Uuid::CreateRandom();
-        AZ::Uuid validSourceGuid5 = AZ::Uuid::CreateRandom();
-        AZ::Uuid validSourceGuid6 = AZ::Uuid::CreateRandom();
-
-        AZ::u32 validFingerprint1 = 1;
-        AZ::u32 validFingerprint2 = 2;
-        AZ::u32 validFingerprint3 = 3;
-        AZ::u32 validFingerprint4 = 4;
-        AZ::u32 validFingerprint5 = 5;
-        AZ::u32 validFingerprint6 = 6;
-
-        AZ::Uuid validBuilderGuid1 = AZ::Uuid::CreateRandom();
-        AZ::Uuid validBuilderGuid2 = AZ::Uuid::CreateRandom();
-        AZ::Uuid validBuilderGuid3 = AZ::Uuid::CreateRandom();
-        AZ::Uuid validBuilderGuid4 = AZ::Uuid::CreateRandom();
-        AZ::Uuid validBuilderGuid5 = AZ::Uuid::CreateRandom();
-        AZ::Uuid validBuilderGuid6 = AZ::Uuid::CreateRandom();
-
-        AZ::Data::AssetType validAssetType1 = AZ::Data::AssetType::CreateRandom();
-        AZ::Data::AssetType validAssetType2 = AZ::Data::AssetType::CreateRandom();
-        AZ::Data::AssetType validAssetType3 = AZ::Data::AssetType::CreateRandom();
-        AZ::Data::AssetType validAssetType4 = AZ::Data::AssetType::CreateRandom();
-        AZ::Data::AssetType validAssetType5 = AZ::Data::AssetType::CreateRandom();
-        AZ::Data::AssetType validAssetType6 = AZ::Data::AssetType::CreateRandom();
-
-        AzToolsFramework::AssetSystem::JobStatus statusQueued = AzToolsFramework::AssetSystem::JobStatus::Queued;
-        AzToolsFramework::AssetSystem::JobStatus statusCompleted = AzToolsFramework::AssetSystem::JobStatus::Completed;
-
-        //////////////////////////////////////////////////////////////////////////
-        //ScanFolder
-        //the database all starts with a scan folder since all sources are have one
         auto ScanFoldersContainScanFolderID = [](const ScanFolderDatabaseEntryContainer& scanFolders, AZ::s64 scanFolderID) -> bool
         {
             for (const auto& scanFolder : scanFolders)
@@ -126,107 +52,6 @@ namespace AssetProcessor
             return false;
         };
 
-        //there are no scan folders yet so trying to find one should fail
-        EXPECT_FALSE(m_connection.GetScanFolders(scanFolders));
-        EXPECT_FALSE(m_connection.GetScanFolderByScanFolderID(0, scanFolder));
-        EXPECT_FALSE(m_connection.GetScanFolderBySourceID(0, scanFolder));
-        EXPECT_FALSE(m_connection.GetScanFolderByProductID(0, scanFolder));
-        EXPECT_FALSE(m_connection.GetScanFolderByPortableKey("sadfsadfsadfsadfs", scanFolder));
-        scanFolders.clear();
-
-        //add a scanfolder
-        scanFolder = ScanFolderDatabaseEntry("c:/O3DE/dev", "dev", "rootportkey");
-        EXPECT_TRUE(m_connection.SetScanFolder(scanFolder));
-        EXPECT_NE(scanFolder.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
-
-        //add the same folder again, should not add another because it already exists, so we should get the same id
-        // not only that, but the path should update.
-        ScanFolderDatabaseEntry dupeScanFolder("c:/O3DE/dev2", "dev", "rootportkey");
-        dupeScanFolder.m_scanFolderID = AzToolsFramework::AssetDatabase::InvalidEntryId;
-        EXPECT_TRUE(m_connection.SetScanFolder(dupeScanFolder));
-        EXPECT_EQ(dupeScanFolder, scanFolder) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
-
-        EXPECT_EQ(dupeScanFolder.m_portableKey, scanFolder.m_portableKey);
-        EXPECT_EQ(dupeScanFolder.m_scanFolderID, scanFolder.m_scanFolderID);
-
-        //get all scan folders, there should only the one we added
-        scanFolders.clear();
-        EXPECT_TRUE(m_connection.GetScanFolders(scanFolders));
-        EXPECT_EQ(scanFolders.size(), 1);
-        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/dev2"));
-        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, scanFolder.m_scanFolderID));
-        EXPECT_TRUE(ScanFoldersContainPortableKey(scanFolders, scanFolder.m_portableKey.c_str()));
-        EXPECT_TRUE(ScanFoldersContainPortableKey(scanFolders, "rootportkey"));
-
-        //retrieve the one we just made by id
-        ScanFolderDatabaseEntry retrieveScanfolderById;
-        EXPECT_TRUE(m_connection.GetScanFolderByScanFolderID(scanFolder.m_scanFolderID, retrieveScanfolderById));
-        EXPECT_NE(retrieveScanfolderById.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
-        EXPECT_EQ(retrieveScanfolderById.m_scanFolderID, scanFolder.m_scanFolderID) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
-
-        //retrieve the one we just made by portable key
-        ScanFolderDatabaseEntry retrieveScanfolderByScanPath;
-        EXPECT_TRUE(m_connection.GetScanFolderByPortableKey("rootportkey", retrieveScanfolderByScanPath));
-        EXPECT_NE(retrieveScanfolderByScanPath.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
-        EXPECT_EQ(retrieveScanfolderByScanPath.m_scanFolderID, scanFolder.m_scanFolderID) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
-
-        //add another folder
-        ScanFolderDatabaseEntry gameScanFolderEntry("c:/O3DE/game", "game", "gameportkey");
-        EXPECT_TRUE(m_connection.SetScanFolder(gameScanFolderEntry));
-        EXPECT_NE(gameScanFolderEntry.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
-        EXPECT_NE(gameScanFolderEntry.m_scanFolderID, scanFolder.m_scanFolderID)<< "AssetProcessingStateDataTest Failed - scan folder failed to add";
-
-        //get all scan folders, there should only the two we added
-        scanFolders.clear();
-        EXPECT_TRUE(m_connection.GetScanFolders(scanFolders));
-        EXPECT_EQ(scanFolders.size(), 2);
-        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/dev2"));
-        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/game"));
-        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, scanFolder.m_scanFolderID));
-        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, gameScanFolderEntry.m_scanFolderID));
-
-        //remove the game scan folder
-        EXPECT_TRUE(m_connection.RemoveScanFolder(848475));//should return true even if it doesn't exist, false only means SQL failed
-        EXPECT_TRUE(m_connection.RemoveScanFolder(gameScanFolderEntry.m_scanFolderID));
-
-        //get all scan folders again, there should now only the first we added
-        scanFolders.clear();
-        EXPECT_TRUE(m_connection.GetScanFolders(scanFolders));
-        EXPECT_EQ(scanFolders.size(), 1);
-        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/dev2"));
-        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, scanFolder.m_scanFolderID));
-
-        //add another folder again
-        gameScanFolderEntry = ScanFolderDatabaseEntry("c:/O3DE/game", "game", "gameportkey2");
-        EXPECT_TRUE(m_connection.SetScanFolder(gameScanFolderEntry));
-        EXPECT_NE(gameScanFolderEntry.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
-        EXPECT_NE(gameScanFolderEntry.m_scanFolderID, scanFolder.m_scanFolderID) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
-
-        //get all scan folders, there should only the two we added
-        scanFolders.clear();
-        EXPECT_TRUE(m_connection.GetScanFolders(scanFolders));
-        EXPECT_EQ(scanFolders.size(), 2);
-        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/dev2"));
-        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/game"));
-        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, scanFolder.m_scanFolderID));
-        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, gameScanFolderEntry.m_scanFolderID));
-
-        //remove scan folder by using a container
-        ScanFolderDatabaseEntryContainer tempScanFolderDatabaseEntryContainer; // note that on clang, its illegal to call a non-const function with a temp variable container as the param
-        EXPECT_TRUE(m_connection.RemoveScanFolders(tempScanFolderDatabaseEntryContainer)); // call with empty
-        EXPECT_TRUE(m_connection.RemoveScanFolders(scanFolders));
-        scanFolders.clear();
-        EXPECT_FALSE(m_connection.GetScanFolders(scanFolders));
-
-        ///////////////////////////////////////////////////////////
-        //setup for sources tests
-        //for the rest of the test lets add the original scan folder
-        scanFolder = ScanFolderDatabaseEntry("c:/O3DE/dev", "dev", "devkey2");
-        EXPECT_TRUE(m_connection.SetScanFolder(scanFolder));
-        ///////////////////////////////////////////////////////////
-
-        //////////////////////////////////////////////////////////////////////////
-        //Sources
         auto SourcesContainSourceID = [](const SourceDatabaseEntryContainer& sources, AZ::s64 sourceID) -> bool
         {
             for (const auto& source : sources)
@@ -263,253 +88,6 @@ namespace AssetProcessor
             return false;
         };
 
-        //there are no sources yet so trying to find one should fail
-        sources.clear();
-        EXPECT_FALSE(m_connection.GetSources(sources));
-        EXPECT_FALSE(m_connection.GetSourceBySourceID(3443, source));
-        EXPECT_FALSE(m_connection.GetSourceBySourceGuid(AZ::Uuid::Create(), source));
-        EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("source", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Raw, sources));
-        EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("source", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::StartsWith, sources));
-        EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("source", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::EndsWith, sources));
-        EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("source", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Matches, sources));
-
-        //trying to add a source without a valid scan folder pk should fail
-        source = SourceDatabaseEntry(234234, "SomeSource1.tif", validSourceGuid1, "");
-        {
-            UnitTestUtils::AssertAbsorber absorber;
-            EXPECT_FALSE(m_connection.SetSource(source));
-            EXPECT_GE(absorber.m_numWarningsAbsorbed, 0);
-        }
-
-        //setting a valid scan folder pk should allow it to be added
-        source = SourceDatabaseEntry(scanFolder.m_scanFolderID, "SomeSource1.tif", validSourceGuid1, "tEsTFingerPrint_TEST");
-        EXPECT_TRUE(m_connection.SetSource(source));
-        EXPECT_NE(source.m_sourceID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - source failed to add";
-
-        //get all sources, there should only the one we added
-        sources.clear();
-        EXPECT_TRUE(m_connection.GetSources(sources));
-        EXPECT_EQ(sources.size(), 1);
-        EXPECT_EQ(sources[0].m_analysisFingerprint, "tEsTFingerPrint_TEST");
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource1.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, source.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, source.m_sourceGuid));
-
-        //add the same source again, should not add another because it already exists, so we should get the same id
-        SourceDatabaseEntry dupeSource(source);
-        dupeSource.m_sourceID = AzToolsFramework::AssetDatabase::InvalidEntryId;
-        EXPECT_TRUE(m_connection.SetSource(dupeSource));
-        EXPECT_EQ(dupeSource.m_sourceID, source.m_sourceID) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
-
-        //get all sources, there should still only the one we added
-        sources.clear();
-        EXPECT_TRUE(m_connection.GetSources(sources));
-        EXPECT_EQ(sources.size(), 1);
-        EXPECT_EQ(sources[0].m_analysisFingerprint, "tEsTFingerPrint_TEST");
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource1.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, source.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, source.m_sourceGuid));
-
-        // make sure that changing a field like fingerprint writes the new field to database but does not
-        // add a new entry (ie, its just modifying existing data)
-        SourceDatabaseEntry sourceWithDifferentFingerprint(source);
-        sourceWithDifferentFingerprint.m_analysisFingerprint = "otherFingerprint";
-        EXPECT_TRUE(m_connection.SetSource(sourceWithDifferentFingerprint));
-        EXPECT_EQ(sourceWithDifferentFingerprint.m_sourceID, source.m_sourceID);
-        sources.clear();
-        EXPECT_TRUE(m_connection.GetSources(sources));
-        EXPECT_EQ(sources.size(), 1);
-        EXPECT_EQ(sources[0].m_analysisFingerprint, "otherFingerprint");
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource1.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, source.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, source.m_sourceGuid));
-
-        //add the same source again, but change the scan folder.  This should NOT add a new source - even if we don't know what the sourceID is:
-        ScanFolderDatabaseEntry scanfolder2 = ScanFolderDatabaseEntry("c:/O3DE/dev2", "dev2", "devkey3");
-        EXPECT_TRUE(m_connection.SetScanFolder(scanfolder2));
-
-        SourceDatabaseEntry dupeSource2(source);
-        dupeSource2.m_scanFolderPK = scanfolder2.m_scanFolderID;
-        dupeSource2.m_analysisFingerprint = "new different fingerprint";
-        dupeSource2.m_sourceID = AzToolsFramework::AssetDatabase::InvalidEntryId;
-        EXPECT_TRUE(m_connection.SetSource(dupeSource2));
-        EXPECT_EQ(dupeSource2.m_sourceID, source.m_sourceID) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
-
-        //get all sources, there should still only the one we added
-        sources.clear();
-        EXPECT_TRUE(m_connection.GetSources(sources));
-        EXPECT_EQ(sources.size(), 1);
-        EXPECT_EQ(sources[0].m_analysisFingerprint, "new different fingerprint"); // verify that this column IS updated.
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource1.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, source.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, source.m_sourceGuid));
-
-        //add the same source again, but change the scan folder back  This should NOT add a new source - this time we do know what the source ID is!
-        SourceDatabaseEntry dupeSource3(source);
-        dupeSource3.m_scanFolderPK = scanFolder.m_scanFolderID; // changing it back here.
-        EXPECT_TRUE(m_connection.SetSource(dupeSource3));
-        EXPECT_EQ(dupeSource3.m_sourceID, source.m_sourceID) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
-
-        //get all sources, there should still only the one we added
-        sources.clear();
-        EXPECT_TRUE(m_connection.GetSources(sources));
-        EXPECT_EQ(sources.size(), 1);
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource1.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, source.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, source.m_sourceGuid));
-
-        // remove the extra scan folder, make sure it doesn't drop the source since it should now be bound to the original scan folder agian
-        EXPECT_TRUE(m_connection.RemoveScanFolder(scanfolder2.m_scanFolderID));
-        sources.clear();
-        EXPECT_TRUE(m_connection.GetSources(sources));
-        EXPECT_EQ(sources.size(), 1);
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource1.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, source.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, source.m_sourceGuid));
-
-        //try retrieving this source by id
-        SourceDatabaseEntry retrieveSourceBySourceID;
-        EXPECT_TRUE(m_connection.GetSourceBySourceID(source.m_sourceID, retrieveSourceBySourceID));
-        EXPECT_NE(retrieveSourceBySourceID.m_sourceID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
-        EXPECT_EQ(retrieveSourceBySourceID.m_sourceID, source.m_sourceID) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
-        EXPECT_EQ(retrieveSourceBySourceID.m_scanFolderPK, source.m_scanFolderPK) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
-        EXPECT_EQ(retrieveSourceBySourceID.m_sourceGuid, source.m_sourceGuid) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
-        EXPECT_EQ(retrieveSourceBySourceID.m_sourceName, source.m_sourceName) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
-
-        //try retrieving this source by guid
-        SourceDatabaseEntry retrieveSourceBySourceGuid;
-        EXPECT_TRUE(m_connection.GetSourceBySourceGuid(source.m_sourceGuid, retrieveSourceBySourceGuid));
-        EXPECT_NE(retrieveSourceBySourceGuid.m_sourceID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
-        EXPECT_EQ(retrieveSourceBySourceGuid.m_sourceID, source.m_sourceID) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
-        EXPECT_EQ(retrieveSourceBySourceGuid.m_scanFolderPK, source.m_scanFolderPK) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
-        EXPECT_EQ(retrieveSourceBySourceGuid.m_sourceGuid, source.m_sourceGuid) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
-        EXPECT_EQ(retrieveSourceBySourceGuid.m_sourceName, source.m_sourceName) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
-
-        //try retrieving this source by source name
-        sources.clear();
-        EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("Source1.tif", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Raw, sources));
-        sources.clear();
-        EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("_SomeSource1_", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Raw, sources));
-        sources.clear();
-        EXPECT_TRUE(m_connection.GetSourcesLikeSourceName("SomeSource1%", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Raw, sources));
-        EXPECT_EQ(sources.size(), 1);
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource1.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, source.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, source.m_sourceGuid));
-        sources.clear();
-        EXPECT_TRUE(m_connection.GetSourcesLikeSourceName("%SomeSource1%", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Raw, sources));
-        EXPECT_EQ(sources.size(), 1);
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource1.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, source.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, source.m_sourceGuid));
-        sources.clear();
-        EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("Source1", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::StartsWith, sources));
-        sources.clear();
-        EXPECT_TRUE(m_connection.GetSourcesLikeSourceName("Some", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::StartsWith, sources));
-        EXPECT_EQ(sources.size(), 1);
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource1.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, source.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, source.m_sourceGuid));
-        sources.clear();
-        EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("SomeSource", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::EndsWith, sources));
-        sources.clear();
-        EXPECT_TRUE(m_connection.GetSourcesLikeSourceName(".tif", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::EndsWith, sources));
-        EXPECT_EQ(sources.size(), 1);
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource1.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, source.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, source.m_sourceGuid));
-        sources.clear();
-        EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("blah", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Matches, sources));
-        sources.clear();
-        EXPECT_TRUE(m_connection.GetSourcesLikeSourceName("meSour", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Matches, sources));
-        EXPECT_EQ(sources.size(), 1);
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource1.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, source.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, source.m_sourceGuid));
-
-
-        //remove a source
-        EXPECT_TRUE(m_connection.RemoveSource(432234));//should return true even if it doesn't exist, false only if SQL failed
-        EXPECT_TRUE(m_connection.RemoveSource(source.m_sourceID));
-
-        //get all sources, there shouldn't be any
-        sources.clear();
-        EXPECT_FALSE(m_connection.GetSources(sources));
-
-        //Add two sources then delete the via container
-        SourceDatabaseEntry source2(scanFolder.m_scanFolderID, "SomeSource2.tif", validSourceGuid2, "");
-        EXPECT_TRUE(m_connection.SetSource(source2));
-        SourceDatabaseEntry source3(scanFolder.m_scanFolderID, "SomeSource3.tif", validSourceGuid3, "");
-        EXPECT_TRUE(m_connection.SetSource(source3));
-
-        //get all sources, there should only the two we added
-        sources.clear();
-        EXPECT_TRUE(m_connection.GetSources(sources));
-        EXPECT_EQ(sources.size(), 2);
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource2.tif"));
-        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource3.tif"));
-        EXPECT_TRUE(SourcesContainSourceID(sources, source2.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, source2.m_sourceGuid));
-        EXPECT_TRUE(SourcesContainSourceID(sources, source3.m_sourceID));
-        EXPECT_TRUE(SourcesContainSourceGuid(sources, source3.m_sourceGuid));
-
-        //Remove source via container
-        SourceDatabaseEntryContainer tempSourceDatabaseEntryContainer;
-        EXPECT_TRUE(m_connection.RemoveSources(tempSourceDatabaseEntryContainer)); // try it with an empty one.
-        EXPECT_TRUE(m_connection.RemoveSources(sources));
-
-        //get all sources, there should none
-        sources.clear();
-        EXPECT_FALSE(m_connection.GetSources(sources));
-
-        //Add two sources then delete the via removing by scan folder id
-        source2 = SourceDatabaseEntry(scanFolder.m_scanFolderID, "SomeSource2.tif", validSourceGuid2, "fingerprint");
-        EXPECT_TRUE(m_connection.SetSource(source2));
-        source3 = SourceDatabaseEntry(scanFolder.m_scanFolderID, "SomeSource3.tif", validSourceGuid3, "fingerprint");
-        EXPECT_TRUE(m_connection.SetSource(source3));
-
-        //remove all sources for a scan folder
-        sources.clear();
-        EXPECT_FALSE(m_connection.RemoveSourcesByScanFolderID(3245532));
-        EXPECT_TRUE(m_connection.RemoveSourcesByScanFolderID(scanFolder.m_scanFolderID));
-
-        //get all sources, there should none
-        sources.clear();
-        EXPECT_FALSE(m_connection.GetSources(sources));
-
-        //Add two sources then delete the via removing the scan folder
-        source2 = SourceDatabaseEntry(scanFolder.m_scanFolderID, "SomeSource2.tif", validSourceGuid2, "");
-        EXPECT_TRUE(m_connection.SetSource(source2));
-        source3 = SourceDatabaseEntry(scanFolder.m_scanFolderID, "SomeSource3.tif", validSourceGuid3, "");
-        EXPECT_TRUE(m_connection.SetSource(source3));
-
-        //remove the scan folder for these sources, the sources should cascade delete
-        EXPECT_TRUE(m_connection.RemoveScanFolder(scanFolder.m_scanFolderID));
-
-        //get all sources, there should none
-        sources.clear();
-        EXPECT_FALSE(m_connection.GetSources(sources));
-
-        ////////////////////////////////////////////////////////////////
-        //Setup for jobs tests by having a scan folder and some sources
-        //Add a scan folder
-        scanFolder = ScanFolderDatabaseEntry("c:/O3DE/dev", "dev", "devkey3");
-        EXPECT_TRUE(m_connection.SetScanFolder(scanFolder));
-
-        auto& config = m_appManager->m_platformConfig;
-        config->AddScanFolder(AssetProcessor::ScanFolderInfo{scanFolder.m_scanFolder.c_str(), scanFolder.m_displayName.c_str(), scanFolder.m_portableKey.c_str(), false, true, {} , 0, scanFolder.m_scanFolderID});
-
-        //Add some sources
-        source = SourceDatabaseEntry(scanFolder.m_scanFolderID, "SomeSource1.tif", validSourceGuid1, "");
-        EXPECT_TRUE(m_connection.SetSource(source));
-        source2 = SourceDatabaseEntry(scanFolder.m_scanFolderID, "SomeSource2.tif", validSourceGuid2, "");
-        EXPECT_TRUE(m_connection.SetSource(source2));
-        source3 = SourceDatabaseEntry(scanFolder.m_scanFolderID, "SomeSource3.tif", validSourceGuid3, "");
-        EXPECT_TRUE(m_connection.SetSource(source3));
-        /////////////////////////////////////////////////////////////////
-
-        //////////////////////////////////////////////////////////////////////////
-        //Jobs
         auto JobsContainJobID = [](const JobDatabaseEntryContainer& jobs, AZ::s64 jobId) -> bool
         {
             for (const auto& job : jobs)
@@ -582,7 +160,6 @@ namespace AssetProcessor
             return false;
         };
 
-
         auto JobsContainRunKey = [](const JobDatabaseEntryContainer& jobs, AZ::u64 runKey) -> bool
         {
             for (const auto& job : jobs)
@@ -595,364 +172,6 @@ namespace AssetProcessor
             return false;
         };
 
-
-        //there are no jobs yet so trying to find one should fail
-        jobs.clear();
-        EXPECT_FALSE(m_connection.GetJobs(jobs));
-        EXPECT_FALSE(m_connection.GetJobByJobID(3443, job));
-        EXPECT_FALSE(m_connection.GetJobsBySourceID(3234, jobs));
-        EXPECT_FALSE(m_connection.GetJobsBySourceName(AssetProcessor::SourceAssetReference("c:/O3DE/dev/none"), jobs));
-
-        //trying to add a job without a valid source pk should fail:
-        {
-            UnitTestUtils::AssertAbsorber absorber;
-            job = JobDatabaseEntry(234234, "jobkey", validFingerprint1, "pc", validBuilderGuid1, statusQueued, 1);
-            EXPECT_FALSE(m_connection.SetJob(job));
-            EXPECT_GE(absorber.m_numWarningsAbsorbed, 0);
-        }
-
-        //trying to add a job with a valid source pk but an invalid job id  should fail:
-        {
-            UnitTestUtils::AssertAbsorber absorber;
-            job = JobDatabaseEntry(source.m_sourceID, "jobkey", validFingerprint1, "pc", validBuilderGuid1, statusQueued, 0);
-            EXPECT_FALSE(m_connection.SetJob(job));
-            EXPECT_GE(absorber.m_numErrorsAbsorbed, 0);
-        }
-
-        //setting a valid scan folder pk should allow it to be added AND should tell you what the job ID will be.
-        // the run key should be untouched.
-        job = JobDatabaseEntry(source.m_sourceID, "jobKey1", validFingerprint1, "pc", validBuilderGuid1, statusQueued, 1);
-        EXPECT_TRUE(m_connection.SetJob(job));
-        EXPECT_NE(job.m_jobID, AzToolsFramework::AssetDatabase::InvalidEntryId);
-        EXPECT_EQ(job.m_jobRunKey, 1);
-
-        //get all jobs, there should only the one we added
-        jobs.clear();
-        EXPECT_TRUE(m_connection.GetJobs(jobs));
-        EXPECT_EQ(jobs.size(), 1);
-        EXPECT_TRUE(JobsContainJobID(jobs, job.m_jobID));
-        EXPECT_TRUE(JobsContainJobKey(jobs, job.m_jobKey.c_str()));
-        EXPECT_TRUE(JobsContainFingerprint(jobs, job.m_fingerprint));
-        EXPECT_TRUE(JobsContainPlatform(jobs, job.m_platform.c_str()));
-        EXPECT_TRUE(JobsContainBuilderGuid(jobs, job.m_builderGuid));
-        EXPECT_TRUE(JobsContainStatus(jobs, job.m_status));
-        EXPECT_TRUE(JobsContainRunKey(jobs, job.m_jobRunKey));
-
-        //add the same job again, should not add another because it already exists, so we should get the same id
-        JobDatabaseEntry dupeJob(job);
-        dupeJob.m_jobID = AzToolsFramework::AssetDatabase::InvalidEntryId;
-        EXPECT_TRUE(m_connection.SetJob(dupeJob));
-        EXPECT_EQ(dupeJob, job) << "AssetProcessingStateDataTest Failed - SetJob failed to add";
-
-        //get all jobs, there should still only the one we added
-        jobs.clear();
-        EXPECT_TRUE(m_connection.GetJobs(jobs));
-        EXPECT_EQ(jobs.size(), 1);
-        EXPECT_TRUE(JobsContainJobID(jobs, job.m_jobID));
-        EXPECT_TRUE(JobsContainJobKey(jobs, job.m_jobKey.c_str()));
-        EXPECT_TRUE(JobsContainFingerprint(jobs, job.m_fingerprint));
-        EXPECT_TRUE(JobsContainPlatform(jobs, job.m_platform.c_str()));
-        EXPECT_TRUE(JobsContainBuilderGuid(jobs, job.m_builderGuid));
-        EXPECT_TRUE(JobsContainStatus(jobs, job.m_status));
-
-        //try retrieving this source by id
-        EXPECT_TRUE(m_connection.GetJobByJobID(job.m_jobID, job));
-        EXPECT_NE(job.m_jobID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - GetJobByJobID failed";
-
-        //try retrieving jobs by source id
-        jobs.clear();
-        EXPECT_TRUE(m_connection.GetJobsBySourceID(source.m_sourceID, jobs));
-        EXPECT_EQ(jobs.size(), 1);
-        EXPECT_TRUE(JobsContainJobID(jobs, job.m_jobID));
-        EXPECT_TRUE(JobsContainJobKey(jobs, job.m_jobKey.c_str()));
-        EXPECT_TRUE(JobsContainFingerprint(jobs, job.m_fingerprint));
-        EXPECT_TRUE(JobsContainPlatform(jobs, job.m_platform.c_str()));
-        EXPECT_TRUE(JobsContainBuilderGuid(jobs, job.m_builderGuid));
-        EXPECT_TRUE(JobsContainStatus(jobs, job.m_status));
-
-        //try retrieving jobs by source name
-        jobs.clear();
-        EXPECT_TRUE(m_connection.GetJobsBySourceName(AssetProcessor::SourceAssetReference(source.m_scanFolderPK, source.m_sourceName.c_str()), jobs));
-        EXPECT_EQ(jobs.size(), 1);
-        EXPECT_TRUE(JobsContainJobID(jobs, job.m_jobID));
-        EXPECT_TRUE(JobsContainJobKey(jobs, job.m_jobKey.c_str()));
-        EXPECT_TRUE(JobsContainFingerprint(jobs, job.m_fingerprint));
-        EXPECT_TRUE(JobsContainPlatform(jobs, job.m_platform.c_str()));
-        EXPECT_TRUE(JobsContainBuilderGuid(jobs, job.m_builderGuid));
-        EXPECT_TRUE(JobsContainStatus(jobs, job.m_status));
-
-        //remove a job
-        EXPECT_TRUE(m_connection.RemoveJob(432234));
-        EXPECT_TRUE(m_connection.RemoveJob(job.m_jobID));
-
-        //get all jobs, there shouldn't be any
-        jobs.clear();
-        EXPECT_FALSE(m_connection.GetJobs(jobs));
-
-        //Add two jobs then delete the via container
-        JobDatabaseEntry job2(source2.m_sourceID, "jobkey2", validFingerprint2, "pc", validBuilderGuid2, statusQueued, 2);
-        EXPECT_TRUE(m_connection.SetJob(job2));
-        JobDatabaseEntry job3(source3.m_sourceID, "jobkey3", validFingerprint3, "pc", validBuilderGuid3, statusQueued, 3);
-        EXPECT_TRUE(m_connection.SetJob(job3));
-
-        //get all jobs, there should be 3
-        jobs.clear();
-        EXPECT_TRUE(m_connection.GetJobs(jobs));
-        EXPECT_EQ(jobs.size(), 2);
-        EXPECT_TRUE(JobsContainJobID(jobs, job2.m_jobID));
-        EXPECT_TRUE(JobsContainJobKey(jobs, job2.m_jobKey.c_str()));
-        EXPECT_TRUE(JobsContainFingerprint(jobs, job2.m_fingerprint));
-        EXPECT_TRUE(JobsContainPlatform(jobs, job2.m_platform.c_str()));
-        EXPECT_TRUE(JobsContainBuilderGuid(jobs, job2.m_builderGuid));
-        EXPECT_TRUE(JobsContainStatus(jobs, job2.m_status));
-        EXPECT_TRUE(JobsContainJobID(jobs, job3.m_jobID));
-        EXPECT_TRUE(JobsContainJobKey(jobs, job3.m_jobKey.c_str()));
-        EXPECT_TRUE(JobsContainFingerprint(jobs, job3.m_fingerprint));
-        EXPECT_TRUE(JobsContainPlatform(jobs, job3.m_platform.c_str()));
-        EXPECT_TRUE(JobsContainBuilderGuid(jobs, job3.m_builderGuid));
-        EXPECT_TRUE(JobsContainStatus(jobs, job3.m_status));
-
-        //Remove job via container
-        JobDatabaseEntryContainer tempJobDatabaseEntryContainer;
-        EXPECT_TRUE(m_connection.RemoveJobs(tempJobDatabaseEntryContainer)); // make sure it works on an empty container.
-        EXPECT_TRUE(m_connection.RemoveJobs(jobs));
-
-        //get all jobs, there should none
-        jobs.clear();
-        EXPECT_FALSE(m_connection.GetJobs(jobs));
-
-        //Add two jobs then delete the via removing by source
-        job2 = JobDatabaseEntry(source.m_sourceID, "jobkey2", validFingerprint2, "pc", validBuilderGuid2, statusQueued, 4);
-        EXPECT_TRUE(m_connection.SetJob(job2));
-        job3 = JobDatabaseEntry(source.m_sourceID, "jobkey3", validFingerprint3, "pc", validBuilderGuid3, statusQueued, 5);
-        EXPECT_TRUE(m_connection.SetJob(job3));
-
-        //remove the scan folder for these jobs, the jobs should cascade delete
-        EXPECT_TRUE(m_connection.RemoveSource(source.m_sourceID));
-
-        //get all jobs, there should none
-        jobs.clear();
-        EXPECT_FALSE(m_connection.GetJobs(jobs));
-
-        ////////////////////////////////////////////////////////////////
-        //Setup for product tests by having a some sources and jobs
-        source = SourceDatabaseEntry(scanFolder.m_scanFolderID, "SomeSource1.tif", validSourceGuid1, "");
-        EXPECT_TRUE(m_connection.SetSource(source));
-
-        //Add jobs
-        job = JobDatabaseEntry(source.m_sourceID, "jobkey1", validFingerprint1, "pc", validBuilderGuid1, statusCompleted, 6);
-        EXPECT_TRUE(m_connection.SetJob(job));
-        job2 = JobDatabaseEntry(source.m_sourceID, "jobkey2", validFingerprint2, "pc", validBuilderGuid2, statusCompleted, 7);
-        EXPECT_TRUE(m_connection.SetJob(job2));
-        job3 = JobDatabaseEntry(source.m_sourceID, "jobkey3", validFingerprint3, "pc", validBuilderGuid3, statusCompleted, 8);
-        EXPECT_TRUE(m_connection.SetJob(job3));
-        /////////////////////////////////////////////////////////////////
-
-        auto ProductsContainProductID = [](const ProductDatabaseEntryContainer& products, AZ::s64 productId) -> bool
-        {
-            for (const auto& product : products)
-            {
-                if (product.m_productID == productId)
-                {
-                    return true;
-                }
-            }
-            return false;
-        };
-
-
-        //Add jobs
-        job = JobDatabaseEntry(source.m_sourceID, "jobkey1", validFingerprint1, "pc", validBuilderGuid1, statusCompleted, 9);
-        EXPECT_TRUE(m_connection.SetJob(job));
-        job2 = JobDatabaseEntry(source.m_sourceID, "jobkey2", validFingerprint2, "pc", validBuilderGuid2, statusCompleted, 10);
-        EXPECT_TRUE(m_connection.SetJob(job2));
-        job3 = JobDatabaseEntry(source.m_sourceID, "jobkey3", validFingerprint3, "pc", validBuilderGuid3, statusCompleted, 11);
-        EXPECT_TRUE(m_connection.SetJob(job3));
-
-        //Add two products then delete the via removing the job
-        ProductDatabaseEntry product2 = ProductDatabaseEntry(job.m_jobID, 2, "SomeProduct2.dds", validAssetType2);
-        EXPECT_TRUE(m_connection.SetProduct(product2));
-        ProductDatabaseEntry product3 = ProductDatabaseEntry(job.m_jobID, 3, "SomeProduct3.dds", validAssetType3);
-        EXPECT_TRUE(m_connection.SetProduct(product3));
-
-        //the products should cascade delete
-        EXPECT_TRUE(m_connection.RemoveSource(source.m_sourceID));
-
-        //get all products, there should none
-        products.clear();
-        EXPECT_FALSE(m_connection.GetProducts(products));
-
-        // ---- test legacy subIds table ----
-
-        // setup:
-        // SomeSource1.tif
-        //   jobkey1
-        //     someproduct1
-        //        legacy ids...
-
-        source = SourceDatabaseEntry(scanFolder.m_scanFolderID, "SomeSource1.tif", validSourceGuid1, "");
-        EXPECT_TRUE(m_connection.SetSource(source));
-
-        job = JobDatabaseEntry(source.m_sourceID, "jobkey1", validFingerprint1, "pc", validBuilderGuid1, statusCompleted, 6);
-        EXPECT_TRUE(m_connection.SetJob(job));
-
-        product = ProductDatabaseEntry(job.m_jobID, 1, "SomeProduct1.dds", validAssetType1);
-        product2 = ProductDatabaseEntry(job.m_jobID, 2, "SomeProduct2.dds", validAssetType1);
-        EXPECT_TRUE(m_connection.SetProduct(product));
-        EXPECT_TRUE(m_connection.SetProduct(product2));
-
-        // test invalid insert for non existant legacy subids.
-        LegacySubIDsEntry legacyEntry(1, product.m_productID, 3);
-        {
-            UnitTestUtils::AssertAbsorber absorber;
-            EXPECT_FALSE(m_connection.CreateOrUpdateLegacySubID(legacyEntry));
-            EXPECT_GT(absorber.m_numWarningsAbsorbed, 0);
-        }
-
-        // test invalid insert for non-existant legacy product FK constraint
-        legacyEntry = LegacySubIDsEntry(AzToolsFramework::AssetDatabase::InvalidEntryId, 9999, 3);
-        {
-            UnitTestUtils::AssertAbsorber absorber;
-            EXPECT_FALSE(m_connection.CreateOrUpdateLegacySubID(legacyEntry));
-            EXPECT_GT(absorber.m_numWarningsAbsorbed, 0);
-        }
-
-        // test valid insert of another for same product
-        legacyEntry = LegacySubIDsEntry(AzToolsFramework::AssetDatabase::InvalidEntryId, product.m_productID, 3);
-        EXPECT_TRUE(m_connection.CreateOrUpdateLegacySubID(legacyEntry));
-        AZ::s64 newPK = legacyEntry.m_subIDsEntryID;
-        EXPECT_NE(newPK, AzToolsFramework::AssetDatabase::InvalidEntryId); // it should have also updated the PK
-
-        legacyEntry = LegacySubIDsEntry(AzToolsFramework::AssetDatabase::InvalidEntryId, product.m_productID, 4);
-        EXPECT_TRUE(m_connection.CreateOrUpdateLegacySubID(legacyEntry));
-        EXPECT_NE(legacyEntry.m_subIDsEntryID, AzToolsFramework::AssetDatabase::InvalidEntryId); // it should have also updated the PK
-        EXPECT_NE(legacyEntry.m_subIDsEntryID, newPK); // pk should be unique
-
-                                                                     // test valid insert of another for different product
-        legacyEntry = LegacySubIDsEntry(AzToolsFramework::AssetDatabase::InvalidEntryId, product2.m_productID, 5);
-        EXPECT_TRUE(m_connection.CreateOrUpdateLegacySubID(legacyEntry));
-
-        // test that the ones inserted can be retrieved.
-        AZStd::vector<LegacySubIDsEntry> entriesReturned;
-        auto handler = [&entriesReturned](LegacySubIDsEntry& entry)
-        {
-            entriesReturned.push_back(entry);
-            return true;
-        };
-        EXPECT_TRUE(m_connection.QueryLegacySubIdsByProductID(product.m_productID, handler));
-        EXPECT_EQ(entriesReturned.size(), 2);
-
-        bool foundSubID3 = false;
-        bool foundSubID4 = false;
-        for (const LegacySubIDsEntry& entryFound : entriesReturned)
-        {
-            EXPECT_NE(entryFound.m_subIDsEntryID, AzToolsFramework::AssetDatabase::InvalidEntryId);
-            EXPECT_EQ(entryFound.m_productPK, product.m_productID);
-            if (entryFound.m_subID == 3)
-            {
-                foundSubID3 = true;
-            }
-            else if (entryFound.m_subID == 4)
-            {
-                foundSubID4 = true;
-            }
-        }
-
-        EXPECT_TRUE(foundSubID3);
-        EXPECT_TRUE(foundSubID4);
-
-        entriesReturned.clear();
-
-        EXPECT_TRUE(m_connection.QueryLegacySubIdsByProductID(product2.m_productID, handler));
-        EXPECT_EQ(entriesReturned.size(), 1);
-        EXPECT_NE(entriesReturned[0].m_subIDsEntryID, AzToolsFramework::AssetDatabase::InvalidEntryId);
-        EXPECT_EQ(entriesReturned[0].m_productPK, product2.m_productID);
-        EXPECT_EQ(entriesReturned[0].m_subID, 5);
-
-        // test UPDATE -> overwrite existing.
-        entriesReturned[0].m_subID = 6;
-        EXPECT_TRUE(m_connection.CreateOrUpdateLegacySubID(entriesReturned[0]));
-        entriesReturned.clear();
-
-        EXPECT_TRUE(m_connection.QueryLegacySubIdsByProductID(product2.m_productID, handler));
-        EXPECT_EQ(entriesReturned.size(), 1);
-        EXPECT_NE(entriesReturned[0].m_subIDsEntryID, AzToolsFramework::AssetDatabase::InvalidEntryId);
-        EXPECT_EQ(entriesReturned[0].m_productPK, product2.m_productID);
-        EXPECT_EQ(entriesReturned[0].m_subID, 6);
-
-        // test delete by product ID
-        EXPECT_TRUE(m_connection.RemoveLegacySubIDsByProductID(product2.m_productID));
-        entriesReturned.clear();
-
-        EXPECT_TRUE(m_connection.QueryLegacySubIdsByProductID(product2.m_productID, handler));
-        EXPECT_TRUE(entriesReturned.empty());
-
-        // test delete by PK.  The prior entries should be here for product1. This also makes sure the above
-        // delete statement didn't delete more than it should have.
-
-        EXPECT_TRUE(m_connection.QueryLegacySubIdsByProductID(product.m_productID, handler));
-        EXPECT_EQ(entriesReturned.size(), 2);
-
-        AZ::s64 toRemove = entriesReturned[0].m_subIDsEntryID;
-        AZ::u32 removingSubID = entriesReturned[0].m_subID;
-
-        EXPECT_TRUE(m_connection.RemoveLegacySubID(toRemove));
-        entriesReturned.clear();
-        EXPECT_TRUE(m_connection.QueryLegacySubIdsByProductID(product.m_productID, handler));
-        EXPECT_EQ(entriesReturned.size(), 1);
-        EXPECT_NE(entriesReturned[0].m_subIDsEntryID, AzToolsFramework::AssetDatabase::InvalidEntryId);
-        EXPECT_NE(entriesReturned[0].m_subIDsEntryID, toRemove);
-        EXPECT_EQ(entriesReturned[0].m_productPK, product.m_productID);
-        EXPECT_NE(entriesReturned[0].m_subID, removingSubID);
-
-        ////////////////////////////////////////////////////////////////
-        //Setup for product dependency tests by having a some sources and jobs
-        source = SourceDatabaseEntry(scanFolder.m_scanFolderID, "SomeSource1.tif", validSourceGuid1, "");
-        EXPECT_TRUE(m_connection.SetSource(source));
-        source2 = SourceDatabaseEntry(scanFolder.m_scanFolderID, "SomeSource2.tif", validSourceGuid2, "");
-        EXPECT_TRUE(m_connection.SetSource(source2));
-        source3 = SourceDatabaseEntry(scanFolder.m_scanFolderID, "SomeSource3.tif", validSourceGuid3, "");
-        EXPECT_TRUE(m_connection.SetSource(source3));
-        SourceDatabaseEntry source4 = SourceDatabaseEntry(scanFolder.m_scanFolderID, "SomeSource4.tif", validSourceGuid4, "");
-        EXPECT_TRUE(m_connection.SetSource(source4));
-        SourceDatabaseEntry source5 = SourceDatabaseEntry(scanFolder.m_scanFolderID, "SomeSource5.tif", validSourceGuid5, "");
-        EXPECT_TRUE(m_connection.SetSource(source5));
-        SourceDatabaseEntry source6 = SourceDatabaseEntry(scanFolder.m_scanFolderID, "SomeSource6.tif", validSourceGuid6, "");
-        EXPECT_TRUE(m_connection.SetSource(source6));
-
-        //Add jobs
-        job = JobDatabaseEntry(source.m_sourceID, "jobkey1", validFingerprint1, "pc", validBuilderGuid1, statusCompleted, 6);
-        EXPECT_TRUE(m_connection.SetJob(job));
-        job2 = JobDatabaseEntry(source2.m_sourceID, "jobkey2", validFingerprint2, "pc", validBuilderGuid2, statusCompleted, 7);
-        EXPECT_TRUE(m_connection.SetJob(job2));
-        job3 = JobDatabaseEntry(source3.m_sourceID, "jobkey3", validFingerprint3, "pc", validBuilderGuid3, statusCompleted, 8);
-        EXPECT_TRUE(m_connection.SetJob(job3));
-        JobDatabaseEntry job4 = JobDatabaseEntry(source4.m_sourceID, "jobkey4", validFingerprint4, "pc", validBuilderGuid4, statusCompleted, 9);
-        EXPECT_TRUE(m_connection.SetJob(job4));
-        JobDatabaseEntry job5 = JobDatabaseEntry(source5.m_sourceID, "jobkey5", validFingerprint5, "pc", validBuilderGuid5, statusCompleted, 10);
-        EXPECT_TRUE(m_connection.SetJob(job5));
-        JobDatabaseEntry job6 = JobDatabaseEntry(source6.m_sourceID, "jobkey6", validFingerprint6, "pc", validBuilderGuid6, statusCompleted, 11);
-        EXPECT_TRUE(m_connection.SetJob(job6));
-
-        //Add products
-        product = ProductDatabaseEntry(job.m_jobID, 1, "SomeProduct1.dds", validAssetType1);
-        EXPECT_TRUE(m_connection.SetProduct(product));
-        product2 = ProductDatabaseEntry(job2.m_jobID, 2, "SomeProduct2.dds", validAssetType2);
-        EXPECT_TRUE(m_connection.SetProduct(product2));
-        product3 = ProductDatabaseEntry(job3.m_jobID, 3, "SomeProduct3.dds", validAssetType3);
-        EXPECT_TRUE(m_connection.SetProduct(product3));
-        ProductDatabaseEntry product4 = ProductDatabaseEntry(job4.m_jobID, 4, "SomeProduct4.dds", validAssetType4);
-        EXPECT_TRUE(m_connection.SetProduct(product4));
-        ProductDatabaseEntry product5 = ProductDatabaseEntry(job5.m_jobID, 5, "SomeProduct5.dds", validAssetType5);
-        EXPECT_TRUE(m_connection.SetProduct(product5));
-        ProductDatabaseEntry product6 = ProductDatabaseEntry(job6.m_jobID, 6, "SomeProduct6.dds", validAssetType6);
-        EXPECT_TRUE(m_connection.SetProduct(product6));
-
-
-        /////////////////////////////////////////////////////////////////
-
-        //////////////////////////////////////////////////////////////////////////
-        //productDependencies
         auto ProductDependenciesContainProductDependencyID = [](const ProductDependencyDatabaseEntryContainer& productDependencies, AZ::s64 productDepdendencyId) -> bool
         {
             for (const auto& productDependency : productDependencies)
@@ -1013,9 +232,989 @@ namespace AssetProcessor
             return false;
         };
 
-        //there are no product dependencies yet so trying to find one should fail
-        productDependencies.clear();
+        auto ProductsContainProductID = [](const ProductDatabaseEntryContainer& products, AZ::s64 productId) -> bool
+        {
+            for (const auto& product : products)
+            {
+                if (product.m_productID == productId)
+                {
+                    return true;
+                }
+            }
+            return false;
+        };
+    }
+
+    class AssetProcessingStateDataUnitTest
+        : public UnitTest::AssetProcessorUnitTestBase
+    {
+    protected:
+        void SetUp() override
+        {
+            UnitTest::AssetProcessorUnitTestBase::SetUp();
+
+            EXPECT_TRUE(m_connection.DataExists());
+            EXPECT_TRUE(m_connection.OpenDatabase());
+        }
+
+        void TearDown() override
+        {
+            m_connection.CloseDatabase();
+
+            UnitTest::AssetProcessorUnitTestBase::TearDown();
+        }
+
+        void AddDefaultScanFolder()
+        {
+            m_defaultScanFolder = ScanFolderDatabaseEntry("c:/O3DE/dev", "dev", "rootportkey");
+            EXPECT_TRUE(m_connection.SetScanFolder(m_defaultScanFolder));
+            EXPECT_NE(m_defaultScanFolder.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+        }
+
+        void AddDefaultSource()
+        {
+            if (m_defaultScanFolder.m_scanFolderID == AzToolsFramework::AssetDatabase::InvalidEntryId)
+            {
+                AddDefaultScanFolder();
+            }
+
+            AZ::Uuid validSourceGuid = AZ::Uuid::CreateRandom();
+            m_defaultSource = SourceDatabaseEntry(m_defaultScanFolder.m_scanFolderID, "SomeSource.tif", validSourceGuid, "12345");
+            EXPECT_TRUE(m_connection.SetSource(m_defaultSource));
+            EXPECT_NE(m_defaultSource.m_sourceID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - source failed to add";
+        }
+
+        void AddDefaultJob()
+        {
+            if (m_defaultSource.m_sourceID == AzToolsFramework::AssetDatabase::InvalidEntryId)
+            {
+                AddDefaultSource();
+            }
+
+            AZ::u32 validFingerprint = 0;
+            AZ::Uuid validBuilderGuid = AZ::Uuid::CreateRandom();
+            AzToolsFramework::AssetSystem::JobStatus statusQueued = AzToolsFramework::AssetSystem::JobStatus::Queued;
+
+            m_defaultJob = JobDatabaseEntry(m_defaultSource.m_sourceID, "jobKey", validFingerprint, "pc", validBuilderGuid, statusQueued, 1);
+            EXPECT_TRUE(m_connection.SetJob(m_defaultJob));
+            EXPECT_NE(m_defaultJob.m_jobID, AzToolsFramework::AssetDatabase::InvalidEntryId);
+            EXPECT_EQ(m_defaultJob.m_jobRunKey, 1);
+        }
+
+        void AddDefaultProduct()
+        {
+            if (m_defaultJob.m_jobID == AzToolsFramework::AssetDatabase::InvalidEntryId)
+            {
+                AddDefaultJob();
+            }
+
+            AZ::Data::AssetType validAssetType = AZ::Data::AssetType::CreateRandom();
+            m_defaultProduct = ProductDatabaseEntry(m_defaultJob.m_jobID, 0, "SomeProduct.dds", validAssetType);
+            EXPECT_TRUE(m_connection.SetProduct(m_defaultProduct));
+        }
+
+        void AddDefaultLegacySubId()
+        {
+            if (m_defaultProduct.m_productID == AzToolsFramework::AssetDatabase::InvalidEntryId)
+            {
+                AddDefaultProduct();
+            }
+
+            m_defaultLegacyEntry = LegacySubIDsEntry(AzToolsFramework::AssetDatabase::InvalidEntryId, m_defaultProduct.m_productID, 0);
+            EXPECT_TRUE(m_connection.CreateOrUpdateLegacySubID(m_defaultLegacyEntry));
+            EXPECT_NE(m_defaultLegacyEntry.m_subIDsEntryID, AzToolsFramework::AssetDatabase::InvalidEntryId); // it should have also updated the PK
+        }
+
+        void CreateProductDependencyTree(SourceDatabaseEntryContainer& sources, ProductDatabaseEntryContainer& products, const AZStd::string& platform = "")
+        {
+            /* Create the product dependency tree as below
+            *
+            * products[0] -> products[1] -> products[2] -> products[4] -> products[5]
+            *                    \
+            *                     -> products[3]
+            */
+            AddDefaultProduct();
+
+            // Add sources
+            sources.emplace_back(m_defaultSource);
+            for (int index = 1; index < 6; ++index)
+            {
+                AZ::Uuid validSourceGuid = AZ::Uuid::CreateRandom();
+                sources.emplace_back(SourceDatabaseEntry(m_defaultScanFolder.m_scanFolderID, AZStd::string::format("SomeSource%d.tif", index).c_str(), validSourceGuid, ""));
+                EXPECT_TRUE(m_connection.SetSource(sources[index]));
+            }
+
+            //Add jobs
+            JobDatabaseEntryContainer jobs;
+            jobs.emplace_back(m_defaultJob);
+            AzToolsFramework::AssetSystem::JobStatus statusCompleted = AzToolsFramework::AssetSystem::JobStatus::Completed;
+            for (int index = 1; index < 6; ++index)
+            {
+                AZ::Uuid validBuilderGuid = AZ::Uuid::CreateRandom();
+                AZ::u32 validFingerprint = index;
+                jobs.emplace_back(JobDatabaseEntry(sources[index].m_sourceID, AZStd::string::format("jobkey%d", index).c_str(), validFingerprint, "pc", validBuilderGuid, statusCompleted, index + 1));
+                EXPECT_TRUE(m_connection.SetJob(jobs[index]));
+            }
+
+            //Add products
+            products.emplace_back(m_defaultProduct);
+            for (int index = 1; index < 6; ++index)
+            {
+                AZ::Data::AssetType validAssetType = AZ::Data::AssetType::CreateRandom();
+                products.emplace_back(ProductDatabaseEntry(jobs[index].m_jobID, index, AZStd::string::format("SomeProduct%d.dds", index).c_str(), validAssetType));
+                EXPECT_TRUE(m_connection.SetProduct(products[index]));
+            }
+
+            //products[0] -> products[1]
+            ProductDependencyDatabaseEntry productDependency = ProductDependencyDatabaseEntry(products[0].m_productID, sources[1].m_sourceGuid, 1, 0, platform, true);
+            EXPECT_TRUE(m_connection.SetProductDependency(productDependency));
+
+            //products[1] -> products[2]
+            productDependency = ProductDependencyDatabaseEntry(products[1].m_productID, sources[2].m_sourceGuid, 2, 0, platform, true);
+            EXPECT_TRUE(m_connection.SetProductDependency(productDependency));
+
+            //products[1] -> products[3]
+            productDependency = ProductDependencyDatabaseEntry(products[1].m_productID, sources[3].m_sourceGuid, 3, 0, platform, true);
+            EXPECT_TRUE(m_connection.SetProductDependency(productDependency));
+
+            //products[2] -> products[4]
+            productDependency = ProductDependencyDatabaseEntry(products[2].m_productID, sources[4].m_sourceGuid, 4, 0, platform, true);
+            EXPECT_TRUE(m_connection.SetProductDependency(productDependency));
+
+            //products[4] -> products[5]
+            productDependency = ProductDependencyDatabaseEntry(products[4].m_productID, sources[5].m_sourceGuid, 5, 0, platform, true);
+            EXPECT_TRUE(m_connection.SetProductDependency(productDependency));
+        }
+
+        void CreateProductDependencyTree(ProductDatabaseEntryContainer& products, const AZStd::string& platform = "")
+        {
+            SourceDatabaseEntryContainer sources;
+            CreateProductDependencyTree(sources, products, platform);
+        }
+
+        void CreateProductDependencyTree(SourceDatabaseEntryContainer& sources, const AZStd::string& platform = "")
+        {
+            ProductDatabaseEntryContainer products;
+            CreateProductDependencyTree(sources, products, platform);
+        }
+
+        AssetProcessor::AssetDatabaseConnection m_connection;
+
+        ScanFolderDatabaseEntry m_defaultScanFolder;
+        SourceDatabaseEntry m_defaultSource;
+        JobDatabaseEntry m_defaultJob;       
+        ProductDatabaseEntry m_defaultProduct;     
+        LegacySubIDsEntry m_defaultLegacyEntry;
+    };
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestScanFolder_AddScanFolder_Succeeds)
+    {
+        // There are no scan folders yet so trying to find one should fail
+        ScanFolderDatabaseEntry scanFolder;
+        ScanFolderDatabaseEntryContainer scanFolders;
+        EXPECT_FALSE(m_connection.GetScanFolders(scanFolders));
+        EXPECT_FALSE(m_connection.GetScanFolderByScanFolderID(0, scanFolder));
+        EXPECT_FALSE(m_connection.GetScanFolderBySourceID(0, scanFolder));
+        EXPECT_FALSE(m_connection.GetScanFolderByProductID(0, scanFolder));
+        EXPECT_FALSE(m_connection.GetScanFolderByPortableKey("sadfsadfsadfsadfs", scanFolder));
+        scanFolders.clear();
+
+        AddDefaultScanFolder();
+
+        // Get all scan folders, there should be one we just added
+        scanFolders.clear();
+        EXPECT_TRUE(m_connection.GetScanFolders(scanFolders));
+        EXPECT_EQ(scanFolders.size(), 1);
+        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/dev"));
+        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, m_defaultScanFolder.m_scanFolderID));
+        EXPECT_TRUE(ScanFoldersContainPortableKey(scanFolders, m_defaultScanFolder.m_portableKey.c_str()));
+        EXPECT_TRUE(ScanFoldersContainPortableKey(scanFolders, "rootportkey"));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestScanFolder_AddDuplicateScanFolder_GetsSameId)
+    {
+        AddDefaultScanFolder();
+
+        // Add the same folder again, should not add another because it already exists, so we should get the same id
+        // not only that, but the path should update.
+        ScanFolderDatabaseEntry dupeScanFolder("c:/O3DE/dev1", "dev", "rootportkey");
+        dupeScanFolder.m_scanFolderID = AzToolsFramework::AssetDatabase::InvalidEntryId;
+        EXPECT_TRUE(m_connection.SetScanFolder(dupeScanFolder));
+        EXPECT_EQ(dupeScanFolder, m_defaultScanFolder) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+
+        EXPECT_EQ(dupeScanFolder.m_portableKey, m_defaultScanFolder.m_portableKey);
+        EXPECT_EQ(dupeScanFolder.m_scanFolderID, m_defaultScanFolder.m_scanFolderID);
+
+        // Get all scan folders, there should only the one we added
+        ScanFolderDatabaseEntryContainer scanFolders;
+        EXPECT_TRUE(m_connection.GetScanFolders(scanFolders));
+        EXPECT_EQ(scanFolders.size(), 1);
+        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/dev1"));
+        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, m_defaultScanFolder.m_scanFolderID));
+        EXPECT_TRUE(ScanFoldersContainPortableKey(scanFolders, m_defaultScanFolder.m_portableKey.c_str()));
+        EXPECT_TRUE(ScanFoldersContainPortableKey(scanFolders, "rootportkey"));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestScanFolder_RetrieveScanFolderById_Succeeds)
+    {
+        AddDefaultScanFolder();
+
+        // Retrieve the one we just made by id
+        ScanFolderDatabaseEntry retrieveScanfolderById;
+        EXPECT_TRUE(m_connection.GetScanFolderByScanFolderID(m_defaultScanFolder.m_scanFolderID, retrieveScanfolderById));
+        EXPECT_NE(retrieveScanfolderById.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+        EXPECT_EQ(retrieveScanfolderById.m_scanFolderID, m_defaultScanFolder.m_scanFolderID) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestScanFolder_RetrieveScanFolderByPortableKey_Succeeds)
+    {
+        AddDefaultScanFolder();
+
+        // Retrieve the one we just made by portable key
+        ScanFolderDatabaseEntry retrieveScanfolderByScanPath;
+        EXPECT_TRUE(m_connection.GetScanFolderByPortableKey("rootportkey", retrieveScanfolderByScanPath));
+        EXPECT_NE(retrieveScanfolderByScanPath.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+        EXPECT_EQ(retrieveScanfolderByScanPath.m_scanFolderID, m_defaultScanFolder.m_scanFolderID) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestScanFolder_RemoveScanFolderById_Succeeds)
+    {
+        AddDefaultScanFolder();
+        // Add another scan folder
+        ScanFolderDatabaseEntry gameScanFolderEntry("c:/O3DE/game", "game", "gameportkey");
+        EXPECT_TRUE(m_connection.SetScanFolder(gameScanFolderEntry));
+        EXPECT_NE(gameScanFolderEntry.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+
+        // Get all scan folders, there should be two scan folders we just added
+        ScanFolderDatabaseEntryContainer scanFolders;
+        EXPECT_TRUE(m_connection.GetScanFolders(scanFolders));
+        EXPECT_EQ(scanFolders.size(), 2);
+        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/dev"));
+        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/game"));
+        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, m_defaultScanFolder.m_scanFolderID));
+        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, gameScanFolderEntry.m_scanFolderID));
+
+        // Remove the game scan folder
+        EXPECT_TRUE(m_connection.RemoveScanFolder(848475));//should return true even if it doesn't exist, false only means SQL failed
+        EXPECT_TRUE(m_connection.RemoveScanFolder(gameScanFolderEntry.m_scanFolderID));
+
+        // Get all scan folders again, there should now only the first we added
+        scanFolders.clear();
+        EXPECT_TRUE(m_connection.GetScanFolders(scanFolders));
+        EXPECT_EQ(scanFolders.size(), 1);
+        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/dev"));
+        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, m_defaultScanFolder.m_scanFolderID));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestScanFolder_RemoveScanFolderByContainer_Succeeds)
+    {
+        AddDefaultScanFolder();
+        // Add another scan folder
+        ScanFolderDatabaseEntry gameScanFolderEntry("c:/O3DE/game", "game", "gameportkey");
+        EXPECT_TRUE(m_connection.SetScanFolder(gameScanFolderEntry));
+        EXPECT_NE(gameScanFolderEntry.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+
+        // Get all scan folders, there should only the two we added
+        ScanFolderDatabaseEntryContainer scanFolders;
+        EXPECT_TRUE(m_connection.GetScanFolders(scanFolders));
+        EXPECT_EQ(scanFolders.size(), 2);
+        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/dev"));
+        EXPECT_TRUE(ScanFoldersContainScanPath(scanFolders, "c:/O3DE/game"));
+        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, m_defaultScanFolder.m_scanFolderID));
+        EXPECT_TRUE(ScanFoldersContainScanFolderID(scanFolders, gameScanFolderEntry.m_scanFolderID));
+
+        // Remove scan folder by using a container
+        ScanFolderDatabaseEntryContainer tempScanFolderDatabaseEntryContainer; // note that on clang, its illegal to call a non-const function with a temp variable container as the param
+        EXPECT_TRUE(m_connection.RemoveScanFolders(tempScanFolderDatabaseEntryContainer)); // call with empty
+        EXPECT_TRUE(m_connection.RemoveScanFolders(scanFolders));
+        scanFolders.clear();
+        EXPECT_FALSE(m_connection.GetScanFolders(scanFolders));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestSources_AddSource_Succeeds)
+    {
+        // There are no sources yet so trying to find one should fail
+        SourceDatabaseEntry source;
+        SourceDatabaseEntryContainer sources;
+        EXPECT_FALSE(m_connection.GetSources(sources));
+        EXPECT_FALSE(m_connection.GetSourceBySourceID(3443, source));
+        EXPECT_FALSE(m_connection.GetSourceBySourceGuid(AZ::Uuid::Create(), source));
+        EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("source", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Raw, sources));
+        EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("source", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::StartsWith, sources));
+        EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("source", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::EndsWith, sources));
+        EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("source", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Matches, sources));
+
+        // Trying to add a source without a valid scan folder pk should fail
+        AZ::Uuid validSourceGuid1 = AZ::Uuid::CreateRandom();
+        source = SourceDatabaseEntry(234234, "SomeSource.tif", validSourceGuid1, "");
+        {
+            UnitTestUtils::AssertAbsorber absorber;
+            EXPECT_FALSE(m_connection.SetSource(source));
+            EXPECT_GE(absorber.m_numWarningsAbsorbed, 0);
+        }
+
+        AddDefaultSource();
+
+        // Get all sources, there should only the one we added
+        sources.clear();
+        EXPECT_TRUE(m_connection.GetSources(sources));
+        EXPECT_EQ(sources.size(), 1);
+        EXPECT_EQ(sources[0].m_analysisFingerprint, "12345");
+        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestSources_AddDuplicateSource_GetsSameId)
+    {
+        AddDefaultSource();
+
+        // Add the same source again, should not add another because it already exists, so we should get the same id
+        SourceDatabaseEntry dupeSource(m_defaultSource);
+        dupeSource.m_sourceID = AzToolsFramework::AssetDatabase::InvalidEntryId;
+        EXPECT_TRUE(m_connection.SetSource(dupeSource));
+        EXPECT_EQ(dupeSource.m_sourceID, m_defaultSource.m_sourceID) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+
+        // Get all sources, there should still only the one we added
+        SourceDatabaseEntryContainer sources;
+        EXPECT_TRUE(m_connection.GetSources(sources));
+        EXPECT_EQ(sources.size(), 1);
+        EXPECT_EQ(sources[0].m_analysisFingerprint, "12345");
+        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestSources_ChangeSourceField_Succeeds)
+    {
+        AddDefaultSource();
+
+        // Make sure that changing a field like fingerprint writes the new field to database but does not
+        // add a new entry (ie, its just modifying existing data)
+        SourceDatabaseEntry sourceWithDifferentFingerprint(m_defaultSource);
+        sourceWithDifferentFingerprint.m_analysisFingerprint = "otherFingerprint";
+        EXPECT_TRUE(m_connection.SetSource(sourceWithDifferentFingerprint));
+        EXPECT_EQ(sourceWithDifferentFingerprint.m_sourceID, m_defaultSource.m_sourceID);
+        SourceDatabaseEntryContainer sources;
+        EXPECT_TRUE(m_connection.GetSources(sources));
+        EXPECT_EQ(sources.size(), 1);
+        EXPECT_EQ(sources[0].m_analysisFingerprint, "otherFingerprint");
+        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestSources_ChangeScanFolder_Succeeds)
+    {
+        AddDefaultSource();
+
+        // Add the same source again, but change the scan folder.  This should NOT add a new source - even if we don't know what the sourceID is:
+        ScanFolderDatabaseEntry scanfolder = ScanFolderDatabaseEntry("c:/O3DE/dev1", "dev1", "devkey");
+        EXPECT_TRUE(m_connection.SetScanFolder(scanfolder));
+
+        SourceDatabaseEntry source(m_defaultSource);
+        source.m_scanFolderPK = scanfolder.m_scanFolderID;
+        source.m_analysisFingerprint = "new different fingerprint";
+        source.m_sourceID = AzToolsFramework::AssetDatabase::InvalidEntryId;
+        EXPECT_TRUE(m_connection.SetSource(source));
+        EXPECT_EQ(source.m_sourceID, m_defaultSource.m_sourceID) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+
+        // Get all sources, there should still only the one we added
+        SourceDatabaseEntryContainer sources;
+        EXPECT_TRUE(m_connection.GetSources(sources));
+        EXPECT_EQ(sources.size(), 1);
+        EXPECT_EQ(sources[0].m_analysisFingerprint, "new different fingerprint"); // verify that this column IS updated.
+        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+
+        // Add the same source again, but change the scan folder back. This should NOT add a new source - this time we do know what the source ID is!
+        SourceDatabaseEntry dupeSource(m_defaultSource);
+        dupeSource.m_scanFolderPK = m_defaultScanFolder.m_scanFolderID; // changing it back here.
+        EXPECT_TRUE(m_connection.SetSource(dupeSource));
+        EXPECT_EQ(dupeSource.m_sourceID, m_defaultSource.m_sourceID) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+
+        // Get all sources, there should still only the one we added
+        sources.clear();
+        EXPECT_TRUE(m_connection.GetSources(sources));
+        EXPECT_EQ(sources.size(), 1);
+        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+
+        // Remove the extra scan folder, make sure it doesn't drop the source since it should now be bound to the original scan folder agian
+        EXPECT_TRUE(m_connection.RemoveScanFolder(scanfolder.m_scanFolderID));
+        sources.clear();
+        EXPECT_TRUE(m_connection.GetSources(sources));
+        EXPECT_EQ(sources.size(), 1);
+        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestSources_RetrieveSourceBySourceId_Succeeds)
+    {
+        AddDefaultSource();
+
+        SourceDatabaseEntry retrieveSourceBySourceID;
+        EXPECT_TRUE(m_connection.GetSourceBySourceID(m_defaultSource.m_sourceID, retrieveSourceBySourceID));
+        EXPECT_NE(retrieveSourceBySourceID.m_sourceID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
+        EXPECT_EQ(retrieveSourceBySourceID.m_sourceID, m_defaultSource.m_sourceID) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
+        EXPECT_EQ(retrieveSourceBySourceID.m_scanFolderPK, m_defaultSource.m_scanFolderPK) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
+        EXPECT_EQ(retrieveSourceBySourceID.m_sourceGuid, m_defaultSource.m_sourceGuid) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
+        EXPECT_EQ(retrieveSourceBySourceID.m_sourceName, m_defaultSource.m_sourceName) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestSources_RetrieveSourceBySourceGuid_Succeeds)
+    {
+        AddDefaultSource();
+
+        // Try retrieving this source by guid
+        SourceDatabaseEntry retrieveSourceBySourceGuid;
+        EXPECT_TRUE(m_connection.GetSourceBySourceGuid(m_defaultSource.m_sourceGuid, retrieveSourceBySourceGuid));
+        EXPECT_NE(retrieveSourceBySourceGuid.m_sourceID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
+        EXPECT_EQ(retrieveSourceBySourceGuid.m_sourceID, m_defaultSource.m_sourceID) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
+        EXPECT_EQ(retrieveSourceBySourceGuid.m_scanFolderPK, m_defaultSource.m_scanFolderPK) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
+        EXPECT_EQ(retrieveSourceBySourceGuid.m_sourceGuid, m_defaultSource.m_sourceGuid) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
+        EXPECT_EQ(retrieveSourceBySourceGuid.m_sourceName, m_defaultSource.m_sourceName) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestSources_RetrieveSourceBySourceName_Succeeds)
+    {
+        AddDefaultSource();
+
+        // Try retrieving this source by source name
+        SourceDatabaseEntryContainer sources;
+        EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("Source.tif", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Raw, sources));
+        sources.clear();
+        EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("_SomeSource_", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Raw, sources));
+        sources.clear();
+        EXPECT_TRUE(m_connection.GetSourcesLikeSourceName("SomeSource%", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Raw, sources));
+        EXPECT_EQ(sources.size(), 1);
+        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        sources.clear();
+        EXPECT_TRUE(m_connection.GetSourcesLikeSourceName("%SomeSource%", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Raw, sources));
+        EXPECT_EQ(sources.size(), 1);
+        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        sources.clear();
+        EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("Source", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::StartsWith, sources));
+        sources.clear();
+        EXPECT_TRUE(m_connection.GetSourcesLikeSourceName("Some", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::StartsWith, sources));
+        EXPECT_EQ(sources.size(), 1);
+        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        sources.clear();
+        EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("SomeSource", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::EndsWith, sources));
+        sources.clear();
+        EXPECT_TRUE(m_connection.GetSourcesLikeSourceName(".tif", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::EndsWith, sources));
+        EXPECT_EQ(sources.size(), 1);
+        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        sources.clear();
+        EXPECT_FALSE(m_connection.GetSourcesLikeSourceName("blah", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Matches, sources));
+        sources.clear();
+        EXPECT_TRUE(m_connection.GetSourcesLikeSourceName("meSour", AzToolsFramework::AssetDatabase::AssetDatabaseConnection::Matches, sources));
+        EXPECT_EQ(sources.size(), 1);
+        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestSources_RemoveSourceById_Succeeds)
+    {
+        AddDefaultSource();
+
+        // Get all sources, there should still only the one we added
+        SourceDatabaseEntryContainer sources;
+        EXPECT_TRUE(m_connection.GetSources(sources));
+        EXPECT_EQ(sources.size(), 1);
+        EXPECT_EQ(sources[0].m_analysisFingerprint, "12345");
+        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+
+        // Remove a source
+        EXPECT_TRUE(m_connection.RemoveSource(432234));//should return true even if it doesn't exist, false only if SQL failed
+        EXPECT_TRUE(m_connection.RemoveSource(m_defaultSource.m_sourceID));
+
+        // Get all sources, there shouldn't be any
+        sources.clear();
+        EXPECT_FALSE(m_connection.GetSources(sources));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestSources_RemoveSourceByContainer_Succeeds)
+    {
+        AddDefaultSource();
+        // Add another source
+        AZ::Uuid validSourceGuid = AZ::Uuid::CreateRandom();
+        SourceDatabaseEntry source(m_defaultScanFolder.m_scanFolderID, "SomeSource1.tif", validSourceGuid, "");
+        EXPECT_TRUE(m_connection.SetSource(source));
+
+        // Get all sources, there should only the two we added
+        SourceDatabaseEntryContainer sources;
+        EXPECT_TRUE(m_connection.GetSources(sources));
+        EXPECT_EQ(sources.size(), 2);
+        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource1.tif"));
+        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        EXPECT_TRUE(SourcesContainSourceID(sources, source.m_sourceID));
+        EXPECT_TRUE(SourcesContainSourceGuid(sources, source.m_sourceGuid));
+
+        // Remove source via container
+        SourceDatabaseEntryContainer tempSourceDatabaseEntryContainer;
+        EXPECT_TRUE(m_connection.RemoveSources(tempSourceDatabaseEntryContainer)); // try it with an empty one.
+        EXPECT_TRUE(m_connection.RemoveSources(sources));
+
+        // Get all sources, there should none
+        sources.clear();
+        EXPECT_FALSE(m_connection.GetSources(sources));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestSources_RemoveSourceByScanFolderId_Succeeds)
+    {
+        AddDefaultSource();
+        // Add another source
+        AZ::Uuid validSourceGuid = AZ::Uuid::CreateRandom();
+        SourceDatabaseEntry source(m_defaultScanFolder.m_scanFolderID, "SomeSource1.tif", validSourceGuid, "");
+        EXPECT_TRUE(m_connection.SetSource(source));
+
+        // Get all sources, there should only the two we added
+        SourceDatabaseEntryContainer sources;
+        EXPECT_TRUE(m_connection.GetSources(sources));
+        EXPECT_EQ(sources.size(), 2);
+        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource.tif"));
+        EXPECT_TRUE(SourcesContainSourceName(sources, "SomeSource1.tif"));
+        EXPECT_TRUE(SourcesContainSourceID(sources, m_defaultSource.m_sourceID));
+        EXPECT_TRUE(SourcesContainSourceGuid(sources, m_defaultSource.m_sourceGuid));
+        EXPECT_TRUE(SourcesContainSourceID(sources, source.m_sourceID));
+        EXPECT_TRUE(SourcesContainSourceGuid(sources, source.m_sourceGuid));
+
+        // Remove the scan folder for these sources, the sources should cascade delete
+        EXPECT_TRUE(m_connection.RemoveScanFolder(m_defaultScanFolder.m_scanFolderID));
+
+        // Get all sources, there should none
+        sources.clear();
+        EXPECT_FALSE(m_connection.GetSources(sources));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestJobs_AddJob_Succeeds)
+    {
+        //there are no jobs yet so trying to find one should fail.
+        JobDatabaseEntryContainer jobs;
+        JobDatabaseEntry job;
+        EXPECT_FALSE(m_connection.GetJobs(jobs));
+        EXPECT_FALSE(m_connection.GetJobByJobID(3443, job));
+        EXPECT_FALSE(m_connection.GetJobsBySourceID(3234, jobs));
+        EXPECT_FALSE(m_connection.GetJobsBySourceName(AssetProcessor::SourceAssetReference("c:/O3DE/dev/none"), jobs));
+
+        AddDefaultSource();
+
+        // Trying to add a job without a valid source pk should fail:
+        AZ::u32 validFingerprint1 = 1;
+        AZ::Uuid validBuilderGuid1 = AZ::Uuid::CreateRandom();
+        AzToolsFramework::AssetSystem::JobStatus statusQueued = AzToolsFramework::AssetSystem::JobStatus::Queued;
+        {
+            UnitTestUtils::AssertAbsorber absorber;
+            job = JobDatabaseEntry(234234, "jobkey", validFingerprint1, "pc", validBuilderGuid1, statusQueued, 1);
+            EXPECT_FALSE(m_connection.SetJob(job));
+            EXPECT_GE(absorber.m_numWarningsAbsorbed, 0);
+        }
+
+        // Trying to add a job with a valid source pk but an invalid job id should fail:
+        {
+            UnitTestUtils::AssertAbsorber absorber;
+            job = JobDatabaseEntry(m_defaultSource.m_sourceID, "jobkey", validFingerprint1, "pc", validBuilderGuid1, statusQueued, 0);
+            EXPECT_FALSE(m_connection.SetJob(job));
+            EXPECT_GE(absorber.m_numErrorsAbsorbed, 0);
+        }
+
+        AddDefaultJob();
+
+        // Get all jobs, there should only the one we added
+        jobs.clear();
+        EXPECT_TRUE(m_connection.GetJobs(jobs));
+        EXPECT_EQ(jobs.size(), 1);
+        EXPECT_TRUE(JobsContainJobID(jobs, m_defaultJob.m_jobID));
+        EXPECT_TRUE(JobsContainJobKey(jobs, m_defaultJob.m_jobKey.c_str()));
+        EXPECT_TRUE(JobsContainFingerprint(jobs, m_defaultJob.m_fingerprint));
+        EXPECT_TRUE(JobsContainPlatform(jobs, m_defaultJob.m_platform.c_str()));
+        EXPECT_TRUE(JobsContainBuilderGuid(jobs, m_defaultJob.m_builderGuid));
+        EXPECT_TRUE(JobsContainStatus(jobs, m_defaultJob.m_status));
+        EXPECT_TRUE(JobsContainRunKey(jobs, m_defaultJob.m_jobRunKey));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestJobs_AddDuplicateJob_GetsSameId)
+    {
+        AddDefaultJob();
+
+        // Add the same job again, should not add another because it already exists, so we should get the same id
+        JobDatabaseEntry dupeJob(m_defaultJob);
+        dupeJob.m_jobID = AzToolsFramework::AssetDatabase::InvalidEntryId;
+        EXPECT_TRUE(m_connection.SetJob(dupeJob));
+        EXPECT_EQ(dupeJob, m_defaultJob) << "AssetProcessingStateDataTest Failed - SetJob failed to add";
+
+        // Get all jobs, there should still only the one we added
+        JobDatabaseEntryContainer jobs;
+        EXPECT_TRUE(m_connection.GetJobs(jobs));
+        EXPECT_EQ(jobs.size(), 1);
+        EXPECT_TRUE(JobsContainJobID(jobs, m_defaultJob.m_jobID));
+        EXPECT_TRUE(JobsContainJobKey(jobs, m_defaultJob.m_jobKey.c_str()));
+        EXPECT_TRUE(JobsContainFingerprint(jobs, m_defaultJob.m_fingerprint));
+        EXPECT_TRUE(JobsContainPlatform(jobs, m_defaultJob.m_platform.c_str()));
+        EXPECT_TRUE(JobsContainBuilderGuid(jobs, m_defaultJob.m_builderGuid));
+        EXPECT_TRUE(JobsContainStatus(jobs, m_defaultJob.m_status));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestJobs_RetrieveJobByJobId_Succeeds)
+    {
+        AddDefaultJob();
+
+        // Try retrieving this source by id
+        EXPECT_TRUE(m_connection.GetJobByJobID(m_defaultJob.m_jobID, m_defaultJob));
+        EXPECT_NE(m_defaultJob.m_jobID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - GetJobByJobID failed";
+
+        // Try retrieving jobs by source id
+        JobDatabaseEntryContainer jobs;
+        EXPECT_TRUE(m_connection.GetJobsBySourceID(m_defaultSource.m_sourceID, jobs));
+        EXPECT_EQ(jobs.size(), 1);
+        EXPECT_TRUE(JobsContainJobID(jobs, m_defaultJob.m_jobID));
+        EXPECT_TRUE(JobsContainJobKey(jobs, m_defaultJob.m_jobKey.c_str()));
+        EXPECT_TRUE(JobsContainFingerprint(jobs, m_defaultJob.m_fingerprint));
+        EXPECT_TRUE(JobsContainPlatform(jobs, m_defaultJob.m_platform.c_str()));
+        EXPECT_TRUE(JobsContainBuilderGuid(jobs, m_defaultJob.m_builderGuid));
+        EXPECT_TRUE(JobsContainStatus(jobs, m_defaultJob.m_status));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestJobs_RetrieveJobBySourceName_Succeeds)
+    {
+        AddDefaultJob();
+
+        // Try retrieving jobs by source name
+        JobDatabaseEntryContainer jobs;
+        EXPECT_TRUE(m_connection.GetJobsBySourceName(AssetProcessor::SourceAssetReference(m_defaultSource.m_scanFolderPK, m_defaultSource.m_sourceName.c_str()), jobs));
+        EXPECT_EQ(jobs.size(), 1);
+        EXPECT_TRUE(JobsContainJobID(jobs, m_defaultJob.m_jobID));
+        EXPECT_TRUE(JobsContainJobKey(jobs, m_defaultJob.m_jobKey.c_str()));
+        EXPECT_TRUE(JobsContainFingerprint(jobs, m_defaultJob.m_fingerprint));
+        EXPECT_TRUE(JobsContainPlatform(jobs, m_defaultJob.m_platform.c_str()));
+        EXPECT_TRUE(JobsContainBuilderGuid(jobs, m_defaultJob.m_builderGuid));
+        EXPECT_TRUE(JobsContainStatus(jobs, m_defaultJob.m_status));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestJobs_RemoveJobByJobId_Succeeds)
+    {
+        AddDefaultJob();
+
+        // Remove a job
+        EXPECT_TRUE(m_connection.RemoveJob(432234));
+        EXPECT_TRUE(m_connection.RemoveJob(m_defaultJob.m_jobID));
+
+        // Get all jobs, there shouldn't be any
+        JobDatabaseEntryContainer jobs;
+        EXPECT_FALSE(m_connection.GetJobs(jobs));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestJobs_RemoveJobByContainer_Succeeds)
+    {
+        AddDefaultJob();
+        // Add another source and job
+        AZ::Uuid validSourceGuid = AZ::Uuid::CreateRandom();
+        SourceDatabaseEntry source = SourceDatabaseEntry(m_defaultScanFolder.m_scanFolderID, "SomeSource1.tif", validSourceGuid, "");
+        EXPECT_TRUE(m_connection.SetSource(source));
+
+        AZ::u32 validFingerprint = 1;
+        AZ::u32 validJobRunKey = 1;
+        AZ::Uuid validBuilderGuid = AZ::Uuid::CreateRandom();
+        AzToolsFramework::AssetSystem::JobStatus statusQueued = AzToolsFramework::AssetSystem::JobStatus::Queued;
+        JobDatabaseEntry job(source.m_sourceID, "jobkey1", validFingerprint, "pc", validBuilderGuid, statusQueued, validJobRunKey);
+        EXPECT_TRUE(m_connection.SetJob(job));
+
+        // Get all jobs, there should be 2
+        JobDatabaseEntryContainer jobs;
+        EXPECT_TRUE(m_connection.GetJobs(jobs));
+        EXPECT_EQ(jobs.size(), 2);
+        EXPECT_TRUE(JobsContainJobID(jobs, m_defaultJob.m_jobID));
+        EXPECT_TRUE(JobsContainJobKey(jobs, m_defaultJob.m_jobKey.c_str()));
+        EXPECT_TRUE(JobsContainFingerprint(jobs, m_defaultJob.m_fingerprint));
+        EXPECT_TRUE(JobsContainPlatform(jobs, m_defaultJob.m_platform.c_str()));
+        EXPECT_TRUE(JobsContainBuilderGuid(jobs, m_defaultJob.m_builderGuid));
+        EXPECT_TRUE(JobsContainStatus(jobs, m_defaultJob.m_status));
+        EXPECT_TRUE(JobsContainJobID(jobs, job.m_jobID));
+        EXPECT_TRUE(JobsContainJobKey(jobs, job.m_jobKey.c_str()));
+        EXPECT_TRUE(JobsContainFingerprint(jobs, job.m_fingerprint));
+        EXPECT_TRUE(JobsContainPlatform(jobs, job.m_platform.c_str()));
+        EXPECT_TRUE(JobsContainBuilderGuid(jobs, job.m_builderGuid));
+        EXPECT_TRUE(JobsContainStatus(jobs, job.m_status));
+
+        //Remove job via container
+        JobDatabaseEntryContainer tempJobDatabaseEntryContainer;
+        EXPECT_TRUE(m_connection.RemoveJobs(tempJobDatabaseEntryContainer)); // make sure it works on an empty container.
+        EXPECT_TRUE(m_connection.RemoveJobs(jobs));
+
+        //get all jobs, there should none
+        jobs.clear();
+        EXPECT_FALSE(m_connection.GetJobs(jobs));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestJobs_RemoveJobBySource_Succeeds)
+    {
+        AddDefaultJob();
+        // Add another job for the same source
+        AZ::u32 validFingerprint = 1;
+        AZ::u32 validJobRunKey = 1;
+        AZ::Uuid validBuilderGuid = AZ::Uuid::CreateRandom();
+        AzToolsFramework::AssetSystem::JobStatus statusQueued = AzToolsFramework::AssetSystem::JobStatus::Queued;
+        JobDatabaseEntry job(m_defaultSource.m_sourceID, "jobkey1", validFingerprint, "pc", validBuilderGuid, statusQueued, validJobRunKey);
+        EXPECT_TRUE(m_connection.SetJob(job));
+
+        // Get all jobs, there should be 2
+        JobDatabaseEntryContainer jobs;
+        EXPECT_TRUE(m_connection.GetJobs(jobs));
+        EXPECT_EQ(jobs.size(), 2);
+        EXPECT_TRUE(JobsContainJobID(jobs, m_defaultJob.m_jobID));
+        EXPECT_TRUE(JobsContainJobKey(jobs, m_defaultJob.m_jobKey.c_str()));
+        EXPECT_TRUE(JobsContainFingerprint(jobs, m_defaultJob.m_fingerprint));
+        EXPECT_TRUE(JobsContainPlatform(jobs, m_defaultJob.m_platform.c_str()));
+        EXPECT_TRUE(JobsContainBuilderGuid(jobs, m_defaultJob.m_builderGuid));
+        EXPECT_TRUE(JobsContainStatus(jobs, m_defaultJob.m_status));
+        EXPECT_TRUE(JobsContainJobID(jobs, job.m_jobID));
+        EXPECT_TRUE(JobsContainJobKey(jobs, job.m_jobKey.c_str()));
+        EXPECT_TRUE(JobsContainFingerprint(jobs, job.m_fingerprint));
+        EXPECT_TRUE(JobsContainPlatform(jobs, job.m_platform.c_str()));
+        EXPECT_TRUE(JobsContainBuilderGuid(jobs, job.m_builderGuid));
+        EXPECT_TRUE(JobsContainStatus(jobs, job.m_status));
+
+        // Remove the source for these jobs, the jobs should cascade delete
+        EXPECT_TRUE(m_connection.RemoveSource(m_defaultSource.m_sourceID));
+
+        // Get all jobs, there should none
+        jobs.clear();
+        EXPECT_FALSE(m_connection.GetJobs(jobs));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestProducts_AddProduct_Succeeds)
+    {
+        // There are no scan folders yet so trying to find one should fail
+        ProductDatabaseEntry product;
+        ProductDatabaseEntryContainer products;
+        EXPECT_FALSE(m_connection.GetProducts(products));
+        EXPECT_EQ(products.size(), 0);
+
+        AddDefaultProduct();
+
+        // Get all products, there should be one we just added
         products.clear();
+        EXPECT_TRUE(m_connection.GetProducts(products));
+        EXPECT_EQ(products.size(), 1);
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestProducts_RemoveProduct_Succeeds)
+    {
+        AddDefaultProduct();
+
+        // Add another product
+        AZ::Data::AssetType validAssetType = AZ::Data::AssetType::CreateRandom();
+        ProductDatabaseEntry product = ProductDatabaseEntry(m_defaultJob.m_jobID, 1, "SomeProduct1.dds", validAssetType);
+        EXPECT_TRUE(m_connection.SetProduct(product));
+
+        // The products should cascade delete
+        EXPECT_TRUE(m_connection.RemoveSource(m_defaultSource.m_sourceID));
+
+        // Get all products, there should none
+        ProductDatabaseEntryContainer products;
+        EXPECT_FALSE(m_connection.GetProducts(products));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestProducts_AddLegacySubIds_Succeeds)
+    {
+        AddDefaultProduct();
+
+        // Test invalid insert for non existant legacy subids.
+        LegacySubIDsEntry legacyEntry(1, m_defaultProduct.m_productID, 0);
+        {
+            UnitTestUtils::AssertAbsorber absorber;
+            EXPECT_FALSE(m_connection.CreateOrUpdateLegacySubID(legacyEntry));
+            EXPECT_GT(absorber.m_numWarningsAbsorbed, 0);
+        }
+
+        // Test invalid insert for non-existant legacy product FK constraint
+        legacyEntry = LegacySubIDsEntry(AzToolsFramework::AssetDatabase::InvalidEntryId, 9999, 0);
+        {
+            UnitTestUtils::AssertAbsorber absorber;
+            EXPECT_FALSE(m_connection.CreateOrUpdateLegacySubID(legacyEntry));
+            EXPECT_GT(absorber.m_numWarningsAbsorbed, 0);
+        }
+
+        // Test valid insert for a product
+        AddDefaultLegacySubId();
+        EXPECT_NE(m_defaultLegacyEntry.m_subIDsEntryID, AzToolsFramework::AssetDatabase::InvalidEntryId); // it should have also updated the PK
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestLegacySubIds_RetrieveLegacySubIds_Succeeds)
+    {
+        AddDefaultLegacySubId();
+
+        // Insert of another for same product
+        LegacySubIDsEntry legacyEntry(AzToolsFramework::AssetDatabase::InvalidEntryId, m_defaultProduct.m_productID, 1);
+        EXPECT_TRUE(m_connection.CreateOrUpdateLegacySubID(legacyEntry));
+        EXPECT_NE(legacyEntry.m_subIDsEntryID, AzToolsFramework::AssetDatabase::InvalidEntryId); // it should have also updated the PK
+        EXPECT_NE(legacyEntry.m_subIDsEntryID, m_defaultLegacyEntry.m_subIDsEntryID); // pk should be unique
+
+        // Insert of another for different product
+        ProductDatabaseEntry product(m_defaultJob.m_jobID, 1, "SomeProduct1.dds", m_defaultProduct.m_assetType);
+        EXPECT_TRUE(m_connection.SetProduct(product));
+        legacyEntry = LegacySubIDsEntry(AzToolsFramework::AssetDatabase::InvalidEntryId, product.m_productID, 2);
+        EXPECT_TRUE(m_connection.CreateOrUpdateLegacySubID(legacyEntry));
+
+        // Test that the ones inserted can be retrieved.
+        AZStd::vector<LegacySubIDsEntry> entriesReturned;
+        auto handler = [&entriesReturned](LegacySubIDsEntry& entry)
+        {
+            entriesReturned.push_back(entry);
+            return true;
+        };
+        EXPECT_TRUE(m_connection.QueryLegacySubIdsByProductID(m_defaultProduct.m_productID, handler));
+        EXPECT_EQ(entriesReturned.size(), 2);
+
+        bool foundSubID3 = false;
+        bool foundSubID4 = false;
+        for (const LegacySubIDsEntry& entryFound : entriesReturned)
+        {
+            EXPECT_NE(entryFound.m_subIDsEntryID, AzToolsFramework::AssetDatabase::InvalidEntryId);
+            EXPECT_EQ(entryFound.m_productPK, m_defaultProduct.m_productID);
+            if (entryFound.m_subID == 0)
+            {
+                foundSubID3 = true;
+            }
+            else if (entryFound.m_subID == 1)
+            {
+                foundSubID4 = true;
+            }
+        }
+
+        EXPECT_TRUE(foundSubID3);
+        EXPECT_TRUE(foundSubID4);
+
+        entriesReturned.clear();
+
+        EXPECT_TRUE(m_connection.QueryLegacySubIdsByProductID(product.m_productID, handler));
+        EXPECT_EQ(entriesReturned.size(), 1);
+        EXPECT_NE(entriesReturned[0].m_subIDsEntryID, AzToolsFramework::AssetDatabase::InvalidEntryId);
+        EXPECT_EQ(entriesReturned[0].m_productPK, product.m_productID);
+        EXPECT_EQ(entriesReturned[0].m_subID, 2);
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestLegacySubIds_OverrideLegacySubId_Succeeds)
+    {
+        AddDefaultLegacySubId();
+
+        // Retrieve the current legacy sub IDs entry
+        AZStd::vector<LegacySubIDsEntry> entriesReturned;
+        auto handler = [&entriesReturned](LegacySubIDsEntry& entry)
+        {
+            entriesReturned.push_back(entry);
+            return true;
+        };
+
+        EXPECT_TRUE(m_connection.QueryLegacySubIdsByProductID(m_defaultProduct.m_productID, handler));
+        EXPECT_EQ(entriesReturned.size(), 1);
+        EXPECT_NE(entriesReturned[0].m_subIDsEntryID, AzToolsFramework::AssetDatabase::InvalidEntryId);
+        EXPECT_EQ(entriesReturned[0].m_productPK, m_defaultProduct.m_productID);
+        EXPECT_EQ(entriesReturned[0].m_subID, 0);
+
+        // Test UPDATE -> overwrite existing.
+        entriesReturned[0].m_subID = 1;
+        EXPECT_TRUE(m_connection.CreateOrUpdateLegacySubID(entriesReturned[0]));
+
+        entriesReturned.clear();
+        EXPECT_TRUE(m_connection.QueryLegacySubIdsByProductID(m_defaultProduct.m_productID, handler));
+        EXPECT_EQ(entriesReturned.size(), 1);
+        EXPECT_NE(entriesReturned[0].m_subIDsEntryID, AzToolsFramework::AssetDatabase::InvalidEntryId);
+        EXPECT_EQ(entriesReturned[0].m_productPK, m_defaultProduct.m_productID);
+        EXPECT_EQ(entriesReturned[0].m_subID, 1);
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestLegacySubIds_RemoveLegacySubIdByProductId_Succeeds)
+    {
+        AddDefaultLegacySubId();
+        AZStd::vector<LegacySubIDsEntry> entriesReturned;
+        auto handler = [&entriesReturned](LegacySubIDsEntry& entry)
+        {
+            entriesReturned.push_back(entry);
+            return true;
+        };
+
+        EXPECT_TRUE(m_connection.RemoveLegacySubIDsByProductID(m_defaultProduct.m_productID));
+        entriesReturned.clear();
+
+        EXPECT_TRUE(m_connection.QueryLegacySubIdsByProductID(m_defaultProduct.m_productID, handler));
+        EXPECT_TRUE(entriesReturned.empty());
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestLegacySubIds_RemoveLegacySubIdByPK_Succeeds)
+    {
+        AddDefaultLegacySubId();
+        // Add a second legacy sub ID
+        LegacySubIDsEntry legacyEntry(AzToolsFramework::AssetDatabase::InvalidEntryId, m_defaultProduct.m_productID, 1);
+        EXPECT_TRUE(m_connection.CreateOrUpdateLegacySubID(legacyEntry));
+        EXPECT_NE(legacyEntry.m_subIDsEntryID, AzToolsFramework::AssetDatabase::InvalidEntryId); // it should have also updated the PK
+        EXPECT_NE(legacyEntry.m_subIDsEntryID, m_defaultLegacyEntry.m_subIDsEntryID); // pk should be unique
+
+        AZStd::vector<LegacySubIDsEntry> entriesReturned;
+        auto handler = [&entriesReturned](LegacySubIDsEntry& entry)
+        {
+            entriesReturned.push_back(entry);
+            return true;
+        };
+
+        EXPECT_TRUE(m_connection.QueryLegacySubIdsByProductID(m_defaultProduct.m_productID, handler));
+        EXPECT_EQ(entriesReturned.size(), 2);
+
+        // Test delete by PK.  The prior entries should be here for product1. This also makes sure the above
+        // delete statement didn't delete more than it should have.
+        AZ::s64 toRemove = entriesReturned[0].m_subIDsEntryID;
+        AZ::u32 removingSubID = entriesReturned[0].m_subID;
+        EXPECT_TRUE(m_connection.RemoveLegacySubID(toRemove));
+
+        entriesReturned.clear();
+        EXPECT_TRUE(m_connection.QueryLegacySubIdsByProductID(m_defaultProduct.m_productID, handler));
+        EXPECT_EQ(entriesReturned.size(), 1);
+        EXPECT_NE(entriesReturned[0].m_subIDsEntryID, AzToolsFramework::AssetDatabase::InvalidEntryId);
+        EXPECT_NE(entriesReturned[0].m_subIDsEntryID, toRemove);
+        EXPECT_EQ(entriesReturned[0].m_productPK, m_defaultProduct.m_productID);
+        EXPECT_NE(entriesReturned[0].m_subID, removingSubID);
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestProductDependency_AddProductDependency_Succeeds)
+    {
+        AddDefaultProduct();
+        // Add a second product
+        AZ::Uuid validSourceGuid = AZ::Uuid::CreateRandom();
+        SourceDatabaseEntry source = SourceDatabaseEntry(m_defaultScanFolder.m_scanFolderID, "SomeSource1.tif", validSourceGuid, "");
+        EXPECT_TRUE(m_connection.SetSource(source));
+
+        AZ::Uuid validBuilderGuid = AZ::Uuid::CreateRandom();
+        AZ::u32 validFingerprint = 2;
+        AZ::u32 validJobRunKey = 1;
+        AzToolsFramework::AssetSystem::JobStatus statusCompleted = AzToolsFramework::AssetSystem::JobStatus::Completed;
+        JobDatabaseEntry job = JobDatabaseEntry(source.m_sourceID, "jobkey1", validFingerprint, "pc", validBuilderGuid, statusCompleted, validJobRunKey);
+        EXPECT_TRUE(m_connection.SetJob(job));
+
+        AZ::Data::AssetType validAssetType = AZ::Data::AssetType::CreateRandom();
+        ProductDatabaseEntry product = ProductDatabaseEntry(job.m_jobID, 1, "SomeProduct1.dds", validAssetType);
+        EXPECT_TRUE(m_connection.SetProduct(product));
+
+        // There are no product dependencies yet so trying to find one should fail
+        ProductDependencyDatabaseEntry productDependency;
+        ProductDatabaseEntryContainer products;
+        ProductDependencyDatabaseEntryContainer productDependencies;
         EXPECT_FALSE(m_connection.GetProductDependencies(productDependencies));
         EXPECT_FALSE(m_connection.GetProductDependencyByProductDependencyID(3443, productDependency));
         EXPECT_FALSE(m_connection.GetProductDependenciesByProductID(3443, productDependencies));
@@ -1023,21 +1222,21 @@ namespace AssetProcessor
         EXPECT_FALSE(m_connection.GetAllProductDependencies(3443, products));
 
         AZStd::string platform;
-        //trying to add a product dependency without a valid product pk should fail
-        productDependency = ProductDependencyDatabaseEntry(234234, validSourceGuid1, 1, 0, platform, true);
+        // Trying to add a product dependency without a valid product pk should fail
+        productDependency = ProductDependencyDatabaseEntry(234234, m_defaultSource.m_sourceGuid, 1, 0, platform, true);
         {
             UnitTestUtils::AssertAbsorber absorber;
             EXPECT_FALSE(m_connection.SetProductDependency(productDependency));
             EXPECT_GE(absorber.m_numWarningsAbsorbed, 0);
         }
 
-        //setting a valid product pk should allow it to be added
-        //Product -> Product2
-        productDependency = ProductDependencyDatabaseEntry(product.m_productID, validSourceGuid2, 2, 0, platform, true);
+        // Setting a valid product pk should allow it to be added
+        // Product -> Product2
+        productDependency = ProductDependencyDatabaseEntry(m_defaultProduct.m_productID, validSourceGuid, 2, 0, platform, true);
         EXPECT_TRUE(m_connection.SetProductDependency(productDependency));
         EXPECT_NE(productDependency.m_productDependencyID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - SetProductDependency failed to add";
 
-        //get all product dependencies, there should only the one we added
+        // Get all product dependencies, there should only the one we added
         productDependencies.clear();
         EXPECT_TRUE(m_connection.GetProductDependencies(productDependencies));
         EXPECT_EQ(productDependencies.size(), 1);
@@ -1048,13 +1247,13 @@ namespace AssetProcessor
         EXPECT_TRUE(ProductDependenciesContainDependencySubID(productDependencies, productDependency.m_dependencySubID));
         EXPECT_TRUE(ProductDependenciesContainDependencyFlags(productDependencies, productDependency.m_dependencyFlags));
 
-        //add the same product again, should not add another because it already exists, so we should get the same id
+        // Add the same product again, should not add another because it already exists, so we should get the same id
         ProductDependencyDatabaseEntry dupeProductDependency(productDependency);
         dupeProductDependency.m_productDependencyID = AzToolsFramework::AssetDatabase::InvalidEntryId;
         EXPECT_TRUE(m_connection.SetProductDependency(dupeProductDependency));
         EXPECT_EQ(dupeProductDependency, dupeProductDependency) << "AssetProcessingStateDataTest Failed - SetProductDependency failed to add";
 
-        //get all product dependencies, there should still only the one we added
+        // Get all product dependencies, there should still only the one we added
         productDependencies.clear();
         EXPECT_TRUE(m_connection.GetProductDependencies(productDependencies));
         EXPECT_EQ(productDependencies.size(), 1);
@@ -1063,172 +1262,168 @@ namespace AssetProcessor
         EXPECT_TRUE(ProductDependenciesContainDependencySoureGuid(productDependencies, productDependency.m_dependencySourceGuid));
         EXPECT_TRUE(ProductDependenciesContainDependencySubID(productDependencies, productDependency.m_dependencySubID));
         EXPECT_TRUE(ProductDependenciesContainDependencyFlags(productDependencies, productDependency.m_dependencyFlags));
-
-        // Setup some more dependencies
-
-        //Product2 -> Product3
-        productDependency = ProductDependencyDatabaseEntry(product2.m_productID, validSourceGuid3, 3, 0, platform, true);
-        EXPECT_TRUE(m_connection.SetProductDependency(productDependency));
-
-        //Product2 -> Product4
-        productDependency = ProductDependencyDatabaseEntry(product2.m_productID, validSourceGuid4, 4, 0, platform, true);
-        EXPECT_TRUE(m_connection.SetProductDependency(productDependency));
-
-        //Product3 -> Product5
-        productDependency = ProductDependencyDatabaseEntry(product3.m_productID, validSourceGuid5, 5, 0, platform, true);
-        EXPECT_TRUE(m_connection.SetProductDependency(productDependency));
-
-        //Product5 -> Product6
-        productDependency = ProductDependencyDatabaseEntry(product5.m_productID, validSourceGuid6, 6, 0, platform, true);
-        EXPECT_TRUE(m_connection.SetProductDependency(productDependency));
-
-        /* Dependency Tree
-        *
-        * Product -> Product2 -> Product3 -> Product5 -> Product 6->
-        *                    \
-        *                     -> Product4
-        */
-
-        // Direct Deps
-
-        // Product -> Product2
-        products.clear();
-        EXPECT_TRUE(m_connection.GetDirectProductDependencies(product.m_productID, products));
-        EXPECT_EQ(products.size(), 1);
-        EXPECT_TRUE(ProductsContainProductID(products, product2.m_productID));
-
-        // Product2 -> Product3, Product4
-        products.clear();
-        EXPECT_TRUE(m_connection.GetDirectProductDependencies(product2.m_productID, products));
-        EXPECT_EQ(products.size(), 2);
-        EXPECT_TRUE(ProductsContainProductID(products, product3.m_productID));
-        EXPECT_TRUE(ProductsContainProductID(products, product4.m_productID));
-
-        // Product3 -> Product5
-        products.clear();
-        EXPECT_TRUE(m_connection.GetDirectProductDependencies(product3.m_productID, products));
-        EXPECT_EQ(products.size(), 1);
-        EXPECT_TRUE(ProductsContainProductID(products, product5.m_productID));
-
-        // Product4 ->
-        products.clear();
-        EXPECT_FALSE(m_connection.GetDirectProductDependencies(product4.m_productID, products));
-        EXPECT_EQ(products.size(), 0);
-
-        // Product5 -> Product6
-        products.clear();
-        EXPECT_TRUE(m_connection.GetDirectProductDependencies(product5.m_productID, products));
-        EXPECT_EQ(products.size(), 1);
-        EXPECT_TRUE(ProductsContainProductID(products, product6.m_productID));
-
-        // Product6 ->
-        products.clear();
-        EXPECT_FALSE(m_connection.GetDirectProductDependencies(product6.m_productID, products));
-        EXPECT_EQ(products.size(), 0);
-
-        // All Deps
-
-        // Product -> Product2, Product3, Product4, Product5, Product6
-        products.clear();
-        EXPECT_TRUE(m_connection.GetAllProductDependencies(product.m_productID, products));
-        EXPECT_EQ(products.size(), 5);
-        EXPECT_TRUE(ProductsContainProductID(products, product2.m_productID));
-        EXPECT_TRUE(ProductsContainProductID(products, product3.m_productID));
-        EXPECT_TRUE(ProductsContainProductID(products, product4.m_productID));
-        EXPECT_TRUE(ProductsContainProductID(products, product5.m_productID));
-        EXPECT_TRUE(ProductsContainProductID(products, product6.m_productID));
-
-        // Product2 -> Product3, Product4, Product5, Product6
-        products.clear();
-        EXPECT_TRUE(m_connection.GetAllProductDependencies(product2.m_productID, products));
-        EXPECT_EQ(products.size(), 4);
-        EXPECT_TRUE(ProductsContainProductID(products, product3.m_productID));
-        EXPECT_TRUE(ProductsContainProductID(products, product4.m_productID));
-        EXPECT_TRUE(ProductsContainProductID(products, product5.m_productID));
-        EXPECT_TRUE(ProductsContainProductID(products, product6.m_productID));
-
-        // Product3 -> Product5, Product6
-        products.clear();
-        EXPECT_TRUE(m_connection.GetAllProductDependencies(product3.m_productID, products));
-        EXPECT_EQ(products.size(), 2);
-        EXPECT_TRUE(ProductsContainProductID(products, product5.m_productID));
-        EXPECT_TRUE(ProductsContainProductID(products, product6.m_productID));
-
-        // Product4 ->
-        products.clear();
-        EXPECT_FALSE(m_connection.GetAllProductDependencies(product4.m_productID, products));
-        EXPECT_EQ(products.size(), 0);
-
-        // Product5 -> Product6
-        products.clear();
-        EXPECT_TRUE(m_connection.GetAllProductDependencies(product5.m_productID, products));
-        EXPECT_EQ(products.size(), 1);
-        EXPECT_TRUE(ProductsContainProductID(products, product6.m_productID));
-
-        // Product6 ->
-        products.clear();
-        EXPECT_FALSE(m_connection.GetAllProductDependencies(product6.m_productID, products));
-        EXPECT_EQ(products.size(), 0);
-
-        //Product6 -> Product (This creates a circular dependency)
-        productDependency = ProductDependencyDatabaseEntry(product6.m_productID, validSourceGuid1, 1, 0, platform, true);
-        EXPECT_TRUE(m_connection.SetProductDependency(productDependency));
-
-        /* Circular Dependency Tree
-        * v--------------------------------------------------------<
-        * |                                                        |
-        * Product -> Product2 -> Product3 -> Product5 -> Product 6-^
-        *                    \
-        *                     -> Product4
-        */
-
-        // Product6 -> Product
-        products.clear();
-        EXPECT_TRUE(m_connection.GetDirectProductDependencies(product6.m_productID, products));
-        EXPECT_EQ(products.size(), 1);
-        EXPECT_TRUE(ProductsContainProductID(products, product.m_productID));
-
-        // Product3 -> Product5, Product6, Product, Product2, Product4
-        products.clear();
-        EXPECT_TRUE(m_connection.GetAllProductDependencies(product3.m_productID, products));
-        EXPECT_EQ(products.size(), 5);
-        EXPECT_TRUE(ProductsContainProductID(products, product5.m_productID));
-        EXPECT_TRUE(ProductsContainProductID(products, product6.m_productID));
-        EXPECT_TRUE(ProductsContainProductID(products, product.m_productID));
-        EXPECT_TRUE(ProductsContainProductID(products, product2.m_productID));
-        EXPECT_TRUE(ProductsContainProductID(products, product4.m_productID));
-
-        m_connection.RemoveProductDependencyByProductId(product5.m_productID);
-        products.clear();
-        EXPECT_TRUE(m_connection.GetAllProductDependencies(product2.m_productID, products));
-        EXPECT_EQ(products.size(), 3);
-        EXPECT_TRUE(ProductsContainProductID(products, product3.m_productID));
-        EXPECT_TRUE(ProductsContainProductID(products, product4.m_productID));
-        EXPECT_TRUE(ProductsContainProductID(products, product5.m_productID));
-
-        // Teardown
-        //The product dependencies should cascade delete
-        EXPECT_TRUE(m_connection.RemoveSource(source.m_sourceID));
-        EXPECT_TRUE(m_connection.RemoveSource(source2.m_sourceID));
-        EXPECT_TRUE(m_connection.RemoveSource(source3.m_sourceID));
-        EXPECT_TRUE(m_connection.RemoveSource(source4.m_sourceID));
-        EXPECT_TRUE(m_connection.RemoveSource(source5.m_sourceID));
-        EXPECT_TRUE(m_connection.RemoveSource(source6.m_sourceID));
-
-        productDependencies.clear();
-        products.clear();
-        EXPECT_FALSE(m_connection.GetProductDependencies(productDependencies));
-        EXPECT_FALSE(m_connection.GetDirectProductDependencies(product.m_productID, products));
-        EXPECT_FALSE(m_connection.GetAllProductDependencies(product.m_productID, products));
     }
 
-    TEST_F(AssetProcessingStateDataUnitTest, BuilderInfoTest_ValidDatabaseConnectionProvided_OperationsSucceed)
+    TEST_F(AssetProcessingStateDataUnitTest, TestProductDependency_VerifyProductDependency_Succeeds)
+    {
+        /* Verify the following product dependency tree
+        *
+        * products[0] -> products[1] -> products[2] -> products[4] -> products[5]
+        *                    \
+        *                     -> products[3]
+        */
+        ProductDatabaseEntryContainer products;
+        CreateProductDependencyTree(products);
+
+        // Direct Deps
+        // products[0] -> products[1]
+        ProductDatabaseEntryContainer dependentProducts;
+        EXPECT_TRUE(m_connection.GetDirectProductDependencies(products[0].m_productID, dependentProducts));
+        EXPECT_EQ(dependentProducts.size(), 1);
+        EXPECT_TRUE(ProductsContainProductID(products, products[1].m_productID));
+
+        // products[1] -> products[2], products[3]
+        dependentProducts.clear();
+        EXPECT_TRUE(m_connection.GetDirectProductDependencies(products[1].m_productID, dependentProducts));
+        EXPECT_EQ(dependentProducts.size(), 2);
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[2].m_productID));
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[3].m_productID));
+
+        // products[2] -> products[4]
+        dependentProducts.clear();
+        EXPECT_TRUE(m_connection.GetDirectProductDependencies(products[2].m_productID, dependentProducts));
+        EXPECT_EQ(dependentProducts.size(), 1);
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[4].m_productID));
+
+        // products[3] ->
+        dependentProducts.clear();
+        EXPECT_FALSE(m_connection.GetDirectProductDependencies(products[3].m_productID, dependentProducts));
+        EXPECT_EQ(dependentProducts.size(), 0);
+
+        // products[4] -> products[5]
+        dependentProducts.clear();
+        EXPECT_TRUE(m_connection.GetDirectProductDependencies(products[4].m_productID, dependentProducts));
+        EXPECT_EQ(dependentProducts.size(), 1);
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[5].m_productID));
+
+        // products[5] ->
+        dependentProducts.clear();
+        EXPECT_FALSE(m_connection.GetDirectProductDependencies(products[5].m_productID, dependentProducts));
+        EXPECT_EQ(dependentProducts.size(), 0);
+
+        // All Deps
+        // products[0] -> products[1], products[2], products[3], products[4], products[5]
+        dependentProducts.clear();
+        EXPECT_TRUE(m_connection.GetAllProductDependencies(products[0].m_productID, dependentProducts));
+        EXPECT_EQ(dependentProducts.size(), 5);
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[1].m_productID));
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[2].m_productID));
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[3].m_productID));
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[4].m_productID));
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[5].m_productID));
+
+        // products[1] -> products[2], products[3], products[4], products[5]
+        dependentProducts.clear();
+        EXPECT_TRUE(m_connection.GetAllProductDependencies(products[1].m_productID, dependentProducts));
+        EXPECT_EQ(dependentProducts.size(), 4);
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[2].m_productID));
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[3].m_productID));
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[4].m_productID));
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[5].m_productID));
+
+        // products[2] -> products[4], products[5]
+        dependentProducts.clear();
+        EXPECT_TRUE(m_connection.GetAllProductDependencies(products[2].m_productID, dependentProducts));
+        EXPECT_EQ(dependentProducts.size(), 2);
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[4].m_productID));
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[5].m_productID));
+
+        // products[3] ->
+        dependentProducts.clear();
+        EXPECT_FALSE(m_connection.GetAllProductDependencies(products[3].m_productID, dependentProducts));
+        EXPECT_EQ(dependentProducts.size(), 0);
+
+        // products[4] -> products[5]
+        dependentProducts.clear();
+        EXPECT_TRUE(m_connection.GetAllProductDependencies(products[4].m_productID, dependentProducts));
+        EXPECT_EQ(dependentProducts.size(), 1);
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[5].m_productID));
+
+        // products[5] ->
+        dependentProducts.clear();
+        EXPECT_FALSE(m_connection.GetAllProductDependencies(products[5].m_productID, dependentProducts));
+        EXPECT_EQ(dependentProducts.size(), 0);
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestProductDependency_VerifyCircularProductDependency_Succeeds)
+    {
+        /* Verify the following circular dependency tree
+        * v-----------------------------------------------------------------------<
+        * |                                                                       |
+        * products[0] -> products[1] -> products[2] -> products[4] -> products[6]-^
+        *                    \
+        *                     -> products[3]
+        */
+        SourceDatabaseEntryContainer sources;
+        ProductDatabaseEntryContainer products;
+        AZStd::string platform;
+        CreateProductDependencyTree(sources, products, platform);
+        // products[5] -> products[0] (This creates a circular dependency)
+        ProductDependencyDatabaseEntry productDependency(products[5].m_productID, sources[0].m_sourceGuid, 0, 0, platform, true);
+        EXPECT_TRUE(m_connection.SetProductDependency(productDependency));
+
+        // products[5] -> products[0]
+        ProductDatabaseEntryContainer dependentProducts;
+        EXPECT_TRUE(m_connection.GetDirectProductDependencies(products[5].m_productID, dependentProducts));
+        EXPECT_EQ(dependentProducts.size(), 1);
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[0].m_productID));
+
+        // products[2] -> products[4], products[5], products[0], products[1], products[3]
+        dependentProducts.clear();
+        EXPECT_TRUE(m_connection.GetAllProductDependencies(products[2].m_productID, dependentProducts));
+        EXPECT_EQ(dependentProducts.size(), 5);
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[4].m_productID));
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[5].m_productID));
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[0].m_productID));
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[1].m_productID));
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[3].m_productID));
+
+        m_connection.RemoveProductDependencyByProductId(products[4].m_productID);
+
+        // products[1] -> products[2], products[3], products[4]
+        dependentProducts.clear();
+        EXPECT_TRUE(m_connection.GetAllProductDependencies(products[1].m_productID, dependentProducts));
+        EXPECT_EQ(dependentProducts.size(), 3);
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[2].m_productID));
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[3].m_productID));
+        EXPECT_TRUE(ProductsContainProductID(dependentProducts, products[4].m_productID));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestProductDependency_RemoveProductDependency_Succeeds)
+    {
+        SourceDatabaseEntryContainer sources;
+        CreateProductDependencyTree(sources);
+
+        // Teardown
+        // The product dependencies should cascade delete
+        for (int index = 0; index < sources.size(); ++index)
+        {
+            EXPECT_TRUE(m_connection.RemoveSource(sources[index].m_sourceID));
+        }
+
+        ProductDependencyDatabaseEntryContainer productDependencies;
+        ProductDatabaseEntryContainer dependentProducts;
+        EXPECT_FALSE(m_connection.GetProductDependencies(productDependencies));
+        EXPECT_FALSE(m_connection.GetDirectProductDependencies(m_defaultProduct.m_productID, dependentProducts));
+        EXPECT_FALSE(m_connection.GetAllProductDependencies(m_defaultProduct.m_productID, dependentProducts));
+    }
+
+    TEST_F(AssetProcessingStateDataUnitTest, TestBuilderInfo_SetBuilderInfoTable_Succeeds)
     {
         using BuilderInfoEntry = AzToolsFramework::AssetDatabase::BuilderInfoEntry;
         using BuilderInfoEntryContainer = AzToolsFramework::AssetDatabase::BuilderInfoEntryContainer;
 
         // empty database should have no builder info:
-
         BuilderInfoEntryContainer results;
         auto resultGatherer = [&results](BuilderInfoEntry&& element)
         {
@@ -1289,7 +1484,7 @@ namespace AssetProcessor
         EXPECT_EQ(results[0].m_analysisFingerprint, newEntries[0].m_analysisFingerprint);
     }
 
-    TEST_F(AssetProcessingStateDataUnitTest, SourceDependencyTest_ValidDatabaseConnectionProvided_OperationsSucceed)
+    TEST_F(AssetProcessingStateDataUnitTest, TestSourceDependency_VerifySourceDependency_Succeeds)
     {
         using namespace AzToolsFramework::AssetDatabase;
 
@@ -1359,50 +1554,30 @@ namespace AssetProcessor
         EXPECT_EQ(results.size(), 1);
         EXPECT_EQ(results[0].m_dependsOnSource.GetPath(), "c.txt");
 
-
         // clean up
         EXPECT_TRUE(m_connection.RemoveSourceFileDependency(newEntry1.m_sourceDependencyID));
         EXPECT_TRUE(m_connection.RemoveSourceFileDependency(newEntry2.m_sourceDependencyID));
     }
 
-    TEST_F(AssetProcessingStateDataUnitTest, SourceFingerprintTest_ValidDatabaseConnectionProvided_OperationsSucceed)
+    TEST_F(AssetProcessingStateDataUnitTest, TestSourceFingerprint_QuerySourceAnalysisFingerprint_Succeeds)
     {
         using SourceDatabaseEntry = AzToolsFramework::AssetDatabase::SourceDatabaseEntry;
         using ScanFolderDatabaseEntry = AzToolsFramework::AssetDatabase::ScanFolderDatabaseEntry;
 
-        // to add a source file you have to add a scan folder first
-        ScanFolderDatabaseEntry scanFolder;
-        scanFolder.m_displayName = "test scan folder";
-        scanFolder.m_isRoot = false;
-        scanFolder.m_portableKey = "1234";
-        scanFolder.m_scanFolder = "//test//test";
-        scanFolder.m_scanFolderID = AzToolsFramework::AssetDatabase::InvalidEntryId;
-
-        EXPECT_TRUE(m_connection.SetScanFolder(scanFolder));
-
-        SourceDatabaseEntry sourceFile1;
-        sourceFile1.m_analysisFingerprint = "12345";
-        sourceFile1.m_scanFolderPK = scanFolder.m_scanFolderID;
-        sourceFile1.m_sourceGuid = AZ::Uuid::CreateRandom();
-        sourceFile1.m_sourceName = "a.txt";
-        EXPECT_TRUE(m_connection.SetSource(sourceFile1));
-
-        SourceDatabaseEntry sourceFile2;
-        sourceFile2.m_analysisFingerprint = "54321";
-        sourceFile2.m_scanFolderPK = scanFolder.m_scanFolderID;
-        sourceFile2.m_sourceGuid = AZ::Uuid::CreateRandom();
-        sourceFile2.m_sourceName = "b.txt";
-
-        EXPECT_TRUE(m_connection.SetSource(sourceFile2));
+        AddDefaultSource();
+        // Add another source
+        AZ::Uuid validSourceGuid = AZ::Uuid::CreateRandom();
+        SourceDatabaseEntry source(m_defaultScanFolder.m_scanFolderID, "SomeSource1.tif", validSourceGuid, "54321");
+        EXPECT_TRUE(m_connection.SetSource(source));
 
         AZStd::string resultString("garbage");
         // its not a database error to ask for a file that does not exist:
-        EXPECT_TRUE(m_connection.QuerySourceAnalysisFingerprint("does not exist", scanFolder.m_scanFolderID, resultString));
+        EXPECT_TRUE(m_connection.QuerySourceAnalysisFingerprint("does not exist", m_defaultScanFolder.m_scanFolderID, resultString));
         // but we do expect it to empty the result:
         EXPECT_TRUE(resultString.empty());
-        EXPECT_TRUE(m_connection.QuerySourceAnalysisFingerprint("a.txt", scanFolder.m_scanFolderID, resultString));
+        EXPECT_TRUE(m_connection.QuerySourceAnalysisFingerprint("SomeSource.tif", m_defaultScanFolder.m_scanFolderID, resultString));
         EXPECT_EQ(resultString, "12345");
-        EXPECT_TRUE(m_connection.QuerySourceAnalysisFingerprint("b.txt", scanFolder.m_scanFolderID, resultString));
+        EXPECT_TRUE(m_connection.QuerySourceAnalysisFingerprint("SomeSource1.tif", m_defaultScanFolder.m_scanFolderID, resultString));
         EXPECT_EQ(resultString, "54321");
     }
 }

--- a/Code/Tools/AssetProcessor/native/unittests/AssetProcessingStateDataUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetProcessingStateDataUnitTests.cpp
@@ -266,9 +266,10 @@ namespace AssetProcessor
 
         void AddDefaultScanFolder()
         {
+            // this isn't a real directory. It just creates an entry in the database, so any string would work.
             m_defaultScanFolder = ScanFolderDatabaseEntry("c:/O3DE/dev", "dev", "rootportkey");
             EXPECT_TRUE(m_connection.SetScanFolder(m_defaultScanFolder));
-            EXPECT_NE(m_defaultScanFolder.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+            EXPECT_NE(m_defaultScanFolder.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId);
         }
 
         void AddDefaultSource()
@@ -281,7 +282,7 @@ namespace AssetProcessor
             AZ::Uuid validSourceGuid = AZ::Uuid::CreateRandom();
             m_defaultSource = SourceDatabaseEntry(m_defaultScanFolder.m_scanFolderID, "SomeSource.tif", validSourceGuid, "12345");
             EXPECT_TRUE(m_connection.SetSource(m_defaultSource));
-            EXPECT_NE(m_defaultSource.m_sourceID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - source failed to add";
+            EXPECT_NE(m_defaultSource.m_sourceID, AzToolsFramework::AssetDatabase::InvalidEntryId);
         }
 
         void AddDefaultJob()
@@ -440,7 +441,7 @@ namespace AssetProcessor
         ScanFolderDatabaseEntry dupeScanFolder("c:/O3DE/dev1", "dev", "rootportkey");
         dupeScanFolder.m_scanFolderID = AzToolsFramework::AssetDatabase::InvalidEntryId;
         EXPECT_TRUE(m_connection.SetScanFolder(dupeScanFolder));
-        EXPECT_EQ(dupeScanFolder, m_defaultScanFolder) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+        EXPECT_EQ(dupeScanFolder, m_defaultScanFolder);
 
         EXPECT_EQ(dupeScanFolder.m_portableKey, m_defaultScanFolder.m_portableKey);
         EXPECT_EQ(dupeScanFolder.m_scanFolderID, m_defaultScanFolder.m_scanFolderID);
@@ -462,8 +463,8 @@ namespace AssetProcessor
         // Retrieve the one we just made by id
         ScanFolderDatabaseEntry retrieveScanfolderById;
         EXPECT_TRUE(m_connection.GetScanFolderByScanFolderID(m_defaultScanFolder.m_scanFolderID, retrieveScanfolderById));
-        EXPECT_NE(retrieveScanfolderById.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
-        EXPECT_EQ(retrieveScanfolderById.m_scanFolderID, m_defaultScanFolder.m_scanFolderID) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+        EXPECT_NE(retrieveScanfolderById.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId);
+        EXPECT_EQ(retrieveScanfolderById.m_scanFolderID, m_defaultScanFolder.m_scanFolderID);
     }
 
     TEST_F(AssetProcessingStateDataUnitTest, TestScanFolder_RetrieveScanFolderByPortableKey_Succeeds)
@@ -473,8 +474,8 @@ namespace AssetProcessor
         // Retrieve the one we just made by portable key
         ScanFolderDatabaseEntry retrieveScanfolderByScanPath;
         EXPECT_TRUE(m_connection.GetScanFolderByPortableKey("rootportkey", retrieveScanfolderByScanPath));
-        EXPECT_NE(retrieveScanfolderByScanPath.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
-        EXPECT_EQ(retrieveScanfolderByScanPath.m_scanFolderID, m_defaultScanFolder.m_scanFolderID) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+        EXPECT_NE(retrieveScanfolderByScanPath.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId);
+        EXPECT_EQ(retrieveScanfolderByScanPath.m_scanFolderID, m_defaultScanFolder.m_scanFolderID);
     }
 
     TEST_F(AssetProcessingStateDataUnitTest, TestScanFolder_RemoveScanFolderById_Succeeds)
@@ -483,7 +484,7 @@ namespace AssetProcessor
         // Add another scan folder
         ScanFolderDatabaseEntry gameScanFolderEntry("c:/O3DE/game", "game", "gameportkey");
         EXPECT_TRUE(m_connection.SetScanFolder(gameScanFolderEntry));
-        EXPECT_NE(gameScanFolderEntry.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+        EXPECT_NE(gameScanFolderEntry.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId);
 
         // Get all scan folders, there should be two scan folders we just added
         ScanFolderDatabaseEntryContainer scanFolders;
@@ -512,7 +513,7 @@ namespace AssetProcessor
         // Add another scan folder
         ScanFolderDatabaseEntry gameScanFolderEntry("c:/O3DE/game", "game", "gameportkey");
         EXPECT_TRUE(m_connection.SetScanFolder(gameScanFolderEntry));
-        EXPECT_NE(gameScanFolderEntry.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+        EXPECT_NE(gameScanFolderEntry.m_scanFolderID, AzToolsFramework::AssetDatabase::InvalidEntryId);
 
         // Get all scan folders, there should only the two we added
         ScanFolderDatabaseEntryContainer scanFolders;
@@ -573,7 +574,7 @@ namespace AssetProcessor
         SourceDatabaseEntry dupeSource(m_defaultSource);
         dupeSource.m_sourceID = AzToolsFramework::AssetDatabase::InvalidEntryId;
         EXPECT_TRUE(m_connection.SetSource(dupeSource));
-        EXPECT_EQ(dupeSource.m_sourceID, m_defaultSource.m_sourceID) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+        EXPECT_EQ(dupeSource.m_sourceID, m_defaultSource.m_sourceID);
 
         // Get all sources, there should still only the one we added
         SourceDatabaseEntryContainer sources;
@@ -617,7 +618,7 @@ namespace AssetProcessor
         source.m_analysisFingerprint = "new different fingerprint";
         source.m_sourceID = AzToolsFramework::AssetDatabase::InvalidEntryId;
         EXPECT_TRUE(m_connection.SetSource(source));
-        EXPECT_EQ(source.m_sourceID, m_defaultSource.m_sourceID) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+        EXPECT_EQ(source.m_sourceID, m_defaultSource.m_sourceID);
 
         // Get all sources, there should still only the one we added
         SourceDatabaseEntryContainer sources;
@@ -632,7 +633,7 @@ namespace AssetProcessor
         SourceDatabaseEntry dupeSource(m_defaultSource);
         dupeSource.m_scanFolderPK = m_defaultScanFolder.m_scanFolderID; // changing it back here.
         EXPECT_TRUE(m_connection.SetSource(dupeSource));
-        EXPECT_EQ(dupeSource.m_sourceID, m_defaultSource.m_sourceID) << "AssetProcessingStateDataTest Failed - scan folder failed to add";
+        EXPECT_EQ(dupeSource.m_sourceID, m_defaultSource.m_sourceID);
 
         // Get all sources, there should still only the one we added
         sources.clear();
@@ -658,11 +659,11 @@ namespace AssetProcessor
 
         SourceDatabaseEntry retrieveSourceBySourceID;
         EXPECT_TRUE(m_connection.GetSourceBySourceID(m_defaultSource.m_sourceID, retrieveSourceBySourceID));
-        EXPECT_NE(retrieveSourceBySourceID.m_sourceID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
-        EXPECT_EQ(retrieveSourceBySourceID.m_sourceID, m_defaultSource.m_sourceID) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
-        EXPECT_EQ(retrieveSourceBySourceID.m_scanFolderPK, m_defaultSource.m_scanFolderPK) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
-        EXPECT_EQ(retrieveSourceBySourceID.m_sourceGuid, m_defaultSource.m_sourceGuid) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
-        EXPECT_EQ(retrieveSourceBySourceID.m_sourceName, m_defaultSource.m_sourceName) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
+        EXPECT_NE(retrieveSourceBySourceID.m_sourceID, AzToolsFramework::AssetDatabase::InvalidEntryId);
+        EXPECT_EQ(retrieveSourceBySourceID.m_sourceID, m_defaultSource.m_sourceID);
+        EXPECT_EQ(retrieveSourceBySourceID.m_scanFolderPK, m_defaultSource.m_scanFolderPK);
+        EXPECT_EQ(retrieveSourceBySourceID.m_sourceGuid, m_defaultSource.m_sourceGuid);
+        EXPECT_EQ(retrieveSourceBySourceID.m_sourceName, m_defaultSource.m_sourceName);
     }
 
     TEST_F(AssetProcessingStateDataUnitTest, TestSources_RetrieveSourceBySourceGuid_Succeeds)
@@ -672,11 +673,11 @@ namespace AssetProcessor
         // Try retrieving this source by guid
         SourceDatabaseEntry retrieveSourceBySourceGuid;
         EXPECT_TRUE(m_connection.GetSourceBySourceGuid(m_defaultSource.m_sourceGuid, retrieveSourceBySourceGuid));
-        EXPECT_NE(retrieveSourceBySourceGuid.m_sourceID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
-        EXPECT_EQ(retrieveSourceBySourceGuid.m_sourceID, m_defaultSource.m_sourceID) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
-        EXPECT_EQ(retrieveSourceBySourceGuid.m_scanFolderPK, m_defaultSource.m_scanFolderPK) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
-        EXPECT_EQ(retrieveSourceBySourceGuid.m_sourceGuid, m_defaultSource.m_sourceGuid) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
-        EXPECT_EQ(retrieveSourceBySourceGuid.m_sourceName, m_defaultSource.m_sourceName) << "AssetProcessingStateDataTest Failed - GetSourceBySourceID failed";
+        EXPECT_NE(retrieveSourceBySourceGuid.m_sourceID, AzToolsFramework::AssetDatabase::InvalidEntryId);
+        EXPECT_EQ(retrieveSourceBySourceGuid.m_sourceID, m_defaultSource.m_sourceID);
+        EXPECT_EQ(retrieveSourceBySourceGuid.m_scanFolderPK, m_defaultSource.m_scanFolderPK);
+        EXPECT_EQ(retrieveSourceBySourceGuid.m_sourceGuid, m_defaultSource.m_sourceGuid);
+        EXPECT_EQ(retrieveSourceBySourceGuid.m_sourceName, m_defaultSource.m_sourceName);
     }
 
     TEST_F(AssetProcessingStateDataUnitTest, TestSources_RetrieveSourceBySourceName_Succeeds)
@@ -858,7 +859,7 @@ namespace AssetProcessor
         JobDatabaseEntry dupeJob(m_defaultJob);
         dupeJob.m_jobID = AzToolsFramework::AssetDatabase::InvalidEntryId;
         EXPECT_TRUE(m_connection.SetJob(dupeJob));
-        EXPECT_EQ(dupeJob, m_defaultJob) << "AssetProcessingStateDataTest Failed - SetJob failed to add";
+        EXPECT_EQ(dupeJob, m_defaultJob);
 
         // Get all jobs, there should still only the one we added
         JobDatabaseEntryContainer jobs;
@@ -878,7 +879,7 @@ namespace AssetProcessor
 
         // Try retrieving this source by id
         EXPECT_TRUE(m_connection.GetJobByJobID(m_defaultJob.m_jobID, m_defaultJob));
-        EXPECT_NE(m_defaultJob.m_jobID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - GetJobByJobID failed";
+        EXPECT_NE(m_defaultJob.m_jobID, AzToolsFramework::AssetDatabase::InvalidEntryId);
 
         // Try retrieving jobs by source id
         JobDatabaseEntryContainer jobs;
@@ -1240,7 +1241,7 @@ namespace AssetProcessor
         // Product -> Product2
         productDependency = ProductDependencyDatabaseEntry(m_defaultProduct.m_productID, validSourceGuid, 2, 0, platform, true);
         EXPECT_TRUE(m_connection.SetProductDependency(productDependency));
-        EXPECT_NE(productDependency.m_productDependencyID, AzToolsFramework::AssetDatabase::InvalidEntryId) << "AssetProcessingStateDataTest Failed - SetProductDependency failed to add";
+        EXPECT_NE(productDependency.m_productDependencyID, AzToolsFramework::AssetDatabase::InvalidEntryId);
 
         // Get all product dependencies, there should only the one we added
         productDependencies.clear();
@@ -1257,7 +1258,8 @@ namespace AssetProcessor
         ProductDependencyDatabaseEntry dupeProductDependency(productDependency);
         dupeProductDependency.m_productDependencyID = AzToolsFramework::AssetDatabase::InvalidEntryId;
         EXPECT_TRUE(m_connection.SetProductDependency(dupeProductDependency));
-        EXPECT_EQ(dupeProductDependency, dupeProductDependency) << "AssetProcessingStateDataTest Failed - SetProductDependency failed to add";
+        EXPECT_EQ(dupeProductDependency, dupeProductDependency);
+        EXPECT_EQ(dupeProductDependency, dupeProductDependency);
 
         // Get all product dependencies, there should still only the one we added
         productDependencies.clear();

--- a/Code/Tools/AssetProcessor/native/unittests/AssetProcessingStateDataUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetProcessingStateDataUnitTests.cpp
@@ -896,9 +896,15 @@ namespace AssetProcessor
     {
         AddDefaultJob();
 
+        auto& config = m_appManager->m_platformConfig;
+        config->AddScanFolder(AssetProcessor::ScanFolderInfo{m_defaultScanFolder.m_scanFolder.c_str(),
+            m_defaultScanFolder.m_displayName.c_str(), m_defaultScanFolder.m_portableKey.c_str(),
+            false, true, {} , 0, m_defaultScanFolder.m_scanFolderID});
+
         // Try retrieving jobs by source name
         JobDatabaseEntryContainer jobs;
-        EXPECT_TRUE(m_connection.GetJobsBySourceName(AssetProcessor::SourceAssetReference(m_defaultSource.m_scanFolderPK, m_defaultSource.m_sourceName.c_str()), jobs));
+        EXPECT_TRUE(m_connection.GetJobsBySourceName(AssetProcessor::SourceAssetReference(
+            m_defaultSource.m_scanFolderPK, m_defaultSource.m_sourceName.c_str()), jobs));
         EXPECT_EQ(jobs.size(), 1);
         EXPECT_TRUE(JobsContainJobID(jobs, m_defaultJob.m_jobID));
         EXPECT_TRUE(JobsContainJobKey(jobs, m_defaultJob.m_jobKey.c_str()));


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?

Refactor and break the AP state data unit tests. Test all the existing functionalities in the current test. 

**Suggest to treat these as new unit tests for review due to the huge refactor.**

## How was this PR tested?

```
[==========] Running 37 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 37 tests from AssetProcessingStateDataUnitTest
[ RUN      ] AssetProcessingStateDataUnitTest.TestScanFolder_AddScanFolder_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestScanFolder_AddScanFolder_Succeeds (339 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestScanFolder_AddDuplicateScanFolder_GetsSameId
[       OK ] AssetProcessingStateDataUnitTest.TestScanFolder_AddDuplicateScanFolder_GetsSameId (306 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestScanFolder_RetrieveScanFolderById_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestScanFolder_RetrieveScanFolderById_Succeeds (309 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestScanFolder_RetrieveScanFolderByPortableKey_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestScanFolder_RetrieveScanFolderByPortableKey_Succeeds (311 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestScanFolder_RemoveScanFolderById_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestScanFolder_RemoveScanFolderById_Succeeds (310 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestScanFolder_RemoveScanFolderByContainer_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestScanFolder_RemoveScanFolderByContainer_Succeeds (311 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestSources_AddSource_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestSources_AddSource_Succeeds (311 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestSources_AddDuplicateSource_GetsSameId
[       OK ] AssetProcessingStateDataUnitTest.TestSources_AddDuplicateSource_GetsSameId (314 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestSources_ChangeSourceField_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestSources_ChangeSourceField_Succeeds (326 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestSources_ChangeScanFolder_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestSources_ChangeScanFolder_Succeeds (308 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestSources_RetrieveSourceBySourceId_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestSources_RetrieveSourceBySourceId_Succeeds (308 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestSources_RetrieveSourceBySourceGuid_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestSources_RetrieveSourceBySourceGuid_Succeeds (310 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestSources_RetrieveSourceBySourceName_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestSources_RetrieveSourceBySourceName_Succeeds (309 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestSources_RemoveSourceById_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestSources_RemoveSourceById_Succeeds (310 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestSources_RemoveSourceByContainer_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestSources_RemoveSourceByContainer_Succeeds (312 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestSources_RemoveSourceByScanFolderId_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestSources_RemoveSourceByScanFolderId_Succeeds (309 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestJobs_AddJob_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestJobs_AddJob_Succeeds (311 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestJobs_AddDuplicateJob_GetsSameId
[       OK ] AssetProcessingStateDataUnitTest.TestJobs_AddDuplicateJob_GetsSameId (390 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestJobs_RetrieveJobByJobId_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestJobs_RetrieveJobByJobId_Succeeds (309 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestJobs_RetrieveJobBySourceName_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestJobs_RetrieveJobBySourceName_Succeeds (310 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestJobs_RemoveJobByJobId_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestJobs_RemoveJobByJobId_Succeeds (308 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestJobs_RemoveJobByContainer_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestJobs_RemoveJobByContainer_Succeeds (313 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestJobs_RemoveJobBySource_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestJobs_RemoveJobBySource_Succeeds (309 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestProducts_AddProduct_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestProducts_AddProduct_Succeeds (307 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestProducts_RemoveProduct_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestProducts_RemoveProduct_Succeeds (311 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestProducts_AddLegacySubIds_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestProducts_AddLegacySubIds_Succeeds (307 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestLegacySubIds_RetrieveLegacySubIds_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestLegacySubIds_RetrieveLegacySubIds_Succeeds (309 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestLegacySubIds_OverrideLegacySubId_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestLegacySubIds_OverrideLegacySubId_Succeeds (309 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestLegacySubIds_RemoveLegacySubIdByProductId_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestLegacySubIds_RemoveLegacySubIdByProductId_Succeeds (307 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestLegacySubIds_RemoveLegacySubIdByPK_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestLegacySubIds_RemoveLegacySubIdByPK_Succeeds (309 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestProductDependency_AddProductDependency_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestProductDependency_AddProductDependency_Succeeds (310 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestProductDependency_VerifyProductDependency_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestProductDependency_VerifyProductDependency_Succeeds (312 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestProductDependency_VerifyCircularProductDependency_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestProductDependency_VerifyCircularProductDependency_Succeeds (315 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestProductDependency_RemoveProductDependency_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestProductDependency_RemoveProductDependency_Succeeds (315 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestBuilderInfo_SetBuilderInfoTable_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestBuilderInfo_SetBuilderInfoTable_Succeeds (311 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestSourceDependency_VerifySourceDependency_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestSourceDependency_VerifySourceDependency_Succeeds (318 ms)
[ RUN      ] AssetProcessingStateDataUnitTest.TestSourceFingerprint_QuerySourceAnalysisFingerprint_Succeeds
[       OK ] AssetProcessingStateDataUnitTest.TestSourceFingerprint_QuerySourceAnalysisFingerprint_Succeeds (310 ms)
[----------] 37 tests from AssetProcessingStateDataUnitTest (11638 ms total)
```
