### PR TITLE
Terminate server on player exit if configured for it

### DIFF
--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -990,6 +990,7 @@ namespace Multiplayer
             if (m_networkInterface->GetConnectionSet().GetActiveConnectionCount() == 0)
             {
                 Terminate(DisconnectReason::TerminatedByServer);
+                AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::ExitMainLoop);
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: puvvadar <puvvadar@amazon.com>

## What does this PR do?

Exits the server application once all clients have disconnected if `sv_terminateOnPlayerExit `is true.

Addresses https://github.com/o3de/o3de/issues/12198

## How was this PR tested?

Opened a server and connected a client and then terminated the client. Observed the server correctly terminating.
