### PR TITLE
bugfix(RHI): set VK_PIPELINE_STAGE_TRANSFER_BIT when pipeline has an explicit clear

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphCompiler.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphCompiler.h
@@ -103,8 +103,8 @@ namespace AZ
             // Add VK_ACCESS_TRANSFER_WRITE_BIT in case we want to do a clear operation.
             if (HasExplicitClear(scopeAttachment, scopeAttachment.GetDescriptor()))
             {
-                srcAccessFlags |= VK_ACCESS_TRANSFER_WRITE_BIT;
-                srcAccessFlags = RHI::FilterBits(srcAccessFlags, GetSupportedAccessFlags(srcPipelineStageFlags));
+                srcPipelineStageFlags |= VK_PIPELINE_STAGE_TRANSFER_BIT;
+                srcAccessFlags = RHI::FilterBits(srcAccessFlags | VK_ACCESS_TRANSFER_WRITE_BIT, GetSupportedAccessFlags(srcPipelineStageFlags));
             }
         
             auto subresourceRange = GetSubresourceRange(scopeAttachment);


### PR DESCRIPTION

ref: https://github.com/o3de/o3de/issues/11225

Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

The last attempt at this introduced a breaking change where this would fail with the vulkan validation layer: https://github.com/o3de/o3de/pull/11381

after reviewing the specification it seems just enough to add the stage to mark a transfer. should be able to then set the access for a write transfer. 

## How was this PR tested?

need to repeat the steps here: https://github.com/o3de/o3de/pull/10876