### PR TITLE
bugfix(UI Editor): prevent zoom when canvas window loses focus

### DIFF
--- a/Gems/LyShine/Code/Editor/ViewportInteraction.cpp
+++ b/Gems/LyShine/Code/Editor/ViewportInteraction.cpp
@@ -985,6 +985,13 @@ void ViewportInteraction::SetCanvasZoomPercent(float percent)
 
 void ViewportInteraction::SetCanvasToViewportScale(float newScale, Vec2i* optionalPivotPoint)
 {
+    // only allow setting the viewport scale if current window is active
+    // OnTick for ViewportWidget is need to re-evaluate the layout but does not update if window loses focus
+    if (!m_editorWindow->isActiveWindow())
+    {
+        return;
+    }
+
     static const float minZoom = 0.1f;
     static const float maxZoom = 10.0f;
     const float currentScale = m_canvasViewportMatrixProps.scale;

--- a/Gems/LyShine/Code/Editor/ViewportInteraction.cpp
+++ b/Gems/LyShine/Code/Editor/ViewportInteraction.cpp
@@ -986,7 +986,7 @@ void ViewportInteraction::SetCanvasZoomPercent(float percent)
 void ViewportInteraction::SetCanvasToViewportScale(float newScale, Vec2i* optionalPivotPoint)
 {
     // only allow setting the viewport scale if current window is active
-    // OnTick for ViewportWidget is need to re-evaluate the layout but does not update if window loses focus
+    // OnTick for ViewportWidget is needed to reevaluate the layout, but does not happen when the window loses focus
     if (!m_editorWindow->isActiveWindow())
     {
         return;


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

OnTick is paused when the window loses focus so the viewport does not correctly handle the change. 

this is the call that would need to happen: `UpdateCanvasInEditorViewport`

## How was this PR tested?

follow steps listed from issue: https://github.com/o3de/o3de/issues/12365
