### PR TITLE
Fix spam caused by preview and thumbnail render request before the asset catalog was loaded

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -106,7 +106,13 @@ namespace AZ
             AzToolsFramework::EditorMenuNotificationBus::Handler::BusConnect();
             AzToolsFramework::EditorEvents::Bus::Handler::BusConnect();
             AzToolsFramework::ToolsApplicationNotificationBus::Handler::BusConnect();
-            AZ::SystemTickBus::Handler::BusConnect();
+            AzFramework::AssetCatalogEventBus::Handler::BusConnect();
+
+            // All material previews use the same model and lighting preset assets
+            // models/sphere.azmodel
+            m_materialPreviewModelAsset.Create(AZ::Data::AssetId("{6DE0E9A8-A1C7-5D0F-9407-4E627C1F223C}", 284780167));
+            // lightingpresets/thumbnail.lightingpreset.azasset
+            m_materialPreviewLightingPresetAsset.Create(AZ::Data::AssetId("{4F3761EF-E279-5FDD-98C3-EF90F924FBAC}", 0));
 
             m_materialBrowserInteractions.reset(aznew MaterialBrowserInteractions);
         }
@@ -122,8 +128,12 @@ namespace AZ
             AzToolsFramework::EditorEvents::Bus::Handler::BusDisconnect(); 
             AzToolsFramework::ToolsApplicationNotificationBus::Handler::BusDisconnect(); 
             AZ::SystemTickBus::Handler::BusDisconnect();
+            AzFramework::AssetCatalogEventBus::Handler::BusDisconnect();
 
             m_materialBrowserInteractions.reset();
+            m_materialPreviewRequests.clear();
+            m_materialPreviewModelAsset.Release();
+            m_materialPreviewLightingPresetAsset.Release();
 
             if (m_openMaterialEditorAction)
             {
@@ -196,6 +206,7 @@ namespace AZ
             const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId)
         {
             m_materialPreviewRequests.emplace(entityId, materialAssignmentId);
+            AZ::SystemTickBus::Handler::BusConnect();
         }
 
         QPixmap EditorMaterialSystemComponent::GetRenderedMaterialPreview(
@@ -221,78 +232,78 @@ namespace AZ
 
         void EditorMaterialSystemComponent::OnSystemTick()
         {
-            if (auto previewRenderer = AZ::Interface<AtomToolsFramework::PreviewRendererInterface>::Get())
+            auto previewRenderer = AZ::Interface<AtomToolsFramework::PreviewRendererInterface>::Get();
+            if (!previewRenderer || !m_materialPreviewModelAsset.IsReady() || !m_materialPreviewLightingPresetAsset.IsReady())
             {
-                // All material previews use the same model and lighting preset assets
-                AZ::Data::Asset<AZ::RPI::ModelAsset> modelAsset;
-                modelAsset.Create(AZ::RPI::AssetUtils::GetAssetIdForProductPath("models/sphere.azmodel"));
-
-                AZ::Data::Asset<AZ::RPI::AnyAsset> lightingPresetAsset;
-                lightingPresetAsset.Create(AZ::RPI::AssetUtils::GetAssetIdForProductPath("lightingpresets/thumbnail.lightingpreset.azasset"));
-
-                for (const auto& materialPreviewRequestPair : m_materialPreviewRequests)
-                {
-                    const auto& entityId = materialPreviewRequestPair.first;
-                    const auto& materialAssignmentId = materialPreviewRequestPair.second;
-
-                    AZ::Data::AssetId materialAssetId = {};
-                    MaterialComponentRequestBus::EventResult(
-                        materialAssetId, entityId, &MaterialComponentRequestBus::Events::GetMaterialAssetId, materialAssignmentId);
-
-                    AZ::Render::MaterialPropertyOverrideMap propertyOverrides;
-                    AZ::Render::MaterialComponentRequestBus::EventResult(
-                        propertyOverrides,
-                        entityId,
-                        &AZ::Render::MaterialComponentRequestBus::Events::GetPropertyValues,
-                        materialAssignmentId);
-
-                    // Having an invalid material asset will use the default asset on the model.
-                    AZ::Data::Asset<AZ::RPI::MaterialAsset> materialAsset;
-                    materialAsset.Create(materialAssetId);
-
-                    previewRenderer->AddCaptureRequest(
-                        { MaterialPreviewResolution,
-                          AZStd::make_shared<AZ::LyIntegration::SharedPreviewContent>(
-                              previewRenderer->GetScene(),
-                              previewRenderer->GetView(),
-                              previewRenderer->GetEntityContextId(),
-                              modelAsset,
-                              materialAsset,
-                              lightingPresetAsset,
-                              propertyOverrides),
-                          [entityId, materialAssignmentId]()
-                          {
-                              AZ_UNUSED(entityId);
-                              AZ_UNUSED(materialAssignmentId);
-
-                              AZ_Warning(
-                                  "EditorMaterialSystemComponent",
-                                  false,
-                                  "RenderMaterialPreview capture failed for entity %s slot %s.",
-                                  entityId.ToString().c_str(),
-                                  materialAssignmentId.ToString().c_str());
-
-                              // If the capture failed to render substitute it with a black image
-                              QPixmap pixmap(1, 1);
-                              pixmap.fill(Qt::black);
-                              AZ::Render::EditorMaterialSystemComponentNotificationBus::Broadcast(
-                                  &AZ::Render::EditorMaterialSystemComponentNotificationBus::Events::OnRenderMaterialPreviewRendered,
-                                  entityId,
-                                  materialAssignmentId,
-                                  pixmap);
-                          },
-                          [entityId, materialAssignmentId](const QPixmap& pixmap)
-                          {
-                              AZ::Render::EditorMaterialSystemComponentNotificationBus::Broadcast(
-                                  &AZ::Render::EditorMaterialSystemComponentNotificationBus::Events::OnRenderMaterialPreviewRendered,
-                                  entityId,
-                                  materialAssignmentId,
-                                  pixmap);
-                          } });
-                }
-
-                m_materialPreviewRequests.clear();
+                return;
             }
+
+            for (const auto& materialPreviewRequestPair : m_materialPreviewRequests)
+            {
+                const auto& entityId = materialPreviewRequestPair.first;
+                const auto& materialAssignmentId = materialPreviewRequestPair.second;
+
+                AZ::Data::AssetId materialAssetId = {};
+                MaterialComponentRequestBus::EventResult(
+                    materialAssetId, entityId, &MaterialComponentRequestBus::Events::GetMaterialAssetId, materialAssignmentId);
+
+                AZ::Render::MaterialPropertyOverrideMap propertyOverrides;
+                AZ::Render::MaterialComponentRequestBus::EventResult(
+                    propertyOverrides, entityId, &AZ::Render::MaterialComponentRequestBus::Events::GetPropertyValues, materialAssignmentId);
+
+                // Having an invalid material asset will use the default asset on the model.
+                AZ::Data::Asset<AZ::RPI::MaterialAsset> materialAsset;
+                materialAsset.Create(materialAssetId);
+
+                previewRenderer->AddCaptureRequest(
+                    { MaterialPreviewResolution,
+                      AZStd::make_shared<AZ::LyIntegration::SharedPreviewContent>(
+                          previewRenderer->GetScene(),
+                          previewRenderer->GetView(),
+                          previewRenderer->GetEntityContextId(),
+                          m_materialPreviewModelAsset,
+                          materialAsset,
+                          m_materialPreviewLightingPresetAsset,
+                          propertyOverrides),
+                      [entityId, materialAssignmentId]()
+                      {
+                          AZ_UNUSED(entityId);
+                          AZ_UNUSED(materialAssignmentId);
+
+                          AZ_Warning(
+                              "EditorMaterialSystemComponent",
+                              false,
+                              "RenderMaterialPreview capture failed for entity %s slot %s.",
+                              entityId.ToString().c_str(),
+                              materialAssignmentId.ToString().c_str());
+
+                          // If the capture failed to render substitute it with a black image
+                          QPixmap pixmap(1, 1);
+                          pixmap.fill(Qt::black);
+                          AZ::Render::EditorMaterialSystemComponentNotificationBus::Broadcast(
+                              &AZ::Render::EditorMaterialSystemComponentNotificationBus::Events::OnRenderMaterialPreviewRendered,
+                              entityId,
+                              materialAssignmentId,
+                              pixmap);
+                      },
+                      [entityId, materialAssignmentId](const QPixmap& pixmap)
+                      {
+                          AZ::Render::EditorMaterialSystemComponentNotificationBus::Broadcast(
+                              &AZ::Render::EditorMaterialSystemComponentNotificationBus::Events::OnRenderMaterialPreviewRendered,
+                              entityId,
+                              materialAssignmentId,
+                              pixmap);
+                      } });
+            }
+
+            m_materialPreviewRequests.clear();
+            AZ::SystemTickBus::Handler::BusDisconnect();
+        }
+
+        void EditorMaterialSystemComponent::OnCatalogLoaded([[maybe_unused]] const char* catalogFile)
+        {
+            m_materialPreviewModelAsset.QueueLoad();
+            m_materialPreviewLightingPresetAsset.QueueLoad();
         }
 
         void EditorMaterialSystemComponent::OnRenderMaterialPreviewRendered(

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
@@ -8,18 +8,22 @@
 
 #pragma once
 
-#include <AtomLyIntegration/CommonFeatures/Material/EditorMaterialSystemComponentRequestBus.h>
+#include <Atom/RPI.Reflect/Material/MaterialAsset.h>
+#include <Atom/RPI.Reflect/Model/ModelAsset.h>
+#include <Atom/RPI.Reflect/System/AnyAsset.h>
 #include <AtomLyIntegration/CommonFeatures/Material/EditorMaterialSystemComponentNotificationBus.h>
+#include <AtomLyIntegration/CommonFeatures/Material/EditorMaterialSystemComponentRequestBus.h>
 #include <AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h>
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/EntityBus.h>
+#include <AzCore/Component/TickBus.h>
+#include <AzFramework/Asset/AssetCatalogBus.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
 #include <AzToolsFramework/Viewport/ActionBus.h>
 #include <Material/MaterialBrowserInteractions.h>
 #include <QPixmap>
-#include <AzCore/Component/TickBus.h>
 
 namespace AZ
 {
@@ -37,6 +41,7 @@ namespace AZ
             , public AzToolsFramework::EditorEvents::Bus::Handler
             , public AzToolsFramework::ToolsApplicationNotificationBus::Handler
             , public AZ::SystemTickBus::Handler
+            , public AzFramework::AssetCatalogEventBus::Handler
         {
         public:
             AZ_COMPONENT(EditorMaterialSystemComponent, "{96652157-DA0B-420F-B49C-0207C585144C}");
@@ -72,6 +77,9 @@ namespace AZ
             //! AZ::SystemTickBus::Handler interface overrides...
             void OnSystemTick() override;
 
+            // AzFramework::AssetCatalogEventBus::Handler overrides...
+            void OnCatalogLoaded(const char* catalogFile) override;
+
             //! EditorMaterialSystemComponentNotificationBus::Handler overrides...
             void OnRenderMaterialPreviewRendered(
                 const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId, const QPixmap& pixmap) override;
@@ -99,6 +107,8 @@ namespace AZ
             AZStd::unique_ptr<MaterialBrowserInteractions> m_materialBrowserInteractions;
             AZStd::unordered_set<AZStd::pair<AZ::EntityId, AZ::Render::MaterialAssignmentId>> m_materialPreviewRequests;
             AZStd::unordered_map<AZ::EntityId, AZStd::unordered_map<AZ::Render::MaterialAssignmentId, QPixmap>> m_materialPreviews;
+            AZ::Data::Asset<AZ::RPI::ModelAsset> m_materialPreviewModelAsset;
+            AZ::Data::Asset<AZ::RPI::AnyAsset> m_materialPreviewLightingPresetAsset;
             static constexpr const size_t MaterialPreviewLimit = 100;
             static constexpr const int MaterialPreviewResolution = 128;
         };

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnailRenderer.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnailRenderer.cpp
@@ -24,23 +24,48 @@ namespace AZ
 {
     namespace LyIntegration
     {
+        template<typename T>
+        void LoadPreviewAsset(AZ::Data::Asset<T>& asset, const AZ::Data::AssetId& assetId)
+        {
+            if (assetId.IsValid())
+            {
+                asset.Create(assetId, true);
+            }
+        }
+
+        template<typename T>
+        void LoadPreviewAsset(AZ::Data::Asset<T>& asset, const AZ::Data::AssetId& assetId, const AZStd::string& assetIdOverrideSettingKey)
+        {
+            LoadPreviewAsset(asset, AtomToolsFramework::GetSettingsObject<AZ::Data::AssetId>(assetIdOverrideSettingKey, assetId));
+        }
+
         SharedThumbnailRenderer::SharedThumbnailRenderer()
         {
-            m_defaultModelAsset.Create(SharedPreviewUtils::GetAssetIdForProductPath(DefaultModelPath), true);
-            m_defaultMaterialAsset.Create(SharedPreviewUtils::GetAssetIdForProductPath(DefaultMaterialPath), true);
-            m_defaultLightingPresetAsset.Create(SharedPreviewUtils::GetAssetIdForProductPath(DefaultLightingPresetPath), true);
+            //models/sphere.azmodel
+            m_defaultModelAsset.Create(AZ::Data::AssetId("{6DE0E9A8-A1C7-5D0F-9407-4E627C1F223C}", 284780167));
+            //lightingpresets/thumbnail.lightingpreset.azasset
+            m_defaultLightingPresetAsset.Create(AZ::Data::AssetId("{4F3761EF-E279-5FDD-98C3-EF90F924FBAC}", 0));
+            //materials/reflectionprobe/reflectionprobevisualization.azmaterial
+            m_reflectionMaterialAsset.Create(AZ::Data::AssetId("{4322FBCB-8916-5572-9CDA-18582E22D238}", 0));
 
             for (const AZ::Uuid& typeId : SharedPreviewUtils::GetSupportedAssetTypes())
             {
                 AzToolsFramework::Thumbnailer::ThumbnailerRendererRequestBus::MultiHandler::BusConnect(typeId);
             }
             SystemTickBus::Handler::BusConnect();
+            AzFramework::AssetCatalogEventBus::Handler::BusConnect();
         }
 
         SharedThumbnailRenderer::~SharedThumbnailRenderer()
         {
             AzToolsFramework::Thumbnailer::ThumbnailerRendererRequestBus::MultiHandler::BusDisconnect();
             SystemTickBus::Handler::BusDisconnect();
+            AzFramework::AssetCatalogEventBus::Handler::BusDisconnect();
+        }
+
+        bool SharedThumbnailRenderer::ThumbnailConfig::IsValid() const
+        {
+            return m_modelAsset.GetId().IsValid() || m_materialAsset.GetId().IsValid() || m_lightingAsset.GetId().IsValid();
         }
 
         SharedThumbnailRenderer::ThumbnailConfig SharedThumbnailRenderer::GetThumbnailConfig(
@@ -49,44 +74,37 @@ namespace AZ
             const auto assetInfo = SharedPreviewUtils::GetSupportedAssetInfo(thumbnailKey);
             if (assetInfo.m_assetType == RPI::ModelAsset::RTTI_Type())
             {
-                static constexpr const char* MaterialAssetPathSetting =
-                    "/O3DE/Atom/CommonFeature/SharedPreview/ModelAssetType/MaterialAssetPath";
-                static constexpr const char* LightingAssetPathSetting =
-                    "/O3DE/Atom/CommonFeature/SharedPreview/ModelAssetType/LightingAssetPath";
-
                 ThumbnailConfig thumbnailConfig;
-                thumbnailConfig.m_modelAsset.Create(assetInfo.m_assetId);
-                thumbnailConfig.m_materialAsset.Create(SharedPreviewUtils::GetAssetIdForProductPath(
-                    AtomToolsFramework::GetSettingsValue<AZStd::string>(MaterialAssetPathSetting, DefaultMaterialPath)));
-                thumbnailConfig.m_lightingAsset.Create(SharedPreviewUtils::GetAssetIdForProductPath(
-                    AtomToolsFramework::GetSettingsValue<AZStd::string>(LightingAssetPathSetting, DefaultLightingPresetPath)));
+                LoadPreviewAsset(thumbnailConfig.m_modelAsset, assetInfo.m_assetId);
+                LoadPreviewAsset(
+                    thumbnailConfig.m_materialAsset,
+                    m_defaultMaterialAsset.GetId(),
+                    "/O3DE/Atom/CommonFeature/SharedPreview/ModelAssetType/MaterialAssetId");
+                LoadPreviewAsset(
+                    thumbnailConfig.m_lightingAsset,
+                    m_defaultLightingPresetAsset.GetId(),
+                    "/O3DE/Atom/CommonFeature/SharedPreview/ModelAssetType/LightingAssetId");
                 return thumbnailConfig;
             }
 
             if (assetInfo.m_assetType == RPI::MaterialAsset::RTTI_Type())
             {
-                static constexpr const char* ModelAssetPathSetting =
-                    "/O3DE/Atom/CommonFeature/SharedPreview/MaterialAssetType/ModelAssetPath";
-                static constexpr const char* LightingAssetPathSetting =
-                    "/O3DE/Atom/CommonFeature/SharedPreview/MaterialAssetType/LightingAssetPath";
-
                 ThumbnailConfig thumbnailConfig;
-                thumbnailConfig.m_modelAsset.Create(SharedPreviewUtils::GetAssetIdForProductPath(
-                    AtomToolsFramework::GetSettingsValue<AZStd::string>(ModelAssetPathSetting, DefaultModelPath)));
-                thumbnailConfig.m_materialAsset.Create(assetInfo.m_assetId);
-                thumbnailConfig.m_lightingAsset.Create(SharedPreviewUtils::GetAssetIdForProductPath(
-                    AtomToolsFramework::GetSettingsValue<AZStd::string>(LightingAssetPathSetting, DefaultLightingPresetPath)));
+                LoadPreviewAsset(thumbnailConfig.m_materialAsset, assetInfo.m_assetId);
+                LoadPreviewAsset(
+                    thumbnailConfig.m_modelAsset,
+                    m_defaultModelAsset.GetId(),
+                    "/O3DE/Atom/CommonFeature/SharedPreview/MaterialAssetType/ModelAssetId");
+                LoadPreviewAsset(
+                    thumbnailConfig.m_lightingAsset,
+                    m_defaultLightingPresetAsset.GetId(),
+                    "/O3DE/Atom/CommonFeature/SharedPreview/MaterialAssetType/LightingAssetId");
                 return thumbnailConfig;
             }
 
             if (assetInfo.m_assetType == RPI::MaterialTypeAsset::RTTI_Type())
             {
-                static constexpr const char* ModelAssetPathSetting =
-                    "/O3DE/Atom/CommonFeature/SharedPreview/MaterialTypeAssetType/ModelAssetPath";
-                static constexpr const char* LightingAssetPathSetting =
-                    "/O3DE/Atom/CommonFeature/SharedPreview/MaterialTypeAssetType/LightingAssetPath";
-
-                // Material type assets are not renderable so we generate a material asset from the material type. 
+                // Material type assets are not renderable so we generate a material asset from the material type.
                 ThumbnailConfig thumbnailConfig;
                 AZ::RPI::MaterialSourceData materialSourceData;
                 materialSourceData.m_materialType = AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetInfo.m_assetId);
@@ -95,11 +113,15 @@ namespace AZ
 
                 if (outcome)
                 {
-                    thumbnailConfig.m_modelAsset.Create(SharedPreviewUtils::GetAssetIdForProductPath(
-                        AtomToolsFramework::GetSettingsValue<AZStd::string>(ModelAssetPathSetting, DefaultModelPath)));
                     thumbnailConfig.m_materialAsset = outcome.TakeValue();
-                    thumbnailConfig.m_lightingAsset.Create(SharedPreviewUtils::GetAssetIdForProductPath(
-                        AtomToolsFramework::GetSettingsValue<AZStd::string>(LightingAssetPathSetting, DefaultLightingPresetPath)));
+                    LoadPreviewAsset(
+                        thumbnailConfig.m_modelAsset,
+                        m_defaultModelAsset.GetId(),
+                        "/O3DE/Atom/CommonFeature/SharedPreview/MaterialTypeAssetType/ModelAssetId");
+                    LoadPreviewAsset(
+                        thumbnailConfig.m_lightingAsset,
+                        m_defaultLightingPresetAsset.GetId(),
+                        "/O3DE/Atom/CommonFeature/SharedPreview/MaterialTypeAssetType/LightingAssetId");
                 }
 
                 return thumbnailConfig;
@@ -108,28 +130,21 @@ namespace AZ
             const auto& path = AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetInfo.m_assetId);
             if (assetInfo.m_assetType == RPI::AnyAsset::RTTI_Type() && AZ::StringFunc::EndsWith(path.c_str(), ".lightingpreset.azasset"))
             {
-                static constexpr const char* ModelAssetPathSetting =
-                    "/O3DE/Atom/CommonFeature/SharedPreview/LightingPresetAssetType/ModelAssetPath";
-                static constexpr const char* MaterialAssetPathSetting =
-                    "/O3DE/Atom/CommonFeature/SharedPreview/LightingPresetAssetType/MaterialAssetPath";
-
                 ThumbnailConfig thumbnailConfig;
-                thumbnailConfig.m_modelAsset.Create(SharedPreviewUtils::GetAssetIdForProductPath(
-                    AtomToolsFramework::GetSettingsValue<AZStd::string>(ModelAssetPathSetting, DefaultModelPath)));
-                thumbnailConfig.m_materialAsset.Create(
-                    SharedPreviewUtils::GetAssetIdForProductPath(AtomToolsFramework::GetSettingsValue<AZStd::string>(
-                        MaterialAssetPathSetting, "materials/reflectionprobe/reflectionprobevisualization.azmaterial")));
-                thumbnailConfig.m_lightingAsset.Create(assetInfo.m_assetId);
+                LoadPreviewAsset(thumbnailConfig.m_lightingAsset, assetInfo.m_assetId);
+                LoadPreviewAsset(
+                    thumbnailConfig.m_modelAsset,
+                    m_defaultModelAsset.GetId(),
+                    "/O3DE/Atom/CommonFeature/SharedPreview/LightingPresetAssetType/ModelAssetId");
+                LoadPreviewAsset(
+                    thumbnailConfig.m_materialAsset,
+                    m_reflectionMaterialAsset.GetId(),
+                    "/O3DE/Atom/CommonFeature/SharedPreview/LightingPresetAssetType/MaterialAssetId");
                 return thumbnailConfig;
             }
 
             if (assetInfo.m_assetType == RPI::AnyAsset::RTTI_Type() && AZ::StringFunc::EndsWith(path.c_str(), ".modelpreset.azasset"))
             {
-                static constexpr const char* MaterialAssetPathSetting =
-                    "/O3DE/Atom/CommonFeature/SharedPreview/ModelPresetAssetType/MaterialAssetPath";
-                static constexpr const char* LightingAssetPathSetting =
-                    "/O3DE/Atom/CommonFeature/SharedPreview/ModelPresetAssetType/LightingAssetPath";
-
                 // Model preset assets are relatively small JSON files containing a reference to a model asset and possibly other
                 // parameters. The preset must be loaded to get the model asset ID. Then the preview will be rendered like any other model.
                 AZ::Data::Asset<AZ::RPI::AnyAsset> asset = AZ::RPI::AssetUtils::LoadAssetById<AZ::RPI::AnyAsset>(assetInfo.m_assetId);
@@ -137,10 +152,14 @@ namespace AZ
 
                 ThumbnailConfig thumbnailConfig;
                 thumbnailConfig.m_modelAsset = preset.m_modelAsset;
-                thumbnailConfig.m_materialAsset.Create(SharedPreviewUtils::GetAssetIdForProductPath(
-                    AtomToolsFramework::GetSettingsValue<AZStd::string>(MaterialAssetPathSetting, DefaultMaterialPath)));
-                thumbnailConfig.m_lightingAsset.Create(SharedPreviewUtils::GetAssetIdForProductPath(
-                    AtomToolsFramework::GetSettingsValue<AZStd::string>(LightingAssetPathSetting, DefaultLightingPresetPath)));
+                LoadPreviewAsset(
+                    thumbnailConfig.m_materialAsset,
+                    m_defaultMaterialAsset.GetId(),
+                    "/O3DE/Atom/CommonFeature/SharedPreview/ModelPresetAssetType/MaterialAssetId");
+                LoadPreviewAsset(
+                    thumbnailConfig.m_lightingAsset,
+                    m_defaultLightingPresetAsset.GetId(),
+                    "/O3DE/Atom/CommonFeature/SharedPreview/ModelPresetAssetType/LightingAssetId");
                 return thumbnailConfig;
             }
 
@@ -194,9 +213,12 @@ namespace AZ
             AzToolsFramework::Thumbnailer::ThumbnailerRendererRequestBus::ExecuteQueuedEvents();
         }
 
-        bool SharedThumbnailRenderer::ThumbnailConfig::IsValid() const
+        void SharedThumbnailRenderer::OnCatalogLoaded([[maybe_unused]] const char* catalogFile)
         {
-            return m_modelAsset.GetId().IsValid() || m_materialAsset.GetId().IsValid() || m_lightingAsset.GetId().IsValid();
+            m_defaultMaterialAsset.QueueLoad();
+            m_defaultModelAsset.QueueLoad();
+            m_defaultLightingPresetAsset.QueueLoad();
+            m_reflectionMaterialAsset.QueueLoad();
         }
     } // namespace LyIntegration
 } // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnailRenderer.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnailRenderer.h
@@ -13,6 +13,7 @@
 #include <Atom/RPI.Reflect/Model/ModelAsset.h>
 #include <Atom/RPI.Reflect/System/AnyAsset.h>
 #include <AzCore/Component/TickBus.h>
+#include <AzFramework/Asset/AssetCatalogBus.h>
 #include <AzToolsFramework/Thumbnails/Thumbnail.h>
 #include <AzToolsFramework/Thumbnails/ThumbnailerBus.h>
 #include <Thumbnails/Thumbnail.h>
@@ -25,6 +26,7 @@ namespace AZ
         class SharedThumbnailRenderer final
             : public AzToolsFramework::Thumbnailer::ThumbnailerRendererRequestBus::MultiHandler
             , public SystemTickBus::Handler
+            , public AzFramework::AssetCatalogEventBus::Handler
         {
         public:
             AZ_CLASS_ALLOCATOR(SharedThumbnailRenderer, AZ::SystemAllocator, 0);
@@ -50,15 +52,14 @@ namespace AZ
             //! SystemTickBus::Handler interface overrides...
             void OnSystemTick() override;
 
+            // AzFramework::AssetCatalogEventBus::Handler overrides...
+            void OnCatalogLoaded(const char* catalogFile) override;
+
             // Default assets to be kept loaded and used for rendering if not overridden
-            static constexpr const char* DefaultLightingPresetPath = "lightingpresets/thumbnail.lightingpreset.azasset";
             Data::Asset<RPI::AnyAsset> m_defaultLightingPresetAsset;
-
-            static constexpr const char* DefaultModelPath = "models/sphere.azmodel";
             Data::Asset<RPI::ModelAsset> m_defaultModelAsset;
-
-            static constexpr const char* DefaultMaterialPath = "";
             Data::Asset<RPI::MaterialAsset> m_defaultMaterialAsset;
+            Data::Asset<RPI::MaterialAsset> m_reflectionMaterialAsset;
         };
     } // namespace LyIntegration
 } // namespace AZ


### PR DESCRIPTION
## What does this PR do?

Replace this hard coded product path references with asset IDs copied from asset processor.
Only attempts to queue the assets for load after the asset Catalog has been loaded just stop warnings about assets that can't be resolved.

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Cleared asset cache and launched main editor and material editor before and after changes to see that messages no longer show