### PR TITLE
Fixed warning caused by dynamic property edit context range attributes being out of bounds for some types

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicProperty/DynamicProperty.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicProperty/DynamicProperty.h
@@ -124,16 +124,6 @@ namespace AtomToolsFramework
         void ApplyRangeEditDataAttributes();
         template<typename AttributeValueType>
         void ApplySliderEditDataAttributes();
-        template<typename AttributeValueType>
-        AttributeValueType GetMin() const;
-        template<typename AttributeValueType>
-        AttributeValueType GetMax() const;
-        template<typename AttributeValueType>
-        AttributeValueType GetSoftMin() const;
-        template<typename AttributeValueType>
-        AttributeValueType GetSoftMax() const;
-        template<typename AttributeValueType>
-        AttributeValueType GetStep() const;
 
         const AZ::Edit::ElementData* GetEditData() const;
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicProperty/DynamicProperty.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicProperty/DynamicProperty.cpp
@@ -334,11 +334,26 @@ namespace AtomToolsFramework
     template<typename AttributeValueType>
     void DynamicProperty::ApplyRangeEditDataAttributes()
     {
-        AddEditDataAttributeMemberFunction(AZ::Edit::Attributes::Min, &DynamicProperty::GetMin<AttributeValueType>);
-        AddEditDataAttributeMemberFunction(AZ::Edit::Attributes::Max, &DynamicProperty::GetMax<AttributeValueType>);
-        AddEditDataAttributeMemberFunction(AZ::Edit::Attributes::SoftMin, &DynamicProperty::GetSoftMin<AttributeValueType>);
-        AddEditDataAttributeMemberFunction(AZ::Edit::Attributes::SoftMax, &DynamicProperty::GetSoftMax<AttributeValueType>);
-        AddEditDataAttributeMemberFunction(AZ::Edit::Attributes::Step, &DynamicProperty::GetStep<AttributeValueType>);
+        if (m_config.m_min.is<AttributeValueType>())
+        {
+            AddEditDataAttribute(AZ::Edit::Attributes::Min, AZStd::any_cast<AttributeValueType>(m_config.m_min));
+        }
+        if (m_config.m_max.is<AttributeValueType>())
+        {
+            AddEditDataAttribute(AZ::Edit::Attributes::Max, AZStd::any_cast<AttributeValueType>(m_config.m_max));
+        }
+        if (m_config.m_softMin.is<AttributeValueType>())
+        {
+            AddEditDataAttribute(AZ::Edit::Attributes::SoftMin, AZStd::any_cast<AttributeValueType>(m_config.m_softMin));
+        }
+        if (m_config.m_softMax.is<AttributeValueType>())
+        {
+            AddEditDataAttribute(AZ::Edit::Attributes::SoftMax, AZStd::any_cast<AttributeValueType>(m_config.m_softMax));
+        }
+        if (m_config.m_step.is<AttributeValueType>())
+        {
+            AddEditDataAttribute(AZ::Edit::Attributes::Step, AZStd::any_cast<AttributeValueType>(m_config.m_step));
+        }
     }
 
     template<typename AttributeValueType>
@@ -349,44 +364,6 @@ namespace AtomToolsFramework
         {
             m_editData.m_elementId = AZ::Edit::UIHandlers::Slider;
         }
-    }
-
-    template<typename AttributeValueType>
-    AttributeValueType DynamicProperty::GetMin() const
-    {
-        return m_config.m_min.is<AttributeValueType>() ? AZStd::any_cast<AttributeValueType>(m_config.m_min)
-                                                       : std::numeric_limits<AttributeValueType>::lowest();
-    }
-
-    template<typename AttributeValueType>
-    AttributeValueType DynamicProperty::GetMax() const
-    {
-        return m_config.m_max.is<AttributeValueType>() ? AZStd::any_cast<AttributeValueType>(m_config.m_max)
-                                                       : std::numeric_limits<AttributeValueType>::max();
-    }
-
-    template<typename AttributeValueType>
-    AttributeValueType DynamicProperty::GetSoftMin() const
-    {
-        return m_config.m_softMin.is<AttributeValueType>() ? AZStd::any_cast<AttributeValueType>(m_config.m_softMin)
-                                                           : GetMin<AttributeValueType>();
-    }
-
-    template<typename AttributeValueType>
-    AttributeValueType DynamicProperty::GetSoftMax() const
-    {
-        return m_config.m_softMax.is<AttributeValueType>() ? AZStd::any_cast<AttributeValueType>(m_config.m_softMax)
-                                                           : GetMax<AttributeValueType>();
-    }
-
-    template<typename AttributeValueType>
-    AttributeValueType DynamicProperty::GetStep() const
-    {
-        if (m_config.m_step.is<AttributeValueType>())
-        {
-            return AZStd::any_cast<AttributeValueType>(m_config.m_step);
-        }
-        return m_config.m_step.is<float>() ? aznumeric_cast<AttributeValueType>(0.001f) : aznumeric_cast<AttributeValueType>(1.0f);
     }
 
     void DynamicProperty::ApplyVectorLabels()


### PR DESCRIPTION
## What does this PR do?

Attempting to eliminate warnings, errors, or spam that might cause test failures.

Changes dynamic property class to only register soft or hard limits if there is an explicit type match instead of forcing limits to the standard ranges for the value type. This stops warning messages if there is a type mismatch or the type does not support limits.

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Verified that dynamic properties continue to work for material editor, material canvas, and the settings dialog in atom tools.