### PR TITLE
Fixes interpolation when re-connecting or re-entering game mode

### DIFF
--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -1001,6 +1001,8 @@ namespace Multiplayer
 
     void MultiplayerSystemComponent::InitializeMultiplayer(MultiplayerAgentType multiplayerType)
     {
+        m_lastReplicatedHostFrameId = HostFrameId{0};
+
         if (m_agentType == multiplayerType)
         {
             return;


### PR DESCRIPTION
Signed-off-by: Olex Lozitskiy <5432499+AMZN-Olex@users.noreply.github.com>

## What does this PR do?

Client interpolation of objects was occasionally broken, when re-connecting from the same client or re-entering game mode in the Editor.

Fixes https://github.com/o3de/o3de/issues/12771 

## How was this PR tested?

In o3de-multiplayersample
