### PR TITLE
GraphModel: Fix bug where hidden graph model slots reappear after copy paste duplicate

### DIFF
--- a/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
@@ -406,6 +406,11 @@ namespace GraphModelIntegration
         //    That's why we loop through SlotDefinitions instead of the actual Slots, which are stored in a map.
         for (SlotDefinitionPtr slotDefinition : node->GetSlotDefinitions())
         {
+            if (!slotDefinition->SupportsEditingOnNode())
+            {
+                continue;
+            }
+
             const AZStd::string& slotName = slotDefinition->GetName();
             GraphCanvas::ExtenderId extenderId;
 

--- a/Gems/GraphModel/Code/Source/Model/DataType.cpp
+++ b/Gems/GraphModel/Code/Source/Model/DataType.cpp
@@ -97,11 +97,6 @@ namespace GraphModel
 
     bool DataType::IsSupportedValue(const AZStd::any& value) const
     {
-        if (m_valueValidator)
-        {
-            return m_valueValidator(value);
-        }
-
-        return IsSupportedType(value.type());
+        return IsSupportedType(value.type()) && (!m_valueValidator || m_valueValidator(value));
     }
 } // namespace GraphModel

--- a/Gems/GraphModel/Code/Source/Model/Node.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Node.cpp
@@ -60,6 +60,33 @@ namespace GraphModel
     {
         RegisterSlots();
 
+        // Moving slots between input data slot and property slot containers in case the layout of the slot definitions change.
+        for (const auto& def : m_inputDataSlotDefinitions)
+        {
+            for (const auto& slot : m_propertySlots)
+            {
+                if (def->GetName() == slot.first.m_name)
+                {
+                    m_inputDataSlots.insert(slot);
+                    m_propertySlots.erase(slot.first);
+                    break;
+                }
+            }
+        }
+
+        for (const auto& def : m_propertySlotDefinitions)
+        {
+            for (const auto& slot : m_inputDataSlots)
+            {
+                if (def->GetName() == slot.first.m_name)
+                {
+                    m_propertySlots.insert(slot);
+                    m_inputDataSlots.erase(slot.first);
+                    break;
+                }
+            }
+        }
+
         // Make sure the loaded Slot data aligns with the Node's input slot descriptions
         SyncAndSetupSlots(m_propertySlots, m_propertySlotDefinitions);
         SyncAndSetupSlots(m_inputDataSlots, m_inputDataSlotDefinitions);


### PR DESCRIPTION
## What does this PR do?

The flag to hide slots was only being respected when initially creating node UI. This change also adds handling for node configurations being rearranged, changing input slots to property slots and vice versa.

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Before the change, duplicating and pasting nodes displayed slots that were hidden on the node UI when they were originally created.
After the change, the hidden slots remain hidden but appear in the inspector in material canvas.
Rearranging note configuration data to move property slots into the input slot list correctly updated the configuration and area where the slots are displayed.