### PR TITLE
feat: add SettingRegistry for LYShine ViewportInteraction

### DIFF
--- a/Code/Framework/AzCore/AzCore/Settings/SettingRegisteryUtility.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingRegisteryUtility.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Settings/SettingsRegistry.h>
+
+namespace AZ::SettingsRegistryUtils
+{
+    template<typename T>
+    inline void SetRegistry(SettingsRegistryInterface* registry, const AZStd::string_view setting, T&& value)
+    {
+        if (registry)
+        {
+            registry->Set(setting, AZStd::forward<T>(value));
+        }
+    }
+
+    template<typename T>
+    inline AZStd::remove_cvref_t<T> GetRegistry(SettingsRegistryInterface* registry, const AZStd::string_view setting, T&& defaultValue)
+    {
+        AZStd::remove_cvref_t<T> value = AZStd::forward<T>(defaultValue);
+        if (registry)
+        {
+            T potentialValue;
+            if (registry->Get(potentialValue, setting))
+            {
+                value = AZStd::move(potentialValue);
+            }
+        }
+
+        return value;
+    }
+} // namespace AZ::SettingsRegistryUtils

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -619,6 +619,7 @@ set(FILES
     Settings/SettingsRegistryOriginTracker.h
     Settings/SettingsRegistryScriptUtils.cpp
     Settings/SettingsRegistryScriptUtils.h
+    Settings/SettingRegisteryUtility.h
     Settings/SettingsRegistryVisitorUtils.cpp
     Settings/SettingsRegistryVisitorUtils.h
     Slice/SliceAsset.cpp

--- a/Gems/LyShine/Code/Editor/CoordinateSystemToolbarSection.cpp
+++ b/Gems/LyShine/Code/Editor/CoordinateSystemToolbarSection.cpp
@@ -8,6 +8,7 @@
 #include "EditorCommon.h"
 #include <LyShine/Bus/UiEditorCanvasBus.h>
 #include "CanvasHelpers.h"
+#include "LyShineEditorSettings.h"
 
 #include <QComboBox>
 #include <QCheckBox>
@@ -16,9 +17,7 @@ namespace
 {
     void SetCoordinateSystemFromCombobox(EditorWindow* editorWindow, QComboBox* combobox, int newIndex)
     {
-        ViewportInteraction::CoordinateSystem s = (ViewportInteraction::CoordinateSystem)combobox->itemData(newIndex).toInt();
-
-        editorWindow->GetViewport()->GetViewportInteraction()->SetCoordinateSystem(s);
+        LyShine::SetCoordinateSystem(static_cast<ViewportInteraction::CoordinateSystem>(combobox->itemData(newIndex).toInt()));
     }
 } // anonymous namespace.
 

--- a/Gems/LyShine/Code/Editor/EditorWindow.cpp
+++ b/Gems/LyShine/Code/Editor/EditorWindow.cpp
@@ -22,6 +22,7 @@
 #include <Util/PathUtil.h>
 #include "EditorDefs.h"
 #include "ErrorDialog.h"
+#include "LyShineEditorSettings.h"
 #include "Settings.h"
 #include "AnchorPresets.h"
 #include "PivotPresets.h"
@@ -1305,8 +1306,8 @@ void EditorWindow::SaveActiveCanvasEditState()
         // Save viewport state
         canvasEditState.m_canvasViewportMatrixProps = m_viewport->GetViewportInteraction()->GetCanvasViewportMatrixProps();
         canvasEditState.m_shouldScaleToFitOnViewportResize = m_viewport->GetViewportInteraction()->ShouldScaleToFitOnViewportResize();
-        canvasEditState.m_viewportInteractionMode = m_viewport->GetViewportInteraction()->GetMode();
-        canvasEditState.m_viewportCoordinateSystem = m_viewport->GetViewportInteraction()->GetCoordinateSystem();
+        canvasEditState.m_viewportInteractionMode = LyShine::GetInteractionMode();
+        canvasEditState.m_viewportCoordinateSystem = LyShine::GetCoordinateSystem();
 
         // Save hierarchy state
         const QTreeWidgetItemRawPtrQList& selection = m_hierarchy->selectedItems();
@@ -1340,8 +1341,8 @@ void EditorWindow::RestoreActiveCanvasEditState()
             {
                 m_viewport->GetViewportInteraction()->CenterCanvasInViewport();
             }
-            m_viewport->GetViewportInteraction()->SetCoordinateSystem(canvasEditState.m_viewportCoordinateSystem);
-            m_viewport->GetViewportInteraction()->SetMode(canvasEditState.m_viewportInteractionMode);
+            LyShine::SetInteractionMode(canvasEditState.m_viewportInteractionMode);
+            LyShine::SetCoordinateSystem(canvasEditState.m_viewportCoordinateSystem);
 
             // Restore hierarchy state
             HierarchyHelpers::SetSelectedItems(m_hierarchy, &canvasEditState.m_selectedElements);

--- a/Gems/LyShine/Code/Editor/LyShineEditorSettings.cpp
+++ b/Gems/LyShine/Code/Editor/LyShineEditorSettings.cpp
@@ -8,57 +8,29 @@
 #include "LyShineEditorSettings.h"
 
 #include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/Settings/SettingRegisteryUtility.h>
 
 namespace LyShine
 {
-
-    namespace Internal
-    {
-        template<typename T>
-        void SetRegistry(const AZStd::string_view setting, T&& value)
-        {
-            if (auto* registry = AZ::SettingsRegistry::Get())
-            {
-                registry->Set(setting, AZStd::forward<T>(value));
-            }
-        }
-
-        template<typename T>
-        AZStd::remove_cvref_t<T> GetRegistry(const AZStd::string_view setting, T&& defaultValue)
-        {
-            AZStd::remove_cvref_t<T> value = AZStd::forward<T>(defaultValue);
-            if (const auto* registry = AZ::SettingsRegistry::Get())
-            {
-                T potentialValue;
-                if (registry->Get(potentialValue, setting))
-                {
-                    value = AZStd::move(potentialValue);
-                }
-            }
-
-            return value;
-        }
-    }
-
     ViewportInteraction::InteractionMode GetInteractionMode()
     {
         return static_cast<ViewportInteraction::InteractionMode>(
-            Internal::GetRegistry(InteractionModeSetting, aznumeric_cast<AZ::u64>(ViewportInteraction::InteractionMode::SELECTION)));
+            AZ::SettingsRegistryUtils::GetRegistry(AZ::SettingsRegistry::Get(), InteractionModeSetting, aznumeric_cast<AZ::u64>(ViewportInteraction::InteractionMode::SELECTION)));
     }
 
     void SetInteractionMode(ViewportInteraction::InteractionMode mode)
     {
-        Internal::SetRegistry(InteractionModeSetting, aznumeric_cast<AZ::u64>(mode));
+        AZ::SettingsRegistryUtils::SetRegistry(AZ::SettingsRegistry::Get(),InteractionModeSetting, aznumeric_cast<AZ::u64>(mode));
     }
 
     ViewportInteraction::CoordinateSystem GetCoordinateSystem()
     {
         return static_cast<ViewportInteraction::CoordinateSystem>(
-            Internal::GetRegistry(CoordinateSystemSetting, aznumeric_cast<AZ::u64>(ViewportInteraction::CoordinateSystem::LOCAL)));
+            AZ::SettingsRegistryUtils::GetRegistry(AZ::SettingsRegistry::Get(), CoordinateSystemSetting, aznumeric_cast<AZ::u64>(ViewportInteraction::CoordinateSystem::LOCAL)));
     }
 
     void SetCoordinateSystem(ViewportInteraction::CoordinateSystem system)
     {
-        Internal::SetRegistry(CoordinateSystemSetting, aznumeric_cast<AZ::u64>(system));
+        AZ::SettingsRegistryUtils::SetRegistry(AZ::SettingsRegistry::Get(),CoordinateSystemSetting, aznumeric_cast<AZ::u64>(system));
     }
 }

--- a/Gems/LyShine/Code/Editor/LyShineEditorSettings.cpp
+++ b/Gems/LyShine/Code/Editor/LyShineEditorSettings.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include "LyShineEditorSettings.h"
+
+#include <AzCore/Settings/SettingsRegistry.h>
+
+namespace LyShine
+{
+
+    namespace Internal
+    {
+        template<typename T>
+        void SetRegistry(const AZStd::string_view setting, T&& value)
+        {
+            if (auto* registry = AZ::SettingsRegistry::Get())
+            {
+                registry->Set(setting, AZStd::forward<T>(value));
+            }
+        }
+
+        template<typename T>
+        AZStd::remove_cvref_t<T> GetRegistry(const AZStd::string_view setting, T&& defaultValue)
+        {
+            AZStd::remove_cvref_t<T> value = AZStd::forward<T>(defaultValue);
+            if (const auto* registry = AZ::SettingsRegistry::Get())
+            {
+                T potentialValue;
+                if (registry->Get(potentialValue, setting))
+                {
+                    value = AZStd::move(potentialValue);
+                }
+            }
+
+            return value;
+        }
+    }
+
+    ViewportInteraction::InteractionMode GetInteractionMode()
+    {
+        return static_cast<ViewportInteraction::InteractionMode>(
+            Internal::GetRegistry(InteractionModeSetting, aznumeric_cast<AZ::u64>(ViewportInteraction::InteractionMode::SELECTION)));
+    }
+
+    void SetInteractionMode(ViewportInteraction::InteractionMode mode)
+    {
+        Internal::SetRegistry(InteractionModeSetting, aznumeric_cast<AZ::u64>(mode));
+    }
+
+    ViewportInteraction::CoordinateSystem GetCoordinateSystem()
+    {
+        return static_cast<ViewportInteraction::CoordinateSystem>(
+            Internal::GetRegistry(CoordinateSystemSetting, aznumeric_cast<AZ::u64>(ViewportInteraction::CoordinateSystem::LOCAL)));
+    }
+
+    void SetCoordinateSystem(ViewportInteraction::CoordinateSystem system)
+    {
+        Internal::SetRegistry(CoordinateSystemSetting, aznumeric_cast<AZ::u64>(system));
+    }
+}

--- a/Gems/LyShine/Code/Editor/LyShineEditorSettings.h
+++ b/Gems/LyShine/Code/Editor/LyShineEditorSettings.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include "AzCore/base.h"
+#include "ViewportInteraction.h"
+
+namespace LyShine
+{
+    static constexpr AZStd::string_view InteractionModeSetting = "/O3DE/Preferences/Editor/LyShine/InteractionMode";
+    static constexpr AZStd::string_view CoordinateSystemSetting = "/O3DE/Preferences/Editor/LyShine/CoordinateSystem";
+    
+    ViewportInteraction::InteractionMode GetInteractionMode();
+    void SetInteractionMode(ViewportInteraction::InteractionMode mode);
+
+    ViewportInteraction::CoordinateSystem GetCoordinateSystem();
+    void SetCoordinateSystem(ViewportInteraction::CoordinateSystem length);
+}

--- a/Gems/LyShine/Code/Editor/LyShineEditorSettings.h
+++ b/Gems/LyShine/Code/Editor/LyShineEditorSettings.h
@@ -13,12 +13,12 @@
 
 namespace LyShine
 {
-    static constexpr AZStd::string_view InteractionModeSetting = "/O3DE/Preferences/Editor/LyShine/InteractionMode";
-    static constexpr AZStd::string_view CoordinateSystemSetting = "/O3DE/Preferences/Editor/LyShine/CoordinateSystem";
-    
+    inline constexpr AZStd::string_view InteractionModeSetting = "/O3DE/Preferences/Editor/LyShine/InteractionMode";
+    inline constexpr AZStd::string_view CoordinateSystemSetting = "/O3DE/Preferences/Editor/LyShine/CoordinateSystem";
+
     ViewportInteraction::InteractionMode GetInteractionMode();
     void SetInteractionMode(ViewportInteraction::InteractionMode mode);
 
     ViewportInteraction::CoordinateSystem GetCoordinateSystem();
     void SetCoordinateSystem(ViewportInteraction::CoordinateSystem length);
-}
+} // namespace LyShine

--- a/Gems/LyShine/Code/Editor/ModeToolbar.cpp
+++ b/Gems/LyShine/Code/Editor/ModeToolbar.cpp
@@ -7,6 +7,7 @@
  */
 #include "EditorCommon.h"
 #include "AlignToolbarSection.h"
+#include "LyShineEditorSettings.h"
 
 ModeToolbar::ModeToolbar(EditorWindow* parent)
     : QToolBar("Mode Toolbar", parent)
@@ -70,7 +71,7 @@ void ModeToolbar::AddModes(EditorWindow* parent)
         QObject::connect(action,
             &QAction::triggered,
             this,
-            [ this, parent, action ]([[maybe_unused]] bool checked)
+            [ this, action ]([[maybe_unused]] bool checked)
             {
                 if (m_previousAction == action)
                 {
@@ -78,7 +79,7 @@ void ModeToolbar::AddModes(EditorWindow* parent)
                     return;
                 }
 
-                parent->GetViewport()->GetViewportInteraction()->SetMode((ViewportInteraction::InteractionMode)action->data().toInt());
+                LyShine::SetInteractionMode((ViewportInteraction::InteractionMode)action->data().toInt());
 
                 m_previousAction = action;
             });

--- a/Gems/LyShine/Code/Editor/ViewportInteraction.cpp
+++ b/Gems/LyShine/Code/Editor/ViewportInteraction.cpp
@@ -132,16 +132,18 @@ ViewportInteraction::ViewportInteraction(EditorWindow* editorWindow)
     using AZ::SettingsRegistryMergeUtils::IsPathAncestorDescendantOrEqual;
     if (auto* registry = AZ::SettingsRegistry::Get())
     {
-        m_settingNotificationHandler = registry->RegisterNotifier([&](const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs) {
-            if (IsPathAncestorDescendantOrEqual(LyShine::InteractionModeSetting, notifyEventArgs.m_jsonKeyPath))
+        m_settingNotificationHandler = registry->RegisterNotifier(
+            [&](const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs)
             {
-                UpdateInteractionMode();
-            }
-            if (IsPathAncestorDescendantOrEqual(LyShine::CoordinateSystemSetting, notifyEventArgs.m_jsonKeyPath))
-            {
-                UpdateCoordinateSystem();
-            }
-        });
+                if (IsPathAncestorDescendantOrEqual(LyShine::InteractionModeSetting, notifyEventArgs.m_jsonKeyPath))
+                {
+                    UpdateInteractionMode();
+                }
+                if (IsPathAncestorDescendantOrEqual(LyShine::CoordinateSystemSetting, notifyEventArgs.m_jsonKeyPath))
+                {
+                    UpdateCoordinateSystem();
+                }
+            });
     }
     m_cursorRotate = CMFCUtils::LoadCursor(IDC_POINTER_OBJECT_ROTATE);
 }

--- a/Gems/LyShine/Code/Editor/ViewportInteraction.h
+++ b/Gems/LyShine/Code/Editor/ViewportInteraction.h
@@ -12,6 +12,7 @@
 
 #include <QObject>
 
+#include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/Math/Vector2.h>
 #endif
 
@@ -111,19 +112,14 @@ public: // member functions
         GUIDE,
         NONE
     };
-
-    void SetMode(InteractionMode mode);
     InteractionMode GetMode() const;
-
     InteractionType GetInteractionType() const;
+    CoordinateSystem GetCoordinateSystem() const;
 
     AZ::Entity* GetActiveElement() const;
     const AZ::EntityId& GetActiveElementId() const;
 
     ViewportHelpers::SelectedAnchors GetGrabbedAnchors() const;
-
-    void SetCoordinateSystem(CoordinateSystem s);
-    CoordinateSystem GetCoordinateSystem() const;
 
     void InitializeToolbars();
 
@@ -175,6 +171,9 @@ public: // member functions
 private: // types
 
 private: // member functions
+
+    void UpdateInteractionMode();
+    void UpdateCoordinateSystem();
 
     //! Update the interaction type based on where the cursor is right now
     void UpdateInteractionType(const AZ::Vector2& mousePosition,
@@ -294,6 +293,7 @@ private: // data
     bool m_activeGuideIsVertical = false;
     int m_activeGuideIndex = 0;
 
+    AZ::SettingsRegistryInterface::NotifyEventHandler m_settingNotificationHandler;
     SerializeHelpers::SerializedEntryList m_selectedEntitiesUndoState;  //! This can be eliminated once the dragInteractions all use ViewportDragInteraction
 };
 

--- a/Gems/LyShine/Code/lyshine_uicanvaseditor_files.cmake
+++ b/Gems/LyShine/Code/lyshine_uicanvaseditor_files.cmake
@@ -92,6 +92,8 @@ set(FILES
     Editor/HierarchyMenu.h
     Editor/HierarchyWidget.cpp
     Editor/HierarchyWidget.h
+    Editor/LyShineEditorSettings.cpp
+    Editor/LyShineEditorSettings.h
     Editor/MainToolbar.cpp
     Editor/MainToolbar.h
     Editor/ModeToolbar.cpp


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

This is an early attempt at moving away from QSettings and moving the configuration to `AZ::SettingsRegistry`. I ended up copying things across since I didn't want to reference large parts of ViewportSettings.h. 

The settings are not saved unless you go through Global Preferences and press saved? Just a little confused how this is intended to work actually?

## How was this PR tested?

open UI Editor and set coordinate and interaction mode.  
