### PR TITLE
Atom Tools: disable python test coverage gem in material canvas to stop warnings until it can be configured

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Registry/gem_autoload.materialcanvas.setreg
+++ b/Gems/Atom/Tools/MaterialCanvas/Registry/gem_autoload.materialcanvas.setreg
@@ -1,6 +1,13 @@
 {
     "O3DE": {
         "Gems": {
+            "PythonCoverage": {
+                "Targets": {
+                    "PythonCoverage.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
             "LyShine": {
                 "Targets": {
                     "LyShine.Editor": {

--- a/Gems/Atom/Tools/MaterialEditor/Registry/gem_autoload.materialeditor.setreg
+++ b/Gems/Atom/Tools/MaterialEditor/Registry/gem_autoload.materialeditor.setreg
@@ -1,6 +1,13 @@
 {
     "O3DE": {
         "Gems": {
+            "PythonCoverage": {
+                "Targets": {
+                    "PythonCoverage.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
             "LyShine": {
                 "Targets": {
                     "LyShine.Editor": {

--- a/Gems/Atom/Tools/ShaderManagementConsole/Registry/gem_autoload.shadermanagementconsole.setreg
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Registry/gem_autoload.shadermanagementconsole.setreg
@@ -1,6 +1,13 @@
 {
     "O3DE": {
         "Gems": {
+            "PythonCoverage": {
+                "Targets": {
+                    "PythonCoverage.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
             "LyShine": {
                 "Targets": {
                     "LyShine.Editor": {


### PR DESCRIPTION
## What does this PR do?

Python automated tests were just restored for material editor and material canvas. Test suites for both tools are just starting to be written. The test coverage gem has not been tested with those tools. It seems like it just needs to be configured correctly. It's currently triggering warnings on startup, which this change disables until that can get sorted out.

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Confirmed corresponding warnings no longer appear after changes.