### PR TITLE
Update RayTracing data when the material instance is changed

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Material/MaterialAssignmentBus.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Material/MaterialAssignmentBus.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+        //! Components should inherit from the MaterialAssignmentNotificationBus to receive notifications
+        class MaterialAssignmentNotifications
+            : public AZ::EBusTraits
+        {
+        public :
+            static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+            static const AZ::EBusAddressPolicy AddressPolicy = EBusAddressPolicy::ById;
+            using BusIdType = AZ::Data::AssetId;
+
+            virtual void OnRebuildMaterialInstance() = 0;
+        };
+        using MaterialAssignmentNotificationBus = AZ::EBus<MaterialAssignmentNotifications>;
+    } // namespace Render
+} // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
@@ -13,6 +13,7 @@
 #include <Atom/RPI.Public/MeshDrawPacket.h>
 #include <Atom/RPI.Public/Shader/ShaderSystemInterface.h>
 #include <Atom/Feature/Material/MaterialAssignment.h>
+#include <Atom/Feature/Material/MaterialAssignmentBus.h>
 #include <Atom/Feature/TransformService/TransformServiceFeatureProcessor.h>
 #include <Atom/Feature/Mesh/ModelReloaderSystemInterface.h>
 #include <RayTracing/RayTracingFeatureProcessor.h>
@@ -31,6 +32,7 @@ namespace AZ
         class RayTracingFeatureProcessor;
 
         class ModelDataInstance
+            : public MaterialAssignmentNotificationBus::MultiHandler
         {
             friend class MeshFeatureProcessor;
             friend class MeshLoader;
@@ -88,7 +90,10 @@ namespace AZ
             void UpdateObjectSrg();
             bool MaterialRequiresForwardPassIblSpecular(Data::Instance<RPI::Material> material) const;
             void SetVisible(bool isVisible);
-            
+
+            // MaterialAssignmentNotificationBus overrides
+            void OnRebuildMaterialInstance() override;
+
             RPI::MeshDrawPacketLods m_drawPacketListsByLod;
 
             RPI::Cullable m_cullable;

--- a/Gems/Atom/Feature/Common/Code/Source/Material/MaterialAssignment.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/MaterialAssignment.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <Atom/Feature/Material/MaterialAssignment.h>
+#include <Atom/Feature/Material/MaterialAssignmentBus.h>
 #include <Atom/RPI.Reflect/Model/ModelAsset.h>
 #include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/RTTI/BehaviorContext.h>
@@ -107,6 +108,9 @@ namespace AZ
             {
                 m_materialInstance = m_propertyOverrides.empty() ? RPI::Material::FindOrCreate(m_materialAsset) : RPI::Material::Create(m_materialAsset);
                 AZ_Error("MaterialAssignment", m_materialInstance, "Material instance not initialized");
+
+                MaterialAssignmentNotificationBus::Event(m_materialInstance->GetAssetId(), &MaterialAssignmentNotifications::OnRebuildMaterialInstance);
+
                 return;
             }
 
@@ -114,6 +118,9 @@ namespace AZ
             {
                 m_materialInstance = m_propertyOverrides.empty() ? RPI::Material::FindOrCreate(m_defaultMaterialAsset) : RPI::Material::Create(m_defaultMaterialAsset);
                 AZ_Error("MaterialAssignment", m_materialInstance, "Material instance not initialized");
+
+                MaterialAssignmentNotificationBus::Event(m_materialInstance->GetAssetId(), &MaterialAssignmentNotifications::OnRebuildMaterialInstance);
+
                 return;
             }
 


### PR DESCRIPTION
The MeshFeatureProcessor was unaware of changes to the material instance, which required reloading the entity to update the mesh RayTracing data.

Added a MaterialAssignmentNotificationBus and handled the notification to update the mesh RayTracing data.

Tested AtomSampleViewer DX12/Vulkan
Tested Editot DX12/Vulkan

Signed-off-by: dmcdiarmid-ly <63674186+dmcdiarmid-ly@users.noreply.github.com>