### PR TITLE
Fixed warnings "Attempting to compile SRG  that's already been queued…

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
@@ -116,7 +116,8 @@ namespace AZ
             bool isQueuedForCompile = shaderResourceGroup.IsQueuedForCompile();
             AZ_Warning(
                 "ShaderResourceGroupPool", !isQueuedForCompile,
-                "Attempting to compile an SRG that's already been queued for compile. Only compile an SRG once per frame.");
+                "Attempting to compile SRG '%s' that's already been queued for compile. Only compile an SRG once per frame.",
+                shaderResourceGroup.GetName().GetCStr());
 
             if (!isQueuedForCompile)
             {

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/Shader.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/Shader.h
@@ -142,14 +142,14 @@ namespace AZ
             //! @param shaderOptions The shader option values will be stored in the SRG's shader variant fallback key (if there is one).
             //! @param compileTheSrg If you need to set other values in the SRG, set this to false, and the call Compile() when you are done.
             //! @return The DrawSrg instance, or null if the shader does not include a DrawSrg.
-            Data::Instance<ShaderResourceGroup> CreateDrawSrgForShaderVariant(const ShaderOptionGroup& shaderOptions, bool compileTheSrg=true);
+            Data::Instance<ShaderResourceGroup> CreateDrawSrgForShaderVariant(const ShaderOptionGroup& shaderOptions, bool compileTheSrg);
 
             //! Creates a DrawSrg that contains the shader variant fallback key, initialized to the default shader options values.
             //! This SRG must be included in the DrawPacket for any shader that has shader options,
             //! otherwise the CommandList will fail validation for SRG being null.
             //! @param compileTheSrg If you need to set other values in the SRG, set this to false, and the call Compile() when you are done.
             //! @return The DrawSrg instance, or null if the shader does not include a DrawSrg.
-            Data::Instance<ShaderResourceGroup> CreateDefaultDrawSrg(bool compileTheSrg = true);
+            Data::Instance<ShaderResourceGroup> CreateDefaultDrawSrg(bool compileTheSrg);
 
             //! Returns a reference to the asset used to initialize this shader.
             const Data::Asset<ShaderAsset>& GetAsset() const;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ComputePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ComputePass.cpp
@@ -102,7 +102,8 @@ namespace AZ
             }
 
             // Load Draw SRG...
-            m_drawSrg = m_shader->CreateDefaultDrawSrg();
+            const bool compileDrawSrg = false; // The SRG will be compiled in CompileResources()
+            m_drawSrg = m_shader->CreateDefaultDrawSrg(compileDrawSrg);
 
             RHI::DispatchDirect dispatchArgs;
             dispatchArgs.m_totalNumberOfThreadsX = passData->m_totalNumberOfThreadsX;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
@@ -121,7 +121,8 @@ namespace AZ
 
             // Load Draw SRG
             // this is necessary since the shader may have options, which require a default draw SRG
-            m_drawShaderResourceGroup = m_shader->CreateDefaultDrawSrg();
+            const bool compileDrawSrg = false; // The SRG will be compiled in CompileResources()
+            m_drawShaderResourceGroup = m_shader->CreateDefaultDrawSrg(compileDrawSrg);
 
             // Store stencil reference value for the draw call
             m_stencilRef = passData->m_stencilRef;


### PR DESCRIPTION
… for compile". I introduced this at https://github.com/o3de/o3de/pull/12459 where I mistakenly introduce an extra Compile() call that wasn't there before.

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>

## How was this PR tested?

Opened AtomSampleViewer RPI/Mesh sample before and after, no more warning.
Ran AtomSampleViewer full suite. The only new failure was MaterialHotReloatTest, which passed when I ran the script again. The only instance of the warning was in StreamingImageTest, which I presume is a separate issue as it doesn't relate to the code in https://github.com/o3de/o3de/pull/12459
