### PR TITLE
Atom Tools: Deferring open document actions to the system tick bus and fixing other timer usage

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentSystem.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentSystem.h
@@ -52,6 +52,8 @@ namespace AtomToolsFramework
         bool SaveDocumentAsChild(const AZ::Uuid& documentId, const AZStd::string& targetPath) override;
         bool SaveAllDocuments() override;
         bool SaveAllModifiedDocuments() override;
+        bool QueueReopenModifiedDocuments() override;
+        bool ReopenModifiedDocuments() override;
         AZ::u32 GetDocumentCount() const override;
         bool IsDocumentOpen(const AZ::Uuid& documentId) const override;
         void AddRecentFilePath(const AZStd::string& absolutePath) override;
@@ -65,15 +67,12 @@ namespace AtomToolsFramework
         void OnDocumentDependencyModified(const AZ::Uuid& documentId) override;
         void OnDocumentExternallyModified(const AZ::Uuid& documentId) override;
 
-        void QueueReopenDocuments();
-        void ReopenDocuments();
-
         const AZ::Crc32 m_toolId = {};
         DocumentTypeInfoVector m_documentTypes;
         AZStd::unordered_map<AZ::Uuid, AZStd::shared_ptr<AtomToolsDocumentRequests>> m_documentMap;
         AZStd::unordered_set<AZ::Uuid> m_documentIdsWithExternalChanges;
         AZStd::unordered_set<AZ::Uuid> m_documentIdsWithDependencyChanges;
-        bool m_queueReopenDocuments = false;
+        bool m_queueReopenModifiedDocuments = false;
         bool m_queueSaveAllModifiedDocuments = false;
         const size_t m_maxMessageBoxLineCount = 15;
     };

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentSystemRequestBus.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentSystemRequestBus.h
@@ -85,6 +85,12 @@ namespace AtomToolsFramework
         //! Save all modified documents
         virtual bool SaveAllModifiedDocuments() = 0;
 
+        //! Queues request to reopen modified documents.
+        virtual bool QueueReopenModifiedDocuments() = 0;
+
+        //! Process requests to reopen modified documents.
+        virtual bool ReopenModifiedDocuments() = 0;
+
         //! Get number of allocated documents
         virtual AZ::u32 GetDocumentCount() const = 0;
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
@@ -438,10 +438,10 @@ namespace AtomToolsFramework
             AtomToolsMainWindowRequestBus::Event(m_toolId, &AtomToolsMainWindowRequestBus::Handler::ActivateWindow);
         }
 
-        const AZStd::string timeoputSwitchName = "timeout";
-        if (commandLine.HasSwitch(timeoputSwitchName))
+        const AZStd::string timeoutSwitchName  = "timeout";
+        if (commandLine.HasSwitch(timeoutSwitchName ))
         {
-            const AZStd::string& timeoutValue = commandLine.GetSwitchValue(timeoputSwitchName, 0);
+            const AZStd::string& timeoutValue = commandLine.GetSwitchValue(timeoutSwitchName , 0);
             const uint32_t timeoutInMs = atoi(timeoutValue.c_str());
             AZ_Printf(m_targetName.c_str(), "Timeout scheduled, shutting down in %u ms", timeoutInMs);
             QTimer::singleShot(timeoutInMs, this, [targetName = m_targetName]{

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
@@ -444,8 +444,8 @@ namespace AtomToolsFramework
             const AZStd::string& timeoutValue = commandLine.GetSwitchValue(timeoputSwitchName, 0);
             const uint32_t timeoutInMs = atoi(timeoutValue.c_str());
             AZ_Printf(m_targetName.c_str(), "Timeout scheduled, shutting down in %u ms", timeoutInMs);
-            QTimer::singleShot(timeoutInMs, this, [this]{
-                AZ_Printf(m_targetName.c_str(), "Timeout reached, shutting down");
+            QTimer::singleShot(timeoutInMs, this, [targetName = m_targetName]{
+                AZ_Printf(targetName.c_str(), "Timeout reached, shutting down");
                 AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::ExitMainLoop);
             });
         }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentApplication.cpp
@@ -50,8 +50,9 @@ namespace AtomToolsFramework
                     if (documentType.IsSupportedExtensionToOpen(entries.front()->GetFullPath()))
                     {
                         menu->addAction(QObject::tr("Open"), [entries, this]() {
-                            AtomToolsDocumentSystemRequestBus::Event(
-                                m_toolId, &AtomToolsDocumentSystemRequestBus::Events::OpenDocument, entries.front()->GetFullPath());
+                            AZ::SystemTickBus::QueueFunction([toolId = m_toolId, path = entries.front()->GetFullPath()]() {
+                                AtomToolsDocumentSystemRequestBus::Event(toolId, &AtomToolsDocumentSystemRequestBus::Events::OpenDocument, path);
+                            });
                         });
                         handledOpen = true;
                         break;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
@@ -82,6 +82,8 @@ namespace AtomToolsFramework
                 ->Event("SaveDocumentAsChild", &AtomToolsDocumentSystemRequestBus::Events::SaveDocumentAsChild)
                 ->Event("SaveAllDocuments", &AtomToolsDocumentSystemRequestBus::Events::SaveAllDocuments)
                 ->Event("SaveAllModifiedDocuments", &AtomToolsDocumentSystemRequestBus::Events::SaveAllModifiedDocuments)
+                ->Event("QueueReopenModifiedDocuments", &AtomToolsDocumentSystemRequestBus::Events::QueueReopenModifiedDocuments)
+                ->Event("ReopenModifiedDocuments", &AtomToolsDocumentSystemRequestBus::Events::ReopenModifiedDocuments)
                 ->Event("GetDocumentCount", &AtomToolsDocumentSystemRequestBus::Events::GetDocumentCount)
                 ->Event("IsDocumentOpen", &AtomToolsDocumentSystemRequestBus::Events::IsDocumentOpen)
                 ->Event("AddRecentFilePath", &AtomToolsDocumentSystemRequestBus::Events::AddRecentFilePath)
@@ -189,7 +191,7 @@ namespace AtomToolsFramework
         }
 
         const AZStd::string& createPath = !openPath.empty() ? openPath : savePath;
-        AZ::Uuid documentId = CreateDocumentFromFileType(createPath);
+        const AZ::Uuid documentId = CreateDocumentFromFileType(createPath);
         if (documentId.IsNull())
         {
             DisplayErrorMessage(
@@ -214,26 +216,23 @@ namespace AtomToolsFramework
             }
         }
 
-        if (!documentId.IsNull())
+        if (!savePath.empty())
         {
-            if (!savePath.empty())
+            if (!SaveDocumentAsChild(documentId, savePath))
             {
-                if (!SaveDocumentAsChild(documentId, savePath))
-                {
-                    CloseDocument(documentId);
-                    return AZ::Uuid::CreateNull();
-                }
+                CloseDocument(documentId);
+                return AZ::Uuid::CreateNull();
+            }
 
-                // Send document open notification after creating new one
-                AddRecentFilePath(savePath);
-                AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
-            }
-            else
-            {
-                AddRecentFilePath(openPath);
-                AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
-            }
+            AddRecentFilePath(savePath);
         }
+        else
+        {
+            AddRecentFilePath(openPath);
+        }
+
+        // Send document open notification after creating new one
+        AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
 
         if (traceRecorder.GetWarningCount(true) > 0)
         {
@@ -266,15 +265,15 @@ namespace AtomToolsFramework
         // Determine if the file is already open and select it
         for (const auto& documentPair : m_documentMap)
         {
+            const auto& documentId = documentPair.first;
+
             AZStd::string openDocumentPath;
-            AtomToolsDocumentRequestBus::EventResult(
-                openDocumentPath, documentPair.first, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
+            AtomToolsDocumentRequestBus::EventResult(openDocumentPath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
             if (AZ::StringFunc::Equal(openDocumentPath, openPath))
             {
                 AddRecentFilePath(openPath);
-                AtomToolsDocumentNotificationBus::Event(
-                    m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentPair.first);
-                return documentPair.first;
+                AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
+                return documentId;
             }
         }
 
@@ -298,7 +297,7 @@ namespace AtomToolsFramework
                 QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
             if (selection == QMessageBox::Cancel)
             {
-                AZ_TracePrintf("AtomToolsDocument", "Close document canceled: %s", documentPath.c_str());
+                AZ_TracePrintf("AtomToolsDocument", "Close document canceled: %s\n", documentPath.c_str());
                 return false;
             }
             if (selection == QMessageBox::Yes)
@@ -517,110 +516,38 @@ namespace AtomToolsFramework
         return result;
     }
 
-    AZ::u32 AtomToolsDocumentSystem::GetDocumentCount() const
+    bool AtomToolsDocumentSystem::QueueReopenModifiedDocuments()
     {
-        return aznumeric_cast<AZ::u32>(m_documentMap.size());
-    }
-
-    bool AtomToolsDocumentSystem::IsDocumentOpen(const AZ::Uuid& documentId) const
-    {
-        bool result = false;
-        AtomToolsDocumentRequestBus::EventResult(result, documentId, &AtomToolsDocumentRequestBus::Events::IsOpen);
-        return result;
-    }
-
-    void AtomToolsDocumentSystem::AddRecentFilePath(const AZStd::string& absolutePath)
-    {
-        if (!absolutePath.empty())
+        if (!m_queueReopenModifiedDocuments)
         {
-            // Get the list of previously stored recent file paths from the settings registry
-            AZStd::vector<AZStd::string> paths = GetRecentFilePaths();
-
-            // If the new path is already in the list then remove it Because it will be moved to the front of the list
-            AZStd::erase_if(paths, [&absolutePath](const AZStd::string& currentPath) {
-                return AZ::StringFunc::Equal(currentPath, absolutePath);
+            m_queueReopenModifiedDocuments = true;
+            const int interval =
+                static_cast<int>(GetSettingsValue<AZ::s64>("/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/ReopenInterval", 500));
+            QTimer::singleShot(interval, [toolId = m_toolId]() {
+                AtomToolsDocumentSystemRequestBus::Event(toolId, &AtomToolsDocumentSystemRequestBus::Events::ReopenModifiedDocuments);
             });
-
-            paths.insert(paths.begin(), absolutePath);
-
-            constexpr const size_t recentFilePathsMax = 10;
-            if (paths.size() > recentFilePathsMax)
-            {
-                paths.resize(recentFilePathsMax);
-            }
-
-            SetRecentFilePaths(paths);
+            return true;
         }
+        return false;
     }
 
-    void AtomToolsDocumentSystem::ClearRecentFilePaths()
+    bool AtomToolsDocumentSystem::ReopenModifiedDocuments()
     {
-        SetRecentFilePaths(AZStd::vector<AZStd::string>());
-    }
-
-    void AtomToolsDocumentSystem::SetRecentFilePaths(const AZStd::vector<AZStd::string>& absolutePaths)
-    {
-        SetSettingsObject("/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/RecentFilePaths", absolutePaths);
-    }
-
-    const AZStd::vector<AZStd::string> AtomToolsDocumentSystem::GetRecentFilePaths() const
-    {
-        return GetSettingsObject("/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/RecentFilePaths", AZStd::vector<AZStd::string>());
-    }
-
-
-    void AtomToolsDocumentSystem::OnDocumentExternallyModified(const AZ::Uuid& documentId)
-    {
-        m_documentIdsWithExternalChanges.insert(documentId);
-        QueueReopenDocuments();
-    }
-
-    void AtomToolsDocumentSystem::OnDocumentModified([[maybe_unused]] const AZ::Uuid& documentId)
-    {
-        if (GetSettingsValue<bool>("/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/AutoSaveEnabled", false))
-        {
-            if (!m_queueSaveAllModifiedDocuments)
-            {
-                m_queueSaveAllModifiedDocuments = true;
-                const int interval =static_cast<int>(
-                    GetSettingsValue<AZ::s64>("/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/AutoSaveInterval", 250));
-                QTimer::singleShot(interval, [this] { SaveAllModifiedDocuments(); });
-            }
-        }
-    }
-
-    void AtomToolsDocumentSystem::OnDocumentDependencyModified(const AZ::Uuid& documentId)
-    {
-        m_documentIdsWithDependencyChanges.insert(documentId);
-        QueueReopenDocuments();
-    }
-
-    void AtomToolsDocumentSystem::QueueReopenDocuments()
-    {
-        if (!m_queueReopenDocuments)
-        {
-            m_queueReopenDocuments = true;
-            QTimer::singleShot(500, [this] { ReopenDocuments(); });
-        }
-    }
-
-    void AtomToolsDocumentSystem::ReopenDocuments()
-    {
-        m_queueReopenDocuments = false;
+        m_queueReopenModifiedDocuments = false;
 
         const bool enableHotReload = GetSettingsValue<bool>("/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/EnableAutomaticReload", true);
         if (!enableHotReload)
         {
             m_documentIdsWithDependencyChanges.clear();
             m_documentIdsWithExternalChanges.clear();
-            return;
+            return false;
         }
 
         // Postpone document reload if a modal dialog is active or the application is out of focus
         if (QApplication::activeModalWidget() || !(QApplication::applicationState() & Qt::ApplicationActive))
         {
-            QueueReopenDocuments();
-            return;
+            QueueReopenModifiedDocuments();
+            return false;
         }
 
         const bool enableHotReloadPrompts =
@@ -686,5 +613,85 @@ namespace AtomToolsFramework
 
         m_documentIdsWithDependencyChanges.clear();
         m_documentIdsWithExternalChanges.clear();
+        return true;
+    }
+
+    AZ::u32 AtomToolsDocumentSystem::GetDocumentCount() const
+    {
+        return aznumeric_cast<AZ::u32>(m_documentMap.size());
+    }
+
+    bool AtomToolsDocumentSystem::IsDocumentOpen(const AZ::Uuid& documentId) const
+    {
+        bool result = false;
+        AtomToolsDocumentRequestBus::EventResult(result, documentId, &AtomToolsDocumentRequestBus::Events::IsOpen);
+        return result;
+    }
+
+    void AtomToolsDocumentSystem::AddRecentFilePath(const AZStd::string& absolutePath)
+    {
+        if (!absolutePath.empty())
+        {
+            // Get the list of previously stored recent file paths from the settings registry
+            AZStd::vector<AZStd::string> paths = GetRecentFilePaths();
+
+            // If the new path is already in the list then remove it Because it will be moved to the front of the list
+            AZStd::erase_if(paths, [&absolutePath](const AZStd::string& currentPath) {
+                return AZ::StringFunc::Equal(currentPath, absolutePath);
+            });
+
+            paths.insert(paths.begin(), absolutePath);
+
+            constexpr const size_t recentFilePathsMax = 10;
+            if (paths.size() > recentFilePathsMax)
+            {
+                paths.resize(recentFilePathsMax);
+            }
+
+            SetRecentFilePaths(paths);
+        }
+    }
+
+    void AtomToolsDocumentSystem::ClearRecentFilePaths()
+    {
+        SetRecentFilePaths(AZStd::vector<AZStd::string>());
+    }
+
+    void AtomToolsDocumentSystem::SetRecentFilePaths(const AZStd::vector<AZStd::string>& absolutePaths)
+    {
+        SetSettingsObject("/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/RecentFilePaths", absolutePaths);
+    }
+
+    const AZStd::vector<AZStd::string> AtomToolsDocumentSystem::GetRecentFilePaths() const
+    {
+        return GetSettingsObject("/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/RecentFilePaths", AZStd::vector<AZStd::string>());
+    }
+
+    void AtomToolsDocumentSystem::OnDocumentModified([[maybe_unused]] const AZ::Uuid& documentId)
+    {
+        if (GetSettingsValue<bool>("/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/AutoSaveEnabled", false))
+        {
+            if (!m_queueSaveAllModifiedDocuments)
+            {
+                m_queueSaveAllModifiedDocuments = true;
+                const int interval =
+                    static_cast<int>(GetSettingsValue<AZ::s64>("/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/AutoSaveInterval", 250));
+                QTimer::singleShot(interval, [toolId = m_toolId]() {
+                    AtomToolsDocumentSystemRequestBus::Event(toolId, &AtomToolsDocumentSystemRequestBus::Events::SaveAllModifiedDocuments);
+                });
+            }
+        }
+    }
+
+    void AtomToolsDocumentSystem::OnDocumentExternallyModified(const AZ::Uuid& documentId)
+    {
+        m_documentIdsWithExternalChanges.insert(documentId);
+        QueueReopenModifiedDocuments();
+    }
+
+    void AtomToolsDocumentSystem::OnDocumentDependencyModified(const AZ::Uuid& documentId)
+    {
+        m_documentIdsWithDependencyChanges.insert(documentId);
+        QueueReopenModifiedDocuments();
     }
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -667,12 +667,12 @@ namespace AtomToolsFramework
 
                     scriptCategoryMenu->addAction(filename.c_str(), [scriptPath, arguments]() {
                         // Delay execution of the script until the next frame.
-                        QTimer::singleShot(0, [scriptPath, arguments]() {
+                        AZ::SystemTickBus::QueueFunction([scriptPath, arguments]() {
                             AzToolsFramework::EditorPythonRunnerRequestBus::Broadcast(
                                 &AzToolsFramework::EditorPythonRunnerRequestBus::Events::ExecuteByFilenameWithArgs,
                                 scriptPath,
                                 AZStd::vector<AZStd::string_view>(arguments.begin(), arguments.end()));
-                            });
+                        });
                     });
                 }
             }
@@ -685,7 +685,7 @@ namespace AtomToolsFramework
             if (!scriptPath.isEmpty())
             {
                 // Delay execution of the script until the next frame.
-                QTimer::singleShot(0, [scriptPath, arguments]() {
+                AZ::SystemTickBus::QueueFunction([scriptPath, arguments]() {
                     AzToolsFramework::EditorPythonRunnerRequestBus::Broadcast(
                         &AzToolsFramework::EditorPythonRunnerRequestBus::Events::ExecuteByFilenameWithArgs,
                         scriptPath.toUtf8().constData(),

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
@@ -195,7 +195,7 @@ namespace AtomToolsFramework
         if (!m_updateMenus)
         {
             m_updateMenus = true;
-            QTimer::singleShot(0, [this]() {
+            QTimer::singleShot(0, this, [this]() {
                 if (m_rebuildMenus)
                 {
                     // Clearing all actions that were added directly to the menu bar
@@ -203,14 +203,14 @@ namespace AtomToolsFramework
 
                     // Instead of destroying and recreating the menu bar, destroying the individual child menus to prevent the UI from
                     // popping when the menu bar is recreated
-                    auto menus = menuBar()->findChildren<QMenu*>(QString(), Qt::FindDirectChildrenOnly);
-                    for (auto menu : menus)
+                    for (auto menu : menuBar()->findChildren<QMenu*>(QString(), Qt::FindDirectChildrenOnly))
                     {
                         delete menu;
                     }
 
                     AtomToolsMainMenuRequestBus::Event(m_toolId, &AtomToolsMainMenuRequestBus::Events::CreateMenus, menuBar());
                 }
+
                 AtomToolsMainMenuRequestBus::Event(m_toolId, &AtomToolsMainMenuRequestBus::Events::UpdateMenus, menuBar());
                 m_updateMenus = false;
                 m_rebuildMenus = false;

--- a/Gems/Atom/Tools/MaterialCanvas/Scripts/TestOpenClose.py
+++ b/Gems/Atom/Tools/MaterialCanvas/Scripts/TestOpenClose.py
@@ -1,0 +1,30 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+import sys
+import os
+import azlmbr.bus
+import azlmbr.paths
+import collections
+import random
+
+def main():
+    paths = azlmbr.atomtools.util.GetPathsInSourceFoldersMatchingWildcard('*.materialcanvas.azasset')
+    for path in paths.copy():
+        if 'cache' in path.lower():
+            paths.remove(path)
+
+    for i in range(0, 100):
+        for path in paths:
+            if azlmbr.atomtools.util.IsDocumentPathEditable(path):
+                azlmbr.atomtools.AtomToolsDocumentSystemRequestBus(azlmbr.bus.Broadcast, 'OpenDocument', path)
+        azlmbr.atomtools.AtomToolsDocumentSystemRequestBus(azlmbr.bus.Broadcast, 'CloseAllDocuments')
+        random.shuffle(paths)
+
+if __name__ == "__main__":
+    main()
+

--- a/Gems/Atom/Tools/MaterialEditor/Scripts/UpgradeAllMaterials.py
+++ b/Gems/Atom/Tools/MaterialEditor/Scripts/UpgradeAllMaterials.py
@@ -12,6 +12,10 @@ import azlmbr.paths
 import collections
 
 def main():
+    paths = azlmbr.atomtools.util.GetPathsInSourceFoldersMatchingWildcard('*.material')
+    for path in paths.copy():
+        if 'cache' in path.lower():
+            paths.remove(path)
 
     documentId = azlmbr.atomtools.AtomToolsDocumentSystemRequestBus(azlmbr.bus.Broadcast, 'CreateDocumentFromTypeName', 'Material')
 
@@ -19,7 +23,7 @@ def main():
         print("The material document could not be opened")
         return
 
-    for path in azlmbr.atomtools.util.GetPathsInSourceFoldersMatchingWildcard('*.material'):
+    for path in paths:
         if azlmbr.atomtools.util.IsDocumentPathEditable(path):
             if azlmbr.atomtools.AtomToolsDocumentRequestBus(azlmbr.bus.Event, 'Open', documentId, path):
                 azlmbr.atomtools.AtomToolsDocumentRequestBus(azlmbr.bus.Event, 'Save', documentId)


### PR DESCRIPTION
## What does this PR do?

Problems were occurring when opening documents from shortcut and menu actions. Modal message boxes can be displayed for documents that log warning and error messages. Opening a document triggers notifications that could subsequently cause the actions that triggered them to be deleted as part of menus refreshing. By deferring the open document commands to use a timer or tick bus, they will be invoked as part of the regular system tick instead of nested inside of the action callback with the potential warning or error message boxes.

Replaced all QTimers that could not be connected to a parent object for lifetime management with system tick bus.

The callbacks bound to most timers and the tick bus were updated to not capture the this pointer.

Some direct function calls were converted to bus calls so the this pointer did not have to be captured.

Created and updated test scripts that do exhaustive document opening and closing to make sure things are being cleaned up correctly.

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Manually opening, editing, closing different material canvas graphs repeatedly.
Created test scripts to open and close all material canvas graphs and a project several times in random order.