### PR TITLE
Material Canvas: Registering matrix slot data types

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/Json/AnySerializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/AnySerializer.cpp
@@ -6,40 +6,37 @@
  *
  */
 
-#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Serialization/Json/AnySerializer.h>
 #include <AzCore/Serialization/Json/JsonSerialization.h>
-#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace AZ
 {
     AZ_CLASS_ALLOCATOR_IMPL(JsonAnySerializer, SystemAllocator, 0);
-    JsonSerializationResult::Result JsonAnySerializer::Load
-        ( void* outputValue
-        , [[maybe_unused]] const Uuid& outputValueTypeId
-        , const rapidjson::Value& inputValue
-        , JsonDeserializerContext& context)
+    JsonSerializationResult::Result JsonAnySerializer::Load(
+        void* outputValue,
+        [[maybe_unused]] const Uuid& outputValueTypeId,
+        const rapidjson::Value& inputValue,
+        JsonDeserializerContext& context)
     {
         namespace JSR = JsonSerializationResult; // Used to remove name conflicts in AzCore in uber builds.
         AZ_Assert(outputValueTypeId == azrtti_typeid<AZStd::any>(), "JsonAnySerializer::Load against value typeID that was not AZStd::any");
 
         if (inputValue.GetType() != rapidjson::kObjectType)
         {
-            return context.Report
-                ( JSR::Tasks::ReadField
-                , JSR::Outcomes::Unsupported
-                , "JsonAnySerializer::Load only supports rapidjson::kObjectType");
-
+            return context.Report(
+                JSR::Tasks::ReadField, JSR::Outcomes::Unsupported, "JsonAnySerializer::Load only supports rapidjson::kObjectType");
         }
 
         AZ::Uuid anyTypeId = AZ::Uuid::CreateNull();
         auto typeIdMember = inputValue.FindMember(JsonSerialization::TypeIdFieldIdentifier);
         if (typeIdMember == inputValue.MemberEnd())
         {
-            return context.Report
-                ( JSR::Tasks::ReadField
-                , JSR::Outcomes::DefaultsUsed // passes one test breaks another?
-                , "JsonAnySerializer::Load created a default, empty AZStd::any");
+            return context.Report(
+                JSR::Tasks::ReadField,
+                JSR::Outcomes::DefaultsUsed, // passes one test breaks another?
+                "JsonAnySerializer::Load created a default, empty AZStd::any");
         }
 
         JsonSerializationResult::ResultCode result(JSR::Tasks::ReadField);
@@ -47,46 +44,39 @@ namespace AZ
 
         if (anyTypeId.IsNull())
         {
-            return context.Report
-                (JSR::Tasks::ReadField
-                , JSR::Outcomes::DefaultsUsed
-                , "JsonAnySerializer::Load created a default, empty AZStd::any");
+            return context.Report(
+                JSR::Tasks::ReadField, JSR::Outcomes::DefaultsUsed, "JsonAnySerializer::Load created a default, empty AZStd::any");
         }
         else
         {
             auto outputAnyPtr = reinterpret_cast<AZStd::any*>(outputValue);
             *outputAnyPtr = context.GetSerializeContext()->CreateAny(anyTypeId);
 
-            if (outputAnyPtr->empty() || outputAnyPtr->type() != anyTypeId)
+            if (outputAnyPtr->type() != anyTypeId)
             {
-                return context.Report(result, "JsonAnySerializer::Load failed to load a value matched the reported AZ TypeId. "
+                return context.Report(
+                    result,
+                    "JsonAnySerializer::Load failed to load a value matched the reported AZ TypeId. "
                     "The C++ declaration may have been deleted or changed.");
             }
 
             // Allowing the serializer to read from objects contained in members "Value" and "value" for backward compatibility
-            if (inputValue.HasMember("Value"))
-            {
-                result.Combine(
-                    ContinueLoadingFromJsonObjectField(AZStd::any_cast<void>(outputAnyPtr), anyTypeId, inputValue, "Value", context));
-            }
-            else
-            {
-                result.Combine(
-                    ContinueLoadingFromJsonObjectField(AZStd::any_cast<void>(outputAnyPtr), anyTypeId, inputValue, "value", context));
-            }
+            result.Combine(ContinueLoadingFromJsonObjectField(
+                AZStd::any_cast<void>(outputAnyPtr), anyTypeId, inputValue, inputValue.HasMember("Value") ? "Value" : "value", context));
         }
 
-        return context.Report(result, result.GetProcessing() != JSR::Processing::Halted
-            ? "JsonAnySerializer::Load finished loading AZStd::any"
-            : "JsonAnySerializer::Load failed to load AZStd::any");
+        return context.Report(
+            result,
+            result.GetProcessing() != JSR::Processing::Halted ? "JsonAnySerializer::Load finished loading AZStd::any"
+                                                              : "JsonAnySerializer::Load failed to load AZStd::any");
     }
 
-    JsonSerializationResult::Result JsonAnySerializer::Store
-        ( rapidjson::Value& outputValue
-        , const void* inputValue
-        , const void* defaultValue
-        , [[maybe_unused]] const Uuid& valueTypeId
-        , JsonSerializerContext& context)
+    JsonSerializationResult::Result JsonAnySerializer::Store(
+        rapidjson::Value& outputValue,
+        const void* inputValue,
+        const void* defaultValue,
+        [[maybe_unused]] const Uuid& valueTypeId,
+        JsonSerializerContext& context)
     {
         namespace JSR = JsonSerializationResult; // Used to remove name conflicts in AzCore in uber builds.
         AZ_Assert(valueTypeId == azrtti_typeid<AZStd::any>(), "JsonAnySerializer::Store against value typeID that was not AZStd::any");
@@ -101,31 +91,22 @@ namespace AZ
         {
             rapidjson::Value typeValue;
             result.Combine(StoreTypeId(typeValue, anyTypeId, context));
-            outputValue.AddMember
-                ( rapidjson::StringRef(JsonSerialization::TypeIdFieldIdentifier)
-                , AZStd::move(typeValue)
-                , context.GetJsonAllocator());
+            outputValue.AddMember(
+                rapidjson::StringRef(JsonSerialization::TypeIdFieldIdentifier), AZStd::move(typeValue), context.GetJsonAllocator());
 
-            if (AZStd::any_cast<void>(inputAnyPtr) != nullptr)
-            {
-                auto defaultAnyPtr = reinterpret_cast<const AZStd::any*>(defaultValue);
-                const void* defaultValueSource = defaultAnyPtr && defaultAnyPtr->type() == anyTypeId
-                    ? AZStd::any_cast<void>(defaultAnyPtr) : nullptr;
+            auto defaultAnyPtr = reinterpret_cast<const AZStd::any*>(defaultValue);
+            const void* defaultValueSource =
+                defaultAnyPtr && defaultAnyPtr->type() == anyTypeId ? AZStd::any_cast<void>(defaultAnyPtr) : nullptr;
 
-                // The serializer will save the object in "Value" with an uppercase "V" which is standard in other serializers
-                result.Combine(ContinueStoringToJsonObjectField
-                    ( outputValue
-                    , "Value"
-                    , AZStd::any_cast<void>(inputAnyPtr)
-                    , defaultValueSource
-                    , anyTypeId
-                    , context));
-            }
-        }      
+            // The serializer will save the object in "Value" with an uppercase "V", which is standard in other serializers
+            result.Combine(ContinueStoringToJsonObjectField(
+                outputValue, "Value", AZStd::any_cast<void>(inputAnyPtr), defaultValueSource, anyTypeId, context));
+        }
 
-        return context.Report(result, result.GetProcessing() != JSR::Processing::Halted
-            ? "JsonAnySerializer::Store finished storing AZStd::any"
-            : "JsonAnySerializer::Store failed to store AZStd::any");
+        return context.Report(
+            result,
+            result.GetProcessing() != JSR::Processing::Halted ? "JsonAnySerializer::Store finished storing AZStd::any"
+                                                              : "JsonAnySerializer::Store failed to store AZStd::any");
     }
 
 } // namespace AZ

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
@@ -110,16 +110,11 @@ namespace MaterialCanvas
     MaterialCanvasDocument::~MaterialCanvasDocument()
     {
         MaterialCanvasDocumentRequestBus::Handler::BusDisconnect();
-
         GraphCanvas::SceneNotificationBus::Handler::BusDisconnect();
-
-        // Stop listening for GraphController notifications for this graph.
         GraphModelIntegration::GraphControllerNotificationBus::Handler::BusDisconnect();
 
-        GraphModelIntegration::GraphManagerRequestBus::Broadcast(
-            &GraphModelIntegration::GraphManagerRequests::DeleteGraphController, m_graphId);
+        DestroyGraph();
 
-        m_graph.reset();
         m_graphId = GraphCanvas::GraphId();
         delete m_sceneEntity;
         m_sceneEntity = {};
@@ -186,7 +181,7 @@ namespace MaterialCanvas
                     // There are currently no indicators for material canvas nodes.
                     return nullptr;
                 };
-                objects.push_back(AZStd::move(objectInfo));
+                objects.emplace_back(AZStd::move(objectInfo));
             }
         }
 
@@ -453,14 +448,15 @@ namespace MaterialCanvas
 
     void MaterialCanvasDocument::BuildEditablePropertyGroups()
     {
-        m_groups.clear();
-
         // Sort nodes according to their connection so they appear in a consistent order in the inspector
         GraphModel::NodePtrList selectedNodes;
         GraphModelIntegration::GraphControllerRequestBus::EventResult(
             selectedNodes, m_graphId, &GraphModelIntegration::GraphControllerRequests::GetSelectedNodes);
 
         SortNodesInExecutionOrder(selectedNodes);
+
+        m_groups.clear();
+        m_groups.reserve(selectedNodes.size());
 
         for (const auto& currentNode : selectedNodes)
         {
@@ -470,6 +466,8 @@ namespace MaterialCanvas
                 continue;
             }
 
+            const auto& nodeConfig = dynamicNode->GetConfig();
+
             // Create a new property group and set up the header to match the node
             AZStd::shared_ptr<AtomToolsFramework::DynamicPropertyGroup> group;
             group.reset(aznew AtomToolsFramework::DynamicPropertyGroup);
@@ -478,8 +476,12 @@ namespace MaterialCanvas
                 AZStd::string::format("Node%u %s", currentNode->GetId(), currentNode->GetTitle()));
             group->m_description = currentNode->GetSubTitle();
 
-            // Visit all of the slots in the order that they will be displayed on the node
-            const auto& nodeConfig = dynamicNode->GetConfig();
+            group->m_properties.reserve(
+                dynamicNode->GetConfig().m_propertySlots.size() +
+                dynamicNode->GetConfig().m_inputSlots.size() +
+                dynamicNode->GetConfig().m_outputSlots.size());
+
+            // Visit all of the slots in the order to find in the configuration to add properties to the container for the inspector.
             AtomToolsFramework::VisitDynamicNodeSlotConfigs(
                 nodeConfig,
                 [&](const AtomToolsFramework::DynamicNodeSlotConfig& slotConfig)
@@ -511,7 +513,7 @@ namespace MaterialCanvas
                                 return AZ::Edit::PropertyRefreshLevels::AttributesAndValues;
                             };
 
-                            group->m_properties.push_back(AtomToolsFramework::DynamicProperty(propertyConfig));
+                            group->m_properties.emplace_back(AZStd::move(propertyConfig));
                         }
                     }
                 });
@@ -573,6 +575,34 @@ namespace MaterialCanvas
         if (auto v = AZStd::any_cast<const AZ::Vector2>(&slotValue))
         {
             return AZStd::string::format("float2(%g, %g)", v->GetX(), v->GetY());
+        }
+        if (auto v = AZStd::any_cast<const AZStd::array<AZ::Vector3, 3>>(&slotValue))
+        {
+            const auto& value = *v;
+            return AZStd::string::format(
+                "float3x3(%g, %g, %g, %g, %g, %g, %g, %g, %g)",
+                value[0].GetX(), value[0].GetY(), value[0].GetZ(),
+                value[1].GetX(), value[1].GetY(), value[1].GetZ(),
+                value[2].GetX(), value[2].GetY(), value[2].GetZ());
+        }
+        if (auto v = AZStd::any_cast<const AZStd::array<AZ::Vector4, 3>>(&slotValue))
+        {
+            const auto& value = *v;
+            return AZStd::string::format(
+                "float4x3(%g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g)",
+                value[0].GetX(), value[0].GetY(), value[0].GetZ(), value[0].GetW(),
+                value[1].GetX(), value[1].GetY(), value[1].GetZ(), value[1].GetW(),
+                value[2].GetX(), value[2].GetY(), value[2].GetZ(), value[2].GetW());
+        }
+        if (auto v = AZStd::any_cast<const AZStd::array<AZ::Vector4, 4>>(&slotValue))
+        {
+            const auto& value = *v;
+            return AZStd::string::format(
+                "float4x4(%g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g)",
+                value[0].GetX(), value[0].GetY(), value[0].GetZ(), value[0].GetW(),
+                value[1].GetX(), value[1].GetY(), value[1].GetZ(), value[1].GetW(),
+                value[2].GetX(), value[2].GetY(), value[2].GetZ(), value[2].GetW(),
+                value[3].GetX(), value[3].GetY(), value[3].GetZ(), value[3].GetW());
         }
         if (auto v = AZStd::any_cast<const float>(&slotValue))
         {

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
@@ -70,6 +70,13 @@ namespace MaterialCanvas
     {
         Base::Reflect(context);
         MaterialCanvasDocument::Reflect(context);
+
+        if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->RegisterGenericType<AZStd::array<AZ::Vector3, 3>>();
+            serialize->RegisterGenericType<AZStd::array<AZ::Vector4, 3>>();
+            serialize->RegisterGenericType<AZStd::array<AZ::Vector4, 4>>();
+        }
     }
 
     const char* MaterialCanvasApplication::GetCurrentConfigurationName() const
@@ -96,9 +103,12 @@ namespace MaterialCanvas
             AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("int"), int32_t{}, "int"),
             AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("uint"), uint32_t{}, "uint"),
             AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("float"), float{}, "float"),
-            AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("float2"), AZ::Vector2::CreateZero(), "float2"),
-            AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("float3"), AZ::Vector3::CreateZero(), "float3"),
-            AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("float4"), AZ::Vector4::CreateZero(), "float4"),
+            AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("float2"), AZ::Vector2{}, "float2"),
+            AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("float3"), AZ::Vector3{}, "float3"),
+            AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("float4"), AZ::Vector4{}, "float4"),
+            AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("float3x3"), AZStd::array<AZ::Vector3, 3>{}, "float3x3"),
+            AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("float4x3"), AZStd::array<AZ::Vector4, 3>{}, "float4x3"),
+            AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("float4x4"), AZStd::array<AZ::Vector4, 4>{}, "float4x4"),
             AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("color"), AZ::Color::CreateOne(), "color"),
             AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("string"), AZStd::string{}, "string"),
             AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("image"), AZ::Data::Asset<AZ::RPI::StreamingImageAsset>{}, "image"),


### PR DESCRIPTION
## What does this PR do?

This change is only registering the data types needed to represent floating point matrix slots on material canvas nodes. Nodes and other test data that uses these new types will be submitted in a subsequent PR.

Using arrays of vectors because they map directly to the corresponding AZSL types, can easily be converted, and are reflected with edit context bindings that automatically work in the inspector without additional attributes for special container handling.

This PR also includes minor simplification to the JSON Any Serializer, removing redundant type checks and code paths.

Minor optimizations were also made for generating the inspector properties in the material canvas document class. Reserving space in containers. Moving data types.

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Code builds and runs. Test data that exercises these changes will be included in a follow up PR.