### PR TITLE
[Terrain] Adding support for bicubic filtering to image gradients.

### DIFF
--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientComponent.h
@@ -62,7 +62,8 @@ namespace GradientSignal
     enum class SamplingType : AZ::u8
     {
         Point,                  //! Point sampling just queries the X,Y point as specified (Default)
-        Bilinear                //! Apply a bilinear filter to the image data
+        Bilinear,               //! Apply a bilinear filter to the image data
+        Bicubic,                //! Apply a bicubic filter to the image data
     };
 
     class ImageGradientConfig
@@ -193,6 +194,8 @@ namespace GradientSignal
         void SetupDefaultMultiplierAndOffset();
         void SetupAutoScaleMultiplierAndOffset();
         void SetupManualScaleMultiplierAndOffset();
+        void Get4x4Neighborhood(uint32_t x, uint32_t y, AZStd::array<AZStd::array<float, 4>, 4>& values) const;
+        float GetClampedValue(int32_t x, int32_t y) const;
         float GetValueForSamplingType(SamplingType samplingType, AZ::u32 x0, AZ::u32 y0, float pixelX, float pixelY) const;
 
         float GetTilingX() const override;
@@ -211,6 +214,8 @@ namespace GradientSignal
         float m_multiplier = 1.0f;
         float m_offset = 0.0f;
         AZ::u32 m_currentMipIndex = 0;
+        int32_t m_maxX = 0;
+        int32_t m_maxY = 0;
         SamplingType m_currentSamplingType = SamplingType::Point;
 
         //! Cached information for our loaded image data.

--- a/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
@@ -398,12 +398,10 @@ namespace GradientSignal
                 // A 16x16 pixel image and tilingX = tilingY = 1  maps the uv range of 0-1 to 0-16 pixels.  
                 // A 16x16 pixel image and tilingX = tilingY = 1.5 maps the uv range of 0-1 to 0-24 pixels.
 
-                const AZ::Vector3 tiledDimensions((width * GetTilingX()),
-                    (height * GetTilingY()),
-                    0.0f);
+                const AZ::Vector2 tiledDimensions(width * GetTilingX(), height * GetTilingY());
 
                 // Convert from uv space back to pixel space
-                AZ::Vector3 pixelLookup = (uvw * tiledDimensions);
+                AZ::Vector2 pixelLookup = (AZ::Vector2(uvw) * tiledDimensions);
 
                 // UVs outside the 0-1 range are treated as infinitely tiling, so that we behave the same as the 
                 // other gradient generators.  As mentioned above, if clamping is desired, we expect it to be applied
@@ -538,6 +536,72 @@ namespace GradientSignal
         SetupMultiplierAndOffset(m_configuration.m_scaleRangeMin, m_configuration.m_scaleRangeMax);
     }
 
+    float ImageGradientComponent::GetClampedValue(int32_t x, int32_t y) const
+    {
+        const auto& width = m_imageDescriptor.m_size.m_width;
+        const auto& height = m_imageDescriptor.m_size.m_height;
+
+        switch (m_gradientTransform.GetWrappingType())
+        {
+        case WrappingType::ClampToZero:
+            if (x < 0 || x > m_maxX || y < 0 || y > m_maxY)
+            {
+                return 0.0f;
+            }
+        case WrappingType::ClampToEdge:
+            x = AZ::GetClamp(x, 0, m_maxX);
+            y = AZ::GetClamp(y, 0, m_maxY);
+            break;
+        case WrappingType::Mirror:
+            if (x < 0)
+            {
+                x = -x;
+            }
+            if (y < 0)
+            {
+                y = -y;
+            }
+            if (x > m_maxX)
+            {
+                x = m_maxX - (x % width);
+            }
+            if (y > m_maxY)
+            {
+                x = m_maxY - (y % height);
+            }
+        case WrappingType::None:
+        case WrappingType::Repeat:
+        default:
+            x = x % width;
+            y = y % height;
+            break;
+        }
+        return  GetPixelValue(x, y);
+    }
+
+    void ImageGradientComponent::Get4x4Neighborhood(uint32_t x, uint32_t y, AZStd::array<AZStd::array<float, 4>, 4>& values) const
+    {
+        values[0][0] = GetClampedValue(x - 1, y - 1);
+        values[1][0] = GetClampedValue(x + 0, y - 1);
+        values[2][0] = GetClampedValue(x + 1, y - 1);
+        values[3][0] = GetClampedValue(x + 2, y - 1);
+
+        values[0][1] = GetClampedValue(x - 1, y + 0);
+        values[1][1] = GetClampedValue(x + 0, y + 0);
+        values[2][1] = GetClampedValue(x + 1, y + 0);
+        values[3][1] = GetClampedValue(x + 2, y + 0);
+
+        values[0][2] = GetClampedValue(x - 1, y + 1);
+        values[1][2] = GetClampedValue(x + 0, y + 1);
+        values[2][2] = GetClampedValue(x + 1, y + 1);
+        values[3][2] = GetClampedValue(x + 2, y + 1);
+
+        values[0][3] = GetClampedValue(x - 1, y + 2);
+        values[1][3] = GetClampedValue(x + 0, y + 2);
+        values[2][3] = GetClampedValue(x + 1, y + 2);
+        values[3][3] = GetClampedValue(x + 2, y + 2);
+    }
+
     float ImageGradientComponent::GetValueForSamplingType(SamplingType samplingType, AZ::u32 x0, AZ::u32 y0, float pixelX, float pixelY) const
     {
         switch (samplingType)
@@ -548,6 +612,7 @@ namespace GradientSignal
             return GetPixelValue(x0, y0);
 
         case SamplingType::Bilinear:
+        {
             // Bilinear interpolation
             //
             //   |
@@ -563,59 +628,42 @@ namespace GradientSignal
             // x0,y0 contains one corner of our grid square, x1,y1 contains the opposite corner, and deltaX/Y is the fractional
             // amount the position exists between those corners.
             // Ex: (3.3, 4.4) would have a x0,y0 of (3, 4), a x1,y1 of (4, 5), and a deltaX/Y of (0.3, 0.4).
-            const auto& width = m_imageDescriptor.m_size.m_width;
-            const auto& height = m_imageDescriptor.m_size.m_height;
+
+            const float valueX0Y0 = GetClampedValue(x0, y0);
+            const float valueX1Y0 = GetClampedValue(x0 + 1, y0);
+            const float valueX0Y1 = GetClampedValue(x0, y0 + 1);
+            const float valueX1Y1 = GetClampedValue(x0 + 1, y0 + 1);
+
             float deltaX = pixelX - floor(pixelX);
             float deltaY = pixelY - floor(pixelY);
-
-            // Handle the x1,y1 points based on the configured wrapping type
-            AZ::u32 x1;
-            AZ::u32 y1;
-            bool x1IsValid = true;
-            bool y1IsValid = true;
-            switch (m_gradientTransform.GetWrappingType())
-            {
-            case WrappingType::ClampToZero:
-                // For ClampToZero, the value will always be 0 outside of the shape
-                // So go ahead and do the calculation here, but if it ends
-                // up being outside of the shape, then it will be considered
-                // invalid and we will use 0 for the value below
-                x1 = x0 + 1;
-                if (x1 >= width)
-                {
-                    x1IsValid = false;
-                }
-                y1 = y0 + 1;
-                if (y1 >= height)
-                {
-                    y1IsValid = false;
-                }
-                break;
-            case WrappingType::ClampToEdge:
-            case WrappingType::Mirror:
-                // On the mirror edge case we are only ever
-                // looking at x+1 or y+1 just out of the image
-                // bounds, so the edge value will be the
-                // mirrored value
-                x1 = AZStd::min(x0 + 1, width - 1);
-                y1 = AZStd::min(y0 + 1, height - 1);
-                break;
-            case WrappingType::None:
-            case WrappingType::Repeat:
-            default:
-                x1 = (x0 + 1) % width;
-                y1 = (y0 + 1) % width;
-                break;
-            }
-
-            // Retrieve all the points in the grid and then perform the interpolation
-            const float valueX0Y0 = GetPixelValue(x0, y0);
-            const float valueX1Y0 = (x1IsValid) ? GetPixelValue(x1, y0) : 0.0f;
-            const float valueX0Y1 = (y1IsValid) ? GetPixelValue(x0, y1) : 0.0f;
-            const float valueX1Y1 = (x1IsValid && y1IsValid) ? GetPixelValue(x1, y1) : 0.0f;
             const float valueXY0 = AZ::Lerp(valueX0Y0, valueX1Y0, deltaX);
             const float valueXY1 = AZ::Lerp(valueX0Y1, valueX1Y1, deltaX);
             return AZ::Lerp(valueXY0, valueXY1, deltaY);
+        }
+        case SamplingType::Bicubic:
+        {
+            // Catmull-Rom style bicubic filtering. This uses the neighborhood of 16 samples to calculate a smooth curve for values
+            // in between discrete sample locations. See https://en.wikipedia.org/wiki/Bicubic_interpolation
+
+            // Simplified interpolation function
+            auto cubicInterpolate = [](float p0, float p1, float p2, float p3, float delta) -> float
+            {
+                return p1 + 0.5f * delta * (p2 - p0 + delta * (2.0f * p0 - 5.0f * p1 + 4.0f * p2 - p3 + delta * (3.0f * (p1 - p2) + p3 - p0)));
+            };
+
+            AZStd::array<AZStd::array<float, 4>, 4> values;
+            Get4x4Neighborhood(x0, y0, values);
+
+            float deltaX = pixelX - floor(pixelX);
+            float deltaY = pixelY - floor(pixelY);
+
+            const float valueXY0 = cubicInterpolate(values[0][0], values[1][0], values[2][0], values[3][0], deltaX);
+            const float valueXY1 = cubicInterpolate(values[0][1], values[1][1], values[2][1], values[3][1], deltaX);
+            const float valueXY2 = cubicInterpolate(values[0][2], values[1][2], values[2][2], values[3][2], deltaX);
+            const float valueXY3 = cubicInterpolate(values[0][3], values[1][3], values[2][3], values[3][3], deltaX);
+
+            return cubicInterpolate(valueXY0, valueXY1, valueXY2, valueXY3, deltaY);
+        }
         }
     }
 
@@ -691,6 +739,9 @@ namespace GradientSignal
 
         m_imageDescriptor = imageDescriptor;
         m_imageData = imageData;
+
+        m_maxX = imageDescriptor.m_size.m_width - 1;
+        m_maxY = imageDescriptor.m_size.m_height - 1;
 
         if (shouldClearModificationBuffer)
         {

--- a/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
@@ -581,25 +581,13 @@ namespace GradientSignal
 
     void ImageGradientComponent::Get4x4Neighborhood(uint32_t x, uint32_t y, AZStd::array<AZStd::array<float, 4>, 4>& values) const
     {
-        values[0][0] = GetClampedValue(x - 1, y - 1);
-        values[1][0] = GetClampedValue(x + 0, y - 1);
-        values[2][0] = GetClampedValue(x + 1, y - 1);
-        values[3][0] = GetClampedValue(x + 2, y - 1);
-
-        values[0][1] = GetClampedValue(x - 1, y + 0);
-        values[1][1] = GetClampedValue(x + 0, y + 0);
-        values[2][1] = GetClampedValue(x + 1, y + 0);
-        values[3][1] = GetClampedValue(x + 2, y + 0);
-
-        values[0][2] = GetClampedValue(x - 1, y + 1);
-        values[1][2] = GetClampedValue(x + 0, y + 1);
-        values[2][2] = GetClampedValue(x + 1, y + 1);
-        values[3][2] = GetClampedValue(x + 2, y + 1);
-
-        values[0][3] = GetClampedValue(x - 1, y + 2);
-        values[1][3] = GetClampedValue(x + 0, y + 2);
-        values[2][3] = GetClampedValue(x + 1, y + 2);
-        values[3][3] = GetClampedValue(x + 2, y + 2);
+        for (int32_t yIndex = 0; yIndex < 4; ++yIndex)
+        {
+            for (int32_t xIndex = 0; xIndex < 4; ++xIndex)
+            {
+                values[xIndex][yIndex] = GetClampedValue(x + xIndex - 1, y + yIndex - 1);
+            }
+        }
     }
 
     float ImageGradientComponent::GetValueForSamplingType(SamplingType samplingType, AZ::u32 x0, AZ::u32 y0, float pixelX, float pixelY) const

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.cpp
@@ -53,6 +53,7 @@ namespace GradientSignal
                         "Sampling Type", "Sampling type to use for the image data.")
                         ->EnumAttribute(SamplingType::Point, "Point")
                         ->EnumAttribute(SamplingType::Bilinear, "Bilinear")
+                        ->EnumAttribute(SamplingType::Bicubic, "Bicubic")
                         ->Attribute(AZ::Edit::Attributes::ReadOnly, &ImageGradientConfig::AreImageOptionsReadOnly)
 
                     ->DataElement(AZ::Edit::UIHandlers::Vector2, &ImageGradientConfig::m_tiling,


### PR DESCRIPTION
## What does this PR do?

This PR adds bicubic filtering support for image gradients. While this could be useful in any application that needs to sample an image gradient at a higher resolution than the source image, this change was made mostly with the intention of improving terrain quality and allowing low resolution heightmaps to be used to make highly detailed terrain.

Here's an example of a 512x512 heightmap being spread over 4 kilometers with 0.5 meter query resolution. This means that each pixel in the source heightmap is spread over 8x8 meters, and makes up 16x16 geometry quads at the highest LOD
![image](https://user-images.githubusercontent.com/1105143/197843752-0573a76b-a0e1-4e8f-bc6c-363866145cd8.png)

Image gradients already have bilinear filtering, and while this can help with small magnifications (less than 2x) it falls apart with large magnifications.
![image](https://user-images.githubusercontent.com/1105143/197843946-f08d365f-fdb2-4113-bb83-942cb4651900.png)

Bicubuc filtering solves this problem by considering not only the positions of the nearest samples, but their derivatives as well.
![image](https://user-images.githubusercontent.com/1105143/197844139-54eae94c-7c90-42af-ab23-9d61f2f68a61.png)

## How was this PR tested?

Tested on several terrain worlds to make sure the image gradient was performing as expected. There is currently a bug in the way image gradient coordinates work where they use pixel corners instead of pixel centers. This causes both bilinear and bicubic filtering to appear to be offset by half a pixel from point sampling. That bug will be fixed separately, then unit tests for bicubic filtering will be added.
