### PR TITLE
added methods MeshVertexCount and FaceVertexHandles for accessing mesh data from Python

### DIFF
--- a/Gems/WhiteBox/Code/Source/WhiteBoxToolApiReflection.cpp
+++ b/Gems/WhiteBox/Code/Source/WhiteBoxToolApiReflection.cpp
@@ -94,10 +94,22 @@ namespace WhiteBox
                         return Api::MeshFaceCount(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle));
                     })
                 ->Method(
+                    "MeshVertexCount",
+                    [](WhiteBoxMeshHandle* whiteBoxMeshHandle)
+                    {
+                        return Api::MeshVertexCount(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle));
+                    })
+                ->Method(
                     "FacePolygonHandle",
                     [](WhiteBoxMeshHandle* whiteBoxMeshHandle, const Api::FaceHandle faceHandle)
                     {
                         return Api::FacePolygonHandle(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), faceHandle);
+                    })
+                ->Method(
+                    "FaceVertexHandles",
+                    [](WhiteBoxMeshHandle* whiteBoxMeshHandle, const Api::FaceHandle faceHandle)
+                    {
+                        return Api::FaceVertexHandles(*WhiteBoxMeshFromHandle(*whiteBoxMeshHandle), faceHandle);
                     })
                 ->Method(
                     "AddVertex",


### PR DESCRIPTION


Signed-off-by: T.J. Kotha <112996779+tkothadev@users.noreply.github.com>

## What does this PR do?

Added two methods from the `WhiteBoxToolApi` class for Python reflection: `MeshVertexCount` and `FaceVertexHandles`.

These two provide minimal support for accessing mesh data from whitebox components, like in the following code excerpt:
```
vertlist = []
facelist = []

vertexCount = mesh.MeshVertexCount()
for i in range(vertexCount):
   vertHandle = azlmbr.object.construct('VertexHandle', i)
   new_vert = mesh.VertexPosition(vertHandle)
   vertlist.append([new_vert.x, new_vert.y, new_vert.z])

faceCount = mesh.MeshFaceCount()
for i in range(faceCount):
   faceHandle = azlmbr.object.construct('FaceHandle', i)
   new_face = mesh.FaceVertexHandles(faceHandle)
   new_list = []
   for f in new_face:
      new_list.append(f.Index())
   facelist.append(new_list)

#now we have minimal model mesh data to pass around as needed
```

I tested this in development in a test python script. It created the intended mesh data (a simple cube using `initializeUnitCube`) and transmitted it to an external location of my choosing. I verified the model was created correctly.