### PR TITLE
Fix sky using wrong SRG and use AddRenderPasses

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmosphereFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmosphereFeatureProcessor.cpp
@@ -37,7 +37,6 @@ namespace AZ::Render
     
     void SkyAtmosphereFeatureProcessor::Activate()
     {
-        CachePasses();
         EnableSceneNotification();
     }
     
@@ -97,22 +96,11 @@ namespace AZ::Render
         }
     }
 
-    void SkyAtmosphereFeatureProcessor::OnRenderPipelineChanged([[maybe_unused]] RPI::RenderPipeline* pipeline,
-        RPI::SceneNotification::RenderPipelineChangeType changeType)
-    {
-        CachePasses();
-        if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Added
-            || changeType == RPI::SceneNotification::RenderPipelineChangeType::PassChanged)
-        {
-            UpdateBackgroundClearColor();
-        }
-    }
-    
-    void SkyAtmosphereFeatureProcessor::CachePasses()
+    void SkyAtmosphereFeatureProcessor::AddRenderPasses(RPI::RenderPipeline* renderPipeline)
     {
         m_skyAtmosphereParentPasses.clear();
 
-        RPI::PassFilter passFilter = RPI::PassFilter::CreateWithTemplateName(Name("SkyAtmosphereParentTemplate"), GetParentScene());
+        RPI::PassFilter passFilter = RPI::PassFilter::CreateWithTemplateName(Name("SkyAtmosphereParentTemplate"), renderPipeline);
         RPI::PassSystemInterface::Get()->ForEachPass(passFilter, [this](RPI::Pass* pass) -> RPI::PassFilterExecutionFlow
             {
                 SkyAtmosphereParentPass* parentPass = static_cast<SkyAtmosphereParentPass*>(pass);
@@ -129,6 +117,16 @@ namespace AZ::Render
             {
                 InitializeAtmosphere(atmosphere.m_id);
             }
+        }
+    }
+
+    void SkyAtmosphereFeatureProcessor::OnRenderPipelineChanged([[maybe_unused]] RPI::RenderPipeline* pipeline,
+        RPI::SceneNotification::RenderPipelineChangeType changeType)
+    {
+        if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Added
+            || changeType == RPI::SceneNotification::RenderPipelineChangeType::PassChanged)
+        {
+            UpdateBackgroundClearColor();
         }
     }
     

--- a/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmosphereFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmosphereFeatureProcessor.h
@@ -32,6 +32,7 @@ namespace AZ::Render
         //! FeatureProcessor 
         void Activate() override;
         void Deactivate() override;
+        void AddRenderPasses(RPI::RenderPipeline* renderPipeline) override;
         void Render(const RenderPacket& packet) override;
 
         //! SkyAtmosphereFeatureProcessorInterface
@@ -46,7 +47,6 @@ namespace AZ::Render
         
         void InitializeAtmosphere(AtmosphereId id);
         void UpdateBackgroundClearColor();
-        void CachePasses();
         bool HasValidAtmosphere();
             
         struct SkyAtmosphere

--- a/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmospherePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmospherePass.cpp
@@ -201,7 +201,7 @@ namespace AZ::Render
         }
     }
 
-    bool SkyAtmospherePass::NeedsShaderDataRebuild()
+    bool SkyAtmospherePass::NeedsShaderDataRebuild() const
     {
         if (m_children.empty())
         {

--- a/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmospherePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmospherePass.cpp
@@ -169,6 +169,8 @@ namespace AZ::Render
                 m_atmospherePassData.push_back({ index, srg, AZStd::move(shaderOptionGroup) });
             }
         }
+
+        m_updateConstants = true;
     }
 
     void SkyAtmospherePass::BuildInternal()
@@ -181,7 +183,6 @@ namespace AZ::Render
 
         BindLUTs();
 
-        m_updateConstants = true;
         m_enableLUTPass = true;
     }
 
@@ -200,8 +201,40 @@ namespace AZ::Render
         }
     }
 
+    bool SkyAtmospherePass::NeedsShaderDataRebuild()
+    {
+        if (m_children.empty())
+        {
+            return false;
+        }
+        else if (m_children.size() != m_atmospherePassData.size())
+        {
+            return true;
+        }
+
+        // SRG may change due to a shader reload
+        for (int i = 0; i < m_atmospherePassData.size(); ++i)
+        {
+            if (RPI::RenderPass* renderPass = azrtti_cast<RPI::RenderPass*>(m_children[i].get()))
+            {
+                auto srg = renderPass->GetShaderResourceGroup();
+                if (m_atmospherePassData[i].m_srg != srg)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     void SkyAtmospherePass::FrameBeginInternal(AZ::RPI::Pass::FramePrepareParams params)
     {
+        if (NeedsShaderDataRebuild())
+        {
+            BuildShaderData();
+        }
+
         if (m_updateConstants && !m_atmospherePassData.empty())
         {
             m_updateConstants = false;

--- a/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmospherePass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmospherePass.h
@@ -52,7 +52,7 @@ namespace AZ::Render
 
         void BindLUTs();
         void BuildShaderData();
-        bool NeedsShaderDataRebuild();
+        bool NeedsShaderDataRebuild() const;
         bool LutParamsEqual(const SkyAtmosphereParams& lhs, const SkyAtmosphereParams& rhs) const;
         void UpdatePassData();
 

--- a/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmospherePass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmospherePass.h
@@ -52,6 +52,7 @@ namespace AZ::Render
 
         void BindLUTs();
         void BuildShaderData();
+        bool NeedsShaderDataRebuild();
         bool LutParamsEqual(const SkyAtmosphereParams& lhs, const SkyAtmosphereParams& rhs) const;
         void UpdatePassData();
 


### PR DESCRIPTION
Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>

## What does this PR do?

Fixes issue where the SRG changed and the sky parent pass did not update the new SRG.
Moves the addition of new passes to the `AddRenderPasses` function instead of in RenderPipelineChanged.

## How was this PR tested?

Verified the bug existed before the change using the steps:
1. Create a level with a skyatmosphere component.
1. save the level and close the editor
2. open the editor and open the level
The sky loads but disappears - verified SRG values are zeroed in RenderDoc capture

After fix, the issue no longer repros in the Editor following the steps above
