### PR TITLE
bugfix(Editor): crash with searching/renaming fields in the AssetBrowser

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.cpp
@@ -38,7 +38,6 @@ namespace AzToolsFramework
             setSortingEnabled(false);
             setItemDelegate(m_delegate);
             setRootIsDecorated(false);
-            connect(m_delegate, &EntryDelegate::RenameEntry, this, &AssetBrowserTableView::SetName);
 
             //Styling the header aligning text to the left and using a bold font.
             header()->setDefaultAlignment(Qt::AlignLeft);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.cpp
@@ -38,6 +38,7 @@ namespace AzToolsFramework
             setSortingEnabled(false);
             setItemDelegate(m_delegate);
             setRootIsDecorated(false);
+            connect(m_delegate, &EntryDelegate::RenameEntry, this, &AssetBrowserTableView::SetName);
 
             //Styling the header aligning text to the left and using a bold font.
             header()->setDefaultAlignment(Qt::AlignLeft);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -58,6 +58,8 @@ namespace AzToolsFramework
         {
             setSortingEnabled(true);
             setItemDelegate(m_delegate);
+            connect(m_delegate, &EntryDelegate::RenameEntry, this, &AssetBrowserTreeView::AfterRename);
+
             header()->hide();
 
             setContextMenuPolicy(Qt::CustomContextMenu);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -62,8 +62,6 @@ namespace AzToolsFramework
 
             header()->hide();
 
-            connect(m_delegate, &EntryDelegate::RenameEntry, this, &AssetBrowserTreeView::AfterRename);
-
             setContextMenuPolicy(Qt::CustomContextMenu);
 
             setMouseTracking(true);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -62,6 +62,8 @@ namespace AzToolsFramework
 
             header()->hide();
 
+            connect(m_delegate, &EntryDelegate::RenameEntry, this, &AssetBrowserTreeView::AfterRename);
+
             setContextMenuPolicy(Qt::CustomContextMenu);
 
             setMouseTracking(true);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.cpp
@@ -42,7 +42,6 @@ namespace AzToolsFramework
         EntryDelegate::EntryDelegate(QWidget* parent)
             : QStyledItemDelegate(parent)
             , m_iconSize(qApp->style()->pixelMetric(QStyle::PM_SmallIconSize))
-            , m_treeView(static_cast<AssetBrowserTreeView*>(parent))
         {
         }
 
@@ -60,10 +59,14 @@ namespace AzToolsFramework
 
         QWidget* EntryDelegate::createEditor(QWidget* parent, [[ maybe_unused]] const QStyleOptionViewItem& option, [[maybe_unused]] const QModelIndex& index) const
         {
-            QLineEdit* widget = static_cast<QLineEdit*>(QStyledItemDelegate::createEditor(parent, option, index));
-            connect(widget, &QLineEdit::editingFinished, this, [this, widget](){
-                m_treeView->AfterRename(widget->text());
-                });
+            QWidget* widget = QStyledItemDelegate::createEditor(parent, option, index);
+            if (auto* lineEdit = qobject_cast<QLineEdit*>(widget))
+            {
+                connect(lineEdit,&QLineEdit::editingFinished, this, [&, lineEdit]()
+                    {
+                        Q_EMIT RenameEntry(lineEdit->text());
+                    });
+            }
             return widget;
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.cpp
@@ -62,9 +62,14 @@ namespace AzToolsFramework
             QWidget* widget = QStyledItemDelegate::createEditor(parent, option, index);
             if (auto* lineEdit = qobject_cast<QLineEdit*>(widget))
             {
-                connect(lineEdit,&QLineEdit::editingFinished, this, [&, lineEdit]()
+                connect(lineEdit, &QLineEdit::editingFinished,
+                    this, [this]()
                     {
-                        Q_EMIT RenameEntry(lineEdit->text());
+                        auto sendingLineEdit = qobject_cast<QLineEdit*>(sender());
+                        if (sendingLineEdit)
+                        {
+                            emit RenameEntry(sendingLineEdit->text());
+                        }
                     });
             }
             return widget;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.h
@@ -54,9 +54,6 @@ namespace AzToolsFramework
             //! Set whether to show source control icons, this is still temporary mainly to support existing functionality of material browser
             void SetShowSourceControlIcons(bool showSourceControl);
         
-        Q_SIGNALS:
-            void RenameEntry(const QString& value) const;
-
         signals:
             void RenameEntry(const QString& value) const;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.h
@@ -57,6 +57,9 @@ namespace AzToolsFramework
         Q_SIGNALS:
             void RenameEntry(const QString& value) const;
 
+        signals:
+            void RenameEntry(const QString& value) const;
+
         protected:
             int m_iconSize;
             bool m_showSourceControl = false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.h
@@ -53,10 +53,12 @@ namespace AzToolsFramework
             QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
             //! Set whether to show source control icons, this is still temporary mainly to support existing functionality of material browser
             void SetShowSourceControlIcons(bool showSourceControl);
+        
+        Q_SIGNALS:
+            void RenameEntry(const QString& value) const;
 
         protected:
             int m_iconSize;
-            AssetBrowserTreeView* m_treeView;
             bool m_showSourceControl = false;
             //! Draw a thumbnail and return its width
             int DrawThumbnail(QPainter* painter, const QPoint& point, const QSize& size, Thumbnailer::SharedThumbnailKey thumbnailKey) const;


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

tried to reproduce this crash but found trying to select an asset to edit in the asset browser would cause a crash: https://github.com/o3de/o3de/issues/12044. Don't think this is related to the linked ticket.

What i'm guessing is happening is AssetBrowserTreeView is deleted so m_assetBrowserSortFilterProxyModel goes out of scope and crashes when it tries to access the shared pointer when GetSelectedAssets is called. This changes the logic to using a signal and slot so this avoids having to share the raw pointer to the delegate. 

```
* thread #1, name = 'Editor', stop reason = signal SIGSEGV: invalid address (fault address: 0x95)
  * frame #0: 0x00007fffec1deecf libEditorLib.so`int QAtomicOps<int>::loadRelaxed<int>(std::atomic<int> const&) [inlined] std::__atomic_base<int>::load(this=0x0000000000000095, __m=memory_order_relaxed) const at atomic_base.h:481:9
    frame #1: 0x00007fffec1dee80 libEditorLib.so`int QAtomicOps<int>::loadRelaxed<int>(_q_value=0x0000000000000095) at qatomic_cxx11.h:239:25
    frame #2: 0x00007fffec1dedc2 libEditorLib.so`QBasicAtomicInteger<int>::loadRelaxed(this=0x0000000000000095) const at qbasicatomic.h:107:45
    frame #3: 0x00007fffec37e6ab libEditorLib.so`QWeakPointer<QObject>::internalData(this=0x0000555560952008) const at qsharedpointer_impl.h:698:45
    frame #4: 0x00007fffeea98372 libEditorLib.so`QPointer<AzToolsFramework::AssetBrowser::AssetBrowserFilterModel>::data(this=0x0000555560952008) const at qpointer.h:77:33
    frame #5: 0x00007fffeea8e7a2 libEditorLib.so`QPointer<AzToolsFramework::AssetBrowser::AssetBrowserFilterModel>::operator->(this=0x0000555560952008) const at qpointer.h:79:14
    frame #6: 0x00007fffeea7a4fd libEditorLib.so`AzToolsFramework::AssetBrowser::AssetBrowserTreeView::GetSelectedAssets(this=0x0000555560951f60, includeProducts=false) const at AssetBrowserTreeView.cpp:145:41
    frame #7: 0x00007fffeea7cbf2 libEditorLib.so`AzToolsFramework::AssetBrowser::AssetBrowserTreeView::AfterRename(this=0x0000555560951f60, newVal=<unavailable>) at AssetBrowserTreeView.cpp:672:28
    frame #8: 0x00007fffeea8da96 libEditorLib.so`AzToolsFramework::AssetBrowser::EntryDelegate::createEditor(this=0x0000555562ddaaa0) const::$_13::operator()() const at EntryDelegate.cpp:65:29
    frame #9: 0x00007fffeea8da16 libEditorLib.so`QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, AzToolsFramework::AssetBrowser::EntryDelegate::createEditor(QWidget*, QStyleOptionViewItem const&, QModelIndex const&) const::$_13>::call(f=0x0000555562ddaaa0, arg=0x00007fffffffb430) const::$_13&, void**) at qobjectdefs_impl.h:146:13
    frame #10: 0x00007fffeea8d9ce libEditorLib.so`void QtPrivate::Functor<AzToolsFramework::AssetBrowser::EntryDelegate::createEditor(QWidget*, QStyleOptionViewItem const&, QModelIndex const&) const::$_13, 0>::call<QtPrivate::List<>, void>(f=0x0000555562ddaaa0, (null)=0x0000555560f43d80, arg=0x00007fffffffb430) const::$_13&, void*, void**) at qobjectdefs_impl.h:256:13
    frame #11: 0x00007fffeea8d91e libEditorLib.so`QtPrivate::QFunctorSlotObject<AzToolsFramework::AssetBrowser::EntryDelegate::createEditor(QWidget*, QStyleOptionViewItem const&, QModelIndex const&) const::$_13, 0, QtPrivate::List<>, void>::impl(which=1, this_=0x0000555562ddaa90, r=0x0000555560f43d80, a=0x00007fffffffb430, ret=0x0000000000000000) at qobjectdefs_impl.h:443:17
    frame #12: 0x00007ffff7c82b1e libQt5Core.so.5`void doActivate<false>(QObject*, int, void**) [inlined] QtPrivate::QSlotObjectBase::call(a=<unavailable>, r=<unavailable>, this=<unavailable>) at qobjectdefs_impl.h:398:57
    frame #13: 0x00007ffff7c82b0c libQt5Core.so.5`void doActivate<false>(sender=0x0000555562fb7070, signal_index=11, argv=0x00007fffffffb430) at qobject.cpp:3886:21
    frame #14: 0x00007ffff7c7bee7 libQt5Core.so.5`QMetaObject::activate(sender=<unavailable>, m=<unavailable>, local_signal_index=<unavailable>, argv=<unavailable>) at qobject.cpp:3946:26 [artificial]
    frame #15: 0x00007fffe03395e7 libQt5Widgets.so.5`QLineEdit::editingFinished(this=<unavailable>) at moc_qlineedit.cpp:473:26 [artificial]
    frame #16: 0x00007fffe03403c9 libQt5Widgets.so.5`QLineEdit::focusOutEvent(this=0x0000555562fb7070, e=<unavailable>) at qlineedit.cpp:1957:37
    frame #17: 0x00007fffe023174d libQt5Widgets.so.5`QWidget::event(this=0x0000555562fb7070, event=0x00007fffffffb850) at qwidget.cpp:8801:22
    frame #18: 0x00007fffe033f7e2 libQt5Widgets.so.5`QLineEdit::event(this=0x0000555562fb7070, e=0x00007fffffffb850) at qlineedit.cpp:1531:26
    frame #19: 0x00007fffe01ede03 libQt5Widgets.so.5`QApplicationPrivate::notify_helper(this=<unavailable>, receiver=0x0000555562fb7070, e=0x00007fffffffb850) at qapplication.cpp:3630:31
    frame #20: 0x00007fffe01f6c58 libQt5Widgets.so.5`QApplication::notify(this=0x0000000000000000, receiver=0x0000555562fb7070, e=0x00007fffffffb850) at qapplication.cpp:3154:39

```


## How was this PR tested?

- search in asset browser and attempt to right click open co0ntext
- search field should trigger a segmentation fault. 
