### PR TITLE
Add BufferedSystemFileStream files to azcore_files.cmake

### DIFF
--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -143,6 +143,8 @@ set(FILES
     EBus/Internal/Handlers.h
     EBus/Internal/StoragePolicies.h
     Interface/Interface.h
+    IO/BufferedSystemFileStream.h
+    IO/BufferedSystemFileStream.cpp
     IO/ByteContainerStream.h
     IO/CompressionBus.h
     IO/CompressionBus.cpp


### PR DESCRIPTION
## What does this PR do?

Adds the `BufferedSystemFileStream` files added in https://github.com/o3de/o3de/pull/12252 to the cmake project for AzCore

## How was this PR tested?

After making this change and building the `ZERO_CHECK` CMake target, project reloaded with these files visible
![image](https://user-images.githubusercontent.com/34254888/198102269-0340fdc3-a234-4d68-9788-eb6b86e6e73a.png)

