### PR TITLE
bugfix(Whitebox, AZToolsFramework): correctly generate unique ids for new Cluster, Switcher, TextField

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.cpp
@@ -331,7 +331,7 @@ namespace AzToolsFramework::ViewportUi
 
     ClusterId ViewportUiManager::RegisterNewCluster(AZStd::shared_ptr<Internal::ButtonGroup>& buttonGroup)
     {
-        ClusterId newId = ClusterId(++m_currentId);
+        ClusterId newId = ClusterId(++m_nextViewportUiElementId);
         m_clusterButtonGroups.insert({ newId, buttonGroup });
 
         return newId;
@@ -339,7 +339,7 @@ namespace AzToolsFramework::ViewportUi
 
     SwitcherId ViewportUiManager::RegisterNewSwitcher(AZStd::shared_ptr<Internal::ButtonGroup>& buttonGroup)
     {
-        SwitcherId newId = SwitcherId(++m_currentId);
+        SwitcherId newId = SwitcherId(++m_nextViewportUiElementId);
         m_switcherButtonGroups.insert({ newId, buttonGroup });
 
         return newId;
@@ -347,7 +347,7 @@ namespace AzToolsFramework::ViewportUi
 
     TextFieldId ViewportUiManager::RegisterNewTextField(AZStd::shared_ptr<Internal::TextField>& textField)
     {
-        TextFieldId newId = TextFieldId(++m_currentId);
+        TextFieldId newId = TextFieldId(++m_nextViewportUiElementId);
         textField->m_textFieldId = newId;
         m_textFields.insert({ newId, textField });
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/Math/Sfmt.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzToolsFramework/ViewportUi/Button.h>
 #include <AzToolsFramework/ViewportUi/ButtonGroup.h>
@@ -331,7 +332,7 @@ namespace AzToolsFramework::ViewportUi
 
     ClusterId ViewportUiManager::RegisterNewCluster(AZStd::shared_ptr<Internal::ButtonGroup>& buttonGroup)
     {
-        ClusterId newId = ClusterId(m_clusterButtonGroups.size() + 1);
+        ClusterId newId = ClusterId(AZ::Sfmt::GetInstance().Rand64());
         m_clusterButtonGroups.insert({ newId, buttonGroup });
 
         return newId;
@@ -339,7 +340,7 @@ namespace AzToolsFramework::ViewportUi
 
     SwitcherId ViewportUiManager::RegisterNewSwitcher(AZStd::shared_ptr<Internal::ButtonGroup>& buttonGroup)
     {
-        SwitcherId newId = SwitcherId(m_switcherButtonGroups.size() + 1);
+        SwitcherId newId = SwitcherId(AZ::Sfmt::GetInstance().Rand64());
         m_switcherButtonGroups.insert({ newId, buttonGroup });
 
         return newId;
@@ -347,7 +348,7 @@ namespace AzToolsFramework::ViewportUi
 
     TextFieldId ViewportUiManager::RegisterNewTextField(AZStd::shared_ptr<Internal::TextField>& textField)
     {
-        TextFieldId newId = TextFieldId(m_textFields.size() + 1);
+        TextFieldId newId = TextFieldId(AZ::Sfmt::GetInstance().Rand64());
         textField->m_textFieldId = newId;
         m_textFields.insert({ newId, textField });
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.cpp
@@ -6,7 +6,6 @@
  *
  */
 
-#include <AzCore/Math/Sfmt.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzToolsFramework/ViewportUi/Button.h>
 #include <AzToolsFramework/ViewportUi/ButtonGroup.h>
@@ -332,7 +331,7 @@ namespace AzToolsFramework::ViewportUi
 
     ClusterId ViewportUiManager::RegisterNewCluster(AZStd::shared_ptr<Internal::ButtonGroup>& buttonGroup)
     {
-        ClusterId newId = ClusterId(AZ::Sfmt::GetInstance().Rand64());
+        ClusterId newId = ClusterId(++m_currentId);
         m_clusterButtonGroups.insert({ newId, buttonGroup });
 
         return newId;
@@ -340,7 +339,7 @@ namespace AzToolsFramework::ViewportUi
 
     SwitcherId ViewportUiManager::RegisterNewSwitcher(AZStd::shared_ptr<Internal::ButtonGroup>& buttonGroup)
     {
-        SwitcherId newId = SwitcherId(AZ::Sfmt::GetInstance().Rand64());
+        SwitcherId newId = SwitcherId(++m_currentId);
         m_switcherButtonGroups.insert({ newId, buttonGroup });
 
         return newId;
@@ -348,7 +347,7 @@ namespace AzToolsFramework::ViewportUi
 
     TextFieldId ViewportUiManager::RegisterNewTextField(AZStd::shared_ptr<Internal::TextField>& textField)
     {
-        TextFieldId newId = TextFieldId(AZ::Sfmt::GetInstance().Rand64());
+        TextFieldId newId = TextFieldId(++m_currentId);
         textField->m_textFieldId = newId;
         m_textFields.insert({ newId, textField });
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.h
@@ -93,6 +93,6 @@ namespace AzToolsFramework::ViewportUi
         //! Update the corresponding ui element for the given text field.
         void UpdateTextFieldUi(Internal::TextField* textField);
 
-        AZ::u64 m_currentId = 0;
+        AZ::u64 m_nextViewportUiElementId = 0;
     };
 } // namespace AzToolsFramework::ViewportUi

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/base.h>
 #include <AzToolsFramework/ViewportUi/Button.h>
 #include <AzToolsFramework/ViewportUi/TextField.h>
 #include <AzToolsFramework/ViewportUi/ViewportUiDisplay.h>
@@ -91,5 +92,7 @@ namespace AzToolsFramework::ViewportUi
         void UpdateSwitcherButtonGroupUi(Internal::ButtonGroup* buttonGroup);
         //! Update the corresponding ui element for the given text field.
         void UpdateTextFieldUi(Internal::TextField* textField);
+
+        AZ::u64 m_currentId = 0;
     };
 } // namespace AzToolsFramework::ViewportUi


### PR DESCRIPTION
ref: https://github.com/o3de/o3de/issues/12813

Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

Looks like the ID's when you register a cluster are not unique so the overlapping id's will delete the wrong cluster when the transform mode icon is selected multiple times

Create Cluster --> 1 [1]
Create Cluster --> 2 [1,2]
Delete Cluster --> 1 [2]
Create Cluster --> 2 [2,2]

## How was this PR tested?

repeat steps in the linked ticket: https://github.com/o3de/o3de/issues/12813