### PR TITLE
Asset Processor - Process activity panel

### DIFF
--- a/Code/Tools/AssetProcessor/assetprocessor_gui_files.cmake
+++ b/Code/Tools/AssetProcessor/assetprocessor_gui_files.cmake
@@ -70,6 +70,8 @@ set(FILES
     native/ui/SourceAssetTreeModel.cpp
     native/ui/SourceAssetTreeFilterModel.h
     native/ui/SourceAssetTreeFilterModel.cpp
+    native/ui/ProcessesModel.h
+    native/ui/ProcessesModel.cpp
     native/utilities/GUIApplicationServer.cpp
     native/utilities/GUIApplicationServer.h
     native/utilities/GUIApplicationManager.cpp

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
@@ -685,6 +685,18 @@ void MainWindow::SetupProcessesTab()
         ui->processUtilization->setText(QStringLiteral("Utilization: %1% (%2/%3)").arg(utilization, 0, 'f', 0).arg(busyCount).arg(builderCount));
         ui->utilizationBar->setValue(int(utilization));
     });
+
+    QObject::connect(ui->processesGrid, &QRadioButton::toggled, [this](bool)
+    {
+        ui->processList->setViewMode(QListView::IconMode);
+        m_processesModel->ShowFilename(false);
+    });
+
+    QObject::connect(ui->processesDetails, &QRadioButton::toggled, [this](bool)
+    {
+        ui->processList->setViewMode(QListView::ListMode);
+        m_processesModel->ShowFilename(true);
+    });
 }
 
 void MainWindow::SetupAssetServerTab()

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.h
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.h
@@ -20,6 +20,7 @@
 #include <native/utilities/AssetUtilEBusHelper.h>
 #include <native/utilities/PlatformConfiguration.h>
 #include <native/ui/CacheServerData.h>
+#include <native/ui/ProcessesModel.h>
 #endif
 
 namespace AzToolsFramework
@@ -40,6 +41,7 @@ class QSettings;
 
 namespace AssetProcessor
 {
+    class Builder;
     class AssetTreeFilterModel;
     class JobSortFilterProxyModel;
     class JobsModel;
@@ -78,7 +80,9 @@ public:
         Logs,
         Connections,
         Builders,
-        Tools
+        Processes,
+        Tools,
+        SharedCache,
     };
 
     struct Config
@@ -171,6 +175,8 @@ private:
     AssetProcessor::BuilderInfoMetricsSortModel* m_builderInfoMetricsSort = nullptr;
     AssetProcessor::CacheServerData m_cacheServerData;
 
+    AssetProcessor::ProcessesModel* m_processesModel = nullptr;
+
     void SetContextLogDetails(const QMap<QString, QString>& details);
     void ClearContextLogDetails();
 
@@ -234,6 +240,7 @@ private:
     /// Fires off one final refresh before invalidating the filter refresh timer.
     void ShutdownAssetTabFilterRefresh();
 
+    void SetupProcessesTab();
     void SetupAssetServerTab();
     void AddPatternRow(AZStd::string_view name, AssetBuilderSDK::AssetBuilderPattern::PatternType type, AZStd::string_view pattern, bool enable);
     void AssembleAssetPatterns();

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
@@ -1467,8 +1467,103 @@
           </item>
          </layout>
         </widget>
+        <widget class="QWidget" name="ProcessesPage">
+         <layout class="QVBoxLayout" name="verticalLayout_8">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="processUtilization">
+            <property name="text">
+             <string>Utilization: 0% (0/0)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item alignment="Qt::AlignTop">
+             <widget class="QProgressBar" name="utilizationBar">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>210</height>
+               </size>
+              </property>
+              <property name="value">
+               <number>24</number>
+              </property>
+              <property name="textVisible">
+               <bool>false</bool>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QListView" name="processList">
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
+              </property>
+              <property name="editTriggers">
+               <set>QAbstractItemView::NoEditTriggers</set>
+              </property>
+              <property name="showDropIndicator" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="selectionMode">
+               <enum>QAbstractItemView::NoSelection</enum>
+              </property>
+              <property name="resizeMode">
+               <enum>QListView::Adjust</enum>
+              </property>
+              <property name="viewMode">
+               <enum>QListView::IconMode</enum>
+              </property>
+              <property name="selectionRectVisible">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
         <widget class="QWidget" name="ToolsPage">
          <layout class="QVBoxLayout" name="verticalLayout_3">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
           <item>
            <widget class="QCheckBox" name="modtimeSkippingCheckBox">
             <property name="styleSheet">

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
@@ -335,7 +335,7 @@
       <item>
        <widget class="QStackedWidget" name="dialogStack">
         <property name="currentIndex">
-         <number>0</number>
+         <number>5</number>
         </property>
         <widget class="QSplitter" name="jobDialogSplitter">
          <property name="orientation">
@@ -1485,11 +1485,75 @@
            <number>0</number>
           </property>
           <item>
-           <widget class="QLabel" name="processUtilization">
+           <widget class="QLabel" name="processesPageLabel">
+            <property name="font">
+             <font>
+              <pointsize>11</pointsize>
+             </font>
+            </property>
             <property name="text">
-             <string>Utilization: 0% (0/0)</string>
+             <string>Process Activity</string>
             </property>
            </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="processDisplayGroup">
+            <property name="title">
+             <string/>
+            </property>
+            <property name="flat">
+             <bool>false</bool>
+            </property>
+            <layout class="QHBoxLayout" name="horizontalLayout_4">
+             <item>
+              <widget class="QRadioButton" name="processesGrid">
+               <property name="text">
+                <string>Grid</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroup</string>
+               </attribute>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="processesDetails">
+               <property name="text">
+                <string>Details</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroup</string>
+               </attribute>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_4">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QLabel" name="processUtilization">
+              <property name="text">
+               <string>Utilization: 0% (0/0)</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout">
@@ -2107,4 +2171,7 @@
   <include location="style/AssetProcessor.qrc"/>
  </resources>
  <connections/>
+ <buttongroups>
+  <buttongroup name="buttonGroup"/>
+ </buttongroups>
 </ui>

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
@@ -335,7 +335,7 @@
       <item>
        <widget class="QStackedWidget" name="dialogStack">
         <property name="currentIndex">
-         <number>5</number>
+         <number>0</number>
         </property>
         <widget class="QSplitter" name="jobDialogSplitter">
          <property name="orientation">

--- a/Code/Tools/AssetProcessor/native/ui/ProcessesModel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/ProcessesModel.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <ui/ProcessesModel.h>
+#include <QColor>
+
+namespace AssetProcessor
+{
+    ProcessesModel::ProcessesModel()
+    {
+        connect(
+            &m_debounceTimer,
+            &QTimer::timeout,
+            [this]()
+            {
+                m_debounceTimer.stop();
+
+                decltype(m_pendingUpdates) swapped;
+                swapped.swap(m_pendingUpdates);
+
+                for (const auto& [id, update] : swapped)
+                {
+                    const auto& [uuid, process, connection, busy] = update;
+
+                    if (!uuid.IsNull())
+                    {
+                        DoUpdate(uuid, process, connection, busy);
+                    }
+                }
+            });
+    }
+
+    void ProcessesModel::OnBuilderAdded(AZ::Uuid uuid, AZStd::shared_ptr<const AssetProcessor::Builder> builder)
+    {
+        Q_EMIT beginInsertRows(QModelIndex(), m_builders.size(), m_builders.size());
+
+        m_builders.emplace_back(uuid, false, false, false);
+        connect(builder.get(), &AssetProcessor::Builder::StatusUpdate, this, &ProcessesModel::OnStatusUpdate, Qt::QueuedConnection);
+
+        Q_EMIT endInsertRows();
+    }
+
+    void ProcessesModel::OnBuilderRemoved(AZ::Uuid builderId)
+    {
+        auto itr = AZStd::find_if(
+            m_builders.begin(),
+            m_builders.end(),
+            [builderId](auto& obj)
+            {
+                return AZStd::get<0>(obj) == builderId;
+            });
+
+        if (itr != m_builders.end())
+        {
+            auto rowNumber = AZStd::distance(m_builders.begin(), itr);
+            Q_EMIT beginRemoveRows(QModelIndex(), rowNumber, rowNumber);
+            m_builders.erase(itr);
+            Q_EMIT endRemoveRows();
+        }
+    }
+
+    void ProcessesModel::DoUpdate(AZ::Uuid builderId, bool process, bool connection, bool busy)
+    {
+        auto itr = AZStd::find_if(
+            m_builders.begin(),
+            m_builders.end(),
+            [builderId](auto& obj)
+            {
+                return AZStd::get<0>(obj) == builderId;
+            });
+
+        if (itr != m_builders.end())
+        {
+            auto rowNumber = AZStd::distance(m_builders.begin(), itr);
+            auto& [builderUuid, builderProcess, builderConnection, builderBusy] = *itr;
+
+            builderProcess = process;
+            builderConnection = connection;
+            builderBusy = busy;
+
+            Q_EMIT dataChanged(index(rowNumber, 0), index(rowNumber, 0));
+        }
+
+        const int numberBusyBuilders = AZStd::count_if(
+            m_builders.begin(),
+            m_builders.end(),
+            [](auto& obj)
+            {
+                return AZStd::get<3>(obj);
+            });
+
+        Q_EMIT UtilizationUpdate(m_builders.size(), numberBusyBuilders);
+    }
+
+    void ProcessesModel::OnStatusUpdate(AZ::Uuid builderId, bool process, bool connection, bool busy)
+    {
+        if (m_debounceTimer.isActive())
+        {
+            m_pendingUpdates[builderId] = { builderId, process, connection, busy };
+            return;
+        }
+
+        DoUpdate(builderId, process, connection, busy);
+        m_debounceTimer.start(200);
+    }
+
+    int ProcessesModel::rowCount(const QModelIndex& index) const
+    {
+        return index.isValid() ? 0 : m_builders.size();
+    }
+
+    QVariant ProcessesModel::data(const QModelIndex& index, int role) const
+    {
+        if (!index.isValid())
+        {
+            return QVariant();
+        }
+
+        if (index.row() >= m_builders.size())
+        {
+            return QVariant();
+        }
+
+        auto& [uuid, process, connection, busy] = m_builders.at(index.row());
+
+        if (role == Qt::DisplayRole)
+        {
+            QString status = busy ? "Busy" : connection ? "Idle" : "Boot";
+            return QStringLiteral("#%1 %2").arg(index.row(), 2, 10, QLatin1Char('0')).arg(status);
+        }
+
+        if (role == Qt::BackgroundRole)
+        {
+            if (busy)
+            {
+                return QColor(255, 236, 31);
+            }
+            if (connection)
+            {
+                return QColor(139, 207, 29);
+            }
+
+            return QColor(255, 98, 62);
+        }
+
+        if (role == Qt::ForegroundRole)
+        {
+            return QColor(0, 0, 0);
+        }
+
+        return QVariant();
+    }
+} // namespace AssetProcessor

--- a/Code/Tools/AssetProcessor/native/ui/ProcessesModel.h
+++ b/Code/Tools/AssetProcessor/native/ui/ProcessesModel.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#if !defined(Q_MOC_RUN)
+#include <QObject>
+#include <QTimer>
+#include <QAbstractListModel>
+#include <AzCore/Math/Uuid.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/containers/unordered_map.h>
+#include <utilities/Builder.h>
+#endif
+
+namespace AssetProcessor
+{
+    class ProcessesModel : public QAbstractListModel
+    {
+        Q_OBJECT
+
+    public:
+        ProcessesModel();
+
+    public Q_SLOTS:
+        void OnBuilderAdded(AZ::Uuid builderId, AZStd::shared_ptr<const AssetProcessor::Builder> builder);
+        void OnBuilderRemoved(AZ::Uuid builderId);
+        void OnStatusUpdate(AZ::Uuid builderId, bool process, bool connection, bool busy);
+
+    Q_SIGNALS:
+        void UtilizationUpdate(int builderCount, int busyCount);
+
+    public:
+        int rowCount(const QModelIndex& parent) const override;
+        QVariant data(const QModelIndex& index, int role) const override;
+
+    private:
+        void DoUpdate(AZ::Uuid builderId, bool process, bool connection, bool busy);
+
+        using BuilderInfo = AZStd::tuple<AZ::Uuid, bool, bool, bool>;
+
+        AZStd::vector<BuilderInfo> m_builders;
+        QTimer m_debounceTimer;
+        AZStd::unordered_map<AZ::Uuid, BuilderInfo> m_pendingUpdates;
+    };
+} // namespace AssetProcessor

--- a/Code/Tools/AssetProcessor/native/ui/ProcessesModel.h
+++ b/Code/Tools/AssetProcessor/native/ui/ProcessesModel.h
@@ -30,7 +30,7 @@ namespace AssetProcessor
     public Q_SLOTS:
         void OnBuilderAdded(AZ::Uuid builderId, AZStd::shared_ptr<const AssetProcessor::Builder> builder);
         void OnBuilderRemoved(AZ::Uuid builderId);
-        void OnStatusUpdate(AZ::Uuid builderId, bool process, bool connection, bool busy);
+        void OnStatusUpdate(AZ::Uuid builderId, bool process, bool connection, bool busy, QString file);
 
     Q_SIGNALS:
         void UtilizationUpdate(int builderCount, int busyCount);
@@ -38,14 +38,16 @@ namespace AssetProcessor
     public:
         int rowCount(const QModelIndex& parent) const override;
         QVariant data(const QModelIndex& index, int role) const override;
+        void ShowFilename(bool show);
 
     private:
-        void DoUpdate(AZ::Uuid builderId, bool process, bool connection, bool busy);
+        void DoUpdate(AZ::Uuid builderId, bool process, bool connection, bool busy, QString file);
 
-        using BuilderInfo = AZStd::tuple<AZ::Uuid, bool, bool, bool>;
+        using BuilderInfo = AZStd::tuple<AZ::Uuid, bool, bool, bool, QString>;
 
         AZStd::vector<BuilderInfo> m_builders;
         QTimer m_debounceTimer;
         AZStd::unordered_map<AZ::Uuid, BuilderInfo> m_pendingUpdates;
+        bool m_showFilename = false;
     };
 } // namespace AssetProcessor

--- a/Code/Tools/AssetProcessor/native/ui/style/AssetProcessor.qss
+++ b/Code/Tools/AssetProcessor/native/ui/style/AssetProcessor.qss
@@ -212,3 +212,23 @@ QWidget#SharedCachePage {
     background-color: rgba(34, 34, 34, 0.5);
     border: none;
 }
+
+QListView#processList {
+    font-family: "Courier New", Courier, monospace;
+    font-weight: bold;
+    font-size: 14px;
+}
+
+QListView#processList::item {
+    outline: 0 !important;
+    min-height: 32px;
+    border: 1px solid grey;
+    padding: 4px;
+    border-radius: 0;
+}
+
+QListView#processList::item:hover,
+QListView#processList::item:disabled:hover,
+QListView#processList::item:hover:!active {
+    background: transparent;
+}

--- a/Code/Tools/AssetProcessor/native/ui/style/AssetProcessor.qss
+++ b/Code/Tools/AssetProcessor/native/ui/style/AssetProcessor.qss
@@ -226,6 +226,7 @@ QListView#processList {
 QListView#processList::item {
     border: 1px solid grey;
     border-radius: 0;
+    padding: 0 4px
 }
 
 QListView#processList::item:hover,

--- a/Code/Tools/AssetProcessor/native/ui/style/AssetProcessor.qss
+++ b/Code/Tools/AssetProcessor/native/ui/style/AssetProcessor.qss
@@ -213,6 +213,10 @@ QWidget#SharedCachePage {
     border: none;
 }
 
+QLabel#processesPageLabel {
+    font-size: 12pt;
+}
+
 QListView#processList {
     font-family: "Courier New", Courier, monospace;
     font-weight: bold;
@@ -220,10 +224,7 @@ QListView#processList {
 }
 
 QListView#processList::item {
-    outline: 0 !important;
-    min-height: 32px;
     border: 1px solid grey;
-    padding: 4px;
     border-radius: 0;
 }
 
@@ -231,4 +232,9 @@ QListView#processList::item:hover,
 QListView#processList::item:disabled:hover,
 QListView#processList::item:hover:!active {
     background: transparent;
+}
+
+#processDisplayGroup
+{
+    border: none;
 }

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -873,8 +873,10 @@ ApplicationManager::BeforeRunStatus ApplicationManagerBase::BeforeRun()
     qRegisterMetaType<AssetProcessor::AssetCatalogStatus>("AssetCatalogStatus");
     qRegisterMetaType<AssetProcessor::AssetCatalogStatus>("AssetProcessor::AssetCatalogStatus");
 
-    qRegisterMetaType<QSet<QString> >("QSet<QString>");
+    qRegisterMetaType<QSet<QString>>("QSet<QString>");
     qRegisterMetaType<QSet<AssetProcessor::AssetFileInfo>>("QSet<AssetFileInfo>");
+
+    qRegisterMetaType<AZStd::shared_ptr<const AssetProcessor::Builder>>("AZStd::shared_ptr<const AssetProcessor::Builder>");
 
     AssetBuilderSDK::AssetBuilderBus::Handler::BusConnect();
     AssetProcessor::AssetBuilderRegistrationBus::Handler::BusConnect();
@@ -1596,7 +1598,7 @@ static void HandleConditionalRetry(const AssetProcessor::BuilderRunJobOutcome& r
             builderRef.release();
 
             AssetProcessor::BuilderManagerBus::BroadcastResult(builderRef, &AssetProcessor::BuilderManagerBusTraits::GetBuilder, purpose);
-            
+
             if (builderRef)
             {
                 AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Lost connection to builder %s. Retrying with a new builder %s (Attempt %d with %d second delay)",
@@ -1724,7 +1726,7 @@ void ApplicationManagerBase::RegisterBuilderInformation(const AssetBuilderSDK::A
                     {
                         return; // exit early if you're shutting down!
                     }
-                    
+
                     retryCount++;
                     result = builderRef->RunJob<AssetBuilder::ProcessJobNetRequest, AssetBuilder::ProcessJobNetResponse>(
                         request, response, s_MaximumProcessJobsTimeSeconds, "process", "", &jobCancelListener, request.m_tempDirPath);

--- a/Code/Tools/AssetProcessor/native/utilities/Builder.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/Builder.cpp
@@ -64,6 +64,7 @@ namespace AssetProcessor
 
             if (result)
             {
+                SendStatusUpdate();
                 return AZ::Success();
             }
 
@@ -109,6 +110,11 @@ namespace AssetProcessor
         return m_uuid.ToString<AZStd::string>(false, false);
     }
 
+    void Builder::SendStatusUpdate() const
+    {
+        Q_EMIT StatusUpdate(m_uuid, IsRunning(), IsConnected(), m_busy);
+    }
+
     void Builder::PumpCommunicator() const
     {
         if (m_tracePrinter)
@@ -137,6 +143,8 @@ namespace AssetProcessor
 
     AZ::Outcome<void, AZStd::string> Builder::Start(BuilderPurpose purpose)
     {
+        SendStatusUpdate();
+
         // Get the current BinXXX folder based on the current running AP
         QString applicationDir = QCoreApplication::instance()->applicationDirPath();
 
@@ -156,6 +164,8 @@ namespace AssetProcessor
         const AZStd::vector<AZStd::string> params = BuildParams("resident", buildersFolder.c_str(), UuidString(), "", "", purpose);
 
         m_processWatcher = LaunchProcess(fullExePathString.c_str(), params);
+
+        SendStatusUpdate();
 
         if (!m_processWatcher)
         {
@@ -367,6 +377,7 @@ namespace AssetProcessor
             AZ_Warning("BuilderRef", m_builder->m_busy, "Builder reference is valid but is already set to not busy");
 
             m_builder->m_busy = false;
+            m_builder->SendStatusUpdate();
             m_builder = nullptr;
         }
     }

--- a/Code/Tools/AssetProcessor/native/utilities/Builder.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/Builder.cpp
@@ -110,9 +110,9 @@ namespace AssetProcessor
         return m_uuid.ToString<AZStd::string>(false, false);
     }
 
-    void Builder::SendStatusUpdate() const
+    void Builder::SendStatusUpdate(QString file) const
     {
-        Q_EMIT StatusUpdate(m_uuid, IsRunning(), IsConnected(), m_busy);
+        Q_EMIT StatusUpdate(m_uuid, IsRunning(), IsConnected(), !file.isEmpty(), file);
     }
 
     void Builder::PumpCommunicator() const

--- a/Code/Tools/AssetProcessor/native/utilities/Builder.h
+++ b/Code/Tools/AssetProcessor/native/utilities/Builder.h
@@ -81,10 +81,10 @@ namespace AssetProcessor
             AssetBuilderSDK::JobCancelListener* jobCancelListener = nullptr,
             AZStd::string tempFolderPath = AZStd::string()) const;
 
-        void SendStatusUpdate() const;
+        void SendStatusUpdate(QString file = "") const;
 
     Q_SIGNALS:
-        void StatusUpdate(AZ::Uuid builderId, bool processRunning, bool connected, bool busy) const;
+        void StatusUpdate(AZ::Uuid builderId, bool processRunning, bool connected, bool busy, QString file) const;
 
     protected:
         //! Blocks waiting for the builder to establish a connection

--- a/Code/Tools/AssetProcessor/native/utilities/Builder.h
+++ b/Code/Tools/AssetProcessor/native/utilities/Builder.h
@@ -13,6 +13,7 @@
 #include <utilities/assetUtils.h>
 #include <AzFramework/Process/ProcessWatcher.h>
 #include <AzFramework/Process/ProcessCommunicatorTracePrinter.h>
+#include <QObject>
 #endif
 
 namespace AssetProcessor

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderList.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderList.cpp
@@ -22,12 +22,14 @@ namespace AssetProcessor
                 return;
             }
 
-            m_createJobsBuilder = AZStd::move(builder);
+            m_createJobsBuilder = builder;
         }
         else
         {
             m_builders.emplace(builder->GetUuid(), builder);
         }
+
+        Q_EMIT BuilderAdded(builder->GetUuid(), builder);
     }
 
     AZStd::shared_ptr<Builder> BuilderList::Find(AZ::Uuid uuid)
@@ -85,6 +87,7 @@ namespace AssetProcessor
                     return BuilderRef(builder);
                 }
 
+                Q_EMIT BuilderRemoved(itr->first);
                 itr = m_builders.erase(itr);
             }
             else
@@ -123,6 +126,7 @@ namespace AssetProcessor
                 {
                     uuidString = builder->UuidString();
                     builder->m_connectionId = 0;
+                    Q_EMIT BuilderRemoved(itr->first);
                     m_builders.erase(itr);
 
                     return uuidString;
@@ -141,6 +145,7 @@ namespace AssetProcessor
         }
         else
         {
+            Q_EMIT BuilderRemoved(uuid);
             m_builders.erase(uuid);
         }
     }

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderList.h
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderList.h
@@ -7,15 +7,19 @@
  */
 #pragma once
 
+#if !defined(Q_MOC_RUN)
 #include <AzCore/std/string/string.h>
 #include <utilities/Builder.h>
+#include <QObject>
+#endif
 
 namespace AssetProcessor
 {
     //! Helper class that keeps track of the Builders and manages reserving a builder specifically for CreateJobs
     //! This class is not inherently thread-safe and must be locked before any access
-    class BuilderList
+    class BuilderList : public QObject
     {
+        Q_OBJECT
     public:
         BuilderList() = default;
 
@@ -27,6 +31,10 @@ namespace AssetProcessor
         void PumpIdleBuilders();
 
         AZ_DISABLE_COPY_MOVE(BuilderList);
+
+    Q_SIGNALS:
+        void BuilderAdded(AZ::Uuid builderId, AZStd::shared_ptr<const AssetProcessor::Builder> builder);
+        void BuilderRemoved(AZ::Uuid builderId);
 
     protected:
         AZStd::unordered_map<AZ::Uuid, AZStd::shared_ptr<Builder>> m_builders;

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
@@ -153,6 +153,12 @@ namespace AssetProcessor
         m_builderDebugOutput[builderId].m_assetsProcessed.push_back(sourceAsset);
     }
 
+    void BuilderManager::ConnectForStatusUpdate(QObject* object)
+    {
+        QObject::connect(&m_builderList, SIGNAL(BuilderAdded(AZ::Uuid, AZStd::shared_ptr<const AssetProcessor::Builder>)), object, SLOT(OnBuilderAdded(AZ::Uuid, AZStd::shared_ptr<const AssetProcessor::Builder>)), Qt::QueuedConnection);
+        QObject::connect(&m_builderList, SIGNAL(BuilderRemoved(AZ::Uuid)), object, SLOT(OnBuilderRemoved(AZ::Uuid)), Qt::QueuedConnection);
+    }
+
     BuilderRef BuilderManager::GetBuilder(BuilderPurpose purpose)
     {
         AZStd::shared_ptr<Builder> newBuilder;

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.h
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.h
@@ -45,6 +45,14 @@ namespace AssetProcessor
 
     using BuilderManagerBus = AZ::EBus<BuilderManagerBusTraits>;
 
+    struct IBuilderManagerStatus
+    {
+        AZ_RTTI(IBuilderManagerStatus, "{E2CEA738-52EF-44F1-8014-D8F6152DA69D}");
+
+        ~IBuilderManagerStatus() = default;
+        virtual void ConnectForStatusUpdate(QObject* object) = 0;
+    };
+
     class BuilderDebugOutput
     {
     public:
@@ -54,19 +62,23 @@ namespace AssetProcessor
     //! Manages the builder pool
     class BuilderManager
         : public BuilderManagerBus::Handler
+        , public AZ::Interface<IBuilderManagerStatus>::Registrar
     {
     public:
         explicit BuilderManager(ConnectionManager* connectionManager);
-        ~BuilderManager();
+        ~BuilderManager() override;
 
         // Disable copy
         AZ_DISABLE_COPY_MOVE(BuilderManager);
 
         void ConnectionLost(AZ::u32 connId);
 
-        //BuilderManagerBus
+        // BuilderManagerBus
         BuilderRef GetBuilder(BuilderPurpose purpose) override;
         void AddAssetToBuilderProcessedList(const AZ::Uuid& builderId, const AZStd::string& sourceAsset) override;
+
+        // IBuilderManagerStatus
+        void ConnectForStatusUpdate(QObject* object) override;
 
     protected:
 

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.inl
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.inl
@@ -26,12 +26,14 @@ namespace AssetProcessor
                 , m_sourceFile(sourceFile)
                 , m_task(task)
             {
+                m_builder.SendStatusUpdate();
                 AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Request started builder [%s] task (%s) %s \n",
                     m_builder.UuidString().c_str(), m_task.c_str(), m_sourceFile.c_str());
             }
 
             ~BuildTracker()
             {
+                m_builder.SendStatusUpdate();
                 AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Request stopped builder [%s] task (%s) %s \n",
                     m_builder.UuidString().c_str(), m_task.c_str(), m_sourceFile.c_str());
             }

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.inl
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.inl
@@ -26,14 +26,12 @@ namespace AssetProcessor
                 , m_sourceFile(sourceFile)
                 , m_task(task)
             {
-                m_builder.SendStatusUpdate();
                 AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Request started builder [%s] task (%s) %s \n",
                     m_builder.UuidString().c_str(), m_task.c_str(), m_sourceFile.c_str());
             }
 
             ~BuildTracker()
             {
-                m_builder.SendStatusUpdate();
                 AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Request stopped builder [%s] task (%s) %s \n",
                     m_builder.UuidString().c_str(), m_task.c_str(), m_sourceFile.c_str());
             }
@@ -47,6 +45,8 @@ namespace AssetProcessor
         [[maybe_unused]] AZ::u32 type;
         QByteArray data;
         AZStd::binary_semaphore wait;
+
+        SendStatusUpdate(request.m_sourceFile.c_str());
 
         unsigned int serial;
         AssetProcessor::ConnectionBus::EventResult(serial, m_connectionId, &AssetProcessor::ConnectionBusTraits::SendRequest, netRequest, [&](AZ::u32 msgType, QByteArray msgData)


### PR DESCRIPTION
## What does this PR do?

Added a process activity panel for AP which shows the number of running AssetBuilder.exe processes and their status (starting up, idle, busy).  Grid view mode just shows an abbreviated form of the status, detail view switches to a list view showing the currently processing file.

## How was this PR tested?

Manually

![image](https://user-images.githubusercontent.com/80125227/198152984-48a6d194-e8d5-42fc-8db6-00d57eb45c4c.png)
![image](https://user-images.githubusercontent.com/80125227/198153042-6b043f5e-5a98-444e-9d45-2a2ce3a7d6eb.png)
![CdNsj3AJvi](https://user-images.githubusercontent.com/80125227/198153378-9354eddf-4448-4e3b-8c0f-ded20f3cc884.gif)

