### PR TITLE
Fixed typo in `recursive` option in the Project Template asset processor settings

### DIFF
--- a/Templates/DefaultProject/Template/Registry/assetprocessor_settings.setreg
+++ b/Templates/DefaultProject/Template/Registry/assetprocessor_settings.setreg
@@ -9,7 +9,7 @@
                 },
                 "ScanFolder Project/Shaders": {
                     "watch": "@PROJECTROOT@/Shaders",
-                    "recurisve": 1,
+                    "recursive": 1,
                     "order": 2
                 },
                 "ScanFolder Project/Registry": {

--- a/Templates/MinimalProject/Template/Registry/assetprocessor_settings.setreg
+++ b/Templates/MinimalProject/Template/Registry/assetprocessor_settings.setreg
@@ -9,7 +9,7 @@
                 },
                 "ScanFolder Project/Shaders": {
                     "watch": "@PROJECTROOT@/Shaders",
-                    "recurisve": 1,
+                    "recursive": 1,
                     "order": 2
                 },
                 "ScanFolder Project/Registry": {


### PR DESCRIPTION
The @PROJECTROOT@/Shaders folder wasn't added as a recursive scan folder due to the typo.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>