### PR TITLE
bugfix(Whitebox): add disable state for button cluster

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ButtonGroup.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ButtonGroup.cpp
@@ -58,7 +58,6 @@ namespace AzToolsFramework::ViewportUi::Internal
             {
                 return;
             }
-
             ClearHighlightedButton();
             buttonEntry->second->m_state = Button::State::Selected;
             m_highlightedButtonId = buttonId;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ButtonGroup.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ButtonGroup.cpp
@@ -58,6 +58,7 @@ namespace AzToolsFramework::ViewportUi::Internal
             {
                 return;
             }
+
             ClearHighlightedButton();
             buttonEntry->second->m_state = Button::State::Selected;
             m_highlightedButtonId = buttonId;

--- a/Gems/WhiteBox/Code/Source/SubComponentModes/EditorWhiteBoxTransformMode.cpp
+++ b/Gems/WhiteBox/Code/Source/SubComponentModes/EditorWhiteBoxTransformMode.cpp
@@ -54,7 +54,6 @@ namespace WhiteBox
     static void SetViewportUiClusterDisableButton(
         AzToolsFramework::ViewportUi::ClusterId clusterId, AzToolsFramework::ViewportUi::ButtonId buttonId, bool isDisabled)
     {
-        
         AzToolsFramework::ViewportUi::ViewportUiRequestBus::Event(
             AzToolsFramework::ViewportUi::DefaultViewportId,
             &AzToolsFramework::ViewportUi::ViewportUiRequestBus::Events::SetClusterDisableButton,

--- a/Gems/WhiteBox/Code/Source/SubComponentModes/EditorWhiteBoxTransformMode.cpp
+++ b/Gems/WhiteBox/Code/Source/SubComponentModes/EditorWhiteBoxTransformMode.cpp
@@ -51,6 +51,18 @@ namespace WhiteBox
             buttonId);
     }
 
+    static void SetViewportUiClusterDisableButton(
+        AzToolsFramework::ViewportUi::ClusterId clusterId, AzToolsFramework::ViewportUi::ButtonId buttonId, bool isDisabled)
+    {
+        
+        AzToolsFramework::ViewportUi::ViewportUiRequestBus::Event(
+            AzToolsFramework::ViewportUi::DefaultViewportId,
+            &AzToolsFramework::ViewportUi::ViewportUiRequestBus::Events::SetClusterDisableButton,
+            clusterId,
+            buttonId,
+            isDisabled);
+    }
+
     TransformMode::TransformMode(const AZ::EntityComponentIdPair& entityComponentIdPair)
         : m_entityComponentIdPair(entityComponentIdPair)
     {
@@ -352,8 +364,21 @@ namespace WhiteBox
 
     void TransformMode::RefreshManipulator()
     {
+        TransformType activeTransformType = m_transformType;
+        if (m_whiteBoxSelection && AZStd::get_if<VertexIntersection>(&m_whiteBoxSelection->m_selection))
+        {
+            SetViewportUiClusterDisableButton(m_transformClusterId, m_transformRotateButtonId, true);
+            SetViewportUiClusterDisableButton(m_transformClusterId, m_transformScaleButtonId, true);
+            activeTransformType = TransformType::Translation;
+        }
+        else
+        {
+            SetViewportUiClusterDisableButton(m_transformClusterId, m_transformRotateButtonId, false);
+            SetViewportUiClusterDisableButton(m_transformClusterId, m_transformScaleButtonId, false);
+        }
+
         DestroyManipulators();
-        switch (m_transformType)
+        switch (activeTransformType)
         {
         case TransformType::Translation:
             CreateTranslationManipulators();
@@ -403,11 +428,11 @@ namespace WhiteBox
             return;
         }
 
-        AZ::Transform worldTranform = AZ::Transform::CreateIdentity();
-        AZ::TransformBus::EventResult(worldTranform, m_entityComponentIdPair.GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);
+        AZ::Transform worldTransform = AZ::Transform::CreateIdentity();
+        AZ::TransformBus::EventResult(worldTransform, m_entityComponentIdPair.GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);
         AZStd::shared_ptr<AzToolsFramework::TranslationManipulators> translationManipulators =
             AZStd::make_shared<AzToolsFramework::TranslationManipulators>(
-                AzToolsFramework::TranslationManipulators::Dimensions::Three, worldTranform, AZ::Vector3::CreateOne());
+                AzToolsFramework::TranslationManipulators::Dimensions::Three, worldTransform, AZ::Vector3::CreateOne());
 
         translationManipulators->SetLineBoundWidth(AzToolsFramework::ManipulatorLineBoundWidth());
         translationManipulators->AddEntityComponentIdPair(m_entityComponentIdPair);


### PR DESCRIPTION
ref: https://github.com/o3de/o3de/issues/12818

Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

This adds a disabled state when a single vertex is selected in whitebox. when a single vertex is selected I disable both the rotation and scale options and switch to translate mode. not sure if this is better since this will switch the mode for the user seems to be just as good to allow this.

for usability I use the user selection as the staged mode so when the user clicks to a face/edge I restore their selection. 

[Screencast from 2022-10-26 20-26-30.webm](https://user-images.githubusercontent.com/854359/198184363-132695a7-a9f5-441c-9d76-ed3acc651aeb.webm)


## How was this PR tested?

details described in: https://github.com/o3de/o3de/issues/12818