### PR TITLE
bugfix(Whitebox): fix uniform scale for manipulator mode

### DIFF
--- a/Gems/WhiteBox/Code/Source/SubComponentModes/EditorWhiteBoxTransformMode.cpp
+++ b/Gems/WhiteBox/Code/Source/SubComponentModes/EditorWhiteBoxTransformMode.cpp
@@ -608,8 +608,20 @@ namespace WhiteBox
             {
                 const AZ::Vector3 vertexLocalPosition =
                     (transformSelection->m_vertexPositions[vertexIndex++] - transformSelection->m_localPosition);
-                const AZ::Vector3 manipulatorScale = (AZ::Vector3::CreateOne() + (action.m_start.m_sign * 
-                    (scaleType == ScaleType::Uniform ? AZ::Vector3(action.LocalScaleOffset().GetZ()) : action.LocalScaleOffset()))); 
+                const AZ::Vector3 scale = [&action, &scaleType]
+                {
+                    switch (scaleType)
+                    {
+                    case ScaleType::Uniform:
+                        return AZ::Vector3(action.LocalScaleOffset().GetZ());
+                    case ScaleType::NonUniform:
+                        return action.LocalScaleOffset();
+                    default:
+                        break;
+                    }
+                    return AZ::Vector3();
+                }();
+                const AZ::Vector3 manipulatorScale = AZ::Vector3::CreateOne() + (action.m_start.m_sign * scale);
                 const AZ::Vector3 vertexPosition = (vertexLocalPosition * manipulatorScale) + transformSelection->m_localPosition;
                 Api::SetVertexPosition(*whiteBox, vertexHandle, vertexPosition);
             }


### PR DESCRIPTION
ref: https://github.com/o3de/o3de/issues/12816

Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

for uniform scale only the Z axis is set. This adds logic to handle scaling uniformly. 

## How was this PR tested?

follow steps here: https://github.com/o3de/o3de/issues/12816
