### PR TITLE
chore: remove unused variables to compile for clang-15

### DIFF
--- a/Code/Framework/AzCore/Tests/StatisticalProfilerTests.cpp
+++ b/Code/Framework/AzCore/Tests/StatisticalProfilerTests.cpp
@@ -19,11 +19,9 @@ namespace UnitTest
 
         TimedScopeType rootScope(profiler, rootId);
 
-        int counter = 0;
         for (int i = 0; i < loopCount; ++i)
         {
             TimedScopeType loopScope(profiler, loopId);
-            ++counter;
         }
     }
 
@@ -33,11 +31,9 @@ namespace UnitTest
     {
         AZ::Statistics::StatisticalProfilerProxy::TimedScope rootScope(ProfilerProxyGroup, rootId);
 
-        int counter = 0;
         for (int i = 0; i < loopCount; ++i)
         {
             AZ::Statistics::StatisticalProfilerProxy::TimedScope loopScope(ProfilerProxyGroup, loopId);
-            ++counter;
         }
     }
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Tests/ImageProcessing_Test.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Tests/ImageProcessing_Test.cpp
@@ -1028,11 +1028,9 @@ namespace UnitTest
         if (process != nullptr)
         {
             //the process can be stopped if the job is canceled or the worker is shutting down
-            int step = 0;
             while (!process->IsFinished())
             {
                 process->UpdateProcess();
-                step++;
             }
 
             //get process result

--- a/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.cpp
@@ -369,8 +369,6 @@ namespace Terrain
     AZ::Data::Asset<Physics::MaterialAsset> TerrainPhysicsColliderComponent::FindMaterialAssetForSurfaceTag(const SurfaceData::SurfaceTag tag) const
     {
         AZStd::shared_lock lock(m_stateMutex);
-        
-        uint8_t index = 0;
 
         for (auto& mapping : m_configuration.m_surfaceMaterialMappings)
         {
@@ -378,7 +376,6 @@ namespace Terrain
             {
                 return mapping.m_materialAsset;
             }
-            index++;
         }
 
         // If this surface isn't mapped, use the default material.


### PR DESCRIPTION
Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

There are some compiling errors with clang-15 in regards to unused variables on linux. I'm currently using ubuntu 22.10 with a newer version of clang. 

## How was this PR tested?

verified that this is able to compile in clang-15
