### PR TITLE
feat: add disable option for switcher and cluster

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/Button.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/Button.h
@@ -19,7 +19,8 @@ namespace AzToolsFramework::ViewportUi::Internal
         enum class State
         {
             Selected,
-            Deselected
+            Deselected,
+            Disabled
         };
 
         Button(AZStd::string icon, ButtonId buttonId);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ButtonGroup.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ButtonGroup.cpp
@@ -37,7 +37,7 @@ namespace AzToolsFramework::ViewportUi::Internal
             {
             case Button::State::Selected:
                 ClearHighlightedButton();
-            [[fallthrough]];
+                [[fallthrough]];
             default:
                 buttonEntry->second->m_state = disabled ? Button::State::Disabled : Button::State::Deselected;
                 break;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ButtonGroup.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ButtonGroup.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/std/algorithm.h>
 #include <AzToolsFramework/ViewportUi/Button.h>
 #include <AzToolsFramework/ViewportUi/ButtonGroup.h>
 #include <AzCore/std/ranges/ranges_algorithm.h>
@@ -28,6 +29,22 @@ namespace AzToolsFramework::ViewportUi::Internal
         return m_viewportUiId;
     }
 
+    void ButtonGroup::SetDisabledButton(ButtonId buttonId, bool disabled)
+    {
+        if (auto buttonEntry = m_buttons.find(buttonId); buttonEntry != m_buttons.end())
+        {
+            switch (buttonEntry->second->m_state)
+            {
+            case Button::State::Selected:
+                ClearHighlightedButton();
+            [[fallthrough]];
+            default:
+                buttonEntry->second->m_state = disabled ? Button::State::Disabled : Button::State::Deselected;
+                break;
+            }
+        }
+    }
+
     void ButtonGroup::SetHighlightedButton(ButtonId buttonId)
     {
         if (buttonId == m_highlightedButtonId) // the requested button is highlighted, so do nothing.
@@ -37,6 +54,11 @@ namespace AzToolsFramework::ViewportUi::Internal
 
         if (auto buttonEntry = m_buttons.find(buttonId); buttonEntry != m_buttons.end())
         {
+            if(buttonEntry->second->m_state == Button::State::Disabled)
+            {
+                return;
+            }
+
             ClearHighlightedButton();
             buttonEntry->second->m_state = Button::State::Selected;
             m_highlightedButtonId = buttonId;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ButtonGroup.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ButtonGroup.h
@@ -25,6 +25,7 @@ namespace AzToolsFramework::ViewportUi::Internal
         ~ButtonGroup() = default;
 
         void SetHighlightedButton(ButtonId buttonId);
+        void SetDisabledButton(ButtonId buttonId, bool disabled);
         void ClearHighlightedButton();
 
         void SetViewportUiElementId(ViewportUiElementId id);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiCluster.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiCluster.cpp
@@ -38,6 +38,7 @@ namespace AzToolsFramework::ViewportUi::Internal
             },
             [button](QAction* action)
             {
+                action->setDisabled(button->m_state == Button::State::Disabled);
                 action->setChecked(button->m_state == Button::State::Selected);
             });
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.cpp
@@ -50,6 +50,16 @@ namespace AzToolsFramework::ViewportUi
         }
     }
 
+    void ViewportUiManager::SetClusterDisableButton(ClusterId clusterId, ButtonId buttonId, bool disabled)
+    {
+        if (auto clusterIt = m_clusterButtonGroups.find(clusterId); clusterIt != m_clusterButtonGroups.end())
+        {
+            auto& cluster = clusterIt->second;
+            cluster->SetDisabledButton(buttonId, disabled);
+            UpdateButtonGroupUi(cluster.get());
+        }
+    }
+
     void ViewportUiManager::ClearClusterActiveButton(ClusterId clusterId)
     {
         if (auto clusterIt = m_clusterButtonGroups.find(clusterId); clusterIt != m_clusterButtonGroups.end())
@@ -67,6 +77,16 @@ namespace AzToolsFramework::ViewportUi
             auto switcher = switcherIt->second;
             switcher->SetHighlightedButton(buttonId);
             m_viewportUi->SetSwitcherActiveButton(switcher->GetViewportUiElementId(), buttonId);
+            UpdateSwitcherButtonGroupUi(switcher.get());
+        }
+    }
+
+    void ViewportUiManager::SetSwitcherDisableButton(SwitcherId switcherId, ButtonId buttonId, bool disabled)
+    {
+        if (auto switcherIt = m_switcherButtonGroups.find(switcherId); switcherIt != m_switcherButtonGroups.end())
+        {
+            auto switcher = switcherIt->second;
+            switcher->SetDisabledButton(buttonId, disabled);
             UpdateSwitcherButtonGroupUi(switcher.get());
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiManager.h
@@ -30,8 +30,10 @@ namespace AzToolsFramework::ViewportUi
         const ClusterId CreateCluster(Alignment align) override;
         const SwitcherId CreateSwitcher(Alignment align) override;
         void SetClusterActiveButton(ClusterId clusterId, ButtonId buttonId) override;
+        void SetClusterDisableButton(ClusterId clusterId, ButtonId buttonId, bool disabled) override;
         void ClearClusterActiveButton(ClusterId clusterId) override;
         void SetSwitcherActiveButton(SwitcherId switcherId, ButtonId buttonId) override;
+        void SetSwitcherDisableButton(SwitcherId switcherId, ButtonId buttonId, bool disabled) override;
         void SetClusterButtonLocked(ClusterId clusterId, ButtonId buttonId, bool isLocked) override;
         void SetClusterButtonTooltip(ClusterId clusterId, ButtonId buttonId, const AZStd::string& tooltip) override;
         void SetSwitcherButtonTooltip(SwitcherId switcherId, ButtonId buttonId, const AZStd::string& tooltip) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiRequestBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiRequestBus.h
@@ -62,10 +62,14 @@ namespace AzToolsFramework::ViewportUi
         virtual const SwitcherId CreateSwitcher(Alignment align) = 0;
         //! Sets the active button of the cluster. This is the button which will display as highlighted.
         virtual void SetClusterActiveButton(ClusterId clusterId, ButtonId buttonId) = 0;
+        //! Disables the Cluster Button. This button won't be clickable by the user.  
+        virtual void SetClusterDisableButton(ClusterId clusterId, ButtonId buttonId, bool disabled) = 0;
         //! Clears the active button of the cluster if one is active. The button will no longer display as highlighted.
         virtual void ClearClusterActiveButton(ClusterId clusterId) = 0;
         //! Sets the active button of the switcher. This is the button which has a text label.
         virtual void SetSwitcherActiveButton(SwitcherId switcherId, ButtonId buttonId) = 0;
+        //! Disables the Switcher button of the switcher. This button won't be clickable by the user.
+        virtual void SetSwitcherDisableButton(SwitcherId switcherId, ButtonId buttonId, bool disabled) = 0;
         //! Adds a locked overlay to the cluster button's icon.
         virtual void SetClusterButtonLocked(ClusterId clusterId, ButtonId buttonId, bool isLocked) = 0;
         //! Updates/sets the cluster button's tooltip to the passed string.

--- a/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportUiManagerTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportUiManagerTests.cpp
@@ -146,6 +146,51 @@ namespace UnitTest
         EXPECT_TRUE(button->m_state == AzToolsFramework::ViewportUi::Internal::Button::State::Deselected);
     }
 
+    TEST_F(ViewportUiManagerTestFixture, SetClusterDisableButtonOnActiveButton)
+    {
+        // setup
+        auto clusterId = m_viewportManagerWrapper.GetViewportManager()->CreateCluster(AzToolsFramework::ViewportUi::Alignment::TopLeft);
+        auto buttonId = m_viewportManagerWrapper.GetViewportManager()->CreateClusterButton(clusterId, "");
+
+        auto clusterEntry = m_viewportManagerWrapper.GetViewportManager()->GetClusterMap().find(clusterId);
+        auto button = clusterEntry->second->GetButton(buttonId);
+
+        // first set a button to active
+        m_viewportManagerWrapper.GetViewportManager()->SetClusterActiveButton(clusterId, buttonId);
+        EXPECT_TRUE(button->m_state == AzToolsFramework::ViewportUi::Internal::Button::State::Selected);
+
+        // Disable active button
+        m_viewportManagerWrapper.GetViewportManager()->SetClusterDisableButton(clusterId, buttonId, true);
+        // try clear active button
+        m_viewportManagerWrapper.GetViewportManager()->ClearClusterActiveButton(clusterId);
+
+        // the button should now be disabled
+        EXPECT_TRUE(button->m_state == AzToolsFramework::ViewportUi::Internal::Button::State::Disabled);
+    }
+
+    TEST_F(ViewportUiManagerTestFixture, SetClusterDisableButton)
+    {
+        // setup
+        auto clusterId = m_viewportManagerWrapper.GetViewportManager()->CreateCluster(AzToolsFramework::ViewportUi::Alignment::TopLeft);
+        auto buttonId = m_viewportManagerWrapper.GetViewportManager()->CreateClusterButton(clusterId, "");
+        auto buttonId2 = m_viewportManagerWrapper.GetViewportManager()->CreateClusterButton(clusterId, "");
+
+        auto clusterEntry = m_viewportManagerWrapper.GetViewportManager()->GetClusterMap().find(clusterId);
+        auto button = clusterEntry->second->GetButton(buttonId);
+        auto button2 = clusterEntry->second->GetButton(buttonId2);
+
+        // the button should now be disable
+        EXPECT_TRUE(button->m_state == AzToolsFramework::ViewportUi::Internal::Button::State::Deselected);
+        EXPECT_TRUE(button2->m_state == AzToolsFramework::ViewportUi::Internal::Button::State::Deselected);
+
+        m_viewportManagerWrapper.GetViewportManager()->SetClusterDisableButton(clusterId, buttonId, true);
+        m_viewportManagerWrapper.GetViewportManager()->SetClusterDisableButton(clusterId, buttonId2, true);
+
+        // the button should now be disabled
+        EXPECT_TRUE(button->m_state == AzToolsFramework::ViewportUi::Internal::Button::State::Disabled);
+        EXPECT_TRUE(button2->m_state == AzToolsFramework::ViewportUi::Internal::Button::State::Disabled);
+    }
+
     TEST_F(ViewportUiManagerTestFixture, RegisterClusterEventHandlerConnectsHandlerToClusterEvent)
     {
         auto clusterId = m_viewportManagerWrapper.GetViewportManager()->CreateCluster(AzToolsFramework::ViewportUi::Alignment::TopLeft);


### PR DESCRIPTION
ref: https://github.com/o3de/o3de/pull/12833

Signed-off-by: Michael Pollind <mpollind@gmail.com>

## What does this PR do?

This add a disable option for buttons for the switcher and cluster. The linked PR should have a video of this working in whitebox. 

## How was this PR tested?

example usage found here: https://github.com/o3de/o3de/pull/12833
