### PR TITLE
Asset Browser: add placeholders for new design

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -32,6 +32,8 @@ AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 AZ_CVAR_EXTERNED(bool, ed_useNewAssetBrowserTableView);
 
+AZ_CVAR(bool, ed_useWIPAssetBrowserDesign, false, nullptr, AZ::ConsoleFunctorFlags::Null, "Use the in-progress new Asset Browser design");
+
 namespace AzToolsFramework
 {
     namespace AssetBrowser
@@ -135,6 +137,16 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
 
         m_ui->m_assetBrowserTableViewWidget->SetName("AssetBrowserTableView_main");
     }
+
+    if (!ed_useWIPAssetBrowserDesign)
+    {
+        m_ui->m_middleStackWidget->hide();
+        m_ui->m_thumbnailViewButton->hide();
+        m_ui->m_listViewButton->hide();
+    }
+
+    connect(m_ui->m_thumbnailViewButton, &QAbstractButton::clicked, this, [this] { m_ui->m_middleStackWidget->setCurrentIndex(0); });
+    connect(m_ui->m_listViewButton, &QAbstractButton::clicked, this, [this] { m_ui->m_middleStackWidget->setCurrentIndex(1); });
 
     m_ui->m_assetBrowserTreeViewWidget->setModel(m_filterModel.data());
 

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.ui
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.ui
@@ -88,6 +88,40 @@
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QToolButton" name="m_thumbnailViewButton">
+           <property name="icon">
+            <iconset resource="../../Framework/AzQtComponents/AzQtComponents/Components/resources.qrc">
+             <normaloff>:/Gallery/Grid-small.svg</normaloff>:/Gallery/Grid-small.svg</iconset>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">m_viewSelectButtonGroup</string>
+           </attribute>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="m_listViewButton">
+           <property name="text">
+            <string>...</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../Framework/AzQtComponents/AzQtComponents/Components/resources.qrc">
+             <normaloff>:/Breadcrumb/img/UI20/Breadcrumb/List_View.svg</normaloff>:/Breadcrumb/img/UI20/Breadcrumb/List_View.svg</iconset>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">m_viewSelectButtonGroup</string>
+           </attribute>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>
@@ -182,6 +216,54 @@
            </item>
           </layout>
          </widget>
+         <widget class="QStackedWidget" name="m_middleStackWidget">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>50</width>
+            <height>0</height>
+           </size>
+          </property>
+          <widget class="QWidget" name="m_iconView">
+           <layout class="QVBoxLayout" name="m_iconViewLayout">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="m_iconViewPlaceholder">
+              <property name="text">
+               <string>Icon view placeholder</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="m_tableView">
+           <layout class="QVBoxLayout" name="m_tableViewLayout">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="m_tableViewPlaceholder">
+              <property name="text">
+               <string>List view placeholder</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </widget>
          <widget class="QWidget" name="previewWidgetWrapper">
           <layout class="QVBoxLayout" name="m_rightLayout">
            <item>
@@ -237,4 +319,7 @@
   <include location="../../Framework/AzQtComponents/AzQtComponents/Components/resources.qrc"/>
  </resources>
  <connections/>
+ <buttongroups>
+  <buttongroup name="m_viewSelectButtonGroup"/>
+ </buttongroups>
 </ui>


### PR DESCRIPTION
A middle stack widget is added that contains placeholders for thumbnail and list view.

Buttons for switching between these views are added.

There's a new cvar for turning this placeholder design on and off. By default it's off.

To turn it on, do these steps:

 1. Write the following in the console:
      `ed_useWIPAssetBrowserDesign 1`
 2. Close the the asset browser tab
 3. Reopen it through Tools -> Asset Browser

Signed-off-by: Miłosz Kosobucki <milosz@kosobucki.pl>

## What does this PR do?

https://user-images.githubusercontent.com/104767/198565557-51eab01e-4486-415d-b7a3-e0d37bb09e88.mp4

## How was this PR tested?

Manually tested