### PR TITLE
Material Canvas: Basic matrix node configs and vector casting improvements (mostly JSON changes)

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/bool.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/bool.materialcanvasnode
@@ -6,7 +6,7 @@
         "id": "{0ED5EA90-466F-421C-9BF6-7EE65D7962C0}",
         "category": "Constants",
         "title": "Bool Constant",
-        "propertySlots": [
+        "inputSlots": [
             {
                 "name": "inValue",
                 "displayName": "Value",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/color.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/color.materialcanvasnode
@@ -6,7 +6,7 @@
         "id": "{6B6603B9-A89E-403B-9AE9-C7E424093EC5}",
         "category": "Constants",
         "title": "Color Constant",
-        "propertySlots": [
+        "inputSlots": [
             {
                 "name": "inValue",
                 "displayName": "Value",
@@ -38,18 +38,61 @@
                 "supportedDataTypes": [
                     "color"
                 ],
-                "defaultValue": {
-                    "$type": "Color",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        1.0
-                    ]
-                },
                 "settings": {
                     "instructions": [
                         "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue;"
+                    ]
+                }
+            },
+            {
+                "name": "outR",
+                "displayName": "R",
+                "description": "R",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue.r;"
+                    ]
+                }
+            },
+            {
+                "name": "outG",
+                "displayName": "G",
+                "description": "G",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue.g;"
+                    ]
+                }
+            },
+            {
+                "name": "outB",
+                "displayName": "B",
+                "description": "B",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue.b;"
+                    ]
+                }
+            },
+            {
+                "name": "outA",
+                "displayName": "A",
+                "description": "A",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue.a;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float.materialcanvasnode
@@ -6,7 +6,7 @@
         "id": "{5E2A378E-D27D-43C0-B708-3586FA2293F3}",
         "category": "Constants",
         "title": "Float Constant",
-        "propertySlots": [
+        "inputSlots": [
             {
                 "name": "inValue",
                 "displayName": "Value",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float2.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float2.materialcanvasnode
@@ -6,7 +6,7 @@
         "id": "{C451808F-3604-46A8-9014-2D51293EAD55}",
         "category": "Constants",
         "title": "Float2 Constant",
-        "propertySlots": [
+        "inputSlots": [
             {
                 "name": "inValue",
                 "displayName": "Value",
@@ -32,6 +32,32 @@
                 "settings": {
                     "instructions": [
                         "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue;"
+                    ]
+                }
+            },
+            {
+                "name": "outX",
+                "displayName": "X",
+                "description": "X",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue.x;"
+                    ]
+                }
+            },
+            {
+                "name": "outY",
+                "displayName": "Y",
+                "description": "Y",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue.y;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float3.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float3.materialcanvasnode
@@ -6,7 +6,7 @@
         "id": "{2C991213-E9B1-4380-A6E9-82F47E3C3B51}",
         "category": "Constants",
         "title": "Float3 Constant",
-        "propertySlots": [
+        "inputSlots": [
             {
                 "name": "inValue",
                 "displayName": "Value",
@@ -32,6 +32,45 @@
                 "settings": {
                     "instructions": [
                         "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue;"
+                    ]
+                }
+            },
+            {
+                "name": "outX",
+                "displayName": "X",
+                "description": "X",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue.x;"
+                    ]
+                }
+            },
+            {
+                "name": "outY",
+                "displayName": "Y",
+                "description": "Y",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue.y;"
+                    ]
+                }
+            },
+            {
+                "name": "outZ",
+                "displayName": "Z",
+                "description": "Z",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue.z;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float3x3.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float3x3.materialcanvasnode
@@ -1,0 +1,90 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "DynamicNodeConfig",
+    "ClassData": {
+        "id": "{5B7EBEFB-298D-45A1-88A4-A702468C8A60}",
+        "category": "Constants",
+        "title": "Float3x3 Constant",
+        "inputSlots": [
+            {
+                "name": "inRow1",
+                "displayName": "Row1",
+                "description": "Row1",
+                "supportedDataTypes": [
+                    "float3"
+                ],
+                "defaultValue": {
+                    "$type": "Vector3",
+                    "Value": [
+                        1.0,
+                        0.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inRow2",
+                "displayName": "Row2",
+                "description": "Row2",
+                "supportedDataTypes": [
+                    "float3"
+                ],
+                "defaultValue": {
+                    "$type": "Vector3",
+                    "Value": [
+                        0.0,
+                        1.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inRow3",
+                "displayName": "Row3",
+                "description": "Row3",
+                "supportedDataTypes": [
+                    "float3"
+                ],
+                "defaultValue": {
+                    "$type": "Vector3",
+                    "Value": [
+                        0.0,
+                        0.0,
+                        1.0
+                    ]
+                },
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            }
+        ],
+        "outputSlots": [
+            {
+                "name": "outValue",
+                "displayName": "Value",
+                "description": "Value",
+                "supportedDataTypes": [
+                    "float3x3"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = float3x3(NODEID_inRow1, NODEID_inRow2, NODEID_inRow3);"
+                    ]
+                }
+            }
+        ]
+    }
+}

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float4.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float4.materialcanvasnode
@@ -6,7 +6,7 @@
         "id": "{643F25FA-FB10-4AF6-9657-2E1BDC2AC219}",
         "category": "Constants",
         "title": "Float4 Constant",
-        "propertySlots": [
+        "inputSlots": [
             {
                 "name": "inValue",
                 "displayName": "Value",
@@ -32,6 +32,58 @@
                 "settings": {
                     "instructions": [
                         "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue;"
+                    ]
+                }
+            },
+            {
+                "name": "outX",
+                "displayName": "X",
+                "description": "X",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue.x;"
+                    ]
+                }
+            },
+            {
+                "name": "outY",
+                "displayName": "Y",
+                "description": "Y",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue.y;"
+                    ]
+                }
+            },
+            {
+                "name": "outZ",
+                "displayName": "Z",
+                "description": "Z",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue.z;"
+                    ]
+                }
+            },
+            {
+                "name": "outW",
+                "displayName": "W",
+                "description": "W",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_inValue.w;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float4x3.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float4x3.materialcanvasnode
@@ -1,0 +1,93 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "DynamicNodeConfig",
+    "ClassData": {
+        "id": "{F9B8E502-7180-4314-BE6E-97C907F74E46}",
+        "category": "Constants",
+        "title": "Float4x3 Constant",
+        "inputSlots": [
+            {
+                "name": "inRow1",
+                "displayName": "Row1",
+                "description": "Row1",
+                "supportedDataTypes": [
+                    "float4"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inRow2",
+                "displayName": "Row2",
+                "description": "Row2",
+                "supportedDataTypes": [
+                    "float4"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        0.0,
+                        1.0,
+                        0.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inRow3",
+                "displayName": "Row3",
+                "description": "Row3",
+                "supportedDataTypes": [
+                    "float4"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        0.0,
+                        0.0,
+                        1.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            }
+        ],
+        "outputSlots": [
+            {
+                "name": "outValue",
+                "displayName": "Value",
+                "description": "Value",
+                "supportedDataTypes": [
+                    "float4x3"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = float4x3(NODEID_inRow1, NODEID_inRow2, NODEID_inRow3);"
+                    ]
+                }
+            }
+        ]
+    }
+}

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float4x4.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float4x4.materialcanvasnode
@@ -1,0 +1,115 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "DynamicNodeConfig",
+    "ClassData": {
+        "id": "{83A5C349-1E8F-4D26-85DD-193B43182835}",
+        "category": "Constants",
+        "title": "Float4x4 Constant",
+        "inputSlots": [
+            {
+                "name": "inRow1",
+                "displayName": "Row1",
+                "description": "Row1",
+                "supportedDataTypes": [
+                    "float4"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inRow2",
+                "displayName": "Row2",
+                "description": "Row2",
+                "supportedDataTypes": [
+                    "float4"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        0.0,
+                        1.0,
+                        0.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inRow3",
+                "displayName": "Row3",
+                "description": "Row3",
+                "supportedDataTypes": [
+                    "float4"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        0.0,
+                        0.0,
+                        1.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inRow4",
+                "displayName": "Row4",
+                "description": "Row4",
+                "supportedDataTypes": [
+                    "float4"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ]
+                },
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            }
+        ],
+        "outputSlots": [
+            {
+                "name": "outValue",
+                "displayName": "Value",
+                "description": "Value",
+                "supportedDataTypes": [
+                    "float4x4"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = float4x4(NODEID_inRow1, NODEID_inRow2, NODEID_inRow3, NODEID_inRow4);"
+                    ]
+                }
+            }
+        ]
+    }
+}

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/int.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/int.materialcanvasnode
@@ -6,7 +6,7 @@
         "id": "{77F59CFF-3EFC-492D-BDF2-FD587FC56704}",
         "category": "Constants",
         "title": "Int Constant",
-        "propertySlots": [
+        "inputSlots": [
             {
                 "name": "inValue",
                 "displayName": "Value",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/uint.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/uint.materialcanvasnode
@@ -6,7 +6,7 @@
         "id": "{03C534CA-436F-40CB-80A2-56229D1E4DBC}",
         "category": "Constants",
         "title": "UInt Constant",
-        "propertySlots": [
+        "inputSlots": [
             {
                 "name": "inValue",
                 "displayName": "Value",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/atan2.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/atan2.materialcanvasnode
@@ -8,9 +8,9 @@
         "title": "atan2",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
+                "name": "inY",
+                "displayName": "Y",
+                "description": "Y",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -34,9 +34,9 @@
                 }
             },
             {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inX",
+                "displayName": "X",
+                "description": "X",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -79,7 +79,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE NODEID_SLOTNAME = atan2(NODEID_inValue1, NODEID_inValue2);"
+                        "SLOTTYPE NODEID_SLOTNAME = atan2(NODEID_inY, NODEID_inX);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/clamp.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/clamp.materialcanvasnode
@@ -1,4 +1,4 @@
-{
+\{
     "Type": "JsonSerialization",
     "Version": 1,
     "ClassName": "DynamicNodeConfig",
@@ -8,9 +8,9 @@
         "title": "clamp",
         "inputSlots": [
             {
-                "name": "inValue1",
-                "displayName": "Value1",
-                "description": "Value1",
+                "name": "inValue",
+                "displayName": "Value",
+                "description": "Value",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -34,9 +34,9 @@
                 }
             },
             {
-                "name": "inValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "inMin",
+                "displayName": "Min",
+                "description": "Min",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -60,9 +60,9 @@
                 }
             },
             {
-                "name": "inValue3",
-                "displayName": "Value3",
-                "description": "Value3",
+                "name": "inMax",
+                "displayName": "Max",
+                "description": "Max",
                 "supportedDataTypes": [
                     "float",
                     "float2",
@@ -105,7 +105,7 @@
                 },
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE NODEID_SLOTNAME = clamp(NODEID_inValue1, NODEID_inValue2, NODEID_inValue3);"
+                        "SLOTTYPE NODEID_SLOTNAME = clamp(NODEID_inValue, NODEID_inMin, NODEID_inMax);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/clip.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/clip.materialcanvasnode
@@ -38,25 +38,6 @@
                     ]
                 }
             }
-        ],
-        "outputSlots": [
-            {
-                "name": "outValue",
-                "displayName": "Value",
-                "description": "Value",
-                "supportedDataTypes": [
-                    "float4"
-                ],
-                "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]
-                }
-            }
         ]
     }
 }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/lerp.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/lerp.materialcanvasnode
@@ -61,8 +61,8 @@
             },
             {
                 "name": "inValue3",
-                "displayName": "Value3",
-                "description": "Value3",
+                "displayName": "T",
+                "description": "T",
                 "supportedDataTypes": [
                     "float",
                     "float2",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/sincos.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/sincos.materialcanvasnode
@@ -8,9 +8,9 @@
         "title": "sincos",
         "settings": {
             "instructions": [
-                "float4 NODEID_outValue1 = float4(0, 0, 0, 0);",
-                "float4 NODEID_outValue2 = float4(0, 0, 0, 0);",
-                "sincos(NODEID_inValue, NODEID_outValue1, NODEID_outValue2);"
+                "float4 NODEID_outSin = float4(0, 0, 0, 0);",
+                "float4 NODEID_outCos = float4(0, 0, 0, 0);",
+                "sincos(NODEID_inValue, NODEID_outSin, NODEID_outCos);"
             ]
         },
         "inputSlots": [
@@ -43,9 +43,9 @@
         ],
         "outputSlots": [
             {
-                "name": "outValue1",
-                "displayName": "Value1",
-                "description": "Value1",
+                "name": "outSin",
+                "displayName": "Sin",
+                "description": "Sin",
                 "supportedDataTypes": [
                     "float4"
                 ],
@@ -60,9 +60,9 @@
                 }
             },
             {
-                "name": "outValue2",
-                "displayName": "Value2",
-                "description": "Value2",
+                "name": "outCos",
+                "displayName": "Cos",
+                "description": "Cos",
                 "supportedDataTypes": [
                     "float4"
                 ],

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialInputs/color.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialInputs/color.materialcanvasnode
@@ -60,6 +60,58 @@
                         "SLOTTYPE NODEID_SLOTNAME = MaterialSrg::NODEID_inValue;"
                     ]
                 }
+            },
+            {
+                "name": "outR",
+                "displayName": "R",
+                "description": "R",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = MaterialSrg::NODEID_inValue.r;"
+                    ]
+                }
+            },
+            {
+                "name": "outG",
+                "displayName": "G",
+                "description": "G",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = MaterialSrg::NODEID_inValue.g;"
+                    ]
+                }
+            },
+            {
+                "name": "outB",
+                "displayName": "B",
+                "description": "B",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = MaterialSrg::NODEID_inValue.b;"
+                    ]
+                }
+            },
+            {
+                "name": "outA",
+                "displayName": "A",
+                "description": "A",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = MaterialSrg::NODEID_inValue.a;"
+                    ]
+                }
             }
         ]
     }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialInputs/float2.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialInputs/float2.materialcanvasnode
@@ -60,6 +60,32 @@
                         "SLOTTYPE NODEID_SLOTNAME = MaterialSrg::NODEID_inValue;"
                     ]
                 }
+            },
+            {
+                "name": "outX",
+                "displayName": "X",
+                "description": "X",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = MaterialSrg::NODEID_inValue.x;"
+                    ]
+                }
+            },
+            {
+                "name": "outY",
+                "displayName": "Y",
+                "description": "Y",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = MaterialSrg::NODEID_inValue.y;"
+                    ]
+                }
             }
         ]
     }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialInputs/float3x3.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialInputs/float3x3.materialcanvasnode
@@ -3,9 +3,9 @@
     "Version": 1,
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
-        "id": "{CE1EF97A-5BFE-4459-8967-53878C7F074F}",
+        "id": "{0CEDEE3B-0A53-438D-9876-38F867C55483}",
         "category": "Material Inputs",
-        "title": "Float3 Input",
+        "title": "Float3x3 Input",
         "propertySlots": [
             {
                 "name": "inGroup",
@@ -34,12 +34,62 @@
                 "supportsEditingOnNode": false
             },
             {
-                "name": "inValue",
-                "displayName": "Value",
-                "description": "Value",
+                "name": "inRow1",
+                "displayName": "Row1",
+                "description": "Row1",
                 "supportedDataTypes": [
                     "float3"
                 ],
+                "defaultValue": {
+                    "$type": "Vector3",
+                    "Value": [
+                        1.0,
+                        0.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "materialInputs": [
+                        "SLOTSTANDARDSRGMEMBER"
+                    ]
+                }
+            },
+            {
+                "name": "inRow2",
+                "displayName": "Row2",
+                "description": "Row2",
+                "supportedDataTypes": [
+                    "float3"
+                ],
+                "defaultValue": {
+                    "$type": "Vector3",
+                    "Value": [
+                        0.0,
+                        1.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "materialInputs": [
+                        "SLOTSTANDARDSRGMEMBER"
+                    ]
+                }
+            },
+            {
+                "name": "inRow3",
+                "displayName": "Row3",
+                "description": "Row3",
+                "supportedDataTypes": [
+                    "float3"
+                ],
+                "defaultValue": {
+                    "$type": "Vector3",
+                    "Value": [
+                        0.0,
+                        0.0,
+                        1.0
+                    ]
+                },
                 "settings": {
                     "materialInputs": [
                         "SLOTSTANDARDSRGMEMBER"
@@ -53,50 +103,11 @@
                 "displayName": "Value",
                 "description": "Value",
                 "supportedDataTypes": [
-                    "float3"
+                    "float3x3"
                 ],
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE NODEID_SLOTNAME = MaterialSrg::NODEID_inValue;"
-                    ]
-                }
-            },
-            {
-                "name": "outX",
-                "displayName": "X",
-                "description": "X",
-                "supportedDataTypes": [
-                    "float"
-                ],
-                "settings": {
-                    "instructions": [
-                        "SLOTTYPE NODEID_SLOTNAME = MaterialSrg::NODEID_inValue.x;"
-                    ]
-                }
-            },
-            {
-                "name": "outY",
-                "displayName": "Y",
-                "description": "Y",
-                "supportedDataTypes": [
-                    "float"
-                ],
-                "settings": {
-                    "instructions": [
-                        "SLOTTYPE NODEID_SLOTNAME = MaterialSrg::NODEID_inValue.y;"
-                    ]
-                }
-            },
-            {
-                "name": "outZ",
-                "displayName": "Z",
-                "description": "Z",
-                "supportedDataTypes": [
-                    "float"
-                ],
-                "settings": {
-                    "instructions": [
-                        "SLOTTYPE NODEID_SLOTNAME = MaterialSrg::NODEID_inValue.z;"
+                        "SLOTTYPE NODEID_SLOTNAME = float3x3(MaterialSrg::NODEID_inRow1, MaterialSrg::NODEID_inRow2, MaterialSrg::NODEID_inRow3);"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialInputs/float4.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialInputs/float4.materialcanvasnode
@@ -60,6 +60,58 @@
                         "SLOTTYPE NODEID_SLOTNAME = MaterialSrg::NODEID_inValue;"
                     ]
                 }
+            },
+            {
+                "name": "outX",
+                "displayName": "X",
+                "description": "X",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = MaterialSrg::NODEID_inValue.x;"
+                    ]
+                }
+            },
+            {
+                "name": "outY",
+                "displayName": "Y",
+                "description": "Y",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = MaterialSrg::NODEID_inValue.y;"
+                    ]
+                }
+            },
+            {
+                "name": "outZ",
+                "displayName": "Z",
+                "description": "Z",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = MaterialSrg::NODEID_inValue.z;"
+                    ]
+                }
+            },
+            {
+                "name": "outW",
+                "displayName": "W",
+                "description": "W",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = MaterialSrg::NODEID_inValue.w;"
+                    ]
+                }
             }
         ]
     }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialInputs/float4x3.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialInputs/float4x3.materialcanvasnode
@@ -1,0 +1,128 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "DynamicNodeConfig",
+    "ClassData": {
+        "id": "{28516866-1A10-48B6-9D7F-D78570F7011C}",
+        "category": "Material Inputs",
+        "title": "Float4x3 Input",
+        "propertySlots": [
+            {
+                "name": "inGroup",
+                "displayName": "Group",
+                "description": "Group",
+                "supportedDataTypes": [
+                    "string"
+                ],
+                "supportsEditingOnNode": false
+            },
+            {
+                "name": "inName",
+                "displayName": "Name",
+                "description": "Name",
+                "supportedDataTypes": [
+                    "string"
+                ]
+            },
+            {
+                "name": "inDescription",
+                "displayName": "Description",
+                "description": "Description",
+                "supportedDataTypes": [
+                    "string"
+                ],
+                "supportsEditingOnNode": false
+            },
+            {
+                "name": "inRow1",
+                "displayName": "Row1",
+                "description": "Row1",
+                "supportedDataTypes": [
+                    "float4"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "materialInputs": [
+                        "SLOTSTANDARDSRGMEMBER"
+                    ]
+                }
+            },
+            {
+                "name": "inRow2",
+                "displayName": "Row2",
+                "description": "Row2",
+                "supportedDataTypes": [
+                    "float4"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        0.0,
+                        1.0,
+                        0.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "materialInputs": [
+                        "SLOTSTANDARDSRGMEMBER"
+                    ]
+                }
+            },
+            {
+                "name": "inRow3",
+                "displayName": "Row3",
+                "description": "Row3",
+                "supportedDataTypes": [
+                    "float4"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        0.0,
+                        0.0,
+                        1.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "materialInputs": [
+                        "SLOTSTANDARDSRGMEMBER"
+                    ]
+                }
+            }
+        ],
+        "outputSlots": [
+            {
+                "name": "outValue",
+                "displayName": "Value",
+                "description": "Value",
+                "supportedDataTypes": [
+                    "float4x3"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ]
+                },
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = float4x3(MaterialSrg::NODEID_inRow1, MaterialSrg::NODEID_inRow2, MaterialSrg::NODEID_inRow3);"
+                    ]
+                }
+            }
+        ]
+    }
+}

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialInputs/float4x4.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialInputs/float4x4.materialcanvasnode
@@ -1,0 +1,141 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "DynamicNodeConfig",
+    "ClassData": {
+        "id": "{972D7CD4-F52F-414A-8FE2-8E8E34F0B531}",
+        "category": "Material Inputs",
+        "title": "Float4x4 Input",
+        "propertySlots": [
+            {
+                "name": "inGroup",
+                "displayName": "Group",
+                "description": "Group",
+                "supportedDataTypes": [
+                    "string"
+                ],
+                "supportsEditingOnNode": false
+            },
+            {
+                "name": "inName",
+                "displayName": "Name",
+                "description": "Name",
+                "supportedDataTypes": [
+                    "string"
+                ]
+            },
+            {
+                "name": "inDescription",
+                "displayName": "Description",
+                "description": "Description",
+                "supportedDataTypes": [
+                    "string"
+                ],
+                "supportsEditingOnNode": false
+            },
+            {
+                "name": "inRow1",
+                "displayName": "Row1",
+                "description": "Row1",
+                "supportedDataTypes": [
+                    "float4"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "materialInputs": [
+                        "SLOTSTANDARDSRGMEMBER"
+                    ]
+                }
+            },
+            {
+                "name": "inRow2",
+                "displayName": "Row2",
+                "description": "Row2",
+                "supportedDataTypes": [
+                    "float4"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        0.0,
+                        1.0,
+                        0.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "materialInputs": [
+                        "SLOTSTANDARDSRGMEMBER"
+                    ]
+                }
+            },
+            {
+                "name": "inRow3",
+                "displayName": "Row3",
+                "description": "Row3",
+                "supportedDataTypes": [
+                    "float4"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        0.0,
+                        0.0,
+                        1.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "materialInputs": [
+                        "SLOTSTANDARDSRGMEMBER"
+                    ]
+                }
+            },
+            {
+                "name": "inRow4",
+                "displayName": "Row4",
+                "description": "Row4",
+                "supportedDataTypes": [
+                    "float4"
+                ],
+                "defaultValue": {
+                    "$type": "Vector4",
+                    "Value": [
+                        0.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ]
+                },
+                "settings": {
+                    "materialInputs": [
+                        "SLOTSTANDARDSRGMEMBER"
+                    ]
+                }
+            }
+        ],
+        "outputSlots": [
+            {
+                "name": "outValue",
+                "displayName": "Value",
+                "description": "Value",
+                "supportedDataTypes": [
+                    "float4x4"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = float4x4(MaterialSrg::NODEID_inRow1, MaterialSrg::NODEID_inRow2, MaterialSrg::NODEID_inRow3, MaterialSrg::NODEID_inRow4);"
+                    ]
+                }
+            }
+        ]
+    }
+}

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialTemplates/ExperimentalPBR/MaterialGraphName_Common.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialTemplates/ExperimentalPBR/MaterialGraphName_Common.azsli
@@ -60,7 +60,7 @@ void Evaluate_CommonVSInput(in CommonVSInput IN, out CommonVSOutput OUT)
     #define O3DE_MC_WORLD_POSITION worldPosition
 
     // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inPositionOffset
-    float4 inPositionOffset = float4(0.0, 0.0, 0.0, 0.0);
+    float3 inPositionOffset = {0.0, 0.0, 0.0};
     // O3DE_GENERATED_INSTRUCTIONS_END
 
     #undef O3DE_MC_POSITION
@@ -70,7 +70,7 @@ void Evaluate_CommonVSInput(in CommonVSInput IN, out CommonVSOutput OUT)
     #undef O3DE_MC_BITANGENT
     #undef O3DE_MC_WORLD_POSITION
 
-    OUT.m_worldPosition = worldPosition + float4(inPositionOffset.xyz, 0.0);
+    OUT.m_worldPosition = worldPosition + float4((float3)inPositionOffset, 0.0);
     OUT.m_position = mul(ViewSrg::m_viewProjectionMatrix, OUT.m_worldPosition);
     OUT.m_normal = IN.m_normal;
     OUT.m_tangent = IN.m_tangent;

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialTemplates/ExperimentalPBR/MaterialGraphName_ForwardPass.azsl
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialTemplates/ExperimentalPBR/MaterialGraphName_ForwardPass.azsl
@@ -38,7 +38,7 @@ VSOutput MainVS(CommonVSInput IN)
     Evaluate_CommonVSInput(IN, commonVSOut);
 
     VSOutput OUT;
-    OUT.m_worldPosition = commonVSOut.m_worldPosition.xyz;
+    OUT.m_worldPosition = (float3)commonVSOut.m_worldPosition;
     OUT.m_position = commonVSOut.m_position;
     OUT.m_normal = commonVSOut.m_normal;
     OUT.m_tangent = commonVSOut.m_tangent;
@@ -62,12 +62,13 @@ ForwardPassOutput MainPS(VSOutput IN)
     #define O3DE_MC_BITANGENT vertexBitangent
     #define O3DE_MC_WORLD_POSITION IN.m_worldPosition
 
-    // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inBaseColor, inEmissive, inMetallic, inRoughness, inSpecularF0Factor
-    float4 inBaseColor = float4(1.0, 1.0, 1.0, 1.0);
-    float4 inEmissive = float4(0.0, 0.0, 0.0, 1.0);
+    // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inBaseColor, inEmissive, inMetallic, inRoughness, inSpecularF0Factor, inAlpha
+    float3 inBaseColor = {1.0, 1.0, 1.0};
+    float3 inEmissive = {0.0, 0.0, 0.0};
     float inMetallic = 0.0;
     float inRoughness = 0.0;
     float inSpecularF0Factor = 0.0;
+    float inAlpha = 1.0;
     // O3DE_GENERATED_INSTRUCTIONS_END
 
     #undef O3DE_MC_POSITION
@@ -80,12 +81,12 @@ ForwardPassOutput MainPS(VSOutput IN)
     // ------- Surface -------
 
     Surface surface;
-    surface.position = IN.m_worldPosition.xyz;
-    surface.normal = vertexNormal;
-    surface.vertexNormal = vertexNormal;
-    surface.roughnessLinear = inRoughness;
+    surface.position = (float3)IN.m_worldPosition;
+    surface.normal = (float3)vertexNormal;
+    surface.vertexNormal = (float3)vertexNormal;
+    surface.roughnessLinear = (float)inRoughness;
     surface.CalculateRoughnessA();
-    surface.SetAlbedoAndSpecularF0(inBaseColor.rgb, inSpecularF0Factor, inMetallic);
+    surface.SetAlbedoAndSpecularF0((float3)inBaseColor, (float)inSpecularF0Factor, (float)inMetallic);
     surface.clearCoat.InitializeToZero();
 
     // ------- LightingData -------
@@ -95,7 +96,7 @@ ForwardPassOutput MainPS(VSOutput IN)
     lightingData.Init(surface.position, surface.normal, surface.roughnessLinear);
     lightingData.specularResponse = FresnelSchlickWithRoughness(lightingData.NdotV, surface.specularF0, surface.roughnessLinear);
     lightingData.diffuseResponse = 1.0f - lightingData.specularResponse;
-    lightingData.emissiveLighting = inEmissive.rgb;
+    lightingData.emissiveLighting = (float3)inEmissive;
 
     // ------- Lighting Calculation -------
 
@@ -111,12 +112,11 @@ ForwardPassOutput MainPS(VSOutput IN)
     // Finalize Lighting
     lightingData.FinalizeLighting();
 
-    PbrLightingOutput lightingOutput = GetPbrLightingOutput(surface, lightingData, inBaseColor.a);
+    PbrLightingOutput lightingOutput = GetPbrLightingOutput(surface, lightingData, (float)inAlpha);
 
     // ------- Output -------
 
     ForwardPassOutput OUT;
-
     OUT.m_diffuseColor = lightingOutput.m_diffuseColor;
     OUT.m_diffuseColor.w = -1; // Subsurface scattering is disabled
     OUT.m_specularColor = lightingOutput.m_specularColor;

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialTemplates/ExperimentalPBR/experimental_pbr.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialTemplates/ExperimentalPBR/experimental_pbr.materialcanvasnode
@@ -37,18 +37,16 @@
                 "description": "Position Offset",
                 "supportedDataTypes": [
                     "float",
-                    "float2",
                     "float3",
                     "float4",
                     "color"
                 ],
                 "defaultValue": {
-                    "$type": "Vector4",
+                    "$type": "Vector3",
                     "Value": [
                         0.0,
                         0.0,
-                        0.0,
-                        1.0
+                        0.0
                     ]
                 },
                 "settings": {
@@ -63,15 +61,13 @@
                 "description": "Base Color",
                 "supportedDataTypes": [
                     "float",
-                    "float2",
                     "float3",
                     "float4",
                     "color"
                 ],
                 "defaultValue": {
-                    "$type": "Vector4",
+                    "$type": "Vector3",
                     "Value": [
-                        1.0,
                         1.0,
                         1.0,
                         1.0
@@ -152,19 +148,38 @@
                 "description": "Emissive",
                 "supportedDataTypes": [
                     "float",
+                    "float3",
+                    "float4",
+                    "color"
+                ],
+                "defaultValue": {
+                    "$type": "Vector3",
+                    "Value": [
+                        0.0,
+                        0.0,
+                        0.0
+                    ]
+                },
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inAlpha",
+                "displayName": "Alpha",
+                "description": "Alpha",
+                "supportedDataTypes": [
+                    "float",
                     "float2",
                     "float3",
                     "float4",
                     "color"
                 ],
                 "defaultValue": {
-                    "$type": "Vector4",
-                    "Value": [
-                        0.0,
-                        0.0,
-                        0.0,
-                        1.0
-                    ]
+                    "$type": "float",
+                    "Value": 1.0
                 },
                 "settings": {
                     "instructions": [

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialTemplates/ExperimentalPBR/experimental_pbr.materialcanvastemplate.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialTemplates/ExperimentalPBR/experimental_pbr.materialcanvastemplate.azasset
@@ -111,22 +111,88 @@
                 }
             },
             {
-                "Key": 8,
+                "Key": 2,
                 "Value": {
                     "$type": "DynamicNode",
                     "m_propertySlots": [
+                        {
+                            "Key": {
+                                "m_name": "inDescription"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                    "Value": ""
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inGroup"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                    "Value": ""
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inName"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                    "Value": ""
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inSampler"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "SamplerState",
+                                    "Value": {
+                                        "m_filterMin": "Linear",
+                                        "m_filterMag": "Linear",
+                                        "m_filterMip": "Linear",
+                                        "m_reductionType": "Comparison"
+                                    }
+                                }
+                            }
+                        },
                         {
                             "Key": {
                                 "m_name": "inValue"
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
+                                    "$type": "{403A7CFE-B218-5D57-8540-BD58E734BCFE} Asset<StreamingImageAsset>",
+                                    "Value": {
+                                        "assetId": {
+                                            "guid": "{78CB60CC-1079-5526-8704-3AE8D722D70A}",
+                                            "subId": 1000
+                                        },
+                                        "assetHint": "testdata/textures/checker8x8_flip_512.png.streamingimage"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "m_inputDataSlots": [
+                        {
+                            "Key": {
+                                "m_name": "inUV"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "Vector2",
                                     "Value": [
-                                        1.0,
                                         0.0,
-                                        0.0,
-                                        1.0
+                                        0.0
                                     ]
                                 }
                             }
@@ -135,22 +201,59 @@
                     "toolId": {
                         "Value": 2034248906
                     },
-                    "configId": "{643F25FA-FB10-4AF6-9657-2E1BDC2AC219}"
+                    "configId": "{C0ADB0F0-39DD-48D9-A4D2-58B40C76C285}"
+                }
+            },
+            {
+                "Key": 5,
+                "Value": {
+                    "$type": "DynamicNode",
+                    "m_inputDataSlots": [
+                        {
+                            "Key": {
+                                "m_name": "inIndex"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "unsigned int",
+                                    "Value": 1
+                                }
+                            }
+                        }
+                    ],
+                    "toolId": {
+                        "Value": 2034248906
+                    },
+                    "configId": "{8E836C09-FA68-42B0-B302-CAC3FD6E4EA2}"
                 }
             }
         ],
         "m_connections": [
             {
                 "m_sourceEndpoint": [
-                    8,
+                    2,
                     {
-                        "m_name": "outValue"
+                        "m_name": "outColor"
                     }
                 ],
                 "m_targetEndpoint": [
                     1,
                     {
                         "m_name": "inBaseColor"
+                    }
+                ]
+            },
+            {
+                "m_sourceEndpoint": [
+                    5,
+                    {
+                        "m_name": "outValue"
+                    }
+                ],
+                "m_targetEndpoint": [
+                    2,
+                    {
+                        "m_name": "inUV"
                     }
                 ]
             }
@@ -164,10 +267,14 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    960.0,
+                                    120.0,
                                     -180.0
                                 ]
                             },
@@ -176,7 +283,7 @@
                             },
                             "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                 "$type": "PersistentIdComponentSaveData",
-                                "PersistentId": "{931CC6D4-CD3C-4979-A8E7-DD3458B6BA78}"
+                                "PersistentId": "{A208FF3B-A3A7-49BA-99D8-8680D8ED7285}"
                             }
                         }
                     }
@@ -188,11 +295,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    300.0,
-                                    120.0
+                                    -180.0,
+                                    -180.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -200,7 +311,7 @@
                             },
                             "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                 "$type": "PersistentIdComponentSaveData",
-                                "PersistentId": "{442701F5-F477-4BA6-8C7D-3CDBB5330C8D}"
+                                "PersistentId": "{ACCC8542-0AF6-46D5-BFD5-F2FE94B3150C}"
                             }
                         }
                     }
@@ -212,11 +323,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    200.0,
-                                    100.0
+                                    -520.0,
+                                    -80.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -224,7 +339,7 @@
                             },
                             "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                 "$type": "PersistentIdComponentSaveData",
-                                "PersistentId": "{3D0698E8-41FE-4601-BF60-CE65F83BD1CF}"
+                                "PersistentId": "{FECB9074-BB13-42B4-9B56-1169B59620E3}"
                             }
                         }
                     }
@@ -236,11 +351,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    160.0,
-                                    180.0
+                                    -40.0,
+                                    80.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -248,7 +367,7 @@
                             },
                             "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                 "$type": "PersistentIdComponentSaveData",
-                                "PersistentId": "{2D5F8E87-CDF7-4B52-A92F-0319E068032C}"
+                                "PersistentId": "{5C7242A5-16C1-49A5-8250-21C1584283C0}"
                             }
                         }
                     }
@@ -260,82 +379,14 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
-                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                "$type": "GeometrySaveData",
-                                "Position": [
-                                    320.0,
-                                    40.0
-                                ]
-                            },
-                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                "$type": "StylingComponentSaveData"
-                            },
-                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                "$type": "PersistentIdComponentSaveData",
-                                "PersistentId": "{C30020BC-EE14-411E-9C65-812EFFC9E8E3}"
-                            }
-                        }
-                    }
-                },
-                {
-                    "Key": 6,
-                    "Value": {
-                        "ComponentData": {
-                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                "$type": "NodeSaveData"
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    180.0,
-                                    -140.0
-                                ]
-                            },
-                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                "$type": "StylingComponentSaveData"
-                            },
-                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                "$type": "PersistentIdComponentSaveData",
-                                "PersistentId": "{79D6F1B5-F012-4AB0-9354-B5F9F435E114}"
-                            }
-                        }
-                    }
-                },
-                {
-                    "Key": 7,
-                    "Value": {
-                        "ComponentData": {
-                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                "$type": "NodeSaveData"
-                            },
-                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                "$type": "GeometrySaveData",
-                                "Position": [
-                                    640.0,
-                                    -80.0
-                                ]
-                            },
-                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                "$type": "StylingComponentSaveData"
-                            },
-                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                "$type": "PersistentIdComponentSaveData",
-                                "PersistentId": "{080B66FB-1AB7-4993-87A9-FEC1334F7CC6}"
-                            }
-                        }
-                    }
-                },
-                {
-                    "Key": 8,
-                    "Value": {
-                        "ComponentData": {
-                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                "$type": "NodeSaveData"
-                            },
-                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                "$type": "GeometrySaveData",
-                                "Position": [
-                                    480.0,
+                                    -480.0,
                                     -180.0
                                 ]
                             },
@@ -344,7 +395,7 @@
                             },
                             "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                 "$type": "PersistentIdComponentSaveData",
-                                "PersistentId": "{86380651-C9D0-4AEC-BE29-36A3338DBFBE}"
+                                "PersistentId": "{6CE967FD-B1BA-4252-BA89-5F8BC9BBCA98}"
                             }
                         }
                     }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialTemplates/ExperimentalPBR/experimental_pbr.materialcanvastemplate.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialTemplates/ExperimentalPBR/experimental_pbr.materialcanvastemplate.azasset
@@ -24,13 +24,23 @@
                     "m_inputDataSlots": [
                         {
                             "Key": {
+                                "m_name": "inAlpha"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 1.0
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
                                 "m_name": "inBaseColor"
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
+                                    "$type": "Vector3",
                                     "Value": [
-                                        1.0,
                                         1.0,
                                         1.0,
                                         1.0
@@ -44,12 +54,11 @@
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
+                                    "$type": "Vector3",
                                     "Value": [
                                         0.0,
                                         0.0,
-                                        0.0,
-                                        1.0
+                                        0.0
                                     ]
                                 }
                             }
@@ -71,12 +80,11 @@
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
+                                    "$type": "Vector3",
                                     "Value": [
                                         0.0,
                                         0.0,
-                                        0.0,
-                                        1.0
+                                        0.0
                                     ]
                                 }
                             }
@@ -247,7 +255,7 @@
                 "m_sourceEndpoint": [
                     5,
                     {
-                        "m_name": "outValue"
+                        "m_name": "outUV"
                     }
                 ],
                 "m_targetEndpoint": [
@@ -386,7 +394,7 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -480.0,
+                                    -340.0,
                                     -180.0
                                 ]
                             },

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Object/normal.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Object/normal.materialcanvasnode
@@ -19,6 +19,45 @@
                         "SLOTTYPE NODEID_SLOTNAME = O3DE_MC_NORMAL;"
                     ]
                 }
+            },
+            {
+                "name": "outX",
+                "displayName": "X",
+                "description": "X",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = O3DE_MC_NORMAL.x;"
+                    ]
+                }
+            },
+            {
+                "name": "outY",
+                "displayName": "Y",
+                "description": "Y",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = O3DE_MC_NORMAL.y;"
+                    ]
+                }
+            },
+            {
+                "name": "outZ",
+                "displayName": "Z",
+                "description": "Z",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = O3DE_MC_NORMAL.z;"
+                    ]
+                }
             }
         ]
     }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Object/normal.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Object/normal.materialcanvasnode
@@ -8,9 +8,9 @@
         "title": "Normal",
         "outputSlots": [
             {
-                "name": "outValue",
-                "displayName": "Value",
-                "description": "Value",
+                "name": "outNormal",
+                "displayName": "Normal",
+                "description": "Normal",
                 "supportedDataTypes": [
                     "float3"
                 ],

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Object/position.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Object/position.materialcanvasnode
@@ -8,9 +8,9 @@
         "title": "Position",
         "outputSlots": [
             {
-                "name": "outValue",
-                "displayName": "Value",
-                "description": "Value",
+                "name": "outPosition",
+                "displayName": "Position",
+                "description": "Position",
                 "supportedDataTypes": [
                     "float3"
                 ],

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Object/position.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Object/position.materialcanvasnode
@@ -19,6 +19,45 @@
                         "SLOTTYPE NODEID_SLOTNAME = O3DE_MC_POSITION;"
                     ]
                 }
+            },
+            {
+                "name": "outX",
+                "displayName": "X",
+                "description": "X",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = O3DE_MC_POSITION.x;"
+                    ]
+                }
+            },
+            {
+                "name": "outY",
+                "displayName": "Y",
+                "description": "Y",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = O3DE_MC_POSITION.y;"
+                    ]
+                }
+            },
+            {
+                "name": "outZ",
+                "displayName": "Z",
+                "description": "Z",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = O3DE_MC_POSITION.z;"
+                    ]
+                }
             }
         ]
     }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Object/uv.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Object/uv.materialcanvasnode
@@ -8,7 +8,7 @@
         "title": "UV",
         "settings": {
             "instructions": [
-                "float2 NODEID_outValue = O3DE_MC_UV(NODEID_inIndex);"
+                "float2 NODEID_outUV = O3DE_MC_UV(NODEID_inIndex);"
             ]
         },
         "inputSlots": [
@@ -32,36 +32,36 @@
         ],
         "outputSlots": [
             {
-                "name": "outValue",
-                "displayName": "Value",
-                "description": "Value",
+                "name": "outUV",
+                "displayName": "UV",
+                "description": "UV",
                 "supportedDataTypes": [
                     "float2"
                 ]
             },
             {
-                "name": "outX",
-                "displayName": "X",
+                "name": "outU",
+                "displayName": "U",
                 "description": "X",
                 "supportedDataTypes": [
                     "float"
                 ],
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE NODEID_SLOTNAME = NODEID_outValue.x;"
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_outUV.x;"
                     ]
                 }
             },
             {
-                "name": "outY",
-                "displayName": "Y",
-                "description": "Y",
+                "name": "outV",
+                "displayName": "V",
+                "description": "V",
                 "supportedDataTypes": [
                     "float"
                 ],
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE NODEID_SLOTNAME = NODEID_outValue.y;"
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_outUV.y;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Object/uv.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Object/uv.materialcanvasnode
@@ -6,6 +6,11 @@
         "id": "{8E836C09-FA68-42B0-B302-CAC3FD6E4EA2}",
         "category": "Object",
         "title": "UV",
+        "settings": {
+            "instructions": [
+                "float2 NODEID_outValue = O3DE_MC_UV(NODEID_inIndex);"
+            ]
+        },
         "inputSlots": [
             {
                 "name": "inIndex",
@@ -32,10 +37,31 @@
                 "description": "Value",
                 "supportedDataTypes": [
                     "float2"
+                ]
+            },
+            {
+                "name": "outX",
+                "displayName": "X",
+                "description": "X",
+                "supportedDataTypes": [
+                    "float"
                 ],
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE NODEID_SLOTNAME = O3DE_MC_UV(NODEID_inIndex);"
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_outValue.x;"
+                    ]
+                }
+            },
+            {
+                "name": "outY",
+                "displayName": "Y",
+                "description": "Y",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = NODEID_outValue.y;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Object/worldposition.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Object/worldposition.materialcanvasnode
@@ -19,6 +19,45 @@
                         "SLOTTYPE NODEID_SLOTNAME = O3DE_MC_WORLD_POSITION;"
                     ]
                 }
+            },
+            {
+                "name": "outX",
+                "displayName": "X",
+                "description": "X",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = O3DE_MC_WORLD_POSITION.x;"
+                    ]
+                }
+            },
+            {
+                "name": "outY",
+                "displayName": "Y",
+                "description": "Y",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = O3DE_MC_WORLD_POSITION.y;"
+                    ]
+                }
+            },
+            {
+                "name": "outZ",
+                "displayName": "Z",
+                "description": "Z",
+                "supportedDataTypes": [
+                    "float"
+                ],
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE NODEID_SLOTNAME = O3DE_MC_WORLD_POSITION.z;"
+                    ]
+                }
             }
         ]
     }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Object/worldposition.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Object/worldposition.materialcanvasnode
@@ -8,9 +8,9 @@
         "title": "World Position",
         "outputSlots": [
             {
-                "name": "outValue",
-                "displayName": "Value",
-                "description": "Value",
+                "name": "outPosition",
+                "displayName": "Position",
+                "description": "Position",
                 "supportedDataTypes": [
                     "float3"
                 ],

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Textures/sample_texture_2d.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Textures/sample_texture_2d.materialcanvasnode
@@ -45,6 +45,7 @@
                 "supportedDataTypes": [
                     "image"
                 ],
+                "supportsEditingOnNode": false,
                 "settings": {
                     "materialInputs": [
                         "SLOTSTANDARDSRGMEMBER"
@@ -58,6 +59,7 @@
                 "supportedDataTypes": [
                     "sampler"
                 ],
+                "supportsEditingOnNode": false,
                 "settings": {
                     "materialInputs": [
                         "SLOTSTANDARDSRGMEMBER"
@@ -77,13 +79,6 @@
                     "float4",
                     "color"
                 ],
-                "defaultValue": {
-                    "$type": "Vector2",
-                    "Value": [
-                        0.0,
-                        0.0
-                    ]
-                },
                 "settings": {
                     "instructions": [
                         "SLOTTYPE NODEID_SLOTNAME = SLOTVALUE;"

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Textures/sample_texture_2d.materialcanvasnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Textures/sample_texture_2d.materialcanvasnode
@@ -8,7 +8,7 @@
         "title": "Sample Texture 2d",
         "settings": {
             "instructions": [
-                "float4 NODEID_outColor = MaterialSrg::NODEID_inValue.Sample(MaterialSrg::NODEID_inSampler, NODEID_inUV);"
+                "float4 NODEID_outColor = MaterialSrg::NODEID_inValue.Sample(MaterialSrg::NODEID_inSampler, (float2)NODEID_inUV);"
             ]
         },
         "propertySlots": [

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test1.materialcanvas.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test1.materialcanvas.azasset
@@ -24,13 +24,23 @@
                     "m_inputDataSlots": [
                         {
                             "Key": {
+                                "m_name": "inAlpha"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 1.0
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
                                 "m_name": "inBaseColor"
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
+                                    "$type": "Vector3",
                                     "Value": [
-                                        1.0,
                                         1.0,
                                         1.0,
                                         1.0
@@ -44,12 +54,11 @@
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
+                                    "$type": "Vector3",
                                     "Value": [
                                         0.0,
                                         0.0,
-                                        0.0,
-                                        1.0
+                                        0.0
                                     ]
                                 }
                             }
@@ -71,12 +80,11 @@
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
+                                    "$type": "Vector3",
                                     "Value": [
                                         0.0,
                                         0.0,
-                                        0.0,
-                                        1.0
+                                        0.0
                                     ]
                                 }
                             }
@@ -171,8 +179,8 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    960.0,
-                                    -180.0
+                                    760.0,
+                                    -200.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -343,8 +351,8 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    380.0,
-                                    -140.0
+                                    180.0,
+                                    -200.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test1.materialcanvas.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test1.materialcanvas.azasset
@@ -114,7 +114,7 @@
                 "Key": 8,
                 "Value": {
                     "$type": "DynamicNode",
-                    "m_propertySlots": [
+                    "m_inputDataSlots": [
                         {
                             "Key": {
                                 "m_name": "inValue"
@@ -163,6 +163,10 @@
                         "ComponentData": {
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
+                            },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -332,11 +336,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    480.0,
-                                    -180.0
+                                    380.0,
+                                    -140.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test2.materialcanvas.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test2.materialcanvas.azasset
@@ -152,7 +152,7 @@
                 "Key": 6,
                 "Value": {
                     "$type": "DynamicNode",
-                    "m_propertySlots": [
+                    "m_inputDataSlots": [
                         {
                             "Key": {
                                 "m_name": "inValue"
@@ -224,7 +224,7 @@
                 "Key": 8,
                 "Value": {
                     "$type": "DynamicNode",
-                    "m_propertySlots": [
+                    "m_inputDataSlots": [
                         {
                             "Key": {
                                 "m_name": "inValue"
@@ -402,11 +402,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    1280.0,
-                                    -200.0
+                                    1740.0,
+                                    -40.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -474,11 +478,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    160.0,
-                                    180.0
+                                    600.0,
+                                    100.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -498,11 +506,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    320.0,
-                                    40.0
+                                    760.0,
+                                    100.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -522,11 +534,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    180.0,
-                                    -140.0
+                                    400.0,
+                                    -120.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -546,11 +562,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    640.0,
-                                    -80.0
+                                    1100.0,
+                                    20.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -569,6 +589,10 @@
                         "ComponentData": {
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
+                            },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -594,11 +618,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    960.0,
-                                    -180.0
+                                    1440.0,
+                                    -40.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test2.materialcanvas.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test2.materialcanvas.azasset
@@ -24,13 +24,23 @@
                     "m_inputDataSlots": [
                         {
                             "Key": {
+                                "m_name": "inAlpha"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 1.0
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
                                 "m_name": "inBaseColor"
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
+                                    "$type": "Vector3",
                                     "Value": [
-                                        1.0,
                                         1.0,
                                         1.0,
                                         1.0
@@ -44,12 +54,11 @@
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
+                                    "$type": "Vector3",
                                     "Value": [
                                         0.0,
                                         0.0,
-                                        0.0,
-                                        1.0
+                                        0.0
                                     ]
                                 }
                             }
@@ -71,12 +80,11 @@
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
+                                    "$type": "Vector3",
                                     "Value": [
                                         0.0,
                                         0.0,
-                                        0.0,
-                                        1.0
+                                        0.0
                                     ]
                                 }
                             }
@@ -291,6 +299,34 @@
                     },
                     "configId": "{7DE0F2F0-1ADC-4B4B-ADDB-CA21B8D97816}"
                 }
+            },
+            {
+                "Key": 10,
+                "Value": {
+                    "$type": "DynamicNode",
+                    "m_inputDataSlots": [
+                        {
+                            "Key": {
+                                "m_name": "inValue"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "Vector4",
+                                    "Value": [
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ]
+                                }
+                            }
+                        }
+                    ],
+                    "toolId": {
+                        "Value": 2034248906
+                    },
+                    "configId": "{2E53F7CC-3C6D-4737-B092-2FB41204ECAC}"
+                }
             }
         ],
         "m_connections": [
@@ -324,20 +360,6 @@
             },
             {
                 "m_sourceEndpoint": [
-                    5,
-                    {
-                        "m_name": "outValue"
-                    }
-                ],
-                "m_targetEndpoint": [
-                    7,
-                    {
-                        "m_name": "inValue2"
-                    }
-                ]
-            },
-            {
-                "m_sourceEndpoint": [
                     8,
                     {
                         "m_name": "outValue"
@@ -359,6 +381,34 @@
                 ],
                 "m_targetEndpoint": [
                     9,
+                    {
+                        "m_name": "inValue2"
+                    }
+                ]
+            },
+            {
+                "m_sourceEndpoint": [
+                    5,
+                    {
+                        "m_name": "outValue"
+                    }
+                ],
+                "m_targetEndpoint": [
+                    10,
+                    {
+                        "m_name": "inValue"
+                    }
+                ]
+            },
+            {
+                "m_sourceEndpoint": [
+                    10,
+                    {
+                        "m_name": "outValue"
+                    }
+                ],
+                "m_targetEndpoint": [
+                    7,
                     {
                         "m_name": "inValue2"
                     }
@@ -485,7 +535,7 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    600.0,
+                                    220.0,
                                     100.0
                                 ]
                             },
@@ -513,7 +563,7 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    760.0,
+                                    380.0,
                                     100.0
                                 ]
                             },
@@ -635,6 +685,34 @@
                             "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                 "$type": "PersistentIdComponentSaveData",
                                 "PersistentId": "{AA403502-AA12-4FAF-B6FE-F2472993F4C6}"
+                            }
+                        }
+                    }
+                },
+                {
+                    "Key": 10,
+                    "Value": {
+                        "ComponentData": {
+                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                "$type": "NodeSaveData"
+                            },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
+                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                "$type": "GeometrySaveData",
+                                "Position": [
+                                    680.0,
+                                    100.0
+                                ]
+                            },
+                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                "$type": "StylingComponentSaveData"
+                            },
+                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                "$type": "PersistentIdComponentSaveData",
+                                "PersistentId": "{72E332FB-DBAB-4F1A-8F51-4D873E2BEF0D}"
                             }
                         }
                     }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test3.materialcanvas.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test3.materialcanvas.azasset
@@ -150,11 +150,34 @@
                         },
                         {
                             "Key": {
+                                "m_name": "inSampler"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "SamplerState",
+                                    "Value": {
+                                        "m_filterMin": "Linear",
+                                        "m_filterMag": "Linear",
+                                        "m_filterMip": "Linear",
+                                        "m_reductionType": "Comparison"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
                                 "m_name": "inValue"
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "{403A7CFE-B218-5D57-8540-BD58E734BCFE} Asset<StreamingImageAsset>"
+                                    "$type": "{403A7CFE-B218-5D57-8540-BD58E734BCFE} Asset<StreamingImageAsset>",
+                                    "Value": {
+                                        "assetId": {
+                                            "guid": "{78CB60CC-1079-5526-8704-3AE8D722D70A}",
+                                            "subId": 1000
+                                        },
+                                        "assetHint": "testdata/textures/checker8x8_flip_512.png.streamingimage"
+                                    }
                                 }
                             }
                         }
@@ -180,6 +203,29 @@
                     },
                     "configId": "{C0ADB0F0-39DD-48D9-A4D2-58B40C76C285}"
                 }
+            },
+            {
+                "Key": 5,
+                "Value": {
+                    "$type": "DynamicNode",
+                    "m_inputDataSlots": [
+                        {
+                            "Key": {
+                                "m_name": "inIndex"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "unsigned int",
+                                    "Value": 1
+                                }
+                            }
+                        }
+                    ],
+                    "toolId": {
+                        "Value": 2034248906
+                    },
+                    "configId": "{8E836C09-FA68-42B0-B302-CAC3FD6E4EA2}"
+                }
             }
         ],
         "m_connections": [
@@ -196,6 +242,20 @@
                         "m_name": "inBaseColor"
                     }
                 ]
+            },
+            {
+                "m_sourceEndpoint": [
+                    5,
+                    {
+                        "m_name": "outValue"
+                    }
+                ],
+                "m_targetEndpoint": [
+                    2,
+                    {
+                        "m_name": "inUV"
+                    }
+                ]
             }
         ],
         "m_uiMetadata": {
@@ -207,11 +267,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    340.0,
-                                    -100.0
+                                    120.0,
+                                    -180.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -231,11 +295,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -140.0,
-                                    -140.0
+                                    -180.0,
+                                    -180.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -244,6 +312,90 @@
                             "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                 "$type": "PersistentIdComponentSaveData",
                                 "PersistentId": "{ACCC8542-0AF6-46D5-BFD5-F2FE94B3150C}"
+                            }
+                        }
+                    }
+                },
+                {
+                    "Key": 3,
+                    "Value": {
+                        "ComponentData": {
+                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                "$type": "NodeSaveData"
+                            },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
+                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                "$type": "GeometrySaveData",
+                                "Position": [
+                                    -520.0,
+                                    -80.0
+                                ]
+                            },
+                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                "$type": "StylingComponentSaveData"
+                            },
+                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                "$type": "PersistentIdComponentSaveData",
+                                "PersistentId": "{FECB9074-BB13-42B4-9B56-1169B59620E3}"
+                            }
+                        }
+                    }
+                },
+                {
+                    "Key": 4,
+                    "Value": {
+                        "ComponentData": {
+                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                "$type": "NodeSaveData"
+                            },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
+                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                "$type": "GeometrySaveData",
+                                "Position": [
+                                    -40.0,
+                                    80.0
+                                ]
+                            },
+                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                "$type": "StylingComponentSaveData"
+                            },
+                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                "$type": "PersistentIdComponentSaveData",
+                                "PersistentId": "{5C7242A5-16C1-49A5-8250-21C1584283C0}"
+                            }
+                        }
+                    }
+                },
+                {
+                    "Key": 5,
+                    "Value": {
+                        "ComponentData": {
+                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                "$type": "NodeSaveData"
+                            },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
+                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                "$type": "GeometrySaveData",
+                                "Position": [
+                                    -480.0,
+                                    -180.0
+                                ]
+                            },
+                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                "$type": "StylingComponentSaveData"
+                            },
+                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                "$type": "PersistentIdComponentSaveData",
+                                "PersistentId": "{6CE967FD-B1BA-4252-BA89-5F8BC9BBCA98}"
                             }
                         }
                     }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test3.materialcanvas.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test3.materialcanvas.azasset
@@ -24,13 +24,23 @@
                     "m_inputDataSlots": [
                         {
                             "Key": {
+                                "m_name": "inAlpha"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 1.0
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
                                 "m_name": "inBaseColor"
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
+                                    "$type": "Vector3",
                                     "Value": [
-                                        1.0,
                                         1.0,
                                         1.0,
                                         1.0
@@ -44,12 +54,11 @@
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
+                                    "$type": "Vector3",
                                     "Value": [
                                         0.0,
                                         0.0,
-                                        0.0,
-                                        1.0
+                                        0.0
                                     ]
                                 }
                             }
@@ -71,12 +80,11 @@
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
+                                    "$type": "Vector3",
                                     "Value": [
                                         0.0,
                                         0.0,
-                                        0.0,
-                                        1.0
+                                        0.0
                                     ]
                                 }
                             }
@@ -247,7 +255,7 @@
                 "m_sourceEndpoint": [
                     5,
                     {
-                        "m_name": "outValue"
+                        "m_name": "outUV"
                     }
                 ],
                 "m_targetEndpoint": [
@@ -386,7 +394,7 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -480.0,
+                                    -340.0,
                                     -180.0
                                 ]
                             },

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test4.materialcanvas.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test4.materialcanvas.azasset
@@ -34,13 +34,23 @@
                     "m_inputDataSlots": [
                         {
                             "Key": {
+                                "m_name": "inAlpha"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 1.0
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
                                 "m_name": "inBaseColor"
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
+                                    "$type": "Vector3",
                                     "Value": [
-                                        1.0,
                                         1.0,
                                         1.0,
                                         1.0
@@ -54,12 +64,11 @@
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
+                                    "$type": "Vector3",
                                     "Value": [
                                         0.0,
                                         0.0,
-                                        0.0,
-                                        1.0
+                                        0.0
                                     ]
                                 }
                             }
@@ -81,12 +90,11 @@
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
+                                    "$type": "Vector3",
                                     "Value": [
                                         0.0,
                                         0.0,
-                                        0.0,
-                                        1.0
+                                        0.0
                                     ]
                                 }
                             }
@@ -271,7 +279,7 @@
                 "m_sourceEndpoint": [
                     14,
                     {
-                        "m_name": "outValue"
+                        "m_name": "outUV"
                     }
                 ],
                 "m_targetEndpoint": [
@@ -571,7 +579,7 @@
                                 "$type": "GeometrySaveData",
                                 "Position": [
                                     240.0,
-                                    -80.0
+                                    -120.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -598,8 +606,8 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    480.0,
-                                    -120.0
+                                    420.0,
+                                    -380.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -626,8 +634,8 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    160.0,
-                                    -340.0
+                                    100.0,
+                                    -380.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -654,8 +662,8 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -200.0,
-                                    -300.0
+                                    -60.0,
+                                    -380.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test4.materialcanvas.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test4.materialcanvas.azasset
@@ -5,7 +5,17 @@
     "ClassData": {
         "m_nodes": [
             {
-                "Key": 1,
+                "Key": 11,
+                "Value": {
+                    "$type": "DynamicNode",
+                    "toolId": {
+                        "Value": 2034248906
+                    },
+                    "configId": "{20D18D54-9A1D-4C4E-B676-F72097AC3A93}"
+                }
+            },
+            {
+                "Key": 12,
                 "Value": {
                     "$type": "DynamicNode",
                     "m_propertySlots": [
@@ -111,7 +121,7 @@
                 }
             },
             {
-                "Key": 2,
+                "Key": 13,
                 "Value": {
                     "$type": "DynamicNode",
                     "m_propertySlots": [
@@ -150,11 +160,34 @@
                         },
                         {
                             "Key": {
+                                "m_name": "inSampler"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "SamplerState",
+                                    "Value": {
+                                        "m_filterMin": "Linear",
+                                        "m_filterMag": "Linear",
+                                        "m_filterMip": "Linear",
+                                        "m_reductionType": "Comparison"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
                                 "m_name": "inValue"
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "{403A7CFE-B218-5D57-8540-BD58E734BCFE} Asset<StreamingImageAsset>"
+                                    "$type": "{403A7CFE-B218-5D57-8540-BD58E734BCFE} Asset<StreamingImageAsset>",
+                                    "Value": {
+                                        "assetId": {
+                                            "guid": "{78CB60CC-1079-5526-8704-3AE8D722D70A}",
+                                            "subId": 1000
+                                        },
+                                        "assetHint": "testdata/textures/checker8x8_flip_512.png.streamingimage"
+                                    }
                                 }
                             }
                         }
@@ -182,66 +215,18 @@
                 }
             },
             {
-                "Key": 3,
+                "Key": 14,
                 "Value": {
                     "$type": "DynamicNode",
-                    "m_propertySlots": [
-                        {
-                            "Key": {
-                                "m_name": "inDescription"
-                            },
-                            "Value": {
-                                "m_value": {
-                                    "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
-                                    "Value": ""
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "m_name": "inGroup"
-                            },
-                            "Value": {
-                                "m_value": {
-                                    "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
-                                    "Value": ""
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "m_name": "inName"
-                            },
-                            "Value": {
-                                "m_value": {
-                                    "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
-                                    "Value": ""
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "m_name": "inValue"
-                            },
-                            "Value": {
-                                "m_value": {
-                                    "$type": "{403A7CFE-B218-5D57-8540-BD58E734BCFE} Asset<StreamingImageAsset>"
-                                }
-                            }
-                        }
-                    ],
                     "m_inputDataSlots": [
                         {
                             "Key": {
-                                "m_name": "inUV"
+                                "m_name": "inIndex"
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector2",
-                                    "Value": [
-                                        0.0,
-                                        0.0
-                                    ]
+                                    "$type": "unsigned int",
+                                    "Value": 1
                                 }
                             }
                         }
@@ -249,20 +234,20 @@
                     "toolId": {
                         "Value": 2034248906
                     },
-                    "configId": "{C0ADB0F0-39DD-48D9-A4D2-58B40C76C285}"
+                    "configId": "{8E836C09-FA68-42B0-B302-CAC3FD6E4EA2}"
                 }
             }
         ],
         "m_connections": [
             {
                 "m_sourceEndpoint": [
-                    3,
+                    11,
                     {
-                        "m_name": "outR"
+                        "m_name": "outZ"
                     }
                 ],
                 "m_targetEndpoint": [
-                    1,
+                    12,
                     {
                         "m_name": "inMetallic"
                     }
@@ -270,43 +255,29 @@
             },
             {
                 "m_sourceEndpoint": [
-                    3,
-                    {
-                        "m_name": "outG"
-                    }
-                ],
-                "m_targetEndpoint": [
-                    1,
-                    {
-                        "m_name": "inSpecularF0Factor"
-                    }
-                ]
-            },
-            {
-                "m_sourceEndpoint": [
-                    3,
-                    {
-                        "m_name": "outB"
-                    }
-                ],
-                "m_targetEndpoint": [
-                    1,
-                    {
-                        "m_name": "inRoughness"
-                    }
-                ]
-            },
-            {
-                "m_sourceEndpoint": [
-                    2,
+                    13,
                     {
                         "m_name": "outColor"
                     }
                 ],
                 "m_targetEndpoint": [
-                    1,
+                    12,
                     {
                         "m_name": "inBaseColor"
+                    }
+                ]
+            },
+            {
+                "m_sourceEndpoint": [
+                    14,
+                    {
+                        "m_name": "outValue"
+                    }
+                ],
+                "m_targetEndpoint": [
+                    13,
+                    {
+                        "m_name": "inUV"
                     }
                 ]
             }
@@ -320,11 +291,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    340.0,
-                                    -120.0
+                                    740.0,
+                                    -140.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -392,11 +367,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    280.0,
-                                    100.0
+                                    320.0,
+                                    -120.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -404,7 +383,287 @@
                             },
                             "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                 "$type": "PersistentIdComponentSaveData",
-                                "PersistentId": "{98A74D48-3EB3-4D0C-8A91-E0EFBB1EB2C9}"
+                                "PersistentId": "{B164A626-AF89-45DA-8C10-211194A3374A}"
+                            }
+                        }
+                    }
+                },
+                {
+                    "Key": 5,
+                    "Value": {
+                        "ComponentData": {
+                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                "$type": "NodeSaveData"
+                            },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
+                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                "$type": "GeometrySaveData",
+                                "Position": [
+                                    20.0,
+                                    -140.0
+                                ]
+                            },
+                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                "$type": "StylingComponentSaveData"
+                            },
+                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                "$type": "PersistentIdComponentSaveData",
+                                "PersistentId": "{004D3382-2559-4195-A79A-1E9065CD9DE2}"
+                            }
+                        }
+                    }
+                },
+                {
+                    "Key": 6,
+                    "Value": {
+                        "ComponentData": {
+                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                "$type": "NodeSaveData"
+                            },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
+                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                "$type": "GeometrySaveData",
+                                "Position": [
+                                    120.0,
+                                    -60.0
+                                ]
+                            },
+                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                "$type": "StylingComponentSaveData"
+                            },
+                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                "$type": "PersistentIdComponentSaveData",
+                                "PersistentId": "{6D0E5F30-D10C-46A5-9BB7-8ED40E64DFE7}"
+                            }
+                        }
+                    }
+                },
+                {
+                    "Key": 7,
+                    "Value": {
+                        "ComponentData": {
+                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                "$type": "NodeSaveData"
+                            },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
+                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                "$type": "GeometrySaveData",
+                                "Position": [
+                                    20.0,
+                                    -120.0
+                                ]
+                            },
+                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                "$type": "StylingComponentSaveData"
+                            },
+                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                "$type": "PersistentIdComponentSaveData",
+                                "PersistentId": "{02594544-A3FB-4090-9434-7A070D4616EE}"
+                            }
+                        }
+                    }
+                },
+                {
+                    "Key": 8,
+                    "Value": {
+                        "ComponentData": {
+                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                "$type": "NodeSaveData"
+                            },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
+                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                "$type": "GeometrySaveData",
+                                "Position": [
+                                    -40.0,
+                                    -140.0
+                                ]
+                            },
+                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                "$type": "StylingComponentSaveData"
+                            },
+                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                "$type": "PersistentIdComponentSaveData",
+                                "PersistentId": "{75306F03-1727-4654-97BE-01A9177288EB}"
+                            }
+                        }
+                    }
+                },
+                {
+                    "Key": 9,
+                    "Value": {
+                        "ComponentData": {
+                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                "$type": "NodeSaveData"
+                            },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
+                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                "$type": "GeometrySaveData",
+                                "Position": [
+                                    380.0,
+                                    -60.0
+                                ]
+                            },
+                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                "$type": "StylingComponentSaveData"
+                            },
+                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                "$type": "PersistentIdComponentSaveData",
+                                "PersistentId": "{9A2CF2D2-A92B-4110-9966-A8AE2CB86155}"
+                            }
+                        }
+                    }
+                },
+                {
+                    "Key": 10,
+                    "Value": {
+                        "ComponentData": {
+                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                "$type": "NodeSaveData"
+                            },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
+                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                "$type": "GeometrySaveData",
+                                "Position": [
+                                    720.0,
+                                    -80.0
+                                ]
+                            },
+                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                "$type": "StylingComponentSaveData"
+                            },
+                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                "$type": "PersistentIdComponentSaveData",
+                                "PersistentId": "{A393EEAC-991D-42A4-9866-A124765B85D2}"
+                            }
+                        }
+                    }
+                },
+                {
+                    "Key": 11,
+                    "Value": {
+                        "ComponentData": {
+                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                "$type": "NodeSaveData"
+                            },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
+                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                "$type": "GeometrySaveData",
+                                "Position": [
+                                    240.0,
+                                    -80.0
+                                ]
+                            },
+                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                "$type": "StylingComponentSaveData"
+                            },
+                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                "$type": "PersistentIdComponentSaveData",
+                                "PersistentId": "{CF8D953C-F6EA-43C1-9DE5-BCD2F1C5BFB3}"
+                            }
+                        }
+                    }
+                },
+                {
+                    "Key": 12,
+                    "Value": {
+                        "ComponentData": {
+                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                "$type": "NodeSaveData"
+                            },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
+                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                "$type": "GeometrySaveData",
+                                "Position": [
+                                    480.0,
+                                    -120.0
+                                ]
+                            },
+                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                "$type": "StylingComponentSaveData"
+                            },
+                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                "$type": "PersistentIdComponentSaveData",
+                                "PersistentId": "{79180BDD-076D-4750-AC6D-10C71986955A}"
+                            }
+                        }
+                    }
+                },
+                {
+                    "Key": 13,
+                    "Value": {
+                        "ComponentData": {
+                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                "$type": "NodeSaveData"
+                            },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
+                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                "$type": "GeometrySaveData",
+                                "Position": [
+                                    160.0,
+                                    -340.0
+                                ]
+                            },
+                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                "$type": "StylingComponentSaveData"
+                            },
+                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                "$type": "PersistentIdComponentSaveData",
+                                "PersistentId": "{5E4577C4-9285-42E8-A642-F1D6CF5A6A0B}"
+                            }
+                        }
+                    }
+                },
+                {
+                    "Key": 14,
+                    "Value": {
+                        "ComponentData": {
+                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                "$type": "NodeSaveData"
+                            },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
+                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                "$type": "GeometrySaveData",
+                                "Position": [
+                                    -200.0,
+                                    -300.0
+                                ]
+                            },
+                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                "$type": "StylingComponentSaveData"
+                            },
+                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                "$type": "PersistentIdComponentSaveData",
+                                "PersistentId": "{EF1F9427-4003-45B3-9F15-CBB243A5C3E5}"
                             }
                         }
                     }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test5.materialcanvas.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test5.materialcanvas.azasset
@@ -114,7 +114,7 @@
                 "Key": 2,
                 "Value": {
                     "$type": "DynamicNode",
-                    "m_propertySlots": [
+                    "m_inputDataSlots": [
                         {
                             "Key": {
                                 "m_name": "inValue"
@@ -142,7 +142,7 @@
                 "Key": 3,
                 "Value": {
                     "$type": "DynamicNode",
-                    "m_propertySlots": [
+                    "m_inputDataSlots": [
                         {
                             "Key": {
                                 "m_name": "inValue"
@@ -403,33 +403,6 @@
                 }
             },
             {
-                "Key": 13,
-                "Value": {
-                    "$type": "DynamicNode",
-                    "m_inputDataSlots": [
-                        {
-                            "Key": {
-                                "m_name": "inValue"
-                            },
-                            "Value": {
-                                "m_value": {
-                                    "$type": "Vector3",
-                                    "Value": [
-                                        0.0,
-                                        0.0,
-                                        0.0
-                                    ]
-                                }
-                            }
-                        }
-                    ],
-                    "toolId": {
-                        "Value": 2034248906
-                    },
-                    "configId": "{1F53AECF-F416-4AD1-9777-A7E6049383A8}"
-                }
-            },
-            {
                 "Key": 14,
                 "Value": {
                     "$type": "DynamicNode",
@@ -589,7 +562,7 @@
                                             "guid": "{61FA63C9-B0A1-5293-9BFB-5FAFFCF85295}",
                                             "subId": 1000
                                         },
-                                        "assetHint": "TestData/Textures/checker8x8_512.png"
+                                        "assetHint": "testdata/textures/checker8x8_512.png.streamingimage"
                                     }
                                 }
                             }
@@ -784,48 +757,6 @@
             },
             {
                 "m_sourceEndpoint": [
-                    13,
-                    {
-                        "m_name": "outX"
-                    }
-                ],
-                "m_targetEndpoint": [
-                    14,
-                    {
-                        "m_name": "inX"
-                    }
-                ]
-            },
-            {
-                "m_sourceEndpoint": [
-                    13,
-                    {
-                        "m_name": "outY"
-                    }
-                ],
-                "m_targetEndpoint": [
-                    14,
-                    {
-                        "m_name": "inY"
-                    }
-                ]
-            },
-            {
-                "m_sourceEndpoint": [
-                    13,
-                    {
-                        "m_name": "outZ"
-                    }
-                ],
-                "m_targetEndpoint": [
-                    14,
-                    {
-                        "m_name": "inZ"
-                    }
-                ]
-            },
-            {
-                "m_sourceEndpoint": [
                     8,
                     {
                         "m_name": "outValue"
@@ -882,20 +813,6 @@
             },
             {
                 "m_sourceEndpoint": [
-                    12,
-                    {
-                        "m_name": "outValue"
-                    }
-                ],
-                "m_targetEndpoint": [
-                    13,
-                    {
-                        "m_name": "inValue"
-                    }
-                ]
-            },
-            {
-                "m_sourceEndpoint": [
                     9,
                     {
                         "m_name": "outValue"
@@ -935,6 +852,48 @@
                         "m_name": "inEmissive"
                     }
                 ]
+            },
+            {
+                "m_sourceEndpoint": [
+                    12,
+                    {
+                        "m_name": "outX"
+                    }
+                ],
+                "m_targetEndpoint": [
+                    14,
+                    {
+                        "m_name": "inX"
+                    }
+                ]
+            },
+            {
+                "m_sourceEndpoint": [
+                    12,
+                    {
+                        "m_name": "outY"
+                    }
+                ],
+                "m_targetEndpoint": [
+                    14,
+                    {
+                        "m_name": "inY"
+                    }
+                ]
+            },
+            {
+                "m_sourceEndpoint": [
+                    12,
+                    {
+                        "m_name": "outZ"
+                    }
+                ],
+                "m_targetEndpoint": [
+                    14,
+                    {
+                        "m_name": "inZ"
+                    }
+                ]
             }
         ],
         "m_uiMetadata": {
@@ -946,11 +905,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    1100.0,
-                                    -20.0
+                                    1160.0,
+                                    260.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -977,8 +940,8 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -160.0,
-                                    80.0
+                                    -700.0,
+                                    -120.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -998,11 +961,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -160.0,
-                                    280.0
+                                    -620.0,
+                                    100.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1022,11 +989,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -520.0,
-                                    300.0
+                                    -500.0,
+                                    320.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1046,11 +1017,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -20.0,
-                                    460.0
+                                    -340.0,
+                                    420.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1077,8 +1052,8 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    640.0,
-                                    300.0
+                                    420.0,
+                                    360.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1098,11 +1073,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    380.0,
-                                    460.0
+                                    100.0,
+                                    420.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1122,11 +1101,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
                                     420.0,
-                                    -200.0
+                                    140.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1146,11 +1129,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -180.0,
-                                    -80.0
+                                    -340.0,
+                                    320.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1194,11 +1181,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "DefaultNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    440.0,
-                                    0.0
+                                    420.0,
+                                    260.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1225,8 +1216,8 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    480.0,
-                                    -360.0
+                                    -500.0,
+                                    -560.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1281,8 +1272,8 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    1260.0,
-                                    -360.0
+                                    -340.0,
+                                    -560.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1309,8 +1300,8 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    900.0,
-                                    -180.0
+                                    800.0,
+                                    400.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1337,8 +1328,8 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -160.0,
-                                    -360.0
+                                    -340.0,
+                                    -380.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1365,8 +1356,8 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -500.0,
-                                    -260.0
+                                    -640.0,
+                                    -380.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test5.materialcanvas.azasset
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test5.materialcanvas.azasset
@@ -24,13 +24,23 @@
                     "m_inputDataSlots": [
                         {
                             "Key": {
+                                "m_name": "inAlpha"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 1.0
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
                                 "m_name": "inBaseColor"
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
+                                    "$type": "Vector3",
                                     "Value": [
-                                        1.0,
                                         1.0,
                                         1.0,
                                         1.0
@@ -44,12 +54,11 @@
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
+                                    "$type": "Vector3",
                                     "Value": [
                                         0.0,
                                         0.0,
-                                        0.0,
-                                        1.0
+                                        0.0
                                     ]
                                 }
                             }
@@ -71,9 +80,8 @@
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
+                                    "$type": "Vector3",
                                     "Value": [
-                                        0.0,
                                         0.0,
                                         0.0,
                                         0.0
@@ -799,20 +807,6 @@
             },
             {
                 "m_sourceEndpoint": [
-                    17,
-                    {
-                        "m_name": "outValue"
-                    }
-                ],
-                "m_targetEndpoint": [
-                    16,
-                    {
-                        "m_name": "inUV"
-                    }
-                ]
-            },
-            {
-                "m_sourceEndpoint": [
                     9,
                     {
                         "m_name": "outValue"
@@ -894,6 +888,20 @@
                         "m_name": "inZ"
                     }
                 ]
+            },
+            {
+                "m_sourceEndpoint": [
+                    17,
+                    {
+                        "m_name": "outUV"
+                    }
+                ],
+                "m_targetEndpoint": [
+                    16,
+                    {
+                        "m_name": "inUV"
+                    }
+                ]
             }
         ],
         "m_uiMetadata": {
@@ -940,7 +948,7 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -700.0,
+                                    -560.0,
                                     -120.0
                                 ]
                             },
@@ -968,7 +976,7 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -620.0,
+                                    -480.0,
                                     100.0
                                 ]
                             },
@@ -996,7 +1004,7 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -500.0,
+                                    -360.0,
                                     320.0
                                 ]
                             },
@@ -1024,7 +1032,7 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -340.0,
+                                    -200.0,
                                     420.0
                                 ]
                             },
@@ -1136,7 +1144,7 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -340.0,
+                                    -200.0,
                                     320.0
                                 ]
                             },
@@ -1216,7 +1224,7 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -500.0,
+                                    -360.0,
                                     -560.0
                                 ]
                             },
@@ -1272,7 +1280,7 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -340.0,
+                                    -200.0,
                                     -560.0
                                 ]
                             },
@@ -1356,7 +1364,7 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -640.0,
+                                    -500.0,
                                     -380.0
                                 ]
                             },

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
@@ -562,25 +562,25 @@ namespace MaterialCanvas
     {
         if (auto v = AZStd::any_cast<const AZ::Color>(&slotValue))
         {
-            return AZStd::string::format("float4(%g, %g, %g, %g)", v->GetR(), v->GetG(), v->GetB(), v->GetA());
+            return AZStd::string::format("{%g, %g, %g, %g}", v->GetR(), v->GetG(), v->GetB(), v->GetA());
         }
         if (auto v = AZStd::any_cast<const AZ::Vector4>(&slotValue))
         {
-            return AZStd::string::format("float4(%g, %g, %g, %g)", v->GetX(), v->GetY(), v->GetZ(), v->GetW());
+            return AZStd::string::format("{%g, %g, %g, %g}", v->GetX(), v->GetY(), v->GetZ(), v->GetW());
         }
         if (auto v = AZStd::any_cast<const AZ::Vector3>(&slotValue))
         {
-            return AZStd::string::format("float3(%g, %g, %g)", v->GetX(), v->GetY(), v->GetZ());
+            return AZStd::string::format("{%g, %g, %g}", v->GetX(), v->GetY(), v->GetZ());
         }
         if (auto v = AZStd::any_cast<const AZ::Vector2>(&slotValue))
         {
-            return AZStd::string::format("float2(%g, %g)", v->GetX(), v->GetY());
+            return AZStd::string::format("{%g, %g}", v->GetX(), v->GetY());
         }
         if (auto v = AZStd::any_cast<const AZStd::array<AZ::Vector3, 3>>(&slotValue))
         {
             const auto& value = *v;
             return AZStd::string::format(
-                "float3x3(%g, %g, %g, %g, %g, %g, %g, %g, %g)",
+                "{%g, %g, %g, %g, %g, %g, %g, %g, %g}",
                 value[0].GetX(), value[0].GetY(), value[0].GetZ(),
                 value[1].GetX(), value[1].GetY(), value[1].GetZ(),
                 value[2].GetX(), value[2].GetY(), value[2].GetZ());
@@ -589,7 +589,7 @@ namespace MaterialCanvas
         {
             const auto& value = *v;
             return AZStd::string::format(
-                "float4x3(%g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g)",
+                "{%g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g}",
                 value[0].GetX(), value[0].GetY(), value[0].GetZ(), value[0].GetW(),
                 value[1].GetX(), value[1].GetY(), value[1].GetZ(), value[1].GetW(),
                 value[2].GetX(), value[2].GetY(), value[2].GetZ(), value[2].GetW());
@@ -598,7 +598,7 @@ namespace MaterialCanvas
         {
             const auto& value = *v;
             return AZStd::string::format(
-                "float4x4(%g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g)",
+                "{%g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g}",
                 value[0].GetX(), value[0].GetY(), value[0].GetZ(), value[0].GetW(),
                 value[1].GetX(), value[1].GetY(), value[1].GetZ(), value[1].GetW(),
                 value[2].GetX(), value[2].GetY(), value[2].GetZ(), value[2].GetW(),


### PR DESCRIPTION
## What does this PR do?

Created basic node configurations for floating point matrix types. Support for connecting to these data types will be added to other nodes after another change that adds more intuitive settings for specifying supported scalar, vector, matrix data types and sizes.

Extended all of the color and vector variable and input nodes with XYZW/RGBA output slots as a convenience to give immediate access to all of the vector and color components.

Updated experimental PBR template and a couple of notes to use explicit C style casting so that scalars and vectors can be converted to the correct type according to HLSL specifications. I was previously attempting to do this with implicit type conversions or accessing vector elements. The C style casting handles the cases uniformly and stops implicit type conversion warnings.

Resolves https://github.com/o3de/o3de/issues/12812

## How was this PR tested?

![image](https://user-images.githubusercontent.com/82461473/198641281-9717ad3b-507c-40eb-b351-8ca3190716ce.png)
![image](https://user-images.githubusercontent.com/82461473/198641965-544fe8f1-d069-4822-a7fa-5d5c233ef809.png)
![image](https://user-images.githubusercontent.com/82461473/198643023-c8731fdb-6e70-413c-b48b-7482e56dad45.png)
