### PR TITLE
Resolve include path aliases that come from shader_build_options.json…

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.cpp
@@ -467,6 +467,7 @@ namespace AZ
 
                     // Run the preprocessor.
                     PreprocessorData output;
+                    buildArgsManager.ResolvePreprocessorIncludeAliases();
                     auto preprocessorArguments = AppendIncludePathsToArgumentList(buildArgsManager.GetCurrentArguments().m_preprocessorArguments, projectIncludePaths);
                     const bool preprocessorSuccess = PreprocessFile(prependedAzslFilePath, output, preprocessorArguments,  true);
                     RHI::ReportMessages(ShaderAssetBuilderName, output.diagnostics, !preprocessorSuccess);

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderBuildArgumentsManager.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderBuildArgumentsManager.cpp
@@ -75,6 +75,18 @@ namespace AZ
             m_argumentsNameStack.push("");
         }
 
+        void ShaderBuildArgumentsManager::ResolvePreprocessorIncludeAliases()
+        {
+            for (AZStd::string& argument : m_argumentsStack.top().m_preprocessorArguments)
+            {
+                if (argument.size() > 2 && argument.substr(0, 3) == "-I@")
+                {
+                    AZStd::string temp = "-I" + ResolvePathAliases(AZStd::string_view(AZStd::begin(argument) + 2, AZStd::end(argument)));
+                    argument = temp;
+                }
+            }
+        }
+
         const AZ::RHI::ShaderBuildArguments& ShaderBuildArgumentsManager::PushArgumentsInternal(const AZStd::string& name, const AZ::RHI::ShaderBuildArguments& arguments)
         {
             m_argumentsNameStack.push(name);

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderBuildArgumentsManager.h
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderBuildArgumentsManager.h
@@ -105,6 +105,10 @@ namespace AZ
             //! @remark: The "" (global) arguments are never popped, regardless of how many times this function is called.
             void PopArgumentScope();
 
+            //! Replaces -I preprocessor arguments that have @ aliases with equivalents that have fully resolved paths
+            //! Only impacts the preprocessor arguments at the top of the stack
+            void ResolvePreprocessorIncludeAliases();
+
         private:
             friend class ::UnitTest::ShaderBuildArgumentsTests;
             void Init(AZStd::unordered_map<AZStd::string, AZ::RHI::ShaderBuildArguments> && removeBuildArgumentsMap


### PR DESCRIPTION
…. There may be a better time/place to resolve them, but this functions.

See https://github.com/o3de/o3de/issues/12902 for deliberation on the best way to approach this.

Signed-off-by: Tommy Walton <waltont@amazon.com>