### PR TITLE
Update CDK version to 1.179.0 for AWSI periodic tests

### DIFF
--- a/scripts/build/Platform/Linux/build_config.json
+++ b/scripts/build/Platform/Linux/build_config.json
@@ -392,7 +392,7 @@
     "COMMAND": "deploy_cdk_applications.sh",
     "PARAMETERS": {
       "NVM_VERSION": "v0.39.1",
-      "CDK_VERSION": "1.154.0",
+      "CDK_VERSION": "1.179.0",
       "PYTHON_RUNTIME": "python-3.10.5-rev1-linux"
     }
   },
@@ -404,7 +404,7 @@
     "COMMAND": "destroy_cdk_applications.sh",
     "PARAMETERS": {
       "NVM_VERSION": "v0.39.1",
-      "CDK_VERSION": "1.154.0",
+      "CDK_VERSION": "1.179.0",
       "PYTHON_RUNTIME": "python-3.10.5-rev1-linux"
     }
   }

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -515,7 +515,7 @@
     },
     "COMMAND": "deploy_cdk_applications.cmd",
     "PARAMETERS": {
-      "CDK_VERSION": "1.154.0"
+      "CDK_VERSION": "1.179.0"
     }
   },
   "awsi_destruction": {
@@ -525,7 +525,7 @@
     },
     "COMMAND": "destroy_cdk_applications.cmd",
     "PARAMETERS": {
-      "CDK_VERSION": "1.154.0"
+      "CDK_VERSION": "1.179.0"
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Resolves https://github.com/o3de/o3de/issues/12487#issuecomment-1297526928 

## How was this PR tested?

1. Reproduced issue with `CDK_VERSION` set to 1.154.0
2. Set `CDK_VERSION` to 1.179.0
3. Deployment now succeeds
4. Destroy also succeeds
