### PR TITLE
Action Manager | Fixes to Open Recent menu displaying invalid levels

### DIFF
--- a/Code/Editor/Core/EditorActionsHandler.h
+++ b/Code/Editor/Core/EditorActionsHandler.h
@@ -87,8 +87,12 @@ private:
     void RefreshLayoutActions();
 
     // Recent Files
+    const char* m_levelExtension = nullptr;
+    int m_recentFileActionsCount = 0;
     bool IsRecentFileActionActive(int index);
+    bool IsRecentFileEntryValid(const QString& entry, const QString& gameFolderPath);
     void UpdateRecentFileActions();
+    void OpenLevelByRecentFileEntryIndex(int index);
 
     // Toolbox Macros
     void RefreshToolboxMacroActions();


### PR DESCRIPTION
## What does this PR do?

Introduces fixes to the `Open Recent...` menu with the new Action Manager enabled.

- In the previous implementation, the full level path would be displayed instead of the display version;
- Fixed the list generation to skip levels that do not belong to the current project;
- Fixed index number to show the correct count (bug that is still in the legacy implementation).

Verified that the menu items open the correct files (had to refactor the code since now there is no longer 1:1 correspondence between the indices).

Legacy menu (new action manager flag off)
![image](https://user-images.githubusercontent.com/82231674/199117717-fa916fe4-e203-4a53-bca6-121e01ac6278.png)

New menu (new action manager flag on)
![image](https://user-images.githubusercontent.com/82231674/199117735-724236cd-6697-490e-9bda-7fec752a00f1.png)

(Note, the ordering of the levels is different due to testing, but the behavior is correct).

## How was this PR tested?
Manual testing.
