### PR TITLE
Merge Mesh Performance Improvements from RosCon->Development

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
@@ -80,7 +80,8 @@ namespace AZ
             };
 
             void DeInit();
-            void Init(Data::Instance<RPI::Model> model);
+            void QueueInit(const Data::Instance<RPI::Model>& model);
+            void Init();
             void BuildDrawPacketList(size_t modelLodIndex);
             void SetRayTracingData();
             void RemoveRayTracingData();
@@ -124,6 +125,7 @@ namespace AZ
 
             bool m_cullBoundsNeedsUpdate = false;
             bool m_cullableNeedsRebuild = false;
+            bool m_needsInit = false;
             bool m_objectSrgNeedsUpdate = true;
             bool m_excludeFromReflectionCubeMaps = false;
             bool m_visible = true;

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -124,6 +124,11 @@ namespace AZ
                             continue;
                         }
 
+                        if (meshDataIter->m_needsInit)
+                        {
+                            meshDataIter->Init();
+                        }
+
                         if (meshDataIter->m_objectSrgNeedsUpdate)
                         {
                             meshDataIter->UpdateObjectSrg();
@@ -356,7 +361,7 @@ namespace AZ
                     Data::Instance<RPI::Model> model = meshHandle->m_model;
                     meshHandle->DeInit();
                     meshHandle->m_materialAssignments = materials;
-                    meshHandle->Init(model);
+                    meshHandle->QueueInit(model);
                 }
                 else
                 {
@@ -746,7 +751,7 @@ namespace AZ
             if (model)
             {
                 m_parent->RemoveRayTracingData();
-                m_parent->Init(model);
+                m_parent->QueueInit(model);
                 m_modelChangedEvent.Signal(AZStd::move(model));
             }
             else
@@ -826,9 +831,14 @@ namespace AZ
             m_model = {};
         }
 
-        void ModelDataInstance::Init(Data::Instance<RPI::Model> model)
+        void ModelDataInstance::QueueInit(const Data::Instance<RPI::Model>& model)
         {
             m_model = model;
+            m_needsInit = true;
+        }
+
+        void ModelDataInstance::Init()
+        {
             const size_t modelLodCount = m_model->GetLodCount();
             m_drawPacketListsByLod.resize(modelLodCount);
             for (size_t modelLodIndex = 0; modelLodIndex < modelLodCount; ++modelLodIndex)
@@ -858,11 +868,12 @@ namespace AZ
                 SetRayTracingData();
             }
 
-            m_aabb = model->GetModelAsset()->GetAabb();
+            m_aabb = m_model->GetModelAsset()->GetAabb();
 
             m_cullableNeedsRebuild = true;
             m_cullBoundsNeedsUpdate = true;
             m_objectSrgNeedsUpdate = true;
+            m_needsInit = false;
         }
 
         void ModelDataInstance::BuildDrawPacketList(size_t modelLodIndex)

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Base.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Base.h
@@ -25,6 +25,18 @@
 //#define AZ_FORCE_CPU_GPU_INSYNC
 
 AZ_DECLARE_BUDGET(RHI);
+
+//#define ENABLE_RHI_PROFILE_VERBOSE
+#ifdef ENABLE_RHI_PROFILE_VERBOSE
+// Add verbose profile markers
+#define RHI_PROFILE_SCOPE_VERBOSE(...) AZ_PROFILE_SCOPE(RHI, __VA_ARGS__);
+#define RHI_PROFILE_FUNCTION_VERBOSE AZ_PROFILE_FUNCTION(RHI);
+#else
+// Define ENABLE_RHI_PROFILE_VERBOSE to get verbose profile markers
+#define RHI_PROFILE_SCOPE_VERBOSE(...)
+#define RHI_PROFILE_FUNCTION_VERBOSE
+#endif
+
 inline static constexpr AZ::Crc32 rhiMetricsId = AZ_CRC_CE("RHI");
 
 namespace UnitTest

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Factory.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Factory.h
@@ -16,8 +16,6 @@
 #include <renderdoc_app.h>
 #endif
 
-AZ_DECLARE_BUDGET(RHI);
-
 namespace AZ
 {
     namespace RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
@@ -233,7 +233,7 @@ namespace AZ
 
             for (ScopeProducer* scopeProducer : m_scopeProducers)
             {
-                AZ_PROFILE_SCOPE(RHI, "FrameScheduler: PrepareProducers: Scope %s", scopeProducer->GetScopeId().GetCStr());
+                RHI_PROFILE_SCOPE_VERBOSE("FrameScheduler: PrepareProducers: Scope %s", scopeProducer->GetScopeId().GetCStr());
                 m_frameGraph->BeginScope(*scopeProducer->GetScope());
                 scopeProducer->SetupFrameGraphDependencies(*m_frameGraph);
                 

--- a/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
@@ -369,7 +369,7 @@ namespace AZ
             for (uint32_t i = interval.m_min; i < interval.m_max; ++i)
             {
                 ShaderResourceGroup* group = m_groupsToCompile[i];
-                AZ_PROFILE_SCOPE(RHI, "CompileGroupsForInterval %s", group->GetName().GetCStr());
+                RHI_PROFILE_SCOPE_VERBOSE("CompileGroupsForInterval %s", group->GetName().GetCStr());
 
                 CompileGroup(*group, group->GetData());
                 group->m_isQueuedForCompile = false;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -372,14 +372,19 @@ namespace AZ
         {
             AZ_PROFILE_SCOPE(RHI, "FrameGraphCompiler: CompileResourceBarriers(DX12)");
 
-            for (RHI::BufferFrameAttachment* bufferFrameAttachment : attachmentDatabase.GetBufferAttachments())
             {
-                CompileBufferBarriers(rootScope, *bufferFrameAttachment);
+                AZ_PROFILE_SCOPE(RHI, "FrameGraphCompiler: CompileBufferBarriers(DX12)");
+                for (RHI::BufferFrameAttachment* bufferFrameAttachment : attachmentDatabase.GetBufferAttachments())
+                {
+                    CompileBufferBarriers(rootScope, *bufferFrameAttachment);
+                }
             }
-
-            for (RHI::ImageFrameAttachment* imageFrameAttachment : attachmentDatabase.GetImageAttachments())
             {
-                CompileImageBarriers(*imageFrameAttachment);
+                AZ_PROFILE_SCOPE(RHI, "FrameGraphCompiler: CompileImageBarriers (DX12)");
+                for (RHI::ImageFrameAttachment* imageFrameAttachment : attachmentDatabase.GetImageAttachments())
+                {
+                    CompileImageBarriers(*imageFrameAttachment);
+                }
             }
         }
 
@@ -390,8 +395,6 @@ namespace AZ
 #else
             ResourceTransitionLoggerNull logger(bufferFrameAttachment.GetId());
 #endif
-
-            AZ_PROFILE_SCOPE(RHI, "FrameGraphCompiler: CompileBufferBarriers(DX12)");
 
             Buffer& buffer = static_cast<Buffer&>(*bufferFrameAttachment.GetBuffer());
             RHI::BufferScopeAttachment* scopeAttachment = bufferFrameAttachment.GetFirstScopeAttachment();
@@ -465,8 +468,6 @@ namespace AZ
 #else
             ResourceTransitionLoggerNull logger(imageFrameAttachment.GetId());
 #endif
-
-            AZ_PROFILE_SCOPE(RHI, "FrameGraphCompiler: CompileImageBarriers (DX12)");
 
             Image& image = static_cast<Image&>(*imageFrameAttachment.GetImage());
             RHI::ImageScopeAttachment* scopeAttachment = imageFrameAttachment.GetFirstScopeAttachment();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
@@ -31,8 +31,13 @@ namespace AZ
             AZ_Assert(srgLayout != nullptr, "Failed to find SRG with name %s, using supervariantIndex %u from shaderAsset %s", srgName.GetCStr(),
                 supervariantIndex.GetIndex(), shaderAsset.GetHint().c_str());
 
-            AZStd::string idString = AZStd::string::format("%s_%u_%s", srgLayout->GetUniqueId().c_str(), supervariantIndex.GetIndex(), srgName.GetCStr());
-            return Data::InstanceId::CreateData(idString.data(), idString.size());
+            // Create a uuid that combines string data for both the srgLayout and the srgName
+            AZ::Uuid instanceUuid =
+                AZ::Uuid::CreateData(reinterpret_cast<const AZStd::byte*>(srgLayout->GetUniqueId().data()), srgLayout->GetUniqueId().size())
+                + AZ::Uuid::CreateData(reinterpret_cast<const AZStd::byte*>(srgName.GetStringView().data()), srgName.GetStringView().size());
+
+            // Use the supervariantIndex as the subId for the InstanceId, since it is already an integer
+            return Data::InstanceId(instanceUuid, supervariantIndex.GetIndex());
         }
 
         Data::Instance<ShaderResourceGroup> ShaderResourceGroup::Create(

--- a/Gems/SurfaceData/Code/Include/SurfaceData/Utility/SurfaceDataUtility.h
+++ b/Gems/SurfaceData/Code/Include/SurfaceData/Utility/SurfaceDataUtility.h
@@ -15,6 +15,8 @@
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Vector3.h>
 
+AZ_DECLARE_BUDGET(SurfaceData);
+
 namespace AZ
 {
     namespace RPI
@@ -33,7 +35,7 @@ namespace SurfaceData
         AZ::Vector3& outPosition,
         AZ::Vector3& outNormal)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(SurfaceData);
 
         const size_t vertexCount = vertices.size();
         if (vertexCount > 0 && vertexCount % 4 == 0)

--- a/Gems/SurfaceData/Code/Source/Components/SurfaceDataColliderComponent.cpp
+++ b/Gems/SurfaceData/Code/Source/Components/SurfaceDataColliderComponent.cpp
@@ -305,7 +305,7 @@ namespace SurfaceData
 
     void SurfaceDataColliderComponent::UpdateColliderData()
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(SurfaceData);
 
         bool colliderValidBeforeUpdate = false;
         bool colliderValidAfterUpdate = false;

--- a/Gems/SurfaceData/Code/Source/Components/SurfaceDataShapeComponent.cpp
+++ b/Gems/SurfaceData/Code/Source/Components/SurfaceDataShapeComponent.cpp
@@ -14,6 +14,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <SurfaceData/SurfaceDataSystemRequestBus.h>
 #include <SurfaceData/Utility/SurfaceDataUtility.h>
+#include <SurfaceDataProfiler.h>
 
 namespace SurfaceData
 {
@@ -150,7 +151,7 @@ namespace SurfaceData
     void SurfaceDataShapeComponent::GetSurfacePointsFromList(
         AZStd::span<const AZ::Vector3> inPositions, SurfacePointList& surfacePointList) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        SURFACE_DATA_PROFILE_FUNCTION_VERBOSE
 
         AZStd::shared_lock<decltype(m_cacheMutex)> lock(m_cacheMutex);
 
@@ -192,7 +193,7 @@ namespace SurfaceData
         AZStd::span<const AZ::EntityId> creatorEntityIds,
         AZStd::span<SurfaceData::SurfaceTagWeights> weights) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        SURFACE_DATA_PROFILE_FUNCTION_VERBOSE
 
         AZ_Assert(
             (positions.size() == creatorEntityIds.size()) && (positions.size() == weights.size()),
@@ -256,7 +257,7 @@ namespace SurfaceData
 
     void SurfaceDataShapeComponent::UpdateShapeData()
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(SurfaceData);
 
         bool shapeValidBeforeUpdate = false;
         bool shapeValidAfterUpdate = false;

--- a/Gems/SurfaceData/Code/Source/SurfaceDataProfiler.h
+++ b/Gems/SurfaceData/Code/Source/SurfaceDataProfiler.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Debug/Profiler.h>
+
+AZ_DECLARE_BUDGET(SurfaceData);
+
+//#define ENABLE_SURFACE_DATA_PROFILE_VERBOSE
+#ifdef ENABLE_SURFACE_DATA_PROFILE_VERBOSE
+// Add verbose profile markers
+#define SURFACE_DATA_PROFILE_SCOPE_VERBOSE(...) AZ_PROFILE_SCOPE(SurfaceData, __VA_ARGS__);
+#define SURFACE_DATA_PROFILE_FUNCTION_VERBOSE AZ_PROFILE_FUNCTION(SurfaceData);
+#else
+// Define ENABLE_SURFACE_DATA_PROFILE_VERBOSE to get verbose profile markers
+#define SURFACE_DATA_PROFILE_SCOPE_VERBOSE(...)
+#define SURFACE_DATA_PROFILE_FUNCTION_VERBOSE
+#endif

--- a/Gems/SurfaceData/Code/Source/SurfaceDataSystemComponent.cpp
+++ b/Gems/SurfaceData/Code/Source/SurfaceDataSystemComponent.cpp
@@ -18,7 +18,9 @@
 #include <SurfaceData/SurfaceDataSystemNotificationBus.h>
 #include <SurfaceData/SurfaceDataProviderRequestBus.h>
 #include <SurfaceData/Utility/SurfaceDataUtility.h>
+#include <SurfaceDataProfiler.h>
 
+AZ_DEFINE_BUDGET(SurfaceData);
 
 namespace SurfaceData
 {
@@ -322,7 +324,7 @@ namespace SurfaceData
         AZStd::span<const AZ::Vector3> inPositions, const AZ::Aabb& inPositionBounds,
         const SurfaceTagVector& desiredTags, SurfacePointList& surfacePointLists) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        SURFACE_DATA_PROFILE_FUNCTION_VERBOSE
 
         AZStd::shared_lock<decltype(m_registrationMutex)> registrationLock(m_registrationMutex);
 
@@ -377,14 +379,14 @@ namespace SurfaceData
         }
 
         {
-            AZ_PROFILE_SCOPE(Entity, "GetSurfacePointsFromListInternal: StartListConstruction");
+            SURFACE_DATA_PROFILE_SCOPE_VERBOSE("GetSurfacePointsFromListInternal: StartListConstruction");
             surfacePointLists.StartListConstruction(inPositions, maxPointsCreatedPerInput, tagFilters);
         }
 
         // Loop through each data provider and generate surface points from the set of input positions.
         // Any generated points that have the same XY coordinates and extremely similar Z values will get combined together.
         {
-            AZ_PROFILE_SCOPE(Entity, "GetSurfacePointsFromListInternal: GetSurfacePointsFromList");
+            SURFACE_DATA_PROFILE_SCOPE_VERBOSE("GetSurfacePointsFromListInternal: GetSurfacePointsFromList");
             for (const auto& [providerHandle, provider] : m_registeredSurfaceDataProviders)
             {
                 if (ProviderIsApplicable(provider))
@@ -401,7 +403,7 @@ namespace SurfaceData
         // are used to annotate points that occur within a volume.  A common example is marking points as "underwater" for points that occur
         // within a water volume.
         {
-            AZ_PROFILE_SCOPE(Entity, "GetSurfacePointsFromListInternal: ModifySurfaceWeights");
+            SURFACE_DATA_PROFILE_SCOPE_VERBOSE("GetSurfacePointsFromListInternal: ModifySurfaceWeights");
             for (const auto& [modifierHandle, modifier] : m_registeredSurfaceDataModifiers)
             {
                 bool hasInfiniteBounds = !modifier.m_bounds.IsValid();

--- a/Gems/SurfaceData/Code/Source/SurfaceDataUtility.cpp
+++ b/Gems/SurfaceData/Code/Source/SurfaceDataUtility.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <SurfaceDataProfiler.h>
 #include <SurfaceData/Utility/SurfaceDataUtility.h>
 #include <Atom/RPI.Reflect/Model/ModelAssetCreator.h>
 
@@ -17,7 +18,7 @@ namespace SurfaceData
         const AZ::Vector3& rayStart, const AZ::Vector3& rayEnd, 
         AZ::Vector3& outPosition, AZ::Vector3& outNormal)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        SURFACE_DATA_PROFILE_FUNCTION_VERBOSE
 
         const AZ::Vector3 clampedScale = nonUniformScale.GetMax(AZ::Vector3(AZ::MinTransformScale));
 

--- a/Gems/SurfaceData/Code/Source/SurfaceTag.cpp
+++ b/Gems/SurfaceData/Code/Source/SurfaceTag.cpp
@@ -15,6 +15,8 @@
 #include <AzCore/Debug/Profiler.h>
 #include <AzCore/std/sort.h>
 
+AZ_DECLARE_BUDGET(SurfaceData);
+
 namespace SurfaceData
 {
     namespace SurfaceTagUtil
@@ -95,7 +97,7 @@ namespace SurfaceData
 
     AZStd::vector<AZStd::pair<AZ::u32, AZStd::string>> SurfaceTag::GetRegisteredTags()
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(SurfaceData);
 
         SurfaceTagNameSet labels;
         SurfaceDataTagProviderRequestBus::Broadcast(&SurfaceDataTagProviderRequestBus::Events::GetRegisteredSurfaceTagNames, labels);
@@ -141,7 +143,7 @@ namespace SurfaceData
 
     AZStd::vector<AZStd::pair<AZ::u32, AZStd::string>> SurfaceTag::BuildSelectableTagList() const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(SurfaceData);
 
         AZStd::vector<AZStd::pair<AZ::u32, AZStd::string>> selectableTags = GetRegisteredTags();
 
@@ -159,7 +161,7 @@ namespace SurfaceData
 
     AZStd::string SurfaceTag::GetDisplayName() const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(SurfaceData);
 
         AZStd::string name;
         FindDisplayName(GetRegisteredTags(), name);

--- a/Gems/SurfaceData/Code/surfacedata_shared_files.cmake
+++ b/Gems/SurfaceData/Code/surfacedata_shared_files.cmake
@@ -9,4 +9,5 @@
 set(FILES
     Source/SurfaceDataModule.h
     Source/SurfaceDataModule.cpp
+    Source/SurfaceDataProfiler.h
 )

--- a/Gems/Terrain/Code/Source/Components/TerrainHeightGradientListComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainHeightGradientListComponent.cpp
@@ -19,8 +19,7 @@
 
 #include <GradientSignal/Ebuses/GradientRequestBus.h>
 #include <SurfaceData/SurfaceDataProviderRequestBus.h>
-
-AZ_DECLARE_BUDGET(Terrain);
+#include <TerrainProfiler.h>
 
 namespace Terrain
 {
@@ -206,7 +205,7 @@ namespace Terrain
     void TerrainHeightGradientListComponent::GetHeights(
         AZStd::span<AZ::Vector3> inOutPositionList, AZStd::span<bool> terrainExistsList)
     {
-        AZ_PROFILE_FUNCTION(Terrain);
+        TERRAIN_PROFILE_FUNCTION_VERBOSE
 
         // Make sure we don't run queries simultaneously with changing any of the cached data.
         AZStd::shared_lock lock(m_queryMutex);

--- a/Gems/Terrain/Code/Source/Components/TerrainSurfaceGradientListComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainSurfaceGradientListComponent.cpp
@@ -14,8 +14,7 @@
 
 #include <GradientSignal/Ebuses/GradientRequestBus.h>
 #include <TerrainSystem/TerrainSystemBus.h>
-
-AZ_DECLARE_BUDGET(Terrain);
+#include <TerrainProfiler.h>
 
 namespace Terrain
 {
@@ -177,7 +176,7 @@ namespace Terrain
         AZStd::span<const AZ::Vector3> inPositionList,
         AZStd::span<AzFramework::SurfaceData::SurfaceTagWeightList> outSurfaceWeightsList) const
     {
-        AZ_PROFILE_FUNCTION(Terrain);
+        TERRAIN_PROFILE_FUNCTION_VERBOSE
 
         AZ_Assert(
             inPositionList.size() == outSurfaceWeightsList.size(), "The position list size doesn't match the outSurfaceWeights list size.");

--- a/Gems/Terrain/Code/Source/TerrainProfiler.h
+++ b/Gems/Terrain/Code/Source/TerrainProfiler.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Debug/Profiler.h>
+
+AZ_DECLARE_BUDGET(Terrain);
+
+//#define ENABLE_TERRAIN_PROFILE_VERBOSE
+#ifdef ENABLE_TERRAIN_PROFILE_VERBOSE
+// Add verbose profile markers
+#define TERRAIN_PROFILE_SCOPE_VERBOSE(...) AZ_PROFILE_SCOPE(Terrain, __VA_ARGS__);
+#define TERRAIN_PROFILE_FUNCTION_VERBOSE AZ_PROFILE_FUNCTION(Terrain);
+#else
+// Define ENABLE_TERRAIN_PROFILE_VERBOSE to get verbose profile markers
+#define TERRAIN_PROFILE_SCOPE_VERBOSE(...)
+#define TERRAIN_PROFILE_FUNCTION_VERBOSE
+#endif

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
@@ -19,6 +19,7 @@
 #include <TerrainRenderer/TerrainFeatureProcessor.h>
 
 #include <Terrain/Ebuses/TerrainAreaSurfaceRequestBus.h>
+#include <TerrainProfiler.h>
 
 using namespace Terrain;
 
@@ -303,7 +304,7 @@ void TerrainSystem::GenerateQueryPositions(const AZStd::span<const AZ::Vector3>&
     AZStd::vector<AZ::Vector3>& outPositions, float queryResolution,
     Sampler sampler) const
 {
-    AZ_PROFILE_FUNCTION(Terrain);
+    TERRAIN_PROFILE_FUNCTION_VERBOSE
 
     const float minHeight = m_currentSettings.m_heightRange.m_min;
     for (auto& position : inPositions)
@@ -384,7 +385,7 @@ void TerrainSystem::MakeBulkQueries(
     AZStd::span<AzFramework::SurfaceData::SurfaceTagWeightList> outSurfaceWeights,
     BulkQueriesCallback queryCallback) const
 {
-    AZ_PROFILE_FUNCTION(Terrain);
+    TERRAIN_PROFILE_FUNCTION_VERBOSE
 
     AZStd::shared_lock<AZStd::shared_mutex> lock(m_areaMutex);
 
@@ -432,7 +433,7 @@ void TerrainSystem::MakeBulkQueries(
 void TerrainSystem::GetHeightsSynchronous(const AZStd::span<const AZ::Vector3>& inPositions, Sampler sampler, 
     AZStd::span<float> heights, AZStd::span<bool> terrainExists) const
 {
-    AZ_PROFILE_FUNCTION(Terrain);
+    TERRAIN_PROFILE_FUNCTION_VERBOSE
 
     AZStd::shared_lock<AZStd::shared_mutex> lock(m_areaMutex);
 
@@ -653,6 +654,7 @@ bool TerrainSystem::GetIsHoleFromFloats(float x, float y, Sampler sampler) const
 void TerrainSystem::GetNormalsSynchronous(const AZStd::span<const AZ::Vector3>& inPositions, Sampler sampler, 
     AZStd::span<AZ::Vector3> normals, AZStd::span<bool> terrainExists) const
 {
+    TERRAIN_PROFILE_FUNCTION_VERBOSE
     // We use different algorithms for calculating the normals depending on the input sampler type,
     // with no real shared logic, so they've been split out into separate methods.
     switch (sampler)
@@ -1266,7 +1268,7 @@ void TerrainSystem::GetOrderedSurfaceWeightsFromList(
     AZStd::span<AzFramework::SurfaceData::SurfaceTagWeightList> outSurfaceWeightsList,
     AZStd::span<bool> terrainExists) const
 {
-    AZ_PROFILE_FUNCTION(Terrain);
+    TERRAIN_PROFILE_FUNCTION_VERBOSE
 
     if (terrainExists.size() == outSurfaceWeightsList.size())
     {
@@ -1409,7 +1411,7 @@ void TerrainSystem::QueryList(
     AzFramework::Terrain::SurfacePointListFillCallback perPositionCallback,
     Sampler sampler) const
 {
-    AZ_PROFILE_FUNCTION(Terrain);
+    TERRAIN_PROFILE_FUNCTION_VERBOSE
 
     if (!perPositionCallback)
     {
@@ -1427,10 +1429,7 @@ void TerrainSystem::QueryList(
     if (requestedData & TerrainDataMask::Normals)
     {
         normals.resize(inPositions.size());
-        {
-            AZ_PROFILE_SCOPE(Terrain, "GetNormalsSynchronous");
-            GetNormalsSynchronous(inPositions, sampler, normals, terrainExists);
-        }
+        GetNormalsSynchronous(inPositions, sampler, normals, terrainExists);
     }
     if (requestedData & TerrainDataMask::Heights)
     {
@@ -1449,7 +1448,7 @@ void TerrainSystem::QueryList(
     }
 
     {
-        AZ_PROFILE_SCOPE(Terrain, "QueryList-PerPositionCallbacks");
+        TERRAIN_PROFILE_SCOPE_VERBOSE("QueryList-PerPositionCallbacks");
 
         AzFramework::SurfaceData::SurfacePoint surfacePoint;
         for (size_t i = 0; i < inPositions.size(); i++)

--- a/Gems/Terrain/Code/terrain_shared_files.cmake
+++ b/Gems/Terrain/Code/terrain_shared_files.cmake
@@ -9,4 +9,5 @@
 set(FILES
     Source/TerrainModule.h
     Source/TerrainModule.cpp
+    Source/TerrainProfiler.h
 )

--- a/Gems/Vegetation/Code/Source/AreaSystemComponent.cpp
+++ b/Gems/Vegetation/Code/Source/AreaSystemComponent.cpp
@@ -619,7 +619,7 @@ namespace Vegetation
 
     void AreaSystemComponent::EnumerateInstancesInOverlappingSectors(const AZ::Aabb& bounds, AreaSystemEnumerateCallback callback) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         if (!bounds.IsValid())
         {
@@ -646,7 +646,7 @@ namespace Vegetation
 
     void AreaSystemComponent::EnumerateInstancesInAabb(const AZ::Aabb& bounds, AreaSystemEnumerateCallback callback) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         if (!bounds.IsValid())
         {
@@ -1058,7 +1058,7 @@ namespace Vegetation
 
     const AreaSystemComponent::SectorInfo* AreaSystemComponent::VegetationThreadTasks::GetSector(const SectorId& sectorId) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         AZStd::lock_guard<decltype(m_sectorRollingWindowMutex)> lock(m_sectorRollingWindowMutex);
         auto itSector = m_sectorRollingWindow.find(sectorId);
@@ -1067,7 +1067,7 @@ namespace Vegetation
 
     AreaSystemComponent::SectorInfo* AreaSystemComponent::VegetationThreadTasks::GetSector(const SectorId& sectorId)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         AZStd::lock_guard<decltype(m_sectorRollingWindowMutex)> lock(m_sectorRollingWindowMutex);
         auto itSector = m_sectorRollingWindow.find(sectorId);
@@ -1076,7 +1076,7 @@ namespace Vegetation
 
     AreaSystemComponent::SectorInfo* AreaSystemComponent::VegetationThreadTasks::CreateSector(const SectorId& sectorId, int sectorDensity, int sectorSizeInMeters, SnapMode sectorPointSnapMode)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         SectorInfo sectorInfo;
         sectorInfo.m_id = sectorId;
@@ -1091,7 +1091,7 @@ namespace Vegetation
 
     void AreaSystemComponent::VegetationThreadTasks::UpdateSectorPoints(SectorInfo& sectorInfo, int sectorDensity, int sectorSizeInMeters, SnapMode sectorPointSnapMode)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
         const float vegStep = sectorSizeInMeters / static_cast<float>(sectorDensity);
 
         //build a free list of all points in the sector for areas to consume
@@ -1186,7 +1186,7 @@ namespace Vegetation
 
     void AreaSystemComponent::VegetationThreadTasks::DeleteSector(const SectorId& sectorId)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         AZStd::lock_guard<decltype(m_sectorRollingWindowMutex)> lock(m_sectorRollingWindowMutex);
         auto itSector = m_sectorRollingWindow.find(sectorId);
@@ -1245,7 +1245,7 @@ namespace Vegetation
 
     void AreaSystemComponent::VegetationThreadTasks::ReleaseUnregisteredClaims(SectorInfo& sectorInfo)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         if (!m_unregisteredVegetationAreaSet.empty())
         {
@@ -1271,7 +1271,7 @@ namespace Vegetation
 
     void AreaSystemComponent::VegetationThreadTasks::ReleaseUnusedClaims(SectorInfo& sectorInfo)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         AZStd::unordered_map<AZ::EntityId, AZStd::unordered_set<ClaimHandle>> claimsToRelease;
 
@@ -1395,13 +1395,13 @@ namespace Vegetation
 
     void AreaSystemComponent::VegetationThreadTasks::CreateClaim(SectorInfo& sectorInfo, const ClaimHandle handle, const InstanceData& instanceData)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
         sectorInfo.m_claimedWorldPoints[handle] = instanceData;
     }
 
     ClaimHandle AreaSystemComponent::VegetationThreadTasks::CreateClaimHandle(const SectorInfo& sectorInfo, uint32_t index) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         ClaimHandle handle = 0;
         AreaSystemUtil::hash_combine_64(handle, sectorInfo.m_id.first);

--- a/Gems/Vegetation/Code/Source/Components/AreaBlenderComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/AreaBlenderComponent.cpp
@@ -16,6 +16,8 @@
 #include <Vegetation/Ebuses/AreaSystemRequestBus.h>
 #include <Vegetation/Ebuses/DebugNotificationBus.h>
 
+#include "../VegetationProfiler.h"
+
 namespace Vegetation
 {
     void AreaBlenderConfig::Reflect(AZ::ReflectContext* context)
@@ -220,7 +222,7 @@ namespace Vegetation
 
     bool AreaBlenderComponent::PrepareToClaim(EntityIdStack& stackIds)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         bool result = true;
 
@@ -257,7 +259,7 @@ namespace Vegetation
 
     void AreaBlenderComponent::ClaimPositions(EntityIdStack& stackIds, ClaimContext& context)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         if (context.m_availablePoints.empty())
         {
@@ -294,7 +296,7 @@ namespace Vegetation
 
     void AreaBlenderComponent::UnclaimPosition(const ClaimHandle handle)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         AZ_ErrorOnce(
             "Vegetation", !AreaRequestBus::HasReentrantEBusUseThisThread(),
@@ -314,7 +316,7 @@ namespace Vegetation
 
     AZ::Aabb AreaBlenderComponent::GetEncompassingAabb() const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         AZ::Aabb bounds = AZ::Aabb::CreateNull();
 
@@ -345,7 +347,7 @@ namespace Vegetation
 
     AZ::u32 AreaBlenderComponent::GetProductCount() const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         AZ::u32 count = 0;
 

--- a/Gems/Vegetation/Code/Source/Components/AreaComponentBase.cpp
+++ b/Gems/Vegetation/Code/Source/Components/AreaComponentBase.cpp
@@ -13,6 +13,8 @@
 #include <Vegetation/Ebuses/AreaSystemRequestBus.h>
 #include <AzCore/Debug/Profiler.h>
 
+#include "../VegetationProfiler.h"
+
 namespace Vegetation
 {
     namespace AreaUtil
@@ -279,13 +281,13 @@ namespace Vegetation
 
     void AreaComponentBase::OnTransformChanged(const AZ::Transform& /*local*/, const AZ::Transform& /*world*/)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
         OnCompositionChanged();
     }
 
     void AreaComponentBase::OnShapeChanged([[maybe_unused]] ShapeComponentNotifications::ShapeChangeReasons reasons)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
         OnCompositionChanged();
     }
 }

--- a/Gems/Vegetation/Code/Source/Components/BlockerComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/BlockerComponent.cpp
@@ -19,6 +19,8 @@
 #include <Vegetation/Ebuses/FilterRequestBus.h>
 #include <Vegetation/InstanceData.h>
 
+#include "../VegetationProfiler.h"
+
 namespace Vegetation
 {
     namespace BlockerUtil
@@ -185,7 +187,7 @@ namespace Vegetation
 
     bool BlockerComponent::ClaimPosition(EntityIdStack& processedIds, const ClaimPoint& point, InstanceData& instanceData)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
 #if VEG_BLOCKER_ENABLE_CACHING
         {
@@ -245,7 +247,7 @@ namespace Vegetation
 
     void BlockerComponent::ClaimPositions(EntityIdStack& stackIds, ClaimContext& context)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         //adding entity id to the stack of entity ids affecting vegetation
         EntityIdStack emptyIds;
@@ -285,7 +287,7 @@ namespace Vegetation
 
     AZ::Aabb BlockerComponent::GetEncompassingAabb() const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         AZ::Aabb bounds = AZ::Aabb::CreateNull();
         LmbrCentral::ShapeComponentRequestsBus::EventResult(bounds, GetEntityId(), &LmbrCentral::ShapeComponentRequestsBus::Events::GetEncompassingAabb);

--- a/Gems/Vegetation/Code/Source/Components/DescriptorListCombinerComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/DescriptorListCombinerComponent.cpp
@@ -13,6 +13,8 @@
 #include <Vegetation/InstanceData.h>
 #include <AzCore/Debug/Profiler.h>
 
+#include "../VegetationProfiler.h"
+
 namespace Vegetation
 {
     void DescriptorListCombinerConfig::Reflect(AZ::ReflectContext* context)
@@ -187,7 +189,7 @@ namespace Vegetation
 
     void DescriptorListCombinerComponent::GetDescriptors(DescriptorPtrVec& descriptors) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         for (const auto& entityId : m_configuration.m_descriptorProviders)
         {
@@ -200,7 +202,7 @@ namespace Vegetation
 
     void DescriptorListCombinerComponent::GetInclusionSurfaceTags(SurfaceData::SurfaceTagVector& tags, bool& includeAll) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         for (const auto& entityId : m_configuration.m_descriptorProviders)
         {
@@ -213,7 +215,7 @@ namespace Vegetation
 
     void DescriptorListCombinerComponent::GetExclusionSurfaceTags(SurfaceData::SurfaceTagVector& tags) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         for (const auto& entityId : m_configuration.m_descriptorProviders)
         {

--- a/Gems/Vegetation/Code/Source/Components/DescriptorWeightSelectorComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/DescriptorWeightSelectorComponent.cpp
@@ -13,7 +13,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <LmbrCentral/Dependency/DependencyNotificationBus.h>
 #include <GradientSignal/Ebuses/GradientRequestBus.h>
-#include <AzCore/Debug/Profiler.h>
+#include <VegetationProfiler.h>
 
 namespace Vegetation
 {
@@ -144,7 +144,7 @@ namespace Vegetation
 
     void DescriptorWeightSelectorComponent::SelectDescriptors(const DescriptorSelectorParams& params, DescriptorPtrVec& descriptors) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         switch (m_configuration.m_sortBehavior)
         {

--- a/Gems/Vegetation/Code/Source/Components/DistanceBetweenFilterComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/DistanceBetweenFilterComponent.cpp
@@ -187,7 +187,7 @@ namespace Vegetation
 
     bool DistanceBetweenFilterComponent::Evaluate(const InstanceData& instanceData) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         bool intersects = false;
 

--- a/Gems/Vegetation/Code/Source/Components/DistributionFilterComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/DistributionFilterComponent.cpp
@@ -189,7 +189,7 @@ namespace Vegetation
 
     bool DistributionFilterComponent::Evaluate(const InstanceData& instanceData) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         const GradientSignal::GradientSampleParams sampleParams(instanceData.m_position);
         const float noise = m_configuration.m_gradientSampler.GetValue(sampleParams);

--- a/Gems/Vegetation/Code/Source/Components/MeshBlockerComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/MeshBlockerComponent.cpp
@@ -21,6 +21,10 @@
 #include <Vegetation/InstanceData.h>
 #include <Atom/RPI.Reflect/Model/ModelAsset.h>
 
+#include "../VegetationProfiler.h"
+
+AZ_DECLARE_BUDGET(Vegetation);
+
 namespace Vegetation
 {
     void MeshBlockerConfig::Reflect(AZ::ReflectContext* context)
@@ -198,7 +202,7 @@ namespace Vegetation
 
     bool MeshBlockerComponent::PrepareToClaim([[maybe_unused]] EntityIdStack& stackIds)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         AZStd::lock_guard<decltype(m_cacheMutex)> cacheLock(m_cacheMutex);
 
@@ -218,7 +222,7 @@ namespace Vegetation
 
     bool MeshBlockerComponent::ClaimPosition(EntityIdStack& processedIds, const ClaimPoint& point, InstanceData& instanceData)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         AZStd::lock_guard<decltype(m_cacheMutex)> cacheLock(m_cacheMutex);
 
@@ -284,7 +288,7 @@ namespace Vegetation
 
     void MeshBlockerComponent::ClaimPositions(EntityIdStack& stackIds, ClaimContext& context)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         //adding entity id to the stack of entity ids affecting vegetation
         EntityIdStack emptyIds;
@@ -376,7 +380,7 @@ namespace Vegetation
 
     void MeshBlockerComponent::UpdateMeshData()
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         AZStd::lock_guard<decltype(m_cacheMutex)> cacheLock(m_cacheMutex);
 

--- a/Gems/Vegetation/Code/Source/Components/PositionModifierComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/PositionModifierComponent.cpp
@@ -15,8 +15,8 @@
 #include <Vegetation/Descriptor.h>
 #include <GradientSignal/Ebuses/GradientRequestBus.h>
 #include <Vegetation/InstanceData.h>
+#include <VegetationProfiler.h>
 #include <SurfaceData/SurfaceDataSystemRequestBus.h>
-#include <AzCore/Debug/Profiler.h>
 
 namespace Vegetation
 {
@@ -281,7 +281,7 @@ namespace Vegetation
 
     void PositionModifierComponent::Execute(InstanceData& instanceData) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         const GradientSignal::GradientSampleParams sampleParams(instanceData.m_position);
         float factorX = m_configuration.m_gradientSamplerX.GetValue(sampleParams);

--- a/Gems/Vegetation/Code/Source/Components/RotationModifierComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/RotationModifierComponent.cpp
@@ -14,7 +14,7 @@
 #include <Vegetation/Descriptor.h>
 #include <GradientSignal/Ebuses/GradientRequestBus.h>
 #include <Vegetation/InstanceData.h>
-#include <AzCore/Debug/Profiler.h>
+#include <VegetationProfiler.h>
 
 namespace Vegetation
 {
@@ -239,7 +239,7 @@ namespace Vegetation
 
     void RotationModifierComponent::Execute(InstanceData& instanceData) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         const GradientSignal::GradientSampleParams sampleParams(instanceData.m_position);
         float factorX = m_configuration.m_gradientSamplerX.GetValue(sampleParams);

--- a/Gems/Vegetation/Code/Source/Components/ScaleModifierComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/ScaleModifierComponent.cpp
@@ -14,7 +14,7 @@
 #include <Vegetation/Descriptor.h>
 #include <GradientSignal/Ebuses/GradientRequestBus.h>
 #include <Vegetation/InstanceData.h>
-#include <AzCore/Debug/Profiler.h>
+#include <VegetationProfiler.h>
 
 namespace Vegetation
 {
@@ -162,7 +162,7 @@ namespace Vegetation
 
     void ScaleModifierComponent::Execute(InstanceData& instanceData) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         const GradientSignal::GradientSampleParams sampleParams(instanceData.m_position);
         float factor = m_configuration.m_gradientSampler.GetValue(sampleParams);

--- a/Gems/Vegetation/Code/Source/Components/ShapeIntersectionFilterComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/ShapeIntersectionFilterComponent.cpp
@@ -147,7 +147,7 @@ namespace Vegetation
 
     bool ShapeIntersectionFilterComponent::Evaluate(const InstanceData& instanceData) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         bool inside = false;
         LmbrCentral::ShapeComponentRequestsBus::EventResult(inside, m_configuration.m_shapeEntityId, &LmbrCentral::ShapeComponentRequestsBus::Events::IsPointInside, instanceData.m_position);

--- a/Gems/Vegetation/Code/Source/Components/SlopeAlignmentModifierComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/SlopeAlignmentModifierComponent.cpp
@@ -17,6 +17,8 @@
 #include <Vegetation/InstanceData.h>
 #include <AzCore/Debug/Profiler.h>
 
+#include "../VegetationProfiler.h"
+
 namespace Vegetation
 {
     void SlopeAlignmentModifierConfig::Reflect(AZ::ReflectContext* context)
@@ -159,7 +161,7 @@ namespace Vegetation
 
     void SlopeAlignmentModifierComponent::Execute(InstanceData& instanceData) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         const bool useOverrides = m_configuration.m_allowOverrides && instanceData.m_descriptorPtr && instanceData.m_descriptorPtr->m_surfaceAlignmentOverrideEnabled;
         const float min = useOverrides ? instanceData.m_descriptorPtr->m_surfaceAlignmentMin : m_configuration.m_rangeMin;

--- a/Gems/Vegetation/Code/Source/Components/SpawnerComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/SpawnerComponent.cpp
@@ -24,6 +24,8 @@
 #include <SurfaceData/Utility/SurfaceDataUtility.h>
 #include <Vegetation/Ebuses/DebugNotificationBus.h>
 
+#include "../VegetationProfiler.h"
+
 namespace Vegetation
 {
     namespace SpawnerUtil
@@ -206,7 +208,7 @@ namespace Vegetation
 
     bool SpawnerComponent::PrepareToClaim(EntityIdStack& stackIds)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         //adding entity id to the stack of entity ids affecting vegetation
         EntityIdStack emptyIds;
@@ -259,7 +261,7 @@ namespace Vegetation
 
     bool SpawnerComponent::CreateInstance([[maybe_unused]] const ClaimPoint &point, InstanceData& instanceData)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         instanceData.m_instanceId = InvalidInstanceId;
         if (instanceData.m_descriptorPtr && instanceData.m_descriptorPtr->IsSpawnable())
@@ -279,7 +281,7 @@ namespace Vegetation
 
     bool SpawnerComponent::EvaluateFilters(EntityIdStack& processedIds, InstanceData& instanceData, const FilterStage intendedStage) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         bool accepted = true;
         for (const auto& id : processedIds)
@@ -302,7 +304,7 @@ namespace Vegetation
 
     bool SpawnerComponent::ProcessInstance(EntityIdStack& processedIds, const ClaimPoint& point, InstanceData& instanceData, DescriptorPtr descriptorPtr)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         if (!descriptorPtr)
         {
@@ -353,7 +355,7 @@ namespace Vegetation
 
     bool SpawnerComponent::ClaimPosition(EntityIdStack& processedIds, const ClaimPoint& point, InstanceData& instanceData)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
 #if VEG_SPAWNER_ENABLE_CACHING
         {
@@ -413,7 +415,7 @@ namespace Vegetation
 
     void SpawnerComponent::ClaimPositions(EntityIdStack& stackIds, ClaimContext& context)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         //reject entire spawner if there are inclusion tags to consider that don't exist in the context
         if (context.m_masks.HasValidTags() &&
@@ -497,7 +499,7 @@ namespace Vegetation
 
     void SpawnerComponent::UnclaimPosition(const ClaimHandle handle)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         InstanceId instanceId = InvalidInstanceId;
         {
@@ -518,7 +520,7 @@ namespace Vegetation
 
     AZ::Aabb SpawnerComponent::GetEncompassingAabb() const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         AZ::Aabb bounds = AZ::Aabb::CreateNull();
         LmbrCentral::ShapeComponentRequestsBus::EventResult(bounds, GetEntityId(), &LmbrCentral::ShapeComponentRequestsBus::Events::GetEncompassingAabb);
@@ -533,7 +535,7 @@ namespace Vegetation
 
     void SpawnerComponent::OnCompositionChanged()
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
         AreaComponentBase::OnCompositionChanged();
 
 #if VEG_SPAWNER_ENABLE_CACHING
@@ -546,7 +548,7 @@ namespace Vegetation
 
     void SpawnerComponent::DestroyAllInstances()
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         ClaimInstanceMapping claimInstanceMapping;
         {

--- a/Gems/Vegetation/Code/Source/Components/SurfaceAltitudeFilterComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/SurfaceAltitudeFilterComponent.cpp
@@ -175,7 +175,7 @@ namespace Vegetation
 
     bool SurfaceAltitudeFilterComponent::Evaluate(const InstanceData& instanceData) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         const bool useOverrides = m_configuration.m_allowOverrides && instanceData.m_descriptorPtr && instanceData.m_descriptorPtr->m_altitudeFilterOverrideEnabled;
         const float min = useOverrides ? instanceData.m_descriptorPtr->m_altitudeFilterMin : m_configuration.m_altitudeMin;

--- a/Gems/Vegetation/Code/Source/Components/SurfaceMaskDepthFilterComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/SurfaceMaskDepthFilterComponent.cpp
@@ -203,7 +203,7 @@ namespace Vegetation
 
     bool SurfaceMaskDepthFilterComponent::Evaluate(const InstanceData& instanceData) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         const bool useOverrides = m_configuration.m_allowOverrides && instanceData.m_descriptorPtr && !instanceData.m_descriptorPtr->m_surfaceTagDistance.m_tags.empty();
         const SurfaceData::SurfaceTagVector& surfaceTagsToCompare = useOverrides ? instanceData.m_descriptorPtr->m_surfaceTagDistance.m_tags : m_configuration.m_depthComparisonTags;

--- a/Gems/Vegetation/Code/Source/Components/SurfaceMaskFilterComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/SurfaceMaskFilterComponent.cpp
@@ -268,7 +268,7 @@ namespace Vegetation
 
     bool SurfaceMaskFilterComponent::Evaluate(const InstanceData& instanceData) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         //determine if tags provided by the component should be considered
         bool useCompTags = !m_configuration.m_allowOverrides || (instanceData.m_descriptorPtr && instanceData.m_descriptorPtr->m_surfaceFilterOverrideMode != OverrideMode::Replace);

--- a/Gems/Vegetation/Code/Source/Components/SurfaceSlopeFilterComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Components/SurfaceSlopeFilterComponent.cpp
@@ -162,7 +162,7 @@ namespace Vegetation
 
     bool SurfaceSlopeFilterComponent::Evaluate(const InstanceData& instanceData) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         const bool useOverrides = m_configuration.m_allowOverrides && instanceData.m_descriptorPtr && instanceData.m_descriptorPtr->m_slopeFilterOverrideEnabled;
         const float min = useOverrides ? instanceData.m_descriptorPtr->m_slopeFilterMin : m_configuration.m_slopeMin;

--- a/Gems/Vegetation/Code/Source/InstanceSystemComponent.cpp
+++ b/Gems/Vegetation/Code/Source/InstanceSystemComponent.cpp
@@ -20,6 +20,8 @@
 #include <Vegetation/Ebuses/DebugNotificationBus.h>
 #include <Vegetation/Ebuses/DebugSystemDataBus.h>
 
+#include "VegetationProfiler.h"
+
 namespace Vegetation
 {
     namespace InstanceSystemUtil
@@ -166,7 +168,7 @@ namespace Vegetation
 
     DescriptorPtr InstanceSystemComponent::RegisterUniqueDescriptor(const Descriptor& descriptor)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         AZStd::lock_guard<decltype(m_uniqueDescriptorsMutex)> lock(m_uniqueDescriptorsMutex);
 
@@ -214,7 +216,7 @@ namespace Vegetation
 
     void InstanceSystemComponent::ReleaseUniqueDescriptor(DescriptorPtr descriptorPtr)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         AZStd::lock_guard<decltype(m_uniqueDescriptorsMutex)> lock(m_uniqueDescriptorsMutex);
 
@@ -264,7 +266,7 @@ namespace Vegetation
 
     void InstanceSystemComponent::CreateInstance(InstanceData& instanceData)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         if (!IsDescriptorValid(instanceData.m_descriptorPtr))
         {
@@ -296,7 +298,7 @@ namespace Vegetation
 
     void InstanceSystemComponent::DestroyInstance(InstanceId instanceId)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         if (instanceId == InvalidInstanceId)
         {
@@ -436,7 +438,7 @@ namespace Vegetation
 
     bool InstanceSystemComponent::IsInstanceSkippable(const InstanceData& instanceData) const
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         //if the instance was queued for deletion before its creation task executed then skip it
         AZStd::lock_guard<decltype(m_instanceDeletionSetMutex)> instanceDeletionSet(m_instanceDeletionSetMutex);
@@ -445,7 +447,7 @@ namespace Vegetation
 
     void InstanceSystemComponent::CreateInstanceNode(const InstanceData& instanceData)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         if (IsInstanceSkippable(instanceData))
         {
@@ -486,7 +488,7 @@ namespace Vegetation
 
     void InstanceSystemComponent::ReleaseInstanceNode(InstanceId instanceId)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         DescriptorPtr descriptor = nullptr;
         InstancePtr opaqueInstanceData = nullptr;
@@ -518,7 +520,7 @@ namespace Vegetation
 
     void InstanceSystemComponent::AddTask(const Task& task)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        VEGETATION_PROFILE_FUNCTION_VERBOSE
 
         AZStd::lock_guard<decltype(m_mainThreadTaskMutex)> mainThreadTaskLock(m_mainThreadTaskMutex);
         if (m_mainThreadTaskQueue.empty() || m_mainThreadTaskQueue.back().size() >= m_configuration.m_maxInstanceTaskBatchSize)
@@ -530,7 +532,7 @@ namespace Vegetation
 
     void InstanceSystemComponent::ClearTasks()
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         AZStd::lock_guard<decltype(m_mainThreadTaskInProgressMutex)> mainThreadTaskInProgressLock(m_mainThreadTaskInProgressMutex);
         AZStd::lock_guard<decltype(m_mainThreadTaskMutex)> mainThreadTaskLock(m_mainThreadTaskMutex);
@@ -542,7 +544,7 @@ namespace Vegetation
 
     bool InstanceSystemComponent::GetTasks(TaskList& removedTasks)
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         AZStd::lock_guard<decltype(m_mainThreadTaskMutex)> mainThreadTaskLock(m_mainThreadTaskMutex);
         if (!m_mainThreadTaskQueue.empty())
@@ -555,7 +557,7 @@ namespace Vegetation
 
     void InstanceSystemComponent::ExecuteTasks()
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         AZStd::lock_guard<decltype(m_mainThreadTaskInProgressMutex)> scopedLock(m_mainThreadTaskInProgressMutex);
 
@@ -584,7 +586,7 @@ namespace Vegetation
 
     void InstanceSystemComponent::ProcessMainThreadTasks()
     {
-        AZ_PROFILE_FUNCTION(Entity);
+        AZ_PROFILE_FUNCTION(Vegetation);
 
         ExecuteTasks();
     }

--- a/Gems/Vegetation/Code/Source/VegetationProfiler.h
+++ b/Gems/Vegetation/Code/Source/VegetationProfiler.h
@@ -7,6 +7,10 @@
  */
 #pragma once
 
+#include <AzCore/Debug/Profiler.h>
+
+AZ_DECLARE_BUDGET(Vegetation);
+
 // VEG_PROFILE_ENABLED is defined in the wscript
 // VEG_PROFILE_ENABLED is only defined in the Vegetation gem by default
 #if defined(VEG_PROFILE_ENABLED)
@@ -15,3 +19,13 @@
 #define VEG_PROFILE_METHOD(...) // no-op
 #endif
 
+//#define ENABLE_VEGETATION_PROFILE_VERBOSE
+#ifdef ENABLE_VEGETATION_PROFILE_VERBOSE
+// Add verbose profile markers
+#define VEGETATION_PROFILE_SCOPE_VERBOSE(...) AZ_PROFILE_SCOPE(Vegetation, __VA_ARGS__);
+#define VEGETATION_PROFILE_FUNCTION_VERBOSE AZ_PROFILE_FUNCTION(Vegetation);
+#else
+// Define ENABLE_VEGETATION_PROFILE_VERBOSE to get verbose profile markers
+#define VEGETATION_PROFILE_SCOPE_VERBOSE
+#define VEGETATION_PROFILE_FUNCTION_VERBOSE
+#endif

--- a/Gems/Vegetation/Code/Source/VegetationSystemComponent.cpp
+++ b/Gems/Vegetation/Code/Source/VegetationSystemComponent.cpp
@@ -20,6 +20,8 @@
 #include <Vegetation/EmptyInstanceSpawner.h>
 #include <Vegetation/PrefabInstanceSpawner.h>
 
+AZ_DEFINE_BUDGET(Vegetation);
+
 namespace Vegetation
 {
     namespace Details


### PR DESCRIPTION
* Replace AZ_PROFILE macros in high frequency functions with system specific _VERBOSE macros that can be enabled/disabled via #define
https://github.com/aws-lumberyard-dev/o3de/pull/464

* Fix compile issue with verbose macros, add budgets for Vegetation and SurfaceData instead of using Entity

* Use Uuid operator + instead of string allocation to create a uuid from two strings (#460)
https://github.com/aws-lumberyard-dev/o3de/pull/460

* Queue mesh initialization for parallel work during MeshFeatureProcessor::Simulate instead of initializing immediately when the model is ready (#462)
https://github.com/aws-lumberyard-dev/o3de/pull/462

Signed-off-by: Tommy Walton <waltont@amazon.com>
Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>

## What does this PR do?

Merges changes that were made for roscon to development.

## How was this PR tested?

Used in the RosCon demo
