### PR TITLE
Disable toolbar customization menu item

### DIFF
--- a/Code/Editor/MainWindow.cpp
+++ b/Code/Editor/MainWindow.cpp
@@ -2021,9 +2021,14 @@ void MainWindow::ShowCustomizeToolbarDialog()
 QMenu* MainWindow::createPopupMenu()
 {
     QMenu* menu = QMainWindow::createPopupMenu();
-    menu->addSeparator();
-    QAction* action = menu->addAction(QStringLiteral("Customize..."));
-    connect(action, &QAction::triggered, this, &MainWindow::ShowCustomizeToolbarDialog);
+
+    if (!IsNewActionManagerEnabled())
+    {
+        menu->addSeparator();
+        QAction* action = menu->addAction(QStringLiteral("Customize..."));
+        connect(action, &QAction::triggered, this, &MainWindow::ShowCustomizeToolbarDialog);
+    }
+
     return menu;
 }
 


### PR DESCRIPTION
Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>

## What does this PR do?

Fixes #12562

Removes the "Customize Toolbars..." menu item from the right click context menu of toolbars in the Main Window.
This functionality won't be available in the MVP for the new Action Manager but will be added as follow-up work. This prevents a crash when selecting that menu item when the new action manager is enabled.

## How was this PR tested?

Manual testing.