### PR TITLE
fix mistake in double precision quaternion conjugate

### DIFF
--- a/Gems/PhysX/Code/NumericalMethods/Source/DoublePrecisionMath/Quaternion.cpp
+++ b/Gems/PhysX/Code/NumericalMethods/Source/DoublePrecisionMath/Quaternion.cpp
@@ -92,6 +92,6 @@ namespace NumericalMethods::DoublePrecisionMath
 
     Quaternion Quaternion::GetConjugate() const
     {
-        return Quaternion(m_x, m_y, m_z, -m_w);
+        return Quaternion(-m_x, -m_y, -m_z, m_w);
     }
 } // namespace NumericalMethods::DoublePrecisionMath

--- a/Gems/PhysX/Code/NumericalMethods/Tests/DoublePrecisionMath/QuaternionTest.cpp
+++ b/Gems/PhysX/Code/NumericalMethods/Tests/DoublePrecisionMath/QuaternionTest.cpp
@@ -116,9 +116,9 @@ namespace NumericalMethods::DoublePrecisionMath
         const double w = 0.32;
         const Quaternion quaternion(x, y, z, w);
         const Quaternion conjugate = quaternion.GetConjugate();
-        EXPECT_NEAR(conjugate.GetX(), x, Tolerance);
-        EXPECT_NEAR(conjugate.GetY(), y, Tolerance);
-        EXPECT_NEAR(conjugate.GetZ(), z, Tolerance);
-        EXPECT_NEAR(conjugate.GetW(), -w, Tolerance);
+        EXPECT_NEAR(conjugate.GetX(), -x, Tolerance);
+        EXPECT_NEAR(conjugate.GetY(), -y, Tolerance);
+        EXPECT_NEAR(conjugate.GetZ(), -z, Tolerance);
+        EXPECT_NEAR(conjugate.GetW(), w, Tolerance);
     }
 } // namespace NumericalMethods::DoublePrecisionMath


### PR DESCRIPTION
Signed-off-by: greerdv <greerdv@amazon.com>

## What does this PR do?
Fixes an error where the implementation of GetConjugate for double precision quaternions was returning the negative of the conjugate. The negative of a quaternion is in some senses an equivalent rotation, so I don't think this would have had a big impact, and doesn't seem to have affected the automatic joint fitting (which is the only feature using the double precision quaternion), but it was technically incorrect.

## How was this PR tested?
Ran unit tests. Tested automatic joint limit fitting in the animation editor.