### PR TITLE
fix issue with not all vertices in icosphere getting normalized

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Geometry3DUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Geometry3DUtils.cpp
@@ -61,13 +61,16 @@ namespace AZ::Geometry3dUtils
 
         // The 12 vertices of an icosahedron centered at the origin with edge length 1 are
         // (+- 1, +- 1/phi, 0), (0, +- 1, +- 1/phi), (+- 1/phi, 0, +- 1)
+
+        // normalization factor to make the radius 1
+        const float norm = 1.0f / AZStd::sqrt(1.0f + 1.0f / (phi * phi));
         const AZ::Vector3 icosahedronVertices[] = {
             // (+- 1, +- 1/phi, 0)
-            { -1.0f, 1.0f/phi, 0.0f }, { 1.0f, 1.0f/phi, 0.0f }, { -1.0f, -1.0f/phi, 0.0f }, { 1.0f, -1.0f/phi, 0.0f },
+            { -norm, norm/phi, 0.0f }, { norm, norm/phi, 0.0f }, { -norm, -norm/phi, 0.0f }, { norm, -norm/phi, 0.0f },
             // (0, +- 1, +- 1/phi)
-            { 0.0f, -1.0f, 1.0f/phi }, { 0.0f, 1.0f, 1.0f/phi }, { 0.0f, -1.0f, -1.0f/phi }, { 0.0f, 1.0f, -1.0f/phi },
+            { 0.0f, -norm, norm/phi }, { 0.0f, norm, norm/phi }, { 0.0f, -norm, -norm/phi }, { 0.0f, norm, -norm/phi },
             // (+- 1/phi, 0, +- 1)
-            { 1.0f/phi, 0.0f, -1.0f }, { 1.0f/phi, 0.0f, 1.0f }, { -1.0f/phi, 0.0f, -1.0f }, { -1.0f/phi, 0.0f, 1.0f } };
+            { norm/phi, 0.0f, -norm }, { norm/phi, 0.0f, norm }, { -norm/phi, 0.0f, -norm }, { -norm/phi, 0.0f, norm } };
 
         // The 20 triangles that make up the faces of the icosahedron.
         int faceIndices[IcosahedronFaces][3] = {

--- a/Code/Framework/AzCore/Tests/Math/Geometry3DUtilsTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Geometry3DUtilsTests.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Math/Geometry3DUtils.h>
+#include <AzCore/UnitTest/TestTypes.h>
+
+namespace UnitTest
+{
+    class Geometry3DUtilsFixture :
+        public UnitTest::AllocatorsFixture,
+        public ::testing::WithParamInterface<uint8_t>
+    {
+    };
+
+    TEST_P(Geometry3DUtilsFixture, IcoSphere_UnitRadius)
+    {
+        const AZStd::vector<AZ::Vector3> icoSphere = AZ::Geometry3dUtils::GenerateIcoSphere(GetParam());
+        float minRadius = AZ::Constants::FloatMax;
+        float maxRadius = 0;
+        for (const auto& vertex : icoSphere)
+        {
+            const float radius = vertex.GetLength();
+            minRadius = AZ::GetMin(minRadius, radius);
+            maxRadius = AZ::GetMax(maxRadius, radius);
+        }
+
+        EXPECT_NEAR(minRadius, 1.0f, 1e-3f);
+        EXPECT_NEAR(maxRadius, 1.0f, 1e-3f);
+    }
+
+    INSTANTIATE_TEST_CASE_P(MATH_Geometry3DUtilsTests, Geometry3DUtilsFixture, ::testing::Values(0u, 1u, 2u, 3u));
+} // namespace UnitTest

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -116,6 +116,7 @@ set(FILES
     Math/CrcTestsCompileTimeLiterals.h
     Math/FrustumTests.cpp
     Math/FrustumPerformanceTests.cpp
+    Math/Geometry3DUtilsTests.cpp
     Math/HemisphereTests.cpp
     Math/IntersectionPerformanceTests.cpp
     Math/IntersectionTestHelpers.cpp


### PR DESCRIPTION
Signed-off-by: greerdv <greerdv@amazon.com>

## What does this PR do?
Fixes an issue where some vertices from GenerateIcoSphere were not normalized to unit radius.

## How was this PR tested?
Added a unit test to check that all vertices in the icosphere have unit radius.