### PR TITLE
[Terrain] Change underlying paint brush settings code to support color.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/PaintBrushManipulator.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/PaintBrushManipulator.h
@@ -12,9 +12,10 @@
 
 #include <AzCore/Math/Quaternion.h>
 #include <AzCore/Memory/SystemAllocator.h>
+#include <AzToolsFramework/PaintBrushSettings/PaintBrushSettings.h>
+#include <AzToolsFramework/PaintBrushSettings/PaintBrushSettingsNotificationBus.h>
 #include <AzToolsFramework/Viewport/ActionBus.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
-#include <AzToolsFramework/PaintBrushSettings/PaintBrushSettingsNotificationBus.h>
 
 namespace AzToolsFramework
 {
@@ -44,7 +45,7 @@ namespace AzToolsFramework
     {
         //! Private constructor.
         PaintBrushManipulator(
-            const AZ::Transform& worldFromLocal, const AZ::EntityComponentIdPair& entityComponentIdPair);
+            const AZ::Transform& worldFromLocal, const AZ::EntityComponentIdPair& entityComponentIdPair, PaintBrushColorMode colorMode);
 
     public:
         AZ_RTTI(PaintBrushManipulator, "{0621CB58-21FD-474A-A296-5B1192E714E7}", BaseManipulator);
@@ -58,7 +59,7 @@ namespace AzToolsFramework
 
         //! A Manipulator must only be created and managed through a shared_ptr.
         static AZStd::shared_ptr<PaintBrushManipulator> MakeShared(
-            const AZ::Transform& worldFromLocal, const AZ::EntityComponentIdPair& entityComponentIdPair);
+            const AZ::Transform& worldFromLocal, const AZ::EntityComponentIdPair& entityComponentIdPair, PaintBrushColorMode colorMode);
 
         //! Draw the current manipulator state.
         void Draw(
@@ -74,8 +75,6 @@ namespace AzToolsFramework
         AZStd::vector<AzToolsFramework::ActionOverride> PopulateActionsImpl();
  
         void AdjustSize(float sizeDelta);
-        void AdjustIntensityPercent(float intensityPercentDelta);
-        void AdjustOpacityPercent(float opacityPercentDelta);
 
     private:
         void OnSettingsChanged(const PaintBrushSettings& newSettings) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/PaintBrushNotificationBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/PaintBrushNotificationBus.h
@@ -64,9 +64,8 @@ namespace AzToolsFramework
         }
 
         //! Notifies listeners that a paint stroke has begun.
-        //! @param intensity The intensity of the paint stroke (0-1)
-        //! @param opacity The opacity of the paint stroke (0-1)
-        virtual void OnPaintStrokeBegin([[maybe_unused]] float intensity, [[maybe_unused]] float opacity)
+        //! @param color The color of the paint stroke, including opacity
+        virtual void OnPaintStrokeBegin([[maybe_unused]] const AZ::Color& color)
         {
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettings.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettings.cpp
@@ -13,13 +13,57 @@
 
 namespace AzToolsFramework
 {
+    AzToolsFramework::ColorEditorConfiguration PaintBrushSettings::GetColorEditorConfig()
+    {
+        enum ColorSpace : uint32_t
+        {
+            LinearSRGB,
+            SRGB
+        };
+
+        AzToolsFramework::ColorEditorConfiguration configuration;
+        configuration.m_colorPickerDialogConfiguration = AzQtComponents::ColorPicker::Configuration::RGBA;
+
+        // The property is in either SRGB or linear, depending on paintbrush settings, but we should display the colors using SRGB.
+        configuration.m_propertyColorSpaceId = (m_colorMode == PaintBrushColorMode::SRGB) ? ColorSpace::SRGB : ColorSpace::LinearSRGB;
+        configuration.m_colorPickerDialogColorSpaceId = ColorSpace::SRGB;
+        configuration.m_colorSwatchColorSpaceId = ColorSpace::SRGB;
+
+        configuration.m_colorSpaceNames[ColorSpace::LinearSRGB] = "Linear sRGB";
+        configuration.m_colorSpaceNames[ColorSpace::SRGB] = "sRGB";
+
+        configuration.m_transformColorCallback = [](const AZ::Color& color, uint32_t fromColorSpaceId, uint32_t toColorSpaceId)
+        {
+            if (fromColorSpaceId == toColorSpaceId)
+            {
+                return color;
+            }
+            else if (fromColorSpaceId == ColorSpace::LinearSRGB && toColorSpaceId == ColorSpace::SRGB)
+            {
+                return color.LinearToGamma();
+            }
+            else if (fromColorSpaceId == ColorSpace::SRGB && toColorSpaceId == ColorSpace::LinearSRGB)
+            {
+                return color.GammaToLinear();
+            }
+            else
+            {
+                AZ_Error("ColorEditorConfiguration", false, "Invalid color space combination");
+                return color;
+            }
+        };
+
+        return configuration;
+    }
+
     void PaintBrushSettings::Reflect(AZ::ReflectContext* context)
     {
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<PaintBrushSettings>()
-                ->Version(3)
+                ->Version(4)
                 ->Field("Size", &PaintBrushSettings::m_size)
+                ->Field("Color", &PaintBrushSettings::m_brushColor)
                 ->Field("Intensity", &PaintBrushSettings::m_intensityPercent)
                 ->Field("Opacity", &PaintBrushSettings::m_opacityPercent)
                 ->Field("Hardness", &PaintBrushSettings::m_hardnessPercent)
@@ -45,24 +89,37 @@ namespace AzToolsFramework
                     ->Attribute(AZ::Edit::Attributes::DisplayDecimals, 2)
                     ->Attribute(AZ::Edit::Attributes::Suffix, " m")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PaintBrushSettings::OnSettingsChanged)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &PaintBrushSettings::m_brushColor, "Color", "Color of the paint brush.")
+                    ->Attribute("ColorEditorConfiguration", &PaintBrushSettings::GetColorEditorConfig)
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &PaintBrushSettings::GetColorVisibility)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PaintBrushSettings::OnColorChanged)
                     ->DataElement(
-                        AZ::Edit::UIHandlers::Slider, &PaintBrushSettings::m_intensityPercent, "Intensity",
+                        AZ::Edit::UIHandlers::Slider,
+                        &PaintBrushSettings::m_intensityPercent,
+                        "Intensity",
                         "Intensity/color percent of the paint brush. 0% = black, 100% = white.")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                     ->Attribute(AZ::Edit::Attributes::Max, 100.0f)
                     ->Attribute(AZ::Edit::Attributes::Step, 0.5f)
                     ->Attribute(AZ::Edit::Attributes::DisplayDecimals, 1)
                     ->Attribute(AZ::Edit::Attributes::Suffix, " %")
-                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PaintBrushSettings::OnSettingsChanged)
-                    ->DataElement(AZ::Edit::UIHandlers::Slider, &PaintBrushSettings::m_opacityPercent, "Opacity",
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &PaintBrushSettings::GetIntensityVisibility)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PaintBrushSettings::OnIntensityChanged)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Slider,
+                        &PaintBrushSettings::m_opacityPercent,
+                        "Opacity",
                         "Opacity percent of each paint brush stroke. 0% = transparent, 100% = opaque.")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                     ->Attribute(AZ::Edit::Attributes::Max, 100.0f)
                     ->Attribute(AZ::Edit::Attributes::Step, 0.5f)
                     ->Attribute(AZ::Edit::Attributes::DisplayDecimals, 1)
                     ->Attribute(AZ::Edit::Attributes::Suffix, " %")
-                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PaintBrushSettings::OnSettingsChanged)
-                    ->DataElement(AZ::Edit::UIHandlers::Slider, &PaintBrushSettings::m_hardnessPercent, "Hardness",
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PaintBrushSettings::OnOpacityChanged)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Slider,
+                        &PaintBrushSettings::m_hardnessPercent,
+                        "Hardness",
                         "Falloff percent around the edges of each paint brush stamp. 0% = soft falloff, 100% = hard edges.")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                     ->Attribute(AZ::Edit::Attributes::Max, 100.0f)
@@ -105,21 +162,36 @@ namespace AzToolsFramework
         }
     }
 
-    void PaintBrushSettings::SetIntensityPercent(float intensityPercent)
+    bool PaintBrushSettings::GetColorVisibility() const
     {
-        m_intensityPercent = AZStd::clamp(intensityPercent, 0.0f, 100.0f);
-        OnSettingsChanged();
+        return (m_colorMode != PaintBrushColorMode::Greyscale);
     }
 
-    void PaintBrushSettings::SetOpacityPercent(float opacityPercent)
+    bool PaintBrushSettings::GetIntensityVisibility() const
     {
-        m_opacityPercent = AZStd::clamp(opacityPercent, 0.0f, 100.0f);
-        OnSettingsChanged();
+        return (m_colorMode == PaintBrushColorMode::Greyscale);
+    }
+
+    void PaintBrushSettings::SetColorMode(PaintBrushColorMode colorMode)
+    {
+        m_colorMode = colorMode;
+        PaintBrushSettingsNotificationBus::Broadcast(&PaintBrushSettingsNotificationBus::Events::OnColorModeChanged, *this);
     }
 
     void PaintBrushSettings::SetBlendMode(PaintBrushBlendMode blendMode)
     {
         m_blendMode = blendMode;
+        OnSettingsChanged();
+    }
+
+    void PaintBrushSettings::SetColor(const AZ::Color& color)
+    {
+        m_brushColor = color;
+
+        // Keep our editable intensity / opacity values in sync with the brush color.
+        m_intensityPercent = m_brushColor.GetR() * 100.0f;
+        m_opacityPercent = m_brushColor.GetA() * 100.0f;
+
         OnSettingsChanged();
     }
 
@@ -146,6 +218,27 @@ namespace AzToolsFramework
         // Distance percent is *normally* 0-100%, but values above 100% are reasonable as well, so we don't clamp the upper limit.
         m_distancePercent = AZStd::max(distancePercent, 0.0f);
         OnSettingsChanged();
+    }
+
+    AZ::u32 PaintBrushSettings::OnColorChanged()
+    {
+        // Keep our editable intensity in sync with the brush color.
+        m_intensityPercent = m_brushColor.GetR() * 100.0f;
+
+        return OnSettingsChanged();
+    }
+
+    AZ::u32 PaintBrushSettings::OnIntensityChanged()
+    {
+        const float intensity = m_intensityPercent / 100.0f;
+        m_brushColor = AZ::Color(intensity, intensity, intensity, m_brushColor.GetA());
+        return OnSettingsChanged();
+    }
+
+    AZ::u32 PaintBrushSettings::OnOpacityChanged()
+    {
+        m_brushColor.SetA(m_opacityPercent / 100.0f);
+        return OnSettingsChanged();
     }
 
     AZ::u32 PaintBrushSettings::OnSettingsChanged()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettingsNotificationBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettingsNotificationBus.h
@@ -22,6 +22,12 @@ namespace AzToolsFramework
     public:
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
 
+        //! Notifies listeners that the paintbrush color mode has changed.
+        //! @param newSettings The settings after the change
+        virtual void OnColorModeChanged([[maybe_unused]] const PaintBrushSettings& newSettings)
+        {
+        }
+
         //! Notifies listeners that the paintbrush settings have changed.
         //! @param newSettings The settings after the change
         virtual void OnSettingsChanged([[maybe_unused]] const PaintBrushSettings& newSettings)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettingsRequestBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettingsRequestBus.h
@@ -31,29 +31,28 @@ namespace AzToolsFramework
         //! Returns a copy of the current paintbrush settings
         virtual PaintBrushSettings GetSettings() const = 0;
 
+        //! Returns the current color mode for the paint brush settings
+        virtual PaintBrushColorMode GetBrushColorMode() const = 0;
+
+        //! Sets the color mode for the paint brush settings.
+        virtual void SetBrushColorMode(PaintBrushColorMode colorMode) = 0;
+
         // Paint Brush Stroke settings
 
-        //! Returns the brush stroke intensity (0=black, 100=white).
-        //! @return The intensity of the brush stroke
-        virtual float GetIntensityPercent() const = 0;
-
-        //! Returns the brush stroke opacity (0=transparent, 100=opaque).
-        virtual float GetOpacityPercent() const = 0;
+        //! Returns the current brush stroke color, including opacity.
+        //! In monochrome painting, the RGB values will all be identical.
+        virtual AZ::Color GetColor() const = 0;
 
         //! Returns the current brush stroke blend mode.
         virtual PaintBrushBlendMode GetBlendMode() const = 0;
 
-        //! Sets the brush stroke intensity.
-        //! @param intensity The new intensity, in 0-100 range (0=black, 100=white).
-        virtual void SetIntensityPercent(float intensityPercent) = 0;
-
-        //! Sets the brush stroke opacity.
-        //! @param opacity The new opacity, in 0-100 range (0=transparent, 100=opaque).
-        virtual void SetOpacityPercent(float opacityPercent) = 0;
-
         //! Sets the brush stroke blend mode.
         //! @param blendMode The new blend mode.
         virtual void SetBlendMode(PaintBrushBlendMode blendMode) = 0;
+
+        //! Set the brush stroke color, including opacity.
+        //! @param color The new brush color. In monochrome painting, only the Red value will be used.
+        virtual void SetColor(const AZ::Color& color) = 0;
 
         // Paint Brush Stamp settings
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettingsSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettingsSystemComponent.cpp
@@ -46,19 +46,24 @@ namespace AzToolsFramework
         return m_settings;
     }
 
+    PaintBrushColorMode PaintBrushSettingsSystemComponent::GetBrushColorMode() const
+    {
+        return m_settings.GetColorMode();
+    }
+
+    void PaintBrushSettingsSystemComponent::SetBrushColorMode(PaintBrushColorMode colorMode)
+    {
+        m_settings.SetColorMode(colorMode);
+    }
+
     float PaintBrushSettingsSystemComponent::GetSize() const
     {
         return m_settings.GetSize();
     }
 
-    float PaintBrushSettingsSystemComponent::GetIntensityPercent() const
+    AZ::Color PaintBrushSettingsSystemComponent::GetColor() const
     {
-        return m_settings.GetIntensityPercent();
-    }
-
-    float PaintBrushSettingsSystemComponent::GetOpacityPercent() const
-    {
-        return m_settings.GetOpacityPercent();
+        return m_settings.GetColor();
     }
 
     float PaintBrushSettingsSystemComponent::GetHardnessPercent() const
@@ -86,14 +91,9 @@ namespace AzToolsFramework
         m_settings.SetSize(size);
     }
 
-    void PaintBrushSettingsSystemComponent::SetIntensityPercent(float intensityPercent)
+    void PaintBrushSettingsSystemComponent::SetColor(const AZ::Color& color)
     {
-        m_settings.SetIntensityPercent(intensityPercent);
-    }
-
-    void PaintBrushSettingsSystemComponent::SetOpacityPercent(float opacityPercent)
-    {
-        m_settings.SetOpacityPercent(opacityPercent);
+        m_settings.SetColor(color);
     }
 
     void PaintBrushSettingsSystemComponent::SetHardnessPercent(float hardnessPercent)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettingsSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettingsSystemComponent.h
@@ -35,16 +35,16 @@ namespace AzToolsFramework
         // PaintBrushSettingsRequestBus overrides...
         PaintBrushSettings* GetSettingsPointerForPropertyEditor() override;
         PaintBrushSettings GetSettings() const override;
+        PaintBrushColorMode GetBrushColorMode() const override;
+        void SetBrushColorMode(PaintBrushColorMode colorMode) override;
         float GetSize() const override;
-        float GetIntensityPercent() const override;
-        float GetOpacityPercent() const override;
+        AZ::Color GetColor() const override;
         float GetHardnessPercent() const override;
         float GetFlowPercent() const override;
         float GetDistancePercent() const override;
         PaintBrushBlendMode GetBlendMode() const override;
         void SetSize(float size) override;
-        void SetIntensityPercent(float intensityPercent) override;
-        void SetOpacityPercent(float opacityPercent) override;
+        void SetColor(const AZ::Color& color) override;
         void SetHardnessPercent(float hardnessPercent) override;
         void SetFlowPercent(float flowPercent) override;
         void SetDistancePercent(float distancePercent) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettingsWindow.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettingsWindow.cpp
@@ -67,6 +67,11 @@ namespace PaintBrush
             AzToolsFramework::PaintBrushSettingsNotificationBus::Handler::BusDisconnect();
         }
 
+        void PaintBrushSettingsWindow::OnColorModeChanged([[maybe_unused]] const AzToolsFramework::PaintBrushSettings& newSettings)
+        {
+            m_propertyEditor->InvalidateAll();
+        }
+
         void PaintBrushSettingsWindow::OnSettingsChanged([[maybe_unused]] const AzToolsFramework::PaintBrushSettings& newSettings)
         {
             m_propertyEditor->InvalidateValues();
@@ -97,4 +102,4 @@ namespace PaintBrush
             viewOptions,
             &Internal::CreateNewPaintBrushSettingsWindow);
     }
-} // namespace Camera
+} // namespace PaintBrush

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettingsWindow_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettingsWindow_Internals.h
@@ -69,6 +69,7 @@ namespace PaintBrush
             }
 
         private:
+            void OnColorModeChanged([[maybe_unused]] const AzToolsFramework::PaintBrushSettings& newSettings) override;
             void OnSettingsChanged([[maybe_unused]] const AzToolsFramework::PaintBrushSettings& newSettings) override;
 
             // RPE Support

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.cpp
@@ -304,7 +304,8 @@ namespace GradientSignal
         AZ::Transform worldFromLocal = AZ::Transform::CreateIdentity();
         AZ::TransformBus::EventResult(worldFromLocal, GetEntityId(), &AZ::TransformInterface::GetWorldTM);
 
-        m_brushManipulator = AzToolsFramework::PaintBrushManipulator::MakeShared(worldFromLocal, entityComponentIdPair);
+        m_brushManipulator = AzToolsFramework::PaintBrushManipulator::MakeShared(
+            worldFromLocal, entityComponentIdPair, AzToolsFramework::PaintBrushColorMode::Greyscale);
         Refresh();
 
         m_brushManipulator->Register(AzToolsFramework::g_mainManipulatorManagerId);
@@ -374,7 +375,7 @@ namespace GradientSignal
         }
     }
 
-    void EditorImageGradientComponentMode::OnPaintStrokeBegin(float intensity, float opacity)
+    void EditorImageGradientComponentMode::OnPaintStrokeBegin(const AZ::Color& color)
     {
         BeginUndoBatch();
 
@@ -386,8 +387,8 @@ namespace GradientSignal
             return;
         }
 
-        m_paintStrokeData.m_intensity = intensity;
-        m_paintStrokeData.m_opacity = opacity;
+        m_paintStrokeData.m_intensity = color.GetR();
+        m_paintStrokeData.m_opacity = color.GetA();
 
         m_paintStrokeData.m_metersPerPixelX = 1.0f / imagePixelsPerMeter.GetX();
         m_paintStrokeData.m_metersPerPixelY = 1.0f / imagePixelsPerMeter.GetY();

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.h
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.h
@@ -35,7 +35,7 @@ namespace GradientSignal
 
     protected:
         // PaintBrushNotificationBus overrides
-        void OnPaintStrokeBegin(float intensity, float opacity) override;
+        void OnPaintStrokeBegin(const AZ::Color& color) override;
         void OnPaintStrokeEnd() override;
         void OnPaint(const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, BlendFn& blendFn) override;
 


### PR DESCRIPTION
## What does this PR do?

This replaces intensity/opacity in the paintbrush APIs with a single AZ::Color value, and adds a paintbrush color mode so that each component mode can specify whether they want linear color, SRGB, or greyscale. 

The paintbrush settings themselves will show either a color picker or an intensity slider depending on whether color or greyscale is selected. The opacity slider remains as well for better UX usability, even though the opacity value just gets merged into the AZ::Color from an API perspective.

The Image Gradient painting code only uses the greyscale mode, nothing currently uses the color mode.

## How was this PR tested?

The color mode was tested in a local branch in which the Terrain Macro Material supports color painting. I was able to use this to verify that the color picking works for component modes that support color, and intensity works for component modes that support greyscale.
