### PR TITLE
Add clientConnectionCount perf metric to Multiplayer gem

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerStats.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerStats.h
@@ -28,7 +28,8 @@ namespace Multiplayer
     enum MultiplayerStatIds
     {
         MultiplayerStat_EntityCount = 1001,
-        MultiplayerStat_FrameTime
+        MultiplayerStat_FrameTime,
+        MultiplayerStat_ClientConnectionCount
     };
 
     struct MultiplayerStats

--- a/Gems/Multiplayer/Code/Source/MultiplayerStats.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerStats.cpp
@@ -129,6 +129,7 @@ namespace Multiplayer
     void MultiplayerStats::TickStats(AZ::TimeMs metricFrameTimeMs)
     {
         SET_PERFORMANCE_STAT(MultiplayerStat_EntityCount, m_entityCount);
+        SET_PERFORMANCE_STAT(MultiplayerStat_ClientConnectionCount, m_clientConnectionCount);
 
         m_totalHistoryTimeMs = metricFrameTimeMs * static_cast<AZ::TimeMs>(RingbufferSamples);
         m_recordMetricIndex = ++m_recordMetricIndex % RingbufferSamples;

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -242,6 +242,7 @@ namespace Multiplayer
         DECLARE_PERFORMANCE_STAT_GROUP(MultiplayerGroup_Networking, "Networking");
         DECLARE_PERFORMANCE_STAT(MultiplayerGroup_Networking, MultiplayerStat_EntityCount, "NumEntities");
         DECLARE_PERFORMANCE_STAT(MultiplayerGroup_Networking, MultiplayerStat_FrameTime, "FrameTimeUs");
+        DECLARE_PERFORMANCE_STAT(MultiplayerGroup_Networking, MultiplayerStat_ClientConnectionCount, "ClientConnections");
 
         AzFramework::RootSpawnableNotificationBus::Handler::BusConnect();
         AZ::TickBus::Handler::BusConnect();


### PR DESCRIPTION
## What does this PR do?

Instruments a metric for `clientConnectionCount` within MultiplayerStats.

## How was this PR tested?

* unit tests pass
* running _o3de-multiplayersample_ with this change results in client count being output to the "args" object of network metrics objects:

```json
// test on localhost with 2 clients running
{"name":"Stats","cat":"Networking","ph":"C","ts":1667341975203292,"pid":27960,"tid":27744,"args":{"NumEntities":274.0,"FrameTimeUs":1881.234375,"ClientConnections":2.0}},
  {"name":"Stats","cat":"Networking","ph":"C","ts":1667341976201165,"pid":27960,"tid":27744,"args":{"NumEntities":274.0,"FrameTimeUs":1972.5546875,"ClientConnections":2.0}},
  {"name":"Stats","cat":"Networking","ph":"C","ts":1667341977218809,"pid":27960,"tid":27744,"args":{"NumEntities":274.0,"FrameTimeUs":1938.296875,"ClientConnections":2.0}},
```
