### PR TITLE
Adding a `ParseConfigFile` function to AzCore

### DIFF
--- a/Code/Framework/AzCore/AzCore/Settings/ConfigParser.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/ConfigParser.cpp
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/IO/GenericStreams.h>
+#include <AzCore/Settings/ConfigParser.h>
+#include <AzCore/std/string/conversions.h>
+#include <AzCore/std/string/fixed_string.h>
+#include <AzCore/std/containers/fixed_vector.h>
+#include <AzCore/StringFunc/StringFunc.h>
+
+namespace AZ::Settings
+{
+    AZStd::string_view ConfigParserSettings::DefaultCommentPrefixFilter(AZStd::string_view line)
+    {
+        constexpr AZStd::string_view commentPrefixes = ";#";
+        for (char commentPrefix : commentPrefixes)
+        {
+            if (size_t commentOffset = line.find(commentPrefix); commentOffset != AZStd::string_view::npos)
+            {
+                line = line.substr(0, commentOffset);
+            }
+        }
+
+        return line;
+    }
+
+    AZStd::string_view ConfigParserSettings::DefaultSectionHeaderFilter(AZStd::string_view line)
+    {
+        AZStd::string_view sectionName;
+        constexpr char sectionHeaderStart = '[';
+        constexpr char sectionHeaderEnd = ']';
+        if (line.starts_with(sectionHeaderStart) && line.ends_with(sectionHeaderEnd))
+        {
+            // View substring of line between the section '[' and ']' characters
+            sectionName = line.substr(1);
+            sectionName = sectionName.substr(0, sectionName.size() - 1);
+            // strip any leading and trailing whitespace from the section name
+            size_t startIndex = 0;
+            for (; startIndex < sectionName.size() && isspace(sectionName[startIndex]); ++startIndex);
+            sectionName = sectionName.substr(startIndex);
+            size_t endIndex = sectionName.size();
+            for (; endIndex > 0 && isspace(sectionName[endIndex - 1]); --endIndex);
+            sectionName = sectionName.substr(0, endIndex);
+        }
+
+        return sectionName;
+    }
+
+    auto ConfigParserSettings::DefaultDelimiterFunc(AZStd::string_view line) -> ConfigKeyValuePair
+    {
+        constexpr AZStd::string_view CommandLineArgumentDelimiters{ "=:" };
+        ConfigKeyValuePair keyValuePair;
+        keyValuePair.m_value = line;
+
+        // Splits the line on the first delimiter and stores that in the keyValuePair key variable
+        // The StringFunc::TokenizeNext function updates the key parameter in place
+        // to contain all the text after the first delimiter
+        // So if keyValuePair.m_key="foo = Hello Ice Cream=World:17", the call to TokenizeNext would
+        // split the value as follows
+        // keyValuePair.m_key = "foo"
+        // keyValuePair.m_value = "Hello Ice Cream=World:17"
+        if (auto keyOpt = AZ::StringFunc::TokenizeNext(keyValuePair.m_value, CommandLineArgumentDelimiters);
+            keyOpt.has_value())
+        {
+            // Strip the whitespace around the key part
+            keyValuePair.m_key = AZ::StringFunc::StripEnds(*keyOpt);
+        }
+
+        // Strip white spaces around the value part
+        keyValuePair.m_value = AZ::StringFunc::StripEnds(keyValuePair.m_value);
+        return keyValuePair;
+    };
+
+    ParseOutcome ParseConfigFile(AZ::IO::GenericStream& configStream, const ConfigParserSettings& configParserSettings)
+    {
+        // The trace system is not being used here as this function INI system is available
+        // before any allocators or initialization of any systems take place
+
+        ParseOutcome parseOutcome;
+        if (!configParserSettings.m_parseConfigEntryFunc)
+        {
+            return AZStd::unexpected(ParseErrorString::format("The Parse Config Entry function is not valid for parsing a Windows Style INI line"));
+        }
+
+        // The ConfigFile is parsed using into a fixed_vector of ConfigBufferMaxSize below
+        // which avoids performing any dynamic memory allocations during parsing
+        // Only the user supplied callback functions as part of the ConfigParserSettings can potentailly allocate memory
+        size_t remainingFileLength = configStream.GetLength();
+        if (remainingFileLength == 0)
+        {
+            return AZStd::unexpected(ParseErrorString::format(R"(Config stream "%s" is empty, nothing to merge)" "\n", configStream.GetFilename()));
+        }
+
+        constexpr size_t ConfigBufferMaxSize = 4096;
+        AZStd::fixed_vector<char, ConfigBufferMaxSize> configBuffer;
+        size_t readSize = (AZStd::min)(configBuffer.max_size(), remainingFileLength);
+        configBuffer.resize_no_construct(readSize);
+
+        size_t bytesRead = configStream.Read(configBuffer.size(), configBuffer.data());
+        remainingFileLength -= bytesRead;
+
+        // Stores the current section header which needs to be stored in a fixed_string
+        // since it is possible for the section header to have been read from a previous block
+        AZStd::fixed_string<256> currentSectionHeader;
+        do
+        {
+            decltype(configBuffer)::iterator frontIter{};
+            for (frontIter = configBuffer.begin(); frontIter != configBuffer.end();)
+            {
+                if (AZStd::isspace(*frontIter, {}))
+                {
+                    ++frontIter;
+                    continue;
+                }
+
+                // Find end of line
+                auto lineStartIter = frontIter;
+                auto lineEndIter = AZStd::find(frontIter, configBuffer.end(), '\n');
+                bool foundNewLine = lineEndIter != configBuffer.end();
+                if (!foundNewLine && remainingFileLength > 0)
+                {
+                    // No newline has been found in the remaining characters in the buffer,
+                    // Read the next chunk(up to ConfigBufferMaxSize) of the config file and look for a new line
+                    // if the file has remaining content
+                    // Otherwise if the file has no more remaining content, then it is improperly terminated
+                    // text file according to the posix standard
+                    // Therefore the final text after the final newline will be parsed
+                    break;
+                }
+
+
+                AZStd::string_view line(lineStartIter, lineEndIter);
+
+                // Remove any trailing carriage returns from the line
+                if (size_t lastValidLineCharIndex = line.find_last_not_of('\r'); lastValidLineCharIndex != AZStd::string_view::npos)
+                {
+                    line = line.substr(0, lastValidLineCharIndex + 1);
+                }
+                // Retrieve non-commented portion of line
+                if (configParserSettings.m_commentPrefixFunc)
+                {
+                    line = configParserSettings.m_commentPrefixFunc(line);
+                }
+                // Lookup any new section names from the line
+                if (configParserSettings.m_sectionHeaderFunc)
+                {
+                    AZStd::string_view sectionName = configParserSettings.m_sectionHeaderFunc(line);
+                    if (!sectionName.empty())
+                    {
+                        currentSectionHeader = sectionName;
+                        // If a section was found, then the line cannot contain a key, value
+                        line = {};
+                    }
+                }
+
+                // Create two views of a key and value from the line
+                ConfigParserSettings::ConfigEntry configEntry;
+                if (configParserSettings.m_delimiterFunc)
+                {
+                    configEntry.m_keyValuePair = configParserSettings.m_delimiterFunc(line);
+                }
+
+                // Assign the current section header
+                configEntry.m_sectionHeader = currentSectionHeader;
+
+                //! Invoke the parse config entry function to allow the caller to parse a single entry
+                if (!configEntry.m_keyValuePair.m_key.empty() && !configParserSettings.m_parseConfigEntryFunc(configEntry))
+                {
+                    parseOutcome = AZStd::unexpected(ParseErrorString::format("The ParseConfigEntry callback returned false"
+                        R"( indicating that the parsing of config entry (key="%.*s", value="%.*s" with section header "%.*s" has failed))",
+                        AZ_STRING_ARG(configEntry.m_keyValuePair.m_key),
+                        AZ_STRING_ARG(configEntry.m_keyValuePair.m_value),
+                        AZ_STRING_ARG(configEntry.m_sectionHeader)));
+                    // Do not break and continue to parse the config file
+                }
+
+                // Skip past the newline character if found
+                frontIter = lineEndIter + (foundNewLine ? 1 : 0);
+            }
+
+            // Read in more data from the config file if available.
+            // If the parsing was in the middle of a parsing line, then move the remaining data of that line to the beginning
+            // of the fixed_vector buffer
+            if (frontIter == configBuffer.begin())
+            {
+                parseOutcome = AZStd::unexpected(ParseErrorString::format(R"(The config stream "%s" contains a line which is longer than the max line length of %zu.)" "\n"
+                    R"(Parsing will halt.)" "\n", configStream.GetFilename(), configBuffer.max_size()));
+                break;
+            }
+            const size_t readOffset = AZStd::distance(frontIter, configBuffer.end());
+            if (readOffset > 0)
+            {
+                memmove(configBuffer.begin(), frontIter, readOffset);
+            }
+
+            // Read up to minimum of remaining file length or 4K in the configBuffer
+            readSize = (AZStd::min)(configBuffer.max_size() - readOffset, remainingFileLength);
+            bytesRead = configStream.Read(readSize, configBuffer.data() + readOffset);
+            // resize_no_construct fixes the size value
+            configBuffer.resize_no_construct(readOffset + readSize);
+            remainingFileLength -= bytesRead;
+        } while (bytesRead > 0);
+
+        return parseOutcome;
+    }
+} // namespace AZ::Settings

--- a/Code/Framework/AzCore/AzCore/Settings/ConfigParser.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/ConfigParser.cpp
@@ -87,9 +87,9 @@ namespace AZ::Settings
             return AZStd::unexpected(ParseErrorString::format("The Parse Config Entry function is not valid for parsing a Windows Style INI line"));
         }
 
-        // The ConfigFile is parsed using into a fixed_vector of ConfigBufferMaxSize below
+        // The ConfigFile is parsed into a fixed_vector of ConfigBufferMaxSize below
         // which avoids performing any dynamic memory allocations during parsing
-        // Only the user supplied callback functions as part of the ConfigParserSettings can potentailly allocate memory
+        // Only the user supplied callback functions as part of the ConfigParserSettings can potentially allocate memory
         size_t remainingFileLength = configStream.GetLength();
         if (remainingFileLength == 0)
         {

--- a/Code/Framework/AzCore/AzCore/Settings/ConfigParser.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/ConfigParser.cpp
@@ -136,11 +136,9 @@ namespace AZ::Settings
 
                 AZStd::string_view line(lineStartIter, lineEndIter);
 
-                // Remove any trailing carriage returns from the line
-                if (size_t lastValidLineCharIndex = line.find_last_not_of('\r'); lastValidLineCharIndex != AZStd::string_view::npos)
-                {
-                    line = line.substr(0, lastValidLineCharIndex + 1);
-                }
+                // Remove leading and surrounding spaces and carriage returns
+                line = AZ::StringFunc::StripEnds(line, " \r");
+
                 // Retrieve non-commented portion of line
                 if (configParserSettings.m_commentPrefixFunc)
                 {

--- a/Code/Framework/AzCore/AzCore/Settings/ConfigParser.h
+++ b/Code/Framework/AzCore/AzCore/Settings/ConfigParser.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/functional.h>
+#include <AzCore/std/string/string_view.h>
+#include <AzCore/std/utility/expected.h>
+
+namespace AZStd
+{
+    // Forward declare basic_fixed_string to avoid including fixed_string.h
+    // in the header
+    template <class Element, size_t MaxElementCount, class Traits>
+    class basic_fixed_string;
+}
+
+namespace AZ::IO
+{
+    class GenericStream;
+}
+
+namespace AZ::Settings
+{
+    //! Settings structure which is used to determine how to parse Windows INI style config file(.cfg, .ini, etc...)
+    //! It supports being able to supply a custom comment filter and section header filter
+    //! The names of section headers are appended to the root Json pointer path member to form new root paths
+    struct ConfigParserSettings
+    {
+        //! Struct which contains a string view to the key part and the value part
+        //! of a parsed INI file line.
+        struct ConfigKeyValuePair
+        {
+            AZStd::string_view m_key;
+            AZStd::string_view m_value;
+        };
+
+        //! Complete struct supplied to the ParseConfigEntry callback function
+        //! representing a single config entry. It will always contains
+        //! a key and value pair.
+        //! The section header will be supplied if the key, value is underneath a section
+        struct ConfigEntry
+        {
+            ConfigKeyValuePair m_keyValuePair;
+            AZStd::string_view m_sectionHeader;
+        };
+
+        //! Callback invoked with each parsed key, value `(key=value)` entry from a Windows Style INI file
+        //! with the section header if available `[section header]`
+        //! This is the the only member that is required to be set within this struct
+        //! All other membes are defaulted to work with INI style files
+        //! IMPORTANT: Any lambda functions or class instances that are larger than 16 bytes
+        //! in size requires a memory allocation to store.
+        //! So it is recommmended that users binding a lambda bind at most 2 reference or pointer members
+        //! to avoid dynamic heap allocations
+        //!
+        //! @return True should be returned from this function to indicate that parsing of the config entry
+        //! has a succeed
+        using ParseConfigEntryFunc = AZStd::function<bool(const ConfigEntry&)>;
+
+        ParseConfigEntryFunc m_parseConfigEntryFunc;
+
+        //! Filters out line which start with a prefix of ';' or '#'
+        //! If a line matches the comment filter and empty view is returned
+        //! Otherwise the line is returned as is
+        //! @param line line to parse for comments
+        //! @return view of line without any comments
+        static AZStd::string_view DefaultCommentPrefixFilter(AZStd::string_view line);
+
+        //!  Matches a section header in the regular expression form of
+        //! \[(?P<header>[^]]+)\] # '[' followed by 1 or more non-']' characters followed by a ']'
+        //! If the line matches section header format, the section name portion of that line
+        //! is returned in the output parameter otherwise an empty view is returned
+        //! @param line to parse for section header
+        //! @return section name header if the line starts contains an INI style section header
+        static AZStd::string_view DefaultSectionHeaderFilter(AZStd::string_view line);
+
+        //! Splits a line into two views of a key and a value pair
+        //! Surrounding whitespace around the key and value are not part of the string views
+        //! This function is invoked after the section header filter is invoked
+        //! @param line to search for delimiter and split int key value params
+        //! @return key, value pair structure representing the setting key and value
+        static ConfigKeyValuePair DefaultDelimiterFunc(AZStd::string_view line);
+
+        //! Callback function that is invoked when a line is read.
+        //! returns a substr of the line which contains the non-commented portion of the line
+        using CommentPrefixFunc = AZStd::function<AZStd::string_view(AZStd::string_view line)>;
+
+        //! Callback function that is after a line has been filtered through the CommentPrefixFunc
+        //! to determine if the text matches a section header
+        //! returns a view of the section name if the line contains a section
+        //! Otherwise an empty view is returned
+        using SectionHeaderFunc = AZStd::function<AZStd::string_view(AZStd::string_view line)>;
+
+        //! Callback function which is invoked after a line has been filtered through the SectionHeaderFunc
+        //! to split the key,value pair of a line
+        //! @return an instance of a ConfigKeyValuePair with the split key and value with surrounding whitespaced
+        //! trimmed
+        using DelimiterFunc = AZStd::function<ConfigKeyValuePair(AZStd::string_view line)>;
+
+
+        //! Function which is invoked to retrieve the non-commented section of a line
+        //! The input line will never start with leading whitespace
+        CommentPrefixFunc m_commentPrefixFunc = &DefaultCommentPrefixFilter;
+
+        //! Invoked on the non-commented section of a line that has been read from the config file
+        //! This function should examine the supplied line to determine if it matches a section header
+        //! If so the section name should be returned
+        //! Any sections names returned will be supplied as a section header to the Parse callback
+        SectionHeaderFunc m_sectionHeaderFunc = &DefaultSectionHeaderFilter;
+
+        //! Function which is invoked on the config line after filtering through the SectionHeaderFunc
+        //! to determine the delimiter of the line
+        //! The structure contains a functor which returns true if a character is a valid delimiter
+        DelimiterFunc m_delimiterFunc = &DefaultDelimiterFunc;
+    };
+
+    // Expected structure which encapsulates the result of the ParseConfigFile function
+    using ParseErrorString = AZStd::basic_fixed_string<char, 512, AZStd::char_traits<char>>;
+    using ParseOutcome = AZStd::expected<void, ParseErrorString>;
+
+    //! Loads basic configuration files which have structures that model Windows INI files
+    //! It is inspired by the Python configparser module: https://docs.python.org/3.10/library/configparser.html
+    //! NOTE: There is a max line length for any one configuration entry of 4096
+    //!       If a line greater than that is found parsing of the configuration file fails
+    //! This function will NOT allocate any dynamic memory.
+    //! It is safe to call without any AZ Allocators
+    //! @param stream GenericStream derived class where the configuration data will be read from
+    //! @param configParseSettigs struct defining configuration on how the INI style file should be parsed
+    //! @return success outcome if the configuration file was parsed without error,
+    //! otherwise a failure string is provided with the parse error
+    ParseOutcome ParseConfigFile(AZ::IO::GenericStream& stream, const ConfigParserSettings& configParserSettings);
+} // namespace AZ::Settings

--- a/Code/Framework/AzCore/AzCore/Settings/ConfigParser.h
+++ b/Code/Framework/AzCore/AzCore/Settings/ConfigParser.h
@@ -30,6 +30,14 @@ namespace AZ::Settings
     //! Settings structure which is used to determine how to parse Windows INI style config file(.cfg, .ini, etc...)
     //! It supports being able to supply a custom comment filter and section header filter
     //! The names of section headers are appended to the root Json pointer path member to form new root paths
+    //! Ex. test.ini
+    /*
+    ; This is a comment
+    # This is also a comment
+    key1 = value1 ; inline comment
+    [Section Header1]
+    sectionKey1 = value2
+    */
     struct ConfigParserSettings
     {
         //! Struct which contains a string view to the key part and the value part
@@ -53,7 +61,7 @@ namespace AZ::Settings
         //! Callback invoked with each parsed key, value `(key=value)` entry from a Windows Style INI file
         //! with the section header if available `[section header]`
         //! This is the the only member that is required to be set within this struct
-        //! All other membes are defaulted to work with INI style files
+        //! All other members are defaulted to work with INI style files
         //! IMPORTANT: Any lambda functions or class instances that are larger than 16 bytes
         //! in size requires a memory allocation to store.
         //! So it is recommmended that users binding a lambda bind at most 2 reference or pointer members
@@ -93,12 +101,16 @@ namespace AZ::Settings
 
         //! Callback function that is after a line has been filtered through the CommentPrefixFunc
         //! to determine if the text matches a section header
-        //! returns a view of the section name if the line contains a section
+        //! NOTE: Leading and trailing whitespace will be removed from the line before invoking the callback
+        //!
+        //! @return returns a view of the section name if the line contains a section
         //! Otherwise an empty view is returned
         using SectionHeaderFunc = AZStd::function<AZStd::string_view(AZStd::string_view line)>;
 
         //! Callback function which is invoked after a line has been filtered through the SectionHeaderFunc
         //! to split the key,value pair of a line
+        //! NOTE: Leading and trailing whitespace will be removed from the line before invoking the callback
+        //!
         //! @return an instance of a ConfigKeyValuePair with the split key and value with surrounding whitespaced
         //! trimmed
         using DelimiterFunc = AZStd::function<ConfigKeyValuePair(AZStd::string_view line)>;

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -596,6 +596,8 @@ set(FILES
     Serialization/std/VariantReflection.inl
     Settings/CommandLine.cpp
     Settings/CommandLine.h
+    Settings/ConfigParser.cpp
+    Settings/ConfigParser.h
     Settings/ConfigurableStack.cpp
     Settings/ConfigurableStack.inl
     Settings/ConfigurableStack.h

--- a/Code/Framework/AzCore/Tests/Settings/ConfigParserTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/ConfigParserTests.cpp
@@ -1,0 +1,353 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/IO/ByteContainerStream.h>
+#include <AzCore/Settings/ConfigParser.h>
+#include <AzCore/std/string/conversions.h>
+#include <AzCore/std/containers/fixed_unordered_map.h>
+#include <AzCore/UnitTest/TestTypes.h>
+
+namespace UnitTest
+{
+    struct ConfigFileParams
+    {
+        AZStd::string_view m_testConfigFileName;
+        AZStd::string_view m_testConfigContents;
+        using SettingsValueVariant = AZStd::variant<AZ::s64, bool, double, AZStd::string_view>;
+        struct SettingsKeyValueTuple
+        {
+            AZStd::string_view m_key;
+            SettingsValueVariant m_value;
+            AZStd::string_view m_sectionHeader;
+        };
+        // The following test below will not have more than 32 settings in their config files
+        AZStd::fixed_vector<SettingsKeyValueTuple, 20> m_expectedSettings;
+    };
+
+    class ConfigParserTestFixture
+        : public UnitTest::ScopedAllocatorSetupFixture
+    {
+    protected:
+        AZStd::string m_configBuffer;
+        AZ::IO::ByteContainerStream<AZStd::string> m_configStream{ &m_configBuffer };
+    };
+
+    // Parameterized test fixture for the ConfigFile Params
+    class ConfigParserParamFixture
+        : public ConfigParserTestFixture
+        , public ::testing::WithParamInterface<ConfigFileParams>
+    {
+        void SetUp() override
+        {
+            auto configFileParam = GetParam();
+
+            // Create the test config stream
+            m_configStream.Write(configFileParam.m_testConfigContents.size(),
+                configFileParam.m_testConfigContents.data());
+            // Seek back to the beginning of the stream for test to read written data
+            m_configStream.Seek(0, AZ::IO::GenericStream::ST_SEEK_BEGIN);
+        }
+    };
+
+    TEST_F(ConfigParserTestFixture, ParseConfigFile_WithEmptyFunction_Fails)
+    {
+        AZ::Settings::ConfigParserSettings parserSettings{ AZ::Settings::ConfigParserSettings::ParseConfigEntryFunc{} };
+
+        m_configBuffer = R"(project_path=/TestProject
+            engine_path=/TestEngine
+        )";
+        EXPECT_FALSE(AZ::Settings::ParseConfigFile(m_configStream, parserSettings));
+    }
+
+    TEST_F(ConfigParserTestFixture, ParseConfigFile_WithParseConfigEntryFunctionWhichAlwaysReturnsFalse_Fails)
+    {
+        auto parseConfigEntry = [](const AZ::Settings::ConfigParserSettings::ConfigEntry&)
+        {
+            return false;
+        };
+
+        AZ::Settings::ConfigParserSettings parserSettings{ parseConfigEntry };
+
+        m_configBuffer = R"(project_path=/TestProject
+            engine_path=/TestEngine
+        )";
+        EXPECT_FALSE(AZ::Settings::ParseConfigFile(m_configStream, parserSettings));
+
+    }
+
+    TEST_F(ConfigParserTestFixture, ParseConfigFile_WithLineLargerThan4096_Fails)
+    {
+        auto parseConfigEntry = [](const AZ::Settings::ConfigParserSettings::ConfigEntry&)
+        {
+            return true;
+        };
+
+        AZ::Settings::ConfigParserSettings parserSettings{ parseConfigEntry };
+
+        m_configBuffer = "project_path=/TestProject\n";
+
+        // append a line longer than 4096 characters
+        m_configBuffer += "foo=";
+        m_configBuffer.append(4096, 'a');
+        m_configBuffer += '\n';
+
+        EXPECT_FALSE(AZ::Settings::ParseConfigFile(m_configStream, parserSettings));
+    }
+
+    TEST_F(ConfigParserTestFixture, ParseConfigFile_WithAllLinesSmallerThan4097_Succeeds)
+    {
+        auto parseConfigEntry = [](const AZ::Settings::ConfigParserSettings::ConfigEntry&)
+        {
+            return true;
+        };
+
+        AZ::Settings::ConfigParserSettings parserSettings{ parseConfigEntry };
+
+        m_configBuffer = "project_path=/TestProject\n";
+
+        // append only 4000 characters
+        m_configBuffer += "foo=";
+        m_configBuffer.append(4000, 'a');
+        m_configBuffer += '\n';
+
+        EXPECT_TRUE(AZ::Settings::ParseConfigFile(m_configStream, parserSettings));
+    }
+
+    TEST_P(ConfigParserParamFixture, ParseConfigFile_ParseContents_Successfully)
+    {
+        auto configFileParam = GetParam();
+
+        // Parse Config File and write output to a map for testing
+        struct TestConfigEntry
+        {
+            AZStd::fixed_string<128> m_value;
+            AZStd::fixed_string<128> m_sectionHeader;
+        };
+        using ParseSettingsMap = AZStd::fixed_unordered_map<AZStd::fixed_string<128>, TestConfigEntry, 7, 32>;
+        ParseSettingsMap parseSettingsMap;
+        auto parseConfigEntry = [&parseSettingsMap](const AZ::Settings::ConfigParserSettings::ConfigEntry& configEntry)
+        {
+            AZStd::fixed_string<128> fullKey(configEntry.m_sectionHeader);
+            if (!fullKey.empty())
+            {
+                fullKey += '/';
+            }
+            fullKey += configEntry.m_keyValuePair.m_key;
+
+            parseSettingsMap.emplace(fullKey, TestConfigEntry{
+                AZStd::fixed_string<128>(configEntry.m_keyValuePair.m_value),
+                AZStd::fixed_string<128>(configEntry.m_sectionHeader) });
+            return true;
+        };
+
+        AZ::Settings::ConfigParserSettings parserSettings{ parseConfigEntry };
+
+        // Update the comment prefix function to also support `--` as a comment chaacter
+        parserSettings.m_commentPrefixFunc = [](AZStd::string_view line) -> AZStd::string_view
+        {
+            constexpr AZStd::string_view commentPrefixes[]{ "--", ";","#" };
+            for (AZStd::string_view commentPrefix : commentPrefixes)
+            {
+                if (size_t commentOffset = line.find(commentPrefix); commentOffset != AZStd::string_view::npos)
+                {
+                    line = line.substr(0, commentOffset);
+                }
+            }
+            return line;
+        };
+
+        auto parseOutcome = AZ::Settings::ParseConfigFile(m_configStream, parserSettings);
+        EXPECT_TRUE(parseOutcome);
+
+        // Validate that map contains expected settings
+        for (auto&& expectedSettingPair : configFileParam.m_expectedSettings)
+        {
+            auto ValidateExpectedSettings = [&parseSettingsMap, settingsKey = expectedSettingPair.m_key,
+                sectionHeader = expectedSettingPair.m_sectionHeader](auto&& settingsValue)
+            {
+                auto foundIt = parseSettingsMap.find(AZStd::fixed_string<128>(settingsKey));
+                ASSERT_NE(parseSettingsMap.end(), foundIt);
+
+                // Check the section header
+                EXPECT_EQ(sectionHeader, foundIt->second.m_sectionHeader);
+
+                // Check the value
+                using SettingsValueType = AZStd::remove_cvref_t<decltype(settingsValue)>;
+                if constexpr (AZStd::is_same_v<SettingsValueType, AZ::s64>
+                    || AZStd::is_same_v<SettingsValueType, AZ::u64>
+                    || AZStd::is_same_v<SettingsValueType, double>
+                    || AZStd::is_same_v<SettingsValueType, bool>)
+                {
+                    AZStd::fixed_string<32> settingsValueAsString;
+                    AZStd::to_string(settingsValueAsString, settingsValue);
+                    EXPECT_EQ(AZStd::string_view(settingsValueAsString), foundIt->second.m_value);
+                }
+                else if constexpr (AZStd::is_same_v<SettingsValueType, AZStd::string_view>)
+                {
+                    EXPECT_EQ(settingsValue, foundIt->second.m_value);
+                }
+            };
+            AZStd::visit(ValidateExpectedSettings, expectedSettingPair.m_value);
+        }
+    }
+
+INSTANTIATE_TEST_CASE_P(
+    ReadConfigFile,
+    ConfigParserParamFixture,
+    ::testing::Values(
+        // Processes a fake bootstrap.cfg file which contains no section headers
+        // and properly terminates the file with a newline
+        ConfigFileParams{ "fake_bootstrap.cfg", R"(
+-- When you see an option that does not have a platform preceding it, that is the default
+-- value for anything not specifically set per platform. So if remote_filesystem=0 and you have
+-- ios_remote_file_system=1 then remote filesystem will be off for all platforms except ios
+-- Any of the settings in this file can be prefixed with a platform name:
+-- android, ios, mac, linux, windows, etc...
+-- or left unprefixed, to set all platforms not specified. The rules apply in the order they're declared
+
+project_path=TestProject
+
+-- remote_filesystem - enable Virtual File System (VFS)
+-- This feature allows a remote instance of the game to run off assets
+-- on the asset processor computers cache instead of deploying them the remote device
+-- By default it is off and can be overridden for any platform
+remote_filesystem=0
+android_remote_filesystem=0
+ios_remote_filesystem=0
+mac_remote_filesystem=0
+
+-- What type of assets are we going to load?
+-- We need to know this before we establish VFS because different platform assets
+-- are stored in different root folders in the cache.  These correspond to the names
+-- In the asset processor config file.  This value also controls what config file is read
+-- when you read system_xxxx_xxxx.cfg (for example, system_windows_pc.cfg or system_android_android.cfg)
+-- by default, pc assets (in the 'pc' folder) are used, with RC being fed 'pc' as the platform
+-- by default on console we use the default assets=pc for better iteration times
+-- we should turn on console specific assets only when in release and/or testing assets and/or loading performance
+-- that way most people will not need to have 3 different caches taking up disk space
+assets = pc
+android_assets = android
+ios_assets = ios
+mac_assets = mac
+
+-- Add the IP address of your console to the white list that will connect to the asset processor here
+-- You can list addresses or CIDR's. CIDR's are helpful if you are using DHCP. A CIDR looks like an ip address with
+-- a /n on the end means how many bits are significant. 8bits.8bits.8bits.8bits = /32
+-- Example: 192.168.1.3
+-- Example: 192.168.1.3, 192.168.1.15
+-- Example: 192.168.1.0/24 will allow any address starting with 192.168.1.
+-- Example: 192.168.0.0/16 will allow any address starting with 192.168.
+-- Example: 192.168.0.0/8 will allow any address starting with 192.
+-- allowed_list =
+
+-- IP address and optionally port of the asset processor.
+-- Set your PC IP here: (and uncomment the next line)
+-- If you are running your asset processor on a windows machine you
+-- can find out your ip address by opening a cmd prompt and typing in ipconfig
+-- remote_ip = 127.0.0.1
+-- remote_port = 45643
+
+-- Which way do you want to connect the asset processor to the game: 1=game connects to AP "connect", 0=AP connects to game "listen"
+-- Note: android and IOS over USB port forwarding may need to listen instead of connect
+connect_to_remote=0
+windows_connect_to_remote=1
+android_connect_to_remote=0
+ios_connect_to_remote=0
+mac_connect_to_remote=0
+
+-- Should we tell the game to wait and not proceed unless we have a connection to the AP or
+-- do we allow it to continue to try to connect in the background without waiting
+-- Note: Certain options REQUIRE that we do not proceed unless we have a connection, and will override this option to 1 when set
+-- Since remote_filesystem=1 requires a connection to proceed it will override our option to 1
+wait_for_connect=0
+windows_wait_for_connect=1
+android_wait_for_connect=0
+ios_wait_for_connect=0
+mac_wait_for_connect=0
+
+-- How long applications should wait while attempting to connect to an already launched AP(in seconds)
+-- connect_ap_timeout=3
+
+-- How long application should wait when launching the AP and wait for the AP to connect back to it(in seconds)
+-- This time is dependent on Machine load as well as how long it takes for the new AP instance to initialize
+-- A debug AP takes longer to start up than a profile AP
+-- launch_ap_timeout=15
+
+-- How long to wait for the AssetProcessor to be ready(i.e have all critical assets processed)
+-- wait_ap_ready_timeout = 1200
+# Commented out line using a number sign character
+; Commented out line using a semicolon
+
+)"
+        , AZStd::fixed_vector<ConfigFileParams::SettingsKeyValueTuple, 20>{
+            ConfigFileParams::SettingsKeyValueTuple{"project_path", AZStd::string_view{"TestProject"}, {}},
+            ConfigFileParams::SettingsKeyValueTuple{"remote_filesystem", AZ::s64{0}, {}},
+            ConfigFileParams::SettingsKeyValueTuple{"android_remote_filesystem", AZ::s64{0}, {}},
+            ConfigFileParams::SettingsKeyValueTuple{"ios_remote_filesystem", AZ::s64{0}, {}},
+            ConfigFileParams::SettingsKeyValueTuple{"mac_remote_filesystem", AZ::s64{0}, {}},
+            ConfigFileParams::SettingsKeyValueTuple{"assets", AZStd::string_view{"pc"}, {}},
+            ConfigFileParams::SettingsKeyValueTuple{"android_assets", AZStd::string_view{"android"}, {}},
+            ConfigFileParams::SettingsKeyValueTuple{"ios_assets", AZStd::string_view{"ios"}, {}},
+            ConfigFileParams::SettingsKeyValueTuple{"mac_assets", AZStd::string_view{"mac"}, {}},
+            ConfigFileParams::SettingsKeyValueTuple{"connect_to_remote", AZ::s64{0}, {}},
+            ConfigFileParams::SettingsKeyValueTuple{"windows_connect_to_remote", AZ::s64{1}, {}},
+            ConfigFileParams::SettingsKeyValueTuple{"android_connect_to_remote", AZ::s64{0}, {}},
+            ConfigFileParams::SettingsKeyValueTuple{"ios_connect_to_remote", AZ::s64{0}, {}},
+            ConfigFileParams::SettingsKeyValueTuple{"mac_connect_to_remote", AZ::s64{0}, {}},
+            ConfigFileParams::SettingsKeyValueTuple{"wait_for_connect", AZ::s64{0}, {}},
+            ConfigFileParams::SettingsKeyValueTuple{"windows_wait_for_connect", AZ::s64{1}, {}},
+            ConfigFileParams::SettingsKeyValueTuple{"android_wait_for_connect", AZ::s64{0}, {}},
+            ConfigFileParams::SettingsKeyValueTuple{"ios_wait_for_connect", AZ::s64{0}, {}},
+            ConfigFileParams::SettingsKeyValueTuple{"mac_wait_for_connect", AZ::s64{0}, {}},
+        }},
+        // Parses a fake AssetProcessorPlatformConfig file which contains sections headers
+        // and does not end with a newline
+            ConfigFileParams{ "fake_AssetProcessorPlatformConfig.ini", R"(
+; ---- Enable/Disable platforms for the entire project. AssetProcessor will automatically add the current platform by default.
+
+; PLATFORM DEFINITIONS
+; [Platform (unique identifier)]
+; tags=(comma-seperated-tags)
+;
+; note:  the 'identifier' of a platform is the word(s) following the "Platform" keyword (so [Platform pc] means identifier
+;        is 'pc' for example.  This is used to name its assets folder in the cache and should be used in your bootstrap.cfg
+;        or your main.cpp to choose what assets to load for that particular platform.
+;        Its primary use is to enable additional non-host platforms (Ios, android...) that are not the current platform.
+; note:  'tags' is a comma-seperated list of tags to tag the platform with that builders can inspect to decide what to do.
+
+; while builders can accept any tags you add in order to make decisions, common tags are
+; tools - this platform can host the tools and editor and such
+; renderer - this platform runs the client engine and renders on a GPU.  If missing we could be on a server-only platform
+; mobile - a mobile platform such as a set top box or phone with limited resources
+; console - a console platform
+; server - a server platform of some kind, usually headless, no renderer.
+
+test_asset_processor_tag = test_value
+[Platform pc]
+tags=tools,renderer,dx12,vulkan
+
+[Platform android]
+tags=android,mobile,renderer,vulkan ; With Comments at the end
+
+[Platform ios]
+tags=mobile,renderer,metal
+
+[Platform mac]
+tags=tools,renderer,metal)"
+        , AZStd::fixed_vector<ConfigFileParams::SettingsKeyValueTuple, 20>{
+            ConfigFileParams::SettingsKeyValueTuple{"test_asset_processor_tag", AZStd::string_view{"test_value"}, {}},
+            ConfigFileParams::SettingsKeyValueTuple{"Platform pc/tags", AZStd::string_view{"tools,renderer,dx12,vulkan"}, "Platform pc"},
+            ConfigFileParams::SettingsKeyValueTuple{"Platform android/tags", AZStd::string_view{"android,mobile,renderer,vulkan"}, "Platform android"},
+            ConfigFileParams::SettingsKeyValueTuple{"Platform ios/tags", AZStd::string_view{"mobile,renderer,metal"}, "Platform ios"},
+            ConfigFileParams::SettingsKeyValueTuple{"Platform mac/tags", AZStd::string_view{"tools,renderer,metal"}, "Platform mac"},
+        }}
+        )
+    );
+
+
+}

--- a/Code/Framework/AzCore/Tests/Settings/ConfigParserTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/ConfigParserTests.cpp
@@ -30,7 +30,7 @@ namespace UnitTest
     };
 
     class ConfigParserTestFixture
-        : public UnitTest::ScopedAllocatorSetupFixture
+        : public LeakDetectionFixture
     {
     protected:
         AZStd::string m_configBuffer;
@@ -333,8 +333,8 @@ tags=tools,renderer,dx12,vulkan
 
 [Platform android]
 tags=android,mobile,renderer,vulkan ; With Comments at the end
-
-[Platform ios]
+; validate leading and trailing whitespace is not parsed when examining the section header
+      [Platform ios]     
 tags=mobile,renderer,metal
 
 [Platform mac]

--- a/Code/Framework/AzCore/Tests/Settings/SettingsRegistryMergeUtilsTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/SettingsRegistryMergeUtilsTests.cpp
@@ -280,7 +280,7 @@ namespace SettingsRegistryMergeUtilsTests
             {
                 if (size_t commentOffset = line.find(commentPrefix); commentOffset != AZStd::string_view::npos)
                 {
-                    return line.substr(0, commentOffset);
+                    line = line.substr(0, commentOffset);
                 }
             }
             return line;

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -225,6 +225,7 @@ set(FILES
     Serialization.cpp
     SerializeContextFixture.h
     Settings/CommandLineTests.cpp
+    Settings/ConfigParserTests.cpp
     Settings/ConfigurableStackTests.cpp
     Settings/SettingsRegistryTests.cpp
     Settings/SettingsRegistryConsoleUtilsTests.cpp

--- a/Code/Tools/SerializeContextTools/Converter.cpp
+++ b/Code/Tools/SerializeContextTools/Converter.cpp
@@ -243,7 +243,7 @@ namespace AZ
                     {
                         if (size_t commentOffset = line.find(commentPrefix); commentOffset != AZStd::string_view::npos)
                         {
-                            return line.substr(0, commentOffset);
+                            line = line.substr(0, commentOffset);
                         }
                     }
                     return line;


### PR DESCRIPTION
The `ParseConfigFile` function can parse a Windows style INI file without any dynamic memory allocations and is suitable to be used in early application startup before O3DE allocators are available.

The SettingsRegistryMergeUtils MergeSettingsToRegistry_ConfigFile function has been updated to use the ParseConfigFile function.

`ParseConfigFile` can can be used for example to parse .ini files containing VFS settings for connecting to the AssetProcessor on Android or allocator configuration settings

Added a fix to the Comment Prefix Filter functions. If a line contained multiple comment start characters such as `";#"` and a commented line of `# This is a comment; More text`, then the Comment Prefix Filter function would only remove up to the first comment start character that was found (in this case it remove up to the semicolon and not the number sign)

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Added UnitTest to validate the ParseConfigFile logic to ConfigParserTests.cpp
Also validated that the SettingsRegistryMergeUtilsTest that read configuration files also suceeded
