### PR TITLE
Replace the outdated Extract Properties node in the AutoComponent_NetworkInput graph

### DIFF
--- a/AutomatedTesting/Levels/Multiplayer/AutoComponent_NetworkInput/AutoComponent_NetworkInput.scriptcanvas
+++ b/AutomatedTesting/Levels/Multiplayer/AutoComponent_NetworkInput/AutoComponent_NetworkInput.scriptcanvas
@@ -5,7 +5,7 @@
     "ClassData": {
         "m_scriptCanvas": {
             "Id": {
-                "id": 11859291537220
+                "id": 736934659091
             },
             "Name": "AutoComponent_NetworkInput",
             "Components": {
@@ -20,6 +20,7 @@
                                 },
                                 "Value": {
                                     "Datum": {
+                                        "isOverloadedStorage": false,
                                         "scriptCanvasType": {
                                             "m_type": 3
                                         },
@@ -39,6 +40,7 @@
                                 },
                                 "Value": {
                                     "Datum": {
+                                        "isOverloadedStorage": false,
                                         "scriptCanvasType": {
                                             "m_type": 3
                                         },
@@ -58,6 +60,7 @@
                                 },
                                 "Value": {
                                     "Datum": {
+                                        "isOverloadedStorage": false,
                                         "scriptCanvasType": {
                                             "m_type": 3
                                         },
@@ -75,13 +78,13 @@
                     }
                 },
                 "Component_[642525765775040231]": {
-                    "$type": "{4D755CA9-AB92-462C-B24F-0B3376F19967} Graph",
+                    "$type": "EditorGraph",
                     "Id": 642525765775040231,
                     "m_graphData": {
                         "m_nodes": [
                             {
                                 "Id": {
-                                    "id": 11872176439108
+                                    "id": 771294397459
                                 },
                                 "Name": "SC-Node(NotEqualTo)",
                                 "Components": {
@@ -209,6 +212,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -218,6 +222,7 @@
                                                 "label": "Value A"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -232,7 +237,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 11893651275588
+                                    "id": 762704462867
                                 },
                                 "Name": "SC-Node(NotEqualTo)",
                                 "Components": {
@@ -360,6 +365,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -369,6 +375,7 @@
                                                 "label": "Value A"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -383,7 +390,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 11897946242884
+                                    "id": 758409495571
                                 },
                                 "Name": "SC-Node(Print)",
                                 "Components": {
@@ -432,7 +439,90 @@
                             },
                             {
                                 "Id": {
-                                    "id": 11885061340996
+                                    "id": 16602543850515
+                                },
+                                "Name": "SC-Node(ExtractProperty)",
+                                "Components": {
+                                    "Component_[16660871655390121927]": {
+                                        "$type": "ExtractProperty",
+                                        "Id": 16660871655390121927,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{41ED5DF1-F072-483C-96D9-F57CC4BEDBC8}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "toolTip": "When signaled assigns property values using the supplied source input",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{E17C4D8F-61C8-4C6A-B55D-E01994D706EC}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "toolTip": "Signaled after all property haves have been pushed to the output slots",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{28A1212F-1E9C-4CCE-B7A2-F7F24D92AB8E}"
+                                                },
+                                                "DynamicTypeOverride": 1,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Source",
+                                                "toolTip": "The value on which to extract properties from.",
+                                                "DisplayDataType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{12A1776B-61F6-4E5F-356A-AD718A62051F}"
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{12A1776B-61F6-4E5F-356A-AD718A62051F}"
+                                                },
+                                                "isNullPointer": true,
+                                                "label": "Source"
+                                            }
+                                        ],
+                                        "m_dataType": {
+                                            "m_type": 4,
+                                            "m_azType": "{12A1776B-61F6-4E5F-356A-AD718A62051F}"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 754114528275
                                 },
                                 "Name": "SC-Node(CreateFromValues)",
                                 "Components": {
@@ -533,6 +623,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -542,6 +633,7 @@
                                                 "label": "fwdBack"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -571,7 +663,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 11867881471812
+                                    "id": 749819560979
                                 },
                                 "Name": "EBusEventHandler",
                                 "Components": {
@@ -785,6 +877,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -796,6 +889,7 @@
                                                 "label": "Source"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 4,
                                                     "m_azType": "{12A1776B-61F6-4E5F-356A-AD718A62051F}"
@@ -862,148 +956,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 11863586504516
-                                },
-                                "Name": "SC-Node(ExtractProperty)",
-                                "Components": {
-                                    "Component_[2395597035843331661]": {
-                                        "$type": "ExtractProperty",
-                                        "Id": 2395597035843331661,
-                                        "Slots": [
-                                            {
-                                                "id": {
-                                                    "m_id": "{C80C50EE-F216-4F44-B107-6B35354AFD52}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "In",
-                                                "toolTip": "When signaled assigns property values using the supplied source input",
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 1
-                                                }
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{C69C098D-D667-4DC7-85E5-AFD119727D94}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "Out",
-                                                "toolTip": "Signaled after all property haves have been pushed to the output slots",
-                                                "Descriptor": {
-                                                    "ConnectionType": 2,
-                                                    "SlotType": 1
-                                                }
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{D387C800-352B-4B01-8765-4F4B40DF45CB}"
-                                                },
-                                                "DynamicTypeOverride": 1,
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "Source",
-                                                "toolTip": "The value on which to extract properties from.",
-                                                "DisplayDataType": {
-                                                    "m_type": 4,
-                                                    "m_azType": "{12A1776B-61F6-4E5F-356A-AD718A62051F}"
-                                                },
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{0C03D491-DE25-46C2-BF09-14769FA49FDB}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "FwdBack: Number",
-                                                "DisplayDataType": {
-                                                    "m_type": 3
-                                                },
-                                                "Descriptor": {
-                                                    "ConnectionType": 2,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{4C13F9EF-60BF-4AD1-8FA9-66F46455411C}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "LeftRight: Number",
-                                                "DisplayDataType": {
-                                                    "m_type": 3
-                                                },
-                                                "Descriptor": {
-                                                    "ConnectionType": 2,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            }
-                                        ],
-                                        "Datums": [
-                                            {
-                                                "scriptCanvasType": {
-                                                    "m_type": 4,
-                                                    "m_azType": "{12A1776B-61F6-4E5F-356A-AD718A62051F}"
-                                                },
-                                                "isNullPointer": false,
-                                                "$type": "NetworkTestPlayerComponentNetworkInput",
-                                                "label": "Source"
-                                            }
-                                        ],
-                                        "m_dataType": {
-                                            "m_type": 4,
-                                            "m_azType": "{12A1776B-61F6-4E5F-356A-AD718A62051F}"
-                                        },
-                                        "m_propertyAccounts": [
-                                            {
-                                                "m_propertySlotId": {
-                                                    "m_id": "{0C03D491-DE25-46C2-BF09-14769FA49FDB}"
-                                                },
-                                                "m_propertyType": {
-                                                    "m_type": 3
-                                                },
-                                                "m_propertyName": "FwdBack"
-                                            },
-                                            {
-                                                "m_propertySlotId": {
-                                                    "m_id": "{4C13F9EF-60BF-4AD1-8FA9-66F46455411C}"
-                                                },
-                                                "m_propertyType": {
-                                                    "m_type": 3
-                                                },
-                                                "m_propertyName": "LeftRight"
-                                            }
-                                        ]
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 11880766373700
+                                    "id": 741229626387
                                 },
                                 "Name": "SC-Node(Print)",
                                 "Components": {
@@ -1052,7 +1005,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 11889356308292
+                                    "id": 775589364755
                                 },
                                 "Name": "SC-Node(Print)",
                                 "Components": {
@@ -1101,7 +1054,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 11876471406404
+                                    "id": 766999430163
                                 },
                                 "Name": "SC-Node(Print)",
                                 "Components": {
@@ -1152,7 +1105,7 @@
                         "m_connections": [
                             {
                                 "Id": {
-                                    "id": 11902241210180
+                                    "id": 779884332051
                                 },
                                 "Name": "srcEndpoint=(NetworkTestPlayerComponentBusHandler Handler: ExecutionSlot:CreateInput), destEndpoint=(Print: In)",
                                 "Components": {
@@ -1161,7 +1114,7 @@
                                         "Id": 3586317167340048684,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 11867881471812
+                                                "id": 749819560979
                                             },
                                             "slotId": {
                                                 "m_id": "{B831AC60-7641-4B74-9829-26A3576B4766}"
@@ -1169,7 +1122,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 11876471406404
+                                                "id": 766999430163
                                             },
                                             "slotId": {
                                                 "m_id": "{2B6DB3BC-AA87-4280-B4C3-42C1EE17CBA3}"
@@ -1180,7 +1133,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 11906536177476
+                                    "id": 784179299347
                                 },
                                 "Name": "srcEndpoint=(NetworkTestPlayerComponentBusHandler Handler: ExecutionSlot:CreateInput), destEndpoint=(CreateFromValues: In)",
                                 "Components": {
@@ -1189,7 +1142,7 @@
                                         "Id": 15956251897822268937,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 11867881471812
+                                                "id": 749819560979
                                             },
                                             "slotId": {
                                                 "m_id": "{B831AC60-7641-4B74-9829-26A3576B4766}"
@@ -1197,7 +1150,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 11885061340996
+                                                "id": 754114528275
                                             },
                                             "slotId": {
                                                 "m_id": "{514CDDAA-290F-4758-B28F-4003E719E635}"
@@ -1208,7 +1161,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 11910831144772
+                                    "id": 788474266643
                                 },
                                 "Name": "srcEndpoint=(CreateFromValues: Result: NetworkTestPlayerComponentNetworkInput), destEndpoint=(NetworkTestPlayerComponentBusHandler Handler: Result: NetworkTestPlayerComponentNetworkInput)",
                                 "Components": {
@@ -1217,7 +1170,7 @@
                                         "Id": 3864080489501353126,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 11885061340996
+                                                "id": 754114528275
                                             },
                                             "slotId": {
                                                 "m_id": "{90E52F81-54E0-4C63-9881-B661FB5D87D1}"
@@ -1225,7 +1178,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 11867881471812
+                                                "id": 749819560979
                                             },
                                             "slotId": {
                                                 "m_id": "{ADF9B366-8324-4C1E-B601-C059DA70FDDE}"
@@ -1236,7 +1189,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 11915126112068
+                                    "id": 792769233939
                                 },
                                 "Name": "srcEndpoint=(NetworkTestPlayerComponentBusHandler Handler: ExecutionSlot:ProcessInput), destEndpoint=(Print: In)",
                                 "Components": {
@@ -1245,7 +1198,7 @@
                                         "Id": 8628095809445337119,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 11867881471812
+                                                "id": 749819560979
                                             },
                                             "slotId": {
                                                 "m_id": "{4C8F2908-12B0-4C35-8468-31D3D4DF36AA}"
@@ -1253,7 +1206,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 11897946242884
+                                                "id": 758409495571
                                             },
                                             "slotId": {
                                                 "m_id": "{D994D58A-DBF1-4929-B779-F0D2CBAD2F0D}"
@@ -1264,175 +1217,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 11919421079364
-                                },
-                                "Name": "srcEndpoint=(NetworkTestPlayerComponentBusHandler Handler: ExecutionSlot:ProcessInput), destEndpoint=(Extract Properties: In)",
-                                "Components": {
-                                    "Component_[10621112306443381493]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 10621112306443381493,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 11867881471812
-                                            },
-                                            "slotId": {
-                                                "m_id": "{4C8F2908-12B0-4C35-8468-31D3D4DF36AA}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 11863586504516
-                                            },
-                                            "slotId": {
-                                                "m_id": "{C80C50EE-F216-4F44-B107-6B35354AFD52}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 11923716046660
-                                },
-                                "Name": "srcEndpoint=(NetworkTestPlayerComponentBusHandler Handler: NetworkTestPlayerComponentNetworkInput), destEndpoint=(Extract Properties: Source)",
-                                "Components": {
-                                    "Component_[14013500888143163469]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 14013500888143163469,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 11867881471812
-                                            },
-                                            "slotId": {
-                                                "m_id": "{8F69FA2E-28D8-4DF1-A4B5-AEF3985095C5}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 11863586504516
-                                            },
-                                            "slotId": {
-                                                "m_id": "{D387C800-352B-4B01-8765-4F4B40DF45CB}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 11928011013956
-                                },
-                                "Name": "srcEndpoint=(Extract Properties: Out), destEndpoint=(Not Equal To (!=): In)",
-                                "Components": {
-                                    "Component_[14597948098713219792]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 14597948098713219792,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 11863586504516
-                                            },
-                                            "slotId": {
-                                                "m_id": "{C69C098D-D667-4DC7-85E5-AFD119727D94}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 11893651275588
-                                            },
-                                            "slotId": {
-                                                "m_id": "{AE7E453C-15DE-47D2-954A-05C3895B7AC6}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 11932305981252
-                                },
-                                "Name": "srcEndpoint=(Extract Properties: FwdBack: Number), destEndpoint=(Not Equal To (!=): Value A)",
-                                "Components": {
-                                    "Component_[14915522756837814768]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 14915522756837814768,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 11863586504516
-                                            },
-                                            "slotId": {
-                                                "m_id": "{0C03D491-DE25-46C2-BF09-14769FA49FDB}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 11893651275588
-                                            },
-                                            "slotId": {
-                                                "m_id": "{57EBC15B-452E-49B3-8BD3-4FBBB07F1F14}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 11936600948548
-                                },
-                                "Name": "srcEndpoint=(Extract Properties: Out), destEndpoint=(Not Equal To (!=): In)",
-                                "Components": {
-                                    "Component_[6510282773353837676]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 6510282773353837676,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 11863586504516
-                                            },
-                                            "slotId": {
-                                                "m_id": "{C69C098D-D667-4DC7-85E5-AFD119727D94}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 11872176439108
-                                            },
-                                            "slotId": {
-                                                "m_id": "{AE7E453C-15DE-47D2-954A-05C3895B7AC6}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 11940895915844
-                                },
-                                "Name": "srcEndpoint=(Extract Properties: LeftRight: Number), destEndpoint=(Not Equal To (!=): Value A)",
-                                "Components": {
-                                    "Component_[16150645152204311425]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 16150645152204311425,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 11863586504516
-                                            },
-                                            "slotId": {
-                                                "m_id": "{4C13F9EF-60BF-4AD1-8FA9-66F46455411C}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 11872176439108
-                                            },
-                                            "slotId": {
-                                                "m_id": "{57EBC15B-452E-49B3-8BD3-4FBBB07F1F14}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 11945190883140
+                                    "id": 822834005011
                                 },
                                 "Name": "srcEndpoint=(Not Equal To (!=): True), destEndpoint=(Print: In)",
                                 "Components": {
@@ -1441,7 +1226,7 @@
                                         "Id": 3322355580364572639,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 11893651275588
+                                                "id": 762704462867
                                             },
                                             "slotId": {
                                                 "m_id": "{AC364E17-A9A1-42DB-A29D-7B2D666E4287}"
@@ -1449,7 +1234,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 11880766373700
+                                                "id": 741229626387
                                             },
                                             "slotId": {
                                                 "m_id": "{733AA75D-022C-45E9-9D0F-3EF9A1633ADC}"
@@ -1460,7 +1245,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 11949485850436
+                                    "id": 827128972307
                                 },
                                 "Name": "srcEndpoint=(Not Equal To (!=): True), destEndpoint=(Print: In)",
                                 "Components": {
@@ -1469,7 +1254,7 @@
                                         "Id": 1975626970668030308,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 11872176439108
+                                                "id": 771294397459
                                             },
                                             "slotId": {
                                                 "m_id": "{AC364E17-A9A1-42DB-A29D-7B2D666E4287}"
@@ -1477,10 +1262,122 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 11889356308292
+                                                "id": 775589364755
                                             },
                                             "slotId": {
                                                 "m_id": "{733AA75D-022C-45E9-9D0F-3EF9A1633ADC}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 17388522865683
+                                },
+                                "Name": "srcEndpoint=(Extract Properties: Out), destEndpoint=(Not Equal To (!=): In)",
+                                "Components": {
+                                    "Component_[12341601607268193617]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 12341601607268193617,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 16602543850515
+                                            },
+                                            "slotId": {
+                                                "m_id": "{E17C4D8F-61C8-4C6A-B55D-E01994D706EC}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 762704462867
+                                            },
+                                            "slotId": {
+                                                "m_id": "{AE7E453C-15DE-47D2-954A-05C3895B7AC6}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 17693465543699
+                                },
+                                "Name": "srcEndpoint=(Extract Properties: Out), destEndpoint=(Not Equal To (!=): In)",
+                                "Components": {
+                                    "Component_[497024756952675111]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 497024756952675111,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 16602543850515
+                                            },
+                                            "slotId": {
+                                                "m_id": "{E17C4D8F-61C8-4C6A-B55D-E01994D706EC}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 771294397459
+                                            },
+                                            "slotId": {
+                                                "m_id": "{AE7E453C-15DE-47D2-954A-05C3895B7AC6}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 17925393777683
+                                },
+                                "Name": "srcEndpoint=(NetworkTestPlayerComponentBusHandler Handler: ExecutionSlot:ProcessInput), destEndpoint=(Extract Properties: In)",
+                                "Components": {
+                                    "Component_[15379369185633518142]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 15379369185633518142,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 749819560979
+                                            },
+                                            "slotId": {
+                                                "m_id": "{4C8F2908-12B0-4C35-8468-31D3D4DF36AA}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 16602543850515
+                                            },
+                                            "slotId": {
+                                                "m_id": "{41ED5DF1-F072-483C-96D9-F57CC4BEDBC8}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 18131552207891
+                                },
+                                "Name": "srcEndpoint=(NetworkTestPlayerComponentBusHandler Handler: NetworkTestPlayerComponentNetworkInput), destEndpoint=(Extract Properties: Source)",
+                                "Components": {
+                                    "Component_[9039483140811830331]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 9039483140811830331,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 749819560979
+                                            },
+                                            "slotId": {
+                                                "m_id": "{8F69FA2E-28D8-4DF1-A4B5-AEF3985095C5}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 16602543850515
+                                            },
+                                            "slotId": {
+                                                "m_id": "{28A1212F-1E9C-4CCE-B7A2-F7F24D92AB8E}"
                                             }
                                         }
                                     }
@@ -1498,16 +1395,16 @@
                     "GraphCanvasData": [
                         {
                             "Key": {
-                                "id": 11859291537220
+                                "id": 736934659091
                             },
                             "Value": {
                                 "ComponentData": {
                                     "{5F84B500-8C45-40D1-8EFC-A5306B241444}": {
                                         "$type": "SceneComponentSaveData",
                                         "ViewParams": {
-                                            "Scale": 0.8416459517191037,
-                                            "AnchorX": -80.7940673828125,
-                                            "AnchorY": -622.589599609375
+                                            "Scale": 0.685187998983534,
+                                            "AnchorX": -296.26904296875,
+                                            "AnchorY": 59.83759307861328
                                         }
                                     }
                                 }
@@ -1515,7 +1412,7 @@
                         },
                         {
                             "Key": {
-                                "id": 11863586504516
+                                "id": 741229626387
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1524,12 +1421,12 @@
                                     },
                                     "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                         "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "DefaultNodeTitlePalette"
+                                        "PaletteOverride": "StringNodeTitlePalette"
                                     },
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            740.0,
+                                            1480.0,
                                             320.0
                                         ]
                                     },
@@ -1538,14 +1435,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{ED8F0B6C-0811-4FB7-AEE8-B71DB87FABF0}"
+                                        "PersistentId": "{9161B9FA-8493-479D-BE35-10D92644D5C0}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 11867881471812
+                                "id": 749819560979
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1582,97 +1479,7 @@
                         },
                         {
                             "Key": {
-                                "id": 11872176439108
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MathNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            1040.0,
-                                            520.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{F64E211C-8DDD-4223-9235-8DB802A017CB}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 11876471406404
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "StringNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            740.0,
-                                            -100.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{26E363EE-F35A-4096-88EF-DF907A809894}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 11880766373700
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "StringNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            1480.0,
-                                            320.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{9161B9FA-8493-479D-BE35-10D92644D5C0}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 11885061340996
+                                "id": 754114528275
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1703,7 +1510,7 @@
                         },
                         {
                             "Key": {
-                                "id": 11889356308292
+                                "id": 758409495571
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1717,8 +1524,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            1480.0,
-                                            520.0
+                                            740.0,
+                                            740.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1726,14 +1533,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{1AF129A6-751C-4FC0-805E-65AC2D4B6D3D}"
+                                        "PersistentId": "{F7407B9B-C302-4B50-BFB0-D1208DF1D5AC}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 11893651275588
+                                "id": 762704462867
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1763,7 +1570,7 @@
                         },
                         {
                             "Key": {
-                                "id": 11897946242884
+                                "id": 766999430163
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1778,7 +1585,7 @@
                                         "$type": "GeometrySaveData",
                                         "Position": [
                                             740.0,
-                                            740.0
+                                            -100.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1786,7 +1593,97 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{F7407B9B-C302-4B50-BFB0-D1208DF1D5AC}"
+                                        "PersistentId": "{26E363EE-F35A-4096-88EF-DF907A809894}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 771294397459
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MathNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1040.0,
+                                            520.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{F64E211C-8DDD-4223-9235-8DB802A017CB}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 775589364755
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "StringNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1480.0,
+                                            520.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{1AF129A6-751C-4FC0-805E-65AC2D4B6D3D}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 16602543850515
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "DefaultNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            740.0,
+                                            360.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{5EB04641-BA35-4D6D-8AB1-5E95440DBF8D}"
                                     }
                                 }
                             }


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?

Replace the outdated node in the SC graph to fix the AP processing failure. Graph looks like below after the change:
![image](https://user-images.githubusercontent.com/68558268/199551421-0a617eb8-dad3-42e4-b148-f3cd5832884d.png)


## How was this PR tested?
Process the file locally without errors.
