### PR TITLE
Adds some extra material document file checks to the MaterialEditor basic tests.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_BasicTests.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_BasicTests.py
@@ -8,29 +8,32 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 
 class Tests:
     open_existing_asset = (
-        "Existing material asset file opened successfully.",
-        "P0: Failed to open existing material asset file.")
+        "Existing material document opened successfully.",
+        "P0: Failed to open existing material document.")
     close_opened_asset = (
-        "Closed existing material asset file.",
-        "P0: Failed to close existing material asset file.")
+        "Closed existing material document.",
+        "P0: Failed to close existing material document.")
     close_all_opened_assets = (
-        "Closed all currently opened asset document files.",
-        "P0: Failed to close all currently opened asset document files.")
+        "Closed all currently opened documents.",
+        "P0: Failed to close all currently opened documents.")
     close_all_opened_assets_except_one = (
-        "Closed all currently opened asset document files except for one file.",
-        "P0: Failed to close all currently opened asset document files except for one file.")
+        "Closed all currently opened documents except for one file.",
+        "P0: Failed to close all currently opened documents except for one file.")
     inspector_pane_visible = (
         "Inspector pane is visible, MaterialEditor launch succeeded",
         "P0: Inspector pane not visible, MaterialEditor launch failed")
     changed_material_asset_color = (
-        "Material asset color changed successfully.",
-        "P0: Failed to change the color values of a material asset file.")
+        "Material document color property value changed successfully.",
+        "P0: Failed to change the color property values of the material document.")
     undo_material_asset_color_change = (
-        "Material asset color change was reverted using undo.",
-        "P0: Failed to undo material asset color change.")
+        "Material document color property value change was reverted using undo.",
+        "P0: Failed to undo material document color property value.")
     redo_material_asset_color_change = (
-        "Material asset color changed again successfully using redo.",
-        "P0: Failed to change material asset color again using redo.")
+        "Material document color property value changed again successfully using redo.",
+        "P0: Failed to change material document color property value again using redo.")
+    verify_all_documents_are_opened = (
+        "Expected material documents are opened.",
+        "P0: Failed to verify the expected material documents are opened.")
 
 
 def MaterialEditor_BasicFunctionalityChecks_AllChecksPass():
@@ -45,12 +48,13 @@ def MaterialEditor_BasicFunctionalityChecks_AllChecksPass():
     1) Open an existing material document.
     2) Close the selected material document.
     3) Open multiple material documents hen use the CloseAllDocuments bus call to close them all.
-    4) Open multiple material documents then use the CloseAllDocumentsExcept bus call to close all but one.
-    5) Verify Material Asset Browser pane visibility.
-    6) Change the baseColor.color property of the test_material_1 material document.
-    7) Revert the baseColor.color property of the test_material_1 material document using undo.
-    8) Use redo to change the baseColor.color property again.
-    9) Look for errors and asserts.
+    4) Open multiple material documents then verify all material documents are opened.
+    5) Use the CloseAllDocumentsExcept bus call to close all but one.
+    6) Verify Material Asset Browser pane visibility.
+    7) Change the baseColor.color property of the test_material_1 material document.
+    8) Revert the baseColor.color property of the test_material_1 material document using undo.
+    9) Use redo to change the baseColor.color property again.
+    10) Look for errors and asserts.
 
     :return: None
     """
@@ -73,6 +77,9 @@ def MaterialEditor_BasicFunctionalityChecks_AllChecksPass():
         test_material_1 = "001_DefaultWhite.material"
         test_material_2 = "002_BaseColorLerp.material"
         test_material_3 = "003_MetalMatte.material"
+        test_material_4 = "004_MetalMap.material"
+        test_material_5 = "005_RoughnessMap.material"
+        test_material_6 = "006_SpecularF0Map.material"
 
         # 1. Open an existing material document.
         material_document_id = atom_tools_utils.open_document(material_type_path)
@@ -93,24 +100,40 @@ def MaterialEditor_BasicFunctionalityChecks_AllChecksPass():
             Tests.close_all_opened_assets,
             atom_tools_utils.close_all_documents() is True)
 
-        # 4. Open multiple material documents then use the CloseAllDocumentsExcept bus call to close all but one.
+        # 4. Open multiple material documents then verify all material documents are opened.
         test_material_1_document_id = atom_tools_utils.open_document(os.path.join(test_data_path, test_material_1))
         test_material_2_document_id = atom_tools_utils.open_document(os.path.join(test_data_path, test_material_2))
         test_material_3_document_id = atom_tools_utils.open_document(os.path.join(test_data_path, test_material_3))
+        test_material_4_document_id = atom_tools_utils.open_document(os.path.join(test_data_path, test_material_4))
+        test_material_5_document_id = atom_tools_utils.open_document(os.path.join(test_data_path, test_material_5))
+        test_material_6_document_id = atom_tools_utils.open_document(os.path.join(test_data_path, test_material_6))
+        Report.result(
+            Tests.verify_all_documents_are_opened,
+            atom_tools_utils.is_document_open(test_material_1_document_id) is True and
+            atom_tools_utils.is_document_open(test_material_2_document_id) is True and
+            atom_tools_utils.is_document_open(test_material_3_document_id) is True and
+            atom_tools_utils.is_document_open(test_material_4_document_id) is True and
+            atom_tools_utils.is_document_open(test_material_5_document_id) is True and
+            atom_tools_utils.is_document_open(test_material_6_document_id) is True)
+
+        # 5. Use the CloseAllDocumentsExcept bus call to close all but one.
         atom_tools_utils.close_all_except_selected(test_material_1_document_id)
         Report.result(
             Tests.close_all_opened_assets_except_one,
             atom_tools_utils.is_document_open(test_material_1_document_id) is True and
             atom_tools_utils.is_document_open(test_material_2_document_id) is False and
-            atom_tools_utils.is_document_open(test_material_3_document_id) is False)
+            atom_tools_utils.is_document_open(test_material_3_document_id) is False and
+            atom_tools_utils.is_document_open(test_material_4_document_id) is False and
+            atom_tools_utils.is_document_open(test_material_5_document_id) is False and
+            atom_tools_utils.is_document_open(test_material_6_document_id) is False)
 
-        # 5. Verify Material Asset Browser pane visibility.
+        # 6. Verify Material Asset Browser pane visibility.
         atom_tools_utils.set_pane_visibility("Asset Browser", True)
         Report.result(
             Tests.inspector_pane_visible,
             atom_tools_utils.is_pane_visible("Asset Browser") is True)
 
-        # 6. Change the baseColor.color property of the test_material_1 material document.
+        # 7. Change the baseColor.color property of the test_material_1 material document.
         base_color_property_name = "baseColor.color"
         document_id = atom_tools_utils.open_document(os.path.join(test_data_path, test_material_1))
         initial_color = material_editor_utils.get_property(document_id, base_color_property_name)
@@ -122,19 +145,19 @@ def MaterialEditor_BasicFunctionalityChecks_AllChecksPass():
             Tests.changed_material_asset_color,
             material_editor_utils.get_property(document_id, base_color_property_name) == expected_color)
 
-        # 7. Revert the baseColor.color property of the test_material_1 material document using undo.
+        # 8. Revert the baseColor.color property of the test_material_1 material document using undo.
         atom_tools_utils.undo(document_id)
         Report.result(
             Tests.undo_material_asset_color_change,
             material_editor_utils.get_property(document_id, base_color_property_name) == initial_color)
 
-        # 8. Use redo to change the baseColor.color property again.
+        # 9. Use redo to change the baseColor.color property again.
         atom_tools_utils.redo(document_id)
         Report.result(
             Tests.redo_material_asset_color_change,
             material_editor_utils.get_property(document_id, base_color_property_name) == expected_color)
 
-        # 9. Look for errors and asserts.
+        # 10. Look for errors and asserts.
         TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
         for error_info in error_tracer.errors:
             Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")


### PR DESCRIPTION
## What does this PR do?
- This PR adds more test material checks to the existing Material Editor basic tests.
- The other tests that were part of the source ticket involved mouse movements and functionality with the mouse, which is something we avoid automating in our null renderer tests. This reduced the complexity of the parts of the test to add and that's why it appears like a small change.
- I also updated the language regarding material documents to be more clear (it made a lot of confusing references previously such as "material asset file" - they are just material documents).

## How was this PR tested?
Ran test command: ` C:\git\o3de\python\runtime\python-3.10.5-rev1-windows\python\python.exe -m pytest -vv -s --build-directory="C:\git\o3de\build\bin\profile" C:\git\o3de\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_Null_Render_MaterialEditor_01.py`
Results: ` ==== 4 passed, 2 xfailed in 86.68s (0:01:26) ====`