### PR TITLE
MaterialEditor crash test.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_MaterialEditor_01.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_MaterialEditor_01.py
@@ -41,3 +41,8 @@ class TestMaterialEditor(AtomToolsTestSuite):
         timeout = 10
 
         from Atom.tests import MaterialEditor_Atom_ExpectsTestTimeout as test_module
+
+    @pytest.mark.xfail
+    class MaterialEditor_Atom_expectsCrashFailure(AtomToolsBatchedTest):
+
+        from Atom.tests import MaterialEditor_Atom_ExpectsCrashFailure as test_module

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_MaterialEditor_01.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_MaterialEditor_01.py
@@ -43,6 +43,6 @@ class TestMaterialEditor(AtomToolsTestSuite):
         from Atom.tests import MaterialEditor_Atom_ExpectsTestTimeout as test_module
 
     @pytest.mark.xfail
-    class MaterialEditor_Atom_expectsCrashFailure(AtomToolsBatchedTest):
+    class MaterialEditor_Atom_expectsCrashFailure(AtomToolsSingleTest):
 
         from Atom.tests import MaterialEditor_Atom_ExpectsCrashFailure as test_module

--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_tools_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_tools_utils.py
@@ -133,6 +133,10 @@ def end_edit(document_id: azlmbr.math.Uuid) -> bool:
     return azlmbr.atomtools.AtomToolsDocumentRequestBus(azlmbr.bus.Event, "EndEdit", document_id)
 
 
+def crash() -> None:
+    azlmbr.atomtools.general.crash()
+
+
 def exit() -> None:
     """
     Closes the current Atom tools executable.

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_ExpectsCrashFailure.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_ExpectsCrashFailure.py
@@ -1,0 +1,40 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+
+class Tests:
+    material_editor_test_crashed = (  # This test result is pytest.mark.xfail.
+        "P0: AtomToolsSingleTest class didn't crash and passed (it should fail from crashing).",
+        "P0: AtomToolsSingleTest crashed before the test could complete (expected failure)."
+    )
+
+
+def MaterialEditor_TestsTimeoutCrashFailure():
+    """
+    Summary:
+    Tests that the MaterialEditor can fail from crashing in a test.
+
+    Expected Behavior:
+    The MaterialEditor test fails due to crash from calling azlmbr.atomtools.crash()
+
+    Test Steps:
+    1) Start the MaterialEditor then force a crash and verify it fails through pytext.mark.xfail result.
+
+    :return: None
+    """
+
+    import Atom.atom_utils.atom_tools_utils as atom_tools_utils
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+
+    with Tracer() as error_tracer:
+        # 1. Start the MaterialEditor then force a crash and verify it fails through pytext.mark.xfail result.
+        atom_tools_utils.crash()
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(MaterialEditor_TestsTimeoutCrashFailure)

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_ExpectsCrashFailure.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_ExpectsCrashFailure.py
@@ -28,11 +28,10 @@ def MaterialEditor_TestsTimeoutCrashFailure():
     """
 
     import Atom.atom_utils.atom_tools_utils as atom_tools_utils
-    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+    from editor_python_test_tools.utils import Report, TestHelper
 
-    with Tracer() as error_tracer:
-        # 1. Start the MaterialEditor then force a crash and verify it fails through pytext.mark.xfail result.
-        atom_tools_utils.crash()
+    # 1. Start the MaterialEditor then force a crash and verify it fails through pytext.mark.xfail result.
+    Report.result(Tests.material_editor_test_crashed, atom_tools_utils.crash())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?
Adds a test to verify crashing is a failing result and that the `azlmbr.atomtools.general.crash` binding works as expected.

## How was this PR tested?
Test command used: `C:\git\o3de\python\runtime\python-3.10.5-rev1-windows\python\python.exe -m pytest -vv -s --build-directory="C:\git\o3de\build\bin\profile" C:\git\o3de\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_Null_Render_MaterialEditor_01.py`
Results: `=== 4 passed, 3 xfailed in 44.19s ===`
