### PR TITLE
Makes FetchRGA older-cmake-version compatible and adds hashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,13 @@
 # Cmake version 3.20 is the minimum version needed for all of Open 3D Engine's supported platforms
 cmake_minimum_required(VERSION 3.20)
 
+if(NOT ${CMAKE_VERSION} VERSION_LESS "3.24") 
+    # CMP0135 - controls whether, when unpacking an archive file, it should:
+    # (OLD) set the file timestamps to what they are in the archive (not recommended)
+    # (NEW) set the file timestamps to the time of extraction (recommended)
+    cmake_policy(SET CMP0135 NEW) 
+endif()
+
 include(cmake/LySet.cmake)
 include(cmake/Version.cmake)
 include(cmake/OutputDirectory.cmake)

--- a/cmake/3rdParty/FetchRGA.cmake
+++ b/cmake/3rdParty/FetchRGA.cmake
@@ -1,26 +1,27 @@
 # This script encapsulates fetching RGA as a dependency and providing the
 # requested targets. To use it, simply include this script from the CMakeLists.txt
 # file of the target platform.
+include(FetchContent)
 
-message(STATUS "started FetchRGA")
-
-if (NOT FETCHED_RGA)
-    include(FetchContent)
+# note that this won't stop it from trying each time, but will stop it from doing anything multiple times in the same
+# cmake invocation.
+FetchContent_GetProperties(rga)
+if (NOT rga_POPULATED) 
+    message(STATUS "Checking to see if Radeon(™) GPU Analyzer needs to be downloaded... ")
     if (WIN32)
         FetchContent_Declare(
             RGA
             URL https://github.com/GPUOpen-Tools/radeon_gpu_analyzer/releases/download/2.6.2/rga-windows-x64-2.6.2.zip
-            DOWNLOAD_EXTRACT_TIMESTAMP true
+            URL_HASH SHA256=35247f29bc81cd86e935b29af26a72cb5f762d4faba2b6aad404f661e639faee
         )
     else()
         FetchContent_Declare(
             RGA
             URL https://github.com/GPUOpen-Tools/radeon_gpu_analyzer/releases/download/2.6.2/rga-linux-2.6.2.tgz
-            DOWNLOAD_EXTRACT_TIMESTAMP true
+            URL_HASH SHA256=e42e51a12de5ff908785603d9fc5bf88fb8f59dd98f7ed728e8346cae251f712
         )
     endif()
-    FetchContent_MakeAvailable(RGA)
-    message("rga will be stored in ${rga_SOURCE_DIR}")
 
-    set(FETCHED_RGA ON)
+    FetchContent_MakeAvailable(RGA)
+    message(STATUS "Radeon(™) GPU Analyzer is located in ${rga_SOURCE_DIR}")
 endif()

--- a/cmake/3rdParty/FetchRGA.cmake
+++ b/cmake/3rdParty/FetchRGA.cmake
@@ -1,6 +1,19 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+if (APPLE)
+    return()  # RGA is not applicable to APPLE host platforms.
+endif()
+
 # This script encapsulates fetching RGA as a dependency and providing the
 # requested targets. To use it, simply include this script from the CMakeLists.txt
 # file of the target platform.
+
 include(FetchContent)
 
 # note that this won't stop it from trying each time, but will stop it from doing anything multiple times in the same


### PR DESCRIPTION
(this makes this file work on versions of cmake earlier than 3.23)

Hashes were added (SHA256) to ensure that the files downloaded were exactly the expected ones at the time of snapshot (security).

Timestamp option was removed - its not necessary for this package and is a brand new feature only in a very new version of cmake.

Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>

## What does this PR do?

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_

_Please add links to any issues, RFCs or other items that are relevant to this PR._

## How was this PR tested?

_Please describe any testing performed._
