### PR TITLE
Fix serialization race condition.

### DIFF
--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -1653,11 +1653,6 @@ bool CCryEditApp::InitInstance()
         return false;
     }
 
-    // Reflect property control classes to the serialize context...
-    AZ::SerializeContext* serializeContext = nullptr;
-    AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
-    AZ_Assert(serializeContext, "Serialization context not available");
-    ReflectedVarInit::setupReflection(serializeContext);
     RegisterReflectedVarHandlers();
 
     CreateSplashScreen();

--- a/Code/Editor/EditorToolsApplication.cpp
+++ b/Code/Editor/EditorToolsApplication.cpp
@@ -20,6 +20,7 @@
 
 // Editor
 #include "MainWindow.h"
+#include "Controls/ReflectedPropertyControl/ReflectedVar.h"
 #include "CryEdit.h"
 #include "DisplaySettingsPythonFuncs.h"
 #include "GameEngine.h"
@@ -128,6 +129,12 @@ namespace EditorInternal
     void EditorToolsApplication::Reflect(AZ::ReflectContext* context)
     {
         ToolsApplication::Reflect(context);
+
+        // Reflect property control classes to the serialize context...
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            ReflectedVarInit::setupReflection(serializeContext);
+        }
 
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {


### PR DESCRIPTION
## What does this PR do?

The ReflectedVarInit reflection was getting called after the main Editor application started up several systems which queued up asset loads. There was a race condition in which completed asset loads on job threads could access the reflection system at the same time that ReflectedVarInit was modifying the reflection data, causing potential crashes.

This fixes the race condition by moving the reflection to the proper place in the startup flow.

## How was this PR tested?

Ran the Editor and verified that the ReflectedVarInit is now getting called before the first call to GetAsset, and consequently no longer crashes my editor startup.
