### PR TITLE
Add Linux profile_nounity to daily metrics job

### DIFF
--- a/scripts/build/Platform/Linux/build_config.json
+++ b/scripts/build/Platform/Linux/build_config.json
@@ -105,6 +105,7 @@
  },
   "profile_nounity": {
     "TAGS": [
+      "daily-pipeline-metrics",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_linux.sh",


### PR DESCRIPTION
Add Linux profile_nounity to daily metrics job. 

Signed-off-by: Shirang Jia <shiranj@amazon.com>
