### PR TITLE
Fix Gem templates to respect the `PAL_TRAIT_<gem_name>_SUPPORTED` option

### DIFF
--- a/Templates/CppToolGem/Template/Code/CMakeLists.txt
+++ b/Templates/CppToolGem/Template/Code/CMakeLists.txt
@@ -19,6 +19,11 @@ o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${
 # is supported by this platform.
 include(${pal_dir}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
 
+# Check to see if building the Gem Modules are supported for the current platform
+if(NOT PAL_TRAIT_${NameUpper}_SUPPORTED)
+    return()
+endif()
+
 # The ${gem_name}.API target declares the common interface that users of this gem should depend on in their targets
 ly_add_target(
     NAME ${gem_name}.API INTERFACE

--- a/Templates/DefaultGem/Template/Code/CMakeLists.txt
+++ b/Templates/DefaultGem/Template/Code/CMakeLists.txt
@@ -19,6 +19,11 @@ o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${
 # is supported by this platform.
 include(${pal_dir}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
 
+# Check to see if building the Gem Modules are supported for the current platform
+if(NOT PAL_TRAIT_${NameUpper}_SUPPORTED)
+    return()
+endif()
+
 # The ${gem_name}.API target declares the common interface that users of this gem should depend on in their targets
 ly_add_target(
     NAME ${gem_name}.API INTERFACE

--- a/Templates/PrebuiltGem/Template/Code/CMakeLists.txt
+++ b/Templates/PrebuiltGem/Template/Code/CMakeLists.txt
@@ -13,6 +13,17 @@
 # Get the platform specific folder ${pal_dir} for the current folder: ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME}
 o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 
+# Now that we have the platform abstraction layer (PAL) folder for this folder, thats where we will find the
+# traits for this platform. Traits for a platform are defines for things like whether or not something in this gem
+# is supported by this platform.
+include(${pal_dir}/PAL.cmake)
+
+# Check to see if the building the Gem Modules are supported for the current platform
+if(NOT PAL_TRAIT_${NameUpper}_SUPPORTED)
+    return()
+endif()
+
+
 # The ${gem_name}.API target declares the common interface that users of this gem should depend on in their targets
 ly_add_target(
     NAME ${gem_name}.API INTERFACE

--- a/Templates/PythonToolGem/Template/Code/CMakeLists.txt
+++ b/Templates/PythonToolGem/Template/Code/CMakeLists.txt
@@ -19,6 +19,10 @@ o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${
 # is supported by this platform.
 include(${pal_dir}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
 
+# Check to see if building the Gem Modules are supported for the current platform
+if(NOT PAL_TRAIT_${NameUpper}_SUPPORTED)
+    return()
+endif()
 
 # If we are on a host platform, we want to add the host tools targets like the ${gem_name}.Editor target which
 # will also depend on ${gem_name}.Editor.API target


### PR DESCRIPTION
The Project templates Gem target already properly check the PAL_TRAIT\_*_SUPPORTED option, so it was already possible to selectively disable building those modules on a per platform basis.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## What does this PR do?

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_

_Please add links to any issues, RFCs or other items that are relevant to this PR._

## How was this PR tested?

Validate that create a gem using the gem templates succeed and produce a compilable gem
```powershell
PS C:\code\o3de> .\scripts\o3de.bat create-gem -gp ..\TestGem2
PS C:\code\o3de> .\scripts\o3de.bat enable-gem -gp ..\TestGem2 -pp .\AutomatedTesting
PS C:\code\o3de> cmake --preset windows-automated-testing
PS C:\code\o3de> cmake --build .\build\windows --target TestGem2
```
