### PR TITLE
Adding PAL functions for query CPUThreadTime

### DIFF
--- a/Code/Framework/AzCore/AzCore/std/time.h
+++ b/Code/Framework/AzCore/AzCore/std/time.h
@@ -21,4 +21,7 @@ namespace AZStd
     // return time in millisecond since 1970/01/01 00:00:00 UTC.
     AZ::u64           GetTimeUTCMilliSecond();
     AZ::u64           GetTimeUTCMicroSecond();
+    //! Returns the cpu time spent on the current thread when invoked
+    //! This time is relative to the running process and has no relation to real time
+    AZStd::chrono::microseconds GetCpuThreadTimeNowMicrosecond();
 }

--- a/Code/Framework/AzCore/Platform/Common/Apple/AzCore/std/time_Apple.cpp
+++ b/Code/Framework/AzCore/Platform/Common/Apple/AzCore/std/time_Apple.cpp
@@ -43,4 +43,9 @@ namespace AZStd
         timeNowSecond =  GetTimeNowTicks()/GetTimeTicksPerSecond();
         return timeNowSecond;
     }
+
+    AZStd::chrono::microseconds GetCpuThreadTimeNowMicrosecond()
+    {
+        return AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(AZStd::chrono::nanoseconds(clock_gettime_nsec_np(CLOCK_THREAD_CPUTIME_ID)));
+    }
 }

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/std/time_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/std/time_UnixLike.cpp
@@ -54,4 +54,14 @@ namespace AZStd
         timeNowSecond =  ts.tv_sec;
         return timeNowSecond;
     }
+
+    AZStd::chrono::microseconds GetCpuThreadTimeNowMicrosecond()
+    {
+        struct timespec ts;
+        errno = 0;
+        int result = clock_gettime(CLOCK_THREAD_CPUTIME_ID , &ts);
+
+        AZ_Assert(result != -1, "clock_gettime error using CLOCK_THREAD_CPUTIME_ID: %s\n", strerror(errno));
+        return AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(AZStd::chrono::seconds(ts.tv_sec) + AZStd::chrono::nanoseconds(ts.tv_nsec));
+    }
 }

--- a/Code/Framework/AzCore/Platform/Windows/AzCore/std/time_Windows.cpp
+++ b/Code/Framework/AzCore/Platform/Windows/AzCore/std/time_Windows.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/std/parallel/thread.h>
 #include <AzCore/std/time.h>
 #include <AzCore/PlatformIncl.h>
 
@@ -43,5 +44,68 @@ namespace AZStd
         // Using get tick count, since it's more stable for longer time measurements.
         timeNowSecond = GetTickCount() / 1000;
         return timeNowSecond;
+    }
+
+    AZStd::chrono::microseconds GetCpuThreadTimeNowMicrosecond()
+    {
+        auto ComputeTimestampCounterPerMicrosecond = []() -> int64_t
+        {
+            static int64_t timeStampCounterPerMicrosecond = 0;
+            if (timeStampCounterPerMicrosecond > 0)
+            {
+                return timeStampCounterPerMicrosecond;
+            }
+
+            // To measure the Cpu time with microsecond precision
+            // on Windows Intel CPUs, the QueryThreadCycleTime is being used
+            // despite the documentation indicating that this function
+            // shouldn't be used to convert to elapsed time
+            // https://learn.microsoft.com/en-us/windows/win32/api/realtimeapiset/nf-realtimeapiset-querythreadcycletime#remarks
+
+            // What is being done here is to measure the processor timestamp difference
+            // over a period of 50 milliseconds and use that as the rate at which the thread ticks per microsecond
+            static const unsigned long long initialProcessorTimestamp = __rdtsc();
+            static const AZStd::chrono::steady_clock::time_point initialTime = AZStd::chrono::steady_clock::now();
+            const unsigned long long processorTimestamp = __rdtsc();
+            const auto elapsedTimeSinceFirstCall =
+                AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(AZStd::chrono::steady_clock::now() - initialTime);
+
+            // Wait 50 milliseconds after the first call to this function
+            // to measure the thread difference in the time-stamp counter for the processor
+            if (elapsedTimeSinceFirstCall <= AZStd::chrono::milliseconds(50))
+            {
+                // return 0 until more accurate data can be gathered
+                return 0;
+            }
+
+            // elapsedTimeSinceFirstCall is in microseconds
+            timeStampCounterPerMicrosecond = static_cast<int64_t>((processorTimestamp - initialProcessorTimestamp) / elapsedTimeSinceFirstCall.count());
+            return timeStampCounterPerMicrosecond;
+        };
+
+        if (int64_t timeStampCounterPerMicrosecond = ComputeTimestampCounterPerMicrosecond();
+            timeStampCounterPerMicrosecond > 0)
+        {
+            unsigned long long threadCycleCount;
+            BOOL result = ::QueryThreadCycleTime(GetCurrentThread(), &threadCycleCount);
+            if (!result)
+            {
+                auto FormatFunc = [](wchar_t* buffer, size_t size)
+                {
+                    return ::FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, GetLastError(), 0, buffer, static_cast<DWORD>(size),
+                        nullptr);
+                };
+                constexpr size_t messageBufferSize = 1024;
+                AZStd::fixed_wstring<messageBufferSize> errorMessage;
+                errorMessage.resize_and_overwrite(errorMessage.capacity(), AZStd::move(FormatFunc));
+                AZ_Assert(false, "Failed to query thread cycle time through QueryThreadCycleTime: "
+                    AZ_TRAIT_FORMAT_STRING_PRINTF_WSTRING "\n", errorMessage.c_str());
+                return AZStd::chrono::microseconds::zero();
+            }
+            return AZStd::chrono::microseconds(threadCycleCount / timeStampCounterPerMicrosecond);
+        }
+
+        // return 0 until more accurate data can be gathered
+        return AZStd::chrono::microseconds::zero();
     }
 }

--- a/Code/Framework/AzCore/Tests/Time/TimeTests.cpp
+++ b/Code/Framework/AzCore/Tests/Time/TimeTests.cpp
@@ -70,4 +70,23 @@ namespace UnitTest
         int64_t delta = static_cast<int64_t>(timeMs) - static_cast<int64_t>(timeUsToMs);
         EXPECT_LT(abs(delta), 1);
     }
+
+    TEST_F(TimeTests, QueryCPUThreadTime_ReturnsNonZero)
+    {
+        (void)AZStd::GetCpuThreadTimeNowMicrosecond();
+
+        // Windows need at least 50 milliseconds of running time to measure the processer tick scale
+        AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(50));
+
+        // The cpu thread time should now return non-zero values
+        AZStd::chrono::microseconds initialCpuThreadTime = AZStd::GetCpuThreadTimeNowMicrosecond();
+        // Sleep for 1 millisecond (or 1000 microseconds) and check the CPU time
+        // less than 1 miilisecond of CPU should have elapsed
+        // Now due to the fact that thread sleep can last got longer than it's duration
+        // this test is only checking that the new CPUThreadTime is at least greater than or equal to the initial
+        AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1));
+        AZStd::chrono::microseconds newCpuThreadTime = AZStd::GetCpuThreadTimeNowMicrosecond();
+
+        EXPECT_GT((newCpuThreadTime - initialCpuThreadTime).count(), 0);
+    }
 } // namespace UnitTest


### PR DESCRIPTION
Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>



## How was this PR tested?

Added a UnitTest to validate that the CpuThread time is non-zero after waiting 50 milliseconds after the first call
