### PR TITLE
Improve Asset Browser design

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -145,6 +145,11 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
         m_ui->m_listViewButton->hide();
     }
 
+    m_ui->horizontalLayout->setAlignment(m_ui->m_listViewButton, Qt::AlignTop);
+    m_ui->horizontalLayout->setAlignment(m_ui->m_thumbnailViewButton, Qt::AlignTop);
+    m_ui->horizontalLayout->setAlignment(m_ui->m_toggleDisplayViewBtn, Qt::AlignTop);
+    m_ui->horizontalLayout->setAlignment(m_ui->m_collapseAllButton, Qt::AlignTop);
+
     connect(m_ui->m_thumbnailViewButton, &QAbstractButton::clicked, this, [this] { m_ui->m_middleStackWidget->setCurrentIndex(0); });
     connect(m_ui->m_listViewButton, &QAbstractButton::clicked, this, [this] { m_ui->m_middleStackWidget->setCurrentIndex(1); });
 

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.ui
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.ui
@@ -17,6 +17,18 @@
    <property name="spacing">
     <number>0</number>
    </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
@@ -24,6 +36,9 @@
        <width>1</width>
        <height>1</height>
       </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
      </property>
      <property name="widgetResizable">
       <bool>true</bool>
@@ -55,6 +70,18 @@
        </property>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="leftMargin">
+          <number>5</number>
+         </property>
+         <property name="topMargin">
+          <number>5</number>
+         </property>
+         <property name="rightMargin">
+          <number>5</number>
+         </property>
+         <property name="bottomMargin">
+          <number>5</number>
+         </property>
          <item>
           <widget class="AzToolsFramework::AssetBrowser::SearchWidget" name="m_searchWidget" native="true">
            <property name="sizePolicy">
@@ -123,6 +150,22 @@
           </widget>
          </item>
         </layout>
+       </item>
+       <item>
+        <widget class="QWidget" name="m_separator" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>1</height>
+          </size>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QSplitter" name="m_splitter">

--- a/Code/Editor/Style/Editor.qss
+++ b/Code/Editor/Style/Editor.qss
@@ -17,9 +17,9 @@ AzAssetBrowserWindow #previewWidgetWrapper
     border: 0 none;
 }
 
-AzAssetBrowserWindow QSplitter
+AzAssetBrowserWindow #m_separator
 {
-    margin-top: 2px;
+    background-color: #222222;
 }
 
 /* Component Palette Widget */

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/Internal/RectangleWidget.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/Internal/RectangleWidget.h
@@ -23,6 +23,8 @@ namespace AzQtComponents::Internal
     class AZ_QT_COMPONENTS_API RectangleWidget : public QWidget
     {
         Q_OBJECT
+
+        Q_PROPERTY(QColor color READ color WRITE setColor)
     public:
         explicit RectangleWidget(QWidget* parent);
 


### PR DESCRIPTION
This is a preliminary work for two-column layout.

* Some paddings are gone.
* When a category is selected in the filtered search field, the remaining buttons in the asset browser still align to the top. Before they got centered and looked weird
* Search area is separated from the views area with a 1px line of the same color as the splitters
* Splitter between the tree view and asset preview now stretches all the way up and down forming nice line
* Unnecessary padding (due to window margin and scroll area frame) in the Asset Browser window were reduced to 0

Drive-by: Add a missing Q_PROPERTY macro to
AzQtComponents::Internal::RectangleWidget.

Task-Id: o3de/o3de#12855

Signed-off-by: Miłosz Kosobucki <milosz@kosobucki.pl>

## What does this PR do?

Asset Browser is made to look more like on the current Figma designs.

Some before/after gifs:

![gimp-2 10_g668aWYSft](https://user-images.githubusercontent.com/104767/199964389-60b20405-3f68-44f9-a790-9679ccb5b443.gif)

With the WIP two-column layout in Asset browser:

![gimp-2 10_hiWUFhO47W](https://user-images.githubusercontent.com/104767/199964417-0521c35b-5d20-4d3c-a7ab-a51dc1601adc.gif)


## How was this PR tested?

Manually. I clicked around.
