### PR TITLE
Fixed a case sensitivity bug in MaterialTypeBuilder on Linux.

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialSourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialSourceData.h
@@ -91,7 +91,7 @@ namespace AZ
             //! @param elevateWarnings Indicates whether to treat warnings as errors
             Outcome<Data::Asset<MaterialAsset>> CreateMaterialAsset(
                 Data::AssetId assetId,
-                AZStd::string_view materialSourceFilePath,
+                const AZStd::string& materialSourceFilePath,
                 MaterialAssetProcessingMode processingMode,
                 bool elevateWarnings = true) const;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -559,6 +559,10 @@ namespace AZ
                 materialType.m_shaderCollection.push_back({});
                 materialType.m_shaderCollection.back().m_shaderFilePath = AZ::IO::Path{outputShaderFilePath.Filename()}.c_str();
 
+                // Files in the cache, including intermediate files, end up using lower case for all files and folders. We have to match this
+                // in the output .materialtype file, because the asset system's source dependencies are case-sensitive on some platforms.
+                AZStd::to_lower(materialType.m_shaderCollection.back().m_shaderFilePath.begin(), materialType.m_shaderCollection.back().m_shaderFilePath.end());
+
                 // TODO(MaterialPipeline): We should warn the user if the shader collection has multiple shaders that use the same draw list.
             }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -43,7 +43,7 @@ namespace AZ
         {
             AssetBuilderSDK::AssetBuilderDesc materialBuilderDescriptor;
             materialBuilderDescriptor.m_name = "Material Type Builder";
-            materialBuilderDescriptor.m_version = 5; // Material pipelines support multiple lighting models
+            materialBuilderDescriptor.m_version = 6; // Fixed shader path casing
             materialBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.materialtype", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             materialBuilderDescriptor.m_busId = azrtti_typeid<MaterialTypeBuilder>();
             materialBuilderDescriptor.m_createJobFunction = AZStd::bind(&MaterialTypeBuilder::CreateJobs, this, AZStd::placeholders::_1, AZStd::placeholders::_2);

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
@@ -119,7 +119,7 @@ namespace AZ
         }
 
         Outcome<Data::Asset<MaterialAsset>> MaterialSourceData::CreateMaterialAsset(
-            Data::AssetId assetId, AZStd::string_view materialSourceFilePath, MaterialAssetProcessingMode processingMode, bool elevateWarnings) const
+            Data::AssetId assetId, const AZStd::string& materialSourceFilePath, MaterialAssetProcessingMode processingMode, bool elevateWarnings) const
         {
             MaterialAssetCreator materialAssetCreator;
             materialAssetCreator.SetElevateWarnings(elevateWarnings);
@@ -165,7 +165,7 @@ namespace AZ
                 {
                     // In this case we need to load the material type data in preparation for the material->Finalize() step below.
                     auto materialTypeAssetOutcome = AssetUtils::LoadAsset<MaterialTypeAsset>(
-                        materialTypeAssetId.GetValue(), AssetUtils::TraceLevel::Error, dontLoadImageAssets);
+                        materialTypeAssetId.GetValue(), materialSourceFilePath.c_str(), AssetUtils::TraceLevel::Error, dontLoadImageAssets);
                     if (!materialTypeAssetOutcome)
                     {
                         return Failure();


### PR DESCRIPTION
## What does this PR do?

AP dependencies are case sensitive and the case of the shader file references were wrong. So the intermediate .materialtype file was not being reprocessed as needed. Also improved error reporting in MaterialSrouceData where the original source file path was not being included.

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>

## How was this PR tested?

Ran the AP on linux before and after. Touched the .shader file and saw the .materialtype get reprocessed.
ASV full test suite on pc dx12, no changes.
ASV material screenshots test on linux vulkan. It seems ASV automated testing isn't supported yet on linux, it couldn't find any of the baseline images. But watching the materials screenshot tests, I could see that it was rendering things as expected. I also manually tested the material pipeline test materials.
