### PR TITLE
Add texture tags and quality

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/TextureSettings.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/TextureSettings.cpp
@@ -56,7 +56,8 @@ namespace ImageProcessingAtom
                 ->Field("MaintainAlphaCoverage", &TextureSettings::m_maintainAlphaCoverage)
                 ->Field("MipMapAlphaAdjustments", &TextureSettings::m_mipAlphaAdjust)
                 ->Field("PlatformSpecificOverrides", &TextureSettings::m_platfromOverrides)
-                ->Field("OverridingPlatform", &TextureSettings::m_overridingPlatform);
+                ->Field("OverridingPlatform", &TextureSettings::m_overridingPlatform)
+                ->Field("Tags", &TextureSettings::m_tags);
 
             AZ::EditContext* edit = serialize->GetEditContext();
             if (edit)
@@ -118,7 +119,8 @@ namespace ImageProcessingAtom
             m_suppressEngineReduce == other.m_suppressEngineReduce &&
             m_maintainAlphaCoverage == other.m_maintainAlphaCoverage &&
             m_mipGenEval == other.m_mipGenEval &&
-            m_mipGenType == other.m_mipGenType;
+            m_mipGenType == other.m_mipGenType &&
+            m_tags == other.m_tags;
     }
 
     bool TextureSettings::Equals(const TextureSettings& other, AZ::SerializeContext* serializeContext)

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/TextureSettings.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/TextureSettings.h
@@ -12,6 +12,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/Serialization/DataPatch.h>
+#include <AzCore/std/containers/set.h>
 
 namespace ImageProcessingAtom
 {
@@ -144,6 +145,8 @@ namespace ImageProcessingAtom
         MipGenEvalType m_mipGenEval;
 
         MipGenType m_mipGenType;
+
+        AZStd::set<AZStd::string> m_tags;
 
     private:
         // Platform overrides in form of DataPatch. Each entry is a patch for a specified platform.

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePresetSelectionWidget.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePresetSelectionWidget.cpp
@@ -96,7 +96,9 @@ namespace ImageProcessingAtomEditor
         AZ::RPI::ImageTagBus::BroadcastResult(textureTags, &AZ::RPI::ImageTagBus::Events::GetTags);
 
         for (const AZ::Name& tag : textureTags)
+        {
             m_ui->tagComboBox->addItem(tag.GetCStr());
+        }
 
         m_ui->tagList->setSortingEnabled(true);
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePresetSelectionWidget.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePresetSelectionWidget.cpp
@@ -102,7 +102,6 @@ namespace ImageProcessingAtomEditor
 
         m_ui->tagList->setSortingEnabled(true);
 
-        QString joinedTags;
         for (const AZStd::string& tag : m_textureSetting->GetMultiplatformTextureSetting().m_tags)
             m_ui->tagList->addItem(QString(tag.c_str()));
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePresetSelectionWidget.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePresetSelectionWidget.cpp
@@ -103,7 +103,9 @@ namespace ImageProcessingAtomEditor
         m_ui->tagList->setSortingEnabled(true);
 
         for (const AZStd::string& tag : m_textureSetting->GetMultiplatformTextureSetting().m_tags)
+        {
             m_ui->tagList->addItem(QString(tag.c_str()));
+        }
 
         QObject::connect(m_ui->tagAddButton, &QPushButton::released, this, &TexturePresetSelectionWidget::OnTagAdded);
         QObject::connect(m_ui->tagRemoveButton, &QPushButton::released, this, &TexturePresetSelectionWidget::OnTagRemoved);

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePresetSelectionWidget.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePresetSelectionWidget.cpp
@@ -16,6 +16,8 @@
 #include <BuilderSettings/PresetSettings.h>
 #include <AzQtComponents/Components/Widgets/CheckBox.h>
 
+#include <Atom/RPI.Public/Image/ImageTagBus.h>
+
 namespace ImageProcessingAtomEditor
 {
     using namespace ImageProcessingAtom;
@@ -90,6 +92,21 @@ namespace ImageProcessingAtomEditor
         m_ui->resetBtn->setToolTip(QString("Reset all values to the default values for the selected texture preset."));
         m_ui->maxResLabel->setToolTip(QString("Use the maximum texture resolution regardless of the target platform specification. Use this setting for textures that feature text or other details that should be legible."));
 
+        AZStd::vector<AZ::Name> textureTags;
+        AZ::RPI::ImageTagBus::BroadcastResult(textureTags, &AZ::RPI::ImageTagBus::Events::GetTags);
+
+        for (const AZ::Name& tag : textureTags)
+            m_ui->tagComboBox->addItem(tag.GetCStr());
+
+        m_ui->tagList->setSortingEnabled(true);
+
+        QString joinedTags;
+        for (const AZStd::string& tag : m_textureSetting->GetMultiplatformTextureSetting().m_tags)
+            m_ui->tagList->addItem(QString(tag.c_str()));
+
+        QObject::connect(m_ui->tagAddButton, &QPushButton::released, this, &TexturePresetSelectionWidget::OnTagAdded);
+        QObject::connect(m_ui->tagRemoveButton, &QPushButton::released, this, &TexturePresetSelectionWidget::OnTagRemoved);
+
         EditorInternalNotificationBus::Handler::BusConnect();
     }
 
@@ -128,6 +145,37 @@ namespace ImageProcessingAtomEditor
         m_presetPopup.reset(new PresetInfoPopup(presetSetting, this));
         m_presetPopup->installEventFilter(this);
         m_presetPopup->show();
+    }
+
+    void TexturePresetSelectionWidget::OnTagAdded()
+    {
+        QString selectedTag = m_ui->tagComboBox->currentText();
+        if (selectedTag.isEmpty())
+        {
+            return;
+        }
+
+        auto& tags = m_textureSetting->GetMultiplatformTextureSetting().m_tags;
+        if (!tags.emplace(selectedTag.toUtf8().data()).second)
+        {
+            return;
+        }
+
+        m_ui->tagList->addItem(selectedTag);
+    }
+
+    void TexturePresetSelectionWidget::OnTagRemoved()
+    {
+        QListWidgetItem* item = m_ui->tagList->currentItem();
+        if (!item)
+        {
+            return;
+        }
+
+        auto& tags = m_textureSetting->GetMultiplatformTextureSetting().m_tags;
+        tags.erase(item->text().toUtf8().data());
+
+        delete item;
     }
 
     void TexturePresetSelectionWidget::OnEditorSettingsChanged(bool needRefresh, const AZStd::string& /*platform*/)

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePresetSelectionWidget.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePresetSelectionWidget.h
@@ -41,6 +41,9 @@ namespace ImageProcessingAtomEditor
         void OnChangePreset(int index);
         void OnPresetInfoButton();
 
+        void OnTagAdded();
+        void OnTagRemoved();
+
     protected:
         ////////////////////////////////////////////////////////////////////////
         //EditorInternalNotificationBus

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePresetSelectionWidget.ui
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePresetSelectionWidget.ui
@@ -84,6 +84,45 @@
                 <widget class="QCheckBox" name="serCheckBox">
                 </widget>
             </item>
+            <item row="2" column="0">
+                <widget class="QLabel" name="tagLabel">
+                    <property name="text">
+                        <string>Tags</string>
+                    </property>
+                </widget>
+            </item>
+            <item row="2" column="1">
+                <layout class="QHBoxLayout" name="tagLayout">
+                    <item>
+                        <layout class="QVBoxLayout" name="tagListLayout">
+                            <item>
+                                <widget class="QComboBox" name="tagComboBox" />
+                            </item>
+                            <item>
+                                <widget class="QListWidget" name="tagList" />
+                            </item>
+                        </layout>
+                    </item>
+                    <item>
+                        <layout class="QVBoxLayout" name="tagButtonLayout">
+                            <item>
+                                <widget class="QPushButton" name="tagAddButton">
+                                    <property name="text">
+                                        <string>Add</string>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item>
+                                <widget class="QPushButton" name="tagRemoveButton">
+                                    <property name="text">
+                                        <string>Remove</string>
+                                    </property>
+                                </widget>
+                            </item>
+                        </layout>
+                    </item>
+                </layout>
+            </item>
         </layout>
     </widget>
     <resources>

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageAssetProducer.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageAssetProducer.cpp
@@ -40,13 +40,15 @@ namespace ImageProcessingAtom
         const Data::AssetId& sourceAssetId,
         AZStd::string_view fileName,
         uint8_t numResidentMips,
-        uint32_t subId)
+        uint32_t subId,
+        AZStd::set<AZStd::string> tags)
         : m_imageObject(imageObject)
         , m_productFolder(saveFolder)
         , m_sourceAssetId(sourceAssetId)
         , m_fileName(fileName)
         , m_numResidentMips(numResidentMips)
         , m_subId(subId)
+        , m_tags(AZStd::move(tags))
     {
         AZ_Assert(imageObject, "Input imageObject can't be empty");
         AZ_Assert(sourceAssetId.IsValid(), "The source asset Id is not valid");
@@ -191,6 +193,11 @@ namespace ImageProcessingAtom
         }
 
         builder.SetAverageColor(m_imageObject->GetAverageColor());
+
+        for (const AZStd::string& tag : m_tags)
+        {
+            builder.AddTag(AZ::Name{ tag });
+        }
 
         product.m_dependenciesHandled = true; // We've output the dependencies immediately above so it's OK to tell the AP we've handled dependencies
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageAssetProducer.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageAssetProducer.h
@@ -80,7 +80,7 @@ namespace ImageProcessingAtom
         const AZStd::string m_fileName;
         const uint32_t m_subId = AZ::RPI::StreamingImageAsset::GetImageAssetSubId();
         const uint8_t m_numResidentMips = 0u;
-         AZStd::set<AZStd::string> m_tags;
+        AZStd::set<AZStd::string> m_tags;
 
         AZStd::vector<AssetBuilderSDK::JobProduct> m_jobProducts;
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageAssetProducer.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageAssetProducer.h
@@ -33,6 +33,7 @@ namespace ImageProcessingAtom
          * @param sourceAssetId is the asset id of this image. It's used to generate full asset id for MipChainAssets which will be referenced in StreamingImageAsset.
          * @param sourceAssetName is the name of source asset file. It doesn't include path.
          * @param subId is the product subId to use for the output product.
+         * @param tags list of tags to save in the image asset.
          */
         ImageAssetProducer(
             const IImageObjectPtr imageObject,
@@ -40,7 +41,8 @@ namespace ImageProcessingAtom
             const Data::AssetId& sourceAssetId,
             AZStd::string_view sourceAssetName,
             uint8_t numResidentMips,
-            uint32_t subId);
+            uint32_t subId,
+            AZStd::set<AZStd::string> tags = AZStd::set<AZStd::string>{});
 
         /// Build image assets for the image object and save them to asset files. It also generates AssetBuilderSDK jobProducts if it success.
         bool BuildImageAssets();
@@ -78,6 +80,7 @@ namespace ImageProcessingAtom
         const AZStd::string m_fileName;
         const uint32_t m_subId = AZ::RPI::StreamingImageAsset::GetImageAssetSubId();
         const uint8_t m_numResidentMips = 0u;
+         AZStd::set<AZStd::string> m_tags;
 
         AZStd::vector<AssetBuilderSDK::JobProduct> m_jobProducts;
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.cpp
@@ -815,7 +815,9 @@ namespace ImageProcessingAtom
             m_input->m_sourceAssetId,
             m_input->m_imageName,
             m_input->m_presetSetting.m_numResidentMips,
-            subId);
+            subId,
+            m_input->m_textureSetting.m_tags
+            );
 
         if (assetProducer.BuildImageAssets())
         {

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/ImageQuality.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/ImageQuality.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/base.h>
+
+namespace AZ
+{
+    namespace RPI
+    {
+        using ImageQuality = u32;
+
+        constexpr ImageQuality ImageQualityHighest = 0;
+        constexpr ImageQuality ImageQualityLowest = 0xFFFFFFFF;
+    }
+}

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/ImageTagBus.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/ImageTagBus.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Name/Name.h>
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/std/containers/vector.h>
+#include <Atom/RPI.Public/Image/ImageQuality.h>
+
+namespace AZ
+{
+    namespace RPI
+    {
+        class ImageTagInterface
+            : public AZ::EBusTraits
+        {
+        public:
+            virtual ImageQuality GetQuality(const AZ::Name& imageTag) const = 0;
+
+            virtual AZStd::vector<AZ::Name> GetTags() const = 0;
+
+            virtual void RegisterImageAsset(AZ::Name imageTag, const Data::AssetId& assetId) = 0;
+
+            virtual void RegisterTag(AZ::Name tag) = 0;
+
+            virtual void SetQuality(const AZ::Name& imageTag, ImageQuality quality) = 0;
+        };
+
+        using ImageTagBus = AZ::EBus<ImageTagInterface>;
+    }
+}

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/ImageTagSystemComponent.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/ImageTagSystemComponent.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+/**
+ * @file TextureTagSystemComponent.h
+ * @brief Contains the definition of the TextureTagSystemComponent that will allow to set all texture tags
+ */
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/std/containers/unordered_map.h>
+#include <Atom/RPI.Public/Image/ImageTagBus.h>
+
+namespace AZ
+{
+    namespace RPI
+    {
+        class ImageTagSystemComponent final
+            : public AZ::Component
+            , ImageTagBus::Handler
+        {
+        public:
+            AZ_COMPONENT(ImageTagSystemComponent, "{1AC446A3-6F20-4D5C-9C09-BB034C9188D5}");
+
+            static void Reflect(AZ::ReflectContext* context);
+            static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+            static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+            static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
+
+            ImageTagSystemComponent() = default;
+            ~ImageTagSystemComponent() override;
+
+            void Activate() override;
+            void Deactivate() override;
+
+            ImageQuality GetQuality(const AZ::Name& imageTag) const override;
+
+            AZStd::vector<AZ::Name> GetTags() const override;
+
+            void RegisterImageAsset(AZ::Name imageTag, const Data::AssetId& assetId) override;
+            void RegisterTag(AZ::Name imageTag) override;
+
+            void SetQuality(const AZ::Name& imageTag, ImageQuality quality) override;
+
+        private:
+            ImageTagSystemComponent(const ImageTagSystemComponent&) = delete;
+
+            struct TagData
+            {
+                AZ_TYPE_INFO(TagData, "{CC8A5564-6A27-48A4-A143-C914C1AB50D5}");
+
+                ImageQuality quality = ImageQualityHighest;
+                AZStd::unordered_set<Data::AssetId> registeredImages;
+            };
+
+            AZStd::unordered_map<AZ::Name, TagData> m_imageTags;
+        };
+    } // namespace RPI
+} // namespace AZ

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImage.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImage.h
@@ -212,6 +212,9 @@ namespace AZ
 
             // The image's streaming priority
             Priority m_streamingPriority = 0; // value 0 means lowest priority
+
+            // The first active mip chain (that will exist on GPU-side)
+            size_t m_firstActiveMipChainIndex = 0;
         };
     }
 }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/StreamingImageAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/StreamingImageAsset.h
@@ -13,6 +13,7 @@
 #include <Atom/RPI.Reflect/Image/ImageAsset.h>
 #include <Atom/RPI.Reflect/Image/StreamingImagePoolAsset.h>
 #include <Atom/RPI.Reflect/Image/ImageMipChainAsset.h>
+#include <AzCore/std/containers/unordered_set.h>
 
 namespace AZ
 {
@@ -104,6 +105,9 @@ namespace AZ
             //! Whether the image has all referenced ImageMipChainAssets loaded
             bool HasFullMipChainAssets() const;
 
+            //! Returns the image tags
+            const AZStd::unordered_set<AZ::Name>& GetTags() const;
+
         private:
             struct MipChain
             {
@@ -143,6 +147,8 @@ namespace AZ
             //! mip chain index, not the level. And will fail for any level
             //! that resides in the tail mip chain.
             const ImageMipChainAsset* GetImageMipChainAsset(AZ::u32 mipLevel) const;
+
+            AZStd::unordered_set<AZ::Name> m_tags;
         };
     }
 }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/StreamingImageAssetCreator.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/StreamingImageAssetCreator.h
@@ -48,7 +48,9 @@ namespace AZ
 
             //! Set the average color of the image.
             void SetAverageColor(Color avgColor);
-            
+
+            void AddTag(AZ::Name tag);
+
             //! Finalizes and assigns ownership of the asset to result, if successful. 
             //! Otherwise false is returned and result is left untouched.
             bool End(Data::Asset<StreamingImageAsset>& result);

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/Module.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/Module.cpp
@@ -10,11 +10,13 @@
 #include <AzCore/Module/Module.h>
 #include <RPI.Private/Module.h>
 
+#include <Atom/RPI.Public/Image/ImageTagSystemComponent.h>
 #include <RPI.Private/RPISystemComponent.h>
 
 AZ::RPI::Module::Module()
 {
     m_descriptors.push_back(AZ::RPI::RPISystemComponent::CreateDescriptor());
+    m_descriptors.push_back(AZ::RPI::ImageTagSystemComponent::CreateDescriptor());
 }
 
 AZ::ComponentTypeList AZ::RPI::Module::GetRequiredSystemComponents() const
@@ -22,6 +24,7 @@ AZ::ComponentTypeList AZ::RPI::Module::GetRequiredSystemComponents() const
     return
     {
         azrtti_typeid<AZ::RPI::RPISystemComponent>(),
+        azrtti_typeid<AZ::RPI::ImageTagSystemComponent>(),
     };
 }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageTagSystemComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageTagSystemComponent.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+/**
+* @file RPISystemComponent.cpp
+* @brief Contains the definition of the RPISystemComponent methods that aren't defined as inline
+*/
+
+#include <Atom/RPI.Public/Image/ImageTagSystemComponent.h>
+#include <AzCore/Asset/AssetManager.h>
+#include <AzCore/Component/TickBus.h>
+#include <AzCore/std/sort.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Settings/SettingsRegistry.h>
+
+namespace AZ
+{
+    namespace RPI
+    {
+        ImageTagSystemComponent::~ImageTagSystemComponent() = default;
+
+        void ImageTagSystemComponent::Reflect(ReflectContext* context)
+        {
+            if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
+            {
+                serializeContext->Class<ImageTagSystemComponent::TagData>()
+                    ->Version(0)
+                    ->Field("Quality", &ImageTagSystemComponent::TagData::quality)
+                    ->Field("RegisteredImages", &ImageTagSystemComponent::TagData::registeredImages)
+                ;
+
+                serializeContext->Class<ImageTagSystemComponent, Component>()
+                    ->Version(0)
+                    ->Field("ImageTags", &ImageTagSystemComponent::m_imageTags)
+                ;
+            }
+        }
+
+        void ImageTagSystemComponent::GetRequiredServices(ComponentDescriptor::DependencyArrayType& /*required*/)
+        {
+        }
+
+        void ImageTagSystemComponent::GetProvidedServices(ComponentDescriptor::DependencyArrayType& provided)
+        {
+            provided.push_back(AZ_CRC_CE("TextureTagSystemComponent"));
+        }
+
+        void ImageTagSystemComponent::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& /*dependent*/)
+        {
+        }
+
+        void ImageTagSystemComponent::Activate()
+        {
+            ImageTagBus::Handler::BusConnect();
+        }
+
+        void ImageTagSystemComponent::Deactivate()
+        {
+            ImageTagBus::Handler::BusDisconnect();
+        }
+
+        ImageQuality ImageTagSystemComponent::GetQuality(const AZ::Name& imageTag) const
+        {
+            auto it = m_imageTags.find(imageTag);
+            if (it == m_imageTags.end())
+            {
+                AZ_Warning("ImageTagSystemComponent", false, "Image tag %s has not been registered", imageTag.GetCStr());
+                return ImageQualityHighest;
+            }
+
+            return it->second.quality;
+        }
+
+        AZStd::vector<AZ::Name> ImageTagSystemComponent::GetTags() const
+        {
+            AZStd::vector<AZ::Name> tags;
+            for (auto&& [tag, tagData] : m_imageTags)
+            {
+                tags.push_back(tag);
+            }
+
+            AZStd::sort(tags.begin(), tags.end(), [](const AZ::Name& lhs, const AZ::Name& rhs) { return lhs.GetStringView() < rhs.GetStringView(); });
+
+            return tags;
+        }
+
+        void ImageTagSystemComponent::RegisterImageAsset(AZ::Name imageTag, const Data::AssetId& assetId)
+        {
+            auto it = m_imageTags.find(imageTag);
+            if (it == m_imageTags.end())
+            {
+                AZ_Warning("ImageTagSystemComponent", false, "Image tag %s has not been registered", imageTag.GetCStr());
+                return;
+            }
+
+            TagData& tagData = it->second;
+            tagData.registeredImages.insert(assetId);
+        }
+
+        void ImageTagSystemComponent::RegisterTag(AZ::Name imageTag)
+        {
+            AZ_Warning("ImageTagSystemComponent", m_imageTags.find(imageTag) == m_imageTags.end(), "Image tag %s has already been registered", imageTag.GetCStr());
+
+            m_imageTags.emplace(AZStd::move(imageTag), TagData{});
+        }
+
+        void ImageTagSystemComponent::SetQuality(const AZ::Name& imageTag, ImageQuality quality)
+        {
+            auto it = m_imageTags.find(imageTag);
+            if (it == m_imageTags.end())
+            {
+                AZ_Warning("ImageTagSystemComponent", false, "Image tag %s has not been registered", imageTag.GetCStr());
+                return;
+            }
+
+            TagData& tagData = it->second;
+            tagData.quality = quality;
+
+            for (const AZ::Data::AssetId& assetId : tagData.registeredImages)
+            {
+                AZ::SystemTickBus::QueueFunction([assetId]
+                {
+                    AZ::Data::AssetManager::Instance().ReloadAsset(assetId, AZ::Data::AssetLoadBehavior::Default);
+                });
+            }
+        }
+    } // namespace RPI
+} // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
@@ -10,6 +10,7 @@
 #include <Atom/RPI.Public/Image/StreamingImage.h>
 #include <Atom/RPI.Public/Image/StreamingImagePool.h>
 #include <Atom/RPI.Public/Image/StreamingImageController.h>
+#include <Atom/RPI.Public/Image/ImageTagBus.h>
 
 #include <Atom/RPI.Reflect/Image/ImageMipChainAssetCreator.h>
 #include <Atom/RPI.Reflect/Image/StreamingImageAssetCreator.h>
@@ -144,11 +145,46 @@ namespace AZ
             
             const ImageMipChainAsset& mipChainTailAsset = imageAsset.GetTailMipChain();
 
+            ImageQuality highestMipChain = ImageQualityHighest;
+            if (const AZStd::unordered_set<AZ::Name>& imageTags = imageAsset.GetTags(); !imageTags.empty())
+            {
+                highestMipChain = ImageQualityLowest;
+                for (const AZ::Name& tag : imageAsset.GetTags())
+                {
+                    ImageQuality tagQuality = ImageQualityHighest;
+                    ImageTagBus::BroadcastResult(tagQuality, &ImageTagBus::Events::GetQuality, tag);
+                    highestMipChain = AZStd::min(highestMipChain, tagQuality);
+
+                    ImageTagBus::Broadcast(&ImageTagBus::Events::RegisterImageAsset, tag, imageAsset.GetId());
+                }
+            }
+
+            if (highestMipChain >= imageAsset.GetMipChainCount())
+                highestMipChain = aznumeric_caster(imageAsset.GetMipChainCount() - 1);
+
+            m_firstActiveMipChainIndex = highestMipChain;
+
             {
                 RHI::StreamingImageInitRequest initRequest;
                 initRequest.m_image = GetRHIImage();
                 initRequest.m_descriptor = imageAsset.GetImageDescriptor();
                 initRequest.m_tailMipSlices = mipChainTailAsset.GetMipSlices();
+
+                if (highestMipChain != ImageQualityHighest)
+                {
+                    // recompute miplevels from the current mipchain index
+                    uint16_t mipmapShift = 0;
+                    for (size_t i = 0; i < highestMipChain; ++i)
+                    {
+                        uint16_t mipCount = aznumeric_cast<uint16_t>(imageAsset.GetMipCount(i));
+
+                        mipmapShift += mipCount;
+                    }
+
+                    AZ_Error("Image", mipmapShift < initRequest.m_descriptor.m_mipLevels, "Unexpected mipmap shift");
+                    initRequest.m_descriptor.m_mipLevels -= mipmapShift;
+                    initRequest.m_descriptor.m_size = initRequest.m_descriptor.m_size.GetReducedMip(mipmapShift);
+                }
 
                 // NOTE: Initialization can fail due to out-of-memory errors. Need to handle it at runtime.
                 resultCode = rhiPool->InitImage(initRequest);
@@ -170,7 +206,10 @@ namespace AZ
 
                     // We want to store off the id, not the AssetData instance. This simplifies the fetch / evict logic which
                     // can do more strict assertions.
-                    m_mipChains.push_back(Data::Asset<ImageMipChainAsset>(assetId, azrtti_typeid<ImageMipChainAsset>()));
+                    if (mipChainIndex >= highestMipChain)
+                        m_mipChains.push_back(Data::Asset<ImageMipChainAsset>(assetId, azrtti_typeid<ImageMipChainAsset>()));
+                    else
+                        m_mipChains.push_back(Data::Asset<ImageMipChainAsset>{});
                 }
 
                 // Initialize the streaming state to have the tail mip active and ready.
@@ -199,7 +238,7 @@ namespace AZ
                 }
                         
 #ifdef AZ_RPI_STREAMING_IMAGE_DEBUG_LOG
-                AZ_TracePrintf("StreamingImage", "Init image [%s]\n", m_image->GetName().data());
+                AZ_TracePrintf("StreamingImage", "Init image [%s]\n", m_image->GetName().GetCStr());
 #endif
                                 
 #if defined (AZ_RPI_STREAMING_IMAGE_HOT_RELOADING)
@@ -323,6 +362,8 @@ namespace AZ
         {
             AZ_Assert(mipChainIndex < m_mipChains.size(), "Exceeded number of mip chains.");
 
+            mipChainIndex = AZStd::max(mipChainIndex, m_firstActiveMipChainIndex);
+
             // Expand operation - queue streaming of mip chains up to target mip chain index. 
             if (m_mipChainState.m_streamingTarget > mipChainIndex)
             {
@@ -362,7 +403,7 @@ namespace AZ
             if (m_mipChainState.m_streamingTarget < m_mipChainState.m_residencyTarget)
             {
 #ifdef AZ_RPI_STREAMING_IMAGE_DEBUG_LOG
-                AZ_TracePrintf("StreamingImage", "Expand image [%s]\n", GetImage()->GetName().data());
+                AZ_TracePrintf("StreamingImage", "Expand image [%s]\n", m_image->GetName().GetCStr());
 #endif
 
                 // Start by assuming we can expand residency to the full target range.
@@ -425,6 +466,7 @@ namespace AZ
         void StreamingImage::FetchMipChainAsset(size_t mipChainIndex)
         {
             AZ_Assert(mipChainIndex < m_mipChains.size(), "Exceeded total number of mip chains.");
+            AZ_Assert(mipChainIndex >= m_firstActiveMipChainIndex, "Trying to fetch disabled mipchain index.");
 
             const uint16_t mipChainBit = static_cast<uint16_t>(1 << mipChainIndex);
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
@@ -207,9 +207,13 @@ namespace AZ
                     // We want to store off the id, not the AssetData instance. This simplifies the fetch / evict logic which
                     // can do more strict assertions.
                     if (mipChainIndex >= highestMipChain)
+                    {
                         m_mipChains.push_back(Data::Asset<ImageMipChainAsset>(assetId, azrtti_typeid<ImageMipChainAsset>()));
+                    }
                     else
+                    {
                         m_mipChains.push_back(Data::Asset<ImageMipChainAsset>{});
+                    }
                 }
 
                 // Initialize the streaming state to have the tail mip active and ready.

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/StreamingImageAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/StreamingImageAsset.cpp
@@ -37,6 +37,7 @@ namespace AZ
                     ->Field("m_tailMipChain", &StreamingImageAsset::m_tailMipChain)
                     ->Field("m_totalImageDataSize", &StreamingImageAsset::m_totalImageDataSize)
                     ->Field("m_averageColor", &StreamingImageAsset::m_averageColor)
+                    ->Field("m_tags", &StreamingImageAsset::m_tags)
                     ;
             }
         }
@@ -131,6 +132,11 @@ namespace AZ
             }
 
             return imageDescriptor;
+        }
+
+        const AZStd::unordered_set<AZ::Name>& StreamingImageAsset::GetTags() const
+        {
+            return m_tags;
         }
 
         AZStd::span<const uint8_t> StreamingImageAsset::GetSubImageData(uint32_t mip, uint32_t slice)

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/StreamingImageAssetCreator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/StreamingImageAssetCreator.cpp
@@ -112,6 +112,14 @@ namespace AZ
             }
         }
 
+        void StreamingImageAssetCreator::AddTag(AZ::Name tag)
+        {
+            if (ValidateIsReady())
+            {
+                m_asset->m_tags.emplace(AZStd::move(tag));
+            }
+        }
+
         bool StreamingImageAssetCreator::End(Data::Asset<StreamingImageAsset>& result)
         {
             if (!ValidateIsReady())

--- a/Gems/Atom/RPI/Code/atom_rpi_public_files.cmake
+++ b/Gems/Atom/RPI/Code/atom_rpi_public_files.cmake
@@ -44,8 +44,11 @@ set(FILES
     Include/Atom/RPI.Public/DynamicDraw/DynamicDrawInterface.h
     Include/Atom/RPI.Public/Image/AttachmentImage.h
     Include/Atom/RPI.Public/Image/AttachmentImagePool.h
+    Include/Atom/RPI.Public/Image/ImageQuality.h
     Include/Atom/RPI.Public/Image/ImageSystem.h
     Include/Atom/RPI.Public/Image/ImageSystemInterface.h
+    Include/Atom/RPI.Public/Image/ImageTagBus.h
+    Include/Atom/RPI.Public/Image/ImageTagSystemComponent.h
     Include/Atom/RPI.Public/Image/StreamingImage.h
     Include/Atom/RPI.Public/Image/StreamingImageContext.h
     Include/Atom/RPI.Public/Image/StreamingImageController.h
@@ -126,6 +129,7 @@ set(FILES
     Source/RPI.Public/Image/AttachmentImage.cpp
     Source/RPI.Public/Image/AttachmentImagePool.cpp
     Source/RPI.Public/Image/ImageSystem.cpp
+    Source/RPI.Public/Image/ImageTagSystemComponent.cpp
     Source/RPI.Public/Image/StreamingImage.cpp
     Source/RPI.Public/Image/StreamingImageContext.cpp
     Source/RPI.Public/Image/StreamingImageController.cpp


### PR DESCRIPTION
Hi,

This commit adds support for texture tags (allowing applications to register tags and then tag textures with them) along with a way to setup a quality level per tag, allowing to change the maximum mipchain that will be uploaded to the GPU.

Quality level defaults on 0 (= current behavior, all mipchains are uploaded), each value means a mipchain will not be uploaded to the GPU (quality level 1 means that the first mipchain won't be uploaded, etc.).  
Textures with multiple tags take their highest quality (= lowest value = biggest mipchain).

Texture quality can be changed at runtime which will trigger an asset reload (since recreating the texture is currently the only way we can prevent unused mipmaps VRAM consumption, although I know this can be improved with the coming sparse texture support).

This comes with an updated texture settings UI to add/remove tags to textures.