### PR TITLE
Fix editor mode feedback, the pass was only added to the pipeline once.

### DIFF
--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -409,17 +409,19 @@ namespace AZ
                 if (pipelineAsset)
                 {
                     RPI::RenderPipelineDescriptor renderPipelineDescriptor =
-                        *RPI::GetDataFromAnyAsset<RPI::RenderPipelineDescriptor>(pipelineAsset);
+                        *RPI::GetDataFromAnyAsset<RPI::RenderPipelineDescriptor>(pipelineAsset); // Copy descriptor from asset
+                    pipelineAsset.Release();
+
                     renderPipelineDescriptor.m_name =
                         AZStd::string::format("%s_%i", renderPipelineDescriptor.m_name.c_str(), viewportContext->GetId());
 
                     multisampleState = renderPipelineDescriptor.m_renderSettings.m_multisampleState;
 
+                    // Create and add render pipeline to the scene (when not added already)
                     if (!scene->GetRenderPipeline(AZ::Name(renderPipelineDescriptor.m_name)))
                     {
                         RPI::RenderPipelinePtr renderPipeline = RPI::RenderPipeline::CreateRenderPipelineForWindow(
                             renderPipelineDescriptor, *viewportContext->GetWindowContext().get(), viewType);
-                        pipelineAsset.Release();
                         scene->AddRenderPipeline(renderPipeline);
                     }
                     return true;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -465,8 +465,11 @@ namespace AZ
             {
                 for (auto& renderPipeline : scene->GetRenderPipelines())
                 {
-                    renderPipeline->GetRenderSettings().m_multisampleState = multisampleState;
-                    renderPipeline->MarkPipelinePassChanges(PipelinePassChanges::MultisampleStateChanged);
+                    if (renderPipeline->GetRenderSettings().m_multisampleState != multisampleState)
+                    {
+                        renderPipeline->GetRenderSettings().m_multisampleState = multisampleState;
+                        renderPipeline->MarkPipelinePassChanges(PipelinePassChanges::MultisampleStateChanged);
+                    }
                 }
             }
         }

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/DrawableMeshEntity.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/DrawableMeshEntity.cpp
@@ -128,7 +128,11 @@ namespace AZ::Render
         for (auto& drawPacket : m_meshDrawPackets)
         {
             drawPacket.Update(*drawabaleMetaData.GetScene());
-            dynamicDraw->AddDrawPacket(drawabaleMetaData.GetScene(), drawPacket.GetRHIDrawPacket());
+            if (auto* rhiDrawPacket = drawPacket.GetRHIDrawPacket();
+                rhiDrawPacket != nullptr)
+            {
+                dynamicDraw->AddDrawPacket(drawabaleMetaData.GetScene(), rhiDrawPacket);
+            }
         }
     }
          

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.cpp
@@ -308,6 +308,7 @@ namespace AZ::Render
         }
         else
         {
+            AZ_Error("EditorStateMeshDrawPacket", false, "Invalid draw packet generated.");
             return false;
         }
     }

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/EditorStatePassSystem.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/EditorStatePassSystem.cpp
@@ -49,107 +49,118 @@ namespace AZ::Render
     void EditorStatePassSystem::AddPassesToRenderPipeline(RPI::RenderPipeline* renderPipeline)
     {
         const auto templateName = Name(MainPassParentTemplateName);
-        if (RPI::PassSystemInterface::Get()->GetPassTemplate(templateName))
+
+        // Early return if pass is already found in render pipeline.
+        auto passFilter = AZ::RPI::PassFilter::CreateWithTemplateName(templateName, renderPipeline);
+        auto foundPass = AZ::RPI::PassSystemInterface::Get()->FindFirstPass(passFilter);
+        if (foundPass)
         {
-            // Template was created by another pipeline, do not to create again
             return;
         }
 
-        auto mainParentPassTemplate = AZStd::make_shared<RPI::PassTemplate>();
-        mainParentPassTemplate->m_name = templateName;
-        mainParentPassTemplate->m_passClass = Name(MainPassParentTemplatePassClassName);
-        
-        // Input depth slot
+        auto mainParentPassTemplate = RPI::PassSystemInterface::Get()->GetPassTemplate(templateName);
+        if (!mainParentPassTemplate)
         {
-            RPI::PassSlot slot;
-            slot.m_name = Name("InputDepth");
-            slot.m_slotType = RPI::PassSlotType::Input;
-            mainParentPassTemplate->AddSlot(slot);
-        }
-        
-        // Input/output color slot
-        {
-            RPI::PassSlot slot;
-            slot.m_name = Name("ColorInputOutput");
-            slot.m_slotType = RPI::PassSlotType::InputOutput;
-            mainParentPassTemplate->AddSlot(slot);
-        }
+            // Create the pass template and add it to the pass system.
+            auto newPassTemplate = AZStd::make_shared<RPI::PassTemplate>();
+            newPassTemplate->m_name = templateName;
+            newPassTemplate->m_passClass = Name(MainPassParentTemplatePassClassName);
 
-        // Entity mask passes
-        m_masks = CreateMaskPassTemplatesFromEditorStates(m_editorStates);
-        for (const auto& drawList : m_masks)
-        {
-            RPI::PassRequest pass;
-            pass.m_passName = GetMaskPassNameForDrawList(drawList);
-            pass.m_templateName = GetMaskPassTemplateNameForDrawList(drawList);
-
-            // Input depth
+            // Input depth slot
             {
-                RPI::PassConnection connection;
-                connection.m_localSlot = Name("InputDepth");
-                connection.m_attachmentRef = { Name("Parent"), Name("InputDepth") };
-                pass.AddInputConnection(connection);
+                RPI::PassSlot slot;
+                slot.m_name = Name("InputDepth");
+                slot.m_slotType = RPI::PassSlotType::Input;
+                newPassTemplate->AddSlot(slot);
             }
 
-            mainParentPassTemplate->AddPassRequest(pass);
-        }
-        
-        // Editor state passes
-        auto previousOutput = AZStd::make_pair<Name, Name>(Name("Parent"), Name("ColorInputOutput"));
-        for (const auto& state : m_editorStates)
-        {
-            CreateAndAddStateParentPassTemplate(*state);
-            RPI::PassRequest pass;
-            pass.m_passName = state->GetPassName();
-            pass.m_templateName = state->GetPassTemplateName();
-        
-            // Input depth
+            // Input/output color slot
             {
-                RPI::PassConnection connection;
-                connection.m_localSlot = Name("InputDepth");
-                connection.m_attachmentRef = { Name("Parent"), Name("InputDepth") };
-                pass.AddInputConnection(connection);
+                RPI::PassSlot slot;
+                slot.m_name = Name("ColorInputOutput");
+                slot.m_slotType = RPI::PassSlotType::InputOutput;
+                newPassTemplate->AddSlot(slot);
             }
-        
-            // Input entity mask
+
+            // Entity mask passes
+            m_masks = CreateMaskPassTemplatesFromEditorStates(m_editorStates);
+            for (const auto& drawList : m_masks)
             {
-                RPI::PassConnection connection;
-                connection.m_localSlot = Name("InputEntityMask");
-                connection.m_attachmentRef = { GetMaskPassNameForDrawList(state->GetEntityMaskDrawList()), Name("OutputEntityMask") };
-                pass.AddInputConnection(connection);
+                RPI::PassRequest pass;
+                pass.m_passName = GetMaskPassNameForDrawList(drawList);
+                pass.m_templateName = GetMaskPassTemplateNameForDrawList(drawList);
+
+                // Input depth
+                {
+                    RPI::PassConnection connection;
+                    connection.m_localSlot = Name("InputDepth");
+                    connection.m_attachmentRef = { Name("Parent"), Name("InputDepth") };
+                    pass.AddInputConnection(connection);
+                }
+
+                newPassTemplate->AddPassRequest(pass);
             }
-        
-            // Input color
+
+            // Editor state passes
+            auto previousOutput = AZStd::make_pair<Name, Name>(Name("Parent"), Name("ColorInputOutput"));
+            for (const auto& state : m_editorStates)
             {
-                RPI::PassConnection connection;
-                connection.m_localSlot = Name("InputColor");
-                connection.m_attachmentRef = { previousOutput.first, previousOutput.second };
-                pass.AddInputConnection(connection);
-            }
-        
-            mainParentPassTemplate->AddPassRequest(pass);
-        
-            // Buffer copy pass 
-            {
-                CreateAndAddBufferCopyPassTemplate(*state);
-                RPI::PassRequest buffercopy;
-                buffercopy.m_passName = GetBufferCopyPassNameForState(*state);
-                buffercopy.m_templateName = GetBufferCopyPassTemplateName(*state);
-                
+                CreateAndAddStateParentPassTemplate(*state);
+                RPI::PassRequest pass;
+                pass.m_passName = state->GetPassName();
+                pass.m_templateName = state->GetPassTemplateName();
+
+                // Input depth
+                {
+                    RPI::PassConnection connection;
+                    connection.m_localSlot = Name("InputDepth");
+                    connection.m_attachmentRef = { Name("Parent"), Name("InputDepth") };
+                    pass.AddInputConnection(connection);
+                }
+
+                // Input entity mask
+                {
+                    RPI::PassConnection connection;
+                    connection.m_localSlot = Name("InputEntityMask");
+                    connection.m_attachmentRef = { GetMaskPassNameForDrawList(state->GetEntityMaskDrawList()), Name("OutputEntityMask") };
+                    pass.AddInputConnection(connection);
+                }
+
                 // Input color
                 {
                     RPI::PassConnection connection;
                     connection.m_localSlot = Name("InputColor");
-                    connection.m_attachmentRef = { pass.m_passName, Name("OutputColor") };
-                    buffercopy.AddInputConnection(connection);
+                    connection.m_attachmentRef = { previousOutput.first, previousOutput.second };
+                    pass.AddInputConnection(connection);
                 }
-        
-                mainParentPassTemplate->AddPassRequest(buffercopy);
-                previousOutput = { buffercopy.m_passName, Name("OutputColor") };
+
+                newPassTemplate->AddPassRequest(pass);
+
+                // Buffer copy pass
+                {
+                    CreateAndAddBufferCopyPassTemplate(*state);
+                    RPI::PassRequest buffercopy;
+                    buffercopy.m_passName = GetBufferCopyPassNameForState(*state);
+                    buffercopy.m_templateName = GetBufferCopyPassTemplateName(*state);
+
+                    // Input color
+                    {
+                        RPI::PassConnection connection;
+                        connection.m_localSlot = Name("InputColor");
+                        connection.m_attachmentRef = { pass.m_passName, Name("OutputColor") };
+                        buffercopy.AddInputConnection(connection);
+                    }
+
+                    newPassTemplate->AddPassRequest(buffercopy);
+                    previousOutput = { buffercopy.m_passName, Name("OutputColor") };
+                }
             }
+
+            RPI::PassSystemInterface::Get()->AddPassTemplate(newPassTemplate->m_name, newPassTemplate);
+
+            mainParentPassTemplate = newPassTemplate;
         }
 
-        RPI::PassSystemInterface::Get()->AddPassTemplate(mainParentPassTemplate->m_name, mainParentPassTemplate);
         AZ::RPI::PassRequest passRequest;
         passRequest.m_passName = Name(MainPassParentPassName);
         passRequest.m_templateName = mainParentPassTemplate->m_name;


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/12682

The pass of editor mode feedback was only added to the render pipeline once because it was doing an early return if the pass template was created. But when the pipelines are reinitialized (for example when setting the MSAA state) then it doesn't re-add the pass because the pass template was already created.

Updated the early return to check if the pass is in the render pipeline fixed the issue.

This PR includes other small improvements done while investigating the issue.
Now the editor mode feedback won't add null draw packets to the system and instead it will print an error if the draw packet generated was incorrect, this way it'll be easier in the future to identify the error since the message will come directly from the visual mode system.

## How was this PR tested?

- Run the editor and selected the shader ball model to check if editor visual feedback works.
- Entered into prefab mode and check the highlighting of objects worked and also the monochromatic effect worked as well.
- Tested adding a Diffuse Probe Grid component, enabled the probes, modified the sun's light and verified the probes were updated accordingly.
