### PR TITLE
Added an option to batch rigid body transform syncs for the entire simulation pass

### DIFF
--- a/Gems/PhysX/Code/Source/ForceRegion.cpp
+++ b/Gems/PhysX/Code/Source/ForceRegion.cpp
@@ -238,7 +238,11 @@ namespace PhysX
         entityParams.m_id = entityId;
 
         AzPhysics::RigidBody* rigidBody = nullptr;
-        Physics::RigidBodyRequestBus::EventResultReverse(rigidBody, entityId, &Physics::RigidBodyRequestBus::Events::GetRigidBody);
+
+        if (auto* handler = Physics::RigidBodyRequestBus::FindFirstHandler(entityId))
+        {
+            rigidBody = handler->GetRigidBody();
+        }
 
         if (!rigidBody)
         {

--- a/Gems/PhysX/Code/Source/ForceRegion.cpp
+++ b/Gems/PhysX/Code/Source/ForceRegion.cpp
@@ -236,16 +236,21 @@ namespace PhysX
     {
         EntityParams entityParams;
         entityParams.m_id = entityId;
-        AZ::TransformBus::EventResult(entityParams.m_position
-            , entityId
-            , &AZ::TransformBus::Events::GetWorldTranslation);
-        Physics::RigidBodyRequestBus::EventResultReverse(entityParams.m_velocity
-            , entityId
-            , &Physics::RigidBodyRequestBus::Events::GetLinearVelocity);
-        Physics::RigidBodyRequestBus::EventResultReverse(entityParams.m_mass
-            , entityId
-            , &Physics::RigidBodyRequestBus::Events::GetMass);
+
+        AzPhysics::RigidBody* rigidBody = nullptr;
+        Physics::RigidBodyRequestBus::EventResultReverse(rigidBody, entityId, &Physics::RigidBodyRequestBus::Events::GetRigidBody);
+
+        if (!rigidBody)
+        {
+            AZ_Error("PhysX", false, "ForceRegionUtil::CreateEntityParams: No rigid body for entity [%llu]", entityId);
+            return entityParams;
+        }
+
+        entityParams.m_position = rigidBody->GetPosition();
+        entityParams.m_velocity = rigidBody->GetLinearVelocity();
+        entityParams.m_mass = rigidBody->GetMass();
         entityParams.m_aabb = GetForceRegionAabb(entityId);
+
         return entityParams;
     }
 

--- a/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
+++ b/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
@@ -612,7 +612,7 @@ namespace PhysX
 
             if (physx_batchTransformSync)
             {
-                m_queuedActiveBodyIndices.Reserve(activeBodyHandles.size());
+                m_queuedActiveBodyIndices.IncreaseCapacity(activeBodyHandles.size());
 
                 for (const AzPhysics::SimulatedBodyHandle& bodyHandle : activeBodyHandles)
                 {
@@ -1326,26 +1326,26 @@ namespace PhysX
 
     void PhysXScene::QueuedActiveBodyIndices::Insert(AzPhysics::SimulatedBodyIndex bodyIndex)
     {
-        if (m_set.insert(bodyIndex).second)
+        if (m_uniqueIndices.insert(bodyIndex).second)
         {
-            m_array.emplace_back(bodyIndex);
+            m_packedIndices.emplace_back(bodyIndex);
         }
     }
 
-    void PhysXScene::QueuedActiveBodyIndices::Reserve(size_t reserveSize)
+    void PhysXScene::QueuedActiveBodyIndices::IncreaseCapacity(size_t extraSize)
     {
-        m_array.reserve(m_array.size() + reserveSize);
+        m_packedIndices.reserve(m_packedIndices.size() + extraSize);
     }
 
     void PhysXScene::QueuedActiveBodyIndices::Clear()
     {
-        m_set.clear();
-        m_array.clear();
+        m_uniqueIndices.clear();
+        m_packedIndices.clear();
     }
 
     void PhysXScene::QueuedActiveBodyIndices::Apply(const AZStd::function<void(AzPhysics::SimulatedBodyIndex)>& applyFunction)
     {
-        AZStd::for_each(m_array.begin(), m_array.end(), applyFunction);
+        AZStd::for_each(m_packedIndices.begin(), m_packedIndices.end(), applyFunction);
     }
 
 } // namespace PhysX

--- a/Gems/PhysX/Code/Source/Scene/PhysXScene.h
+++ b/Gems/PhysX/Code/Source/Scene/PhysXScene.h
@@ -91,13 +91,13 @@ namespace PhysX
         {
         public:
             void Insert(AzPhysics::SimulatedBodyIndex bodyIndex);
-            void Reserve(size_t reserveSize);
+            void IncreaseCapacity(size_t extraSize);
             void Clear();
             void Apply(const AZStd::function<void(AzPhysics::SimulatedBodyIndex)>& applyFunction);
 
         private:
-            AZStd::unordered_set<AzPhysics::SimulatedBodyIndex> m_set;
-            AZStd::vector<AzPhysics::SimulatedBodyIndex> m_array;
+            AZStd::unordered_set<AzPhysics::SimulatedBodyIndex> m_uniqueIndices;
+            AZStd::vector<AzPhysics::SimulatedBodyIndex> m_packedIndices;
         };
 
         void EnableSimulationOfBodyInternal(AzPhysics::SimulatedBody& body);

--- a/Gems/PhysX/Code/Source/Scene/PhysXScene.h
+++ b/Gems/PhysX/Code/Source/Scene/PhysXScene.h
@@ -28,7 +28,7 @@ namespace physx
 namespace PhysX
 {
     //! PhysX implementation of the AzPhysics::Scene.
-    class PhysXScene
+    class PhysXScene final
         : public AzPhysics::Scene
     {
     public:
@@ -79,7 +79,27 @@ namespace PhysX
 
         physx::PxControllerManager* GetOrCreateControllerManager();
 
+        //! Apply batched transform sync events for the current simulation pass. 
+        //! This will clear the batched data for the next simulation pass.
+        void FlushTransformSync();
+        
     private:
+
+        //! Data structure for efficient unique vector functionality.
+        //! Body indices are inserted avoiding duplicated data and stored in a vector for efficient iteration.
+        class QueuedActiveBodyIndices
+        {
+        public:
+            void Insert(AzPhysics::SimulatedBodyIndex bodyIndex);
+            void Reserve(size_t reserveSize);
+            void Clear();
+            void Apply(const AZStd::function<void(AzPhysics::SimulatedBodyIndex)>& applyFunction);
+
+        private:
+            AZStd::unordered_set<AzPhysics::SimulatedBodyIndex> m_set;
+            AZStd::vector<AzPhysics::SimulatedBodyIndex> m_array;
+        };
+
         void EnableSimulationOfBodyInternal(AzPhysics::SimulatedBody& body);
         void DisableSimulationOfBodyInternal(AzPhysics::SimulatedBody& body);
 
@@ -93,11 +113,24 @@ namespace PhysX
         void SyncActiveBodyTransform(const AzPhysics::SimulatedBodyHandleList& activeBodyHandles);
 
         bool m_isEnabled = true;
+
+        // Batch transform sync data. Here we store the indices of actors that have moved since the last simulation pass.
+        // After the full simulation pass (possibly made of multiple simulation sub-steps) is complete,
+        // we send the transform sync event once.
+        QueuedActiveBodyIndices m_queuedActiveBodyIndices;
+
+        // Accumulated delta time over multiple simulation sub-steps.
+        // When we run the batched transform sync, the accumulated simulation time is provided
+        // to tell how much time was simulated in this full pass.
+        float m_accumulatedDeltaTime = 0.0f;
+
         AzPhysics::SceneConfiguration m_config;
         AzPhysics::SceneHandle m_sceneHandle;
+
+        // Delta time for the current simulation sub-step
         float m_currentDeltaTime = 0.0f;
 
-        AZStd::vector<AZStd::pair<AZ::Crc32, AzPhysics::SimulatedBody*>> m_simulatedBodies; //this will become a SimulatedBody with LYN-1334
+        AZStd::vector<AZStd::pair<AZ::Crc32, AzPhysics::SimulatedBody*>> m_simulatedBodies;
         AZStd::vector<AzPhysics::SimulatedBody*> m_deferredDeletions;
         AZStd::queue<AzPhysics::SimulatedBodyIndex> m_freeSceneSlots;
 

--- a/Gems/PhysX/Code/Tests/Benchmarks/PhysXBenchmarksCommon.cpp
+++ b/Gems/PhysX/Code/Tests/Benchmarks/PhysXBenchmarksCommon.cpp
@@ -11,6 +11,7 @@
 #include <Benchmarks/PhysXBenchmarksCommon.h>
 #include <PhysXTestUtil.h>
 #include <PhysXTestCommon.h>
+#include <Scene/PhysXScene.h>
 
 namespace PhysX::Benchmarks
 {

--- a/Gems/PhysX/Code/Tests/Benchmarks/PhysXBenchmarksCommon.cpp
+++ b/Gems/PhysX/Code/Tests/Benchmarks/PhysXBenchmarksCommon.cpp
@@ -50,6 +50,7 @@ namespace PhysX::Benchmarks
     {
         m_defaultScene->StartSimulation(timeStep);
         m_defaultScene->FinishSimulation();
+        static_cast<PhysX::PhysXScene*>(m_defaultScene)->FlushTransformSync();
     }
 
     void PhysXBaseBenchmarkFixture::SetUpInternal()

--- a/Gems/PhysX/Code/Tests/PhysXSpecificTest.cpp
+++ b/Gems/PhysX/Code/Tests/PhysXSpecificTest.cpp
@@ -34,6 +34,7 @@
 #include <PhysX/PhysXLocks.h>
 #include <PhysX/SystemComponentBus.h>
 #include <PhysX/Material/PhysXMaterialConfiguration.h>
+#include <Scene/PhysXScene.h>
 #include <Tests/PhysXTestCommon.h>
 
 namespace PhysX
@@ -611,6 +612,8 @@ namespace PhysX
                 testBox.reset();
             }
         }
+        static_cast<PhysX::PhysXScene*>(m_defaultScene)->FlushTransformSync();
+
 
         ASSERT_EQ(testBox, nullptr);
         ASSERT_EQ(enteredEvents.size(), 1);
@@ -651,6 +654,7 @@ namespace PhysX
                 staticBox.reset();
             }
         }
+        static_cast<PhysX::PhysXScene*>(m_defaultScene)->FlushTransformSync();
 
         ASSERT_EQ(staticBox, nullptr);
         ASSERT_EQ(enteredEvents.size(), 1);

--- a/Gems/PhysX/Code/Tests/PhysXTestCommon.cpp
+++ b/Gems/PhysX/Code/Tests/PhysXTestCommon.cpp
@@ -23,6 +23,7 @@
 #include <CapsuleColliderComponent.h>
 #include <RigidBodyComponent.h>
 #include <SphereColliderComponent.h>
+#include <Scene/PhysXScene.h>
 #include <Tests/PhysXTestUtil.h>
 
 namespace PhysX
@@ -68,6 +69,7 @@ namespace PhysX
             {
                 scene->StartSimulation(timeStep);
                 scene->FinishSimulation();
+                static_cast<PhysX::PhysXScene*>(scene)->FlushTransformSync();
             }
         }
 

--- a/Gems/PhysX/Code/Tests/RagdollTests.cpp
+++ b/Gems/PhysX/Code/Tests/RagdollTests.cpp
@@ -15,6 +15,7 @@
 #include <PhysXCharacters/Components/RagdollComponent.h>
 #include <PhysX/NativeTypeIdentifiers.h>
 #include <PhysX/PhysXLocks.h>
+#include <Scene/PhysXScene.h>
 #include <Tests/PhysXTestFixtures.h>
 #include <Tests/PhysXTestCommon.h>
 
@@ -305,6 +306,7 @@ namespace PhysX
             EXPECT_TRUE(ragdoll->GetAabb().GetMax().IsClose(initialAabb.GetMax()));
             EXPECT_TRUE(ragdoll->GetAabb().GetMin().IsClose(initialAabb.GetMin()));
         }
+        static_cast<PhysX::PhysXScene*>(m_defaultScene)->FlushTransformSync();
     }
 
     AZ::u32 GetNumRigidDynamicActors(physx::PxScene* scene)


### PR DESCRIPTION
Signed-off-by: Sergey Pereslavtsev <pereslav@amazon.com>

## What does this PR do?

Added an option to batch rigid body transform syncs for the entire simulation pass
Disabled by default as needs documentation update and more real world testing

Gives up to 40% cut on physics simulation pass cost: 

![batchedUpdate](https://user-images.githubusercontent.com/60428010/200066375-bd564df9-3a22-4d50-80dd-6c088626396c.png)

## How was this PR tested?
Unit tests, manual testing various conditions: boxes, ragdolls, with & without interpolation
