### PR TITLE
Force Component Mode to close when exiting the Editor.

### DIFF
--- a/Code/Editor/CryEditDoc.cpp
+++ b/Code/Editor/CryEditDoc.cpp
@@ -28,6 +28,7 @@
 #include <AzFramework/API/ApplicationAPI.h>
 
 // AzToolsFramework
+#include <AzToolsFramework/ComponentMode/EditorComponentModeBus.h>
 #include <AzToolsFramework/Slice/SliceUtilities.h>
 #include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
 #include <AzToolsFramework/UI/Layer/NameConflictWarning.hxx>
@@ -607,6 +608,12 @@ int CCryEditDoc::GetModifiedModule()
 
 bool CCryEditDoc::CanCloseFrame()
 {
+    if (AzToolsFramework::ComponentModeFramework::InComponentMode())
+    {
+        AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequestBus::Broadcast(
+            &AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequests::EndComponentMode);
+    }
+
     // Ask the base class to ask for saving, which also includes the save
     // status of the plugins. Additionaly we query if all the plugins can exit
     // now. A reason for a failure might be that one of the plugins isn't


### PR DESCRIPTION
## What does this PR do?

It was possible to select "Exit" while in Component Mode, which could cause the work currently being done in Component Mode to get lost. This gives Component Mode a chance to save the work before exiting.

In particular, this improves two behaviors for the Image Gradient Component Mode:
1. Ensures that the user has a chance to save the image when Exiting the Editor.
2. Ensures that the Paint Brush Settings window closes cleanly and doesn't reappear on the next run of the Editor.

## How was this PR tested?

Exited the Editor while in Component Mode and verified that it ended Component Mode before exiting.
