### PR TITLE
[Terrain] Make editing during an image reload more stable.

### DIFF
--- a/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
@@ -706,12 +706,13 @@ namespace GradientSignal
     void ImageGradientComponent::UpdateCachedImageBufferData(
         const AZ::RHI::ImageDescriptor& imageDescriptor, AZStd::span<const uint8_t> imageData)
     {
-        bool shouldClearModificationBuffer = false;
+        bool shouldRefreshModificationBuffer = false;
 
-        // If we're changing our image data from our modification buffer to something else, clear out the modification buffer.
+        // If we're changing our image data from our modification buffer to something else while it's active,
+        // let's refresh the modification buffer with the new data.
         if (ModificationBufferIsActive() && (imageData.data() != m_imageData.data()))
         {
-            shouldClearModificationBuffer = true;
+            shouldRefreshModificationBuffer = true;
         }
 
         m_imageDescriptor = imageDescriptor;
@@ -720,9 +721,10 @@ namespace GradientSignal
         m_maxX = imageDescriptor.m_size.m_width - 1;
         m_maxY = imageDescriptor.m_size.m_height - 1;
 
-        if (shouldClearModificationBuffer)
+        if (shouldRefreshModificationBuffer)
         {
-            ClearImageModificationBuffer();
+            m_modifiedImageData.resize(0);
+            CreateImageModificationBuffer();
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

If an image reload happens (from the user editing and saving the image in a paint program for example) while still in image edit mode, instead of asserting and/or crashing, the Editor now replaces the painted data with the newly-reloaded data and lets the user keep painting. The one quirky part is that any existing undo/redo buffers will no longer directly match the modified image, so they can introduce unwanted artifacts if the user tries to undo/redo painted data into an image that has been reloaded this way. Not perfect, but it's a better experience than crashing. :)

This is just handling an edge case behavior, because the user really _shouldn't_ try to paint on the same image from two different programs at the same time and have any expectations about the chaos that might ensue.

## How was this PR tested?

Tried editing an image in the Editor and in Gimp at the same time, including both shrinking and growing the image from Gimp. Everything remained stable, but as listed above, the undo/redo can cause pixels in strange places to change when the image is resized, and because undo/redo works on entire tile squares of images, everything in that square can get overwritten on the undo/redo, even if it doesn't match the new image.

This video demonstrates the overall stability of the experience, but also shows the artifacts that can occur when using undo/redo after the image hot-reloads.
https://user-images.githubusercontent.com/82224783/200082695-d93d162c-feaa-4f8f-bba3-ae9c4905c3c1.mp4

