### PR TITLE
Refactor heavy TranslationResult and RuntimeAsset header file

### DIFF
--- a/Gems/ScriptCanvas/Code/Asset/EditorAssetSystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Asset/EditorAssetSystemComponent.cpp
@@ -22,7 +22,7 @@
  // Undo this
 AZ_PUSH_DISABLE_WARNING(4251 4800 4244, "-Wunknown-warning-option")
 #include <ScriptCanvas/Asset/RuntimeAsset.h>
-
+#include <ScriptCanvas/Asset/SubgraphInterfaceAsset.h>
 #include <ScriptCanvas/Components/EditorGraph.h>
 #include <ScriptCanvas/Components/EditorGraphVariableManagerComponent.h>
 AZ_POP_DISABLE_WARNING

--- a/Gems/ScriptCanvas/Code/Asset/RuntimeAssetSystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Asset/RuntimeAssetSystemComponent.cpp
@@ -11,6 +11,7 @@
 
 #include <ScriptCanvas/Asset/RuntimeAsset.h>
 #include <ScriptCanvas/Asset/RuntimeAssetHandler.h>
+#include <ScriptCanvas/Asset/SubgraphInterfaceAsset.h>
 #include <Asset/RuntimeAssetSystemComponent.h>
 #include <Asset/SubgraphInterfaceAssetHandler.h>
 #include <Execution/ExecutionState.h>

--- a/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderComponent.cpp
@@ -13,8 +13,8 @@
 #include <Builder/ScriptCanvasBuilderComponent.h>
 #include <Builder/ScriptCanvasBuilderWorker.h>
 #include <ScriptCanvas/Asset/RuntimeAssetHandler.h>
+#include <ScriptCanvas/Asset/SubgraphInterfaceAsset.h>
 #include <ScriptCanvas/Asset/SubgraphInterfaceAssetHandler.h>
-
 #include <ScriptCanvas/Utils/BehaviorContextUtils.h>
 
 namespace ScriptCanvasBuilder

--- a/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderWorker.cpp
+++ b/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderWorker.cpp
@@ -16,8 +16,8 @@
 #include <AzFramework/Script/ScriptComponent.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 #include <Builder/ScriptCanvasBuilderWorker.h>
-#include <ScriptCanvas/Asset/RuntimeAssetHandler.h>
-#include <ScriptCanvas/Asset/SubgraphInterfaceAssetHandler.h>
+#include <ScriptCanvas/Asset/RuntimeAsset.h>
+#include <ScriptCanvas/Asset/SubgraphInterfaceAsset.h>
 #include <ScriptCanvas/Assets/ScriptCanvasFileHandling.h>
 #include <ScriptCanvas/Components/EditorGraph.h>
 #include <ScriptCanvas/Components/EditorGraphVariableManagerComponent.h>

--- a/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderWorker.h
+++ b/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderWorker.h
@@ -13,10 +13,11 @@
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzCore/Asset/AssetCommon.h>
-#include <ScriptCanvas/Translation/Translation.h>
+
 #include <ScriptCanvas/Asset/RuntimeAsset.h>
 #include <ScriptCanvas/Asset/RuntimeAssetHandler.h>
 #include <ScriptCanvas/Core/Core.h>
+#include <ScriptCanvas/Translation/Translation.h>
 
 namespace AZ
 {
@@ -30,8 +31,7 @@ namespace AZ
 
 namespace ScriptCanvas
 {
-    class RuntimeAsset;
-    class SubgraphInterfaceAsset;
+    struct SubgraphInterfaceData;
 }
 
 namespace ScriptCanvasEditor

--- a/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderWorkerUtility.cpp
+++ b/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderWorkerUtility.cpp
@@ -17,9 +17,8 @@
 #include <AzFramework/Script/ScriptComponent.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 #include <Builder/ScriptCanvasBuilderWorker.h>
+#include <ScriptCanvas/Asset/SubgraphInterfaceAsset.h>
 #include <ScriptCanvas/Asset/SubgraphInterfaceAssetHandler.h>
-#include <ScriptCanvas/Asset/RuntimeAsset.h>
-#include <ScriptCanvas/Asset/RuntimeAssetHandler.h>
 #include <ScriptCanvas/Components/EditorGraph.h>
 #include <ScriptCanvas/Components/EditorGraphVariableManagerComponent.h>
 #include <ScriptCanvas/Core/Connection.h>

--- a/Gems/ScriptCanvas/Code/Editor/Assets/ScriptCanvasFileHandling.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Assets/ScriptCanvasFileHandling.cpp
@@ -18,7 +18,7 @@
 #include <AzCore/std/string/string_view.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
-#include <ScriptCanvas/Asset/RuntimeAsset.h>
+#include <ScriptCanvas/Asset/SubgraphInterfaceAsset.h>
 #include <ScriptCanvas/Bus/ScriptCanvasBus.h>
 #include <ScriptCanvas/Components/EditorGraph.h>
 #include <ScriptCanvas/Components/EditorUtils.h>

--- a/Gems/ScriptCanvas/Code/Editor/Framework/ScriptCanvasGraphUtilities.h
+++ b/Gems/ScriptCanvas/Code/Editor/Framework/ScriptCanvasGraphUtilities.h
@@ -13,6 +13,7 @@
 #include <Editor/Framework/ScriptCanvasReporter.h>
 #include <ScriptCanvas/Assets/ScriptCanvasFileHandling.h>
 #include <ScriptCanvas/Core/Core.h>
+#include <ScriptCanvas/Translation/TranslationResult.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/PivotTree/GraphPivotTree/GraphPivotTree.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/PivotTree/GraphPivotTree/GraphPivotTree.cpp
@@ -11,7 +11,7 @@
 #include <AzToolsFramework/AssetBrowser/AssetBrowserModel.h>
 #include <AzToolsFramework/AssetBrowser/Entries/ProductAssetBrowserEntry.h>
 #include <Editor/View/Widgets/LoggingPanel/PivotTree/GraphPivotTree/GraphPivotTree.h>
-#include <ScriptCanvas/Asset/RuntimeAsset.h>
+#include <ScriptCanvas/Asset/SubgraphInterfaceAsset.h>
 
 namespace ScriptCanvasEditor
 {

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/ScriptCanvasNodePaletteDockWidget.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/ScriptCanvasNodePaletteDockWidget.cpp
@@ -61,7 +61,7 @@
 #include <GraphCanvas/Widgets/NodePalette/NodePaletteWidget.h>
 #include <GraphCanvas/Widgets/NodePalette/TreeItems/NodePaletteTreeItem.h>
 
-#include <ScriptCanvas/Asset/RuntimeAsset.h>
+#include <ScriptCanvas/Asset/SubgraphInterfaceAsset.h>
 #include <ScriptCanvas/Core/Attributes.h>
 #include <ScriptCanvas/Core/SubgraphInterfaceUtility.h>
 #include <ScriptCanvas/Data/DataRegistry.h>

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -147,6 +147,7 @@
 
 #include <Editor/Assets/ScriptCanvasAssetHelpers.h>
 #include <ScriptCanvas/Asset/AssetDescription.h>
+#include <ScriptCanvas/Asset/SubgraphInterfaceAsset.h>
 #include <ScriptCanvas/Components/EditorScriptCanvasComponent.h>
 
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Modifier.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Modifier.cpp
@@ -9,8 +9,8 @@
 #include <Editor/Include/ScriptCanvas/Components/EditorGraph.h>
 #include <Editor/View/Windows/Tools/UpgradeTool/LogTraits.h>
 #include <Editor/View/Windows/Tools/UpgradeTool/Modifier.h>
-#include <ScriptCanvas/Asset/RuntimeAsset.h>
 
+#include <ScriptCanvas/Asset/SubgraphInterfaceAsset.h>
 #include <ScriptCanvas/Assets/ScriptCanvasFileHandling.h>
 #include <ScriptCanvas/Core/Graph.h>
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/RuntimeAsset.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/RuntimeAsset.cpp
@@ -6,10 +6,10 @@
  *
  */
 
-#include "RuntimeAsset.h"
-
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Asset/AssetSerializer.h>
+#include <ScriptCanvas/Asset/RuntimeAsset.h>
+#include <ScriptEvents/ScriptEventsAsset.h>
 
 namespace DoNotVersionRuntimeAssetsBumpTheBuilderVersionInstead
 {
@@ -29,17 +29,6 @@ namespace DoNotVersionRuntimeAssetsBumpTheBuilderVersionInstead
 
         // add description above
         Current,
-    };
-
-    enum class FunctionRuntimeDataVersion
-    {
-        MergeBackEnd2dotZero,
-        AddSubgraphInterface,
-        RemoveLegacyData,
-        RemoveConnectionToRuntimeData,
-
-        // add description above
-        Current
     };
 }
 
@@ -67,7 +56,7 @@ namespace ScriptCanvas
 
     void RuntimeData::Reflect(AZ::ReflectContext* reflectContext)
     {
-        Translation::RuntimeInputs::Reflect(reflectContext);
+        RuntimeInputs::Reflect(reflectContext);
 
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(reflectContext))
         {
@@ -254,55 +243,5 @@ namespace ScriptCanvas
                     ;
             }
         }
-    }
-
-    ////////////////////////
-    // SubgraphInterfaceData
-    ////////////////////////
-
-    SubgraphInterfaceAssetDescription::SubgraphInterfaceAssetDescription()
-        : AssetDescription(
-            azrtti_typeid<SubgraphInterfaceAsset>(),
-            "Script Canvas Function Interface",
-            "Script Canvas Function Interface",
-            "@projectroot@/scriptcanvas",
-            ".scriptcanvas_fn_compiled",
-            "Script Canvas Function Interface",
-            "Untitled-Function-%i",
-            "Script Canvas Compiled Function Interfaces (*.scriptcanvas_fn_compiled)",
-            "Script Canvas Function Interface",
-            "Script Canvas Function Interface",
-            "Icons/ScriptCanvas/Viewport/ScriptCanvas_Function.png",
-            AZ::Color(1.0f, 0.0f, 0.0f, 1.0f),
-            false
-        )
-    {}
-
-    void SubgraphInterfaceData::Reflect(AZ::ReflectContext* reflectContext)
-    {
-        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(reflectContext))
-        {
-            serializeContext->Class<SubgraphInterfaceData>()
-                ->Version(static_cast<int>(DoNotVersionRuntimeAssetsBumpTheBuilderVersionInstead::FunctionRuntimeDataVersion::Current))
-                ->Field("name", &SubgraphInterfaceData::m_name)
-                ->Field("interface", &SubgraphInterfaceData::m_interface)
-                ;
-        }
-    }
-
-    SubgraphInterfaceData::SubgraphInterfaceData(SubgraphInterfaceData&& other)
-    {
-        *this = AZStd::move(other);
-    }
-
-    SubgraphInterfaceData& SubgraphInterfaceData::operator=(SubgraphInterfaceData&& other)
-    {
-        if (this != &other)
-        {
-            m_name = AZStd::move(other.m_name);
-            m_interface = AZStd::move(other.m_interface);
-        }
-
-        return *this;
     }
 }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/RuntimeAsset.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/RuntimeAsset.h
@@ -9,17 +9,19 @@
 
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Script/ScriptAsset.h>
-
 #include <ScriptCanvas/Asset/AssetDescription.h>
+#include <ScriptCanvas/Asset/RuntimeInputs.h>
 #include <ScriptCanvas/Core/Core.h>
-#include <ScriptCanvas/Core/SubgraphInterface.h>
-#include <ScriptCanvas/Core/GraphData.h>
 #include <ScriptCanvas/Grammar/DebugMap.h>
-#include <ScriptCanvas/Translation/TranslationResult.h>
 #include <ScriptCanvas/Variable/VariableData.h>
 #include <ScriptCanvas/Execution/ExecutionContext.h>
 #include <ScriptCanvas/Execution/ExecutionObjectCloning.h>
 #include <ScriptCanvas/Execution/ExecutionStateDeclarations.h>
+
+namespace ScriptEvents
+{
+    class ScriptEventsAsset;
+}
 
 namespace ScriptCanvas
 {
@@ -32,9 +34,9 @@ namespace ScriptCanvas
     struct RuntimeVariable;
 
     constexpr const AZ::u32 RuntimeDataSubId = AZ_CRC_CE("RuntimeData"); // 0x163310ae
-    constexpr const AZ::u32 SubgraphInterfaceSubId = AZ_CRC_CE("SubgraphInterface"); // 0xdfe6dc72
 
-    class RuntimeAssetDescription : public AssetDescription
+    class RuntimeAssetDescription
+        : public AssetDescription
     {
     public:
 
@@ -56,7 +58,7 @@ namespace ScriptCanvas
 
         static void Reflect(AZ::ReflectContext* reflectContext);
 
-        Translation::RuntimeInputs m_input;
+        RuntimeInputs m_input;
         Grammar::DebugSymbolMap m_debugMap;
 
         // populate all and set to all to AssetLoadBehavior::Preload at build time
@@ -146,49 +148,4 @@ namespace ScriptCanvas
     using RuntimeAssetPtr = AZ::Data::Asset<RuntimeAsset>;
 
     IsPreloadedResult IsPreloaded(RuntimeAssetPtr asset);
-
-    class SubgraphInterfaceAsset;
-
-    class SubgraphInterfaceAssetDescription : public AssetDescription
-    {
-    public:
-
-        AZ_TYPE_INFO(SubgraphInterfaceAssetDescription, "{7F7BE1A5-9447-41C2-9190-18580075094C}");
-
-        SubgraphInterfaceAssetDescription();
-    };
-
-    struct SubgraphInterfaceData
-    {
-        AZ_TYPE_INFO(SubgraphInterfaceData, "{1734C569-7D40-4491-9EEE-A225E333C9BA}");
-        AZ_CLASS_ALLOCATOR(SubgraphInterfaceData, AZ::SystemAllocator, 0);
-        SubgraphInterfaceData() = default;
-        ~SubgraphInterfaceData() = default;
-        SubgraphInterfaceData(const SubgraphInterfaceData&) = default;
-        SubgraphInterfaceData& operator=(const SubgraphInterfaceData&) = default;
-        SubgraphInterfaceData(SubgraphInterfaceData&&);
-        SubgraphInterfaceData& operator=(SubgraphInterfaceData&&);
-
-        static void Reflect(AZ::ReflectContext* reflectContext);
-
-        AZStd::string m_name;
-        Grammar::SubgraphInterface m_interface;
-    };
-
-    class SubgraphInterfaceAsset
-        : public AZ::Data::AssetData
-    {
-    public:
-        AZ_RTTI(SubgraphInterfaceAsset, "{E22967AC-7673-4778-9125-AF49D82CAF9F}", AZ::Data::AssetData);
-        AZ_CLASS_ALLOCATOR(SubgraphInterfaceAsset, AZ::SystemAllocator, 0);
-
-        static const char* GetFileExtension() { return "scriptcanvas_fn_compiled"; }
-        static const char* GetFileFilter() { return "*.scriptcanvas_fn_compiled"; }
-
-        SubgraphInterfaceData m_interfaceData;
-
-        SubgraphInterfaceAsset(const AZ::Data::AssetId& assetId = AZ::Data::AssetId(), AZ::Data::AssetData::AssetStatus status = AZ::Data::AssetData::AssetStatus::NotLoaded)
-            : AZ::Data::AssetData(assetId, status)
-        {}
-    };
 }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/RuntimeInputs.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/RuntimeInputs.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <ScriptCanvas/Asset/RuntimeInputs.h>
+#include <ScriptCanvas/Core/Nodeable.h>
+#include <ScriptCanvas/Grammar/Primitives.h>
+
+namespace ScriptCanvas
+{
+    enum RuntimeInputsVersion
+    {
+        RemoveGraphType = 0,
+        AddedStaticVariables,
+        SupportMemberVariableInputs,
+        ExecutionStateSelectionIncludesOnGraphStart,
+        Last,
+        DoNotVersionRuntimeAssetsBumpTheBuilderVersionInstead
+    };
+
+    RuntimeInputs::RuntimeInputs(RuntimeInputs&& rhs)
+    {
+        *this = AZStd::move(rhs);
+    }
+
+    void RuntimeInputs::CopyFrom(const Grammar::ParsedRuntimeInputs& rhs)
+    {
+        m_nodeables = rhs.m_nodeables;
+        m_variables = rhs.m_variables;
+        m_entityIds = rhs.m_entityIds;
+        m_staticVariables = rhs.m_staticVariables;
+    }
+
+    size_t RuntimeInputs::GetConstructorParameterCount() const
+    {
+        return m_nodeables.size() + m_variables.size() + m_entityIds.size();
+    }
+
+    RuntimeInputs& RuntimeInputs::operator=(RuntimeInputs&& rhs)
+    {
+        if (this != &rhs)
+        {
+            m_executionSelection = AZStd::move(rhs.m_executionSelection);
+            m_nodeables = AZStd::move(rhs.m_nodeables);
+            m_variables = AZStd::move(rhs.m_variables);
+            m_entityIds = AZStd::move(rhs.m_entityIds);
+            m_staticVariables = AZStd::move(rhs.m_staticVariables);
+        }
+
+        return *this;
+    }
+
+    void RuntimeInputs::Reflect(AZ::ReflectContext* reflectContext)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(reflectContext))
+        {
+            serializeContext->Class<RuntimeInputs>()
+                ->Version(RuntimeInputsVersion::DoNotVersionRuntimeAssetsBumpTheBuilderVersionInstead)
+                ->Field("executionSelection", &RuntimeInputs::m_executionSelection)
+                ->Field("nodeables", &RuntimeInputs::m_nodeables)
+                ->Field("variables", &RuntimeInputs::m_variables)
+                ->Field("entityIds", &RuntimeInputs::m_entityIds)
+                ->Field("staticVariables", &RuntimeInputs::m_staticVariables);
+        }
+    }
+} // namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/RuntimeInputs.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/RuntimeInputs.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/any.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/utils.h>
+#include <ScriptCanvas/Data/DataType.h>
+#include <ScriptCanvas/Grammar/PrimitivesDeclarations.h>
+
+namespace ScriptCanvas
+{
+    class Datum;
+    class Nodeable;
+    struct VariableId;
+
+    namespace Grammar
+    {
+        struct ParsedRuntimeInputs;
+    }
+
+    // Information required at runtime begin execution of the compiled graph from the host
+    struct RuntimeInputs
+    {
+        AZ_TYPE_INFO(RuntimeInputs, "{CFF0820B-EE0D-4E02-B847-2B295DD5B5CF}");
+        AZ_CLASS_ALLOCATOR(RuntimeInputs, AZ::SystemAllocator, 0);
+
+        static void Reflect(AZ::ReflectContext* reflectContext);
+
+        Grammar::ExecutionStateSelection m_executionSelection = Grammar::ExecutionStateSelection::InterpretedPure;
+
+        AZStd::vector<Nodeable*> m_nodeables;
+        // \todo Datum should be able to be cut by now, replaced by AZStd::any (and maybe TypedNullPointer if necessary)
+        AZStd::vector<AZStd::pair<VariableId, Datum>> m_variables;
+
+        // either the entityId was a (member) variable in the source graph, or it got promoted to one during parsing
+        AZStd::vector<AZStd::pair<VariableId, Data::EntityIDType>> m_entityIds;
+
+        // Statics required for internal, local values that need non-code constructible initialization,
+        // when the system can't pass in the input from C++.
+        AZStd::vector<AZStd::pair<VariableId, AZStd::any>> m_staticVariables;
+
+        RuntimeInputs() = default;
+        RuntimeInputs(const RuntimeInputs&) = default;
+        RuntimeInputs(RuntimeInputs&&);
+        ~RuntimeInputs() = default;
+
+        void CopyFrom(const Grammar::ParsedRuntimeInputs& inputs);
+
+        size_t GetConstructorParameterCount() const;
+
+        RuntimeInputs& operator=(const RuntimeInputs&) = default;
+        RuntimeInputs& operator=(RuntimeInputs&&);
+    };
+} // namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/SubgraphInterfaceAsset.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/SubgraphInterfaceAsset.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <ScriptCanvas/Asset/SubgraphInterfaceAsset.h>
+
+namespace ScriptCanvas
+{
+    enum class FunctionRuntimeDataVersion
+    {
+        MergeBackEnd2dotZero,
+        AddSubgraphInterface,
+        RemoveLegacyData,
+        RemoveConnectionToRuntimeData,
+
+        // add description above
+        Current
+    };
+
+    SubgraphInterfaceAssetDescription::SubgraphInterfaceAssetDescription()
+        : AssetDescription(
+              azrtti_typeid<SubgraphInterfaceAsset>(),
+              "Script Canvas Function Interface",
+              "Script Canvas Function Interface",
+              "@projectroot@/scriptcanvas",
+              ".scriptcanvas_fn_compiled",
+              "Script Canvas Function Interface",
+              "Untitled-Function-%i",
+              "Script Canvas Compiled Function Interfaces (*.scriptcanvas_fn_compiled)",
+              "Script Canvas Function Interface",
+              "Script Canvas Function Interface",
+              "Icons/ScriptCanvas/Viewport/ScriptCanvas_Function.png",
+              AZ::Color(1.0f, 0.0f, 0.0f, 1.0f),
+              false)
+    {
+    }
+
+    void SubgraphInterfaceData::Reflect(AZ::ReflectContext* reflectContext)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(reflectContext))
+        {
+            serializeContext->Class<SubgraphInterfaceData>()
+                ->Version(static_cast<int>(FunctionRuntimeDataVersion::Current))
+                ->Field("name", &SubgraphInterfaceData::m_name)
+                ->Field("interface", &SubgraphInterfaceData::m_interface);
+        }
+    }
+
+    SubgraphInterfaceData::SubgraphInterfaceData(SubgraphInterfaceData&& other)
+    {
+        *this = AZStd::move(other);
+    }
+
+    SubgraphInterfaceData& SubgraphInterfaceData::operator=(SubgraphInterfaceData&& other)
+    {
+        if (this != &other)
+        {
+            m_name = AZStd::move(other.m_name);
+            m_interface = AZStd::move(other.m_interface);
+        }
+
+        return *this;
+    }
+} // namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/SubgraphInterfaceAsset.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/SubgraphInterfaceAsset.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Asset/AssetCommon.h>
+#include <ScriptCanvas/Asset/AssetDescription.h>
+#include <ScriptCanvas/Core/SubgraphInterface.h>
+
+namespace ScriptCanvas
+{
+    constexpr const AZ::u32 SubgraphInterfaceSubId = AZ_CRC_CE("SubgraphInterface"); // 0xdfe6dc72
+
+    class SubgraphInterfaceAsset;
+
+    class SubgraphInterfaceAssetDescription
+        : public AssetDescription
+    {
+    public:
+        AZ_TYPE_INFO(SubgraphInterfaceAssetDescription, "{7F7BE1A5-9447-41C2-9190-18580075094C}");
+
+        SubgraphInterfaceAssetDescription();
+    };
+
+    struct SubgraphInterfaceData
+    {
+        AZ_TYPE_INFO(SubgraphInterfaceData, "{1734C569-7D40-4491-9EEE-A225E333C9BA}");
+        AZ_CLASS_ALLOCATOR(SubgraphInterfaceData, AZ::SystemAllocator, 0);
+        SubgraphInterfaceData() = default;
+        ~SubgraphInterfaceData() = default;
+        SubgraphInterfaceData(const SubgraphInterfaceData&) = default;
+        SubgraphInterfaceData& operator=(const SubgraphInterfaceData&) = default;
+        SubgraphInterfaceData(SubgraphInterfaceData&&);
+        SubgraphInterfaceData& operator=(SubgraphInterfaceData&&);
+
+        static void Reflect(AZ::ReflectContext* reflectContext);
+
+        AZStd::string m_name;
+        Grammar::SubgraphInterface m_interface;
+    };
+
+    class SubgraphInterfaceAsset
+        : public AZ::Data::AssetData
+    {
+    public:
+        AZ_RTTI(SubgraphInterfaceAsset, "{E22967AC-7673-4778-9125-AF49D82CAF9F}", AZ::Data::AssetData);
+        AZ_CLASS_ALLOCATOR(SubgraphInterfaceAsset, AZ::SystemAllocator, 0);
+
+        static const char* GetFileExtension()
+        {
+            return "scriptcanvas_fn_compiled";
+        }
+        static const char* GetFileFilter()
+        {
+            return "*.scriptcanvas_fn_compiled";
+        }
+
+        SubgraphInterfaceData m_interfaceData;
+
+        SubgraphInterfaceAsset(
+            const AZ::Data::AssetId& assetId = AZ::Data::AssetId(),
+            AZ::Data::AssetData::AssetStatus status = AZ::Data::AssetData::AssetStatus::NotLoaded)
+            : AZ::Data::AssetData(assetId, status)
+        {
+        }
+    };
+} // namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/SubgraphInterfaceAssetHandler.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/SubgraphInterfaceAssetHandler.cpp
@@ -6,12 +6,6 @@
  *
  */
 
-#include <ScriptCanvas/Core/Graph.h>
-#include <ScriptCanvas/Asset/RuntimeAsset.h>
-#include <ScriptCanvas/Execution/RuntimeComponent.h>
-
-#include <ScriptCanvas/Core/ScriptCanvasBus.h>
-
 #include <AzCore/IO/GenericStreams.h>
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/Serialization/Utils.h>
@@ -19,7 +13,9 @@
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/Entity.h>
 
+#include <ScriptCanvas/Asset/SubgraphInterfaceAsset.h>
 #include <ScriptCanvas/Asset/SubgraphInterfaceAssetHandler.h>
+#include <ScriptCanvas/Execution/RuntimeComponent.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Nodeable.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Nodeable.cpp
@@ -6,10 +6,8 @@
  *
  */
 
-#include "Nodeable.h"
-
 #include <AzCore/Serialization/SerializeContext.h>
-#include <ScriptCanvas/Core/SubgraphInterface.h>
+#include <ScriptCanvas/Core/Nodeable.h>
 
 namespace NodeableOutCpp
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Nodeable.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Nodeable.h
@@ -10,22 +10,11 @@
 
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <ScriptCanvas/Core/Node.h>
+#include <ScriptCanvas/Core/NodeableOut.h>
 #include <ScriptCanvas/Execution/ExecutionState.h>
-
-#include "NodeableOut.h"
-
-namespace AZ
-{
-    class SerializeContext;
-}
 
 namespace ScriptCanvas
 {
-    namespace Grammar
-    {
-        class SubgraphInterface;
-    } 
-
     /*
     Note: Many parts of AzAutoGen, compilation, and runtime depend on the order of declaration and addition of slots.
     The display order can be manipulated in the editor, but it will always just be a change of view.

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionState.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionState.cpp
@@ -8,8 +8,8 @@
 
 #include <AzCore/Asset/AssetManager.h>
 #include <ScriptCanvas/Asset/RuntimeAsset.h>
+#include <ScriptCanvas/Asset/SubgraphInterfaceAsset.h>
 #include <ScriptCanvas/Execution/RuntimeComponent.h>
-
 #include <ScriptCanvas/Execution/ExecutionState.h>
 
 namespace ExecutionStateCpp

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionStateHandler.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionStateHandler.cpp
@@ -11,10 +11,10 @@
 #include <AzCore/Debug/Profiler.h>
 #include <AzCore/Serialization/IdUtils.h>
 #include <AzCore/Serialization/Utils.h>
+#include <ScriptCanvas/Core/ExecutionNotificationsBus.h>
 #include <ScriptCanvas/Execution/ExecutionBus.h>
 #include <ScriptCanvas/Execution/ExecutionContext.h>
 #include <ScriptCanvas/Execution/ExecutionState.h>
-
 #include <ScriptCanvas/Execution/ExecutionStateHandler.h>
 
 namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionStateHandler.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionStateHandler.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <ScriptCanvas/Execution/ExecutionStateStorage.h>
-#include <ScriptCanvas/Asset/RuntimeAsset.h>
 
 namespace AZ
 {
@@ -18,6 +17,8 @@ namespace AZ
 
 namespace ScriptCanvas
 {
+    struct ActivationInfo;
+
     /**
     * ExecutionStateHandler provides RAII semantics and an interface for the ExecutionStateStorage for ScriptCanvas graph. It and executes
     * and stops the runtime graph, if possible.

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/FunctionCallNode.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/FunctionCallNode.h
@@ -11,7 +11,7 @@
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/parallel/mutex.h>
-#include <ScriptCanvas/Asset/RuntimeAsset.h>
+#include <ScriptCanvas/Asset/SubgraphInterfaceAsset.h>
 #include <ScriptCanvas/Core/SubgraphInterface.h>
 #include <ScriptCanvas/Core/Graph.h>
 #include <ScriptCanvas/Core/Node.h>
@@ -22,8 +22,6 @@
 #include <Include/ScriptCanvas/Libraries/Core/FunctionCallNode.generated.h>
 
 namespace ScriptCanvas { class RuntimeComponent; }
-
-namespace ScriptCanvas { struct SubgraphInterfaceData; }
 
 namespace AZ
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/GraphToLua.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/GraphToLua.h
@@ -12,13 +12,13 @@
 #include <AzCore/std/containers/set.h>
 #include <AzCore/Outcome/Outcome.h>
 
+#include <ScriptCanvas/Asset/RuntimeInputs.h>
 #include <ScriptCanvas/Grammar/PrimitivesDeclarations.h>
 #include <ScriptCanvas/Variable/VariableCore.h>
 #include <ScriptCanvas/Core/ScriptCanvasBus.h>
 
 #include "GraphToX.h"
 #include "TranslationContext.h"
-#include "TranslationResult.h"
 #include "TranslationUtilities.h"
 
 namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/TranslationResult.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/TranslationResult.cpp
@@ -6,23 +6,8 @@
  *
  */
 
-#include "TranslationResult.h"
-
-#include <ScriptCanvas/Core/Nodeable.h>
 #include <ScriptCanvas/Grammar/AbstractCodeModel.h>
-
-namespace TranslationResultCpp
-{
-    enum RuntimeInputsVersion
-    {
-        RemoveGraphType = 0,
-        AddedStaticVariables,
-        SupportMemberVariableInputs,
-        ExecutionStateSelectionIncludesOnGraphStart,
-        Last,
-        DoNotVersionRuntimeAssetsBumpTheBuilderVersionInstead
-    };
-}
+#include <ScriptCanvas/Translation/TranslationResult.h>
 
 namespace ScriptCanvas
 {
@@ -118,56 +103,5 @@ namespace ScriptCanvas
         {
             return m_translations.find(flag) != m_translations.end();
         }
-
-        RuntimeInputs::RuntimeInputs(RuntimeInputs&& rhs)
-        {
-            *this = AZStd::move(rhs);
-        }
-
-        void RuntimeInputs::CopyFrom(const Grammar::ParsedRuntimeInputs& rhs)
-        {
-            m_nodeables = rhs.m_nodeables;
-            m_variables = rhs.m_variables;
-            m_entityIds = rhs.m_entityIds;
-            m_staticVariables = rhs.m_staticVariables;
-        }
-
-        size_t RuntimeInputs::GetConstructorParameterCount() const
-        {
-            return m_nodeables.size() + m_variables.size() + m_entityIds.size();
-        }
-
-        RuntimeInputs& RuntimeInputs::operator=(RuntimeInputs&& rhs)
-        {
-            if (this != &rhs)
-            {
-                m_executionSelection = AZStd::move(rhs.m_executionSelection);
-                m_nodeables = AZStd::move(rhs.m_nodeables);
-                m_variables = AZStd::move(rhs.m_variables);
-                m_entityIds = AZStd::move(rhs.m_entityIds);
-                m_staticVariables = AZStd::move(rhs.m_staticVariables);
-            }
-
-            return *this;
-        }
-
-        void RuntimeInputs::Reflect(AZ::ReflectContext* reflectContext)
-        {
-            using namespace TranslationResultCpp;
-
-            if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(reflectContext))
-            {
-                serializeContext->Class<RuntimeInputs>()
-                    ->Version(RuntimeInputsVersion::DoNotVersionRuntimeAssetsBumpTheBuilderVersionInstead)
-                    ->Field("executionSelection", &RuntimeInputs::m_executionSelection)
-                    ->Field("nodeables", &RuntimeInputs::m_nodeables)
-                    ->Field("variables", &RuntimeInputs::m_variables)
-                    ->Field("entityIds", &RuntimeInputs::m_entityIds)
-                    ->Field("staticVariables", &RuntimeInputs::m_staticVariables)
-                    ;
-            }
-        }
-
     } 
-
 } 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/TranslationResult.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/TranslationResult.h
@@ -11,6 +11,7 @@
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Script/ScriptAsset.h>
 #include <AzCore/std/any.h>
+#include <ScriptCanvas/Asset/RuntimeInputs.h>
 #include <ScriptCanvas/Core/Core.h>
 #include <ScriptCanvas/Core/SubgraphInterface.h>
 #include <ScriptCanvas/Data/Data.h>
@@ -18,23 +19,8 @@
 #include <ScriptCanvas/Grammar/DebugMap.h>
 #include <ScriptCanvas/Grammar/PrimitivesDeclarations.h>
 
-namespace AZ
-{
-    class EntityId;
-}
-
 namespace ScriptCanvas
 {
-    class Datum;
-    class Nodeable;
-
-    struct VariableId;
-
-    namespace Grammar
-    {
-        class AbstractCodeModel;
-    }
-
     namespace Translation
     {
         enum TargetFlags
@@ -42,40 +28,6 @@ namespace ScriptCanvas
             Lua = 1 << 0,
             Cpp = 1 << 1,
             Hpp = 1 << 2,
-        };
-
-        // information required at runtime begin execution of the compiled graph from the host 
-        struct RuntimeInputs
-        {
-            AZ_TYPE_INFO(RuntimeInputs, "{CFF0820B-EE0D-4E02-B847-2B295DD5B5CF}");
-            AZ_CLASS_ALLOCATOR(RuntimeInputs, AZ::SystemAllocator, 0);
-
-            static void Reflect(AZ::ReflectContext* reflectContext);
-
-            Grammar::ExecutionStateSelection m_executionSelection = Grammar::ExecutionStateSelection::InterpretedPure;
-            
-            AZStd::vector<Nodeable*> m_nodeables;
-            // \todo Datum should be able to be cut by now, replaced by AZStd::any (and maybe TypedNullPointer if necessary)
-            AZStd::vector<AZStd::pair<VariableId, Datum>> m_variables;
-
-            // either the entityId was a (member) variable in the source graph, or it got promoted to one during parsing
-            AZStd::vector<AZStd::pair<VariableId, Data::EntityIDType>> m_entityIds;
-
-            // Statics required for internal, local values that need non-code constructible initialization,
-            // when the system can't pass in the input from C++.
-            AZStd::vector<AZStd::pair<VariableId, AZStd::any>> m_staticVariables;
-
-            RuntimeInputs() = default;
-            RuntimeInputs(const RuntimeInputs&) = default;
-            RuntimeInputs(RuntimeInputs&&);
-            ~RuntimeInputs() = default;
-
-            void CopyFrom(const Grammar::ParsedRuntimeInputs& inputs);
-
-            size_t GetConstructorParameterCount() const;
-
-            RuntimeInputs& operator=(const RuntimeInputs&) = default;
-            RuntimeInputs& operator=(RuntimeInputs&&);
         };
 
         struct TargetResult

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Utils/VersionConverters.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Utils/VersionConverters.cpp
@@ -5,12 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include "VersionConverters.h"
 
 #include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/Serialization/Utils.h>
 
-#include <ScriptCanvas/Asset/RuntimeAsset.h>
+#include <ScriptCanvas/Asset/SubgraphInterfaceAsset.h>
 #include <ScriptCanvas/Core/Contracts/DisallowReentrantExecutionContract.h>
 #include <ScriptCanvas/Core/Node.h>
 #include <ScriptCanvas/Core/NodeableNode.h>
@@ -19,6 +18,7 @@
 #include <ScriptCanvas/Libraries/Core/EBusEventHandler.h>
 #include <ScriptCanvas/Libraries/Deprecated/Time/Repeater.h>
 #include <ScriptCanvas/Utils/SerializationUtils.h>
+#include <ScriptCanvas/Utils/VersionConverters.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Tests/ScriptCanvasBuilderTests.cpp
+++ b/Gems/ScriptCanvas/Code/Tests/ScriptCanvasBuilderTests.cpp
@@ -6,8 +6,8 @@
  *
  */
 
-
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
+#include <AssetBuilderSDK/SerializationDependencies.h>
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/Component/Component.h>
@@ -18,8 +18,8 @@
 #include <AzTest/AzTest.h>
 #include <Builder/ScriptCanvasBuilderWorker.h>
 
-#include "ScriptCanvas/Asset/RuntimeAsset.h"
-#include "AssetBuilderSDK/SerializationDependencies.h"
+#include <ScriptCanvas/Core/GraphData.h>
+#include <ScriptCanvas/Asset/RuntimeAsset.h>
 
 struct MockAsset
     : public AZ::Data::AssetData

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_common_files.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_common_files.cmake
@@ -15,6 +15,8 @@ set(FILES
     Include/ScriptCanvas/Asset/ExecutionLogAsset.cpp
     Include/ScriptCanvas/Asset/RuntimeAsset.cpp
     Include/ScriptCanvas/Asset/RuntimeAssetHandler.cpp
+    Include/ScriptCanvas/Asset/RuntimeInputs.cpp
+    Include/ScriptCanvas/Asset/SubgraphInterfaceAsset.cpp
     Include/ScriptCanvas/Asset/SubgraphInterfaceAssetHandler.cpp
     Include/ScriptCanvas/Core/ExecutionNotificationsBus.cpp
     Include/ScriptCanvas/Core/Connection.cpp

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_headers.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_headers.cmake
@@ -16,6 +16,8 @@ set(FILES
     Include/ScriptCanvas/Asset/ExecutionLogAssetBus.h
     Include/ScriptCanvas/Asset/RuntimeAsset.h
     Include/ScriptCanvas/Asset/RuntimeAssetHandler.h
+    Include/ScriptCanvas/Asset/RuntimeInputs.h
+    Include/ScriptCanvas/Asset/SubgraphInterfaceAsset.h
     Include/ScriptCanvas/Asset/SubgraphInterfaceAssetHandler.h
     Include/ScriptCanvas/Core/ScriptCanvasBus.h
     Include/ScriptCanvas/Core/ExecutionNotificationsBus.h


### PR DESCRIPTION
Signed-off-by: onecent1101 <liug@amazon.com>

## What does this PR do?
Break down large and mixed header files into smaller pieces with better scope. It is benefit to create a light weighted scriptcanvas target for external gem usage.

## How was this PR tested?
No behavior change, pass existing tests.
