### PR TITLE
Asset Processor - Disable file state cache for asset processor batch

### DIFF
--- a/Code/Tools/AssetProcessor/native/tests/ApplicationManagerTests.h
+++ b/Code/Tools/AssetProcessor/native/tests/ApplicationManagerTests.h
@@ -19,6 +19,7 @@ namespace UnitTests
     struct MockBatchApplicationManager : BatchApplicationManager
     {
         using ApplicationManagerBase::InitFileMonitor;
+        using ApplicationManagerBase::InitFileStateCache;
         using ApplicationManagerBase::m_assetProcessorManager;
         using ApplicationManagerBase::m_fileProcessor;
         using ApplicationManagerBase::m_fileStateCache;

--- a/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
@@ -38,6 +38,8 @@ namespace AssetProcessorMessagesTests
 
         }
 
+        using ApplicationManagerBase::InitFileStateCache;
+
         friend class AssetProcessorMessages;
     };
 
@@ -105,7 +107,7 @@ namespace AssetProcessorMessagesTests
             ASSERT_EQ(status, ApplicationManager::BeforeRunStatus::Status_Success);
 
             m_batchApplicationManager->m_platformConfiguration = new PlatformConfiguration();
-            
+
             AZStd::vector<ApplicationManagerBase::APCommandLineSwitch> commandLineInfo;
             m_batchApplicationManager->InitAssetProcessorManager(commandLineInfo);
 

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.h
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.h
@@ -162,7 +162,7 @@ protected:
     virtual void InitConnectionManager();
     void DestroyConnectionManager();
     void InitAssetRequestHandler(AssetProcessor::AssetRequestHandler* assetRequestHandler);
-    void InitFileStateCache();
+    virtual void InitFileStateCache();
     void CreateQtApplication() override;
 
     bool InitializeInternalBuilders();

--- a/Code/Tools/AssetProcessor/native/utilities/BatchApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/BatchApplicationManager.cpp
@@ -106,6 +106,15 @@ void BatchApplicationManager::InitSourceControl()
     }
 }
 
+void BatchApplicationManager::InitFileStateCache()
+{
+    // File state cache is disabled for batch mode because it relies on the file monitor to function properly.
+    // Since the file monitor is disabled, the cache must be disabled as well.
+    // Note the main reason this is disabled is because intermediate assets can be created during processing which would
+    // need to be recorded in the cache.
+    m_fileStateCache = AZStd::make_unique<AssetProcessor::FileStatePassthrough>();
+}
+
 void BatchApplicationManager::MakeActivationConnections()
 {
     QObject::connect(m_rcController, &AssetProcessor::RCController::FileCompiled,

--- a/Code/Tools/AssetProcessor/native/utilities/BatchApplicationManager.h
+++ b/Code/Tools/AssetProcessor/native/utilities/BatchApplicationManager.h
@@ -40,6 +40,7 @@ private:
     const char* GetLogBaseName() override;
     RegistryCheckInstructions PopupRegistryProblemsMessage(QString warningText) override;
     void InitSourceControl() override;
+    void InitFileStateCache() override;
 
     void MakeActivationConnections() override;
 


### PR DESCRIPTION
## What does this PR do?

Disables the file state cache for APB.

The file state cache requires the file monitor to update its state but the file monitor is disabled in batch mode. Since intermediate assets are created while running, this meant the cache would be out of date.

This was causing a particular problem for atom systems which attempt to look up dependency files using the GetSourceInfo API before declaring a dependency.  The API was always returning that intermediate asset files did not exist, resulting in the atom builder reporting the dependency as a source dependency instead of a job dependency (this is common behavior for atom builders because they work with relative paths that can refer to multiple locations and don't want to spam job dependency errors by reporting dependencies on files that will never exist).

Running batch on a clean cache with the file state cache ENABLED took 737s (approx 12.2 minutes)
With the file state cache DISABLED the same test took 843s (approx 14 minutes)

This change only affects asset processor BATCH and does not affect the GUI mode.

Partial fix for https://github.com/o3de/o3de/issues/12745

## How was this PR tested?

Manually ran APB and verified the passthrough cache is created instead of the actual state cache.
