### PR TITLE
Enable render pipeline modification for cubemap baking render pipeline

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CubeMapCapture/CubeMapRenderer.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CubeMapCapture/CubeMapRenderer.cpp
@@ -35,6 +35,7 @@ namespace AZ
             environmentCubeMapPipelineDesc.m_renderSettings.m_multisampleState = RPI::RPISystemInterface::Get()->GetApplicationMultisampleState();
             environmentCubeMapPipelineDesc.m_renderSettings.m_size.m_width = RPI::EnvironmentCubeMapPass::CubeMapFaceSize;
             environmentCubeMapPipelineDesc.m_renderSettings.m_size.m_height = RPI::EnvironmentCubeMapPass::CubeMapFaceSize;
+            environmentCubeMapPipelineDesc.m_allowModification = true; // Enable pipeline modification since we need to have GI lighting for the baking
 
             // create a unique name for the pipeline
             AZ::Uuid uuid = AZ::Uuid::CreateRandom();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ParentPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ParentPass.cpp
@@ -55,7 +55,10 @@ namespace AZ
         void ParentPass::AddChild(const Ptr<Pass>& child, [[maybe_unused]] bool skipStateCheckWhenRunningTests)
         {
             // Todo: investigate if there's a way for this to not trigger on edge cases such as testing, then turn back into an Error instead of Warning.
-            AZ_Warning("PassSystem", GetPassState() == PassState::Building || IsRootPass() || skipStateCheckWhenRunningTests, "Do not add child passes outside of build phase");
+            if (!(GetPassState() == PassState::Building || IsRootPass() || skipStateCheckWhenRunningTests))
+            {
+                AZ_Warning("PassSystem", false, "Do not add child passes outside of build phase");
+            }
 
             if (child->m_parent != nullptr)
             {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -369,6 +369,7 @@ namespace AZ
             }
 
             pipeline->OnAddedToScene(this);
+            pipeline->ProcessQueuedPassChanges();
 
             TryApplyRenderPipelineChanges(pipeline.get());
 

--- a/Gems/LyShine/Code/Source/LyShineFeatureProcessor.h
+++ b/Gems/LyShine/Code/Source/LyShineFeatureProcessor.h
@@ -29,5 +29,7 @@ namespace LyShine
     private:        
         // AZ::RPI::FeatureProcessor overrides...
         void AddRenderPasses(AZ::RPI::RenderPipeline* renderPipeline) override;
+
+        AZStd::unique_ptr<AZ::RPI::PassRequest> m_passRequest;
     };
 }

--- a/Gems/LyShine/Code/Source/LyShineFeatureProcessor.h
+++ b/Gems/LyShine/Code/Source/LyShineFeatureProcessor.h
@@ -9,6 +9,8 @@
 #pragma once
 
 #include <Atom/RPI.Public/FeatureProcessor.h>
+#include <Atom/RPI.Reflect/System/AnyAsset.h>
+#include <AzCore/Asset/AssetCommon.h>
 
 
 namespace LyShine
@@ -30,6 +32,6 @@ namespace LyShine
         // AZ::RPI::FeatureProcessor overrides...
         void AddRenderPasses(AZ::RPI::RenderPipeline* renderPipeline) override;
 
-        AZStd::unique_ptr<AZ::RPI::PassRequest> m_passRequest;
+        AZ::Data::Asset<AZ::RPI::AnyAsset> m_passRequestAsset;
     };
 }

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.cpp
@@ -131,13 +131,9 @@ namespace Terrain
     }
 
     void TerrainFeatureProcessor::OnRenderPipelineChanged([[maybe_unused]] AZ::RPI::RenderPipeline* renderPipeline,
-        AZ::RPI::SceneNotification::RenderPipelineChangeType changeType)
+        [[maybe_unused]] AZ::RPI::SceneNotification::RenderPipelineChangeType changeType)
     {
-        if (changeType == AZ::RPI::SceneNotification::RenderPipelineChangeType::Added
-            || changeType == AZ::RPI::SceneNotification::RenderPipelineChangeType::PassChanged)
-        {
-            CachePasses();
-        }
+        CachePasses();
     }
 
     void AddPassRequestToRenderPipeline(
@@ -196,7 +192,12 @@ namespace Terrain
     {
         // Get the pass requests to create passes from the asset
         AddPassRequestToRenderPipeline(renderPipeline, "Passes/TerrainPassRequest.azasset", "DepthPrePass", true);
-        AddPassRequestToRenderPipeline(renderPipeline, "Passes/TerrainDebugPassRequest.azasset", "DebugOverlayPass", false);
+
+        // Only add debug pass if the DebugOverlayPass exists
+        if (renderPipeline->FindFirstPass(AZ::Name("DebugOverlayPass")))
+        {
+            AddPassRequestToRenderPipeline(renderPipeline, "Passes/TerrainDebugPassRequest.azasset", "DebugOverlayPass", false);
+        }
     }
 
     void TerrainFeatureProcessor::PrepareMaterialData()


### PR DESCRIPTION
- Fixed issue with invalid pass cached in terrain FP when remove render pipeline
- Check reference pass before insert pass for LyShine FP and Terrain FP

Signed-off-by: Qing Tao <55564570+VickyAtAZ@users.noreply.github.com>

## What does this PR do?
Enable render pipeline modification for cubemap baking render pipeline
Fixed some errors reported by LyShine  feature processor and Terrain feature processor when enable them for cubemap baking

## How was this PR tested?
Open Sponza level in Editor. Add an entity with Cubemap Baker component. In level prefab, add Terrain Renderer and Terrain level components.
Press capture button and see the cubemap was baked successfully with GI baked in the cubemap texture. 
No errors in the editor error window. 

(There are warnings in the output, they will be addressed separately).
