### PR TITLE
Removed strict dependency of O3DE on the MovieSystem (which is a gem)

### DIFF
--- a/Code/Editor/AnimationContext.cpp
+++ b/Code/Editor/AnimationContext.cpp
@@ -149,7 +149,10 @@ CAnimationContext::~CAnimationContext()
 //////////////////////////////////////////////////////////////////////////
 void CAnimationContext::Init()
 {
-    gEnv->pMovieSystem->SetCallback(&s_movieCallback);
+    if (gEnv->pMovieSystem)
+    {
+        gEnv->pMovieSystem->SetCallback(&s_movieCallback);
+    }
 
     REGISTER_COMMAND("mov_goToFrameEditor", (ConsoleCommandFunc)GoToFrameCmd, 0, "Make a specified sequence go to a given frame time in the editor.");
 }
@@ -365,7 +368,11 @@ void CAnimationContext::Pause()
         SetRecordingInternal(false);
     }
 
-    GetIEditor()->GetMovieSystem()->Pause();
+    if (GetIEditor()->GetMovieSystem())
+    {
+        GetIEditor()->GetMovieSystem()->Pause();
+    }
+
     if (m_pSequence)
     {
         m_pSequence->Pause();
@@ -381,7 +388,11 @@ void CAnimationContext::Resume()
     {
         SetRecordingInternal(true);
     }
-    GetIEditor()->GetMovieSystem()->Resume();
+
+    if (GetIEditor()->GetMovieSystem())
+    {
+        GetIEditor()->GetMovieSystem()->Resume();
+    }
 
     if (m_pSequence)
     {
@@ -425,43 +436,44 @@ void CAnimationContext::SetPlaying(bool playing)
     m_recording = false;
     SetRecordingInternal(false);
 
-    if (playing)
+    IMovieSystem* pMovieSystem = GetIEditor()->GetMovieSystem();
+    if (pMovieSystem)
     {
-        IMovieSystem* pMovieSystem = GetIEditor()->GetMovieSystem();
-
-        pMovieSystem->Resume();
-        if (m_pSequence)
+        if (playing)
         {
-            m_pSequence->Resume();
+            pMovieSystem->Resume();
 
-            IMovieUser* pMovieUser = pMovieSystem->GetUser();
-
-            if (pMovieUser)
+            if (m_pSequence)
             {
-                m_pSequence->BeginCutScene(true);
+                m_pSequence->Resume();
+
+                IMovieUser* pMovieUser = pMovieSystem->GetUser();
+
+                if (pMovieUser)
+                {
+                    m_pSequence->BeginCutScene(true);
+                }
             }
+            pMovieSystem->ResumeCutScenes();
         }
-        pMovieSystem->ResumeCutScenes();
-    }
-    else
-    {
-        IMovieSystem* pMovieSystem = GetIEditor()->GetMovieSystem();
-
-        pMovieSystem->Pause();
-
-        if (m_pSequence)
+        else
         {
-            m_pSequence->Pause();
-        }
+            pMovieSystem->Pause();
 
-        pMovieSystem->PauseCutScenes();
-        if (m_pSequence)
-        {
-            IMovieUser* pMovieUser = pMovieSystem->GetUser();
-
-            if (pMovieUser)
+            if (m_pSequence)
             {
-                m_pSequence->EndCutScene();
+                m_pSequence->Pause();
+            }
+
+            pMovieSystem->PauseCutScenes();
+            if (m_pSequence)
+            {
+                IMovieUser* pMovieUser = pMovieSystem->GetUser();
+
+                if (pMovieUser)
+                {
+                    m_pSequence->EndCutScene();
+                }
             }
         }
     }
@@ -479,11 +491,17 @@ void CAnimationContext::Update()
     // If looking through camera object and recording animation, do not allow camera shake
     if ((GetIEditor()->GetViewManager()->GetCameraObjectId() != GUID_NULL) && GetIEditor()->GetAnimation()->IsRecording())
     {
-        GetIEditor()->GetMovieSystem()->EnableCameraShake(false);
+        if (GetIEditor()->GetMovieSystem())
+        {
+            GetIEditor()->GetMovieSystem()->EnableCameraShake(false);
+        }
     }
     else
     {
-        GetIEditor()->GetMovieSystem()->EnableCameraShake(true);
+        if (GetIEditor()->GetMovieSystem())
+        {
+            GetIEditor()->GetMovieSystem()->EnableCameraShake(true);
+        }
     }
 
     if (m_paused > 0 || !(m_playing || m_bAutoRecording))
@@ -495,7 +513,10 @@ void CAnimationContext::Update()
 
         if (!m_recording)
         {
-            GetIEditor()->GetMovieSystem()->StillUpdate();
+            if (GetIEditor()->GetMovieSystem())
+            {
+                GetIEditor()->GetMovieSystem()->StillUpdate();
+            }
         }
 
         return;
@@ -512,8 +533,11 @@ void CAnimationContext::Update()
 
         if (!m_recording)
         {
-            GetIEditor()->GetMovieSystem()->PreUpdate(frameDeltaTime);
-            GetIEditor()->GetMovieSystem()->PostUpdate(frameDeltaTime);
+            if (GetIEditor()->GetMovieSystem())
+            {
+                GetIEditor()->GetMovieSystem()->PreUpdate(frameDeltaTime);
+                GetIEditor()->GetMovieSystem()->PostUpdate(frameDeltaTime);
+            }
         }
     }
     else
@@ -784,7 +808,11 @@ void CAnimationContext::OnEditorNotifyEvent(EEditorNotifyEvent event)
 
 void CAnimationContext::SetRecordingInternal(bool enableRecording)
 {
-    GetIEditor()->GetMovieSystem()->SetRecording(enableRecording);
+    if (GetIEditor()->GetMovieSystem())
+    {
+        GetIEditor()->GetMovieSystem()->SetRecording(enableRecording);
+    }
+
     if (m_pSequence)
     {
         m_pSequence->SetRecording(enableRecording);

--- a/Code/Editor/SelectLightAnimationDialog.cpp
+++ b/Code/Editor/SelectLightAnimationDialog.cpp
@@ -35,26 +35,29 @@ void CSelectLightAnimationDialog::OnInitDialog()
 void CSelectLightAnimationDialog::GetItems(std::vector<SItem>& outItems)
 {
     IMovieSystem* pMovieSystem = GetIEditor()->GetMovieSystem();
-    for (int i = 0; i < pMovieSystem->GetNumSequences(); ++i)
+    if (pMovieSystem)
     {
-        IAnimSequence* pSequence = pMovieSystem->GetSequence(i);
-        if ((pSequence->GetFlags() & IAnimSequence::eSeqFlags_LightAnimationSet) == 0)
+        for (int i = 0; i < pMovieSystem->GetNumSequences(); ++i)
         {
-            continue;
-        }
-
-        for (int k = 0; k < pSequence->GetNodeCount(); ++k)
-        {
-            assert(pSequence->GetNode(k)->GetType() == AnimNodeType::Light);
-            if (pSequence->GetNode(k)->GetType() != AnimNodeType::Light)
+            IAnimSequence* pSequence = pMovieSystem->GetSequence(i);
+            if ((pSequence->GetFlags() & IAnimSequence::eSeqFlags_LightAnimationSet) == 0)
             {
                 continue;
             }
-            SItem item;
-            item.name = pSequence->GetNode(k)->GetName();
-            outItems.push_back(item);
+
+            for (int k = 0; k < pSequence->GetNodeCount(); ++k)
+            {
+                assert(pSequence->GetNode(k)->GetType() == AnimNodeType::Light);
+                if (pSequence->GetNode(k)->GetType() != AnimNodeType::Light)
+                {
+                    continue;
+                }
+                SItem item;
+                item.name = pSequence->GetNode(k)->GetName();
+                outItems.push_back(item);
+            }
+            return;
         }
-        return;
     }
 }
 

--- a/Code/Editor/SelectSequenceDialog.cpp
+++ b/Code/Editor/SelectSequenceDialog.cpp
@@ -33,13 +33,16 @@ CSelectSequenceDialog::OnInitDialog()
 CSelectSequenceDialog::GetItems(std::vector<SItem>& outItems)
 {
     IMovieSystem* pMovieSys = GetIEditor()->GetMovieSystem();
-    for (int i = 0; i < pMovieSys->GetNumSequences(); ++i)
+    if (pMovieSys)
     {
-        IAnimSequence* pSeq = pMovieSys->GetSequence(i);
-        SItem item;
-        AZStd::string fullname = pSeq->GetName();
-        item.name = fullname.c_str();
-        outItems.push_back(item);
+        for (int i = 0; i < pMovieSys->GetNumSequences(); ++i)
+        {
+            IAnimSequence* pSeq = pMovieSys->GetSequence(i);
+            SItem item;
+            AZStd::string fullname = pSeq->GetName();
+            item.name = fullname.c_str();
+            outItems.push_back(item);
+        }
     }
 }
 

--- a/Code/Editor/TrackView/TrackViewPythonFuncs.cpp
+++ b/Code/Editor/TrackView/TrackViewPythonFuncs.cpp
@@ -398,14 +398,21 @@ namespace
             throw std::runtime_error("Couldn't find node");
         }
 
-        const CAnimParamType paramType = GetIEditor()->GetMovieSystem()->GetParamTypeFromString(paramName);
-        CTrackViewTrack* pTrack = pNode->GetTrackForParameter(paramType, index);
-        if (!pTrack)
+        if (GetIEditor()->GetMovieSystem())
         {
-            throw std::runtime_error("Track doesn't exist");
-        }
+            const CAnimParamType paramType = GetIEditor()->GetMovieSystem()->GetParamTypeFromString(paramName);
+            CTrackViewTrack* pTrack = pNode->GetTrackForParameter(paramType, index);
+            if (!pTrack)
+            {
+                throw std::runtime_error("Track doesn't exist");
+            }
 
-        return pTrack;
+            return pTrack;
+        }
+        else
+        {
+            throw std::runtime_error("MovieSystem does not exist");
+        }
     }
 
     std::set<float> GetKeyTimeSet(CTrackViewTrack* pTrack)

--- a/Code/Legacy/CryCommon/IMovieSystem.h
+++ b/Code/Legacy/CryCommon/IMovieSystem.h
@@ -1519,15 +1519,24 @@ struct IMovieSystem
 
 inline void CAnimParamType::SaveToXml(XmlNodeRef& xmlNode) const
 {
-    gEnv->pMovieSystem->SaveParamTypeToXml(*this, xmlNode);
+    if (gEnv->pMovieSystem)
+    {
+        gEnv->pMovieSystem->SaveParamTypeToXml(*this, xmlNode);
+    }
 }
 
 inline void CAnimParamType::LoadFromXml(const XmlNodeRef& xmlNode, const uint version)
 {
-    gEnv->pMovieSystem->LoadParamTypeFromXml(*this, xmlNode, version);
+    if (gEnv->pMovieSystem)
+    {
+        gEnv->pMovieSystem->LoadParamTypeFromXml(*this, xmlNode, version);
+    }
 }
 
 inline void CAnimParamType::Serialize(XmlNodeRef& xmlNode, bool bLoading, const uint version)
 {
-    gEnv->pMovieSystem->SerializeParamType(*this, xmlNode, bLoading, version);
+    if (gEnv->pMovieSystem)
+    {
+        gEnv->pMovieSystem->SerializeParamType(*this, xmlNode, bLoading, version);
+    }
 }

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1068,13 +1068,6 @@ AZ_POP_DISABLE_WARNING
     // Execute any deferred commands that uses the CVar commands that were just registered
     AZ::Interface<AZ::IConsole>::Get()->ExecuteDeferredConsoleCommands();
 
-    // Verify that the Maestro Gem initialized the movie system correctly. This can be removed if and when Maestro is not a required Gem
-    if (gEnv->IsEditor() && !gEnv->pMovieSystem)
-    {
-        AZ_Assert(false, "Error initializing the Cinematic System. Please check that the Maestro Gem is enabled for this project.");
-        return false;
-    }
-
     if (ISystemEventDispatcher* systemEventDispatcher = GetISystemEventDispatcher())
     {
         systemEventDispatcher->OnSystemEvent(ESYSTEM_EVENT_GAME_POST_INIT, 0, 0);


### PR DESCRIPTION
Signed-off-by: Luis Sempé <58790905+lsemp3d@users.noreply.github.com>

## What does this PR do?

The MovieSystem is implemented by the Maestro gem, if this gem is not part of the project or built into the engine the engine would fail to run. Given that gems are optional components, I removed the strict dependency and safeguarded calls to retrieve the IMovieSystem. 

No longer show TrackView as an option if no MovieSystem is present.

## How was this PR tested?

Ran the editor, verified no crashes, then verified TrackView no longer shows in the tools menu
