### PR TITLE
Asset browser: implement switching between layouts

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -141,17 +141,20 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
     if (!ed_useWIPAssetBrowserDesign)
     {
         m_ui->m_middleStackWidget->hide();
+        m_ui->m_treeViewButton->hide();
         m_ui->m_thumbnailViewButton->hide();
-        m_ui->m_listViewButton->hide();
+        m_ui->m_tableViewButton->hide();
     }
 
-    m_ui->horizontalLayout->setAlignment(m_ui->m_listViewButton, Qt::AlignTop);
-    m_ui->horizontalLayout->setAlignment(m_ui->m_thumbnailViewButton, Qt::AlignTop);
     m_ui->horizontalLayout->setAlignment(m_ui->m_toggleDisplayViewBtn, Qt::AlignTop);
     m_ui->horizontalLayout->setAlignment(m_ui->m_collapseAllButton, Qt::AlignTop);
+    m_ui->horizontalLayout->setAlignment(m_ui->m_treeViewButton, Qt::AlignTop);
+    m_ui->horizontalLayout->setAlignment(m_ui->m_tableViewButton, Qt::AlignTop);
+    m_ui->horizontalLayout->setAlignment(m_ui->m_thumbnailViewButton, Qt::AlignTop);
 
-    connect(m_ui->m_thumbnailViewButton, &QAbstractButton::clicked, this, [this] { m_ui->m_middleStackWidget->setCurrentIndex(0); });
-    connect(m_ui->m_listViewButton, &QAbstractButton::clicked, this, [this] { m_ui->m_middleStackWidget->setCurrentIndex(1); });
+    connect(m_ui->m_thumbnailViewButton, &QAbstractButton::clicked, this, [this] { SetTwoColumnMode(m_ui->m_thumbnailView); });
+    connect(m_ui->m_tableViewButton, &QAbstractButton::clicked, this, [this] { SetTwoColumnMode(m_ui->m_tableView); });
+    connect(m_ui->m_treeViewButton, &QAbstractButton::clicked, this, &AzAssetBrowserWindow::SetOneColumnMode);
 
     m_ui->m_assetBrowserTreeViewWidget->setModel(m_filterModel.data());
 
@@ -331,6 +334,17 @@ void AzAssetBrowserWindow::UpdatePreview() const
     }
 
     m_ui->m_previewerFrame->Display(selectedAssets.front());
+}
+
+void AzAssetBrowserWindow::SetTwoColumnMode(QWidget* viewToShow)
+{
+    m_ui->m_middleStackWidget->show();
+    m_ui->m_middleStackWidget->setCurrentWidget(viewToShow);
+}
+
+void AzAssetBrowserWindow::SetOneColumnMode()
+{
+    m_ui->m_middleStackWidget->hide();
 }
 
 static void ExpandTreeToIndex(QTreeView* treeView, const QModelIndex& index)

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.h
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.h
@@ -69,6 +69,8 @@ protected slots:
     void SetTreeViewMode();
     void SetListViewMode();
     void UpdateWidgetAfterFilter();
+    void SetTwoColumnMode(QWidget* viewToShow);
+    void SetOneColumnMode();
 
 private:
     QScopedPointer<Ui::AzAssetBrowserWindowClass> m_ui;

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.ui
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.ui
@@ -116,6 +116,23 @@
           </widget>
          </item>
          <item>
+          <widget class="QToolButton" name="m_treeViewButton">
+           <property name="text">
+            <string>...</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../Framework/AzQtComponents/AzQtComponents/Components/resources.qrc">
+             <normaloff>:/stylesheet/img/UI20/browse-edit-select-files.svg</normaloff>:/stylesheet/img/UI20/browse-edit-select-files.svg</iconset>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">m_viewSelectButtonGroup</string>
+           </attribute>
+          </widget>
+         </item>
+         <item>
           <widget class="QToolButton" name="m_thumbnailViewButton">
            <property name="icon">
             <iconset resource="../../Framework/AzQtComponents/AzQtComponents/Components/resources.qrc">
@@ -133,7 +150,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QToolButton" name="m_listViewButton">
+          <widget class="QToolButton" name="m_tableViewButton">
            <property name="text">
             <string>...</string>
            </property>
@@ -272,13 +289,13 @@
             <height>0</height>
            </size>
           </property>
-          <widget class="QWidget" name="m_iconView">
+          <widget class="QWidget" name="m_thumbnailView">
            <layout class="QVBoxLayout" name="m_iconViewLayout">
             <property name="spacing">
              <number>0</number>
             </property>
             <item>
-             <widget class="QLabel" name="m_iconViewPlaceholder">
+             <widget class="QLabel" name="m_thumbnailViewPlaceholder">
               <property name="text">
                <string>Icon view placeholder</string>
               </property>


### PR DESCRIPTION
I also renamed some widgets in the UI file to have consistent naming.

We now have:
 - List View
 - Thumbnail View
 - Tree view

Fixes #12855

Signed-off-by: Miłosz Kosobucki <milosz@kosobucki.pl>

## What does this PR do?

A new button is introduced that lets the user show/hide the middle stack view

https://user-images.githubusercontent.com/104767/200311019-961d2995-0cf9-439b-8ab5-3098919e9a59.mp4


## How was this PR tested?

Manual testing and running EditorLib unit tests.