### PR TITLE
[Terrain] Auto-scaling brush size ranges

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettings.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettings.h
@@ -143,6 +143,11 @@ namespace AzToolsFramework
             return m_size;
         }
 
+        AZStd::pair<float, float> GetSizeRange() const
+        {
+            return { m_sizeMin, m_sizeMax };
+        }
+
         float GetHardnessPercent() const
         {
             return m_hardnessPercent;
@@ -157,6 +162,7 @@ namespace AzToolsFramework
         }
 
         void SetSize(float size);
+        void SetSizeRange(float minSize, float maxSize);
         void SetHardnessPercent(float hardnessPercent);
         void SetFlowPercent(float flowPercent);
         void SetDistancePercent(float distancePercent);
@@ -182,6 +188,10 @@ namespace AzToolsFramework
         bool GetBlendModeVisibility() const;
         bool GetSmoothModeVisibility() const;
 
+        float GetSizeMin() const;
+        float GetSizeMax() const;
+        float GetSizeStep() const;
+
         //! Brush settings brush mode
         PaintBrushMode m_brushMode = PaintBrushMode::Paintbrush;
 
@@ -197,6 +207,9 @@ namespace AzToolsFramework
 
         //! Brush stamp diameter in meters
         float m_size = 10.0f;
+        float m_sizeMin = 0.0f;
+        float m_sizeMax = 1024.0f;
+
         //! Brush stamp hardness percent (0=soft falloff, 100=hard edge)
         float m_hardnessPercent = 100.0f;
         //! Brush stamp flow percent (0=transparent stamps, 100=opaque stamps)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettingsRequestBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettingsRequestBus.h
@@ -73,6 +73,12 @@ namespace AzToolsFramework
         //! @return The size of the paintbrush in meters
         virtual float GetSize() const = 0;
 
+        //! Returns the brush stamp min/max size range.
+        //! The range is used to ensure that our brush size is appropriately sized relative to the world size of the data we're painting.
+        //! If we let it get too big, we can run into serious performance issues.
+        //! @return A pair containing the min size and max size that constrain the range of sizes in meters for the paintbrush.
+        virtual AZStd::pair<float, float> GetSizeRange() const = 0;
+
         //! Returns the brush stamp hardness (0=soft falloff, 100=hard edge).
         virtual float GetHardnessPercent() const = 0;
 
@@ -85,6 +91,13 @@ namespace AzToolsFramework
         //! Sets the brush stamp size (diameter).
         //! @param size The new size, in meters.
         virtual void SetSize(float size) = 0;
+
+        //! Sets the brush stamp min/max size range.
+        //! The range is used to ensure that our brush size is appropriately sized relative to the world size of the data we're painting.
+        //! If we let it get too big, we can run into serious performance issues.
+        //! @param minSize The minimum size of the paint brush in meters.
+        //! @param maxSize The maximum size of the paint brush in meters.
+        virtual void SetSizeRange(float minSize, float maxSize) = 0;
 
         //! Sets the brush stamp hardness.
         //! @param hardness The new hardness, in 0-100 range.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettingsSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettingsSystemComponent.cpp
@@ -71,6 +71,11 @@ namespace AzToolsFramework
         return m_settings.GetSize();
     }
 
+    AZStd::pair<float, float> PaintBrushSettingsSystemComponent::GetSizeRange() const
+    {
+        return m_settings.GetSizeRange();
+    }
+
     AZ::Color PaintBrushSettingsSystemComponent::GetColor() const
     {
         return m_settings.GetColor();
@@ -104,6 +109,11 @@ namespace AzToolsFramework
     void PaintBrushSettingsSystemComponent::SetSize(float size)
     {
         m_settings.SetSize(size);
+    }
+
+    void PaintBrushSettingsSystemComponent::SetSizeRange(float minSize, float maxSize)
+    {
+        m_settings.SetSizeRange(minSize, maxSize);
     }
 
     void PaintBrushSettingsSystemComponent::SetColor(const AZ::Color& color)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettingsSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrushSettings/PaintBrushSettingsSystemComponent.h
@@ -40,6 +40,7 @@ namespace AzToolsFramework
         PaintBrushColorMode GetBrushColorMode() const override;
         void SetBrushColorMode(PaintBrushColorMode colorMode) override;
         float GetSize() const override;
+        AZStd::pair<float, float> GetSizeRange() const override;
         AZ::Color GetColor() const override;
         float GetHardnessPercent() const override;
         float GetFlowPercent() const override;
@@ -47,6 +48,7 @@ namespace AzToolsFramework
         PaintBrushBlendMode GetBlendMode() const override;
         PaintBrushSmoothMode GetSmoothMode() const override;
         void SetSize(float size) override;
+        void SetSizeRange(float minSize, float maxSize) override;
         void SetColor(const AZ::Color& color) override;
         void SetHardnessPercent(float hardnessPercent) override;
         void SetFlowPercent(float flowPercent) override;

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.cpp
@@ -430,16 +430,20 @@ namespace GradientSignal
     {
         AZ_Assert(m_paintBrushUndoBuffer != nullptr, "Undo batch is expected to exist while painting");
 
-        // Expand the dirty region for this brush stroke by one pixel in each direction
-        // to account for any data affected by bilinear filtering as well.
-        m_paintStrokeData.m_dirtyRegion.Expand(AZ::Vector3(m_paintStrokeData.m_metersPerPixelX, m_paintStrokeData.m_metersPerPixelY, 0.0f));
+        if (m_paintStrokeData.m_dirtyRegion.IsValid())
+        {
+            // Expand the dirty region for this brush stroke by one pixel in each direction
+            // to account for any data affected by bilinear filtering as well.
+            m_paintStrokeData.m_dirtyRegion.Expand(
+                AZ::Vector3(m_paintStrokeData.m_metersPerPixelX, m_paintStrokeData.m_metersPerPixelY, 0.0f));
 
-        // Expand the dirty region to encompass the full Z range since image gradients are 2D.
-        auto dirtyRegionMin = m_paintStrokeData.m_dirtyRegion.GetMin();
-        auto dirtyRegionMax = m_paintStrokeData.m_dirtyRegion.GetMax();
-        m_paintStrokeData.m_dirtyRegion.Set(
-            AZ::Vector3(dirtyRegionMin.GetX(), dirtyRegionMin.GetY(), AZStd::numeric_limits<float>::lowest()),
-            AZ::Vector3(dirtyRegionMax.GetX(), dirtyRegionMax.GetY(), AZStd::numeric_limits<float>::max()));
+            // Expand the dirty region to encompass the full Z range since image gradients are 2D.
+            auto dirtyRegionMin = m_paintStrokeData.m_dirtyRegion.GetMin();
+            auto dirtyRegionMax = m_paintStrokeData.m_dirtyRegion.GetMax();
+            m_paintStrokeData.m_dirtyRegion.Set(
+                AZ::Vector3(dirtyRegionMin.GetX(), dirtyRegionMin.GetY(), AZStd::numeric_limits<float>::lowest()),
+                AZ::Vector3(dirtyRegionMax.GetX(), dirtyRegionMax.GetY(), AZStd::numeric_limits<float>::max()));
+        }
 
         // Hand over ownership of the paint stroke buffer to the undo/redo buffer.
         m_paintBrushUndoBuffer->SetUndoBufferAndDirtyArea(


### PR DESCRIPTION
## What does this PR do?

When using the image gradient paintbrush, the number of pixels per meter in world space changes based on how the image gradient is mapped into the world. This PR scales the min/max sizes of the brush relative to the image gradient scale so that we don't let the user pick brushes that are too large relative to the image density and would destroy performance.

There doesn't fix _all_ of the performance problems introduced by a high density though, because rapid large world-space mouse movements with a small brush will still generate a vast number of points to compute. This would need additional fixes outside the scope of this PR. (Possibly clamping the max speed of brush movements for example) 

## How was this PR tested?

Tested with images mapped at 512 pixels to 1 meter, 512 pixels to 512 meters, at 8192 pixels to 1024 meters. The brush size ranges scaled appropriately.
