### PR TITLE
Fix template/gem missing without projects add test

### DIFF
--- a/scripts/o3de/o3de/manifest.py
+++ b/scripts/o3de/o3de/manifest.py
@@ -686,10 +686,15 @@ def get_registered(engine_name: str = None,
             gems = get_all_gems(project_path)
         else:
             # If project_path is not supplied
-            # query all registered projects
-            for registered_project_path in get_all_projects():
-                gems.extend(get_all_gems(registered_project_path))
-            gems = list(dict.fromkeys(gems))
+            registered_project_paths = get_all_projects()
+            if not registered_project_paths:
+                # query all gems from this engine if no projects exist
+                gems = get_all_gems()
+            else:
+                # query all registered projects
+                for registered_project_path in registered_project_paths:
+                    gems.extend(get_all_gems(registered_project_path))
+                gems = list(dict.fromkeys(gems))
 
         for gem_path in gems:
             gem_path = pathlib.Path(gem_path).resolve()
@@ -713,10 +718,15 @@ def get_registered(engine_name: str = None,
             templates = get_all_templates(project_path)
         else:
             # If project_path is not supplied
-            # query all registered projects
-            for registered_project_path in get_all_projects():
-                templates.extend(get_all_templates(registered_project_path))
-            templates = list(dict.fromkeys(templates))
+            registered_project_paths = get_all_projects()
+            if not registered_project_paths:
+                # if no projects exist, query all templates from this engine and gems
+                templates = get_all_templates()
+            else:
+                # query all registered projects
+                for registered_project_path in registered_project_paths:
+                    templates.extend(get_all_templates(registered_project_path))
+                templates = list(dict.fromkeys(templates))
 
         for template_path in templates:
             template_path = pathlib.Path(template_path).resolve()

--- a/scripts/o3de/tests/test_manifest.py
+++ b/scripts/o3de/tests/test_manifest.py
@@ -374,6 +374,11 @@ class TestManifestGetRegistered:
         return pathlib.Path('D:/o3de/o3de')
 
     @staticmethod
+    def is_file(self) -> bool:
+        # use a simple suffix check to avoid hitting the actual file system
+        return self.suffix != ''
+
+    @staticmethod
     def resolve(self):
         return self
 
@@ -408,11 +413,6 @@ class TestManifestGetRegistered:
                 manifest_payload['projects'] = []
                 return manifest_payload
 
-            def is_file(path : pathlib.Path) -> bool:
-                if path.match("*.json"):
-                    return True
-                return False
-
             with patch('o3de.manifest.get_engine_json_data', side_effect=get_engine_json_data) as _1, \
                 patch('o3de.manifest.get_project_json_data', side_effect=get_project_json_data) as _2, \
                 patch('o3de.manifest.get_gem_json_data', side_effect=get_gem_json_data) as _3, \
@@ -420,7 +420,7 @@ class TestManifestGetRegistered:
                 patch('pathlib.Path.resolve', self.resolve) as _5, \
                 patch('pathlib.Path.samefile', self.samefile) as _6, \
                 patch('pathlib.Path.open', return_value=io.StringIO(TEST_PROJECT_TEMPLATE_JSON_PAYLOAD)) as _7, \
-                patch('pathlib.Path.is_file', new=is_file) as _8,\
+                patch('pathlib.Path.is_file', self.is_file) as _8,\
                 patch('o3de.manifest.get_this_engine_path', side_effect=self.get_this_engine_path) as _9: 
 
                 path = manifest.get_registered(template_name=template_name)

--- a/scripts/o3de/tests/test_manifest.py
+++ b/scripts/o3de/tests/test_manifest.py
@@ -370,6 +370,10 @@ class TestGetAllGems:
 
 class TestManifestGetRegistered:
     @staticmethod
+    def get_this_engine_path() -> pathlib.Path:
+        return pathlib.Path('D:/o3de/o3de')
+
+    @staticmethod
     def resolve(self):
         return self
 
@@ -377,16 +381,16 @@ class TestManifestGetRegistered:
     def samefile(self, otherFile):
         return self.as_posix() == otherFile.as_posix()
 
-    @pytest.mark.parametrize("template_name, expected_path", [
-            pytest.param('DefaultProject', pathlib.Path('C:/o3de/o3de/Templates/DefaultProject')),
-            pytest.param('InvalidProject', None)
+    @pytest.mark.parametrize("template_name, relative_template_path, expected_path", [
+            pytest.param('DefaultProject', pathlib.Path('Templates/DefaultProject'), pathlib.Path('D:/o3de/o3de/Templates/DefaultProject'), ),
+            pytest.param('InvalidProject', pathlib.Path('Templates/DefaultProject'), None)
     ])
-    def test_get_registered_template(self, template_name, expected_path):
+    def test_get_registered_template(self, template_name, relative_template_path, expected_path):
             def get_engine_json_data(engine_name: str = None,
                                     engine_path: str or pathlib.Path = None) -> dict or None:
                 engine_payload = json.loads(TEST_ENGINE_JSON_PAYLOAD)
                 if expected_path:
-                    engine_payload['templates'] = [expected_path]
+                    engine_payload['templates'] = [relative_template_path]
                 return engine_payload
 
             def get_gem_json_data(gem_name: str = None,
@@ -416,7 +420,8 @@ class TestManifestGetRegistered:
                 patch('pathlib.Path.resolve', self.resolve) as _5, \
                 patch('pathlib.Path.samefile', self.samefile) as _6, \
                 patch('pathlib.Path.open', return_value=io.StringIO(TEST_PROJECT_TEMPLATE_JSON_PAYLOAD)) as _7, \
-                patch('pathlib.Path.is_file', new=is_file) as _8:
+                patch('pathlib.Path.is_file', new=is_file) as _8,\
+                patch('o3de.manifest.get_this_engine_path', side_effect=self.get_this_engine_path) as _9: 
 
                 path = manifest.get_registered(template_name=template_name)
                 assert path == expected_path

--- a/scripts/o3de/tests/test_manifest.py
+++ b/scripts/o3de/tests/test_manifest.py
@@ -6,6 +6,7 @@
 #
 #
 
+import io
 import json
 import pytest
 import pathlib
@@ -38,6 +39,12 @@ TEST_GEM_JSON_PAYLOAD = '''
     ],
     "external_subdirectories": [
     ]
+}
+'''
+
+TEST_PROJECT_TEMPLATE_JSON_PAYLOAD = '''
+{
+    "template_name": "DefaultProject"
 }
 '''
 
@@ -168,7 +175,7 @@ class TestGetTemplatesForCreation:
             pytest.param([pathlib.Path('D:/o3de/Templates/DefaultProject')])
         ]
     )
-    def test_get_templates_for_gem_creation(self, valid_project_json_paths, valid_gem_json_paths,
+    def test_get_templates_for_project_creation(self, valid_project_json_paths, valid_gem_json_paths,
                                                 expected_template_paths):
         def validate_project_json(project_json_path) -> bool:
             return pathlib.Path(project_json_path) in valid_project_json_paths
@@ -204,7 +211,7 @@ class TestGetTemplatesForCreation:
             pytest.param([pathlib.Path('D:/o3de/Templates/DefaultGem')])
         ]
     )
-    def test_get_templates_for_project_creation(self, valid_project_json_paths, valid_gem_json_paths,
+    def test_get_templates_for_gem_creation(self, valid_project_json_paths, valid_gem_json_paths,
                                                 expected_template_paths):
         def validate_project_json(project_json_path) -> bool:
             return pathlib.Path(project_json_path) in valid_project_json_paths
@@ -360,6 +367,59 @@ class TestGetAllGems:
             manifest.get_gem_external_subdirectories(gem_path, list())
 
             assert self.cycle_detected == expected_cycle_detected
+
+class TestManifestGetRegistered:
+    @staticmethod
+    def resolve(self):
+        return self
+
+    @staticmethod
+    def samefile(self, otherFile ):
+        return self.as_posix() == otherFile.as_posix()
+
+    @pytest.mark.parametrize("template_name, expected_path", [
+            pytest.param('DefaultProject', pathlib.Path('C:/o3de/o3de/Templates/DefaultProject')),
+            pytest.param('InvalidProject', None)
+    ])
+    def test_get_registered_template(self, template_name, expected_path):
+            def get_engine_json_data(engine_name: str = None,
+                                    engine_path: str or pathlib.Path = None) -> dict or None:
+                engine_payload = json.loads(TEST_ENGINE_JSON_PAYLOAD)
+                if expected_path:
+                    engine_payload['templates'] = [expected_path]
+                return engine_payload
+
+            def get_gem_json_data(gem_name: str = None,
+                                    gem_path: str or pathlib.Path = None) -> dict or None:
+                gem_payload = json.loads(TEST_GEM_JSON_PAYLOAD)
+                return gem_payload
+
+            def get_project_json_data(project_name: str = None,
+                                    project_path: str or pathlib.Path = None) -> dict or None:
+                project_payload = json.loads(TEST_PROJECT_JSON_PAYLOAD)
+                return project_payload
+
+            def load_o3de_manifest(manifest_path: pathlib.Path = None) -> dict:
+                manifest_payload = json.loads(TEST_O3DE_MANIFEST_JSON_PAYLOAD)
+                manifest_payload['projects'] = []
+                return manifest_payload
+
+            def is_file(path : pathlib.Path) -> bool:
+                if path.match("*.json"):
+                    return True
+                return False
+
+            with patch('o3de.manifest.get_engine_json_data', side_effect=get_engine_json_data) as _1, \
+                patch('o3de.manifest.get_project_json_data', side_effect=get_project_json_data) as _2, \
+                patch('o3de.manifest.get_gem_json_data', side_effect=get_gem_json_data) as _3, \
+                patch('o3de.manifest.load_o3de_manifest', side_effect=load_o3de_manifest) as _4, \
+                patch('pathlib.Path.resolve', self.resolve) as _5, \
+                patch('pathlib.Path.samefile', self.samefile) as _6, \
+                patch('pathlib.Path.open', return_value=io.StringIO(TEST_PROJECT_TEMPLATE_JSON_PAYLOAD)) as _7, \
+                patch('pathlib.Path.is_file', new=is_file) as _8:
+
+                path = manifest.get_registered(template_name=template_name)
+                assert path == expected_path
 
 class TestManifestProjects:
     @staticmethod

--- a/scripts/o3de/tests/test_manifest.py
+++ b/scripts/o3de/tests/test_manifest.py
@@ -374,7 +374,7 @@ class TestManifestGetRegistered:
         return self
 
     @staticmethod
-    def samefile(self, otherFile ):
+    def samefile(self, otherFile):
         return self.as_posix() == otherFile.as_posix()
 
     @pytest.mark.parametrize("template_name, expected_path", [


### PR DESCRIPTION
Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>

## What does this PR do?
1. Fix an issue where template/gem discovery fails when no projects are registered which is the case when using the Installer.
2. Fixed a minor naming issue where gem/projects were misnamed.
3. Add a unit test for template discovery

Closes #13020 

This should fix our installer tests which failed to create a Project because the DefaultProject template could not be found.
Applied the fix in the installer SDK and verified the `create-project` now succeeds

## How was this PR tested?

- Unit test added, verified test failed before the change and succeeded after
