### PR TITLE
Simplified `construct_at` SFINAE to avoid internal compiler error in

### DIFF
--- a/Code/Framework/AzCore/AzCore/Memory/AllocatorManager.h
+++ b/Code/Framework/AzCore/AzCore/Memory/AllocatorManager.h
@@ -34,13 +34,11 @@ namespace AZ
         friend IAllocator;
         friend class AllocatorBase;
         friend class Debug::AllocationRecords;
-        template<typename T, typename... Args> friend constexpr auto AZStd::construct_at(T*, Args&&... args)
-            ->AZStd::enable_if_t<AZStd::is_void_v<AZStd::void_t<decltype(new (AZStd::declval<void*>()) T(AZStd::forward<Args>(args)...))>>, T*>;
-        template<typename T> constexpr friend void AZStd::destroy_at(T*);
 
     public:
 
         AllocatorManager();
+        ~AllocatorManager();
 
         typedef AZStd::function<void (IAllocator* allocator, size_t /*byteSize*/, size_t /*alignment*/, int/* flags*/, const char* /*name*/, const char* /*fileName*/, int lineNum /*=0*/)>    OutOfMemoryCBType;
 
@@ -167,8 +165,6 @@ namespace AZ
 
         AZ::Debug::AllocationRecords::Mode m_defaultTrackingRecordMode;
         AZStd::unique_ptr<AZ::MallocSchema, void(*)(AZ::MallocSchema*)> m_mallocSchema;
-
-        ~AllocatorManager();
 
         static AllocatorManager g_allocMgr;    ///< The single instance of the allocator manager
     };

--- a/Code/Framework/AzCore/AzCore/Name/NameDictionary.h
+++ b/Code/Framework/AzCore/AzCore/Name/NameDictionary.h
@@ -56,10 +56,6 @@ namespace AZ
         template<class ConcurrentcyTestThreadT>
         friend void UnitTest::RunConcurrencyTest(uint32_t nameCount, uint32_t threadsPerName);
 
-        template<typename T, typename... Args> friend constexpr auto AZStd::construct_at(T*, Args&&... args)
-            -> AZStd::enable_if_t<AZStd::is_void_v<AZStd::void_t<decltype(new (AZStd::declval<void*>()) T(AZStd::forward<Args>(args)...))>>, T*>;
-        template<typename T> constexpr friend void AZStd::destroy_at(T*);
-
     public:
         AZ_TYPE_INFO(NameDictionary, "{6DBF9DEA-1F65-44DB-977C-65BA9047E869}");
         static void Create();

--- a/Code/Framework/AzCore/AzCore/std/createdestroy.h
+++ b/Code/Framework/AzCore/AzCore/std/createdestroy.h
@@ -191,7 +191,7 @@ namespace AZStd
     //! `new (declval<void*>()) T(declval<Args>()...)` is well-formed
     template <typename T, typename... Args>
     constexpr auto construct_at(T* ptr, Args&&... args)
-        -> enable_if_t<AZStd::is_void_v<AZStd::void_t<decltype(new (AZStd::declval<void*>()) T(AZStd::forward<Args>(args)...))>>, T*>
+        -> decltype(new (AZStd::declval<void*>()) T(AZStd::forward<Args>(args)...), (T*)nullptr)
     {
         return ::new (ptr) T(AZStd::forward<Args>(args)...);
     }


### PR DESCRIPTION
VS2022

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Built AzCore.Tests using VS2022 
