### PR TITLE
adding platform support for editing gem properties in python CLI

### DIFF
--- a/scripts/o3de/o3de/gem_properties.py
+++ b/scripts/o3de/o3de/gem_properties.py
@@ -59,6 +59,9 @@ def edit_gem_props(gem_path: pathlib.Path = None,
                    new_tags: list or str = None,
                    remove_tags: list or str = None,
                    replace_tags: list or str = None,
+                   new_platforms: list or str = None,
+                   remove_platforms: list or str = None,
+                   replace_platforms: list or str = None
                    ) -> int:
 
     if not gem_path and not gem_name:
@@ -103,6 +106,9 @@ def edit_gem_props(gem_path: pathlib.Path = None,
 
     update_key_dict['user_tags'] = update_values_in_key_list(gem_json_data.get('user_tags', []), new_tags,
                                                      remove_tags, replace_tags)
+    
+    update_key_dict['platforms'] = update_values_in_key_list(gem_json_data.get('platforms', []), new_platforms,
+                                                     remove_platforms, replace_platforms)
 
     gem_json_data.update(update_key_dict)
 
@@ -161,6 +167,12 @@ def add_parser_args(parser):
                        help='Removes tag(s) from the user_tags property. Can be specified multiple times.')
     group.add_argument('-rt', '--replace-tags', type=str, nargs='*', required=False,
                        help='Replace tag(s) in user_tags property. Can be specified multiple times.')
+    group.add_argument('-apl', '--add-platforms', type=str, nargs='*', required=False,
+                       help='Adds platform(s) to platforms property. Can be specified multiple times.')
+    group.add_argument('-dpl', '--remove-platforms', type=str, nargs='*', required=False,
+                       help='Removes platform(s) from the platforms property. Can be specified multiple times.')
+    group.add_argument('-rpl', '--replace-platforms', type=str, nargs='*', required=False,
+                       help='Replace platform(s) in platforms property. Can be specified multiple times.')
     parser.set_defaults(func=_edit_gem_props)
 
 

--- a/scripts/o3de/tests/test_gem_properties.py
+++ b/scripts/o3de/tests/test_gem_properties.py
@@ -28,6 +28,8 @@ TEST_GEM_JSON_PAYLOAD = '''
     "user_tags": [
         "TestGem"
     ],
+    "platforms": [
+    ],
     "icon_path": "preview.png",
     "requirements": "",
     "documentation_url": "https://o3de.org/docs/",
@@ -49,29 +51,36 @@ class TestEditGemProperties:
     @pytest.mark.parametrize("gem_path, gem_name, gem_new_name, gem_display, gem_origin,\
                             gem_type, gem_summary, gem_icon, gem_requirements, gem_documentation_url,\
                             gem_license, gem_license_url, add_tags, remove_tags, replace_tags,\
-                            expected_tags, expected_result", [
+                            expected_tags, add_platforms, remove_platforms, replace_platforms, expected_platforms,\
+                            expected_result", [
         pytest.param(pathlib.PurePath('D:/TestProject'),
                      None, 'TestGem2', 'New Gem Name', 'O3DE', 'Code', 'Gem that exercises Default Gem Template',
                      'new_preview.png', 'Do this extra thing', 'https://o3de.org/docs/user-guide/gems/',
                      'Apache 2.0', 'https://www.apache.org/licenses/LICENSE-2.0',
                      ['Physics', 'Rendering', 'Scripting'], None, None, ['TestGem', 'Physics', 'Rendering', 'Scripting'],
+                     ['Windows', 'MacOS', 'Linux'], None, None, ['Windows', 'MacOS', 'Linux'],
                      0),
         pytest.param(None,
                      'TestGem2', None, 'New Gem Name', 'O3DE', 'Asset', 'Gem that exercises Default Gem Template',
                      'new_preview.png', 'Do this extra thing', 'https://o3de.org/docs/user-guide/gems/', 
                      'Apache 2.0', 'https://www.apache.org/licenses/LICENSE-2.0',
-                     None, ['Physics'], None, ['TestGem', 'Rendering', 'Scripting'], 0),
+                     None, ['Physics'], None, ['TestGem', 'Rendering', 'Scripting'], 
+                     ['Windows', 'MacOS'], ['Linux'], None, ['Windows', 'MacOS'],
+                     0),
         pytest.param(None,
                      'TestGem2', None, 'New Gem Name', 'O3DE', 'Tool', 'Gem that exercises Default Gem Template',
                      'new_preview.png', 'Do this extra thing', 'https://o3de.org/docs/user-guide/gems/',
                      'Apache 2.0', 'https://www.apache.org/licenses/LICENSE-2.0',
-                     None, None, ['Animation', 'TestGem'], ['Animation', 'TestGem'], 0)
+                     None, None, ['Animation', 'TestGem'], ['Animation', 'TestGem'],
+                     ['Windows'], None, ['MacOS', 'Linux'], ['MacOS', 'Linux'],
+                     0)
         ]
     )
     def test_edit_gem_properties(self, gem_path, gem_name, gem_new_name, gem_display, gem_origin,
                                     gem_type, gem_summary, gem_icon, gem_requirements, 
                                     gem_documentation_url, gem_license, gem_license_url, add_tags, remove_tags,
-                                    replace_tags, expected_tags, expected_result):
+                                    replace_tags, expected_tags, add_platforms, remove_platforms, replace_platforms,
+                                    expected_platforms, expected_result):
 
         def get_gem_json_data(gem_path: pathlib.Path) -> dict:
             return self.gem_json.data
@@ -89,7 +98,8 @@ class TestEditGemProperties:
             result = gem_properties.edit_gem_props(gem_path, gem_name, gem_new_name, gem_display, gem_origin,
                                                    gem_type, gem_summary, gem_icon, gem_requirements,
                                                    gem_documentation_url, gem_license, gem_license_url,
-                                                   add_tags, remove_tags, replace_tags)
+                                                   add_tags, remove_tags, replace_tags,
+                                                   add_platforms, remove_platforms, replace_platforms)
             assert result == expected_result
             if gem_new_name:
                 assert self.gem_json.data.get('gem_name', '') == gem_new_name
@@ -113,3 +123,5 @@ class TestEditGemProperties:
                 assert self.gem_json.data.get('license_url', '') == gem_license_url
 
             assert set(self.gem_json.data.get('user_tags', [])) == set(expected_tags)
+
+            assert set(self.gem_json.data.get('platforms', [])) == set(expected_platforms)


### PR DESCRIPTION
Signed-off-by: T.J. Kotha <112996779+tkothadev@users.noreply.github.com>

## What does this PR do?
This PR provides the ability to specify platforms for gems in `edit_gem_props` in `gem_properties.py` of the o3de CLI tooling.

## How was this PR tested?

Unit tests have been updated to test for platform changes. The tests are passing.

```
c:\workspace\o3de(Prism/PythonPlatformSupportEditGemProperties -> upstream)
λ python\python.cmd -m pytest scripts\o3de\tests\test_gem_properties.py
Pytest custom argument "--build-directory" was not provided, tests using LyTestTools will fail
Pytest custom argument "--output-path" was not provided, defaulting Test Results output to: c:\workspace\o3de\pytest_results\2022-11-07T16-21-13-491375
=================================================================== test session starts =================================================================== platform win32 -- Python 3.10.5, pytest-6.2.5, py-1.11.0, pluggy-0.13.1
rootdir: c:\workspace\o3de, configfile: pytest.ini
plugins: cov-4.0.0, mock-3.8.2, timeout-2.1.0, ly-test-tools-1.0.0
timeout: 1200.0s
timeout method: thread
timeout func_only: False
collected 3 items

scripts\o3de\tests\test_gem_properties.py ...                                                                                                        [100%]

==================================================================== 3 passed in 0.04s ====================================================================
```