### PR TITLE
Use ScopedAutoTempDirectory for files generated in RPI builder unit tests.

### DIFF
--- a/Gems/Atom/RPI/Code/Tests.Builders/AnyAssetBuilderTest.cpp
+++ b/Gems/Atom/RPI/Code/Tests.Builders/AnyAssetBuilderTest.cpp
@@ -225,7 +225,7 @@ namespace UnitTest
 
         // Helper function to generate source AnyAsset and save it to specified folder
         template<typename T>
-        void SaveClassToAnyAssetSourceFile(T& data, const char* saveFileName)
+        void SaveClassToAnyAssetSourceFile(T& data, const AZStd::string& saveFileName)
         {
             JsonSerializationUtils::SaveObjectToFile<T>(&data, saveFileName);
         }
@@ -263,8 +263,7 @@ namespace UnitTest
         const char* testAssetName = "AnyAssetTest.source";
         AZ::Test::ScopedAutoTempDirectory productDir;
         AZ::Test::ScopedAutoTempDirectory sourceDir;
-        AZStd::string sourceFilePath;
-        AzFramework::StringFunc::Path::Join(sourceDir.GetDirectory(), testAssetName, sourceFilePath, true, true);
+        AZ::IO::Path sourceFilePath = sourceDir.Resolve(testAssetName);
 
         // Basic test: test data before and after are same. Test data class doesn't have converter or asset reference.
         RPI::AnyAssetBuilder builder;
@@ -272,12 +271,12 @@ namespace UnitTest
         AssetBuilderSDK::ProcessJobResponse response;
 
         // Initial job request
-        request.m_fullPath = sourceFilePath;
+        request.m_fullPath = sourceFilePath.Native();
         request.m_tempDirPath = productDir.GetDirectory();
 
         Test1 test1;
         test1.m_data = "first";
-        SaveClassToAnyAssetSourceFile<Test1>(test1, sourceFilePath.c_str());
+        SaveClassToAnyAssetSourceFile<Test1>(test1, sourceFilePath.Native());
 
         // Process
         builder.ProcessJob(request, response);
@@ -298,20 +297,19 @@ namespace UnitTest
         const char* testAssetName = "AnyAssetTest.source";
         AZ::Test::ScopedAutoTempDirectory productDir;
         AZ::Test::ScopedAutoTempDirectory sourceDir;
-        AZStd::string sourceFilePath;
-        AzFramework::StringFunc::Path::Join(sourceDir.GetDirectory(), testAssetName, sourceFilePath, true, true);
+        AZ::IO::Path sourceFilePath = sourceDir.Resolve(testAssetName);
 
         RPI::AnyAssetBuilder builder;
         AssetBuilderSDK::ProcessJobRequest request;
         AssetBuilderSDK::ProcessJobResponse response;
 
         // Initial job request 
-        request.m_fullPath = sourceFilePath;
+        request.m_fullPath = sourceFilePath.Native();
         request.m_tempDirPath = productDir.GetDirectory();
         
         // Test data class which has a converter
         Test2Source test2;
-        SaveClassToAnyAssetSourceFile<Test2Source>(test2, sourceFilePath.c_str());
+        SaveClassToAnyAssetSourceFile<Test2Source>(test2, sourceFilePath.Native());
 
         builder.ProcessJob(request, response);
         EXPECT_TRUE(response.m_resultCode == AssetBuilderSDK::ProcessJobResult_Success);
@@ -327,21 +325,20 @@ namespace UnitTest
         const char* testAssetName = "AnyAssetTest.source";
         AZ::Test::ScopedAutoTempDirectory productDir;
         AZ::Test::ScopedAutoTempDirectory sourceDir;
-        AZStd::string sourceFilePath;
-        AzFramework::StringFunc::Path::Join(sourceDir.GetDirectory(), testAssetName, sourceFilePath, true, true);
+        AZ::IO::Path sourceFilePath = sourceDir.Resolve(testAssetName);
 
         RPI::AnyAssetBuilder builder;
         AssetBuilderSDK::ProcessJobRequest request;
             AssetBuilderSDK::ProcessJobResponse response;
 
         // Initial job request once
-        request.m_fullPath = sourceFilePath;
+        request.m_fullPath = sourceFilePath.Native();
         request.m_tempDirPath = productDir.GetDirectory();
 
         // Test class which has asset id and asset reference as member variables
         TestAssetIdReference objectHasAssetIds;
         objectHasAssetIds.Init();
-        SaveClassToAnyAssetSourceFile<TestAssetIdReference>(objectHasAssetIds, sourceFilePath.c_str());
+        SaveClassToAnyAssetSourceFile<TestAssetIdReference>(objectHasAssetIds, sourceFilePath.Native());
         
         builder.ProcessJob(request, response);
         EXPECT_TRUE(response.m_resultCode == AssetBuilderSDK::ProcessJobResult_Success);
@@ -357,21 +354,20 @@ namespace UnitTest
         const char* testAssetName = "AnyAssetTest.source";
         AZ::Test::ScopedAutoTempDirectory productDir;
         AZ::Test::ScopedAutoTempDirectory sourceDir;
-        AZStd::string sourceFilePath;
-        AzFramework::StringFunc::Path::Join(sourceDir.GetDirectory(), testAssetName, sourceFilePath, true, true);
+        AZ::IO::Path sourceFilePath = sourceDir.Resolve(testAssetName);
 
         RPI::AnyAssetBuilder builder;
         AssetBuilderSDK::ProcessJobRequest request;
         AssetBuilderSDK::ProcessJobResponse response;
 
         // Initial job request once
-        request.m_fullPath = sourceFilePath;
+        request.m_fullPath = sourceFilePath.Native();
         request.m_tempDirPath = productDir.GetDirectory();
                 
         // Test class includes member which its class has asset id and asset reference as children
         TestIndirectAssetIdReference test4;
         test4.Init();
-        SaveClassToAnyAssetSourceFile<TestIndirectAssetIdReference>(test4, sourceFilePath.c_str());
+        SaveClassToAnyAssetSourceFile<TestIndirectAssetIdReference>(test4, sourceFilePath.Native());
 
         builder.ProcessJob(request, response);
         EXPECT_TRUE(response.m_resultCode == AssetBuilderSDK::ProcessJobResult_Success);

--- a/Gems/Atom/RPI/Code/Tests.Builders/AnyAssetBuilderTest.cpp
+++ b/Gems/Atom/RPI/Code/Tests.Builders/AnyAssetBuilderTest.cpp
@@ -8,6 +8,7 @@
 
 #include <AzTest/AzTest.h>
 
+#include <AzCore/IO/Streamer/FileRequest.h>
 #include <AzCore/Serialization/ObjectStream.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/Utils.h>
@@ -239,6 +240,19 @@ namespace UnitTest
             stream->Open(assetFile, 0, fileLength);
             stream->BlockUntilLoadComplete();
             m_assetHandler->LoadAssetData(outAsset, stream, {});
+            stream->Close();
+
+            // Force a file streamer flush to ensure that file handles don't remain used
+            auto streamer = AZ::Interface<AZ::IO::IStreamer>::Get();
+            AZStd::binary_semaphore wait;
+            AZ::IO::FileRequestPtr flushRequest = streamer->FlushCaches();
+            streamer->SetRequestCompleteCallback(flushRequest, [&wait]([[maybe_unused]] AZ::IO::FileRequestHandle request)
+                {
+                    wait.release();
+                });
+            streamer->QueueRequest(flushRequest);
+            wait.acquire();
+
             return outAsset;
         }
         
@@ -246,19 +260,24 @@ namespace UnitTest
     
     TEST_F(AnyAssetBuilderTests, ProcessJobBasic)
     {
+        const char* testAssetName = "AnyAssetTest.source";
+        AZ::Test::ScopedAutoTempDirectory productDir;
+        AZ::Test::ScopedAutoTempDirectory sourceDir;
+        AZStd::string sourceFilePath;
+        AzFramework::StringFunc::Path::Join(sourceDir.GetDirectory(), testAssetName, sourceFilePath, true, true);
+
         // Basic test: test data before and after are same. Test data class doesn't have converter or asset reference.
         RPI::AnyAssetBuilder builder;
         AssetBuilderSDK::ProcessJobRequest request;
         AssetBuilderSDK::ProcessJobResponse response;
 
         // Initial job request
-        const char* testAssetName = "AnyAssetTest.source";
-        request.m_fullPath = testAssetName;
-        request.m_tempDirPath = m_currentDir;
+        request.m_fullPath = sourceFilePath;
+        request.m_tempDirPath = productDir.GetDirectory();
 
         Test1 test1;
         test1.m_data = "first";
-        SaveClassToAnyAssetSourceFile<Test1>(test1, testAssetName);        
+        SaveClassToAnyAssetSourceFile<Test1>(test1, sourceFilePath.c_str());
 
         // Process
         builder.ProcessJob(request, response);
@@ -276,18 +295,23 @@ namespace UnitTest
 
     TEST_F(AnyAssetBuilderTests, ProcessJobConvert)
     {
+        const char* testAssetName = "AnyAssetTest.source";
+        AZ::Test::ScopedAutoTempDirectory productDir;
+        AZ::Test::ScopedAutoTempDirectory sourceDir;
+        AZStd::string sourceFilePath;
+        AzFramework::StringFunc::Path::Join(sourceDir.GetDirectory(), testAssetName, sourceFilePath, true, true);
+
         RPI::AnyAssetBuilder builder;
         AssetBuilderSDK::ProcessJobRequest request;
         AssetBuilderSDK::ProcessJobResponse response;
 
         // Initial job request 
-        const char* testAssetName = "AnyAssetTest.source";
-        request.m_fullPath = testAssetName;
-        request.m_tempDirPath = m_currentDir;
+        request.m_fullPath = sourceFilePath;
+        request.m_tempDirPath = productDir.GetDirectory();
         
         // Test data class which has a converter
         Test2Source test2;
-        SaveClassToAnyAssetSourceFile<Test2Source>(test2, testAssetName);
+        SaveClassToAnyAssetSourceFile<Test2Source>(test2, sourceFilePath.c_str());
 
         builder.ProcessJob(request, response);
         EXPECT_TRUE(response.m_resultCode == AssetBuilderSDK::ProcessJobResult_Success);
@@ -300,19 +324,24 @@ namespace UnitTest
 
     TEST_F(AnyAssetBuilderTests, ProcessJobDependencyDirect)
     {
+        const char* testAssetName = "AnyAssetTest.source";
+        AZ::Test::ScopedAutoTempDirectory productDir;
+        AZ::Test::ScopedAutoTempDirectory sourceDir;
+        AZStd::string sourceFilePath;
+        AzFramework::StringFunc::Path::Join(sourceDir.GetDirectory(), testAssetName, sourceFilePath, true, true);
+
         RPI::AnyAssetBuilder builder;
         AssetBuilderSDK::ProcessJobRequest request;
             AssetBuilderSDK::ProcessJobResponse response;
 
         // Initial job request once
-        const char* testAssetName = "AnyAssetTest.source";
-        request.m_fullPath = testAssetName;
-        request.m_tempDirPath = m_currentDir;
+        request.m_fullPath = sourceFilePath;
+        request.m_tempDirPath = productDir.GetDirectory();
 
         // Test class which has asset id and asset reference as member variables
         TestAssetIdReference objectHasAssetIds;
         objectHasAssetIds.Init();
-        SaveClassToAnyAssetSourceFile<TestAssetIdReference>(objectHasAssetIds, testAssetName);
+        SaveClassToAnyAssetSourceFile<TestAssetIdReference>(objectHasAssetIds, sourceFilePath.c_str());
         
         builder.ProcessJob(request, response);
         EXPECT_TRUE(response.m_resultCode == AssetBuilderSDK::ProcessJobResult_Success);
@@ -325,19 +354,24 @@ namespace UnitTest
         
     TEST_F(AnyAssetBuilderTests, ProcessJobDependencyIndirect)
     {
+        const char* testAssetName = "AnyAssetTest.source";
+        AZ::Test::ScopedAutoTempDirectory productDir;
+        AZ::Test::ScopedAutoTempDirectory sourceDir;
+        AZStd::string sourceFilePath;
+        AzFramework::StringFunc::Path::Join(sourceDir.GetDirectory(), testAssetName, sourceFilePath, true, true);
+
         RPI::AnyAssetBuilder builder;
         AssetBuilderSDK::ProcessJobRequest request;
         AssetBuilderSDK::ProcessJobResponse response;
 
         // Initial job request once
-        const char* testAssetName = "AnyAssetTest.source";
-        request.m_fullPath = testAssetName;
-        request.m_tempDirPath = m_currentDir;
+        request.m_fullPath = sourceFilePath;
+        request.m_tempDirPath = productDir.GetDirectory();
                 
         // Test class includes member which its class has asset id and asset reference as children
         TestIndirectAssetIdReference test4;
         test4.Init();
-        SaveClassToAnyAssetSourceFile<TestIndirectAssetIdReference>(test4, testAssetName);
+        SaveClassToAnyAssetSourceFile<TestIndirectAssetIdReference>(test4, sourceFilePath.c_str());
 
         builder.ProcessJob(request, response);
         EXPECT_TRUE(response.m_resultCode == AssetBuilderSDK::ProcessJobResult_Success);

--- a/Gems/Atom/RPI/Code/Tests.Builders/PassBuilderTest.cpp
+++ b/Gems/Atom/RPI/Code/Tests.Builders/PassBuilderTest.cpp
@@ -97,14 +97,13 @@ namespace UnitTest
         const char* testAssetName = "PassTestAsset.pass";
         AZ::Test::ScopedAutoTempDirectory productDir;
         AZ::Test::ScopedAutoTempDirectory sourceDir;
-        AZStd::string testAssetPath;
-        AzFramework::StringFunc::Path::Join(sourceDir.GetDirectory(), testAssetName, testAssetPath, true, true);
+        AZ::IO::Path sourceFilePath = sourceDir.Resolve(testAssetName);
 
         // Basic test: test data before and after are same. Test data class doesn't have converter or asset reference.
         AssetBuilderSDK::ProcessJobRequest request;
 
         // Initial job request
-        request.m_fullPath = testAssetPath;
+        request.m_fullPath = sourceFilePath.Native();
         request.m_tempDirPath = productDir.GetDirectory();
 
         // Dummy pass template
@@ -119,7 +118,7 @@ namespace UnitTest
         // Create and write pass data
         RPI::PassAsset passAsset;
         SetPassTemplateForTestingOnly(passAsset, passTemplate);
-        JsonSerializationUtils::SaveObjectToFile(&passAsset, testAssetPath);
+        JsonSerializationUtils::SaveObjectToFile(&passAsset, sourceFilePath.Native());
 
         // Process job
         RPI::PassBuilder builder;

--- a/Gems/Atom/RPI/Code/Tests.Builders/PassBuilderTest.cpp
+++ b/Gems/Atom/RPI/Code/Tests.Builders/PassBuilderTest.cpp
@@ -11,6 +11,7 @@
 #include <AssetBuilderSDK/AssetBuilderBusses.h>
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
 
+#include <AzCore/IO/Streamer/FileRequest.h>
 #include <AzCore/Serialization/ObjectStream.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/Utils.h>

--- a/Gems/Atom/RPI/Code/Tests.Builders/ResourcePoolBuilderTest.cpp
+++ b/Gems/Atom/RPI/Code/Tests.Builders/ResourcePoolBuilderTest.cpp
@@ -64,10 +64,15 @@ namespace UnitTest
         AssetBuilderSDK::ProcessJobRequest request;
         AssetBuilderSDK::ProcessJobResponse response;
 
+        AZ::Test::ScopedAutoTempDirectory productDir;
+        AZ::Test::ScopedAutoTempDirectory sourceDir;
+        const char* testAssetName = "TestBufferPool.resourcepool";
+        AZStd::string sourceFilePath;
+        AzFramework::StringFunc::Path::Join(sourceDir.GetDirectory(), testAssetName, sourceFilePath, true, true);
+
         // Initial job request
-        const char* testAssetName = "BufferPool.resourcepool";
-        request.m_fullPath = testAssetName;
-        request.m_tempDirPath = m_currentDir;
+        request.m_fullPath = sourceFilePath;
+        request.m_tempDirPath = productDir.GetDirectory();
 
         RPI::ResourcePoolSourceData sourceData;
         sourceData.m_poolName = "DefaultIndexBufferPool";
@@ -78,7 +83,7 @@ namespace UnitTest
         sourceData.m_bufferPoolBindFlags = RHI::BufferBindFlags::InputAssembly;
 
         Outcome<void, AZStd::string> saveResult = AZ::JsonSerializationUtils::SaveObjectToFile<RPI::ResourcePoolSourceData>(&sourceData,
-            testAssetName);
+            sourceFilePath);
         
         // Process
         builder.ProcessJob(request, response);
@@ -106,11 +111,16 @@ namespace UnitTest
         RPI::ResourcePoolBuilder builder;
         AssetBuilderSDK::ProcessJobRequest request;
         AssetBuilderSDK::ProcessJobResponse response;
+        
+        AZ::Test::ScopedAutoTempDirectory productDir;
+        AZ::Test::ScopedAutoTempDirectory sourceDir;
+        const char* testAssetName = "TestImagePool.resourcepool";
+        AZStd::string sourceFilePath;
+        AzFramework::StringFunc::Path::Join(sourceDir.GetDirectory(), testAssetName, sourceFilePath, true, true);
 
         // Initial job request
-        const char* testAssetName = "ImagePool.resourcepool";
-        request.m_fullPath = testAssetName;
-        request.m_tempDirPath = m_currentDir;
+        request.m_fullPath = sourceFilePath;
+        request.m_tempDirPath = productDir.GetDirectory();
 
         RPI::ResourcePoolSourceData sourceData;
         sourceData.m_poolName = "DefaultImagePool";
@@ -119,7 +129,7 @@ namespace UnitTest
         sourceData.m_imagePoolBindFlags = RHI::ImageBindFlags::Color;
 
         Outcome<void, AZStd::string> saveResult = AZ::JsonSerializationUtils::SaveObjectToFile<RPI::ResourcePoolSourceData>(&sourceData,
-            testAssetName);
+            sourceFilePath);
 
         // Process
         builder.ProcessJob(request, response);
@@ -145,11 +155,16 @@ namespace UnitTest
         RPI::ResourcePoolBuilder builder;
         AssetBuilderSDK::ProcessJobRequest request;
         AssetBuilderSDK::ProcessJobResponse response;
+        
+        AZ::Test::ScopedAutoTempDirectory productDir;
+        AZ::Test::ScopedAutoTempDirectory sourceDir;
+        const char* testAssetName = "TestStreamingImagePool.resourcepool";
+        AZStd::string sourceFilePath;
+        AzFramework::StringFunc::Path::Join(sourceDir.GetDirectory(), testAssetName, sourceFilePath, true, true);
 
         // Initial job request
-        const char* testAssetName = "streamingImagePool.resourcepool";
-        request.m_fullPath = testAssetName;
-        request.m_tempDirPath = m_currentDir;
+        request.m_fullPath = sourceFilePath;
+        request.m_tempDirPath = productDir.GetDirectory();
 
         RPI::ResourcePoolSourceData sourceData;
         sourceData.m_poolName = "DefaultStreamingImagePool";
@@ -157,7 +172,7 @@ namespace UnitTest
         sourceData.m_budgetInBytes = 2147483648;
 
         Outcome<void, AZStd::string> saveResult = AZ::JsonSerializationUtils::SaveObjectToFile<RPI::ResourcePoolSourceData>(&sourceData,
-            testAssetName);
+            sourceFilePath);
 
         // Process
         builder.ProcessJob(request, response);

--- a/Gems/Atom/RPI/Code/Tests.Builders/ResourcePoolBuilderTest.cpp
+++ b/Gems/Atom/RPI/Code/Tests.Builders/ResourcePoolBuilderTest.cpp
@@ -67,11 +67,10 @@ namespace UnitTest
         AZ::Test::ScopedAutoTempDirectory productDir;
         AZ::Test::ScopedAutoTempDirectory sourceDir;
         const char* testAssetName = "TestBufferPool.resourcepool";
-        AZStd::string sourceFilePath;
-        AzFramework::StringFunc::Path::Join(sourceDir.GetDirectory(), testAssetName, sourceFilePath, true, true);
+        AZ::IO::Path sourceFilePath = sourceDir.Resolve(testAssetName);
 
         // Initial job request
-        request.m_fullPath = sourceFilePath;
+        request.m_fullPath = sourceFilePath.Native();
         request.m_tempDirPath = productDir.GetDirectory();
 
         RPI::ResourcePoolSourceData sourceData;
@@ -83,7 +82,7 @@ namespace UnitTest
         sourceData.m_bufferPoolBindFlags = RHI::BufferBindFlags::InputAssembly;
 
         Outcome<void, AZStd::string> saveResult = AZ::JsonSerializationUtils::SaveObjectToFile<RPI::ResourcePoolSourceData>(&sourceData,
-            sourceFilePath);
+            sourceFilePath.Native());
         
         // Process
         builder.ProcessJob(request, response);
@@ -115,11 +114,10 @@ namespace UnitTest
         AZ::Test::ScopedAutoTempDirectory productDir;
         AZ::Test::ScopedAutoTempDirectory sourceDir;
         const char* testAssetName = "TestImagePool.resourcepool";
-        AZStd::string sourceFilePath;
-        AzFramework::StringFunc::Path::Join(sourceDir.GetDirectory(), testAssetName, sourceFilePath, true, true);
+        AZ::IO::Path sourceFilePath = sourceDir.Resolve(testAssetName);
 
         // Initial job request
-        request.m_fullPath = sourceFilePath;
+        request.m_fullPath = sourceFilePath.Native();
         request.m_tempDirPath = productDir.GetDirectory();
 
         RPI::ResourcePoolSourceData sourceData;
@@ -129,7 +127,7 @@ namespace UnitTest
         sourceData.m_imagePoolBindFlags = RHI::ImageBindFlags::Color;
 
         Outcome<void, AZStd::string> saveResult = AZ::JsonSerializationUtils::SaveObjectToFile<RPI::ResourcePoolSourceData>(&sourceData,
-            sourceFilePath);
+            sourceFilePath.Native());
 
         // Process
         builder.ProcessJob(request, response);
@@ -159,11 +157,10 @@ namespace UnitTest
         AZ::Test::ScopedAutoTempDirectory productDir;
         AZ::Test::ScopedAutoTempDirectory sourceDir;
         const char* testAssetName = "TestStreamingImagePool.resourcepool";
-        AZStd::string sourceFilePath;
-        AzFramework::StringFunc::Path::Join(sourceDir.GetDirectory(), testAssetName, sourceFilePath, true, true);
+        AZ::IO::Path sourceFilePath = sourceDir.Resolve(testAssetName);
 
         // Initial job request
-        request.m_fullPath = sourceFilePath;
+        request.m_fullPath = sourceFilePath.Native();
         request.m_tempDirPath = productDir.GetDirectory();
 
         RPI::ResourcePoolSourceData sourceData;
@@ -172,7 +169,7 @@ namespace UnitTest
         sourceData.m_budgetInBytes = 2147483648;
 
         Outcome<void, AZStd::string> saveResult = AZ::JsonSerializationUtils::SaveObjectToFile<RPI::ResourcePoolSourceData>(&sourceData,
-            sourceFilePath);
+            sourceFilePath.Native());
 
         // Process
         builder.ProcessJob(request, response);


### PR DESCRIPTION
Signed-off-by: Qing Tao <55564570+VickyAtAZ@users.noreply.github.com>

## What does this PR do?

Update RPI builder unit tests which will clean up temporary files generated by the unit tests which unblocks the TIAF pipeline work. 

## How was this PR tested?
Run unittests in Atom_RPI.Builders.Tests and make sure the temporary files are deleted after tests end.
