### PR TITLE
Fix miscellaneous minor Multiplayer Gem issues

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
@@ -585,7 +585,7 @@ namespace AzFramework
         EBUS_EVENT_PTR(m_notificationBus, AZ::TransformNotificationBus, OnParentChanged, oldParent, parentId);
         m_parentChangedEvent.Signal(oldParent, parentId);
 
-        if (oldParent != parentId) // Don't send removal notification while activating.
+        if (oldParent.IsValid() && oldParent != parentId) // Don't send removal notification while activating.
         {
             EBUS_EVENT_ID(oldParent, AZ::TransformNotificationBus, OnChildRemoved, GetEntityId());
             auto oldParentTransform = AZ::TransformBus::FindFirstHandler(oldParent);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/SpawnableUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/SpawnableUtils.cpp
@@ -114,9 +114,9 @@ namespace AzToolsFramework::Prefab::SpawnableUtils
             // Keep a transform component on the placeholder to maintain parent/child relationship.
             // This is used during prefab processing to sort the corresponding spawnable's entities by hierarchy
             auto transformComponent = aznew AzFramework::TransformComponent();
+            placeholder->AddComponent(transformComponent);
             auto entityTransformComponent = entityData->get().FindComponent<AzFramework::TransformComponent>();
             transformComponent->SetParentRelative(entityTransformComponent->GetParentId());
-            placeholder->AddComponent(transformComponent);
             return instance->ReplaceEntity(AZStd::move(placeholder), alias);
         }
 

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
@@ -27,11 +27,12 @@
 #include <AzCore/Utils/Utils.h>
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzNetworking/Framework/INetworking.h>
-#include <AzToolsFramework/Viewport/ViewportMessages.h>
+#include <AzToolsFramework/API/EntityCompositionRequestBus.h>
+#include <AzToolsFramework/ContainerEntity/ContainerEntityInterface.h>
 #include <AzToolsFramework/Entity/PrefabEditorEntityOwnershipInterface.h>
 #include <AzToolsFramework/Entity/ReadOnly/ReadOnlyEntityInterface.h>
 #include <AzToolsFramework/UI/Prefab/PrefabIntegrationInterface.h>
-#include <AzToolsFramework/API/EntityCompositionRequestBus.h>
+#include <AzToolsFramework/Viewport/ViewportMessages.h>
 #include <AzToolsFramework/ViewportSelection/EditorHelpers.h>
 #include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
 #include <Atom/RPI.Public/RPISystemInterface.h>
@@ -587,7 +588,9 @@ namespace Multiplayer
         }
 
         auto readOnlyEntityPublicInterface = AZ::Interface<AzToolsFramework::ReadOnlyEntityPublicInterface>::Get();
-        if (readOnlyEntityPublicInterface && !readOnlyEntityPublicInterface->IsReadOnly(parentEntityId))
+        auto containerEntityInterface = AZ::Interface<AzToolsFramework::ContainerEntityInterface>::Get();
+        if ((readOnlyEntityPublicInterface && !readOnlyEntityPublicInterface->IsReadOnly(parentEntityId)) &&
+            (containerEntityInterface && containerEntityInterface->IsContainerOpen(parentEntityId)))
         {
             menu->setToolTipsVisible(true);
 

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicationManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicationManager.cpp
@@ -570,7 +570,12 @@ namespace Multiplayer
         }
         else
         {
-            AZLOG_WARN("Replicator for id %llu is null on remote host %s. It may have already been deleted.", static_cast<AZ::u64>(updateMessage.GetEntityId()), GetRemoteHostId().GetString().c_str());
+            // Replicators are cleared on the server via ScheduledEvent. It's possible for redundant delete messages to be sent before the event fires.
+            AZLOG(
+                NET_RepDeletes,
+                "Replicator for id %llu is null on remote host %s. It likely has already been deleted.",
+                static_cast<AZ::u64>(updateMessage.GetEntityId()),
+                GetRemoteHostId().GetString().c_str());
             return true;
         }
 


### PR DESCRIPTION
Signed-off-by: puvvadar <puvvadar@amazon.com>

## What does this PR do?

This change addresses the following minor to major issues:

Multiplayer warning whenever an entity is removed (properly with MarkForRemoval): https://github.com/o3de/o3de/issues/12847

- This changes the related WARN to an INFO. A timing issue on the server can cause multiple delete messages to be sent. This behavior is however innocuous. 

Entering game mode in a multiplayer level throws warnings: https://github.com/o3de/o3de/issues/12755

- This fixes an order of ops issue in the MP Editor Game Mode pipeline in which a Transform Component was operated on prior to being added to an entity. It also adds a safety check.

Assert after creating multiplayer entity from context menu of selected prefab: https://github.com/o3de/o3de/issues/12614

- This change updates Create Multiplayer Entity's display conditions to match Create Entity's

## How was this PR tested?
Each fix was tested against the provided repro.
