### PR TITLE
Prism/python platform support engine template create gem

### DIFF
--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -1823,6 +1823,7 @@ def create_gem(gem_path: pathlib.Path,
                origin: str = None,
                origin_url: str = None,
                user_tags: list or str = None,
+               platforms: list or str = None,
                icon_path: str = None,
                documentation_url: str = None,
                repo_uri: str = None,
@@ -1858,6 +1859,7 @@ def create_gem(gem_path: pathlib.Path,
     :param origin: The name of the originator i.e. XYZ Inc.
     :param origin_url: The primary website for your Gem i.e. http://www.mydomain.com
     :param user_tags: A comma separated string of user tags
+    :param platforms: A comma separated string of platforms for your Gem
     :param icon_path: The relative path to the icon PNG image in your Gem i.e. preview.png
     :param documentation_url: Link to any documentation for your Gem i.e. https://o3de.org/docs/user-guide/gems/...
     :param repo_uri: Optional link to the gem repository for your Gem.
@@ -2118,6 +2120,16 @@ def create_gem(gem_path: pathlib.Path,
     tags_quoted = ','.join(f'"{word.strip()}"' for word in set(tags))
     # remove the first and last quote because those already exist in gem.json
     replacements.append(("${UserTags}", tags_quoted[1:-1]))
+
+    temp_platforms = []
+    if platforms:
+        #same as tags, allow commas or spaces as platform separators
+        new_platforms = platforms.replace(',', ' ').split() if isinstance(platforms, str) else platforms
+        temp_platforms.extend(new_platforms)
+    platforms_quoted = ','.join(f'"{word.strip()}"' for word in set(temp_platforms))
+    #remove the first and last quote because those already exist in gem.json
+    print("Temp platforms is : " + str(temp_platforms))
+    replacements.append(("${Platforms}", platforms_quoted[1:-1]))
 
     if icon_path:
         replacements.append(("${IconPath}", pathlib.PurePath(icon_path).as_posix()))
@@ -2740,6 +2752,8 @@ def add_args(subparsers) -> None:
                        help='The website for your Gem. i.e. http://www.mydomain.com')
     create_gem_subparser.add_argument('-ut', '--user-tags', type=str, nargs='*', required=False,
                        help='Adds tag(s) to user_tags property. Can be specified multiple times.')
+    create_gem_subparser.add_argument('-pl', '--platforms', type=str, nargs='*', required=False,
+                       help='Add platform(s) to platforms property. Can be specified multiple times.')
     create_gem_subparser.add_argument('-ip', '--icon-path', type=str, required=False, 
                        default="preview.png",
                        help='Select Gem icon path')

--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -2327,6 +2327,7 @@ def _run_create_gem(args: argparse) -> int:
                       args.origin,
                       args.origin_url,
                       args.user_tags,
+                      args.platforms,
                       args.icon_path,
                       args.documentation_url,
                       args.repo_uri,

--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -2128,7 +2128,6 @@ def create_gem(gem_path: pathlib.Path,
         temp_platforms.extend(new_platforms)
     platforms_quoted = ','.join(f'"{word.strip()}"' for word in set(temp_platforms))
     #remove the first and last quote because those already exist in gem.json
-    print("Temp platforms is : " + str(temp_platforms))
     replacements.append(("${Platforms}", platforms_quoted[1:-1]))
 
     if icon_path:

--- a/scripts/o3de/o3de/gem_properties.py
+++ b/scripts/o3de/o3de/gem_properties.py
@@ -130,7 +130,10 @@ def _edit_gem_props(args: argparse) -> int:
                           args.gem_license_url,
                           args.add_tags,
                           args.remove_tags,
-                          args.replace_tags)
+                          args.replace_tags,
+                          args.add_platforms,
+                          args.remove_platforms,
+                          args.replace_platforms)
 
 
 def add_parser_args(parser):

--- a/scripts/o3de/tests/test_engine_template.py
+++ b/scripts/o3de/tests/test_engine_template.py
@@ -360,27 +360,27 @@ class TestCreateTemplate:
         " keep_license_text, force, expect_failure,"
         " template_json_contents,"
         " display_name, summary, requirements, license, license_url,"
-        " origin, origin_url, user_tags, icon_path, documentation_url, repo_uri,"
-        " expected_tags", [
+        " origin, origin_url, user_tags, platforms, icon_path, documentation_url, repo_uri,"
+        " expected_tags, expected_platforms", [
             pytest.param(TEST_CONCRETE_TESTGEM_TEMPLATE_CONTENT_WITH_LICENSE, TEST_TEMPLATED_CONTENT_WITH_LICENSE,
                          True, True, False,
                          TEST_TEMPLATE_JSON_CONTENTS,
                          "Test Gem", "Test Summary", "Test Requirements", "Test License", "https://o3de.org/license", 
-                         "Test Origin", "https://o3de.org", "tag1", "preview.png", "https://o3de.org/docs", "https://o3de.org/repo",
-                         ["tag1","TestGem"] ),
+                         "Test Origin", "https://o3de.org", "tag1", "Windows", "preview.png", "https://o3de.org/docs", "https://o3de.org/repo",
+                         ["tag1","TestGem"], ['Windows']),
             pytest.param(TEST_CONCRETE_TESTGEM_TEMPLATE_CONTENT_WITHOUT_LICENSE, TEST_TEMPLATED_CONTENT_WITH_LICENSE,
                          False, True, False,
                          TEST_TEMPLATE_JSON_CONTENTS,
                          "Test Gem2", "Test Summary2", "Test Requirements2", "Test License2", "https://o3de.org/license2", 
-                         "Test Origin2", "https://o3de.org/2", "tag2 tag3  tag4", "preview2.png", "https://o3de.org/docs2", "https://o3de.org/repo2",
-                         ["tag2","tag3","tag4","TestGem"] ),
+                         "Test Origin2", "https://o3de.org/2", "tag2 tag3  tag4", "MacOS Linux Windows", "preview2.png", "https://o3de.org/docs2", "https://o3de.org/repo2",
+                         ["tag2","tag3","tag4","TestGem"], ['MacOS', 'Linux', 'Windows']),
         ]
     )
     def test_create_gem(self, tmpdir, concrete_contents, templated_contents, keep_license_text, force,
                                   expect_failure, template_json_contents,
                                   display_name, summary, requirements, license, license_url,
-                                  origin, origin_url, user_tags, icon_path, documentation_url, repo_uri,
-                                  expected_tags):
+                                  origin, origin_url, user_tags, platforms, icon_path, documentation_url, repo_uri,
+                                  expected_tags, expected_platforms):
         # Create a gem.json file in the template folder
         template_file_map = {'gem.json':
                                  '''
@@ -394,6 +394,7 @@ class TestCreateTemplate:
                                    "origin": "${Origin}",
                                    "origin_url": "${OriginURL}",
                                    "user_tags": ["${UserTags}"],
+                                   "platforms": ["${Platforms}"],
                                    "icon_path": "${IconPath}",
                                    "documentation_url": "${DocumentationURL}",
                                    "repo_uri": "${RepoURI}"
@@ -414,7 +415,7 @@ class TestCreateTemplate:
                                           template_json_contents, template_file_map, gem_name="TestGem", 
                                           display_name=display_name, summary=summary, requirements=requirements,
                                           license=license, license_url=license_url, origin=origin, origin_url=origin_url,
-                                          user_tags=user_tags, icon_path=icon_path, documentation_url=documentation_url,
+                                          user_tags=user_tags, platforms=platforms, icon_path=icon_path, documentation_url=documentation_url,
                                           repo_uri=repo_uri, no_register=True)
         if not expect_failure:
             test_gem_manifest = test_folder / 'gem.json'
@@ -431,6 +432,7 @@ class TestCreateTemplate:
                 assert json_data['origin'] == origin
                 assert json_data['origin_url'] == origin_url
                 assert set(json_data['user_tags']) == set(expected_tags)
+                assert set(json_data['platforms']) == set(expected_platforms)
                 assert json_data['icon_path'] == icon_path
                 assert json_data['documentation_url'] == documentation_url
                 assert json_data['repo_uri'] == repo_uri


### PR DESCRIPTION
## What does this PR do?

This PR adds ability to specify platforms when creating a gem in `create_gem` for `engine_template.py` for the O3DE CLI tooling.

Note: In PR https://github.com/o3de/o3de/pull/13048 , I missed updating `edit_gem_props` to also link argument parsing for platform related arguments to actually running the function. That is fixed in this PR. Argument parsing is updated for `create_gem` as well.

## How was this PR tested?

Unit tests have been updated to account for platform support. Tests are passing.

```
c:\workspace\o3de(Prism/PythonPlatformSupportEngineTemplateCreateGem -> upstream)                                                                           
λ python\python.cmd -m pytest scripts\o3de\tests\test_engine_template.py                                                                                    
Pytest custom argument "--build-directory" was not provided, tests using LyTestTools will fail                                                              
Pytest custom argument "--output-path" was not provided, defaulting Test Results output to: c:\workspace\o3de\pytest_results\2022-11-07T22-02-18-139030     
=================================================================== test session starts =================================================================== 
platform win32 -- Python 3.10.5, pytest-6.2.5, py-1.11.0, pluggy-0.13.1                                                                                     
rootdir: c:\workspace\o3de, configfile: pytest.ini                                                                                                          
plugins: cov-4.0.0, mock-3.8.2, timeout-2.1.0, ly-test-tools-1.0.0                                                                                          
timeout: 1200.0s                                                                                                                                            
timeout method: thread                                                                                                                                      
timeout func_only: False                                                                                                                                    
collected 8 items                                                                                                                                           
                                                                                                                                                            
scripts\o3de\tests\test_engine_template.py ........                                                                                                  [100%] 
                                                                                                                                                            
==================================================================== 8 passed in 0.31s ==================================================================== 
                                                                                                                                                            
```