### PR TITLE
Fixed function setting MSAA to application

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -465,11 +465,14 @@ namespace AZ
             {
                 for (auto& renderPipeline : scene->GetRenderPipelines())
                 {
-                    if (renderPipeline->GetRenderSettings().m_multisampleState != multisampleState)
-                    {
-                        renderPipeline->GetRenderSettings().m_multisampleState = multisampleState;
-                        renderPipeline->MarkPipelinePassChanges(PipelinePassChanges::MultisampleStateChanged);
-                    }
+                    // MSAA state set to the render pipeline at creation time from its data might be different
+                    // from the one set to the application. So it can arrive here having the same new
+                    // target state, but still needs to be marked as its MSAA state has changed so its passes
+                    // are recreated using the new supervariant name comming from MSAA at application level just set above.
+                    // In conclusion, it's not safe to skip here setting MSAA state to the render pipeline when it's the
+                    // same as the target.
+                    renderPipeline->GetRenderSettings().m_multisampleState = multisampleState;
+                    renderPipeline->MarkPipelinePassChanges(PipelinePassChanges::MultisampleStateChanged);
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

Fixed the following error being spammed when using a render pipeline with MSAA state with 1 sample:

````
[Error] (ShaderResourceGroupData) - Image Input 'm_depth[0]': The image has multisample count 1 but the shader expected more than 1.
````

## How was this PR tested?

- Manually tested the conditions for the error to occur and check it was fixed. This is by default the application is set to 4x MSAA, create render pipeline whose data has 1x MSAA, and then later set MSAA 1x to the application.
- Checked Editor and Launcher running a default level.
- Checked XR pipeline on Editor and Launcher running through link cable to Quest 2.
- Checked XR pipeline on Launcher running natively on Quest 2.
- Tested adding a Diffuse Probe Grid component, enabled the probes, modified the sun's light and verified the probes were updated accordingly.
