### PR TITLE
Editor uses default render pipeline even when XR system is present

### DIFF
--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -314,9 +314,18 @@ namespace AZ
                 // Load the main default pipeline if applicable
                 if (loadDefaultRenderPipeline)
                 {
-                    const AZ::CVarFixedString pipelineName = xrSystem
-                        ? "passes/LowEndRenderPipeline.azasset" // OpenXr uses low end render pipeline
-                        : static_cast<AZ::CVarFixedString>(r_default_pipeline_name);
+                    AZ::CVarFixedString pipelineName = static_cast<AZ::CVarFixedString>(r_default_pipeline_name);
+                    if (xrSystem)
+                    {
+                        // When running launcher on PC having an XR system present then the default render pipeline is suppose to reflect
+                        // what's being rendered into XR device. XR render pipeline uses low end render pipeline.
+                        AZ::ApplicationTypeQuery appType;
+                        ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::QueryApplicationType, appType);
+                        if (appType.IsGame())
+                        {
+                            pipelineName = "passes/LowEndRenderPipeline.azasset";
+                        }
+                    }
 
                     if (!LoadPipeline(scene, viewportContext, pipelineName, AZ::RPI::ViewType::Default, multisampleState))
                     {


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

Editor uses default render pipeline even when XR system is present, but when running launcher then the default render pipeline is suppose to reflect what's being rendered into XR device, so with the launcher the default render pipeline will use the low end render pipeline to match the XR's.

## How was this PR tested?

Checked XR pipeline on Editor and Launcher running through link cable to Quest 2. Only launcher used low end render pipeline.
