### PR TITLE
TIAF: Make the Python test runner live for profile_pipe_tiaf and disabled for profile_pipe

### DIFF
--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestEngine/Python/TestImpactPythonTestEngine.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestEngine/Python/TestImpactPythonTestEngine.cpp
@@ -16,6 +16,7 @@
 #include <TestRunner/Python/TestImpactPythonTestRunner.h>
 #include <TestRunner/Python/TestImpactPythonNullTestRunner.h>
 
+#include <iostream>
 namespace TestImpact
 {
     AZStd::optional<Client::TestRunResult> PythonInstrumentedTestRunnerErrorCodeChecker(
@@ -92,12 +93,12 @@ namespace TestImpact
         {
             if (!stdOutDelta.empty())
             {
-                AZ_Printf("StdOut", stdOutDelta.c_str());
+                std::cout << stdOutDelta.c_str() << "\n";
             }
 
             if (!stdErrDelta.empty())
             {
-                AZ_Printf("StdError", stdErrDelta.c_str());
+                std::cout << stdErrDelta.c_str() << "\n";
             }
 
             return TestImpact::ProcessCallbackResult::Continue;

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -25,8 +25,7 @@
     "steps": [
       "profile",
       "asset_profile",
-      "test_cpu_profile",
-      "test_impact_analysis_profile_python"
+      "test_cpu_profile"
     ]
   },
   "profile_pipe_tiaf": {

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -77,7 +77,7 @@
       "CONFIGURATION": "profile",
       "SCRIPT_PATH": "scripts/build/TestImpactAnalysis/tiaf_driver.py",
       "SCRIPT_PARAMETERS": 
-      "--config=\"%OUTPUT_DIRECTORY%/bin/TestImpactFramework/profile/Persistent/tiaf.json\" --src-branch=%BRANCH_NAME% --dst-branch=%CHANGE_TARGET% --commit=%CHANGE_ID% --s3-bucket=%TEST_IMPACT_S3_BUCKET% --mars-index-prefix=o3de-tiaf --s3-top-level-dir=%REPOSITORY_NAME% --build-number=%BUILD_NUMBER% --suite=main --test-failure-policy=continue --runtime-type=python --testrunner=live"
+      "--config=\"%OUTPUT_DIRECTORY%/bin/TestImpactFramework/profile/Persistent/tiaf.json\" --src-branch=%BRANCH_NAME% --dst-branch=%CHANGE_TARGET% --commit=%CHANGE_ID% --s3-bucket=%TEST_IMPACT_S3_BUCKET% --mars-index-prefix=o3de-tiaf --s3-top-level-dir=%REPOSITORY_NAME% --build-number=%BUILD_NUMBER% --suite=main --test-failure-policy=continue --runtime-type=python --testrunner=live --targetout=stdout"
     }
   },
   "debug": {

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -78,7 +78,7 @@
       "CONFIGURATION": "profile",
       "SCRIPT_PATH": "scripts/build/TestImpactAnalysis/tiaf_driver.py",
       "SCRIPT_PARAMETERS": 
-      "--config=\"%OUTPUT_DIRECTORY%/bin/TestImpactFramework/profile/Persistent/tiaf.json\" --src-branch=%BRANCH_NAME% --dst-branch=%CHANGE_TARGET% --commit=%CHANGE_ID% --s3-bucket=%TEST_IMPACT_S3_BUCKET% --mars-index-prefix=o3de-tiaf --s3-top-level-dir=%REPOSITORY_NAME% --build-number=%BUILD_NUMBER% --suite=main --test-failure-policy=continue --runtime-type=python --testrunner=null"
+      "--config=\"%OUTPUT_DIRECTORY%/bin/TestImpactFramework/profile/Persistent/tiaf.json\" --src-branch=%BRANCH_NAME% --dst-branch=%CHANGE_TARGET% --commit=%CHANGE_ID% --s3-bucket=%TEST_IMPACT_S3_BUCKET% --mars-index-prefix=o3de-tiaf --s3-top-level-dir=%REPOSITORY_NAME% --build-number=%BUILD_NUMBER% --suite=main --test-failure-policy=continue --runtime-type=python --testrunner=live"
     }
   },
   "debug": {


### PR DESCRIPTION
## What does this PR do?

This PR removes the `test_impact_analysis_profile_python` stage from `profile_pipe` and makes the Python test runner live for `profile_pipe_tiaf`.

## How was this PR tested?

This PR will be tested in AR as a PR build, and again in AR when the PR is merged.
