### PR TITLE
Added performance metric:Frame Gpu Time.

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/GpuQuery/GpuPassProfiler.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/GpuQuery/GpuPassProfiler.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/containers/array.h>
+#include <AzCore/Name/Name.h>
+
+#include <Atom/RPI.Public/GpuQuery/GpuQueryTypes.h>
+
+namespace AZ
+{
+    namespace RPI
+    {
+        class Pass;
+        class ParentPass;
+
+        //! This is a helper class that can be used to measure, per frame, the time it takes
+        //! for the render pipeline to execute in the GPU from the first to the last pass.
+        //! The core functionality is provided by the function MeasureRenderPipelineGpuTimeInNanoseconds(),
+        //! but other functions are available for tools who need to report more details, like time spent at each pass, etc.
+        //! REMARK: Use judiciously, as MeasureRenderPipelineGpuTimeInNanoseconds() can itself affect performance when called.
+        //! For example, if a scene is running at 300fps, calling MeasureRenderPipelineGpuTimeInNanoseconds(), each frame, can reduce the FPS to
+        //! ~265fps.
+        class GpuPassProfiler final
+        {
+        public:
+
+            //! Intermediate data that represents the structure of a Pass within the FrameGraph.
+            //! A tree structure will be created from these entries that mimics the pass' structure.
+            //! By default, all entries have a parent<-child reference, but only entries that pass the filter will also hold a parent->child reference.
+            struct PassEntry
+            {
+                //! Total number of attributes collected per  PipelineStatistics.
+                static const uint32_t PipelineStatisticsAttributeCount = 7u;
+
+                using PipelineStatisticsArray = AZStd::array<uint64_t, PipelineStatisticsAttributeCount>;
+
+                PassEntry() = default;
+                PassEntry(const class AZ::RPI::Pass* pass, PassEntry* parent);
+
+                ~PassEntry() = default;
+
+                //! Links the child TimestampEntry to the parent's, and sets the dirty flag for both the parent and child entry.
+                //! Calling this method will effectively add a parent->child reference for this instance, and all parent entries leading up to this
+                //! entry from the root entry.
+                void LinkChild(PassEntry* childEntry);
+
+                //! Checks if timestamp queries are enabled for this PassEntry.
+                bool IsTimestampEnabled() const;
+                //! Checks if PipelineStatistics queries are enabled for this PassEntry.
+                bool IsPipelineStatisticsEnabled() const;
+
+                //! The name of the pass.
+                Name m_name;
+                //! Cache the path name of the Pass as a unique identifier.
+                Name m_path;
+
+                RPI::TimestampResult m_timestampResult;
+                uint64_t m_interpolatedTimestampInNanoseconds = 0u;
+
+                //! Convert the PipelineStatistics result to an array for easier access.
+                PipelineStatisticsArray m_pipelineStatistics;
+
+                //! Used as a double linked structure to reference the parent <-> child relationship.
+                PassEntry* m_parent = nullptr;
+                AZStd::vector<PassEntry*> m_children;
+
+                //! Mirrors the enabled queries state of the pass.
+                bool m_timestampEnabled = false;
+                bool m_pipelineStatisticsEnabled = false;
+
+                //! Mirrors the enabled/disabled state of the pass.
+                bool m_enabled = false;
+
+                //! Dirty flag to determine if this entry is linked to an parent entry.
+                bool m_linked = false;
+
+                //! Cache if the pass is a parent.
+                bool m_isParent = false;
+            };
+
+            GpuPassProfiler() = default;
+            ~GpuPassProfiler() = default;
+
+            GpuPassProfiler(GpuPassProfiler&& other) = delete;
+            GpuPassProfiler(const GpuPassProfiler& other) = delete;
+            GpuPassProfiler& operator=(const GpuPassProfiler& other) = delete;
+
+            void SetRenderPipelineGpuTimeMeasurementEnabled(bool enabled) { m_measureRenderPipelineGpuTime = enabled; }
+            bool IsRenderPipelineGpuTimeMeasurementEnabled() { return m_measureRenderPipelineGpuTime; }
+
+            // Measures the total time spent by the Render Pipeline inside the GPU.
+            // It measures the time by using the functions CreatePassEntriesDatabase(), SortPassEntriesByTimestamps() & CalculateTotalGpuPassTime().
+            // The above functions are public and exist in split form to faciliate integration in tools like the ImGuiGpuProfiler, etc.
+            // if @m_measureRenderPipelineGpuTime is false this function returns 0.
+            uint64_t MeasureRenderPipelineGpuTimeInNanoseconds(RHI::Ptr<RPI::ParentPass> rootPass);
+
+            //////////////////////////////////////////////////////////////////
+            // Support Functions START
+            // The following functions provide all the details when measuring
+            // the render pipeline performance.
+            
+            // Returns the pass entry database where the key is PathName -> value is PassEntry
+            AZStd::unordered_map<Name, PassEntry> CreatePassEntriesDatabase(RHI::Ptr<RPI::ParentPass> rootPass);
+
+            // Measures the time spent in the GPU for each pass.
+            // Returns the total amount of nanoseconds spent in the GPU for the Root Parent Pass.
+            AZStd::vector<GpuPassProfiler::PassEntry*> SortPassEntriesByTimestamps(AZStd::unordered_map<Name, PassEntry>& timestampEntryDatabase);
+
+            // Returns the total amount spent in the GPU by the root pass. Assumes sortedPassEntries
+            // is sorted by timestamp.
+            uint64_t CalculateTotalGpuPassTime(const AZStd::vector<GpuPassProfiler::PassEntry*>& sortedPassEntries);
+
+            // Support Functions END
+            ///////////////////////////////////////////////////////////////////
+
+
+        private:
+            // Interpolates the values of the PassEntries from the previous frame.
+            void InterpolatePassEntries(AZStd::unordered_map<Name, PassEntry>& passEntryDatabase, float weight) const;
+
+            bool m_measureRenderPipelineGpuTime = false;
+ 
+        };
+
+    }   // namespace RPI
+}   // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/PerformanceCVarManager.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/PerformanceCVarManager.cpp
@@ -89,7 +89,7 @@ namespace AZ
                 AZ_TracePrintf(LogName, "%s r_metricsFrameCountPerCaptureBatch=%u.\n", __FUNCTION__, metricsFrameCountPerCaptureBatch);
                 bool metricsMeasureGpuTime = r_metricsMeasureGpuTime;
                 AZ_TracePrintf(LogName, "%s value of r_metricsMeasureGpuTime=%s.\n", __FUNCTION__, metricsMeasureGpuTime ? "true" : "false");
-                bool metricsQuitUponCompletion = r_metricsQuitUponCompletion;
+                [[maybe_unused]] bool metricsQuitUponCompletion = r_metricsQuitUponCompletion;
                 AZ_TracePrintf(LogName, "%s value of r_metricsQuitUponCompletion=%s.\n", __FUNCTION__, metricsQuitUponCompletion ? "true" : "false");
 
                 auto gpuPassProfiler = performanceCollectorOwner->GetGpuPassProfiler();

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/PerformanceCVarManager.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/PerformanceCVarManager.cpp
@@ -35,15 +35,15 @@ namespace AZ
             ConsoleFunctorFlags::DontReplicate,
             "Number of frames in which performance will be measured per batch.");
 
-        // "Render Pipeline Gpu Time" is the only gated performance metric because it takes a considerable amount
+        // "Frame Gpu Time" is the only gated performance metric because it takes a considerable amount
         // of CPU time. For example, when NOT capturing this metric, the default level runs at 300fps on a GTX 3070,
         // if this metric is enabled, the FPS drops to 270. It is recommended that this metric is captured in isolation
         // so it doesn't affect the results of the "Engine Cpu Time" metric.
-        AZ_CVAR(bool, r_metricsEnableRenderPipelineGpuTime,
+        AZ_CVAR(bool, r_metricsMeasureGpuTime,
             false,
             nullptr,
             ConsoleFunctorFlags::DontReplicate,
-            "If true, The Root Pass Gpu Time is measured. By default it is false, as this measurement is CPU expensive.");
+            "If true, The Frame Gpu Time is measured. By default it is false, as this measurement is CPU expensive.");
 
         AZ_CVAR(bool, r_metricsQuitUponCompletion,
             false, // If true the application will quit when Number Of Capture Batches reaches 0.
@@ -87,15 +87,15 @@ namespace AZ
                 AZ_TracePrintf(LogName, "%s r_metricsWaitTimePerCaptureBatch=%u.\n", __FUNCTION__, metricsWaitTimePerCaptureBatch);
                 AZ::u32 metricsFrameCountPerCaptureBatch = r_metricsFrameCountPerCaptureBatch;
                 AZ_TracePrintf(LogName, "%s r_metricsFrameCountPerCaptureBatch=%u.\n", __FUNCTION__, metricsFrameCountPerCaptureBatch);
-                bool metricsEnableRenderPipelineGpuTime = r_metricsEnableRenderPipelineGpuTime;
-                AZ_TracePrintf(LogName, "%s value of r_metricsEnableRenderPipelineGpuTime=%s.\n", __FUNCTION__, metricsEnableRenderPipelineGpuTime ? "true" : "false");
+                bool metricsMeasureGpuTime = r_metricsMeasureGpuTime;
+                AZ_TracePrintf(LogName, "%s value of r_metricsMeasureGpuTime=%s.\n", __FUNCTION__, metricsMeasureGpuTime ? "true" : "false");
                 bool metricsQuitUponCompletion = r_metricsQuitUponCompletion;
                 AZ_TracePrintf(LogName, "%s value of r_metricsQuitUponCompletion=%s.\n", __FUNCTION__, metricsQuitUponCompletion ? "true" : "false");
 
                 auto gpuPassProfiler = performanceCollectorOwner->GetGpuPassProfiler();
                 if (gpuPassProfiler)
                 {
-                    gpuPassProfiler->SetRenderPipelineGpuTimeMeasurementEnabled(metricsEnableRenderPipelineGpuTime);
+                    gpuPassProfiler->SetGpuTimeMeasurementEnabled(metricsMeasureGpuTime);
                 }
                 performanceCollector->UpdateDataLogType(GetDataLogTypeFromCVar(metricsDataLogType));
                 performanceCollector->UpdateWaitTimeBeforeEachBatch(AZStd::chrono::seconds(metricsWaitTimePerCaptureBatch));

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/PerformanceCVarManager.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/PerformanceCVarManager.cpp
@@ -8,12 +8,48 @@
 
 #include <AzCore/Debug/PerformanceCollector.h>
 
+#include <Atom/RPI.Public/Pass/PassSystemInterface.h>
+#include <Atom/RPI.Public/Pass/ParentPass.h>
+#include <Atom/RPI.Public/GpuQuery/GpuPassProfiler.h>
 #include "PerformanceCVarManager.h"
 
 namespace AZ
 {
     namespace RPI
     {
+        AZ_CVAR(AZ::CVarFixedString, r_metricsDataLogType,
+            "statistical", // (s)(S)tatistical Summary (average, min, max, stdev) / (a)(A)ll Samples. Default=s.
+            nullptr, //&PerformanceCvarManager::OnDataLogTypeChanged,
+            ConsoleFunctorFlags::DontReplicate,
+            "Defines the kind of data collection and logging. If starts with 's' it will log statistical summaries, if starts with 'a' will log each sample of data (high verbosity).");
+
+        AZ_CVAR(AZ::u32, r_metricsWaitTimePerCaptureBatch,
+            0, // Starts at 0, which means "do not capture performance data". When this variable changes to >0 we'll start performance capture.
+            nullptr, //&PerformanceCvarManager::OnWaitTimePerCaptureBatchChanged,
+            ConsoleFunctorFlags::DontReplicate,
+            "How many seconds to wait before each batch of performance capture.");
+
+        AZ_CVAR(AZ::u32, r_metricsFrameCountPerCaptureBatch,
+            1200, // Number of frames in which performance will be measured per batch.
+            nullptr, //&PerformanceCvarManager::OnFrameCountPerCaptureBatchChanged,
+            ConsoleFunctorFlags::DontReplicate,
+            "Number of frames in which performance will be measured per batch.");
+
+        // "Render Pipeline Gpu Time" is the only gated performance metric because it takes a considerable amount
+        // of CPU time. For example, when NOT capturing this metric, the default level runs at 300fps on a GTX 3070,
+        // if this metric is enabled, the FPS drops to 270. It is recommended that this metric is captured in isolation
+        // so it doesn't affect the results of the "Engine Cpu Time" metric.
+        AZ_CVAR(bool, r_metricsEnableRenderPipelineGpuTime,
+            false,
+            nullptr,
+            ConsoleFunctorFlags::DontReplicate,
+            "If true, The Root Pass Gpu Time is measured. By default it is false, as this measurement is CPU expensive.");
+
+        AZ_CVAR(bool, r_metricsQuitUponCompletion,
+            false, // If true the application will quit when Number Of Capture Batches reaches 0.
+            nullptr,
+            ConsoleFunctorFlags::DontReplicate,
+            "If true the application will quit when Number Of Capture Batches reaches 0.");
 
         AZ::Debug::PerformanceCollector::DataLogType GetDataLogTypeFromCVar(const AZ::CVarFixedString& newCaptureType)
         {
@@ -29,22 +65,6 @@ namespace AZ
         public:
             static constexpr char LogName[] = "RPIPerformanceCvarManager";
 
-            static void OnDataLogTypeChanged(const AZ::CVarFixedString& newCaptureType)
-            {
-                AZ_TracePrintf(LogName, "%s cvar changed to %s.\n", __FUNCTION__, newCaptureType.c_str());
-                auto performanceCollectorOwner = PerformanceCollectorOwner::Get();
-                if (!performanceCollectorOwner)
-                {
-                    return;
-                }
-                auto performanceCollector = performanceCollectorOwner->GetPerformanceCollector();
-                if (!performanceCollector)
-                {
-                    return;
-                }
-                performanceCollector->UpdateDataLogType(GetDataLogTypeFromCVar(newCaptureType));
-            }
-
             static void OnNumberOfCaptureBatchesChanged(const AZ::u32& newValue)
             {
                 AZ_TracePrintf(LogName, "%s cvar changed to %u.\n", __FUNCTION__, newValue);
@@ -58,40 +78,31 @@ namespace AZ
                 {
                     return;
                 }
+
+                // For diagnostics purposes write to the log the state of the CVars involved
+                // in Graphics performance collection.
+                CVarFixedString metricsDataLogType = r_metricsDataLogType;
+                AZ_TracePrintf(LogName, "%s r_metricsDataLogType=%s.\n", __FUNCTION__, metricsDataLogType.c_str());
+                AZ::u32 metricsWaitTimePerCaptureBatch = r_metricsWaitTimePerCaptureBatch;
+                AZ_TracePrintf(LogName, "%s r_metricsWaitTimePerCaptureBatch=%u.\n", __FUNCTION__, metricsWaitTimePerCaptureBatch);
+                AZ::u32 metricsFrameCountPerCaptureBatch = r_metricsFrameCountPerCaptureBatch;
+                AZ_TracePrintf(LogName, "%s r_metricsFrameCountPerCaptureBatch=%u.\n", __FUNCTION__, metricsFrameCountPerCaptureBatch);
+                bool metricsEnableRenderPipelineGpuTime = r_metricsEnableRenderPipelineGpuTime;
+                AZ_TracePrintf(LogName, "%s value of r_metricsEnableRenderPipelineGpuTime=%s.\n", __FUNCTION__, metricsEnableRenderPipelineGpuTime ? "true" : "false");
+                bool metricsQuitUponCompletion = r_metricsQuitUponCompletion;
+                AZ_TracePrintf(LogName, "%s value of r_metricsQuitUponCompletion=%s.\n", __FUNCTION__, metricsQuitUponCompletion ? "true" : "false");
+
+                auto gpuPassProfiler = performanceCollectorOwner->GetGpuPassProfiler();
+                if (gpuPassProfiler)
+                {
+                    gpuPassProfiler->SetRenderPipelineGpuTimeMeasurementEnabled(metricsEnableRenderPipelineGpuTime);
+                }
+                performanceCollector->UpdateDataLogType(GetDataLogTypeFromCVar(metricsDataLogType));
+                performanceCollector->UpdateWaitTimeBeforeEachBatch(AZStd::chrono::seconds(metricsWaitTimePerCaptureBatch));
+                performanceCollector->UpdateFrameCountPerCaptureBatch(metricsFrameCountPerCaptureBatch);
                 performanceCollector->UpdateNumberOfCaptureBatches(newValue);
             }
 
-            static void OnWaitTimePerCaptureBatchChanged(const AZ::u32& newValue)
-            {
-                AZ_TracePrintf(LogName, "%s cvar changed to %u.\n", __FUNCTION__, newValue);
-                auto performanceCollectorOwner = PerformanceCollectorOwner::Get();
-                if (!performanceCollectorOwner)
-                {
-                    return;
-                }
-                auto performanceCollector = performanceCollectorOwner->GetPerformanceCollector();
-                if (!performanceCollector)
-                {
-                    return;
-                }
-                performanceCollector->UpdateWaitTimeBeforeEachBatch(AZStd::chrono::seconds(newValue));
-            }
-
-            static void OnFrameCountPerCaptureBatchChanged(const AZ::u32& newValue)
-            {
-                AZ_TracePrintf(LogName, "%s cvar changed to %u.\n", __FUNCTION__, newValue);
-                auto performanceCollectorOwner = PerformanceCollectorOwner::Get();
-                if (!performanceCollectorOwner)
-                {
-                    return;
-                }
-                auto performanceCollector = performanceCollectorOwner->GetPerformanceCollector();
-                if (!performanceCollector)
-                {
-                    return;
-                }
-                performanceCollector->UpdateFrameCountPerCaptureBatch(newValue);
-            }
         };
 
         AZ_CVAR(AZ::u32, r_metricsNumberOfCaptureBatches,
@@ -99,30 +110,6 @@ namespace AZ
             &PerformanceCvarManager::OnNumberOfCaptureBatchesChanged,
             ConsoleFunctorFlags::DontReplicate,
             "Collects and reports graphics performance in this number of batches.");
-
-        AZ_CVAR(AZ::CVarFixedString, r_metricsDataLogType,
-            "statistical", // (s)(S)tatistical Summary (average, min, max, stdev) / (a)(A)ll Samples. Default=s.
-            &PerformanceCvarManager::OnDataLogTypeChanged,
-            ConsoleFunctorFlags::DontReplicate,
-            "Defines the kind of data collection and logging. If starts with 's' it will log statistical summaries, if starts with 'a' will log each sample of data (high verbosity).");
-
-        AZ_CVAR(AZ::u32, r_metricsWaitTimePerCaptureBatch,
-            0, // Starts at 0, which means "do not capture performance data". When this variable changes to >0 we'll start performance capture.
-            &PerformanceCvarManager::OnWaitTimePerCaptureBatchChanged,
-            ConsoleFunctorFlags::DontReplicate,
-            "How many seconds to wait before each batch of performance capture.");
-
-        AZ_CVAR(AZ::u32, r_metricsFrameCountPerCaptureBatch,
-            1200, // Number of frames in which performance will be measured per batch.
-            &PerformanceCvarManager::OnFrameCountPerCaptureBatchChanged,
-            ConsoleFunctorFlags::DontReplicate,
-            "Number of frames in which performance will be measured per batch.");
-
-        AZ_CVAR(bool, r_metricsQuitUponCompletion,
-            false, // If true the application will quit when Number Of Capture Batches reaches 0.
-            nullptr,
-            ConsoleFunctorFlags::DontReplicate,
-            "If true the application will quit when Number Of Capture Batches reaches 0.");
 
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/PerformanceCVarManager.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/PerformanceCVarManager.h
@@ -20,6 +20,8 @@ namespace AZ
 
     namespace RPI
     {
+        class GpuPassProfiler;
+
         // A simple helper function.
         AZ::Debug::PerformanceCollector::DataLogType GetDataLogTypeFromCVar(const AZ::CVarFixedString& newCaptureType);
 
@@ -37,6 +39,7 @@ namespace AZ
         protected:
             friend class PerformanceCvarManager;
             virtual AZ::Debug::PerformanceCollector* GetPerformanceCollector() { return nullptr; }
+            virtual GpuPassProfiler* GetGpuPassProfiler() { return nullptr;  }
         };
         using PerformanceCollectorOwner = AZ::Interface<IPerformanceCollectorOwner>;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
@@ -138,13 +138,13 @@ namespace AZ
         {
             if (m_performanceCollector)
             {
-                if (m_gpuPassProfiler && !m_performanceCollector->IsWaitingBeforeCapture() && m_gpuPassProfiler->IsRenderPipelineGpuTimeMeasurementEnabled())
+                if (m_gpuPassProfiler && !m_performanceCollector->IsWaitingBeforeCapture() && m_gpuPassProfiler->IsGpuTimeMeasurementEnabled())
                 {
-                    uint64_t durationNanoseconds = m_gpuPassProfiler->MeasureRenderPipelineGpuTimeInNanoseconds(AZ::RPI::PassSystemInterface::Get()->GetRootPass());
+                    uint64_t durationNanoseconds = m_gpuPassProfiler->MeasureGpuTimeInNanoseconds(AZ::RPI::PassSystemInterface::Get()->GetRootPass());
                     // The first three frames, it is expected to be zero. So only record non-zero samples.
                     if (durationNanoseconds > 0)
                     {
-                        m_performanceCollector->RecordSample(PerformanceSpecRenderPipelineGpuTime, AZStd::chrono::microseconds(aznumeric_cast<int64_t>(durationNanoseconds / 1000)));
+                        m_performanceCollector->RecordSample(PerformanceSpecGpuTime, AZStd::chrono::microseconds(aznumeric_cast<int64_t>(durationNanoseconds / 1000)));
                     }
                 }
 
@@ -197,7 +197,7 @@ namespace AZ
         AZ_CVAR_EXTERNED(AZ::CVarFixedString, r_metricsDataLogType);
         AZ_CVAR_EXTERNED(AZ::u32, r_metricsWaitTimePerCaptureBatch);
         AZ_CVAR_EXTERNED(AZ::u32, r_metricsFrameCountPerCaptureBatch);
-        AZ_CVAR_EXTERNED(bool, r_metricsEnableRenderPipelineGpuTime);
+        AZ_CVAR_EXTERNED(bool, r_metricsMeasureGpuTime);
         AZ_CVAR_EXTERNED(bool, r_metricsQuitUponCompletion);
 
         AZStd::string RPISystemComponent::GetLogCategory()
@@ -215,7 +215,7 @@ namespace AZ
                 r_metricsNumberOfCaptureBatches = pendingBatches;
                 if (pendingBatches == 0)
                 {
-                    m_gpuPassProfiler->SetRenderPipelineGpuTimeMeasurementEnabled(false);
+                    m_gpuPassProfiler->SetGpuTimeMeasurementEnabled(false);
                     // Force disabling timestamp collection in the root pass.
                     AZ::RPI::PassSystemInterface::Get()->GetRootPass()->SetTimestampQueryEnabled(false);
                 }
@@ -230,7 +230,7 @@ namespace AZ
                 PerformanceSpecGraphicsSimulationTime,
                 PerformanceSpecGraphicsRenderTime,
                 PerformanceSpecEngineCpuTime,
-                PerformanceSpecRenderPipelineGpuTime,
+                PerformanceSpecGpuTime,
                 });
             AZStd::string logCategory = GetLogCategory();
             m_performanceCollector = AZStd::make_unique<AZ::Debug::PerformanceCollector>(
@@ -238,7 +238,7 @@ namespace AZ
             m_gpuPassProfiler = AZStd::make_unique<GpuPassProfiler>();
 
             //Feed the CVAR values.
-            m_gpuPassProfiler->SetRenderPipelineGpuTimeMeasurementEnabled(r_metricsEnableRenderPipelineGpuTime);
+            m_gpuPassProfiler->SetGpuTimeMeasurementEnabled(r_metricsMeasureGpuTime);
             m_performanceCollector->UpdateDataLogType(GetDataLogTypeFromCVar(r_metricsDataLogType));
             m_performanceCollector->UpdateFrameCountPerCaptureBatch(r_metricsFrameCountPerCaptureBatch);
             m_performanceCollector->UpdateWaitTimeBeforeEachBatch(AZStd::chrono::seconds(r_metricsWaitTimePerCaptureBatch));

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
@@ -138,6 +138,16 @@ namespace AZ
         {
             if (m_performanceCollector)
             {
+                if (m_gpuPassProfiler && !m_performanceCollector->IsWaitingBeforeCapture() && m_gpuPassProfiler->IsRenderPipelineGpuTimeMeasurementEnabled())
+                {
+                    uint64_t durationNanoseconds = m_gpuPassProfiler->MeasureRenderPipelineGpuTimeInNanoseconds(AZ::RPI::PassSystemInterface::Get()->GetRootPass());
+                    // The first three frames, it is expected to be zero. So only record non-zero samples.
+                    if (durationNanoseconds > 0)
+                    {
+                        m_performanceCollector->RecordSample(PerformanceSpecRenderPipelineGpuTime, AZStd::chrono::microseconds(aznumeric_cast<int64_t>(durationNanoseconds / 1000)));
+                    }
+                }
+
                 m_performanceCollector->RecordPeriodicEvent(PerformanceSpecEngineCpuTime);
                 m_performanceCollector->FrameTick();
             }
@@ -187,6 +197,7 @@ namespace AZ
         AZ_CVAR_EXTERNED(AZ::CVarFixedString, r_metricsDataLogType);
         AZ_CVAR_EXTERNED(AZ::u32, r_metricsWaitTimePerCaptureBatch);
         AZ_CVAR_EXTERNED(AZ::u32, r_metricsFrameCountPerCaptureBatch);
+        AZ_CVAR_EXTERNED(bool, r_metricsEnableRenderPipelineGpuTime);
         AZ_CVAR_EXTERNED(bool, r_metricsQuitUponCompletion);
 
         AZStd::string RPISystemComponent::GetLogCategory()
@@ -199,9 +210,15 @@ namespace AZ
 
         void RPISystemComponent::InitializePerformanceCollector()
         {
-            auto onBatchCompleteCallback = [](AZ::u32 pendingBatches) {
+            auto onBatchCompleteCallback = [&](AZ::u32 pendingBatches) {
                 AZ_TracePrintf("RPISystem", "Completed a performance batch, still %u batches are pending.\n", pendingBatches);
                 r_metricsNumberOfCaptureBatches = pendingBatches;
+                if (pendingBatches == 0)
+                {
+                    m_gpuPassProfiler->SetRenderPipelineGpuTimeMeasurementEnabled(false);
+                    // Force disabling timestamp collection in the root pass.
+                    AZ::RPI::PassSystemInterface::Get()->GetRootPass()->SetTimestampQueryEnabled(false);
+                }
                 if (r_metricsQuitUponCompletion && (pendingBatches == 0))
                 {
                     AzFramework::ConsoleRequestBus::Broadcast(
@@ -213,11 +230,15 @@ namespace AZ
                 PerformanceSpecGraphicsSimulationTime,
                 PerformanceSpecGraphicsRenderTime,
                 PerformanceSpecEngineCpuTime,
+                PerformanceSpecRenderPipelineGpuTime,
                 });
             AZStd::string logCategory = GetLogCategory();
             m_performanceCollector = AZStd::make_unique<AZ::Debug::PerformanceCollector>(
                 logCategory, performanceMetrics, onBatchCompleteCallback);
+            m_gpuPassProfiler = AZStd::make_unique<GpuPassProfiler>();
+
             //Feed the CVAR values.
+            m_gpuPassProfiler->SetRenderPipelineGpuTimeMeasurementEnabled(r_metricsEnableRenderPipelineGpuTime);
             m_performanceCollector->UpdateDataLogType(GetDataLogTypeFromCVar(r_metricsDataLogType));
             m_performanceCollector->UpdateFrameCountPerCaptureBatch(r_metricsFrameCountPerCaptureBatch);
             m_performanceCollector->UpdateWaitTimeBeforeEachBatch(AZStd::chrono::seconds(r_metricsWaitTimePerCaptureBatch));

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.h
@@ -18,6 +18,7 @@
 
 #include <Atom/RHI/RHISystemInterface.h>
 #include <Atom/RPI.Public/RPISystem.h>
+#include <Atom/RPI.Public/GpuQuery/GpuPassProfiler.h>
 #include <Atom/RPI.Public/XR/XRRenderingInterface.h>
 
 #include "PerformanceCVarManager.h"
@@ -74,6 +75,7 @@ namespace AZ
             ///////////////////////////////////////////////////////////////////
             // IPerformanceCollectorOwner overrides
             AZ::Debug::PerformanceCollector* GetPerformanceCollector() override { return m_performanceCollector.get(); }
+            GpuPassProfiler* GetGpuPassProfiler() override { return m_gpuPassProfiler.get(); }
             ///////////////////////////////////////////////////////////////////
 
             ///////////////////////////////////////////////////////////////////
@@ -89,8 +91,10 @@ namespace AZ
             static constexpr AZStd::string_view PerformanceSpecGraphicsSimulationTime = "Graphics Simulation Time";
             static constexpr AZStd::string_view PerformanceSpecGraphicsRenderTime = "Graphics Render Time";
             static constexpr AZStd::string_view PerformanceSpecEngineCpuTime = "Engine Cpu Time";
+            static constexpr AZStd::string_view PerformanceSpecRenderPipelineGpuTime = "Render Pipeline Gpu Time";
 
             AZStd::unique_ptr<AZ::Debug::PerformanceCollector> m_performanceCollector;
+            AZStd::unique_ptr<GpuPassProfiler> m_gpuPassProfiler; // Used to measure "Render Pipeline Gpu Time".
             ///////////////////////////////////////////////////////////////////
 
             RPISystem m_rpiSystem;

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.h
@@ -91,7 +91,7 @@ namespace AZ
             static constexpr AZStd::string_view PerformanceSpecGraphicsSimulationTime = "Graphics Simulation Time";
             static constexpr AZStd::string_view PerformanceSpecGraphicsRenderTime = "Graphics Render Time";
             static constexpr AZStd::string_view PerformanceSpecEngineCpuTime = "Engine Cpu Time";
-            static constexpr AZStd::string_view PerformanceSpecRenderPipelineGpuTime = "Render Pipeline Gpu Time";
+            static constexpr AZStd::string_view PerformanceSpecGpuTime = "Frame Gpu Time";
 
             AZStd::unique_ptr<AZ::Debug::PerformanceCollector> m_performanceCollector;
             AZStd::unique_ptr<GpuPassProfiler> m_gpuPassProfiler; // Used to measure "Render Pipeline Gpu Time".

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/GpuPassProfiler.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/GpuPassProfiler.cpp
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/sort.h>
+
+#include <Atom/RPI.Public/Pass/ParentPass.h>
+#include <Atom/RPI.Public/GpuQuery/GpuPassProfiler.h>
+
+
+namespace AZ
+{
+    namespace RPI
+    {
+        ///////////////////////////////////////////////////////////////////////
+        // --- PassEntry Start---
+        GpuPassProfiler::PassEntry::PassEntry(const RPI::Pass* pass, GpuPassProfiler::PassEntry* parent)
+        {
+            m_name = pass->GetName();
+            m_path = pass->GetPathName();
+            m_parent = parent;
+            m_enabled = pass->IsEnabled();
+            m_timestampEnabled = pass->IsTimestampQueryEnabled();
+            m_pipelineStatisticsEnabled = pass->IsPipelineStatisticsQueryEnabled();
+            m_isParent = pass->AsParent() != nullptr;
+
+            // [GFX TODO][ATOM-4001] Cache the timestamp and PipelineStatistics results.
+            // Get the query results from the passes.
+            m_timestampResult = pass->GetLatestTimestampResult();
+
+            const RPI::PipelineStatisticsResult rps = pass->GetLatestPipelineStatisticsResult();
+            m_pipelineStatistics = { rps.m_vertexCount, rps.m_primitiveCount, rps.m_vertexShaderInvocationCount,
+                rps.m_rasterizedPrimitiveCount, rps.m_renderedPrimitiveCount, rps.m_pixelShaderInvocationCount, rps.m_computeShaderInvocationCount };
+
+            // Disable the entry if it has a parent that is also not enabled.
+            if (m_parent)
+            {
+                m_enabled = pass->IsEnabled() && m_parent->m_enabled;
+            }
+        }
+
+        void GpuPassProfiler::PassEntry::LinkChild(PassEntry* childEntry)
+        {
+            m_children.push_back(childEntry);
+
+            if (!m_linked && m_parent)
+            {
+                m_linked = true;
+
+                // Recursively create parent->child references for entries that aren't linked to the root entry yet.
+                // Effectively walking the tree backwards from the leaf to the root entry, and establishing parent->child references to
+                // entries that aren't connected to the root entry yet.
+                m_parent->LinkChild(this);
+            }
+
+            childEntry->m_linked = true;
+        }
+
+        bool GpuPassProfiler::PassEntry::IsTimestampEnabled() const
+        {
+            return m_enabled && m_timestampEnabled;
+        }
+
+        bool GpuPassProfiler::PassEntry::IsPipelineStatisticsEnabled() const
+        {
+            return m_enabled && m_pipelineStatisticsEnabled;
+        }
+        // --- PassEntry End ---
+        ///////////////////////////////////////////////////////////////////////
+
+        AZStd::unordered_map<Name, GpuPassProfiler::PassEntry> GpuPassProfiler::CreatePassEntriesDatabase(RHI::Ptr<RPI::ParentPass> rootPass)
+        {
+            AZStd::unordered_map<Name, GpuPassProfiler::PassEntry> passEntryDatabase;
+            const auto addPassEntry = [&passEntryDatabase](const RPI::Pass* pass, GpuPassProfiler::PassEntry* parent) -> GpuPassProfiler::PassEntry*
+            {
+                // If parent a nullptr, it's assumed to be the rootpass.
+                if (parent == nullptr)
+                {
+                    return &passEntryDatabase[pass->GetPathName()];
+                }
+                else
+                {
+                    GpuPassProfiler::PassEntry entry(pass, parent);
+
+                    // Set the time stamp in the database.
+                    [[maybe_unused]] const auto passEntry = passEntryDatabase.find(entry.m_path);
+                    AZ_Assert(passEntry == passEntryDatabase.end(), "There already is an entry with the name \"%s\".", entry.m_path.GetCStr());
+
+                    // Set the entry in the map.
+                    GpuPassProfiler::PassEntry& entryRef = passEntryDatabase[entry.m_path] = entry;
+                    return &entryRef;
+                }
+            };
+
+            // NOTE: Write it all out, can't have recursive functions for lambdas.
+            const AZStd::function<void(const RPI::Pass*, PassEntry*)> getPassEntryRecursive = [&addPassEntry, &getPassEntryRecursive](const RPI::Pass* pass, GpuPassProfiler::PassEntry* parent) -> void
+            {
+                const RPI::ParentPass* passAsParent = pass->AsParent();
+
+                // Add new entry to the timestamp map.
+                GpuPassProfiler::PassEntry* entry = addPassEntry(pass, parent);
+
+                // Recur if it's a parent.
+                if (passAsParent)
+                {
+                    for (const auto& childPass : passAsParent->GetChildren())
+                    {
+                        getPassEntryRecursive(childPass.get(), entry);
+                    }
+                }
+            };
+
+            // Set up the root entry.
+            GpuPassProfiler::PassEntry rootEntry(static_cast<RPI::Pass*>(rootPass.get()), nullptr);
+            passEntryDatabase[rootPass->GetPathName()] = rootEntry;
+
+            // Create an intermediate structure from the passes.
+            // Recursively create the timestamp entries tree.
+            getPassEntryRecursive(static_cast<RPI::Pass*>(rootPass.get()), nullptr);
+
+            // Interpolate the old values.
+            const float lerpWeight = 0.2f;
+            InterpolatePassEntries(passEntryDatabase, lerpWeight);
+
+            return passEntryDatabase;
+        }
+
+        void GpuPassProfiler::InterpolatePassEntries(AZStd::unordered_map<Name, GpuPassProfiler::PassEntry>& passEntryDatabase, float weight) const
+        {
+            for (auto& entry : passEntryDatabase)
+            {
+                const auto oldEntryIt = passEntryDatabase.find(entry.second.m_path);
+                if (oldEntryIt != passEntryDatabase.end())
+                {
+                    // Interpolate the timestamps.
+                    const double interpolated = Lerp(static_cast<double>(oldEntryIt->second.m_interpolatedTimestampInNanoseconds),
+                        static_cast<double>(entry.second.m_timestampResult.GetDurationInNanoseconds()),
+                        static_cast<double>(weight));
+                    entry.second.m_interpolatedTimestampInNanoseconds = static_cast<uint64_t>(interpolated);
+                }
+            }
+        }
+
+        AZStd::vector<GpuPassProfiler::PassEntry*> GpuPassProfiler::SortPassEntriesByTimestamps(AZStd::unordered_map<Name, PassEntry>& timestampEntryDatabase)
+        {
+            // pass entry grid based on its timestamp
+            AZStd::vector<GpuPassProfiler::PassEntry*> sortedPassEntries;
+            sortedPassEntries.reserve(timestampEntryDatabase.size());
+
+            // Set the child of the parent, only if it passes the filter.
+            for (auto& passEntryIt : timestampEntryDatabase)
+            {
+                PassEntry* passEntry = &passEntryIt.second;
+
+                // Collect all pass entries with non-zero durations
+                if (passEntry->m_timestampResult.GetDurationInTicks() > 0)
+                {
+                    sortedPassEntries.push_back(passEntry);
+                }
+            }
+
+            // Sort the pass entries based on their starting time and duration
+            AZStd::sort(sortedPassEntries.begin(), sortedPassEntries.end(), [](const PassEntry* passEntry1, const PassEntry* passEntry2) {
+                if (passEntry1->m_timestampResult.GetTimestampBeginInTicks() == passEntry2->m_timestampResult.GetTimestampBeginInTicks())
+                {
+                    return passEntry1->m_timestampResult.GetDurationInTicks() < passEntry2->m_timestampResult.GetDurationInTicks();
+                }
+                return passEntry1->m_timestampResult.GetTimestampBeginInTicks() < passEntry2->m_timestampResult.GetTimestampBeginInTicks();
+            });
+
+            return sortedPassEntries;
+        }
+
+
+        uint64_t GpuPassProfiler::CalculateTotalGpuPassTime(const AZStd::vector<GpuPassProfiler::PassEntry*>& sortedPassEntries)
+        {
+            // calculate the total GPU duration.
+            RPI::TimestampResult gpuTimestamp;
+            if (sortedPassEntries.size() > 0)
+            {
+                gpuTimestamp = sortedPassEntries.front()->m_timestampResult;
+                gpuTimestamp.Add(sortedPassEntries.back()->m_timestampResult);
+            }
+
+            return gpuTimestamp.GetDurationInNanoseconds();
+        }
+
+        uint64_t GpuPassProfiler::MeasureRenderPipelineGpuTimeInNanoseconds(RHI::Ptr<RPI::ParentPass> rootPass)
+        {
+            if (m_measureRenderPipelineGpuTime)
+            {
+                if (!rootPass->IsTimestampQueryEnabled())
+                {
+                    rootPass->SetTimestampQueryEnabled(true);
+                }
+            }
+            else
+            {
+                if (rootPass->IsTimestampQueryEnabled())
+                {
+                    rootPass->SetTimestampQueryEnabled(false);
+                }
+                return 0;
+            }
+
+            auto passEntryDatabase = CreatePassEntriesDatabase(rootPass);
+            auto sortedPassEntries = SortPassEntriesByTimestamps(passEntryDatabase);
+            return CalculateTotalGpuPassTime(sortedPassEntries);
+
+        }
+
+    }   // namespace RPI
+}   // namespace AZ

--- a/Gems/Atom/RPI/Code/atom_rpi_public_files.cmake
+++ b/Gems/Atom/RPI/Code/atom_rpi_public_files.cmake
@@ -99,6 +99,7 @@ set(FILES
     Include/Atom/RPI.Public/GpuQuery/Query.h
     Include/Atom/RPI.Public/GpuQuery/QueryPool.h
     Include/Atom/RPI.Public/GpuQuery/TimestampQueryPool.h
+    Include/Atom/RPI.Public/GpuQuery/GpuPassProfiler.h
     Include/Atom/RPI.Public/XR/XRRenderingInterface.h
     Source/RPI.Public/Culling.cpp
     Source/RPI.Public/FeatureProcessor.cpp
@@ -178,4 +179,5 @@ set(FILES
     Source/RPI.Public/GpuQuery/Query.cpp
     Source/RPI.Public/GpuQuery/QueryPool.cpp
     Source/RPI.Public/GpuQuery/TimestampQueryPool.cpp
+    Source/RPI.Public/GpuQuery/GpuPassProfiler.cpp
 )


### PR DESCRIPTION
## What does this PR do?

Added class GpuPassProfiler, that is based on the existing ImGuiGpuProfiler but did not make changes to ImGuiGpuProfiler at this time to simplify the size of the PR.

The core function is in
GpuPassProfiler::MeasureGpuTimeInNanoseconds(). Use judiciously, as MeasureGpuTimeInNanoseconds() can itself affect performance when called. For example, if a scene is running at 300fps, calling
 MeasureGpuTimeInNanoseconds(), each frame, can reduce the FPS to ~290fps.

Added CVAR r_metricsMeasureGpuTime, which defaults to false, as it is the only parameter that can be expensive to measure.

## How was this PR tested?

Collected data around the new "Frame Gpu Time" metric on the Editor, AutomatedTesting.GameLauncher and LoftSample.GameLauncher.

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>
