### PR TITLE
AZ Networking ISerialize Support for AZ::s64 and AZ::u64

### DIFF
--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/DeltaSerializer.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/DeltaSerializer.cpp
@@ -319,6 +319,14 @@ namespace AzNetworking
         return SerializeHelper(value, 0, false, unused, name);
     }
 
+    #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+    bool DeltaSerializerApply::Serialize(AZ::s64& value, const char* name, [[maybe_unused]] AZ::s64 minValue, [[maybe_unused]] AZ::s64 maxValue)
+    {
+        uint32_t unused = 0;
+        return SerializeHelper(value, 0, false, unused, name);
+    }
+    #endif
+
     bool DeltaSerializerApply::Serialize(uint8_t& value, const char* name, [[maybe_unused]] uint8_t minValue, [[maybe_unused]] uint8_t maxValue)
     {
         uint32_t unused = 0;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/DeltaSerializer.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/DeltaSerializer.cpp
@@ -119,6 +119,14 @@ namespace AzNetworking
         return SerializeHelper(value, 0, false, unused, name);
     }
 
+    #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+    bool DeltaSerializerCreate::Serialize(AZ::s64& value, const char* name, [[maybe_unused]] AZ::s64 minValue, [[maybe_unused]] AZ::s64 maxValue)
+    {
+        uint32_t unused = 0;
+        return SerializeHelper(value, 0, false, unused, name);
+    }
+    #endif
+
     bool DeltaSerializerCreate::Serialize(uint8_t& value, const char* name, [[maybe_unused]] uint8_t minValue, [[maybe_unused]] uint8_t maxValue)
     {
         uint32_t unused = 0;
@@ -142,6 +150,14 @@ namespace AzNetworking
         uint32_t unused = 0;
         return SerializeHelper(value, 0, false, unused, name);
     }
+
+    #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+    bool DeltaSerializerCreate::Serialize(AZ::u64& value, const char* name, [[maybe_unused]] AZ::u64 minValue, [[maybe_unused]] AZ::u64 maxValue)
+    {
+        uint32_t unused = 0;
+        return SerializeHelper(value, 0, false, unused, name);
+    }
+    #endif
 
     bool DeltaSerializerCreate::Serialize(float& value, const char* name, [[maybe_unused]] float minValue, [[maybe_unused]] float maxValue)
     {
@@ -326,6 +342,14 @@ namespace AzNetworking
         uint32_t unused = 0;
         return SerializeHelper(value, 0, false, unused, name);
     }
+
+    #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+    bool DeltaSerializerApply::Serialize(AZ::u64& value, const char* name, [[maybe_unused]] AZ::u64 minValue, [[maybe_unused]] AZ::u64 maxValue)
+    {
+        uint32_t unused = 0;
+        return SerializeHelper(value, 0, false, unused, name);
+    }
+    #endif
 
     bool DeltaSerializerApply::Serialize(float& value, const char* name, [[maybe_unused]] float minValue, [[maybe_unused]] float maxValue)
     {

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/DeltaSerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/DeltaSerializer.h
@@ -68,10 +68,16 @@ namespace AzNetworking
         bool Serialize(int16_t& value, const char* name, int16_t minValue, int16_t maxValue) override;
         bool Serialize(int32_t& value, const char* name, int32_t minValue, int32_t maxValue) override;
         bool Serialize(int64_t& value, const char* name, int64_t minValue, int64_t maxValue) override;
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max()) override;
+        #endif
         bool Serialize(uint8_t& value, const char* name, uint8_t minValue, uint8_t maxValue) override;
         bool Serialize(uint16_t& value, const char* name, uint16_t minValue, uint16_t maxValue) override;
         bool Serialize(uint32_t& value, const char* name, uint32_t minValue, uint32_t maxValue) override;
         bool Serialize(uint64_t& value, const char* name, uint64_t minValue, uint64_t maxValue) override;
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue = AZStd::numeric_limits<AZ::u64>::min(), AZ::u64 maxValue = AZStd::numeric_limits<AZ::u64>::max()) override;
+        #endif
         bool Serialize(float& value, const char* name, float minValue, float maxValue) override;
         bool Serialize(double& value, const char* name, double minValue, double maxValue) override;
         bool SerializeBytes(uint8_t* buffer, uint32_t bufferCapacity, bool isString, uint32_t& outSize, const char* name) override;
@@ -128,10 +134,16 @@ namespace AzNetworking
         bool Serialize(int16_t& value, const char* name, int16_t minValue, int16_t maxValue) override;
         bool Serialize(int32_t& value, const char* name, int32_t minValue, int32_t maxValue) override;
         bool Serialize(int64_t& value, const char* name, int64_t minValue, int64_t maxValue) override;
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max()) override;
+        #endif
         bool Serialize(uint8_t& value, const char* name, uint8_t minValue, uint8_t maxValue) override;
         bool Serialize(uint16_t& value, const char* name, uint16_t minValue, uint16_t maxValue) override;
         bool Serialize(uint32_t& value, const char* name, uint32_t minValue, uint32_t maxValue) override;
         bool Serialize(uint64_t& value, const char* name, uint64_t minValue, uint64_t maxValue) override;
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue = AZStd::numeric_limits<AZ::u64>::min(), AZ::u64 maxValue = AZStd::numeric_limits<AZ::u64>::max()) override;
+        #endif
         bool Serialize(float& value, const char* name, float minValue, float maxValue) override;
         bool Serialize(double& value, const char* name, double minValue, double maxValue) override;
         bool SerializeBytes(uint8_t* buffer, uint32_t bufferCapacity, bool isString, uint32_t& outSize, const char* name) override;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/DeltaSerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/DeltaSerializer.h
@@ -69,14 +69,14 @@ namespace AzNetworking
         bool Serialize(int32_t& value, const char* name, int32_t minValue, int32_t maxValue) override;
         bool Serialize(int64_t& value, const char* name, int64_t minValue, int64_t maxValue) override;
         #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
-        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max()) override;
+        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue, AZ::s64 maxValue) override;
         #endif
         bool Serialize(uint8_t& value, const char* name, uint8_t minValue, uint8_t maxValue) override;
         bool Serialize(uint16_t& value, const char* name, uint16_t minValue, uint16_t maxValue) override;
         bool Serialize(uint32_t& value, const char* name, uint32_t minValue, uint32_t maxValue) override;
         bool Serialize(uint64_t& value, const char* name, uint64_t minValue, uint64_t maxValue) override;
         #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
-        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue = AZStd::numeric_limits<AZ::u64>::min(), AZ::u64 maxValue = AZStd::numeric_limits<AZ::u64>::max()) override;
+        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue, AZ::u64 maxValue) override;
         #endif
         bool Serialize(float& value, const char* name, float minValue, float maxValue) override;
         bool Serialize(double& value, const char* name, double minValue, double maxValue) override;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/HashSerializer.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/HashSerializer.cpp
@@ -75,6 +75,14 @@ namespace AzNetworking
         return true;
     }
 
+    #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+    bool HashSerializer::Serialize(AZ::s64& value, [[maybe_unused]] const char* name, [[maybe_unused]] AZ::s64 minValue, [[maybe_unused]] AZ::s64 maxValue)
+    {
+        m_hash = AZ::TypeHash64(value, m_hash);
+        return true;
+    }
+    #endif
+
     bool HashSerializer::Serialize(uint8_t& value, [[maybe_unused]] const char* name, [[maybe_unused]] uint8_t minValue, [[maybe_unused]] uint8_t maxValue)
     {
         m_hash = AZ::TypeHash64(value, m_hash);
@@ -98,6 +106,14 @@ namespace AzNetworking
         m_hash = AZ::TypeHash64(value, m_hash);
         return true;
     }
+    
+    #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+    bool HashSerializer::Serialize(AZ::u64& value, [[maybe_unused]] const char* name, [[maybe_unused]] AZ::u64 minValue, [[maybe_unused]] AZ::u64 maxValue)
+    {
+        m_hash = AZ::TypeHash64(value, m_hash);
+        return true;
+    }
+    #endif
 
     bool HashSerializer::Serialize(float& value, [[maybe_unused]] const char* name, [[maybe_unused]] float minValue, [[maybe_unused]] float maxValue)
     {

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/HashSerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/HashSerializer.h
@@ -35,14 +35,14 @@ namespace AzNetworking
         bool Serialize(int32_t& value, const char* name, int32_t minValue, int32_t maxValue) override;
         bool Serialize(int64_t& value, const char* name, int64_t minValue, int64_t maxValue) override;
         #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
-        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max()) override;
+        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue, AZ::s64 maxValue) override;
         #endif
         bool Serialize(uint8_t& value, const char* name, uint8_t minValue, uint8_t maxValue) override;
         bool Serialize(uint16_t& value, const char* name, uint16_t minValue, uint16_t maxValue) override;
         bool Serialize(uint32_t& value, const char* name, uint32_t minValue, uint32_t maxValue) override;
         bool Serialize(uint64_t& value, const char* name, uint64_t minValue, uint64_t maxValue) override;
         #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
-        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue = AZStd::numeric_limits<AZ::u64>::min(), AZ::u64 maxValue = AZStd::numeric_limits<AZ::u64>::max()) override;
+        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue, AZ::u64 maxValue) override;
         #endif
         bool Serialize(float& value, const char* name, float minValue, float maxValue) override;
         bool Serialize(double& value, const char* name, double minValue, double maxValue) override;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/HashSerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/HashSerializer.h
@@ -34,10 +34,16 @@ namespace AzNetworking
         bool Serialize(int16_t& value, const char* name, int16_t minValue, int16_t maxValue) override;
         bool Serialize(int32_t& value, const char* name, int32_t minValue, int32_t maxValue) override;
         bool Serialize(int64_t& value, const char* name, int64_t minValue, int64_t maxValue) override;
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max()) override;
+        #endif
         bool Serialize(uint8_t& value, const char* name, uint8_t minValue, uint8_t maxValue) override;
         bool Serialize(uint16_t& value, const char* name, uint16_t minValue, uint16_t maxValue) override;
         bool Serialize(uint32_t& value, const char* name, uint32_t minValue, uint32_t maxValue) override;
         bool Serialize(uint64_t& value, const char* name, uint64_t minValue, uint64_t maxValue) override;
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue = AZStd::numeric_limits<AZ::u64>::min(), AZ::u64 maxValue = AZStd::numeric_limits<AZ::u64>::max()) override;
+        #endif
         bool Serialize(float& value, const char* name, float minValue, float maxValue) override;
         bool Serialize(double& value, const char* name, double minValue, double maxValue) override;
         bool SerializeBytes(uint8_t* buffer, uint32_t bufferCapacity, bool isString, uint32_t& outSize, const char* name) override;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <AzCore/base.h>
 #include <AzCore/std/limits.h>
 
 namespace AzNetworking
@@ -100,6 +101,12 @@ namespace AzNetworking
         //! @return boolean true for success, false for failure
         virtual bool Serialize(int64_t& value, const char* name, int64_t minValue = AZStd::numeric_limits<int64_t>::min(), int64_t maxValue = AZStd::numeric_limits<int64_t>::max()) = 0;
 
+        //! Serialize a signed 64-bit integer.
+        //! @param value    signed 64-bit integer input value to serialize
+        //! @param name     string name of the value being serialized
+        //! @param minValue the minimum value expected during serialization
+        //! @param maxValue the maximum value expected during serialization
+        //! @return boolean true for success, false for failure
         #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
         virtual bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max()) = 0;
         #endif

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
@@ -100,6 +100,10 @@ namespace AzNetworking
         //! @return boolean true for success, false for failure
         virtual bool Serialize(int64_t& value, const char* name, int64_t minValue = AZStd::numeric_limits<int64_t>::min(), int64_t maxValue = AZStd::numeric_limits<int64_t>::max()) = 0;
 
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        virtual bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max()) = 0;
+        #endif
+
         //! Serialize an unsigned byte.
         //! @param value    unsigned byte input value to serialize
         //! @param name     string name of the value being serialized
@@ -131,6 +135,16 @@ namespace AzNetworking
         //! @param maxValue the maximum value expected during serialization
         //! @return boolean true for success, false for failure
         virtual bool Serialize(uint64_t& value, const char* name, uint64_t minValue = AZStd::numeric_limits<uint64_t>::min(), uint64_t maxValue = AZStd::numeric_limits<uint64_t>::max()) = 0;
+
+        //! Serialize an unsigned 64-bit integer.
+        //! @param value    signed 64-bit integer input value to serialize
+        //! @param name     string name of the value being serialized
+        //! @param minValue the minimum value expected during serialization
+        //! @param maxValue the maximum value expected during serialization
+        //! @return boolean true for success, false for failure
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        virtual bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue = AZStd::numeric_limits<AZ::u64>::min(), AZ::u64 maxValue = AZStd::numeric_limits<AZ::u64>::max()) = 0;
+        #endif
 
         //! Serialize a 32-bit floating point number.
         //! @param value    32-bit floating point input value to serialize

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
@@ -9,7 +9,9 @@
 #pragma once
 
 #include <stdint.h>
+#if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
 #include <AzCore/base.h>
+#endif
 #include <AzCore/std/limits.h>
 
 namespace AzNetworking

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
@@ -9,9 +9,7 @@
 #pragma once
 
 #include <stdint.h>
-#if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
 #include <AzCore/base.h>
-#endif
 #include <AzCore/std/limits.h>
 
 namespace AzNetworking

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkInputSerializer.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkInputSerializer.cpp
@@ -59,6 +59,13 @@ namespace AzNetworking
         return SerializeBoundedValue<int64_t>(minValue, maxValue, value);
     }
 
+    #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+    bool NetworkInputSerializer::Serialize(AZ::s64& value, [[maybe_unused]] const char* name, AZ::s64 minValue, AZ::s64 maxValue)
+    {
+        return SerializeBoundedValue<AZ::s64>(minValue, maxValue, value);
+    }
+    #endif
+
     bool NetworkInputSerializer::Serialize(uint8_t& value, [[maybe_unused]] const char* name, uint8_t minValue, uint8_t maxValue)
     {
         return SerializeBoundedValue<uint8_t>(minValue, maxValue, value);
@@ -78,6 +85,13 @@ namespace AzNetworking
     {
         return SerializeBoundedValue<uint64_t>(minValue, maxValue, value);
     }
+
+    #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+    bool NetworkInputSerializer::Serialize(AZ::u64& value, [[maybe_unused]] const char* name, AZ::u64 minValue, AZ::u64 maxValue)
+    {
+        return SerializeBoundedValue<AZ::u64>(minValue, maxValue, value);
+    }
+    #endif
 
     bool NetworkInputSerializer::Serialize(float& value, [[maybe_unused]] const char* name, [[maybe_unused]] float minValue, [[maybe_unused]] float maxValue)
     {

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkInputSerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkInputSerializer.h
@@ -39,14 +39,14 @@ namespace AzNetworking
         bool Serialize(int32_t& value, const char* name, int32_t minValue, int32_t maxValue) override;
         bool Serialize(int64_t& value, const char* name, int64_t minValue, int64_t maxValue) override;
         #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
-        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max()) override;
+        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue, AZ::s64 maxValue) override;
         #endif
         bool Serialize(uint8_t& value, const char* name, uint8_t minValue, uint8_t maxValue) override;
         bool Serialize(uint16_t& value, const char* name, uint16_t minValue, uint16_t maxValue) override;
         bool Serialize(uint32_t& value, const char* name, uint32_t minValue, uint32_t maxValue) override;
         bool Serialize(uint64_t& value, const char* name, uint64_t minValue, uint64_t maxValue) override;
         #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
-        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue = AZStd::numeric_limits<AZ::u64>::min(), AZ::u64 maxValue = AZStd::numeric_limits<AZ::u64>::max()) override;
+        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue, AZ::u64 maxValue) override;
         #endif
         bool Serialize(float& value, const char* name, float minValue, float maxValue) override;
         bool Serialize(double& value, const char* name, double minValue, double maxValue) override;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkInputSerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkInputSerializer.h
@@ -38,10 +38,16 @@ namespace AzNetworking
         bool Serialize(int16_t& value, const char* name, int16_t minValue, int16_t maxValue) override;
         bool Serialize(int32_t& value, const char* name, int32_t minValue, int32_t maxValue) override;
         bool Serialize(int64_t& value, const char* name, int64_t minValue, int64_t maxValue) override;
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max()) override;
+        #endif
         bool Serialize(uint8_t& value, const char* name, uint8_t minValue, uint8_t maxValue) override;
         bool Serialize(uint16_t& value, const char* name, uint16_t minValue, uint16_t maxValue) override;
         bool Serialize(uint32_t& value, const char* name, uint32_t minValue, uint32_t maxValue) override;
         bool Serialize(uint64_t& value, const char* name, uint64_t minValue, uint64_t maxValue) override;
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue = AZStd::numeric_limits<AZ::u64>::min(), AZ::u64 maxValue = AZStd::numeric_limits<AZ::u64>::max()) override;
+        #endif
         bool Serialize(float& value, const char* name, float minValue, float maxValue) override;
         bool Serialize(double& value, const char* name, double minValue, double maxValue) override;
         bool SerializeBytes(uint8_t* buffer, uint32_t bufferCapacity, bool isString, uint32_t& outSize, const char* name) override;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkOutputSerializer.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkOutputSerializer.cpp
@@ -61,6 +61,13 @@ namespace AzNetworking
         return SerializeBoundedValue<int64_t>(minValue, maxValue, value);
     }
 
+    #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+    bool NetworkOutputSerializer::Serialize(AZ::s64& value, [[maybe_unused]] const char* name, AZ::s64 minValue, AZ::s64 maxValue)
+    {
+        return SerializeBoundedValue<AZ::s64>(minValue, maxValue, value);
+    }
+    #endif
+
     bool NetworkOutputSerializer::Serialize(uint8_t& value, [[maybe_unused]] const char* name, uint8_t minValue, uint8_t maxValue)
     {
         return SerializeBoundedValue<uint8_t>(minValue, maxValue, value);
@@ -80,6 +87,13 @@ namespace AzNetworking
     {
         return SerializeBoundedValue<uint64_t>(minValue, maxValue, value);
     }
+
+    #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+    bool NetworkOutputSerializer::Serialize(AZ::u64& value, [[maybe_unused]] const char* name, AZ::u64 minValue, AZ::u64 maxValue)
+    {
+        return SerializeBoundedValue<AZ::u64>(minValue, maxValue, value);
+    }
+    #endif
 
     bool NetworkOutputSerializer::Serialize(float& value, [[maybe_unused]] const char* name, [[maybe_unused]] float minValue, [[maybe_unused]] float maxValue)
     {

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkOutputSerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkOutputSerializer.h
@@ -44,10 +44,16 @@ namespace AzNetworking
         bool Serialize(int16_t& value, const char* name, int16_t minValue, int16_t maxValue) override;
         bool Serialize(int32_t& value, const char* name, int32_t minValue, int32_t maxValue) override;
         bool Serialize(int64_t& value, const char* name, int64_t minValue, int64_t maxValue) override;
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max()) override;
+        #endif
         bool Serialize(uint8_t& value, const char* name, uint8_t minValue, uint8_t maxValue) override;
         bool Serialize(uint16_t& value, const char* name, uint16_t minValue, uint16_t maxValue) override;
         bool Serialize(uint32_t& value, const char* name, uint32_t minValue, uint32_t maxValue) override;
         bool Serialize(uint64_t& value, const char* name, uint64_t minValue, uint64_t maxValue) override;
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue = AZStd::numeric_limits<AZ::u64>::min(), AZ::u64 maxValue = AZStd::numeric_limits<AZ::u64>::max()) override;
+        #endif
         bool Serialize(float& value, const char* name, float minValue, float maxValue) override;
         bool Serialize(double& value, const char* name, double minValue, double maxValue) override;
         bool SerializeBytes(uint8_t* buffer, uint32_t bufferCapacity, bool isString, uint32_t& outSize, const char* name) override;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkOutputSerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkOutputSerializer.h
@@ -45,14 +45,14 @@ namespace AzNetworking
         bool Serialize(int32_t& value, const char* name, int32_t minValue, int32_t maxValue) override;
         bool Serialize(int64_t& value, const char* name, int64_t minValue, int64_t maxValue) override;
         #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
-        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max()) override;
+        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue, AZ::s64 maxValue ) override;
         #endif
         bool Serialize(uint8_t& value, const char* name, uint8_t minValue, uint8_t maxValue) override;
         bool Serialize(uint16_t& value, const char* name, uint16_t minValue, uint16_t maxValue) override;
         bool Serialize(uint32_t& value, const char* name, uint32_t minValue, uint32_t maxValue) override;
         bool Serialize(uint64_t& value, const char* name, uint64_t minValue, uint64_t maxValue) override;
         #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
-        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue = AZStd::numeric_limits<AZ::u64>::min(), AZ::u64 maxValue = AZStd::numeric_limits<AZ::u64>::max()) override;
+        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue, AZ::u64 maxValue) override;
         #endif
         bool Serialize(float& value, const char* name, float minValue, float maxValue) override;
         bool Serialize(double& value, const char* name, double minValue, double maxValue) override;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/StringifySerializer.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/StringifySerializer.cpp
@@ -61,6 +61,13 @@ namespace AzNetworking
         return ProcessData(name, value);
     }
 
+    #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+    bool StringifySerializer::Serialize(AZ::s64& value, const char* name, AZ::s64, AZ::s64)
+    {
+        return ProcessData(name, value);
+    }
+    #endif
+
     bool StringifySerializer::Serialize(uint8_t& value, const char* name, uint8_t, uint8_t)
     {
         return ProcessData(name, value);
@@ -80,6 +87,14 @@ namespace AzNetworking
     {
         return ProcessData(name, value);
     }
+
+    #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+    bool StringifySerializer::Serialize(AZ::u64& value, const char* name, AZ::u64, AZ::u64)
+    {
+        return ProcessData(name, value);
+    }
+    #endif
+
 
     bool StringifySerializer::Serialize(float& value, const char* name, float, float)
     {

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/StringifySerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/StringifySerializer.h
@@ -37,14 +37,14 @@ namespace AzNetworking
         bool Serialize(int32_t& value, const char* name, int32_t minValue, int32_t maxValue) override;
         bool Serialize(int64_t& value, const char* name, int64_t minValue, int64_t maxValue) override;
         #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
-        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max()) override;
+        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue, AZ::s64 maxValue) override;
         #endif
         bool Serialize(uint8_t& value, const char* name, uint8_t minValue, uint8_t maxValue) override;
         bool Serialize(uint16_t& value, const char* name, uint16_t minValue, uint16_t maxValue) override;
         bool Serialize(uint32_t& value, const char* name, uint32_t minValue, uint32_t maxValue) override;
         bool Serialize(uint64_t& value, const char* name, uint64_t minValue, uint64_t maxValue) override;
         #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
-        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue = AZStd::numeric_limits<AZ::u64>::min(), AZ::u64 maxValue = AZStd::numeric_limits<AZ::u64>::max()) override;
+        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue, AZ::u64 maxValue) override;
         #endif
         bool Serialize(float& value, const char* name, float minValue, float maxValue) override;
         bool Serialize(double& value, const char* name, double minValue, double maxValue) override;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/StringifySerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/StringifySerializer.h
@@ -36,10 +36,16 @@ namespace AzNetworking
         bool Serialize(int16_t& value, const char* name, int16_t minValue, int16_t maxValue) override;
         bool Serialize(int32_t& value, const char* name, int32_t minValue, int32_t maxValue) override;
         bool Serialize(int64_t& value, const char* name, int64_t minValue, int64_t maxValue) override;
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max()) override;
+        #endif
         bool Serialize(uint8_t& value, const char* name, uint8_t minValue, uint8_t maxValue) override;
         bool Serialize(uint16_t& value, const char* name, uint16_t minValue, uint16_t maxValue) override;
         bool Serialize(uint32_t& value, const char* name, uint32_t minValue, uint32_t maxValue) override;
         bool Serialize(uint64_t& value, const char* name, uint64_t minValue, uint64_t maxValue) override;
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue = AZStd::numeric_limits<AZ::u64>::min(), AZ::u64 maxValue = AZStd::numeric_limits<AZ::u64>::max()) override;
+        #endif
         bool Serialize(float& value, const char* name, float minValue, float maxValue) override;
         bool Serialize(double& value, const char* name, double minValue, double maxValue) override;
         bool SerializeBytes(uint8_t* buffer, uint32_t bufferCapacity, bool isString, uint32_t& outSize, const char* name) override;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/TrackChangedSerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/TrackChangedSerializer.h
@@ -34,10 +34,16 @@ namespace AzNetworking
         bool Serialize( int16_t& value, const char* name,  int16_t minValue,  int16_t maxValue) override;
         bool Serialize( int32_t& value, const char* name,  int32_t minValue,  int32_t maxValue) override;
         bool Serialize( int64_t& value, const char* name,  int64_t minValue,  int64_t maxValue) override;
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue, AZ::s64 maxValue) override;
+        #endif
         bool Serialize( uint8_t& value, const char* name,  uint8_t minValue,  uint8_t maxValue) override;
         bool Serialize(uint16_t& value, const char* name, uint16_t minValue, uint16_t maxValue) override;
         bool Serialize(uint32_t& value, const char* name, uint32_t minValue, uint32_t maxValue) override;
         bool Serialize(uint64_t& value, const char* name, uint64_t minValue, uint64_t maxValue) override;
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue, AZ::u64 maxValue) override;
+        #endif
         bool Serialize(   float& value, const char* name,    float minValue,    float maxValue) override;
         bool Serialize(  double& value, const char* name,   double minValue,   double maxValue) override;
         bool SerializeBytes(uint8_t* buffer, uint32_t bufferCapacity, bool isString, uint32_t& outSize, const char* name) override;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/TrackChangedSerializer.inl
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/TrackChangedSerializer.inl
@@ -79,6 +79,7 @@ namespace AzNetworking
     }
 
     #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+    template <typename BASE_TYPE>
     bool TrackChangedSerializer<BASE_TYPE>::Serialize(AZ::s64& value, const char* name, AZ::s64 minValue, AZ::s64 maxValue)
     {
         const AZ::s64 cached = value;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/TrackChangedSerializer.inl
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/TrackChangedSerializer.inl
@@ -78,6 +78,16 @@ namespace AzNetworking
         return result;
     }
 
+    #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+    bool TrackChangedSerializer<BASE_TYPE>::Serialize(AZ::s64& value, const char* name, AZ::s64 minValue, AZ::s64 maxValue)
+    {
+        const AZ::s64 cached = value;
+        const bool result = BASE_TYPE::Serialize(value, name, minValue, maxValue);
+        m_hasChanged |= (cached != value);
+        return result;
+    }
+    #endif
+
     template <typename BASE_TYPE>
     bool TrackChangedSerializer<BASE_TYPE>::Serialize(uint8_t& value, const char* name, uint8_t minValue, uint8_t maxValue)
     {
@@ -113,6 +123,17 @@ namespace AzNetworking
         m_hasChanged |= (cached != value);
         return result;
     }
+
+    #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+    template<typename BASE_TYPE>
+    bool TrackChangedSerializer<BASE_TYPE>::Serialize(AZ::u64& value, const char* name, AZ::u64 minValue, AZ::u64 maxValue)
+    {
+        const AZ::u64 cached = value;
+        const bool result = BASE_TYPE::Serialize(value, name, minValue, maxValue);
+        m_hasChanged |= (cached != value);
+        return result;
+    }
+    #endif
 
     template <typename BASE_TYPE>
     bool TrackChangedSerializer<BASE_TYPE>::Serialize(float& value, const char* name, float minValue, float maxValue)

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/TypeValidatingSerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/TypeValidatingSerializer.h
@@ -55,10 +55,16 @@ namespace AzNetworking
         bool Serialize(int16_t& value, const char* name, int16_t minValue, int16_t maxValue) override;
         bool Serialize(int32_t& value, const char* name, int32_t minValue, int32_t maxValue) override;
         bool Serialize(int64_t& value, const char* name, int64_t minValue, int64_t maxValue) override;
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue, AZ::s64 maxValue) override;
+        #endif
         bool Serialize(uint8_t& value, const char* name, uint8_t minValue, uint8_t maxValue) override;
         bool Serialize(uint16_t& value, const char* name, uint16_t minValue, uint16_t maxValue) override;
         bool Serialize(uint32_t& value, const char* name, uint32_t minValue, uint32_t maxValue) override;
         bool Serialize(uint64_t& value, const char* name, uint64_t minValue, uint64_t maxValue) override;
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue, AZ::u64 maxValue) override;
+        #endif
         bool Serialize(float& value, const char* name, float minValue, float maxValue) override;
         bool Serialize(double& value, const char* name, double minValue, double maxValue) override;
         bool SerializeBytes(uint8_t* buffer, uint32_t bufferCapacity, bool isString, uint32_t& outSize, const char* name) override;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/TypeValidatingSerializer.inl
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/TypeValidatingSerializer.inl
@@ -112,6 +112,15 @@ namespace AzNetworking
         return BASE_TYPE::Serialize(value, name, minValue, maxValue) && result;
     }
 
+    #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+    template<typename BASE_TYPE>
+    bool TypeValidatingSerializer<BASE_TYPE>::Serialize(AZ::s64& value, const char* name, AZ::s64 minValue, AZ::s64 maxValue)
+    {
+        bool result = Validate(name, ValidateSerializeType::Int64);
+        return BASE_TYPE::Serialize(value, name, minValue, maxValue) && result;
+    }
+    #endif
+
     template <typename BASE_TYPE>
     bool TypeValidatingSerializer<BASE_TYPE>::Serialize(uint8_t& value, const char* name, uint8_t minValue, uint8_t maxValue)
     {
@@ -139,6 +148,15 @@ namespace AzNetworking
         bool result = Validate(name, ValidateSerializeType::Uint64);
         return BASE_TYPE::Serialize(value, name, minValue, maxValue) && result;
     }
+
+    #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+    template<typename BASE_TYPE>
+    bool TypeValidatingSerializer<BASE_TYPE>::Serialize(AZ::u64& value, const char* name, AZ::u64 minValue, AZ::u64 maxValue)
+    {
+        bool result = Validate(name, ValidateSerializeType::Uint64);
+        return BASE_TYPE::Serialize(value, name, minValue, maxValue) && result;
+    }
+    #endif
 
     template <typename BASE_TYPE>
     bool TypeValidatingSerializer<BASE_TYPE>::Serialize(float& value, const char* name, float minValue, float maxValue)

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpConnection.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpConnection.cpp
@@ -11,7 +11,6 @@
 #include <AzNetworking/UdpTransport/UdpNetworkInterface.h>
 #include <AzNetworking/Serialization/NetworkInputSerializer.h>
 #include <AzNetworking/Serialization/NetworkOutputSerializer.h>
-#include <AzNetworking/Serialization/TrackChangedSerializer.h>
 #include <AzNetworking/AutoGen/CorePackets.AutoPackets.h>
 #include <AzNetworking/Utilities/NetworkCommon.h>
 #include <AzCore/Console/IConsole.h>

--- a/Gems/Multiplayer/Code/Tests/MockInterfaces.h
+++ b/Gems/Multiplayer/Code/Tests/MockInterfaces.h
@@ -165,10 +165,16 @@ namespace UnitTest
         MOCK_METHOD4(Serialize, bool (int16_t&, const char*, int16_t, int16_t));
         MOCK_METHOD4(Serialize, bool (int32_t&, const char*, int32_t, int32_t));
         MOCK_METHOD4(Serialize, bool (int64_t&, const char*, int64_t, int64_t));
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        MOCK_METHOD4(Serialize, bool (AZ::s64&, const char*, AZ::s64, AZ::s64));
+        #endif
         MOCK_METHOD4(Serialize, bool (uint8_t&, const char*, uint8_t, uint8_t));
         MOCK_METHOD4(Serialize, bool (uint16_t&, const char*, uint16_t, uint16_t));
         MOCK_METHOD4(Serialize, bool (uint32_t&, const char*, uint32_t, uint32_t));
         MOCK_METHOD4(Serialize, bool (uint64_t&, const char*, uint64_t, uint64_t));
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        MOCK_METHOD4(Serialize, bool (AZ::u64&, const char*, AZ::u64, AZ::u64));
+        #endif
         MOCK_METHOD4(Serialize, bool (float&, const char*, float, float));
         MOCK_METHOD4(Serialize, bool (double&, const char*, double, double));
         MOCK_METHOD5(SerializeBytes, bool (uint8_t*, uint32_t, bool, uint32_t&, const char*));


### PR DESCRIPTION
## What does this PR do?
Allows AzNetworking to serialize AZ::s64 and AZ::u64.
AzNetworking ISerialize current supports int64_t and uint64_t, which (depending on the system) is sometimes long and sometimes long long. AZ types such as AZ::u64 are set up to always be defined as long long. This change makes it so that if int64_t is long (not long long), then we'll define a new method to support long long.

Fixes #13019 

