### PR TITLE
Adds application frametime to multiplayer metrics

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerMetrics.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerMetrics.h
@@ -10,16 +10,18 @@
 
 namespace Multiplayer
 {
+    //! Declares multiplayer metric group ids.
     enum MultiplayerGroupIds
     {
-        MultiplayerGroup_Networking = 101
+        MultiplayerGroup_Networking = 101           // A group of multiplayer metrics
     };
 
+    //! Declares multiplayer metric stat ids.
     enum MultiplayerStatIds
     {
-        MultiplayerStat_EntityCount = 1001,
-        MultiplayerStat_FrameTimeUs,
-        MultiplayerStat_ClientConnectionCount,
-        MultiplayerStat_ApplicationFrameTimeUs
+        MultiplayerStat_EntityCount = 1001,         // Number of multiplayer entities active
+        MultiplayerStat_FrameTimeUs,                // Multiplayer tick cost within a single application frame
+        MultiplayerStat_ClientConnectionCount,      // Current connection (applicable to a server)
+        MultiplayerStat_ApplicationFrameTimeUs      // The entire application frame time
     };
 }

--- a/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerMetrics.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerMetrics.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+namespace Multiplayer
+{
+    enum MultiplayerGroupIds
+    {
+        MultiplayerGroup_Networking = 101
+    };
+
+    enum MultiplayerStatIds
+    {
+        MultiplayerStat_EntityCount = 1001,
+        MultiplayerStat_FrameTimeUs,
+        MultiplayerStat_ClientConnectionCount,
+        MultiplayerStat_ApplicationFrameTimeUs
+    };
+}

--- a/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerStats.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerStats.h
@@ -20,18 +20,6 @@ namespace AzNetworking
 
 namespace Multiplayer
 {
-    enum MultiplayerGroupIds
-    {
-        MultiplayerGroup_Networking = 101
-    };
-
-    enum MultiplayerStatIds
-    {
-        MultiplayerStat_EntityCount = 1001,
-        MultiplayerStat_FrameTime,
-        MultiplayerStat_ClientConnectionCount
-    };
-
     struct MultiplayerStats
     {
         AZ::u64 m_entityCount = 0;

--- a/Gems/Multiplayer/Code/Source/MultiplayerStats.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerStats.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <Multiplayer/MultiplayerMetrics.h>
 #include <Multiplayer/MultiplayerPerformanceStats.h>
 #include <Multiplayer/MultiplayerStats.h>
 
@@ -260,6 +261,6 @@ namespace Multiplayer
 
     void MultiplayerStats::RecordFrameTime(AZ::TimeUs networkFrameTime)
     {
-        SET_PERFORMANCE_STAT(MultiplayerStat_FrameTime, networkFrameTime);
+        SET_PERFORMANCE_STAT(MultiplayerStat_FrameTimeUs, networkFrameTime);
     }
 } // namespace Multiplayer

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -20,7 +20,10 @@
 #include <Source/AutoGen/AutoComponentTypes.h>
 #include <Multiplayer/Session/ISessionRequests.h>
 #include <Multiplayer/Session/SessionConfig.h>
+#include <Multiplayer/MultiplayerPerformanceStats.h>
+#include <Multiplayer/MultiplayerMetrics.h>
 
+#include <AzCore/Debug/Profiler.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/Utils.h>
 #include <AzCore/Interface/Interface.h>
@@ -38,8 +41,6 @@
 #include <AzFramework/Process/ProcessWatcher.h>
 
 #include <cmath>
-#include <AzCore/Debug/Profiler.h>
-#include <Multiplayer/MultiplayerPerformanceStats.h>
 
 AZ_DEFINE_BUDGET(MULTIPLAYER);
 

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -241,8 +241,9 @@ namespace Multiplayer
     {
         DECLARE_PERFORMANCE_STAT_GROUP(MultiplayerGroup_Networking, "Networking");
         DECLARE_PERFORMANCE_STAT(MultiplayerGroup_Networking, MultiplayerStat_EntityCount, "NumEntities");
-        DECLARE_PERFORMANCE_STAT(MultiplayerGroup_Networking, MultiplayerStat_FrameTime, "FrameTimeUs");
+        DECLARE_PERFORMANCE_STAT(MultiplayerGroup_Networking, MultiplayerStat_FrameTimeUs, "FrameTimeUs");
         DECLARE_PERFORMANCE_STAT(MultiplayerGroup_Networking, MultiplayerStat_ClientConnectionCount, "ClientConnections");
+        DECLARE_PERFORMANCE_STAT(MultiplayerGroup_Networking, MultiplayerStat_ApplicationFrameTimeUs, "Application FrameTimeUs");
 
         AzFramework::RootSpawnableNotificationBus::Handler::BusConnect();
         AZ::TickBus::Handler::BusConnect();
@@ -437,6 +438,7 @@ namespace Multiplayer
     void MultiplayerSystemComponent::OnTick(float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
     {
         AZ_PROFILE_SCOPE(MULTIPLAYER, "MultiplayerSystemComponent: OnTick");
+        SET_PERFORMANCE_STAT(MultiplayerStat_ApplicationFrameTimeUs, AZ::SecondsToTimeUs(deltaTime));
 
         const AZStd::chrono::steady_clock::time_point startMultiplayerTickTime = AZStd::chrono::steady_clock::now();
 

--- a/Gems/Multiplayer/Code/multiplayer_files.cmake
+++ b/Gems/Multiplayer/Code/multiplayer_files.cmake
@@ -14,6 +14,7 @@ set(FILES
     Include/Multiplayer/MultiplayerConstants.h
     Include/Multiplayer/MultiplayerDebug.h
     Include/Multiplayer/MultiplayerDebug.inl
+    Include/Multiplayer/MultiplayerMetrics.h
     Include/Multiplayer/MultiplayerStats.h
     Include/Multiplayer/MultiplayerTypes.h
     Include/Multiplayer/MultiplayerEditorServerBus.h

--- a/Gems/Multiplayer/Code/multiplayerstats_api_files.cmake
+++ b/Gems/Multiplayer/Code/multiplayerstats_api_files.cmake
@@ -7,6 +7,7 @@
 #
 
 set(FILES
+    Include/Multiplayer/MultiplayerMetrics.h
     Include/Multiplayer/MultiplayerPerformanceStats.h
     Include/Multiplayer/MultiplayerStatSystemInterface.h
 )


### PR DESCRIPTION
Signed-off-by: Olex Lozitskiy <5432499+AMZN-Olex@users.noreply.github.com>

## What does this PR do?

- Adds application frame time to network metrics
- Some light refactoring as well to put metrics into their own header file.

## How was this PR tested?

Tested with o3de-multiplayersample
