### PR TITLE
{ghi12844} fixing the product asset reference for procedural prefab

### DIFF
--- a/Code/Editor/Plugins/EditorAssetImporter/AssetImporterDocument.cpp
+++ b/Code/Editor/Plugins/EditorAssetImporter/AssetImporterDocument.cpp
@@ -44,7 +44,7 @@ bool AssetImporterDocument::LoadScene(const AZStd::string& sceneFullPath)
 {
     AZ_PROFILE_FUNCTION(Editor);
     namespace SceneEvents = AZ::SceneAPI::Events;
-    SceneEvents::SceneSerializationBus::BroadcastResult(m_scene, &SceneEvents::SceneSerializationBus::Events::LoadScene, sceneFullPath, AZ::Uuid::CreateNull());
+    SceneEvents::SceneSerializationBus::BroadcastResult(m_scene, &SceneEvents::SceneSerializationBus::Events::LoadScene, sceneFullPath, AZ::Uuid::CreateNull(), "");
     return !!m_scene;
 }
 

--- a/Code/Editor/Plugins/EditorAssetImporter/SceneSerializationHandler.cpp
+++ b/Code/Editor/Plugins/EditorAssetImporter/SceneSerializationHandler.cpp
@@ -38,11 +38,14 @@ namespace AZ
     }
 
     AZStd::shared_ptr<SceneAPI::Containers::Scene> SceneSerializationHandler::LoadScene(
-        const AZStd::string& sceneFilePath, Uuid sceneSourceGuid)
+        const AZStd::string& sceneFilePath,
+        Uuid sceneSourceGuid,
+        const AZStd::string& watchFolder)
     {
         AZ_PROFILE_FUNCTION(Editor);
         namespace Utilities = AZ::SceneAPI::Utilities;
         using AZ::SceneAPI::Events::AssetImportRequest;
+        using namespace SceneAPI::SceneCore;
 
         CleanSceneMap();
 
@@ -76,8 +79,8 @@ namespace AZ
         {
             bool result = false;
             AZ::Data::AssetInfo info;
-            AZStd::string watchFolder;
-            AzToolsFramework::AssetSystemRequestBus::BroadcastResult(result, &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourcePath, cleanPath.c_str(), info, watchFolder);
+            AZStd::string watchFolderFromDatabase;
+            AzToolsFramework::AssetSystemRequestBus::BroadcastResult(result, &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourcePath, cleanPath.c_str(), info, watchFolderFromDatabase);
             if (!result)
             {
                 AZ_TracePrintf(Utilities::ErrorWindow, "Failed to retrieve file info needed to determine the uuid of the source file.");
@@ -87,7 +90,7 @@ namespace AZ
         }
 
         AZStd::shared_ptr<SceneAPI::Containers::Scene> scene = 
-            AssetImportRequest::LoadSceneFromVerifiedPath(cleanPath.Native(), sceneSourceGuid, AssetImportRequest::RequestingApplication::Editor, SceneAPI::SceneCore::LoadingComponent::TYPEINFO_Uuid());
+            AssetImportRequest::LoadSceneFromVerifiedPath(cleanPath.Native(), sceneSourceGuid, AssetImportRequest::RequestingApplication::Editor, LoadingComponent::TYPEINFO_Uuid(), watchFolder);
         if (!scene)
         {
             AZ_TracePrintf(Utilities::ErrorWindow, "Failed to load the requested scene.");

--- a/Code/Editor/Plugins/EditorAssetImporter/SceneSerializationHandler.h
+++ b/Code/Editor/Plugins/EditorAssetImporter/SceneSerializationHandler.h
@@ -26,7 +26,9 @@ namespace AZ
         void Deactivate();
 
         AZStd::shared_ptr<SceneAPI::Containers::Scene> LoadScene(
-            const AZStd::string& sceneFilePath, Uuid sceneSourceGuid) override;
+            const AZStd::string& sceneFilePath,
+            Uuid sceneSourceGuid,
+            const AZStd::string& watchFolder) override;
         bool IsSceneCached(const AZStd::string& sceneFilePath) override;
 
     private:

--- a/Code/Tools/SceneAPI/SceneCore/Events/AssetImportRequest.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Events/AssetImportRequest.cpp
@@ -234,8 +234,12 @@ namespace AZ
             {
             }
 
-            AZStd::shared_ptr<Containers::Scene> AssetImportRequest::LoadSceneFromVerifiedPath(const AZStd::string& assetFilePath, const Uuid& sourceGuid,
-                                                                                               RequestingApplication requester, const Uuid& loadingComponentUuid)
+            AZStd::shared_ptr<Containers::Scene> AssetImportRequest::LoadSceneFromVerifiedPath(
+                const AZStd::string& assetFilePath,
+                const Uuid& sourceGuid,
+                RequestingApplication requester,
+                const Uuid& loadingComponentUuid,
+                const AZStd::string& watchFolder)
             {
                 ImportScope importScope;
                 AZStd::string sceneName;
@@ -244,17 +248,19 @@ namespace AZ
                 AZ_Assert(scene, "Unable to create new scene for asset importing.");
 
                 Data::AssetInfo assetInfo;
-                AZStd::string watchFolder;
+                AZStd::string watchFolderFromDatabase;
                 bool result = false;
-                AzToolsFramework::AssetSystemRequestBus::BroadcastResult(result, &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourceUUID, sourceGuid, assetInfo, watchFolder);
+                AzToolsFramework::AssetSystemRequestBus::BroadcastResult(result, &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourceUUID, sourceGuid, assetInfo, watchFolderFromDatabase);
 
                 if (result)
                 {
-                    scene->SetWatchFolder(watchFolder);
+                    scene->SetWatchFolder(watchFolderFromDatabase);
                 }
                 else
                 {
-                    AZ_Error(
+                    scene->SetWatchFolder(watchFolder);
+
+                    AZ_Warning(
                         "AssetImportRequest", false, "Failed to get watch folder for source %s",
                         sourceGuid.ToString<AZStd::string>().c_str());
                 }

--- a/Code/Tools/SceneAPI/SceneCore/Events/AssetImportRequest.h
+++ b/Code/Tools/SceneAPI/SceneCore/Events/AssetImportRequest.h
@@ -169,11 +169,15 @@ namespace AZ
                 //! Utility function to load an asset and manifest from file by using the EBus functions above.
                 //! @param assetFilePath The absolute path to the source file (not the manifest).
                 //! @param sourceGuid The guid assigned to the source file (not the manifest).
-                //! @param requester The application making the request to load the file. This can be used to optimize the type and amount of data
-                //! to load.
+                //! @param requester The application making the request to load the file. This can be used to optimize the type and amount of data to load.
                 //! @param loadingComponentUuid The UUID assigned to the loading component.
-                static AZStd::shared_ptr<Containers::Scene> LoadSceneFromVerifiedPath(const AZStd::string& assetFilePath,
-                    const Uuid& sourceGuid, RequestingApplication requester, const Uuid& loadingComponentUuid);
+                //! @param watchFolder is the scan folder that it was found inside
+                static AZStd::shared_ptr<Containers::Scene> LoadSceneFromVerifiedPath(
+                    const AZStd::string& assetFilePath,
+                    const Uuid& sourceGuid,
+                    RequestingApplication requester,
+                    const Uuid& loadingComponentUuid,
+                    const AZStd::string& watchFolder);
 
                 //! Utility function to determine if a given file path points to a scene manifest file (.assetinfo).
                 //! @param filePath A relative or absolute path to the file to check.

--- a/Code/Tools/SceneAPI/SceneCore/Events/SceneSerializationBus.h
+++ b/Code/Tools/SceneAPI/SceneCore/Events/SceneSerializationBus.h
@@ -39,11 +39,11 @@ namespace AZ
                 //! Loads a scene and its corresponding manifest if available, otherwise a new manifest
                 //! is created.
                 //! @param sceneFilePath The absolute or relative path to the scene file in the source folder.
-                //! @param sceneSourceGuid The source uuid for the scene file. If a null-uuid is given LoadScene 
-                //! will attempt to query the Asset Processor for the uuid.
+                //! @param sceneSourceGuid The source uuid for the scene file. If a null-uuid is given LoadScene will attempt to query the Asset Processor for the uuid.
+                //! @param watchFolder is the scan folder that it was found inside
                 //! @return The loaded scene or null if the file couldn't be fully resolved or an error 
                 //! occurred during loading.
-                virtual AZStd::shared_ptr<Containers::Scene> LoadScene(const AZStd::string& sceneFilePath, Uuid sceneSourceGuid) = 0;
+                virtual AZStd::shared_ptr<Containers::Scene> LoadScene(const AZStd::string& sceneFilePath, Uuid sceneSourceGuid, const AZStd::string& watchFolder) = 0;
 
                 //! The scene system caches loaded scenes. This checks if the given scene is valid and in the cache or not.
                 //! @param sceneFilePath The absolute or relative path to the scene file in the source folder.

--- a/Code/Tools/SceneAPI/SceneCore/Tests/Events/AssetImporterRequestTests.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Tests/Events/AssetImporterRequestTests.cpp
@@ -190,7 +190,7 @@ namespace AZ
                 EXPECT_CALL(handler, UpdateManifest(_, _, _)).Times(0);
 
                 AZStd::shared_ptr<Containers::Scene> result = 
-                    AssetImportRequest::LoadSceneFromVerifiedPath("test.asset", m_testId, Events::AssetImportRequest::RequestingApplication::Generic, SceneCore::LoadingComponent::TYPEINFO_Uuid());
+                    AssetImportRequest::LoadSceneFromVerifiedPath("test.asset", m_testId, Events::AssetImportRequest::RequestingApplication::Generic, SceneCore::LoadingComponent::TYPEINFO_Uuid(), "");
                 EXPECT_EQ(nullptr, result);
             }
 
@@ -232,7 +232,7 @@ namespace AZ
                 EXPECT_CALL(manifestHandler, LoadAsset(_, _, _, _)).Times(1);
 
                 AZStd::shared_ptr<Containers::Scene> result =
-                    AssetImportRequest::LoadSceneFromVerifiedPath("test.asset", m_testId, Events::AssetImportRequest::RequestingApplication::Generic, SceneCore::LoadingComponent::TYPEINFO_Uuid());
+                    AssetImportRequest::LoadSceneFromVerifiedPath("test.asset", m_testId, Events::AssetImportRequest::RequestingApplication::Generic, SceneCore::LoadingComponent::TYPEINFO_Uuid(), "");
                 EXPECT_NE(nullptr, result);
                 EXPECT_TRUE(anEmptyManifestWorks);
             }
@@ -256,7 +256,7 @@ namespace AZ
                 EXPECT_CALL(handler, UpdateManifest(_, _, _)).Times(0);
 
                 AZStd::shared_ptr<Containers::Scene> result = 
-                    AssetImportRequest::LoadSceneFromVerifiedPath("test.asset", m_testId, Events::AssetImportRequest::RequestingApplication::Generic, SceneCore::LoadingComponent::TYPEINFO_Uuid());
+                    AssetImportRequest::LoadSceneFromVerifiedPath("test.asset", m_testId, Events::AssetImportRequest::RequestingApplication::Generic, SceneCore::LoadingComponent::TYPEINFO_Uuid(), "");
                 EXPECT_EQ(nullptr, result);
             }
 
@@ -279,7 +279,7 @@ namespace AZ
                 EXPECT_CALL(handler, UpdateManifest(_, _, _)).Times(0);
 
                 AZStd::shared_ptr<Containers::Scene> result =
-                    AssetImportRequest::LoadSceneFromVerifiedPath("test.asset", m_testId, Events::AssetImportRequest::RequestingApplication::Generic, SceneCore::LoadingComponent::TYPEINFO_Uuid());
+                    AssetImportRequest::LoadSceneFromVerifiedPath("test.asset", m_testId, Events::AssetImportRequest::RequestingApplication::Generic, SceneCore::LoadingComponent::TYPEINFO_Uuid(), "");
                 EXPECT_EQ(nullptr, result);
             }
 
@@ -302,7 +302,7 @@ namespace AZ
                 EXPECT_CALL(handler, UpdateManifest(_, _, _)).Times(0);
 
                 AZStd::shared_ptr<Containers::Scene> result =
-                    AssetImportRequest::LoadSceneFromVerifiedPath("test.asset", m_testId, Events::AssetImportRequest::RequestingApplication::Generic, SceneCore::LoadingComponent::TYPEINFO_Uuid());
+                    AssetImportRequest::LoadSceneFromVerifiedPath("test.asset", m_testId, Events::AssetImportRequest::RequestingApplication::Generic, SceneCore::LoadingComponent::TYPEINFO_Uuid(), "");
                 EXPECT_EQ(nullptr, result);
             }
 
@@ -334,7 +334,7 @@ namespace AZ
                 EXPECT_CALL(manifestHandler, UpdateManifest(_, _, _)).Times(1);
 
                 AZStd::shared_ptr<Containers::Scene> result =
-                    AssetImportRequest::LoadSceneFromVerifiedPath("test.asset", m_testId, Events::AssetImportRequest::RequestingApplication::Generic, SceneCore::LoadingComponent::TYPEINFO_Uuid());
+                    AssetImportRequest::LoadSceneFromVerifiedPath("test.asset", m_testId, Events::AssetImportRequest::RequestingApplication::Generic, SceneCore::LoadingComponent::TYPEINFO_Uuid(), "");
                 EXPECT_EQ(nullptr, result);
             }
 
@@ -362,7 +362,7 @@ namespace AZ
                 EXPECT_CALL(manifestHandler, UpdateManifest(_, _, _)).Times(1);
 
                 AZStd::shared_ptr<Containers::Scene> result =
-                    AssetImportRequest::LoadSceneFromVerifiedPath("test.asset", m_testId, Events::AssetImportRequest::RequestingApplication::Generic, SceneCore::LoadingComponent::TYPEINFO_Uuid());
+                    AssetImportRequest::LoadSceneFromVerifiedPath("test.asset", m_testId, Events::AssetImportRequest::RequestingApplication::Generic, SceneCore::LoadingComponent::TYPEINFO_Uuid(), "");
                 EXPECT_NE(nullptr, result);
             }
 
@@ -469,7 +469,8 @@ namespace AZ
                     "test.asset",
                     AZ::Uuid("{B28DA8AF-B5F5-48E2-8E1A-3FE2CEFC2817}"),
                     AssetImportRequest::RequestingApplication::Generic,
-                    LoadingComponent::TYPEINFO_Uuid());
+                    LoadingComponent::TYPEINFO_Uuid(),
+                    "");
 
                 EXPECT_NE(nullptr, result);
             }
@@ -519,7 +520,8 @@ namespace AZ
                     "test.asset",
                     AZ::Uuid("{B28DA8AF-B5F5-48E2-8E1A-3FE2CEFC2817}"),
                     AssetImportRequest::RequestingApplication::Generic,
-                    LoadingComponent::TYPEINFO_Uuid());                
+                    LoadingComponent::TYPEINFO_Uuid(),
+                    "");
             }
 
         } // Events

--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Rules/MetaDataRule.inl
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Rules/MetaDataRule.inl
@@ -46,7 +46,7 @@ namespace EMotionFX
 
                 // Load the manifest from disk.
                 AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> scene;
-                SceneEvents::SceneSerializationBus::BroadcastResult(scene, &SceneEvents::SceneSerializationBus::Events::LoadScene, sourceAssetFilename, AZ::Uuid::CreateNull());
+                SceneEvents::SceneSerializationBus::BroadcastResult(scene, &SceneEvents::SceneSerializationBus::Events::LoadScene, sourceAssetFilename, AZ::Uuid::CreateNull(), "");
                 if (!scene)
                 {
                     outResult = "Unable to save meta data to manifest due to failed scene loading.";

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/Commands.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/Commands.cpp
@@ -156,7 +156,7 @@ namespace EMStudio
 
         // Load the manifest from disk.
         AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> scene;
-        AZ::SceneAPI::Events::SceneSerializationBus::BroadcastResult(scene, &AZ::SceneAPI::Events::SceneSerializationBus::Events::LoadScene, sourceAssetFilename, AZ::Uuid::CreateNull());
+        AZ::SceneAPI::Events::SceneSerializationBus::BroadcastResult(scene, &AZ::SceneAPI::Events::SceneSerializationBus::Events::LoadScene, sourceAssetFilename, AZ::Uuid::CreateNull(), "");
         if (!scene)
         {
             AZ_Error("EMotionFX", false, "Unable to save meta data to manifest due to failed scene loading.");
@@ -299,7 +299,7 @@ namespace EMStudio
 
         // Load the manifest from disk.
         AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> scene;
-        AZ::SceneAPI::Events::SceneSerializationBus::BroadcastResult(scene, &AZ::SceneAPI::Events::SceneSerializationBus::Events::LoadScene, sourceAssetFilename, AZ::Uuid::CreateNull());
+        AZ::SceneAPI::Events::SceneSerializationBus::BroadcastResult(scene, &AZ::SceneAPI::Events::SceneSerializationBus::Events::LoadScene, sourceAssetFilename, AZ::Uuid::CreateNull(), "");
         if (!scene)
         {
             AZ_Error("EMotionFX", false, "Unable to save meta data to manifest due to failed scene loading.");

--- a/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
+++ b/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
@@ -348,7 +348,7 @@ namespace SceneBuilder
 
         AZ_TracePrintf(Utilities::LogWindow, "Loading scene.\n");
 
-        SceneSerializationBus::BroadcastResult(result, &SceneSerializationBus::Events::LoadScene, request.m_fullPath, request.m_sourceFileUUID, "");
+        SceneSerializationBus::BroadcastResult(result, &SceneSerializationBus::Events::LoadScene, request.m_fullPath, request.m_sourceFileUUID, request.m_watchFolder);
         if (!result)
         {
             AZ_TracePrintf(Utilities::ErrorWindow, "Failed to load scene file.\n");

--- a/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
+++ b/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
@@ -348,7 +348,7 @@ namespace SceneBuilder
 
         AZ_TracePrintf(Utilities::LogWindow, "Loading scene.\n");
 
-        SceneSerializationBus::BroadcastResult(result, &SceneSerializationBus::Events::LoadScene, request.m_fullPath, request.m_sourceFileUUID);
+        SceneSerializationBus::BroadcastResult(result, &SceneSerializationBus::Events::LoadScene, request.m_fullPath, request.m_sourceFileUUID, "");
         if (!result)
         {
             AZ_TracePrintf(Utilities::ErrorWindow, "Failed to load scene file.\n");
@@ -387,7 +387,7 @@ namespace SceneBuilder
         result += Process<GenerateLODEventContext>(*scene, platformIdentifier);
         AZ_TracePrintf(Utilities::LogWindow, "Generating additions...\n");
         result += Process<GenerateAdditionEventContext>(*scene, platformIdentifier);
-        AZ_TracePrintf(Utilities::LogWindow, "Simplifing scene...\n");
+        AZ_TracePrintf(Utilities::LogWindow, "Simplifying scene...\n");
         result += Process<GenerateSimplificationEventContext>(*scene, platformIdentifier);
         AZ_TracePrintf(Utilities::LogWindow, "Finalizing generation process.\n");
         result += Process<PostGenerateEventContext>(*scene, platformIdentifier);

--- a/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneSerializationHandler.cpp
+++ b/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneSerializationHandler.cpp
@@ -45,7 +45,10 @@ namespace SceneBuilder
     }
 
     AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> SceneSerializationHandler::LoadScene(
-        const AZStd::string& filePath, AZ::Uuid sceneSourceGuid)
+        const AZStd::string& filePath,
+        AZ::Uuid sceneSourceGuid,
+        const AZStd::string& watchFolder
+    )
     {
         namespace Utilities = AZ::SceneAPI::Utilities;
         using AZ::SceneAPI::Events::AssetImportRequest;
@@ -82,7 +85,7 @@ namespace SceneBuilder
 
         AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> scene = AssetImportRequest::LoadSceneFromVerifiedPath(
             filePath, sceneSourceGuid, AssetImportRequest::RequestingApplication::AssetProcessor,
-            AZ::SceneAPI::SceneCore::LoadingComponent::TYPEINFO_Uuid());
+            AZ::SceneAPI::SceneCore::LoadingComponent::TYPEINFO_Uuid(), watchFolder);
 
         if (!scene)
         {

--- a/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneSerializationHandler.h
+++ b/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneSerializationHandler.h
@@ -31,6 +31,8 @@ namespace SceneBuilder
         static void Reflect(AZ::ReflectContext* context);
 
         AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> LoadScene(
-            const AZStd::string& sceneFilePath, AZ::Uuid sceneSourceGuid) override;
+            const AZStd::string& sceneFilePath,
+            AZ::Uuid sceneSourceGuid,
+            const AZStd::string& watchFolder) override;
     };
 } // namespace SceneBuilder

--- a/Gems/SceneProcessing/Code/Tests/SceneBuilder/SceneBuilderPhasesTests.cpp
+++ b/Gems/SceneProcessing/Code/Tests/SceneBuilder/SceneBuilderPhasesTests.cpp
@@ -114,9 +114,9 @@ class TestSceneSerializationHandler
 public:
     TestSceneSerializationHandler() { BusConnect(); }
     ~TestSceneSerializationHandler() override { BusDisconnect(); }
-    MOCK_METHOD2(LoadScene, AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene>(const AZStd::string& sceneFilePath, AZ::Uuid sceneSourceGuid));
+    MOCK_METHOD3(LoadScene, AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene>(const AZStd::string& sceneFilePath, AZ::Uuid sceneSourceGuid, const AZStd::string& watchFolder));
 
-    void GenerateImportEvents(const AZStd::string& assetFilePath, [[maybe_unused]] const AZ::Uuid& sourceGuid)
+    void GenerateImportEvents(const AZStd::string& assetFilePath, [[maybe_unused]] const AZ::Uuid& sourceGuid, [[maybe_unused]] const AZStd::string& watchFolder)
     {
         auto loaders = AZ::SceneAPI::SceneCore::EntityConstructor::BuildEntity("Scene Loading", azrtti_typeid<AZ::SceneAPI::SceneCore::LoadingComponent>());
         auto scene = AZStd::make_shared<AZ::SceneAPI::Containers::Scene>("import scene");
@@ -209,7 +209,7 @@ TEST_F(SceneBuilderPhasesFixture, TestProcessingPhases)
     scene->SetManifestFilename("testScene.manifest");
 
     TestSceneSerializationHandler sceneLoadingHandler;
-    EXPECT_CALL(sceneLoadingHandler, LoadScene(testing::_, testing::_))
+    EXPECT_CALL(sceneLoadingHandler, LoadScene(testing::_, testing::_, testing::_))
         .WillOnce(testing::DoAll(
             testing::Invoke(&sceneLoadingHandler, &TestSceneSerializationHandler::GenerateImportEvents),
             testing::Return(scene)


### PR DESCRIPTION
## What does this PR do?

* this fixes the miss named product asset for the procedural prefab when the watch folder was blank
* the watch folder was attempted to be found with non-deterministic means from the asset database
* the fix pushes the watch folder down the Load Scene pipeline

## How was this PR tested?

Reprocessed all the source assets in Automated Testing.
