### PR TITLE
RHI/Vulkan: Fix error message in ImageView.cpp

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImageView.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImageView.cpp
@@ -150,7 +150,7 @@ namespace AZ
                         AZ_Assert(width == height, "Image of Cube or CubeArray form a square.");
                         AZ_Assert(depth == 1, "Depth of Cube or CubeArray = 1.");
                         AZ_Assert(samples == 1, "Sample of Cube or CubeArray = 1.");
-                        AZ_Assert(arrayLayers % 6 == 0, "ArrayLayers % 6 == 0 for Cube or CubeArray.");
+                        AZ_Assert(arrayLayers % 6 == 0, "ArrayLayers %% 6 == 0 for Cube or CubeArray.");
                         if (arrayLayers == 6)
                         {
                             return VK_IMAGE_VIEW_TYPE_CUBE;


### PR DESCRIPTION
Signed-off-by: JLeclercq <99494374+CyaNinix@users.noreply.github.com>

When this assert triggers (which is does incorrectly with cubemaps and default image view because of this line:
```cpp
            const uint16_t arrayLayers = AZStd::min(static_cast<uint16_t>(imgViewDesc.m_arraySliceMax - imgViewDesc.m_arraySliceMin), static_cast<uint16_t>(imgDesc.m_arraySize - 1)) + 1;
```), a crash follows because the format string is incorrect (single % have to be escaped as %%)
