### PR TITLE
Remove defaultValue from the choice parameter

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -835,7 +835,7 @@ try {
                             }
                         } else {
                             // Non-PR builds
-                            pipelineParameters.add(choice(defaultValue: DEFAULT_BUILD_SNAPSHOT, name: 'SNAPSHOT', choices: BUILD_SNAPSHOTS_WITH_EMPTY, description: 'Selects the build snapshot to use. A more diverted snapshot will cause longer build times, but will not cause build failures.'))
+                            pipelineParameters.add(choice(name: 'SNAPSHOT', choices: BUILD_SNAPSHOTS_WITH_EMPTY, description: 'Selects the build snapshot to use. A more diverted snapshot will cause longer build times, but will not cause build failures.'))
                             snapshot = env.SNAPSHOT
                             echo "Snapshot \"${snapshot}\" selected."
                         }


### PR DESCRIPTION
## What does this PR do?

`defaultValue` is not a valid option for the choice parameter and will cause an error in the latest version of Jenkins.

This will not change the current behavior of the pipeline. The defaultValue option was ignored before, but the latest version of Jenkins now generates an error with invalid options. The pipeline will still default to the `development` snapshot for PR builds since it is the first entry on the list. 

## How was this PR tested?

Tested on my branch using a branch build on the sandbox with the latest version of Jenkins installed. 


