### PR TITLE
Fixed PythonToolGem template to allow dashes in gem name

### DIFF
--- a/Templates/PythonToolGem/Template/Editor/Scripts/${SanitizedNameLower}_dialog.py
+++ b/Templates/PythonToolGem/Template/Editor/Scripts/${SanitizedNameLower}_dialog.py
@@ -5,7 +5,7 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 # -------------------------------------------------------------------------
-"""${SanitizedCppName}\\editor\\scripts\\${SanitizedCppName}_dialog.py
+"""${SanitizedCppName}\\editor\\scripts\\${SanitizedNameLower}_dialog.py
 Generated from O3DE PythonToolGem Template"""
 
 from PySide2.QtCore import Qt

--- a/Templates/PythonToolGem/Template/Editor/Scripts/__init__.py
+++ b/Templates/PythonToolGem/Template/Editor/Scripts/__init__.py
@@ -6,4 +6,4 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 # -------------------------------------------------------------------------
 
-__ALL__ = ['bootstrap','${NameLower}_dialog']
+__ALL__ = ['bootstrap','${SanitizedNameLower}_dialog']

--- a/Templates/PythonToolGem/Template/Editor/Scripts/bootstrap.py
+++ b/Templates/PythonToolGem/Template/Editor/Scripts/bootstrap.py
@@ -10,7 +10,7 @@ Generated from O3DE PythonToolGem Template"""
 
 import az_qt_helpers
 import azlmbr.editor as editor
-from ${NameLower}_dialog import ${SanitizedCppName}Dialog
+from ${SanitizedNameLower}_dialog import ${SanitizedCppName}Dialog
 
 if __name__ == "__main__":
     print("${SanitizedCppName}.boostrap, Generated from O3DE PythonToolGem Template")

--- a/Templates/PythonToolGem/template.json
+++ b/Templates/PythonToolGem/template.json
@@ -135,7 +135,7 @@
             "isTemplated": true
         },
         {
-            "file": "Editor/Scripts/${NameLower}_dialog.py",
+            "file": "Editor/Scripts/${SanitizedNameLower}_dialog.py",
             "isTemplated": true
         },
         {

--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -1380,10 +1380,13 @@ def create_from_template(destination_path: pathlib.Path,
         replacements.append((replace_this, with_this))
 
     sanitized_cpp_name = utils.sanitize_identifier_for_cpp(destination_name)
+    lowercase_name = destination_name.lower()
+    sanitized_lowercase_name = utils.sanitize_identifier_for_cpp(lowercase_name)
     # dst name is Name
     replacements.append(("${Name}", destination_name))
     replacements.append(("${NameUpper}", destination_name.upper()))
-    replacements.append(("${NameLower}", destination_name.lower()))
+    replacements.append(("${NameLower}", lowercase_name))
+    replacements.append(("${SanitizedNameLower}", lowercase_name))
     replacements.append(("${SanitizedCppName}", sanitized_cpp_name))
 
     if _instantiate_template(template_json_data,
@@ -2090,10 +2093,13 @@ def create_gem(gem_path: pathlib.Path,
         replacements.append((replace_this, with_this))
 
     sanitized_cpp_name = utils.sanitize_identifier_for_cpp(gem_name)
+    lowercase_name = gem_name.lower()
+    sanitized_lowercase_name = utils.sanitize_identifier_for_cpp(lowercase_name)
     # gem name
     replacements.append(("${Name}", gem_name))
     replacements.append(("${NameUpper}", gem_name.upper()))
-    replacements.append(("${NameLower}", gem_name.lower()))
+    replacements.append(("${NameLower}", lowercase_name))
+    replacements.append(("${SanitizedNameLower}", sanitized_lowercase_name))
     replacements.append(("${SanitizedCppName}", sanitized_cpp_name))
 
     if display_name:


### PR DESCRIPTION
## What does this PR do?

Fixes #13096 

It was discovered that the `PythonToolGem` template fails to register its tool if the user creates a gem name with the "-" character. This is because the template will create a <gem_name_lowercase>_dialog.py file that the tool's dialog will be imported from, but python doesn't allow dashes in a module name. 

We need to provide a sanitized (alphanumeric, dash replaced with underscore) lower-case name for any filenames that will be used as python modules. The current default replacements provided for templates are `Name`, `NameUpper`, `NameLower`, and `SanitizedCppName`. I have added a new `SanitizedNameLower`, which is a combination of the lower-case replacement + also being sanitized to replace the dashes with underscores, and ensure it is alphanumeric. Another possible solution would be to automatically also sanitize the `NameLower` replacement, but I felt like that would be too heavy handed.

This PR updates the template support to include `SanitizedNameLower` as a default replacement, and updates the `PythonToolGem` to use this new replacement for its generated dialog module filename.

## How was this PR tested?

Created a new gem from the `PythonToolGem` template using dashes in the name and verified the tool can now be imported, and is automatically registered as a view pane so it gets a menu option and toolbar icon in the Editor

Signed-off-by: Chris Galvan <chgalvan@amazon.com>