### PR TITLE
Add support for EnumValue attribute to DPE

### DIFF
--- a/Code/Framework/AzCore/AzCore/RTTI/AttributeReader.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/AttributeReader.h
@@ -21,7 +21,6 @@ namespace AZ
             // try a value
             if (auto data = azdynamic_cast<AttributeData<AttrType>*>(attr); data != nullptr)
             {
-                // This is where we should probably be landing, but instead we get a nullptr from that azdynamic_cast above
                 value = static_cast<DestType>(data->Get(instance));
                 return true;
             }

--- a/Code/Framework/AzCore/AzCore/RTTI/AttributeReader.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/AttributeReader.h
@@ -19,9 +19,9 @@ namespace AZ
         bool AttributeRead(DestType& value, Attribute* attr, InstType&& instance, Args&& ... args)
         {
             // try a value
-            
             if (auto data = azdynamic_cast<AttributeData<AttrType>*>(attr); data != nullptr)
             {
+                // This is where we should probably be landing, but instead we get a nullptr from that azdynamic_cast above
                 value = static_cast<DestType>(data->Get(instance));
                 return true;
             }

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContextEnum.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContextEnum.cpp
@@ -10,7 +10,7 @@
 
 namespace AZ
 {
-    const Crc32 Serialize::Attributes::EnumValueKey(AZ_CRC("EnumValue", 0xe4f32eed));
+    const Crc32 Serialize::Attributes::EnumValueKey(AZ_CRC_CE("EnumValueKey"));
     const Crc32 Serialize::Attributes::EnumUnderlyingType(AZ_CRC("EnumUnderlyingType", 0x8c461f93));
 
     SerializeContext::EnumBuilder::EnumBuilder(SerializeContext* context, const typename SerializeContext::UuidToClassMap::iterator& classMapIter)

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.cpp
@@ -104,48 +104,6 @@ namespace AZ::DocumentPropertyEditor
         return Dom::Value(result.GetStringView(), false);
     }
 
-    Dom::Value EnumValueAttributeDefinition::ValueToDom(const EnumConstantValue& attribute) const
-    {
-        Dom::Value result(Dom::Type::Object);
-        result[EntryNameKey] = Dom::Value(attribute.m_name, true);
-        result[EntryValueKey] = Dom::Value(static_cast<uint64_t>(attribute.m_value));
-        return result;
-    }
-
-    AZStd::optional<EnumConstantValue> EnumValueAttributeDefinition::DomToValue(const Dom::Value& value) const
-    {
-        if (!value.IsObject() || !value.HasMember(EntryNameKey) || !value.HasMember(EntryValueKey))
-        {
-            return {};
-        }
-
-        return EnumConstantValue{ value[EntryNameKey].GetString(), static_cast<AZ::u64>(value[EntryValueKey].GetUint64()) };
-    }
-
-    AZ::Dom::Value EnumValueAttributeDefinition::LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const
-    {
-        if (attribute == nullptr)
-        {
-            return AZ::Dom::Value();
-        }
-
-        using EnumConstantBasePtr = AZStd::unique_ptr<SerializeContextEnumInternal::EnumConstantBase>;
-        if (auto internalEnumConsantBase = azdynamic_cast<AttributeData<EnumConstantBasePtr>*>(attribute); internalEnumConsantBase)
-        {
-            EnumConstantValue* value = reinterpret_cast<EnumConstantValue*>(internalEnumConsantBase->Get(instance).get());
-            return ValueToDom(*value);
-        }
-        else if (auto azEditEnumConstant = azdynamic_cast<AttributeData<AZ::Edit::EnumConstant<AZ::u64>>*>(attribute); azEditEnumConstant)
-        {
-            AZ::Edit::EnumConstant<AZ::u64> value = static_cast<AZ::Edit::EnumConstant<AZ::u64>>(azEditEnumConstant->Get(instance));
-            Dom::Value domValue(Dom::Type::Object);
-            domValue[EntryDescriptionKey] = Dom::Value(value.m_description, true);
-            domValue[EntryValueKey] = Dom::Value(static_cast<uint64_t>(value.m_value));
-            return domValue;
-        }
-        return Dom::Value();
-    }
-
     Dom::Value EnumValuesAttributeDefinition::ValueToDom(const EnumValuesContainer& attribute) const
     {
         Dom::Value result(Dom::Type::Array);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.cpp
@@ -107,19 +107,43 @@ namespace AZ::DocumentPropertyEditor
     Dom::Value EnumValueAttributeDefinition::ValueToDom(const EnumConstantValue& attribute) const
     {
         Dom::Value result(Dom::Type::Object);
-        result[EntryDescriptionKey] = Dom::Value(attribute.m_description, true);
+        result[EntryNameKey] = Dom::Value(attribute.m_name, true);
         result[EntryValueKey] = Dom::Value(static_cast<uint64_t>(attribute.m_value));
         return result;
     }
 
     AZStd::optional<EnumConstantValue> EnumValueAttributeDefinition::DomToValue(const Dom::Value& value) const
     {
-        if (!value.IsObject() || !value.HasMember(EntryDescriptionKey) || !value.HasMember(EntryValueKey))
+        if (!value.IsObject() || !value.HasMember(EntryNameKey) || !value.HasMember(EntryValueKey))
         {
             return {};
         }
 
-        return EnumConstantValue{ static_cast<AZ::u64>(value[EntryValueKey].GetUint64()), value[EntryDescriptionKey].GetString() };
+        return EnumConstantValue{ value[EntryNameKey].GetString(), static_cast<AZ::u64>(value[EntryValueKey].GetUint64()) };
+    }
+
+    AZ::Dom::Value EnumValueAttributeDefinition::LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const
+    {
+        if (attribute == nullptr)
+        {
+            return AZ::Dom::Value();
+        }
+
+        using EnumConstantBasePtr = AZStd::unique_ptr<SerializeContextEnumInternal::EnumConstantBase>;
+        if (auto internalEnumConsantBase = azdynamic_cast<AttributeData<EnumConstantBasePtr>*>(attribute); internalEnumConsantBase)
+        {
+            EnumConstantValue* value = reinterpret_cast<EnumConstantValue*>(internalEnumConsantBase->Get(instance).get());
+            return ValueToDom(*value);
+        }
+        else if (auto azEditEnumConstant = azdynamic_cast<AttributeData<AZ::Edit::EnumConstant<AZ::u64>>*>(attribute); azEditEnumConstant)
+        {
+            AZ::Edit::EnumConstant<AZ::u64> value = static_cast<AZ::Edit::EnumConstant<AZ::u64>>(azEditEnumConstant->Get(instance));
+            Dom::Value domValue(Dom::Type::Object);
+            domValue[EntryDescriptionKey] = Dom::Value(value.m_description, true);
+            domValue[EntryValueKey] = Dom::Value(static_cast<uint64_t>(value.m_value));
+            return domValue;
+        }
+        return Dom::Value();
     }
 
     Dom::Value EnumValuesAttributeDefinition::ValueToDom(const EnumValuesContainer& attribute) const

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.cpp
@@ -104,6 +104,24 @@ namespace AZ::DocumentPropertyEditor
         return Dom::Value(result.GetStringView(), false);
     }
 
+    Dom::Value EnumValueAttributeDefinition::ValueToDom(const EnumConstantValue& attribute) const
+    {
+        Dom::Value result(Dom::Type::Object);
+        result[EntryDescriptionKey] = Dom::Value(attribute.m_description, true);
+        result[EntryValueKey] = Dom::Value(static_cast<uint64_t>(attribute.m_value));
+        return result;
+    }
+
+    AZStd::optional<EnumConstantValue> EnumValueAttributeDefinition::DomToValue(const Dom::Value& value) const
+    {
+        if (!value.IsObject() || !value.HasMember(EntryDescriptionKey) || !value.HasMember(EntryValueKey))
+        {
+            return {};
+        }
+
+        return EnumConstantValue{ static_cast<AZ::u64>(value[EntryValueKey].GetUint64()), value[EntryDescriptionKey].GetString() };
+    }
+
     Dom::Value EnumValuesAttributeDefinition::ValueToDom(const EnumValuesContainer& attribute) const
     {
         Dom::Value result(Dom::Type::Array);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -247,8 +247,23 @@ namespace AZ::DocumentPropertyEditor
         AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const override;
     };
 
-    using EnumValuesContainer = AZStd::vector<AZ::Edit::EnumConstant<AZ::u64>>;
+    using EnumConstantValue = AZ::Edit::EnumConstant<AZ::u64>;
+    class EnumValueAttributeDefinition final : public AttributeDefinition<EnumConstantValue>
+    {
+    public:
+        static constexpr const char* EntryDescriptionKey = "description";
+        static constexpr const char* EntryValueKey = "value";
 
+        explicit constexpr EnumValueAttributeDefinition(AZStd::string_view name)
+            : AttributeDefinition<EnumConstantValue>(name)
+        {
+        }
+
+        Dom::Value ValueToDom(const EnumConstantValue& attribute) const override;
+        AZStd::optional<EnumConstantValue> DomToValue(const Dom::Value& value) const override;
+    };
+
+    using EnumValuesContainer = AZStd::vector<EnumConstantValue>;
     class EnumValuesAttributeDefinition final : public AttributeDefinition<EnumValuesContainer>
     {
     public:

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -265,7 +265,7 @@ namespace AZ::DocumentPropertyEditor
         {
             Dom::Value result(Dom::Type::Object);
             result[EntryDescriptionKey] = Dom::Value(attribute.m_description, true);
-            result[EntryValueKey] = Dom::Value(static_cast<EnumType>(attribute.m_value));
+            result[EntryValueKey] = Dom::Value(attribute.m_value);
             return result;
         }
 

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -247,11 +247,12 @@ namespace AZ::DocumentPropertyEditor
         AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const override;
     };
 
-    using EnumConstantValue = AZ::Edit::EnumConstant<AZ::u64>;
+    using EnumConstantValue = SerializeContextEnumInternal::EnumConstant<AZ::u64>;
     class EnumValueAttributeDefinition final : public AttributeDefinition<EnumConstantValue>
     {
     public:
         static constexpr const char* EntryDescriptionKey = "description";
+        static constexpr const char* EntryNameKey = "name";
         static constexpr const char* EntryValueKey = "value";
 
         explicit constexpr EnumValueAttributeDefinition(AZStd::string_view name)
@@ -261,9 +262,10 @@ namespace AZ::DocumentPropertyEditor
 
         Dom::Value ValueToDom(const EnumConstantValue& attribute) const override;
         AZStd::optional<EnumConstantValue> DomToValue(const Dom::Value& value) const override;
+        AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const override;
     };
 
-    using EnumValuesContainer = AZStd::vector<EnumConstantValue>;
+    using EnumValuesContainer = AZStd::vector<AZ::Edit::EnumConstant<AZ::u64>>;
     class EnumValuesAttributeDefinition final : public AttributeDefinition<EnumValuesContainer>
     {
     public:

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -265,7 +265,8 @@ namespace AZ::DocumentPropertyEditor
         {
             Dom::Value result(Dom::Type::Object);
             result[EntryDescriptionKey] = Dom::Value(attribute.m_description, true);
-            result[EntryValueKey] = Dom::Value(attribute.m_value);
+            result[EntryValueKey] = Dom::Value();
+            result[EntryValueKey].SetUint64(attribute.m_value);
             return result;
         }
 

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -57,7 +57,16 @@ namespace AZ::DocumentPropertyEditor::Nodes
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::ValueType);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumType);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumUnderlyingType);
-        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumValue);
+        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumValue<char>);
+        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumValue<AZ::s8>);
+        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumValue<AZ::u8>);
+        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumValue<AZ::s16>);
+        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumValue<AZ::u16>);
+        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumValue<int>);
+        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumValue<AZ::s32>);
+        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumValue<AZ::u32>);
+        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumValue<AZ::s64>);
+        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumValue<AZ::u64>);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumValues);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::ChangeNotify);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::AddNotify);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -138,7 +138,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
 
         static constexpr auto EnumType = TypeIdAttributeDefinition("EnumType");
         static constexpr auto EnumUnderlyingType = TypeIdAttributeDefinition("EnumUnderlyingType");
-        static constexpr auto EnumValue = AttributeDefinition<Dom::Value>("EnumValue");
+        static constexpr auto EnumValue = EnumValueAttributeDefinition("EnumValue");
         static constexpr auto EnumValues = EnumValuesAttributeDefinition("EnumValues");
         static constexpr auto ChangeNotify = CallbackAttributeDefinition<PropertyRefreshLevel()>("ChangeNotify");
         static constexpr auto RequestTreeUpdate = CallbackAttributeDefinition<void(PropertyRefreshLevel)>("RequestTreeUpdate");

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -138,8 +138,10 @@ namespace AZ::DocumentPropertyEditor::Nodes
 
         static constexpr auto EnumType = TypeIdAttributeDefinition("EnumType");
         static constexpr auto EnumUnderlyingType = TypeIdAttributeDefinition("EnumUnderlyingType");
-        static constexpr auto EnumValue = EnumValueAttributeDefinition("EnumValue");
+        template <typename EnumValueType>
+        static constexpr auto EnumValue = EnumValueAttributeDefinition<EnumValueType>("EnumValue");
         static constexpr auto EnumValues = EnumValuesAttributeDefinition("EnumValues");
+
         static constexpr auto ChangeNotify = CallbackAttributeDefinition<PropertyRefreshLevel()>("ChangeNotify");
         static constexpr auto RequestTreeUpdate = CallbackAttributeDefinition<void(PropertyRefreshLevel)>("RequestTreeUpdate");
 

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -557,6 +557,10 @@ namespace AZ::Reflection
 
                 AZ::Name handlerName;
 
+                // This array node is for caching related EnumValue attributes if any are seen
+                Dom::Value enumValueCache = Dom::Value(Dom::Type::Array);
+                const AZ::Name enumValueName = AZ::Name("EnumValue");
+
                 auto checkAttribute = [&](const AZ::AttributePair* it, void* instance, bool shouldDescribeChildren)
                 {
                     if (it->second->m_describesChildren != shouldDescribeChildren)
@@ -567,8 +571,9 @@ namespace AZ::Reflection
                     AZ::Name name = propertyEditorSystem->LookupNameFromId(it->first);
                     if (!name.IsEmpty())
                     {
-                        // If a more specific attribute is already loaded, ignore the new value
-                        if (visitedAttributes.find(name) != visitedAttributes.end())
+                        // If a more specific attribute is already loaded, ignore the new value unless it is an
+                        // EnumValue attribute since those may come in multiples
+                        if (visitedAttributes.find(name) != visitedAttributes.end() && name != enumValueName)
                         {
                             return;
                         }
@@ -594,6 +599,12 @@ namespace AZ::Reflection
                                 }
                             });
 
+                        // Collect related EnumValue attributes for later
+                        if (name == enumValueName && !attributeValue.IsNull())
+                        {
+                            enumValueCache.ArrayPushBack(attributeValue);
+                        }
+
                         // Fall back on a generic read that handles primitives.
                         if (attributeValue.IsNull())
                         {
@@ -609,6 +620,12 @@ namespace AZ::Reflection
                             {
                                 handlerName = AZ::Name();
                             }
+
+                            if (name == enumValueName)
+                            {
+                                return;
+                            }
+
                             cachedAttributes.push_back({ group, AZStd::move(name), AZStd::move(attributeValue) });
                         }
                     }
@@ -732,6 +749,15 @@ namespace AZ::Reflection
                             labelAttributeValue = labelAttributeBuffer;
                         }
                     }
+                }
+
+                if (enumValueCache.ArraySize() > 0)
+                {
+                    nodeData.m_cachedAttributes.push_back({
+                        group, DocumentPropertyEditor::Nodes::PropertyEditor::EnumValues.GetName(), enumValueCache });
+                    nodeData.m_cachedAttributes.push_back({
+                        group,
+                        DocumentPropertyEditor::Nodes::PropertyEditor::Value.GetName(), enumValueCache.GetArray()[0]["value"] });
                 }
 
                 if (!nodeData.m_labelOverride.empty())

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -180,7 +180,7 @@ namespace AZ::Reflection
                 , m_serializeContext(serializeContext)
             {
                 m_stack.push_back({ instance, nullptr, typeId });
-                RegisterPrimitiveHandlers<bool, AZ::u8, AZ::u16, AZ::u32, AZ::u64, AZ::s8, AZ::s16, AZ::s32, AZ::s64, float, double>();
+                RegisterPrimitiveHandlers<bool, char, AZ::u8, AZ::u16, AZ::u32, AZ::u64, AZ::s8, AZ::s16, AZ::s32, AZ::s64, float, double>();
             }
 
             template<typename T>
@@ -755,9 +755,6 @@ namespace AZ::Reflection
                 {
                     nodeData.m_cachedAttributes.push_back({
                         group, DocumentPropertyEditor::Nodes::PropertyEditor::EnumValues.GetName(), enumValueCache });
-                    nodeData.m_cachedAttributes.push_back({
-                        group,
-                        DocumentPropertyEditor::Nodes::PropertyEditor::Value.GetName(), enumValueCache.GetArray()[0]["value"] });
                 }
 
                 if (!nodeData.m_labelOverride.empty())

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/Visitor.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/Visitor.cpp
@@ -14,6 +14,10 @@ namespace AZ::Reflection
     {
     }
 
+    void IRead::Visit(char, const IAttributes&)
+    {
+    }
+
     void IRead::Visit(AZ::s8, const IAttributes&)
     {
     }
@@ -91,6 +95,10 @@ namespace AZ::Reflection
     }
 
     void IReadWrite::Visit(bool&, const IAttributes&)
+    {
+    }
+
+    void IReadWrite::Visit(char&, const IAttributes&)
     {
     }
 

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/Visitor.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/Visitor.h
@@ -189,6 +189,8 @@ namespace AZ::Reflection
 
         virtual void Visit(bool value, const IAttributes& attributes);
 
+        virtual void Visit(char value, const IAttributes& attributes);
+
         virtual void Visit(AZ::s8 value, const IAttributes& attributes);
         virtual void Visit(AZ::s16 value, const IAttributes& attributes);
         virtual void Visit(AZ::s32 value, const IAttributes& attributes);
@@ -225,6 +227,8 @@ namespace AZ::Reflection
 
         virtual void Visit(bool& value, const IAttributes& attributes);
 
+        virtual void Visit(char& value, const IAttributes& attributes);
+
         virtual void Visit(AZ::s8& value, const IAttributes& attributes);
         virtual void Visit(AZ::s16& value, const IAttributes& attributes);
         virtual void Visit(AZ::s32& value, const IAttributes& attributes);
@@ -260,6 +264,8 @@ namespace AZ::Reflection
         IReadWriteToRead(IRead* reader) : m_reader(reader) {}
 
         void Visit(bool& value, const IAttributes& attributes) override { m_reader->Visit(value, attributes); }
+
+        void Visit(char& value, const IAttributes& attributes) override { m_reader->Visit(value, attributes); }
 
         void Visit(AZ::s8& value, const IAttributes& attributes) override { m_reader->Visit(value, attributes); }
         void Visit(AZ::s16& value, const IAttributes& attributes) override { m_reader->Visit(value, attributes); }

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -278,6 +278,11 @@ namespace AZ::DocumentPropertyEditor
             VisitPrimitive(value, attributes);
         }
 
+        void Visit(char& value, const Reflection::IAttributes& attributes) override
+        {
+            VisitPrimitive(value, attributes);
+        }
+
         void Visit(AZ::s8& value, const Reflection::IAttributes& attributes) override
         {
             VisitPrimitive(value, attributes);

--- a/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
@@ -71,6 +71,14 @@ namespace DPEDebugView
             NotReflected = 0xFF
         };
 
+        // This enum is being used to test parsing of AZ::Edit::EnumConstant attributes from the reflection context
+        enum class EnumValueType : char
+        {
+            AValue,
+            BValue,
+            CValue
+        };
+
         AZStd::vector<AZ::Edit::EnumConstant<EnumType>> GetEnumValues() const
         {
             AZStd::vector<AZ::Edit::EnumConstant<EnumType>> values;
@@ -88,14 +96,15 @@ namespace DPEDebugView
         AZStd::map<AZStd::string, float> m_map;
         AZStd::map<AZStd::string, float> m_readOnlyMap;
         AZStd::unordered_map<AZStd::pair<int, double>, int> m_unorderedMap;
-        AZStd::unordered_map<EnumType, int> m_simpleEnum;
-        AZStd::unordered_map<EnumType, double> m_immutableEnum;
+        AZStd::unordered_map<EnumType, int> m_simpleEnumMap;
+        AZStd::unordered_map<EnumType, double> m_immutableEnumMap;
         AZStd::set<int> m_set;
         AZStd::unordered_set<EnumType> m_unorderedSet;
         AZStd::unordered_multimap<int, AZStd::string> m_multiMap;
         AZStd::unordered_map<EnumType, AZStd::unordered_map<int, int>> m_nestedMap;
         AZStd::unordered_map<AZ::EntityId, int> m_entityIdMap;
         EnumType m_enumValue = EnumType::Value1;
+        EnumValueType m_enumValueType = EnumValueType::BValue;
         AZ::EntityId m_entityId;
 
         // For testing invocable ReadOnly attributes
@@ -114,14 +123,15 @@ namespace DPEDebugView
                     ->Field("vector", &TestContainer::m_vector)
                     ->Field("map", &TestContainer::m_map)
                     ->Field("unorderedMap", &TestContainer::m_unorderedMap)
-                    ->Field("simpleEnum", &TestContainer::m_simpleEnum)
-                    ->Field("immutableEnum", &TestContainer::m_immutableEnum)
+                    ->Field("simpleEnum", &TestContainer::m_simpleEnumMap)
+                    ->Field("immutableEnum", &TestContainer::m_immutableEnumMap)
                     ->Field("set", &TestContainer::m_set)
                     ->Field("unorderedSet", &TestContainer::m_unorderedSet)
                     ->Field("multiMap", &TestContainer::m_multiMap)
                     ->Field("nestedMap", &TestContainer::m_nestedMap)
                     ->Field("entityIdMap", &TestContainer::m_entityIdMap)
                     ->Field("enumValue", &TestContainer::m_enumValue)
+                    ->Field("enumValueType", &TestContainer::m_enumValueType)
                     ->Field("entityId", &TestContainer::m_entityId)
                     ->Field("readonlyInt", &TestContainer::m_readOnlyInt)
                     ->Field("map", &TestContainer::m_readOnlyMap);
@@ -150,9 +160,9 @@ namespace DPEDebugView
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->DataElement(
                             AZ::Edit::UIHandlers::Default, &TestContainer::m_unorderedMap, "unordered_map<pair<int, double>, int>", "")
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_simpleEnum, "unordered_map<enum, int>", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_simpleEnumMap, "unordered_map<enum, int>", "")
                         ->DataElement(
-                            AZ::Edit::UIHandlers::Default, &TestContainer::m_immutableEnum, "unordered_map<enum, double> (fixed contents)",
+                            AZ::Edit::UIHandlers::Default, &TestContainer::m_immutableEnumMap, "unordered_map<enum, double> (fixed contents)",
                             "")
                         ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, false)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_set, "set<int>", "")
@@ -163,9 +173,13 @@ namespace DPEDebugView
                             AZ::Edit::UIHandlers::Default, &TestContainer::m_nestedMap, "unordered_map<enum, unordered_map<int, int>>", "")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_entityIdMap, "unordered_map<EntityId, Number>", "")
                         ->ClassElement(AZ::Edit::ClassElements::Group, "")
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_enumValue, "enum (no multi-edit)", "")
+                        ->DataElement(AZ::Edit::UIHandlers::ComboBox, &TestContainer::m_enumValue, "enum (no multi-edit)", "")
                         ->Attribute(AZ::Edit::Attributes::EnumValues, &TestContainer::GetEnumValues)
                         ->Attribute(AZ::Edit::Attributes::AcceptsMultiEdit, false)
+                        ->DataElement(AZ::Edit::UIHandlers::ComboBox, &TestContainer::m_enumValueType, "enum (multi-edit)", "")
+                        ->EnumAttribute(EnumValueType::AValue, "AValueDescription")
+                        ->EnumAttribute(EnumValueType::BValue, "BValueDescription")
+                        ->EnumAttribute(EnumValueType::CValue, "CValueDescription")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_entityId, "entityId", "")
                         ->UIElement(AZ::Edit::UIHandlers::Button, "")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &Button2)
@@ -243,13 +257,13 @@ int main(int argc, char** argv)
     testContainer.m_unorderedMap[{1, 2.}] = 3;
     testContainer.m_unorderedMap[{ 4, 5. }] = 6;
 
-    testContainer.m_simpleEnum[DPEDebugView::TestContainer::EnumType::Value1] = 1;
-    testContainer.m_simpleEnum[DPEDebugView::TestContainer::EnumType::Value2] = 2;
-    testContainer.m_simpleEnum[DPEDebugView::TestContainer::EnumType::ValueZ] = 10;
+    testContainer.m_simpleEnumMap[DPEDebugView::TestContainer::EnumType::Value1] = 1;
+    testContainer.m_simpleEnumMap[DPEDebugView::TestContainer::EnumType::Value2] = 2;
+    testContainer.m_simpleEnumMap[DPEDebugView::TestContainer::EnumType::ValueZ] = 10;
 
-    testContainer.m_immutableEnum[DPEDebugView::TestContainer::EnumType::Value1] = 1.;
-    testContainer.m_immutableEnum[DPEDebugView::TestContainer::EnumType::Value2] = 2.;
-    testContainer.m_immutableEnum[DPEDebugView::TestContainer::EnumType::ValueZ] = 10.;
+    testContainer.m_immutableEnumMap[DPEDebugView::TestContainer::EnumType::Value1] = 1.;
+    testContainer.m_immutableEnumMap[DPEDebugView::TestContainer::EnumType::Value2] = 2.;
+    testContainer.m_immutableEnumMap[DPEDebugView::TestContainer::EnumType::ValueZ] = 10.;
 
     testContainer.m_set.insert(1);
     testContainer.m_set.insert(3);
@@ -258,7 +272,7 @@ int main(int argc, char** argv)
     testContainer.m_unorderedSet.insert(DPEDebugView::TestContainer::EnumType::Value1);
     testContainer.m_unorderedSet.insert(DPEDebugView::TestContainer::EnumType::ValueZ);
 
-    testContainer.m_multiMap.insert({1, "one"});
+    testContainer.m_multiMap.insert({ 1, "one"});
     testContainer.m_multiMap.insert({ 2, "two" });
     testContainer.m_multiMap.insert({ 1, "also one" });
 
@@ -274,8 +288,10 @@ int main(int argc, char** argv)
 
     sortFilter->SetSourceAdapter(cvarAdapter);
 
+    debugViewer->AddAdapterToList(
+        "Reflection Adapter",
+        AZStd::make_shared<AZ::DocumentPropertyEditor::ReflectionAdapter>(&testContainer, azrtti_typeid<DPEDebugView::TestContainer>()));
     debugViewer->AddAdapterToList("CVar Adapter", sortFilter);
-    debugViewer->AddAdapterToList("Reflection Adapter", AZStd::make_shared<AZ::DocumentPropertyEditor::ReflectionAdapter>(&testContainer, azrtti_typeid<DPEDebugView::TestContainer>()));
     debugViewer->AddAdapterToList("Example Adapter", AZStd::make_shared<AZ::DocumentPropertyEditor::ExampleAdapter>());
     debugViewer->AddAdapterToList("Settings Registry Adapter", AZStd::make_shared<AZ::DocumentPropertyEditor::SettingsRegistryAdapter>());
 


### PR DESCRIPTION
**Description**
Before this PR, EnumValue attributes were not being converted to DPE node attributes correctly in the LegacyReflectionBridge.

That was partly due to the way that attributes are being identified by a CRC of their string name; there was an EnumValue attribute in the SerializeContext and another in the EditContext.

This PR does a few things in order to handle EnumValue attributes in the DPE:
- Changes the CRC of the SerializeContext's EnumValue attribute key
- Templatizes EnumValueAttributeDefinition so it can work with the enum's original type
- Registers AttributeDefinitions for those enum types supported by the combo box property controls
- Caches related EnumValue attributes in the LegacyReflectionBridge and puts them into an EnumValues DOM node for the DPE to use
- Adds a char Visit function to the reader writer interfaces in Visitor.h as well as registering a char primitive handler in the LegacyReflectionBridge; this allows the Value attribute of a PropertyEditor node to be parsed correctly when the reflected enum values are of type char

**Testing**
- Verified that combo boxes are populated with their full list of reflected EnumValue attributes
- Verified the flow of control in the debugger and saw that the reflected attributes are being turned into DOM nodes in the DPE
- Verified that values specified as member defaults by any class reflecting an enum using EnumValue attributes is the value selected in DPE ComboBox handlers