### PR TITLE
Added supported platform text rendering for gem catalog cards.

### DIFF
--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.cpp
@@ -375,18 +375,23 @@ namespace O3DE::ProjectManager
     }
 
 
-    void GemItemDelegate::DrawPlatformText(QPainter* painter, const QRect& contentRect, const QFont& standardFont, [[maybe_unused]] const QModelIndex& modelIndex) const
+    void GemItemDelegate::DrawPlatformText(QPainter* painter, const QRect& contentRect, const QFont& standardFont, const QModelIndex& modelIndex) const
     {
         const GemInfo::Platforms platforms = GemModel::GetPlatforms(modelIndex);
         
         auto xbounds = CalcColumnXBounds(HeaderOrder::Name);
-        int startX = s_platformTextleftMarginCorrection + xbounds.first;
+        const int startX = s_platformTextleftMarginCorrection + xbounds.first;
         QFont platformFont(standardFont);
         platformFont.setPixelSize(s_featureTagFontSize);
         platformFont.setBold(false);
         painter->setFont(platformFont);
         QString platformText = "";
 
+        //If no platforms are specified, there is nothing to draw
+        if(platforms == 0)
+        {
+            return;
+        }
         
         //UX prefers that we show platforms in reverse alphabetical order
         for(int i = GemInfo::NumPlatforms-1; i >= 0; i--)
@@ -394,23 +399,21 @@ namespace O3DE::ProjectManager
             const GemInfo::Platform platform = static_cast<GemInfo::Platform>(1 << i);
             if (platforms & platform)
             {
-                QString singlePlatformText = GemInfo::GetPlatformString(platform);
+                const QString& singlePlatformText = GemInfo::GetPlatformString(platform);
                 if(i != GemInfo::NumPlatforms-1)
                 {
                     platformText.append(", ");
                 }
                 platformText.append(singlePlatformText);
-                
             }
         }
-        
 
         //figure out the ideal rect size for the platform text space constraints
-        QRect platformRect = QRect(contentRect.left() + startX, contentRect.bottom() - s_platformTextHeightAdjustment,
+        const QRect platformRect = QRect(contentRect.left() + startX, contentRect.bottom() - s_platformTextHeightAdjustment,
                                    xbounds.second -xbounds.first - s_platformTextWrapAroundMargin,
                                    (s_featureTagFontSize + s_platformTextLineBottomMargin) * s_platformTextWrapAroundLineMaxCount);
 
-        DrawText(platformText, painter, platformRect, platformFont, !platforms);
+        DrawText(platformText, painter, platformRect, platformFont);     
     }
 
     void GemItemDelegate::DrawFeatureTags(
@@ -470,7 +473,7 @@ namespace O3DE::ProjectManager
         return doc;
     }
 
-    void GemItemDelegate::DrawText(const QString& text, QPainter* painter, const QRect& rect, const QFont& standardFont, const bool& greyedOut) const 
+    void GemItemDelegate::DrawText(const QString& text, QPainter* painter, const QRect& rect, const QFont& standardFont) const 
     {
         painter->save();
 
@@ -489,14 +492,7 @@ namespace O3DE::ProjectManager
         else
         {
             painter->setFont(standardFont);
-            if(greyedOut)
-            {
-                painter->setPen(m_greyedOutTextColor);
-            }
-            else
-            {
-                painter->setPen(m_textColor);
-            }
+            painter->setPen(m_textColor);
             painter->drawText(rect, Qt::AlignLeft | Qt::TextWordWrap, text);
         }
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.cpp
@@ -387,26 +387,20 @@ namespace O3DE::ProjectManager
         painter->setFont(platformFont);
         QString platformText = "";
 
-        if(!platforms)
+        
+        //UX prefers that we show platforms in reverse alphabetical order
+        for(int i = GemInfo::NumPlatforms-1; i >= 0; i--)
         {
-            platformText.append("Unspecified");
-        }
-        else
-        {
-            //UX prefers that we show platforms in reverse alphabetical order
-            for(int i = GemInfo::NumPlatforms-1; i >= 0; i--)
+            const GemInfo::Platform platform = static_cast<GemInfo::Platform>(1 << i);
+            if (platforms & platform)
             {
-                const GemInfo::Platform platform = static_cast<GemInfo::Platform>(1 << i);
-                if (platforms & platform)
+                QString singlePlatformText = GemInfo::GetPlatformString(platform);
+                if(i != GemInfo::NumPlatforms-1)
                 {
-                    QString singlePlatformText = GemInfo::GetPlatformString(platform);
-                    if(i != GemInfo::NumPlatforms-1)
-                    {
-                        platformText.append(", ");
-                    }
-                    platformText.append(singlePlatformText);
-                    
+                    platformText.append(", ");
                 }
+                platformText.append(singlePlatformText);
+                
             }
         }
         

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.cpp
@@ -385,7 +385,7 @@ namespace O3DE::ProjectManager
         platformFont.setPixelSize(s_featureTagFontSize);
         platformFont.setBold(false);
         painter->setFont(platformFont);
-        QString platformText = "";
+        QStringList platformList;
 
         //If no platforms are specified, there is nothing to draw
         if(platforms == 0)
@@ -399,12 +399,7 @@ namespace O3DE::ProjectManager
             const GemInfo::Platform platform = static_cast<GemInfo::Platform>(1 << i);
             if (platforms & platform)
             {
-                const QString& singlePlatformText = GemInfo::GetPlatformString(platform);
-                if(i != GemInfo::NumPlatforms-1)
-                {
-                    platformText.append(", ");
-                }
-                platformText.append(singlePlatformText);
+                platformList.append(GemInfo::GetPlatformString(platform));
             }
         }
 
@@ -413,7 +408,7 @@ namespace O3DE::ProjectManager
                                    xbounds.second -xbounds.first - s_platformTextWrapAroundMargin,
                                    (s_featureTagFontSize + s_platformTextLineBottomMargin) * s_platformTextWrapAroundLineMaxCount);
 
-        DrawText(platformText, painter, platformRect, platformFont);     
+        DrawText(platformList.join(", "), painter, platformRect, platformFont);     
     }
 
     void GemItemDelegate::DrawFeatureTags(

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.h
@@ -36,6 +36,7 @@ namespace O3DE::ProjectManager
 
         // Colors
         const QColor m_textColor = QColor("#FFFFFF");
+        const QColor m_greyedOutTextColor =QColor("#888888");
         const QColor m_linkColor = QColor("#94D2FF");
         const QColor m_backgroundColor = QColor("#333333"); // Outside of the actual gem item
         const QColor m_itemBackgroundColor = QColor("#404040"); // Background color of the gem item
@@ -68,6 +69,13 @@ namespace O3DE::ProjectManager
         inline constexpr static int s_featureTagBorderMarginY = 3;
         inline constexpr static int s_featureTagSpacing = 7;
 
+        // Platform text
+        inline constexpr static int s_platformTextleftMarginCorrection = -3;
+        inline constexpr static int s_platformTextHeightAdjustment = 25;
+        inline constexpr static int s_platformTextWrapAroundMargin = 5;
+        inline constexpr static int s_platformTextLineBottomMargin = 5;
+        inline constexpr static int s_platformTextWrapAroundLineMaxCount = 2;
+
         // Status icon
         inline constexpr static int s_statusIconSize = 16;
         inline constexpr static int s_statusButtonSpacing = 5;
@@ -93,6 +101,7 @@ namespace O3DE::ProjectManager
         QRect CalcButtonRect(const QRect& contentRect) const;
         QRect CalcSummaryRect(const QRect& contentRect, bool hasTags) const;
         void DrawPlatformIcons(QPainter* painter, const QRect& contentRect, const QModelIndex& modelIndex) const;
+        void DrawPlatformText(QPainter* painter, const QRect& contentRect,  const QFont& standardFont, const QModelIndex& modelIndex) const;
         void DrawButton(QPainter* painter, const QRect& buttonRect, const QModelIndex& modelIndex) const;
         void DrawFeatureTags(
             QPainter* painter,
@@ -100,7 +109,7 @@ namespace O3DE::ProjectManager
             const QStringList& featureTags,
             const QFont& standardFont,
             const QRect& summaryRect) const;
-        void DrawText(const QString& text, QPainter* painter, const QRect& rect, const QFont& standardFont) const;
+        void DrawText(const QString& text, QPainter* painter, const QRect& rect, const QFont& standardFont, const bool& greyedOut = false) const;
         void DrawDownloadStatusIcon(
             QPainter* painter, const QRect& contentRect, const QRect& buttonRect, const QModelIndex& modelIndex) const;
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.h
@@ -36,7 +36,6 @@ namespace O3DE::ProjectManager
 
         // Colors
         const QColor m_textColor = QColor("#FFFFFF");
-        const QColor m_greyedOutTextColor =QColor("#888888");
         const QColor m_linkColor = QColor("#94D2FF");
         const QColor m_backgroundColor = QColor("#333333"); // Outside of the actual gem item
         const QColor m_itemBackgroundColor = QColor("#404040"); // Background color of the gem item
@@ -109,7 +108,7 @@ namespace O3DE::ProjectManager
             const QStringList& featureTags,
             const QFont& standardFont,
             const QRect& summaryRect) const;
-        void DrawText(const QString& text, QPainter* painter, const QRect& rect, const QFont& standardFont, const bool& greyedOut = false) const;
+        void DrawText(const QString& text, QPainter* painter, const QRect& rect, const QFont& standardFont) const;
         void DrawDownloadStatusIcon(
             QPainter* painter, const QRect& contentRect, const QRect& buttonRect, const QModelIndex& modelIndex) const;
 


### PR DESCRIPTION
Signed-off-by: T.J. Kotha <112996779+tkothadev@users.noreply.github.com>

## What does this PR do?

This PR provides text rendering for gems to indicate their supported platforms. Please see the testing section for examples.

_Note on implementation:_ The original plan was to implement the text rendering using a QLabel and adjusting layout (i.e. implementing from scratch). However, rendering the text via QPainter was chosen, because the `GemItemDelegate` class uses QPainter to render everything. To go with the original plan would have meant overhauling the class, which is too drastic for this PR.

## How was this PR tested?

The rendering logic was visually tested for various scenarios. Note that at the time of writing this PR,  there is currently no logic for fetching the supported platforms from `GemModel`. That will be addressed in a future PR. These scenarios were tested via manually inputting values for the `platforms` field @ `GemItemDelegate.cpp:L380`. Rendering logic was verified via this approach.

When platforms are unspecified:
![image(1)](https://user-images.githubusercontent.com/112996779/200999108-fb370883-fa66-4945-8ac7-add005dda3b8.png)

When at least four are specified:
![image (14)](https://user-images.githubusercontent.com/112996779/200999323-36f6929b-a3f8-4410-954d-9fcbc5cc8120.png)

When there is wrap around:
![image (15)](https://user-images.githubusercontent.com/112996779/200999399-5172ac03-70fc-4147-a42d-1091e13280cd.png)

When there is extreme wrap around:
![image (16)](https://user-images.githubusercontent.com/112996779/200999525-0ff9010f-1061-4147-a4db-a50e4a3a50d8.png)
![GemCatalogSupportedPlatformWordWrap](https://user-images.githubusercontent.com/112996779/201162530-ce9b059f-b486-4a6f-a478-efe4a2432406.gif)



Showcasing both cases where unspecified and specified are present:
![image (17)](https://user-images.githubusercontent.com/112996779/200999665-a907b200-f3e3-4f62-9aaf-c72f679dde61.png)
