### PR TITLE
AZ Networking ISerialize Support for AZ::s64 and AZ::u64

### DIFF
--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
@@ -108,10 +108,7 @@ namespace AzNetworking
         //! @param maxValue the maximum value expected during serialization
         //! @return boolean true for success, false for failure
         #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
-        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max())
-        {
-            return Serialize(static_cast<int64_t>(value), name, minValue, maxValue);
-        }
+        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max());
         #endif
 
         //! Serialize an unsigned byte.
@@ -153,10 +150,7 @@ namespace AzNetworking
         //! @param maxValue the maximum value expected during serialization
         //! @return boolean true for success, false for failure
         #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
-        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue = AZStd::numeric_limits<AZ::u64>::min(), AZ::u64 maxValue = AZStd::numeric_limits<AZ::u64>::max())
-        {
-            return Serialize(static_cast<uint64_t>(value), name, minValue, maxValue);
-        }
+        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue = AZStd::numeric_limits<AZ::u64>::min(), AZ::u64 maxValue = AZStd::numeric_limits<AZ::u64>::max());
         #endif
 
         //! Serialize a 32-bit floating point number.

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
@@ -108,7 +108,7 @@ namespace AzNetworking
         //! @param maxValue the maximum value expected during serialization
         //! @return boolean true for success, false for failure
         #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
-        virtual bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max());
+        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max());
         #endif
 
         //! Serialize an unsigned byte.
@@ -150,7 +150,7 @@ namespace AzNetworking
         //! @param maxValue the maximum value expected during serialization
         //! @return boolean true for success, false for failure
         #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
-        virtual bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue = AZStd::numeric_limits<AZ::u64>::min(), AZ::u64 maxValue = AZStd::numeric_limits<AZ::u64>::max());
+        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue = AZStd::numeric_limits<AZ::u64>::min(), AZ::u64 maxValue = AZStd::numeric_limits<AZ::u64>::max());
         #endif
 
         //! Serialize a 32-bit floating point number.

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <AzCore/base.h>
 #include <AzCore/std/limits.h>
 
 namespace AzNetworking
@@ -100,6 +101,19 @@ namespace AzNetworking
         //! @return boolean true for success, false for failure
         virtual bool Serialize(int64_t& value, const char* name, int64_t minValue = AZStd::numeric_limits<int64_t>::min(), int64_t maxValue = AZStd::numeric_limits<int64_t>::max()) = 0;
 
+        //! Serialize a signed 64-bit integer.
+        //! @param value    signed 64-bit integer input value to serialize
+        //! @param name     string name of the value being serialized
+        //! @param minValue the minimum value expected during serialization
+        //! @param maxValue the maximum value expected during serialization
+        //! @return boolean true for success, false for failure
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max())
+        {
+            return Serialize(static_cast<int64_t>(value), name, minValue, maxValue);
+        }
+        #endif
+
         //! Serialize an unsigned byte.
         //! @param value    unsigned byte input value to serialize
         //! @param name     string name of the value being serialized
@@ -131,6 +145,19 @@ namespace AzNetworking
         //! @param maxValue the maximum value expected during serialization
         //! @return boolean true for success, false for failure
         virtual bool Serialize(uint64_t& value, const char* name, uint64_t minValue = AZStd::numeric_limits<uint64_t>::min(), uint64_t maxValue = AZStd::numeric_limits<uint64_t>::max()) = 0;
+
+        //! Serialize an unsigned 64-bit integer.
+        //! @param value    signed 64-bit integer input value to serialize
+        //! @param name     string name of the value being serialized
+        //! @param minValue the minimum value expected during serialization
+        //! @param maxValue the maximum value expected during serialization
+        //! @return boolean true for success, false for failure
+        #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue = AZStd::numeric_limits<AZ::u64>::min(), AZ::u64 maxValue = AZStd::numeric_limits<AZ::u64>::max())
+        {
+            return Serialize(static_cast<uint64_t>(value), name, minValue, maxValue);
+        }
+        #endif
 
         //! Serialize a 32-bit floating point number.
         //! @param value    32-bit floating point input value to serialize

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
@@ -108,7 +108,7 @@ namespace AzNetworking
         //! @param maxValue the maximum value expected during serialization
         //! @return boolean true for success, false for failure
         #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
-        bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max());
+        virtual bool Serialize(AZ::s64& value, const char* name, AZ::s64 minValue = AZStd::numeric_limits<AZ::s64>::min(), AZ::s64 maxValue = AZStd::numeric_limits<AZ::s64>::max());
         #endif
 
         //! Serialize an unsigned byte.
@@ -150,7 +150,7 @@ namespace AzNetworking
         //! @param maxValue the maximum value expected during serialization
         //! @return boolean true for success, false for failure
         #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
-        bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue = AZStd::numeric_limits<AZ::u64>::min(), AZ::u64 maxValue = AZStd::numeric_limits<AZ::u64>::max());
+        virtual bool Serialize(AZ::u64& value, const char* name, AZ::u64 minValue = AZStd::numeric_limits<AZ::u64>::min(), AZ::u64 maxValue = AZStd::numeric_limits<AZ::u64>::max());
         #endif
 
         //! Serialize a 32-bit floating point number.

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.inl
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.inl
@@ -100,6 +100,19 @@ namespace AzNetworking
         m_serializerValid = false;
     }
 
+    #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
+    inline bool ISerializer::Serialize(AZ::s64& value, const char* name, AZ::s64 minValue, AZ::s64 maxValue))
+    {
+        return Serialize(static_cast<int64_t>(value), name, static_cast<int64_t>(minValue), static_cast<int64_t>(maxValue));
+    }
+
+    inline bool ISerializer::Serialize(AZ::u64& value, const char* name, AZ::u64 minValue, AZ::u64 maxValue))
+    {
+        return Serialize(static_cast<uint64_t>(value), name, static_cast<uint64_t>(minValue), static_cast<uint64_t>(maxValue));
+    }
+    #endif
+
+
     template <typename TYPE>
     inline bool ISerializer::Serialize(TYPE& value, const char* name)
     {

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.inl
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.inl
@@ -101,12 +101,12 @@ namespace AzNetworking
     }
 
     #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
-    inline bool ISerializer::Serialize(AZ::s64& value, const char* name, AZ::s64 minValue, AZ::s64 maxValue))
+    inline bool ISerializer::Serialize(AZ::s64& value, const char* name, AZ::s64 minValue, AZ::s64 maxValue)
     {
         return Serialize(static_cast<int64_t>(value), name, static_cast<int64_t>(minValue), static_cast<int64_t>(maxValue));
     }
 
-    inline bool ISerializer::Serialize(AZ::u64& value, const char* name, AZ::u64 minValue, AZ::u64 maxValue))
+    inline bool ISerializer::Serialize(AZ::u64& value, const char* name, AZ::u64 minValue, AZ::u64 maxValue)
     {
         return Serialize(static_cast<uint64_t>(value), name, static_cast<uint64_t>(minValue), static_cast<uint64_t>(maxValue));
     }

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.inl
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.inl
@@ -103,12 +103,12 @@ namespace AzNetworking
     #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
     inline bool ISerializer::Serialize(AZ::s64& value, const char* name, AZ::s64 minValue, AZ::s64 maxValue)
     {
-        return Serialize(static_cast<int64_t>(value), name, static_cast<int64_t>(minValue), static_cast<int64_t>(maxValue));
+        return Serialize(reinterpret_cast<int64_t&>(value), name, static_cast<int64_t>(minValue), static_cast<int64_t>(maxValue));
     }
 
     inline bool ISerializer::Serialize(AZ::u64& value, const char* name, AZ::u64 minValue, AZ::u64 maxValue)
     {
-        return Serialize(static_cast<uint64_t>(value), name, static_cast<uint64_t>(minValue), static_cast<uint64_t>(maxValue));
+        return Serialize(reinterpret_cast<uint64_t&>(value), name, static_cast<uint64_t>(minValue), static_cast<uint64_t>(maxValue));
     }
     #endif
 

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.inl
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.inl
@@ -112,7 +112,6 @@ namespace AzNetworking
     }
     #endif
 
-
     template <typename TYPE>
     inline bool ISerializer::Serialize(TYPE& value, const char* name)
     {


### PR DESCRIPTION
Allows AzNetworking to serialize AZ::s64 and AZ::u64.
AzNetworking ISerialize current supports int64_t and uint64_t, which (depending on the system) is sometimes long and sometimes long long. AZ types such as AZ::u64 are set up to always be defined as long long. This change makes it so that if int64_t is long (not long long), then we'll define a new method to support long long.

Fixes https://github.com/o3de/o3de/issues/13019

Signed-off-by: Gene Walters <genewalt@amazon.com>
