### PR TITLE
[Terrain] Prevent AP from processing image until after it's done saving

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.cpp
@@ -675,8 +675,8 @@ namespace ImageProcessingAtom
         if (outPreset == emptyPreset)
         {        
             auto image = IImageObjectPtr(LoadImageFromFile(imageFilePath));
-            if (image->GetAlphaContent() == EAlphaContent::eAlphaContent_Absent
-                || image->GetAlphaContent() == EAlphaContent::eAlphaContent_OnlyWhite)
+            if (image && ((image->GetAlphaContent() == EAlphaContent::eAlphaContent_Absent
+                || image->GetAlphaContent() == EAlphaContent::eAlphaContent_OnlyWhite)))
             {
                 outPreset = m_defaultPreset;
             }

--- a/Gems/GradientSignal/Code/Source/Editor/EditorGradientImageCreatorUtils.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorGradientImageCreatorUtils.cpp
@@ -211,22 +211,22 @@ namespace GradientSignal::ImageCreatorUtils
             return false;
         };
 
-        bool result = outputImage->write_image(
+        bool writeResult = outputImage->write_image(
             pixelFormat, pixelBuffer.data(), OIIO::AutoStride, OIIO::AutoStride, OIIO::AutoStride, WriteProgressCallback, saveDialog);
-        if (!result)
+        if (!writeResult)
         {
-            AZ_Error("EditorImageGradientComponent", result, "Failed to write out gradient image to path: %s", tempSavePath.c_str());
+            AZ_Error("EditorImageGradientComponent", writeResult, "Failed to write out gradient image to path: %s", tempSavePath.c_str());
         }
 
         outputImage->close();
 
         // Now that we're done saving the temporary image, rename it to the correct file name.
-        [[maybe_unused]] auto moveResult = AZ::IO::SmartMove(tempSavePath.c_str(), absolutePath.c_str());
+        auto moveResult = AZ::IO::SmartMove(tempSavePath.c_str(), absolutePath.c_str());
         AZ_Error("EditorImageGradientComponent", moveResult,
             "Failed to rename temporary image asset %s to %s", tempSavePath.c_str(), absolutePath.c_str());
 
         delete saveDialog;
-        return result;
+        return writeResult && moveResult;
     }
 
 }

--- a/Gems/GradientSignal/Code/Source/Editor/EditorGradientImageCreatorUtils.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorGradientImageCreatorUtils.cpp
@@ -223,7 +223,7 @@ namespace GradientSignal::ImageCreatorUtils
         // Now that we're done saving the temporary image, rename it to the correct file name.
         [[maybe_unused]] auto moveResult = AZ::IO::SmartMove(tempSavePath.c_str(), absolutePath.c_str());
         AZ_Error("EditorImageGradientComponent", moveResult,
-            "Failed to rename temporary image asset %s", tempSavePath.c_str(), absolutePath.c_str());
+            "Failed to rename temporary image asset %s to %s", tempSavePath.c_str(), absolutePath.c_str());
 
         delete saveDialog;
         return result;

--- a/Gems/GradientSignal/Code/Source/Editor/EditorGradientImageCreatorUtils.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorGradientImageCreatorUtils.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <Editor/EditorGradientImageCreatorUtils.h>
+#include <AzFramework/IO/FileOperations.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
 
@@ -182,18 +183,21 @@ namespace GradientSignal::ImageCreatorUtils
             return false;
         }
 
-        // Create and save the image on disk
+        // Create and save the image on disk. We initially save it to a temporary name so that the Asset Processor won't start
+        // processing it, and then we'll move it to the correct name at the end.
+        AZStd::string tempSavePath;
+        AZ::IO::CreateTempFileName(absolutePath.c_str(), tempSavePath);
 
-        std::unique_ptr<OIIO::ImageOutput> outputImage = OIIO::ImageOutput::create(absolutePath.c_str());
+        std::unique_ptr<OIIO::ImageOutput> outputImage = OIIO::ImageOutput::create(tempSavePath.c_str());
         if (!outputImage)
         {
-            AZ_Error("EditorImageGradientComponent", false, "Failed to create image at path: %s", absolutePath.c_str());
+            AZ_Error("EditorImageGradientComponent", false, "Failed to create image at path: %s", tempSavePath.c_str());
             delete saveDialog;
             return false;
         }
 
         OIIO::ImageSpec spec(imageResolutionX, imageResolutionY, channels, pixelFormat);
-        outputImage->open(absolutePath.c_str(), spec);
+        outputImage->open(tempSavePath.c_str(), spec);
 
         // Callback to upgrade our progress dialog during image saving.
         auto WriteProgressCallback = [](void* opaqueData, float percentDone) -> bool
@@ -211,10 +215,15 @@ namespace GradientSignal::ImageCreatorUtils
             pixelFormat, pixelBuffer.data(), OIIO::AutoStride, OIIO::AutoStride, OIIO::AutoStride, WriteProgressCallback, saveDialog);
         if (!result)
         {
-            AZ_Error("EditorImageGradientComponent", result, "Failed to write out gradient image to path: %s", absolutePath.c_str());
+            AZ_Error("EditorImageGradientComponent", result, "Failed to write out gradient image to path: %s", tempSavePath.c_str());
         }
 
         outputImage->close();
+
+        // Now that we're done saving the temporary image, rename it to the correct file name.
+        [[maybe_unused]] auto moveResult = AZ::IO::SmartMove(tempSavePath.c_str(), absolutePath.c_str());
+        AZ_Error("EditorImageGradientComponent", moveResult,
+            "Failed to rename temporary image asset %s", tempSavePath.c_str(), absolutePath.c_str());
 
         delete saveDialog;
         return result;


### PR DESCRIPTION
## What does this PR do?

When painting or baking an image gradient, it was possible for the Asset Processor to start processing the asset before the image was fully written, which would result in an incorrect processed asset. Furthermore, the AP didn't know to reprocess the asset without a manual trigger.

This change uses special temp file naming to make the AP ignore the image while it's being written, then renames it _after_ it's done so that the AP processes the fully-written image.

Also fixed a tiny null dereference problem in the image builder that could happen occasionally if the source image couldn't be read in for some reason.

## How was this PR tested?

Tried painting on images that were 64x64 in size and saving them. Oddly enough, tiny images like these were triggering the problem 100% of the time for me. They now trigger it 0% of the time.
