### PR TITLE
Fixed Android running on VFS. 

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
@@ -810,6 +810,16 @@ namespace AzFramework
     // the results.  For this reason, it is a direct call and protects its structures with a lock.
     void AssetCatalog::AssetChanged(const AZStd::vector<AzFramework::AssetSystem::AssetNotificationMessage>& messages, bool isCatalogInitialize)
     {
+        if (isCatalogInitialize && !m_initialized)
+        {
+            // This can happen when running with VFS, where the AP connection is done first
+            // and it's too early to send asset changed messages since catalog is not initialized yet.
+            AZ_TracePrintf(
+                "AssetCatalog",
+                "Skipping AssetChanged to update the catalog since it's too early, catalog has not been initialized yet.");
+            return;
+        }
+
         for (const auto& message : messages)
         {
             AZStd::string relativePath = message.m_data;

--- a/Code/LauncherUnified/Launcher.cpp
+++ b/Code/LauncherUnified/Launcher.cpp
@@ -252,6 +252,8 @@ namespace O3DELauncher
             };
             AZ::Data::AssetCatalogRequestBus::Broadcast(AZStd::move(LoadCatalog));
 
+            AZ_TracePrintf("Launcher", "CriticalAssetsCompiled\n");
+
             // Broadcast that critical assets are ready
             AZ::ComponentApplicationLifecycle::SignalEvent(*settingsRegistry, "CriticalAssetsCompiled", R"({})");
         }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
@@ -370,6 +370,8 @@ namespace AtomToolsFramework
             AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::ExitMainLoop);
         }
 
+        AZ_TracePrintf("AtomToolsApplication", "CriticalAssetsCompiled\n");
+
         AZ::ComponentApplicationLifecycle::SignalEvent(*m_settingsRegistry, "CriticalAssetsCompiled", R"({})");
 
         // Reload the assetcatalog.xml at this point again


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

The following fix https://github.com/o3de/o3de/pull/12509 caused Android to start crashing when running with VFS in AtomSampleViewer project.

This happens because as soon as the connection with Asset Processor is stablished it's sending a `BulkAssetNotificationMessage` with `AssetChanged` events for all the assets, but with VFS that's happening before the catalog is initialized (with VFS the initialization happens after connecting to AP and reads the catalog from the remote system). Skipping `AssetChanged` event for this scenario when the catalog is supposed to be initialized fixes the issue.

Also added `CriticalAssetsCompiled` printfs as it's useful to know when they happen in the log. The editor already has one, added the one for the launcher and atom tools.

## How was this PR tested?

- Run ASV on Android using VFS now doesn't crash.
- Run editor with ASV and XR samples.
