### PR TITLE
Asset Processor - Fix missing scanfolder crash

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/SourceAssetReference.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/SourceAssetReference.cpp
@@ -104,6 +104,22 @@ namespace AssetProcessor
         Normalize();
     }
 
+    SourceAssetReference::SourceAssetReference(
+        AZ::s64 scanFolderId, AZ::IO::PathView scanFolderPath, AZ::IO::PathView pathRelativeToScanFolder)
+    {
+        if (scanFolderPath.empty() || pathRelativeToScanFolder.empty())
+        {
+            return;
+        }
+
+        m_scanFolderPath = scanFolderPath;
+        m_relativePath = pathRelativeToScanFolder;
+        m_absolutePath = m_scanFolderPath / m_relativePath;
+        m_scanFolderId = scanFolderId;
+
+        Normalize();
+    }
+
     bool SourceAssetReference::operator==(const SourceAssetReference& other) const
     {
         return m_absolutePath == other.m_absolutePath;

--- a/Code/Tools/AssetProcessor/native/AssetManager/SourceAssetReference.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/SourceAssetReference.cpp
@@ -43,6 +43,41 @@ namespace AssetProcessor
         Normalize();
     }
 
+    SourceAssetReference::SourceAssetReference(AZ::s64 scanFolderId, AZ::IO::PathView pathRelativeToScanFolder)
+    {
+            IPathConversion* pathConversion = AZ::Interface<IPathConversion>::Get();
+
+            AZ_Assert(pathConversion, "IPathConversion interface is not available");
+
+            auto* scanFolder = pathConversion->GetScanFolderById(scanFolderId);
+
+            if(!scanFolder)
+            {
+                return;
+            }
+
+            AZ::IO::Path scanFolderPath = scanFolder->ScanPath().toUtf8().constData();
+
+            if(scanFolderPath.empty() || pathRelativeToScanFolder.empty())
+            {
+                return;
+            }
+
+            auto* scanFolderInfo = pathConversion->GetScanFolderForFile(scanFolderPath.FixedMaxPathStringAsPosix().c_str());
+
+            if(!scanFolderInfo)
+            {
+                return;
+            }
+
+            m_scanFolderPath = scanFolderPath;
+            m_relativePath = pathRelativeToScanFolder;
+            m_absolutePath = m_scanFolderPath / m_relativePath;
+            m_scanFolderId = scanFolderInfo->ScanFolderID();
+
+            Normalize();
+        }
+
     SourceAssetReference::SourceAssetReference(AZ::IO::PathView scanFolderPath, AZ::IO::PathView pathRelativeToScanFolder)
     {
         IPathConversion* pathConversion = AZ::Interface<IPathConversion>::Get();

--- a/Code/Tools/AssetProcessor/native/AssetManager/SourceAssetReference.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/SourceAssetReference.h
@@ -49,6 +49,8 @@ namespace AssetProcessor
 
         SourceAssetReference(AZ::IO::PathView scanFolderPath, AZ::IO::PathView pathRelativeToScanFolder);
 
+        SourceAssetReference(AZ::s64 scanFolderId, AZ::IO::PathView scanFolderPath, AZ::IO::PathView pathRelativeToScanFolder);
+
         AZ_DEFAULT_COPY_MOVE(SourceAssetReference);
 
         bool operator==(const SourceAssetReference& other) const;

--- a/Code/Tools/AssetProcessor/native/AssetManager/SourceAssetReference.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/SourceAssetReference.h
@@ -34,10 +34,7 @@ namespace AssetProcessor
 
         explicit SourceAssetReference(AZ::IO::PathView absolutePath);
 
-        SourceAssetReference(AZ::s64 scanFolderId, AZ::IO::PathView pathRelativeToScanFolder)
-            : SourceAssetReference(AZ::Interface<IPathConversion>::Get()->GetScanFolderById(scanFolderId)->ScanPath().toUtf8().constData(), pathRelativeToScanFolder)
-        {
-        }
+        SourceAssetReference(AZ::s64 scanFolderId, AZ::IO::PathView pathRelativeToScanFolder);
 
         SourceAssetReference(QString scanFolderPath, QString pathRelativeToScanFolder)
             : SourceAssetReference(

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -100,11 +100,16 @@ namespace AssetProcessor
 
             if (m_stateData->GetSourceByJobID(jobEntry.m_jobID, sourceEntry))
             {
-                JobDesc jobDesc(SourceAssetReference(sourceEntry.m_scanFolderPK, sourceEntry.m_sourceName.c_str()), jobEntry.m_jobKey, jobEntry.m_platform);
-                JobIndentifier jobIdentifier(jobDesc, jobEntry.m_builderGuid);
+                SourceAssetReference sourceAsset(sourceEntry.m_scanFolderPK, sourceEntry.m_sourceName.c_str());
 
-                m_jobDescToBuilderUuidMap[jobDesc].insert(jobEntry.m_builderGuid);
-                m_jobFingerprintMap[jobIdentifier] = jobEntry.m_fingerprint;
+                if (sourceAsset)
+                {
+                    JobDesc jobDesc(sourceAsset, jobEntry.m_jobKey, jobEntry.m_platform);
+                    JobIndentifier jobIdentifier(jobDesc, jobEntry.m_builderGuid);
+
+                    m_jobDescToBuilderUuidMap[jobDesc].insert(jobEntry.m_builderGuid);
+                    m_jobFingerprintMap[jobIdentifier] = jobEntry.m_fingerprint;
+                }
             }
         }
     }
@@ -498,10 +503,13 @@ namespace AssetProcessor
         // note that m_SourceFilesInDatabase is a map from (full absolute path) --> (database name for file)
         for (auto iter = m_sourceFilesInDatabase.begin(); iter != m_sourceFilesInDatabase.end(); iter++)
         {
-            // CheckDeletedSourceFile actually expects the database name as the second value
-            // iter.key is the full path normalized.  iter.value is the database path.
-            // we need the relative path too:
-            CheckDeletedSourceFile(iter.value().m_sourceAssetReference, AZStd::chrono::steady_clock::now());
+            if (iter.value().m_sourceAssetReference)
+            {
+                // CheckDeletedSourceFile actually expects the database name as the second value
+                // iter.key is the full path normalized.  iter.value is the database path.
+                // we need the relative path too:
+                CheckDeletedSourceFile(iter.value().m_sourceAssetReference, AZStd::chrono::steady_clock::now());
+            }
         }
 
         // we want to remove any left over scan folders from the database only after

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -147,9 +147,12 @@ namespace AssetProcessor
 
             auto sourcesFunction = [this](AzToolsFramework::AssetDatabase::SourceAndScanFolderDatabaseEntry& entry)
             {
-                SourceAssetReference sourceAsset(entry.m_scanFolder.c_str(), entry.m_sourceName.c_str());
+                SourceAssetReference sourceAsset(entry.m_scanFolderID, entry.m_scanFolder.c_str(), entry.m_sourceName.c_str());
 
-                m_sourceFilesInDatabase[sourceAsset.AbsolutePath().c_str()] = { sourceAsset, entry.m_analysisFingerprint.c_str() };
+                if (sourceAsset)
+                {
+                    m_sourceFilesInDatabase[sourceAsset.AbsolutePath().c_str()] = { sourceAsset, entry.m_analysisFingerprint.c_str() };
+                }
 
                 return true;
             };
@@ -1915,9 +1918,7 @@ namespace AssetProcessor
         bool deleteFailure = false;
         AzToolsFramework::AssetDatabase::SourceDatabaseEntryContainer sources;
 
-        auto scanFolder = m_platformConfig->GetScanFolderByPath(sourceAsset.ScanFolderPath().c_str());
-
-        if (m_stateData->GetSourcesBySourceNameScanFolderId(sourceAsset.RelativePath().c_str(), scanFolder->ScanFolderID(), sources))
+        if (m_stateData->GetSourcesBySourceNameScanFolderId(sourceAsset.RelativePath().c_str(), sourceAsset.ScanFolderId(), sources))
         {
             for (const auto& source : sources)
             {


### PR DESCRIPTION
## What does this PR do?

Fixed issue where AP crashed when running after having processed with a scanfolder which no longer exists.  A few places in the code were assuming a 'find scanfolder' call would always have a return value.

Fixes https://github.com/o3de/o3de/issues/13114

## How was this PR tested?

Followed repro steps in https://github.com/o3de/o3de/issues/13114