### PR TITLE
Improve ScriptEvent file open and save in Editor

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -705,9 +705,9 @@ namespace ScriptCanvasEditor
 
         connect(ui->actionAdd_Script_Event_Helpers, &QAction::triggered, this, &MainWindow::OnScriptEventAddHelpers);
         connect(ui->actionClear_Script_Event_Status, &QAction::triggered, this, &MainWindow::OnScriptEventClearStatus);
-        connect(ui->actionOpen_Script_Event, &QAction::triggered, this, &MainWindow::OnScriptEventOpen);
-        connect(ui->actionParse_As_Script_Event, &QAction::triggered, this, &MainWindow::OnScriptEventParseAs);
-        connect(ui->actionSave_As_ScriptEvent, &QAction::triggered, this, &MainWindow::OnScriptEventSaveAs);
+        connect(ui->actionOpen_Script_Event, &QAction::triggered, this, [this](){ OnScriptEventOpen(AZ::IO::Path()); });
+        connect(ui->actionSave_ScriptEvent, &QAction::triggered, this, [this](){ OnScriptEventSave(Save::InPlace); });
+        connect(ui->actionSave_As_ScriptEvent, &QAction::triggered, this, [this](){ OnScriptEventSave(Save::As); });
         connect(ui->menuScript_Events_PREVIEW, &QMenu::aboutToShow, this, &MainWindow::OnScriptEventMenuPreShow);
 
         // List of recent files.
@@ -1306,6 +1306,14 @@ namespace ScriptCanvasEditor
             return;
         }
 
+        // Redirect script event file open process
+        AZ::IO::Path filePath = fullPath;
+        if (filePath.Extension() == ".scriptevents")
+        {
+            OnScriptEventOpen(fullPath);
+            return;
+        }
+
         AZStd::string watchFolder;
         AZ::Data::AssetInfo assetInfo;
         bool sourceInfoFound{};
@@ -1617,32 +1625,10 @@ namespace ScriptCanvasEditor
             return false;
         }
 
-        if (sourceHandle.Get()->IsScriptEventExtension())
+        // Redirect script event file save process
+        if (sourceHandle.Get()->IsScriptEventExtension() || sourceHandle.AbsolutePath().Extension() == ".scriptevents")
         {
-            QMessageBox mb
-                ( QMessageBox::Warning
-                , QObject::tr("Select ScriptCanvas or ScriptEvent source type:")
-                , QObject::tr("Graph defines a ScriptEvent. Press 'Discard' and use Script Event menu to save it as .scriptevent, or 'Ok' to continue to save as .scriptcanvas")
-                , QMessageBox::Ok | QMessageBox::Discard
-                , nullptr);
-
-            if (mb.exec() == QMessageBox::Discard)
-            {
-                return false;
-            }
-        }
-
-        if (sourceHandle.AbsolutePath().Extension() == ".scriptevents")
-        {
-            auto newPath = sourceHandle.AbsolutePath();
-            newPath.ReplaceExtension(".scriptcanvas");
-
-            if (auto relativeOption = ScriptCanvasEditor::CreateFromAnyPath(sourceHandle, newPath))
-            {
-                sourceHandle = *relativeOption;
-            }
-
-            sourceHandle = SourceHandle::MarkAbsolutePath(sourceHandle, newPath);
+            return OnScriptEventSave(save);
         }
 
         if (!m_activeGraph.AnyEquals(sourceHandle))
@@ -1754,20 +1740,35 @@ namespace ScriptCanvasEditor
 
     void MainWindow::OnSaveCallBack(const VersionExplorer::FileSaveResult& result)
     {
-        const bool saveSuccess = result.IsSuccess();
+        auto memoryAsset = OnSaveComplete(m_fileSaver->GetSource(), result);
 
+        const bool displayAsNotification = true;
+        RunGraphValidation(displayAsNotification);
+
+        m_closeCurrentGraphAfterSave = false;
+
+        EnableAssetView(memoryAsset);
+
+        UpdateSaveState(true);
+        UnblockCloseRequests();
+        m_fileSaver.reset();
+    }
+
+    SourceHandle MainWindow::OnSaveComplete(const SourceHandle& sourceHandle, const VersionExplorer::FileSaveResult& result)
+    {
+        const bool saveSuccess = result.IsSuccess();
         int saveTabIndex = -1;
         SourceHandle memoryAsset;
         {
-            int saverIndex = m_tabBar->FindTab(m_fileSaver->GetSource());
+            int saverIndex = m_tabBar->FindTab(sourceHandle);
             if (saverIndex >= 0)
             {
                 saveTabIndex = saverIndex;
-                memoryAsset = m_fileSaver->GetSource();
+                memoryAsset = sourceHandle;
             }
             else
             {
-                auto completeDescription = CompleteDescription(m_fileSaver->GetSource());
+                auto completeDescription = CompleteDescription(sourceHandle);
                 if (completeDescription)
                 {
                     memoryAsset = *completeDescription;
@@ -1829,17 +1830,7 @@ namespace ScriptCanvasEditor
         UpdateAssignToSelectionState();
 
         OnSaveToast toast(tabName, GetActiveGraphCanvasGraphId(), saveSuccess);
-
-        const bool displayAsNotification = true;
-        RunGraphValidation(displayAsNotification);
-
-        m_closeCurrentGraphAfterSave = false;
-
-        EnableAssetView(memoryAsset);
-
-        UpdateSaveState(true);
-        UnblockCloseRequests();
-        m_fileSaver.reset();
+        return memoryAsset;
     }
 
     bool MainWindow::ActivateAndSaveAsset(const SourceHandle& unsavedAssetId)
@@ -4465,11 +4456,10 @@ namespace ScriptCanvasEditor
 
     void MainWindow::OnScriptEventAddHelpers()
     {
-        if (ScriptEvents::Editor::MakeHelpersAction(m_activeGraph).first)
+        if (ScriptEvents::Editor::MakeHelpersAction(m_activeGraph))
         {
-            GraphCanvas::GraphModelRequestBus::Event
-                ( m_activeGraph.Mod()->GetEntityId()
-                , &GraphCanvas::GraphModelRequests::RequestUndoPoint);
+            GraphCanvas::GraphModelRequestBus::Event(m_activeGraph.Mod()->GetEntityId(),
+                &GraphCanvas::GraphModelRequests::RequestUndoPoint);
         }
     }
 
@@ -4483,104 +4473,38 @@ namespace ScriptCanvasEditor
         auto result = ScriptEvents::Editor::UpdateMenuItemsEnabled(m_activeGraph);
         ui->actionAdd_Script_Event_Helpers->setEnabled(result.m_addHelpers);
         ui->actionClear_Script_Event_Status->setEnabled(result.m_clear);
-        ui->actionParse_As_Script_Event->setEnabled(result.m_parse);
-        ui->actionSave_As_ScriptEvent->setEnabled(result.m_save);
+        ui->actionSave_ScriptEvent->setEnabled(result.m_save);
+        ui->actionSave_As_ScriptEvent->setEnabled(result.m_saveAs);
     }
 
-    void MainWindow::OnScriptEventOpen()
+    void MainWindow::OnScriptEventOpen(const AZ::IO::Path& filePath)
     {
-        AZStd::pair<ScriptCanvas::SourceHandle, AZStd::string> result = ScriptEvents::Editor::OpenAction();
+        ScriptCanvas::SourceHandle sourceAsset(ScriptEvents::Editor::OpenAction(filePath));
 
-        if (result.first.Get())
+        if (sourceAsset.IsGraphValid())
         {
-            OpenScriptCanvasAssetImplementation(result.first, Tracker::ScriptCanvasFileState::UNMODIFIED);
-        }
-        else
-        {
-            if (!result.second.empty())
-            {
-                QMessageBox mb
-                    ( QMessageBox::Warning
-                    , tr("Failed to open ScriptEvent file into ScriptCanvas Editor.")
-                    , result.second.c_str()
-                    , QMessageBox::Close
-                    , nullptr);
-
-                mb.exec();
-            }
+            AddRecentFile(sourceAsset.AbsolutePath().c_str());
+            OpenScriptCanvasAssetImplementation(sourceAsset, Tracker::ScriptCanvasFileState::UNMODIFIED);
         }
     }
 
-    void MainWindow::OnScriptEventParseAs()
+    bool MainWindow::OnScriptEventSave(Save save)
     {
-        if (!m_activeGraph.IsGraphValid())
+        bool saveInPlace = save == Save::InPlace ? true : false;
+        auto savedSource = ScriptEvents::Editor::SaveAction(m_activeGraph, saveInPlace);
+
+        if (savedSource.IsGraphValid())
         {
-            return;
+            VersionExplorer::FileSaveResult result;
+            result.absolutePath = savedSource.AbsolutePath();
+            auto memoryAsset = OnSaveComplete(savedSource, result);
+
+            m_newlySavedFile = savedSource.AbsolutePath().Native();
+            // Forcing the file add here, since we are creating a new file
+            AddRecentFile(m_newlySavedFile.c_str());
+            return true;
         }
-
-        AZStd::pair<bool, AZStd::vector<AZStd::string>> result = ScriptEvents::Editor::ParseAsAction(m_activeGraph);
-
-        if (result.first)
-        {
-            QMessageBox mb
-                ( QMessageBox::Information
-                , QObject::tr("Success!")
-                , QObject::tr("Graph parsed as ScriptEvent, and may be saved as one.")
-                , QMessageBox::Close
-                , nullptr);
-
-            mb.exec();
-        }
-        else
-        {
-            AZStd::string parseErrorString;
-
-            if (!result.second.empty())
-            {
-                parseErrorString = "Parse Errors:\n";
-
-                for (auto& entry : result.second)
-                {
-                    parseErrorString += "* ";
-                    parseErrorString += entry;
-                    parseErrorString += "\n";
-                }
-            }
-
-            QMessageBox mb
-                ( QMessageBox::Warning
-                , QObject::tr("Graph did not parse as ScriptEvent, please fix issues below to save as a ScriptEvent")
-                , parseErrorString.c_str()
-                , QMessageBox::Close
-                , nullptr);
-
-            mb.exec();
-        }
-    }
-
-    void MainWindow::OnScriptEventSaveAs()
-    {
-        auto result = ScriptEvents::Editor::SaveAsAction(m_activeGraph);
-        if (result.first)
-        {
-            OnSaveToast toast
-                ( result.second
-                , GetActiveGraphCanvasGraphId()
-                , true
-                , AZStd::string("Graph Saved .scriptevent, and this editor can open that file.\n"
-                    "No .scriptcanvas file was saved from this graph."));
-        }
-        else
-        {
-            QMessageBox mb
-                ( QMessageBox::Warning
-                , QObject::tr("Failed to Save As Script Event")
-                , result.second.c_str()
-                , QMessageBox::Close
-                , nullptr);
-
-            mb.exec();
-        }
+        return false;
     }
 
 #include <Editor/View/Windows/moc_MainWindow.cpp>

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -4490,7 +4490,7 @@ namespace ScriptCanvasEditor
 
     bool MainWindow::OnScriptEventSave(Save save)
     {
-        bool saveInPlace = save == Save::InPlace ? true : false;
+        bool saveInPlace = (save == Save::InPlace);
         auto savedSource = ScriptEvents::Editor::SaveAction(m_activeGraph, saveInPlace);
 
         if (savedSource.IsGraphValid())

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.h
@@ -393,9 +393,8 @@ namespace ScriptCanvasEditor
         void OnScriptEventAddHelpers();
         void OnScriptEventClearStatus();
         void OnScriptEventMenuPreShow();
-        void OnScriptEventOpen();
-        void OnScriptEventParseAs();
-        void OnScriptEventSaveAs();
+        void OnScriptEventOpen(const AZ::IO::Path& filePath);
+        bool OnScriptEventSave(Save save);
 
         void UpdateViewMenu();
         /////////////////////////////////////////////////////////////////////////////////////////////
@@ -765,7 +764,7 @@ namespace ScriptCanvasEditor
         AZStd::unique_ptr<VersionExplorer::FileSaver> m_fileSaver;
         VersionExplorer::FileSaveResult m_fileSaveResult;
         void OnSaveCallBack(const VersionExplorer::FileSaveResult& result);
-
+        SourceHandle OnSaveComplete(const SourceHandle& sourceHandle, const VersionExplorer::FileSaveResult& result);
         void ClearStaleSaves();
         bool IsRecentSave(const SourceHandle& handle) const;
         void MarkRecentSave(const SourceHandle& handle);

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/ScriptEventMenu.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/ScriptEventMenu.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/Utils/Utils.h>
 #include <Editor/Include/ScriptCanvas/Components/EditorGraph.h>
 #include <QFileDialog>
 #include <QMessageBox>
@@ -33,9 +34,7 @@ namespace ScriptEvents
         {
             if (sourceFilePath.empty())
             {
-                AZ::IO::FixedMaxPath resolvedProjectRoot;
-                AZ::IO::FileIOBase::GetInstance()->ResolvePath(resolvedProjectRoot, "@projectroot@");
-
+                AZ::IO::FixedMaxPathString resolvedProjectRoot = AZ::Utils::GetProjectPath();
                 AZStd::string errorMessage;
 
                 const QStringList nameFilters = { "ScriptEvent Files Saved from the ScriptCanvas Editor (*.scriptevents)" };
@@ -60,8 +59,7 @@ namespace ScriptEvents
             }
             else
             {
-                AZ::IO::FixedMaxPath resolvedProjectRoot;
-                AZ::IO::FileIOBase::GetInstance()->ResolvePath(resolvedProjectRoot, "@projectroot@");
+                AZ::IO::FixedMaxPathString resolvedProjectRoot = AZ::Utils::GetProjectPath();
                 const auto saveAsFilePath = QFileDialog::getSaveFileName(
                     nullptr, QObject::tr("Save As..."), resolvedProjectRoot.c_str(), QObject::tr("All ScriptEvent Files (*.scriptevents)"));
                 if (!saveAsFilePath.toUtf8().isEmpty())

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/ScriptEventMenu.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/ScriptEventMenu.cpp
@@ -29,131 +29,160 @@ namespace ScriptEvents
             }
         }
 
-        AZStd::pair<bool, AZStd::string> MakeHelpersAction(const ScriptCanvas::SourceHandle& sourceHandle)
+        AZ::IO::Path GetOpenFilePath(const AZ::IO::Path& sourceFilePath)
+        {
+            if (sourceFilePath.empty())
+            {
+                AZ::IO::FixedMaxPath resolvedProjectRoot;
+                AZ::IO::FileIOBase::GetInstance()->ResolvePath(resolvedProjectRoot, "@projectroot@");
+
+                AZStd::string errorMessage;
+
+                const QStringList nameFilters = { "ScriptEvent Files Saved from the ScriptCanvas Editor (*.scriptevents)" };
+                QFileDialog dialog(nullptr, QObject::tr("Open a single file..."), resolvedProjectRoot.c_str());
+                dialog.setFileMode(QFileDialog::ExistingFiles);
+                dialog.setNameFilters(nameFilters);
+
+                if (dialog.exec() == QDialog::Accepted && dialog.selectedFiles().count() >= 1)
+                {
+                    return AZ::IO::Path(dialog.selectedFiles().begin()->toUtf8().constData());
+                }
+            }
+            return sourceFilePath;
+        }
+
+        AZ::IO::Path GetSaveFilePath(const ScriptCanvas::SourceHandle& sourceHandle, bool saveInPlace)
+        {
+            AZ::IO::Path saveFilePath;
+            if (saveInPlace)
+            {
+                saveFilePath = sourceHandle.AbsolutePath();
+            }
+            else
+            {
+                AZ::IO::FixedMaxPath resolvedProjectRoot;
+                AZ::IO::FileIOBase::GetInstance()->ResolvePath(resolvedProjectRoot, "@projectroot@");
+                const auto saveAsFilePath = QFileDialog::getSaveFileName(
+                    nullptr, QObject::tr("Save As..."), resolvedProjectRoot.c_str(), QObject::tr("All ScriptEvent Files (*.scriptevents)"));
+                if (!saveAsFilePath.toUtf8().isEmpty())
+                {
+                    saveFilePath = AZ::IO::Path(saveAsFilePath.toUtf8().constData());
+                }
+            }
+            return saveFilePath;
+        }
+
+        ScriptCanvas::SourceHandle LoadScriptEventSource(const AZ::IO::Path& sourceFilePath, AZStd::string& outErrorMessage)
+        {
+            AZ::Outcome<ScriptEvents::ScriptEvent, AZStd::string> loadOutcome = AZ::Failure(AZStd::string());
+            ScriptEventBus::BroadcastResult(loadOutcome, &ScriptEvents::ScriptEventRequests::LoadDefinitionSource, sourceFilePath);
+
+            if (loadOutcome.IsSuccess())
+            {
+                auto deserializeResult = ScriptCanvas::Deserialize(
+                    loadOutcome.GetValue().GetScriptCanvasSerializationData(), ScriptCanvas::MakeInternalGraphEntitiesUnique::Yes);
+                if (deserializeResult.m_isSuccessful)
+                {
+                    auto result = ScriptCanvas::SourceHandle::FromRelativePath(deserializeResult.m_graphDataPtr, sourceFilePath.Filename());
+                    return ScriptCanvas::SourceHandle::MarkAbsolutePath(result, sourceFilePath.Native());
+                }
+                else
+                {
+                    outErrorMessage = deserializeResult.m_errors;
+                }
+            }
+            else
+            {
+                outErrorMessage = loadOutcome.GetError();
+            }
+            return ScriptCanvas::SourceHandle();
+        }
+
+        bool MakeHelpersAction(const ScriptCanvas::SourceHandle& sourceHandle)
         {
             if (!sourceHandle.Mod())
             {
-                return { false, "no active graph" };
+                return false;
             }
 
             sourceHandle.Mod()->MarkScriptEventExtension();
             AddScriptEventHelpers(*sourceHandle.Mod());
-            return { true, "" };
+            return true;
         }
 
-        AZStd::pair<ScriptCanvas::SourceHandle, AZStd::string> OpenAction()
+        ScriptCanvas::SourceHandle OpenAction(const AZ::IO::Path& sourceFilePath)
         {
-            using namespace ScriptCanvas;
-
-            AZ::IO::FixedMaxPath resolvedProjectRoot;
-            AZ::IO::FileIOBase::GetInstance()->ResolvePath(resolvedProjectRoot, "@projectroot@");
+            ScriptCanvas::SourceHandle result;
+            AZ::IO::Path filePath = GetOpenFilePath(sourceFilePath);
+            if (filePath.empty())
+            {
+                return result;
+            }
 
             AZStd::string errorMessage;
-
-            const QStringList nameFilters = { "ScriptEvent Files Saved from the ScriptCanvas Editor (*.scriptevents)" };
-            QFileDialog dialog(nullptr, QObject::tr("Open a single file..."), resolvedProjectRoot.c_str());
-            dialog.setFileMode(QFileDialog::ExistingFiles);
-            dialog.setNameFilters(nameFilters);
-
-            if (dialog.exec() == QDialog::Accepted && dialog.selectedFiles().count() == 1)
+            result = LoadScriptEventSource(filePath, errorMessage);
+            if (!result.IsGraphValid())
             {
-                const AZ::IO::Path path(dialog.selectedFiles().begin()->toUtf8().constData());
-                AZ::Outcome<ScriptEvents::ScriptEvent, AZStd::string> loadOutcome = AZ::Failure(AZStd::string("failed to save"));
-                ScriptEventBus::BroadcastResult
-                    ( loadOutcome
-                    , &ScriptEvents::ScriptEventRequests::LoadDefinitionSource
-                    , path);
+                QMessageBox messageBox(QMessageBox::Warning, QObject::tr("Failed to open ScriptEvent file into ScriptCanvas Editor."),
+                    errorMessage.c_str(), QMessageBox::Close, nullptr);
+                messageBox.exec();
+            }
+            return result;
+        }
 
-                if (loadOutcome.IsSuccess())
+        ScriptCanvas::SourceHandle SaveScriptEventSource(
+            const ScriptCanvas::SourceHandle& sourceHandle, const AZ::IO::Path& saveFilePath, AZStd::string& outErrorMessage)
+        {
+            using namespace ScriptCanvas::ScriptEventGrammar;
+            GraphToScriptEventsResult parsingResult = ParseScriptEventsDefinition(*sourceHandle.Get());
+            if (parsingResult.m_isScriptEvents)
+            {
+                // use the ScriptEventBus, also to get fundamental types(?)
+                AZ::Outcome<void, AZStd::string> saveOutcome = AZ::Failure(AZStd::string("failed to save"));
+                ScriptEvents::ScriptEventBus::BroadcastResult(
+                    saveOutcome, &ScriptEvents::ScriptEventRequests::SaveDefinitionSourceFile, parsingResult.m_event, saveFilePath);
+
+                if (saveOutcome.IsSuccess())
                 {
-                    auto deserializeResult = Deserialize(loadOutcome.GetValue().GetScriptCanvasSerializationData(), MakeInternalGraphEntitiesUnique::Yes);
-                    if (deserializeResult.m_isSuccessful)
-                    {
-
-                        // success
-                        return { SourceHandle::FromRelativePath(deserializeResult.m_graphDataPtr, path.Filename()), "" };
-                    }
-                    else
-                    {
-                        errorMessage = "failed to deserialize script canvas source data";
-                    }
+                    auto result = ScriptCanvas::SourceHandle::FromRelativePath(sourceHandle.Data(), saveFilePath.Filename());
+                    return ScriptCanvas::SourceHandle::MarkAbsolutePath(result, saveFilePath);
                 }
                 else
                 {
-                    errorMessage = "Failed to load selected file.";
+                    outErrorMessage = saveOutcome.TakeError();
                 }
-            }
-
-            // failure or canceled
-            return { SourceHandle(), errorMessage };
-        }
-
-        AZStd::pair<bool, AZStd::vector<AZStd::string>> ParseAsAction(const ScriptCanvas::SourceHandle& sourceHandle)
-        {
-            using namespace ScriptCanvas::ScriptEventGrammar;
-
-            if (sourceHandle.IsGraphValid())
-            {
-                GraphToScriptEventsResult result = ParseScriptEventsDefinition(*sourceHandle.Get());
-                return { result.m_isScriptEvents, result.m_parseErrors };
             }
             else
             {
-                return { false, { "no valid graph supplied" } };
+                outErrorMessage = "Changes are required to properly parse graph as ScriptEvents file.";
             }
+            return ScriptCanvas::SourceHandle();
         }
 
-        AZStd::pair<bool, AZStd::string> SaveAsAction([[maybe_unused]] const ScriptCanvas::SourceHandle& sourceHandle)
+        ScriptCanvas::SourceHandle SaveAction(const ScriptCanvas::SourceHandle& sourceHandle, bool saveInPlace)
         {
             using namespace ScriptCanvas::ScriptEventGrammar;
 
-            AZStd::string errorMessage;
-            
+            ScriptCanvas::SourceHandle result;
+            AZStd::string errorMessage = "Invalid ScriptEvent graph.";
+
             if (sourceHandle.Get())
             {
-                GraphToScriptEventsResult result = ParseScriptEventsDefinition(*sourceHandle.Get());
-
-                if (result.m_isScriptEvents)
+                auto saveFilePath = GetSaveFilePath(sourceHandle, saveInPlace);
+                if (saveFilePath.empty())
                 {
-                    sourceHandle.Mod()->MarkScriptEventExtension();
-
-                    AZ::IO::FixedMaxPath resolvedProjectRoot;
-                    AZ::IO::FileIOBase::GetInstance()->ResolvePath(resolvedProjectRoot, "@projectroot@");
-                    const auto fileName = QFileDialog::getSaveFileName
-                        ( nullptr, QObject::tr("Save As..."), resolvedProjectRoot.c_str(), QObject::tr("All ScriptEvent Files (*.scriptevents)"));
-
-                    if (!fileName.isEmpty())
-                    {
-                        AZ::IO::Path path(fileName.toUtf8().constData());
-                        // use the ScriptEventBus, also to get fundamental types(?)
-                        AZ::Outcome<void, AZStd::string> saveOutcome = AZ::Failure(AZStd::string("failed to save"));
-                        ScriptEvents::ScriptEventBus::BroadcastResult
-                            ( saveOutcome
-                            , &ScriptEvents::ScriptEventRequests::SaveDefinitionSourceFile
-                            , result.m_event
-                            , path);
-
-                        if (saveOutcome.IsSuccess())
-                        {
-                            return { true, path.Filename().FixedMaxPathString().c_str() };
-                        }
-                        else
-                        {
-                            errorMessage = saveOutcome.TakeError();
-                        }
-                    }
-                    else
-                    {
-                        errorMessage = "Invalid file name.";
-                    }
+                    return result;
                 }
-                else
-                {
-                    errorMessage = "Changes are required to properly parse graph as ScriptEvents file.";
-                }
+                result = SaveScriptEventSource(sourceHandle, saveFilePath, errorMessage);
             }
-                            
-            return { false, errorMessage };
+
+            if (!result.IsGraphValid())
+            {
+                QMessageBox messageBox(QMessageBox::Warning, QObject::tr("Failed to Save ScriptEvent"),
+                    errorMessage.c_str(), QMessageBox::Close, nullptr);
+                messageBox.exec();
+            }
+            return result;
         }
 
         MenuItemsEnabled UpdateMenuItemsEnabled([[maybe_unused]] const ScriptCanvas::SourceHandle& sourceHandle)
@@ -162,11 +191,11 @@ namespace ScriptEvents
 
             auto graph = sourceHandle.Mod();
             MenuItemsEnabled menuItemsEnabled;
-            bool isParsed = graph && ScriptEventGrammar::ParseMinimumScriptEventArtifacts(*graph).m_isScriptEvents;
-            menuItemsEnabled.m_addHelpers = graph && !isParsed;
+            bool isScriptEventGraph = graph && ScriptEventGrammar::ParseMinimumScriptEventArtifacts(*graph).m_isScriptEvents;
+            menuItemsEnabled.m_addHelpers = graph && !isScriptEventGraph;
             menuItemsEnabled.m_clear = graph && graph->IsScriptEventExtension();
-            menuItemsEnabled.m_parse = graph != nullptr;
-            menuItemsEnabled.m_save = isParsed;
+            menuItemsEnabled.m_save = isScriptEventGraph;
+            menuItemsEnabled.m_saveAs = isScriptEventGraph;
             return menuItemsEnabled;
         }
     }

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/ScriptEventMenu.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/ScriptEventMenu.h
@@ -16,20 +16,18 @@ namespace ScriptEvents
     {
         void ClearStatusAction(const ScriptCanvas::SourceHandle& sourceHandle);
 
-        AZStd::pair<bool, AZStd::string> MakeHelpersAction(const ScriptCanvas::SourceHandle& sourceHandle);
+        bool MakeHelpersAction(const ScriptCanvas::SourceHandle& sourceHandle);
 
-        AZStd::pair<ScriptCanvas::SourceHandle, AZStd::string> OpenAction();
+        ScriptCanvas::SourceHandle OpenAction(const AZ::IO::Path& sourceFilePath);
 
-        AZStd::pair<bool, AZStd::vector<AZStd::string>> ParseAsAction(const ScriptCanvas::SourceHandle& sourceHandle);
-
-        AZStd::pair<bool, AZStd::string> SaveAsAction(const ScriptCanvas::SourceHandle& sourceHandle);
+        ScriptCanvas::SourceHandle SaveAction(const ScriptCanvas::SourceHandle& sourceHandle, bool saveInPlace);
 
         struct MenuItemsEnabled
         {
             bool m_addHelpers = false;
             bool m_clear = false;
-            bool m_parse = false;
             bool m_save = false;
+            bool m_saveAs = false;
         };
 
         MenuItemsEnabled UpdateMenuItemsEnabled(const ScriptCanvas::SourceHandle& sourceHandle);

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/mainwindow.ui
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/mainwindow.ui
@@ -167,10 +167,10 @@
      <string>Script Events [PREVIEW]</string>
     </property>
     <addaction name="actionOpen_Script_Event"/>
+    <addaction name="actionSave_ScriptEvent"/>
     <addaction name="actionSave_As_ScriptEvent"/>
     <addaction name="separator"/>
     <addaction name="actionAdd_Script_Event_Helpers"/>
-    <addaction name="actionParse_As_Script_Event"/>
     <addaction name="actionClear_Script_Event_Status"/>
    </widget>
    <addaction name="menuFile"/>
@@ -792,15 +792,23 @@
   </action>
   <action name="actionOpen_Script_Event">
    <property name="text">
-    <string>Open Script Event</string>
+    <string>&amp;Open ...</string>
    </property>
+  </action>
+  <action name="actionSave_ScriptEvent">
+    <property name="enabled">
+      <bool>false</bool>
+    </property>
+    <property name="text">
+      <string>&amp;Save</string>
+    </property>
   </action>
   <action name="actionSave_As_ScriptEvent">
    <property name="enabled">
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Save As Script Event</string>
+    <string>&amp;Save As ...</string>
    </property>
   </action>
   <action name="actionAdd_Script_Event_Helpers">
@@ -808,15 +816,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Add Script Event Helpers</string>
-   </property>
-  </action>
-  <action name="actionParse_As_Script_Event">
-   <property name="enabled">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Parse As Script Event</string>
+    <string>&amp;Add ScriptEvent Helpers</string>
    </property>
   </action>
   <action name="actionClear_Script_Event_Status">
@@ -824,7 +824,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Clear Script Event Status</string>
+    <string>&amp;Clear ScriptEvent Status</string>
    </property>
   </action>
   <addaction name="action_ViewNodePalette"/>


### PR DESCRIPTION
Signed-off-by: onecent1101 <liug@amazon.com>

## What does this PR do?
Saving ScriptEvents in the SC editor is pretty much hacked in, it does not follow standard saving/loading operations and displays confusing dialogs to try and disambiguate between ScriptCanvas and ScriptEvent assets.

This change removes the conversion between ScriptCanvas and ScriptEvent assets, and removes unnecessary dialog while saving ScriptEvent assets.

## How was this PR tested?
Manually tested in Editor
