### PR TITLE
Prevent entities being marked dirty outside of an undo batch

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -1383,6 +1383,14 @@ namespace AzToolsFramework
             return;
         }
 
+        // Only accept entities as dirty between a begin/end undo batch. This filters out entities
+        // that have been marked dirty by a non-user operation such as entity activation. This can
+        // occur if SetDirty is called from a common function used in both user and non-user actions
+        if (!m_currentBatchUndo)
+        {
+            return;
+        }
+
         m_dirtyEntities.insert(entityId);
 
         // Check if this dirty entity is in a layer by walking up its parenting hierarchy.

--- a/Code/Framework/AzToolsFramework/Tests/ToolsComponents/EditorLayerComponentTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/ToolsComponents/EditorLayerComponentTests.cpp
@@ -580,6 +580,8 @@ namespace AzToolsFramework
         m_layerEntity.m_layer->ClearUnsavedChanges();
 
         AZ::Entity* childEntity = CreateEditorReadyEntity("ChildEntity");
+        // An undo batch needs to begin before the entity can be registered as dirty
+        AzToolsFramework::ScopedUndoBatch undoBatch("Reparent Entity");
         AZ::TransformBus::Event(
             childEntity->GetId(),
             &AZ::TransformBus::Events::SetParent,
@@ -604,6 +606,8 @@ namespace AzToolsFramework
         m_layerEntity.m_layer->ClearUnsavedChanges();
 
         // Change the scale of the child entity so it registers as an unsaved change on the layer.
+        // An undo batch needs to begin before the entity can be registered as dirty
+        AzToolsFramework::ScopedUndoBatch undoBatch("Scale Entity");
         float scale = 0.0f;
         AZ::TransformBus::EventResult(
             scale,


### PR DESCRIPTION
Signed-off-by: michabr <82236305+michabr@users.noreply.github.com>

## What does this PR do?

This PR checks if there is a current undo batch in progress before adding an entity to the dirty entity list. This prevents entities being dirtied unintentionally such as during level load. An example of this is the TransformComponent calling SetDirty() from its Activate().

This manifested as a performance issue for large levels in the prefab system because the dirty entity list became bloated after level load causing the next user undo operation, such as entity selection, to take a long time since it was creating undo commands for all those dirty entities.

## How was this PR tested?

Tested common undo/redo operations in editor. Opened/closed/switched levels.