### PR TITLE
Changed MSAA and SpecularAA

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/GeneralCommonPropertyGroup.json
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/GeneralCommonPropertyGroup.json
@@ -14,7 +14,7 @@
             "displayName": "Apply Specular AA",
             "description": "Whether to apply specular anti-aliasing in the shader.",
             "type": "Bool",
-            "defaultValue": false,
+            "defaultValue": true,
             "connection": {
                 "type": "ShaderOption",
                 "name": "o_applySpecularAA"

--- a/Gems/Atom/Feature/Common/Assets/Passes/MainRenderPipeline.azasset
+++ b/Gems/Atom/Feature/Common/Assets/Passes/MainRenderPipeline.azasset
@@ -9,7 +9,35 @@
         "AllowModification": true,
         "RenderSettings": {
             "MultisampleState": {
-                "samples": 4
+                "samples": 2,
+                "customPositionsCount": 16,
+                "customPositions": [
+                    // First sample is dead center of the pixel for accurate resolve -> non-MSAA depth
+                    // When we resolve MSAA depth to non-MSAA depth, we just pick this first sample
+                    // Being at the center of the pixel makes SSAO and world space reprojection more accurate
+                    { "x":  8,   "y":  8 },
+
+                    // Second sample is top-left corner so that samples from neighboring pixels can be used for
+                    // Quincux anti-aliasing techniques
+                    { "x":  0,   "y":  0 },
+                    
+                    { "x":  7,   "y": 15 },
+                    { "x": 15,   "y":  7 },
+                    
+                    { "x":  8,   "y":  0 },
+                    { "x":  0,   "y":  8 },
+                    { "x":  4,   "y": 11 },
+                    { "x": 11,   "y":  4 },
+                    
+                    { "x":  0,   "y": 15 },
+                    { "x": 15,   "y":  0 },
+                    { "x": 15,   "y": 15 },
+                    { "x":  3,   "y":  3 },
+                    { "x":  4,   "y":  7 },
+                    { "x":  7,   "y":  4 },
+                    { "x": 10,   "y": 13 },
+                    { "x": 13,   "y": 10 }
+                ]
             }
         }
     }

--- a/Gems/Atom/TestData/TestData/Materials/StandardPbrTestCases/013_SpecularAA_Off.material
+++ b/Gems/Atom/TestData/TestData/Materials/StandardPbrTestCases/013_SpecularAA_Off.material
@@ -2,6 +2,7 @@
     "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
     "materialTypeVersion": 5,
     "propertyValues": {
+        "general.applySpecularAA": false,
         "metallic.factor": 1.0,
         "normal.flipY": true,
         "normal.textureMap": "../../Textures/TextureHaven/4k_castle_brick_02_red/4k_castle_brick_02_red_normal.png",


### PR DESCRIPTION
Changed MSAA to be 2x by default (better performance than 4x) with custom sample points (fix some artifacts, including this bug: https://github.com/o3de/o3de/issues/9882) and turned on specular AA by default for better image quality and less aliasing across the board

Signed-off-by: antonmic <56370189+antonmic@users.noreply.github.com>