### PR TITLE
Fixes a crash on AP shutdown

### DIFF
--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -894,8 +894,7 @@ void ApplicationManagerBase::Destroy()
     delete m_assetRequestHandler;
     m_assetRequestHandler = nullptr;
 
-    // Destroy file monitor early so now new events get generated to propogate through
-    // other systems during destroy.
+    // Destroy file monitor early so that no callbacks fire during shutdown.
     DestroyFileMonitor();
 
     ShutdownBuilderManager();

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -894,6 +894,10 @@ void ApplicationManagerBase::Destroy()
     delete m_assetRequestHandler;
     m_assetRequestHandler = nullptr;
 
+    // Destroy file monitor early so now new events get generated to propogate through
+    // other systems during destroy.
+    DestroyFileMonitor();
+
     ShutdownBuilderManager();
     ShutDownFileProcessor();
 
@@ -902,7 +906,6 @@ void ApplicationManagerBase::Destroy()
     DestroyAssetServerHandler();
     DestroyRCController();
     DestroyAssetScanner();
-    DestroyFileMonitor();
     ShutDownAssetDatabase();
     DestroyPlatformConfiguration();
     DestroyApplicationServer();


### PR DESCRIPTION

## What does this PR do?
fixes #13124
The file monitor is now destroyed up front during shutdown so that it can no longer generate extra events during shutdown.


## How was this PR tested?

Tested while the crash was active.  It no longer crashes.

Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>