### PR TITLE
Fix for linux unused compile error on Linux

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
@@ -42,6 +42,7 @@
 
 namespace MaterialCanvas
 {
+#if defined(AZ_ENABLE_TRACING)
     namespace
     {
         bool IsCompileLoggingEnabled()
@@ -49,7 +50,7 @@ namespace MaterialCanvas
             return AtomToolsFramework::GetSettingsValue("/O3DE/Atom/MaterialCanvasDocument/CompileLoggingEnabled", false);
         }
     } // namespace
-
+#endif // AZ_ENABLE_TRACING
     void MaterialCanvasDocument::Reflect(AZ::ReflectContext* context)
     {
         if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))


### PR DESCRIPTION
## What does this PR do?

Wrap IsCompileLoggingEnabled() with AZ_ENABLE_TRACING to match AZ_TracePrintf_IfTrue to fix a linux unused compile error

## How was this PR tested?

Built with AZ_ENABLE_TRACING not defined

