### PR TITLE
DPE: Support invocable ReadOnly attributes

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -273,8 +273,24 @@ namespace AZ::Reflection
                 {
                     if (auto readOnlyAttribute = classElement->m_editData->FindAttribute(AZ::Crc32("ReadOnly")); readOnlyAttribute)
                     {
-                        Dom::Value readOnlyValue = readOnlyAttribute->GetAsDomValue(instance);
-                        nodeData->m_disableEditor |= readOnlyValue.GetBool();
+                        Dom::Value readOnlyValue;
+                        if (readOnlyAttribute->CanDomInvoke(Dom::Value(Dom::Type::Array)))
+                        {
+                            readOnlyValue = readOnlyAttribute->DomInvoke(instance, Dom::Value(Dom::Type::Array));
+                        }
+                        else
+                        {
+                            readOnlyValue = readOnlyAttribute->GetAsDomValue(instance);
+                        }
+
+                        if (readOnlyValue.IsBool())
+                        {
+                            nodeData->m_disableEditor |= readOnlyValue.GetBool();
+                        }
+                        else
+                        {
+                            AZ_Warning("LegacyReflectionBridge", false, "ReadOnly attribute yielded non-bool Value");
+                        }
                     }
                 }
 
@@ -541,7 +557,7 @@ namespace AZ::Reflection
                     }
                     else
                     {
-                        AZ_Warning("DPE", false, "Unable to lookup name for attribute CRC: %" PRId32, it->first);
+                        AZ_Warning("LegacyReflectionBridge", false, "Unable to lookup name for attribute CRC: %" PRId32, it->first);
                     }
                 };
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
@@ -98,6 +98,12 @@ namespace DPEDebugView
         EnumType m_enumValue = EnumType::Value1;
         AZ::EntityId m_entityId;
 
+        // For testing invocable ReadOnly attributes
+        bool IsDataReadOnly()
+        {
+            return true;
+        }
+
         static void Reflect(AZ::ReflectContext* context)
         {
             if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
@@ -167,7 +173,7 @@ namespace DPEDebugView
                         ->Attribute(AZ::Edit::Attributes::AcceptsMultiEdit, true)
                         ->ClassElement(AZ::Edit::ClassElements::Group, "ReadOnly")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_readOnlyInt, "readonly int", "")
-                        ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
+                        ->Attribute(AZ::Edit::Attributes::ReadOnly, &TestContainer::IsDataReadOnly)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_readOnlyMap, "readonly map<string, float>", "")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->Attribute(AZ::Edit::Attributes::ReadOnly, true);


### PR DESCRIPTION
**Description**
Before this PR, it was possible to encounter an assertion caused by the incorrect assumption that `ReadOnly` attributes were always `bool` values. In fact, `ReadOnly` attributes can be invocable values that reference member functions/data that will yield a `bool` value.

This PR adds support for those invocable `ReadOnly` values to the `LegacyReflectionBridge`.

**Testing**
- Verified opening the EntityInspector no longer throws an assertion for attempting to access a non-bool Value
- Added a test case to the standalone debug DPE app and verified that the property editor is enabled/disabled at runtime as appropriate

Signed-off-by: amzn-tmryan <104796591+amzn-tmryan@users.noreply.github.com>