### PR TITLE
DPE: Add default transient in-memory expansion state saving

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -1240,8 +1240,10 @@ namespace AzToolsFramework
             });
         m_adapter->ConnectMessageHandler(m_domMessageHandler);
 
-        // Free the settings ptr which in turn saves any in-memory settings to disk
+        // Free the settings ptr which saves any in-memory settings to disk and replace it
+        // with a default in-memory only settings object until a saved state key is specified
         m_dpeSettings.reset();
+        m_dpeSettings = AZStd::make_unique<DocumentPropertyEditorSettings>();
 
         // populate the view from the full adapter contents, just like a reset
         HandleReset();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditorSettings.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditorSettings.cpp
@@ -24,6 +24,7 @@ namespace AzToolsFramework
             .ReplaceExtension(SettingsRegistrar::SettingsRegistryFileExt);
 
         m_wereSettingsLoaded = LoadExpanderStates();
+        m_shouldSettingsPersist = true;
     }
 
     DocumentPropertyEditorSettings::~DocumentPropertyEditorSettings()
@@ -85,7 +86,7 @@ namespace AzToolsFramework
             }
         }
 
-        if (!m_expandedElementStates.empty())
+        if (m_shouldSettingsPersist && !m_expandedElementStates.empty())
         {
             SaveExpanderStates();
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditorSettings.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditorSettings.h
@@ -22,8 +22,9 @@ namespace AzToolsFramework
         using ExpanderStateMap = AZStd::unordered_map<AZStd::string, bool>;
         using CleanExpanderStateCallback = AZStd::function<bool(ExpanderStateMap&)>;
 
-        // Default ctor is required by SerializeContext but is not intended for use otherwise
+        //! Use this constructor when temporary in-memory only storage is desired
         DocumentPropertyEditorSettings() = default;
+        //! Use this constructor when storing settings in a persistent registry file on-disk
         DocumentPropertyEditorSettings(const AZStd::string& settingsRegistryKey, const AZStd::string& propertyEditorName);
 
         virtual ~DocumentPropertyEditorSettings();
@@ -66,6 +67,7 @@ namespace AzToolsFramework
         CleanExpanderStateCallback m_cleanExpanderStateCallback;
 
         bool m_wereSettingsLoaded = false;
+        bool m_shouldSettingsPersist = false;
 
         SettingsRegistrar m_settingsRegistrar;
 


### PR DESCRIPTION
**Description**
Before this PR, only persistent expansion state storage existed in the DPE. This meant that editors needed to create and set a GUID state key if they wanted the DPE to remember expansion states and there was no way to activate it only for the time a document was open (transient in-memory storage only).

This PR makes the DPE's default expansion state saving behavior the non-persistent in-memory only (wiped after the document is closed) behavior. Setting a save state key will continue to work as before where settings are saved to disk when a document is closed.

**Testing**
- Tested in the AssetEditor by disabling the current save to disk behavior
- Tested in the standalone debug DPE app by collapsing and expanding rows in various configs as well as switching between the available adapters

Signed-off-by: amzn-tmryan <104796591+amzn-tmryan@users.noreply.github.com>