### PR TITLE
Standardize widget names in Asset Browser window

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.ui
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.ui
@@ -290,14 +290,14 @@
            </size>
           </property>
           <widget class="QWidget" name="m_thumbnailView">
-           <layout class="QVBoxLayout" name="m_iconViewLayout">
+           <layout class="QVBoxLayout" name="m_thumbnailViewLayout">
             <property name="spacing">
              <number>0</number>
             </property>
             <item>
              <widget class="QLabel" name="m_thumbnailViewPlaceholder">
               <property name="text">
-               <string>Icon view placeholder</string>
+               <string>Thumbnail view placeholder</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignCenter</set>
@@ -314,7 +314,7 @@
             <item>
              <widget class="QLabel" name="m_tableViewPlaceholder">
               <property name="text">
-               <string>List view placeholder</string>
+               <string>Table view placeholder</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignCenter</set>


### PR DESCRIPTION
Some of them didn't use proper terminology. Placeholder texts also use proper naming

Signed-off-by: Miłosz Kosobucki <milosz@kosobucki.pl>

## What does this PR do?

Fixes minor naming issues in .ui files

## How was this PR tested?

Compiled and ran the editor. Worked as expected
