### PR TITLE
Fixed Physics Material RTTI name

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/Material/PhysicsMaterial.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Material/PhysicsMaterial.h
@@ -18,7 +18,7 @@ namespace Physics
     class Material
     {
     public:
-        AZ_RTTI(Physics::MaterialAsset, "{B0C593B9-F58E-47BF-856B-2F202A9E8813}");
+        AZ_RTTI(Physics::Material, "{B0C593B9-F58E-47BF-856B-2F202A9E8813}");
 
         Material() = default;
         Material(const MaterialId& id, const AZ::Data::Asset<MaterialAsset>& materialAsset);


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

Fixed Physics Material RTTI name. It's not expected to cause any issues since the type uuid of the class used is the same.

## How was this PR tested?

Run editor and test a physics collider with different materials.
