### PR TITLE
Improve naming in Motion Sets window

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetsWindowPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetsWindowPlugin.cpp
@@ -87,12 +87,12 @@ namespace EMStudio
         // create the set management window
         m_motionSetManagementWindow = new MotionSetManagementWindow(this, m_dialogStack);
         m_motionSetManagementWindow->Init();
-        m_dialogStack->Add(m_motionSetManagementWindow, "Motion Set Management", /*closed=*/false, /*maximizeSize=*/false, /*closable=*/true, /*strecthWhenMaximize=*/false);
+        m_dialogStack->Add(m_motionSetManagementWindow, tr("Available Motion Sets"), /*closed=*/false, /*maximizeSize=*/false, /*closable=*/true, /*strecthWhenMaximize=*/false);
 
         // create the motion set properties window
         m_motionSetWindow = new MotionSetWindow(this, m_dialogStack);
         m_motionSetWindow->Init();
-        m_dialogStack->Add(m_motionSetWindow, "Motion Set", /*closed=*/false, /*maximizeSize=*/true);
+        m_dialogStack->Add(m_motionSetWindow, tr("Selected Motion Set"), /*closed=*/false, /*maximizeSize=*/true);
 
         ReInit();
         CommandSystem::CreateDefaultMotionSet();


### PR DESCRIPTION
Task-Id: #10960

Signed-off-by: Miłosz Kosobucki <milosz@kosobucki.pl>

## What does this PR do?

Fixed header names in motion sets window as requested by @hultonha :
![image](https://user-images.githubusercontent.com/104767/201339626-cde73aed-33b7-443b-84d4-9b6b3f6bf362.png)


## How was this PR tested?

Manually
