### PR TITLE
Remove rapidjson default type customizations

### DIFF
--- a/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsContainer.cpp
+++ b/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsContainer.cpp
@@ -301,7 +301,7 @@ namespace ProjectSettingsTool
         return nullptr;
     }
 
-    rapidjson::RAPIDJSON_DEFAULT_ALLOCATOR& ProjectSettingsContainer::GetProjectJsonAllocator()
+    rapidjson::Document::AllocatorType& ProjectSettingsContainer::GetProjectJsonAllocator()
     {
         return m_projectJson.m_document->GetAllocator();
     }

--- a/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsContainer.h
+++ b/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsContainer.h
@@ -109,7 +109,7 @@ namespace ProjectSettingsTool
         AZStd::unique_ptr<PlistDictionary> CreatePlistDictionary(const Platform& plat);
 
         // Returns the allocator used by ProjectJson
-        rapidjson::RAPIDJSON_DEFAULT_ALLOCATOR& GetProjectJsonAllocator();
+        rapidjson::Document::AllocatorType& GetProjectJsonAllocator();
 
         static AZ::Outcome<rapidjson::Value*, void> GetJsonValue(rapidjson::Document& settings, const char* key);
 

--- a/Code/Framework/AzCore/AzCore/JSON/RapidJsonAllocator.h
+++ b/Code/Framework/AzCore/AzCore/JSON/RapidJsonAllocator.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Memory/ChildAllocatorSchema.h>
+#include <AzCore/Memory/OSAllocator.h>
+
+namespace AZ::JSON
+{
+    class RapidJSONAllocator : public AZ::ChildAllocatorSchema<AZ::OSAllocator>
+    {
+    public:
+        AZ_TYPE_INFO(RapidJSONAllocator, "{CCD24805-0E41-48CC-B92E-DB77F10FBEE3}");
+    };
+} // namespace AZ::JSON
+
+

--- a/Code/Framework/AzCore/AzCore/JSON/rapidjson.cpp
+++ b/Code/Framework/AzCore/AzCore/JSON/rapidjson.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/JSON/rapidjson.h>
+#include <AzCore/JSON/RapidJsonAllocator.h>
+
+#if USING_AZCORE_RAPIDJSON_ALLOCATION_OVERRIDES
+    namespace AZ::JSON
+    {
+        pointer_type do_malloc(
+            size_type byteSize,
+            size_type alignment,
+            int flags,
+            const char* name,
+            const char* fileName,
+            int lineNum,
+            unsigned int suppressStackRecord)
+        {
+            return AllocatorInstance<RapidJSONAllocator>::Get().Allocate(
+                byteSize, alignment, flags, name, fileName, lineNum, suppressStackRecord);
+        }
+
+        pointer_type do_realloc(pointer_type ptr, size_type newSize, size_type newAlignment)
+        {
+            return AllocatorInstance<RapidJSONAllocator>::Get().ReAllocate(ptr, newSize, newAlignment);
+        }
+
+        void do_free(pointer_type ptr)
+        {
+            return AllocatorInstance<RapidJSONAllocator>::Get().DeAllocate(ptr);
+        }
+    } // namespace AZ::JSON
+
+#endif // USING_AZCORE_RAPIDJSON_ALLOCATION_OVERRIDES
+

--- a/Code/Framework/AzCore/AzCore/JSON/rapidjson.h
+++ b/Code/Framework/AzCore/AzCore/JSON/rapidjson.h
@@ -8,52 +8,97 @@
 
 #pragma once
 
-#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/base.h>
 
-// Skip the error as we are including the recommended way.
-#define RAPIDJSON_SKIP_AZCORE_ERROR
-
-#if defined(AZ_ENABLE_TRACING)
-#   define RAPIDJSON_ASSERT(x) AZ_Assert(x, "Assert[rapidjson]: " #x)
-#else
-#   define RAPIDJSON_ASSERT(x) (void)(0)
+#if defined(RAPIDJSON_RAPIDJSON_H_)
+// if this happens, someone has alrady included the default rapidjson.h already, which is a bad idea as it won't
+// include any customizations such as memory management.
+#error vanilla rapidjson was included before including <AzCore/JSON/rapidjson.h>
 #endif
-#define RAPIDJSON_STATIC_ASSERT(x) static_assert(x, "Assert[rapidjson]: " #x)
-#define RAPIDJSON_HAS_CXX11_TYPETRAITS 1
-#define RAPIDJSON_HAS_CXX11_RVALUE_REFS 1
 
-namespace rapidjson_ly_internal
-{
-    template<typename T>
-    void Delete(T* instance)
+// Only override RAPIDJSON_ customization macros which are not already defined.
+// This allows the user to pre-define these before including O3DE if they want to use default values
+// or their own values.
+
+#if !defined(RAPIDJSON_ASSERT)
+#   if defined(AZ_ENABLE_TRACING)
+#       define RAPIDJSON_ASSERT(x) AZ_Assert(x, "Assert[rapidjson]: " #x)
+#   else
+#       define RAPIDJSON_ASSERT(x) (void)(0)
+#   endif
+#endif
+
+#if !defined(RAPIDJSON_STATIC_ASSERT)
+   #define RAPIDJSON_STATIC_ASSERT(x) static_assert(x, "Assert[rapidjson]: " #x)
+#endif
+
+#if !defined(RAPIDJSON_HAS_CXX11_TYPETRAITS)
+#   define RAPIDJSON_HAS_CXX11_TYPETRAITS 1
+#endif
+
+#if !defined(RAPIDJSON_HAS_CXX11_RVALUE_REFS)
+#   define RAPIDJSON_HAS_CXX11_RVALUE_REFS 1
+#endif
+
+// note for future maintainers:
+// RapidJSON allows you to customize the default allocator type for documents by overriding with RAPIDJSON_DEFAULT_ALLOCATOR.
+// However, customizing the default type of rapidjson::Document and rapidjson::Value in that way will cause incompatibilities
+// with external software libraries that use unmodified RapidJSON.   It is not thus recommended
+// to actually set the value of RAPIDJSON_DEFAULT_ALLOCATOR or redefine what a rapidjson::Document itself is.
+// The other way to get a 'custom' allocator installed in RapidJSON is to make your own Document/Value/Pointer type, since it's templated
+// on allocator type - for example, implement your own allocator and do
+// using MyDocument = rapidjson::GenericDocument<rapidjson::UTF8<char>, MyAllocator, MyAllocator> and then use MyDocument in your code
+// instead of RapidJSON::Document.  Note GenericDocument<> customized must use customized GenericValue<> and GenericPointer<>
+// or else you haven't acutally plugged into all the places where memory is allocated and will lose some.
+// 
+// Unfortunately, rapidjson::Pointer can't deal with these customized values or documents due to a bug in the code where functions
+// like Set/Get/Create use the default template parameter instead of deducing it:
+// ie, they are set up like somefunction<T>(GenericValue<char> val) which will only accept default GenericValue<char, CrtAllocator>.
+// correct form: somefunction<T>(GenericValue<char, T::AllocatorType> val, which would allow MyValue<char, MyAllocator> to be passed in.
+// thus, it is not recommended to use customized documents, values, or pointers either, (until that bug is fixed).
+
+// this leaves just one avenue for customization of memory of Rapidjson - overriding the macros RAPIDJSON_xxxx (new,delete, malloc, realloc..)
+
+// forward all allocations to our own allocators.  But preferrably without acutally having to drag our allocators into this header:
+
+// note that we cannot partially define allocation forwarding - for example, it is not okay to just override new, but not delete.
+// So either we define them all, or we define none.  If a user has defined any of them, we don't define any of them:
+// Users can manually switch the entire system off by setting USING_AZCORE_RAPIDJSON_ALLOCATION_OVERRIDES 0
+
+#if !defined(USING_AZCORE_RAPIDJSON_ALLOCATION_OVERRIDES)
+#   if  !defined(RAPIDJSON_MALLOC) && !defined(RAPIDJSON_REALLOC) && !defined(RAPIDJSON_FREE) && !defined(RAPIDJSON_NEW) && !defined(RAPIDJSON_DELETE)
+#       define USING_AZCORE_RAPIDJSON_ALLOCATION_OVERRIDES 1
+#   else
+#       define USING_AZCORE_RAPIDJSON_ALLOCATION_OVERRIDES 0
+#   endif
+#endif
+
+#if USING_AZCORE_RAPIDJSON_ALLOCATION_OVERRIDES
+
+    namespace AZ::JSON
     {
-        if (instance)
-        {
-            instance->~T();
-            azfree(instance, AZ::SystemAllocator);
-        }
+        typedef void* pointer_type;
+        typedef size_t size_type;
+
+        pointer_type do_malloc(size_type byteSize, size_type alignment, int flags, const char* name, const char* fileName, int lineNum, unsigned int suppressStackRecord);
+        pointer_type do_realloc(pointer_type ptr, size_type newSize, size_type newAlignment);
+        void do_free(pointer_type ptr);
+    } 
+
+#   define RAPIDJSON_MALLOC(_size)         AZ::JSON::do_malloc(_size, 16, 0, "RapidJSON", __FILE__, __LINE__, 0)
+#   define RAPIDJSON_REALLOC(_ptr, _size)  AZ::JSON::do_realloc(_ptr, _size, 16)
+#   define RAPIDJSON_FREE(_ptr)            AZ::JSON::do_free(_ptr)
+#   define RAPIDJSON_NEW(x)           new (AZ::JSON::do_malloc(sizeof(x), alignof(x), 0, "RapidJSON", __FILE__, __LINE__, 0)) x
+#   define RAPIDJSON_DELETE(x)                 \
+    {                                          \
+        if (x)                                 \
+        {                                      \
+            std::destroy_at(x);                \
+            AZ::JSON::do_free(x);              \
+        }                                      \
     }
-}
 
-
-#define RAPIDJSON_NEW(x)  new(azmalloc(sizeof(x), alignof(x), AZ::SystemAllocator)) x
-#define RAPIDJSON_DELETE(x) rapidjson_ly_internal::Delete(x)
-#define RAPIDJSON_MALLOC(_size) AZ::AllocatorInstance<AZ::SystemAllocator>::Get().allocate(_size, 16)
-#define RAPIDJSON_REALLOC(_ptr, _newSize) _ptr ? AZ::AllocatorInstance<AZ::SystemAllocator>::Get().reallocate(_ptr, _newSize, 16) : RAPIDJSON_MALLOC(_newSize)
-#define RAPIDJSON_FREE(_ptr) if (_ptr) { AZ::AllocatorInstance<AZ::SystemAllocator>::Get().deallocate(_ptr, 0, 0); }
-#define RAPIDJSON_CLASS_ALLOCATOR(_class) AZ_CLASS_ALLOCATOR(_class, AZ::SystemAllocator, 0)
-
-// By default, RapidJSON uses its own pooling allocator that allocates in 64k chunks and then uses the
-// contents of those chunks internally.
-// However, O3DE defines the above macros, which redirect the RapidJSON allocations into the O3DE system
-// allocator, which itself is a also a chunk-based pooling allocator (HPHA).
-// This double-chunking would be wasteful, so tell RapidJSON to directly ask for allocations instead
-// of attempting to pool them.  The rapidjson::CrtAllocator just passes allocation and deallocation to the above
-// macros.
-#define RAPIDJSON_DEFAULT_ALLOCATOR CrtAllocator
-
-// Set custom namespace for AzCore's rapidjson to avoid various collisions.
-#define RAPIDJSON_NAMESPACE rapidjson_ly
+#endif // USING_AZCORE_RAPIDJSON_ALLOCATION_OVERRIDES
 
 #if AZ_TRAIT_JSON_CLANG_IGNORE_UNKNOWN_WARNING && defined(AZ_COMPILER_CLANG)
 #pragma clang diagnostic push
@@ -94,5 +139,3 @@ namespace rapidjson_ly_internal
 #pragma clang diagnostic pop
 #endif
 
-// Allow our existing code to continue use "rapidjson::"
-#define rapidjson RAPIDJSON_NAMESPACE

--- a/Code/Framework/AzCore/AzCore/JSON/rapidjson.h
+++ b/Code/Framework/AzCore/AzCore/JSON/rapidjson.h
@@ -139,3 +139,6 @@
 #pragma clang diagnostic pop
 #endif
 
+// retain backward compatibility by aliasing rapidjson_ly to rapidjson
+namespace rapidjson_ly = rapidjson;
+

--- a/Code/Framework/AzCore/AzCore/Memory/SystemAllocator.cpp
+++ b/Code/Framework/AzCore/AzCore/Memory/SystemAllocator.cpp
@@ -54,12 +54,6 @@ namespace AZ
     //=========================================================================
     bool SystemAllocator::Create()
     {
-        AZ_Assert(IsReady() == false, "System allocator was already created!");
-        if (IsReady())
-        {
-            return false;
-        }
-
         m_subAllocator = new (&g_systemSchema) HphaSchema();
         return true;
     }

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -252,6 +252,8 @@ set(FILES
     JSON/pointer.h
     JSON/prettywriter.h
     JSON/rapidjson.h
+    JSON/rapidjson.cpp
+    JSON/RapidJsonAllocator.h
     JSON/RapidjsonAllocatorAdapter.h
     JSON/reader.h
     JSON/schema.h

--- a/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/rapidjson.natvis
+++ b/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/rapidjson.natvis
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
 	<!-- rapidjson::GenericValue - basic support -->
-	<Type Name="rapidjson_ly::GenericValue&lt;*,*&gt;">
+	<Type Name="rapidjson::GenericValue&lt;*,*&gt;">
 		<DisplayString Condition="(data_.f.flags &amp; kTypeMask) == kNullType">null</DisplayString>
 		<DisplayString Condition="data_.f.flags == kTrueFlag">true</DisplayString>
 		<DisplayString Condition="data_.f.flags == kFalseFlag">false</DisplayString>
@@ -20,7 +20,7 @@
 			<ArrayItems Condition="data_.f.flags == kObjectType">
 				<Size>data_.o.size</Size>
 				<!-- NOTE: Rapidjson stores some extra data in the high bits of pointers, which is why the mask -->
-				<ValuePointer>(rapidjson_ly::GenericMember&lt;$T1,$T2&gt;*)(((size_t)data_.o.members) &amp; 0x0000FFFFFFFFFFFF)</ValuePointer>
+				<ValuePointer>(rapidjson::GenericMember&lt;$T1,$T2&gt;*)(((size_t)data_.o.members) &amp; 0x0000FFFFFFFFFFFF)</ValuePointer>
 			</ArrayItems>
 
 			<Item Condition="data_.f.flags == kArrayType" Name="[size]">data_.a.size</Item>
@@ -28,7 +28,7 @@
 			<ArrayItems Condition="data_.f.flags == kArrayType">
 				<Size>data_.a.size</Size>
 				<!-- NOTE: Rapidjson stores some extra data in the high bits of pointers, which is why the mask -->
-				<ValuePointer>(rapidjson_ly::GenericValue&lt;$T1,$T2&gt;*)(((size_t)data_.a.elements) &amp; 0x0000FFFFFFFFFFFF)</ValuePointer>
+				<ValuePointer>(rapidjson::GenericValue&lt;$T1,$T2&gt;*)(((size_t)data_.a.elements) &amp; 0x0000FFFFFFFFFFFF)</ValuePointer>
 			</ArrayItems>
 
 		</Expand>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EntityUtilityComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EntityUtilityComponent.cpp
@@ -8,6 +8,8 @@
 
 #include <sstream>
 #include <AzCore/JSON/rapidjson.h>
+#include <AzCore/JSON/document.h>
+
 #include <AzCore/Serialization/Json/JsonSerialization.h>
 #include <AzCore/Serialization/Json/JsonSerializationSettings.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>
@@ -15,7 +17,6 @@
 #include <AzFramework/FileFunc/FileFunc.h>
 #include <AzToolsFramework/Entity/EntityUtilityComponent.h>
 #include <Entity/EditorEntityContextBus.h>
-#include <rapidjson/document.h>
 
 namespace AzToolsFramework
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Metadata/MetadataManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Metadata/MetadataManager.cpp
@@ -28,7 +28,7 @@ namespace AzToolsFramework
 
     bool MetadataManager::GetValue(AZ::IO::PathView file, AZStd::string_view key, void* outValue, AZ::Uuid typeId)
     {
-        rapidjson_ly::Document value;
+        rapidjson::Value value;
 
         if (!GetJson(file, key, value))
         {
@@ -41,12 +41,12 @@ namespace AzToolsFramework
         return resultCode.GetProcessing() != AZ::JsonSerializationResult::Processing::Halted;
     }
 
-    bool MetadataManager::GetJson(AZ::IO::PathView file, AZStd::string_view key, rapidjson_ly::Document& outValue)
+    bool MetadataManager::GetJson(AZ::IO::PathView file, AZStd::string_view key, rapidjson::Document& outValue)
     {
         auto path = ToMetadataPath(file);
 
         // Make a JSONPath pointer and validate it
-        rapidjson_ly::Pointer pointer(key.data(), key.length());
+        rapidjson::Pointer pointer(key.data(), key.length());
 
         if (!pointer.IsValid())
         {
@@ -84,21 +84,21 @@ namespace AzToolsFramework
         auto& document = result.GetValue();
 
         // Use the pointer to find the value we're trying to read
-        rapidjson_ly::Value* value = pointer.Get(document);
+        rapidjson::Value* value = pointer.Get(document);
 
         if (!value)
         {
             return false;
         }
 
-        outValue = rapidjson_ly::Document(); // Make sure to release any existing memory if the document happens to be non-empty
+        outValue = rapidjson::Document(); // Make sure to release any existing memory if the document happens to be non-empty
         outValue.CopyFrom(*value, document.GetAllocator());
         return true;
     }
 
     bool MetadataManager::GetValueVersion(AZ::IO::PathView file, AZStd::string_view key, int& version)
     {
-        rapidjson_ly::Document value;
+        rapidjson::Document value;
         if (!GetJson(file, key, value))
         {
             return false;
@@ -137,8 +137,8 @@ namespace AzToolsFramework
         auto path = ToMetadataPath(file);
 
         // Make a JSONPath pointer and validate it
-        rapidjson_ly::Pointer pointer(key.data(), key.length());
-        rapidjson_ly::Pointer versionPointer(MetadataVersionKey);
+        rapidjson::Pointer pointer(key.data(), key.length());
+        rapidjson::Pointer versionPointer(MetadataVersionKey);
 
         if (!pointer.IsValid())
         {
@@ -155,7 +155,7 @@ namespace AzToolsFramework
         // Otherwise, just start a new, blank document
         auto result = AZ::JsonSerializationUtils::ReadJsonFile(path.Native());
 
-        rapidjson_ly::Document document;
+        rapidjson::Document document;
 
         if (result)
         {
@@ -208,11 +208,11 @@ namespace AzToolsFramework
         };
 
         // Encode the version into JSON
-        rapidjson_ly::Value serializedVersion;
+        rapidjson::Value serializedVersion;
         AZ::JsonSerialization::Store(serializedVersion, document.GetAllocator(), &MetadataVersion, nullptr, azrtti_typeid<int>(), settings);
 
         // Encode the value into JSON
-        rapidjson_ly::Value serializedValue;
+        rapidjson::Value serializedValue;
         auto resultCode = AZ::JsonSerialization::Store(serializedValue, document.GetAllocator(), inValue, nullptr, typeId, settings);
 
         // Try to insert the version of the type being serialized into the serialized data
@@ -230,10 +230,10 @@ namespace AzToolsFramework
             }
             else
             {
-                rapidjson_ly::Value versionValue;
+                rapidjson::Value versionValue;
                 versionValue.SetInt(currentVersion);
                 serializedValue.GetObject().AddMember(
-                    rapidjson_ly::Value(MetadataObjectVersionField, document.GetAllocator()).Move(), versionValue, document.GetAllocator());
+                    rapidjson::Value(MetadataObjectVersionField, document.GetAllocator()).Move(), versionValue, document.GetAllocator());
             }
         }
 
@@ -242,11 +242,11 @@ namespace AzToolsFramework
             // Create the file version JSON entry in the document and store the encoded value
             // This will update the saved version to the current version
             // Note that this is the version of the entire saved document (the metadata version), not the version of the type being saved
-            rapidjson_ly::Value& versionStore = versionPointer.Create(document, document.GetAllocator());
+            rapidjson::Value& versionStore = versionPointer.Create(document, document.GetAllocator());
             versionStore = AZStd::move(serializedVersion);
 
             // Create the user JSON entry in the document and store the encoded value
-            rapidjson_ly::Value& store = pointer.Create(document, document.GetAllocator());
+            rapidjson::Value& store = pointer.Create(document, document.GetAllocator());
             store = AZStd::move(serializedValue);
 
             // Save JSON to disk

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Metadata/MetadataManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Metadata/MetadataManager.cpp
@@ -28,7 +28,7 @@ namespace AzToolsFramework
 
     bool MetadataManager::GetValue(AZ::IO::PathView file, AZStd::string_view key, void* outValue, AZ::Uuid typeId)
     {
-        rapidjson::Value value;
+        rapidjson::Document value;
 
         if (!GetJson(file, key, value))
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Metadata/MetadataManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Metadata/MetadataManager.h
@@ -42,7 +42,7 @@ namespace AzToolsFramework
         //! @param file Absolute path to the file (or metadata file).
         //! @param key JSONPath formatted key for the metadata value to read.  Ex: /Settings/Platform/pc.
         //! @return True if metadata file and key exists and was successfully read, false otherwise.
-        virtual bool GetJson(AZ::IO::PathView file, AZStd::string_view key, rapidjson_ly::Document& outValue) = 0;
+        virtual bool GetJson(AZ::IO::PathView file, AZStd::string_view key, rapidjson::Document& outValue) = 0;
 
         //! Gets the version for a stored key/value from the metadata file associated with the file.
         //! @param file Absolute path to the file (or metadata file).
@@ -91,7 +91,7 @@ namespace AzToolsFramework
 
     public:
         bool GetValue(AZ::IO::PathView file, AZStd::string_view key, void* outValue, AZ::Uuid typeId) override;
-        bool GetJson(AZ::IO::PathView file, AZStd::string_view key, rapidjson_ly::Document& outValue) override;
+        bool GetJson(AZ::IO::PathView file, AZStd::string_view key, rapidjson::Document& outValue) override;
         bool GetValueVersion(AZ::IO::PathView file, AZStd::string_view key, int& version) override;
         bool SetValue(AZ::IO::PathView file, AZStd::string_view key, const void* inValue, AZ::Uuid typeId) override;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.cpp
@@ -316,7 +316,7 @@ namespace AzToolsFramework
             ClearEntities();
 
             m_nestedInstances.clear();
-            m_cachedInstanceDom.SetNull();
+            m_cachedInstanceDom = PrefabDom();
             m_containerEntity.reset(aznew AZ::Entity());
             RegisterEntity(m_containerEntity->GetId(), GenerateEntityAlias());
 
@@ -947,6 +947,7 @@ namespace AzToolsFramework
 
         void Instance::SetCachedInstanceDom(PrefabDomValueConstReference instanceDom)
         {
+            m_cachedInstanceDom = PrefabDom(); // force a flush of memory by clearing first.
             m_cachedInstanceDom.CopyFrom(instanceDom->get(), m_cachedInstanceDom.GetAllocator());
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.h
@@ -38,14 +38,14 @@ namespace AzToolsFramework
             //! In addition, container entity is updated depending on the above relationship with the focused instance.
             //! Note: Link id would be valid in the generated DOM only if the given instance is a proper descendant
             //! of the focused or root instance.
-            //! @param[out] instanceDom The output instance DOM that will be modified.
+            //! @param[out] instanceDom The output instance DOM that will be modified. It must be empty so that it can be filled.
             //! @param instance The given instance object.
             void GenerateInstanceDom(PrefabDom& instanceDom, const Instance& instance) const override;
 
             //! Generates an entity DOM for a given entity object based on the currently focused instance.
             //! If the owning instance of the given entity is descendant of the focused instance, entity DOM stored in focused
             //! template DOM is used; otherwise, the entity DOM stored in the root template DOM is used.
-            //! @param[out] entityDom The output entity DOM that will be modified.
+            //! @param[out] entityDom The output entity DOM that will be modified. It must be empty so that it can be filled.
             //! @param entity The given entity object.
             void GenerateEntityDom(PrefabDom& entityDom, const AZ::Entity& entity) const override;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -157,6 +157,7 @@ namespace AzToolsFramework
             LazyConnectGameModeEventHandler();
 
             bool isUpdateSuccessful = true;
+            bool updatedInstances = false;
             if (!m_updatingTemplateInstancesInQueue && !m_shouldPausePropagation)
             {
                 m_updatingTemplateInstancesInQueue = true;
@@ -180,6 +181,7 @@ namespace AzToolsFramework
                     // make sure to end the loop once the queue is empty, regardless of what the initial size was.
                     for (int i = 0; (i < instanceCountToUpdateInBatch) && !m_instancesUpdateQueue.empty(); ++i)
                     {
+                        updatedInstances = true;
                         Instance* instanceToUpdate = m_instancesUpdateQueue.front();
                         m_instancesUpdateQueue.pop_front();
                         AZ_Assert(instanceToUpdate != nullptr, "Invalid instance on update queue.");
@@ -287,13 +289,17 @@ namespace AzToolsFramework
                     // Notify Propagation has ended, then update selection (which is frozen during propagation, so this order matters)
                     PrefabPublicNotificationBus::Broadcast(&PrefabPublicNotifications::OnPrefabInstancePropagationEnd);
                     ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequests::SetSelectedEntities, selectedEntityIds);
-
-                    // after an instance update operation finishes, garbage collect to reclaim memory.
-                    AZ::AllocatorManager::Instance().GarbageCollect();
-                    AZ_MALLOC_TRIM(0);
                 }
 
                 m_updatingTemplateInstancesInQueue = false;
+            }
+            
+            // this logic avoids calling garbage collect on every frame when no instances have been updated or when 
+            // we are still processing the update queue (if in a mode where the processing queue is emptied slowly over time).
+            if ( (updatedInstances) && (m_instancesUpdateQueue.empty()) )
+            {
+                AZ::AllocatorManager::Instance().GarbageCollect();
+                AZ_MALLOC_TRIM(0);
             }
 
             return isUpdateSuccessful;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.cpp
@@ -173,29 +173,28 @@ namespace AzToolsFramework
             PrefabDom& targetTemplatePrefabDom = m_prefabSystemComponentInterface->FindTemplateDom(m_targetTemplateId);
             PrefabDom& sourceTemplatePrefabDom = m_prefabSystemComponentInterface->FindTemplateDom(m_sourceTemplateId);
 
-            // Copy the source template dom so that the actual template DOM does not change and only the linked instance DOM does.
-            PrefabDom sourceTemplateDomCopy;
-            sourceTemplateDomCopy.CopyFrom(sourceTemplatePrefabDom, sourceTemplatePrefabDom.GetAllocator());
-
-            
             PrefabDom patchesDom;
             ConstructLinkDomFromPatches(patchesDom, patchesDom.GetAllocator());
             PrefabDomValueReference patchesReference = PrefabDomUtils::FindPrefabDomValue(patchesDom, PrefabDomUtils::PatchesName);
             if (!patchesReference.has_value())
             {
-                if (AZ::JsonSerialization::Compare(linkedInstanceDom, sourceTemplateDomCopy) != AZ::JsonSerializerCompareResult::Equal)
+                // if there are no patches, it means that the instance being copied should just be identical to the one
+                // in the source.
+                if (AZ::JsonSerialization::Compare(linkedInstanceDom, sourceTemplatePrefabDom) != AZ::JsonSerializerCompareResult::Equal)
                 {
-                    linkedInstanceDom.CopyFrom(sourceTemplateDomCopy, targetTemplatePrefabDom.GetAllocator());
+                    linkedInstanceDom.CopyFrom(sourceTemplatePrefabDom, targetTemplatePrefabDom.GetAllocator());
                 }
             }
             else
             {
+                // Copy the source template dom so that the actual template DOM does not change and only the linked instance DOM does.
+                linkedInstanceDom.CopyFrom(sourceTemplatePrefabDom, targetTemplatePrefabDom.GetAllocator());
+
                 AZ::JsonSerializationResult::ResultCode applyPatchResult =
-                    PrefabDomUtils::ApplyPatches(sourceTemplateDomCopy, targetTemplatePrefabDom.GetAllocator(), patchesReference->get());
-                linkedInstanceDom.CopyFrom(sourceTemplateDomCopy, targetTemplatePrefabDom.GetAllocator());
+                    PrefabDomUtils::ApplyPatches(linkedInstanceDom, targetTemplatePrefabDom.GetAllocator(), patchesReference->get());
 
                 [[maybe_unused]] PrefabDomValueReference sourceTemplateName =
-                    PrefabDomUtils::FindPrefabDomValue(sourceTemplateDomCopy, PrefabDomUtils::SourceName);
+                    PrefabDomUtils::FindPrefabDomValue(sourceTemplatePrefabDom, PrefabDomUtils::SourceName);
                 AZ_Assert(sourceTemplateName && sourceTemplateName->get().IsString(), "A valid source template name couldn't be found");
                 [[maybe_unused]] PrefabDomValueReference targetTemplateName =
                     PrefabDomUtils::FindPrefabDomValue(targetTemplatePrefabDom, PrefabDomUtils::SourceName);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.cpp
@@ -602,20 +602,28 @@ namespace AzToolsFramework
                 return false;
             }
 
+            PrefabDom& loadedTemplateDomRef = loadedTemplateDom->get();
+
+            // first, decode the template DOM into actual Instance data.  This will actually create real
+            // C++ classes for the instances in the template DOM and fill their member properties with the
+            // properties from the DOM.
             Instance loadedPrefabInstance;
-            if (!PrefabDomUtils::LoadInstanceFromPrefabDom(loadedPrefabInstance, loadedTemplateDom->get(),
+            if (!PrefabDomUtils::LoadInstanceFromPrefabDom(loadedPrefabInstance, loadedTemplateDomRef,
                 PrefabDomUtils::LoadFlags::ReportDeprecatedComponents))
             {
                 return false;
             }
 
-            PrefabDom storedPrefabDom(&loadedTemplateDom->get().GetAllocator());
-            if (!PrefabDomUtils::StoreInstanceInPrefabDom(loadedPrefabInstance, storedPrefabDom, PrefabDomUtils::StoreFlags::StripLinkIds))
+            // To avoid having double the memory allocated at any given time, first empty the original:
+            loadedTemplateDomRef = PrefabDom(); // this will deallocate all the memory previously held.
+
+            // Now that the Instance has been created, convert it back into a Prefab DOM.  Because we
+            // don't specify to skip default fields in the call to StoreInstanceInPrefabDom,
+            // this new DOM will have all fields from all classes.
+            if (!PrefabDomUtils::StoreInstanceInPrefabDom(loadedPrefabInstance, loadedTemplateDomRef))
             {
                 return false;
             }
-
-            loadedTemplateDom->get().CopyFrom(storedPrefabDom, loadedTemplateDom->get().GetAllocator());
             return true;
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -2083,7 +2083,7 @@ namespace AzToolsFramework
 
                 // Create the new Entity DOM from parsing the JSON string
                 PrefabDom entityDomAfter(&domToAddDuplicatedEntitiesUnder.GetAllocator());
-                entityDomAfter.Parse(newEntityDomString.toUtf8().constData());
+                entityDomAfter.Parse<rapidjson::kParseFullPrecisionFlag>(newEntityDomString.toUtf8().constData());
 
                 EntityAlias parentEntityAlias;
                 if (auto componentsIter = entityDomAfter.FindMember(PrefabDomUtils::ComponentsName);
@@ -2222,7 +2222,7 @@ namespace AzToolsFramework
 
                 // Create the new Instance DOM from parsing the JSON string
                 PrefabDom nestedInstanceDomAfter(&domToAddDuplicatedInstancesUnder.GetAllocator());
-                nestedInstanceDomAfter.Parse(newInstanceDomString.toUtf8().constData());
+                nestedInstanceDomAfter.Parse<rapidjson::kParseFullPrecisionFlag>(newInstanceDomString.toUtf8().constData());
 
                 // Add the new Instance DOM to the Instances member of the instance
                 rapidjson::Value aliasName(newInstanceAlias.c_str(), static_cast<rapidjson::SizeType>(newInstanceAlias.length()), domToAddDuplicatedInstancesUnder.GetAllocator());

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
@@ -117,9 +117,30 @@ namespace AzToolsFramework
         {
         }
 
+        void PrefabSystemComponent::GarbageCollectTemplates(bool doAll)
+        {
+            // garbage collect 1 template per system tick:
+            while (!m_templatesWhichNeedGarbageCollection.empty())
+            {
+                TemplateId whichOne = *m_templatesWhichNeedGarbageCollection.begin();
+                m_templatesWhichNeedGarbageCollection.erase(whichOne);
+                TemplateReference findTemplateResult = FindTemplate(whichOne);
+                if (findTemplateResult.has_value())
+                {
+                    findTemplateResult->get().GarbageCollect();
+                }
+
+                if (!doAll)
+                {
+                    break;
+                }
+            }
+        }
+
         void PrefabSystemComponent::OnSystemTick()
         {
             m_instanceUpdateExecutor.UpdateTemplateInstancesInQueue();
+            GarbageCollectTemplates(false);
         }
 
         AZStd::unique_ptr<Instance> PrefabSystemComponent::CreatePrefab(
@@ -224,6 +245,7 @@ namespace AzToolsFramework
                     UpdateLinkedInstances(linkIdsToUpdateQueue);
                 }
                 UpdatePrefabInstances(templateId, instanceToExclude);
+                m_templatesWhichNeedGarbageCollection.insert(templateId);
             }
         }
 
@@ -249,11 +271,13 @@ namespace AzToolsFramework
 
         void PrefabSystemComponent::UpdateLinkedInstances(AZStd::queue<LinkIds>& linkIdsQueue)
         {
+            TargetTemplateIdToLinkIdMap targetTemplateIdToLinkIdMap;
+
             while (!linkIdsQueue.empty())
             {
+
                 // Fetch the list of linkIds at the head of the queue.
                 LinkIds& LinkIdsToUpdate = linkIdsQueue.front();
-                TargetTemplateIdToLinkIdMap targetTemplateIdToLinkIdMap;
                 BucketLinkIdsByTargetTemplateId(LinkIdsToUpdate, targetTemplateIdToLinkIdMap);
 
                 // Update all the linked instances corresponding to the LinkIds before fetching the next set of linkIds.
@@ -262,7 +286,17 @@ namespace AzToolsFramework
                 {
                     UpdateLinkedInstance(linkIdToUpdate, targetTemplateIdToLinkIdMap, linkIdsQueue);
                 }
+
                 linkIdsQueue.pop();
+            }
+
+            for (const auto& element : targetTemplateIdToLinkIdMap)
+            {
+                bool wasModified = element.second.second;
+                if (wasModified)
+                {
+                    m_templatesWhichNeedGarbageCollection.insert(element.first);
+                }
             }
         }
 
@@ -285,21 +319,36 @@ namespace AzToolsFramework
             }
         }
 
+      
         void PrefabSystemComponent::UpdateLinkedInstance(const LinkId linkIdToUpdate,
             TargetTemplateIdToLinkIdMap& targetTemplateIdToLinkIdMap, AZStd::queue<LinkIds>& linkIdsQueue)
         {
             Link& linkToUpdate = m_linkIdMap[linkIdToUpdate];
             TemplateId targetTemplateId = linkToUpdate.GetTargetTemplateId();
-            PrefabDomValue& linkdedInstanceDom = linkToUpdate.GetLinkedInstanceDom();
-            PrefabDomValue linkDomBeforeUpdate;
-            linkDomBeforeUpdate.CopyFrom(linkdedInstanceDom, m_templateIdMap[targetTemplateId].GetPrefabDom().GetAllocator());
+            PrefabDomValue& linkedInstanceDom = linkToUpdate.GetLinkedInstanceDom();
+
+            // create an empty Dom to hold the temp allocations so they are cleared when we leave this scope:
+            PrefabDom linkedDomBeforeUpdate; 
+            linkedDomBeforeUpdate.CopyFrom(linkedInstanceDom, linkedDomBeforeUpdate.GetAllocator());
+
+            // the following call modifies the linkedInstanceDom to have the updated changes.
+            // Most of the time, this modifies the actual linkedInstanceDom to have patches.
+            // The only circumstance this doesn't happen is if the linkedInstanceDom happens to already have the values
+            // that the override would have applied, in which case the patches don't do anything to it when applied to it
+            // and 'linkedDomBeforeUpdate == linkedDomAfterUpdate'.
             linkToUpdate.UpdateTarget();
 
-            // If any of the templates links are already updated, we don't need to check whether the linkedInstance DOM differs
-            // in content because the template is already marked to be sent for change propagation.
+            // the below chunk of code's job is to determine whether the template actually changed or not from UpdateTarget
+            // if it didn't change, we don't need to recurse into its children and propogate the changes - the propogation
+            // will end at this point in the heirarchy since it will not have any downstream effects.
+
+            // It is expensive to compare a DOM, so once we've compared one, we cache the fact that we compared it and it differed
+            // from before in targetTemplateIdToLinkIdMap[targetTemplateId].second.  This also means that if
+            // targetTemplateIdToLinkIdMap[targetTemplateId].second is true, there is no need to compare it again, as it will have
+            // already added its links to the queue.
+            
             bool isTemplateUpdated = targetTemplateIdToLinkIdMap[targetTemplateId].second;
-            if (isTemplateUpdated ||
-                AZ::JsonSerialization::Compare(linkDomBeforeUpdate, linkdedInstanceDom) != AZ::JsonSerializerCompareResult::Equal)
+            if (!isTemplateUpdated || AZ::JsonSerialization::Compare(linkedDomBeforeUpdate, linkedInstanceDom) != AZ::JsonSerializerCompareResult::Equal)
             {
                 targetTemplateIdToLinkIdMap[targetTemplateId].second = true;
             }
@@ -446,7 +495,7 @@ namespace AzToolsFramework
 
         PrefabDom& PrefabSystemComponent::FindTemplateDom(TemplateId templateId)
         {
-            AZStd::optional<AZStd::reference_wrapper<Template>> findTemplateResult = FindTemplate(templateId);
+            TemplateReference findTemplateResult = FindTemplate(templateId);
             AZ_Assert(
                 findTemplateResult.has_value(),
                 "PrefabSystemComponent::FindTemplateDom - Unable to retrieve Prefab template with id: '%llu'. "
@@ -878,6 +927,10 @@ namespace AzToolsFramework
             if (auto templateReference = FindTemplate(templateId); templateReference.has_value())
             {
                 templateReference->get().MarkAsDirty(dirty);
+                if (dirty)
+                {
+                    m_templatesWhichNeedGarbageCollection.insert(templateId);
+                }
 
                 PrefabPublicNotificationBus::Broadcast(
                     &PrefabPublicNotificationBus::Events::OnPrefabTemplateDirtyFlagUpdated, templateId, dirty);
@@ -1030,7 +1083,7 @@ namespace AzToolsFramework
                     rapidjson::Value(instanceIterator->name.GetString(), targetTemplatePrefabDom.GetAllocator()),
                     instanceObject.Move(), targetTemplatePrefabDom.GetAllocator());
             }
-            //initialize link 
+            //initialize link
             if (!link.UpdateTarget())
             {
                 AZ_Error("Prefab", false,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.h
@@ -390,6 +390,13 @@ namespace AzToolsFramework
             //! Called by the AssetProcessor when the source file has been removed.
             void SourceFileRemoved(AZStd::string relativePath, AZStd::string scanFolder, AZ::Uuid sourceUUID) override;
 
+            //! Free memory if memory is available to free.  This is only necessary if the underlying system
+            //! retains memory (ie, rapidjson, not AZ::DOM).  Doing so will invalidate all existing PrefabDom&
+            //! and PrefabDomValue& references that might be pointing at the garbage collected memory.
+            //! @param doAll if doAll is true, it will garbage collect all templates in the set of those needing
+            //! to be garbage collected - otherwise, it will only garbage collect one (meant for continuous calling).
+            void GarbageCollectTemplates(bool doAll);
+
             // A container for mapping Templates to the Links they may propagate changes to.
             AZStd::unordered_map<TemplateId, AZStd::unordered_set<LinkId>> m_templateToLinkIdsMap;
 
@@ -437,6 +444,8 @@ namespace AzToolsFramework
 
             // If true, individual template-remove messages will be suppressed
             bool m_removingAllTemplates = false;
+
+            AZStd::unordered_set<TemplateId> m_templatesWhichNeedGarbageCollection;
         };
     } // namespace Prefab
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Procedural/ProceduralPrefabAsset.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Procedural/ProceduralPrefabAsset.cpp
@@ -86,6 +86,9 @@ namespace AZ::Prefab
 
     void PrefabDomData::CopyValue(const rapidjson::Value& inputValue)
     {
+        // Force a memory clear by first assigning to empty.  Simply calling copyfrom
+        // just allocates more memory without clearing existing memory usage.
+        m_prefabDom = AzToolsFramework::Prefab::PrefabDom();
         m_prefabDom.CopyFrom(inputValue, m_prefabDom.GetAllocator());
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/PrefabDocument.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/PrefabDocument.cpp
@@ -32,6 +32,8 @@ namespace AzToolsFramework::Prefab::PrefabConversionUtils
         if (ConstructInstanceFromPrefabDom(prefab))
         {
             constexpr bool copyConstStrings = true;
+            // CopyFrom does not clear memory.  Force a clear by empty assignment first:
+            m_dom = PrefabDom();
             m_dom.CopyFrom(prefab, m_dom.GetAllocator(), copyConstStrings);
             return true;
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Template/Template.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Template/Template.h
@@ -41,6 +41,8 @@ namespace AzToolsFramework
             Template(Template&& other) noexcept;
             Template& operator=(Template&& other) noexcept;
 
+            void GarbageCollect();
+
             virtual ~Template() noexcept = default;
 
             bool IsValid() const;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndo.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndo.cpp
@@ -56,8 +56,7 @@ namespace AzToolsFramework
 
                     // Create redo patch.
                     PrefabDomValue redoPatch(rapidjson::kObjectType);
-                    rapidjson::Value path =
-                        rapidjson::Value(entityAliasPath.data(), aznumeric_caster(entityAliasPath.length()), m_redoPatch.GetAllocator());
+                    PrefabDomValue path(entityAliasPath.data(), aznumeric_caster(entityAliasPath.length()), m_redoPatch.GetAllocator());
 
                     redoPatch.AddMember(rapidjson::StringRef("op"), rapidjson::StringRef("remove"), m_redoPatch.GetAllocator())
                         .AddMember(rapidjson::StringRef("path"), AZStd::move(path), m_redoPatch.GetAllocator());
@@ -65,9 +64,9 @@ namespace AzToolsFramework
 
                     // Create undo patch.
                     PrefabDomValue undoPatch(rapidjson::kObjectType);
-                    path = rapidjson::Value(entityAliasPath.data(), aznumeric_caster(entityAliasPath.length()), m_undoPatch.GetAllocator());
+                    path = PrefabDomValue(entityAliasPath.data(), aznumeric_caster(entityAliasPath.length()), m_undoPatch.GetAllocator());
 
-                    rapidjson::Value patchValue;
+                    PrefabDomValue patchValue;
                     patchValue.CopyFrom(*(entityDomAndPath.first), m_undoPatch.GetAllocator(), true);
                     undoPatch.AddMember(rapidjson::StringRef("op"), rapidjson::StringRef("add"), m_undoPatch.GetAllocator())
                         .AddMember(rapidjson::StringRef("path"), AZStd::move(path), m_undoPatch.GetAllocator())
@@ -119,13 +118,8 @@ namespace AzToolsFramework
 
                 if (cachedDom.has_value())
                 {
-                    // Create a copy of the DOM of the end state so that it shares the lifecycle of the cached DOM.
-                    PrefabDom endStateCopy;
-                    endStateCopy.CopyFrom(endState, cachedDom->get().GetAllocator());
                     Prefab::PrefabDomPath entityPathInDom(entityAliasPath.c_str());
-
-                    // Update the cached instance DOM corresponding to the entity so that the same modified entity isn't reloaded again.
-                    entityPathInDom.Set(cachedDom->get(), AZStd::move(endStateCopy));
+                    entityPathInDom.Set(cachedDom->get(), endState);
                 }
             }
         }

--- a/Code/Framework/AzToolsFramework/Tests/MetadataManagerTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/MetadataManagerTests.cpp
@@ -310,7 +310,7 @@ namespace UnitTest
         EXPECT_TRUE(m_metadata->GetValueVersion("mockfile", "/Test", version));
         EXPECT_EQ(version, 1);
 
-        rapidjson_ly::Document inValue;
+        rapidjson::Document inValue;
         EXPECT_TRUE(m_metadata->GetJson("mockfile", "/Test", inValue));
 
         auto intItr = inValue.FindMember("int");

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestData.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestData.cpp
@@ -22,6 +22,8 @@ namespace UnitTest
     {
         m_name = other.m_name;
         m_source = other.m_source;
+        // copyfrom does not free existing memory, so force this to occur:
+        m_patches = AzToolsFramework::Prefab::PrefabDom();
         m_patches.CopyFrom(other.m_patches, m_patches.GetAllocator());
         return *this;
     }

--- a/Gems/AWSCore/Code/Include/Framework/JsonWriter.h
+++ b/Gems/AWSCore/Code/Include/Framework/JsonWriter.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/std/string/string.h>
+#include <AzCore/std/containers/vector.h>
 #include <AzCore/JSON/writer.h>
 #include <aws/core/utils/memory/stl/AWSStreamFwd.h>
 

--- a/Gems/GraphCanvas/Code/Source/Translation/TranslationDatabase.h
+++ b/Gems/GraphCanvas/Code/Source/Translation/TranslationDatabase.h
@@ -14,9 +14,9 @@
 #include <AzFramework/Asset/GenericAssetHandler.h>
 #include <AzFramework/Asset/AssetCatalogBus.h>
 
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/prettywriter.h>
-#include <rapidjson/rapidjson.h>
+#include <AzCore/JSON/stringbuffer.h>
+#include <AzCore/JSON/prettywriter.h>
+#include <AzCore/JSON/rapidjson.h>
 
 namespace GraphCanvas
 {

--- a/Gems/PhysX/Code/Editor/Source/Material/Conversion/LegacyPhysicsMaterialPrefabConversion.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Material/Conversion/LegacyPhysicsMaterialPrefabConversion.cpp
@@ -170,7 +170,7 @@ namespace PhysX
         // Fix terrain mappings, which is an array of legacy material ids, which will be converted to new material assets.
         if (auto* mappingMember = Physics::Utils::FindMemberChainInPrefabComponent({ "Configuration", "Mappings" }, component); mappingMember != nullptr)
         {
-            for (rapidjson_ly::SizeType i = 0; i < mappingMember->Size(); ++i)
+            for (rapidjson::SizeType i = 0; i < mappingMember->Size(); ++i)
             {
                 if (FixPhysicsMaterialId(prefabInfo, (*mappingMember)[i], legacyMaterialIdToNewAssetIdMap,
                     { "Material" }, { "MaterialAsset" }))

--- a/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
+++ b/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
@@ -38,7 +38,7 @@
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
-#include <rapidjson/pointer.h>
+#include <AzCore/JSON/pointer.h>
 #include <SceneBuilder/SceneBuilderWorker.h>
 #include <SceneBuilder/TraceMessageHook.h>
 

--- a/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.cpp
+++ b/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.cpp
@@ -10,10 +10,10 @@
 
 #include <Source/Translation/TranslationBus.h>
 
-#include <rapidjson/rapidjson.h>
-#include <rapidjson/document.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/prettywriter.h>
+#include <AzCore/JSON/rapidjson.h>
+#include <AzCore/JSON/document.h>
+#include <AzCore/JSON/stringbuffer.h>
+#include <AzCore/JSON/prettywriter.h>
 
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/IO/SystemFile.h>
@@ -1082,15 +1082,15 @@ namespace ScriptCanvasEditorTools
 
     void TranslationGeneration::SaveJSONData(const AZStd::string& filename, TranslationFormat& translationRoot)
     {
-        rapidjson_ly::Document document;
+        rapidjson::Document document;
         document.SetObject();
-        rapidjson_ly::Value entries(rapidjson_ly::kArrayType);
+        rapidjson::Value entries(rapidjson::kArrayType);
 
         // Here I'll need to parse translationRoot myself and produce the JSON
         for (const auto& entrySource : translationRoot.m_entries)
         {
-            rapidjson_ly::Value entry(rapidjson_ly::kObjectType);
-            rapidjson_ly::Value value(rapidjson_ly::kStringType);
+            rapidjson::Value entry(rapidjson::kObjectType);
+            rapidjson::Value value(rapidjson::kStringType);
 
             value.SetString(entrySource.m_key.c_str(), document.GetAllocator());
             entry.AddMember(GraphCanvas::Schema::Field::key, value, document.GetAllocator());
@@ -1101,7 +1101,7 @@ namespace ScriptCanvasEditorTools
             value.SetString(entrySource.m_variant.c_str(), document.GetAllocator());
             entry.AddMember(GraphCanvas::Schema::Field::variant, value, document.GetAllocator());
 
-            rapidjson_ly::Value details(rapidjson_ly::kObjectType);
+            rapidjson::Value details(rapidjson::kObjectType);
             value.SetString(entrySource.m_details.m_name.c_str(), document.GetAllocator());
             details.AddMember("name", value, document.GetAllocator());
 
@@ -1113,11 +1113,11 @@ namespace ScriptCanvasEditorTools
 
             if (!entrySource.m_methods.empty())
             {
-                rapidjson_ly::Value methods(rapidjson_ly::kArrayType);
+                rapidjson::Value methods(rapidjson::kArrayType);
 
                 for (const auto& methodSource : entrySource.m_methods)
                 {
-                    rapidjson_ly::Value theMethod(rapidjson_ly::kObjectType);
+                    rapidjson::Value theMethod(rapidjson::kObjectType);
 
                     value.SetString(methodSource.m_key.c_str(), document.GetAllocator());
                     theMethod.AddMember(GraphCanvas::Schema::Field::key, value, document.GetAllocator());
@@ -1130,7 +1130,7 @@ namespace ScriptCanvasEditorTools
 
                     if (!methodSource.m_entry.m_name.empty())
                     {
-                        rapidjson_ly::Value entrySlot(rapidjson_ly::kObjectType);
+                        rapidjson::Value entrySlot(rapidjson::kObjectType);
                         value.SetString(methodSource.m_entry.m_name.c_str(), document.GetAllocator());
                         entrySlot.AddMember("name", value, document.GetAllocator());
 
@@ -1141,7 +1141,7 @@ namespace ScriptCanvasEditorTools
 
                     if (!methodSource.m_exit.m_name.empty())
                     {
-                        rapidjson_ly::Value exitSlot(rapidjson_ly::kObjectType);
+                        rapidjson::Value exitSlot(rapidjson::kObjectType);
                         value.SetString(methodSource.m_exit.m_name.c_str(), document.GetAllocator());
                         exitSlot.AddMember("name", value, document.GetAllocator());
 
@@ -1150,7 +1150,7 @@ namespace ScriptCanvasEditorTools
                         theMethod.AddMember("exit", exitSlot, document.GetAllocator());
                     }
 
-                    rapidjson_ly::Value methodDetails(rapidjson_ly::kObjectType);
+                    rapidjson::Value methodDetails(rapidjson::kObjectType);
 
                     value.SetString(methodSource.m_details.m_name.c_str(), document.GetAllocator());
                     methodDetails.AddMember("name", value, document.GetAllocator());
@@ -1162,13 +1162,13 @@ namespace ScriptCanvasEditorTools
 
                     if (!methodSource.m_arguments.empty())
                     {
-                        rapidjson_ly::Value methodArguments(rapidjson_ly::kArrayType);
+                        rapidjson::Value methodArguments(rapidjson::kArrayType);
 
                         [[maybe_unused]] size_t index = 0;
                         for (const auto& argSource : methodSource.m_arguments)
                         {
-                            rapidjson_ly::Value argument(rapidjson_ly::kObjectType);
-                            rapidjson_ly::Value argumentDetails(rapidjson_ly::kObjectType);
+                            rapidjson::Value argument(rapidjson::kObjectType);
+                            rapidjson::Value argumentDetails(rapidjson::kObjectType);
 
                             value.SetString(argSource.m_typeId.c_str(), document.GetAllocator());
                             argument.AddMember("typeid", value, document.GetAllocator());
@@ -1192,12 +1192,12 @@ namespace ScriptCanvasEditorTools
 
                     if (!methodSource.m_results.empty())
                     {
-                        rapidjson_ly::Value methodArguments(rapidjson_ly::kArrayType);
+                        rapidjson::Value methodArguments(rapidjson::kArrayType);
 
                         for (const auto& argSource : methodSource.m_results)
                         {
-                            rapidjson_ly::Value argument(rapidjson_ly::kObjectType);
-                            rapidjson_ly::Value argumentDetails(rapidjson_ly::kObjectType);
+                            rapidjson::Value argument(rapidjson::kObjectType);
+                            rapidjson::Value argumentDetails(rapidjson::kObjectType);
 
                             value.SetString(argSource.m_typeId.c_str(), document.GetAllocator());
                             argument.AddMember("typeid", value, document.GetAllocator());
@@ -1226,16 +1226,16 @@ namespace ScriptCanvasEditorTools
 
             if (!entrySource.m_slots.empty())
             {
-                rapidjson_ly::Value slotsArray(rapidjson_ly::kArrayType);
+                rapidjson::Value slotsArray(rapidjson::kArrayType);
 
                 for (const auto& slotSource : entrySource.m_slots)
                 {
-                    rapidjson_ly::Value theSlot(rapidjson_ly::kObjectType);
+                    rapidjson::Value theSlot(rapidjson::kObjectType);
 
                     value.SetString(slotSource.m_key.c_str(), document.GetAllocator());
                     theSlot.AddMember(GraphCanvas::Schema::Field::key, value, document.GetAllocator());
 
-                    rapidjson_ly::Value sloDetails(rapidjson_ly::kObjectType);
+                    rapidjson::Value sloDetails(rapidjson::kObjectType);
                     if (!slotSource.m_details.m_name.empty())
                     {
                         Helpers::WriteString(sloDetails, "name", slotSource.m_details.m_name, document);
@@ -1245,7 +1245,7 @@ namespace ScriptCanvasEditorTools
 
                     if (!slotSource.m_data.m_details.m_name.empty())
                     {
-                        rapidjson_ly::Value slotDataDetails(rapidjson_ly::kObjectType);
+                        rapidjson::Value slotDataDetails(rapidjson::kObjectType);
                         Helpers::WriteString(slotDataDetails, "name", slotSource.m_data.m_details.m_name, document);
                         theSlot.AddMember("details", slotDataDetails, document.GetAllocator());
                     }
@@ -1293,9 +1293,9 @@ namespace ScriptCanvasEditorTools
             return;
         }
 
-        rapidjson_ly::StringBuffer scratchBuffer;
+        rapidjson::StringBuffer scratchBuffer;
 
-        rapidjson_ly::PrettyWriter<rapidjson_ly::StringBuffer> writer(scratchBuffer);
+        rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(scratchBuffer);
         document.Accept(writer);
 
         outputFile.Write(scratchBuffer.GetString(), scratchBuffer.GetSize());
@@ -1400,17 +1400,17 @@ namespace ScriptCanvasEditorTools
             return { typeID };
         }
 
-        void WriteString(rapidjson_ly::Value& owner, const AZStd::string& key, const AZStd::string& value, rapidjson_ly::Document& document)
+        void WriteString(rapidjson::Value& owner, const AZStd::string& key, const AZStd::string& value, rapidjson::Document& document)
         {
             if (key.empty() || value.empty())
             {
                 return;
             }
 
-            rapidjson_ly::Value item(rapidjson_ly::kStringType);
+            rapidjson::Value item(rapidjson::kStringType);
             item.SetString(value.c_str(), document.GetAllocator());
 
-            rapidjson_ly::Value keyVal(rapidjson_ly::kStringType);
+            rapidjson::Value keyVal(rapidjson::kStringType);
             keyVal.SetString(key.c_str(), document.GetAllocator());
 
             owner.AddMember(keyVal, item, document.GetAllocator());


### PR DESCRIPTION
## What does this PR do?
The previous attempt to wrangle the memory usage of rapidjson worked but was incompatible with all 3rd party plugins that also used rapidjson internally or shipped with their own custom version of rapidjson, becuase it modified the actual default types for rapidjson::Document, and rapidjson::Value.  While this works, the vast majority of all existing software that interfaces with rapidjson does not do that, causing all sorts of weird errors to crop up when a piece of software (for example Cesium) uses 'vanilla' rapidjson internally links to or includes headers from AzCore when it redefines basic rapidjson types such as rapidjson::Document.

Note that rapidjson::Pointer code (from the actual rapidjson library) has several bugs in it that makes it incompatible with non-default rapidjson::Document and rapidjson::Value, also, so even if we were to, for example, define our own type instead of modify the default, this would still not function.   A comment is included that explains this for future maintainers.

This change reverts the previous change to rapidjson::Document and removes the special rapidjson_ly namespace.  Instead, it works at the allocator level, so that the types remain the default types, but memory is shunted into a special rapidjson allocator so that its still tracked by the memory system.

## How was this PR tested?
Turning on the Cesium addon and ensuring it compiles without modification to any of the rapidjson stuff.  
Using Visual Studio's "Heap Capture" memory profiler to check for memory leaks or memory accumulation before and after opening levels, after performing large numbers of undo operations, after undoing them and removing the stack, etc.

With this change memory consumption is even better than before, better than even using the default non-tracked rapidjson allocators.

Note that as part of this change, several cases where rapidjson was accumulating memory were replaced with swaps and clears from default, and some places where the wrong allocator was being used were also repaired.

## other notes

The structure of rapidjson.h was modified to be forward-declaring and a companion rapidjson.cpp was added which is the only place where the system allocator header is pulled in.  This allows the inclusion of rapidjson.h very lightweight (just the rapidjson stuff itself and azcore/base.h), reducing include chain complexity significantly.
