### PR TITLE
Material Canvas: Center and show entire graph when first opened + other fixes

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Material/MaterialAssignment.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/MaterialAssignment.cpp
@@ -104,23 +104,29 @@ namespace AZ
                 return;
             }
 
-            if (m_materialAsset.IsReady())
+            if (m_materialAsset.GetId().IsValid() || m_materialAsset.IsReady())
             {
                 m_materialInstance = m_propertyOverrides.empty() ? RPI::Material::FindOrCreate(m_materialAsset) : RPI::Material::Create(m_materialAsset);
                 AZ_Error("MaterialAssignment", m_materialInstance, "Material instance not initialized");
 
-                MaterialAssignmentNotificationBus::Event(m_materialInstance->GetAssetId(), &MaterialAssignmentNotifications::OnRebuildMaterialInstance);
-
+                if (m_materialInstance)
+                {
+                    MaterialAssignmentNotificationBus::Event(
+                        m_materialAsset.GetId(), &MaterialAssignmentNotifications::OnRebuildMaterialInstance);
+                }
                 return;
             }
 
-            if (m_defaultMaterialAsset.IsReady())
+            if (m_defaultMaterialAsset.GetId().IsValid() || m_defaultMaterialAsset.IsReady())
             {
                 m_materialInstance = m_propertyOverrides.empty() ? RPI::Material::FindOrCreate(m_defaultMaterialAsset) : RPI::Material::Create(m_defaultMaterialAsset);
                 AZ_Error("MaterialAssignment", m_materialInstance, "Material instance not initialized");
 
-                MaterialAssignmentNotificationBus::Event(m_materialInstance->GetAssetId(), &MaterialAssignmentNotifications::OnRebuildMaterialInstance);
-
+                if (m_materialInstance)
+                {
+                    MaterialAssignmentNotificationBus::Event(
+                        m_defaultMaterialAsset.GetId(), &MaterialAssignmentNotifications::OnRebuildMaterialInstance);
+                }
                 return;
             }
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicNode/DynamicNodeManager.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicNode/DynamicNodeManager.h
@@ -22,9 +22,10 @@ namespace AtomToolsFramework
     {
     public:
         AZ_CLASS_ALLOCATOR(DynamicNodeManager, AZ::SystemAllocator, 0);
-        AZ_RTTI(Graph, "{0DE0A2FA-3296-4E11-AA7F-831FAFA4126F}");
-        AZ_DISABLE_COPY_MOVE(DynamicNodeManager);
+        AZ_RTTI(DynamicNodeManager, "{D5330BF2-945F-4C8B-A5CF-68145EE6CBED}");
+        static void Reflect(AZ::ReflectContext* context);
 
+        DynamicNodeManager() = default;
         DynamicNodeManager(const AZ::Crc32& toolId);
         virtual ~DynamicNodeManager();
 
@@ -36,10 +37,14 @@ namespace AtomToolsFramework
         DynamicNodeConfig GetConfigById(const AZ::Uuid& configId) const override;
         void Clear() override;
         GraphCanvas::GraphCanvasTreeItem* CreateNodePaletteTree() const override;
+        GraphModel::NodePtr CreateNodeById(GraphModel::GraphPtr graph, const AZ::Uuid& configId) override;
+        GraphModel::NodePtr CreateNodeByName(GraphModel::GraphPtr graph, const AZStd::string& name) override;
         void RegisterEditDataForSetting(const AZStd::string& settingName, const AZ::Edit::ElementData& editData) override;
         const AZ::Edit::ElementData* GetEditDataForSetting(const AZStd::string& settingName) const override;
 
     private:
+        AZ_DISABLE_COPY_MOVE(DynamicNodeManager);
+
         bool ValidateSlotConfig(const AZ::Uuid& configId, const DynamicNodeSlotConfig& slotConfig) const;
         bool ValidateSlotConfigVec(const AZ::Uuid& configId, const AZStd::vector<DynamicNodeSlotConfig>& slotConfigVec) const;
         bool IsNodeConfigLoggingEnabled() const;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicNode/DynamicNodeManagerRequestBus.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicNode/DynamicNodeManagerRequestBus.h
@@ -14,6 +14,7 @@
 #include <AzCore/std/string/string.h>
 #include <GraphCanvas/Widgets/NodePalette/TreeItems/NodePaletteTreeItem.h>
 #include <GraphModel/Model/DataType.h>
+#include <GraphModel/Model/Node.h>
 
 namespace AtomToolsFramework
 {
@@ -52,6 +53,12 @@ namespace AtomToolsFramework
 
         //! Generate the node palette tree from registered DynamicNodeConfig
         virtual GraphCanvas::GraphCanvasTreeItem* CreateNodePaletteTree() const = 0;
+
+        //! Create a dynamic node from the configuration matching the specified id.
+        virtual GraphModel::NodePtr CreateNodeById(GraphModel::GraphPtr graph, const AZ::Uuid& configId) = 0;
+
+        //! Create a dynamic node from the configuration matching the specified name.
+        virtual GraphModel::NodePtr CreateNodeByName(GraphModel::GraphPtr graph, const AZStd::string& name) = 0;
 
         //! Register dynamic edit data for dynamic node settings so that the edit context handler and attribute can be overridden for a
         //! particular settings group.

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNode.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNode.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AtomToolsFramework/DynamicNode/DynamicNode.h>
+#include <AtomToolsFramework/DynamicNode/DynamicNodeManager.h>
 #include <AtomToolsFramework/DynamicNode/DynamicNodeManagerRequestBus.h>
 #include <GraphModel/Model/Graph.h>
 #include <GraphModel/Model/GraphContext.h>
@@ -18,6 +19,7 @@ namespace AtomToolsFramework
     {
         DynamicNodeSlotConfig::Reflect(context);
         DynamicNodeConfig::Reflect(context);
+        DynamicNodeManager::Reflect(context);
 
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodePaletteItem.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicNode/DynamicNodePaletteItem.cpp
@@ -47,8 +47,8 @@ namespace AtomToolsFramework
                 // Handle undo/redo adding a single node. This will need to be done at a higher level for multiple nodes.
                 GraphCanvas::ScopedGraphUndoBatch undoBatch(graphCanvasSceneId);
 
-                GraphModelIntegration::GraphControllerRequestBus::Event(
-                    graphCanvasSceneId, &GraphModelIntegration::GraphControllerRequests::AddNode, node, dropPosition);
+                GraphModelIntegration::GraphControllerRequestBus::EventResult(
+                    m_createdNodeId, graphCanvasSceneId, &GraphModelIntegration::GraphControllerRequests::AddNode, node, dropPosition);
                 return true;
             }
         }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/GraphView/GraphView.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/GraphView/GraphView.cpp
@@ -92,15 +92,20 @@ namespace AtomToolsFramework
         m_sceneContextMenu = aznew GraphCanvas::SceneContextMenu(m_toolId, this);
         m_sceneContextMenu->AddNodePaletteMenuAction(nodePaletteConfig);
 
-        // Set up style sheet to fix highlighting in the node palette
-        AzQtComponents::StyleManager::setStyleSheet(
-            const_cast<GraphCanvas::NodePaletteWidget*>(m_sceneContextMenu->GetNodePalette()), QStringLiteral(":/GraphView/GraphView.qss"));
-
         // Setup the context menu with node palette for proposing a new node
         // when dropping a connection in an empty space in the graph
         nodePaletteConfig.m_rootTreeItem = m_graphViewConfig.m_createNodeTreeItemsFn(m_toolId);
         m_createNodeProposalContextMenu = aznew GraphCanvas::EditorContextMenu(m_toolId, this);
         m_createNodeProposalContextMenu->AddNodePaletteMenuAction(nodePaletteConfig);
+
+        // Set up style sheet to fix highlighting in node palettes
+        AzQtComponents::StyleManager::setStyleSheet(
+            const_cast<GraphCanvas::NodePaletteWidget*>(m_sceneContextMenu->GetNodePalette()),
+            QStringLiteral(":/GraphView/GraphView.qss"));
+
+        AzQtComponents::StyleManager::setStyleSheet(
+            const_cast<GraphCanvas::NodePaletteWidget*>(m_createNodeProposalContextMenu->GetNodePalette()),
+            QStringLiteral(":/GraphView/GraphView.qss"));
 
         CreateActions();
 

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/color.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/color.materialgraphnode
@@ -16,7 +16,7 @@
                 "name": "inValue",
                 "displayName": "Value",
                 "description": "Value",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[14]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "color",
                 "defaultValue": {
                     "$type": "Color",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float3.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float3.materialgraphnode
@@ -16,7 +16,7 @@
                 "name": "inValue",
                 "displayName": "Value",
                 "description": "Value",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[134]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float3",
                 "defaultValue": {
                     "$type": "Vector3",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float3x3.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float3x3.materialgraphnode
@@ -16,7 +16,7 @@
                 "name": "inRow1",
                 "displayName": "Row1",
                 "description": "Row1",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[134]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float3",
                 "defaultValue": {
                     "$type": "Vector3",
@@ -36,7 +36,7 @@
                 "name": "inRow2",
                 "displayName": "Row2",
                 "description": "Row2",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[134]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float3",
                 "defaultValue": {
                     "$type": "Vector3",
@@ -56,7 +56,7 @@
                 "name": "inRow3",
                 "displayName": "Row3",
                 "description": "Row3",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[134]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float3",
                 "defaultValue": {
                     "$type": "Vector3",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float4.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float4.materialgraphnode
@@ -16,7 +16,7 @@
                 "name": "inValue",
                 "displayName": "Value",
                 "description": "Value",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[14]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float4",
                 "defaultValue": {
                     "$type": "Vector4",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float4x3.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float4x3.materialgraphnode
@@ -16,7 +16,7 @@
                 "name": "inRow1",
                 "displayName": "Row1",
                 "description": "Row1",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[14]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float4",
                 "defaultValue": {
                     "$type": "Vector4",
@@ -37,7 +37,7 @@
                 "name": "inRow2",
                 "displayName": "Row2",
                 "description": "Row2",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[14]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float4",
                 "defaultValue": {
                     "$type": "Vector4",
@@ -58,7 +58,7 @@
                 "name": "inRow3",
                 "displayName": "Row3",
                 "description": "Row3",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[14]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float4",
                 "defaultValue": {
                     "$type": "Vector4",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float4x4.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Constants/float4x4.materialgraphnode
@@ -16,7 +16,7 @@
                 "name": "inRow1",
                 "displayName": "Row1",
                 "description": "Row1",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[14]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float4",
                 "defaultValue": {
                     "$type": "Vector4",
@@ -37,7 +37,7 @@
                 "name": "inRow2",
                 "displayName": "Row2",
                 "description": "Row2",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[14]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float4",
                 "defaultValue": {
                     "$type": "Vector4",
@@ -58,7 +58,7 @@
                 "name": "inRow3",
                 "displayName": "Row3",
                 "description": "Row3",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[14]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float4",
                 "defaultValue": {
                     "$type": "Vector4",
@@ -79,7 +79,7 @@
                 "name": "inRow4",
                 "displayName": "Row4",
                 "description": "Row4",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[14]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float4",
                 "defaultValue": {
                     "$type": "Vector4",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/cross.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/cross.materialgraphnode
@@ -15,7 +15,7 @@
                 "name": "inValue1",
                 "displayName": "Value1",
                 "description": "Value1",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[134]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float3",
                 "defaultValue": {
                     "$type": "Vector3",
@@ -35,7 +35,7 @@
                 "name": "inValue2",
                 "displayName": "Value2",
                 "description": "Value2",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[134]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float3",
                 "defaultValue": {
                     "$type": "Vector3",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/split3.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/split3.materialgraphnode
@@ -16,7 +16,7 @@
                 "name": "inValue",
                 "displayName": "Value",
                 "description": "Value",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[134]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float3",
                 "defaultValue": {
                     "$type": "Vector3",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/transform3.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/transform3.materialgraphnode
@@ -16,7 +16,7 @@
                 "name": "inVector",
                 "displayName": "Vector",
                 "description": "Vector",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[134]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float3",
                 "defaultValue": {
                     "$type": "Vector3",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/transform4.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/transform4.materialgraphnode
@@ -16,7 +16,7 @@
                 "name": "inVector",
                 "displayName": "Vector",
                 "description": "Vector",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[14]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float4",
                 "defaultValue": {
                     "$type": "Vector4",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialTemplates/ExperimentalPBR/experimental_pbr.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialTemplates/ExperimentalPBR/experimental_pbr.materialgraphnode
@@ -40,7 +40,7 @@
                 "name": "inPositionOffset",
                 "displayName": "Position Offset",
                 "description": "Position Offset",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[134]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float3",
                 "defaultValue": {
                     "$type": "Vector3",
@@ -61,7 +61,7 @@
                 "name": "inBaseColor",
                 "displayName": "Base Color",
                 "description": "Base Color",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[134]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float3",
                 "defaultValue": {
                     "$type": "Vector3",
@@ -133,7 +133,7 @@
                 "name": "inEmissive",
                 "displayName": "Emissive",
                 "description": "Emissive",
-                "supportedDataTypeRegex": "color|(bool|int|uint|float)[134]?",
+                "supportedDataTypeRegex": "color|(bool|int|uint|float)[1-4]?",
                 "defaultDataType": "float3",
                 "defaultValue": {
                     "$type": "Vector3",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialTemplates/ExperimentalPBR/experimental_pbr.materialgraphtemplate
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/MaterialTemplates/ExperimentalPBR/experimental_pbr.materialgraphtemplate
@@ -277,7 +277,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "MaterialTemplateNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -305,7 +305,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "TexturingNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -389,12 +389,12 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "ObjectNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -340.0,
+                                    -480.0,
                                     -180.0
                                 ]
                             },

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test1.materialgraph
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test1.materialgraph
@@ -38,7 +38,7 @@
                             "Value": {
                                 "m_value": {
                                     "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
-                                    "Value": "dfrytrtrtft  43ewq   `1`1``1              "
+                                    "Value": ""
                                 }
                             }
                         },
@@ -472,12 +472,12 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "MaterialInputNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    560.0,
+                                    800.0,
                                     60.0
                                 ]
                             },
@@ -500,13 +500,13 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "MaterialTemplateNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
                                     1100.0,
-                                    -80.0
+                                    -60.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -528,12 +528,12 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "ConstantNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    380.0,
+                                    440.0,
                                     -160.0
                                 ]
                             },

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test2.materialgraph
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test2.materialgraph
@@ -454,7 +454,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "MaterialTemplateNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -530,7 +530,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "TimeNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -558,7 +558,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "MathNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -586,7 +586,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "ConstantNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -614,7 +614,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "MathNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -642,7 +642,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "ConstantNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -670,7 +670,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "MathNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -698,7 +698,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "MathNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test3.materialgraph
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test3.materialgraph
@@ -277,12 +277,12 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "MaterialTemplateNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    120.0,
+                                    260.0,
                                     -180.0
                                 ]
                             },
@@ -305,12 +305,12 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "TexturingNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -180.0,
+                                    -40.0,
                                     -180.0
                                 ]
                             },
@@ -389,7 +389,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "ObjectNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test4.materialgraph
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test4.materialgraph
@@ -579,7 +579,7 @@
                                 "$type": "GeometrySaveData",
                                 "Position": [
                                     800.0,
-                                    -100.0
+                                    -120.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test4.materialgraph
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test4.materialgraph
@@ -573,13 +573,13 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "ObjectNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    240.0,
-                                    -120.0
+                                    800.0,
+                                    -100.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -601,12 +601,12 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "MaterialTemplateNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    420.0,
+                                    980.0,
                                     -380.0
                                 ]
                             },
@@ -629,12 +629,12 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "TexturingNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    100.0,
+                                    660.0,
                                     -380.0
                                 ]
                             },
@@ -657,12 +657,12 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "ObjectNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    -60.0,
+                                    360.0,
                                     -380.0
                                 ]
                             },

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test5.materialgraph
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test5.materialgraph
@@ -817,7 +817,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "MaterialTemplateNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -845,7 +845,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "ConstantNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -873,7 +873,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "ConstantNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -901,7 +901,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "TimeNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -929,7 +929,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "MathNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -957,7 +957,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "MathNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -985,7 +985,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "MathNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -1013,7 +1013,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "MathNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -1041,7 +1041,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "MathNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -1093,7 +1093,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "MathNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -1121,7 +1121,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "ObjectNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -1205,7 +1205,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "MathNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -1233,7 +1233,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "TexturingNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
@@ -1261,7 +1261,7 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "DefaultNodeTitlePalette"
+                                "PaletteOverride": "ObjectNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.h
@@ -54,6 +54,7 @@ namespace MaterialCanvas
         bool IsModified() const override;
         bool BeginEdit() override;
         bool EndEdit() override;
+        void Clear() override;
 
         // MaterialCanvasDocumentRequestBus::Handler overrides...
         GraphModel::GraphPtr GetGraph() const override;
@@ -61,13 +62,14 @@ namespace MaterialCanvas
         AZStd::string GetGraphName() const override;
         const AZStd::vector<AZStd::string>& GetGeneratedFilePaths() const override;
         bool CompileGraph() const override;
-        void BuildSlotValueTable(const AZStd::vector<GraphModel::ConstNodePtr>& allNodes) const;
         void QueueCompileGraph() const override;
         bool IsCompileGraphQueued() const override;
 
     private:
-        // AtomToolsFramework::AtomToolsDocument overrides...
-        void Clear() override;
+        void BuildSlotValueTable() const;
+        void CompileGraphStarted() const;
+        void CompileGraphFailed() const;
+        void CompileGraphCompleted() const;
 
         // GraphModelIntegration::GraphControllerNotificationBus::Handler overrides...
         void OnGraphModelSlotModified(GraphModel::SlotPtr slot) override;

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.h
@@ -108,6 +108,12 @@ namespace MaterialCanvas
         AZStd::any ConvertToVector(const AZStd::any& slotValue) const;
         AZStd::any ConvertToVector(const AZStd::any& slotValue, unsigned int score) const;
 
+        // Returns the value of the slot or the slots incoming connection if present.
+        AZStd::any GetValueFromSlot(GraphModel::ConstSlotPtr slot) const;
+
+        // Returns the value for the corresponding slot or the slot providing its input, if connected. 
+        AZStd::any GetValueFromSlotOrConnection(GraphModel::ConstSlotPtr slot) const;
+
         // Convert special slot type names, like color, into one compatible with AZSL shader code.
         AZStd::string GetAzslTypeFromSlot(GraphModel::ConstSlotPtr slot) const;
 

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocumentNotificationBus.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocumentNotificationBus.h
@@ -19,8 +19,14 @@ namespace MaterialCanvas
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
         typedef AZ::Crc32 BusIdType;
 
+        // This notification is sent whenever graph compilation has started.
+        virtual void OnCompileGraphStarted([[maybe_unused]] const AZ::Uuid& documentId){};
+
         // This notification is sent whenever graph compilation has completed.
         virtual void OnCompileGraphCompleted([[maybe_unused]] const AZ::Uuid& documentId){};
+
+        // This notification is sent whenever graph compilation has failed.
+        virtual void OnCompileGraphFailed([[maybe_unused]] const AZ::Uuid& documentId){};
     };
 
     using MaterialCanvasDocumentNotificationBus = AZ::EBus<MaterialCanvasDocumentNotifications>;

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasTestData.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasTestData.cpp
@@ -20,7 +20,7 @@ namespace MaterialCanvas
         AZStd::string baseName = AZ::RPI::AssetUtils::SanitizeFileName(nodeConfig.m_title);
         AZStd::to_lower(baseName.begin(), baseName.end());
         return AZStd::string::format(
-            "@gemroot:MaterialCanvas@/Assets/MaterialCanvas/TestData/Nodes/Functions/%s.materialgraphnode.azasset", baseName.c_str());
+            "@gemroot:MaterialCanvas@/Assets/MaterialCanvas/TestData/Nodes/Functions/%s.materialgraphnode", baseName.c_str());
     }
 
     void CreateTestNodes()

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasGraphView.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasGraphView.cpp
@@ -21,6 +21,7 @@ namespace MaterialCanvas
     {
         AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler::BusConnect(m_toolId);
         OnDocumentOpened(m_documentId);
+        m_openedBefore = false;
     }
 
     MaterialCanvasGraphView::~MaterialCanvasGraphView()
@@ -30,13 +31,25 @@ namespace MaterialCanvas
 
     void MaterialCanvasGraphView::OnDocumentOpened(const AZ::Uuid& documentId)
     {
-        GraphCanvas::GraphId activeGraphId = GraphCanvas::GraphId();
         if (m_documentId == documentId)
         {
+            GraphCanvas::GraphId activeGraphId = GraphCanvas::GraphId();
             MaterialCanvasDocumentRequestBus::EventResult(
                 activeGraphId, m_documentId, &MaterialCanvasDocumentRequestBus::Events::GetGraphId);
+            SetActiveGraphId(activeGraphId, true);
+
+            // Show the entire graph and center the view the first time a graph is opened
+            if (!m_openedBefore && activeGraphId.IsValid())
+            {
+                GraphCanvas::ViewId viewId;
+                GraphCanvas::SceneRequestBus::EventResult(viewId, activeGraphId, &GraphCanvas::SceneRequests::GetViewId);
+                GraphCanvas::ViewRequestBus::Event(viewId, &GraphCanvas::ViewRequests::ShowEntireGraph);
+                m_openedBefore = true;
+            }
+            return;
         }
-        SetActiveGraphId(activeGraphId, m_documentId == documentId);
+
+        SetActiveGraphId(GraphCanvas::GraphId(), false);
     }
 
     void MaterialCanvasGraphView::OnDocumentClosed([[maybe_unused]] const AZ::Uuid& documentId)

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasGraphView.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasGraphView.h
@@ -39,5 +39,6 @@ namespace MaterialCanvas
         void OnDocumentDestroyed(const AZ::Uuid& documentId) override;
 
         const AZ::Uuid m_documentId;
+        bool m_openedBefore = false;
     };
 } // namespace MaterialCanvas

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.h
@@ -26,14 +26,14 @@ namespace AZ
             static constexpr AZStd::string_view MaterialExtension("material");
             static constexpr AZStd::string_view MaterialTypeExtension("materialtype");
             static constexpr AZStd::string_view MaterialGraphExtension("materialgraph");
-            static constexpr AZStd::string_view MaterialGraphNodeExtension("materialgraphnoode");
+            static constexpr AZStd::string_view MaterialGraphNodeExtension("materialgraphnode");
             static constexpr AZStd::string_view MaterialGraphTemplateExtension("materialgraphtemplate");
             static constexpr AZStd::string_view ShaderExtension("shader");
 
             static constexpr AZStd::string_view MaterialExtensionWithDot(".material");
             static constexpr AZStd::string_view MaterialTypeExtensionWithDot(".materialtype");
             static constexpr AZStd::string_view MaterialGraphExtensionWithDot(".materialgraph");
-            static constexpr AZStd::string_view MaterialGraphNodeExtensionWithDot(".materialgraphnoode");
+            static constexpr AZStd::string_view MaterialGraphNodeExtensionWithDot(".materialgraphnode");
             static constexpr AZStd::string_view MaterialGraphTemplateExtensionWithDot(".materialgraphtemplate");
             static constexpr AZStd::string_view ShaderExtensionWithDot(".shader");
 

--- a/Gems/GraphModel/Code/Source/Model/Slot.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Slot.cpp
@@ -412,25 +412,7 @@ namespace GraphModel
 
     AZStd::any Slot::GetValue() const
     {
-        if (SupportsValues() && SupportsConnections())
-        {
-            for (const auto& connection : GetGraph()->GetConnections())
-            {
-                const auto& sourceSlot = connection->GetSourceSlot();
-                const auto& targetSlot = connection->GetTargetSlot();
-                if (targetSlot && sourceSlot && targetSlot != sourceSlot && targetSlot.get() == this)
-                {
-                    return sourceSlot->GetValue();
-                }
-            }
-        }
-
-        if (!m_value.empty())
-        {
-            return m_value;
-        }
-
-        return GetDefaultValue();
+        return !m_value.empty() ? m_value : GetDefaultValue();
     }
 
     Slot::ConnectionList Slot::GetConnections() const


### PR DESCRIPTION
## What does this PR do?

Updates the material canvas graph view to show the entire graph after it is first opened. Prior to this, the user could potentially open a graph and see nothing at all if all of the nodes were off screen.

Fixed a typo, by removing an extra O, from one of the extension constant variables added to the last iteration of the last PR.

## How was this PR tested?

Open multiple graphs to see them centered instead of off screen as usual.