### PR TITLE
Temporarily bring bitangent back in vertex shader to fix the screenshot test

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_VertexData.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_VertexData.azsli
@@ -25,7 +25,8 @@ struct VsInput_BasePBR
     float3 position : POSITION;
     float3 normal : NORMAL;
     float4 tangent : TANGENT;
- 
+    float3 bitangent : BITANGENT;
+
     // Extended fields (only referenced in this azsl file)...
     float2 uv0 : UV0;
     float2 uv1 : UV1;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_VertexData.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_VertexData.azsli
@@ -25,6 +25,7 @@ struct VsInput_BasePBR
     float3 position : POSITION;
     float3 normal : NORMAL;
     float4 tangent : TANGENT;
+    // Bitangent is temporarily added back to fix the eye material screenshot test.
     float3 bitangent : BITANGENT;
 
     // Extended fields (only referenced in this azsl file)...

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_PixelGeometryEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_PixelGeometryEval.azsli
@@ -81,6 +81,7 @@ PixelGeometryData EvaluatePixelGeometry_Eye(VsOutput IN, bool isFrontFace)
 
     float3 vertexNormal, vertexTangent, vertexBitangent;
     ConstructTBN(IN.normal, IN.tangent, objectToWorld, objectToWorldIT, vertexNormal, vertexTangent, vertexBitangent);
+    vertexBitangent = normalize(mul(objectToWorld, float4(IN.bitangent, 0.0)).xyz);
 
     return EvaluatePixelGeometry_Eye(
         IN.worldPosition,

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_PixelGeometryEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_PixelGeometryEval.azsli
@@ -81,6 +81,7 @@ PixelGeometryData EvaluatePixelGeometry_Eye(VsOutput IN, bool isFrontFace)
 
     float3 vertexNormal, vertexTangent, vertexBitangent;
     ConstructTBN(IN.normal, IN.tangent, objectToWorld, objectToWorldIT, vertexNormal, vertexTangent, vertexBitangent);
+    // Bitangent is temporarily added back to fix the eye material screenshot test.
     vertexBitangent = normalize(mul(objectToWorld, float4(IN.bitangent, 0.0)).xyz);
 
     return EvaluatePixelGeometry_Eye(

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_VertexData.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_VertexData.azsli
@@ -21,6 +21,7 @@ struct VSOutput_Eye
     float4 position : SV_Position;
     float3 normal: NORMAL;
     float4 tangent : TANGENT;
+    float3 bitangent : BITANGENT;
     float3 worldPosition : UV0;
     float2 uvs[UvSetCount] : UV1;
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_VertexEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_VertexEval.azsli
@@ -21,6 +21,7 @@ VsOutput EvaluateVertexGeometry_Eye(
     float3 position,
     float3 normal,
     float4 tangent,
+    float3 bitangent,
     float2 uv0,
     float2 uv1)
 {
@@ -36,6 +37,7 @@ VsOutput EvaluateVertexGeometry_Eye(
 
     output.normal = normal;
     output.tangent = tangent;
+    output.bitangent = bitangent;
 
     output.localPosition = position.xyz;
 
@@ -48,6 +50,7 @@ VsOutput EvaluateVertexGeometry_Eye(VsInput IN)
         IN.position,
         IN.normal,
         IN.tangent,
+        IN.bitangent,
         IN.uv0,
         IN.uv1);
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_VertexEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_VertexEval.azsli
@@ -37,6 +37,7 @@ VsOutput EvaluateVertexGeometry_Eye(
 
     output.normal = normal;
     output.tangent = tangent;
+    // Bitangent is temporarily added back to fix the eye material screenshot test.
     output.bitangent = bitangent;
 
     output.localPosition = position.xyz;


### PR DESCRIPTION
Signed-off-by: jiaweig <51759646+jiaweig-amzn@users.noreply.github.com>

## What does this PR do?

The calculated bitangent seems to be inconsistent from the vertex stream. Bring the bitangent back before further investigation to determine the correctness of the bitangent.

## How was this PR tested?

The test should pass with little difference.
![eye](https://user-images.githubusercontent.com/51759646/201427689-9757abd7-eb43-4fed-983c-0d8b5e735354.JPG)

And for reference:
Before and after this change:
https://github.com/o3de/o3de/pull/12173
Calculated TBN in vertex shader:
![BeforeTBNChange](https://user-images.githubusercontent.com/51759646/201428121-537f2e86-fe77-4ea7-875d-a9c4171b922a.JPG)
Calculated TBN in pixel shader:
![AfterTBNChange](https://user-images.githubusercontent.com/51759646/201428128-ddf95f1b-d3e6-49fe-988a-21ac7912ca9c.JPG)
