### PR TITLE
Add AttachSubTree and DetachSubTree functions for AZ::Dom::DomPrefixTree

### DIFF
--- a/Code/Framework/AzCore/AzCore/DOM/DomPrefixTree.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPrefixTree.h
@@ -133,7 +133,7 @@ namespace AZ::Dom
         //! @param path The path which corresponds to the node at which the subtree should be attached.
         //! @param subTree The subtree to attach at the provided path.
         //! @return True if the subTree was attached successfully. Return false otherwise.
-        bool AttachSubTree(const Path& path, const DomPrefixTree& subTree);
+        bool AttachSubTree(const Path& path, DomPrefixTree&& subTree);
         //! Removes all entries from this tree.
         void Clear();
 
@@ -162,7 +162,7 @@ namespace AZ::Dom
         //! @param path The path which corresponds to the node at which the subtree should be attached.
         //! @param node The node to be attached.
         //! @return True if the node was attached successfully. Return false otherwise.
-        bool AttachNodeAtPath(const Path& path, const Node& node);
+        bool AttachNodeAtPath(const Path& path, Node&& node);
 
         Node m_rootNode;
     };

--- a/Code/Framework/AzCore/AzCore/DOM/DomPrefixTree.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPrefixTree.h
@@ -137,6 +137,9 @@ namespace AZ::Dom
         //! Removes all entries from this tree.
         void Clear();
 
+        //! Returns true if the root node is empty.
+        bool IsEmpty() const;
+
     private:
         struct Node
         {

--- a/Code/Framework/AzCore/AzCore/DOM/DomPrefixTree.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPrefixTree.h
@@ -122,6 +122,18 @@ namespace AZ::Dom
         void SetValue(const Path& path, Deduced&& value);
         //! Removes the value stored at path. If removeChildren is true, also removes any values stored at subpaths.
         void EraseValue(const Path& path, bool removeChildren = false);
+
+        //! Detaches a sub tree whose root node matches the provided path.
+        //! The detach operation removes the node and its children from the existing tree.
+        //! @param path The path which corresponds to the root node of the subtree to be detached.
+        //! @return The DomPrefixTree that is detached.
+        DomPrefixTree<T> DetachSubTree(const Path& path);
+
+        //! Attaches a subtree provided at the node that matches the provided path. Attaching will overwrite the node at the path.
+        //! @param path The path which corresponds to the node at which the subtree should be attached.
+        //! @param subTree The subtree to attach at the provided path.
+        //! @return True if the subTree was attached successfully. Return false otherwise.
+        bool AttachSubTree(const Path& path, const DomPrefixTree& subTree);
         //! Removes all entries from this tree.
         void Clear();
 
@@ -130,10 +142,27 @@ namespace AZ::Dom
         {
             AZStd::unordered_map<PathEntry, Node> m_values;
             AZStd::optional<T> m_data;
+
+            bool IsEmpty() const;
         };
+
+        //! Since Node is an internal private struct in this class, this constructor that uses Node is also private.
+        explicit DomPrefixTree(Node&& node);
 
         Node* GetNodeForPath(const Path& path);
         const Node* GetNodeForPath(const Path& path) const;
+
+        //! Detaches the node that matches the provided path.
+        //! The detach operation removes the node and its children from the existing tree.
+        //! @param path The path at which the node should be detached.
+        //! @return The Node that is detached.
+        Node DetachNodeAtPath(const Path& path);
+
+        //! Attaches a node that matches the provided path. Attaching will overwrite the node at the path.
+        //! @param path The path which corresponds to the node at which the subtree should be attached.
+        //! @param node The node to be attached.
+        //! @return True if the node was attached successfully. Return false otherwise.
+        bool AttachNodeAtPath(const Path& path, const Node& node);
 
         Node m_rootNode;
     };

--- a/Code/Framework/AzCore/AzCore/DOM/DomPrefixTree.inl
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPrefixTree.inl
@@ -48,9 +48,66 @@ namespace AZ::Dom
     }
 
     template<class T>
+    DomPrefixTree<T>::DomPrefixTree(Node&& node)
+    {
+        m_rootNode = AZStd::move(node);
+    }
+
+    template<class T>
+    bool DomPrefixTree<T>::DomPrefixTree::Node::IsEmpty() const
+    {
+        return (m_values.empty() && m_data);
+    }
+
+    template<class T>
     auto DomPrefixTree<T>::GetNodeForPath(const Path& path) -> Node*
     {
         return const_cast<Node*>(AZStd::as_const(*this).GetNodeForPath(path));
+    }
+
+    template<class T>
+    auto DomPrefixTree<T>::DetachNodeAtPath(const Path& path) -> Node
+    {
+        Node* node = &m_rootNode;
+        const size_t entriesToIterate = path.Size() - 1;
+        for (size_t i = 0; i < entriesToIterate; ++i)
+        {
+            const PathEntry& entry = path[i];
+            auto nodeIt = node->m_values.find(entry);
+            if (nodeIt == node->m_values.end())
+            {
+                return Node();
+            }
+            node = &nodeIt->second;
+        }
+        auto nodeIt = node->m_values.find(path[path.Size() - 1]);
+        if (nodeIt != node->m_values.end())
+        {
+            Node detachedNode = AZStd::move(nodeIt->second);
+            node->m_values.erase(nodeIt);
+            return detachedNode;
+        }
+        return Node();
+    }
+
+    template<class T>
+    bool DomPrefixTree<T>::AttachNodeAtPath(const Path& path, const Node& nodeToAttach)
+    {
+        Node* node = &m_rootNode;
+        const size_t entriesToIterate = path.Size() - 1;
+        for (size_t i = 0; i < entriesToIterate; ++i)
+        {
+            const PathEntry& entry = path[i];
+            auto nodeIt = node->m_values.find(entry);
+            if (nodeIt == node->m_values.end())
+            {
+                return false;
+            }
+            node = &nodeIt->second;
+        }
+
+        node->m_values[path[path.Size() - 1]] = nodeToAttach;
+        return true;
     }
 
     template<class T>
@@ -326,6 +383,24 @@ namespace AZ::Dom
                 nodeIt->second.m_data = {};
             }
         }
+    }
+
+    template<class T>
+    DomPrefixTree<T> DomPrefixTree<T>::DetachSubTree(const Path& path)
+    {
+        Node node = DetachNodeAtPath(path);
+        if (!node.IsEmpty())
+        {
+            return DomPrefixTree<T>(AZStd::move(node));
+        }
+        return DomPrefixTree<T>();
+    }
+
+    template<class T>
+    bool DomPrefixTree<T>::AttachSubTree(const Path& path, const DomPrefixTree& subTree)
+    {
+        const Node* node = subTree.GetNodeForPath(AZ::Dom::Path());
+        return AttachNodeAtPath(path, *node);
     }
 
     template<class T>

--- a/Code/Framework/AzCore/AzCore/DOM/DomPrefixTree.inl
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPrefixTree.inl
@@ -91,7 +91,7 @@ namespace AZ::Dom
     }
 
     template<class T>
-    bool DomPrefixTree<T>::AttachNodeAtPath(const Path& path, const Node& nodeToAttach)
+    bool DomPrefixTree<T>::AttachNodeAtPath(const Path& path, Node&& nodeToAttach)
     {
         Node* node = &m_rootNode;
         const size_t entriesToIterate = path.Size() - 1;
@@ -106,7 +106,7 @@ namespace AZ::Dom
             node = &nodeIt->second;
         }
 
-        node->m_values[path[path.Size() - 1]] = nodeToAttach;
+        node->m_values[path[path.Size() - 1]] = AZStd::move(nodeToAttach);
         return true;
     }
 
@@ -397,10 +397,10 @@ namespace AZ::Dom
     }
 
     template<class T>
-    bool DomPrefixTree<T>::AttachSubTree(const Path& path, const DomPrefixTree& subTree)
+    bool DomPrefixTree<T>::AttachSubTree(const Path& path, DomPrefixTree&& subTree)
     {
-        const Node* node = subTree.GetNodeForPath(AZ::Dom::Path());
-        return AttachNodeAtPath(path, *node);
+        Node* node = subTree.GetNodeForPath(AZ::Dom::Path());
+        return AttachNodeAtPath(path, AZStd::move(*node));
     }
 
     template<class T>

--- a/Code/Framework/AzCore/AzCore/DOM/DomPrefixTree.inl
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPrefixTree.inl
@@ -56,7 +56,7 @@ namespace AZ::Dom
     template<class T>
     bool DomPrefixTree<T>::DomPrefixTree::Node::IsEmpty() const
     {
-        return (m_values.empty() && m_data);
+        return (m_values.empty() && !(m_data.has_value()));
     }
 
     template<class T>
@@ -407,5 +407,11 @@ namespace AZ::Dom
     void DomPrefixTree<T>::Clear()
     {
         m_rootNode = Node();
+    }
+
+    template<class T>
+    bool DomPrefixTree<T>::IsEmpty() const
+    {
+        return m_rootNode.IsEmpty();
     }
 } // namespace AZ::Dom


### PR DESCRIPTION
Signed-off-by: srikappa-amzn <82230713+srikappa-amzn@users.noreply.github.com>

## What does this PR do?
This PR adds 2 new public functions to attach and detach sub trees within an AZ::Dom::PrefixTree. It also adds a few private helper functions and a constructor to achieve this.

These functions are required in order to support several override operations for Prefabs. Once these changes are in, they will be integrated immediately with the 'prefab revert overrides' feature. The draft PR for that can be found here along with a working video of the feature: https://github.com/aws-lumberyard-dev/o3de/pull/468

## How was this PR tested?

Tested manually to accomplish a prefab feature. Once this direction is agreed upon, I'll also add unit tests to this same PR.
