### PR TITLE
fixes for editor tests in debug

### DIFF
--- a/Gems/PhysX/Code/Include/PhysX/MathConversion.h
+++ b/Gems/PhysX/Code/Include/PhysX/MathConversion.h
@@ -41,7 +41,11 @@ inline AZ::Quaternion PxMathConvert(const physx::PxQuat& pxQuat)
 
 inline AZ::Aabb PxMathConvert(const physx::PxBounds3& bounds)
 {
-    return AZ::Aabb::CreateFromMinMax(PxMathConvert(bounds.minimum), PxMathConvert(bounds.maximum));
+    if (bounds.minimum.x <= bounds.maximum.x && bounds.minimum.y <= bounds.maximum.y && bounds.minimum.z <= bounds.maximum.z)
+    {
+        return AZ::Aabb::CreateFromMinMax(PxMathConvert(bounds.minimum), PxMathConvert(bounds.maximum));
+    }
+    return AZ::Aabb::CreateNull();
 }
 
 inline physx::PxTransform PxMathConvert(const AZ::Transform& lyTransform)

--- a/Gems/PhysX/Code/Include/PhysX/MathConversion.h
+++ b/Gems/PhysX/Code/Include/PhysX/MathConversion.h
@@ -41,6 +41,7 @@ inline AZ::Quaternion PxMathConvert(const physx::PxQuat& pxQuat)
 
 inline AZ::Aabb PxMathConvert(const physx::PxBounds3& bounds)
 {
+    // check that the PhysX bounds are valid, otherwise CreateFromMinMax will assert.
     if (bounds.minimum.x <= bounds.maximum.x && bounds.minimum.y <= bounds.maximum.y && bounds.minimum.z <= bounds.maximum.z)
     {
         return AZ::Aabb::CreateFromMinMax(PxMathConvert(bounds.minimum), PxMathConvert(bounds.maximum));

--- a/Gems/PhysX/Code/Tests/EditorTestUtilities.cpp
+++ b/Gems/PhysX/Code/Tests/EditorTestUtilities.cpp
@@ -15,6 +15,7 @@
 #include <LmbrCentral/Shape/CapsuleShapeComponentBus.h>
 #include <LmbrCentral/Shape/CylinderShapeComponentBus.h>
 #include <LmbrCentral/Shape/SphereShapeComponentBus.h>
+#include <PhysX/MathConversion.h>
 #include <PhysX/PhysXLocks.h>
 #include <PhysXCharacters/Components/EditorCharacterControllerComponent.h>
 #include <RigidBodyStatic.h>
@@ -101,6 +102,20 @@ namespace PhysXEditorTests
             editorEntityId, &LmbrCentral::ShapeComponentRequests::SetTranslationOffset, translationOffset);
 
         return editorEntity;
+    }
+
+    AZ::Aabb GetSimulatedBodyAabb(AZ::EntityId entityId)
+    {
+        AzPhysics::SimulatedBody* simulatedBody = nullptr;
+        AzPhysics::SimulatedBodyComponentRequestsBus::EventResult(
+            simulatedBody, entityId, &AzPhysics::SimulatedBodyComponentRequests::GetSimulatedBody);
+        if (simulatedBody)
+        {
+            const auto* pxActor = static_cast<const physx::PxActor*>(simulatedBody->GetNativePointer());
+            PHYSX_SCENE_READ_LOCK(pxActor->getScene());
+            return PxMathConvert(pxActor->getWorldBounds(1.0f));
+        }
+        return AZ::Aabb::CreateNull();
     }
 
     void PhysXEditorFixture::SetUp()

--- a/Gems/PhysX/Code/Tests/EditorTestUtilities.h
+++ b/Gems/PhysX/Code/Tests/EditorTestUtilities.h
@@ -45,6 +45,9 @@ namespace PhysXEditorTests
     //! Creates an active editor entity with shape collider and sphere shape components.
     EntityPtr CreateSphereShapeColliderEditorEntity(const AZ::Transform& transform, float radius, const AZ::Vector3& translationOffset);
 
+    //! Gets the AABB for the simulated body on the entity with the given ID, or returns a null AABB if no body is found.
+    AZ::Aabb GetSimulatedBodyAabb(AZ::EntityId entityId);
+
     //! Class used for loading system components from this gem.
     class PhysXEditorSystemComponentEntity
         : public AZ::Entity

--- a/Gems/PhysX/Code/Tests/ShapeColliderComponentTests.cpp
+++ b/Gems/PhysX/Code/Tests/ShapeColliderComponentTests.cpp
@@ -160,12 +160,7 @@ namespace PhysXEditorTests
         AZ::Vector3 translationOffset(-4.0f, 3.0f, -1.0f);
         EntityPtr editorEntity = CreateBoxShapeColliderEditorEntity(transform, nonUniformScale, boxDimensions, translationOffset);
 
-        AzPhysics::SimulatedBody* simulatedBody = nullptr;
-        AzPhysics::SimulatedBodyComponentRequestsBus::EventResult(
-            simulatedBody, editorEntity->GetId(), &AzPhysics::SimulatedBodyComponentRequests::GetSimulatedBody);
-        const auto* pxRigidStatic = static_cast<const physx::PxRigidStatic*>(simulatedBody->GetNativePointer());
-
-        AZ::Aabb aabb = PxMathConvert(pxRigidStatic->getWorldBounds(1.0f));
+        AZ::Aabb aabb = GetSimulatedBodyAabb(editorEntity->GetId());
         EXPECT_THAT(aabb.GetMin(), UnitTest::IsClose(AZ::Vector3(-25.488f, -10.16f, -11.448f)));
         EXPECT_THAT(aabb.GetMax(), UnitTest::IsClose(AZ::Vector3(1.136f, 18.32f, 16.584f)));
     }
@@ -181,12 +176,7 @@ namespace PhysXEditorTests
         editorEntity->Deactivate();
         editorEntity->Activate();
 
-        AzPhysics::SimulatedBody* simulatedBody = nullptr;
-        AzPhysics::SimulatedBodyComponentRequestsBus::EventResult(
-            simulatedBody, editorEntity->GetId(), &AzPhysics::SimulatedBodyComponentRequests::GetSimulatedBody);
-        const auto* pxRigidDynamic = static_cast<const physx::PxRigidDynamic*>(simulatedBody->GetNativePointer());
-
-        AZ::Aabb aabb = PxMathConvert(pxRigidDynamic->getWorldBounds(1.0f));
+        AZ::Aabb aabb = GetSimulatedBodyAabb(editorEntity->GetId());
         EXPECT_THAT(aabb.GetMin(), UnitTest::IsClose(AZ::Vector3(-20.264f, 15.68f, -6.864f)));
         EXPECT_THAT(aabb.GetMax(), UnitTest::IsClose(AZ::Vector3(-7.592f, 26.0f, 6.672f)));
     }
@@ -200,12 +190,7 @@ namespace PhysXEditorTests
         EntityPtr editorEntity = CreateBoxShapeColliderEditorEntity(transform, nonUniformScale, boxDimensions, translationOffset);
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
-        AzPhysics::SimulatedBody* simulatedBody = nullptr;
-        AzPhysics::SimulatedBodyComponentRequestsBus::EventResult(
-            simulatedBody, gameEntity->GetId(), &AzPhysics::SimulatedBodyComponentRequests::GetSimulatedBody);
-        const auto* pxRigidStatic = static_cast<const physx::PxRigidStatic*>(simulatedBody->GetNativePointer());
-
-        AZ::Aabb aabb = PxMathConvert(pxRigidStatic->getWorldBounds(1.0f));
+        AZ::Aabb aabb = GetSimulatedBodyAabb(gameEntity->GetId());
         EXPECT_THAT(aabb.GetMin(), UnitTest::IsClose(AZ::Vector3(-4.8f, -14.14f, 5.265f)));
         EXPECT_THAT(aabb.GetMax(), UnitTest::IsClose(AZ::Vector3(12.4f, 15.02f, 31.895f)));
     }
@@ -219,12 +204,7 @@ namespace PhysXEditorTests
         EntityPtr editorEntity = CreateBoxShapeColliderEditorEntity(transform, nonUniformScale, boxDimensions, translationOffset);
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
-        AzPhysics::SimulatedBody* simulatedBody = nullptr;
-        AzPhysics::SimulatedBodyComponentRequestsBus::EventResult(
-            simulatedBody, gameEntity->GetId(), &AzPhysics::SimulatedBodyComponentRequests::GetSimulatedBody);
-        const auto* pxRigidDynamic = static_cast<const physx::PxRigidDynamic*>(simulatedBody->GetNativePointer());
-
-        AZ::Aabb aabb = PxMathConvert(pxRigidDynamic->getWorldBounds(1.0f));
+        AZ::Aabb aabb = GetSimulatedBodyAabb(gameEntity->GetId());
         EXPECT_THAT(aabb.GetMin(), UnitTest::IsClose(AZ::Vector3(-1.664f, -8.352f, -0.88f)));
         EXPECT_THAT(aabb.GetMax(), UnitTest::IsClose(AZ::Vector3(9.536f, 2.848f, 9.04f)));
     }
@@ -237,12 +217,7 @@ namespace PhysXEditorTests
             AZ::Vector3(2.0f, 3.0f, -7.0f)
         );
 
-        AzPhysics::SimulatedBody* simulatedBody = nullptr;
-        AzPhysics::SimulatedBodyComponentRequestsBus::EventResult(
-            simulatedBody, editorEntity->GetId(), &AzPhysics::SimulatedBodyComponentRequests::GetSimulatedBody);
-        const auto* pxRigidStatic = static_cast<const physx::PxRigidStatic*>(simulatedBody->GetNativePointer());
-
-        AZ::Aabb aabb = PxMathConvert(pxRigidStatic->getWorldBounds(1.0f));
+        AZ::Aabb aabb = GetSimulatedBodyAabb(editorEntity->GetId());
         EXPECT_THAT(aabb.GetMin(), UnitTest::IsClose(AZ::Vector3(22.12f, -7.24f, -10.4f)));
         EXPECT_THAT(aabb.GetMax(), UnitTest::IsClose(AZ::Vector3(31.72f, 2.36f, -0.8f)));
     }
@@ -258,12 +233,7 @@ namespace PhysXEditorTests
         editorEntity->Deactivate();
         editorEntity->Activate();
 
-        AzPhysics::SimulatedBody* simulatedBody = nullptr;
-        AzPhysics::SimulatedBodyComponentRequestsBus::EventResult(
-            simulatedBody, editorEntity->GetId(), &AzPhysics::SimulatedBodyComponentRequests::GetSimulatedBody);
-        const auto* pxRigidDynamic = static_cast<const physx::PxRigidDynamic*>(simulatedBody->GetNativePointer());
-
-        AZ::Aabb aabb = PxMathConvert(pxRigidDynamic->getWorldBounds(1.0f));
+        AZ::Aabb aabb = GetSimulatedBodyAabb(editorEntity->GetId());
         EXPECT_THAT(aabb.GetMin(), UnitTest::IsClose(AZ::Vector3(0.2f, -7.44f, -6.68f)));
         EXPECT_THAT(aabb.GetMax(), UnitTest::IsClose(AZ::Vector3(3.0f, -4.64f, -3.88f)));
     }
@@ -278,12 +248,7 @@ namespace PhysXEditorTests
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
-        AzPhysics::SimulatedBody* simulatedBody = nullptr;
-        AzPhysics::SimulatedBodyComponentRequestsBus::EventResult(
-            simulatedBody, gameEntity->GetId(), &AzPhysics::SimulatedBodyComponentRequests::GetSimulatedBody);
-        const auto* pxRigidStatic = static_cast<const physx::PxRigidStatic*>(simulatedBody->GetNativePointer());
-
-        AZ::Aabb aabb = PxMathConvert(pxRigidStatic->getWorldBounds(1.0f));
+        AZ::Aabb aabb = GetSimulatedBodyAabb(gameEntity->GetId());
         EXPECT_THAT(aabb.GetMin(), UnitTest::IsClose(AZ::Vector3(-12.032f, 5.92f, 17.624f)));
         EXPECT_THAT(aabb.GetMax(), UnitTest::IsClose(AZ::Vector3(-2.432f, 15.52f, 27.224f)));
     }
@@ -298,12 +263,7 @@ namespace PhysXEditorTests
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
-        AzPhysics::SimulatedBody* simulatedBody = nullptr;
-        AzPhysics::SimulatedBodyComponentRequestsBus::EventResult(
-            simulatedBody, gameEntity->GetId(), &AzPhysics::SimulatedBodyComponentRequests::GetSimulatedBody);
-        const auto* pxRigidDynamic = static_cast<const physx::PxRigidDynamic*>(simulatedBody->GetNativePointer());
-
-        AZ::Aabb aabb = PxMathConvert(pxRigidDynamic->getWorldBounds(1.0f));
+        AZ::Aabb aabb = GetSimulatedBodyAabb(gameEntity->GetId());
         EXPECT_THAT(aabb.GetMin(), UnitTest::IsClose(AZ::Vector3(38.6f, -16.0f, 3.2f)));
         EXPECT_THAT(aabb.GetMax(), UnitTest::IsClose(AZ::Vector3(42.6f, -12.0f, 7.2f)));
     }
@@ -317,12 +277,7 @@ namespace PhysXEditorTests
             AZ::Vector3(2.0f, 3.0f, 5.0f)
         );
 
-        AzPhysics::SimulatedBody* simulatedBody = nullptr;
-        AzPhysics::SimulatedBodyComponentRequestsBus::EventResult(
-            simulatedBody, editorEntity->GetId(), &AzPhysics::SimulatedBodyComponentRequests::GetSimulatedBody);
-        const auto* pxRigidStatic = static_cast<const physx::PxRigidStatic*>(simulatedBody->GetNativePointer());
-
-        AZ::Aabb aabb = PxMathConvert(pxRigidStatic->getWorldBounds(1.0f));
+        AZ::Aabb aabb = GetSimulatedBodyAabb(editorEntity->GetId());
         EXPECT_THAT(aabb.GetMin(), UnitTest::IsClose(AZ::Vector3(-16.56f, 9.8f, -7.92f)));
         EXPECT_THAT(aabb.GetMax(), UnitTest::IsClose(AZ::Vector3(7.12f, 38.6f, 13.84f)));
     }
@@ -339,12 +294,7 @@ namespace PhysXEditorTests
         editorEntity->Deactivate();
         editorEntity->Activate();
 
-        AzPhysics::SimulatedBody* simulatedBody = nullptr;
-        AzPhysics::SimulatedBodyComponentRequestsBus::EventResult(
-            simulatedBody, editorEntity->GetId(), &AzPhysics::SimulatedBodyComponentRequests::GetSimulatedBody);
-        const auto* pxRigidDynamic = static_cast<const physx::PxRigidDynamic*>(simulatedBody->GetNativePointer());
-
-        AZ::Aabb aabb = PxMathConvert(pxRigidDynamic->getWorldBounds(1.0f));
+        AZ::Aabb aabb = GetSimulatedBodyAabb(editorEntity->GetId());
         EXPECT_THAT(aabb.GetMin(), UnitTest::IsClose(AZ::Vector3(5.5f, -10.816f, 2.688f)));
         EXPECT_THAT(aabb.GetMax(), UnitTest::IsClose(AZ::Vector3(6.5f, -10.416f, 3.088f)));
     }
@@ -360,12 +310,7 @@ namespace PhysXEditorTests
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
-        AzPhysics::SimulatedBody* simulatedBody = nullptr;
-        AzPhysics::SimulatedBodyComponentRequestsBus::EventResult(
-            simulatedBody, gameEntity->GetId(), &AzPhysics::SimulatedBodyComponentRequests::GetSimulatedBody);
-        const auto* pxRigidStatic = static_cast<const physx::PxRigidStatic*>(simulatedBody->GetNativePointer());
-
-        AZ::Aabb aabb = PxMathConvert(pxRigidStatic->getWorldBounds(1.0f));
+        AZ::Aabb aabb = GetSimulatedBodyAabb(gameEntity->GetId());
         EXPECT_THAT(aabb.GetMin(), UnitTest::IsClose(AZ::Vector3(-6.4f, -6.92f, -0.36f)));
         EXPECT_THAT(aabb.GetMax(), UnitTest::IsClose(AZ::Vector3(1.28f, -1.704f, 5.528f)));
     }
@@ -381,12 +326,7 @@ namespace PhysXEditorTests
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
-        AzPhysics::SimulatedBody* simulatedBody = nullptr;
-        AzPhysics::SimulatedBodyComponentRequestsBus::EventResult(
-            simulatedBody, gameEntity->GetId(), &AzPhysics::SimulatedBodyComponentRequests::GetSimulatedBody);
-        const auto* pxRigidDynamic = static_cast<const physx::PxRigidDynamic*>(simulatedBody->GetNativePointer());
-
-        AZ::Aabb aabb = PxMathConvert(pxRigidDynamic->getWorldBounds(1.0f));
+        AZ::Aabb aabb = GetSimulatedBodyAabb(gameEntity->GetId());
         EXPECT_THAT(aabb.GetMin(), UnitTest::IsClose(AZ::Vector3(-11.0f, -7.8f, 47.4f)));
         EXPECT_THAT(aabb.GetMax(), UnitTest::IsClose(AZ::Vector3(-6.2f, 4.92f, 62.76f)));
     }


### PR DESCRIPTION
Signed-off-by: greerdv <greerdv@amazon.com>

## What does this PR do?
Fixes some newly added tests which were reading from the PhysX scene without a lock. Also fixes the conversion code from PhysX to O3DE math types for AABBs in the case when PhysX returns an invalid AABB (thanks to @SergeyAMZN for finding).

## How was this PR tested?
Ran editor unit tests in debug.