### PR TITLE
fix editor rigid body component editor world body creation

### DIFF
--- a/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
@@ -428,7 +428,6 @@ namespace PhysX
         configuration.m_position = colliderTransform.GetTranslation();
         configuration.m_entityId = GetEntityId();
         configuration.m_debugName = GetEntity()->GetName();
-        configuration.m_startSimulationEnabled = false;
         configuration.m_colliderAndShapeData = Internal::GetCollisionShapes(GetEntity());
 
         if (auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get())
@@ -442,6 +441,12 @@ namespace PhysX
                 m_config.m_mass = body->GetMass();
                 m_config.m_centerOfMassOffset = body->GetCenterOfMassLocal();
                 m_config.m_inertiaTensor = body->GetInertiaLocal();
+
+                // Set simulation disabled for this actor so it doesn't actually interact when the editor world is updated.
+                if (physx::PxActor* pxActor = static_cast<physx::PxActor*>(body->GetNativePointer()))
+                {
+                    pxActor->setActorFlag(physx::PxActorFlag::eDISABLE_SIMULATION, true);
+                }
             }
         }
         AZ_Error("EditorRigidBodyComponent",


### PR DESCRIPTION
Signed-off-by: greerdv <greerdv@amazon.com>

## What does this PR do?
Makes the editor world body created by the editor rigid body component actually get added to the editor world, but made inactive so it doesn't move when the editor world updates.

## How was this PR tested?
Tested in the editor with physx_debug on.