### PR TITLE
Fixed by checking if source or product before showing the menu

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
@@ -427,6 +427,7 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
 
     AZStd::string fullFilePath;
     AZStd::string extension;
+    bool selectionIsSource{ true };
 
     switch (entry->GetEntryType())
     {
@@ -439,6 +440,7 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
             AZ_Assert(false, "Asset Browser entry product has a non-source parent?");
             break;     // no valid parent.
         }
+        selectionIsSource = false;
     // the fall through to the next case is intentional here.
     case AssetBrowserEntry::AssetEntryType::Source:
     {
@@ -543,7 +545,7 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
             {
                 CFileUtil::PopulateQMenu(caller, menu, fullFilePath);
             }
-            if (calledFromAssetBrowser)
+            if (calledFromAssetBrowser && selectionIsSource)
             {
                 // Add Rename option
                 QAction* action = menu->addAction(
@@ -557,7 +559,7 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
             }
         }
 
-        if (calledFromAssetBrowser)
+        if (calledFromAssetBrowser && selectionIsSource)
         {
             // Add Delete option
             QAction* action = menu->addAction(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -507,7 +507,7 @@ namespace AzToolsFramework
 
         void AssetBrowserTreeView::DeleteEntries()
         {
-            auto entries = GetSelectedAssets(false); // you cannot rename product files.
+            auto entries = GetSelectedAssets(false); // you cannot delete product files.
             if (entries.empty())
             {
                 return;
@@ -762,7 +762,7 @@ namespace AzToolsFramework
 
         void AssetBrowserTreeView::MoveEntries()
         {
-            auto entries = GetSelectedAssets(false); // you cannot rename product files.
+            auto entries = GetSelectedAssets(false); // you cannot move product files.
             if (entries.empty())
             {
                 return;


### PR DESCRIPTION
Signed-off-by: John Jones-Steele <82226755+jjjoness@users.noreply.github.com>

## What does this PR do?

Fixes bug #13111 

This bug was caused by not checking the asset for being source not product before adding to the context menu.

## How was this PR tested?

Checked many items in the Asset Browser to see that the menu works correctly.
