### PR TITLE
Added parallel transform sync for rigid bodies when batched sync is enabled

### DIFF
--- a/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
+++ b/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
@@ -30,17 +30,22 @@
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/Debug/Profiler.h>
+#include <AzCore/Task/TaskGraph.h>
 #include <AzFramework/Physics/Character.h>
 #include <AzFramework/Physics/Collision/CollisionEvents.h>
 #include <AzFramework/Physics/Configuration/RigidBodyConfiguration.h>
 #include <AzFramework/Physics/Configuration/StaticRigidBodyConfiguration.h>
 #include <AzFramework/Physics/Material/PhysicsMaterialManager.h>
 
-
-AZ_CVAR_EXTERNED(bool, physx_batchTransformSync);
-
 namespace PhysX
 {
+    AZ_CVAR_EXTERNED(bool, physx_batchTransformSync);
+
+    AZ_CVAR(bool, physx_parallelTransformSync, true, nullptr, AZ::ConsoleFunctorFlags::Null, "Multithreaded transform update for rigid bodies. "
+        "Only relevant if batched transform update is enabled.");
+    AZ_CVAR(size_t, physx_parallelTransformSyncBatchSize, 250, nullptr, AZ::ConsoleFunctorFlags::Null,
+        "How many rigid bodies should be processed per task");
+
     AZ_CLASS_ALLOCATOR_IMPL(PhysXScene, AZ::SystemAllocator, 0);
 
     /*static*/ thread_local AZStd::vector<physx::PxRaycastHit> PhysXScene::s_rayCastBuffer;
@@ -1311,14 +1316,22 @@ namespace PhysX
     {
         AZ_PROFILE_SCOPE(Physics, "PhysX::FlushTransformSync");
 
-        m_queuedActiveBodyIndices.Apply(
-            [this](AzPhysics::SimulatedBodyIndex bodyIndex)
+        auto transformSync = [this](AzPhysics::SimulatedBodyIndex bodyIndex)
+        {
+            if (bodyIndex < m_simulatedBodies.size() && m_simulatedBodies[bodyIndex].second)
             {
-                if (bodyIndex < m_simulatedBodies.size() && m_simulatedBodies[bodyIndex].second)
-                {
-                    m_simulatedBodies[bodyIndex].second->SyncTransform(m_accumulatedDeltaTime);
-                }
-            });
+                m_simulatedBodies[bodyIndex].second->SyncTransform(m_accumulatedDeltaTime);
+            }
+        };
+
+        if (physx_parallelTransformSync)
+        {
+            m_queuedActiveBodyIndices.ApplyParallel(transformSync, m_pxScene);
+        }
+        else
+        {
+            m_queuedActiveBodyIndices.Apply(transformSync);
+        }
 
         m_queuedActiveBodyIndices.Clear();
         m_accumulatedDeltaTime = 0.0f;
@@ -1346,6 +1359,43 @@ namespace PhysX
     void PhysXScene::QueuedActiveBodyIndices::Apply(const AZStd::function<void(AzPhysics::SimulatedBodyIndex)>& applyFunction)
     {
         AZStd::for_each(m_packedIndices.begin(), m_packedIndices.end(), applyFunction);
+    }
+
+    void PhysXScene::QueuedActiveBodyIndices::ApplyParallel(const AZStd::function<void(AzPhysics::SimulatedBodyIndex)>& applyFunction, physx::PxScene* pxScene)
+    {
+        AZ::TaskGraph taskGraph("Parallel Sync");
+        AZ::TaskGraphEvent finishEvent("Parallel sync event");
+
+        {
+            AZ_PROFILE_SCOPE(Physics, "Sync Setup");
+
+            size_t batchSize = physx_parallelTransformSyncBatchSize;
+            size_t fullSize = m_packedIndices.size();
+            for (size_t i = 0; i < fullSize; i += batchSize)
+            {
+                AZ::TaskDescriptor taskDescriptor{"SyncTask", "Physics"};
+                taskGraph.AddTask(
+                    taskDescriptor,
+                    [start = i, end = AZStd::min(i + batchSize, fullSize), &applyFunction, pxScene, this]()
+                    {
+                        AZ_PROFILE_SCOPE(Physics, "Sync Task");
+
+                        // Note: It is important to keep the scene locked for read for the entire task execution.
+                        // Otherwise the functions reading data from the rigid body will have to lock it locally.
+                        // This causes a huge amount of context switches making the execution of each task ~20x slower. 
+                        PHYSX_SCENE_READ_LOCK(pxScene);
+
+                        for (size_t batchIndex = start; batchIndex < end; ++batchIndex)
+                        {
+                            applyFunction(m_packedIndices[batchIndex]);
+                        }
+                    });
+            }
+
+            taskGraph.Submit(&finishEvent);
+        }
+
+        finishEvent.Wait();
     }
 
 } // namespace PhysX

--- a/Gems/PhysX/Code/Source/Scene/PhysXScene.h
+++ b/Gems/PhysX/Code/Source/Scene/PhysXScene.h
@@ -94,6 +94,7 @@ namespace PhysX
             void IncreaseCapacity(size_t extraSize);
             void Clear();
             void Apply(const AZStd::function<void(AzPhysics::SimulatedBodyIndex)>& applyFunction);
+            void ApplyParallel(const AZStd::function<void(AzPhysics::SimulatedBodyIndex)>& applyFunction, physx::PxScene* pxScene);
 
         private:
             AZStd::unordered_set<AzPhysics::SimulatedBodyIndex> m_uniqueIndices;

--- a/Gems/PhysX/Code/Source/System/PhysXSystem.cpp
+++ b/Gems/PhysX/Code/Source/System/PhysXSystem.cpp
@@ -23,11 +23,6 @@
 #include <AzCore/PlatformId/PlatformId.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 
-AZ_CVAR(bool, physx_batchTransformSync, false, nullptr, AZ::ConsoleFunctorFlags::Null,
-    "Batch entity transform syncs for the entire simulation pass. "
-    "True: Sync entity transform once per Simulate call. "
-    "False: Sync entity transform for every simulation sub-step.");
-
 // only enable physx timestep warning when not running debug or in Release
 #if !defined(DEBUG) && !defined(RELEASE)
 #define ENABLE_PHYSX_TIMESTEP_WARNING
@@ -36,6 +31,11 @@ AZ_CVAR(bool, physx_batchTransformSync, false, nullptr, AZ::ConsoleFunctorFlags:
 
 namespace PhysX
 {
+    AZ_CVAR(bool, physx_batchTransformSync, false, nullptr, AZ::ConsoleFunctorFlags::Null,
+        "Batch entity transform syncs for the entire simulation pass. "
+        "True: Sync entity transform once per Simulate call. "
+        "False: Sync entity transform for every simulation sub-step.");
+
     AZ_CLASS_ALLOCATOR_IMPL(PhysXSystem, AZ::SystemAllocator, 0);
 
 #ifdef ENABLE_PHYSX_TIMESTEP_WARNING


### PR DESCRIPTION
Added parallel transform sync for rigid bodies when batched sync is enabled

Signed-off-by: Sergey Pereslavtsev <pereslav@amazon.com>

## What does this PR do?

Enables parallelized transform sync for rigid bodies using `AZ::TaskGraph`. 

## How was this PR tested?

Manual testing with 4320 rigid bodies, unit tests

![Parallel_sync](https://user-images.githubusercontent.com/60428010/201691060-0f79a05f-2819-4dd4-8d67-bdea949948ca.png)
