### PR TITLE
Organizational updates and test fix for Prefab TestSuite_Periodic

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Periodic.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Periodic.py
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 
 import pytest
 
-from ly_test_tools.o3de.editor_test import EditorSingleTest, EditorSharedTest, EditorParallelTest, EditorTestSuite
+from ly_test_tools.o3de.editor_test import EditorSingleTest, EditorBatchedTest, EditorParallelTest, EditorTestSuite
 
 
 @pytest.mark.SUITE_periodic
@@ -15,65 +15,63 @@ from ly_test_tools.o3de.editor_test import EditorSingleTest, EditorSharedTest, E
 @pytest.mark.parametrize("project", ["AutomatedTesting"])
 class TestAutomationNoAutoTestMode(EditorTestSuite):
 
-    # Enable only -BatchMode for these tests. Some tests cannot run in -autotest_mode due to UI interactions
-    global_extra_cmdline_args = ["-BatchMode"]
+    global_extra_cmdline_args = ["--regset=O3DE/Preferences/Prefabs/EnableOverridesUx=true"]
 
-    class test_DeleteEntity_UnderNestedEntityHierarchy(EditorSharedTest):
+    # Delete tests
+    class test_DeleteEntity_UnderNestedEntityHierarchy(EditorBatchedTest):
         from .tests.delete_entity import DeleteEntity_UnderNestedEntityHierarchy as test_module
 
-    class test_InstantiatePrefab_LevelPrefab(EditorSharedTest):
-        from .tests.instantiate_prefab import InstantiatePrefab_LevelPrefab as test_module
-
-    class test_InstantiatePrefab_WithNestedEntities(EditorSharedTest):
-        from .tests.instantiate_prefab import InstantiatePrefab_WithNestedEntities as test_module
-
-    class test_InstantiatePrefab_WithNestedEntitiesAndNestedPrefabs(EditorSharedTest):
-        from .tests.instantiate_prefab import InstantiatePrefab_WithNestedEntitiesandNestedPrefabs as test_module
-
-    class test_DuplicateEntity_WithNestedEntities(EditorSharedTest):
+    # Duplicate tests
+    class test_DuplicateEntity_WithNestedEntities(EditorBatchedTest):
         from .tests.duplicate_prefab import DuplicateEntity_WithNestedEntities as test_module
 
-    class test_DuplicateEntity_WithNestedEntitiesAndNestedPrefabs(EditorSharedTest):
+    class test_DuplicateEntity_WithNestedEntitiesAndNestedPrefabs(EditorBatchedTest):
         from .tests.duplicate_prefab import DuplicateEntity_WithNestedEntitiesAndNestedPrefabs as test_module
 
-    class test_AddEntity_UnderUnfocusedInstanceAsOverride(EditorSharedTest):
+    # Instantiate tests
+
+    class test_InstantiatePrefab_LevelPrefab(EditorBatchedTest):
+        from .tests.instantiate_prefab import InstantiatePrefab_LevelPrefab as test_module
+
+    class test_InstantiatePrefab_WithNestedEntities(EditorBatchedTest):
+        from .tests.instantiate_prefab import InstantiatePrefab_WithNestedEntities as test_module
+
+    class test_InstantiatePrefab_WithNestedEntitiesAndNestedPrefabs(EditorBatchedTest):
+        from .tests.instantiate_prefab import InstantiatePrefab_WithNestedEntitiesandNestedPrefabs as test_module
+
+    # Overrides tests
+
+    class test_AddEntity_UnderUnfocusedInstanceAsOverride(EditorBatchedTest):
         from .tests.overrides import AddEntity_UnderUnfocusedInstanceAsOverride as test_module
 
+    # Spawnables tests
 
-@pytest.mark.SUITE_periodic
-@pytest.mark.parametrize("launcher_platform", ['windows_editor'])
-@pytest.mark.parametrize("project", ["AutomatedTesting"])
-class TestAutomationAutoTestMode(EditorTestSuite):
-
-    # Enable only -autotest_mode for these tests. Tests cannot run in -BatchMode due to UI interactions
-    global_extra_cmdline_args = ["-autotest_mode"]
-
-    class test_SC_Spawnables_SimpleSpawnAndDespawn(EditorSharedTest):
-        from .tests.spawnables import SC_Spawnables_SimpleSpawnAndDespawn as test_module
-
-    class test_SC_Spawnables_EntityClearedOnGameModeExit(EditorSharedTest):
-        from .tests.spawnables import SC_Spawnables_EntityClearedOnGameModeExit as test_module
-
-    class test_SC_Spawnables_MultipleSpawnsFromSingleTicket(EditorSharedTest):
-        from .tests.spawnables import SC_Spawnables_MultipleSpawnsFromSingleTicket as test_module
-
-    class test_SC_Spawnables_NestedSpawn(EditorSharedTest):
-        from .tests.spawnables import SC_Spawnables_NestedSpawn as test_module
-
-    class test_SC_Spawnables_DespawnOnEntityDeactivate(EditorSharedTest):
+    class test_SC_Spawnables_DespawnOnEntityDeactivate(EditorBatchedTest):
         from .tests.spawnables import SC_Spawnables_DespawnOnEntityDeactivate as test_module
 
-    class test_Lua_Spawnables_SimpleSpawnAndDespawn(EditorSharedTest):
-        from .tests.spawnables import Lua_Spawnables_SimpleSpawnAndDespawn as test_module
+    class test_SC_Spawnables_EntityClearedOnGameModeExit(EditorBatchedTest):
+        from .tests.spawnables import SC_Spawnables_EntityClearedOnGameModeExit as test_module
 
-    class test_Lua_Spawnables_EntityClearedOnGameModeExit(EditorSharedTest):
+    class test_SC_Spawnables_MultipleSpawnsFromSingleTicket(EditorBatchedTest):
+        from .tests.spawnables import SC_Spawnables_MultipleSpawnsFromSingleTicket as test_module
+
+    class test_SC_Spawnables_NestedSpawn(EditorBatchedTest):
+        from .tests.spawnables import SC_Spawnables_NestedSpawn as test_module
+
+    class test_SC_Spawnables_SimpleSpawnAndDespawn(EditorBatchedTest):
+        from .tests.spawnables import SC_Spawnables_SimpleSpawnAndDespawn as test_module
+
+    class test_Lua_Spawnables_DespawnOnEntityDeactivate(EditorBatchedTest):
+        from .tests.spawnables import Lua_Spawnables_DespawnOnEntityDeactivate as test_module
+
+    class test_Lua_Spawnables_EntityClearedOnGameModeExit(EditorBatchedTest):
         from .tests.spawnables import Lua_Spawnables_EntityClearedOnGameModeExit as test_module
 
-    class test_Lua_Spawnables_MultipleSpawnsFromSingleTicket(EditorSharedTest):
+    class test_Lua_Spawnables_MultipleSpawnsFromSingleTicket(EditorBatchedTest):
         from .tests.spawnables import Lua_Spawnables_MultipleSpawnsFromSingleTicket as test_module
 
-    class test_Lua_Spawnables_NestedSpawn(EditorSharedTest):
+    class test_Lua_Spawnables_NestedSpawn(EditorBatchedTest):
         from .tests.spawnables import Lua_Spawnables_NestedSpawn as test_module
 
-    class test_Lua_Spawnables_DespawnOnEntityDeactivate(EditorSharedTest):
-        from .tests.spawnables import Lua_Spawnables_DespawnOnEntityDeactivate as test_module
+    class test_Lua_Spawnables_SimpleSpawnAndDespawn(EditorBatchedTest):
+        from .tests.spawnables import Lua_Spawnables_SimpleSpawnAndDespawn as test_module

--- a/AutomatedTesting/Levels/Prefab/SC_Spawnables_MultipleSpawnsFromSingleTicket/SC_Spawnables_MultipleSpawnsFromSingleTicket.prefab
+++ b/AutomatedTesting/Levels/Prefab/SC_Spawnables_MultipleSpawnsFromSingleTicket/SC_Spawnables_MultipleSpawnsFromSingleTicket.prefab
@@ -20,8 +20,7 @@
                 "Id": 14126657869720434043,
                 "Child Entity Order": [
                     "Entity_[1176639161715]",
-                    "Entity_[704828390021]",
-                    ""
+                    "Entity_[704828390021]"
                 ]
             },
             "Component_[15230859088967841193]": {
@@ -37,13 +36,14 @@
                 "$type": "EditorEntityIconComponent",
                 "Id": 5688118765544765547
             },
-            "Component_[6545738857812235305]": {
-                "$type": "SelectionComponent",
-                "Id": 6545738857812235305
-            },
             "Component_[7247035804068349658]": {
                 "$type": "EditorPrefabComponent",
                 "Id": 7247035804068349658
+            },
+            "Component_[7391669843529928707]": {
+                "$type": "LocalViewBookmarkComponent",
+                "Id": 7391669843529928707,
+                "LocalBookmarkFileName": "SC_Spawnables_MultipleSpawnsFromSingleTicket_16684438658026104.setreg"
             },
             "Component_[9307224322037797205]": {
                 "$type": "EditorLockComponent",
@@ -60,10 +60,6 @@
             "Id": "Entity_[1155164325235]",
             "Name": "Sun",
             "Components": {
-                "Component_[10440557478882592717]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10440557478882592717
-                },
                 "Component_[13620450453324765907]": {
                     "$type": "EditorLockComponent",
                     "Id": 13620450453324765907
@@ -140,7 +136,7 @@
                     "Controller": {
                         "Configuration": {
                             "Field of View": 55.0,
-                            "EditorEntityId": 7227535073012202800
+                            "EditorEntityId": 5735295310260646130
                         }
                     }
                 },
@@ -168,10 +164,6 @@
                             -43.623355865478516
                         ]
                     }
-                },
-                "Component_[18387556550380114975]": {
-                    "$type": "SelectionComponent",
-                    "Id": 18387556550380114975
                 },
                 "Component_[2654521436129313160]": {
                     "$type": "EditorVisibilityComponent",
@@ -224,10 +216,6 @@
                     "$type": "EditorLockComponent",
                     "Id": 14988041764659020032
                 },
-                "Component_[15808690248755038124]": {
-                    "$type": "SelectionComponent",
-                    "Id": 15808690248755038124
-                },
                 "Component_[15900837685796817138]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15900837685796817138
@@ -278,10 +266,6 @@
                         }
                     }
                 },
-                "Component_[11980494120202836095]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11980494120202836095
-                },
                 "Component_[1428633914413949476]": {
                     "$type": "EditorLockComponent",
                     "Id": 1428633914413949476
@@ -306,6 +290,20 @@
                                 "assetHint": "lightingpresets/highcontrast/goegap_4k_iblglobalcm_iblspecular.exr.streamingimage"
                             }
                         }
+                    },
+                    "diffuseImageAsset": {
+                        "assetId": {
+                            "guid": "{3FD09945-D0F2-55C8-B9AF-B2FD421FE3BE}",
+                            "subId": 3000
+                        },
+                        "assetHint": "lightingpresets/highcontrast/goegap_4k_iblglobalcm_ibldiffuse.exr.streamingimage"
+                    },
+                    "specularImageAsset": {
+                        "assetId": {
+                            "guid": "{3FD09945-D0F2-55C8-B9AF-B2FD421FE3BE}",
+                            "subId": 2000
+                        },
+                        "assetHint": "lightingpresets/highcontrast/goegap_4k_iblglobalcm_iblspecular.exr.streamingimage"
                     }
                 },
                 "Component_[14994774102579326069]": {
@@ -374,13 +372,13 @@
                     "configuration": {
                         "sourceHandle": {
                             "id": "{A3F94F50-FD9F-5F3F-A17F-D0FE5681FEC5}",
-                            "path": "GitHub/o3de/AutomatedTesting/ScriptCanvas/Spawnables/MultipleSpawnsFromSingleTicket.scriptcanvas"
+                            "path": "ScriptCanvas/Spawnables/MultipleSpawnsFromSingleTicket.scriptcanvas"
                         },
                         "sourceName": "MultipleSpawnsFromSingleTicket.scriptcanvas",
                         "propertyOverrides": {
                             "source": {
                                 "id": "{A3F94F50-FD9F-5F3F-A17F-D0FE5681FEC5}",
-                                "path": "GitHub/o3de/AutomatedTesting/ScriptCanvas/Spawnables/MultipleSpawnsFromSingleTicket.scriptcanvas"
+                                "path": "ScriptCanvas/Spawnables/MultipleSpawnsFromSingleTicket.scriptcanvas"
                             }
                         }
                     }
@@ -396,10 +394,6 @@
                 "Component_[6725293197224110972]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 6725293197224110972
-                },
-                "Component_[6974260037781999503]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6974260037781999503
                 },
                 "Component_[8311803811942838815]": {
                     "$type": "EditorLockComponent",


### PR DESCRIPTION
Signed-off-by: jckand-amzn <82226555+jckand-amzn@users.noreply.github.com>

## What does this PR do?

- Adds necessary setreg flag for running test_AddEntity_UnderUnfocusedInstanceAsOverride - Fixes https://github.com/o3de/o3de/issues/13150
- Moves all tests to use EditorBatchedTest to avoid parallel Editor issues
- Combined separate test classes, and now utilize both -BatchMode and -autotest_mode for all tests
- Updates a test level to remove deprecated SelectionComponent warning

## How was this PR tested?

- Ran updated periodic suite several times with 0 failures
