### PR TITLE
[Terrain] First batch of unit tests for PaintBrush

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/PaintBrushManipulator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/PaintBrushManipulator.cpp
@@ -269,7 +269,7 @@ namespace AzToolsFramework
                 break;
             case PaintBrushMode::Eyedropper:
                 {
-                    AZ::Color eyedropperColor = m_paintBrush.UseEyedropper(brushCenter, brushSettings);
+                    AZ::Color eyedropperColor = m_paintBrush.UseEyedropper(brushCenter);
 
                     // Set the color in our paintbrush settings to the color selected by the eyedropper.
                     PaintBrushSettingsRequestBus::Broadcast(&PaintBrushSettingsRequestBus::Events::SetColor, eyedropperColor);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrush/PaintBrush.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrush/PaintBrush.h
@@ -80,10 +80,17 @@ namespace AzToolsFramework
 
         //! Get the color from the underlying data that's located at the brush center
         //! @param brushCenter The current center of the paintbrush.
-        //! @param brushSettings The current paintbrush settings.
-        AZ::Color UseEyedropper(const AZ::Vector3& brushCenter, const PaintBrushSettings& brushSettings);
+        AZ::Color UseEyedropper(const AZ::Vector3& brushCenter);
 
     private:
+        //! For now, the paintbrush will perform all of its calculations in 2D space.
+        //! This could eventually get exposed as a paintbrush setting if we add a paintbrush consumer that needs to paint in 3D space.
+        static constexpr bool PaintIn2D = true;
+
+        //! Adjust the given location to either remain in 3D or get "flattened" to 2D with a Z value of 0
+        //! depending on the value of PaintIn2D.
+        static AZ::Vector3 OptionallyAdjustTo2D(const AZ::Vector3& location);
+
         //! Get an appropriate blend function for the requested blend mode.
         //! @param blendMode The blend mode to use.
         static PaintBrushNotifications::BlendFn GetBlendFunction(const PaintBrushBlendMode& blendMode);
@@ -99,7 +106,7 @@ namespace AzToolsFramework
         void CalculateBrushStampCentersAndStrokeRegion(
             const AZ::Vector3& brushCenter,
             const PaintBrushSettings& brushSettings,
-            AZStd::vector<AZ::Vector2>& brushStampCenters,
+            AZStd::vector<AZ::Vector3>& brushStampCenters,
             AZ::Aabb& strokeRegion);
 
         //! Determine which of the passed-in points are within our current brush stroke, and calculate the opacity at each point.
@@ -110,7 +117,7 @@ namespace AzToolsFramework
         //! @param opacities [out] For each point in validPoints, the opacity of the brush at that point
         static void CalculatePointsInBrush(
             const PaintBrushSettings& brushSettings,
-            const AZStd::vector<AZ::Vector2>& brushStampCenters,
+            const AZStd::vector<AZ::Vector3>& brushStampCenters,
             AZStd::span<const AZ::Vector3> points,
             AZStd::vector<AZ::Vector3>& validPoints,
             AZStd::vector<float>& opacities);
@@ -119,7 +126,7 @@ namespace AzToolsFramework
         AZ::EntityComponentIdPair m_ownerEntityComponentId;
 
         //! Location of the last mouse point that we processed while painting.
-        AZ::Vector2 m_lastBrushCenter;
+        AZ::Vector3 m_lastBrushCenter;
 
         //! Distance that the mouse has traveled since the last time we drew a paint stamp.
         float m_distanceSinceLastDraw = 0.0f;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrush/PaintBrushNotificationBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrush/PaintBrushNotificationBus.h
@@ -10,8 +10,10 @@
 
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Math/Aabb.h>
+#include <AzCore/Math/Color.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/std/containers/span.h>
+#include <AzCore/std/containers/vector.h>
 #include <AzCore/std/functional.h>
 #include <AzCore/Component/ComponentBus.h>
 

--- a/Code/Framework/AzToolsFramework/Tests/PaintBrush/MockPaintBrushNotificationHandler.h
+++ b/Code/Framework/AzToolsFramework/Tests/PaintBrush/MockPaintBrushNotificationHandler.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzTest/AzTest.h>
+#include <AzToolsFramework/PaintBrush/PaintBrush.h>
+#include <AZTestShared/Math/MathTestHelpers.h>
+
+namespace UnitTest
+{
+    class MockPaintBrushNotificationBusHandler : public AzToolsFramework::PaintBrushNotificationBus::Handler
+    {
+    public:
+        MockPaintBrushNotificationBusHandler(const AZ::EntityComponentIdPair& entityComponentIdPair)
+        {
+            AzToolsFramework::PaintBrushNotificationBus::Handler::BusConnect(entityComponentIdPair);
+        }
+
+        ~MockPaintBrushNotificationBusHandler() override
+        {
+            AzToolsFramework::PaintBrushNotificationBus::Handler::BusDisconnect();
+        }
+
+        MOCK_METHOD0(OnPaintModeBegin, void());
+        MOCK_METHOD0(OnPaintModeEnd, void());
+        MOCK_METHOD1(OnBrushStrokeBegin, void(const AZ::Color& color));
+        MOCK_METHOD0(OnBrushStrokeEnd, void());
+        MOCK_METHOD3(OnPaint, void(const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, BlendFn& blendFn));
+        MOCK_METHOD1(OnGetColor, AZ::Color(const AZ::Vector3& brushCenterPoint));
+        MOCK_METHOD4(OnSmooth, void(
+            const AZ::Aabb& dirtyArea,
+            ValueLookupFn& valueLookupFn,
+            AZStd::span<const AZ::Vector3> valuePointOffsets,
+            SmoothFn& smoothFn));
+    };
+}
+

--- a/Code/Framework/AzToolsFramework/Tests/PaintBrush/PaintBrushBaseTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/PaintBrush/PaintBrushBaseTests.cpp
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzTest/AzTest.h>
+#include <AzToolsFramework/PaintBrush/PaintBrush.h>
+#include <AZTestShared/Math/MathTestHelpers.h>
+#include <Tests/PaintBrush/MockPaintBrushNotificationHandler.h>
+
+/*
+This set of unit tests validates that the basic PaintBrush functionality and notifications work:
+- Begin/End Paint Mode
+- Begin/End Brush Stroke
+- Use Eyedropper
+*/
+
+namespace UnitTest
+{
+    class PaintBrushTestFixture : public ScopedAllocatorSetupFixture
+    {
+    public:
+
+        // Some common default values that we'll use in our tests.
+        const AZ::EntityComponentIdPair EntityComponentIdPair{ AZ::EntityId(123), AZ::ComponentId(456) };
+        const AZ::Vector3 TestBrushCenter{ 10.0f, 20.0f, 30.0f };
+        const AZ::Vector3 TestBrushCenter2d{ 10.0f, 20.0f, 0.0f };  // This should be the same as TestBrushCenter, but with Z=0
+        const AZ::Color TestColor{ 0.25f, 0.50f, 0.75f, 1.0f };
+
+        // Useful helpers for our tests
+        AzToolsFramework::PaintBrushSettings m_settings;
+    };
+
+    TEST_F(PaintBrushTestFixture, TrivialConstruction)
+    {
+        // We can construct / destroy a PaintBrush without any errors.
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+    }
+
+    TEST_F(PaintBrushTestFixture, BeginAndEndPaintModeMustBePairedCorrectly)
+    {
+        // BeginPaintMode() / EndPaintMode() can only be called in the correct order in pairs.
+        // They will error if they're called in the wrong order or more than once in a row.
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+
+        // End before Begin should assert.
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        paintBrush.EndPaintMode();
+        AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+
+        paintBrush.BeginPaintMode();
+
+        // Calling Begin twice should assert.
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        paintBrush.BeginPaintMode();
+        AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+
+        paintBrush.EndPaintMode();
+
+        // Calling End twice should assert.
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        paintBrush.EndPaintMode();
+        AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+    }
+
+    TEST_F(PaintBrushTestFixture, IsInPaintModeFunctionsCorrectly)
+    {
+        // IsInPaintMode() correctly identifies when we're between a BeginPaintMode() and EndPaintMode() call.
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+
+        EXPECT_FALSE(paintBrush.IsInPaintMode());
+        paintBrush.BeginPaintMode();
+        EXPECT_TRUE(paintBrush.IsInPaintMode());
+        paintBrush.EndPaintMode();
+        EXPECT_FALSE(paintBrush.IsInPaintMode());
+    }
+
+    TEST_F(PaintBrushTestFixture, BeginAndEndBrushStrokeMustBePairedCorrectlyInsidePaintMode)
+    {
+        // BeginBrushStroke() / EndBrushStroke() can only be called in the correct order in pairs.
+        // They will error if they're called in the wrong order, more than once in a row, or outside of BeginPaintMode().
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+
+        // BeginBrushStroke without BeginPaintMode should assert.
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        paintBrush.BeginBrushStroke(m_settings);
+        AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+
+        paintBrush.BeginPaintMode();
+
+        // End before Begin should assert.
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        paintBrush.EndBrushStroke();
+        AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+
+        paintBrush.BeginBrushStroke(m_settings);
+
+        // Calling Begin twice should assert.
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        paintBrush.BeginBrushStroke(m_settings);
+        AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+
+        paintBrush.EndBrushStroke();
+
+        // Calling End twice should assert.
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        paintBrush.EndBrushStroke();
+        AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+
+        paintBrush.EndPaintMode();
+    }
+
+    TEST_F(PaintBrushTestFixture, IsInBrushStrokeFunctionsCorrectly)
+    {
+        // IsInBrushStroke() correctly identifies when we're between a BeginBrushStroke() and EndBrushStroke() call.
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+
+        paintBrush.BeginPaintMode();
+
+        EXPECT_FALSE(paintBrush.IsInBrushStroke());
+        paintBrush.BeginBrushStroke(m_settings);
+        EXPECT_TRUE(paintBrush.IsInBrushStroke());
+        paintBrush.EndBrushStroke();
+        EXPECT_FALSE(paintBrush.IsInBrushStroke());
+
+        paintBrush.EndPaintMode();
+    }
+
+    TEST_F(PaintBrushTestFixture, PaintModeNotifiesCorrectly)
+    {
+        // BeginPaintMode() / EndPaintMode() should call the PaintBrushNotificationBus with OnPaintModeBegin() / OnPaintModeEnd().
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+        ::testing::NiceMock<MockPaintBrushNotificationBusHandler> mockHandler(EntityComponentIdPair);
+
+        EXPECT_CALL(mockHandler, OnPaintModeBegin()).Times(1);
+        paintBrush.BeginPaintMode();
+
+        EXPECT_CALL(mockHandler, OnPaintModeEnd()).Times(1);
+        paintBrush.EndPaintMode();
+    }
+
+    TEST_F(PaintBrushTestFixture, BrushStrokeNotifiesCorrectly)
+    {
+        // BeginBrushStroke() / EndBrushStroke() should call the PaintBrushNotificationBus with OnBrushStrokeBegin() / OnBrushStrokeEnd().
+        // OnBrushStrokeBegin should be passed the current color in the PaintBrushSettings that we called BeginBrushStroke() with.
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+        ::testing::NiceMock<MockPaintBrushNotificationBusHandler> mockHandler(EntityComponentIdPair);
+
+        m_settings.SetColor(TestColor);
+
+        EXPECT_CALL(mockHandler, OnBrushStrokeBegin(::testing::_)).Times(1);
+
+        ON_CALL(mockHandler, OnBrushStrokeBegin)
+            .WillByDefault(
+                [=](const AZ::Color& strokeColor)
+                {
+                    EXPECT_THAT(TestColor, IsClose(strokeColor));
+                    return TestColor;
+                });
+
+        paintBrush.BeginPaintMode();
+        paintBrush.BeginBrushStroke(m_settings);
+
+        EXPECT_CALL(mockHandler, OnBrushStrokeEnd()).Times(1);
+        paintBrush.EndBrushStroke();
+        paintBrush.EndPaintMode();
+    }
+
+    TEST_F(PaintBrushTestFixture, UseEyedropperFunctionsCorrectlyOutsideOfPaintMode)
+    {
+        // UseEyedropper should return the expected color for the given world position even if we're not currently
+        // in Paint Mode or inside a Brush Stroke.
+        // This verifies that PaintBrushNotificationBus::OnGetColor is called with the expected world position and that the color
+        // returned from UseEyedropper matches the one we returned from OnGetColor.
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+        ::testing::NiceMock<MockPaintBrushNotificationBusHandler> mockHandler(EntityComponentIdPair);
+
+        ON_CALL(mockHandler, OnGetColor)
+            .WillByDefault(
+                [=](const AZ::Vector3& brushCenterPoint)
+                {
+                    // We expect the brush center to match what we passed in but with a Z value of 0
+                    // because we only support painting in 2D for now.
+                    EXPECT_THAT(brushCenterPoint, IsClose(TestBrushCenter2d));
+                    return TestColor;
+                });
+
+
+        // Note that UseEyedropper() can be called without being in a paint mode or brush stroke.
+        const AZ::Color color = paintBrush.UseEyedropper(TestBrushCenter);
+
+        EXPECT_THAT(color, IsClose(TestColor));
+    }
+
+    TEST_F(PaintBrushTestFixture, UseEyedropperFunctionsCorrectlyInsideOfPaintMode)
+    {
+        // UseEyedropper should return the expected color for the given world position even if we are currently
+        // in Paint Mode and inside a Brush Stroke.
+        // This verifies that PaintBrushNotificationBus::OnGetColor is called with the expected world position and that the color
+        // returned from UseEyedropper matches the one we returned from OnGetColor.
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+        ::testing::NiceMock<MockPaintBrushNotificationBusHandler> mockHandler(EntityComponentIdPair);
+
+        ON_CALL(mockHandler, OnGetColor)
+            .WillByDefault(
+                [=](const AZ::Vector3& brushCenterPoint)
+                {
+                    // We expect the brush center to match what we passed in but with a Z value of 0
+                    // because we only support painting in 2D for now.
+                    EXPECT_THAT(brushCenterPoint, IsClose(TestBrushCenter2d));
+                    return TestColor;
+                });
+
+        // UseEyedropper should still work even if a paint mode and brush stroke is active.
+        paintBrush.BeginPaintMode();
+        paintBrush.BeginBrushStroke(m_settings);
+        const AZ::Color color = paintBrush.UseEyedropper(TestBrushCenter);
+        paintBrush.EndBrushStroke();
+        paintBrush.EndPaintMode();
+
+        EXPECT_THAT(color, IsClose(TestColor));
+    }
+
+    TEST_F(PaintBrushTestFixture, PaintToLocationMustBeUsedWithinBrushStroke)
+    {
+        // PaintToLocation() can only be called if we're currently within a brush stroke.
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+        ::testing::NiceMock<MockPaintBrushNotificationBusHandler> mockHandler(EntityComponentIdPair);
+
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        paintBrush.PaintToLocation(TestBrushCenter, m_settings);
+        AZ_TEST_STOP_TRACE_SUPPRESSION(2);
+    }
+} // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/PaintBrush/PaintBrushPaintLocationTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/PaintBrush/PaintBrushPaintLocationTests.cpp
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzTest/AzTest.h>
+#include <AzToolsFramework/PaintBrush/PaintBrush.h>
+#include <AZTestShared/Math/MathTestHelpers.h>
+#include <Tests/PaintBrush/MockPaintBrushNotificationHandler.h>
+
+// This set of unit tests validates that the PaintToLocation API trivially works and calculates location changes correctly.
+
+namespace UnitTest
+{
+    class PaintBrushPaintLocationTestFixture : public ScopedAllocatorSetupFixture
+    {
+    public:
+
+        // Some common default values that we'll use in our tests.
+        const AZ::EntityComponentIdPair EntityComponentIdPair{ AZ::EntityId(123), AZ::ComponentId(456) };
+        const AZ::Vector3 TestBrushCenter{ 10.0f, 20.0f, 30.0f };
+        const AZ::Vector3 TestBrushCenter2d{ 10.0f, 20.0f, 0.0f };  // This should be the same as TestBrushCenter, but with Z=0
+        const AZ::Color TestColor{ 0.25f, 0.50f, 0.75f, 1.0f };
+
+        // Useful helpers for our tests
+        AzToolsFramework::PaintBrushSettings m_settings;
+    };
+
+    TEST_F(PaintBrushPaintLocationTestFixture, PaintToLocationAtSingleLocationFunctionsCorrectly)
+    {
+        // This tests all of the basic PaintToLocation() functionality:
+        // - It will call OnPaint with the correct dirty area for the brush settings and initial location
+        // - The valueLookupFn will only return valid points that occur within the brush.
+        // - The blendFn will blend two values together.
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+        ::testing::NiceMock<MockPaintBrushNotificationBusHandler> mockHandler(EntityComponentIdPair);
+
+        const float TestBrushRadius = 1.0f;
+        m_settings.SetSize(TestBrushRadius * 2.0f);
+
+        EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_)).Times(1);
+
+        ON_CALL(mockHandler, OnPaint)
+            .WillByDefault(
+                [=](const AZ::Aabb& dirtyArea,
+                    AzToolsFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
+                    AzToolsFramework::PaintBrushNotifications::BlendFn& blendFn)
+                {
+                    // The OnPaint method for a listener to the PaintBrushNotificationBus should work as follows:
+                    // - It should receive a dirtyArea AABB that contains the region that's been painted.
+                    // - For each point that the listener cares about in that region, it should call valueLookupFn() to find
+                    //   out which points actually fall within the paintbrush, and what the opacities of those points are.
+                    // - For each valid point and opacity, the listener should call blendFn() to blend the values together.
+
+                    // Validate the dirtyArea AABB:
+                    // We expect the AABB to be centered around the TestBrushCenter but with a Z value of 0
+                    // because we only support painting in 2D for now. The radius of the AABB should match the radius of our paintbrush.
+                    EXPECT_THAT(dirtyArea, IsClose(AZ::Aabb::CreateCenterRadius(TestBrushCenter2d, TestBrushRadius)));
+
+                    // Validate the valueLookupFn:
+                    // Create a 3x3 square grid of points. Because our brush is a circle, we expect only the points in along a + to be
+                    // returned as valid points. The corners of the square should fall outside the circle and not get returned.
+                    const AZStd::vector<AZ::Vector3> points = {
+                        AZ::Vector3(dirtyArea.GetMin().GetX(), dirtyArea.GetMin().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetCenter().GetX(), dirtyArea.GetMin().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetMax().GetX(), dirtyArea.GetMin().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetMin().GetX(), dirtyArea.GetCenter().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetCenter().GetX(), dirtyArea.GetCenter().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetMax().GetX(), dirtyArea.GetCenter().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetMin().GetX(), dirtyArea.GetMax().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetCenter().GetX(), dirtyArea.GetMax().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetMax().GetX(), dirtyArea.GetMax().GetY(), 0.0f),
+                    };
+                    AZStd::vector<AZ::Vector3> validPoints;
+                    AZStd::vector<float> opacities;
+                    valueLookupFn(points, validPoints, opacities);
+
+                    // We should only have the 5 points along the + in validPoints.
+                    EXPECT_EQ(validPoints.size(), 5);
+                    const AZStd::vector<AZ::Vector3> expectedValidPoints = {
+                        AZ::Vector3(dirtyArea.GetCenter().GetX(), dirtyArea.GetMin().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetMin().GetX(), dirtyArea.GetCenter().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetCenter().GetX(), dirtyArea.GetCenter().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetMax().GetX(), dirtyArea.GetCenter().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetCenter().GetX(), dirtyArea.GetMax().GetY(), 0.0f),
+                    };
+                    EXPECT_THAT(validPoints, ::testing::Pointwise(ContainerIsClose(), expectedValidPoints));
+
+                    // We should only have 5 opacities, and they should all be 1.0 because we haven't adjusted any brush settings.
+                    EXPECT_EQ(opacities.size(), 5);
+                    for (auto& opacity : opacities)
+                    {
+                        EXPECT_NEAR(opacity, 1.0f, 0.001f);
+                    }
+
+                    // Validate the blendFn:
+                    // By default, it should be a normal blend, so verify that a base value of 0, a new value of 1, and an opacity of 0.5
+                    // gives us back a blended value of 0.5.
+                    const float blend = blendFn(0.0f, 1.0f, 0.5f);
+                    EXPECT_NEAR(blend, 0.5f, 0.001f);
+                });
+
+
+        paintBrush.BeginPaintMode();
+        paintBrush.BeginBrushStroke(m_settings);
+        paintBrush.PaintToLocation(TestBrushCenter, m_settings);
+        paintBrush.EndBrushStroke();
+        paintBrush.EndPaintMode();
+    }
+
+    TEST_F(PaintBrushPaintLocationTestFixture, PaintToLocationWithSmallMovementDoesNotTriggerPainting)
+    {
+        // This verifies that if the distance between two PaintToLocation calls is small enough, it won't trigger
+        // an OnPaint. "small" is defined as less than (brush size * distance %).
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+        ::testing::NiceMock<MockPaintBrushNotificationBusHandler> mockHandler(EntityComponentIdPair);
+
+        // Set the distance between brush stamps to 50%
+        const float TestDistancePercent = 50.0f;
+        m_settings.SetDistancePercent(TestDistancePercent);
+
+        // Set the brush radius to 1 meter (diameter is 2 meters)
+        const float TestBrushRadius = 1.0f;
+        m_settings.SetSize(TestBrushRadius * 2.0f);
+
+        // The distance we expect to need to move to trigger another paint call is 50% of our brush size.
+        const float DistanceToTriggerSecondCall = TestBrushRadius * 2.0f * (TestDistancePercent / 100.0f);
+
+        // Choose a second brush center location that's just slightly under the threshold that should be needed to trigger a second
+        // OnPaint call.
+        const AZ::Vector3 tooSmallSecondLocation = TestBrushCenter + AZ::Vector3(DistanceToTriggerSecondCall - 0.01f, 0.0f, 0.0f);
+
+        // We expect to get called only once for our initial PaintToLocation(); the second PaintToLocation() won't
+        // have moved far enough to trigger a second OnPaint call.
+        EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_)).Times(1);
+
+        paintBrush.BeginPaintMode();
+        paintBrush.BeginBrushStroke(m_settings);
+        paintBrush.PaintToLocation(TestBrushCenter, m_settings);
+        paintBrush.PaintToLocation(tooSmallSecondLocation, m_settings);
+        paintBrush.EndBrushStroke();
+        paintBrush.EndPaintMode();
+
+        // Try the test again, this time moving exactly the amount we need to so that we trigger a second call.
+        // (We do this to verify that we've correctly identified the threshold under which we should not trigger another OnPaint)
+        const AZ::Vector3 largeEnoughSecondLocation = TestBrushCenter + AZ::Vector3(DistanceToTriggerSecondCall, 0.0f, 0.0f);
+        EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_)).Times(2);
+
+        paintBrush.BeginPaintMode();
+        paintBrush.BeginBrushStroke(m_settings);
+        paintBrush.PaintToLocation(TestBrushCenter, m_settings);
+        paintBrush.PaintToLocation(largeEnoughSecondLocation, m_settings);
+        paintBrush.EndBrushStroke();
+        paintBrush.EndPaintMode();
+    }
+
+    TEST_F(PaintBrushPaintLocationTestFixture, PaintToLocationSecondMovementDoesNotIncludeFirstCircle)
+    {
+        // When painting, the first PaintToLocation call should just contain a single paint stamp at the passed-in location.
+        // The second PaintToLocation call should contain paint stamps from the first location to the second, but should NOT
+        // have a second paint stamp at the first location. Ex:
+        //     O            <- first PaintToLocation
+        //     -OOO         <- second PaintToLocation
+        // If the Distance % is anything less than 100% in the paint brush settings, the Os will overlap.
+        // We'll set it to 100% just to make it obvious that we've gotten the correct result.
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+        ::testing::NiceMock<MockPaintBrushNotificationBusHandler> mockHandler(EntityComponentIdPair);
+
+        // Set the distance between brush stamps to 100%
+        const float TestDistancePercent = 100.0f;
+        m_settings.SetDistancePercent(TestDistancePercent);
+
+        // Set the brush radius to 1 meter (diameter is 2 meters)
+        const float TestBrushRadius = 1.0f;
+        const float TestBrushSize = TestBrushRadius * 2.0f;
+        m_settings.SetSize(TestBrushSize);
+
+        // Choose a second brush center location that's 3 full brush stamps away. This should give us a total
+        // of 4 brush stamps that get painted between the two calls.
+        const AZ::Vector3 secondLocation = TestBrushCenter + AZ::Vector3(TestBrushSize * 3.0f, 0.0f, 0.0f);
+
+        // We expect to get two OnPaint calls.
+        EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_)).Times(2);
+
+        paintBrush.BeginPaintMode();
+        paintBrush.BeginBrushStroke(m_settings);
+
+        ON_CALL(mockHandler, OnPaint)
+            .WillByDefault(
+                [=](const AZ::Aabb& dirtyArea,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::BlendFn& blendFn)
+                {
+                    // On the first PaintToLocation, we expect to get a dirtyArea that exactly fits our first paint brush stamp.
+                    const AZ::Aabb expectedFirstDirtyArea = AZ::Aabb::CreateCenterRadius(TestBrushCenter2d, TestBrushRadius);
+                    EXPECT_THAT(dirtyArea, IsClose(expectedFirstDirtyArea));
+                });
+
+        paintBrush.PaintToLocation(TestBrushCenter, m_settings);
+
+        ON_CALL(mockHandler, OnPaint)
+            .WillByDefault(
+                [=](const AZ::Aabb& dirtyArea,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::BlendFn& blendFn)
+                {
+                    // On the second PaintToLocation, we expect the dirtyArea to only contain the next 3 paint brush stamps,
+                    // but not the first one.
+                    const AZ::Vector3 stampIncrement = AZ::Vector3(TestBrushSize, 0.0f, 0.0f);
+                    AZ::Aabb expectedSecondDirtyArea = AZ::Aabb::CreateCenterRadius(TestBrushCenter2d + stampIncrement, TestBrushRadius);
+                    expectedSecondDirtyArea.AddAabb(
+                        AZ::Aabb::CreateCenterRadius(TestBrushCenter2d + (3.0f * stampIncrement), TestBrushRadius));
+                    EXPECT_THAT(dirtyArea, IsClose(expectedSecondDirtyArea));
+                });
+
+        paintBrush.PaintToLocation(secondLocation, m_settings);
+
+        paintBrush.EndBrushStroke();
+        paintBrush.EndPaintMode();
+    }
+
+    TEST_F(PaintBrushPaintLocationTestFixture, EyedropperDoesNotAffectPaintToLocation)
+    {
+        // When painting, we should be able to call UseEyedropper at any arbitrary location without affecting the current
+        // state of PaintToLocation.
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+        ::testing::NiceMock<MockPaintBrushNotificationBusHandler> mockHandler(EntityComponentIdPair);
+
+        // Set the brush radius to 1 meter (diameter is 2 meters)
+        const float TestBrushRadius = 1.0f;
+        const float TestBrushSize = TestBrushRadius * 2.0f;
+        m_settings.SetSize(TestBrushSize);
+
+        // Choose a second brush center location that's 2 full brush stamps away in the X direction only.
+        AZ::Vector3 secondLocation = TestBrushCenter + AZ::Vector3(TestBrushSize * 2.0f, 0.0f, 0.0f);
+
+        // We expect to get two OnPaint calls.
+        EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_)).Times(2);
+
+        ON_CALL(mockHandler, OnPaint)
+            .WillByDefault(
+                [=](const AZ::Aabb& dirtyArea,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::BlendFn& blendFn)
+                {
+                    // We expect that the Y value for our dirtyArea won't be changed even though we'll call UseEyedropper
+                    // with a large Y value in-between the two paint calls.
+                    EXPECT_NEAR(dirtyArea.GetMin().GetY(), TestBrushCenter.GetY() - TestBrushRadius, 0.01f);
+                    EXPECT_NEAR(dirtyArea.GetMax().GetY(), TestBrushCenter.GetY() + TestBrushRadius, 0.01f);
+                });
+
+        paintBrush.BeginPaintMode();
+        paintBrush.BeginBrushStroke(m_settings);
+
+        paintBrush.PaintToLocation(TestBrushCenter, m_settings);
+
+        // Call UseEyeDropper with a large Y value so that we can easily detect if it affected our PaintToLocation calls.
+        [[maybe_unused]] AZ::Color color = paintBrush.UseEyedropper(TestBrushCenter + AZ::Vector3(0.0f, 1000.0f, 0.0f));
+
+        paintBrush.PaintToLocation(secondLocation, m_settings);
+
+        paintBrush.EndBrushStroke();
+        paintBrush.EndPaintMode();
+    }
+
+    TEST_F(PaintBrushPaintLocationTestFixture, ResetBrushStrokeTrackingWorksCorrectly)
+    {
+        // If ResetBrushStrokeTracking is called in-between two calls to PaintToLocation within a brush stroke,
+        // there should be a discontinuity between the two locations as if the brush has been picked up and put back down.
+        // i.e. Instead of 'OOOOOO' between two locations it should create 'O     O'.
+        // This is typically used for handling things like leaving the edge of the image at one location and coming back onto
+        // the image at a different location.
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+        ::testing::NiceMock<MockPaintBrushNotificationBusHandler> mockHandler(EntityComponentIdPair);
+
+        // Set the distance between brush stamps to 100%
+        const float TestDistancePercent = 100.0f;
+        m_settings.SetDistancePercent(TestDistancePercent);
+
+        // Set the brush radius to 1 meter (diameter is 2 meters)
+        const float TestBrushRadius = 1.0f;
+        const float TestBrushSize = TestBrushRadius * 2.0f;
+        m_settings.SetSize(TestBrushSize);
+
+        // Choose a second brush center location that's 10 full brush stamps away to make it obvious whether or not
+        // there are any points tracked between the two locations.
+        const AZ::Vector3 secondLocation = TestBrushCenter + AZ::Vector3(TestBrushSize * 10.0f, 0.0f, 0.0f);
+
+        // We expect to get two OnPaint calls.
+        EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_)).Times(2);
+
+        paintBrush.BeginPaintMode();
+        paintBrush.BeginBrushStroke(m_settings);
+
+        ON_CALL(mockHandler, OnPaint)
+            .WillByDefault(
+                [=](const AZ::Aabb& dirtyArea,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::BlendFn& blendFn)
+                {
+                    // On the first PaintToLocation, we expect to get a dirtyArea that exactly fits our first paint brush stamp.
+                    const AZ::Aabb expectedFirstDirtyArea = AZ::Aabb::CreateCenterRadius(TestBrushCenter2d, TestBrushRadius);
+                    EXPECT_THAT(dirtyArea, IsClose(expectedFirstDirtyArea));
+                });
+
+        paintBrush.PaintToLocation(TestBrushCenter, m_settings);
+
+        // Reset the brush stroke tracking, so that the next location will look like the start of a stroke again.
+        paintBrush.ResetBrushStrokeTracking();
+
+        ON_CALL(mockHandler, OnPaint)
+            .WillByDefault(
+                [=](const AZ::Aabb& dirtyArea,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::BlendFn& blendFn)
+                {
+                    // On the second PaintToLocation, we expect to get a dirtyArea that exactly fits our second paint brush stamp.
+                    // It should *not* include any of the space bewteen the first and the second brush stamp.
+                    const AZ::Vector3 secondLocation2d(AZ::Vector2(secondLocation), 0.0f);
+                    const AZ::Aabb expectedSecondDirtyArea = AZ::Aabb::CreateCenterRadius(secondLocation2d, TestBrushRadius);
+                    EXPECT_THAT(dirtyArea, IsClose(expectedSecondDirtyArea));
+                });
+
+        paintBrush.PaintToLocation(secondLocation, m_settings);
+
+        paintBrush.EndBrushStroke();
+        paintBrush.EndPaintMode();
+    }
+} // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/PaintBrush/PaintBrushSmoothLocationTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/PaintBrush/PaintBrushSmoothLocationTests.cpp
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzTest/AzTest.h>
+#include <AzToolsFramework/PaintBrush/PaintBrush.h>
+#include <AZTestShared/Math/MathTestHelpers.h>
+#include <Tests/PaintBrush/MockPaintBrushNotificationHandler.h>
+
+// This set of unit tests validates that the SmoothToLocation API trivially works and calculates location changes correctly.
+
+namespace UnitTest
+{
+    class PaintBrushSmoothLocationTestFixture : public ScopedAllocatorSetupFixture
+    {
+    public:
+
+        // Some common default values that we'll use in our tests.
+        const AZ::EntityComponentIdPair EntityComponentIdPair{ AZ::EntityId(123), AZ::ComponentId(456) };
+        const AZ::Vector3 TestBrushCenter{ 10.0f, 20.0f, 30.0f };
+        const AZ::Vector3 TestBrushCenter2d{ 10.0f, 20.0f, 0.0f };  // This should be the same as TestBrushCenter, but with Z=0
+        const AZ::Color TestColor{ 0.25f, 0.50f, 0.75f, 1.0f };
+
+        // Useful helpers for our tests
+        AzToolsFramework::PaintBrushSettings m_settings;
+    };
+
+    TEST_F(PaintBrushSmoothLocationTestFixture, SmoothToLocationAtSingleLocationFunctionsCorrectly)
+    {
+        // This tests all of the basic SmoothToLocation() functionality:
+        // - It will call OnSmooth with the correct dirty area for the brush settings and initial location
+        // - The valueLookupFn will only return valid points that occur within the brush.
+        // - The smoothFn will smooth values together.
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+        ::testing::NiceMock<MockPaintBrushNotificationBusHandler> mockHandler(EntityComponentIdPair);
+
+        const float TestBrushRadius = 1.0f;
+        m_settings.SetSize(TestBrushRadius * 2.0f);
+
+        // We'll set the smooth mode to "Mean" just so that it's easy to verify that the smoothFn trivially works.
+        m_settings.SetSmoothMode(AzToolsFramework::PaintBrushSmoothMode::Mean);
+
+        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
+
+        ON_CALL(mockHandler, OnSmooth)
+            .WillByDefault(
+                [=](const AZ::Aabb& dirtyArea,
+                    AzToolsFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
+                    AZStd::span<const AZ::Vector3> valuePointOffsets,
+                    AzToolsFramework::PaintBrushNotifications::SmoothFn& smoothFn)
+                {
+                    // The OnSmooth method for a listener to the PaintBrushNotificationBus should work as follows:
+                    // - It should receive a dirtyArea AABB that contains the region that's been smoothed.
+                    // - For each point that the listener cares about in that region, it should call valueLookupFn() to find
+                    //   out which points actually fall within the paintbrush, and what the opacities of those points are.
+                    // - For each valid point and opacity, the listener should gather all of the points around the point based
+                    //   on the relative valuePointOffsets, and then call smoothFn with all of those points to get a smoothed value.
+
+                    // Validate the dirtyArea AABB:
+                    // We expect the AABB to be centered around the TestBrushCenter but with a Z value of 0
+                    // because we only support painting in 2D for now. The radius of the AABB should match the radius of our paintbrush.
+                    EXPECT_THAT(dirtyArea, IsClose(AZ::Aabb::CreateCenterRadius(TestBrushCenter2d, TestBrushRadius)));
+
+                    // Validate the valueLookupFn:
+                    // Create a 3x3 square grid of points. Because our brush is a circle, we expect only the points in along a + to be
+                    // returned as valid points. The corners of the square should fall outside the circle and not get returned.
+                    const AZStd::vector<AZ::Vector3> points = {
+                        AZ::Vector3(dirtyArea.GetMin().GetX(), dirtyArea.GetMin().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetCenter().GetX(), dirtyArea.GetMin().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetMax().GetX(), dirtyArea.GetMin().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetMin().GetX(), dirtyArea.GetCenter().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetCenter().GetX(), dirtyArea.GetCenter().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetMax().GetX(), dirtyArea.GetCenter().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetMin().GetX(), dirtyArea.GetMax().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetCenter().GetX(), dirtyArea.GetMax().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetMax().GetX(), dirtyArea.GetMax().GetY(), 0.0f),
+                    };
+                    AZStd::vector<AZ::Vector3> validPoints;
+                    AZStd::vector<float> opacities;
+                    valueLookupFn(points, validPoints, opacities);
+
+                    // We should only have the 5 points along the + in validPoints.
+                    EXPECT_EQ(validPoints.size(), 5);
+                    const AZStd::vector<AZ::Vector3> expectedValidPoints = {
+                        AZ::Vector3(dirtyArea.GetCenter().GetX(), dirtyArea.GetMin().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetMin().GetX(), dirtyArea.GetCenter().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetCenter().GetX(), dirtyArea.GetCenter().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetMax().GetX(), dirtyArea.GetCenter().GetY(), 0.0f),
+                        AZ::Vector3(dirtyArea.GetCenter().GetX(), dirtyArea.GetMax().GetY(), 0.0f),
+                    };
+                    EXPECT_THAT(validPoints, ::testing::Pointwise(ContainerIsClose(), expectedValidPoints));
+
+                    // We should only have 5 opacities, and they should all be 1.0 because we haven't adjusted any brush settings.
+                    EXPECT_EQ(opacities.size(), 5);
+                    for (auto& opacity : opacities)
+                    {
+                        EXPECT_NEAR(opacity, 1.0f, 0.001f);
+                    }
+
+                    // By default, the smoothing brush uses a 3x3 kernel, so we expect our relative offsets to be -1 to 1
+                    // in each direction.
+                    EXPECT_EQ(valuePointOffsets.size(), 9);
+                    const AZStd::vector<AZ::Vector3> expectedPointOffsets = {
+                        AZ::Vector3(-1.0f, -1.0f, 0.0f), AZ::Vector3(0.0f, -1.0f, 0.0f), AZ::Vector3(1.0f, -1.0f, 0.0f),
+                        AZ::Vector3(-1.0f, 0.0f, 0.0f),  AZ::Vector3(0.0f, 0.0f, 0.0f),  AZ::Vector3(1.0f, 0.0f, 0.0f),
+                        AZ::Vector3(-1.0f, 1.0f, 0.0f),  AZ::Vector3(0.0f, 1.0f, 0.0f),  AZ::Vector3(1.0f, 1.0f, 0.0f),
+                    };
+                    EXPECT_THAT(valuePointOffsets, ::testing::Pointwise(ContainerIsClose(), expectedPointOffsets));
+
+                    const float baseValue = 1.0f;
+
+                    // We'll set our kernel to only have a single value of 1. The mean should be 1/9.
+                    float kernelValues[] = { 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+                    const float expectedMean = 1.0f / 9.0f;
+
+                    // With full opacity, we should just get back the mean of our kernel values.
+                    const float smoothedValue = smoothFn(baseValue, kernelValues, 1.0f);
+                    EXPECT_NEAR(smoothedValue, expectedMean, 0.01f);
+
+                    // With half opacity, we should get back a value halfway between the mean and 1.0f.
+                    const float partialSmoothedValue = smoothFn(baseValue, kernelValues, 0.5f);
+                    EXPECT_NEAR(partialSmoothedValue, expectedMean + ((1.0f - expectedMean) / 2.0f), 0.01f);
+                });
+
+
+        paintBrush.BeginPaintMode();
+        paintBrush.BeginBrushStroke(m_settings);
+        paintBrush.SmoothToLocation(TestBrushCenter, m_settings);
+        paintBrush.EndBrushStroke();
+        paintBrush.EndPaintMode();
+    }
+
+    TEST_F(PaintBrushSmoothLocationTestFixture, SmoothToLocationWithSmallMovementDoesNotTriggerPainting)
+    {
+        // This verifies that if the distance between two SmoothToLocation calls is small enough, it won't trigger
+        // an OnSmooth. "small" is defined as less than (brush size * distance %).
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+        ::testing::NiceMock<MockPaintBrushNotificationBusHandler> mockHandler(EntityComponentIdPair);
+
+        // Set the distance between brush stamps to 50%
+        const float TestDistancePercent = 50.0f;
+        m_settings.SetDistancePercent(TestDistancePercent);
+
+        // Set the brush radius to 1 meter (diameter is 2 meters)
+        const float TestBrushRadius = 1.0f;
+        m_settings.SetSize(TestBrushRadius * 2.0f);
+
+        // The distance we expect to need to move to trigger another paint call is 50% of our brush size.
+        const float DistanceToTriggerSecondCall = TestBrushRadius * 2.0f * (TestDistancePercent / 100.0f);
+
+        // Choose a second brush center location that's just slightly under the threshold that should be needed to trigger a second
+        // OnPaint call.
+        const AZ::Vector3 tooSmallSecondLocation = TestBrushCenter + AZ::Vector3(DistanceToTriggerSecondCall - 0.01f, 0.0f, 0.0f);
+
+        // We expect to get called only once for our initial SmoothToLocation(); the second SmoothToLocation() won't
+        // have moved far enough to trigger a second OnSmooth call.
+        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
+
+        paintBrush.BeginPaintMode();
+        paintBrush.BeginBrushStroke(m_settings);
+        paintBrush.SmoothToLocation(TestBrushCenter, m_settings);
+        paintBrush.SmoothToLocation(tooSmallSecondLocation, m_settings);
+        paintBrush.EndBrushStroke();
+        paintBrush.EndPaintMode();
+
+        // Try the test again, this time moving exactly the amount we need to so that we trigger a second call.
+        // (We do this to verify that we've correctly identified the threshold under which we should not trigger another OnSmooth)
+        const AZ::Vector3 largeEnoughSecondLocation = TestBrushCenter + AZ::Vector3(DistanceToTriggerSecondCall, 0.0f, 0.0f);
+        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(2);
+
+        paintBrush.BeginPaintMode();
+        paintBrush.BeginBrushStroke(m_settings);
+        paintBrush.SmoothToLocation(TestBrushCenter, m_settings);
+        paintBrush.SmoothToLocation(largeEnoughSecondLocation, m_settings);
+        paintBrush.EndBrushStroke();
+        paintBrush.EndPaintMode();
+    }
+
+    TEST_F(PaintBrushSmoothLocationTestFixture, SmoothToLocationSecondMovementDoesNotIncludeFirstCircle)
+    {
+        // When smoothing, the first SmoothToLocation call should just contain a single brush stamp at the passed-in location.
+        // The second SmoothToLocation call should contain brush stamps from the first location to the second, but should NOT
+        // have a second brush stamp at the first location. Ex:
+        //     O            <- first SmoothToLocation
+        //     -OOO         <- second SmoothToLocation
+        // If the Distance % is anything less than 100% in the paint brush settings, the Os will overlap.
+        // We'll set it to 100% just to make it obvious that we've gotten the correct result.
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+        ::testing::NiceMock<MockPaintBrushNotificationBusHandler> mockHandler(EntityComponentIdPair);
+
+        // Set the distance between brush stamps to 100%
+        const float TestDistancePercent = 100.0f;
+        m_settings.SetDistancePercent(TestDistancePercent);
+
+        // Set the brush radius to 1 meter (diameter is 2 meters)
+        const float TestBrushRadius = 1.0f;
+        const float TestBrushSize = TestBrushRadius * 2.0f;
+        m_settings.SetSize(TestBrushSize);
+
+        // Choose a second brush center location that's 3 full brush stamps away. This should give us a total
+        // of 4 brush stamps that get painted between the two calls.
+        const AZ::Vector3 secondLocation = TestBrushCenter + AZ::Vector3(TestBrushSize * 3.0f, 0.0f, 0.0f);
+
+        // We expect to get two OnSmooth calls.
+        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(2);
+
+        paintBrush.BeginPaintMode();
+        paintBrush.BeginBrushStroke(m_settings);
+
+        ON_CALL(mockHandler, OnSmooth)
+            .WillByDefault(
+                [=](const AZ::Aabb& dirtyArea,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
+                    [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::SmoothFn& smoothFn)
+                {
+                    // On the first SmoothToLocation, we expect to get a dirtyArea that exactly fits our first paint brush stamp.
+                    const AZ::Aabb expectedFirstDirtyArea = AZ::Aabb::CreateCenterRadius(TestBrushCenter2d, TestBrushRadius);
+                    EXPECT_THAT(dirtyArea, IsClose(expectedFirstDirtyArea));
+                });
+
+        paintBrush.SmoothToLocation(TestBrushCenter, m_settings);
+
+        ON_CALL(mockHandler, OnSmooth)
+            .WillByDefault(
+                [=](const AZ::Aabb& dirtyArea,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
+                    [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::SmoothFn& smoothFn)
+                {
+                    // On the second SmoothToLocation, we expect the dirtyArea to only contain the next 3 paint brush stamps,
+                    // but not the first one.
+                    const AZ::Vector3 stampIncrement = AZ::Vector3(TestBrushSize, 0.0f, 0.0f);
+                    AZ::Aabb expectedSecondDirtyArea = AZ::Aabb::CreateCenterRadius(TestBrushCenter2d + stampIncrement, TestBrushRadius);
+                    expectedSecondDirtyArea.AddAabb(
+                        AZ::Aabb::CreateCenterRadius(TestBrushCenter2d + (3.0f * stampIncrement), TestBrushRadius));
+                    EXPECT_THAT(dirtyArea, IsClose(expectedSecondDirtyArea));
+                });
+
+        paintBrush.SmoothToLocation(secondLocation, m_settings);
+
+        paintBrush.EndBrushStroke();
+        paintBrush.EndPaintMode();
+    }
+
+    TEST_F(PaintBrushSmoothLocationTestFixture, EyedropperDoesNotAffectSmoothToLocation)
+    {
+        // When smoothing, we should be able to call UseEyedropper at any arbitrary location without affecting the current
+        // state of SmoothToLocation.
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+        ::testing::NiceMock<MockPaintBrushNotificationBusHandler> mockHandler(EntityComponentIdPair);
+
+        // Set the brush radius to 1 meter (diameter is 2 meters)
+        const float TestBrushRadius = 1.0f;
+        const float TestBrushSize = TestBrushRadius * 2.0f;
+        m_settings.SetSize(TestBrushSize);
+
+        // Choose a second brush center location that's 2 full brush stamps away in the X direction only.
+        AZ::Vector3 secondLocation = TestBrushCenter + AZ::Vector3(TestBrushSize * 2.0f, 0.0f, 0.0f);
+
+        // We expect to get two OnSmooth calls.
+        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(2);
+
+        ON_CALL(mockHandler, OnSmooth)
+            .WillByDefault(
+                [=](const AZ::Aabb& dirtyArea,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
+                    [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::SmoothFn& smoothFn)
+                {
+                    // We expect that the Y value for our dirtyArea won't be changed even though we'll call UseEyedropper
+                    // with a large Y value in-between the two paint calls.
+                    EXPECT_NEAR(dirtyArea.GetMin().GetY(), TestBrushCenter.GetY() - TestBrushRadius, 0.01f);
+                    EXPECT_NEAR(dirtyArea.GetMax().GetY(), TestBrushCenter.GetY() + TestBrushRadius, 0.01f);
+                });
+
+        paintBrush.BeginPaintMode();
+        paintBrush.BeginBrushStroke(m_settings);
+
+        paintBrush.SmoothToLocation(TestBrushCenter, m_settings);
+
+        // Call UseEyeDropper with a large Y value so that we can easily detect if it affected our SmoothToLocation calls.
+        [[maybe_unused]] AZ::Color color = paintBrush.UseEyedropper(TestBrushCenter + AZ::Vector3(0.0f, 1000.0f, 0.0f));
+
+        paintBrush.SmoothToLocation(secondLocation, m_settings);
+
+        paintBrush.EndBrushStroke();
+        paintBrush.EndPaintMode();
+    }
+
+    TEST_F(PaintBrushSmoothLocationTestFixture, ResetBrushStrokeTrackingWorksCorrectly)
+    {
+        // If ResetBrushStrokeTracking is called in-between two calls to SmoothtToLocation within a brush stroke,
+        // there should be a discontinuity between the two locations as if the brush has been picked up and put back down.
+        // i.e. Instead of 'OOOOOO' between two locations it should create 'O     O'.
+        // This is typically used for handling things like leaving the edge of the image at one location and coming back onto
+        // the image at a different location.
+
+        AzToolsFramework::PaintBrush paintBrush(EntityComponentIdPair);
+        ::testing::NiceMock<MockPaintBrushNotificationBusHandler> mockHandler(EntityComponentIdPair);
+
+        // Set the distance between brush stamps to 100%
+        const float TestDistancePercent = 100.0f;
+        m_settings.SetDistancePercent(TestDistancePercent);
+
+        // Set the brush radius to 1 meter (diameter is 2 meters)
+        const float TestBrushRadius = 1.0f;
+        const float TestBrushSize = TestBrushRadius * 2.0f;
+        m_settings.SetSize(TestBrushSize);
+
+        // Choose a second brush center location that's 10 full brush stamps away to make it obvious whether or not
+        // there are any points tracked between the two locations.
+        const AZ::Vector3 secondLocation = TestBrushCenter + AZ::Vector3(TestBrushSize * 10.0f, 0.0f, 0.0f);
+
+        // We expect to get two OnSmooth calls.
+        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(2);
+
+        paintBrush.BeginPaintMode();
+        paintBrush.BeginBrushStroke(m_settings);
+
+        ON_CALL(mockHandler, OnSmooth)
+            .WillByDefault(
+                [=](const AZ::Aabb& dirtyArea,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
+                    [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::SmoothFn& smoothFn)
+                {
+                    // On the first PaintToLocation, we expect to get a dirtyArea that exactly fits our first paint brush stamp.
+                    const AZ::Aabb expectedFirstDirtyArea = AZ::Aabb::CreateCenterRadius(TestBrushCenter2d, TestBrushRadius);
+                    EXPECT_THAT(dirtyArea, IsClose(expectedFirstDirtyArea));
+                });
+
+        paintBrush.SmoothToLocation(TestBrushCenter, m_settings);
+
+        // Reset the brush stroke tracking, so that the next location will look like the start of a stroke again.
+        paintBrush.ResetBrushStrokeTracking();
+
+        ON_CALL(mockHandler, OnSmooth)
+            .WillByDefault(
+                [=](const AZ::Aabb& dirtyArea,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
+                    [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,
+                    [[maybe_unused]] AzToolsFramework::PaintBrushNotifications::SmoothFn& smoothFn)
+                {
+                    // On the second PaintToLocation, we expect to get a dirtyArea that exactly fits our second paint brush stamp.
+                    // It should *not* include any of the space bewteen the first and the second brush stamp.
+                    const AZ::Vector3 secondLocation2d(AZ::Vector2(secondLocation), 0.0f);
+                    const AZ::Aabb expectedSecondDirtyArea = AZ::Aabb::CreateCenterRadius(secondLocation2d, TestBrushRadius);
+                    EXPECT_THAT(dirtyArea, IsClose(expectedSecondDirtyArea));
+                });
+
+        paintBrush.SmoothToLocation(secondLocation, m_settings);
+
+        paintBrush.EndBrushStroke();
+        paintBrush.EndPaintMode();
+    }
+} // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
+++ b/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
@@ -67,6 +67,10 @@ set(FILES
     ManipulatorViewTests.cpp
     PerforceComponentTests.cpp
     PlatformAddressedAssetCatalogTests.cpp
+    PaintBrush/MockPaintBrushNotificationHandler.h
+    PaintBrush/PaintBrushBaseTests.cpp
+    PaintBrush/PaintBrushPaintLocationTests.cpp
+    PaintBrush/PaintBrushSmoothLocationTests.cpp
     Prefab/Benchmark/Link/SingleInstanceMultiplePatchesBenchmarks.cpp
     Prefab/Benchmark/Link/SingleInstanceMultiplePatchesBenchmarks.h
     Prefab/Benchmark/PrefabBenchmarkFixture.cpp


### PR DESCRIPTION
## What does this PR do?

This adds a set of unit tests for PaintBrush that test most of the base functionality:
- Paint Mode begin/end
- Brush Stroke begin/end
- PaintToLocation, SmoothToLocation, ResetPaintBrushTracking all trivially work and handle locations correctly

The one functional change introduced here is that I realized the PaintBrush code was inconsistently converting things into 2D space for painting calculations. I've made this more explicit and consistent and (not really) conditional based on the constant "PaintIn2D". It's structured this way because we might eventually want to open this up as a runtime parameter so that we can have full 3D painting as well, but since we don't have any use cases for that yet I'd like to avoid adding extra parameters and unit tests before we have the need.

## How was this PR tested?

Ran the unit tests and verified they all passed.
