### PR TITLE
Update the bug template to include commit ID

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -32,8 +32,9 @@ If applicable, add screenshots and/or a video to help explain your problem.
 **Found in Branch**
 Name of or link to the branch where the issue occurs.
 
-**Commit ID from Branch**
-ID (SHA-1 hash) of the latest commit from the branch where the issue occurs.
+**Commit ID from [o3de/o3de](https://github.com/o3de/o3de) Repository**
+Please provide the SHA/hash that identifies the latest commit from the o3de/o3de repository if the issue is reproducible in the development or other official branches. 
+You can get the commit ID by running the `git rev-parse HEAD` command on your current branch.
 
 **Desktop/Device (please complete the following information):**
  - Device: [e.g. PC, Mac, iPhone, Samsung] 

--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -32,6 +32,9 @@ If applicable, add screenshots and/or a video to help explain your problem.
 **Found in Branch**
 Name of or link to the branch where the issue occurs.
 
+**Commit ID from Branch**
+ID (SHA-1 hash) of the latest commit from the branch where the issue occurs.
+
 **Desktop/Device (please complete the following information):**
  - Device: [e.g. PC, Mac, iPhone, Samsung] 
  - OS: [e.g. Windows, macOS, iOS, Android]


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?

Add the commit ID information to the GHI bug template which helps people to check whether the bug has been fixed in the latest for proper triage.

## How was this PR tested?

Cannot test the change locally. Will try to create a new GHI after the merge to verify it.
