### PR TITLE
Asset Processor - Avoid FindFirstMatchingFile on absolute path

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -4155,19 +4155,21 @@ namespace AssetProcessor
             }
             else if (QFileInfo(encodedFileData).isAbsolute())
             {
-                // attempt to split:
                 QString scanFolderName;
-                if (!m_platformConfig->ConvertToRelativePath(encodedFileData, resultDatabaseSourceName, scanFolderName))
+                // Verify the path is in a scanfolder
+                if (!m_platformConfig->GetScanFolderForFile(encodedFileData))
                 {
                     AZ_Warning(AssetProcessor::ConsoleChannel, false, "'%s' does not appear to be in any input folder.  Use relative paths instead.", sourceDependency.m_sourceFileDependencyPath.c_str());
                 }
                 else
                 {
+                    // Return the absolute path
                     resultDatabaseSourceName = encodedFileData;
                 }
             }
             else
             {
+                // Return the relative path
                 resultDatabaseSourceName = encodedFileData;
             }
         }
@@ -5193,11 +5195,18 @@ namespace AssetProcessor
             }
             else
             {
-                absolutePath = m_platformConfig->FindFirstMatchingFile(dep.GetPath().c_str());
-
-                if (absolutePath.isEmpty())
+                if (AZ::IO::PathView(dep.GetPath()).IsAbsolute())
                 {
-                    continue;
+                    absolutePath = dep.GetPath().c_str();
+                }
+                else
+                {
+                    absolutePath = m_platformConfig->FindFirstMatchingFile(dep.GetPath().c_str());
+
+                    if (absolutePath.isEmpty())
+                    {
+                        continue;
+                    }
                 }
             }
 


### PR DESCRIPTION
## What does this PR do?

Avoid calling FindFirstMatchingFile on an absolute path as its unnecessary and doesn't really make sense.

Also switch out a call to ConvertToRelativePath to GetScanFolderForFile since the relative path was not used and made the code confusing.

## How was this PR tested?

Ran AP and unit tests
