### PR TITLE
New automated tests for delete entity or prefab as overrides

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Periodic.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Periodic.py
@@ -85,3 +85,15 @@ class TestAutomationOverrides(EditorTestSuite):
 
     class test_AddEntity_UnderUnfocusedInstanceAsOverride(EditorBatchedTest):
         from .tests.overrides import AddEntity_UnderUnfocusedInstanceAsOverride as test_module
+
+    class test_DeleteEntity_UnderImmediateInstance(EditorBatchedTest):
+        from .tests.overrides import DeleteEntity_UnderImmediateInstance as test_module
+
+    class test_DeleteEntity_UnderNestedInstance(EditorBatchedTest):
+        from .tests.overrides import DeleteEntity_UnderNestedInstance as test_module
+    
+    class test_DeletePrefab_UnderImmediateInstance(EditorBatchedTest):
+        from .tests.overrides import DeletePrefab_UnderImmediateInstance as test_module
+
+    class test_DeletePrefab_UnderNestedInstance(EditorBatchedTest):
+        from .tests.overrides import DeletePrefab_UnderNestedInstance as test_module

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/PrefabTestUtils.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/PrefabTestUtils.py
@@ -190,6 +190,32 @@ def check_entity_children_count(entity_id, expected_children_count):
     return entity_children_count_matched
 
 
+def validate_count_for_editor_entity(entity_name, expected_count):
+    """
+    This is a helper function which helps validate the number of entities for a given name in editor.
+
+    :param entity_name: Entity name for the entities to be validated.
+    :param expected_count: Expected number of entities.
+    """
+    entities = EditorEntity.find_editor_entities([entity_name])
+    assert len(entities) == expected_count, f"{len(entities)} entity(s) found. " \
+                                            f"Expected {expected_count} {entity_name} entity(s)."
+
+
+def validate_children_count_for_editor_entity(entity_name, expected_children_count):
+    """
+    This is a helper function which helps validate the number of children of entities for a given name in editor.
+
+    :param entity_name: Entity name for the entities to be validated.
+    :param expected_children_count: Expected number of children.
+    """
+    entities = EditorEntity.find_editor_entities([entity_name])
+    for entity in entities:
+        child_entities = entity.get_children()
+        assert len(child_entities) == expected_children_count, f"{len(child_entities)} children found. " \
+                                                               f"Expected {expected_children_count} children for all {entity_name} entity(s)."
+
+
 def open_base_tests_level():
     helper.init_idle()
     helper.open_level("Prefab", "Base")

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/PrefabTestUtils.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/PrefabTestUtils.py
@@ -190,7 +190,7 @@ def check_entity_children_count(entity_id, expected_children_count):
     return entity_children_count_matched
 
 
-def validate_count_for_editor_entity(entity_name, expected_count):
+def validate_count_for_named_editor_entity(entity_name, expected_count):
     """
     This is a helper function which helps validate the number of entities for a given name in editor.
 
@@ -202,18 +202,18 @@ def validate_count_for_editor_entity(entity_name, expected_count):
                                             f"Expected {expected_count} {entity_name} entity(s)."
 
 
-def validate_children_count_for_editor_entity(entity_name, expected_children_count):
+def validate_child_count_for_named_editor_entity(entity_name, expected_child_count):
     """
     This is a helper function which helps validate the number of children of entities for a given name in editor.
 
     :param entity_name: Entity name for the entities to be validated.
-    :param expected_children_count: Expected number of children.
+    :param expected_child_count: Expected number of children.
     """
     entities = EditorEntity.find_editor_entities([entity_name])
     for entity in entities:
         child_entities = entity.get_children()
-        assert len(child_entities) == expected_children_count, f"{len(child_entities)} children found. " \
-                                                               f"Expected {expected_children_count} children for all {entity_name} entity(s)."
+        assert len(child_entities) == expected_child_count, f"{len(child_entities)} children found. " \
+                                                            f"Expected {expected_child_count} children for all {entity_name} entity(s)."
 
 
 def open_base_tests_level():

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/DeleteEntity_UnderImmediateInstance.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/DeleteEntity_UnderImmediateInstance.py
@@ -59,7 +59,7 @@ def DeleteEntity_UnderImmediateInstance():
     PrefabWaiter.wait_for_propagation()
 
     # Validate after entity deletion.
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 1)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_ENTITY_NAME, 1)
     prefab_test_utils.check_entity_children_count(car_instance_1.container_entity.id, 0)
     prefab_test_utils.check_entity_children_count(car_instance_2.container_entity.id, 1)
 
@@ -67,7 +67,7 @@ def DeleteEntity_UnderImmediateInstance():
     general.undo()
     PrefabWaiter.wait_for_propagation()
 
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 2)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_ENTITY_NAME, 2)
     prefab_test_utils.check_entity_children_count(car_instance_1.container_entity.id, 1)
     prefab_test_utils.check_entity_children_count(car_instance_2.container_entity.id, 1)
 
@@ -75,7 +75,7 @@ def DeleteEntity_UnderImmediateInstance():
     general.redo()
     PrefabWaiter.wait_for_propagation()
 
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 1)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_ENTITY_NAME, 1)
     prefab_test_utils.check_entity_children_count(car_instance_1.container_entity.id, 0)
     prefab_test_utils.check_entity_children_count(car_instance_2.container_entity.id, 1)
 
@@ -86,7 +86,7 @@ def DeleteEntity_UnderImmediateInstance():
     prefab_test_utils.check_entity_children_count(car_instance_1.container_entity.id, 1)
 
     # Note: This should be 2 because the tire entity inside the second car is not deleted.
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 2)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_ENTITY_NAME, 2)
 
 
 if __name__ == "__main__":

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/DeleteEntity_UnderImmediateInstance.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/DeleteEntity_UnderImmediateInstance.py
@@ -1,0 +1,94 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+def DeleteEntity_UnderImmediateInstance():
+    """
+    Test description:
+    - Deletes the "Tire_Entity" of the "First_Car" instance.
+    - Checks that the "Tire_Entity" is deleted only in "First_Car" instance.
+    - Checks undo/redo correctness.
+    - Checks that the deleted "Tire_Entity" should re-appear after focusing on
+      its owning instance (i.e. "First_Car").
+
+    Hierarchy:
+    - Level                   <-- focus on this prefab
+      - First_Car
+        - Tire_Entity         <-- delete this entity as override
+      - Second_Car
+        - Tire_Entity         <-- this entity is unchanged
+    """
+
+    from editor_python_test_tools.editor_entity_utils import EditorEntity
+    from editor_python_test_tools.prefab_utils import Prefab
+    from editor_python_test_tools.wait_utils import PrefabWaiter
+
+    import azlmbr.legacy.general as general
+    import Prefab.tests.PrefabTestUtils as prefab_test_utils
+
+    CAR_PREFAB_FILE_NAME = Path(__file__).stem + "_" + "car_prefab"
+
+    FIRST_CAR_NAME = "First_Car"
+    SECOND_CAR_NAME = "Second_Car"
+    TIRE_ENTITY_NAME = "Tire_Entity"
+
+    prefab_test_utils.open_base_tests_level()
+
+    # Create a new entity at the root level.
+    tire_entity = EditorEntity.create_editor_entity_at((100.0, 100.0, 100.0), TIRE_ENTITY_NAME)
+    assert tire_entity.id.IsValid(), f"Failed to create new entity: {TIRE_ENTITY_NAME}."
+
+    # Create a car prefab and the first car instance from the tire entity.
+    car_prefab_entities = [tire_entity]
+    car_prefab, car_instance_1 = Prefab.create_prefab(car_prefab_entities, CAR_PREFAB_FILE_NAME, FIRST_CAR_NAME)
+    assert car_instance_1.is_valid(), f"Failed to instantiate instance: {FIRST_CAR_NAME}."
+
+    # Create the second car instance.
+    car_instance_2 = car_prefab.instantiate(name=SECOND_CAR_NAME)
+    assert car_instance_2.is_valid(), f"Failed to instantiate instance: {SECOND_CAR_NAME}."
+    
+    # Delete the tire entity in the first car. Note: Level prefab is currently being focused by default during deletion.
+    tire_entities_in_car_instance_1 = car_instance_1.get_direct_child_entities()
+    tire_entity_in_car_instance_1 = tire_entities_in_car_instance_1[0]
+    tire_entity_in_car_instance_1.delete()
+
+    # Wait till prefab propagation finishes before validating deletion.
+    PrefabWaiter.wait_for_propagation()
+
+    # Validate after entity deletion.
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 1)
+    prefab_test_utils.check_entity_children_count(car_instance_1.container_entity.id, 0)
+    prefab_test_utils.check_entity_children_count(car_instance_2.container_entity.id, 1)
+
+    # Validate undo on entity deletion.
+    general.undo()
+    PrefabWaiter.wait_for_propagation()
+
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 2)
+    prefab_test_utils.check_entity_children_count(car_instance_1.container_entity.id, 1)
+    prefab_test_utils.check_entity_children_count(car_instance_2.container_entity.id, 1)
+
+    # Validate redo on entity deletion.
+    general.redo()
+    PrefabWaiter.wait_for_propagation()
+
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 1)
+    prefab_test_utils.check_entity_children_count(car_instance_1.container_entity.id, 0)
+    prefab_test_utils.check_entity_children_count(car_instance_2.container_entity.id, 1)
+
+    # Focus on the first car instance. Deleted tire entity should appear in Prefab Edit Mode.
+    car_instance_1.container_entity.focus_on_owning_prefab()
+
+    PrefabWaiter.wait_for_propagation() # propagate source template changes after focusing on
+    prefab_test_utils.check_entity_children_count(car_instance_1.container_entity.id, 1)
+
+    # Note: This should be 2 because the tire entity inside the second car is not deleted.
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 2)
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(DeleteEntity_UnderImmediateInstance)

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/DeleteEntity_UnderNestedInstance.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/DeleteEntity_UnderNestedInstance.py
@@ -90,25 +90,25 @@ def DeleteEntity_UnderNestedInstance():
     PrefabWaiter.wait_for_propagation()
 
     # Validate after entity deletion.
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 2)
-    prefab_test_utils.validate_children_count_for_editor_entity(FRONT_WHEEL_NAME, 0)
-    prefab_test_utils.validate_children_count_for_editor_entity(BACK_WHEEL_NAME, 1)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_ENTITY_NAME, 2)
+    prefab_test_utils.validate_child_count_for_named_editor_entity(FRONT_WHEEL_NAME, 0)
+    prefab_test_utils.validate_child_count_for_named_editor_entity(BACK_WHEEL_NAME, 1)
 
     # Validate undo on entity deletion.
     general.undo()
     PrefabWaiter.wait_for_propagation()
 
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 4)
-    prefab_test_utils.validate_children_count_for_editor_entity(FRONT_WHEEL_NAME, 1)
-    prefab_test_utils.validate_children_count_for_editor_entity(BACK_WHEEL_NAME, 1)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_ENTITY_NAME, 4)
+    prefab_test_utils.validate_child_count_for_named_editor_entity(FRONT_WHEEL_NAME, 1)
+    prefab_test_utils.validate_child_count_for_named_editor_entity(BACK_WHEEL_NAME, 1)
 
     # Validate redo on entity deletion.
     general.redo()
     PrefabWaiter.wait_for_propagation()
 
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 2)
-    prefab_test_utils.validate_children_count_for_editor_entity(FRONT_WHEEL_NAME, 0)
-    prefab_test_utils.validate_children_count_for_editor_entity(BACK_WHEEL_NAME, 1)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_ENTITY_NAME, 2)
+    prefab_test_utils.validate_child_count_for_named_editor_entity(FRONT_WHEEL_NAME, 0)
+    prefab_test_utils.validate_child_count_for_named_editor_entity(BACK_WHEEL_NAME, 1)
 
     # Focus on first wheel instance in first car. Deleted tire entity should appear in Prefab Edit Mode.
     front_wheel_container_entities = EditorEntity.find_editor_entities([FRONT_WHEEL_NAME])
@@ -125,7 +125,7 @@ def DeleteEntity_UnderNestedInstance():
     prefab_test_utils.check_entity_children_count(front_wheel_in_car_instance_1.id, 1)
     
     # Note: This should be 3 because the tire entity inside the front wheel under the second car is still deleted.
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 3)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_ENTITY_NAME, 3)
 
 
 if __name__ == "__main__":

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/DeleteEntity_UnderNestedInstance.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/DeleteEntity_UnderNestedInstance.py
@@ -1,0 +1,133 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+def DeleteEntity_UnderNestedInstance():
+    """
+    Test description:
+    - Focuses on the "First_Car" instance.
+    - Deletes the "Tire_Entity" of the "Front_Wheel" of "First_Car".
+    - Checks that there are 2 "Tire_Entity" and the deleted
+      entities are only under the "Front_Wheel" instances in both cars.
+    - Checks undo/redo correctness.
+    - Checks that the deleted "Tire_Entity" should re-appear after focusing on
+      its owning instance (i.e. "Front_Wheel") in "First_Car".
+
+    Hierarchy:
+    - Level
+      - First_Car              <-- focus on this prefab
+        - Front_Wheel
+          - Tire_Entity        <-- delete this entity as override
+        - Back_Wheel
+          - Tire_Entity
+      - Second_Car
+        - Front_Wheel
+          - Tire_Entity        <-- this should be deleted as well after propagation
+        - Back_Wheel
+          - Tire_Entity
+    """
+
+    from editor_python_test_tools.editor_entity_utils import EditorEntity
+    from editor_python_test_tools.prefab_utils import Prefab
+    from editor_python_test_tools.wait_utils import PrefabWaiter
+
+    import azlmbr.legacy.general as general
+    import Prefab.tests.PrefabTestUtils as prefab_test_utils
+
+    CAR_PREFAB_FILE_NAME = Path(__file__).stem + "_" + "car_prefab"
+    WHEEL_PREFAB_FILE_NAME = Path(__file__).stem + "_" + "wheel_prefab"
+
+    FIRST_CAR_NAME = "First_Car"
+    SECOND_CAR_NAME = "Second_Car"
+    FRONT_WHEEL_NAME = "Front_Wheel"
+    BACK_WHEEL_NAME = "Back_Wheel"
+    TIRE_ENTITY_NAME = "Tire_Entity"
+
+    prefab_test_utils.open_base_tests_level()
+
+    # Create a new entity at the root level.
+    tire_entity = EditorEntity.create_editor_entity_at((100.0, 100.0, 100.0), TIRE_ENTITY_NAME)
+    assert tire_entity.id.IsValid(), f"Failed to create new entity: {TIRE_ENTITY_NAME}."
+
+    # Create a wheel prefab and front wheel instance from the tire entity.
+    wheel_prefab_entities = [tire_entity]
+    wheel_prefab, front_wheel_instance = Prefab.create_prefab(wheel_prefab_entities, WHEEL_PREFAB_FILE_NAME, \
+        FRONT_WHEEL_NAME)
+    assert front_wheel_instance.is_valid(), f"Failed to instantiate instance: {FRONT_WHEEL_NAME}."
+
+    # Create a back wheel instance.
+    back_wheel_instance = wheel_prefab.instantiate(name=BACK_WHEEL_NAME)
+    assert back_wheel_instance.is_valid(), f"Failed to instantiate instance: {BACK_WHEEL_NAME}."
+    
+    # Create a car prefab and the first car instance from two wheels.
+    car_prefab_entities = [front_wheel_instance.container_entity, back_wheel_instance.container_entity]
+    car_prefab, car_instance_1 = Prefab.create_prefab(car_prefab_entities, CAR_PREFAB_FILE_NAME, \
+        FIRST_CAR_NAME)
+    assert car_instance_1.is_valid(), f"Failed to instantiate instance: {FIRST_CAR_NAME}."
+
+    # Create a second car instance.
+    car_instance_2 = car_prefab.instantiate(name=SECOND_CAR_NAME)
+    assert car_instance_2.is_valid(), f"Failed to instantiate instance: {SECOND_CAR_NAME}."
+
+    # Focus on the first car instance.
+    car_instance_1.container_entity.focus_on_owning_prefab()
+
+    # Delete the tire entity in the front wheel instance in the first car instance.
+    wheel_container_entities_in_car_instance_1 = car_instance_1.get_direct_child_entities()
+    filtered_wheel_list = list(filter(lambda wheel_container_entity: \
+        wheel_container_entity.get_name() == FRONT_WHEEL_NAME, \
+        wheel_container_entities_in_car_instance_1))
+    assert len(filtered_wheel_list) == 1, f"Found {len(filtered_wheel_list)} {FRONT_WHEEL_NAME}. " \
+                                          f"Expected 1 {FRONT_WHEEL_NAME} in {FIRST_CAR_NAME} to delete."
+
+    tire_entity_in_front_wheel_in_car_instance_1 = filtered_wheel_list[0].get_children()[0]
+    tire_entity_in_front_wheel_in_car_instance_1.delete()
+
+    # Wait till prefab propagation finishes before validating deletion.
+    PrefabWaiter.wait_for_propagation()
+
+    # Validate after entity deletion.
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 2)
+    prefab_test_utils.validate_children_count_for_editor_entity(FRONT_WHEEL_NAME, 0)
+    prefab_test_utils.validate_children_count_for_editor_entity(BACK_WHEEL_NAME, 1)
+
+    # Validate undo on entity deletion.
+    general.undo()
+    PrefabWaiter.wait_for_propagation()
+
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 4)
+    prefab_test_utils.validate_children_count_for_editor_entity(FRONT_WHEEL_NAME, 1)
+    prefab_test_utils.validate_children_count_for_editor_entity(BACK_WHEEL_NAME, 1)
+
+    # Validate redo on entity deletion.
+    general.redo()
+    PrefabWaiter.wait_for_propagation()
+
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 2)
+    prefab_test_utils.validate_children_count_for_editor_entity(FRONT_WHEEL_NAME, 0)
+    prefab_test_utils.validate_children_count_for_editor_entity(BACK_WHEEL_NAME, 1)
+
+    # Focus on first wheel instance in first car. Deleted tire entity should appear in Prefab Edit Mode.
+    front_wheel_container_entities = EditorEntity.find_editor_entities([FRONT_WHEEL_NAME])
+    filtered_front_wheel_list = list(filter(lambda front_wheel: \
+        front_wheel.get_parent_id() == car_instance_1.container_entity.id, \
+        front_wheel_container_entities))
+    assert len(filtered_front_wheel_list) == 1, f"Found {len(filtered_front_wheel_list)} {FRONT_WHEEL_NAME}. " \
+                                                f"Expected 1 {FRONT_WHEEL_NAME} in {FIRST_CAR_NAME} to focus on."
+    front_wheel_in_car_instance_1 = filtered_front_wheel_list[0]
+
+    front_wheel_in_car_instance_1.focus_on_owning_prefab()
+    PrefabWaiter.wait_for_propagation() # propagate source template changes after focusing on
+
+    prefab_test_utils.check_entity_children_count(front_wheel_in_car_instance_1.id, 1)
+    
+    # Note: This should be 3 because the tire entity inside the front wheel under the second car is still deleted.
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 3)
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(DeleteEntity_UnderNestedInstance)

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/DeletePrefab_UnderImmediateInstance.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/DeletePrefab_UnderImmediateInstance.py
@@ -69,8 +69,8 @@ def DeletePrefab_UnderImmediateInstance():
     PrefabWaiter.wait_for_propagation()
 
     # Validate after instance deletion.
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_PREFAB_NAME, 1)
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 1)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_PREFAB_NAME, 1)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_ENTITY_NAME, 1)
     prefab_test_utils.check_entity_children_count(car_instance_1.container_entity.id, 0)
     prefab_test_utils.check_entity_children_count(car_instance_2.container_entity.id, 1)
 
@@ -78,8 +78,8 @@ def DeletePrefab_UnderImmediateInstance():
     general.undo()
     PrefabWaiter.wait_for_propagation()
 
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_PREFAB_NAME, 2)
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 2)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_PREFAB_NAME, 2)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_ENTITY_NAME, 2)
     prefab_test_utils.check_entity_children_count(car_instance_1.container_entity.id, 1)
     prefab_test_utils.check_entity_children_count(car_instance_2.container_entity.id, 1)
 
@@ -87,8 +87,8 @@ def DeletePrefab_UnderImmediateInstance():
     general.redo()
     PrefabWaiter.wait_for_propagation()
 
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_PREFAB_NAME, 1)
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 1)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_PREFAB_NAME, 1)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_ENTITY_NAME, 1)
     prefab_test_utils.check_entity_children_count(car_instance_1.container_entity.id, 0)
     prefab_test_utils.check_entity_children_count(car_instance_2.container_entity.id, 1)
 
@@ -99,8 +99,8 @@ def DeletePrefab_UnderImmediateInstance():
     prefab_test_utils.check_entity_children_count(car_instance_1.container_entity.id, 1)
 
     # Note: This should be 2 because the tire entity (and instance) inside the second car is not deleted.
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_PREFAB_NAME, 2)
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 2)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_PREFAB_NAME, 2)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_ENTITY_NAME, 2)
 
 
 if __name__ == "__main__":

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/DeletePrefab_UnderImmediateInstance.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/DeletePrefab_UnderImmediateInstance.py
@@ -1,0 +1,108 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+def DeletePrefab_UnderImmediateInstance():
+    """
+    Test description:
+    - Deletes the "Tire_Prefab" instance of the "First_Car".
+    - Checks that the "Tire_Prefab" is deleted only in "First_Car".
+    - Checks undo/redo correctness.
+    - Checks that the deleted "Tire_Prefab" instance (and "Tire_Entity") should re-appear
+      after focusing on its owning instance (i.e. "First_Car").
+    
+    Hierarchy:
+    - Level                    <-- focus on this prefab
+      - First_Car
+        - Tire_Prefab          <-- delete this instance as override
+          - Tire_Entity
+      - Second_Car
+        - Tire_Prefab          <-- this instance is unchanged
+          - Tire_Entity
+    """
+
+    from editor_python_test_tools.editor_entity_utils import EditorEntity
+    from editor_python_test_tools.prefab_utils import Prefab
+    from editor_python_test_tools.wait_utils import PrefabWaiter
+
+    import azlmbr.legacy.general as general
+    import Prefab.tests.PrefabTestUtils as prefab_test_utils
+
+    CAR_PREFAB_FILE_NAME = Path(__file__).stem + "_" + "car_prefab"
+    WHEEL_PREFAB_FILE_NAME = Path(__file__).stem + "_" + "wheel_prefab"
+    TIRE_PREFAB_FILE_NAME = Path(__file__).stem + "_" + "tire_prefab"
+
+    FIRST_CAR_NAME = "First_Car"
+    SECOND_CAR_NAME = "Second_Car"
+    TIRE_PREFAB_NAME = "Tire_Prefab"
+    TIRE_ENTITY_NAME = "Tire_Entity"
+
+    prefab_test_utils.open_base_tests_level()
+
+    # Create a new entity at the root level.
+    tire_entity = EditorEntity.create_editor_entity_at((100.0, 100.0, 100.0), TIRE_ENTITY_NAME)
+    assert tire_entity.id.IsValid(), f"Failed to create new entity: {TIRE_ENTITY_NAME}."
+
+    # Create a tire prefab from the tire entity.
+    tire_prefab_entities = [tire_entity]
+    tire_prefab, tire_instance = Prefab.create_prefab(tire_prefab_entities, TIRE_PREFAB_FILE_NAME, TIRE_PREFAB_NAME)
+    assert tire_instance.is_valid(), f"Failed to instantiate instance: {TIRE_PREFAB_NAME}."
+
+    # Create a car prefab and the first car instance from the tire entity.
+    car_prefab_entities = [tire_instance.container_entity]
+    car_prefab, car_instance_1 = Prefab.create_prefab(car_prefab_entities, CAR_PREFAB_FILE_NAME, FIRST_CAR_NAME)
+    assert car_instance_1.is_valid(), f"Failed to instantiate instance: {FIRST_CAR_NAME}."
+
+    # Create the second car instance.
+    car_instance_2 = car_prefab.instantiate(name=SECOND_CAR_NAME)
+    assert car_instance_2.is_valid(), f"Failed to instantiate instance: {SECOND_CAR_NAME}."
+    
+    # Delete the tire instance the first car. Note: Level prefab is currently being focused by default during deletion.
+    tire_container_entities_in_car_instance_1 = car_instance_1.get_direct_child_entities()
+    tire_container_entity_in_car_instance_1 = tire_container_entities_in_car_instance_1[0]
+    tire_container_entity_in_car_instance_1.delete()
+
+    # Wait till prefab propagation finishes before validating deletion.
+    PrefabWaiter.wait_for_propagation()
+
+    # Validate after instance deletion.
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_PREFAB_NAME, 1)
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 1)
+    prefab_test_utils.check_entity_children_count(car_instance_1.container_entity.id, 0)
+    prefab_test_utils.check_entity_children_count(car_instance_2.container_entity.id, 1)
+
+    # Validate undo on instance deletion.
+    general.undo()
+    PrefabWaiter.wait_for_propagation()
+
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_PREFAB_NAME, 2)
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 2)
+    prefab_test_utils.check_entity_children_count(car_instance_1.container_entity.id, 1)
+    prefab_test_utils.check_entity_children_count(car_instance_2.container_entity.id, 1)
+
+    # Validate redo on instance deletion.
+    general.redo()
+    PrefabWaiter.wait_for_propagation()
+
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_PREFAB_NAME, 1)
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 1)
+    prefab_test_utils.check_entity_children_count(car_instance_1.container_entity.id, 0)
+    prefab_test_utils.check_entity_children_count(car_instance_2.container_entity.id, 1)
+
+    # Focus on the first car instance. Deleted tire instance should appear in Prefab Edit Mode.
+    car_instance_1.container_entity.focus_on_owning_prefab()
+
+    PrefabWaiter.wait_for_propagation() # propagate source template changes after focusing on
+    prefab_test_utils.check_entity_children_count(car_instance_1.container_entity.id, 1)
+
+    # Note: This should be 2 because the tire entity (and instance) inside the second car is not deleted.
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_PREFAB_NAME, 2)
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 2)
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(DeletePrefab_UnderImmediateInstance)

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/DeletePrefab_UnderNestedInstance.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/DeletePrefab_UnderNestedInstance.py
@@ -100,31 +100,31 @@ def DeletePrefab_UnderNestedInstance():
     PrefabWaiter.wait_for_propagation()
 
     # Validate after instance deletion.
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_PREFAB_NAME, 2)
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 2)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_PREFAB_NAME, 2)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_ENTITY_NAME, 2)
 
-    prefab_test_utils.validate_children_count_for_editor_entity(FRONT_WHEEL_NAME, 0)
-    prefab_test_utils.validate_children_count_for_editor_entity(BACK_WHEEL_NAME, 1)
+    prefab_test_utils.validate_child_count_for_named_editor_entity(FRONT_WHEEL_NAME, 0)
+    prefab_test_utils.validate_child_count_for_named_editor_entity(BACK_WHEEL_NAME, 1)
 
     # Validate undo on instance deletion.
     general.undo()
     PrefabWaiter.wait_for_propagation()
     
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_PREFAB_NAME, 4)
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 4)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_PREFAB_NAME, 4)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_ENTITY_NAME, 4)
 
-    prefab_test_utils.validate_children_count_for_editor_entity(FRONT_WHEEL_NAME, 1)
-    prefab_test_utils.validate_children_count_for_editor_entity(BACK_WHEEL_NAME, 1)
+    prefab_test_utils.validate_child_count_for_named_editor_entity(FRONT_WHEEL_NAME, 1)
+    prefab_test_utils.validate_child_count_for_named_editor_entity(BACK_WHEEL_NAME, 1)
 
     # Validate redo on instance deletion.
     general.redo()
     PrefabWaiter.wait_for_propagation()
 
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_PREFAB_NAME, 2)
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 2)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_PREFAB_NAME, 2)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_ENTITY_NAME, 2)
     
-    prefab_test_utils.validate_children_count_for_editor_entity(FRONT_WHEEL_NAME, 0)
-    prefab_test_utils.validate_children_count_for_editor_entity(BACK_WHEEL_NAME, 1)
+    prefab_test_utils.validate_child_count_for_named_editor_entity(FRONT_WHEEL_NAME, 0)
+    prefab_test_utils.validate_child_count_for_named_editor_entity(BACK_WHEEL_NAME, 1)
 
     # Focus on first wheel instance in first car instance. Deleted tire instance should appear in Prefab Edit Mode.
     front_wheel_container_entities = EditorEntity.find_editor_entities([FRONT_WHEEL_NAME])
@@ -141,8 +141,8 @@ def DeletePrefab_UnderNestedInstance():
     prefab_test_utils.check_entity_children_count(front_wheel_in_car_instance_1.id, 1)
 
     # Note: This should be 3 because the tire instance inside the front wheel under the second car is still deleted.
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_PREFAB_NAME, 3)
-    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 3)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_PREFAB_NAME, 3)
+    prefab_test_utils.validate_count_for_named_editor_entity(TIRE_ENTITY_NAME, 3)
 
 
 if __name__ == "__main__":

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/DeletePrefab_UnderNestedInstance.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/DeletePrefab_UnderNestedInstance.py
@@ -1,0 +1,150 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+def DeletePrefab_UnderNestedInstance():
+    """
+    Test description:
+    - Focuses on the "First_Car" instance.
+    - Deletes the "Tire_Prefab" instance of the "Front_Wheel" under "First_Car".
+    - Checks that there are 2 "Tire_Prefab" and 2 "Tire_Entity" and the deleted 
+      instances are only in the "Front_Wheel" under both car instances.
+    - Checks undo/redo correctness.
+    - Checks that the deleted "Tire_Prefab" (and "Tire_Entity") should re-appear 
+      after focusing on its owning instance (i.e. "Front_Wheel") in "First_Car".
+
+    Hierarchy:
+    - Level
+      - First_Car                <-- focus on this prefab
+        - Front_Wheel
+          - Tire_Prefab          <-- delete this instance as override
+            - Tire_Entity
+        - Back_Wheel
+          - Tire_Prefab
+            - Tire_Entity
+      - Second_Car
+        - Front_Wheel
+          - Tire_Prefab          <-- this should be deleted as well after propagation
+            - Tire_Entity
+        - Back_Wheel
+          - Tire_Prefab
+            - Tire_Entity
+    """
+
+    from editor_python_test_tools.editor_entity_utils import EditorEntity
+    from editor_python_test_tools.prefab_utils import Prefab
+    from editor_python_test_tools.wait_utils import PrefabWaiter
+
+    import azlmbr.legacy.general as general
+    import Prefab.tests.PrefabTestUtils as prefab_test_utils
+
+    CAR_PREFAB_FILE_NAME = Path(__file__).stem + "_" + "car_prefab"
+    WHEEL_PREFAB_FILE_NAME = Path(__file__).stem + "_" + "wheel_prefab"
+    TIRE_PREFAB_FILE_NAME = Path(__file__).stem + "_" + "tire_prefab"
+
+    FIRST_CAR_NAME = "First_Car"
+    SECOND_CAR_NAME = "Second_Car"
+    FRONT_WHEEL_NAME = "Front_Wheel"
+    BACK_WHEEL_NAME = "Back_Wheel"
+    TIRE_PREFAB_NAME = "Tire_Prefab"
+    TIRE_ENTITY_NAME = "Tire_Entity"
+
+    prefab_test_utils.open_base_tests_level()
+
+    # Create a new entity at the root level.
+    tire_entity = EditorEntity.create_editor_entity_at((100.0, 100.0, 100.0), TIRE_ENTITY_NAME)
+    assert tire_entity.id.IsValid(), f"Failed to create new entity: {TIRE_ENTITY_NAME}."
+
+    # Create a tire prefab from the tire entity.
+    tire_prefab_entities = [tire_entity]
+    tire_prefab, tire_instance = Prefab.create_prefab(tire_prefab_entities, TIRE_PREFAB_FILE_NAME, TIRE_PREFAB_NAME)
+    assert tire_instance.is_valid(), f"Failed to instantiate instance: {TIRE_PREFAB_NAME}."
+
+    # Create a wheel prefab and front wheel instance from the tire instance.
+    wheel_prefab_entities = [tire_instance.container_entity]
+    wheel_prefab, front_wheel_instance = Prefab.create_prefab(wheel_prefab_entities, WHEEL_PREFAB_FILE_NAME, \
+        FRONT_WHEEL_NAME)
+    assert front_wheel_instance.is_valid(), f"Failed to instantiate instance: {FRONT_WHEEL_NAME}."
+
+    # Create a back wheel instance.
+    back_wheel_instance = wheel_prefab.instantiate(name=BACK_WHEEL_NAME)
+    assert back_wheel_instance.is_valid(), f"Failed to instantiate instance: {BACK_WHEEL_NAME}."
+    
+    # Create a car prefab and the first car instance from two wheels.
+    car_prefab_entities = [front_wheel_instance.container_entity, back_wheel_instance.container_entity]
+    car_prefab, car_instance_1 = Prefab.create_prefab(car_prefab_entities, CAR_PREFAB_FILE_NAME, FIRST_CAR_NAME)
+    assert car_instance_1.is_valid(), f"Failed to instantiate instance: {FIRST_CAR_NAME}."
+
+    # Create a second car instance.
+    car_instance_2 = car_prefab.instantiate(name=SECOND_CAR_NAME)
+    assert car_instance_2.is_valid(), f"Failed to instantiate instance: {SECOND_CAR_NAME}."
+    
+    # Focus on the first car instance.
+    car_instance_1.container_entity.focus_on_owning_prefab()
+
+    # Delete the tire instance in the front wheel instance in the first car instance.
+    wheel_container_entities_in_car_instance_1 = car_instance_1.get_direct_child_entities()
+    filtered_wheel_list = list(filter(lambda wheel_container_entity: \
+        wheel_container_entity.get_name() == FRONT_WHEEL_NAME, \
+        wheel_container_entities_in_car_instance_1))
+    assert len(filtered_wheel_list) == 1, f"Found {len(filtered_wheel_list)} {FRONT_WHEEL_NAME}. " \
+                                          f"Expected 1 {FRONT_WHEEL_NAME} in {FIRST_CAR_NAME} to delete."
+
+    tire_container_entity_in_front_wheel_in_car_instance_1 = filtered_wheel_list[0].get_children()[0]
+    tire_container_entity_in_front_wheel_in_car_instance_1.delete()
+
+    # Wait till prefab propagation finishes before validating deletion.
+    PrefabWaiter.wait_for_propagation()
+
+    # Validate after instance deletion.
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_PREFAB_NAME, 2)
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 2)
+
+    prefab_test_utils.validate_children_count_for_editor_entity(FRONT_WHEEL_NAME, 0)
+    prefab_test_utils.validate_children_count_for_editor_entity(BACK_WHEEL_NAME, 1)
+
+    # Validate undo on entity deletion.
+    general.undo()
+    PrefabWaiter.wait_for_propagation()
+    
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_PREFAB_NAME, 4)
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 4)
+
+    prefab_test_utils.validate_children_count_for_editor_entity(FRONT_WHEEL_NAME, 1)
+    prefab_test_utils.validate_children_count_for_editor_entity(BACK_WHEEL_NAME, 1)
+
+    # Validate redo on entity deletion.
+    general.redo()
+    PrefabWaiter.wait_for_propagation()
+
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_PREFAB_NAME, 2)
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 2)
+    
+    prefab_test_utils.validate_children_count_for_editor_entity(FRONT_WHEEL_NAME, 0)
+    prefab_test_utils.validate_children_count_for_editor_entity(BACK_WHEEL_NAME, 1)
+
+    # Focus on first wheel instance in first car instance. Deleted tire instance should appear in Prefab Edit Mode.
+    front_wheel_container_entities = EditorEntity.find_editor_entities([FRONT_WHEEL_NAME])
+    filtered_front_wheel_list = list(filter(lambda front_wheel: \
+        front_wheel.get_parent_id() == car_instance_1.container_entity.id, \
+        front_wheel_container_entities))
+    assert len(filtered_front_wheel_list) == 1, f"Found {len(filtered_front_wheel_list)} {FRONT_WHEEL_NAME}. " \
+                                                f"Expected 1 {FRONT_WHEEL_NAME} in {FIRST_CAR_NAME} to focus on."
+    front_wheel_in_car_instance_1 = filtered_front_wheel_list[0]
+
+    front_wheel_in_car_instance_1.focus_on_owning_prefab()
+    PrefabWaiter.wait_for_propagation() # propagate source template changes after focusing on
+
+    prefab_test_utils.check_entity_children_count(front_wheel_in_car_instance_1.id, 1)
+
+    # Note: This should be 3 because the tire instance inside the front wheel under the second car is still deleted.
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_PREFAB_NAME, 3)
+    prefab_test_utils.validate_count_for_editor_entity(TIRE_ENTITY_NAME, 3)
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(DeletePrefab_UnderNestedInstance)

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/DeletePrefab_UnderNestedInstance.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/overrides/DeletePrefab_UnderNestedInstance.py
@@ -106,7 +106,7 @@ def DeletePrefab_UnderNestedInstance():
     prefab_test_utils.validate_children_count_for_editor_entity(FRONT_WHEEL_NAME, 0)
     prefab_test_utils.validate_children_count_for_editor_entity(BACK_WHEEL_NAME, 1)
 
-    # Validate undo on entity deletion.
+    # Validate undo on instance deletion.
     general.undo()
     PrefabWaiter.wait_for_propagation()
     
@@ -116,7 +116,7 @@ def DeletePrefab_UnderNestedInstance():
     prefab_test_utils.validate_children_count_for_editor_entity(FRONT_WHEEL_NAME, 1)
     prefab_test_utils.validate_children_count_for_editor_entity(BACK_WHEEL_NAME, 1)
 
-    # Validate redo on entity deletion.
+    # Validate redo on instance deletion.
     general.redo()
     PrefabWaiter.wait_for_propagation()
 


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

This PR adds new automated tests under Prefab/TestSuite_Periodic for delete-entity and delete-prefab as overrides.

- DeleteEntity_UnderImmediateInstance
- DeleteEntity_UnderNestedInstance
- DeletePrefab_UnderImmediateInstance
- DeletePrefab_UnderNestedInstance

In addition, it adds two helper functions to validate count and child count for named editor entity:
1. validate_count_for_named_editor_entity
2. validate_child_count_for_named_editor_entity

It is a follow-up PR for the new feature introduced in https://github.com/o3de/o3de/pull/13171.

## How was this PR tested?

- [x] Passed all tests