### PR TITLE
Update build nodes to JDK 11

### DIFF
--- a/scripts/build/build_node/Platform/Mac/install-jdk.sh
+++ b/scripts/build/build_node/Platform/Mac/install-jdk.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 
-JDK_VERSION="8.282.08.1"
+JDK_VERSION="11.0.17.8.1"
 
 echo "Installing Corretto JDK ${JDK_VERSION}"
 curl -o /tmp/amazon-corretto-${JDK_VERSION}-macosx-x64.pkg https://corretto.aws/downloads/resources/${JDK_VERSION}/amazon-corretto-${JDK_VERSION}-macosx-x64.pkg

--- a/scripts/build/build_node/Platform/Windows/install_utiltools.ps1
+++ b/scripts/build/build_node/Platform/Windows/install_utiltools.ps1
@@ -21,7 +21,16 @@ git config --global "credential.helper" "!aws codecommit credential-helper $@"
 git config --global "credential.UseHttpPath" "true"
 
 # Install Java (for Jenkins)
+choco install corretto11jdk -y --ia INSTALLDIR="c:\jdk11" # Custom directory to handle cases where whitespace in the path is not quote wrapped
+
+# Install Java (for Android)
 choco install corretto8jdk -y --ia INSTALLDIR="c:\jdk8" # Custom directory to handle cases where whitespace in the path is not quote wrapped
+
+# Set JDK_PATH for Android
+[Environment]::SetEnvironmentVariable("JDK_PATH", "c:\jdk8", [EnvironmentVariableTarget]::Machine)
+    
+# Set Java path for Jenkins node agent
+[Environment]::SetEnvironmentVariable("JENKINS_JAVA_CMD", "c:\jdk11", [EnvironmentVariableTarget]::Machine)
 
 # Install CMake
 choco install cmake --version=3.24.0 -y --installargs 'ADD_CMAKE_TO_PATH=System'


### PR DESCRIPTION
## What does this PR do?

Updates the build node dependencies for JDK 11 for Windows and Mac (Linux is already on JDK 11). Also configures Windows nodes to use JDK 11 only for the Jenkins agent, while leaving JDK 8 for Android builds 

## How was this PR tested?

Tested in a sandbox Jenkins instance
