### PR TITLE
Fix name flicker on the Component Mode Switcher and update the Switcher when ActiveComponentMode changes

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
@@ -427,7 +427,7 @@ namespace AzToolsFramework::ComponentModeFramework
         }
     }
 
-    void ComponentModeSwitcher::ActiveComponentModeChanged([[maybe_unused]] const AZ::Uuid& componentType)
+    void ComponentModeSwitcher::ActiveComponentModeChanged(const AZ::Uuid& componentType)
     {
         // ActiveComponentModeChanged refers to switching within component mode
         // i.e. cycling through the Spline component and Tube Shape component

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
@@ -281,7 +281,9 @@ namespace AzToolsFramework::ComponentModeFramework
     {
         if (mode == ViewportEditorMode::Component)
         {
-            // wait one frame to check if component mode has been re-entered before changing back to transform
+            m_activeSwitcherComponent = nullptr;
+
+            // wait one frame to check if component mode has been re-entered before changing switcher button to transform
             AZ::TickBus::QueueFunction(
                 [this]()
                 {
@@ -296,8 +298,6 @@ namespace AzToolsFramework::ComponentModeFramework
                             &ViewportUi::ViewportUiRequestBus::Events::SetSwitcherActiveButton,
                             m_switcherId,
                             m_transformButtonId);
-
-                        m_activeSwitcherComponent = nullptr;
                     }
                 });
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
@@ -444,6 +444,8 @@ namespace AzToolsFramework::ComponentModeFramework
                 &ViewportUi::ViewportUiRequestBus::Events::SetSwitcherActiveButton,
                 m_switcherId,
                 componentDataIt->m_buttonId);
+
+            m_activeSwitcherComponent = componentDataIt->m_component;
         }
     }
 } // namespace AzToolsFramework::ComponentModeFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzFramework/Viewport/ViewportBus.h>
+
 #include <AzToolsFramework/API/EntityCompositionNotificationBus.h>
 #include <AzToolsFramework/API/ViewportEditorModeTrackerNotificationBus.h>
 #include <AzToolsFramework/ComponentMode/EditorComponentModeBus.h>
@@ -109,6 +110,9 @@ namespace AzToolsFramework
             // ComponentModeDelegateNotificationBus overrides ...
             void OnComponentModeDelegateConnect(const AZ::EntityComponentIdPair& pairId) override;
             void OnComponentModeDelegateDisconnect(const AZ::EntityComponentIdPair& pairId) override;
+
+            // EditorComponentModeBus overrides ...
+            void ActiveComponentModeChanged(const AZ::Uuid& componentType) override;
 
             // Member variables
             AZ::Component* m_activeSwitcherComponent = nullptr; //!< The component that is currently in component mode

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.h
@@ -111,7 +111,7 @@ namespace AzToolsFramework
             void OnComponentModeDelegateConnect(const AZ::EntityComponentIdPair& pairId) override;
             void OnComponentModeDelegateDisconnect(const AZ::EntityComponentIdPair& pairId) override;
 
-            // EditorComponentModeBus overrides ...
+            // EditorComponentModeNotificationBus overrides ...
             void ActiveComponentModeChanged(const AZ::Uuid& componentType) override;
 
             // Member variables

--- a/Code/Framework/AzToolsFramework/Tests/ComponentModeSwitcherTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/ComponentModeSwitcherTests.cpp
@@ -24,8 +24,9 @@
 
 namespace UnitTest
 {
-    using AzToolsFramework::ComponentModeFramework::AnotherPlaceholderEditorComponent;
     using AzToolsFramework::ComponentModeFramework::PlaceholderEditorComponent;
+    using AzToolsFramework::ComponentModeFramework::AnotherPlaceholderEditorComponent;
+    using AzToolsFramework::ComponentModeFramework::DependentPlaceholderEditorComponent;
     using ComponentModeSwitcher = AzToolsFramework::ComponentModeFramework::ComponentModeSwitcher;
     using ComponentModeSwitcherTestFixture = ComponentModeTestFixture;
 
@@ -465,5 +466,42 @@ namespace UnitTest
         EXPECT_EQ(2, componentModeSwitcher->GetComponentCount());
 
         Disconnect();
+    }
+
+    TEST_F(ComponentModeSwitcherTestFixture, SwitchingBetweenComponentsDoesNotSwitchToTransformFirst)
+    {
+        // Given an entity with two components
+        AZStd::shared_ptr<ComponentModeSwitcher> componentModeSwitcher = AZStd::make_shared<ComponentModeSwitcher>();
+
+        AzToolsFramework::EditorTransformComponentSelectionRequestBus::Event(
+            AzToolsFramework::GetEntityContextId(),
+            &AzToolsFramework::EditorTransformComponentSelectionRequestBus::Events::OverrideComponentModeSwitcher,
+            componentModeSwitcher);
+
+        AZ::Entity* entity = nullptr;
+        AZ::EntityId entityId = CreateDefaultEditorEntity("ComponentModeEntity", &entity);
+
+        entity->Deactivate();
+        const AZ::Component* placeholder = entity->CreateComponent<AnotherPlaceholderEditorComponent>();
+        const AZ::Component* dependentPlaceholder = entity->CreateComponent<DependentPlaceholderEditorComponent>();
+        entity->Activate();
+
+        const AzToolsFramework::EntityIdList entityIds = { entityId };
+        AzToolsFramework::ToolsApplicationRequestBus::Broadcast(
+            &AzToolsFramework::ToolsApplicationRequests::SetSelectedEntities, entityIds);
+
+        AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequestBus::Broadcast(
+            &AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequests::AddSelectedComponentModesOfType,
+            dependentPlaceholder->GetUnderlyingComponentType());
+
+        auto activeComponent = componentModeSwitcher->GetActiveComponent()->GetId();
+        EXPECT_EQ(activeComponent, dependentPlaceholder->GetId());
+
+        // When the user is in a dependent component mode and presses tab
+        QTest::keyPress(&m_editorActions.m_componentModeWidget, Qt::Key_Tab);
+
+        // The swticher changes to the next active component mode
+        activeComponent = componentModeSwitcher->GetActiveComponent()->GetId();
+        EXPECT_EQ(activeComponent, placeholder->GetId());
     }
 } // namespace UnitTest


### PR DESCRIPTION
Signed-off-by: amzn-ahmadkrm <105638312+amzn-ahmadkrm@users.noreply.github.com>

## What does this PR do?

The Switcher has a difficult to notice flicker when switching between components, the text changes to "Transform" before changing to the new Components' name. This PR fixes this by ensuring that the Editor is not in Component Mode with TickBus::QueueFunction.

https://user-images.githubusercontent.com/105638312/202327349-cbf0babc-26e2-4b2f-963d-998b6665911f.mp4

Another bug was that the Switcher did not switch between the Component icons when cycling through Component Mode with Tab. i.e. Switching between Spline Component and Tube Shape Component. 

After:
https://user-images.githubusercontent.com/105638312/202327719-b67e10d4-ce59-4e33-adc4-a28f417353f0.mp4



## How was this PR tested?

Manual testing for the transform flicker and unit test for tab switching.

Before:
![mstsc_SKssPJ1Z33](https://user-images.githubusercontent.com/105638312/202451599-72e63959-23f4-4ad4-9a0c-5c2312a9c951.png)

After:

![VsDebugConsole_ctzl6tEwHK](https://user-images.githubusercontent.com/105638312/202451444-66ac853a-052b-4db6-bb1a-777b92af1416.png)
