### PR TITLE
Add more comparison operators to Dom::Path and Dom::PathEntry

### DIFF
--- a/Code/Framework/AzCore/AzCore/DOM/DomPath.cpp
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPath.cpp
@@ -150,12 +150,12 @@ namespace AZ::Dom
 
     bool operator<(const AZ::Dom::PathEntry& entry, size_t index)
     {
-        return entry.IsIndex() && entry.GetIndex() < index;
+        return entry < AZStd::to_string(index);
     }
 
     bool operator<(size_t index, const AZ::Dom::PathEntry& entry)
     {
-        return !entry.IsIndex() || index < entry.GetIndex();
+        return AZStd::to_string(index) < entry;
     }
 
     bool operator<(const AZ::Dom::PathEntry& entry, const AZ::Name& key)
@@ -170,12 +170,26 @@ namespace AZ::Dom
 
     bool operator<(const AZ::Dom::PathEntry& entry, AZStd::string_view key)
     {
-        return entry.IsIndex() || entry.GetKey().GetStringView() < key;
+        if (entry.IsIndex())
+        {
+            return AZStd::to_string(entry.GetIndex()) < key;
+        }
+        else
+        {
+            return entry.GetKey().GetStringView() < key;
+        }
     }
 
     bool operator<(AZStd::string_view key, const AZ::Dom::PathEntry& entry)
     {
-        return entry.IsKey() && key < entry.GetKey().GetStringView();
+        if (entry.IsIndex())
+        {
+            return key < AZStd::to_string(entry.GetIndex());
+        }
+        else
+        {
+            return key < entry.GetKey().GetStringView();
+        }
     }
 } // namespace AZ::Dom
 

--- a/Code/Framework/AzCore/AzCore/DOM/DomPath.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPath.h
@@ -47,6 +47,21 @@ namespace AZ::Dom
         bool operator!=(const AZ::Name& key) const;
         bool operator!=(AZStd::string_view key) const;
 
+        //! The desired sort order of PathEntry first has index values sorted
+        //! by numerical value then key values sorted in lexicographic order.
+        //! For example:
+        //! 0
+        //! 10
+        //! 0hello (note that this is a key, not an index)
+        //! two
+        friend bool operator<(const PathEntry& lhs, const PathEntry& rhs);
+        friend bool operator<(const PathEntry& entry, size_t index);
+        friend bool operator<(size_t index, const PathEntry& entry);
+        friend bool operator<(const PathEntry& entry, const AZ::Name& key);
+        friend bool operator<(const AZ::Name& key, const PathEntry& entry);
+        friend bool operator<(const PathEntry& entry, AZStd::string_view key);
+        friend bool operator<(AZStd::string_view key, const PathEntry& entry);
+
         void SetEndOfArray();
 
         bool IsEndOfArray() const;
@@ -111,6 +126,19 @@ namespace AZ::Dom
         {
             return !operator==(rhs);
         }
+
+        //! The ordering of Path objects is based on PathEntry sort order.
+        //! An example sort would be:
+        //! /0/1/3
+        //! /1
+        //! /1/4
+        //! /apple
+        //! /two
+        //! /two/0hello
+        bool operator<(const Path&) const;
+        bool operator>(const Path&) const;
+        bool operator<=(const Path&) const;
+        bool operator>=(const Path&) const;
 
         const ContainerType& GetEntries() const;
         void Push(PathEntry entry);

--- a/Code/Framework/AzCore/AzCore/DOM/DomPath.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPath.h
@@ -47,13 +47,7 @@ namespace AZ::Dom
         bool operator!=(const AZ::Name& key) const;
         bool operator!=(AZStd::string_view key) const;
 
-        //! The desired sort order of PathEntry first has index values sorted
-        //! by numerical value then key values sorted in lexicographic order.
-        //! For example:
-        //! 0
-        //! 10
-        //! 0hello (note that this is a key, not an index)
-        //! two
+        //! PathEnty objects are ordered lexicographically.
         friend bool operator<(const PathEntry& lhs, const PathEntry& rhs);
         friend bool operator<(const PathEntry& entry, size_t index);
         friend bool operator<(size_t index, const PathEntry& entry);
@@ -127,14 +121,11 @@ namespace AZ::Dom
             return !operator==(rhs);
         }
 
-        //! The ordering of Path objects is based on PathEntry sort order.
-        //! An example sort would be:
-        //! /0/1/3
-        //! /1
-        //! /1/4
-        //! /apple
-        //! /two
-        //! /two/0hello
+        //! Path objects are ordered lexicographically based on their full path. Note that
+        //! paths can contain a mix of interger or string value PathEntry components.
+        //! PathEntry objects with string values, as opposed to integer values, will not
+        //! necessarily sort as they appear in the DOM. Paths consisting only of
+        //! indexed PathEntry objects will be ordered as they are positioned in the DOM.
         bool operator<(const Path&) const;
         bool operator>(const Path&) const;
         bool operator<=(const Path&) const;

--- a/Code/Framework/AzCore/Tests/DOM/DomPathTests.cpp
+++ b/Code/Framework/AzCore/Tests/DOM/DomPathTests.cpp
@@ -153,37 +153,46 @@ namespace AZ::Dom::Tests
 
     TEST_F(DomPathTests, OperatorOverloads_LessThanGreaterThan)
     {
+        // Path - index and key tests
         EXPECT_TRUE(Path("/0/99") < Path("/0/a"));
         EXPECT_FALSE(Path("/0/a") < Path("/0/99"));
-
+        // Path - key and key tests
         EXPECT_FALSE(Path("/0/b") < Path("/0/aa"));
         EXPECT_TRUE(Path("/0/a") < Path("/0/aa"));
-
+        // Path - index and index tests
         EXPECT_TRUE(Path("/0/1") < Path("/0/2"));
         EXPECT_FALSE(Path("/0/3/1") < Path("/0/3"));
-
-        size_t index = 2;
-        EXPECT_FALSE(Path("/3").GetEntries()[0] < index);
-        EXPECT_TRUE(Path("/1").GetEntries()[0] < index);
-
-        AZ::Name name = Name("ab");
-        EXPECT_TRUE(Path("/1").GetEntries()[0] < name);
-        EXPECT_TRUE(Path("/a").GetEntries()[0] < name);
-
-        AZStd::string_view nameStrView = "ab";
-        EXPECT_TRUE(Path("/1").GetEntries()[0] < nameStrView);
-        EXPECT_TRUE(Path("/a").GetEntries()[0] < nameStrView);
-
+        // Path - greather than tests
         EXPECT_TRUE(Path("/0/a") > Path("/0/1"));
         EXPECT_FALSE(Path("/0/1") > Path("/0/a"));
-
+        // Path - less than or equal tests
         EXPECT_TRUE(Path("/0/3/1") >= Path("/0/3"));
         EXPECT_TRUE(Path("/0/3") >= Path("/0/3"));
         EXPECT_FALSE(Path("/0/1") >= Path("/0/a"));
-
+        // Path - greater than or equal tests
         EXPECT_TRUE(Path("/0/3") <= Path("/0/3/1"));
         EXPECT_TRUE(Path("/0/3") <= Path("/0/3"));
         EXPECT_FALSE(Path("/0/a") <= Path("/0/1"));
+
+        // PathEntry - entry and size_t tests
+        size_t index = 2;
+        EXPECT_FALSE(Path("/3").GetEntries()[0] < index);
+        EXPECT_TRUE(Path("/1").GetEntries()[0] < index);
+        EXPECT_FALSE(Path("/a").GetEntries()[0] < index);
+        EXPECT_TRUE(Path("/0a").GetEntries()[0] < index);
+        EXPECT_TRUE(index < Path("/a").GetEntries()[0]);
+        EXPECT_FALSE(index < Path("/0").GetEntries()[0]);
+        // PathEntry - entry and Name tests
+        AZ::Name name = Name("ab");
+        EXPECT_TRUE(Path("/1").GetEntries()[0] < name);
+        EXPECT_TRUE(Path("/a").GetEntries()[0] < name);
+        EXPECT_FALSE(name < Path("/1").GetEntries()[0]);
+        EXPECT_FALSE(name < Path("/a").GetEntries()[0]);
+        EXPECT_FALSE(name < Path("/0a").GetEntries()[0]);
+        // PathEntry - entry and string_view tests
+        AZStd::string_view nameStrView = "ab";
+        EXPECT_TRUE(Path("/1").GetEntries()[0] < nameStrView);
+        EXPECT_TRUE(Path("/a").GetEntries()[0] < nameStrView);
     }
 
     TEST_F(DomPathTests, EndOfArray_FromString)

--- a/Code/Framework/AzCore/Tests/DOM/DomPathTests.cpp
+++ b/Code/Framework/AzCore/Tests/DOM/DomPathTests.cpp
@@ -151,6 +151,41 @@ namespace AZ::Dom::Tests
         EXPECT_EQ(p, Path("/foo/bar/baz/0/1"));
     }
 
+    TEST_F(DomPathTests, OperatorOverloads_LessThanGreaterThan)
+    {
+        EXPECT_TRUE(Path("/0/99") < Path("/0/a"));
+        EXPECT_FALSE(Path("/0/a") < Path("/0/99"));
+
+        EXPECT_FALSE(Path("/0/b") < Path("/0/aa"));
+        EXPECT_TRUE(Path("/0/a") < Path("/0/aa"));
+
+        EXPECT_TRUE(Path("/0/1") < Path("/0/2"));
+        EXPECT_FALSE(Path("/0/3/1") < Path("/0/3"));
+
+        size_t index = 2;
+        EXPECT_FALSE(Path("/3").GetEntries()[0] < index);
+        EXPECT_TRUE(Path("/1").GetEntries()[0] < index);
+
+        AZ::Name name = Name("ab");
+        EXPECT_TRUE(Path("/1").GetEntries()[0] < name);
+        EXPECT_TRUE(Path("/a").GetEntries()[0] < name);
+
+        AZStd::string_view nameStrView = "ab";
+        EXPECT_TRUE(Path("/1").GetEntries()[0] < nameStrView);
+        EXPECT_TRUE(Path("/a").GetEntries()[0] < nameStrView);
+
+        EXPECT_TRUE(Path("/0/a") > Path("/0/1"));
+        EXPECT_FALSE(Path("/0/1") > Path("/0/a"));
+
+        EXPECT_TRUE(Path("/0/3/1") >= Path("/0/3"));
+        EXPECT_TRUE(Path("/0/3") >= Path("/0/3"));
+        EXPECT_FALSE(Path("/0/1") >= Path("/0/a"));
+
+        EXPECT_TRUE(Path("/0/3") <= Path("/0/3/1"));
+        EXPECT_TRUE(Path("/0/3") <= Path("/0/3"));
+        EXPECT_FALSE(Path("/0/a") <= Path("/0/1"));
+    }
+
     TEST_F(DomPathTests, EndOfArray_FromString)
     {
         EXPECT_FALSE(Path("/foo/-")[0].IsEndOfArray());


### PR DESCRIPTION
**Description**
Before this PR, `Dom::PathEntry` and `Dom::Path` didn't have their own `operator<` which made comparisons difficult when ordering `Dom::Path` objects.

This PR adds `operator<` to `Dom::PathEntry` and operators `<, >, <=, >=` to `Dom::Path`.

The `Dom::PathEntry` sort order:
- Considers `size_t` < than `AZ::Name`
- Compares `AZ::Name` vs `AZ::Name` lexicographically
- Returns true for matching `PathEntry` values

The `Dom::Path` operators:
- Utilizes `Dom::PathEntry` operators
- Handles compares for mixed value paths
- Returns true for matching `Path` objects

Example sort order:
```
/0
/1
/1/4
/0hello (because this is actually a key, not a size_t index)
/two
/two/three
/two/threes
```

**Testing**
- Newly added and old AzCore.Tests passed

Signed-off-by: amzn-tmryan <104796591+amzn-tmryan@users.noreply.github.com>