### PR TITLE
Material Canvas: Improving startup time

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/AssetSelection/AssetSelectionComboBox.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/AssetSelection/AssetSelectionComboBox.h
@@ -27,7 +27,8 @@ namespace AtomToolsFramework
         AssetSelectionComboBox(const FilterFn& filterFn, QWidget* parent = 0);
         ~AssetSelectionComboBox();
 
-        void Reset();
+        void Clear();
+        void Populate();
         void AddPath(const AZStd::string& path);
         void RemovePath(const AZStd::string& path);
         void SetFilter(const FilterFn& filterFn);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/AssetSelection/AssetSelectionComboBox.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/AssetSelection/AssetSelectionComboBox.h
@@ -31,6 +31,7 @@ namespace AtomToolsFramework
         void AddPath(const AZStd::string& path);
         void RemovePath(const AZStd::string& path);
         void SetFilter(const FilterFn& filterFn);
+        const FilterFn& GetFilter() const;
         void SelectPath(const AZStd::string& path);
         AZStd::string GetSelectedPath() const;
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/AssetSelection/AssetSelectionGrid.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/AssetSelection/AssetSelectionGrid.h
@@ -43,7 +43,8 @@ namespace AtomToolsFramework
 
         ~AssetSelectionGrid();
 
-        void Reset();
+        void Clear();
+        void Populate();
         void SetFilter(const FilterFn& filterFn);
         const FilterFn& GetFilter() const;
         void AddPath(const AZStd::string& path);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/AssetSelection/AssetSelectionGrid.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/AssetSelection/AssetSelectionGrid.h
@@ -45,6 +45,7 @@ namespace AtomToolsFramework
 
         void Reset();
         void SetFilter(const FilterFn& filterFn);
+        const FilterFn& GetFilter() const;
         void AddPath(const AZStd::string& path);
         void RemovePath(const AZStd::string& path);
         void SelectPath(const AZStd::string& path);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/EntityPreviewViewport/EntityPreviewViewportSettingsInspector.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/EntityPreviewViewport/EntityPreviewViewportSettingsInspector.h
@@ -19,6 +19,8 @@
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h>
 #endif
 
+#include <QFutureWatcher>
+
 namespace AtomToolsFramework
 {
     //! EntityPreviewViewportSettingsInspector provides controls for viewing and editing presets and other common viewport settings.
@@ -81,5 +83,7 @@ namespace AtomToolsFramework
         AZStd::unique_ptr<AssetSelectionGrid> m_lightingPresetDialog;
 
         EntityPreviewViewportSettings m_viewportSettings;
+
+        QFutureWatcher<AZStd::vector<AZStd::string>> m_watcher;
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/EntityPreviewViewport/EntityPreviewViewportToolBar.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/EntityPreviewViewport/EntityPreviewViewportToolBar.h
@@ -13,6 +13,7 @@
 #include <AtomToolsFramework/EntityPreviewViewport/EntityPreviewViewportSettingsNotificationBus.h>
 
 #include <QAction>
+#include <QFutureWatcher>
 #include <QToolBar>
 #endif
 
@@ -40,5 +41,6 @@ namespace AtomToolsFramework
         QAction* m_toggleGrid = {};
         QAction* m_toggleShadowCatcher = {};
         QAction* m_toggleAlternateSkybox = {};
+        QFutureWatcher<AZStd::vector<AZStd::string>> m_watcher;
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionComboBox.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionComboBox.cpp
@@ -21,6 +21,7 @@ namespace AtomToolsFramework
 {
     AssetSelectionComboBox::AssetSelectionComboBox(const FilterFn& filterFn, QWidget* parent)
         : QComboBox(parent)
+        , m_filterFn(filterFn)
     {
         QSignalBlocker signalBlocker(this);
 
@@ -32,7 +33,6 @@ namespace AtomToolsFramework
             this, static_cast<void (QComboBox::*)(const int)>(&QComboBox::currentIndexChanged), this,
             [this]() { emit PathSelected(GetSelectedPath()); });
 
-        SetFilter(filterFn);
         AzFramework::AssetCatalogEventBus::Handler::BusConnect();
     }
 
@@ -46,24 +46,31 @@ namespace AtomToolsFramework
         clear();
         m_thumbnailKeys.clear();
 
-        if (m_filterFn)
+        for (const auto& path : GetPathsInSourceFoldersMatchingFilter(m_filterFn))
         {
-            for (const auto& path : GetPathsInSourceFoldersMatchingFilter(m_filterFn))
-            {
-                AddPath(path);
-            }
-            setCurrentIndex(0);
+            AddPath(path);
         }
+
+        setCurrentIndex(0);
     }
 
     void AssetSelectionComboBox::SetFilter(const FilterFn& filterFn)
     {
         m_filterFn = filterFn;
-        Reset();
+    }
+
+    const AssetSelectionComboBox::FilterFn& AssetSelectionComboBox::GetFilter() const
+    {
+        return m_filterFn;
     }
 
     void AssetSelectionComboBox::AddPath(const AZStd::string& path)
     {
+        if (m_filterFn && !m_filterFn(path))
+        {
+            return;
+        }
+
         const QVariant pathItemData(QString::fromUtf8(path.data(), static_cast<int>(path.size())));
         if (const int index = findData(pathItemData); index < 0)
         {
@@ -118,27 +125,13 @@ namespace AtomToolsFramework
 
     void AssetSelectionComboBox::OnCatalogAssetAdded(const AZ::Data::AssetId& assetId)
     {
-        if (m_filterFn)
-        {
-            const auto& path = AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetId);
-            if (m_filterFn(path))
-            {
-                AddPath(path);
-            }
-        }
+        AddPath(AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetId));
     }
 
     void AssetSelectionComboBox::OnCatalogAssetRemoved(
         const AZ::Data::AssetId& assetId, [[maybe_unused]] const AZ::Data::AssetInfo& assetInfo)
     {
-        if (m_filterFn)
-        {
-            const auto& path = AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetId);
-            if (m_filterFn(path))
-            {
-                RemovePath(path);
-            }
-        }
+        RemovePath(AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetId));
     }
 
     void AssetSelectionComboBox::RegisterThumbnail(const AZStd::string& path)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionComboBox.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionComboBox.cpp
@@ -41,10 +41,15 @@ namespace AtomToolsFramework
         AzFramework::AssetCatalogEventBus::Handler::BusDisconnect();
     }
 
-    void AssetSelectionComboBox::Reset()
+    void AssetSelectionComboBox::Clear()
     {
         clear();
         m_thumbnailKeys.clear();
+    }
+
+    void AssetSelectionComboBox::Populate()
+    {
+        Clear();
 
         for (const auto& path : GetPathsInSourceFoldersMatchingFilter(m_filterFn))
         {

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionGrid.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionGrid.cpp
@@ -54,9 +54,14 @@ namespace AtomToolsFramework
         AzFramework::AssetCatalogEventBus::Handler::BusDisconnect();
     }
 
-    void AssetSelectionGrid::Reset()
+    void AssetSelectionGrid::Clear()
     {
         m_ui->m_assetList->clear();
+    }
+
+    void AssetSelectionGrid::Populate()
+    {
+        Clear();
 
         for (const auto& path : GetPathsInSourceFoldersMatchingFilter(m_filterFn))
         {

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionGrid.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionGrid.cpp
@@ -33,6 +33,7 @@ namespace AtomToolsFramework
         : QDialog(parent)
         , m_tileSize(tileSize)
         , m_ui(new Ui::AssetSelectionGrid)
+        , m_filterFn(filterFn)
     {
         m_ui->setupUi(this);
 
@@ -45,7 +46,6 @@ namespace AtomToolsFramework
         SetupDialogButtons();
         setModal(true);
 
-        SetFilter(filterFn);
         AzFramework::AssetCatalogEventBus::Handler::BusConnect();
     }
 
@@ -58,25 +58,32 @@ namespace AtomToolsFramework
     {
         m_ui->m_assetList->clear();
 
-        if (m_filterFn)
+        for (const auto& path : GetPathsInSourceFoldersMatchingFilter(m_filterFn))
         {
-            for (const auto& path : GetPathsInSourceFoldersMatchingFilter(m_filterFn))
-            {
-                AddPath(path);
-            }
-            m_ui->m_assetList->sortItems();
-            m_ui->m_assetList->setCurrentItem(0);
+            AddPath(path);
         }
+
+        m_ui->m_assetList->sortItems();
+        m_ui->m_assetList->setCurrentItem(0);
     }
 
     void AssetSelectionGrid::SetFilter(const FilterFn& filterFn)
     {
         m_filterFn = filterFn;
-        Reset();
+    }
+
+    const AssetSelectionGrid::FilterFn& AssetSelectionGrid::GetFilter() const
+    {
+        return m_filterFn;
     }
 
     void AssetSelectionGrid::AddPath(const AZStd::string& path)
     {
+        if(m_filterFn && !m_filterFn(path))
+        {
+            return;
+        }
+
         const QVariant pathItemData(QString::fromUtf8(path.data(), static_cast<int>(path.size())));
         const QString title(GetDisplayNameFromPath(path).c_str());
 
@@ -174,26 +181,12 @@ namespace AtomToolsFramework
 
     void AssetSelectionGrid::OnCatalogAssetAdded(const AZ::Data::AssetId& assetId)
     {
-        if (m_filterFn)
-        {
-            const auto& path = AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetId);
-            if (m_filterFn(path))
-            {
-                AddPath(path);
-            }
-        }
+        AddPath(AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetId));
     }
 
     void AssetSelectionGrid::OnCatalogAssetRemoved(const AZ::Data::AssetId& assetId, [[maybe_unused]] const AZ::Data::AssetInfo& assetInfo)
     {
-        if (m_filterFn)
-        {
-            const auto& path = AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetId);
-            if (m_filterFn(path))
-            {
-                RemovePath(path);
-            }
-        }
+        RemovePath(AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetId));
     }
 
     void AssetSelectionGrid::SetupAssetList()

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
@@ -386,9 +386,9 @@ namespace AtomToolsFramework
             const QString name = tr("New %1 Document...").arg(documentType.m_documentTypeName.c_str());
             CreateActionAtPosition(parentMenu, insertPostion, name, [documentType, toolId = m_toolId, this]() {
                 // Open the create document dialog with labels and filters configured from the document type info.
-                    CreateDocumentDialog dialog(
-                        documentType, AZStd::string::format("%s/Assets", AZ::Utils::GetProjectPath().c_str()).c_str(), this);
-                    dialog.adjustSize();
+                CreateDocumentDialog dialog(
+                    documentType, AZStd::string::format("%s/Assets", AZ::Utils::GetProjectPath().c_str()).c_str(), this);
+                dialog.adjustSize();
 
                 if (dialog.exec() == QDialog::Accepted)
                 {
@@ -458,6 +458,9 @@ namespace AtomToolsFramework
         m_tabWidget->setMovable(true);
         m_tabWidget->setTabsClosable(true);
         m_tabWidget->setUsesScrollButtons(true);
+
+        // Update document tab styling to fix the close button and be conformant with similar windows 
+        AzQtComponents::TabWidget::applySecondaryStyle(m_tabWidget);
 
         // This signal will be triggered whenever a tab is added, removed, selected, clicked, dragged
         // When the last tab is removed tabIndex will be -1 and the document ID will be null

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
@@ -505,13 +505,12 @@ namespace AtomToolsFramework
 
     bool AtomToolsDocumentSystem::ReopenModifiedDocuments()
     {
-        m_queueReopenModifiedDocuments = false;
-
         const bool enableHotReload = GetSettingsValue<bool>("/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/EnableAutomaticReload", true);
         if (!enableHotReload)
         {
             m_documentIdsWithDependencyChanges.clear();
             m_documentIdsWithExternalChanges.clear();
+            m_queueReopenModifiedDocuments = false;
             return false;
         }
 
@@ -585,6 +584,7 @@ namespace AtomToolsFramework
 
         m_documentIdsWithDependencyChanges.clear();
         m_documentIdsWithExternalChanges.clear();
+        m_queueReopenModifiedDocuments = false;
         return true;
     }
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/CreateDocumentDialog.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/CreateDocumentDialog.cpp
@@ -54,8 +54,8 @@ namespace AtomToolsFramework
             verticalLayout->addWidget(sourceSelectionComboBoxLabel);
 
             m_sourceSelectionComboBox = new AssetSelectionComboBox(filterFn, this);
-            m_sourceSelectionComboBox->Reset();
             m_sourceSelectionComboBox->setSizePolicy(QSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed));
+            m_sourceSelectionComboBox->Populate();
             m_sourceSelectionComboBox->SelectPath(defaultSourcePath.toUtf8().constData());
             m_sourcePath = m_sourceSelectionComboBox->GetSelectedPath().c_str();
             QObject::connect(m_sourceSelectionComboBox, &AssetSelectionComboBox::PathSelected, this, [this](const AZStd::string& path) {

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/CreateDocumentDialog.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/CreateDocumentDialog.cpp
@@ -54,6 +54,7 @@ namespace AtomToolsFramework
             verticalLayout->addWidget(sourceSelectionComboBoxLabel);
 
             m_sourceSelectionComboBox = new AssetSelectionComboBox(filterFn, this);
+            m_sourceSelectionComboBox->Reset();
             m_sourceSelectionComboBox->setSizePolicy(QSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed));
             m_sourceSelectionComboBox->SelectPath(defaultSourcePath.toUtf8().constData());
             m_sourcePath = m_sourceSelectionComboBox->GetSelectedPath().c_str();

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettingsInspector.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettingsInspector.cpp
@@ -23,6 +23,7 @@
 #include <QPushButton>
 #include <QToolButton>
 #include <QVBoxLayout>
+#include <QtConcurrent/QtConcurrent>
 
 namespace AtomToolsFramework
 {
@@ -42,16 +43,6 @@ namespace AtomToolsFramework
             return path.ends_with(AZ::Render::ModelPreset::Extension);
         }, QSize(modelPresetDialogItemSize, modelPresetDialogItemSize), GetToolMainWindow()));
 
-        connect(m_modelPresetDialog.get(), &AssetSelectionGrid::PathRejected, this, [this]() {
-            EntityPreviewViewportSettingsRequestBus::Event(
-                m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::LoadModelPreset, m_modelPresetPath);
-        });
-
-        connect(m_modelPresetDialog.get(), &AssetSelectionGrid::PathSelected, this, [this](const AZStd::string& path) {
-            EntityPreviewViewportSettingsRequestBus::Event(
-                m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::LoadModelPreset, path);
-        });
-
         // Pre create the lighting preset dialog so that it is not repopulated every time it's opened.
         const int lightingPresetDialogItemSize = aznumeric_cast<int>(GetSettingsValue<AZ::u64>(
             "/O3DE/AtomToolsFramework/EntityPreviewViewportSettingsInspector/AssetSelectionGrid/LightingItemSize", 128));
@@ -60,15 +51,41 @@ namespace AtomToolsFramework
             return path.ends_with(AZ::Render::LightingPreset::Extension);
         }, QSize(lightingPresetDialogItemSize, lightingPresetDialogItemSize), GetToolMainWindow()));
 
-        connect(m_lightingPresetDialog.get(), &AssetSelectionGrid::PathRejected, this, [this]() {
-            EntityPreviewViewportSettingsRequestBus::Event(
-                m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::LoadLightingPreset, m_lightingPresetPath);
+        connect(&m_watcher, &QFutureWatcher<AZStd::vector<AZStd::string>>::finished, this, [this](){
+            for (const auto& path : m_watcher.result())
+            {
+                m_lightingPresetDialog->AddPath(path);
+                m_modelPresetDialog->AddPath(path);
+            }
+
+            connect(m_modelPresetDialog.get(), &AssetSelectionGrid::PathRejected, this, [this]() {
+                EntityPreviewViewportSettingsRequestBus::Event(
+                    m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::LoadModelPreset, m_modelPresetPath);
+            });
+
+            connect(m_modelPresetDialog.get(), &AssetSelectionGrid::PathSelected, this, [this](const AZStd::string& path) {
+                EntityPreviewViewportSettingsRequestBus::Event(
+                    m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::LoadModelPreset, path);
+            });
+
+            connect(m_lightingPresetDialog.get(), &AssetSelectionGrid::PathRejected, this, [this]() {
+                EntityPreviewViewportSettingsRequestBus::Event(
+                    m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::LoadLightingPreset, m_lightingPresetPath);
+            });
+
+            connect(m_lightingPresetDialog.get(), &AssetSelectionGrid::PathSelected, this, [this](const AZStd::string& path) {
+                EntityPreviewViewportSettingsRequestBus::Event(
+                    m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::LoadLightingPreset, path);
+            });
+
+            OnViewportSettingsChanged();
         });
 
-        connect(m_lightingPresetDialog.get(), &AssetSelectionGrid::PathSelected, this, [this](const AZStd::string& path) {
-            EntityPreviewViewportSettingsRequestBus::Event(
-                m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::LoadLightingPreset, path);
-        });
+        m_watcher.setFuture(QtConcurrent::run([]() {
+            return GetPathsInSourceFoldersMatchingFilter([](const AZStd::string& path) {
+                return path.ends_with(AZ::Render::LightingPreset::Extension) || path.ends_with(AZ::Render::ModelPreset::Extension);
+            });
+        }));
 
         EntityPreviewViewportSettingsNotificationBus::Handler::BusConnect(m_toolId);
     }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportToolBar.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportToolBar.cpp
@@ -96,7 +96,22 @@ namespace AtomToolsFramework
         }, this);
         addWidget(m_modelPresetComboBox);
 
-        connect(&m_watcher, &QFutureWatcher<AZStd::vector<AZStd::string>>::finished, this, [this](){
+        // Add the last known paths for lighting and model presets to the browsers so they are not empty while the rest of the data is
+        // being processed in the background.
+        EntityPreviewViewportSettingsRequestBus::Event(
+            m_toolId,
+            [this](EntityPreviewViewportSettingsRequests* viewportRequests)
+            {
+                m_lightingPresetComboBox->AddPath(viewportRequests->GetLastLightingPresetPath());
+                m_modelPresetComboBox->AddPath(viewportRequests->GetLastModelPresetPath());
+            });
+
+        // Using a future watcher to monitor a background process that enumerates all of the lighting and model presets in the project.
+        // After the background process is complete, the watcher will receive the finished signal and add all of the enumerated files to
+        // the browsers.
+        connect(&m_watcher, &QFutureWatcher<AZStd::vector<AZStd::string>>::finished, this, [this]() {
+            m_lightingPresetComboBox->Clear();
+            m_modelPresetComboBox->Clear();
             for (const auto& path : m_watcher.result())
             {
                 m_lightingPresetComboBox->AddPath(path);
@@ -116,6 +131,7 @@ namespace AtomToolsFramework
             OnViewportSettingsChanged();
         });
 
+        // Start the future watcher with the background process to enumerate all of the lighting and model preset files.
         m_watcher.setFuture(QtConcurrent::run([]() {
             return GetPathsInSourceFoldersMatchingFilter([](const AZStd::string& path) {
                 return path.ends_with(AZ::Render::LightingPreset::Extension) || path.ends_with(AZ::Render::ModelPreset::Extension);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportToolBar.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportToolBar.cpp
@@ -19,6 +19,7 @@
 #include <QIcon>
 #include <QMenu>
 #include <QToolButton>
+#include <QtConcurrent/QtConcurrent>
 
 namespace AtomToolsFramework
 {
@@ -87,22 +88,40 @@ namespace AtomToolsFramework
         m_lightingPresetComboBox = new AssetSelectionComboBox([](const AZStd::string& path) {
             return path.ends_with(AZ::Render::LightingPreset::Extension);
         }, this);
-        connect(m_lightingPresetComboBox, &AssetSelectionComboBox::PathSelected, this, [this](const AZStd::string& path) {
-            EntityPreviewViewportSettingsRequestBus::Event(
-                m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::LoadLightingPreset, path);
-        });
         addWidget(m_lightingPresetComboBox);
 
         // Add model preset combo box
         m_modelPresetComboBox = new AssetSelectionComboBox([](const AZStd::string& path) {
             return path.ends_with(AZ::Render::ModelPreset::Extension);
         }, this);
-        connect(m_modelPresetComboBox, &AssetSelectionComboBox::PathSelected, this, [this](const AZStd::string& path) {
-            EntityPreviewViewportSettingsRequestBus::Event(
-                m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::LoadModelPreset, path);
-        });
         addWidget(m_modelPresetComboBox);
 
+        connect(&m_watcher, &QFutureWatcher<AZStd::vector<AZStd::string>>::finished, this, [this](){
+            for (const auto& path : m_watcher.result())
+            {
+                m_lightingPresetComboBox->AddPath(path);
+                m_modelPresetComboBox->AddPath(path);
+            }
+
+            connect(m_lightingPresetComboBox, &AssetSelectionComboBox::PathSelected, this, [this](const AZStd::string& path) {
+                EntityPreviewViewportSettingsRequestBus::Event(
+                    m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::LoadLightingPreset, path);
+            });
+
+            connect(m_modelPresetComboBox, &AssetSelectionComboBox::PathSelected, this, [this](const AZStd::string& path) {
+                EntityPreviewViewportSettingsRequestBus::Event(
+                    m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::LoadModelPreset, path);
+            });
+
+            OnViewportSettingsChanged();
+        });
+
+        m_watcher.setFuture(QtConcurrent::run([]() {
+            return GetPathsInSourceFoldersMatchingFilter([](const AZStd::string& path) {
+                return path.ends_with(AZ::Render::LightingPreset::Extension) || path.ends_with(AZ::Render::ModelPreset::Extension);
+            });
+        }));
+        
         OnViewportSettingsChanged();
         EntityPreviewViewportSettingsNotificationBus::Handler::BusConnect(m_toolId);
     }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -623,6 +623,11 @@ namespace AtomToolsFramework
     void VisitFilesInFolder(
         const AZStd::string& folder, const AZStd::function<bool(const AZStd::string&)> visitorFn, bool recurse)
     {
+        if (!visitorFn)
+        {
+            return;
+        }
+
         AZStd::string fullFilter = folder + AZ_CORRECT_FILESYSTEM_SEPARATOR_STRING + "*";
         AZ::StringFunc::Replace(fullFilter, "\\", "/");
 
@@ -660,6 +665,11 @@ namespace AtomToolsFramework
 
     void VisitFilesInScanFolders(const AZStd::function<bool(const AZStd::string&)> visitorFn)
     {
+        if (!visitorFn)
+        {
+            return;
+        }
+
         AZStd::vector<AZStd::string> scanFolders;
         scanFolders.reserve(100);
         AzToolsFramework::AssetSystemRequestBus::Broadcast(
@@ -691,7 +701,7 @@ namespace AtomToolsFramework
                     scanFolder,
                     [&](const AZStd::string& path)
                     {
-                        if (filterFn(path))
+                        if (!filterFn || filterFn(path))
                         {
                             AZStd::scoped_lock lock(resultsMutex);
                             results.emplace_back(path);

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/acos.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/Nodes/Functions/acos.materialgraphnode
@@ -6,7 +6,7 @@
         "id": "{9B82F836-E7E9-49AA-AC72-30B3E6D751CD}",
         "category": "Math Functions",
         "title": "Acos",
-        "titlePaletteName": "MathNodeTitlePalettef",
+        "titlePaletteName": "MathNodeTitlePalette",
         "slotDataTypeGroups": [
             "inValue|outValue"
         ],

--- a/Gems/Atom/Tools/MaterialCanvas/Registry/gem_autoload.materialcanvas.setreg
+++ b/Gems/Atom/Tools/MaterialCanvas/Registry/gem_autoload.materialcanvas.setreg
@@ -8,9 +8,157 @@
                     }
                 }
             },
+            "InAppPurchases": {
+                "Targets": {
+                    "InAppPurchases": {
+                        "AutoLoad": false
+                    },
+                    "InAppPurchases.Editor": {
+                        "AutoLoad": false
+                    },
+                    "InAppPurchases.Tools": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "Stars": {
+                "Targets": {
+                    "Stars": {
+                        "AutoLoad": false
+                    },
+                    "Stars.Editor": {
+                        "AutoLoad": false
+                    },
+                    "Stars.Tools": {
+                        "AutoLoad": false
+                    }
+                }
+            },
             "LyShine": {
                 "Targets": {
+                    "LyShine": {
+                        "AutoLoad": false
+                    },
                     "LyShine.Editor": {
+                        "AutoLoad": false
+                    },
+                    "LyShine.Tools": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "LyShineExamples": {
+                "Targets": {
+                    "LyShineExamples": {
+                        "AutoLoad": false
+                    },
+                    "LyShineExamples.Editor": {
+                        "AutoLoad": false
+                    },
+                    "LyShineExamples.Tools": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "Vegetation": {
+                "Targets": {
+                    "Vegetation.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "Terrain": {
+                "Targets": {
+                    "Terrain.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "FastNoise": {
+                "Targets": {
+                    "FastNoise.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "GradientSignal": {
+                "Targets": {
+                    "GradientSignal.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "SurfaceData": {
+                "Targets": {
+                    "SurfaceData.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "PrefabBuilder": {
+                "Targets": {
+                    "PrefabBuilder.Builders": {
+                        "AutoLoad": false
+                    },
+                    "PrefabBuilder.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "SceneProcessing": {
+                "Targets": {
+                    "SceneProcessing.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "ScriptEvents": {
+                "Targets": {
+                    "ScriptEvents.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "ExpressionEvaluation": {
+                "Targets": {
+                    "ExpressionEvaluation": {
+                        "AutoLoad": false
+                    },
+                    "ExpressionEvaluation.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "AtomTressFX": {
+                "Targets": {
+                    "AtomTressFX": {
+                        "AutoLoad": false
+                    },
+                    "AtomTressFX.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AtomTressFX.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "Maestro": {
+                "Targets": {
+                    "Maestro.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "EMotionFX": {
+                "Targets": {
+                    "EMotionFX.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "EMotionFX_Atom": {
+                "Targets": {
+                    "EMotionFX_Atom.Editor": {
                         "AutoLoad": false
                     }
                 }
@@ -31,7 +179,44 @@
             },
             "Gestures": {
                 "Targets": {
+                    "Gestures": {
+                        "AutoLoad": false
+                    },
                     "Gestures.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "EditorModeFeedback": {
+                "Targets": {
+                    "EditorModeFeedback": {
+                        "AutoLoad": false
+                    },
+                    "EditorModeFeedback.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "RecastNavigation": {
+                "Targets": {
+                    "RecastNavigation.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "AudioSystem": {
+                "Targets": {
+                    "AudioSystem.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "Metastream": {
+                "Targets": {
+                    "Metastream": {
+                        "AutoLoad": false
+                    },
+                    "Metastream.Editor": {
                         "AutoLoad": false
                     }
                 }
@@ -57,9 +242,12 @@
                     }
                 }
             },
-            "NVCloth": {
+            "NvCloth": {
                 "Targets": {
-                    "NVCloth.Editor": {
+                    "NvCloth.Editor": {
+                        "AutoLoad": false
+                    },
+                    "NvCloth.Editor.Gem": {
                         "AutoLoad": false
                     }
                 }

--- a/Gems/Atom/Tools/MaterialEditor/Registry/gem_autoload.materialeditor.setreg
+++ b/Gems/Atom/Tools/MaterialEditor/Registry/gem_autoload.materialeditor.setreg
@@ -8,9 +8,157 @@
                     }
                 }
             },
+            "InAppPurchases": {
+                "Targets": {
+                    "InAppPurchases": {
+                        "AutoLoad": false
+                    },
+                    "InAppPurchases.Editor": {
+                        "AutoLoad": false
+                    },
+                    "InAppPurchases.Tools": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "Stars": {
+                "Targets": {
+                    "Stars": {
+                        "AutoLoad": false
+                    },
+                    "Stars.Editor": {
+                        "AutoLoad": false
+                    },
+                    "Stars.Tools": {
+                        "AutoLoad": false
+                    }
+                }
+            },
             "LyShine": {
                 "Targets": {
+                    "LyShine": {
+                        "AutoLoad": false
+                    },
                     "LyShine.Editor": {
+                        "AutoLoad": false
+                    },
+                    "LyShine.Tools": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "LyShineExamples": {
+                "Targets": {
+                    "LyShineExamples": {
+                        "AutoLoad": false
+                    },
+                    "LyShineExamples.Editor": {
+                        "AutoLoad": false
+                    },
+                    "LyShineExamples.Tools": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "Vegetation": {
+                "Targets": {
+                    "Vegetation.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "Terrain": {
+                "Targets": {
+                    "Terrain.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "FastNoise": {
+                "Targets": {
+                    "FastNoise.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "GradientSignal": {
+                "Targets": {
+                    "GradientSignal.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "SurfaceData": {
+                "Targets": {
+                    "SurfaceData.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "PrefabBuilder": {
+                "Targets": {
+                    "PrefabBuilder.Builders": {
+                        "AutoLoad": false
+                    },
+                    "PrefabBuilder.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "SceneProcessing": {
+                "Targets": {
+                    "SceneProcessing.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "ScriptEvents": {
+                "Targets": {
+                    "ScriptEvents.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "ExpressionEvaluation": {
+                "Targets": {
+                    "ExpressionEvaluation": {
+                        "AutoLoad": false
+                    },
+                    "ExpressionEvaluation.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "AtomTressFX": {
+                "Targets": {
+                    "AtomTressFX": {
+                        "AutoLoad": false
+                    },
+                    "AtomTressFX.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AtomTressFX.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "Maestro": {
+                "Targets": {
+                    "Maestro.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "EMotionFX": {
+                "Targets": {
+                    "EMotionFX.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "EMotionFX_Atom": {
+                "Targets": {
+                    "EMotionFX_Atom.Editor": {
                         "AutoLoad": false
                     }
                 }
@@ -31,7 +179,44 @@
             },
             "Gestures": {
                 "Targets": {
+                    "Gestures": {
+                        "AutoLoad": false
+                    },
                     "Gestures.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "EditorModeFeedback": {
+                "Targets": {
+                    "EditorModeFeedback": {
+                        "AutoLoad": false
+                    },
+                    "EditorModeFeedback.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "RecastNavigation": {
+                "Targets": {
+                    "RecastNavigation.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "AudioSystem": {
+                "Targets": {
+                    "AudioSystem.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "Metastream": {
+                "Targets": {
+                    "Metastream": {
+                        "AutoLoad": false
+                    },
+                    "Metastream.Editor": {
                         "AutoLoad": false
                     }
                 }
@@ -71,9 +256,12 @@
                     }
                 }
             },
-            "NVCloth": {
+            "NvCloth": {
                 "Targets": {
-                    "NVCloth.Editor": {
+                    "NvCloth.Editor": {
+                        "AutoLoad": false
+                    },
+                    "NvCloth.Editor.Gem": {
                         "AutoLoad": false
                     }
                 }

--- a/Gems/Atom/Tools/ShaderManagementConsole/Registry/gem_autoload.shadermanagementconsole.setreg
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Registry/gem_autoload.shadermanagementconsole.setreg
@@ -8,9 +8,157 @@
                     }
                 }
             },
+            "InAppPurchases": {
+                "Targets": {
+                    "InAppPurchases": {
+                        "AutoLoad": false
+                    },
+                    "InAppPurchases.Editor": {
+                        "AutoLoad": false
+                    },
+                    "InAppPurchases.Tools": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "Stars": {
+                "Targets": {
+                    "Stars": {
+                        "AutoLoad": false
+                    },
+                    "Stars.Editor": {
+                        "AutoLoad": false
+                    },
+                    "Stars.Tools": {
+                        "AutoLoad": false
+                    }
+                }
+            },
             "LyShine": {
                 "Targets": {
+                    "LyShine": {
+                        "AutoLoad": false
+                    },
                     "LyShine.Editor": {
+                        "AutoLoad": false
+                    },
+                    "LyShine.Tools": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "LyShineExamples": {
+                "Targets": {
+                    "LyShineExamples": {
+                        "AutoLoad": false
+                    },
+                    "LyShineExamples.Editor": {
+                        "AutoLoad": false
+                    },
+                    "LyShineExamples.Tools": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "Vegetation": {
+                "Targets": {
+                    "Vegetation.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "Terrain": {
+                "Targets": {
+                    "Terrain.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "FastNoise": {
+                "Targets": {
+                    "FastNoise.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "GradientSignal": {
+                "Targets": {
+                    "GradientSignal.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "SurfaceData": {
+                "Targets": {
+                    "SurfaceData.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "PrefabBuilder": {
+                "Targets": {
+                    "PrefabBuilder.Builders": {
+                        "AutoLoad": false
+                    },
+                    "PrefabBuilder.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "SceneProcessing": {
+                "Targets": {
+                    "SceneProcessing.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "ScriptEvents": {
+                "Targets": {
+                    "ScriptEvents.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "ExpressionEvaluation": {
+                "Targets": {
+                    "ExpressionEvaluation": {
+                        "AutoLoad": false
+                    },
+                    "ExpressionEvaluation.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "AtomTressFX": {
+                "Targets": {
+                    "AtomTressFX": {
+                        "AutoLoad": false
+                    },
+                    "AtomTressFX.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AtomTressFX.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "Maestro": {
+                "Targets": {
+                    "Maestro.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "EMotionFX": {
+                "Targets": {
+                    "EMotionFX.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "EMotionFX_Atom": {
+                "Targets": {
+                    "EMotionFX_Atom.Editor": {
                         "AutoLoad": false
                     }
                 }
@@ -31,21 +179,44 @@
             },
             "Gestures": {
                 "Targets": {
+                    "Gestures": {
+                        "AutoLoad": false
+                    },
                     "Gestures.Editor": {
                         "AutoLoad": false
                     }
                 }
             },
-            "GraphCanvas": {
+            "EditorModeFeedback": {
                 "Targets": {
-                    "GraphCanvas.Editor": {
+                    "EditorModeFeedback": {
+                        "AutoLoad": false
+                    },
+                    "EditorModeFeedback.Editor": {
                         "AutoLoad": false
                     }
                 }
             },
-            "GraphModel": {
+            "RecastNavigation": {
                 "Targets": {
-                    "GraphModel.Editor": {
+                    "RecastNavigation.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "AudioSystem": {
+                "Targets": {
+                    "AudioSystem.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "Metastream": {
+                "Targets": {
+                    "Metastream": {
+                        "AutoLoad": false
+                    },
+                    "Metastream.Editor": {
                         "AutoLoad": false
                     }
                 }
@@ -71,9 +242,12 @@
                     }
                 }
             },
-            "NVCloth": {
+            "NvCloth": {
                 "Targets": {
-                    "NVCloth.Editor": {
+                    "NvCloth.Editor": {
+                        "AutoLoad": false
+                    },
+                    "NvCloth.Editor.Gem": {
                         "AutoLoad": false
                     }
                 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
@@ -575,7 +575,7 @@ namespace AZ
 
                     // It's significant that we check IsGroupHidden rather than IsGroupVisisble, because it follows the same rules as QWidget::isHidden().
                     // We don't care whether the widget and all its parents are visible, we only care about whether the group was hidden within the context
-                    // of the material property inspector.
+                    // of the Material Instance Editor.
                     metadata.m_visibility = IsGroupHidden(groupPair.first) ?
                         AZ::RPI::MaterialPropertyGroupVisibility::Hidden : AZ::RPI::MaterialPropertyGroupVisibility::Enabled;
                 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -391,7 +391,7 @@ namespace AZ
             inspectorOptions.showInMenu = false;
             inspectorOptions.showOnToolsToolbar = false;
             AzToolsFramework::RegisterViewPane<AZ::Render::EditorMaterialComponentInspector::MaterialPropertyInspector>(
-                "Material Property Inspector", LyViewPane::CategoryTools, inspectorOptions);
+                "Material Instance Editor", LyViewPane::CategoryTools, inspectorOptions);
         }
         
         void EditorMaterialSystemComponent::AfterEntitySelectionChanged(const AzToolsFramework::EntityIdList& newlySelectedEntities, const AzToolsFramework::EntityIdList&)


### PR DESCRIPTION
## What does this PR do?

Initializing lighting and model preset widget contents off the main thread. 
Removing auto population from asset selection control constructors. 
Disabling several modules unused in material editor and material canvas.

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Confirmed that lighting and model preset dropdowns and dialogues populate correctly after asynchronous file enumeration is complete.