### PR TITLE
Added PIX implementation for AZ_PROFILE_DATAPOINTs

### DIFF
--- a/Code/Framework/AzCore/AzCore/Debug/Profiler.h
+++ b/Code/Framework/AzCore/AzCore/Debug/Profiler.h
@@ -47,9 +47,16 @@
 #endif
 
 #ifndef AZ_PROFILE_DATAPOINT
-#define AZ_PROFILE_DATAPOINT(...)
+#define AZ_PROFILE_DATAPOINT(budget, value, counterName)\
+    ::AZ::Debug::Profiler::ReportCounter(AZ_BUDGET_GETTER(budget)(), counterName, value)
 #define AZ_PROFILE_DATAPOINT_PERCENT(...)
 #endif
+
+#ifndef AZ_PROFILE_EVENT
+#define AZ_PROFILE_EVENT(budget, eventName) \
+    ::AZ::Debug::Profiler::ReportProfileEvent(AZ_BUDGET_GETTER(budget)(), eventName)
+#endif
+
 
 namespace AZStd
 {
@@ -69,6 +76,10 @@ namespace AZ::Debug
 
         virtual void BeginRegion(const Budget* budget, const char* eventName, size_t eventNameArgCount, ...) = 0;
         virtual void EndRegion(const Budget* budget) = 0;
+
+        template<typename T>
+        static void ReportCounter(const Budget* budget, const wchar_t* counterName, const T& value);
+        static void ReportProfileEvent(const Budget* budget, const char* eventName);
     };
 
     class ProfileScope

--- a/Code/Framework/AzCore/AzCore/Debug/Profiler.inl
+++ b/Code/Framework/AzCore/AzCore/Debug/Profiler.inl
@@ -17,7 +17,7 @@ namespace AZ::Debug
         void BeginProfileRegion(Budget* budget, const char* eventName);
         void EndProfileRegion(Budget* budget);
         template<typename T>
-        static void ReportCounter(const Budget* budget, const wchar_t* counterName, const T& value);
+        void ReportCounter(const Budget* budget, const wchar_t* counterName, const T& value);
         void ReportProfileEvent(const Budget* budget, const char* eventName);
     } // namespace Platform
 

--- a/Code/Framework/AzCore/AzCore/Debug/Profiler.inl
+++ b/Code/Framework/AzCore/AzCore/Debug/Profiler.inl
@@ -16,6 +16,9 @@ namespace AZ::Debug
         void BeginProfileRegion(Budget* budget, const char* eventName, T const&... args);
         void BeginProfileRegion(Budget* budget, const char* eventName);
         void EndProfileRegion(Budget* budget);
+        template<typename T>
+        static void ReportCounter(const Budget* budget, const wchar_t* counterName, const T& value);
+        void ReportProfileEvent(const Budget* budget, const char* eventName);
     } // namespace Platform
 
     template<typename... T>
@@ -64,6 +67,23 @@ namespace AZ::Debug
     inline ProfileScope::~ProfileScope()
     {
         EndRegion(m_budget);
+    }
+
+    template<typename T>
+    inline void Profiler::ReportCounter(
+        [[maybe_unused]] const Budget* budget, [[maybe_unused]] const wchar_t* counterName,
+        [[maybe_unused]] const T& value)
+    {
+#if !defined(_RELEASE)
+        Platform::ReportCounter(budget, counterName, value);
+#endif // !defined(_RELEASE)
+    }
+    inline void Profiler::ReportProfileEvent([[maybe_unused]] const Budget* budget,
+        [[maybe_unused]] const char* eventName)
+    {
+#if !defined(_RELEASE)
+        Platform::ReportProfileEvent(budget, eventName);
+#endif // !defined(_RELEASE)
     }
 
 } // namespace AZ::Debug

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/Statistics.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/Statistics.cpp
@@ -140,7 +140,7 @@ namespace AZ::IO
         [[maybe_unused]] double value)
     {
         AZ_PROFILE_DATAPOINT(AzCore, value,
-            AZStd::string::format(L"Streamer/%.*s/%.*s (Raw)",
+            AZStd::wstring::format(L"Streamer/%.*s/%.*s (Raw)",
             aznumeric_cast<int>(owner.size()), owner.data(),
             aznumeric_cast<int>(name.size()), name.data()).data());
     }

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/Statistics.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/Statistics.cpp
@@ -140,9 +140,9 @@ namespace AZ::IO
         [[maybe_unused]] double value)
     {
         AZ_PROFILE_DATAPOINT(AzCore, value,
-            "Streamer/%.*s/%.*s (Raw)",
+            AZStd::string::format(L"Streamer/%.*s/%.*s (Raw)",
             aznumeric_cast<int>(owner.size()), owner.data(),
-            aznumeric_cast<int>(name.size()), name.data());
+            aznumeric_cast<int>(name.size()), name.data()).data());
     }
 
     AZStd::string_view Statistic::GetOwner() const

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/Streamer.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/Streamer.cpp
@@ -265,13 +265,13 @@ namespace AZ::IO
                 if constexpr (AZStd::is_same_v<Type, bool>)
                 {
                     AZ_PROFILE_DATAPOINT(
-                        AzCore, (value ? 1 : 0), AZStd::string::format(L"Streamer/%.*s/%.*s", aznumeric_cast<int>(stat.GetOwner().length()), stat.GetOwner().data(),
+                        AzCore, (value ? 1 : 0), AZStd::wstring::format(L"Streamer/%.*s/%.*s", aznumeric_cast<int>(stat.GetOwner().length()), stat.GetOwner().data(),
                         aznumeric_cast<int>(stat.GetName().length()), stat.GetName().data()).data());
                 }
                 else if constexpr (AZStd::is_same_v<Type, double> || AZStd::is_same_v<Type, s64>)
                 {
                     AZ_PROFILE_DATAPOINT(
-                        AzCore, value, AZStd::string::format(L"Streamer/%.*s/%.*s", aznumeric_cast<int>(stat.GetOwner().length()),
+                        AzCore, value, AZStd::wstring::format(L"Streamer/%.*s/%.*s", aznumeric_cast<int>(stat.GetOwner().length()),
                         stat.GetOwner().data(), aznumeric_cast<int>(stat.GetName().length()), stat.GetName().data()).data());
                 }
                 else if constexpr (
@@ -279,7 +279,7 @@ namespace AZ::IO
                     AZStd::is_same_v<Type, Statistic::ByteSize> || AZStd::is_same_v<Type, Statistic::ByteSizeRange>)
                 {
                     AZ_PROFILE_DATAPOINT(
-                        AzCore, value.m_value, AZStd::string::format(L"Streamer/%.*s/%.*s", aznumeric_cast<int>(stat.GetOwner().length()), stat.GetOwner().data(),
+                        AzCore, value.m_value, AZStd::wstring::format(L"Streamer/%.*s/%.*s", aznumeric_cast<int>(stat.GetOwner().length()), stat.GetOwner().data(),
                         aznumeric_cast<int>(stat.GetName().length()), stat.GetName().data()).data());
                 }
                 else if constexpr (AZStd::is_same_v<Type, Statistic::Time> || AZStd::is_same_v<Type, Statistic::TimeRange>)

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/Streamer.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/Streamer.cpp
@@ -265,22 +265,22 @@ namespace AZ::IO
                 if constexpr (AZStd::is_same_v<Type, bool>)
                 {
                     AZ_PROFILE_DATAPOINT(
-                        AzCore, value ? 1 : 0, "Streamer/%.*s/%.*s", aznumeric_cast<int>(stat.GetOwner().length()), stat.GetOwner().data(),
-                        aznumeric_cast<int>(stat.GetName().length()), stat.GetName().data());
+                        AzCore, (value ? 1 : 0), AZStd::string::format(L"Streamer/%.*s/%.*s", aznumeric_cast<int>(stat.GetOwner().length()), stat.GetOwner().data(),
+                        aznumeric_cast<int>(stat.GetName().length()), stat.GetName().data()).data());
                 }
                 else if constexpr (AZStd::is_same_v<Type, double> || AZStd::is_same_v<Type, s64>)
                 {
                     AZ_PROFILE_DATAPOINT(
-                        AzCore, value, "Streamer/%.*s/%.*s", aznumeric_cast<int>(stat.GetOwner().length()),
-                        stat.GetOwner().data(), aznumeric_cast<int>(stat.GetName().length()), stat.GetName().data());
+                        AzCore, value, AZStd::string::format(L"Streamer/%.*s/%.*s", aznumeric_cast<int>(stat.GetOwner().length()),
+                        stat.GetOwner().data(), aznumeric_cast<int>(stat.GetName().length()), stat.GetName().data()).data());
                 }
                 else if constexpr (
                     AZStd::is_same_v<Type, Statistic::FloatRange> || AZStd::is_same_v<Type, Statistic::IntegerRange> ||
                     AZStd::is_same_v<Type, Statistic::ByteSize> || AZStd::is_same_v<Type, Statistic::ByteSizeRange>)
                 {
                     AZ_PROFILE_DATAPOINT(
-                        AzCore, value.m_value, "Streamer/%.*s/%.*s", aznumeric_cast<int>(stat.GetOwner().length()), stat.GetOwner().data(),
-                        aznumeric_cast<int>(stat.GetName().length()), stat.GetName().data());
+                        AzCore, value.m_value, AZStd::string::format(L"Streamer/%.*s/%.*s", aznumeric_cast<int>(stat.GetOwner().length()), stat.GetOwner().data(),
+                        aznumeric_cast<int>(stat.GetName().length()), stat.GetName().data()).data());
                 }
                 else if constexpr (AZStd::is_same_v<Type, Statistic::Time> || AZStd::is_same_v<Type, Statistic::TimeRange>)
                 {

--- a/Code/Framework/AzCore/Platform/Android/AzCore/Debug/Profiler_Android.inl
+++ b/Code/Framework/AzCore/Platform/Android/AzCore/Debug/Profiler_Android.inl
@@ -34,4 +34,14 @@ namespace AZ::Debug::Platform
     {
         ATrace_endSection();
     }
+
+    template<typename T>
+    inline void ReportCounter(
+        [[maybe_unused]] const Budget* budget, [[maybe_unused]] const wchar_t* counterName, [[maybe_unused]] const T& value)
+    {
+    }
+
+    inline void ReportProfileEvent([[maybe_unused]] const Budget* budget, [[maybe_unused]] const char* eventName)
+    {
+    }
 } // namespace AZ::Debug::Platform

--- a/Code/Framework/AzCore/Platform/Common/Unimplemented/AzCore/Debug/Profiler_Unimplemented.inl
+++ b/Code/Framework/AzCore/Platform/Common/Unimplemented/AzCore/Debug/Profiler_Unimplemented.inl
@@ -20,4 +20,14 @@ namespace AZ::Debug::Platform
     inline void EndProfileRegion([[maybe_unused]] Budget* budget)
     {
     }
+    
+    template<typename T>
+    inline void ReportCounter(
+        [[maybe_unused]] const Budget* budget, [[maybe_unused]] const wchar_t* counterName, [[maybe_unused]] const T& value)
+    {
+    }
+
+    inline void ReportProfileEvent([[maybe_unused]] const Budget* budget, [[maybe_unused]] const char* eventName)
+    {
+    }
 } // namespace AZ::Debug::Platform

--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Debug/Profiler_WinAPI.inl
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Debug/Profiler_WinAPI.inl
@@ -34,4 +34,22 @@ namespace AZ::Debug::Platform
         PIXEndEvent();
     #endif
     }
+
+    template<typename T>
+    inline void ReportCounter(
+        [[maybe_unused]] const Budget* budget, [[maybe_unused]] const wchar_t* counterName, [[maybe_unused]] const T& value)
+    {
+#ifdef USE_PIX
+        PIXReportCounter(counterName, aznumeric_cast<float>(value)); // PIX API requires a float value
+#endif
+    }
+
+    inline void ReportProfileEvent([[maybe_unused]] const Budget* budget,
+        [[maybe_unused]] const char* eventName)
+    {
+#ifdef USE_PIX
+        PIXSetMarker(PIX_COLOR_INDEX(budget->Crc() & 0xff), eventName);
+#endif
+    }
+
 } // namespace AZ::Debug::Platform

--- a/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
+++ b/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
@@ -1217,7 +1217,7 @@ namespace PhysX
 
     void PhysXScene::UpdateAzProfilerDataPoints()
     {
-#if !defined(_RELEASE)
+#if !defined(AZ_RELEASE_BUILD)
         if (!physx_profileSimulationDatapoints)
         {
             return;
@@ -1292,7 +1292,7 @@ namespace PhysX
         AZ_PROFILE_DATAPOINT(Physics, ccdPairs, L"PhysX/Collisions/CCDPairs");
         AZ_PROFILE_DATAPOINT(Physics, modifiedPairs, L"PhysX/Collisions/ModifiedPairs");
         AZ_PROFILE_DATAPOINT(Physics, triggerPairs, L"PhysX/Collisions/TriggerPairs");
-#endif
+#endif // !defined(AZ_RELEASE_BUILD)
     }
 
     void PhysXScene::SyncActiveBodyTransform(const AzPhysics::SimulatedBodyHandleList& activeBodyHandles)

--- a/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
+++ b/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
@@ -48,6 +48,11 @@ namespace PhysX
 
     AZ_CLASS_ALLOCATOR_IMPL(PhysXScene, AZ::SystemAllocator, 0);
 
+    AZ_CVAR(bool, physx_profileSimulationDatapoints, true, nullptr, AZ::ConsoleFunctorFlags::Null,
+        "Expose PhysX simulation statistics to profiler. "
+        "True: Simulation statistics will be collected for the profiler. "
+        "False: Simulation statistics will not be collected.");
+
     /*static*/ thread_local AZStd::vector<physx::PxRaycastHit> PhysXScene::s_rayCastBuffer;
     /*static*/ thread_local AZStd::vector<physx::PxSweepHit> PhysXScene::s_sweepBuffer;
     /*static*/ thread_local AZStd::vector<physx::PxOverlapHit> PhysXScene::s_overlapBuffer;
@@ -1212,15 +1217,8 @@ namespace PhysX
 
     void PhysXScene::UpdateAzProfilerDataPoints()
     {
-        using physx::PxGeometryType;
-
-        bool isProfilingActive = false;
-        if (auto profilerSystem = AZ::Debug::ProfilerSystemInterface::Get(); profilerSystem)
-        {
-            isProfilingActive = profilerSystem->IsActive();
-        }
-
-        if (!isProfilingActive)
+#if !defined(_RELEASE)
+        if (!physx_profileSimulationDatapoints)
         {
             return;
         }
@@ -1234,39 +1232,47 @@ namespace PhysX
             m_pxScene->getSimulationStatistics(stats);
         }
 
-        [[maybe_unused]] const char* RootCategory = "PhysX/%s/%s";
+        // Shapes
+        using physx::PxGeometryType;
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbShapes[PxGeometryType::eSPHERE], L"PhysX/Shapes/Sphere");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbShapes[PxGeometryType::ePLANE], L"PhysX/Shapes/Plane");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbShapes[PxGeometryType::eCAPSULE], L"PhysX/Shapes/Capsule");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbShapes[PxGeometryType::eBOX], L"PhysX/Shapes/Box");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbShapes[PxGeometryType::eCONVEXMESH], L"PhysX/Shapes/ConvexMesh");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbShapes[PxGeometryType::eTRIANGLEMESH], L"PhysX/Shapes/TriangleMesh");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbShapes[PxGeometryType::eHEIGHTFIELD], L"PhysX/Shapes/Heightfield");
 
-        [[maybe_unused]] const char* ShapesSubCategory = "Shapes";
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbShapes[PxGeometryType::eSPHERE], RootCategory, ShapesSubCategory, "Sphere");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbShapes[PxGeometryType::ePLANE], RootCategory, ShapesSubCategory, "Plane");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbShapes[PxGeometryType::eCAPSULE], RootCategory, ShapesSubCategory, "Capsule");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbShapes[PxGeometryType::eBOX], RootCategory, ShapesSubCategory, "Box");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbShapes[PxGeometryType::eCONVEXMESH], RootCategory, ShapesSubCategory, "ConvexMesh");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbShapes[PxGeometryType::eTRIANGLEMESH], RootCategory, ShapesSubCategory, "TriangleMesh");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbShapes[PxGeometryType::eHEIGHTFIELD], RootCategory, ShapesSubCategory, "Heightfield");
+        // Objects
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbActiveConstraints, L"PhysX/Objects/ActiveConstraints");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbActiveDynamicBodies, L"PhysX/Objects/ActiveDynamicBodies");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbActiveKinematicBodies, L"PhysX/Objects/ActiveKinematicBodies");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbStaticBodies, L"PhysX/Objects/StaticBodies");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbDynamicBodies, L"PhysX/Objects/DynamicBodies");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbKinematicBodies, L"PhysX/Objects/KinematicBodies");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbAggregates, L"PhysX/Objects/Aggregates");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbArticulations, L"PhysX/Objects/Articulations");
 
-        [[maybe_unused]] const char* ObjectsSubCategory = "Objects";
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbActiveConstraints, RootCategory, ObjectsSubCategory, "ActiveConstraints");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbActiveDynamicBodies, RootCategory, ObjectsSubCategory, "ActiveDynamicBodies");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbActiveKinematicBodies, RootCategory, ObjectsSubCategory, "ActiveKinematicBodies");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbStaticBodies, RootCategory, ObjectsSubCategory, "StaticBodies");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbDynamicBodies, RootCategory, ObjectsSubCategory, "DynamicBodies");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbKinematicBodies, RootCategory, ObjectsSubCategory, "KinematicBodies");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbAggregates, RootCategory, ObjectsSubCategory, "Aggregates");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbArticulations, RootCategory, ObjectsSubCategory, "Articulations");
+        // Solver
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbAxisSolverConstraints, L"PhysX/Solver/AxisSolverConstraints");
+        AZ_PROFILE_DATAPOINT(Physics, stats.compressedContactSize, L"PhysX/Solver/CompressedContactSize");
+        AZ_PROFILE_DATAPOINT(Physics, stats.requiredContactConstraintMemory, L"PhysX/Solver/RequiredContactConstraintMemory");
+        AZ_PROFILE_DATAPOINT(Physics, stats.peakConstraintMemory, L"PhysX/Solver/PeakConstraintMemory");
 
-        [[maybe_unused]] const char* SolverSubCategory = "Solver";
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbAxisSolverConstraints, RootCategory, SolverSubCategory, "AxisSolverConstraints");
-        AZ_PROFILE_DATAPOINT(Physics, stats.compressedContactSize, RootCategory, SolverSubCategory, "CompressedContactSize");
-        AZ_PROFILE_DATAPOINT(Physics, stats.requiredContactConstraintMemory, RootCategory, SolverSubCategory, "RequiredContactConstraintMemory");
-        AZ_PROFILE_DATAPOINT(Physics, stats.peakConstraintMemory, RootCategory, SolverSubCategory, "PeakConstraintMemory");
+        // Broadphase
+        AZ_PROFILE_DATAPOINT(Physics, stats.getNbBroadPhaseAdds(), L"PhysX/Broadphase/BroadPhaseAdds");
+        AZ_PROFILE_DATAPOINT(Physics, stats.getNbBroadPhaseRemoves(), L"PhysX/Broadphase/BroadPhaseRemoves");
 
-        [[maybe_unused]] const char* BroadphaseSubCategory = "Broadphase";
-        AZ_PROFILE_DATAPOINT(Physics, stats.getNbBroadPhaseAdds(), RootCategory, BroadphaseSubCategory, "BroadPhaseAdds");
-        AZ_PROFILE_DATAPOINT(Physics, stats.getNbBroadPhaseRemoves(), RootCategory, BroadphaseSubCategory, "BroadPhaseRemoves");
+        // Collisions
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbDiscreteContactPairsTotal, L"PhysX/Collisions/DiscreteContactPairsTotal");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbDiscreteContactPairsWithCacheHits, L"PhysX/Collisions/DiscreteContactPairsWithCacheHits");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbDiscreteContactPairsWithContacts, L"PhysX/Collisions/DiscreteContactPairsWithContacts");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbNewPairs, L"PhysX/Collisions/NewPairs");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbLostPairs, L"PhysX/Collisions/LostPairs");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbNewTouches, L"PhysX/Collisions/NewTouches");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbLostTouches, L"PhysX/Collisions/LostTouches");
+        AZ_PROFILE_DATAPOINT(Physics, stats.nbPartitions, L"PhysX/Collisions/Partitions");
 
         // Compute pair stats for all geometry types
-#if AZ_PROFILE_DATAPOINT
         AZ::u32 ccdPairs = 0;
         AZ::u32 modifiedPairs = 0;
         AZ::u32 triggerPairs = 0;
@@ -1282,20 +1288,11 @@ namespace PhysX
                 triggerPairs += stats.getRbPairStats(physx::PxSimulationStatistics::eTRIGGER_PAIRS, firstGeom, secondGeom);
             }
         }
-#endif
 
-        [[maybe_unused]] const char* CollisionsSubCategory = "Collisions";
-        AZ_PROFILE_DATAPOINT(Physics, ccdPairs, RootCategory, CollisionsSubCategory, "CCDPairs");
-        AZ_PROFILE_DATAPOINT(Physics, modifiedPairs, RootCategory, CollisionsSubCategory, "ModifiedPairs");
-        AZ_PROFILE_DATAPOINT(Physics, triggerPairs, RootCategory, CollisionsSubCategory, "TriggerPairs");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbDiscreteContactPairsTotal, RootCategory, CollisionsSubCategory, "DiscreteContactPairsTotal");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbDiscreteContactPairsWithCacheHits, RootCategory, CollisionsSubCategory, "DiscreteContactPairsWithCacheHits");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbDiscreteContactPairsWithContacts, RootCategory, CollisionsSubCategory, "DiscreteContactPairsWithContacts");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbNewPairs, RootCategory, CollisionsSubCategory, "NewPairs");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbLostPairs, RootCategory, CollisionsSubCategory, "LostPairs");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbNewTouches, RootCategory, CollisionsSubCategory, "NewTouches");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbLostTouches, RootCategory, CollisionsSubCategory, "LostTouches");
-        AZ_PROFILE_DATAPOINT(Physics, stats.nbPartitions, RootCategory, CollisionsSubCategory, "Partitions");
+        AZ_PROFILE_DATAPOINT(Physics, ccdPairs, L"PhysX/Collisions/CCDPairs");
+        AZ_PROFILE_DATAPOINT(Physics, modifiedPairs, L"PhysX/Collisions/ModifiedPairs");
+        AZ_PROFILE_DATAPOINT(Physics, triggerPairs, L"PhysX/Collisions/TriggerPairs");
+#endif
     }
 
     void PhysXScene::SyncActiveBodyTransform(const AzPhysics::SimulatedBodyHandleList& activeBodyHandles)


### PR DESCRIPTION
Signed-off-by: Sergey Pereslavtsev <pereslav@amazon.com>

## What does this PR do?

Adds PIX implementation for AZ_PROFILE_DATAPOINTs. 
Now we can plot data point metrics along with profiling information of the functions.

## How was this PR tested?

Manual testing.

![pix1](https://user-images.githubusercontent.com/60428010/202479419-c36b145d-e42d-4983-8db3-b00d8b7dd713.png)
![pix2](https://user-images.githubusercontent.com/60428010/202479425-c6c8f7f5-b8ac-4e90-8a58-5bcfc0fd861d.png)

