### PR TITLE
Fixed UX for Gem Template Location Filepath widget

### DIFF
--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
@@ -225,6 +225,7 @@ namespace O3DE::ProjectManager
         gemSetupLayout->addWidget(rightPaneSubheader);
 
         LoadButtonsFromGemTemplatePaths(gemSetupLayout);
+
         m_formFolderRadioButton = new QRadioButton("Choose existing template");
         m_formFolderRadioButton->setObjectName("createAGem");
         m_radioButtonGroup->addButton(m_formFolderRadioButton);
@@ -233,6 +234,11 @@ namespace O3DE::ProjectManager
         m_gemTemplateLocation->setObjectName("createAGemRadioButtonSubFormField");
         gemSetupLayout->addWidget(m_formFolderRadioButton);
         gemSetupLayout->addWidget(m_gemTemplateLocation);
+        m_gemTemplateLocation->setEnabled(false);
+
+        connect(m_formFolderRadioButton, &QRadioButton::toggled, this, [=](bool checked){
+            m_gemTemplateLocation->setEnabled(checked);
+        });
 
         return gemSetupScrollArea;
     }


### PR DESCRIPTION
Signed-off-by: T.J. Kotha <112996779+tkothadev@users.noreply.github.com>

## What does this PR do?

Updated `CreateGem::m_gemTemplateLocation` filepath widget so that at the start of the CreateGem workflow it is disable by default. Only if the appropriate radio button is selected will it be enabled for editing.

![CreateGemFixTemplateFileLocationUX](https://user-images.githubusercontent.com/112996779/202507904-e840702d-3781-4f05-8a16-f22f505dba1c.gif)


This PR is to address the following github issue: https://github.com/o3de/o3de/issues/13250

## How was this PR tested?
All testing was performed manually. Results are shown in the gif above.