### PR TITLE
Prefab Bug Fix - Remove unexpected transform update of container entity for add-entity

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntity.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntity.cpp
@@ -53,10 +53,10 @@ namespace AzToolsFramework
             // contain the transform data, which may generate unexpected patches to update transform.
             if (parentEntityId == focusedInstance.GetContainerEntityId())
             {
-                PrefabDom parentContainerEntityDom;
-                m_instanceDomGeneratorInterface->GenerateEntityDom(parentContainerEntityDom, parentEntity);
+                PrefabDom parentEntityDomBeforeAddingEntity;
+                m_instanceDomGeneratorInterface->GenerateEntityDom(parentEntityDomBeforeAddingEntity, parentEntity);
 
-                if (parentContainerEntityDom.IsNull())
+                if (parentEntityDomBeforeAddingEntity.IsNull())
                 {
                     AZ_Error("Prefab", false, "PrefabUndoAddEntity::Capture - "
                         "Cannot retrieve parent container entity DOM from root template via instance DOM generator.");
@@ -64,9 +64,9 @@ namespace AzToolsFramework
                 else
                 {
                     PrefabUndoUtils::GenerateUpdateEntityPatch(
-                        m_redoPatch, parentContainerEntityDom, parentEntityDomAfterAddingEntity, parentEntityAliasPath);
+                        m_redoPatch, parentEntityDomBeforeAddingEntity, parentEntityDomAfterAddingEntity, parentEntityAliasPath);
                     PrefabUndoUtils::GenerateUpdateEntityPatch(
-                        m_undoPatch, parentEntityDomAfterAddingEntity, parentContainerEntityDom, parentEntityAliasPath);
+                        m_undoPatch, parentEntityDomAfterAddingEntity, parentEntityDomBeforeAddingEntity, parentEntityAliasPath);
                 }
             }
             else

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntity.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntity.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/Interface/Interface.h>
+#include <AzToolsFramework/Prefab/Instance/InstanceDomGeneratorInterface.h>
 #include <AzToolsFramework/Prefab/Instance/InstanceToTemplateInterface.h>
 #include <AzToolsFramework/Prefab/PrefabDomUtils.h>
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
@@ -46,21 +47,50 @@ namespace AzToolsFramework
             PrefabDom parentEntityDomAfterAddingEntity;
             m_instanceToTemplateInterface->GenerateDomForEntity(parentEntityDomAfterAddingEntity, parentEntity);
 
-            PrefabDom& focusedTemplateDom =
-                m_prefabSystemComponentInterface->FindTemplateDom(m_templateId);
-            PrefabDomPath entityPathInFocusedTemplate(parentEntityAliasPath.c_str());
-            // This scope is added to limit their usage and ensure DOM is not modified when it is being used.
+            // If the parent is the focused container entity, we need to fetch from root template rather than
+            // retrieving from the focused template. The focused containter entity DOM in focused template does
+            // not contain transform data seen from root, but after-state entity DOM from serialization always
+            // contain the transform data, which may generate unexpected patches to update transform.
+            if (parentEntityId == focusedInstance.GetContainerEntityId())
             {
-                // DOM value pointers can't be relied upon if the original DOM gets modified after pointer creation.
-                const PrefabDomValue* parentEntityDomInFocusedTemplate = entityPathInFocusedTemplate.Get(focusedTemplateDom);
-                AZ_Assert(parentEntityDomInFocusedTemplate,
-                    "Could not load parent entity's DOM from the focused template's DOM. "
-                    "Focused template id: '%llu'.", static_cast<AZ::u64>(m_templateId));
+                PrefabDom parentContainerEntityDom;
+                m_instanceDomGeneratorInterface->GenerateEntityDom(parentContainerEntityDom, parentEntity);
 
-                PrefabUndoUtils::GenerateUpdateEntityPatch(m_redoPatch,
-                    *parentEntityDomInFocusedTemplate, parentEntityDomAfterAddingEntity, parentEntityAliasPath);
-                PrefabUndoUtils::GenerateUpdateEntityPatch(m_undoPatch,
-                    parentEntityDomAfterAddingEntity, *parentEntityDomInFocusedTemplate, parentEntityAliasPath);
+                if (parentContainerEntityDom.IsNull())
+                {
+                    AZ_Error("Prefab", false, "PrefabUndoAddEntity::Capture - "
+                        "Cannot retrieve parent container entity DOM from root template via instance DOM generator.");
+                }
+                else
+                {
+                    PrefabUndoUtils::GenerateUpdateEntityPatch(
+                        m_redoPatch, parentContainerEntityDom, parentEntityDomAfterAddingEntity, parentEntityAliasPath);
+                    PrefabUndoUtils::GenerateUpdateEntityPatch(
+                        m_undoPatch, parentEntityDomAfterAddingEntity, parentContainerEntityDom, parentEntityAliasPath);
+                }
+            }
+            else
+            {
+                PrefabDom& focusedTemplateDom = m_prefabSystemComponentInterface->FindTemplateDom(m_templateId);
+                PrefabDomPath entityPathInFocusedTemplate(parentEntityAliasPath.c_str());
+                // This scope is added to limit their usage and ensure DOM is not modified when it is being used.
+                {
+                    // DOM value pointers can't be relied upon if the original DOM gets modified after pointer creation.
+                    const PrefabDomValue* parentEntityDomInFocusedTemplate = entityPathInFocusedTemplate.Get(focusedTemplateDom);
+
+                    if (!parentEntityDomInFocusedTemplate)
+                    {
+                        AZ_Error("Prefab", false, "PrefabUndoAddEntity::Capture - "
+                            "Cannot retrieve parent entity DOM from focused template.");
+                    }
+                    else
+                    {
+                        PrefabUndoUtils::GenerateUpdateEntityPatch(
+                            m_redoPatch, *parentEntityDomInFocusedTemplate, parentEntityDomAfterAddingEntity, parentEntityAliasPath);
+                        PrefabUndoUtils::GenerateUpdateEntityPatch(
+                            m_undoPatch, parentEntityDomAfterAddingEntity, *parentEntityDomInFocusedTemplate, parentEntityAliasPath);
+                    }
+                }
             }
 
             PrefabDom newEntityDom;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDelete.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDelete.cpp
@@ -87,7 +87,7 @@ namespace AzToolsFramework
                     if (parentContainerEntityDom.IsNull())
                     {
                         AZ_Error("Prefab", false, "PrefabUndoDeleteEntity::Capture - "
-                            "Cannot retrieve parent container entity DOM from root template from instance DOM generator.");
+                            "Cannot retrieve parent container entity DOM from root template via instance DOM generator.");
                         continue;
                     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDelete.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDelete.cpp
@@ -81,10 +81,10 @@ namespace AzToolsFramework
                 // contain the transform data, which may generate unexpected patches to update transform.
                 if (parentEntity->GetId() == focusedInstance.GetContainerEntityId())
                 {
-                    PrefabDom parentContainerEntityDom;
-                    m_instanceDomGeneratorInterface->GenerateEntityDom(parentContainerEntityDom, *parentEntity);
+                    PrefabDom parentEntityDomBeforeRemoving;
+                    m_instanceDomGeneratorInterface->GenerateEntityDom(parentEntityDomBeforeRemoving, *parentEntity);
 
-                    if (parentContainerEntityDom.IsNull())
+                    if (parentEntityDomBeforeRemoving.IsNull())
                     {
                         AZ_Error("Prefab", false, "PrefabUndoDeleteEntity::Capture - "
                             "Cannot retrieve parent container entity DOM from root template via instance DOM generator.");
@@ -92,9 +92,9 @@ namespace AzToolsFramework
                     }
 
                     PrefabUndoUtils::AppendUpdateEntityPatch(
-                        m_redoPatch, parentContainerEntityDom, parentEntityDomAfterRemovingChildren, parentEntityAliasPath);
+                        m_redoPatch, parentEntityDomBeforeRemoving, parentEntityDomAfterRemovingChildren, parentEntityAliasPath);
                     PrefabUndoUtils::AppendUpdateEntityPatch(
-                        m_undoPatch, parentEntityDomAfterRemovingChildren, parentContainerEntityDom, parentEntityAliasPath);
+                        m_undoPatch, parentEntityDomAfterRemovingChildren, parentEntityDomBeforeRemoving, parentEntityAliasPath);
                 }
                 else
                 {


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

Fix: https://github.com/o3de/o3de/issues/13155

This PR addresses the issue of an unexpected patch for updating the parent container entity's transform in the source template. During add-entity operation, if the container entity is being focused and we fetch from focused template, the transform in the retrieved entity DOM will be empty. An unexpected patch will be generated to update the transform.

- Patch 1: Add new entity DOM
- Patch 2: Update parent's child entity order
- **Patch 3: Update parent entity's transform    <-- unexpected**

In this case, we need to change it to "fetch from root" such that the transform contains data and later patch generation would not generate an extra patch to update parent transform.

## How was this PR tested?

The recently added unit tests could not verify the redo/undo patches. With changes of connecting PrefabTestFixture to EditorRequestBus going in (https://github.com/o3de/o3de/pull/13211), we should be able to correctly capture the behavior of parent update patches and add some new validations for patch types in undo node unit tests.