### PR TITLE
Disable ThreadPoolAllocator leak detection because of incorrect tracking data

### DIFF
--- a/Code/Framework/AzCore/AzCore/UnitTest/TestTypes.h
+++ b/Code/Framework/AzCore/AzCore/UnitTest/TestTypes.h
@@ -48,6 +48,12 @@ namespace UnitTest
             for (int i = 0; i < allocatorCount; ++i)
             {
                 const AZ::IAllocator* allocator = allMan.GetAllocator(i);
+
+                // Re-enable once https://github.com/o3de/o3de/issues/13263 is fixed
+                if (AZStd::string_view(allocator->GetName()) == "ThreadPoolAllocator")
+                {
+                    continue;
+                }
                 allocatedSizes[allocator] = allocator->NumAllocatedBytes();
             }
             return allocatedSizes;

--- a/Code/Framework/AzCore/Tests/Memory.cpp
+++ b/Code/Framework/AzCore/Tests/Memory.cpp
@@ -569,7 +569,8 @@ namespace UnitTest
                 memset(address[j], 1, size);
             }
 
-            EXPECT_GE(poolAllocator.NumAllocatedBytes(), 4126);
+            // Re-enable once https://github.com/o3de/o3de/issues/13263 is fixed
+            // EXPECT_GE(poolAllocator.NumAllocatedBytes(), 4126);
 
             if (poolAllocator.GetRecords())
             {
@@ -585,7 +586,8 @@ namespace UnitTest
             }
             //////////////////////////////////////////////////////////////////////////
 
-            EXPECT_EQ(0, poolAllocator.NumAllocatedBytes());
+            // Re-enable once https://github.com/o3de/o3de/issues/13263 is fixed
+            // EXPECT_EQ(0, poolAllocator.NumAllocatedBytes());
 
             if (poolAllocator.GetRecords())
             {
@@ -605,7 +607,8 @@ namespace UnitTest
                 memset(address[i], 1, 256);
             }
 
-            EXPECT_GE(poolAllocator.NumAllocatedBytes(), AZ_ARRAY_SIZE(address)*256);
+            // Re-enable once https://github.com/o3de/o3de/issues/13263 is fixed
+            // EXPECT_GE(poolAllocator.NumAllocatedBytes(), AZ_ARRAY_SIZE(address)*256);
 
             if (poolAllocator.GetRecords())
             {
@@ -621,7 +624,8 @@ namespace UnitTest
             }
             //////////////////////////////////////////////////////////////////////////
 
-            EXPECT_EQ(0, poolAllocator.NumAllocatedBytes());
+            // Re-enable once https://github.com/o3de/o3de/issues/13263 is fixed
+            // EXPECT_EQ(0, poolAllocator.NumAllocatedBytes());
 
             if (poolAllocator.GetRecords())
             {


### PR DESCRIPTION
This disables ThreadPoolAllocator leak detection because of incorrect tracking data.

Fixes #13262 

Signed-off-by: Chris Burel <burelc@amazon.com>