### PR TITLE
Fixes bug #13196 Opening .animgraph or .motionset assets via Asset Browser does not work

### DIFF
--- a/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
@@ -870,7 +870,7 @@ namespace EMotionFX
             if (HandlesSource(fullSourceFileName))
             {
                 auto animationEditorCallback =
-                    [fullSourceFileName]([[maybe_unused]] const char* fullSourceFileNameInCall, const AZ::Uuid& sourceUUIDInCall)
+                    []([[maybe_unused]] const char* fullSourceFileNameInCall, const AZ::Uuid& sourceUUIDInCall)
                 {
                     AZ::Outcome<int, AZStd::string> openOutcome = AZ::Failure(AZStd::string());
                     const SourceAssetBrowserEntry* fullDetails = SourceAssetBrowserEntry::GetSourceByUuid(sourceUUIDInCall);
@@ -880,7 +880,7 @@ namespace EMotionFX
 
                         EMStudio::GetMainWindow()->ApplicationModeChanged("AnimGraph");
 
-                        if (AZStd::wildcard_match("*.motionset", fullSourceFileName))
+                        if (AZStd::wildcard_match("*.motionset", fullSourceFileNameInCall))
                         {
                             EMStudio::EMStudioPlugin* plugin =
                                 EMStudio::GetPluginManager()->FindActivePlugin(EMStudio::MotionSetsWindowPlugin::CLASS_ID);
@@ -890,9 +890,9 @@ namespace EMotionFX
                                 // We need to wait for the end of frame otherwise setting the current widget fails
                                 QTimer::singleShot(
                                     0,
-                                    [motionSetPlugin, fullSourceFileName]()
+                                    [motionSetPlugin, fullSourceFileNameInCall]()
                                     {
-                                        motionSetPlugin->LoadMotionSet(AZStd::string(fullSourceFileName));
+                                        motionSetPlugin->LoadMotionSet(AZStd::string(fullSourceFileNameInCall));
                                         QDockWidget* dockWidget = motionSetPlugin->GetDockWidget();
                                         AzQtComponents::DockTabWidget* tabWidget =
                                             AzQtComponents::DockTabWidget::ParentTabWidget(dockWidget);
@@ -907,7 +907,7 @@ namespace EMotionFX
                             EMStudio::AnimGraphPlugin* animGraphPlugin = (EMStudio::AnimGraphPlugin*)plugin;
                             if (plugin)
                             {
-                                animGraphPlugin->FileOpen(AZStd::string(fullSourceFileName));
+                                animGraphPlugin->FileOpen(AZStd::string(fullSourceFileNameInCall));
                             }
                         }
 


### PR DESCRIPTION
Signed-off-by: John Jones-Steele <82226755+jjjoness@users.noreply.github.com>

## What does this PR do?
Fixes bug #13196

## How was this PR tested?

Tried opening .animgraph and .motionset and ensuring they open correctly.
