### PR TITLE
Update VS2022 build node config to 17.4.1

### DIFF
--- a/scripts/build/build_node/Platform/Windows/install_vsbuildtools.ps1
+++ b/scripts/build/build_node/Platform/Windows/install_vsbuildtools.ps1
@@ -5,7 +5,7 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 #>
 
-choco install visualstudio2022buildtools --version=17.2.10 --package-parameters "--config .\vs2022bt.vsconfig" -y
+choco install visualstudio2022buildtools --version=17.4.1 --package-parameters "--config .\vs2022bt.vsconfig" -y
 choco install visualstudio2019buildtools --version=16.11.21 --package-parameters "--config .\vs2019bt.vsconfig" -y
 
 Write-Host "Installing downstream dependancies"


### PR DESCRIPTION
Signed-off-by: Mike Chang <changml@amazon.com>

## What does this PR do?

Bumps Visual Studio 2022 to 17.4.1, including latest compiler

## How was this PR tested?

Tested in a sandbox Jenkins instance
