### PR TITLE
Switch to reset deleted entity in prefab delete-entity operation

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -1408,7 +1408,6 @@ namespace AzToolsFramework
             {
                 const AZ::EntityId entityId = entity->GetId();
                 const AZStd::string nestedEntityAliasPath = m_instanceToTemplateInterface->GenerateEntityAliasPath(entityId);
-                detachedEntityAliasPaths.push_back(AZStd::move(nestedEntityAliasPath));
 
                 // Captures the parent entity that needs to be updated.
                 AZ::EntityId parentEntityId;
@@ -1419,7 +1418,9 @@ namespace AzToolsFramework
                     parentEntitiesToUpdate.insert(GetEntityById(parentEntityId));
                 }
 
-                commonOwningInstance->get().DetachEntity(entityId).reset();
+                commonOwningInstance->get().DetachEntity(entityId);
+
+                detachedEntityAliasPaths.push_back(AZStd::move(nestedEntityAliasPath));
             }
 
             // 3. Updates template DOM with undo/redo support.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -1408,6 +1408,7 @@ namespace AzToolsFramework
             {
                 const AZ::EntityId entityId = entity->GetId();
                 const AZStd::string nestedEntityAliasPath = m_instanceToTemplateInterface->GenerateEntityAliasPath(entityId);
+                detachedEntityAliasPaths.push_back(AZStd::move(nestedEntityAliasPath));
 
                 // Captures the parent entity that needs to be updated.
                 AZ::EntityId parentEntityId;
@@ -1418,10 +1419,7 @@ namespace AzToolsFramework
                     parentEntitiesToUpdate.insert(GetEntityById(parentEntityId));
                 }
 
-                commonOwningInstance->get().DetachEntity(entityId).release();
-                AZ::ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationRequests::DeleteEntity, entityId);
-
-                detachedEntityAliasPaths.push_back(AZStd::move(nestedEntityAliasPath));
+                commonOwningInstance->get().DetachEntity(entityId).reset();
             }
 
             // 3. Updates template DOM with undo/redo support.


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

This PR changes DeleteEntity call to reset() in prefab delete operation.

Difference: [ComponentApplication::DeleteEntity](https://github.com/o3de/o3de/blob/development/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp#L1139) also signals "entity removed event".

Since not noticing any of this event handler being registered (i.e. empty), we discussed that we can try to switch to calling reset() to keep consistency with how it's deleting entities in nested instances `detachedInstance.reset()`.

**Note:** We can revert this commit later if we see new issue because of this change.

Before:

```cpp
AZ::ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationRequests::DeleteEntity, entityId);
```

After:

```cpp
commonOwningInstance->get().DetachEntity(entityId).reset();
```

See previous discussion here: https://github.com/o3de/o3de/pull/13171#discussion_r1022152546

## How was this PR tested?

Manually tested delete operation. Passed tests.
