### PR TITLE
[Terrain] Redcode dead terrain code.

### DIFF
--- a/Code/Editor/2DViewport.cpp
+++ b/Code/Editor/2DViewport.cpp
@@ -89,7 +89,6 @@ Q2DViewport::Q2DViewport(QWidget* parent)
     m_viewType = ET_ViewportXY;
     m_axis = VPA_XY;
 
-    m_bShowTerrain = true;
     m_bShowGrid = true;
     m_bShowObjectsInfo = true;
     m_bShowMinorGridLines = true;

--- a/Code/Editor/2DViewport.h
+++ b/Code/Editor/2DViewport.h
@@ -175,7 +175,6 @@ protected:
 
     AABB m_displayBounds;
 
-    bool m_bShowTerrain;
     bool m_bShowViewMarker;
     bool m_bShowGrid;
     bool m_bShowObjectsInfo;

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -55,7 +55,6 @@ AZ_POP_DISABLE_WARNING
 
 // AzFramework
 #include <AzFramework/Components/CameraBus.h>
-#include <AzFramework/Terrain/TerrainDataRequestBus.h>
 #include <AzFramework/Process/ProcessWatcher.h>
 #include <AzFramework/ProjectManager/ProjectManager.h>
 #include <AzFramework/Spawnable/RootSpawnableInterface.h>
@@ -2524,7 +2523,7 @@ void CCryEditApp::ExportToGame(bool bNoMsgBox)
         }
 
         CErrorsRecorder errRecorder(GetIEditor());
-        // If level not loaded first fast export terrain.
+        // If level not loaded first fast export the level.
         m_bIsExportingLegacyData = true;
         CGameExporter gameExporter;
         gameExporter.Export();
@@ -3138,7 +3137,7 @@ CCryEditApp::ECreateLevelResult CCryEditApp::CreateLevel(const QString& levelNam
 
     if (!usePrefabSystemForLevels)
     {
-        // No terrain, but still need to export default octree and visarea data.
+        // export default octree and visarea data.
         CGameExporter gameExporter;
         gameExporter.Export(eExp_CoverSurfaces | eExp_SurfaceTexture, eLittleEndian, ".");
     }

--- a/Code/Editor/CryEditDoc.h
+++ b/Code/Editor/CryEditDoc.h
@@ -200,7 +200,6 @@ protected:
     QString m_pathName;
     QString m_slicePathName;
     QString m_title;
-    float m_terrainSize;
     const char* m_envProbeSliceRelativePath = "EngineAssets/Slices/DefaultLevelSetup.slice";
     const float m_envProbeHeight = 200.0f;
     bool m_hasErrors = false; ///< This is used to warn the user that they may lose work when they go to save.

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -253,9 +253,6 @@ private:
     void RenderSnapMarker();
     void RenderAll();
 
-    // Draw a selected region if it has been selected
-    void RenderSelectedRegion();
-
     bool RayRenderMeshIntersection(IRenderMesh* pRenderMesh, const Vec3& vInPos, const Vec3& vInDir, Vec3& vOutPos, Vec3& vOutNormal) const;
 
     bool AddCameraMenuItems(QMenu* menu);

--- a/Code/Editor/Export/ExportManager.cpp
+++ b/Code/Editor/Export/ExportManager.cpp
@@ -825,7 +825,7 @@ bool CExportManager::AddSelectedRegionObjects()
     const size_t numObjects = objects.size();
     if (numObjects > m_data.m_objects.size())
     {
-        m_data.m_objects.reserve(numObjects + 1); // +1 for terrain
+        m_data.m_objects.reserve(numObjects);
     }
     // First run pipeline to precache geometry
     m_isPrecaching = true;

--- a/Code/Editor/GameEngine.cpp
+++ b/Code/Editor/GameEngine.cpp
@@ -26,7 +26,6 @@
 #include <AzFramework/Asset/AssetSystemBus.h>
 #include <AzFramework/Input/Devices/Mouse/InputDeviceMouse.h>
 #include <AzFramework/Input/Buses/Requests/InputSystemCursorRequestBus.h>
-#include <AzFramework/Terrain/TerrainDataRequestBus.h>      // for TerrainDataRequests
 #include <AzFramework/Archive/IArchive.h>
 
 // Editor
@@ -828,32 +827,6 @@ void CGameEngine::OnEditorNotifyEvent(EEditorNotifyEvent event)
         }
     }
     break;
-    }
-}
-
-void CGameEngine::OnTerrainModified(const Vec2& modPosition, float modAreaRadius, bool fullTerrain)
-{
-    INavigationSystem* pNavigationSystem = nullptr; // INavigationSystem will be converted to an AZInterface (LY-111343)
-
-    if (pNavigationSystem)
-    {
-        // Only report local modifications, not a change in the full terrain (probably happening during initialization)
-        if (fullTerrain == false)
-        {
-            const Vec2 offset(modAreaRadius * 1.5f, modAreaRadius * 1.5f);
-            AABB updateBox;
-            updateBox.min = modPosition - offset;
-            updateBox.max = modPosition + offset;
-            AzFramework::Terrain::TerrainDataRequests* terrain = AzFramework::Terrain::TerrainDataRequestBus::FindFirstHandler();
-            AZ_Assert(terrain != nullptr, "Expecting a valid terrain handler when the terrain is modified");
-            const float terrainHeight1 = terrain->GetHeightFromFloats(updateBox.min.x, updateBox.min.y);
-            const float terrainHeight2 = terrain->GetHeightFromFloats(updateBox.max.x, updateBox.max.y);
-            const float terrainHeight3 = terrain->GetHeightFromFloats(modPosition.x, modPosition.y);
-
-            updateBox.min.z = min(terrainHeight1, min(terrainHeight2, terrainHeight3)) - (modAreaRadius * 2.0f);
-            updateBox.max.z = max(terrainHeight1, max(terrainHeight2, terrainHeight3)) + (modAreaRadius * 2.0f);
-            pNavigationSystem->WorldChanged(updateBox);
-        }
     }
 }
 

--- a/Code/Editor/GameEngine.h
+++ b/Code/Editor/GameEngine.h
@@ -58,7 +58,7 @@ public:
     //! Initialize game.
     //! @return true if initialization succeeded, false otherwise
     bool InitGame(const char* sGameDLL);
-    //! Load new terrain level into 3d engine.
+    //! Load new level into 3d engine.
     //! Also load AI triangulation for this level.
     bool LoadLevel(
         bool bDeleteAIGraph,
@@ -105,7 +105,6 @@ public:
     //! Called every frame.
     void Update();
     virtual void OnEditorNotifyEvent(EEditorNotifyEvent event);
-    void OnTerrainModified(const Vec2& modPosition, float modAreaRadius, bool fullTerrain);
     void OnAreaModified(const AABB& modifiedArea);
 
     void ExecuteQueuedEvents();

--- a/Code/Editor/GameExporter.cpp
+++ b/Code/Editor/GameExporter.cpp
@@ -27,7 +27,6 @@
 
 #include "Objects/EntityObject.h"
 
-#include <AzFramework/Terrain/TerrainDataRequestBus.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/GameExporter.h
+++ b/Code/Editor/GameExporter.h
@@ -101,14 +101,3 @@ private:
 
     static CGameExporter* m_pCurrentExporter;
 };
-
-// Helper to setup terrain info.
-template<typename Func>
-void SetupTerrainInfo(const size_t octreeCompiledDataSize, Func&& setupTerrainFn)
-{
-    // only setup the terrain if we know space has been allocated for the octree
-    if (octreeCompiledDataSize > 0)
-    {
-        setupTerrainFn(octreeCompiledDataSize);
-    }
-}

--- a/Code/Editor/IEditor.h
+++ b/Code/Editor/IEditor.h
@@ -121,10 +121,6 @@ enum EEditorNotifyEvent
     eNotify_OnEditModeChange,          // Sent when editing mode change (move,rotate,scale,....)
     eNotify_OnEditToolChange,          // Sent when edit tool is changed (ObjectMode,TerrainModify,....)
 
-    // Deferred terrain create event.
-    eNotify_OnBeginTerrainCreate,      // Sent when terrain is created later (and not during level creation)
-    eNotify_OnEndTerrainCreate,        // Sent when terrain is created later (and not during level creation)
-
     // Game related events.
     eNotify_OnBeginGameMode,           // Sent when editor goes to game mode.
     eNotify_OnEndGameMode,             // Sent when editor goes out of game mode.
@@ -148,12 +144,6 @@ enum EEditorNotifyEvent
     eNotify_OnStopSequence,            // Sent when editor stop playing animation sequence.
 
     // Task specific events.
-    eNotify_OnTerrainRebuild,          // Sent when terrain was rebuilt (resized,...)
-    eNotify_OnBeginTerrainRebuild,     // Sent when terrain begin rebuilt (resized,...)
-    eNotify_OnEndTerrainRebuild,       // Sent when terrain end rebuilt (resized,...)
-    eNotify_OnVegetationObjectSelection, // When vegetation objects selection change.
-    eNotify_OnVegetationPanelUpdate,   // When vegetation objects selection change.
-
     eNotify_OnDataBaseUpdate,          // DataBase Library was modified.
 
     eNotify_OnLayerImportBegin,         //layer import was started

--- a/Code/Editor/LyViewPaneNames.h
+++ b/Code/Editor/LyViewPaneNames.h
@@ -36,13 +36,9 @@ namespace LyViewPane
     static const char* const UiEditor = "UI Editor";
 
     static const char* const EditorSettingsManager = "Editor Settings Manager";
-    static const char* const TerrainEditor = "Terrain Editor";
-    static const char* const TerrainTool = "Terrain Tool";
-    static const char* const TerrainTextureLayers = "Terrain Texture Layers";
     static const char* const ParticleEditor = "Particle Editor";
     static const char* const AudioControlsEditor = "Audio Controls Editor";
     static const char* const SubstanceEditor = "Substance Editor";
-    static const char* const VegetationEditor = "Vegetation Editor";
     static const char* const LandscapeCanvas = "Landscape Canvas";
     static const char* const AnimationEditor = "EMotion FX Animation Editor";
     static const char* const PhysXConfigurationEditor = "PhysX Configuration (PREVIEW)";

--- a/Code/Editor/Resource.h
+++ b/Code/Editor/Resource.h
@@ -72,11 +72,8 @@
 #define IDC_GROUPBOX_GLOBALTAGS                    2916
 #define IDC_GROUPBOX_FRAGMENTTAGS                  2917
 #define ID_RESOURCES_REDUCEWORKINGSET              32896
-#define ID_RELOAD_TERRAIN                          32902
 #define ID_VIEW_CONFIGURELAYOUT                    32906
 #define ID_TOOLS_LOGMEMORYUSAGE                    32908
-#define ID_TERRAIN_EXPORTBLOCK                     32909
-#define ID_TERRAIN_IMPORTBLOCK                     32910
 #define ID_TOOLS_CONFIGURETOOLS                    32911
 #define ID_TOOLS_TOOL1                             32913
 #define ID_TOOLS_CUSTOMIZEKEYBOARD                 32914
@@ -86,8 +83,6 @@
 #define ID_PHYSICS_RESETPHYSICSSTATE               32938
 #define ID_GAME_SYNCPLAYER                         32941
 #define ID_FILE_SAVELEVELRESOURCES                 32942
-#define ID_TERRAIN_RESIZE                          32944
-#define ID_TERRAIN_COLLISION                       32960
 #define ID_TOOL_FIRST                              32972
 #define ID_EDIT_UNFREEZE                           32973
 #define ID_EDIT_UNHIDE                             32974
@@ -95,7 +90,6 @@
 #define ID_TOOL_SHELVE_FIRST                       33174
 #define ID_TOOL_SHELVE_LAST                        33375
 #define ID_WIREFRAME                               33410
-#define ID_FILE_GENERATETERRAINTEXTURE             33445
 #define ID_GENERATORS_TEXTURE                      33448
 #define ID_FILE_IMPORT                             33457
 #define ID_EDIT_HOLD                               33464
@@ -162,7 +156,6 @@
 #define ID_TV_PREVKEY                              33602
 #define ID_TV_NEXTKEY                              33603
 #define ID_PLAY_LOOP                               33607
-#define ID_TERRAIN                                 33611
 #define ID_PANEL_VEG_EXPORT                        33672
 #define ID_PANEL_VEG_IMPORT                        33673
 #define ID_PANEL_VEG_DISTRIBUTE                    33674
@@ -176,9 +169,6 @@
 #define ID_PANEL_VEG_RENAMECATEGORY                33683
 #define ID_PANEL_VEG_REMOVECATEGORY                33684
 #define ID_TOOLS_PREFERENCES                       33691
-#define ID_TOOLTERRAINMODIFY_SMOOTH                33695
-#define ID_TERRAINMODIFY_SMOOTH                    33696
-#define ID_TERRAIN_PAINTLAYERS                     33698
 #define ID_SWITCHCAMERA_DEFAULTCAMERA              33700
 #define ID_SWITCHCAMERA_SEQUENCECAMERA             33701
 #define ID_SWITCHCAMERA_SELECTEDCAMERA             33702
@@ -192,8 +182,6 @@
 #define ID_MODIFY_AIPOINT_PICKIMPASSLINK           33865
 #define ID_FILE_EXPORTSELECTION                    33875
 #define ID_EDIT_PASTE_WITH_LINKS                   33893
-#define ID_FILE_EXPORT_TERRAINAREA                 33904
-#define ID_FILE_EXPORT_TERRAINAREAWITHOBJECTS      33910
 #define ID_FILE_EXPORT_SELECTEDOBJECTS             33911
 #define ID_SPLINE_PREVIOUS_KEY                     33916
 #define ID_SPLINE_NEXT_KEY                         33917
@@ -216,7 +204,6 @@
 #define ID_TOOLS_UPDATEPROCEDURALVEGETATION        33999
 #define ID_DISPLAY_GOTOPOSITION                    34004
 #define ID_PHYSICS_SIMULATEOBJECTS                 34007
-#define ID_TERRAIN_TEXTURE_EXPORT                  34008
 #define ID_TV_SEQUENCE_NEW                         34049
 #define ID_TV_MODE_DOPESHEET                       34052
 #define ID_VIEW_LAYOUTS                            34053
@@ -285,11 +272,8 @@
 #define ID_FILE_PROJECT_MANAGER_SETTINGS                            35082
 #define ID_TV_TRACKS_TOOLBAR_BASE                                   35083               // range between ID_TV_TRACKS_TOOLBAR_BASE to ID_TV_TRACKS_TOOLBAR_LAST reserved
 #define ID_TV_TRACKS_TOOLBAR_LAST                                   35183               // for up to 100 "Add Tracks..." dynamically added Track View Track buttons
-#define ID_OPEN_TERRAIN_EDITOR          36007
 #define ID_OPEN_UICANVASEDITOR          36010
-#define ID_OPEN_TERRAINTEXTURE_EDITOR   36012
 #define ID_SKINS_REFRESH                36014
-#define ID_FILE_GENERATETERRAIN         36016
 #define ID_DOCUMENTATION_GETTINGSTARTEDGUIDE    36023
 #define ID_DOCUMENTATION_TUTORIALS              36024
 #define ID_DOCUMENTATION_GLOSSARY               36025

--- a/Code/Editor/Settings.cpp
+++ b/Code/Editor/Settings.cpp
@@ -157,7 +157,6 @@ SEditorSettings::SEditorSettings()
     wheelZoomSpeed = 1;
     invertYRotation = false;
     invertPan = false;
-    fBrMultiplier = 2;
     bPreviewGeometryWindow = true;
     bBackupOnSave = true;
     backupOnSaveMaxCount = 3;
@@ -191,8 +190,6 @@ SEditorSettings::SEditorSettings()
     textureEditor = "";
 #endif
     animEditor = "";
-
-    terrainTextureExport = "";
 
     sTextureBrowserSettings.nCellSize = 128;
 
@@ -442,7 +439,6 @@ void SEditorSettings::Save(bool isEditorClosing)
     SaveValue("Settings", "WheelZoomSpeed", wheelZoomSpeed);
     SaveValue("Settings", "InvertYRotation", invertYRotation);
     SaveValue("Settings", "InvertPan", invertPan);
-    SaveValue("Settings", "BrMultiplier", fBrMultiplier);
     SaveValue("Settings", "CameraFastMoveSpeed", cameraFastMoveSpeed);
     SaveValue("Settings", "PreviewGeometryWindow", bPreviewGeometryWindow);
 
@@ -508,8 +504,6 @@ void SEditorSettings::Save(bool isEditorClosing)
     SaveValue("Settings\\Snap", "GridUserDefined", snap.bGridUserDefined);
     SaveValue("Settings\\Snap", "GridGetFromSelected", snap.bGridGetFromSelected);
     //////////////////////////////////////////////////////////////////////////
-
-    SaveValue("Settings", "TerrainTextureExport", terrainTextureExport);
 
     //////////////////////////////////////////////////////////////////////////
     // Texture browser settings
@@ -630,7 +624,6 @@ void SEditorSettings::Load()
     LoadValue("Settings", "WheelZoomSpeed", wheelZoomSpeed);
     LoadValue("Settings", "InvertYRotation", invertYRotation);
     LoadValue("Settings", "InvertPan", invertPan);
-    LoadValue("Settings", "BrMultiplier", fBrMultiplier);
     LoadValue("Settings", "CameraFastMoveSpeed", cameraFastMoveSpeed);
     LoadValue("Settings", "PreviewGeometryWindow", bPreviewGeometryWindow);
 
@@ -702,8 +695,6 @@ void SEditorSettings::Load()
     LoadValue("Settings\\Snap", "GridUserDefined", snap.bGridUserDefined);
     LoadValue("Settings\\Snap", "GridGetFromSelected", snap.bGridGetFromSelected);
     //////////////////////////////////////////////////////////////////////////
-
-    LoadValue("Settings", "TerrainTextureExport", terrainTextureExport);
 
     //////////////////////////////////////////////////////////////////////////
     // Texture browser settings
@@ -871,30 +862,6 @@ void SEditorSettings::LoadDefaultGamePaths()
     iconsPath /= "Editor/UI/Icons";
     iconsPath.MakePreferred();
     searchPaths[EDITOR_PATH_UI_ICONS].push_back(iconsPath.c_str());
-}
-
-//////////////////////////////////////////////////////////////////////////
-bool SEditorSettings::BrowseTerrainTexture(bool bIsSave)
-{
-    QString path;
-
-    if (!terrainTextureExport.isEmpty())
-    {
-        path = Path::GetPath(terrainTextureExport);
-    }
-    else
-    {
-        path = Path::GetEditingGameDataFolder().c_str();
-    }
-
-    if (bIsSave)
-    {
-        return CFileUtil::SelectSaveFile("Bitmap Image File (*.bmp)", "bmp", path, terrainTextureExport);
-    }
-    else
-    {
-        return CFileUtil::SelectFile("Bitmap Image File (*.bmp)", path, terrainTextureExport);
-    }
 }
 
 void EnableSourceControl(bool enable)

--- a/Code/Editor/Settings.h
+++ b/Code/Editor/Settings.h
@@ -279,8 +279,6 @@ AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 
     void PostInitApply();
 
-    bool BrowseTerrainTexture(bool bIsSave);
-
     //////////////////////////////////////////////////////////////////////////
     // Variables.
     //////////////////////////////////////////////////////////////////////////
@@ -370,9 +368,6 @@ AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 
     SGUI_Settings gui;
 
-    //! Terrain Texture Export/Import filename.
-    QString terrainTextureExport;
-
     // Read only parameter.
     // Refects the status of GetIEditor()->GetOperationMode
     // To change current operation mode use GetIEditor()->SetOperationMode
@@ -389,9 +384,6 @@ AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     SAssetBrowserSettings sAssetBrowserSettings;
 
     SSelectObjectDialogSettings selectObjectDialog;
-
-    // For Terrain Texture Generation Multiplier.
-    float fBrMultiplier;
 
     AzToolsFramework::ConsoleColorTheme consoleBackgroundColorTheme;
 


### PR DESCRIPTION
## What does this PR do?

Removed a bunch of low-hanging fruit in the Editor that contained dead references to the legacy terrain system. 

There are more references that could still be removed, but they require more effort because they involve API changes or additional research to verify that the code is truly unused.

## How was this PR tested?

Removed the code, verified that everything still compiled and ran and seemed to function correctly. Since these changes were just removals that didn't require any code fixups, it's very unlikely that they have any hidden side effects.
