### PR TITLE
Fixed IMGUI Unusable: Mouse Doesn't Work in Game Launcher

### DIFF
--- a/Gems/AtomLyIntegration/ImguiAtom/Code/Source/ImguiAtomSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/ImguiAtom/Code/Source/ImguiAtomSystemComponent.cpp
@@ -95,13 +95,6 @@ namespace AZ
 #endif
         }
 
-        void ImguiAtomSystemComponent::WaitForRender()
-        {
-#if defined(IMGUI_ENABLED)
-            ImGui::ImGuiManagerBus::Broadcast(&ImGui::IImGuiManager::WaitForRenderToFinish);
-#endif
-        }
-
         void ImguiAtomSystemComponent::OnViewportSizeChanged([[maybe_unused]] AzFramework::WindowSize size)
         {
 #if defined(IMGUI_ENABLED)

--- a/Gems/AtomLyIntegration/ImguiAtom/Code/Source/ImguiAtomSystemComponent.h
+++ b/Gems/AtomLyIntegration/ImguiAtom/Code/Source/ImguiAtomSystemComponent.h
@@ -51,7 +51,6 @@ namespace AZ
 
             // ViewportContextNotificationBus overrides...
             void OnRenderTick() override;
-            void WaitForRender() override;
             void OnViewportSizeChanged(AzFramework::WindowSize size) override;
             void OnViewportDpiScalingChanged(float dpiScale) override;
 

--- a/Gems/ImGui/Code/Include/ImGuiBus.h
+++ b/Gems/ImGui/Code/Include/ImGuiBus.h
@@ -95,7 +95,6 @@ namespace ImGui
         virtual void SetDpiScalingFactor(float dpiScalingFactor) = 0;
         virtual float GetDpiScalingFactor() const = 0;
         virtual void Render() = 0;
-        virtual void WaitForRenderToFinish() = 0;
 
         using ImGuiSetEnabledEvent = AZ::Event<bool>;
         ImGuiSetEnabledEvent m_setEnabledEvent;

--- a/Gems/ImGui/Code/Source/ImGuiManager.cpp
+++ b/Gems/ImGui/Code/Source/ImGuiManager.cpp
@@ -251,31 +251,6 @@ float ImGui::ImGuiManager::GetDpiScalingFactor() const
 
 void ImGui::ImGuiManager::Render()
 {
-    m_renderJobCompletion = aznew AZ::JobCompletion();
-
-    const auto jobLambda = [this]([[maybe_unused]] AZ::Job& owner)
-    {
-        this->RenderJob();
-    };
-
-    AZ::Job* renderJob = AZ::CreateJobFunction(AZStd::move(jobLambda), true, nullptr);  //auto-deletes
-    renderJob->SetDependent(m_renderJobCompletion);
-    renderJob->Start();
-}
-
-void ImGui::ImGuiManager::WaitForRenderToFinish()
-{
-    if (m_renderJobCompletion)
-    {
-        AZ_PROFILE_SCOPE(ImGui, "ImGuiManager::WaitForRenderToFinish");
-        m_renderJobCompletion->StartAndWaitForCompletion();
-        delete m_renderJobCompletion;
-        m_renderJobCompletion = nullptr;
-    }
-}
-
-void ImGui::ImGuiManager::RenderJob()
-{
     AZ_PROFILE_FUNCTION(ImGui);
 
     if (m_clientMenuBarState == DisplayState::Hidden && m_editorWindowState == DisplayState::Hidden)

--- a/Gems/ImGui/Code/Source/ImGuiManager.h
+++ b/Gems/ImGui/Code/Source/ImGuiManager.h
@@ -75,7 +75,6 @@ namespace ImGui
         void SetDpiScalingFactor(float dpiScalingFactor) override;
         float GetDpiScalingFactor() const override;
         void Render() override;
-        void WaitForRenderToFinish() override;
         void ToggleThroughImGuiVisibleState() override;
         void ToggleToImGuiVisibleState(DisplayState state) override;
         // -- ImGuiManagerBus Interface -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/12932

The problem was introduced at https://github.com/o3de/o3de/pull/12609 which moved ImGuiManager rendering to a job thread, as an optimization. I simply reverted that part of the changes, as there isn't time for a thorough investigation and proper fix, and I'm concerned there might be more threading issues yet to be uncovered. If we really want ImGuiManager to render on a separate thread, someone else will have to do a deep dive.

## How was this PR tested?

The original change is reported to have saved 5ms, but only when the ImGui CPU profiler tool was open, and on a specific level. I checked the CPU profiler performance in Editor.exe before and after the change. When I tested using the default scene, the main thread took about 2.75 ms before my change and 3.25ms after.

I tested Editor.exe and the GameLauncher to make sure the mouse worked.
