### PR TITLE
The browse action on the motion set window should point to the source folder

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetWindow.cpp
@@ -1617,7 +1617,12 @@ namespace EMStudio
                     for (size_t i = 0; i < selection.GetNumSelectedMotions(); ++i)
                     {
                         EMotionFX::Motion* motion = selection.GetMotion(i);
-                        AzQtComponents::ShowFileOnDesktop(motion->GetFileName());
+
+                        // The browser action should point to the source file's folder.
+                        AZStd::string fileName = motion->GetFileName();
+                        GetMainWindow()->GetFileManager()->RelocateToAssetSourceFolder(fileName);
+
+                        AzQtComponents::ShowFileOnDesktop(fileName.c_str());
                     }
                 });
         }


### PR DESCRIPTION
Signed-off-by: Roman Hong <rhhong@amazon.com>

Before the change, the open in explorer action on the motion set window point to the cache folder. When user select the browser action, they almost always want to look at the source file, not the .motion file in the cache.
 

https://user-images.githubusercontent.com/69218254/202828442-937a46a7-d83d-4404-bd9d-feeef1fb83b1.mp4

