### PR TITLE
Prefer `snprintf` to `sprintf`, the former is deprecated on macOS

### DIFF
--- a/Code/Editor/Util/GuidUtil.cpp
+++ b/Code/Editor/Util/GuidUtil.cpp
@@ -11,7 +11,7 @@
 const char* GuidUtil::ToString(REFGUID guid)
 {
     static char guidString[64];
-    azsprintf(guidString, "{%.8" GUID_FORMAT_DATA1 "-%.4X-%.4X-%.2X%.2X-%.2X%.2X%.2X%.2X%.2X%.2X}", guid.Data1, guid.Data2, guid.Data3, guid.Data4[0], guid.Data4[1],
+    azsnprintf(guidString, AZ_ARRAY_SIZE(guidString), "{%.8" GUID_FORMAT_DATA1 "-%.4X-%.4X-%.2X%.2X-%.2X%.2X%.2X%.2X%.2X%.2X}", guid.Data1, guid.Data2, guid.Data3, guid.Data4[0], guid.Data4[1],
         guid.Data4[2], guid.Data4[3], guid.Data4[4], guid.Data4[5], guid.Data4[6], guid.Data4[7]);
     return guidString;
 }

--- a/Code/Legacy/CrySystem/IDebugCallStack.cpp
+++ b/Code/Legacy/CrySystem/IDebugCallStack.cpp
@@ -176,7 +176,7 @@ AZ_PUSH_DISABLE_WARNING(4996, "-Wunknown-warning-option")
         const char* logfile = gEnv->pLog->GetFileName();
         if (logfile)
         {
-            sprintf (s, "LogFile: %s\n", logfile);
+            azsnprintf (s, AZ_ARRAY_SIZE(s), "LogFile: %s\n", logfile);
             azstrcat(str, length, s);
         }
     }

--- a/Code/Legacy/CrySystem/XConsole.cpp
+++ b/Code/Legacy/CrySystem/XConsole.cpp
@@ -2113,7 +2113,7 @@ void CXConsole::ExecuteCommand(CConsoleCommand& cmd, AZStd::string& str, bool bI
             for (unsigned int i = 1; i <= args.size(); i++)
             {
                 char pat[10];
-                azsprintf(pat, "%%%d", i);
+                azsnprintf(pat, AZ_ARRAY_SIZE(pat), "%%%d", i);
                 size_t pos = buf.find(pat);
                 if (pos == AZStd::string::npos)
                 {

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialPropertyValueSourceDataTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialPropertyValueSourceDataTests.cpp
@@ -241,7 +241,7 @@ namespace UnitTest
         for (uint32_t i = static_cast<uint32_t>(MaterialPropertyDataType::Invalid) + 1u; i < propertyTypeCount; ++i)
         {
             MaterialPropertyDataType type = static_cast<MaterialPropertyDataType>(i);
-            azsprintf(inputJson,
+            azsnprintf(inputJson, AZ_ARRAY_SIZE(inputJson),
                 R"(
                     {
                         "propertyName": "general.%s",

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialTypeSourceDataTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialTypeSourceDataTests.cpp
@@ -2010,7 +2010,7 @@ namespace UnitTest
     TEST_F(MaterialTypeSourceDataTests, CreateMaterialTypeAsset_PropertyImagePath)
     {
         char inputJson[2048];
-        azsprintf(inputJson,
+        azsnprintf(inputJson, AZ_ARRAY_SIZE(inputJson),
             R"(
                 {
                     "description": "",
@@ -2060,7 +2060,7 @@ namespace UnitTest
     TEST_F(MaterialTypeSourceDataTests, CreateMaterialTypeAsset_ResolveSetValueVersionUpdates)
     {
         char inputJson[2048];
-        azsprintf(inputJson,
+        azsnprintf(inputJson, AZ_ARRAY_SIZE(inputJson),
         R"(
             {
                 "description": "",

--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugHierarchyReporter.cpp
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugHierarchyReporter.cpp
@@ -138,7 +138,7 @@ namespace Multiplayer
                     {
                         const AZStd::vector<AZ::Entity*>& hierarchicalChildren = rootComponent->GetHierarchicalEntities();
 
-                        azsprintf(m_statusBuffer, "Hierarchy [%s] %u members", rootComponent->GetEntity()->GetName().c_str(),
+                        azsnprintf(m_statusBuffer, AZ_ARRAY_SIZE(m_statusBuffer), "Hierarchy [%s] %u members", rootComponent->GetEntity()->GetName().c_str(),
                             aznumeric_cast<AZ::u32>(hierarchicalChildren.size()));
 
                         AZ::Vector3 entityPosition = rootComponent->GetEntity()->GetTransform()->GetWorldTranslation();

--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugPerEntityReporter.cpp
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugPerEntityReporter.cpp
@@ -362,16 +362,16 @@ namespace Multiplayer
 
             if (networkEntity.second.m_down > net_DebugEntities_ShowAboveKbps && networkEntity.second.m_up > net_DebugEntities_ShowAboveKbps)
             {
-                azsprintf(m_statusBuffer, "[%s] %.0f down / %0.f up (kbps)", networkEntity.second.m_name,
+                azsnprintf(m_statusBuffer, AZ_ARRAY_SIZE(m_statusBuffer), "[%s] %.0f down / %0.f up (kbps)", networkEntity.second.m_name,
                     networkEntity.second.m_down, networkEntity.second.m_up);
             }
             else if (networkEntity.second.m_down > net_DebugEntities_ShowAboveKbps)
             {
-                azsprintf(m_statusBuffer, "[%s] %.0f down (kbps)", networkEntity.second.m_name, networkEntity.second.m_down);
+                azsnprintf(m_statusBuffer, AZ_ARRAY_SIZE(m_statusBuffer), "[%s] %.0f down (kbps)", networkEntity.second.m_name, networkEntity.second.m_down);
             }
             else
             {
-                azsprintf(m_statusBuffer, "[%s] %.0f up (kbps)", networkEntity.second.m_name, networkEntity.second.m_up);
+                azsnprintf(m_statusBuffer, AZ_ARRAY_SIZE(m_statusBuffer), "[%s] %.0f up (kbps)", networkEntity.second.m_name, networkEntity.second.m_up);
             }
 
             AZ::Vector3 entityPosition = AZ::Vector3::CreateZero();


### PR DESCRIPTION
This fixes the macOS build, where `sprintf` is deprecated

Signed-off-by: Chris Burel <burelc@amazon.com>