### PR TITLE
Fix path width calculation in BreadCrumbs

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.h
@@ -60,7 +60,6 @@ namespace AzQtComponents
         struct Config
         {
             QString linkColor;      //!< Color for links. Must be a string using the hex format #rrggbb.
-            float optimalPathWidth; //!< The portion of the total width used to display the path. Must be a value between 0.0 and 1.0.
         };
 
         explicit BreadCrumbs(QWidget* parent = nullptr);
@@ -103,6 +102,10 @@ namespace AzQtComponents
         //! @return The pointer to the newly created separator.
         //! Note: the separator will need to be added to a layout manually.
         QWidget* createSeparator();
+
+        //! Size hint reports the space that would be taken if the whole
+        //! path would be shown.
+        QSize sizeHint() const override;
 
         //! Sets the Breadcrumbs style configuration.
         //! @param settings The settings object to load the configuration from.


### PR DESCRIPTION
BreadCrumbs::fillPath used a crude approximation for how much space will the path string take based on font metrics of a plain text string of the path. This patch fixes a bunch of issues with this:

The actual html that was put into the QLabel was very different. It used different spacing, could add icons, etc.

In some situations it could cause a crash because the html inserted into the label could be longer that the available space. This caused a resize that again, caused the re-calculation of the path. This time there was enough space so a path portion was added again. This led to infinite recursion and stack overflow.

Instead, the path label has the horizontal policy set to "Ignore". We ourselves make sure to use the available space in the best way.

The calculation of the path width was also improved. Now it properly takes the separators ("  >  ") and icons into account. Thus, the OptimalPathWidth config option became redundant.

QFontMetrics::width was replaced with the non-deprecated QFontMetrics::horizontalAdvance.

The showing/hiding of the menu button is now handled by ::resizeEvent(). We first calculate if the whole path will fit, and if not, we show it.

Some additional improvements:
 - configuration variables are now static so they have internal linkage, no need for them to be external
 - Rich text setting is explicitly set on the label, without it, there could be a situation where autodetection didn't work
 - any operation that can influence the total width of the path now calls updateGeometry() to make sure that layout is re-calculated

Signed-off-by: Miłosz Kosobucki <milosz@kosobucki.pl>

## What does this PR do?

Fixes various problem with the calculation of breadcrumbs path for the purpose of showing only the part that fits. Now the breadcrumbs predictably show only the part of the path that fits:

https://user-images.githubusercontent.com/104767/203140259-c2bf3a11-04bb-429f-a816-b4cdfd87f6ff.mp4

## How was this PR tested?

Manually in all occurences of breadcrumbs in the editor.
