### PR TITLE
Add logger config to Multiplayer gem and shorted AppFrametime metrics…

### DIFF
--- a/Gems/Multiplayer/Code/Source/MultiplayerStatSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerStatSystemComponent.cpp
@@ -54,7 +54,8 @@ namespace Multiplayer
             constexpr AZ::IO::OpenMode openMode = AZ::IO::OpenMode::ModeWrite | AZ::IO::OpenMode::ModeCreatePath;
 
             auto stream = AZStd::make_unique<AZ::IO::SystemFileStream>(metricsFilepath.c_str(), openMode);
-            auto eventLogger = AZStd::make_unique<AZ::Metrics::JsonTraceEventLogger>(AZStd::move(stream));
+            AZ::Metrics::JsonTraceLoggerEventConfig config{ "Multiplayer" };
+            auto eventLogger = AZStd::make_unique<AZ::Metrics::JsonTraceEventLogger>(AZStd::move(stream), config);
             eventLoggerFactory->RegisterEventLogger(NetworkingMetricsId, AZStd::move(eventLogger));
         }
     }

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -249,7 +249,7 @@ namespace Multiplayer
         DECLARE_PERFORMANCE_STAT(MultiplayerGroup_Networking, MultiplayerStat_EntityCount, "NumEntities");
         DECLARE_PERFORMANCE_STAT(MultiplayerGroup_Networking, MultiplayerStat_FrameTimeUs, "FrameTimeUs");
         DECLARE_PERFORMANCE_STAT(MultiplayerGroup_Networking, MultiplayerStat_ClientConnectionCount, "ClientConnections");
-        DECLARE_PERFORMANCE_STAT(MultiplayerGroup_Networking, MultiplayerStat_ApplicationFrameTimeUs, "Application FrameTimeUs");
+        DECLARE_PERFORMANCE_STAT(MultiplayerGroup_Networking, MultiplayerStat_ApplicationFrameTimeUs, "AppFrameTimeUs");
 
         AzFramework::RootSpawnableNotificationBus::Handler::BusConnect();
         AZ::TickBus::Handler::BusConnect();


### PR DESCRIPTION
… name

## What does this PR do?

 * Configures a name for the Multiplayer gem perf logger
 * Shortens the output key name for the Application Frame Time metrics

## How was this PR tested?

 * Multiplayer gem unit tests pass
 * Running a release build of the [o3de-multiplayersample](https://github.com/o3de/o3de-multiplayersample) `ServerLauncher` with `--regset="/O3DE/Metrics/Multiplayer/Active=true"` results in metrics output to `user/Metrics`
 * Example metric output:
```
{"name":"Stats","cat":"Networking","ph":"C","ts":1668894015371994,"pid":22164,"tid":19644,"args":{"NumEntities":155.0,"FrameTimeUs":262.4516129032258,"ClientConnections":0.0,"AppFrameTimeUs":31975.516129032258}}
```
