### PR TITLE
Added INCREMENT_PERFORMANCE_STAT. Added correction counter.

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerMetrics.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerMetrics.h
@@ -22,6 +22,7 @@ namespace Multiplayer
         MultiplayerStat_EntityCount = 1001,         // Number of multiplayer entities active
         MultiplayerStat_FrameTimeUs,                // Multiplayer tick cost within a single application frame
         MultiplayerStat_ClientConnectionCount,      // Current connection (applicable to a server)
-        MultiplayerStat_ApplicationFrameTimeUs      // The entire application frame time
+        MultiplayerStat_ApplicationFrameTimeUs,     // The entire application frame time
+        MultiplayerStat_CorrectionCounter,          // Number of corrections (desyncs)
     };
 }

--- a/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerPerformanceStats.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerPerformanceStats.h
@@ -78,6 +78,18 @@
         }                                                                                                                                  \
     }
 
+#define INCREMENT_PERFORMANCE_STAT(STATID)                                                                                                 \
+    {                                                                                                                                      \
+        if (auto* statSystem = AZ::Interface<IMultiplayerStatSystem>::Get())                                                               \
+        {                                                                                                                                  \
+            statSystem->IncrementStat(STATID);                                                                                             \
+        }                                                                                                                                  \
+        else                                                                                                                               \
+        {                                                                                                                                  \
+            AZLOG_WARN("INCREMENT_PERFORMANCE_STAT was called too early. IMultiplayerStatSystem isn't ready yet.");                        \
+        }                                                                                                                                  \
+    }
+
 #else
 
 #define DECLARE_PERFORMANCE_STAT_GROUP()
@@ -85,5 +97,7 @@
 #define DECLARE_PERFORMANCE_STAT()
 
 #define SET_PERFORMANCE_STAT()
+
+#define INCREMENT_PERFORMANCE_STAT()
 
 #endif

--- a/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerStatSystemInterface.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerStatSystemInterface.h
@@ -50,5 +50,11 @@ namespace Multiplayer
         //! @param uniqueStatId a unique stat id
         //! @param value current value
         virtual void SetStat(int uniqueStatId, double value) = 0;
+
+        //! It's recommended to use INCREASE_PERFORMANCE_STAT macro instead.
+        //! Increments the value of a given stat by one (1) that has been already declared with DECLARE_PERFORMANCE_STAT
+        //! Note: metrics will take the average value of a stat within the period configured with @SetReportPeriod and reset to back to zero each time.
+        //! @param uniqueStatId a unique stat id
+        virtual void IncrementStat(int uniqueStatId) = 0;
     };
 } // namespace Multiplayer

--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugSystemComponent.cpp
@@ -16,6 +16,8 @@
 #include <AzNetworking/Framework/INetworkInterface.h>
 #include <Multiplayer/IMultiplayer.h>
 #include <Multiplayer/MultiplayerConstants.h>
+#include <Multiplayer/MultiplayerPerformanceStats.h>
+#include <Multiplayer/MultiplayerMetrics.h>
 #include <Atom/Feature/ImGui/SystemBus.h>
 #include <ImGuiContextScope.h>
 #include <ImGui/ImGuiPass.h>
@@ -93,6 +95,11 @@ namespace Multiplayer
         [[maybe_unused]] const AZStd::string& name,
         [[maybe_unused]] AZStd::vector<MultiplayerAuditingElement>&& entryDetails)
     {
+        if (category == AuditCategory::Desync)
+        {
+            INCREMENT_PERFORMANCE_STAT(MultiplayerStat_CorrectionCounter);
+        }
+
 #ifdef IMGUI_ENABLED
         while (m_auditTrailElems.size() >= net_DebutAuditTrail_HistorySize)
         {

--- a/Gems/Multiplayer/Code/Source/MultiplayerStatSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerStatSystemComponent.cpp
@@ -208,6 +208,25 @@ namespace Multiplayer
         AZLOG_WARN("Stat with id %d has not been declared using DECLARE_PERFORMANCE_STAT", uniqueStatId);
     }
 
+    void MultiplayerStatSystemComponent::IncrementStat(int uniqueStatId)
+    {
+        AZStd::lock_guard lock(m_access);
+        const auto statIterator = m_statIdToGroupId.find(uniqueStatId);
+        if (statIterator != m_statIdToGroupId.end())
+        {
+            if (const auto group = m_statGroups.Find(statIterator->second))
+            {
+                if (CumulativeAverage* stat = group->m_stats.Find(uniqueStatId))
+                {
+                    stat->m_counterValue++;
+                    return;
+                }
+            }
+        }
+
+        AZLOG_WARN("Stat with id %d has not been declared using DECLARE_PERFORMANCE_STAT", uniqueStatId);
+    }
+
     void MultiplayerStatSystemComponent::RecordMetrics()
     {
         if (const auto* eventLoggerFactory = AZ::Interface<AZ::Metrics::IEventLoggerFactory>::Get())
@@ -225,6 +244,13 @@ namespace Multiplayer
                         {
                             // If there are new entries, update the average.
                             argsContainer.emplace_back(stat.m_name.c_str(), stat.m_average.CalculateAverage());
+                        }
+                        else if (stat.m_counterValue > 0)
+                        {
+                            // counter metric
+                            argsContainer.emplace_back(stat.m_name.c_str(), stat.m_counterValue);
+                            stat.m_counterValue = 0;
+                            stat.m_lastValue = 0;
                         }
                         else
                         {

--- a/Gems/Multiplayer/Code/Source/MultiplayerStatSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerStatSystemComponent.h
@@ -46,6 +46,7 @@ namespace Multiplayer
         void DeclareStatGroup(int uniqueGroupId, const char* groupName) override;
         void DeclareStat(int uniqueGroupId, int uniqueStatId, const char* statName) override;
         void SetStat(int uniqueStatId, double value) override;
+        void IncrementStat(int uniqueStatId) override;
         //! @}
 
     private:
@@ -63,6 +64,7 @@ namespace Multiplayer
             AZStd::string m_name;
             AverageWindowType m_average;
             double m_lastValue = 0;
+            AZ::u64 m_counterValue = 0; // Used by counters.
         };
 
         //! A custom combined data structure for fast iteration and fast insertion.

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -250,6 +250,7 @@ namespace Multiplayer
         DECLARE_PERFORMANCE_STAT(MultiplayerGroup_Networking, MultiplayerStat_FrameTimeUs, "FrameTimeUs");
         DECLARE_PERFORMANCE_STAT(MultiplayerGroup_Networking, MultiplayerStat_ClientConnectionCount, "ClientConnections");
         DECLARE_PERFORMANCE_STAT(MultiplayerGroup_Networking, MultiplayerStat_ApplicationFrameTimeUs, "Application FrameTimeUs");
+        DECLARE_PERFORMANCE_STAT(MultiplayerGroup_Networking, MultiplayerStat_CorrectionCounter, "Corrections");
 
         AzFramework::RootSpawnableNotificationBus::Handler::BusConnect();
         AZ::TickBus::Handler::BusConnect();


### PR DESCRIPTION
Signed-off-by: Olex Lozitskiy <5432499+AMZN-Olex@users.noreply.github.com>

## What does this PR do?

- Added `INCREMENT_PERFORMANCE_STAT` to network metrics system
- Added MultiplayerStat_CorrectionCounter to counter number of desyncs

## How was this PR tested?

Tested in o3de-multiplayersample:

```
... {"NumEntities":162.0,"FrameTimeUs":1685,"ClientConnections":1.0,"Application FrameTimeUs":30697,"Corrections":1}},
... {"NumEntities":162.0,"FrameTimeUs":1694,"ClientConnections":1.0,"Application FrameTimeUs":33274,"Corrections":0}},
... {"NumEntities":162.0,"FrameTimeUs":1710,"ClientConnections":1.0,"Application FrameTimeUs":31785,"Corrections":2}},
... {"NumEntities":162.0,"FrameTimeUs":1604,"ClientConnections":1.0,"Application FrameTimeUs":32397,"Corrections":0}},
```
