### PR TITLE
Added static_assert to string/fixed_string format

### DIFF
--- a/Code/Framework/AzCore/AzCore/std/string/fixed_string.h
+++ b/Code/Framework/AzCore/AzCore/std/string/fixed_string.h
@@ -38,7 +38,7 @@ namespace AZStd
 
         using iterator = pointer;
         using const_iterator = const_pointer;
-       
+
         using reverse_iterator = AZStd::reverse_iterator<iterator>;
         using const_reverse_iterator = AZStd::reverse_iterator<const_iterator>;
         using value_type = Element;

--- a/Code/Framework/AzCore/AzCore/std/string/fixed_string.inl
+++ b/Code/Framework/AzCore/AzCore/std/string/fixed_string.inl
@@ -1578,7 +1578,7 @@ namespace AZStd
     {
         va_list mark;
         va_start(mark, format);
-        basic_fixed_string<char, MaxElementCount, char_traits<char>> result = format_arg(format, mark);
+        auto result = format_arg(format, mark);
         va_end(mark);
         return result;
     }
@@ -1588,7 +1588,7 @@ namespace AZStd
     {
         va_list mark;
         va_start(mark, format);
-        basic_fixed_string<wchar_t, MaxElementCount, char_traits<wchar_t>> result = format_arg(format, mark);
+        auto result = format_arg(format, mark);
         va_end(mark);
         return result;
     }

--- a/Code/Framework/AzCore/AzCore/std/string/string.h
+++ b/Code/Framework/AzCore/AzCore/std/string/string.h
@@ -1544,7 +1544,7 @@ namespace AZStd
             {
                 va_list args;
                 va_start(args, formatStr);
-                basic_string<char, char_traits<char>, Allocator> result = this_type::format_arg(formatStr, args);
+                auto result = this_type::format_arg(formatStr, args);
                 va_end(args);
                 return result;
             }
@@ -1553,7 +1553,7 @@ namespace AZStd
             {
                 va_list args;
                 va_start(args, formatStr);
-                basic_string<wchar_t, char_traits<wchar_t>, Allocator> result = this_type::format_arg(formatStr, args);
+                auto result = this_type::format_arg(formatStr, args);
                 va_end(args);
                 return result;
             }
@@ -1578,7 +1578,7 @@ namespace AZStd
         {
             va_list args;
             va_start(args, formatStr);
-            basic_string<char, char_traits<char>, Allocator> result = format_arg(formatStr, args);
+            auto result = format_arg(formatStr, args);
             va_end(args);
             return result;
         }
@@ -1587,12 +1587,6 @@ namespace AZStd
 #    undef FORMAT_FUNC_ARG
 
 #else // !AZ_COMPILER_CLANG && !defined(_PREFAST_) && !defined(_RELEASE)
-
-        static basic_string<char, char_traits<char>, Allocator> format(const char* formatStr)
-        {
-            return { formatStr };
-        }
-
         template<typename... Args>
         static basic_string<char, char_traits<char>, Allocator> format(const char* formatStr, Args... args)
         {
@@ -1605,16 +1599,12 @@ namespace AZStd
                 return isValid;
             };
             constexpr bool allValid = (IsValidFormatArg(args) && ...);
-            static_assert(allValid, "Invalid string::format arguments, must be: numeric(floating point, integral, pointer) or C String(char/w_char)");
+            static_assert(allValid, "Invalid string::format arguments, must be: numeric(floating point, integral, pointer) or C String(char/wchar_t)");
 
             return _Format_Internal::raw_format(formatStr, args...);
         }
 #endif // AZ_COMPILER_CLANG || defined(_PREFAST_) || defined(_RELEASE)
 
-        static inline basic_string<wchar_t, char_traits<wchar_t>, Allocator> format(const wchar_t* formatStr)
-        {
-            return { formatStr };
-        }
 
         template<typename... Args>
         static basic_string<wchar_t, char_traits<wchar_t>, Allocator> format(const wchar_t* formatStr, Args... args)
@@ -1628,7 +1618,7 @@ namespace AZStd
                 return isValid;
             };
             constexpr bool allValid = (IsValidFormatArg(args) && ...);
-            static_assert(allValid, "Invalid wstring::format arguments, must be: numeric(floating point, integral, pointer) or C String(char/w_char)");
+            static_assert(allValid, "Invalid wstring::format arguments, must be: numeric(floating point, integral, pointer) or C String(char/wchar_t)");
 
             return _Format_Internal::raw_format(formatStr, args...);
         }

--- a/Code/Framework/AzCore/Platform/Common/MSVC/AzCore/std/string/fixed_string_MSVC.inl
+++ b/Code/Framework/AzCore/Platform/Common/MSVC/AzCore/std/string/fixed_string_MSVC.inl
@@ -16,7 +16,7 @@ namespace AZStd
         int len = _vscwprintf(format, argList);
         if (len > 0)
         {
-            result.resize(len);
+            result.resize_no_construct(len);
             len = azvsnwprintf(result.data(), result.capacity() + 1, format, argList);
             AZ_Assert(len == static_cast<int>(result.size()), "azvsnwprintf failed!");
         }


### PR DESCRIPTION
The static_assert validates that the format overload that is called with a `char*` argument is used with a string_type with a value_type that is `char`.
The format overload that accepts a `wchar_t*` is validated that the value_type that is `wchar_t`

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Built the codebase
