### PR TITLE
Check for material changes before updating Mesh ray tracing data

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
@@ -96,6 +96,8 @@ namespace AZ
             void UpdateObjectSrg();
             bool MaterialRequiresForwardPassIblSpecular(Data::Instance<RPI::Material> material) const;
             void SetVisible(bool isVisible);
+            void UpdateMaterialChangeIds();
+            bool CheckForMaterialChanges() const;
 
             // MaterialAssignmentNotificationBus overrides
             void OnRebuildMaterialInstance() override;
@@ -104,6 +106,9 @@ namespace AZ
 
             RPI::Cullable m_cullable;
             MaterialAssignmentMap m_materialAssignments;
+
+            typedef AZStd::unordered_map<Data::Instance<RPI::Material>, RPI::Material::ChangeId> MaterialChangeIdMap;
+            MaterialChangeIdMap m_materialChangeIds;
 
             MeshHandleDescriptor m_descriptor;
             Data::Instance<RPI::Model> m_model;

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -1663,7 +1663,7 @@ namespace AZ
             // update the material changeId list with the current material assignments
             m_materialChangeIds.clear();
 
-            for (const auto materialAssignment : m_materialAssignments)
+            for (const auto& materialAssignment : m_materialAssignments)
             {
                 const AZ::Data::Instance<RPI::Material>& materialInstance = materialAssignment.second.m_materialInstance;
                 if (materialInstance.get())
@@ -1682,7 +1682,7 @@ namespace AZ
             }
 
             // check for material changes using the changeId
-            for (const auto materialAssignment : m_materialAssignments)
+            for (const auto& materialAssignment : m_materialAssignments)
             {
                 const AZ::Data::Instance<RPI::Material>& materialInstance = materialAssignment.second.m_materialInstance;
 

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -264,6 +264,8 @@ namespace AZ
             meshDataHandle->m_originalModelAsset = descriptor.m_modelAsset;
             meshDataHandle->m_meshLoader = AZStd::make_unique<ModelDataInstance::MeshLoader>(descriptor.m_modelAsset, &*meshDataHandle);
 
+            meshDataHandle->UpdateMaterialChangeIds();
+
             return meshDataHandle;
         }
 
@@ -362,6 +364,8 @@ namespace AZ
                 {
                     meshHandle->m_materialAssignments = materials;
                 }
+
+                meshHandle->UpdateMaterialChangeIds();
 
                 meshHandle->m_objectSrgNeedsUpdate = true;
             }
@@ -822,6 +826,7 @@ namespace AZ
 
             m_drawPacketListsByLod.clear();
             m_materialAssignments.clear();
+            m_materialChangeIds.clear();
             m_objectSrgList = {};
             m_model = {};
         }
@@ -1653,11 +1658,55 @@ namespace AZ
             m_cullable.m_isHidden = !isVisible;
         }
 
+        void ModelDataInstance::UpdateMaterialChangeIds()
+        {
+            // update the material changeId list with the current material assignments
+            m_materialChangeIds.clear();
+
+            for (const auto materialAssignment : m_materialAssignments)
+            {
+                const AZ::Data::Instance<RPI::Material>& materialInstance = materialAssignment.second.m_materialInstance;
+                if (materialInstance.get())
+                {
+                    m_materialChangeIds[materialInstance] = materialInstance->GetCurrentChangeId();
+                }
+            }
+        }
+
+        bool ModelDataInstance::CheckForMaterialChanges() const
+        {
+            // check for the same number of materials
+            if (m_materialChangeIds.size() != m_materialAssignments.size())
+            {
+                return true;
+            }
+
+            // check for material changes using the changeId
+            for (const auto materialAssignment : m_materialAssignments)
+            {
+                const AZ::Data::Instance<RPI::Material>& materialInstance = materialAssignment.second.m_materialInstance;
+
+                MaterialChangeIdMap::const_iterator it = m_materialChangeIds.find(materialInstance);
+                if (it == m_materialChangeIds.end() || it->second != materialInstance->GetCurrentChangeId())
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         void ModelDataInstance::OnRebuildMaterialInstance()
         {
             if (m_visible && m_descriptor.m_isRayTracingEnabled)
             {
-                SetRayTracingData();
+                if (CheckForMaterialChanges())
+                {
+                    SetRayTracingData();
+
+                    // update the material changeId list with the latest materials
+                    UpdateMaterialChangeIds();
+                }
             }
         }
     } // namespace Render


### PR DESCRIPTION
Added a list of material changeIds and checked for material changes before updating the Mesh ray tracing data.

Tested AtomSampleViewer DX12/Vulkan
Tested Editor DX12/Vulkan

Signed-off-by: dmcdiarmid-ly <63674186+dmcdiarmid-ly@users.noreply.github.com>
