### PR TITLE
Fixed SDK Install layout issue

### DIFF
--- a/cmake/install/Findo3de.cmake.in
+++ b/cmake/install/Findo3de.cmake.in
@@ -34,6 +34,13 @@ o3de_current_file_path(find_o3de_path)
 cmake_path(SET engine_root_folder NORMALIZE ${find_o3de_path}/..)
 set_property(GLOBAL PROPERTY O3DE_ENGINE_ROOT_FOLDER "${engine_root_folder}")
 
+# If the generation of the SDK layout had LY_DISABLE_TEST_MODULES cache variable set, 
+# then the PAL_TRAIT_BUILD_TESTS_SUPPORTED value needs to be propagated as FALSE
+set(disable_test_modules @LY_DISABLE_TEST_MODULES@)
+if (disable_test_modules)
+    set(PAL_TRAIT_BUILD_TESTS_SUPPORTED FALSE)
+endif()
+
 # Inject the CompilerSettings.cmake to be included before the project command
 set(CMAKE_PROJECT_INCLUDE_BEFORE "${engine_root_folder}cmake/CompilerSettings.cmake")
 


### PR DESCRIPTION
If the Installer was built with the `LY_DISABLE_TEST_MODULES` cache variable set to TRUE, then it would not include the test modules in the SDK layout which is OK.

The issue however is that when the Installer SDK layout is used with a project and external gems, it doesn't have the PAL_TRAIT_BUILD_TEST_SUPPORTED trait set to FALSE.

Therefore when a project and external gems with test attempts to configure using the Installer SDK layout, configuration fails.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## What does this PR do?


## How was this PR tested?
Built an SDK layout with the LY_DISABLE_TEST_MODULES cache variable set to TRUE and validated that configuring a new project with a external gem that includes test modules succeed.
