### PR TITLE
Material Canvas: Fixing graph canvas crashes on shut down

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
@@ -112,7 +112,6 @@ class TestMaterialEditor(AtomToolsTestSuite):
         from Atom.tests import MaterialEditor_Atom_LaunchMaterialEditor as test_module
 
 
-@pytest.mark.skip(reason="GHI #12152 - Non-zero exit code on test success.")
 @pytest.mark.parametrize("project", ["AutomatedTesting"])
 @pytest.mark.parametrize("launcher_platform", ['windows_atom_tools'])
 class TestMaterialCanvas(AtomToolsTestSuite):

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_MaterialCanvas_01.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_MaterialCanvas_01.py
@@ -13,7 +13,6 @@ from ly_test_tools.o3de.atom_tools_test import AtomToolsBatchedTest, AtomToolsTe
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skip(reason="GHI #12152 - Non-zero exit code on test success.")
 @pytest.mark.parametrize("project", ["AutomatedTesting"])
 @pytest.mark.parametrize("launcher_platform", ['windows_atom_tools'])
 class TestMaterialCanvas(AtomToolsTestSuite):

--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_tools_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_tools_utils.py
@@ -127,7 +127,7 @@ def get_last_lighting_preset_path() -> str:
     "C:/git/o3de/Gems/Atom/Feature/Common/Assets/LightingPresets/LowContrast/artist_workshop.lightingpreset.azasset"
     "C:/git/o3de/Gems/Atom/TestData/TestData/LightingPresets/beach_parking.lightingpreset.azasset"
     """
-    return azlmbr.atomtools.EntityPreviewViewportSettingsRequestBus(azlmbr.bus.Broadcast, "GetLastLightingPresetPath")
+    return azlmbr.atomtools.EntityPreviewViewportSettingsRequestBus(azlmbr.bus.Broadcast, "GetLastLightingPresetPathWithoutAlias")
 
 
 def get_last_model_preset_path() -> str:
@@ -138,7 +138,7 @@ def get_last_model_preset_path() -> str:
     "C:/git/o3de/Gems/Atom/Tools/MaterialEditor/Assets/MaterialEditor/ViewportModels/Cone.modelpreset.azasset"
     "C:/git/o3de/Gems/Atom/Tools/MaterialEditor/Assets/MaterialEditor/ViewportModels/BeveledCone.modelpreset.azasset"
     """
-    return azlmbr.atomtools.EntityPreviewViewportSettingsRequestBus(azlmbr.bus.Broadcast, "GetLastModelPresetPath")
+    return azlmbr.atomtools.EntityPreviewViewportSettingsRequestBus(azlmbr.bus.Broadcast, "GetLastModelPresetPathWithoutAlias")
 
 
 def get_last_model_preset_asset_id() -> azlmbr.math.Uuid:

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/EntityPreviewViewport/EntityPreviewViewportSettingsRequestBus.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/EntityPreviewViewport/EntityPreviewViewportSettingsRequestBus.h
@@ -47,6 +47,9 @@ namespace AtomToolsFramework
         //! Get last lighting preset path
         virtual AZStd::string GetLastLightingPresetPath() const = 0;
 
+        //! Get last lighting preset path
+        virtual AZStd::string GetLastLightingPresetPathWithoutAlias() const = 0;
+
         //! Get last lighting preset asset id
         virtual AZ::Data::AssetId GetLastLightingPresetAssetId() const = 0;
 
@@ -82,6 +85,9 @@ namespace AtomToolsFramework
         //! Get last model preset path
         virtual AZStd::string GetLastModelPresetPath() const = 0;
 
+        //! Get last model preset path
+        virtual AZStd::string GetLastModelPresetPathWithoutAlias() const = 0;
+
         //! Get last model preset asset id
         virtual AZ::Data::AssetId GetLastModelPresetAssetId() const = 0;
 
@@ -104,6 +110,9 @@ namespace AtomToolsFramework
 
         //! Get last render pipeline path
         virtual AZStd::string GetLastRenderPipelinePath() const = 0;
+
+        //! Get last render pipeline path
+        virtual AZStd::string GetLastRenderPipelinePathWithoutAlias() const = 0;
 
         //! Get last render pipeline asset id
         virtual AZ::Data::AssetId GetLastRenderPipelineAssetId() const = 0;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/EntityPreviewViewport/EntityPreviewViewportSettingsSystem.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/EntityPreviewViewport/EntityPreviewViewportSettingsSystem.h
@@ -43,8 +43,9 @@ namespace AtomToolsFramework
         const AZ::Render::LightingPreset& GetLightingPreset() const override;
         bool SaveLightingPreset(const AZStd::string& path) override;
         bool LoadLightingPreset(const AZStd::string& path) override;
-        bool LoadLightingPresetByAssetId(const AZ::Data::AssetId& assetId) override;
         AZStd::string GetLastLightingPresetPath() const override;
+        AZStd::string GetLastLightingPresetPathWithoutAlias() const override;
+        bool LoadLightingPresetByAssetId(const AZ::Data::AssetId& assetId) override;
         AZ::Data::AssetId GetLastLightingPresetAssetId() const override;
         void RegisterLightingPresetPath(const AZStd::string& path) override;
         void UnregisterLightingPresetPath(const AZStd::string& path) override;
@@ -56,6 +57,7 @@ namespace AtomToolsFramework
         bool LoadModelPreset(const AZStd::string& path) override;
         bool LoadModelPresetByAssetId(const AZ::Data::AssetId& assetId) override;
         AZStd::string GetLastModelPresetPath() const override;
+        AZStd::string GetLastModelPresetPathWithoutAlias() const override;
         AZ::Data::AssetId GetLastModelPresetAssetId() const override;
         void RegisterModelPresetPath(const AZStd::string& path) override;
         void UnregisterModelPresetPath(const AZStd::string& path) override;
@@ -64,6 +66,7 @@ namespace AtomToolsFramework
         bool LoadRenderPipeline(const AZStd::string& path) override;
         bool LoadRenderPipelineByAssetId(const AZ::Data::AssetId& assetId) override;
         AZStd::string GetLastRenderPipelinePath() const override;
+        AZStd::string GetLastRenderPipelinePathWithoutAlias() const override;
         AZ::Data::AssetId GetLastRenderPipelineAssetId() const override;
         void RegisterRenderPipelinePath(const AZStd::string& path) override;
         void UnregisterRenderPipelinePath(const AZStd::string& path) override;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
@@ -39,6 +39,7 @@
 #include "AtomToolsFramework_Traits_Platform.h"
 
 AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
+#include <QClipboard>
 #include <QMessageBox>
 #include <QObject>
 AZ_POP_DISABLE_WARNING
@@ -237,6 +238,9 @@ namespace AtomToolsFramework
 
     void AtomToolsApplication::Destroy()
     {
+        // Clearing graph canvas clipboard mime data for copied nodes before exiting the application to prevent a crash in qt_call_post_routines
+        QApplication::clipboard()->clear();
+
         m_assetBrowserInteractions.reset();
         m_styleManager.reset();
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettingsSystem.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettingsSystem.cpp
@@ -60,14 +60,27 @@ namespace AtomToolsFramework
                 ->Event("LoadLightingPreset", &EntityPreviewViewportSettingsRequestBus::Events::LoadLightingPreset)
                 ->Event("LoadLightingPresetByAssetId", &EntityPreviewViewportSettingsRequestBus::Events::LoadLightingPresetByAssetId)
                 ->Event("GetLastLightingPresetPath", &EntityPreviewViewportSettingsRequestBus::Events::GetLastLightingPresetPath)
-                ->Event("GetLastLightingPresetAssetId", &EntityPreviewViewportSettingsRequestBus::Events::GetLastLightingPresetAssetId)
+                ->Event("GetLastLightingPresetPathWithoutAlias", &EntityPreviewViewportSettingsRequestBus::Events::GetLastLightingPresetPathWithoutAlias)
+                ->Event("RegisterLightingPresetPath", &EntityPreviewViewportSettingsRequestBus::Events::RegisterLightingPresetPath)
+                ->Event("UnregisterLightingPresetPath", &EntityPreviewViewportSettingsRequestBus::Events::UnregisterLightingPresetPath)
+                ->Event("GetRegisteredLightingPresetPaths", &EntityPreviewViewportSettingsRequestBus::Events::GetRegisteredLightingPresetPaths)
                 ->Event("SetModelPreset", &EntityPreviewViewportSettingsRequestBus::Events::SetModelPreset)
                 ->Event("GetModelPreset", &EntityPreviewViewportSettingsRequestBus::Events::GetModelPreset)
                 ->Event("SaveModelPreset", &EntityPreviewViewportSettingsRequestBus::Events::SaveModelPreset)
                 ->Event("LoadModelPreset", &EntityPreviewViewportSettingsRequestBus::Events::LoadModelPreset)
                 ->Event("LoadModelPresetByAssetId", &EntityPreviewViewportSettingsRequestBus::Events::LoadModelPresetByAssetId)
                 ->Event("GetLastModelPresetPath", &EntityPreviewViewportSettingsRequestBus::Events::GetLastModelPresetPath)
-                ->Event("GetLastModelPresetAssetId", &EntityPreviewViewportSettingsRequestBus::Events::GetLastModelPresetAssetId)
+                ->Event("GetLastModelPresetPathWithoutAlias", &EntityPreviewViewportSettingsRequestBus::Events::GetLastModelPresetPathWithoutAlias)
+                ->Event("RegisterModelPresetPath", &EntityPreviewViewportSettingsRequestBus::Events::RegisterModelPresetPath)
+                ->Event("UnregisterModelPresetPath", &EntityPreviewViewportSettingsRequestBus::Events::UnregisterModelPresetPath)
+                ->Event("GetRegisteredModelPresetPaths", &EntityPreviewViewportSettingsRequestBus::Events::GetRegisteredModelPresetPaths)
+                ->Event("LoadRenderPipeline", &EntityPreviewViewportSettingsRequestBus::Events::LoadRenderPipeline)
+                ->Event("LoadRenderPipelineByAssetId", &EntityPreviewViewportSettingsRequestBus::Events::LoadRenderPipelineByAssetId)
+                ->Event("GetLastRenderPipelinePath", &EntityPreviewViewportSettingsRequestBus::Events::GetLastRenderPipelinePath)
+                ->Event("GetLastRenderPipelinePathWithoutAlias", &EntityPreviewViewportSettingsRequestBus::Events::GetLastRenderPipelinePathWithoutAlias)
+                ->Event("RegisterRenderPipelinePath", &EntityPreviewViewportSettingsRequestBus::Events::RegisterRenderPipelinePath)
+                ->Event("UnregisterRenderPipelinePath", &EntityPreviewViewportSettingsRequestBus::Events::UnregisterRenderPipelinePath)
+                ->Event("GetRegisteredRenderPipelinePaths", &EntityPreviewViewportSettingsRequestBus::Events::GetRegisteredRenderPipelinePaths)
                 ->Event("SetShadowCatcherEnabled", &EntityPreviewViewportSettingsRequestBus::Events::SetShadowCatcherEnabled)
                 ->Event("GetShadowCatcherEnabled", &EntityPreviewViewportSettingsRequestBus::Events::GetShadowCatcherEnabled)
                 ->Event("SetGridEnabled", &EntityPreviewViewportSettingsRequestBus::Events::SetGridEnabled)
@@ -188,6 +201,11 @@ namespace AtomToolsFramework
             "@gemroot:MaterialEditor@/Assets/MaterialEditor/LightingPresets/neutral_urban.lightingpreset.azasset");
     }
 
+    AZStd::string EntityPreviewViewportSettingsSystem::GetLastLightingPresetPathWithoutAlias() const
+    {
+        return GetPathWithoutAlias(GetLastLightingPresetPath());
+    }
+
     AZ::Data::AssetId EntityPreviewViewportSettingsSystem::GetLastLightingPresetAssetId() const
     {
         const auto& result = AZ::RPI::AssetUtils::MakeAssetId(GetLastLightingPresetPath(), 0);
@@ -288,6 +306,11 @@ namespace AtomToolsFramework
             "@gemroot:MaterialEditor@/Assets/MaterialEditor/ViewportModels/Shaderball.modelpreset.azasset");
     }
 
+    AZStd::string EntityPreviewViewportSettingsSystem::GetLastModelPresetPathWithoutAlias() const
+    {
+        return GetPathWithoutAlias(GetLastModelPresetPath());
+    }
+
     AZ::Data::AssetId EntityPreviewViewportSettingsSystem::GetLastModelPresetAssetId() const
     {
         const auto& result = AZ::RPI::AssetUtils::MakeAssetId(GetLastModelPresetPath(), 0);
@@ -375,6 +398,11 @@ namespace AtomToolsFramework
         return GetPathWithoutAlias(GetSettingsValue<AZStd::string>(
             "/O3DE/AtomToolsFramework/EntityPreviewViewportSettings/RenderPipelinePath",
             "@gemroot:Atom_Feature_Common@/Assets/Passes/MainRenderPipeline.azasset"));
+    }
+
+    AZStd::string EntityPreviewViewportSettingsSystem::GetLastRenderPipelinePathWithoutAlias() const
+    {
+        return GetPathWithoutAlias(GetLastRenderPipelinePath());
     }
 
     AZ::Data::AssetId EntityPreviewViewportSettingsSystem::GetLastRenderPipelineAssetId() const

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/GraphView/GraphView.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/GraphView/GraphView.cpp
@@ -56,10 +56,11 @@ namespace AtomToolsFramework
         setLayout(new QVBoxLayout());
 
         m_editorToolbar = aznew GraphCanvas::AssetEditorToolbar(m_toolId);
+        m_editorToolbar->setParent(this);
         layout()->addWidget(m_editorToolbar);
 
         // Screenshot
-        m_takeScreenshot = new QToolButton();
+        m_takeScreenshot = new QToolButton(m_editorToolbar);
         m_takeScreenshot->setToolTip("Captures a full resolution screenshot of the entire graph or selected nodes into the clipboard");
         m_takeScreenshot->setIcon(QIcon(":/Icons/screenshot.png"));
         m_takeScreenshot->setEnabled(false);
@@ -74,10 +75,10 @@ namespace AtomToolsFramework
         m_graphicsView->SetEditorId(m_toolId);
         layout()->addWidget(m_graphicsView);
 
-        m_presetEditor = aznew GraphCanvas::ConstructPresetDialog(nullptr);
+        m_presetEditor = aznew GraphCanvas::ConstructPresetDialog(this);
         m_presetEditor->SetEditorId(m_toolId);
 
-        m_presetWrapper = new AzQtComponents::WindowDecorationWrapper(AzQtComponents::WindowDecorationWrapper::OptionAutoTitleBarButtons);
+        m_presetWrapper = new AzQtComponents::WindowDecorationWrapper(AzQtComponents::WindowDecorationWrapper::OptionAutoTitleBarButtons, this);
         m_presetWrapper->setGuest(m_presetEditor);
         m_presetWrapper->hide();
 
@@ -610,8 +611,7 @@ namespace AtomToolsFramework
 
                     for (GraphCanvas::Endpoint proposedEndpoint : endpoints)
                     {
-                        QAction* action = aznew GraphCanvas::EndpointSelectionAction(proposedEndpoint);
-                        menu.addAction(action);
+                        menu.addAction(aznew GraphCanvas::EndpointSelectionAction(proposedEndpoint));
                     }
 
                     QAction* result = menu.exec(screenPoint);

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
@@ -175,7 +175,7 @@ namespace MaterialCanvas
         // Overriding documentview factory function to create graph view
         documentTypeInfo.m_documentViewFactoryCallback = [this, graphViewConfig](const AZ::Crc32& toolId, const AZ::Uuid& documentId)
         {
-            return m_window->AddDocumentTab(documentId, aznew MaterialCanvasGraphView(toolId, documentId, graphViewConfig));
+            return m_window->AddDocumentTab(documentId, aznew MaterialCanvasGraphView(toolId, documentId, graphViewConfig, m_window.get()));
         };
 
         AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Event(

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
@@ -234,7 +234,7 @@ namespace MaterialCanvas
 
     AZStd::vector<AZStd::string> MaterialCanvasApplication::GetCriticalAssetFilters() const
     {
-        return AZStd::vector<AZStd::string>({ "passes/", "config/"});
+        return AZStd::vector<AZStd::string>({ "passes/", "config/", "MaterialEditor/", "MaterialCanvas/" });
     }
 
     QWidget* MaterialCanvasApplication::GetAppMainWindow()

--- a/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/VectorNodePropertyDisplay.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/VectorNodePropertyDisplay.cpp
@@ -355,14 +355,14 @@ namespace GraphCanvas
         {
             m_proxyWidget = new QGraphicsProxyWidget();
 
-            QWidget* widgetContainer  = new QWidget(nullptr);
-            QHBoxLayout* layout = new QHBoxLayout(widgetContainer);
-            widgetContainer->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
-            
+            m_widgetContainer = new QWidget();
+            QHBoxLayout* layout = new QHBoxLayout(m_widgetContainer);
+            m_widgetContainer->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
+
             layout->setAlignment(Qt::AlignLeft);
             layout->setContentsMargins(0, 0, 0, 0);
 
-            m_button = new QToolButton();
+            m_button = new QToolButton(m_widgetContainer);
             m_button->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
             m_button->setVisible(false);
             QObject::connect(m_button, &QToolButton::clicked, [this] () {
@@ -378,7 +378,7 @@ namespace GraphCanvas
             m_proxyWidget->setAcceptDrops(false);
 
             const int elementCount = m_dataInterface->GetElementCount();
-            m_propertyVectorCtrl = new AzQtComponents::VectorInput(nullptr, elementCount);
+            m_propertyVectorCtrl = new AzQtComponents::VectorInput(m_widgetContainer, elementCount);
 
             for (int i = 0; i < elementCount; ++i)
             {
@@ -394,8 +394,8 @@ namespace GraphCanvas
             QObject::connect(m_propertyVectorCtrl, &AzQtComponents::VectorInput::editingFinished, [this]() { SubmitValue(); });
 
             layout->addWidget(m_propertyVectorCtrl);
-            widgetContainer->setProperty("HasNoWindowDecorations", true);
-            m_proxyWidget->setWidget(widgetContainer);
+            m_widgetContainer->setProperty("HasNoWindowDecorations", true);
+            m_proxyWidget->setWidget(m_widgetContainer);
             
             UpdateDisplay();
             RefreshStyle();
@@ -408,14 +408,11 @@ namespace GraphCanvas
         if (m_propertyVectorCtrl)
         {
             UnregisterShortcutDispatcher(m_propertyVectorCtrl);
-            delete m_propertyVectorCtrl; // NB: this implicitly deletes m_proxy widget
+            delete m_widgetContainer; // NB: this implicitly deletes m_proxy widget
+            m_widgetContainer = nullptr;
             m_propertyVectorCtrl = nullptr;
+            m_button= nullptr;
             m_proxyWidget = nullptr;
-        }
-        if (m_button) 
-        {
-            delete m_button;
-            m_button = nullptr;
         }
     }
 

--- a/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/VectorNodePropertyDisplay.h
+++ b/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/VectorNodePropertyDisplay.h
@@ -120,17 +120,19 @@ namespace GraphCanvas
         void SubmitValue();
     
         Styling::StyleHelper m_styleHelper;
-        VectorDataInterface*  m_dataInterface;
-        
-        GraphCanvasLabel*                           m_disabledLabel;
-        AzQtComponents::VectorInput*                m_propertyVectorCtrl;
-        QToolButton*                                m_button;
-        QGraphicsProxyWidget*                       m_proxyWidget;
-        
-        QGraphicsWidget*                            m_displayWidget;
-        IconLayoutItem*                             m_iconDisplay;
-        AZStd::vector< ReadOnlyVectorControl* >     m_vectorDisplays;
+        VectorDataInterface* m_dataInterface{};
 
-        bool                                        m_releaseLayout;
+        QWidget* m_widgetContainer{};
+
+        GraphCanvasLabel* m_disabledLabel{};
+        AzQtComponents::VectorInput* m_propertyVectorCtrl{};
+        QToolButton* m_button{};
+        QGraphicsProxyWidget* m_proxyWidget{};
+
+        QGraphicsWidget* m_displayWidget{};
+        IconLayoutItem* m_iconDisplay{};
+        AZStd::vector<ReadOnlyVectorControl*> m_vectorDisplays{};
+
+        bool m_releaseLayout{};
     };
-}
+} // namespace GraphCanvas

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/AssetEditorToolbar/AssetEditorToolbar.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/AssetEditorToolbar/AssetEditorToolbar.cpp
@@ -39,7 +39,7 @@ namespace GraphCanvas
         QObject::connect(m_ui->groupNodes, &QToolButton::clicked, this, &AssetEditorToolbar::GroupSelection);
         QObject::connect(m_ui->ungroupNodes, &QToolButton::clicked, this, &AssetEditorToolbar::UngroupSelection);
 
-        m_commentPresetsMenu = aznew EditorContextMenu(editorId);
+        m_commentPresetsMenu = aznew EditorContextMenu(editorId, this);
         m_commentPresetsMenu->SetIsToolBarMenu(true);
 
         QObject::connect(m_commentPresetsMenu, &QMenu::aboutToShow, this, &AssetEditorToolbar::OnCommentMenuAboutToShow);
@@ -49,7 +49,7 @@ namespace GraphCanvas
         m_ui->addComment->setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
         QObject::connect(m_ui->addComment, &QWidget::customContextMenuRequested, this, &AssetEditorToolbar::OnCommentPresetsContextMenu);
 
-        m_nodeGroupPresetsMenu = aznew EditorContextMenu(editorId);
+        m_nodeGroupPresetsMenu = aznew EditorContextMenu(editorId, this);
         m_nodeGroupPresetsMenu->SetIsToolBarMenu(true);
 
         QObject::connect(m_nodeGroupPresetsMenu, &QMenu::aboutToShow, this, &AssetEditorToolbar::OnNodeGroupMenuAboutToShow);


### PR DESCRIPTION
## What does this PR do?

The first issue was improper widget cleanup in recently added code for the color picker button on the graph canvas vector property display class.

The second issue was caused by trying to access clipboard mime data before the application exits. In this case, I clear the clipboard when the application is destroyed. This prevents the crash from happening but the clipboard data should be managed by Qt.

Set up other widget parents to make sure they were cleaned up correctly while debugging the previously mentioned problems.

Resolves https://github.com/o3de/o3de/issues/12152

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Manually and rapidly creating, destroying, cutting, copying, pasting, duplicating several notes, shutting down confirm exceptions or crashes no longer occur.

Being able to shut down cleanly with correct return codes will unlock automated test creation.