### PR TITLE
EMFX: Improve the solid skeleton render

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
@@ -542,17 +542,18 @@ namespace AZ::Render
             const AZ::Vector3 bone = parentWorldPos - nodeWorldPos;
             const AZ::Vector3 boneDirection = bone.GetNormalizedEstimate();
             const AZ::Vector3 centerWorldPos = bone / 2 + nodeWorldPos;
+            const float maxBoneScale = 0.05f;
             const float boneLength = bone.GetLengthEstimate();
-            const float boneScale = CalculateBoneScale(instance, joint);
-            const float parentBoneScale = CalculateBoneScale(instance, skeleton->GetNode(parentIndex));
+            const float boneScale = AZStd::min(CalculateBoneScale(instance, joint), maxBoneScale);
+            const float parentBoneScale = AZStd::min(CalculateBoneScale(instance, skeleton->GetNode(parentIndex)), maxBoneScale);
             const float cylinderSize = boneLength - boneScale - parentBoneScale;
 
             renderColor = GetModifiedColor(color, parentIndex, cachedSelectedJointIndices, cachedHoveredJointIndex);
-            renderColor.SetA(0.75f);
+            renderColor.SetA(0.5f);
             debugDisplay->SetColor(renderColor);
 
             // Render the bone cylinder, the cylinder will be directed towards the node's parent and must fit between the spheres
-            debugDisplay->DrawSolidCylinder(centerWorldPos, boneDirection, boneScale * 0.75f, cylinderSize);
+            debugDisplay->DrawSolidCylinder(centerWorldPos, boneDirection, boneScale, cylinderSize);
             debugDisplay->DrawBall(nodeWorldPos, boneScale);
         }
 


### PR DESCRIPTION
Signed-off-by: Roman Hong <rhhong@amazon.com>

Mainly just limited the size of the scale of the solid joints, and lower the alpha number down.

Before
![image](https://user-images.githubusercontent.com/69218254/203480681-ae54061a-a70a-426a-954e-6e5f8520c238.png)
![image](https://user-images.githubusercontent.com/69218254/203480715-a9131ae0-82dc-4a4d-9584-880fad199972.png)

After
![image](https://user-images.githubusercontent.com/69218254/203480132-b7a6a80e-4f4d-4271-930e-25e840d88f19.png)
![image](https://user-images.githubusercontent.com/69218254/203480217-b7d0a6cd-e455-4592-bb19-08786792f3c7.png)

