### PR TITLE
13234 fix shaking inspector layout

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterCreateEditWidget.cpp
@@ -45,6 +45,7 @@ namespace EMStudio
         QHBoxLayout* valueTypeLayout = new QHBoxLayout();
         m_valueTypeLabel = new QLabel("Value type", this);
         m_valueTypeLabel->setFixedWidth(100);
+        valueTypeLayout->addItem(new QSpacerItem(4, 0, QSizePolicy::Fixed, QSizePolicy::Fixed));
         valueTypeLayout->addWidget(m_valueTypeLabel);
         m_valueTypeCombo = new QComboBox(this);
         m_valueTypeCombo->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Preferred);
@@ -301,7 +302,6 @@ namespace EMStudio
     void ParameterCreateEditWidget::AfterPropertyModified(AzToolsFramework::InstanceDataNode*)
     {
         m_previewWidget->InvalidateAttributesAndValues();
-        adjustSize();
     }
 } // namespace EMStudio
 


### PR DESCRIPTION
## What does this PR do?

This change fixes a bug where the Inspector layout was shaking when a parameter name was being edited.

Fixes #13234 

## How was this PR tested?

The PR was tested by adding a new parameter and editing its name, the layout is not shaking anymore.