### PR TITLE
13273 skeleton outliner update character node icon

### DIFF
--- a/Gems/EMotionFX/Code/Source/Editor/SkeletonModel.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/SkeletonModel.cpp
@@ -22,6 +22,7 @@ namespace EMotionFX
     const char* SkeletonModel::s_ragdollJointLimitIconPath = ":/EMotionFX/RagdollJointLimit.svg";
     const char* SkeletonModel::s_simulatedJointIconPath = ":/EMotionFX/SimulatedObjectColored.svg";
     const char* SkeletonModel::s_simulatedColliderIconPath = ":/EMotionFX/SimulatedObjectCollider.svg";
+    const char* SkeletonModel::s_characterIconPath = ":/EMotionFX/Character.svg";
 
     SkeletonModel::SkeletonModel()
         : m_selectionModel(this)
@@ -36,6 +37,7 @@ namespace EMotionFX
         , m_ragdollJointLimitIcon(s_ragdollJointLimitIconPath)
         , m_simulatedJointIcon(s_simulatedJointIconPath)
         , m_simulatedColliderIcon(s_simulatedColliderIconPath)
+        , m_characterIcon(s_characterIconPath)
     {
         m_selectionModel.setModel(this);
 
@@ -283,6 +285,8 @@ namespace EMotionFX
                 {
                     switch (index.column())
                     {
+                    case COLUMN_NAME:
+                        return m_characterIcon;
                     case COLUMN_RAGDOLL_LIMIT:
                     case COLUMN_RAGDOLL_COLLIDERS:
                     case COLUMN_HITDETECTION_COLLIDERS:

--- a/Gems/EMotionFX/Code/Source/Editor/SkeletonModel.h
+++ b/Gems/EMotionFX/Code/Source/Editor/SkeletonModel.h
@@ -99,6 +99,7 @@ namespace EMotionFX
         static const char* s_ragdollJointLimitIconPath;
         static const char* s_simulatedJointIconPath;
         static const char* s_simulatedColliderIconPath;
+        static const char* s_characterIconPath;
 
         static bool IndexIsRootNode(const QModelIndex& idx);
         static bool IndicesContainRootNode(const QModelIndexList& indices);
@@ -135,6 +136,7 @@ namespace EMotionFX
         QIcon m_ragdollJointLimitIcon;
         QIcon m_simulatedJointIcon;
         QIcon m_simulatedColliderIcon;
+        QIcon m_characterIcon;
     };
 
 } // namespace EMotionFX


### PR DESCRIPTION
## What does this PR do?

On the skeleton outliner the root node used to have a joint icon, that has been changed to the character icon.

Fixes #13273 

## How was this PR tested?

Opening the skeleton outliner after adding an actor. The icon on the root node is now is the expected one.
