### PR TITLE
EMotionFX: fix editing node group name when multiple groups exist

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodeGraph.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodeGraph.cpp
@@ -2557,7 +2557,6 @@ namespace EMStudio
                 else
                 {
                     // Draw group name label
-                    m_nodeGroupNameLineEdit->hide();
                     QRect textRect = groupRect;
                     textRect.setHeight(m_groupFontMetrics->height());
                     textRect.setLeft(textRect.left() + sGroupRectTextHPadding);
@@ -2598,6 +2597,10 @@ namespace EMStudio
             m_nodeGroupNameLineEdit->setText({});
             m_currentNameEditNodeGroup->SetNameEditOngoing(false);
             m_currentNameEditNodeGroup = nullptr;
+            // This needs to be done after setting m_currentNameEditNodeGroup = nullptr because
+            // it triggers the QLineEdit::editingFinished signal which this function is connected to,
+            // which is effectively a recursive function call.
+            m_nodeGroupNameLineEdit->hide();
         }
     }
 


### PR DESCRIPTION
When multiple node groups existed, trying to edit the name of any of them would immediately disable editing the name because QLineEdit::hide triggers the QLineEdit::editingFinished signal.

Fixes https://github.com/o3de/o3de/issues/13279

## How was this PR tested?
manually
