### PR TITLE
Fix for new Mac Xcode 14.1 64bit to 32bit truncation errors

### DIFF
--- a/Code/Editor/PythonEditorFuncs.cpp
+++ b/Code/Editor/PythonEditorFuncs.cpp
@@ -61,7 +61,7 @@ namespace
         }
         else if (pCVar->GetType() == CVAR_INT)
         {
-            PySetCVarFromInt(pName, std::stol(pValue));
+            PySetCVarFromInt(pName, static_cast<int>(std::stol(pValue)));
         }
         else if (pCVar->GetType() == CVAR_FLOAT)
         {

--- a/Code/Editor/QtUI/ColorButton_mac.mm
+++ b/Code/Editor/QtUI/ColorButton_mac.mm
@@ -19,7 +19,7 @@
 void macRaiseWindowDelayed(QWidget* window)
 {
     NSWindow* nativeWindow = [(NSView*)(window->winId()) window];
-    CGWindowLevel level = nativeWindow.level;
+    CGWindowLevel level = static_cast<CGWindowLevel>(nativeWindow.level);
     QTimer* t = new QTimer(window);
     QObject::connect(t, &QTimer::timeout, t, [t,nativeWindow,level] {
         if (nativeWindow.level != level)

--- a/Code/Editor/Util/ImageUtil.cpp
+++ b/Code/Editor/Util/ImageUtil.cpp
@@ -139,7 +139,7 @@ bool CImageUtil::LoadPGM(const QString& fileName, CImageEx& image)
 
 
     fseek(file, 0, SEEK_END);
-    int fileSize = ftell(file);
+    int fileSize = static_cast<int>(ftell(file));
     fseek(file, 0, SEEK_SET);
 
     char* str = new char[fileSize];

--- a/Code/Editor/Util/MemoryBlock.cpp
+++ b/Code/Editor/Util/MemoryBlock.cpp
@@ -154,12 +154,12 @@ void CMemoryBlock::Compress(CMemoryBlock& toBlock) const
     assert(this != &toBlock);
     unsigned long destSize = m_size * 2 + 128;
     CMemoryBlock temp;
-    temp.Allocate(destSize);
+    temp.Allocate(static_cast<int>(destSize));
 
     compress((unsigned char*)temp.GetBuffer(), &destSize, (unsigned char*)GetBuffer(), m_size);
 
-    toBlock.Allocate(destSize);
-    toBlock.Copy(temp.GetBuffer(), destSize);
+    toBlock.Allocate(static_cast<int>(destSize));
+    toBlock.Copy(temp.GetBuffer(), static_cast<int>(destSize));
     toBlock.m_uncompressedSize = GetSize();
 }
 

--- a/Code/Editor/Util/NamedData.cpp
+++ b/Code/Editor/Util/NamedData.cpp
@@ -174,9 +174,9 @@ bool CNamedData::Serialize(CArchive& ar)
             {
                 nOriginalSize = pBlock->compressedData.GetUncompressedSize();
                 // Compressed data.
-                unsigned long destSize = pBlock->compressedData.GetSize();
+                unsigned int destSize = static_cast<unsigned int>(pBlock->compressedData.GetSize());
                 void* dest = pBlock->compressedData.GetBuffer();
-                nSizeFlags = destSize | (1 << 31);
+                nSizeFlags = destSize | (1u << 31);
 
                 ar << key;
                 ar << nSizeFlags; // Current size of data + 1 bit for compressed flag.

--- a/Code/Framework/AzCore/AzCore/Asset/AssetCommon.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetCommon.cpp
@@ -46,7 +46,7 @@ namespace AZ::Data
             return AssetId();
         }
 
-        assetId.m_subId = strtoul(&input[separatorIdx + 1], nullptr, 16);
+        assetId.m_subId = static_cast<AZ::u32>(strtoul(&input[separatorIdx + 1], nullptr, 16));
 
         return assetId;
     }

--- a/Code/Framework/AzCore/AzCore/Threading/ThreadUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Threading/ThreadUtils.cpp
@@ -18,7 +18,7 @@ namespace AZ::Threading
         const uint32_t numReservedThreads = AZ::GetMin<uint32_t>(reservedNumThreads, maxHardwareThreads); // protect against num reserved being bigger than the number of hw threads
         const uint32_t maxWorkerThreads = maxNumWorkerThreads > 0 ? maxNumWorkerThreads : maxHardwareThreads - numReservedThreads;
         const float requestedWorkerThreads = AZ::GetClamp<float>(workerThreadsRatio, 0.0f, 1.0f) * static_cast<float>(maxWorkerThreads);
-        const uint32_t requestedWorkerThreadsRounded = AZStd::lround(requestedWorkerThreads);
+        const uint32_t requestedWorkerThreadsRounded = static_cast<uint32_t>(AZStd::lround(requestedWorkerThreads));
         const uint32_t numWorkerThreads = AZ::GetMax<uint32_t>(minNumWorkerThreads, requestedWorkerThreadsRounded);
         return numWorkerThreads;
     }

--- a/Code/Framework/AzCore/Platform/Common/Apple/AzCore/IO/SystemFile_Apple.h
+++ b/Code/Framework/AzCore/Platform/Common/Apple/AzCore/IO/SystemFile_Apple.h
@@ -95,12 +95,12 @@ namespace AZ
 
             inline int Read(int fileDescriptor, void* data, size_t size)
             {
-                return read(fileDescriptor, data, size);
+                return static_cast<int>(read(fileDescriptor, data, size));
             }
 
             inline int Write(int fileDescriptor, const void* data, size_t size)
             {
-                return write(fileDescriptor, data, size);
+                return static_cast<int>(write(fileDescriptor, data, size));
             }
 
             int Dup(int fileDescriptor);

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Socket/AzSocket_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Socket/AzSocket_UnixLike.cpp
@@ -276,12 +276,12 @@ namespace AZ::AzSock
     AZ::s32 Send(AZSOCKET sock, const char* buf, AZ::s32 len, AZ::s32 flags)
     {
         AZ::s32 msgNoSignal = MSG_NOSIGNAL;
-        return HandleSocketError(send(sock, buf, len, flags | msgNoSignal));
+        return HandleSocketError(static_cast<AZ::s32>(send(sock, buf, len, flags | msgNoSignal)));
     }
 
     AZ::s32 Recv(AZSOCKET sock, char* buf, AZ::s32 len, AZ::s32 flags)
     {
-        return HandleSocketError(recv(sock, buf, len, flags));
+        return HandleSocketError(static_cast<AZ::s32>(recv(sock, buf, len, flags)));
     }
 
     AZ::s32 Bind(AZSOCKET sock, const AzSocketAddress& addr)

--- a/Code/Framework/AzCore/Platform/Mac/AzCore/IPC/SharedMemory_Mac.cpp
+++ b/Code/Framework/AzCore/Platform/Mac/AzCore/IPC/SharedMemory_Mac.cpp
@@ -123,7 +123,7 @@ namespace AZ
         fstat(m_mapHandle, &st);
         if (size == 0)
         {
-            size = st.st_size;
+            size = static_cast<unsigned int>(st.st_size);
         }
         int dwDesiredAccess = (mode == ReadOnly ? PROT_READ : PROT_READ | PROT_WRITE);
         m_mappedBase = mmap(0, size, dwDesiredAccess, MAP_SHARED, m_mapHandle, 0);
@@ -141,7 +141,7 @@ namespace AZ
             return false;
         }
 
-        m_dataSize = st.st_size;
+        m_dataSize = static_cast<unsigned int>(st.st_size);
 
         return true;
     }

--- a/Code/Framework/AzFramework/Platform/Mac/AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard_Mac.mm
+++ b/Code/Framework/AzFramework/Platform/Mac/AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard_Mac.mm
@@ -648,7 +648,7 @@ namespace AzFramework
             break;
             case NSEventTypeFlagsChanged:
             {
-                QueueRawModifierKeyEvent(nsEvent.keyCode, nsEvent.modifierFlags);
+                QueueRawModifierKeyEvent(nsEvent.keyCode, static_cast<AZ::u32>(nsEvent.modifierFlags));
             }
             break;
             default:

--- a/Code/Framework/AzFramework/Platform/Mac/AzFramework/Process/ProcessCommunicator_Mac.cpp
+++ b/Code/Framework/AzFramework/Platform/Mac/AzFramework/Process/ProcessCommunicator_Mac.cpp
@@ -58,7 +58,7 @@ namespace AzFramework
             handle->Break();
         }
 
-        return bytesAvailable;
+        return static_cast<AZ::u32>(bytesAvailable);
     }
 
     AZ::u32 StdInOutCommunication::ReadDataFromHandle(StdProcessCommunicatorHandle& handle, void* readBuffer, AZ::u32 bufferSize)
@@ -99,10 +99,10 @@ namespace AzFramework
             {
                 // Child process exited, we may have read something, so return amount
                 handle->Break();
-                return bytesRead;
+                return static_cast<AZ::u32>(bytesRead);
             }
             AZ_Assert(false, "Unexpected error from ReadFile %d", errno);
-            return bytesRead;
+            return static_cast<AZ::u32>(bytesRead);
         }
 
         //EOF
@@ -110,7 +110,7 @@ namespace AzFramework
         {
             handle->Break();
         }
-        return bytesRead;
+        return static_cast<AZ::u32>(bytesRead);
     }
 
     AZ::u32 StdInOutCommunication::WriteDataToHandle(StdProcessCommunicatorHandle& handle, const void* writeBuffer, AZ::u32 bytesToWrite)
@@ -130,13 +130,13 @@ namespace AzFramework
             {
                 // Child process exited, may have written something, so return amount
                 handle->Break();
-                return bytesWritten;
+                return static_cast<AZ::u32>(bytesWritten);
             }
             AZ_Assert(false, "Unexpected error trying to write to child process. errno = %d", errno);
             return 0;
         }
 
-        return bytesWritten;
+        return static_cast<AZ::u32>(bytesWritten);
     }
 
     bool StdInOutProcessCommunicator::CreatePipesForProcess(ProcessData* processData)

--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpSocket.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpSocket.cpp
@@ -109,7 +109,7 @@ namespace AzNetworking
 
     int32_t TcpSocket::SendInternal(const uint8_t* data, uint32_t size) const
     {
-        const int32_t sentBytes = send(aznumeric_cast<int32_t>(m_socketFd), (const char*)data, size, 0);
+        const int32_t sentBytes = static_cast<int32_t>(send(aznumeric_cast<int32_t>(m_socketFd), (const char*)data, size, 0));
 
         if (sentBytes < 0)
         {
@@ -126,7 +126,7 @@ namespace AzNetworking
 
     int32_t TcpSocket::ReceiveInternal(uint8_t* outData, uint32_t size) const
     {
-        const int32_t receivedBytes = recv(aznumeric_cast<int32_t>(m_socketFd), (char*)outData, (int32_t)size, 0);
+        const int32_t receivedBytes = static_cast<int32_t>(recv(aznumeric_cast<int32_t>(m_socketFd), (char*)outData, (int32_t)size, 0));
 
         if (receivedBytes < 0)
         {

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpSocket.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpSocket.cpp
@@ -185,7 +185,7 @@ namespace AzNetworking
         sockaddr_in from;
         socklen_t   fromLen = sizeof(from);
 
-        const int32_t receivedBytes = recvfrom(static_cast<int32_t>(m_socketFd), reinterpret_cast<char*>(outData), static_cast<int32_t>(size), 0, (sockaddr*)&from, &fromLen);
+        const int32_t receivedBytes = static_cast<int32_t>(recvfrom(static_cast<int32_t>(m_socketFd), reinterpret_cast<char*>(outData), static_cast<int32_t>(size), 0, (sockaddr*)&from, &fromLen));
 
         outAddress = IpAddress(ByteOrder::Network, from.sin_addr.s_addr, from.sin_port);
 
@@ -232,7 +232,7 @@ namespace AzNetworking
         destAddr.sin_family = AF_INET;
         destAddr.sin_addr.s_addr = address.GetAddress(ByteOrder::Network);
         destAddr.sin_port = address.GetPort(ByteOrder::Network);
-        return sendto(static_cast<int32_t>(m_socketFd), reinterpret_cast<const char*>(data), size, 0, (sockaddr*)&destAddr, sizeof(destAddr));
+        return static_cast<int32_t>(sendto(static_cast<int32_t>(m_socketFd), reinterpret_cast<const char*>(data), size, 0, (sockaddr*)&destAddr, sizeof(destAddr)));
     }
 
 #ifdef ENABLE_LATENCY_DEBUG

--- a/Code/Framework/AzNetworking/AzNetworking/Utilities/EncryptionCommon.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/Utilities/EncryptionCommon.cpp
@@ -54,9 +54,9 @@ namespace AzNetworking
 
         #if OPENSSL_VERSION_NUMBER >= 0x30000000L
             const char *func = nullptr;
-            const int32_t errorCode = ERR_get_error_all(nullptr, nullptr, &func, nullptr, nullptr);
+            const int32_t errorCode = static_cast<int32_t>(ERR_get_error_all(nullptr, nullptr, &func, nullptr, nullptr));
         #else
-            const int32_t errorCode = ERR_get_error();
+            const int32_t errorCode = static_cast<int32_t>(ERR_get_error());
         #endif 
         const int32_t systemError = GetLastNetworkError();
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -629,7 +629,7 @@ namespace AzToolsFramework
             PrefabDom patchesCopyForUndoSupport;
             PrefabDom nestedInstanceLinkDom;
             nestedInstanceLink->get().GetLinkDom(nestedInstanceLinkDom, nestedInstanceLinkDom.GetAllocator());
-            PrefabDomValueConstReference nestedInstanceLinkPatches =
+            PrefabDomValueReference nestedInstanceLinkPatches =
                 PrefabDomUtils::FindPrefabDomValue(nestedInstanceLinkDom, PrefabDomUtils::PatchesName);
             if (nestedInstanceLinkPatches.has_value())
             {

--- a/Code/Legacy/CrySystem/XML/XMLBinaryNode.cpp
+++ b/Code/Legacy/CrySystem/XML/XMLBinaryNode.cpp
@@ -99,7 +99,7 @@ bool CBinaryXmlNode::getAttr(const char* key, unsigned int& value) const
     const char* svalue = GetValue(key);
     if (svalue)
     {
-        value = strtoul(svalue, nullptr, 10);
+        value = static_cast<unsigned int>(strtoul(svalue, nullptr, 10));
         return true;
     }
     return false;

--- a/Code/Legacy/CrySystem/XML/xml.cpp
+++ b/Code/Legacy/CrySystem/XML/xml.cpp
@@ -387,7 +387,7 @@ bool CXmlNode::getAttr(const char* key, unsigned int& value) const
     const char* svalue = GetValue(key);
     if (svalue)
     {
-        value = strtoul(svalue, NULL, 10);
+        value = static_cast<unsigned int>(strtoul(svalue, NULL, 10));
         return true;
     }
     return false;
@@ -1271,7 +1271,7 @@ void    XmlParserImp::onStartElement(const char* tagName, const char** atts)
         node->AddRef(); // Childs need to be add refed.
     }
 
-    node->setLine(XML_GetCurrentLineNumber((XML_Parser)m_parser));
+    node->setLine(static_cast<int>(XML_GetCurrentLineNumber((XML_Parser)m_parser)));
 
     // Call start element callback.
     int i = 0;

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -4951,7 +4951,7 @@ namespace AssetProcessor
             // it may not be necessary to actually alter the database here.
             m_remainingJobsForEachSourceFile.erase(foundTrackingInfo);
 
-            Q_EMIT FinishedAnalysis(m_remainingJobsForEachSourceFile.size());
+            Q_EMIT FinishedAnalysis(static_cast<int>(m_remainingJobsForEachSourceFile.size()));
 
             return;
         }
@@ -5024,7 +5024,7 @@ namespace AssetProcessor
 
         m_remainingJobsForEachSourceFile.erase(foundTrackingInfo);
 
-        Q_EMIT FinishedAnalysis(m_remainingJobsForEachSourceFile.size());
+        Q_EMIT FinishedAnalysis(static_cast<int>(m_remainingJobsForEachSourceFile.size()));
     }
 
     void AssetProcessorManager::SetEnableModtimeSkippingFeature(bool enable)

--- a/Gems/Atom/RHI/Metal/Code/Source/Platform/Mac/RHI/Metal_RHI_Mac.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/Platform/Mac/RHI/Metal_RHI_Mac.cpp
@@ -164,7 +164,7 @@ namespace Platform
                 }
                 mappedData += request.m_byteOffset;                
                 response.m_data = mappedData;
-                buffer.SetMapRequestOffset(request.m_byteOffset);
+                buffer.SetMapRequestOffset(static_cast<uint32_t>(request.m_byteOffset));
                 break;
             }
             default:

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/AliasingBarrierTracker.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/AliasingBarrierTracker.cpp
@@ -38,8 +38,8 @@ namespace AZ
 
         void AliasingBarrierTracker::EndInternal()
         {
-            uint32_t numFencesNeeded = m_resourceFenceData.size();
-            uint32_t numFencesExist = m_resourceFences.size();
+            uint32_t numFencesNeeded = static_cast<uint32_t>(m_resourceFenceData.size());
+            uint32_t numFencesExist = static_cast<uint32_t>(m_resourceFences.size());
                         
             //Calculate the number of new fences we need to create.
             uint32_t numFencesNeededToCreate = 0;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/AsyncUploadQueue.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/AsyncUploadQueue.cpp
@@ -184,7 +184,7 @@ namespace AZ
                 FramePacket* framePacket = BeginFramePacket(commandQueue);
                 
                 //[GFX TODO][ATOM-5605] - Cache alignments for all formats at Init
-                const static uint32_t bufferOffsetAlign = [mtlDevice minimumTextureBufferAlignmentForPixelFormat: ConvertPixelFormat(image->GetDescriptor().m_format)];
+                const static uint32_t bufferOffsetAlign = static_cast<uint32_t>([mtlDevice minimumTextureBufferAlignmentForPixelFormat: ConvertPixelFormat(image->GetDescriptor().m_format)]);
 
                 // Variables for split subresource slice.
                 // If a subresource slice pitch is large than one staging size, we may split the slice by rows.

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/BufferPool.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/BufferPool.cpp
@@ -45,7 +45,7 @@ namespace AZ
             Device& device = static_cast<Device&>(deviceBase);
             
             RHI::HeapMemoryUsage* heapMemoryUsage = &m_memoryUsage.GetHeapMemoryUsage(descriptorBase.m_heapMemoryLevel);
-            uint32_t bufferPageSize = RHI::RHISystemInterface::Get()->GetPlatformLimitsDescriptor()->m_platformDefaultValues.m_bufferPoolPageSizeInBytes;
+            uint32_t bufferPageSize = static_cast<uint32_t>(RHI::RHISystemInterface::Get()->GetPlatformLimitsDescriptor()->m_platformDefaultValues.m_bufferPoolPageSizeInBytes);
             
             // The descriptor provides an explicit buffer page size override.
             if (const Metal::BufferPoolDescriptor* descriptor = azrtti_cast<const Metal::BufferPoolDescriptor*>(&descriptorBase))

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/BufferPoolResolver.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/BufferPoolResolver.cpp
@@ -66,10 +66,10 @@ namespace AZ
                 
                 RHI::CopyBufferDescriptor copyDescriptor;
                 copyDescriptor.m_sourceBuffer = stagingBuffer;
-                copyDescriptor.m_sourceOffset = stagingBuffer->GetMemoryView().GetOffset();
+                copyDescriptor.m_sourceOffset = static_cast<uint32_t>(stagingBuffer->GetMemoryView().GetOffset());
                 copyDescriptor.m_destinationBuffer = destBuffer;
-                copyDescriptor.m_destinationOffset = destBuffer->GetMemoryView().GetOffset() + static_cast<uint32_t>(packet.m_byteOffset);
-                copyDescriptor.m_size = stagingBuffer->GetMemoryView().GetSize();
+                copyDescriptor.m_destinationOffset = static_cast<uint32_t>(destBuffer->GetMemoryView().GetOffset() + packet.m_byteOffset);
+                copyDescriptor.m_size = static_cast<uint32_t>(stagingBuffer->GetMemoryView().GetSize());
 
                 commandList.Submit(RHI::CopyItem(copyDescriptor));
                 device.QueueForRelease(stagingBuffer->GetMemoryView());

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
@@ -281,13 +281,13 @@ namespace AZ
             for (uint32_t slot = 0; slot < RHI::Limits::Pipeline::ShaderResourceGroupCountMax; ++slot)
             {
                 const ShaderResourceGroup* shaderResourceGroup = bindings.m_srgsBySlot[slot];
-                uint32_t slotIndex = pipelineLayout.GetIndexBySlot(slot);
+                uint32_t slotIndex = static_cast<uint32_t>(pipelineLayout.GetIndexBySlot(slot));
                 if(!shaderResourceGroup || slotIndex == RHI::Limits::Pipeline::ShaderResourceGroupCountMax)
                 {
                     continue;
                 }
 
-                uint32_t srgVisIndex = pipelineLayout.GetIndexBySlot(shaderResourceGroup->GetBindingSlot());
+                uint32_t srgVisIndex = static_cast<uint32_t>(pipelineLayout.GetIndexBySlot(shaderResourceGroup->GetBindingSlot()));
                 const RHI::ShaderStageMask& srgVisInfo = pipelineLayout.GetSrgVisibility(srgVisIndex);
                 const ShaderResourceGroupVisibility& srgResourcesVisInfo = pipelineLayout.GetSrgResourcesVisibility(srgVisIndex);
 
@@ -544,7 +544,7 @@ namespace AZ
                     uint32_t indexTypeSize = 0;
                     GetIndexTypeSizeInBytes(mtlIndexType, indexTypeSize);
 
-                    uint32_t indexOffset = indexBuffDescriptor.GetByteOffset() + (indexed.m_indexOffset * indexTypeSize) + buff->GetMemoryView().GetOffset();
+                    uint32_t indexOffset = static_cast<uint32_t>(indexBuffDescriptor.GetByteOffset() + (indexed.m_indexOffset * indexTypeSize) + buff->GetMemoryView().GetOffset());
                     [renderEncoder drawIndexedPrimitives: mtlPrimType
                                               indexCount: indexed.m_indexCount
                                                indexType: mtlIndexType
@@ -668,7 +668,7 @@ namespace AZ
                     {
                         const Buffer * buff = static_cast<const Buffer*>(streams[i].GetBuffer());
                         id<MTLBuffer> mtlBuff = buff->GetMemoryView().GetGpuAddress<id<MTLBuffer>>();
-                        uint32_t offset = streams[i].GetByteOffset() + buff->GetMemoryView().GetOffset();
+                        uint32_t offset = static_cast<uint32_t>(streams[i].GetByteOffset() + buff->GetMemoryView().GetOffset());
                         mtlStreamBuffers[bufferArrayLen] = mtlBuff;
                         mtlStreamBufferOffsets[bufferArrayLen] = offset;
                         bufferArrayLen++;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandQueueCommandBuffer.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandQueueCommandBuffer.cpp
@@ -57,7 +57,7 @@ namespace AZ
                         const char * cbLabel = [ buffer.label UTF8String ];
                         AZ_Printf("RHI", "Command Buffer %s failed to execute\n", cbLabel);
                         
-                        int eCode = buffer.error.code;
+                        int eCode = static_cast<int>(buffer.error.code);
                         switch (eCode)
                         {
                         case MTLCommandBufferErrorNone:

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
@@ -372,7 +372,7 @@ namespace AZ
         ResourceDescriptor ConvertBufferDescriptor(const RHI::BufferDescriptor& descriptor, RHI::HeapMemoryLevel heapMemoryLevel)
         {
             ResourceDescriptor resourceDesc;
-            resourceDesc.m_width = descriptor.m_byteCount;
+            resourceDesc.m_width = static_cast<uint32_t>(descriptor.m_byteCount);
             resourceDesc.m_mtlStorageMode = ConvertBufferStorageMode(descriptor, heapMemoryLevel);
             resourceDesc.m_mtlCPUCacheMode = ConvertBufferCPUCacheMode();
             resourceDesc.m_mtlHazardTrackingMode = ConvertBufferHazardTrackingMode();

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Image.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Image.cpp
@@ -56,7 +56,7 @@ namespace AZ
                         RHI::ImageSubresourceLayoutPlaced& layout = subresourceLayouts[subresourceIndex];
                         layout.m_bytesPerRow = subresourceLayout.m_bytesPerRow;
                         layout.m_bytesPerImage = subresourceLayout.m_rowCount * subresourceLayout.m_bytesPerRow;
-                        layout.m_offset = subresourceByteCount;
+                        layout.m_offset = static_cast<uint32_t>(subresourceByteCount);
                         layout.m_rowCount = subresourceLayout.m_rowCount;
                         layout.m_size = subresourceLayout.m_size;
                     }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/ImageView.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/ImageView.cpp
@@ -46,7 +46,7 @@ namespace AZ
                        
             //Since we divide the array length of a cubemap by NumCubeMapSlices when creating the base texture
             //we have to do reverse of that here
-            uint32_t textureLength = mtlTexture.arrayLength;
+            uint32_t textureLength = static_cast<uint32_t>(mtlTexture.arrayLength);
             if(imgDesc.m_isCubemap)
             {
                 textureLength = textureLength * RHI::ImageDescriptor::NumCubeMapSlices;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/NullDescriptorManager.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/NullDescriptorManager.cpp
@@ -100,7 +100,7 @@ namespace AZ
                 {
                     m_nullImages[imageIndex].m_memoryView = device.CreateImagePlaced(m_nullImages[imageIndex].m_imageDescriptor, m_nullDescriptorHeap, alignedHeapSize, textureSizeAndAlign);
                 }
-                heapSize = (alignedHeapSize + textureSizeAndAlign.size) ;
+                heapSize = static_cast<uint32_t>(alignedHeapSize + textureSizeAndAlign.size);
                 if(!m_nullImages[imageIndex].m_memoryView.IsValid())
                 {
                     AZ_Assert(false, "Couldnt create a null image for ArgumentTable");

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/PhysicalDevice.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/PhysicalDevice.cpp
@@ -37,7 +37,7 @@ namespace AZ
                 NSString * deviceName = [mtlDevice name];
                 const char * deviceNameCStr = [ deviceName UTF8String ];
                 m_descriptor.m_description = AZStd::string(deviceNameCStr);
-                m_descriptor.m_deviceId = deviceName.hash; //Used for storing PipelineLibraries
+                m_descriptor.m_deviceId = static_cast<uint32_t>(deviceName.hash); //Used for storing PipelineLibraries
                 
                 if(strstr(m_descriptor.m_description.c_str(), ToString(RHI::VendorId::Apple).data()))
                 {

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
@@ -72,7 +72,7 @@ namespace AZ
             }
             
             const uint8_t* shaderByteCode = reinterpret_cast<const uint8_t*>(shaderFunction->GetByteCode().data());
-            const int byteCodeLength = shaderFunction->GetByteCode().size();
+            const int byteCodeLength = static_cast<int>(shaderFunction->GetByteCode().size());
             if(byteCodeLength > 0 && loadFromByteCode)
             {
                 dispatch_data_t dispatchByteCodeData = dispatch_data_create(shaderByteCode, byteCodeLength, NULL, DISPATCH_DATA_DESTRUCTOR_DEFAULT);

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/SwapChain.cpp
@@ -230,8 +230,8 @@ namespace AZ
                     else
                     {
                         RHI::ImageDescriptor imgDescriptor = swapChainImage->GetDescriptor();
-                        imgDescriptor.m_size.m_width = mtlDrawableTexture.width;
-                        imgDescriptor.m_size.m_height = mtlDrawableTexture.height;
+                        imgDescriptor.m_size.m_width = static_cast<uint32_t>(mtlDrawableTexture.width);
+                        imgDescriptor.m_size.m_height = static_cast<uint32_t>(mtlDrawableTexture.height);
                         swapChainImage->SetDescriptor(imgDescriptor);
                         
                         RHI::Ptr<MetalResource> resc = MetalResource::Create(MetalResourceDescriptor{mtlDrawableTexture, ResourceType::MtlTextureType, swapChainImage->m_isSwapChainImage});

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderOptionGroupLayout.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderOptionGroupLayout.cpp
@@ -385,7 +385,7 @@ namespace AZ
         {
             shaderVariantKey >>= m_bitOffset;
             shaderVariantKey &= AZ_BIT_MASK(m_bitCount);
-            uint32_t value = shaderVariantKey.to_ulong();
+            uint32_t value = static_cast<uint32_t>(shaderVariantKey.to_ulong());
             return value;
         }
         

--- a/Gems/Atom/Utils/Code/Source/PpmFile.cpp
+++ b/Gems/Atom/Utils/Code/Source/PpmFile.cpp
@@ -99,7 +99,7 @@ namespace AZ
 
             const char* startOfInt = reinterpret_cast<const char*>(&ppmData[pos]);
             char* endOfInt = nullptr;
-            uint32_t value = strtoul(startOfInt, &endOfInt, 10);
+            uint32_t value = static_cast<uint32_t>(strtoul(startOfInt, &endOfInt, 10));
             pos += endOfInt - startOfInt;
 
             return value;

--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/FFontXML_Internal.h
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/FFontXML_Internal.h
@@ -191,7 +191,15 @@ namespace AtomFontInternal
                     m_FontTexSize.set(512, 512);
                 }
 
-                bool fontLoaded = m_font->Load(m_strFontPath.c_str(), m_FontTexSize.x, m_FontTexSize.y, m_slotSizes.x, m_slotSizes.y, CreateTTFFontFlag(m_FontSmoothMethod, m_FontSmoothAmount), m_SizeRatio);
+                bool fontLoaded = m_font->Load(
+                                            m_strFontPath.c_str(), 
+                                            static_cast<unsigned int>(m_FontTexSize.x), 
+                                            static_cast<unsigned int>(m_FontTexSize.y), 
+                                            m_slotSizes.x, 
+                                            m_slotSizes.y, 
+                                            CreateTTFFontFlag(m_FontSmoothMethod, m_FontSmoothAmount), 
+                                            m_SizeRatio
+                                            );
                 if (!fontLoaded)
                 {
                     FoundElementImpl();

--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/FontRenderer.cpp
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/FontRenderer.cpp
@@ -230,7 +230,7 @@ int AZ::FontRenderer::GetGlyph(GlyphBitmap* glyphBitmap, int* horizontalAdvance,
 
     if (horizontalAdvance)
     {
-        *horizontalAdvance = m_glyph->metrics.horiAdvance / FractionalPixelUnits;
+        *horizontalAdvance = static_cast<int>(m_glyph->metrics.horiAdvance) / FractionalPixelUnits;
     }
 
     if (glyphWidth)

--- a/Gems/LmbrCentral/Code/Source/Builders/BenchmarkAssetBuilder/BenchmarkAssetBuilderWorker.cpp
+++ b/Gems/LmbrCentral/Code/Source/Builders/BenchmarkAssetBuilder/BenchmarkAssetBuilderWorker.cpp
@@ -192,8 +192,8 @@ namespace BenchmarkAssetBuilder
     {
         settings.m_primaryAssetByteSize = AZStd::stoul(jobParameters.at(AZ_CRC_CE("PrimaryAssetByteSize")));
         settings.m_dependentAssetByteSize = AZStd::stoul(jobParameters.at(AZ_CRC_CE("DependentAssetByteSize")));
-        settings.m_numAssetsPerDependency = AZStd::stoul(jobParameters.at(AZ_CRC_CE("NumAssetsPerDependency")));
-        settings.m_dependencyDepth = AZStd::stoul(jobParameters.at(AZ_CRC_CE("DependencyDepth")));
+        settings.m_numAssetsPerDependency = static_cast<uint32_t>(AZStd::stoul(jobParameters.at(AZ_CRC_CE("NumAssetsPerDependency"))));
+        settings.m_dependencyDepth = static_cast<uint32_t>(AZStd::stoul(jobParameters.at(AZ_CRC_CE("DependencyDepth"))));
         settings.m_assetStorageType = static_cast<AZ::DataStream::StreamType>(
             AZStd::stoul(jobParameters.at(AZ_CRC_CE("AssetStorageType"))));
     }

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -1715,7 +1715,7 @@ namespace Multiplayer
                 mutableAddress[portSeparator] = '\0';
                 const char* addressStr = mutableAddress;
                 const char* portStr = &(mutableAddress[portSeparator + 1]);
-                int32_t portNumber = atol(portStr);
+                int32_t portNumber = static_cast<int32_t>(atol(portStr));
                 AZ::Interface<IMultiplayer>::Get()->Connect(addressStr, static_cast<uint16_t>(portNumber));
             }
         }

--- a/Gems/Terrain/Code/Source/TerrainRenderer/ClipmapBounds.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/ClipmapBounds.cpp
@@ -284,8 +284,8 @@ namespace Terrain
         {
         case RoundMode::Average:
             returnValue = Vector2i(
-                AZStd::lround(clipSpaceCoord.GetX()),
-                AZStd::lround(clipSpaceCoord.GetY())
+                aznumeric_cast<int32_t>(AZStd::lround(clipSpaceCoord.GetX())),
+                aznumeric_cast<int32_t>(AZStd::lround(clipSpaceCoord.GetY()))
             );
             break;
         case RoundMode::Floor:

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
@@ -273,7 +273,7 @@ namespace Terrain
             m_detailTextureScale, &AzFramework::Terrain::TerrainDataRequests::GetTerrainSurfaceDataQueryResolution);
 
         // Texture size needs to be twice the render distance because the camera is positioned in the middle of the texture.
-        m_detailTextureSize = lroundf(m_config.m_renderDistance / m_detailTextureScale) * 2;
+        m_detailTextureSize = static_cast<int32_t>(lroundf(m_config.m_renderDistance / m_detailTextureScale) * 2);
 
         ClipmapBoundsDescriptor desc;
         desc.m_clipmapUpdateMultiple = 1;

--- a/Gems/TextureAtlas/Code/Source/Editor/AtlasBuilderWorker.cpp
+++ b/Gems/TextureAtlas/Code/Source/Editor/AtlasBuilderWorker.cpp
@@ -286,7 +286,7 @@ namespace TextureAtlasBuilder
                     {
                         AZStd::string color = AZStd::string::format("%s%s%s%s", args[1].substr(7).c_str(), args[1].substr(5, 2).c_str(),
                                                                     args[1].substr(3, 2).c_str(), args[1].substr(1, 2).c_str());
-                        data.m_unusedColor.FromU32(AZStd::stoul(color, nullptr, 16));
+                        data.m_unusedColor.FromU32(static_cast<AZ::u32>(AZStd::stoul(color, nullptr, 16)));
                     }
                 }
                 else if (args[0] == "presetname")


### PR DESCRIPTION
On Mac long is a 64 bit type, on windows it's a 32 bit type, most of the errors are from assuming long can silently cast to a 32 bit int.
Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>
