### PR TITLE
Ensure event data editor refreshes correctly

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/EventDataEditor.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/EventDataEditor.cpp
@@ -100,8 +100,11 @@ namespace EMStudio
                             this->m_eventDataSelectionMenu->addAction(
                                 editData->m_name,
                                 this,
-                                [this, classData]() { this->AppendEventData(classData->m_typeId); }
-                            );
+                                [this, classData]
+                                {
+                                    AppendEventData(classData->m_typeId);
+                                    emit eventsChanged(GetMotion(), GetMotionEvent());
+                                });
                             break;
                         }
                     }
@@ -114,8 +117,11 @@ namespace EMStudio
         m_deleteAction = m_deleteCurrentEventDataMenu->addAction(
             "Delete",
             this,
-            [this]() { this->RemoveEventData(this->m_deleteAction->data().value<size_t>()); }
-        );
+            [this]()
+            {
+                RemoveEventData(m_deleteAction->data().value<size_t>());
+                emit eventsChanged(GetMotion(), GetMotionEvent());
+            });
 
         m_emptyLabel = new QLabel("<i>No event data added</i>");
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/EventDataEditor.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/EventDataEditor.h
@@ -79,6 +79,9 @@ namespace EMStudio
         EMotionFX::Motion* GetMotion() const;
         EMotionFX::MotionEvent* GetMotionEvent() const;
 
+    Q_SIGNALS:
+        void eventsChanged(EMotionFX::Motion*, EMotionFX::MotionEvent*);
+
     private:
         void Init();
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventEditor.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventEditor.cpp
@@ -24,6 +24,7 @@ namespace EMStudio
     {
         Init();
         SetMotionEvent(motion, motionEvent);
+        connect(&m_eventDataEditor, &EventDataEditor::eventsChanged, this, &MotionEventEditor::SetMotionEvent);
     }
 
     void MotionEventEditor::Init()

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventEditor.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventEditor.h
@@ -45,6 +45,6 @@ namespace EMStudio
 
         EMotionFX::MotionEvent* m_motionEvent = nullptr;
         EMotionFX::ObjectEditor* m_baseObjectEditor = nullptr;
-        EMStudio::EventDataEditor m_eventDataEditor;
+        EventDataEditor m_eventDataEditor;
     };
-} // end namespace EMStudio
+} // namespace EMStudio


### PR DESCRIPTION
Ensure event data editor refreshes when event data entry is added/removed

Signed-off-by: Tom Hulton-Harrop <82228511+hultonha@users.noreply.github.com>

## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/12665

This PR ensures the MotionEventEditor refreshes correctly when MotionEvents are added/removed from a MotionEvent in the TimeView.

This is a follow-on from https://github.com/o3de/o3de/pull/12692 to address things at the Editor level.

## How was this PR tested?

The reproductions steps outlined in the original issue were followed to verify the fix was working as expected. Tested manually.

### Video demonstrating fix

https://user-images.githubusercontent.com/82228511/203779444-f0bbc1d1-1e77-45bb-af55-7c1244ad35e0.mp4

Tagging @pollend for visibility