### PR TITLE
Fix style application in EMotionFX

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodePaletteWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodePaletteWidget.cpp
@@ -20,6 +20,7 @@
 #include <GraphCanvas/Widgets/NodePalette/TreeItems/NodePaletteTreeItem.h>
 #include <AzQtComponents/Utilities/Conversions.h>
 #include "AnimGraphPlugin.h"
+#include <AzQtComponents/Components/StyleManager.h>
 #include <QVBoxLayout>
 #include <QIcon>
 #include <QAction>
@@ -88,6 +89,8 @@ namespace EMStudio
         m_palette->SetupNodePalette(config);
         m_palette->hide();
         m_layout->addWidget(m_palette);
+        // GHI-13382 Investigate why we need to apply the style here even though it's applied globally to the editor
+        AzQtComponents::StyleManager::setStyleSheet(m_palette, QStringLiteral("style:Editor.qss"));
 
         // set the default layout
         setLayout(m_layout);


### PR DESCRIPTION
For some reason the Editor.qss stylesheet is not applied to the NodePaletteWidget when it's inserted into the dock widget in EMotionFX.

This widget is later reparented to the chain originating in the editor main window so in theory it should be applied and the palette for the tree view delegate should be proper.

As a workaround, we apply the style directly.

Fixes: #13235
Signed-off-by: Miłosz Kosobucki <milosz@kosobucki.pl>

## What does this PR do?

Fixes the search highlight in Node Palette window in EMotionFX

## How was this PR tested?

Manually
