### PR TITLE
EMotionFX: Apply consistent naming for node palette

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphPlugin.cpp
@@ -182,7 +182,7 @@ namespace EMStudio
         {
             m_dockWindowActions[WINDOWS_PARAMETERWINDOW] = parent->addAction("Parameter Window");
             m_dockWindowActions[WINDOWS_PARAMETERWINDOW]->setCheckable(true);
-            m_dockWindowActions[WINDOWS_PALETTEWINDOW] = parent->addAction("Palette Window");
+            m_dockWindowActions[WINDOWS_PALETTEWINDOW] = parent->addAction("Node Palette");
             m_dockWindowActions[WINDOWS_PALETTEWINDOW]->setCheckable(true);
 
             connect(m_dockWindowActions[WINDOWS_PARAMETERWINDOW], &QAction::triggered, this, [this](bool checked) {
@@ -377,7 +377,7 @@ namespace EMStudio
         // By default, it's hidden in AnimGraph.layout. Users should mostly use
         // the context menu to add nodes, but we let them show the palette dock
         // if needed
-        m_nodePaletteDock = new AzQtComponents::StyledDockWidget("Anim Graph Palette", mainWindow);
+        m_nodePaletteDock = new AzQtComponents::StyledDockWidget("Node Palette", mainWindow);
         mainWindow->addDockWidget(Qt::RightDockWidgetArea, m_nodePaletteDock);
         features = QDockWidget::NoDockWidgetFeatures;
         //features |= QDockWidget::DockWidgetClosable;


### PR DESCRIPTION
All other graph-based tools call this element just the "Node Palette"

Fixes: #13375

Signed-off-by: Miłosz Kosobucki <milosz@kosobucki.pl>

## What does this PR do?

Changes the menu entry name and window title of node palette tool in EMotionFX to be consistent with other canvas-based tools.
![image](https://user-images.githubusercontent.com/104767/203787412-bdd570cf-ccbe-43c3-ae9b-decb26550a5d.png)

## How was this PR tested?

Manually
