### PR TITLE
Fix warning message for AZ::Name in python script

### DIFF
--- a/Code/Framework/AzCore/AzCore/Name/Name.cpp
+++ b/Code/Framework/AzCore/AzCore/Name/Name.cpp
@@ -344,6 +344,7 @@ namespace AZ
                 ->Method("Set", [](Name* thisPtr, AZStd::string_view name) { thisPtr->SetName(name); })
                 ->Method("IsEmpty", &Name::IsEmpty)
                 ->Method("Equal", static_cast<bool(Name::*)(const Name&)const>(&Name::operator==))
+                ->Method("__repr__", &Name::GetCStr)
                 ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::Equal)
                 ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
                 ;

--- a/Code/Framework/AzCore/AzCore/Name/Name.cpp
+++ b/Code/Framework/AzCore/AzCore/Name/Name.cpp
@@ -341,10 +341,10 @@ namespace AZ
                 ->Constructor()
                 ->Constructor<AZStd::string_view>()
                 ->Method("ToString", &Name::GetCStr)
+                ->Method("__repr__", &Name::GetCStr)
                 ->Method("Set", [](Name* thisPtr, AZStd::string_view name) { thisPtr->SetName(name); })
                 ->Method("IsEmpty", &Name::IsEmpty)
                 ->Method("Equal", static_cast<bool(Name::*)(const Name&)const>(&Name::operator==))
-                ->Method("__repr__", &Name::GetCStr)
                 ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::Equal)
                 ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
                 ;


### PR DESCRIPTION
Signed-off-by: Ethan Chen <ethanchen1227@gmail.com>

Addressing a remaining issue in https://github.com/o3de/o3de/issues/13137
Add `__repr__` in `AZ::Name` Behavior Context to avoid the warning.

## How was this PR tested?

Test on my local PC
