### PR TITLE
AnimGraph: Fix node groups bleeding into different levels (#13232).

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphNodeGroup.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphNodeGroup.cpp
@@ -188,6 +188,16 @@ namespace EMotionFX
         return m_nameEditOngoing;
     }
 
+    AnimGraphNodeId AnimGraphNodeGroup::GetParentNodeId() const
+    {
+        return m_parentNodeId;
+    }
+
+    void AnimGraphNodeGroup::SetParentNodeId(AnimGraphNodeId nodeId)
+    {
+        m_parentNodeId = nodeId;
+    }
+
     void AnimGraphNodeGroup::Reflect(AZ::ReflectContext* context)
     {
         AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);

--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphNodeGroup.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphNodeGroup.h
@@ -174,6 +174,18 @@ namespace EMotionFX
          */
         bool IsNameEditOngoing() const;
 
+        /**
+         * Returns the id of the parent AnimGraphNode to which this group belongs.
+         * If the group belongs to the root level, this function will return an invalid id.
+         * This function is used to make sure that groups can be filtered by level.
+         */
+        AnimGraphNodeId GetParentNodeId() const;
+
+        /**
+         * Sets the id of the parent AnimGraphNode for this group.
+         */
+        void SetParentNodeId(AnimGraphNodeId nodeId);
+
         static void Reflect(AZ::ReflectContext* context);
 
     protected:
@@ -181,6 +193,7 @@ namespace EMotionFX
         AZStd::string           m_name;             /**< The unique identification number for the node group name. */
         AZ::u32                 m_color;            /**< The color the nodes of the group will be filled with. */
         bool                    m_isVisible;
-        bool m_nameEditOngoing = false; /**< Whether the user is currently typing a new name */
+        bool                    m_nameEditOngoing = false; /**< Whether the user is currently typing a new name */
+        AnimGraphNodeId         m_parentNodeId; /**< The id of the parent AnimGraphNode */
     };
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.cpp
@@ -1292,6 +1292,13 @@ namespace EMStudio
             }
 
             EMotionFX::AnimGraphNodeGroup* newGroup = animGraph->GetNodeGroup(animGraph->GetNumNodeGroups() - 1);
+            // A new group has just been created. We're making sure that it gets bound to the level that is currently being
+            // shown on the animation graph, so it can be properly filtered later on.
+            auto currentLevelParentIndex = GetActiveGraph()->GetAnimGraphModel().GetFocus();
+            auto currentLevelParentId = currentLevelParentIndex.isValid()
+                ? currentLevelParentIndex.data(AnimGraphModel::ROLE_ID).value<EMotionFX::AnimGraphNodeId>()
+                : EMotionFX::AnimGraphNodeId{};
+            newGroup->SetParentNodeId(currentLevelParentId);
             AZ_Assert(animGraph->GetNumNodeGroups() > 0, "Creating AnimGraphNodeGroup failed");
 
             AssignNodesToGroup(animGraph, nodes, newGroup);


### PR DESCRIPTION
Node groups can now be created in all levels, and every level only sees node groups created in that level.

Signed-off-by: Alessandro Ambrosano <1006222+aambrosano@users.noreply.github.com>

Fixes https://github.com/o3de/o3de/issues/13232

## What does this PR do?

This PR prevents node groups to be mixed between different levels on an animation graph.
Every new node group is now bound to a level and can only be used in that level.

## How was this PR tested?

Manually navigating a multi-level animation graph, assigning and removing node groups.

Before:
![Editor_rkDdgnCGeH](https://user-images.githubusercontent.com/1006222/204015173-5e538ea9-b075-4f39-a30a-ccc34bce9af9.gif)

After:
![Editor_diaKKL0FJs](https://user-images.githubusercontent.com/1006222/204015191-e2e2523e-3407-4c6f-bf5b-77a43fdd5c56.gif)

