### PR TITLE
[Terrain] Surface weights could be invalid in some edge cases

### DIFF
--- a/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
@@ -847,9 +847,10 @@ namespace GradientSignal
 
         AZStd::shared_lock lock(m_queryMutex);
 
-        // Return immediately if our cached image data hasn't been retrieved yet
+        // Just clear the output values and return if our cached image data hasn't been retrieved yet
         if (m_imageData.empty())
         {
+            AZStd::fill(outValues.begin(), outValues.end(), 0.0f);
             return;
         }
 

--- a/Gems/Terrain/Code/Source/Components/TerrainSurfaceGradientListComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainSurfaceGradientListComponent.cpp
@@ -190,10 +190,15 @@ namespace Terrain
             return;
         }
 
-        AZStd::vector<float> gradientValues(inPositionList.size());
+        AZStd::vector<float> gradientValues;
+
+        gradientValues.resize_no_construct(inPositionList.size());
 
         for (const auto& mapping : m_configuration.m_gradientSurfaceMappings)
         {
+            // Clear out the gradient values before every GetValues call to ensure we don't accidentally end up with stale data.
+            AZStd::fill(gradientValues.begin(), gradientValues.end(), 0.0f);
+
             GradientSignal::GradientRequestBus::Event(
                 mapping.m_gradientEntityId, &GradientSignal::GradientRequestBus::Events::GetValues, inPositionList, gradientValues);
 


### PR DESCRIPTION
## What does this PR do?

If a terrain had two surface types that were both image gradients, and the second image gradient didn't have an image connected to it, the code would hit a couple of edge cases where the weights from the first image gradient would get applied to both surface types. Specifically, the image gradient never filled in any output values in a GetValues() call if the image wasn't loaded, and the Terrain Surface Detail Materials component never cleared the output value list between calls.

This fixes both sides of the problem by adding clears to both. They're both necessary because gradients are expected to always return values so the Image Gradient was breaking its API contract, and the Terrain Surface Detail Materials could also hit the same edge case on its own if an invalid gradient entity had been selected where nothing was listening to the Gradient Request Bus.

## How was this PR tested?

Created a terrain using two surface types with image gradients, then removed the image on one of the gradients. Previously, doing that would immediately cause an incorrect 50/50 blend between the two surfaces everywhere. Now it correctly changes it so that only the first surface displays.
