### PR TITLE
Material Canvas: Fixing creation and serialization of node groups, bookmarks, comments

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
@@ -393,8 +393,11 @@ namespace MaterialCanvas
 
     void MaterialCanvasDocument::RecordGraphState()
     {
-        // Serialize the current graph to a byte stream so that it can be restored with undo redo operations.
+        // Forcing all of the graph model metadata to be updated before serializing to the binary stream. This will ensure that data for
+        // bookmarks, comments, and groups is recorded.
         GraphCanvas::GraphModelRequestBus::Event(m_graphId, &GraphCanvas::GraphModelRequests::OnSaveDataDirtied, m_graphId);
+
+        // Serialize the current graph to a byte stream so that it can be restored with undo redo operations.
         m_graphStateForUndoRedo.clear();
         AZ::IO::ByteContainerStream<decltype(m_graphStateForUndoRedo)> undoGraphStateStream(&m_graphStateForUndoRedo);
         AZ::Utils::SaveObjectToStream(undoGraphStateStream, AZ::ObjectStream::ST_BINARY, m_graph.get());

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialCanvasDocument.cpp
@@ -394,6 +394,7 @@ namespace MaterialCanvas
     void MaterialCanvasDocument::RecordGraphState()
     {
         // Serialize the current graph to a byte stream so that it can be restored with undo redo operations.
+        GraphCanvas::GraphModelRequestBus::Event(m_graphId, &GraphCanvas::GraphModelRequests::OnSaveDataDirtied, m_graphId);
         m_graphStateForUndoRedo.clear();
         AZ::IO::ByteContainerStream<decltype(m_graphStateForUndoRedo)> undoGraphStateStream(&m_graphStateForUndoRedo);
         AZ::Utils::SaveObjectToStream(undoGraphStateStream, AZ::ObjectStream::ST_BINARY, m_graph.get());

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasGraphView.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasGraphView.cpp
@@ -11,14 +11,51 @@
 
 namespace MaterialCanvas
 {
+    void MaterialCanvasGraphConstructPresets::InitializeConstructType(GraphCanvas::ConstructType constructType)
+    {
+        if (constructType == GraphCanvas::ConstructType::NodeGroup)
+        {
+            auto presetBucket = static_cast<GraphCanvas::NodeGroupPresetBucket*>(ModPresetBucket(GraphCanvas::ConstructType::NodeGroup));
+            if (presetBucket)
+            {
+                presetBucket->ClearPresets();
+
+                const AZStd::map<AZStd::string, AZ::Color> defaultPresetGroups = {
+                    { "Logic", AZ::Color(0.188f, 0.972f, 0.243f, 1.0f) },
+                    { "Function", AZ::Color(0.396f, 0.788f, 0.788f, 1.0f) },
+                    { "Output", AZ::Color(0.866f, 0.498f, 0.427f, 1.0f) },
+                    { "Input", AZ::Color(0.396f, 0.788f, 0.549f, 1.0f) } };
+
+                for (const auto& defaultPresetPair : defaultPresetGroups)
+                {
+                    if (auto preset = presetBucket->CreateNewPreset(defaultPresetPair.first))
+                    {
+                        const auto& presetSaveData = preset->GetPresetData();
+                        if (auto saveData = presetSaveData.FindSaveDataAs<GraphCanvas::CommentNodeTextSaveData>())
+                        {
+                            saveData->m_backgroundColor = defaultPresetPair.second;
+                        }
+                    }
+                }
+            }
+        }
+        else if (constructType == GraphCanvas::ConstructType::CommentNode)
+        {
+            auto presetBucket = static_cast<GraphCanvas::CommentPresetBucket*>(ModPresetBucket(GraphCanvas::ConstructType::CommentNode));
+            if (presetBucket)
+            {
+                presetBucket->ClearPresets();
+            }
+        }
+    }
+
     MaterialCanvasGraphView::MaterialCanvasGraphView(
-        const AZ::Crc32& toolId,
-        const AZ::Uuid& documentId,
-        const AtomToolsFramework::GraphViewConfig& graphViewConfig,
-        QWidget* parent)
+        const AZ::Crc32& toolId, const AZ::Uuid& documentId, const AtomToolsFramework::GraphViewConfig& graphViewConfig, QWidget* parent)
         : AtomToolsFramework::GraphView(toolId, GraphCanvas::GraphId(), graphViewConfig, parent)
         , m_documentId(documentId)
     {
+        m_materialCanvasGraphConstructPresets.SetEditorId(m_toolId);
+
         AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler::BusConnect(m_toolId);
         OnDocumentOpened(m_documentId);
         m_openedBefore = false;
@@ -66,6 +103,17 @@ namespace MaterialCanvas
         {
             SetActiveGraphId(GraphCanvas::GraphId(), true);
         }
+    }
+
+    GraphCanvas::EditorConstructPresets* MaterialCanvasGraphView::GetConstructPresets() const
+    {
+        return &m_materialCanvasGraphConstructPresets;
+    }
+
+    const GraphCanvas::ConstructTypePresetBucket* MaterialCanvasGraphView::GetConstructTypePresetBucket(
+        GraphCanvas::ConstructType constructType) const
+    {
+        return m_materialCanvasGraphConstructPresets.FindPresetBucket(constructType);
     }
 } // namespace MaterialCanvas
 

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasGraphView.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasGraphView.h
@@ -12,10 +12,24 @@
 #include <AtomToolsFramework/Document/AtomToolsDocumentNotificationBus.h>
 #include <AtomToolsFramework/GraphView/GraphView.h>
 #include <AtomToolsFramework/Window/AtomToolsMainWindowRequestBus.h>
+#include <GraphCanvas/Components/Nodes/Comment/CommentBus.h>
+#include <GraphCanvas/Types/ConstructPresets.h>
 #endif
 
 namespace MaterialCanvas
 {
+    //! The implementation of the graph view requires construct presets in order to be able to create node groups and comment blocks.
+    class MaterialCanvasGraphConstructPresets : public GraphCanvas::EditorConstructPresets
+    {
+    public:
+        AZ_RTTI(MaterialCanvasGraphConstructPresets, "{8E349BC8-1D8B-4A1B-8DE0-FFD61438DBBD}", GraphCanvas::EditorConstructPresets);
+        AZ_CLASS_ALLOCATOR(MaterialCanvasGraphConstructPresets, AZ::SystemAllocator, 0);
+
+        MaterialCanvasGraphConstructPresets() = default;
+        ~MaterialCanvasGraphConstructPresets() = default;
+        void InitializeConstructType(GraphCanvas::ConstructType constructType) override;
+    };
+
     //! MaterialCanvasGraphView handles displaying and managing interactions for a single graph
     class MaterialCanvasGraphView
         : public AtomToolsFramework::GraphView
@@ -38,7 +52,12 @@ namespace MaterialCanvas
         void OnDocumentClosed(const AZ::Uuid& documentId) override;
         void OnDocumentDestroyed(const AZ::Uuid& documentId) override;
 
+        // GraphCanvas::AssetEditorSettingsRequestBus::Handler overrides...
+        GraphCanvas::EditorConstructPresets* GetConstructPresets() const override;
+        const GraphCanvas::ConstructTypePresetBucket* GetConstructTypePresetBucket(GraphCanvas::ConstructType constructType) const override;
+
         const AZ::Uuid m_documentId;
         bool m_openedBefore = false;
+        mutable MaterialCanvasGraphConstructPresets m_materialCanvasGraphConstructPresets;
     };
 } // namespace MaterialCanvas

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Types/ConstructPresets.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Types/ConstructPresets.cpp
@@ -509,7 +509,7 @@ namespace GraphCanvas
 
     void EditorConstructPresets::SetDefaultPreset(ConstructType constructType, int presetIndex)
     {
-        ConstructTypePresetBucket* typeBucket = ModPresetBuckket(constructType);
+        ConstructTypePresetBucket* typeBucket = ModPresetBucket(constructType);
 
         if (typeBucket)
         {
@@ -517,7 +517,7 @@ namespace GraphCanvas
         }
     }
 
-    ConstructTypePresetBucket* EditorConstructPresets::ModPresetBuckket(ConstructType constructType)
+    ConstructTypePresetBucket* EditorConstructPresets::ModPresetBucket(ConstructType constructType)
     {
         auto mapIter = m_presetMapping.find(constructType);
 

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Types/ConstructPresets.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Types/ConstructPresets.h
@@ -230,7 +230,7 @@ namespace GraphCanvas
 
     protected:
 
-        ConstructTypePresetBucket* ModPresetBuckket(ConstructType presets);
+        ConstructTypePresetBucket* ModPresetBucket(ConstructType presets);
 
     private:
 

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/ConstructMenuActions/ConstructPresetMenuActions.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/ConstructMenuActions/ConstructPresetMenuActions.cpp
@@ -258,7 +258,7 @@ namespace GraphCanvas
             // more dynamic. For now I'll just bypass most of the underlying logic
             // and treat it like a normal QMenu.
             bool isFinalized = m_contextMenu->IsFinalized();
-            
+
             if (isFinalized)
             {
                 if (m_contextMenu->IsToolBarMenu())
@@ -269,11 +269,8 @@ namespace GraphCanvas
                 {
                     for (const AZStd::string& subMenu : m_subMenus)
                     {
-                        QMenu* menu = m_contextMenu->FindSubMenu(subMenu);
-
-                        // Remove all of the previous preset actions to avoid needing to figure out what
-                        // actually changed.
-                        if (menu)
+                        // Remove all of the previous preset actions to avoid needing to figure out what actually changed.
+                        if (QMenu* menu = m_contextMenu->FindSubMenu(subMenu))
                         {
                             menu->clear();
                         }
@@ -282,32 +279,35 @@ namespace GraphCanvas
             }
 
             const ConstructTypePresetBucket* presetBucket = nullptr;
-            AssetEditorSettingsRequestBus::EventResult(presetBucket, m_contextMenu->GetEditorId(), &AssetEditorSettingsRequests::GetConstructTypePresetBucket, m_constructType);
+            AssetEditorSettingsRequestBus::EventResult(
+                presetBucket, m_contextMenu->GetEditorId(), &AssetEditorSettingsRequests::GetConstructTypePresetBucket, m_constructType);
 
             if (presetBucket)
             {
                 for (auto preset : presetBucket->GetPresets())
                 {
-                    ConstructContextMenuAction* menuAction = CreatePresetMenuAction(m_contextMenu, preset);
-
-                    if (isFinalized)
+                    if (ConstructContextMenuAction* menuAction = CreatePresetMenuAction(m_contextMenu, preset))
                     {
-                        if (m_contextMenu->IsToolBarMenu())
+                        if (isFinalized)
                         {
-                            m_contextMenu->addAction(menuAction);
+                            if (m_contextMenu->IsToolBarMenu())
+                            {
+                                m_contextMenu->addAction(menuAction);
+                            }
+                            else
+                            {
+                                if (QMenu* menu = m_contextMenu->FindSubMenu(menuAction->GetSubMenuPath()))
+                                {
+                                    menu->addAction(menuAction);
+                                    m_menus.insert(menu);
+                                }
+                            }
                         }
                         else
                         {
-                            QMenu* menu = m_contextMenu->FindSubMenu(menuAction->GetSubMenuPath());
-                            menu->addAction(menuAction);
-
-                            m_menus.insert(menu);
+                            m_subMenus.insert(menuAction->GetSubMenuPath());
+                            m_contextMenu->AddMenuAction(menuAction);
                         }
-                    }
-                    else
-                    {
-                        m_subMenus.insert(menuAction->GetSubMenuPath());
-                        m_contextMenu->AddMenuAction(menuAction);
                     }
                 }
             }

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/GraphCanvasMetadata.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/GraphCanvasMetadata.h
@@ -53,9 +53,5 @@ namespace GraphModelIntegration
         //! Graph Canvas metadata that pertains to each node in our data model. For example,
         //! the position of each node.
         NodeMetadataMap m_nodeMetadata;
-
-        //! Graph Canvas metadata that is not related to our data model. For example,
-        //! Comment nodes and Group Box nodes.
-        OtherMetadataMap m_otherMetadata;
     };
 }

--- a/Gems/GraphModel/Code/Source/Integration/GraphCanvasMetadata.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/GraphCanvasMetadata.cpp
@@ -26,7 +26,6 @@ namespace GraphModelIntegration
                 ->Version(0)
                 ->Field("m_sceneMetadata", &GraphCanvasMetadata::m_sceneMetadata)
                 ->Field("m_nodeMetadata", &GraphCanvasMetadata::m_nodeMetadata)
-                ->Field("m_otherMetadata", &GraphCanvasMetadata::m_otherMetadata)
                 ;
         }
     }

--- a/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
@@ -227,21 +227,10 @@ namespace GraphModelIntegration
     {
         using namespace GraphModel;
 
+        // This notification is needed by the graph canvassing component prior to repopulating the entire scene.
+        GraphCanvas::SceneRequestBus::Event(GetGraphCanvasSceneId(), &GraphCanvas::SceneRequests::SignalLoadStart);
+
         GraphCanvasMetadata* graphCanvasMetadata = GetGraphMetadata();
-
-        // Load graph canvas metadata for the scene
-        if (graphCanvasMetadata->m_sceneMetadata)
-        {
-            GraphCanvas::EntitySaveDataRequestBus::Event(
-                GetGraphCanvasSceneId(), &GraphCanvas::EntitySaveDataRequests::ReadSaveData, *graphCanvasMetadata->m_sceneMetadata);
-        }
-
-        // Load graph canvas metadata for non data model elements like comment nodes
-        for (const auto& pair : graphCanvasMetadata->m_otherMetadata)
-        {
-            GraphCanvas::EntitySaveDataRequestBus::Event(
-                AZ::Entity::MakeId(), &GraphCanvas::EntitySaveDataRequests::ReadSaveData, *pair.second);
-        }
 
         // Create UI for all the Nodes
         for (const auto& pair : m_graph->GetNodes())
@@ -254,12 +243,11 @@ namespace GraphModelIntegration
             {
                 AZ::Vector2 position(0, 0);
 
-                auto metadataIter = graphCanvasMetadata->m_nodeMetadata.find(nodeId);
-                if (metadataIter != graphCanvasMetadata->m_nodeMetadata.end())
+                const auto metadataIter = graphCanvasMetadata->m_nodeMetadata.find(nodeId);
+                if (metadataIter != graphCanvasMetadata->m_nodeMetadata.end(); metadataIter->second)
                 {
-                    AZStd::shared_ptr<GraphCanvas::EntitySaveDataContainer> saveDataContainer = metadataIter->second;
                     GraphCanvas::EntitySaveDataRequestBus::Event(
-                        nodeUiId, &GraphCanvas::EntitySaveDataRequests::ReadSaveData, (*saveDataContainer));
+                        nodeUiId, &GraphCanvas::EntitySaveDataRequests::ReadSaveData, *metadataIter->second);
                 }
                 else
                 {
@@ -268,7 +256,6 @@ namespace GraphModelIntegration
                 }
 
                 GraphCanvas::GeometryRequestBus::EventResult(position, nodeUiId, &GraphCanvas::GeometryRequests::GetPosition);
-
                 return position;
             };
 
@@ -289,6 +276,18 @@ namespace GraphModelIntegration
         {
             CreateConnectionUi(connection);
         }
+
+        // Load graph canvas metadata for the scene
+        if (graphCanvasMetadata->m_sceneMetadata)
+        {
+            GraphCanvas::EntitySaveDataRequestBus::Event(
+                GetGraphCanvasSceneId(), &GraphCanvas::EntitySaveDataRequests::ReadSaveData, *graphCanvasMetadata->m_sceneMetadata);
+        }
+
+        // After the graph has been reconstructed, this signal will Inform the scene, node groups, and other types to update their state
+        // after all of the graph elements are in place. This is necessary for node groups to reclaim nodes that were contained within them
+        // when the graph was saved.
+        GraphCanvas::SceneRequestBus::Event(GetGraphCanvasSceneId(), &GraphCanvas::SceneRequests::SignalLoadEnd);
     }
 
     AZ::Entity* GraphController::CreateSlotUi(GraphModel::SlotPtr slot, AZ::EntityId nodeUiId)
@@ -1484,64 +1483,25 @@ namespace GraphModelIntegration
 
         GraphCanvasMetadata* graphCanvasMetadata = GetGraphMetadata();
 
-        NodePtr node = m_elementMap.Find<Node>(graphCanvasElement);
-
         // Save into m_nodeMetadata
-        if (node)
+        if (const auto node = m_elementMap.Find<Node>(graphCanvasElement))
         {
-            const NodeId nodeId = node->GetId();
-
-            AZStd::shared_ptr<GraphCanvas::EntitySaveDataContainer> container;
-
-            auto mapIter = graphCanvasMetadata->m_nodeMetadata.find(nodeId);
-
-            if (mapIter == graphCanvasMetadata->m_nodeMetadata.end())
-            {
-                container = AZStd::make_shared<GraphCanvas::EntitySaveDataContainer>();
-                graphCanvasMetadata->m_nodeMetadata[nodeId] = container;
-            }
-            else
-            {
-                container = mapIter->second;
-            }
-
+            auto container = AZStd::make_shared<GraphCanvas::EntitySaveDataContainer>();
             GraphCanvas::EntitySaveDataRequestBus::Event(
-                graphCanvasElement, &GraphCanvas::EntitySaveDataRequests::WriteSaveData, (*container));
+                graphCanvasElement, &GraphCanvas::EntitySaveDataRequests::WriteSaveData, *container);
+
+            const NodeId nodeId = node->GetId();
+            graphCanvasMetadata->m_nodeMetadata[nodeId] = container;
 
             GraphControllerNotificationBus::Event(m_graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, node);
         }
         // Save into m_sceneMetadata
         else if (graphCanvasElement == GetGraphCanvasSceneId())
         {
-            if (!graphCanvasMetadata->m_sceneMetadata)
-            {
-                graphCanvasMetadata->m_sceneMetadata = AZStd::make_shared<GraphCanvas::EntitySaveDataContainer>();
-            }
-
+            auto container = AZStd::make_shared<GraphCanvas::EntitySaveDataContainer>();
             GraphCanvas::EntitySaveDataRequestBus::Event(
-                graphCanvasElement, &GraphCanvas::EntitySaveDataRequests::WriteSaveData, (*graphCanvasMetadata->m_sceneMetadata));
-
-            GraphControllerNotificationBus::Event(m_graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, nullptr);
-        }
-        // Save into m_otherMetadata
-        else
-        {
-            AZStd::shared_ptr<GraphCanvas::EntitySaveDataContainer> container;
-
-            auto mapIter = graphCanvasMetadata->m_otherMetadata.find(graphCanvasElement);
-
-            if (mapIter == graphCanvasMetadata->m_otherMetadata.end())
-            {
-                container = AZStd::make_shared<GraphCanvas::EntitySaveDataContainer>();
-                graphCanvasMetadata->m_otherMetadata[graphCanvasElement] = container;
-            }
-            else
-            {
-                container = mapIter->second;
-            }
-
-            GraphCanvas::EntitySaveDataRequestBus::Event(
-                graphCanvasElement, &GraphCanvas::EntitySaveDataRequests::WriteSaveData, (*container));
+                graphCanvasElement, &GraphCanvas::EntitySaveDataRequests::WriteSaveData, *container);
+            graphCanvasMetadata->m_sceneMetadata = container;
 
             GraphControllerNotificationBus::Event(m_graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, nullptr);
         }

--- a/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
@@ -244,7 +244,7 @@ namespace GraphModelIntegration
                 AZ::Vector2 position(0, 0);
 
                 const auto metadataIter = graphCanvasMetadata->m_nodeMetadata.find(nodeId);
-                if (metadataIter != graphCanvasMetadata->m_nodeMetadata.end(); metadataIter->second)
+                if (metadataIter != graphCanvasMetadata->m_nodeMetadata.end() && metadataIter->second)
                 {
                     GraphCanvas::EntitySaveDataRequestBus::Event(
                         nodeUiId, &GraphCanvas::EntitySaveDataRequests::ReadSaveData, *metadataIter->second);

--- a/Gems/ScriptCanvas/Code/Editor/Settings.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Settings.cpp
@@ -47,7 +47,7 @@ namespace ScriptCanvasEditor
         {
             if (constructType == GraphCanvas::ConstructType::NodeGroup)
             {
-                GraphCanvas::NodeGroupPresetBucket* nodeGroupPresetBucket = static_cast<GraphCanvas::NodeGroupPresetBucket*>(ModPresetBuckket(GraphCanvas::ConstructType::NodeGroup));
+                GraphCanvas::NodeGroupPresetBucket* nodeGroupPresetBucket = static_cast<GraphCanvas::NodeGroupPresetBucket*>(ModPresetBucket(GraphCanvas::ConstructType::NodeGroup));
 
                 if (nodeGroupPresetBucket)
                 {
@@ -81,7 +81,7 @@ namespace ScriptCanvasEditor
             }
             else if (constructType == GraphCanvas::ConstructType::CommentNode)
             {
-                GraphCanvas::CommentPresetBucket* commentPresetBucket = static_cast<GraphCanvas::CommentPresetBucket*>(ModPresetBuckket(GraphCanvas::ConstructType::CommentNode));
+                GraphCanvas::CommentPresetBucket* commentPresetBucket = static_cast<GraphCanvas::CommentPresetBucket*>(ModPresetBucket(GraphCanvas::ConstructType::CommentNode));
                 commentPresetBucket->ClearPresets();
             }
         }


### PR DESCRIPTION
## What does this PR do?

- Implemented construct presets for material canvas graph view. The toolbar actions for creating groups of nodes are only functional if presets are set up.
- Graph model controller was not sending all of the requests and notifications needed to fully initialize a new graph, update bookmarks, and allow groups to resolve and re add contained nodes.
- Graph model controller was serializing “other” redundant metadata and then attempts to capture information about comments and groups. The information is already captured as part of the scene metadata when it is serialized.
- Graph model controller does not currently clear metadata from nodes that have been deleted. This may be a requirement for landscape canvas and will need to be addressed so excess data is not retained or serialized between sessions.

## How was this PR tested?

Verified that node groups can now be created in material canvas from the toolbar.
Verified that bookmarks and node groups are serialized with material graph file and restored on reload.
Verified that the collapsed state of note groups is correctly serialized and restored.
Verified that material graphs continue to compile correctly with instruction and input nodes wrapped in node groups.

![image](https://user-images.githubusercontent.com/82461473/204059619-6c7ccc07-f3ac-4729-b204-0e70700897c7.png)
![image](https://user-images.githubusercontent.com/82461473/204059640-7f899788-cb78-4bf5-91bb-e4ea841157de.png)
