### PR TITLE
Fix for camera boost getting stuck on

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
@@ -536,6 +536,8 @@ namespace AzFramework
     {
         if (const auto& input = AZStd::get_if<DiscreteInputEvent>(&state.m_inputEvent))
         {
+            m_boost = state.m_modifiers.IsActive(GetCorrespondingModifierKeyMask(m_translateCameraInputChannelIds.m_boostChannelId));
+
             if (input->m_state == InputChannel::State::Began)
             {
                 if (auto translation = TranslationFromKey(input->m_channelId, m_translateCameraInputChannelIds);
@@ -543,11 +545,6 @@ namespace AzFramework
                 {
                     m_translation |= translation;
                     BeginActivation();
-                }
-
-                if (input->m_channelId == m_translateCameraInputChannelIds.m_boostChannelId)
-                {
-                    m_boost = true;
                 }
             }
             // ensure we don't process end events in the idle state
@@ -561,11 +558,6 @@ namespace AzFramework
                     {
                         EndActivation();
                     }
-                }
-
-                if (input->m_channelId == m_translateCameraInputChannelIds.m_boostChannelId)
-                {
-                    m_boost = false;
                 }
             }
         }

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
@@ -542,6 +542,11 @@ namespace AzFramework
         AZStd::function<float()> m_translateSpeedFn;
         AZStd::function<float()> m_boostMultiplierFn;
 
+        bool Boosting() const
+        {
+            return m_boost;
+        }
+
     private:
         //! The type of translation the camera input is performing (multiple may be active at once).
         enum class TranslationType


### PR DESCRIPTION
Signed-off-by: Tom Hulton-Harrop <82228511+hultonha@users.noreply.github.com>

## What does this PR do?

Fixes an input issue where 'boost' for `TranslateCameraInput` could get stuck on when focus changed

## How was this PR tested?

Tested manually in the editor and also created a unit test to replicate the failure and show the fix worked

### Before

```
[ RUN      ] CameraInputFixture.TranslateCameraInputBoostDoesNotGetStuckOn
D:/o3de/Code/Framework/AzFramework/Tests/CameraInputTests.cpp(651): error: Value of: m_firstPersonTranslateCamera->Boosting()
Expected: is false
  Actual: true (of type bool)
```

### After

```
[ RUN      ] CameraInputFixture.TranslateCameraInputBoostDoesNotGetStuckOn
[       OK ] CameraInputFixture.TranslateCameraInputBoostDoesNotGetStuckOn (1 ms)
[----------] 1 test from CameraInputFixture (1 ms total)
```
