### PR TITLE
Partial draft: Add selective disabling of CTest target types.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ include(cmake/Install.cmake)
 include(cmake/LYWrappers.cmake)
 include(cmake/Gems.cmake)
 include(cmake/UnitTest.cmake)
+include(cmake/TestImpactFramework/TestImpactTestTargetConfig.cmake) # LYTestWrappers dependency
 include(cmake/LYTestWrappers.cmake)
 include(cmake/Monolithic.cmake)
 include(cmake/SettingsRegistry.cmake)

--- a/Code/Tools/TestImpactFramework/CMakeLists.txt
+++ b/Code/Tools/TestImpactFramework/CMakeLists.txt
@@ -10,7 +10,7 @@ o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} ${O
 
 include(${pal_dir}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
 
-if(PAL_TRAIT_TEST_IMPACT_FRAMEWORK_SUPPORTED AND LY_TEST_IMPACT_ACTIVE)
+if(PAL_TRAIT_TEST_IMPACT_FRAMEWORK_SUPPORTED AND O3DE_TEST_IMPACT_ACTIVE)
     add_subdirectory(Runtime)
     add_subdirectory(Frontend)
     ly_add_pytest(

--- a/cmake/LYTestWrappers.cmake
+++ b/cmake/LYTestWrappers.cmake
@@ -279,6 +279,9 @@ function(ly_add_test)
     set(LY_TEST_PARAMS "${LY_TEST_PARAMS}#${ly_add_test_TIMEOUT}")
     # Store the params for this test target
     set_property(GLOBAL APPEND PROPERTY LY_ALL_TESTS_${test_target}_PARAMS ${LY_TEST_PARAMS})
+
+    # Allow TIAF to disable tests of supported types from being run by CTest 
+    o3de_test_impact_apply_test_properties(${LY_ADDED_TEST_NAME} ${ly_add_test_TEST_LIBRARY})
 endfunction()
 
 #! ly_add_pytest: registers target PyTest-based test with CTest

--- a/cmake/TestImpactFramework/LYTestImpactFramework.cmake
+++ b/cmake/TestImpactFramework/LYTestImpactFramework.cmake
@@ -6,9 +6,6 @@
 #
 #
 
-# Path to test instrumentation binary
-set(LY_TEST_IMPACT_INSTRUMENTATION_BIN "" CACHE PATH "Path to test impact framework instrumentation binary")
-
 # Name of test impact framework console static library target
 set(LY_TEST_IMPACT_CONSOLE_NATIVE_STATIC_TARGET "TestImpact.Frontend.Console.Native.Static")
 
@@ -68,15 +65,6 @@ set(LY_TEST_IMPACT_NATIVE_TEST_RUN_DIR "${GTEST_XML_OUTPUT_DIR}")
 
 # Path to the directory that the result of python runs will be stored in.
 set(LY_TEST_IMPACT_PYTHON_TEST_RUN_DIR "${PYTEST_XML_OUTPUT_DIR}")
-
-# If we are not provided a path to the Instrumentation bin,
-# set LY_TEST_IMPACT to false so that our tests don't get added
-# and TIAF doesn't get built.
-if(LY_TEST_IMPACT_INSTRUMENTATION_BIN)
-    set(LY_TEST_IMPACT_ACTIVE true)
-else()
-    set(LY_TEST_IMPACT_ACTIVE false)
-endif()
 
 #! ly_test_impact_rebase_file_to_repo_root: rebases the relative and/or absolute path to be relative to repo root directory and places the resulting path in quotes.
 #
@@ -283,7 +271,7 @@ function(ly_test_impact_write_test_enumeration_file TEST_ENUMERATION_TEMPLATE_FI
             ly_test_impact_extract_python_test_params(${test} "${test_params}" test_namespace test_name test_suites)
             list(APPEND python_tests "        { \"namespace\": \"${test_namespace}\", \"name\": \"${test_name}\", \"suites\": [${test_suites}] }")
         elseif("${test_type}" STREQUAL "pytest_editor")
-            # Python editor tests            
+            # Python editor tests
             ly_test_impact_extract_python_test_params(${test} "${test_params}" test_namespace test_name test_suites)
             list(APPEND python_editor_tests "        { \"namespace\": \"${test_namespace}\", \"name\": \"${test_name}\", \"suites\": [${test_suites}] }")
         elseif("${test_type}" STREQUAL "googletest")
@@ -334,9 +322,9 @@ function(ly_test_impact_write_gem_target_enumeration_file GEM_TARGET_TEMPLATE_FI
         endif()
     endforeach()
     string (REPLACE ";" ",\n" enumerated_gem_targets "${enumerated_gem_targets}")
-     # Write out source to target mapping file
-     set(mapping_path "${LY_TEST_IMPACT_GEM_TARGET_FILE}")
-     configure_file(${GEM_TARGET_TEMPLATE_FILE} ${mapping_path})
+    # Write out source to target mapping file
+    set(mapping_path "${LY_TEST_IMPACT_GEM_TARGET_FILE}")
+    configure_file(${GEM_TARGET_TEMPLATE_FILE} ${mapping_path})
 endfunction()
 
 #! ly_extract_aliased_target_dependencies: recursively extracts the aliases of a target to retrieve the true de-aliased target.
@@ -513,14 +501,14 @@ function(ly_test_impact_write_config_file CONFIG_TEMPLATE_FILE BIN_DIR)
     set(build_config "$<CONFIG>")
 
     # Instrumentation binary
-    if(NOT LY_TEST_IMPACT_INSTRUMENTATION_BIN)
+    if(NOT O3DE_TEST_IMPACT_INSTRUMENTATION_BIN)
         # No binary specified is not an error, it just means that the test impact analysis part of the framework is disabled
         message("No test impact framework instrumentation binary was specified, test impact analysis framework will fall back to regular test sequences instead")
         set(use_tiaf false)
         set(instrumentation_bin "")
     else()
         set(use_tiaf true)
-        file(TO_CMAKE_PATH ${LY_TEST_IMPACT_INSTRUMENTATION_BIN} instrumentation_bin)
+        file(TO_CMAKE_PATH ${O3DE_TEST_IMPACT_INSTRUMENTATION_BIN} instrumentation_bin)
     endif()
 
     # Testrunner binary
@@ -595,7 +583,7 @@ function(ly_test_impact_write_pytest_file CONFIGURATION_FILE)
         set(config_path "${LY_TEST_IMPACT_WORKING_DIR}/${config_type}/${LY_TEST_IMPACT_PERSISTENT_DIR}/${LY_TEST_IMPACT_CONFIG_FILE_NAME}")
         list(APPEND build_configs "\"${config_type}\" : { \"config\" : \"${config_path}\"}")
     endforeach()
- 
+
     # Configure our list of entries
     string(REPLACE ";" ",\n" build_configs "${build_configs}")
     
@@ -604,7 +592,8 @@ function(ly_test_impact_write_pytest_file CONFIGURATION_FILE)
     string(CONFIGURE ${test_file} test_file)
     file(GENERATE
         OUTPUT "${LY_TEST_IMPACT_PYTEST_FILE_PATH}/ly_test_impact_test_data.json"
-        CONTENT "${test_file}")
+        CONTENT "${test_file}"
+    )
 
 endfunction()
 
@@ -630,7 +619,8 @@ endfunction()
 
 #! ly_test_impact_post_step: runs the post steps to be executed after all other cmake scripts have been executed.
 function(ly_test_impact_post_step)
-    if(NOT LY_TEST_IMPACT_ACTIVE)
+    if(NOT O3DE_TEST_IMPACT_ACTIVE)
+        message("TIAF is disabled, no post step will be performed.")
         return()
     endif()
 

--- a/cmake/TestImpactFramework/TestImpactTestTargetConfig.cmake
+++ b/cmake/TestImpactFramework/TestImpactTestTargetConfig.cmake
@@ -1,0 +1,65 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Path to test instrumentation binary
+set(O3DE_TEST_IMPACT_INSTRUMENTATION_BIN "" CACHE PATH "Path to test impact framework instrumentation binary")
+
+# Test impact analysis opt-in for native test targets
+set(O3DE_TEST_IMPACT_NATIVE_TEST_TARGETS_ENABLED FALSE CACHE BOOL "Whether to enable native C++ test targets for test impact analysis (otherwise, CTest will be used to run these targets).")
+
+# Test impact analysis opt-in for Python test targets
+set(O3DE_TEST_IMPACT_PYTHON_TEST_TARGETS_ENABLED FALSE CACHE BOOL "Whether to enable Python test targets for test impact analysis (otherwise, CTest will be used to run these targets).")
+
+# If we are not provided a path to the Instrumentation bin,
+# set LY_TEST_IMPACT to false so that our tests don't get added
+# and TIAF doesn't get built.
+if(O3DE_TEST_IMPACT_INSTRUMENTATION_BIN)
+    # TIAF is only enabled if at least one supported test target type has opted in for test impact analysis
+    if(O3DE_TEST_IMPACT_NATIVE_TEST_TARGETS_ENABLED OR O3DE_TEST_IMPACT_PYTHON_TEST_TARGETS_ENABLED)
+        set(O3DE_TEST_IMPACT_ACTIVE true)
+        if(O3DE_TEST_IMPACT_NATIVE_TEST_TARGETS_ENABLED)
+            message("TIAF enabled for native tests.")
+        else()
+            message("TIAF disabled for native tests.")
+        endif()
+        if(O3DE_TEST_IMPACT_PYTHON_TEST_TARGETS_ENABLED)
+            message("TIAF enabled for Python tests.")
+        else()
+            message("TIAF disabled for Python tests.")
+        endif()
+    else()
+        set(O3DE_TEST_IMPACT_ACTIVE false)
+        message("TIAF disabled. No test target types have opted in.")
+    endif()
+else()
+    set(O3DE_TEST_IMPACT_ACTIVE false)
+    message("TIAF disabled. Instrumentation bin not provided.")
+endif()
+
+#! o3de_test_impact_apply_test_properties: selectively disables a test target for running in CTest according to whether
+# or not their test library type is enabled for running in TIAF.
+#
+# \arg:TEST_NAME The test target name
+# \arg:TEST_LIBRARY the test library type of the test target
+function(o3de_test_impact_apply_test_properties TEST_NAME TEST_LIBRARY)
+    if("${TEST_LIBRARY}" STREQUAL "pytest" OR "${TEST_LIBRARY}" STREQUAL "pytest_editor")
+        if(O3DE_TEST_IMPACT_PYTHON_TEST_TARGETS_ENABLED)
+            set_tests_properties(${TEST_NAME}
+                PROPERTIES
+                    DISABLED True
+            )
+        endif()
+    elseif("${TEST_LIBRARY}" STREQUAL "googletest" OR "${TEST_LIBRARY}" STREQUAL "googlebenchmark")
+        if(O3DE_TEST_IMPACT_NATIVE_TEST_TARGETS_ENABLED)
+            set_tests_properties(${TEST_NAME}
+                PROPERTIES
+                    DISABLED True
+            )
+        endif()
+    endif()
+endfunction()


### PR DESCRIPTION
Signed-off-by: John <jonawals@amazon.com>

## What does this PR do?

This PR shows the proposed mechanism for selectively sending test targets to either CTest or TIAF depending on the test type.

All other changes have been removed for clarity.

The idea behind this mechanism is to use a CMake variable for both native and Python tests to determine whether they will be run by CTest or TIAF. Note that this decision is not made on a per-target basis but on a per-test type basis.

As far as I can tell, there doesn't seem to be a way to achieve this in a less intrusive manner as the TIAF CMake function depends on test specific state that cannot be determined ahead of time.

Looking forward to the comments 👍 

## How was this PR tested?


