### PR TITLE
Add missing reflection of AZ::Component base class for MetadataManager

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Metadata/MetadataManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Metadata/MetadataManager.cpp
@@ -22,7 +22,7 @@ namespace AzToolsFramework
         if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             // Note the version here is not the same as the MetadataFile version, since this is a separate serialization
-            serializeContext->Class<MetadataManager>()->Version(1);
+            serializeContext->Class<MetadataManager, AZ::Component>()->Version(1);
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

Adds missing AZ::Component base class to the reflection call for MetadataManager

## How was this PR tested?

Ran editor and confirmed warning message no longer shows up
