### PR TITLE
AnimGraph: Make it possible for a node in a group to be assigned to another group (#13373)

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.cpp
@@ -1243,6 +1243,15 @@ namespace EMStudio
         {
             AZ_Error("EMotionFX", false, outResult.c_str());
         }
+
+        for (int i = 0; i < animGraph->GetNumNodeGroups(); i++)
+        {
+            if (animGraph->GetNodeGroup(i)->GetNumNodes() == 0)
+            {
+                animGraph->RemoveNodeGroup(i);
+                i--;
+            }
+        }
     }
 
     void BlendGraphWidget::CreateNodeGroup()
@@ -1305,12 +1314,9 @@ namespace EMStudio
         }
     }
 
-    void BlendGraphWidget::AssignSelectedNodesToGroup()
+    void BlendGraphWidget::AssignSelectedNodesToGroup(EMotionFX::AnimGraphNodeGroup* nodeGroup)
     {
-        AZ_Assert(sender()->inherits("QAction"), "CreateNodeGroup called apart from a connection to a QAction's signal");
-        QAction* action = qobject_cast<QAction*>(sender());
-
-        // find the selected node
+        // find the selected nodes
         const QItemSelection selection = m_plugin->GetAnimGraphModel().GetSelectionModel().selection();
         const QModelIndexList selectionList = selection.indexes();
         if (selectionList.empty())
@@ -1326,10 +1332,6 @@ namespace EMStudio
             return;
         }
 
-        // get the node group name from the action and search the node group
-        const AZStd::string nodeGroupName = FromQtString(action->text());
-        EMotionFX::AnimGraphNodeGroup* newNodeGroup = animGraph->FindNodeGroupByName(nodeGroupName.c_str());
-
         AZStd::vector<EMotionFX::AnimGraphNode*> nodes;
         for (const QModelIndex& selectedIndex : selectionList)
         {
@@ -1343,7 +1345,7 @@ namespace EMStudio
             nodes.push_back(selectedIndex.data(AnimGraphModel::ROLE_NODE_POINTER).value<EMotionFX::AnimGraphNode*>());
         }
 
-        AssignNodesToGroup(animGraph, nodes, newNodeGroup);
+        AssignNodesToGroup(animGraph, nodes, nodeGroup);
     }
 
     bool BlendGraphWidget::PreparePainting()

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.h
@@ -111,7 +111,7 @@ namespace EMStudio
         bool CheckIfIsStateMachine();
 
         // context menu shared function (definitions in ContextMenu.cpp)
-        void AddAssignNodeToGroupSubmenu(QMenu* menu, EMotionFX::AnimGraph* animGraph);
+        void AddAssignNodeToGroupSubmenu(QMenu* menu, EMotionFX::AnimGraph* animGraph, EMotionFX::AnimGraphNodeGroup* currentlyAssignedGroup);
         void AddPreviewMotionSubmenu(QMenu* menu, AnimGraphActionManager* actionManager, const EMotionFX::AnimGraphNode* selectedNode);
 
         void OnContextMenuEvent(QWidget* parentWidget, QPoint localMousePos, QPoint globalMousePos, AnimGraphPlugin* plugin,
@@ -146,7 +146,7 @@ namespace EMStudio
         void CreateNodeFromMimeEvent(const BlendGraphMimeEvent* event, const QPoint& location);
 
         void CreateNodeGroup();
-        void AssignSelectedNodesToGroup();
+        void AssignSelectedNodesToGroup(EMotionFX::AnimGraphNodeGroup* nodeGroup);
         void RenameNodeGroup(EMotionFX::AnimGraphNodeGroup* nodeGroup);
         void ChangeNodeGroupColor(EMotionFX::AnimGraphNodeGroup* nodeGroup);
         void DeleteNodeGroup(EMotionFX::AnimGraphNodeGroup* nodeGroup);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ContextMenu.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ContextMenu.cpp
@@ -33,13 +33,15 @@
 
 namespace EMStudio
 {
-    void BlendGraphWidget::AddAssignNodeToGroupSubmenu(QMenu* menu, EMotionFX::AnimGraph* animGraph)
+    void BlendGraphWidget::AddAssignNodeToGroupSubmenu(QMenu* menu, EMotionFX::AnimGraph* animGraph, EMotionFX::AnimGraphNodeGroup* currentlyAssignedGroup)
     {
         const size_t numNodeGroups = animGraph->GetNumNodeGroups();
         if (numNodeGroups == 0)
         {
             return;
         }
+
+        const size_t selectedNodeCount = GetActiveGraph()->GetSelectedAnimGraphNodes().size();
 
         QMenu* nodeGroupMenu = new QMenu(tr("Assign To Node Group"), menu);
 
@@ -65,8 +67,23 @@ namespace EMStudio
                 AZ::Color nodeGroupColor;
                 nodeGroupColor.FromU32(nodeGroup->GetColor());
                 QAction* nodeGroupAction = nodeGroupMenu->addAction(QIcon(new SolidColorIconEngine(nodeGroupColor)), nodeGroup->GetName());
+                nodeGroupAction->setCheckable(true);
                 nodeGroupAction->setData(qulonglong(i + 1)); // index of the menu added, not used
-                connect(nodeGroupAction, &QAction::triggered, this, &BlendGraphWidget::AssignSelectedNodesToGroup);
+                if (currentlyAssignedGroup == nodeGroup && selectedNodeCount == 1)
+                {
+                    nodeGroupAction->setChecked(true);
+                }
+                else
+                {
+                    connect(
+                        nodeGroupAction,
+                        &QAction::triggered,
+                        this,
+                        [this, nodeGroup]()
+                        {
+                            AssignSelectedNodesToGroup(nodeGroup);
+                        });
+                }
                 validGroupCount++;
             }
         }
@@ -393,23 +410,20 @@ namespace EMStudio
                 connect(createNodeGroupAction, &QAction::triggered, this, &BlendGraphWidget::CreateNodeGroup);
                 if (actionFilter.m_editNodeGroups && !inReferenceGraph && animGraphNode->GetParentNode())
                 {
-                    AddAssignNodeToGroupSubmenu(menu, animGraphNode->GetAnimGraph());
+                    AddAssignNodeToGroupSubmenu(menu, animGraphNode->GetAnimGraph(), nullptr);
                 }
             }
             else
             {
+                AddAssignNodeToGroupSubmenu(menu, animGraphNode->GetAnimGraph(), nodeGroup);
                 QAction* removeFromGroupAction = menu->addAction(tr("Remove From Node Group"));
                 connect(
                     removeFromGroupAction,
                     &QAction::triggered,
                     this,
-                    [this, nodeGroup, selectedNodes]
+                    [this]
                     {
-                        nodeGroup->RemoveNodeById(selectedNodes[0]->GetId());
-                        if (nodeGroup->GetNumNodes() == 0)
-                        {
-                            DeleteNodeGroup(nodeGroup);
-                        }
+                        AssignSelectedNodesToGroup(nullptr);
                     });
             }
 
@@ -544,30 +558,20 @@ namespace EMStudio
                 connect(createNodeGroupAction, &QAction::triggered, this, &BlendGraphWidget::CreateNodeGroup);
                 if (actionFilter.m_editNodeGroups && !inReferenceGraph)
                 {
-                    AddAssignNodeToGroupSubmenu(&menu, selectedNodes[0]->GetAnimGraph());
+                    AddAssignNodeToGroupSubmenu(&menu, selectedNodes[0]->GetAnimGraph(), nullptr);
                 }
             }
             else
             {
+                AddAssignNodeToGroupSubmenu(&menu, selectedNodes[0]->GetAnimGraph(), nullptr);
                 QAction* removeFromGroupAction = menu.addAction(tr("Remove From Node Group"));
                 connect(
                     removeFromGroupAction,
                     &QAction::triggered,
                     this,
-                    [this, &selectedNodes]
+                    [this]
                     {
-                        for (EMotionFX::AnimGraphNode* node : selectedNodes)
-                        {
-                            auto* group = node->GetAnimGraph()->FindNodeGroupForNode(node);
-                            if (group)
-                            {
-                                group->RemoveNodeById(node->GetId());
-                                if (group->GetNumNodes() == 0)
-                                {
-                                    DeleteNodeGroup(group);
-                                }
-                            }
-                        }
+                        AssignSelectedNodesToGroup(nullptr);
                     });
             }
 


### PR DESCRIPTION
Signed-off-by: Alessandro Ambrosano <1006222+aambrosano@users.noreply.github.com>

## What does this PR do?

Fixes #13373

Nodes in an animation graph couldn't be assigned to any other node group once they were assigned the first time.

This PR makes it possible to let a node switch the groups to which it belongs.

## How was this PR tested?

Manually switching graph nodes from a group to another through the menu.

https://user-images.githubusercontent.com/1006222/204567271-669dd4ed-07ef-422f-8073-6b0d77c193e7.mp4

Fixes #13373