### PR TITLE
[Issue Template] Remove duplicated security policy lines

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Security Vulnerabilities
-    about: Report a security issue in O3DE. See the O3DE security policy for reporting guidance
-    url: https://www.o3de.org/docs/contributing/security
   - name: Documentation Issues
     about: Report issues with the documentation for O3DE
     url: https://github.com/o3de/o3de.org/issues/new/choose 


### PR DESCRIPTION
## What does this PR do?

Remove duplicated security policy lines in new issue reporting. Github is now autogenerating one based on our `SECURITY.md`

Remove our explicit line to reduce duplication of effort

Before change:
> There are two 'security' policy links. User given two actions of "**report a security vulnerability**" or "**Security Vulnerability**"
![lines](https://user-images.githubusercontent.com/61438964/204385480-c37b2177-eff8-4a03-a7b8-e97caea9d174.png)

After change:

![after](https://user-images.githubusercontent.com/61438964/204385844-4cd9e9ff-1726-4072-9ede-dd3db96c820b.png)

## How was this PR tested?

Tested in private repro, confirmed that security policy link is in place.
