### PR TITLE
Removed flaky comparison from PerformanceCollectorTest

### DIFF
--- a/Code/Framework/AzCore/Tests/Debug/PerformanceCollectorTests.cpp
+++ b/Code/Framework/AzCore/Tests/Debug/PerformanceCollectorTests.cpp
@@ -97,11 +97,6 @@ namespace UnitTest
             ASSERT_TRUE(argsObj.HasMember(AZ::Debug::PerformanceCollector::STDEV.data()));
             ASSERT_TRUE(argsObj.HasMember(AZ::Debug::PerformanceCollector::SAMPLE_COUNT.data()));
 
-            // Remark, here we call GetDouble() and later cast to unsigned int, because
-            // GetUint() returns weird numbers when reading a floating point value.
-            auto avgAsDouble = argsObj[AZ::Debug::PerformanceCollector::AVG.data()].GetDouble();
-            EXPECT_EQ(jsonDoc[i]["dur"].GetUint(), aznumeric_cast<unsigned int>(avgAsDouble));
-
             auto sampleCount = argsObj[AZ::Debug::PerformanceCollector::SAMPLE_COUNT.data()].GetUint();
             if (paramName == PerfParam1)
             {


### PR DESCRIPTION
## What does this PR do?

Removes a Uint & Double comparison that was causing flaky test results.
Fixes https://github.com/o3de/o3de/issues/13419

## How was this PR tested?

Validated all AzCore.Tests still passed locally.

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>
