### PR TITLE
Ensure autosave timers are stopped and started correctly.

### DIFF
--- a/Code/Editor/CryEditDoc.cpp
+++ b/Code/Editor/CryEditDoc.cpp
@@ -1037,7 +1037,6 @@ bool CCryEditDoc::AfterSaveDocument([[maybe_unused]] const QString& lpszPathName
         CLogFile::WriteLine("$3Document successfully saved");
         SetModifiedFlag(false);
         SetModifiedModules(eModifiedNothing);
-        MainWindow::instance()->ResetAutoSaveTimers();
     }
 
     return bSaved;

--- a/Code/Editor/EditorPreferencesDialog.cpp
+++ b/Code/Editor/EditorPreferencesDialog.cpp
@@ -190,7 +190,8 @@ void EditorPreferencesDialog::OnAccept()
             origAutoBackup.nTime != gSettings.autoBackupTime ||
             origAutoBackup.nRemindTime != gSettings.autoRemindTime))
     {
-        MainWindow::instance()->ResetAutoSaveTimers(true);
+        // Ensure timers restart with the correct interval.
+        MainWindow::instance()->ResetAutoSaveTimers();
     }
 
     AzToolsFramework::EditorPreferencesNotificationBus::Broadcast(&AzToolsFramework::EditorPreferencesNotifications::OnEditorPreferencesChanged);

--- a/Code/Editor/MainWindow.h
+++ b/Code/Editor/MainWindow.h
@@ -155,7 +155,9 @@ public:
     void RefreshStyle();
 
     //! Reset timers used for auto saving.
-    void ResetAutoSaveTimers(bool bForceInit = false);
+    void StopAutoSaveTimers();
+    void StartAutoSaveTimers();
+    void ResetAutoSaveTimers();
     void ResetBackgroundUpdateTimer();
 
     void UpdateToolsMenu();


### PR DESCRIPTION
Signed-off-by: sphrose <82213493+sphrose@users.noreply.github.com>

## What does this PR do?

This PR fixes #5485. Previously the auto save timer would be killed after the first time it triggered, and never be restarted unless the interval was changed in the settings. Now the timer runs continuously, resetting if the interval is modified, and being restarted on a new scene load.

## How was this PR tested?

Tested manually.
