### PR TITLE
DPE: Handle entity change undo events in ComponentAdapter

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.h
@@ -29,10 +29,13 @@ namespace AZ::DocumentPropertyEditor
         ComponentAdapter(AZ::Component* componentInstance);
         ~ComponentAdapter();
 
+        // AzToolsFramework::PropertyEditorEntityChangeNotificationBus::Bus overrides
         void OnEntityComponentPropertyChanged(AZ::ComponentId componentId) override;
 
+        // AzToolsFramework::ToolsApplicationEvents::Bus overrides
         void InvalidatePropertyDisplay(AzToolsFramework::PropertyModificationRefreshLevel level) override;
 
+        // AzToolsFramework::PropertyEditorGUIMessages::Bus overrides
         void RequestRefresh(AzToolsFramework::PropertyModificationRefreshLevel level) override;
 
         //! Sets the component, connects the appropriate Bus Handlers and sets the reflect data for this instance
@@ -41,8 +44,13 @@ namespace AZ::DocumentPropertyEditor
         //! Trigger a refresh based on messages from the listeners
         void DoRefresh();
 
+        Dom::Value HandleMessage(const AdapterMessage& message) override;
+
     protected:
         AZ::Component* m_componentInstance = nullptr;
+
+        AzToolsFramework::UndoSystem::URSequencePoint* m_currentUndoNode = nullptr;
+
         enum AzToolsFramework::PropertyModificationRefreshLevel m_queuedRefreshLevel =
             AzToolsFramework::PropertyModificationRefreshLevel::Refresh_None;
     };


### PR DESCRIPTION
**Description**
Before this PR, changes made internally to a prefab weren't being propagated to other instances of the same prefab in a scene when the DPE EntityInspector was being used.

This PR adds handler code to the DPEComponentAdapter similar to what is done in the RPE's EntityPropertyEditor for creation and tracking of undo nodes. This allows the necessary events to reach the prefab system interface, triggering the propagation of those changes to other instances of the same prefab.

**Testing**
- Verified behavior with the RPE enabled seems consistent with DPE-enabled behavior in the EntityInspector regarding prefab change propagation and undoing those changes

Signed-off-by: amzn-tmryan <104796591+amzn-tmryan@users.noreply.github.com>
