### PR TITLE
NodeGraph: fix scaling of node group font size when editing it

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodeGraph.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodeGraph.cpp
@@ -2550,7 +2550,7 @@ namespace EMStudio
                     m_nodeGroupNameLineEdit->move(m_transform.dx() + x_delta, m_transform.dy() + y_delta);
                     m_nodeGroupNameLineEdit->setBaseSize(
                         QSize(groupRect.width() - 2 * sGroupRectTextHPadding, m_groupFontMetrics->height()));
-                    m_nodeGroupNameLineEdit->setBaseFontPointSizeF(m_groupFont.pointSizeF());
+                    m_nodeGroupNameLineEdit->setBaseFontPixelSize(m_groupFont.pixelSize());
                     m_nodeGroupNameLineEdit->setScale(GetScale());
                     m_nodeGroupNameLineEdit->show();
                 }

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ZoomableLineEdit.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ZoomableLineEdit.cpp
@@ -30,15 +30,15 @@ namespace EMStudio
         m_baseSize = sz;
     }
 
-    void ZoomableLineEdit::setBaseFontPointSizeF(qreal pointSize)
+    void ZoomableLineEdit::setBaseFontPixelSize(qreal pointSize)
     {
-        m_fontPointSize = pointSize;
+        m_fontPixelSize = pointSize;
     }
 
     void ZoomableLineEdit::updateScaledSize()
     {
         QFont f = font();
-        f.setPointSizeF(m_fontPointSize * m_scale);
+        f.setPixelSize(m_fontPixelSize * m_scale);
         setFont(f);
         resize(m_baseSize.width() * m_scale, m_baseSize.height() * m_scale);
     }

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ZoomableLineEdit.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ZoomableLineEdit.h
@@ -25,12 +25,12 @@ namespace EMStudio
 
         // Use these functions just before showing the widget
         void setBaseSize(QSize sz);
-        void setBaseFontPointSizeF(qreal pointSizeF);
+        void setBaseFontPixelSize(qreal pointSizeF);
 
     private:
         float m_scale = 1.0f;
         QSize m_baseSize;
-        qreal m_fontPointSize;
+        qreal m_fontPixelSize;
 
         void updateScaledSize();
     };


### PR DESCRIPTION
## What does this PR do?

Partial fix for https://github.com/o3de/o3de/issues/13372 by fixing scaling of the font size of the QLineEdit used for editing a node group's name. This is not a complete fix for https://github.com/o3de/o3de/issues/13372 because the height of the line edit is still not set correctly.

## How was this PR tested?

manually
