### PR TITLE
Implement BreadCrumbs in AssetBrowser

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -34,6 +34,10 @@ AZ_CVAR_EXTERNED(bool, ed_useNewAssetBrowserTableView);
 
 AZ_CVAR(bool, ed_useWIPAssetBrowserDesign, false, nullptr, AZ::ConsoleFunctorFlags::Null, "Use the in-progress new Asset Browser design");
 
+//! When the Asset Browser window is resized to be less than this many pixels in width
+//! the layout changes to accomodate its narrow state better. See AzAssetBrowserWindow::SetNarrowMode
+static constexpr int s_narrowModeThreshold = 700;
+
 namespace AzToolsFramework
 {
     namespace AssetBrowser
@@ -130,16 +134,24 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
 
     if (!ed_useWIPAssetBrowserDesign)
     {
+        m_ui->m_breadcrumbsWrapper->hide(); 
         m_ui->m_middleStackWidget->hide();
         m_ui->m_treeViewButton->hide();
         m_ui->m_thumbnailViewButton->hide();
         m_ui->m_tableViewButton->hide();
+        m_ui->m_searchWidget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
     }
 
     m_ui->horizontalLayout->setAlignment(m_ui->m_toolsMenuButton, Qt::AlignTop);
     m_ui->horizontalLayout->setAlignment(m_ui->m_treeViewButton, Qt::AlignTop);
     m_ui->horizontalLayout->setAlignment(m_ui->m_tableViewButton, Qt::AlignTop);
     m_ui->horizontalLayout->setAlignment(m_ui->m_thumbnailViewButton, Qt::AlignTop);
+    m_ui->horizontalLayout->setAlignment(m_ui->m_breadcrumbsWrapper, Qt::AlignTop);
+
+    m_ui->m_pathBreadCrumbs->setPushPathOnLinkActivation(false);
+    connect(m_ui->m_pathBreadCrumbs, &AzQtComponents::BreadCrumbs::linkClicked, this, [this](const QString& path) {
+        m_ui->m_assetBrowserTreeViewWidget->SelectFolder(path.toUtf8().constData());
+    });
 
     connect(m_ui->m_thumbnailViewButton, &QAbstractButton::clicked, this, [this] { SetTwoColumnMode(m_ui->m_thumbnailView); });
     connect(m_ui->m_tableViewButton, &QAbstractButton::clicked, this, [this] { SetTwoColumnMode(m_ui->m_tableView); });
@@ -213,7 +225,10 @@ void AzAssetBrowserWindow::resizeEvent(QResizeEvent* resizeEvent)
     const float oldWidth = aznumeric_cast<float>(leftLayout->geometry().width() + rightLayout->geometry().width());
 
     const float newWidth = oldLeftLayoutWidth * aznumeric_cast<float>(resizeEvent->size().width()) / oldWidth;
-    
+
+    const bool isNarrow = resizeEvent->size().width() < s_narrowModeThreshold;
+    SetNarrowMode(isNarrow);
+
     emit SizeChangedSignal(aznumeric_cast<int>(newWidth));
     QWidget::resizeEvent(resizeEvent);
 }
@@ -281,6 +296,33 @@ void AzAssetBrowserWindow::UpdateDisplayInfo()
     }
 }
 
+void AzAssetBrowserWindow::SetNarrowMode(bool narrow)
+{
+    if (m_inNarrowMode == narrow)
+    {
+        return;
+    }
+
+    // In narrow mode, breadcrumbs are below the search bar and view switching buttons
+    m_inNarrowMode = narrow;
+    if (narrow)
+    {
+        m_ui->scrollAreaVerticalLayout->insertWidget(1, m_ui->m_breadcrumbsWrapper);
+        m_ui->m_searchWidget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+    }
+    else
+    {
+        m_ui->horizontalLayout->insertWidget(0, m_ui->m_breadcrumbsWrapper);
+        m_ui->horizontalLayout->setAlignment(m_ui->m_breadcrumbsWrapper, Qt::AlignTop);
+
+        // Once we fully move to new design this cvar will be gone and the condition can be deleted
+        if (ed_useWIPAssetBrowserDesign)
+        {
+            m_ui->m_searchWidget->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
+        }
+    }
+}
+
 void AzAssetBrowserWindow::SetTreeViewMode()
 {
     namespace AzAssetBrowser = AzToolsFramework::AssetBrowser;
@@ -315,18 +357,41 @@ void AzAssetBrowserWindow::UpdateWidgetAfterFilter()
     }
 }
 
-void AzAssetBrowserWindow::UpdatePreview() const
+void AzAssetBrowserWindow::UpdatePreview(const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry) const
 {
-    const auto& selectedAssets = m_ui->m_assetBrowserTreeViewWidget->isVisible() ? m_ui->m_assetBrowserTreeViewWidget->GetSelectedAssets()
-                                                                                 : m_ui->m_assetBrowserTableViewWidget->GetSelectedAssets();
-
-    if (selectedAssets.size() != 1)
+    if (selectedEntry)
+    {
+        m_ui->m_previewerFrame->Display(selectedEntry);
+    }
+    else
     {
         m_ui->m_previewerFrame->Clear();
-        return;
     }
+}
 
-    m_ui->m_previewerFrame->Display(selectedAssets.front());
+void AzAssetBrowserWindow::UpdateBreadcrumbs(const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry) const
+{
+    using namespace AzToolsFramework::AssetBrowser;
+
+    QString entryPath;
+    if (selectedEntry)
+    {
+        auto folderForEntry = [](const AssetBrowserEntry* entry)
+        {
+            while (entry && entry->GetEntryType() != AssetBrowserEntry::AssetEntryType::Folder)
+            {
+                entry = entry->GetParent();
+            }
+            return entry;
+        };
+
+        const AssetBrowserEntry* folderEntry = folderForEntry(selectedEntry);
+        if (folderEntry)
+        {
+            entryPath = QString::fromUtf8(folderEntry->GetRelativePath().c_str());
+        }
+    }
+    m_ui->m_pathBreadCrumbs->setCurrentPath(entryPath);
 }
 
 void AzAssetBrowserWindow::SetTwoColumnMode(QWidget* viewToShow)
@@ -392,7 +457,13 @@ void AzAssetBrowserWindow::SelectAsset(const QString& assetPath)
 
 void AzAssetBrowserWindow::SelectionChangedSlot(const QItemSelection& /*selected*/, const QItemSelection& /*deselected*/) const
 {
-    UpdatePreview();
+    const auto& selectedAssets = sender() == m_ui->m_assetBrowserTreeViewWidget ? m_ui->m_assetBrowserTreeViewWidget->GetSelectedAssets()
+                                                                                : m_ui->m_assetBrowserTableViewWidget->GetSelectedAssets();
+
+    AzToolsFramework::AssetBrowser::AssetBrowserEntry* entry = selectedAssets.size() == 1 ? selectedAssets.front() : nullptr;
+
+    UpdatePreview(entry);
+    UpdateBreadcrumbs(entry);
 }
 
 // while its tempting to use Activated here, we don't actually want it to count as activation

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.h
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.h
@@ -24,6 +24,7 @@ namespace AzToolsFramework
 {
     namespace AssetBrowser
     {
+        class AssetBrowserEntry;
         class AssetBrowserFilterModel;
         class AssetBrowserTableModel;
         class AssetBrowserModel;
@@ -63,6 +64,7 @@ protected:
 private:
     void OnInitToolsMenuButton();
     void UpdateDisplayInfo();
+    void SetNarrowMode(bool narrow);
 
 protected slots:
     void CreateToolsMenu();
@@ -83,7 +85,15 @@ private:
     AzToolsFramework::AssetBrowser::AssetBrowserDisplayState m_assetBrowserDisplayState =
         AzToolsFramework::AssetBrowser::AssetBrowserDisplayState::ListViewMode;
 
-    void UpdatePreview() const;
+    //! Updates the asset preview panel with data about the passed entry.
+    //! Clears the panel if nullptr is passed
+    void UpdatePreview(const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry) const;
+
+    //! Updates breadcrumbs with the selectedEntry relative path if it's a folder or with the
+    //! relative path of the first folder parent of the passed entry.
+    //! Clears breadcrumbs if nullptr is passed or there's no folder parent.
+    void UpdateBreadcrumbs(const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry) const;
+    bool m_inNarrowMode = false;
 
 private Q_SLOTS:
     void SelectionChangedSlot(const QItemSelection& selected, const QItemSelection& deselected) const;

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.ui
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.ui
@@ -83,23 +83,37 @@
           <number>5</number>
          </property>
          <item>
-          <widget class="AzToolsFramework::AssetBrowser::SearchWidget" name="m_searchWidget" native="true">
+          <widget class="QWidget" name="m_breadcrumbsWrapper" native="true">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QToolButton" name="m_toolsMenuButton">
-           <property name="toolTip">
-            <string extracomment="Asset Browser menu">Asset Browser menu</string>
-           </property>
-           <property name="text">
-            <string>...</string>
-           </property>
+           <layout class="QHBoxLayout" name="m_breadcrumbsLayout">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="AzQtComponents::BreadCrumbs" name="m_pathBreadCrumbs" native="true">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </widget>
          </item>
          <item>
@@ -151,6 +165,32 @@
            <attribute name="buttonGroup">
             <string notr="true">m_viewSelectButtonGroup</string>
            </attribute>
+          </widget>
+         </item>
+         <item>
+          <widget class="AzToolsFramework::AssetBrowser::SearchWidget" name="m_searchWidget" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>150</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="m_toolsMenuButton">
+           <property name="toolTip">
+            <string extracomment="Asset Browser menu">Asset Browser menu</string>
+           </property>
+           <property name="text">
+            <string>...</string>
+           </property>
           </widget>
          </item>
         </layout>
@@ -357,6 +397,11 @@
    <class>AzToolsFramework::AssetBrowser::AssetBrowserTableView</class>
    <extends>AzQtComponents::TableView</extends>
    <header>AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.h</header>
+  </customwidget>
+  <customwidget>
+   <class>AzQtComponents::BreadCrumbs</class>
+   <extends>QWidget</extends>
+   <header>AzQtComponents/Components/Widgets/BreadCrumbs.h</header>
   </customwidget>
  </customwidgets>
  <resources>


### PR DESCRIPTION
These breadcrumbs show the relative path of a selected folder or, if an assets is selected, its folder.

Breadcrumbs are for now hidden behind the `ed_useWIPAssetBrowserDesign` cvar.

When the width of Asset Browser window falls below a certain threshold, it goes into "narrow" mode, breadcrumbs are then shown below the search bar, view switchers and the tools menu.

Fixes: #13236

Signed-off-by: Miłosz Kosobucki <milosz@kosobucki.pl>

## What does this PR do?

Implements breadcrumbs in the Asset Browser:


https://user-images.githubusercontent.com/104767/204834768-c186df03-7619-4f4f-a36c-cfdf5ea87197.mp4

Note:
 - It's not working right for Engine assets and Gems assets. We have to fix the Relative path of asset browser entries before it works properly
 - Back and forth arrows are not implemented yet. To do in o3de/o3de#12859
 - When Asset browser doesn't have any default location to open, breadcrumbs show nothing. We should probably implement opening of some default location but I think it should be a separate task.

## How was this PR tested?

Manually
