### PR TITLE
Clean up the magic numbers in AP unit tests

### DIFF
--- a/Code/Tools/AssetProcessor/native/unittests/PlatformConfigurationUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/PlatformConfigurationUnitTests.cpp
@@ -24,42 +24,54 @@ public:
 
         m_assetRootPath = QDir(m_assetDatabaseRequestsHandler->GetAssetRootDir().c_str());
 
-        m_config.EnablePlatform({ "pc",{ "desktop", "host" } }, true);
-        m_config.EnablePlatform({ "android",{ "mobile", "android" } }, true);
+        for (const AssetBuilderSDK::PlatformInfo& enabledPlatform : m_enabledPlatforms)
+        {
+            m_config.EnablePlatform(enabledPlatform, true);
+        }
         m_config.EnablePlatform({ "fandago",{ "console" } }, false);
+
         AZStd::vector<AssetBuilderSDK::PlatformInfo> platforms;
         m_config.PopulatePlatformsForScanFolder(platforms);
 
-        //                                         PATH               DisplayName  PortKey root   recurse  platforms,      isunittesting
-        m_config.AddScanFolder(ScanFolderInfo(m_assetRootPath.filePath("subfolder3"),   "", "sf3",  false, false,   platforms), true); // subfolder 3 overrides subfolder2
-        m_config.AddScanFolder(ScanFolderInfo(m_assetRootPath.filePath("subfolder2"),   "", "sf4",  false, true,    platforms), true); // subfolder 2 overrides subfolder1
-        m_config.AddScanFolder(ScanFolderInfo(m_assetRootPath.filePath("subfolder1"),   "", "sf1",  false, true,    platforms), true); // subfolder1 overrides root
-        m_config.AddScanFolder(ScanFolderInfo(m_assetRootPath.filePath("subfolder4"),   "", "sf4",  false, true,    platforms), true); // subfolder4 overrides subfolder5
-        m_config.AddScanFolder(ScanFolderInfo(m_assetRootPath.filePath("subfolder5"),   "", "sf5",  false, true,    platforms), true); // subfolder5 overrides subfolder6
-        m_config.AddScanFolder(ScanFolderInfo(m_assetRootPath.filePath("subfolder6"), "", "sf6", false, true,    platforms), true); // subfolder6 overrides subfolder7
-        m_config.AddScanFolder(ScanFolderInfo(m_assetRootPath.filePath("subfolder7"), "", "sf7", false, true,    platforms), true); // subfolder7 overrides subfolder8
-        m_config.AddScanFolder(ScanFolderInfo(m_assetRootPath.filePath("subfolder8/x"), "", "sf8", false, true,    platforms), true); // subfolder8 overrides root
-        m_config.AddScanFolder(ScanFolderInfo(m_assetRootPath.absolutePath(),       "temp", "temp", true, false,    platforms), true); // add the root
+        //                                                       PATH             DisplayName PortKey root recurse platforms
+        m_scanFolders.emplace_back(ScanFolderInfo(m_assetRootPath.filePath("subfolder3"), "", "sf3", false, false, platforms)); // subfolder 3 is expected to override subfolder2
+        m_scanFolders.emplace_back(ScanFolderInfo(m_assetRootPath.filePath("subfolder2"),   "", "sf4",  false, true,    platforms)); // subfolder 2 is expected to override subfolder1
+        m_scanFolders.emplace_back(ScanFolderInfo(m_assetRootPath.filePath("subfolder1"),   "", "sf1",  false, true,    platforms)); // subfolder1 is expected to override root
+        m_scanFolders.emplace_back(ScanFolderInfo(m_assetRootPath.filePath("subfolder4"),   "", "sf4",  false, true,    platforms)); // subfolder4 is expected to override subfolder5
+        m_scanFolders.emplace_back(ScanFolderInfo(m_assetRootPath.filePath("subfolder5"),   "", "sf5",  false, true,    platforms)); // subfolder5 is expected to override subfolder6
+        m_scanFolders.emplace_back(ScanFolderInfo(m_assetRootPath.filePath("subfolder6"), "", "sf6", false, true,    platforms)); // subfolder6 is expected to override subfolder7
+        m_scanFolders.emplace_back(ScanFolderInfo(m_assetRootPath.filePath("subfolder7"), "", "sf7", false, true,    platforms)); // subfolder7 is expected to override subfolder8
+        m_scanFolders.emplace_back(ScanFolderInfo(m_assetRootPath.filePath("subfolder8/x"), "", "sf8", false, true,    platforms)); // subfolder8 is expected to override root
+        m_scanFolders.emplace_back(ScanFolderInfo(m_assetRootPath.absolutePath(),       "temp", "temp", true, false,    platforms)); // add the root
 
-                                                                                                                                     // these are checked for later.
-        m_config.AddScanFolder(ScanFolderInfo(m_assetRootPath.filePath("GameName"),             "gn",    "", false, true, platforms), true);
-        m_config.AddScanFolder(ScanFolderInfo(m_assetRootPath.filePath("GameNameButWithExtra"), "gnbwe", "", false, true, platforms), true);
+        m_scanFolders.emplace_back(ScanFolderInfo(m_assetRootPath.filePath("GameName"),  "gn",    "",   false, true, platforms));
+        m_scanFolders.emplace_back(ScanFolderInfo(m_assetRootPath.filePath("GameNameButWithExtra"), "gnbwe", "", false, true, platforms));
 
-        AssetRecognizer rec;
+        for (const ScanFolderInfo& scanFolder : m_scanFolders)
+        {
+            m_config.AddScanFolder(scanFolder, true);
+        }
 
-        rec.m_name = "txt files";
-        rec.m_patternMatcher = AssetBuilderSDK::FilePatternMatcher("*.txt", AssetBuilderSDK::AssetBuilderPattern::Wildcard);
-        rec.m_platformSpecs.insert({"pc", AssetInternalSpec::Copy});
-        rec.m_platformSpecs.insert({"android", AssetInternalSpec::Copy});
-        rec.m_platformSpecs.insert({"fandago", AssetInternalSpec::Copy});
-        m_config.AddRecognizer(rec);
+        AssetRecognizer txtRecognizer;
+        txtRecognizer.m_name = "txt files";
+        txtRecognizer.m_patternMatcher = AssetBuilderSDK::FilePatternMatcher("*.txt", AssetBuilderSDK::AssetBuilderPattern::Wildcard);
+        txtRecognizer.m_platformSpecs.insert({"pc", AssetInternalSpec::Copy});
+        txtRecognizer.m_platformSpecs.insert({"android", AssetInternalSpec::Copy});
+        txtRecognizer.m_platformSpecs.insert({"fandago", AssetInternalSpec::Copy});
+        m_txtRecognizerContainer[txtRecognizer.m_name] = txtRecognizer;
 
         // test dual-recognisers - two recognisers for the same pattern.
-        rec.m_name = "txt files 2";
-        m_config.AddRecognizer(rec);
-        rec.m_patternMatcher = AssetBuilderSDK::FilePatternMatcher(".*\\/test\\/.*\\.format", AssetBuilderSDK::AssetBuilderPattern::Regex);
-        rec.m_name = "format files that live in a folder called test";
-        m_config.AddRecognizer(rec);
+        txtRecognizer.m_name = "txt files 2";
+        m_txtRecognizerContainer[txtRecognizer.m_name] = txtRecognizer;
+
+        for (const auto& recognizerKeyPair : m_txtRecognizerContainer)
+        {
+            m_config.AddRecognizer(recognizerKeyPair.second);
+        }
+
+        m_formatRecognizer.m_patternMatcher = AssetBuilderSDK::FilePatternMatcher(".*\\/test\\/.*\\.format", AssetBuilderSDK::AssetBuilderPattern::Regex);
+        m_formatRecognizer.m_name = "format files that live in a folder called test";
+        m_config.AddRecognizer(m_formatRecognizer);
     }
 
 protected:
@@ -109,21 +121,29 @@ protected:
     FileStatePassthrough m_fileStateCache;
     QDir m_assetRootPath;
     PlatformConfiguration m_config;
+    AZStd::vector<ScanFolderInfo> m_scanFolders;
+    AZStd::vector<AssetBuilderSDK::PlatformInfo> m_enabledPlatforms = {
+        { "pc",{ "desktop", "host" }},
+        { "android",{ "mobile", "android" }}
+    };
+    RecognizerContainer m_txtRecognizerContainer;
+    AssetRecognizer m_formatRecognizer;
 };
 
 TEST_F(PlatformConfigurationTests, TestPlatformsAndScanFolders_FeedPlatformConfiguration_Succeeds)
 {
-    EXPECT_EQ(m_config.GetEnabledPlatforms().size(), 2);
-    EXPECT_EQ(m_config.GetEnabledPlatforms()[0].m_identifier, "pc");
-    EXPECT_EQ(m_config.GetEnabledPlatforms()[1].m_identifier, "android");
+    EXPECT_EQ(m_config.GetEnabledPlatforms().size(), m_enabledPlatforms.size());
+    for (int index = 0; index < m_enabledPlatforms.size(); ++index)
+    {
+        EXPECT_EQ(m_config.GetEnabledPlatforms()[index].m_identifier, m_enabledPlatforms[index].m_identifier);
+    }
 
-    EXPECT_EQ(m_config.GetScanFolderCount(), 11);
-    EXPECT_FALSE(m_config.GetScanFolderAt(0).IsRoot());
-    EXPECT_TRUE(m_config.GetScanFolderAt(8).IsRoot());
-    EXPECT_FALSE(m_config.GetScanFolderAt(0).RecurseSubFolders());
-    EXPECT_TRUE(m_config.GetScanFolderAt(1).RecurseSubFolders());
-    EXPECT_TRUE(m_config.GetScanFolderAt(2).RecurseSubFolders());
-    EXPECT_FALSE(m_config.GetScanFolderAt(8).RecurseSubFolders());
+    EXPECT_EQ(m_config.GetScanFolderCount(), m_scanFolders.size());
+    for (int index = 0; index < m_scanFolders.size(); ++index)
+    {
+        EXPECT_EQ(m_config.GetScanFolderAt(index).IsRoot(), m_scanFolders[index].IsRoot());
+        EXPECT_EQ(m_config.GetScanFolderAt(index).RecurseSubFolders(), m_scanFolders[index].RecurseSubFolders());
+    }
 }
 
 TEST_F(PlatformConfigurationTests, TestRecogonizer_FeedPlatformConfiguration_Succeeds)
@@ -132,18 +152,18 @@ TEST_F(PlatformConfigurationTests, TestRecogonizer_FeedPlatformConfiguration_Suc
 
     RecognizerPointerContainer results;
     EXPECT_TRUE(m_config.GetMatchingRecognizers(m_assetRootPath.absoluteFilePath("subfolder1/rootfile1.txt"), results));
-    EXPECT_EQ(results.size(), 2);
-    EXPECT_TRUE(results[0]);
-    EXPECT_TRUE(results[1]);
-    EXPECT_NE(results[0]->m_name, results[1]->m_name);
-    EXPECT_TRUE(results[0]->m_name == "txt files" || results[1]->m_name == "txt files");
-    EXPECT_TRUE(results[0]->m_name == "txt files 2" || results[1]->m_name == "txt files 2");
+    EXPECT_EQ(results.size(), m_txtRecognizerContainer.size());
+    for (int index = 0; index < results.size(); ++index)
+    {
+        EXPECT_TRUE(results[index]);
+        EXPECT_NE(m_txtRecognizerContainer.find(results[index]->m_name), m_txtRecognizerContainer.end());
+    }
 
     results.clear();
     EXPECT_FALSE(m_config.GetMatchingRecognizers(m_assetRootPath.absoluteFilePath("test.format"), results));
     EXPECT_TRUE(m_config.GetMatchingRecognizers(m_assetRootPath.absoluteFilePath("subfolder1/test/test.format"), results));
     EXPECT_EQ(results.size(), 1);
-    EXPECT_EQ(results[0]->m_name, "format files that live in a folder called test");
+    EXPECT_EQ(results[0]->m_name, m_formatRecognizer.m_name);
 
     // double call:
     EXPECT_FALSE(m_config.GetMatchingRecognizers(m_assetRootPath.absoluteFilePath("unrecognised.file"), results));

--- a/Code/Tools/AssetProcessor/native/unittests/RCcontrollerUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/RCcontrollerUnitTests.cpp
@@ -31,6 +31,8 @@ namespace
     constexpr int MaxProcessingWaitTimeMs = 60 * 1000; // Wait up to 1 minute.  Give a generous amount of time to allow for slow CPUs
     const ScanFolderInfo TestScanFolderInfo("c:/samplepath", "sampledisplayname", "samplekey", false, false);
     const AZ::Uuid BuilderUuid = AZ::Uuid::CreateRandom();
+    constexpr int MinRCJobs = 1;
+    constexpr int MaxRCJobs = 4;
 }
 
 class MockRCJob
@@ -57,7 +59,7 @@ void RCcontrollerUnitTests::FinishJob(AssetProcessor::RCJob* rcJob)
     m_rcController->FinishJob(rcJob);
 }
 
-void RCcontrollerUnitTests::PrepareRCJobListModelTest()
+void RCcontrollerUnitTests::PrepareRCJobListModelTest(int& numJobs)
 {
     // Create 6 jobs
     using namespace AssetProcessor;
@@ -72,6 +74,7 @@ void RCcontrollerUnitTests::PrepareRCJobListModelTest()
     RCJob* job0 = new RCJob(m_rcJobListModel);
     job0->Init(jobDetails);
     m_rcJobListModel->addNewJob(job0);
+    ++numJobs;
 
     RCJob* job1 = new RCJob(m_rcJobListModel);
     jobDetails.m_jobEntry.m_sourceAssetReference = AssetProcessor::SourceAssetReference("c:/somerandomfolder/someFile1.txt");
@@ -79,6 +82,7 @@ void RCcontrollerUnitTests::PrepareRCJobListModelTest()
     jobDetails.m_jobEntry.m_jobKey = "Text files";
     job1->Init(jobDetails);
     m_rcJobListModel->addNewJob(job1);
+    ++numJobs;
 
     RCJob* job2 = new RCJob(m_rcJobListModel);
     jobDetails.m_jobEntry.m_sourceAssetReference = AssetProcessor::SourceAssetReference("c:/somerandomfolder/someFile2.txt");
@@ -86,6 +90,7 @@ void RCcontrollerUnitTests::PrepareRCJobListModelTest()
     jobDetails.m_jobEntry.m_jobKey = "Text files";
     job2->Init(jobDetails);
     m_rcJobListModel->addNewJob(job2);
+    ++numJobs;
 
     RCJob* job3 = new RCJob(m_rcJobListModel);
     jobDetails.m_jobEntry.m_sourceAssetReference = AssetProcessor::SourceAssetReference("c:/somerandomfolder/someFile3.txt");
@@ -93,6 +98,7 @@ void RCcontrollerUnitTests::PrepareRCJobListModelTest()
     jobDetails.m_jobEntry.m_jobKey = "Text files";
     job3->Init(jobDetails);
     m_rcJobListModel->addNewJob(job3);
+    ++numJobs;
 
     RCJob* job4 = new RCJob(m_rcJobListModel);
     jobDetails.m_jobEntry.m_sourceAssetReference = AssetProcessor::SourceAssetReference("c:/somerandomfolder/someFile4.txt");
@@ -100,6 +106,7 @@ void RCcontrollerUnitTests::PrepareRCJobListModelTest()
     jobDetails.m_jobEntry.m_jobKey = "Text files";
     job4->Init(jobDetails);
     m_rcJobListModel->addNewJob(job4);
+    ++numJobs;
 
     RCJob* job5 = new RCJob(m_rcJobListModel);
     jobDetails.m_jobEntry.m_sourceAssetReference = AssetProcessor::SourceAssetReference("c:/somerandomfolder/someFile5.txt");
@@ -107,6 +114,7 @@ void RCcontrollerUnitTests::PrepareRCJobListModelTest()
     jobDetails.m_jobEntry.m_jobKey = "Text files";
     job5->Init(jobDetails);
     m_rcJobListModel->addNewJob(job5);
+    ++numJobs;
 
     // Complete 1 job
     RCJob* rcJob = job0;
@@ -121,43 +129,13 @@ void RCcontrollerUnitTests::PrepareRCJobListModelTest()
     QCoreApplication::processEvents(QEventLoop::AllEvents);
 }
 
-void RCcontrollerUnitTests::PrepareCompileGroupTests(bool& gotCreated, bool& gotCompleted, AssetProcessor::NetworkRequestID& gotGroupID, AzFramework::AssetSystem::AssetStatus& gotStatus)
+void RCcontrollerUnitTests::PrepareCompileGroupTests(const QStringList& tempJobNames, bool& gotCreated, bool& gotCompleted, AssetProcessor::NetworkRequestID& gotGroupID, AzFramework::AssetSystem::AssetStatus& gotStatus)
 {
-    QStringList tempJobNames;
-
     // Note that while this is an OS-SPECIFIC path, this test does not actually invoke the file system
     // or file operators, so is purely doing in-memory testing.  So the path does not actually matter and the
     // test should function on other operating systems too.
 
-    // test - exact match
-    tempJobNames << "c:/somerandomfolder/dev/blah/test.dds";
-    tempJobNames << "c:/somerandomfolder/dev/blah/test.cre"; // must not match
-
-    // test - NO MATCH
-    tempJobNames << "c:/somerandomfolder/dev/wap/wap.wap";
-
-    // test - Multiple match, ignoring extensions
-    tempJobNames << "c:/somerandomfolder/dev/abc/123.456";
-    tempJobNames << "c:/somerandomfolder/dev/abc/123.567";
-    tempJobNames << "c:/somerandomfolder/dev/def/123.456"; // must not match
-    tempJobNames << "c:/somerandomfolder/dev/def/123.567"; // must not match
-
-    // test - Multiple match, wide search, ignoring extensions and postfixes like underscore
-    tempJobNames << "c:/somerandomfolder/dev/aaa/bbb/123.456";
-    tempJobNames << "c:/somerandomfolder/dev/aaa/bbb/123.567";
-    tempJobNames << "c:/somerandomfolder/dev/aaa/bbb/123.890";
-    tempJobNames << "c:/somerandomfolder/dev/aaa/ccc/123.567"; // must not match!
-    tempJobNames << "c:/somerandomfolder/dev/aaa/ccc/456.567"; // must not match
-
-    // test - compile group fails the moment any file in it fails
-    tempJobNames << "c:/somerandomfolder/mmmnnnoo/123.456";
-    tempJobNames << "c:/somerandomfolder/mmmnnnoo/123.567";
-
-    // test - compile group by uuid is always an exact match.  Its the same code path
-    // as the others in terms of success/failure.
-    tempJobNames << "c:/somerandomfolder/pqr/123.456";
-
-    // test - compile group for an exact ID succeeds when that exact ID is called.
+    // Compile group for an exact ID succeeds when that exact ID is called.
     for (QString name : tempJobNames)
     {
         AZ::Uuid uuidOfSource = AZ::Uuid::CreateName(name.toUtf8().constData());
@@ -254,7 +232,8 @@ void RCcontrollerUnitTests::ConnectJobSignalsAndSlots(bool& allJobsCompleted, Jo
 void RCcontrollerUnitTests::SetUp()
 {
     UnitTest::AssetProcessorUnitTestBase::SetUp();
-    m_rcController = AZStd::make_unique<AssetProcessor::RCController>(1, 4);
+
+    m_rcController = AZStd::make_unique<AssetProcessor::RCController>(MinRCJobs, MaxRCJobs);
 
     QDir assetRootPath(m_assetDatabaseRequestsHandler->GetAssetRootDir().c_str());
 
@@ -283,10 +262,11 @@ void RCcontrollerUnitTests::TearDown()
 
 TEST_F(RCcontrollerUnitTests, TestRCJobListModel_AddJobEntries_Succeeds)
 {
-    PrepareRCJobListModelTest();
+    int numJobs = 0;
+    PrepareRCJobListModelTest(numJobs);
 
     int returnedCount = m_rcJobListModel->rowCount(QModelIndex());
-    int expectedCount = 5; // Finished jobs should be removed, so they shouldn't show up
+    int expectedCount = numJobs - 1; // Finished jobs should be removed, so they shouldn't show up
 
     ASSERT_EQ(returnedCount, expectedCount) << AZStd::string::format("RCJobListModel has %d elements, which is invalid. Expected %d", returnedCount, expectedCount).c_str();
 
@@ -313,9 +293,11 @@ TEST_F(RCcontrollerUnitTests, TestCompileGroup_RequestExactMatchCompileGroup_Suc
     bool gotCompleted = false;
     NetworkRequestID gotGroupID;
     AssetStatus gotStatus = AssetStatus_Unknown;
-    PrepareCompileGroupTests(gotCreated, gotCompleted, gotGroupID, gotStatus);
+    QStringList tempJobNames;
+    tempJobNames << "c:/somerandomfolder/dev/blah/test.dds";
+    tempJobNames << "c:/somerandomfolder/dev/blah/test.cre"; // must not match
+    PrepareCompileGroupTests(tempJobNames, gotCreated, gotCompleted, gotGroupID, gotStatus);
 
-    // EXACT MATCH TEST (with prefixes and such)
     m_rcController->OnRequestCompileGroup(RequestID, "pc", "@products@/blah/test.dds", AZ::Data::AssetId());
     QCoreApplication::processEvents(QEventLoop::AllEvents);
 
@@ -349,7 +331,9 @@ TEST_F(RCcontrollerUnitTests, TestCompileGroup_RequestNoMatchCompileGroup_Succee
     bool gotCompleted = false;
     NetworkRequestID gotGroupID;
     AssetStatus gotStatus = AssetStatus_Unknown;
-    PrepareCompileGroupTests(gotCreated, gotCompleted, gotGroupID, gotStatus);
+    QStringList tempJobNames;
+    tempJobNames << "c:/somerandomfolder/dev/wap/wap.wap";
+    PrepareCompileGroupTests(tempJobNames, gotCreated, gotCompleted, gotGroupID, gotStatus);
 
     // give it a name that for sure does not match:
     m_rcController->OnRequestCompileGroup(RequestID, "pc", "bibbidybobbidy.boo", AZ::Data::AssetId());
@@ -367,7 +351,9 @@ TEST_F(RCcontrollerUnitTests, TestCompileGroup_RequestCompileGroupWithInvalidPla
     bool gotCompleted = false;
     NetworkRequestID gotGroupID;
     AssetStatus gotStatus = AssetStatus_Unknown;
-    PrepareCompileGroupTests(gotCreated, gotCompleted, gotGroupID, gotStatus);
+    QStringList tempJobNames;
+    tempJobNames << "c:/somerandomfolder/dev/blah/test.cre"; // must not match
+    PrepareCompileGroupTests(tempJobNames, gotCreated, gotCompleted, gotGroupID, gotStatus);
 
     // give it a name that for sure does not match due to platform.
     m_rcController->OnRequestCompileGroup(RequestID, "aaaaaa", "blah/test.cre", AZ::Data::AssetId());
@@ -388,7 +374,12 @@ TEST_F(RCcontrollerUnitTests, TestCompileGroup_FinishEachAssetsInGroup_Succeeds)
     bool gotCompleted = false;
     NetworkRequestID gotGroupID;
     AssetStatus gotStatus = AssetStatus_Unknown;
-    PrepareCompileGroupTests(gotCreated, gotCompleted, gotGroupID, gotStatus);
+    QStringList tempJobNames;
+    tempJobNames << "c:/somerandomfolder/dev/abc/123.456";
+    tempJobNames << "c:/somerandomfolder/dev/abc/123.567";
+    tempJobNames << "c:/somerandomfolder/dev/def/123.456"; // must not match
+    tempJobNames << "c:/somerandomfolder/dev/def/123.567"; // must not match
+    PrepareCompileGroupTests(tempJobNames, gotCreated, gotCompleted, gotGroupID, gotStatus);
 
     m_rcController->OnRequestCompileGroup(RequestID, "pc", "abc/123.nnn", AZ::Data::AssetId());
     QCoreApplication::processEvents(QEventLoop::AllEvents);
@@ -398,13 +389,14 @@ TEST_F(RCcontrollerUnitTests, TestCompileGroup_FinishEachAssetsInGroup_Succeeds)
     EXPECT_EQ(gotGroupID, RequestID);
     EXPECT_EQ(gotStatus, AssetStatus_Queued);
 
-    // complete one of them.  It should still be a busy group
+    // complete one of them. It should still be a busy group.
+    int IndexOfJobToComplete = 0;
     gotCreated = false;
     gotCompleted = false;
-    m_rcJobListModel->markAsProcessing(m_createdJobs[3]);
-    m_createdJobs[3]->SetState(RCJob::completed);
-    FinishJob(m_createdJobs[3]);
-    m_rcController->OnJobComplete(m_createdJobs[3]->GetJobEntry(), AzToolsFramework::AssetSystem::JobStatus::Completed);
+    m_rcJobListModel->markAsProcessing(m_createdJobs[IndexOfJobToComplete]);
+    m_createdJobs[IndexOfJobToComplete]->SetState(RCJob::completed);
+    FinishJob(m_createdJobs[IndexOfJobToComplete]);
+    m_rcController->OnJobComplete(m_createdJobs[IndexOfJobToComplete]->GetJobEntry(), AzToolsFramework::AssetSystem::JobStatus::Completed);
 
     QCoreApplication::processEvents(QEventLoop::AllEvents);
 
@@ -413,12 +405,14 @@ TEST_F(RCcontrollerUnitTests, TestCompileGroup_FinishEachAssetsInGroup_Succeeds)
     EXPECT_FALSE(gotCompleted);
 
     // finish the other
+    ++IndexOfJobToComplete;
+    EXPECT_LT(IndexOfJobToComplete, m_createdJobs.size());
     gotCreated = false;
     gotCompleted = false;
-    m_rcJobListModel->markAsProcessing(m_createdJobs[4]);
-    m_createdJobs[4]->SetState(RCJob::completed);
-    FinishJob(m_createdJobs[4]);
-    m_rcController->OnJobComplete(m_createdJobs[4]->GetJobEntry(), AzToolsFramework::AssetSystem::JobStatus::Completed);
+    m_rcJobListModel->markAsProcessing(m_createdJobs[IndexOfJobToComplete]);
+    m_createdJobs[IndexOfJobToComplete]->SetState(RCJob::completed);
+    FinishJob(m_createdJobs[IndexOfJobToComplete]);
+    m_rcController->OnJobComplete(m_createdJobs[IndexOfJobToComplete]->GetJobEntry(), AzToolsFramework::AssetSystem::JobStatus::Completed);
 
     QCoreApplication::processEvents(QEventLoop::AllEvents);
 
@@ -430,12 +424,17 @@ TEST_F(RCcontrollerUnitTests, TestCompileGroup_FinishEachAssetsInGroup_Succeeds)
 
 TEST_F(RCcontrollerUnitTests, TestCompileGroup_RequestWideSearchCompileGroup_Succeeds)
 {
-    // Multiple match, wide search, ignoring extensions and postfixes like underscore.
     bool gotCreated = false;
     bool gotCompleted = false;
     NetworkRequestID gotGroupID;
     AssetStatus gotStatus = AssetStatus_Unknown;
-    PrepareCompileGroupTests(gotCreated, gotCompleted, gotGroupID, gotStatus);
+    QStringList tempJobNames;
+    tempJobNames << "c:/somerandomfolder/dev/aaa/bbb/123.456";
+    tempJobNames << "c:/somerandomfolder/dev/aaa/bbb/123.567";
+    tempJobNames << "c:/somerandomfolder/dev/aaa/bbb/123.890";
+    tempJobNames << "c:/somerandomfolder/dev/aaa/ccc/123.567"; // must not match!
+    tempJobNames << "c:/somerandomfolder/dev/aaa/ccc/456.567"; // must not match
+    PrepareCompileGroupTests(tempJobNames, gotCreated, gotCompleted, gotGroupID, gotStatus);
 
     m_rcController->OnRequestCompileGroup(RequestID, "pc", "aaa/bbb/123_45.abc", AZ::Data::AssetId());
     QCoreApplication::processEvents(QEventLoop::AllEvents);
@@ -446,18 +445,21 @@ TEST_F(RCcontrollerUnitTests, TestCompileGroup_RequestWideSearchCompileGroup_Suc
     EXPECT_EQ(gotStatus, AssetStatus_Queued);
 
     // complete two of them.  It should still be a busy group!
+    int IndexOfJobToComplete = 0;
     gotCreated = false;
     gotCompleted = false;
 
-    m_rcJobListModel->markAsProcessing(m_createdJobs[7]);
-    m_createdJobs[7]->SetState(RCJob::completed);
-    FinishJob(m_createdJobs[7]);
-    m_rcController->OnJobComplete(m_createdJobs[7]->GetJobEntry(), AzToolsFramework::AssetSystem::JobStatus::Completed);
+    m_rcJobListModel->markAsProcessing(m_createdJobs[IndexOfJobToComplete]);
+    m_createdJobs[IndexOfJobToComplete]->SetState(RCJob::completed);
+    FinishJob(m_createdJobs[IndexOfJobToComplete]);
+    m_rcController->OnJobComplete(m_createdJobs[IndexOfJobToComplete]->GetJobEntry(), AzToolsFramework::AssetSystem::JobStatus::Completed);
 
-    m_rcJobListModel->markAsProcessing(m_createdJobs[8]);
-    m_createdJobs[8]->SetState(RCJob::completed);
-    FinishJob(m_createdJobs[8]);
-    m_rcController->OnJobComplete(m_createdJobs[8]->GetJobEntry(), AzToolsFramework::AssetSystem::JobStatus::Completed);
+    ++IndexOfJobToComplete;
+    EXPECT_LT(IndexOfJobToComplete, m_createdJobs.size());
+    m_rcJobListModel->markAsProcessing(m_createdJobs[IndexOfJobToComplete]);
+    m_createdJobs[IndexOfJobToComplete]->SetState(RCJob::completed);
+    FinishJob(m_createdJobs[IndexOfJobToComplete]);
+    m_rcController->OnJobComplete(m_createdJobs[IndexOfJobToComplete]->GetJobEntry(), AzToolsFramework::AssetSystem::JobStatus::Completed);
 
     QCoreApplication::processEvents(QEventLoop::AllEvents);
 
@@ -465,10 +467,12 @@ TEST_F(RCcontrollerUnitTests, TestCompileGroup_RequestWideSearchCompileGroup_Suc
     EXPECT_FALSE(gotCompleted);
 
     // finish the final one
-    m_rcJobListModel->markAsProcessing(m_createdJobs[9]);
-    m_createdJobs[9]->SetState(RCJob::completed);
-    FinishJob(m_createdJobs[9]);
-    m_rcController->OnJobComplete(m_createdJobs[9]->GetJobEntry(), AzToolsFramework::AssetSystem::JobStatus::Completed);
+    ++IndexOfJobToComplete;
+    EXPECT_LT(IndexOfJobToComplete, m_createdJobs.size());
+    m_rcJobListModel->markAsProcessing(m_createdJobs[IndexOfJobToComplete]);
+    m_createdJobs[IndexOfJobToComplete]->SetState(RCJob::completed);
+    FinishJob(m_createdJobs[IndexOfJobToComplete]);
+    m_rcController->OnJobComplete(m_createdJobs[IndexOfJobToComplete]->GetJobEntry(), AzToolsFramework::AssetSystem::JobStatus::Completed);
 
     QCoreApplication::processEvents(QEventLoop::AllEvents);
 
@@ -485,7 +489,10 @@ TEST_F(RCcontrollerUnitTests, TestCompileGroup_GroupMemberFails_GroupFails)
     bool gotCompleted = false;
     NetworkRequestID gotGroupID;
     AssetStatus gotStatus = AssetStatus_Unknown;
-    PrepareCompileGroupTests(gotCreated, gotCompleted, gotGroupID, gotStatus);
+    QStringList tempJobNames;
+    tempJobNames << "c:/somerandomfolder/mmmnnnoo/123.456";
+    tempJobNames << "c:/somerandomfolder/mmmnnnoo/123.567";
+    PrepareCompileGroupTests(tempJobNames, gotCreated, gotCompleted, gotGroupID, gotStatus);
 
     m_rcController->OnRequestCompileGroup(RequestID, "pc", "mmmnnnoo/123.ZZZ", AZ::Data::AssetId()); // should match exactly 2 elements
     QCoreApplication::processEvents(QEventLoop::AllEvents);
@@ -498,10 +505,11 @@ TEST_F(RCcontrollerUnitTests, TestCompileGroup_GroupMemberFails_GroupFails)
     gotCreated = false;
     gotCompleted = false;
 
-    m_rcJobListModel->markAsProcessing(m_createdJobs[12]);
-    m_createdJobs[12]->SetState(RCJob::failed);
-    FinishJob(m_createdJobs[12]);
-    m_rcController->OnJobComplete(m_createdJobs[12]->GetJobEntry(), AzToolsFramework::AssetSystem::JobStatus::Failed);
+    int IndexOfJobToFail = 0;
+    m_rcJobListModel->markAsProcessing(m_createdJobs[IndexOfJobToFail]);
+    m_createdJobs[IndexOfJobToFail]->SetState(RCJob::failed);
+    FinishJob(m_createdJobs[IndexOfJobToFail]);
+    m_rcController->OnJobComplete(m_createdJobs[IndexOfJobToFail]->GetJobEntry(), AzToolsFramework::AssetSystem::JobStatus::Failed);
 
     QCoreApplication::processEvents(QEventLoop::AllEvents);
 
@@ -520,9 +528,12 @@ TEST_F(RCcontrollerUnitTests, TestCompileGroup_RequestCompileGroupWithUuid_Succe
     bool gotCompleted = false;
     NetworkRequestID gotGroupID;
     AssetStatus gotStatus = AssetStatus_Unknown;
-    PrepareCompileGroupTests(gotCreated, gotCompleted, gotGroupID, gotStatus);
+    QStringList tempJobNames;
+    tempJobNames << "c:/somerandomfolder/pqr/123.456";
+    PrepareCompileGroupTests(tempJobNames, gotCreated, gotCompleted, gotGroupID, gotStatus);
 
-    AZ::Data::AssetId sourceDataID(m_createdJobs[14]->GetJobEntry().m_sourceFileUUID);
+    int IndexOfJobToRequest = 0;
+    AZ::Data::AssetId sourceDataID(m_createdJobs[IndexOfJobToRequest]->GetJobEntry().m_sourceFileUUID);
     m_rcController->OnRequestCompileGroup(RequestID, "pc", "", sourceDataID); // should match exactly 1 element.
     QCoreApplication::processEvents(QEventLoop::AllEvents);
 
@@ -534,10 +545,10 @@ TEST_F(RCcontrollerUnitTests, TestCompileGroup_RequestCompileGroupWithUuid_Succe
     gotCreated = false;
     gotCompleted = false;
 
-    m_rcJobListModel->markAsProcessing(m_createdJobs[14]);
-    m_createdJobs[14]->SetState(RCJob::completed);
-    FinishJob(m_createdJobs[14]);
-    m_rcController->OnJobComplete(m_createdJobs[14]->GetJobEntry(), AzToolsFramework::AssetSystem::JobStatus::Completed);
+    m_rcJobListModel->markAsProcessing(m_createdJobs[IndexOfJobToRequest]);
+    m_createdJobs[IndexOfJobToRequest]->SetState(RCJob::completed);
+    FinishJob(m_createdJobs[IndexOfJobToRequest]);
+    m_rcController->OnJobComplete(m_createdJobs[IndexOfJobToRequest]->GetJobEntry(), AzToolsFramework::AssetSystem::JobStatus::Completed);
 
     QCoreApplication::processEvents(QEventLoop::AllEvents);
 

--- a/Code/Tools/AssetProcessor/native/unittests/RCcontrollerUnitTests.h
+++ b/Code/Tools/AssetProcessor/native/unittests/RCcontrollerUnitTests.h
@@ -28,8 +28,8 @@ public:
 
 protected:
     void FinishJob(AssetProcessor::RCJob* rcJob);
-    void PrepareRCJobListModelTest();
-    void PrepareCompileGroupTests(bool& gotCreated, bool& gotCompleted, AssetProcessor::NetworkRequestID& gotGroupID, AzFramework::AssetSystem::AssetStatus& gotStatus);
+    void PrepareRCJobListModelTest(int& numJobs);
+    void PrepareCompileGroupTests(const QStringList& tempJobNames, bool& gotCreated, bool& gotCompleted, AssetProcessor::NetworkRequestID& gotGroupID, AzFramework::AssetSystem::AssetStatus& gotStatus);
     void Reset();
 
     void ConnectCompileGroupSignalsAndSlots(bool& gotCreated, bool& gotCompleted, AssetProcessor::NetworkRequestID& gotGroupID, AzFramework::AssetSystem::AssetStatus& gotStatus);

--- a/Code/Tools/AssetProcessor/native/unittests/UtilitiesUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/UtilitiesUnitTests.cpp
@@ -127,8 +127,6 @@ TEST_F(UtilitiesUnitTests, ChangeFileAttributes_MakeFileReadOnlyOrWritable_Succe
 
 TEST_F(UtilitiesUnitTests, NormalizeAndRemoveAlias_FeedFilePathWithDoubleSlackesAndAlias_Succeeds)
 {
-    // ------------- Test NormalizeAndRemoveAlias --------------
-
     EXPECT_EQ(AssetUtilities::NormalizeAndRemoveAlias("@test@\\my\\file.txt"), QString("my/file.txt"));
     EXPECT_EQ(AssetUtilities::NormalizeAndRemoveAlias("@test@my\\file.txt"), QString("my/file.txt"));
     EXPECT_EQ(AssetUtilities::NormalizeAndRemoveAlias("@TeSt@my\\file.txt"), QString("my/file.txt")); // case sensitivity test!
@@ -145,6 +143,7 @@ TEST_F(UtilitiesUnitTests, CopyFileWithTimeout_FeedFilesInDifferentStates_Succee
     QFile outputFile(outputFileName);
     outputFile.open(QFile::WriteOnly);
 
+    const int waitTimeInSeconds = 1; // Timeout for copying files
 #if defined(AZ_PLATFORM_WINDOWS)
     // this test is intentionally disabled on other platforms
     // because in general on other platforms its actually possible to delete and move
@@ -153,10 +152,15 @@ TEST_F(UtilitiesUnitTests, CopyFileWithTimeout_FeedFilesInDifferentStates_Succee
     //Trying to copy when the output file is open for reading should fail.
     {
         UnitTestUtils::AssertAbsorber absorb;
-        EXPECT_FALSE(CopyFileWithTimeout(fileName, outputFileName, 1));
-        EXPECT_EQ(absorb.m_numWarningsAbsorbed, 2); // 2 for each fail
-        //Trying to move when the output file is open for reading
-        EXPECT_FALSE(MoveFileWithTimeout(fileName, outputFileName, 1));
+        EXPECT_FALSE(CopyFileWithTimeout(fileName, outputFileName, waitTimeInSeconds));
+        // Expected two warnings for copying files:
+        // 1) Failed to remove old files
+        // 2) Copy operation failed for the given timeout
+        EXPECT_EQ(absorb.m_numWarningsAbsorbed, 2);
+        // Expected another two warnings for moving files:
+        // 1) Failed to remove old files
+        // 2) Move operation failed for the given timeout
+        EXPECT_FALSE(MoveFileWithTimeout(fileName, outputFileName, waitTimeInSeconds));
         EXPECT_EQ(absorb.m_numWarningsAbsorbed, 4);
     }
 #endif // AZ_PLATFORM_WINDOWS ONLY
@@ -165,11 +169,11 @@ TEST_F(UtilitiesUnitTests, CopyFileWithTimeout_FeedFilesInDifferentStates_Succee
     outputFile.close();
 
     //Trying to copy when the output file is not open
-    EXPECT_TRUE(CopyFileWithTimeout(fileName, outputFileName, 1));
+    EXPECT_TRUE(CopyFileWithTimeout(fileName, outputFileName, waitTimeInSeconds));
     EXPECT_TRUE(CopyFileWithTimeout(fileName, outputFileName, aznumeric_caster(-1)));//invalid timeout time
     // Trying to move when the output file is not open
-    EXPECT_TRUE(MoveFileWithTimeout(fileName, outputFileName, 1));
-    EXPECT_TRUE(MoveFileWithTimeout(outputFileName, fileName, 1));
+    EXPECT_TRUE(MoveFileWithTimeout(fileName, outputFileName, waitTimeInSeconds));
+    EXPECT_TRUE(MoveFileWithTimeout(outputFileName, fileName, waitTimeInSeconds));
 
     // Open the file and then close it in the near future
     AZStd::atomic_bool setupDone{ false };
@@ -194,7 +198,7 @@ TEST_F(UtilitiesUnitTests, CopyFileWithTimeout_FeedFilesInDifferentStates_Succee
     //Trying to copy when the output file is open,but will close before the timeout inputted
     {
         UnitTestUtils::AssertAbsorber absorb;
-        EXPECT_TRUE(CopyFileWithTimeout(fileName, outputFileName, 1));
+        EXPECT_TRUE(CopyFileWithTimeout(fileName, outputFileName, waitTimeInSeconds));
 #if defined(AZ_PLATFORM_WINDOWS)
         // only windows has an issue with moving files out that are in use.
         // other platforms do so without issue.
@@ -249,71 +253,105 @@ TEST_F(UtilitiesUnitTests, TestByteArrayStream_WriteToStream_Succeeds)
     // reserving does not alter the length.
     stream.Reserve(128);
     EXPECT_EQ(stream.GetLength(), 0);
-    EXPECT_EQ(stream.Write(7, tempReadBuffer), 7);
-    EXPECT_EQ(stream.GetCurPos(), 7);
-    EXPECT_EQ(stream.GetLength(), 7);
-    EXPECT_EQ(memcmp(stream.GetArray().constData(), tempReadBuffer, 7), 0);
-    EXPECT_EQ(stream.Write(7, tempReadBuffer), 7);
-    EXPECT_EQ(stream.GetLength(), 14);
-    EXPECT_EQ(stream.GetCurPos(), 14);
-    EXPECT_EQ(memcmp(stream.GetArray().constData(), "This isThis is", 14), 0);
 
+    // Write 7 bytes from the buffer to the stream
+    AZ::IO::SizeType sizeInBytesToWrite = 7;
+    EXPECT_EQ(stream.Write(sizeInBytesToWrite, tempReadBuffer), sizeInBytesToWrite);
+    AZ::IO::SizeType expectedPosition = sizeInBytesToWrite;
+    AZ::IO::SizeType expectedLength = sizeInBytesToWrite;
+    EXPECT_EQ(stream.GetCurPos(), expectedPosition);
+    EXPECT_EQ(stream.GetLength(), expectedLength);
+    EXPECT_EQ(memcmp(stream.GetArray().constData(), tempReadBuffer, expectedLength), 0); 
 
-    stream.Seek(0, AZ::IO::GenericStream::ST_SEEK_BEGIN); // write at begin, without overrunning
-    EXPECT_EQ(stream.GetCurPos(), 0);
-    EXPECT_EQ(stream.Write(4, "that"), 4);
-    EXPECT_EQ(stream.GetLength(), 14);
-    EXPECT_EQ(stream.GetCurPos(), 4);
-    EXPECT_EQ(memcmp(stream.GetArray().constData(), "that isThis is", 14), 0);
+    // Write 7 bytes from the buffer to the stream again
+    EXPECT_EQ(stream.Write(sizeInBytesToWrite, tempReadBuffer), sizeInBytesToWrite);
+    expectedPosition += sizeInBytesToWrite;
+    expectedLength += sizeInBytesToWrite;
+    EXPECT_EQ(stream.GetLength(), expectedLength);
+    EXPECT_EQ(stream.GetCurPos(), expectedPosition);
+    EXPECT_EQ(memcmp(stream.GetArray().constData(), "This isThis is", expectedLength), 0);
 
-    stream.Seek(2, AZ::IO::GenericStream::ST_SEEK_CUR); // write in middle, without overrunning
-    EXPECT_EQ(stream.GetCurPos(), 6);
-    EXPECT_EQ(stream.Write(4, "1234"), 4);
-    EXPECT_EQ(stream.GetLength(), 14);
-    EXPECT_EQ(stream.GetCurPos(), 10);
-    EXPECT_EQ(memcmp(stream.GetArray().constData(), "that i1234s is", 14), 0);
+    sizeInBytesToWrite = 4;
+    AZ::IO::SizeType offsite = 0;
+    stream.Seek(offsite, AZ::IO::GenericStream::ST_SEEK_BEGIN); // write at begin, without overrunning
+    expectedPosition = offsite;
+    EXPECT_EQ(stream.GetCurPos(), expectedPosition);
+    EXPECT_EQ(stream.Write(sizeInBytesToWrite, "that"), sizeInBytesToWrite);
+    expectedPosition += sizeInBytesToWrite;
+    EXPECT_EQ(stream.GetLength(), expectedLength);
+    EXPECT_EQ(stream.GetCurPos(), expectedPosition);
+    EXPECT_EQ(memcmp(stream.GetArray().constData(), "that isThis is", expectedLength), 0);
 
-    stream.Seek(-6, AZ::IO::GenericStream::ST_SEEK_END); // write in end, negative offset, without overrunning
-    EXPECT_EQ(stream.GetCurPos(), 8);
-    EXPECT_EQ(stream.Write(4, "5555"), 4);
-    EXPECT_EQ(stream.GetCurPos(), 12);
-    EXPECT_EQ(stream.GetLength(), 14);
-    EXPECT_EQ(memcmp(stream.GetArray().constData(), "that i125555is", 14), 0);
+    offsite = 2;
+    stream.Seek(offsite, AZ::IO::GenericStream::ST_SEEK_CUR); // write in middle, without overrunning
+    expectedPosition += offsite;
+    EXPECT_EQ(stream.GetCurPos(), expectedPosition);
+    EXPECT_EQ(stream.Write(sizeInBytesToWrite, "1234"), sizeInBytesToWrite);
+    expectedPosition += sizeInBytesToWrite;
+    EXPECT_EQ(stream.GetLength(), expectedLength);
+    EXPECT_EQ(stream.GetCurPos(), expectedPosition);
+    EXPECT_EQ(memcmp(stream.GetArray().constData(), "that i1234s is", expectedLength), 0);
 
-    stream.Seek(2, AZ::IO::GenericStream::ST_SEEK_BEGIN); // write at begin offset, with overrun:
-    EXPECT_EQ(stream.GetCurPos(), 2);
-    EXPECT_EQ(stream.GetLength(), 14);
-    EXPECT_EQ(stream.Write(14, "xxxxxxxxxxxxxx"), 14);
-    EXPECT_EQ(stream.GetLength(), 16);
-    EXPECT_EQ(stream.GetCurPos(), 16);
-    EXPECT_EQ(memcmp(stream.GetArray().constData(), "thxxxxxxxxxxxxxx", 16), 0);
+    offsite = AZ::IO::SizeType(-6);
+    stream.Seek(offsite, AZ::IO::GenericStream::ST_SEEK_END); // write in end, negative offset, without overrunning
+    expectedPosition = expectedLength + offsite;
+    EXPECT_EQ(stream.GetCurPos(), expectedPosition);
+    EXPECT_EQ(stream.Write(sizeInBytesToWrite, "5555"), sizeInBytesToWrite);
+    expectedPosition += sizeInBytesToWrite;
+    EXPECT_EQ(stream.GetCurPos(), expectedPosition);
+    EXPECT_EQ(stream.GetLength(), expectedLength);
+    EXPECT_EQ(memcmp(stream.GetArray().constData(), "that i125555is", expectedLength), 0);
 
+    offsite = 2;
+    sizeInBytesToWrite = 14;
+    stream.Seek(offsite, AZ::IO::GenericStream::ST_SEEK_BEGIN); // write at begin offset, with overrun:
+    expectedPosition = offsite;
+    EXPECT_EQ(stream.GetCurPos(), offsite);
+    EXPECT_EQ(stream.GetLength(), expectedLength);
+    EXPECT_EQ(stream.Write(sizeInBytesToWrite, "xxxxxxxxxxxxxx"), sizeInBytesToWrite);
+    expectedPosition += sizeInBytesToWrite;
+    expectedLength = expectedPosition;
+    EXPECT_EQ(stream.GetCurPos(), expectedPosition);
+    EXPECT_EQ(stream.GetLength(), expectedLength);
+    EXPECT_EQ(memcmp(stream.GetArray().constData(), "thxxxxxxxxxxxxxx", expectedLength), 0);
+
+    offsite = 14;
+    sizeInBytesToWrite = 4;
     stream.Seek(0, AZ::IO::GenericStream::ST_SEEK_BEGIN);
-    stream.Seek(14, AZ::IO::GenericStream::ST_SEEK_CUR); // write in middle, with overrunning:
-    EXPECT_EQ(stream.GetCurPos(), 14);
-    EXPECT_EQ(stream.GetLength(), 16);
-    EXPECT_EQ(stream.Write(4, "yyyy"), 4);
-    EXPECT_EQ(stream.GetCurPos(), 18);
-    EXPECT_EQ(stream.GetLength(), 18);
-    EXPECT_EQ(memcmp(stream.GetArray().constData(), "thxxxxxxxxxxxxyyyy", 18), 0);
+    stream.Seek(offsite, AZ::IO::GenericStream::ST_SEEK_CUR); // write in middle, with overrunning:
+    expectedPosition = offsite;
+    EXPECT_EQ(stream.GetCurPos(), expectedPosition);
+    EXPECT_EQ(stream.GetLength(), expectedLength);
+    EXPECT_EQ(stream.Write(sizeInBytesToWrite, "yyyy"), sizeInBytesToWrite);
+    expectedPosition += sizeInBytesToWrite;
+    expectedLength = expectedPosition;
+    EXPECT_EQ(stream.GetCurPos(), expectedPosition);
+    EXPECT_EQ(stream.GetLength(), expectedLength);
+    EXPECT_EQ(memcmp(stream.GetArray().constData(), "thxxxxxxxxxxxxyyyy", expectedLength), 0);
 
-    stream.Seek(-2, AZ::IO::GenericStream::ST_SEEK_END); // write in end, negative offset, with overrunning
-    EXPECT_EQ(stream.GetCurPos(), 16);
-    EXPECT_EQ(stream.GetLength(), 18);
-    EXPECT_EQ(stream.Write(4, "ZZZZ"), 4);
-    EXPECT_EQ(stream.GetCurPos(), 20);
-    EXPECT_EQ(stream.GetLength(), 20);
-    EXPECT_EQ(memcmp(stream.GetArray().constData(), "thxxxxxxxxxxxxyyZZZZ", 20), 0);
+    offsite = AZ::IO::SizeType(-2);
+    stream.Seek(offsite, AZ::IO::GenericStream::ST_SEEK_END); // write in end, negative offset, with overrunning
+    expectedPosition = expectedLength + offsite;
+    EXPECT_EQ(stream.GetCurPos(), expectedPosition);
+    EXPECT_EQ(stream.GetLength(), expectedLength);
+    EXPECT_EQ(stream.Write(sizeInBytesToWrite, "ZZZZ"), sizeInBytesToWrite);
+    expectedPosition += sizeInBytesToWrite;
+    expectedLength = expectedPosition;
+    EXPECT_EQ(stream.GetCurPos(), expectedPosition);
+    EXPECT_EQ(stream.GetLength(), expectedLength);
+    EXPECT_EQ(memcmp(stream.GetArray().constData(), "thxxxxxxxxxxxxyyZZZZ", expectedLength), 0);
 
     // read test.
     stream.Seek(0, AZ::IO::GenericStream::ST_SEEK_BEGIN);
-    EXPECT_EQ(stream.Read(20, tempReadBuffer), 20);
-    EXPECT_EQ(memcmp(tempReadBuffer, "thxxxxxxxxxxxxyyZZZZ", 20), 0);
-    EXPECT_EQ(stream.Read(20, tempReadBuffer), 0); // because its already at end.
-    EXPECT_EQ(memcmp(tempReadBuffer, "thxxxxxxxxxxxxyyZZZZ", 20), 0); // it should not have disturbed the buffer.
-    stream.Seek(2, AZ::IO::GenericStream::ST_SEEK_BEGIN);
-    EXPECT_EQ(stream.Read(20, tempReadBuffer), 18);
-    EXPECT_EQ(memcmp(tempReadBuffer, "xxxxxxxxxxxxyyZZZZZZ", 20), 0); // it should not have disturbed the buffer bits that it was not asked to touch.
+    EXPECT_EQ(stream.Read(expectedLength, tempReadBuffer), expectedLength);
+    EXPECT_EQ(memcmp(tempReadBuffer, "thxxxxxxxxxxxxyyZZZZ", expectedLength), 0);
+    EXPECT_EQ(stream.Read(expectedLength, tempReadBuffer), 0); // because its already at end.
+    EXPECT_EQ(memcmp(tempReadBuffer, "thxxxxxxxxxxxxyyZZZZ", expectedLength), 0); // it should not have disturbed the buffer.
+
+    offsite = 2;
+    stream.Seek(offsite, AZ::IO::GenericStream::ST_SEEK_BEGIN);
+    EXPECT_EQ(stream.Read(expectedLength, tempReadBuffer), expectedLength - offsite);
+    EXPECT_EQ(memcmp(tempReadBuffer, "xxxxxxxxxxxxyyZZZZZZ", expectedLength), 0); // it should not have disturbed the buffer bits that it was not asked to touch.
 }
 
 TEST_F(UtilitiesUnitTests, MatchFilePattern_FeedDifferentPatternsAndFilePaths_Succeeds)


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?

Clean up the magic numbers in PlatformConfigurationUnitTests, RCcontrollerUnitTests and UtilitiesUnitTests.

## How was this PR tested?

All unit tests passed with the changes.
