### PR TITLE
Mac build fix for non-unity, missing header include

### DIFF
--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/std/algorithm.h>
 #include <RHI/ArgumentBuffer.h>
 #include <RHI/Buffer.h>
+#include <RHI/BufferView.h>
 #include <RHI/BufferMemoryView.h>
 #include <RHI/CommandList.h>
 #include <RHI/Conversions.h>


### PR DESCRIPTION
Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>