### PR TITLE
Add a folder filter for the Asset Browser two column mode

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -257,8 +257,9 @@ void AzAssetBrowserWindow::CreateToolsMenu()
         auto* projectSourceAssets = new QAction(tr("Filter Project and Source Assets"), this);
         projectSourceAssets->setCheckable(true);
         projectSourceAssets->setChecked(true);
-        connect(projectSourceAssets, &QAction::triggered, this, [this] { m_ui->m_searchWidget->FilterProjectSourceAssets(); });
+        connect(projectSourceAssets, &QAction::triggered, this, [this] { m_ui->m_searchWidget->ToggleProjectSourceAssetFilter(); });
         m_ui->m_searchWidget->GetFilter()->AddFilter(m_ui->m_searchWidget->GetProjectSourceFilter());
+        m_ui->m_searchWidget->AddFolderFilter();
         m_toolsMenu->addAction(projectSourceAssets);
     }
 
@@ -344,11 +345,13 @@ void AzAssetBrowserWindow::SetTwoColumnMode(QWidget* viewToShow)
 {
     m_ui->m_middleStackWidget->show();
     m_ui->m_middleStackWidget->setCurrentWidget(viewToShow);
+    m_ui->m_searchWidget->AddFolderFilter();
 }
 
 void AzAssetBrowserWindow::SetOneColumnMode()
 {
     m_ui->m_middleStackWidget->hide();
+    m_ui->m_searchWidget->RemoveFolderFilter();
 }
 
 static void ExpandTreeToIndex(QTreeView* treeView, const QModelIndex& index)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.cpp
@@ -83,6 +83,7 @@ namespace AzToolsFramework
             , m_stringFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::AND))
             , m_typesFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::OR))
             , m_projectSourceFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::AND))
+            , m_folderFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::AND))
         {
             m_filter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
 
@@ -94,6 +95,9 @@ namespace AzToolsFramework
 
             m_projectSourceFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
             m_projectSourceFilter->SetTag("ProjectSource");
+
+            m_folderFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
+            m_folderFilter->SetTag("Folder");
 
             connect(this, &AzQtComponents::FilteredSearchWidget::TextFilterChanged, this,
                     [this](const QString& text)
@@ -173,9 +177,14 @@ namespace AzToolsFramework
             auto pathFilter = new AssetPathFilter();
             pathFilter->SetAssetPath(AZStd::string_view{ AZ::Utils::GetProjectPath() });
             m_projectSourceFilter->AddFilter(FilterConstType(pathFilter));
+
+            auto directoryFilter = new EntryTypeFilter();
+            directoryFilter->SetName("Folder");
+            directoryFilter->SetEntryType(AssetBrowserEntry::AssetEntryType::Folder);
+            m_folderFilter->AddFilter(FilterConstType(directoryFilter));
         }
 
-        void SearchWidget::FilterProjectSourceAssets()
+        void SearchWidget::ToggleProjectSourceAssetFilter()
         {
             if (m_filter->GetSubFilters().contains(m_projectSourceFilter))
             {
@@ -184,6 +193,22 @@ namespace AzToolsFramework
             else
             {
                 m_filter->AddFilter(FilterConstType(m_projectSourceFilter));
+            }
+        }
+
+        void SearchWidget::AddFolderFilter()
+        {
+            if (!m_filter->GetSubFilters().contains(m_folderFilter))
+            {
+                m_filter->AddFilter(FilterConstType(m_folderFilter));
+            }
+        }
+
+        void SearchWidget::RemoveFolderFilter()
+        {
+            if (m_filter->GetSubFilters().contains(m_folderFilter))
+            {
+                m_filter->RemoveFilter(FilterConstType(m_folderFilter));
             }
         }
 
@@ -207,6 +232,10 @@ namespace AzToolsFramework
             return m_projectSourceFilter;
         }
 
+        QSharedPointer<CompositeFilter> SearchWidget::GetFolderFilter() const
+        {
+            return m_folderFilter;
+        }
     } // namespace AssetBrowser
 } // namespace AzToolsFramework
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.h
@@ -33,7 +33,11 @@ namespace AzToolsFramework
 
             void Setup(bool stringFilter, bool assetTypeFilter);
 
-            void FilterProjectSourceAssets();
+            void ToggleProjectSourceAssetFilter();
+
+            void AddFolderFilter();
+
+            void RemoveFolderFilter();
 
             QSharedPointer<CompositeFilter> GetFilter() const;
 
@@ -43,6 +47,8 @@ namespace AzToolsFramework
 
             QSharedPointer<CompositeFilter> GetProjectSourceFilter() const;
 
+            QSharedPointer<CompositeFilter> GetFolderFilter() const;
+
             QString GetFilterString() const { return textFilter(); }
             void ClearStringFilter() { ClearTextFilter(); }
 
@@ -51,6 +57,7 @@ namespace AzToolsFramework
             QSharedPointer<CompositeFilter> m_stringFilter;
             QSharedPointer<CompositeFilter> m_typesFilter;
             QSharedPointer<CompositeFilter> m_projectSourceFilter;
+            QSharedPointer<CompositeFilter> m_folderFilter;
         };
 
     } // namespace AssetBrowser


### PR DESCRIPTION
Signed-off-by: Daniel Tamkin <jotamkin@amazon.com>

## What does this PR do?

Adds a filter to only show folders in the leftmost tree view of the new two column views in the asset browser. 
Resolves #13309.

![Editor_L401Xj6U0m](https://user-images.githubusercontent.com/84731577/204911875-c8c291a7-be5d-479e-8d94-bee23cebb720.gif)

## How was this PR tested?

Locally under the new WIP asset browser.
