### PR TITLE
Re-enable asset path checks for MaterialEditor test.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_BasicTests.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_BasicTests.py
@@ -213,13 +213,13 @@ def MaterialEditor_BasicFunctionalityChecks_AllChecksPass():
         Report.result(Tests.viewport_background_selected, neutral_urban_background_loaded is True)
 
         # 11. Verify the lighting background asset is the expected value.
-        # neutral_urban_background_path = os.path.join(
-        #     azlmbr.paths.engroot, "Gems", "Atom", "Tools", "MaterialEditor", "Assets", "MaterialEditor",
-        #     "LightingPresets", "neutral_urban.lightingpreset.azasset")
-        # neutral_urban_background_path = neutral_urban_background_path.replace(os.sep, '/')
-        # Report.result(
-        #     Tests.viewport_background_has_expected_asset,
-        #     atom_tools_utils.get_last_lighting_preset_path() == neutral_urban_background_path)
+        neutral_urban_background_path = os.path.join(
+            azlmbr.paths.engroot, "Gems", "Atom", "Tools", "MaterialEditor", "Assets", "MaterialEditor",
+            "LightingPresets", "neutral_urban.lightingpreset.azasset")
+        neutral_urban_background_path = neutral_urban_background_path.replace(os.sep, '/')
+        Report.result(
+            Tests.viewport_background_has_expected_asset,
+            atom_tools_utils.get_last_lighting_preset_path() == neutral_urban_background_path)
 
         # 12. Change the lighting background again and verify the change succeeded.
         lythwood_room_asset_path = os.path.join(
@@ -229,13 +229,13 @@ def MaterialEditor_BasicFunctionalityChecks_AllChecksPass():
         Report.result(Tests.viewport_background_changed, lythwood_room_asset_loaded is True)
 
         # 13. Verify the lighting background asset is changed to a new expected value.
-        # lythwood_room_background_path = os.path.join(
-        #     azlmbr.paths.engroot, "Gems", "Atom", "Tools", "MaterialEditor", "Assets", "MaterialEditor",
-        #     "LightingPresets", "lythwood_room.lightingpreset.azasset")
-        # lythwood_room_background_path = lythwood_room_background_path.replace(os.sep, '/')
-        # Report.result(
-        #     Tests.viewport_background_has_changed_asset,
-        #     atom_tools_utils.get_last_lighting_preset_path() == lythwood_room_background_path)
+        lythwood_room_background_path = os.path.join(
+            azlmbr.paths.engroot, "Gems", "Atom", "Tools", "MaterialEditor", "Assets", "MaterialEditor",
+            "LightingPresets", "lythwood_room.lightingpreset.azasset")
+        lythwood_room_background_path = lythwood_room_background_path.replace(os.sep, '/')
+        Report.result(
+            Tests.viewport_background_has_changed_asset,
+            atom_tools_utils.get_last_lighting_preset_path() == lythwood_room_background_path)
 
         # 14. Select the model and verify the selection  succeeded.
         beveled_cone_model_path = os.path.join(
@@ -244,13 +244,13 @@ def MaterialEditor_BasicFunctionalityChecks_AllChecksPass():
         Report.result(Tests.viewport_model_selected, beveled_cone_model_asset is True)
 
         # 15. Verify the model asset is the expected value.
-        # beveled_cone_model_asset_path = os.path.join(
-        #     azlmbr.paths.engroot, "Gems", "Atom", "Tools", "MaterialEditor", "Assets", "MaterialEditor",
-        #     "ViewPortModels", "BeveledCone.modelpreset.azasset")
-        # beveled_cone_model_asset_path = beveled_cone_model_asset_path.replace(os.sep, '/')
-        # Report.result(
-        #     Tests.viewport_model_has_expected_asset,
-        #     atom_tools_utils.get_last_model_preset_path() == beveled_cone_model_asset_path)
+        beveled_cone_model_asset_path = os.path.join(
+            azlmbr.paths.engroot, "Gems", "Atom", "Tools", "MaterialEditor", "Assets", "MaterialEditor",
+            "ViewPortModels", "BeveledCone.modelpreset.azasset")
+        beveled_cone_model_asset_path = beveled_cone_model_asset_path.replace(os.sep, '/')
+        Report.result(
+            Tests.viewport_model_has_expected_asset,
+            atom_tools_utils.get_last_model_preset_path() == beveled_cone_model_asset_path)
 
         # 16. Change the model asset and verify the change succeeded.
         cone_model_path = os.path.join(
@@ -259,13 +259,13 @@ def MaterialEditor_BasicFunctionalityChecks_AllChecksPass():
         Report.result(Tests.viewport_model_changed, cone_model_asset is True)
 
         # 17. Verify the model asset is changed to a new expected value.
-        # cone_model_asset_path = os.path.join(
-        #     azlmbr.paths.engroot, "Gems", "Atom", "Tools", "MaterialEditor", "Assets", "MaterialEditor",
-        #     "ViewPortModels", "Cone.modelpreset.azasset")
-        # cone_model_asset_path = cone_model_asset_path.replace(os.sep, '/')
-        # Report.result(
-        #     Tests.viewport_model_has_changed_asset,
-        #     atom_tools_utils.get_last_model_preset_path() == cone_model_asset_path)
+        cone_model_asset_path = os.path.join(
+            azlmbr.paths.engroot, "Gems", "Atom", "Tools", "MaterialEditor", "Assets", "MaterialEditor",
+            "ViewPortModels", "Cone.modelpreset.azasset")
+        cone_model_asset_path = cone_model_asset_path.replace(os.sep, '/')
+        Report.result(
+            Tests.viewport_model_has_changed_asset,
+            atom_tools_utils.get_last_model_preset_path() == cone_model_asset_path)
 
         # 18. Disable the Grid.
         atom_tools_utils.set_grid_enabled(False)


### PR DESCRIPTION
Signed-off-by: NULL <jromnoa@amazon.com>

## What does this PR do?
Re-enables failing tests for MaterialEditor asset paths that now pass since the underlying issue is fixed.
Related PR: https://github.com/o3de/o3de/issues/13354 

## How was this PR tested?
Tested using command `C:\git\o3de\python\runtime\python-3.10.5-rev1-windows\python\python.exe -m pytest -vv -s --build-directory="C:\git\o3de\build\bin\profile" C:\git\o3de\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_Null_Render_MaterialEditor_01.py -k MaterialEditor_Atom_BasicTests`
Results:
```py
Starting test MaterialEditor_BasicFunctionalityChecks_AllChecksPass...
Test MaterialEditor_BasicFunctionalityChecks_AllChecksPass finished.
Report:
[SUCCESS] Success: Existing material document opened successfully.
[SUCCESS] Success: Closed existing material document.
[SUCCESS] Success: Closed all currently opened documents.
[SUCCESS] Success: Expected material documents are opened.
[SUCCESS] Success: Closed all currently opened documents except for one file.
[SUCCESS] Success: Inspector pane is visible, MaterialEditor launch succeeded
[SUCCESS] Success: Material document color property value changed successfully.
[SUCCESS] Success: Material document color property value change was reverted using undo.
[SUCCESS] Success: Material document color property value changed again successfully using redo.
[SUCCESS] Success: Viewport lighting background successfully selected.
[SUCCESS] Success: Viewport lighting background has the expected asset set.
[SUCCESS] Success: Viewport lighting background changed successfully.
[SUCCESS] Success: Viewport lighting background successfully changed assets.
[SUCCESS] Success: Viewport model successfully selected.
[SUCCESS] Success: Viewport model has the expected asset set.
[SUCCESS] Success: Viewport model changed successfully
[SUCCESS] Success: Viewport model successfully changed.
[SUCCESS] Success: Grid disabled successfully.
[SUCCESS] Success: Grid enabled successfully.
[SUCCESS] Success: Shadow Catcher disabled successfully.
[SUCCESS] Success: Shadow Catcher enabled successfully
Test result:  SUCCESS
```