### PR TITLE
BlendGraphWidget: remove nodes from group from assignment menu

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ContextMenu.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ContextMenu.cpp
@@ -72,6 +72,15 @@ namespace EMStudio
                 if (currentlyAssignedGroup == nodeGroup && selectedNodeCount == 1)
                 {
                     nodeGroupAction->setChecked(true);
+                    // Remove the nodes from the group they are already in
+                    connect(
+                        nodeGroupAction,
+                        &QAction::triggered,
+                        this,
+                        [this]()
+                        {
+                            AssignSelectedNodesToGroup(nullptr);
+                        });
                 }
                 else
                 {


### PR DESCRIPTION
Previously, the checked menu item representing the group the nodes were already in didn't do anything. Now selecting that menu item removes the nodes from that group, as expected when unchecking the item.

Follow up to https://github.com/o3de/o3de/pull/13416#discussion_r1034006566

## How was this PR tested?

manually
