### PR TITLE
Remove redundant azmalloc, azcreate, and azcalloc overloads

### DIFF
--- a/Code/Framework/AzCore/AzCore/IO/CompressorZLib.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/CompressorZLib.cpp
@@ -117,7 +117,7 @@ namespace AZ::IO
 
         if (m_decompressionCachePerStream)
         {
-            zlibData->m_decompressedCache = reinterpret_cast<unsigned char*>(azmalloc(m_decompressionCachePerStream, m_CompressedDataBufferAlignment, AZ::SystemAllocator, "CompressorZLib"));
+            zlibData->m_decompressedCache = reinterpret_cast<unsigned char*>(azmalloc(m_decompressionCachePerStream, m_CompressedDataBufferAlignment, AZ::SystemAllocator));
         }
 
         zlibData->m_decompressLastOffset = seekPointOffset; // set the start address of the seek points as the last valid read address for the compressed stream.
@@ -526,7 +526,7 @@ namespace AZ::IO
         if (m_compressedDataBuffer == nullptr)
         {
             AZ_Assert(m_compressedDataBufferUseCount == 0, "Buffer usecount should be 0 if the buffer is NULL");
-            m_compressedDataBuffer = reinterpret_cast<unsigned char*>(azmalloc(m_compressedDataBufferSize, m_CompressedDataBufferAlignment, AZ::SystemAllocator, "CompressorZLib"));
+            m_compressedDataBuffer = reinterpret_cast<unsigned char*>(azmalloc(m_compressedDataBufferSize, m_CompressedDataBufferAlignment, AZ::SystemAllocator));
             m_lastReadStream = nullptr; // reset the cache info in the m_dataBuffer
         }
         ++m_compressedDataBufferUseCount;

--- a/Code/Framework/AzCore/AzCore/IO/CompressorZStd.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/CompressorZStd.cpp
@@ -95,7 +95,7 @@ namespace AZ::IO
 
         if (m_decompressionCachePerStream)
         {
-            zstdData->m_decompressedCache = reinterpret_cast<unsigned char*>(azmalloc(m_decompressionCachePerStream, m_CompressedDataBufferAlignment, AZ::SystemAllocator, "CompressorZStd"));
+            zstdData->m_decompressedCache = reinterpret_cast<unsigned char*>(azmalloc(m_decompressionCachePerStream, m_CompressedDataBufferAlignment, AZ::SystemAllocator));
         }
 
         zstdData->m_decompressLastOffset = seekPointOffset; // set the start address of the seek points as the last valid read address for the compressed stream.
@@ -466,7 +466,7 @@ namespace AZ::IO
         if (m_compressedDataBuffer == nullptr)
         {
             AZ_Assert(m_compressedDataBufferUseCount == 0, "Buffer usecount should be 0 if the buffer is NULL");
-            m_compressedDataBuffer = reinterpret_cast<unsigned char*>(azmalloc(m_compressedDataBufferSize, m_CompressedDataBufferAlignment, AZ::SystemAllocator, "CompressorZStd"));
+            m_compressedDataBuffer = reinterpret_cast<unsigned char*>(azmalloc(m_compressedDataBufferSize, m_CompressedDataBufferAlignment, AZ::SystemAllocator));
             m_lastReadStream = nullptr; // reset the cache info in the m_dataBuffer
         }
         ++m_compressedDataBufferUseCount;

--- a/Code/Framework/AzCore/AzCore/JSON/rapidjson.h
+++ b/Code/Framework/AzCore/AzCore/JSON/rapidjson.h
@@ -36,7 +36,7 @@ namespace rapidjson_ly_internal
 }
 
 
-#define RAPIDJSON_NEW(x)  new(azmalloc(sizeof(x), alignof(x), AZ::SystemAllocator, "RapidJSON")) x
+#define RAPIDJSON_NEW(x)  new(azmalloc(sizeof(x), alignof(x), AZ::SystemAllocator)) x
 #define RAPIDJSON_DELETE(x) rapidjson_ly_internal::Delete(x)
 #define RAPIDJSON_MALLOC(_size) AZ::AllocatorInstance<AZ::SystemAllocator>::Get().allocate(_size, 16)
 #define RAPIDJSON_REALLOC(_ptr, _newSize) _ptr ? AZ::AllocatorInstance<AZ::SystemAllocator>::Get().reallocate(_ptr, _newSize, 16) : RAPIDJSON_MALLOC(_newSize)

--- a/Code/Framework/AzCore/AzCore/Memory/Memory.h
+++ b/Code/Framework/AzCore/AzCore/Memory/Memory.h
@@ -37,19 +37,11 @@
     #define azmalloc_2(_1, _2)                                      AZ::AllocatorInstance< AZ::SystemAllocator >::Get().allocate(_1, _2)
 /// azmalloc(size,alignment,Allocator)
     #define azmalloc_3(_1, _2, _3)                                  AZ::AllocatorInstance< _3 >::Get().allocate(_1, _2)
-/// azmalloc(size,alignment,Allocator,allocationName)
-    #define azmalloc_4(_1, _2, _3, _4)                              AZ::AllocatorInstance< _3 >::Get().allocate(_1, _2)
-/// azmalloc(size,alignment,Allocator,allocationName,flags)
-    #define azmalloc_5(_1, _2, _3, _4, _5)                          AZ::AllocatorInstance< _3 >::Get().allocate(_1, _2)
 
 /// azcreate(class,params)
-    #define azcreate_2(_1, _2)                                      new(azmalloc_4(sizeof(_1), AZStd::alignment_of< _1 >::value, AZ::SystemAllocator,#_1)) _1 _2
+    #define azcreate_2(_1, _2)                                      new(azmalloc_3(sizeof(_1), AZStd::alignment_of< _1 >::value, AZ::SystemAllocator)) _1 _2
 /// azcreate(class,params,Allocator)
-    #define azcreate_3(_1, _2, _3)                                  new(azmalloc_4(sizeof(_1), AZStd::alignment_of< _1 >::value, _3,#_1)) _1 _2
-/// azcreate(class,params,Allocator,allocationName)
-    #define azcreate_4(_1, _2, _3, _4)                              new(azmalloc_4(sizeof(_1), AZStd::alignment_of< _1 >::value, _3, _4)) _1 _2
-/// azcreate(class,params,Allocator,allocationName,flags)
-    #define azcreate_5(_1, _2, _3, _4, _5)                          new(azmalloc_5(sizeof(_1), AZStd::alignment_of< _1 >::value, _3, _4, _5)) _1 _2
+    #define azcreate_3(_1, _2, _3)                                  new(azmalloc_3(sizeof(_1), AZStd::alignment_of< _1 >::value, _3)) _1 _2
 #else
     #define aznew           new
     #define aznewex(_Name)  new
@@ -60,26 +52,18 @@
     #define azmalloc_2(_1, _2)                                      AZ::AllocatorInstance< AZ::SystemAllocator >::Get().allocate(_1, _2)
 /// azmalloc(size,alignment,Allocator)
     #define azmalloc_3(_1, _2, _3)                                  AZ::AllocatorInstance< _3 >::Get().allocate(_1, _2)
-/// azmalloc(size,alignment,Allocator,allocationName)
-    #define azmalloc_4(_1, _2, _3, _4)                              AZ::AllocatorInstance< _3 >::Get().allocate(_1, _2)
-/// azmalloc(size,alignment,Allocator,allocationName,flags)
-    #define azmalloc_5(_1, _2, _3, _4, _5)                          AZ::AllocatorInstance< _3 >::Get().allocate(_1, _2)
 
 /// azcreate(class)
-    #define azcreate_1(_1)                                          new(azmalloc_4(sizeof(_1), AZStd::alignment_of< _1 >::value, AZ::SystemAllocator, #_1)) _1()
+    #define azcreate_1(_1)                                          new(azmalloc_3(sizeof(_1), AZStd::alignment_of< _1 >::value, AZ::SystemAllocator)) _1()
 /// azcreate(class,params)
-    #define azcreate_2(_1, _2)                                      new(azmalloc_4(sizeof(_1), AZStd::alignment_of< _1 >::value, AZ::SystemAllocator, #_1)) _1 _2
+    #define azcreate_2(_1, _2)                                      new(azmalloc_3(sizeof(_1), AZStd::alignment_of< _1 >::value, AZ::SystemAllocator)) _1 _2
 /// azcreate(class,params,Allocator)
-    #define azcreate_3(_1, _2, _3)                                  new(azmalloc_4(sizeof(_1), AZStd::alignment_of< _1 >::value, _3, #_1)) _1 _2
-/// azcreate(class,params,Allocator,allocationName)
-    #define azcreate_4(_1, _2, _3, _4)                              new(azmalloc_4(sizeof(_1), AZStd::alignment_of< _1 >::value, _3, _4)) _1 _2
-/// azcreate(class,params,Allocator,allocationName,flags)
-    #define azcreate_5(_1, _2, _3, _4, _5)                          new(azmalloc_5(sizeof(_1), AZStd::alignment_of< _1 >::value, _3, _4, _5)) _1 _2
+    #define azcreate_3(_1, _2, _3)                                  new(azmalloc_3(sizeof(_1), AZStd::alignment_of< _1 >::value, _3)) _1 _2
 #endif
 
 /**
 * azmalloc is equivalent to ::malloc(...). It should be used with corresponding azfree call.
-* macro signature: azmalloc(size_t byteSize, size_t alignment = DefaultAlignment, AllocatorType = AZ::SystemAllocator, const char* name = "Default Name", int flags = 0)
+* macro signature: azmalloc(size_t byteSize, size_t alignment = DefaultAlignment, AllocatorType = AZ::SystemAllocator)
 */
 #define azmalloc(...)       AZ_MACRO_SPECIALIZE(azmalloc_, AZ_VA_NUM_ARGS(__VA_ARGS__), (__VA_ARGS__))
 
@@ -89,10 +73,6 @@
 #define azcalloc_2(_1, _2)              ::memset(azmalloc_2(_1, _2), 0, _1);
 /// azcalloc(size, alignment, Allocator)
 #define azcalloc_3(_1, _2, _3)          ::memset(azmalloc_3(_1, _2, _3), 0, _1);
-/// azcalloc(size, alignment, allocationName)
-#define azcalloc_4(_1, _2, _3, _4)      ::memset(azmalloc_4(_1, _2, _3, _4), 0, _1);
-/// azcalloc(size, alignment, allocationName, flags)
-#define azcalloc_5(_1, _2, _3, _4, _5)  ::memset(azmalloc_5(_1, _2, _3, _4, _5), 0, _1);
 
 /**
 * azcalloc is equivalent to ::memset(azmalloc(...), 0, size);
@@ -117,7 +97,7 @@
  * azcreate is customized aznew function call. aznew can be used anywhere where we use new, while azcreate has a function call signature.
  * azcreate allows you to override the operator new and by this you can override the allocator per object instance. It should
  * be used with corresponding azdestroy call.
- * macro signature: azcreate(ClassName, CtorParams = (), AllocatorType = AZ::SystemAllocator, AllocationName = "ClassName", int flags = 0)
+ * macro signature: azcreate(ClassName, CtorParams = (), AllocatorType = AZ::SystemAllocator)
  */
 #define azcreate(...)       AZ_MACRO_SPECIALIZE(azcreate_, AZ_VA_NUM_ARGS(__VA_ARGS__), (__VA_ARGS__))
 

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.cpp
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.cpp
@@ -715,7 +715,7 @@ namespace AZ
         }
         else
         {
-            return azmalloc(m_size, m_alignment, AZ::SystemAllocator, m_name.c_str());
+            return azmalloc(m_size, m_alignment, AZ::SystemAllocator);
         }
     }
 

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.h
@@ -1538,7 +1538,7 @@ namespace AZ
             static void* Allocate(void* userData)
             {
                 (void)userData;
-                return azmalloc(sizeof(T), AZStd::alignment_of<T>::value, AZ::SystemAllocator, AZ::AzTypeInfo<T>::Name());
+                return azmalloc(sizeof(T), AZStd::alignment_of<T>::value, AZ::SystemAllocator);
             }
 
             static void DeAllocate(void* address, void* userData)

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
@@ -1473,7 +1473,7 @@ namespace AZ
             else
             {
                 // Otherwise use the AZ::SystemAllocator
-                return azmalloc(sizeof(T), alignof(T), AZ::SystemAllocator, "");
+                return azmalloc(sizeof(T), alignof(T), AZ::SystemAllocator);
             }
         }
         template<typename T>
@@ -1731,7 +1731,7 @@ namespace AZ
         {
             void* Create([[maybe_unused]] const char* name) override
             {
-                return new(azmalloc(sizeof(T), AZStd::alignment_of<T>::value, AZ::SystemAllocator, name))T;
+                return new(azmalloc(sizeof(T), AZStd::alignment_of<T>::value, AZ::SystemAllocator))T;
             }
             void Destroy(void* ptr) override
             {

--- a/Code/Framework/AzCore/Tests/Memory.cpp
+++ b/Code/Framework/AzCore/Tests/Memory.cpp
@@ -747,7 +747,7 @@ namespace UnitTest
                 const Debug::AllocationRecordsType& records = sysAllocator.GetRecords()->GetMap();
                 EXPECT_TRUE(records.find(ptr)==records.end());  // our allocation is NOT in the list
             }
-            ptr = azmalloc(16*1024, 32, SystemAllocator, allocName);
+            ptr = azmalloc(16*1024, 32, SystemAllocator);
             EXPECT_EQ(0, ((size_t)ptr & 31));  // check alignment
             if (sysAllocator.GetRecords())
             {

--- a/Code/Framework/AzCore/Tests/Script.cpp
+++ b/Code/Framework/AzCore/Tests/Script.cpp
@@ -1586,7 +1586,7 @@ namespace UnitTest
     void* ScriptClassAllocate(void* userData)
     {
         (void)userData;
-        return azmalloc(sizeof(ScriptClass),AZStd::alignment_of<ScriptClass>::value,AZ::SystemAllocator,"ScriptClass");
+        return azmalloc(sizeof(ScriptClass),AZStd::alignment_of<ScriptClass>::value,AZ::SystemAllocator);
     }
 
     void ScriptClassFree(void* obj, void* userData)

--- a/Code/Framework/AzCore/Tests/Serialization.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization.cpp
@@ -1808,7 +1808,7 @@ namespace UnitTest
         AZStd::vector<int*> vectorOfIntPointers;
 
         vectorOfInts.push_back(5);
-        vectorOfIntPointers.push_back(azcreate(int, (5), AZ::SystemAllocator, "Container Int Pointer"));
+        vectorOfIntPointers.push_back(azcreate(int, (5), AZ::SystemAllocator));
 
         // Write Vector of Int to object stream
         AZStd::vector<char> vectorIntBuffer;
@@ -2046,7 +2046,7 @@ TEST_F(SerializeBasicTest, BasicTypeTest_Succeed)
         AssociativePtrContainer testObj;
         testObj.m_setOfPointers.insert(aznew AZ::Entity("Entity1"));
         testObj.m_setOfPointers.insert(aznew AZ::Entity("Entity2"));
-        testObj.m_mapOfFloatPointers.emplace(5, azcreate(float, (3.14f), AZ::SystemAllocator, "Bob the Float"));
+        testObj.m_mapOfFloatPointers.emplace(5, azcreate(float, (3.14f), AZ::SystemAllocator));
         testObj.m_sharedEntityPointer.reset(aznew AZ::Entity("Entity3"));
 
         // XML
@@ -3237,7 +3237,7 @@ TEST_F(SerializeBasicTest, BasicTypeTest_Succeed)
         ClonableAssociativePointerContainer testObj;
         testObj.m_setOfPointers.insert(aznew AZ::Entity("Entity1"));
         testObj.m_setOfPointers.insert(aznew AZ::Entity("Entity2"));
-        testObj.m_mapOfFloatPointers.emplace(5, azcreate(float, (3.14f), AZ::SystemAllocator, "Frank the Float"));
+        testObj.m_mapOfFloatPointers.emplace(5, azcreate(float, (3.14f), AZ::SystemAllocator));
         testObj.m_sharedEntityPointer.reset(aznew AZ::Entity("Entity3"));
 
         ClonableAssociativePointerContainer* cloneObj = m_serializeContext->CloneObject(&testObj);

--- a/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/AssetBuilderSDK.cpp
+++ b/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/AssetBuilderSDK.cpp
@@ -874,7 +874,7 @@ namespace AssetBuilderSDK
 
             // this is why new asset types REALLY need to have an extension (or other indicator) on their source or product that are different and can easily determine their
             // intended usage.
-            AZ::rapidxml::xml_document<char>* xmlDoc = azcreate(AZ::rapidxml::xml_document<char>, (), AZ::SystemAllocator, "BuilderSDK Temp XML Reader");
+            AZ::rapidxml::xml_document<char>* xmlDoc = azcreate(AZ::rapidxml::xml_document<char>, (), AZ::SystemAllocator);
             if (xmlDoc->parse<AZ::rapidxml::parse_no_data_nodes>(buffer.data()))
             {
                 // note that PARSE_FASTEST does not null-terminate strings, instead we just PARSE_NO_DATA_NODES so that xdata and other such blobs are ignored since they don't matter

--- a/Gems/AudioEngineWwise/Code/Source/Engine/AudioSystemImpl_wwise.cpp
+++ b/Gems/AudioEngineWwise/Code/Source/Engine/AudioSystemImpl_wwise.cpp
@@ -1426,7 +1426,7 @@ namespace Audio
                 fileEntryInfo->bLocalized = isLocalized;
                 fileEntryInfo->sFileName = audioFileEntryName;
                 fileEntryInfo->nMemoryBlockAlignment = AK_BANK_PLATFORM_DATA_ALIGNMENT;
-                fileEntryInfo->pImplData = azcreate(SATLAudioFileEntryData_wwise, (), Audio::AudioImplAllocator, "ATLAudioFileEntryData_wwise");
+                fileEntryInfo->pImplData = azcreate(SATLAudioFileEntryData_wwise, (), Audio::AudioImplAllocator);
                 result = EAudioRequestStatus::Success;
             }
             else
@@ -1463,14 +1463,14 @@ namespace Audio
     SATLAudioObjectData_wwise* CAudioSystemImpl_wwise::NewGlobalAudioObjectData(const TAudioObjectID objectId)
     {
         AZ_UNUSED(objectId);
-        auto newObjectData = azcreate(SATLAudioObjectData_wwise, (AK_INVALID_GAME_OBJECT, false), Audio::AudioImplAllocator, "ATLAudioObjectData_wwise-Global");
+        auto newObjectData = azcreate(SATLAudioObjectData_wwise, (AK_INVALID_GAME_OBJECT, false), Audio::AudioImplAllocator);
         return newObjectData;
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////
     SATLAudioObjectData_wwise* CAudioSystemImpl_wwise::NewAudioObjectData(const TAudioObjectID objectId)
     {
-        auto newObjectData = azcreate(SATLAudioObjectData_wwise, (static_cast<AkGameObjectID>(objectId), true), Audio::AudioImplAllocator, "ATLAudioObjectData_wwise");
+        auto newObjectData = azcreate(SATLAudioObjectData_wwise, (static_cast<AkGameObjectID>(objectId), true), Audio::AudioImplAllocator);
         return newObjectData;
     }
 
@@ -1483,7 +1483,7 @@ namespace Audio
     ///////////////////////////////////////////////////////////////////////////////////////////////////
     SATLListenerData_wwise* CAudioSystemImpl_wwise::NewDefaultAudioListenerObjectData(const TATLIDType listenerId)
     {
-        auto newObjectData = azcreate(SATLListenerData_wwise, (static_cast<AkGameObjectID>(listenerId)), Audio::AudioImplAllocator, "ATLListenerData_wwise-Default");
+        auto newObjectData = azcreate(SATLListenerData_wwise, (static_cast<AkGameObjectID>(listenerId)), Audio::AudioImplAllocator);
         if (newObjectData)
         {
             auto listenerName = AZStd::string::format("DefaultAudioListener(%llu)", static_cast<AZ::u64>(newObjectData->nAKListenerObjectId));
@@ -1512,7 +1512,7 @@ namespace Audio
     ///////////////////////////////////////////////////////////////////////////////////////////////////
     SATLListenerData_wwise* CAudioSystemImpl_wwise::NewAudioListenerObjectData(const TATLIDType listenerId)
     {
-        auto newObjectData = azcreate(SATLListenerData_wwise, (static_cast<AkGameObjectID>(listenerId)), Audio::AudioImplAllocator, "ATLListenerData_wwise");
+        auto newObjectData = azcreate(SATLListenerData_wwise, (static_cast<AkGameObjectID>(listenerId)), Audio::AudioImplAllocator);
         if (newObjectData)
         {
             auto listenerName = AZStd::string::format("AudioListener(%llu)", static_cast<AZ::u64>(newObjectData->nAKListenerObjectId));
@@ -1552,7 +1552,7 @@ namespace Audio
     ///////////////////////////////////////////////////////////////////////////////////////////////////
     SATLEventData_wwise* CAudioSystemImpl_wwise::NewAudioEventData(const TAudioEventID eventId)
     {
-        auto newObjectData = azcreate(SATLEventData_wwise, (eventId), Audio::AudioImplAllocator, "ATLEventData_wwise");
+        auto newObjectData = azcreate(SATLEventData_wwise, (eventId), Audio::AudioImplAllocator);
         return newObjectData;
     }
 
@@ -1590,7 +1590,7 @@ namespace Audio
 
                 if (akId != AK_INVALID_UNIQUE_ID)
                 {
-                    newTriggerImpl = azcreate(SATLTriggerImplData_wwise, (akId), Audio::AudioImplAllocator, "ATLTriggerImplData_wwise");
+                    newTriggerImpl = azcreate(SATLTriggerImplData_wwise, (akId), Audio::AudioImplAllocator);
                 }
             }
         }
@@ -1617,7 +1617,7 @@ namespace Audio
 
         if (akRtpcId != AK_INVALID_RTPC_ID)
         {
-            newRtpcImpl = azcreate(SATLRtpcImplData_wwise, (akRtpcId, mult, shift), Audio::AudioImplAllocator, "ATLRtpcImplData_wwise");
+            newRtpcImpl = azcreate(SATLRtpcImplData_wwise, (akRtpcId, mult, shift), Audio::AudioImplAllocator);
         }
 
         return newRtpcImpl;
@@ -1672,7 +1672,7 @@ namespace Audio
 
                 if (akBusId != AK_INVALID_AUX_ID)
                 {
-                    newEnvironmentImpl = azcreate(SATLEnvironmentImplData_wwise, (eWAET_AUX_BUS, static_cast<AkAuxBusID>(akBusId)), Audio::AudioImplAllocator, "ATLEnvironmentImplData_wwise");
+                    newEnvironmentImpl = azcreate(SATLEnvironmentImplData_wwise, (eWAET_AUX_BUS, static_cast<AkAuxBusID>(akBusId)), Audio::AudioImplAllocator);
                 }
             }
         }
@@ -1685,7 +1685,7 @@ namespace Audio
 
             if (akRtpcId != AK_INVALID_RTPC_ID)
             {
-                newEnvironmentImpl = azcreate(SATLEnvironmentImplData_wwise, (eWAET_RTPC, akRtpcId, mult, shift), Audio::AudioImplAllocator, "ATLEnvironmentImplData_wwise");
+                newEnvironmentImpl = azcreate(SATLEnvironmentImplData_wwise, (eWAET_RTPC, akRtpcId, mult, shift), Audio::AudioImplAllocator);
             }
         }
 
@@ -1813,7 +1813,7 @@ namespace Audio
 
                     if (akSGroupId != AK_INVALID_UNIQUE_ID && akSNameId != AK_INVALID_UNIQUE_ID)
                     {
-                        switchStateImpl = azcreate(SATLSwitchStateImplData_wwise, (type, akSGroupId, akSNameId), Audio::AudioImplAllocator, "ATLSwitchStateImplData_wwise");
+                        switchStateImpl = azcreate(SATLSwitchStateImplData_wwise, (type, akSGroupId, akSNameId), Audio::AudioImplAllocator);
                     }
                 }
             }
@@ -1843,7 +1843,7 @@ namespace Audio
                     const AkUniqueID akRtpcId = AK::SoundEngine::GetIDFromString(rtpcName);
                     if (akRtpcId != AK_INVALID_RTPC_ID)
                     {
-                        switchStateImpl = azcreate(SATLSwitchStateImplData_wwise, (eWST_RTPC, akRtpcId, akRtpcId, rtpcValue), Audio::AudioImplAllocator, "ATLSwitchStateImplData_wwise");
+                        switchStateImpl = azcreate(SATLSwitchStateImplData_wwise, (eWST_RTPC, akRtpcId, akRtpcId, rtpcValue), Audio::AudioImplAllocator);
                     }
                 }
             }

--- a/Gems/AudioSystem/Code/Source/Engine/ATL.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/ATL.cpp
@@ -767,7 +767,7 @@ namespace Audio
                 pGlobalObjectData, &AudioSystemImplementationRequestBus::Events::NewGlobalAudioObjectData, m_nGlobalAudioObjectID);
 
             m_pGlobalAudioObject = azcreate(
-                CATLGlobalAudioObject, (m_nGlobalAudioObjectID, pGlobalObjectData), Audio::AudioSystemAllocator, "ATLGlobalAudioObject");
+                CATLGlobalAudioObject, (m_nGlobalAudioObjectID, pGlobalObjectData), Audio::AudioSystemAllocator);
 
             m_oAudioListenerMgr.Initialize();
             m_oAudioObjectMgr.Initialize();

--- a/Gems/AudioSystem/Code/Source/Engine/ATLComponents.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/ATLComponents.cpp
@@ -83,7 +83,7 @@ namespace Audio
             const TAudioEventID nEventID = m_oAudioEventPool.GetNextID();
             IATLEventData* pNewEventData = nullptr;
             AudioSystemImplementationRequestBus::BroadcastResult(pNewEventData, &AudioSystemImplementationRequestBus::Events::NewAudioEventData, nEventID);
-            auto pNewEvent = azcreate(CATLEvent, (nEventID, eAS_AUDIO_SYSTEM_IMPLEMENTATION, pNewEventData), Audio::AudioSystemAllocator, "ATLEvent");
+            auto pNewEvent = azcreate(CATLEvent, (nEventID, eAS_AUDIO_SYSTEM_IMPLEMENTATION, pNewEventData), Audio::AudioSystemAllocator);
             m_oAudioEventPool.m_cReserved.push_back(pNewEvent);
         }
 
@@ -208,7 +208,7 @@ namespace Audio
 
             IATLEventData* pNewEventData = nullptr;
             AudioSystemImplementationRequestBus::BroadcastResult(pNewEventData, &AudioSystemImplementationRequestBus::Events::NewAudioEventData, nNewID);
-            pEvent = azcreate(CATLEvent, (nNewID, eAS_AUDIO_SYSTEM_IMPLEMENTATION, pNewEventData), Audio::AudioSystemAllocator, "ATLEvent");
+            pEvent = azcreate(CATLEvent, (nNewID, eAS_AUDIO_SYSTEM_IMPLEMENTATION, pNewEventData), Audio::AudioSystemAllocator);
 
             if (!pEvent)
             {
@@ -461,7 +461,7 @@ namespace Audio
 
             if (unallocatedMemorySize >= minimalMemorySize)
             {
-                pObject = azcreate(CATLAudioObject, (nNewID, pObjectData), Audio::AudioSystemAllocator, "ATLAudioObject");
+                pObject = azcreate(CATLAudioObject, (nNewID, pObjectData), Audio::AudioSystemAllocator);
             }
 
             if (!pObject)
@@ -522,7 +522,7 @@ namespace Audio
             const auto nObjectID = AudioObjectIDFactory::GetNextID();
             IATLAudioObjectData* pObjectData = nullptr;
             AudioSystemImplementationRequestBus::BroadcastResult(pObjectData, &AudioSystemImplementationRequestBus::Events::NewAudioObjectData, nObjectID);
-            auto pObject = azcreate(CATLAudioObject, (nObjectID, pObjectData), Audio::AudioSystemAllocator, "ATLAudioObject");
+            auto pObject = azcreate(CATLAudioObject, (nObjectID, pObjectData), Audio::AudioSystemAllocator);
             m_cObjectPool.m_cReserved.push_back(pObject);
         }
 
@@ -697,7 +697,7 @@ namespace Audio
 
         // Default listener...
         AudioSystemImplementationRequestBus::BroadcastResult(pNewListenerData, &AudioSystemImplementationRequestBus::Events::NewDefaultAudioListenerObjectData, m_nDefaultListenerID);
-        m_pDefaultListenerObject = azcreate(CATLListenerObject, (m_nDefaultListenerID, pNewListenerData), Audio::AudioSystemAllocator, "ATLListenerObject-Default");
+        m_pDefaultListenerObject = azcreate(CATLListenerObject, (m_nDefaultListenerID, pNewListenerData), Audio::AudioSystemAllocator);
         if (m_pDefaultListenerObject)
         {
             m_cActiveListeners[m_nDefaultListenerID] = m_pDefaultListenerObject;
@@ -708,7 +708,7 @@ namespace Audio
         {
             const TAudioObjectID listenerId = AudioObjectIDFactory::GetNextID();
             AudioSystemImplementationRequestBus::BroadcastResult(pNewListenerData, &AudioSystemImplementationRequestBus::Events::NewAudioListenerObjectData, listenerId);
-            auto listenerObject = azcreate(CATLListenerObject, (listenerId, pNewListenerData), Audio::AudioSystemAllocator, "ATLListenerObject");
+            auto listenerObject = azcreate(CATLListenerObject, (listenerId, pNewListenerData), Audio::AudioSystemAllocator);
             m_cListenerPool.push_back(listenerObject);
         }
     }
@@ -1073,7 +1073,7 @@ namespace Audio
                 auto it = m_rPreloadRequests.find(preloadRequestId);
                 if (it == m_rPreloadRequests.end())
                 {
-                    auto preloadRequest = azcreate(CATLPreloadRequest, (preloadRequestId, dataScope, autoLoad, fileEntryIds), Audio::AudioSystemAllocator, "ATLPreloadRequest");
+                    auto preloadRequest = azcreate(CATLPreloadRequest, (preloadRequestId, dataScope, autoLoad, fileEntryIds), Audio::AudioSystemAllocator);
                     m_rPreloadRequests[preloadRequestId] = preloadRequest;
 
                 #if !defined(AUDIO_RELEASE)
@@ -1230,7 +1230,7 @@ namespace Audio
 
                     if (environmentImplData)
                     {
-                        auto environmentImpl = azcreate(CATLEnvironmentImpl, (receiver, environmentImplData), Audio::AudioSystemAllocator, "ATLEnvironmentImpl");
+                        auto environmentImpl = azcreate(CATLEnvironmentImpl, (receiver, environmentImplData), Audio::AudioSystemAllocator);
                         envImpls.push_back(environmentImpl);
                     }
 
@@ -1239,7 +1239,7 @@ namespace Audio
 
                 if (!envImpls.empty())
                 {
-                    auto newEnvironment = azcreate(CATLAudioEnvironment, (atlEnvironmentId, dataScope, envImpls), Audio::AudioSystemAllocator, "ATLAudioEnvironment");
+                    auto newEnvironment = azcreate(CATLAudioEnvironment, (atlEnvironmentId, dataScope, envImpls), Audio::AudioSystemAllocator);
                     m_rEnvironments[atlEnvironmentId] = newEnvironment;
 
                 #if !defined(AUDIO_RELEASE)
@@ -1289,7 +1289,7 @@ namespace Audio
 
                     if (triggerImplData)
                     {
-                        auto triggerImpl = azcreate(CATLTriggerImpl, (++m_nTriggerImplIDCounter, atlTriggerId, receiver, triggerImplData), Audio::AudioSystemAllocator, "ATLTriggerImpl");
+                        auto triggerImpl = azcreate(CATLTriggerImpl, (++m_nTriggerImplIDCounter, atlTriggerId, receiver, triggerImplData), Audio::AudioSystemAllocator);
                         triggerImpls.push_back(triggerImpl);
                     }
 
@@ -1298,7 +1298,7 @@ namespace Audio
 
                 if (!triggerImpls.empty())
                 {
-                    auto newTrigger = azcreate(CATLTrigger, (atlTriggerId, dataScope, triggerImpls), Audio::AudioSystemAllocator, "ATLTrigger");
+                    auto newTrigger = azcreate(CATLTrigger, (atlTriggerId, dataScope, triggerImpls), Audio::AudioSystemAllocator);
                     m_rTriggers[atlTriggerId] = newTrigger;
 
                 #if !defined(AUDIO_RELEASE)
@@ -1327,7 +1327,7 @@ namespace Audio
 
             if ((atlSwitchId != INVALID_AUDIO_CONTROL_ID) && (m_rSwitches.find(atlSwitchId) == m_rSwitches.end()))
             {
-                auto newSwitch = azcreate(CATLSwitch, (atlSwitchId, dataScope), Audio::AudioSystemAllocator, "ATLSwitch");
+                auto newSwitch = azcreate(CATLSwitch, (atlSwitchId, dataScope), Audio::AudioSystemAllocator);
 
             #if !defined(AUDIO_RELEASE)
                 m_pDebugNameStore->AddAudioSwitch(atlSwitchId, atlSwitchName);
@@ -1366,14 +1366,14 @@ namespace Audio
 
                             if (newSwitchStateImplData)
                             {
-                                auto switchStateImpl = azcreate(CATLSwitchStateImpl, (receiver, newSwitchStateImplData), Audio::AudioSystemAllocator, "ATLSwitchStateImpl");
+                                auto switchStateImpl = azcreate(CATLSwitchStateImpl, (receiver, newSwitchStateImplData), Audio::AudioSystemAllocator);
                                 switchStateImplVec.push_back(switchStateImpl);
                             }
 
                             stateImplNode = stateImplNode->next_sibling(nullptr, 0, false);
                         }
 
-                        auto newState = azcreate(CATLSwitchState, (atlSwitchId, atlStateId, switchStateImplVec), Audio::AudioSystemAllocator, "ATLSwitchState");
+                        auto newState = azcreate(CATLSwitchState, (atlSwitchId, atlStateId, switchStateImplVec), Audio::AudioSystemAllocator);
                         newSwitch->cStates[atlStateId] = newState;
 
                     #if !defined(AUDIO_RELEASE)
@@ -1424,7 +1424,7 @@ namespace Audio
 
                     if (rtpcImplData)
                     {
-                        auto rtpcImpl = azcreate(CATLRtpcImpl, (receiver, rtpcImplData), Audio::AudioSystemAllocator, "ATLRtpcImpl");
+                        auto rtpcImpl = azcreate(CATLRtpcImpl, (receiver, rtpcImplData), Audio::AudioSystemAllocator);
                         rtpcImpls.push_back(rtpcImpl);
                     }
 
@@ -1433,7 +1433,7 @@ namespace Audio
 
                 if (!rtpcImpls.empty())
                 {
-                    auto newRtpc = azcreate(CATLRtpc, (atlRtpcId, dataScope, rtpcImpls), Audio::AudioSystemAllocator, "ATLRtpc");
+                    auto newRtpc = azcreate(CATLRtpc, (atlRtpcId, dataScope, rtpcImpls), Audio::AudioSystemAllocator);
                     m_rRtpcs[atlRtpcId] = newRtpc;
 
                 #if !defined(AUDIO_RELEASE)
@@ -1480,7 +1480,7 @@ namespace Audio
 
                     if (internalSwitchId != INVALID_AUDIO_CONTROL_ID && internalStateId != INVALID_AUDIO_SWITCH_STATE_ID)
                     {
-                        switchStateImpl = azcreate(SATLSwitchStateImplData_internal, (internalSwitchId, internalStateId), Audio::AudioSystemAllocator, "ATLSwitchStateImplData_internal");
+                        switchStateImpl = azcreate(SATLSwitchStateImplData_internal, (internalSwitchId, internalStateId), Audio::AudioSystemAllocator);
                     }
                 }
             }

--- a/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
@@ -262,7 +262,7 @@ namespace Audio
 
             for (AZ::u64 i = 0; i < Audio::CVars::s_AudioObjectPoolSize; ++i)
             {
-                auto audioProxy = azcreate(CAudioProxy, (), Audio::AudioSystemAllocator, "AudioProxy");
+                auto audioProxy = azcreate(CAudioProxy, (), Audio::AudioSystemAllocator);
                 m_apAudioProxies.push_back(audioProxy);
             }
 
@@ -419,7 +419,7 @@ namespace Audio
         }
         else
         {
-            audioProxy = azcreate(CAudioProxy, (), Audio::AudioSystemAllocator, "AudioProxyEx");
+            audioProxy = azcreate(CAudioProxy, (), Audio::AudioSystemAllocator);
             AZ_Assert(audioProxy != nullptr, "AudioSystem::GetAudioProxy - failed to create new AudioProxy instance!");
         }
 

--- a/Gems/AudioSystem/Code/Source/Engine/FileCacheManager.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/FileCacheManager.cpp
@@ -106,7 +106,7 @@ namespace Audio
             AudioSystemImplementationRequestBus::BroadcastResult(fileLocation, &AudioSystemImplementationRequestBus::Events::GetAudioFileLocation, &fileEntryInfo);
             AZStd::string filePath;
             AZ::StringFunc::AssetDatabasePath::Join(fileLocation, fileEntryInfo.sFileName, filePath);
-            auto newAudioFileEntry = azcreate(CATLAudioFileEntry, (filePath.c_str(), fileEntryInfo.pImplData), Audio::AudioSystemAllocator, "ATLAudioFileEntry");
+            auto newAudioFileEntry = azcreate(CATLAudioFileEntry, (filePath.c_str(), fileEntryInfo.pImplData), Audio::AudioSystemAllocator);
 
             if (newAudioFileEntry)
             {

--- a/Gems/RemoteTools/Code/Source/RemoteToolsSystemComponent.cpp
+++ b/Gems/RemoteTools/Code/Source/RemoteToolsSystemComponent.cpp
@@ -478,7 +478,7 @@ namespace RemoteTools
             {
                 if (msg->GetCustomBlobSize() > 0)
                 {
-                    void* blob = azmalloc(msg->GetCustomBlobSize(), 1, AZ::OSAllocator, "TmMsgBlob");
+                    void* blob = azmalloc(msg->GetCustomBlobSize(), 1, AZ::OSAllocator);
                     msgBuffer.Read(msg->GetCustomBlobSize(), blob);
                     msg->AddCustomBlob(blob, msg->GetCustomBlobSize(), true);
                 }


### PR DESCRIPTION
The allocation records no longer fill in allocation names that are supplied by the user. In many cases these names would come from AZStd containers, and were not that useful. It is more informative to track the location that the allocation originated from, which is captured in the record's callstack.

Signed-off-by: Chris Burel <burelc@amazon.com>