### PR TITLE
add AzQtComponents::InputDialog to allow validator to be used.

### DIFF
--- a/Code/Editor/MainWindow.cpp
+++ b/Code/Editor/MainWindow.cpp
@@ -53,6 +53,7 @@
 // AzQtComponents
 #include <AzQtComponents/Buses/ShortcutDispatch.h>
 #include <AzQtComponents/Components/DockMainWindow.h>
+#include <AzQtComponents/Components/InputDialog.h>
 #include <AzQtComponents/Components/Style.h>
 #include <AzQtComponents/Components/Widgets/SpinBox.h>
 #include <AzQtComponents/Components/WindowDecorationWrapper.h>
@@ -1640,7 +1641,7 @@ void MainWindow::SaveLayout()
         return;
     }
 
-    QString layoutName = QInputDialog::getText(this, tr("Layout Name"), QString()).toLower();
+    QString layoutName = InputDialog::getText(this, tr("Layout Name"), QString(), QLineEdit::Normal, QString(), "[a-z]+[a-z0-9\\-\\_]*");
     if (layoutName.isEmpty())
     {
         return;
@@ -1694,11 +1695,7 @@ void MainWindow::ViewRenamePaneLayout(const QString& layoutName)
     bool validName = false;
     while (!validName)
     {
-        newLayoutName = QInputDialog::getText(this, tr("Rename layout '%1'").arg(layoutName), QString());
-        if (newLayoutName.isEmpty())
-        {
-            return;
-        }
+        newLayoutName = InputDialog::getText(this, tr("Layout Name"), QString(), QLineEdit::Normal, QString(), "[a-z]+[a-z0-9\\-\\_]*");
 
         if (m_viewPaneManager->HasLayout(newLayoutName))
         {

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/InputDialog.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/InputDialog.cpp
@@ -32,6 +32,8 @@ namespace AzQtComponents
 
     void InputDialog::setValidator(QValidator* validator)
     {
+        m_validator = validator;
+
         AttemptAssignValidator();
     }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/InputDialog.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/InputDialog.cpp
@@ -20,11 +20,9 @@ namespace AzQtComponents
     {
     }
 
-    void InputDialog::setValidator(QValidator* validator)
+    void InputDialog::AttemptAssignValidator()
     {
-        m_validator = validator;
-
-        // If this is called after show has been called, the QLineEdit will be available to patch.
+        // This will succeed only if show() has happened, which sets up the UI.
         QLineEdit* lineEdit = this->findChild<QLineEdit*>();
         if (lineEdit)
         {
@@ -32,18 +30,16 @@ namespace AzQtComponents
         }
     }
 
+    void InputDialog::setValidator(QValidator* validator)
+    {
+        AttemptAssignValidator();
+    }
+
     void InputDialog::show()
     {
         QInputDialog::show();
 
-        if (m_validator)
-        {
-            QLineEdit* lineEdit = this->findChild<QLineEdit*>();
-            if (lineEdit)
-            {
-                lineEdit->setValidator(m_validator);
-            }
-        }
+        AttemptAssignValidator();
     }
 
     int InputDialog::exec()

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/InputDialog.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/InputDialog.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "InputDialog.h"
+
+#include <QEventLoop>
+#include <QInputDialog>
+#include <QRegularExpressionValidator>
+
+namespace AzQtComponents
+{
+    InputDialog::InputDialog(QWidget* parent)
+        : QInputDialog(parent)
+        , m_validator(nullptr)
+    {
+    }
+
+    void InputDialog::setValidator(QValidator* validator)
+    {
+        m_validator = validator;
+
+        // If this is called after show has been called, the QLineEdit will be available to patch.
+        QLineEdit* lineEdit = this->findChild<QLineEdit*>();
+        if (lineEdit)
+        {
+            lineEdit->setValidator(m_validator);
+        }
+    }
+
+    void InputDialog::show()
+    {
+        QInputDialog::show();
+
+        if (m_validator)
+        {
+            QLineEdit* lineEdit = this->findChild<QLineEdit*>();
+            if (lineEdit)
+            {
+                lineEdit->setValidator(m_validator);
+            }
+        }
+    }
+
+    int InputDialog::exec()
+    {
+        show();
+
+        this->setWindowModality(Qt::WindowModality::WindowModal);
+        return QInputDialog::exec();
+    }
+
+    QString InputDialog::getText(
+        QWidget* parent,
+        const QString& title,
+        const QString& label,
+        QLineEdit::EchoMode mode,
+        const QString& text,
+        const QString& validationRegExp)
+    {
+        InputDialog dialog(parent);
+        dialog.setWindowTitle(title);
+        dialog.setLabelText(label);
+        dialog.setTextValue(text);
+        dialog.setTextEchoMode(mode);
+
+        if (!validationRegExp.isEmpty())
+        {
+            dialog.setValidator(new QRegularExpressionValidator(QRegularExpression(validationRegExp), &dialog));
+        }
+
+        const int ret = dialog.exec();
+        if (ret)
+        {
+            return dialog.textValue();
+        }
+        else
+        {
+            return QString();
+        }
+    }
+
+} // namespace AzQtComponents
+
+#include "Components/moc_InputDialog.cpp"

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/InputDialog.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/InputDialog.h
@@ -49,6 +49,8 @@ namespace AzQtComponents
                                const QString& text = QString(),
                                const QString& validationRegExp = QString());
     private:
+        void AttemptAssignValidator();
+
         QValidator* m_validator = nullptr;
     };
 } // namespace AzQtComponents

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/InputDialog.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/InputDialog.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#if !defined(Q_MOC_RUN)
+#include <AzCore/PlatformDef.h>
+
+AZ_PUSH_DISABLE_WARNING(
+    4251 4244 4800,
+    "-Wunknown-warning-option") // 4251: class 'QScopedPointer<QBrushData,QBrushDataPointerDeleter>' needs to have dll-interface to be used
+                                // by clients of class 'QBrush' 4800: 'uint': forcing value to bool 'true' or 'false' (performance warning)
+#include <QInputDialog>
+#include <QLineEdit>
+#include <QRegularExpression>
+AZ_POP_DISABLE_WARNING
+
+#include <AzQtComponents/AzQtComponentsAPI.h>
+#endif
+
+class QValidator;
+
+namespace AzQtComponents
+{
+    //! An improved QInputDialog which allows a validator to be placed on the TextEdit line.
+    class AZ_QT_COMPONENTS_API InputDialog
+        : public QInputDialog
+    {
+        Q_OBJECT
+
+    public:
+        explicit InputDialog(QWidget* parent = nullptr);
+
+        //! Sets a validator on the LineEdit.
+        void setValidator(QValidator* validator);
+
+        void show();
+        int exec();
+
+        static QString getText(QWidget* parent,
+                               const QString& title,
+                               const QString& label,
+                               QLineEdit::EchoMode echo = QLineEdit::Normal,
+                               const QString& text = QString(),
+                               const QString& validationRegExp = QString());
+    private:
+        QValidator* m_validator = nullptr;
+    };
+} // namespace AzQtComponents

--- a/Code/Framework/AzQtComponents/AzQtComponents/azqtcomponents_files.cmake
+++ b/Code/Framework/AzQtComponents/AzQtComponents/azqtcomponents_files.cmake
@@ -44,6 +44,8 @@ set(FILES
     Components/FilteredSearchWidget.ui
     Components/GlobalEventFilter.h
     Components/GlobalEventFilter.cpp
+    Components/InputDialog.h
+    Components/InputDialog.cpp
     Components/O3DEStylesheet.h
     Components/Titlebar.cpp
     Components/Titlebar.h


### PR DESCRIPTION
Signed-off-by: sphrose <82213493+sphrose@users.noreply.github.com>

## What does this PR do?

This PR fixes #11688. It adds an AzQtComponents::InputDialog class which expands QInputDialog by allowing a text validator to be added to the text input. It then used this to prevent the user from adding illegal characters, e.g. '/' to layout filenames.

It also fixes a discrepancy between naming and renaming a layout, where naming forced the name to lower case, whereas renaming did not. Layout names are now always lower case.

## How was this PR tested?

Testing performed manually.
