### PR TITLE
BugFix - Move back override subtree in prefab override revert redo

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoRevertOverrides.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoRevertOverrides.cpp
@@ -53,7 +53,7 @@ namespace AzToolsFramework
             LinkReference link = m_prefabSystemComponentInterface->FindLink(m_linkId);
             if (link.has_value())
             {
-                link->get().RemoveOverrides(m_pathToSubTree);
+                m_overrideSubTree = AZStd::move(link->get().RemoveOverrides(m_pathToSubTree));
                 link->get().UpdateTarget();
                 m_prefabSystemComponentInterface->SetTemplateDirtyFlag(link->get().GetTargetTemplateId(), true);
                 m_prefabSystemComponentInterface->PropagateTemplateChanges(link->get().GetTargetTemplateId());

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Overrides/PrefabOverridePublicInterfaceTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Overrides/PrefabOverridePublicInterfaceTests.cpp
@@ -71,6 +71,12 @@ namespace UnitTest
         EXPECT_FALSE(m_prefabOverridePublicInterface->AreOverridesPresent(newEntityId));
         AZ::TransformBus::EventResult(worldX, newEntityId, &AZ::TransformInterface::GetWorldX);
         EXPECT_EQ(worldX, 0.0f);
+
+        // Second undo to validate that override subtree was populated back in previous redo.
+        Undo();
+        EXPECT_TRUE(m_prefabOverridePublicInterface->AreOverridesPresent(newEntityId));
+        AZ::TransformBus::EventResult(worldX, newEntityId, &AZ::TransformInterface::GetWorldX);
+        EXPECT_EQ(worldX, 10.0f);
     }
 
     TEST_F(PrefabOverridePublicInterfaceTest, RevertOverridesOnEntityWithoutOverrides)


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

This PR adds the missing "move operation" in prefab override revert undo node. Without moving back, the subtree stored in the undo node will become empty in subsequent undo/redo operations.

Before this fix, issue occurs when hitting "revert", undo, redo, and undo. In redo, the override subtree is not populated correctly, then in the second undo, the override subtree is empty.

## How was this PR tested?

1. Verified in editor
2. Update existing unit test to cover this fix. Verified that it failed before the fix and passed after the fix.
