### PR TITLE
EMotionFX: reload node group's parent node ID from file

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphNodeGroup.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphNodeGroup.cpp
@@ -212,6 +212,7 @@ namespace EMotionFX
             ->Field("name", &AnimGraphNodeGroup::m_name)
             ->Field("color", &AnimGraphNodeGroup::m_color)
             ->Field("isVisible", &AnimGraphNodeGroup::m_isVisible)
-            ->Field("isNameEditOngoing", &AnimGraphNodeGroup::m_nameEditOngoing);
+            ->Field("isNameEditOngoing", &AnimGraphNodeGroup::m_nameEditOngoing)
+            ->Field("parentNodeId", &AnimGraphNodeGroup::m_parentNodeId);
     }
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/EMotionFX/Source/ObjectId.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/ObjectId.cpp
@@ -6,10 +6,10 @@
  *
  */
 
-#include <EMotionFX/Source/ObjectId.h>
 #include <AzCore/Math/Sfmt.h>
+#include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/string/conversions.h>
-
+#include <EMotionFX/Source/ObjectId.h>
 
 namespace EMotionFX
 {
@@ -74,5 +74,16 @@ namespace EMotionFX
     bool ObjectId::operator!=(const ObjectId& rhs) const
     {
         return m_id != rhs.m_id;
+    }
+
+    void ObjectId::Reflect(AZ::ReflectContext* context)
+    {
+        AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+        if (!serializeContext)
+        {
+            return;
+        }
+
+        serializeContext->Class<ObjectId>()->Version(1)->Field("id", &ObjectId::m_id);
     }
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/EMotionFX/Source/ObjectId.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/ObjectId.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/std/string/string.h>
 #include <EMotionFX/Source/Allocators.h>
 
@@ -82,6 +83,8 @@ namespace EMotionFX
          * @return True if the ids are different. Otherwise, false.
          */
         bool operator!=(const ObjectId& rhs) const;
+
+        static void Reflect(AZ::ReflectContext* context);
 
     protected:
         AZ::u64 m_id;

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ContextMenu.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ContextMenu.cpp
@@ -59,6 +59,7 @@ namespace EMStudio
         {
             EMotionFX::AnimGraphNodeGroup* nodeGroup = animGraph->GetNodeGroup(i);
             auto nodeGroupParentId = nodeGroup->GetParentNodeId();
+            AZ_Assert(nodeGroupParentId.IsValid(), "Invalid nodeGroupParentId");
 
             // Check if the node group being iterated belongs to the same level currently being shown on the animation graph.
             // We only want to add it to the assignable node groups list if the levels match.

--- a/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
@@ -35,6 +35,7 @@
 #include <EMotionFX/Source/AnimGraphSyncTrack.h>
 #include <EMotionFX/Source/AnimGraph.h>
 #include <EMotionFX/Source/ActorManager.h>
+#include <EMotionFX/Source/ObjectId.h>
 
 #include <EMotionFX/Source/PhysicsSetup.h>
 #include <EMotionFX/Source/SimulatedObjectSetup.h>
@@ -291,6 +292,8 @@ namespace EMotionFX
             MCore::ReflectionSerializer::Reflect(context);
             MCore::StringIdPoolIndex::Reflect(context);
             EMotionFX::ConstraintTransformRotationAngles::Reflect(context);
+
+            EMotionFX::ObjectId::Reflect(context);
 
             // Actor
             EMotionFX::PhysicsSetup::Reflect(context);


### PR DESCRIPTION
AnimGraphNodeGroup::m_parentNodeId added in 337565f79a0c1d90ace2e5e29e2e14fd6d2f508d (https://github.com/o3de/o3de/pull/13395) was not being serialized/deserialized when saving/loading AnimGraphs to files, causing the context menu for assigning nodes to groups to be unable to assign nodes to groups that were created from the saved file.

Fixes https://github.com/o3de/o3de/issues/13426

## How was this PR tested?

manually, and confirming the new AZ_Assert failed before adding the new code
