### PR TITLE
Fixed: Duplicating a file with an appended filename can cause an Editor deadlock

### DIFF
--- a/Code/Framework/AzCore/AzCore/StringFunc/StringFunc.cpp
+++ b/Code/Framework/AzCore/AzCore/StringFunc/StringFunc.cpp
@@ -2321,23 +2321,23 @@ namespace AZ::StringFunc
             return inout;
         }
 
-        void MakeUniqueFilenameWithSuffix(
-            const AZStd::string& directoryPath, const AZStd::string& filename, AZStd::string& outFilePath, const AZStd::string& suffix)
+        AZ::IO::FixedMaxPath MakeUniqueFilenameWithSuffix(const AZ::IO::PathView& basePath, const AZStd::string_view& suffix)
         {
-            ConstructFull(directoryPath.c_str(), filename.c_str(), outFilePath);
+            AZ::IO::FixedMaxPath outFilePath(basePath);
             if (AZ::IO::FileIOBase::GetInstance()->Exists(outFilePath.c_str()))
             {
-                AZ::IO::Path oldPath = outFilePath;
-                AZ::IO::PathView extension = oldPath.Extension();
-                AZ::IO::PathView stem = oldPath.Stem();
+                AZ::IO::PathView extension = basePath.Extension();
+                AZ::IO::PathView stem = basePath.Stem();
                 int value = 1;
                 AZStd::string originalFname;
                 do
                 {
-                    originalFname = AZStd::string(stem.Native()) + suffix + AZStd::to_string(value++) + extension.Native().data();
-                    ConstructFull(directoryPath.c_str(), originalFname.c_str(), extension.Native().data(), outFilePath);
+                    auto uniqueFilename = AZ::IO::FixedMaxPathString::format(
+                        "%.*s%.*s%d%.*s", AZ_STRING_ARG(stem.Native()), AZ_STRING_ARG(suffix), value++, AZ_STRING_ARG(extension.Native()));
+                    outFilePath.ReplaceFilename(AZ::IO::PathView(uniqueFilename));
                 } while (AZ::IO::FileIOBase::GetInstance()->Exists(outFilePath.c_str()));
             }
+            return outFilePath;
         }
 
     } // namespace Path

--- a/Code/Framework/AzCore/AzCore/StringFunc/StringFunc.cpp
+++ b/Code/Framework/AzCore/AzCore/StringFunc/StringFunc.cpp
@@ -2334,7 +2334,7 @@ namespace AZ::StringFunc
                 AZStd::string originalFname;
                 do
                 {
-                    originalFname = AZStd::string(stem.Native()) + suffix + AZStd::to_string(value++);
+                    originalFname = AZStd::string(stem.Native()) + suffix + AZStd::to_string(value++) + extension.Native().data();
                     ConstructFull(directoryPath.c_str(), originalFname.c_str(), extension.Native().data(), outFilePath);
                 } while (AZ::IO::FileIOBase::GetInstance()->Exists(outFilePath.c_str()));
             }

--- a/Code/Framework/AzCore/AzCore/StringFunc/StringFunc.h
+++ b/Code/Framework/AzCore/AzCore/StringFunc/StringFunc.h
@@ -945,15 +945,13 @@ namespace AZ
             AZStd::string& AppendSeparator(AZStd::string& inout);
 
             //! MakeUniqueFilenameWithSuffix
-            /*! given a directory path, a filename and an optional extension will return a unique filename
-            *! EX: StringFunc::Path::MakeUniqueFilenameWithSuffix("c:\\folder","NewFile.txt", outPath, "-copy")
-            *! if "NewFile.txt" doesn't exist, returns "c:\\folder\\Newfile.txt" in outFilePath
-            *! if "NewFile.txt" exists, returns "c:\\folder\\Newfile-copy1.txt" in outFilePath
-            *! if both "NewFile.txt" and "NewFile-copy1.txt" exist, returns "c:\\folder\\Newfile-copy2.txt" in outFilePath
-            *! etc.
+            /*! given a directory path and an optional extension will return a unique filename
+            *! EX: StringFunc::Path::MakeUniqueFilenameWithSuffix("c:\\folder\\NewFile.txt", "-copy")
+            *! if "NewFile.txt" doesn't exist, returns "c:\\folder\\Newfile.txt"
+            *! if "NewFile.txt" exists, returns "c:\\folder\\Newfile-copy1.txt"
+            *! if both "NewFile.txt" and "NewFile-copy1.txt" exist, returns "c:\\folder\\Newfile-copy2.txt" etc.
             */
-            void MakeUniqueFilenameWithSuffix(
-                const AZStd::string& directoryPath, const AZStd::string& filename, AZStd::string& outFilePath, const AZStd::string& suffix = "");
+            AZ::IO::FixedMaxPath MakeUniqueFilenameWithSuffix(const AZ::IO::PathView& basePath, const AZStd::string_view& suffix = "");
 
         } // namespace Path
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -745,9 +745,7 @@ namespace AzToolsFramework
             {
                 using namespace AZ::IO;
                 Path oldPath = entry->GetFullPath();
-                AZStd::string newPath;
-                AzFramework::StringFunc::Path::MakeUniqueFilenameWithSuffix(
-                    oldPath.ParentPath().Native(), oldPath.Filename().Native(), newPath, "-copy");
+                AZ::IO::FixedMaxPath newPath = AzFramework::StringFunc::Path::MakeUniqueFilenameWithSuffix( AZ::IO::PathView(oldPath.Native()), "-copy");
                 QFile::copy(oldPath.c_str(), newPath.c_str());
             }
         }

--- a/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
@@ -931,9 +931,8 @@ namespace EMotionFX
                   QIcon(),
                   [&]( const AZStd::string& fullSourceFolderNameInCallback, [[maybe_unused]] const AZ::Uuid& sourceUUID)
                   {
-                      AZStd::string outFilePath;
-                      AzFramework::StringFunc::Path::MakeUniqueFilenameWithSuffix(
-                          fullSourceFolderNameInCallback, "NewAnimGraph.animgraph", outFilePath);
+                      AZ::IO::FixedMaxPath outFilePath = AzFramework::StringFunc::Path::MakeUniqueFilenameWithSuffix(
+                          AZ::IO::PathView(fullSourceFolderNameInCallback + "/NewAnimGraph.animgraph"));
 
                       EMotionFX::AnimGraph* animGraph = aznew EMotionFX::AnimGraph();
                       // create the root state machine object
@@ -948,7 +947,7 @@ namespace EMotionFX
                           animGraph->RecursiveInvalidateUniqueDatas();
                           AZ::SerializeContext* serializeContext = nullptr;
                           AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
-                          animGraph->SaveToFile(outFilePath, serializeContext);
+                          animGraph->SaveToFile(outFilePath.Native().c_str(), serializeContext);
                           delete animGraph;
                       }
                   } });
@@ -959,9 +958,8 @@ namespace EMotionFX
                   QIcon(),
                   [&]( const AZStd::string& fullSourceFolderNameInCallback, [[maybe_unused]] const AZ::Uuid& sourceUUID)
                   {
-                      AZStd::string outFilePath;
-                      AzFramework::StringFunc::Path::MakeUniqueFilenameWithSuffix(
-                          fullSourceFolderNameInCallback, "NewMotionSet.motionset", outFilePath);
+                      AZ::IO::FixedMaxPath outFilePath = AzFramework::StringFunc::Path::MakeUniqueFilenameWithSuffix(
+                          AZ::IO::PathView(fullSourceFolderNameInCallback + "/NewMotionSet.motionset"));
 
                       AZ::IO::PathView filePath = outFilePath.c_str();
                       AZStd::string motionSetName = filePath.Stem().Native();
@@ -970,7 +968,7 @@ namespace EMotionFX
                       AZ::SerializeContext* serializeContext = nullptr;
                       AZ::ComponentApplicationBus::BroadcastResult(
                           serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
-                      motionSet->SaveToFile(outFilePath, serializeContext);
+                      motionSet->SaveToFile(outFilePath.Native().c_str(), serializeContext);
                       delete motionSet;
                   } });
         }


### PR DESCRIPTION
Signed-off-by: John Jones-Steele <82226755+jjjoness@users.noreply.github.com>

## What does this PR do?

Fixes critical bug #13486

## How was this PR tested?
Tried various previously failing filenames.