### PR TITLE
re-enabled platform filters for gem catalog

### DIFF
--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterWidget.cpp
@@ -224,6 +224,7 @@ namespace O3DE::ProjectManager
         ResetGemOriginFilter();
         ResetTypeFilter();
         ResetFeatureFilter();
+        ResetPlatformFilter();
     }
 
     void GemFilterWidget::ResetFilterWidget(
@@ -421,7 +422,7 @@ namespace O3DE::ProjectManager
     void GemFilterWidget::ResetPlatformFilter()
     {
         ResetSimpleOrFilter<GemInfo::Platform, GemInfo::Platforms>(
-            m_platformFilter, "Supported Platforms", GemInfo::NumPlatforms,
+            m_platformFilter, "Platforms", GemInfo::NumPlatforms,
             [](GemModel* gemModel, GemInfo::Platform platform, int gemIndex)
             {
                 return static_cast<bool>(platform & gemModel->GetPlatforms(gemModel->index(gemIndex, 0)));


### PR DESCRIPTION
Signed-off-by: T.J. Kotha <112996779+tkothadev@users.noreply.github.com>

## What does this PR do?
This PR re-enables platform based filtering for gems in the Gem Catalog screen. Implementation was simple: there already existed logic in the filter widget classes similar to what already exists for Type, Feature, and Origin filtering. I just re-enabled that in the main code path for resetting filters.

## How was this PR tested?

Testing was performed manually. Results can be found in this gif.
![GemCatalogPlatformFilter](https://user-images.githubusercontent.com/112996779/205317362-4600a1f9-5a40-4b25-b599-6c68426b2d99.gif)
