### PR TITLE
Fixed iOS when built non-monolithically.

### DIFF
--- a/cmake/Platform/Common/RuntimeDependencies_common.cmake
+++ b/cmake/Platform/Common/RuntimeDependencies_common.cmake
@@ -84,10 +84,10 @@ function(ly_get_runtime_dependencies ly_RUNTIME_DEPENDENCIES ly_TARGET)
                 continue()
             endif()
 
-            # If the link dependency target is a shared library then
+            # If the link dependency target has runtime outputs itself then
             # add it as a runtime dependency as well.
             get_target_property(link_dependency_type ${link_dependency} TYPE)
-            if(${link_dependency_type} STREQUAL "SHARED_LIBRARY")
+            if(link_dependency_type IN_LIST LY_TARGET_TYPES_WITH_RUNTIME_OUTPUTS)
                 list(APPEND all_runtime_dependencies ${link_dependency})
             endif()
         endif()

--- a/cmake/Platform/Common/RuntimeDependencies_common.cmake
+++ b/cmake/Platform/Common/RuntimeDependencies_common.cmake
@@ -83,6 +83,13 @@ function(ly_get_runtime_dependencies ly_RUNTIME_DEPENDENCIES ly_TARGET)
             if(is_imported AND is_system_library)
                 continue()
             endif()
+
+            # If the link dependency target is a shared library then
+            # add it as a runtime dependency as well.
+            get_target_property(link_dependency_type ${link_dependency} TYPE)
+            if(${link_dependency_type} STREQUAL "SHARED_LIBRARY")
+                list(APPEND all_runtime_dependencies ${link_dependency})
+            endif()
         endif()
 
         unset(dependencies)


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

If fixes configuring and running iOS when built non-monolithically.

There were 3 issues:
1. Target dependencies were not picked up correctly, using `O3DE_PROJECTS_NAME` property now uses the correct project name to query dependencies.
2. Configuration was failing due to not been able to find `IMPORTED` targets, which in iOS they shouldn't be included as dependencies of targets, but it will include the imported target's dependencies.
3. The app was crashing at runtime due to not having O3DEKernel. The issue was that when a static lib depended on a shared lib, that dependency was not transmitted when a target depended on that static lib. Fixed in `ly_get_runtime_dependencies` now including the shared lib as runtime dependencies (and not only its dependencies).

## How was this PR tested?

Built and run iOS monolithically and non-monolithically.
