### PR TITLE
[Terrain] Move ImageGradient paint logic to the runtime and expose via API

### DIFF
--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientModification.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientModification.h
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Component/Component.h>
+#include <AzCore/Math/Vector2.h>
+#include <AzCore/Serialization/Json/BaseJsonSerializer.h>
+#include <AzCore/Serialization/Json/RegistrationContext.h>
+#include <AzCore/std/parallel/shared_mutex.h>
+#include <AzFramework/PaintBrush/PaintBrushNotificationBus.h>
+#include <GradientSignal/Ebuses/GradientRequestBus.h>
+#include <GradientSignal/Ebuses/GradientTransformRequestBus.h>
+#include <GradientSignal/Ebuses/ImageGradientRequestBus.h>
+#include <GradientSignal/Ebuses/ImageGradientModificationBus.h>
+#include <GradientSignal/Util.h>
+
+namespace GradientSignal
+{
+    //! Tracks all of the image modifications for a single continuous paint stroke. Since most modifications will only affect a small
+    //! portion of an image, this buffer divides the total image space into fixed-size tiles and only creates an individual tile
+    //! buffer when at least one pixel in that tile's space is modified.
+    //! While painting the paint stroke, this buffer caches all of the unmodified gradient values and the modifications for each
+    //! modified pixel. The buffer is used to create a special "stroke layer" that accumulates opacity for each stroke, which
+    //! then combines with the stroke opacity, stroke intensity, and blend mode to blend back into the base layer.
+    //! After the paint stroke finishes, the stroke buffer ownership is handed over to the undo/redo system so that it can
+    //! be used to undo/redo each individual paint stroke.
+    class ImageTileBuffer
+    {
+    public:
+        ImageTileBuffer(uint32_t imageWidth, uint32_t imageHeight, AZ::EntityId imageGradientEntityId);
+        ~ImageTileBuffer() = default;
+
+        //! Returns true if we don't have any pixel modifications, false if we do.
+        bool Empty() const;
+
+        //! Get the original gradient value for the given pixel index.
+        //! Since we "lazy-cache" our unmodified image as tiles, create it here the first time we request a pixel from a tile.
+        AZStd::pair<float, float> GetOriginalPixelValueAndOpacity(const PixelIndex& pixelIndex);
+
+        //! Set a modified gradient value for the given pixel index.
+        void SetModifiedPixelValue(const PixelIndex& pixelIndex, float modifiedValue, float opacity);
+
+        //! For undo/redo operations, apply the buffer of changes back to the image gradient.
+        void ApplyChangeBuffer(bool undo);
+
+    private:
+        //! Given a pixel index, get the tile index that it maps to.
+        uint32_t GetTileIndex(const PixelIndex& pixelIndex) const;
+
+        //! Given a tile index, get the absolute start pixel index for the upper left corner of the tile.
+        PixelIndex GetStartPixelIndex(uint32_t tileIndex) const;
+
+        // Given a pixel index, get the relative pixel index within the tile
+        uint32_t GetPixelTileIndex(const PixelIndex& pixelIndex) const;
+
+        //! Create an image tile initialized with the image gradient values if it doesn't already exist.
+        void CreateImageTile(uint32_t tileIndex);
+
+        //! Size of each modified image tile that we'll cache off.
+        //! This size is chosen somewhat arbitrarily to keep the number of tiles balanced at a reasonable size.
+        static inline constexpr uint32_t ImageTileSize = 32;
+
+        //! Keeps track of all the unmodified and modified gradient values, as well as our paint stroke opacity layer, for an NxN tile.
+        //! We store it a struct of arrays instead of an array of structs for better compatibility with the ImageGradient APIs,
+        //! where we can just pass in a full array of values to update a full tile of values at once.
+        struct ImageTile
+        {
+            AZStd::array<float, ImageTileSize * ImageTileSize> m_unmodifiedData;
+            AZStd::array<float, ImageTileSize * ImageTileSize> m_modifiedData;
+            AZStd::array<float, ImageTileSize * ImageTileSize> m_modifiedDataOpacity;
+        };
+
+        //! A vector of pointers to image tiles.
+        //! All of the tile pointer entries are always expected to exist, even if the pointers are null.
+        using ImageTileList = AZStd::vector<AZStd::unique_ptr<ImageTile>>;
+
+        //! The actual storage for the set of image tile pointers. Image tiles get created on-demand whenever pixels in them change.
+        //! This ultimately contains all of the changes for one continuous brush stroke.
+        ImageTileList m_paintedImageTiles;
+
+        //! The number of tiles we're creating in the X and Y directions to contain a full Image Gradient.
+        const uint32_t m_numTilesX = 0;
+        const uint32_t m_numTilesY = 0;
+
+        //! The entity ID of the Image Gradient that we're modifying.
+        const AZ::EntityId m_imageGradientEntityId;
+
+        //! Track whether or not we've modified any pixels.
+        bool m_modifiedAnyPixels = false;
+    };
+
+    struct PaintStrokeData
+    {
+        //! A buffer to accumulate a single paint stroke into. This buffer is used to ensure that within a single paint stroke,
+        //! we only perform an operation on a pixel once, not multiple times.
+        //! After the paint stroke is complete, this buffer is handed off to the undo/redo batch so that we can undo/redo each stroke.
+        AZStd::shared_ptr<ImageTileBuffer> m_strokeBuffer;
+
+        //! The meters per pixel in each direction for this image gradient.
+        //! These help us query the paintbrush for exactly one world position per image pixel.
+        float m_metersPerPixelX = 0.0f;
+        float m_metersPerPixelY = 0.0f;
+
+        //! The intensity of the paint stroke (0 - 1)
+        float m_intensity = 0.0f;
+
+        //! The opacity of the paint stroke (0 - 1)
+        float m_opacity = 0.0f;
+
+        //! Track the dirty region for each paint stroke so that we can store it in the undo/redo buffer
+        //! to send with change notifications.
+        AZ::Aabb m_dirtyRegion = AZ::Aabb::CreateNull();
+    };
+
+    class ImageGradientModifier : private AzFramework::PaintBrushNotificationBus::Handler
+    {
+    public:
+        ImageGradientModifier(const AZ::EntityComponentIdPair& entityComponentIdPair);
+        ~ImageGradientModifier() override;
+
+    protected:
+        // PaintBrushNotificationBus overrides
+        void OnBrushStrokeBegin(const AZ::Color& color) override;
+        void OnBrushStrokeEnd() override;
+        void OnPaint(const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, BlendFn& blendFn) override;
+        void OnSmooth(
+            const AZ::Aabb& dirtyArea,
+            ValueLookupFn& valueLookupFn,
+            AZStd::span<const AZ::Vector3> valuePointOffsets,
+            SmoothFn& smoothFn) override;
+        AZ::Color OnGetColor(const AZ::Vector3& brushCenter) override;
+
+        void OnPaintSmoothInternal(
+            const AZ::Aabb& dirtyArea,
+            ValueLookupFn& valueLookupFn,
+            AZStd::function<float(const AZ::Vector3& worldPosition, float gradientValue, float opacity)> combineFn);
+
+    private:
+        PaintStrokeData m_paintStrokeData;
+
+        //! The entity/component that owns this paintbrush.
+        AZ::EntityComponentIdPair m_ownerEntityComponentId;
+    };
+
+} // namespace GradientSignal

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Ebuses/ImageGradientModificationBus.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Ebuses/ImageGradientModificationBus.h
@@ -9,11 +9,14 @@
 #pragma once
 
 #include <AzCore/Component/ComponentBus.h>
-
+#include <AzFramework/PaintBrush/PaintBrushSettings.h>
 #include <GradientSignal/Util.h>
+
 
 namespace GradientSignal
 {
+    class ImageTileBuffer;
+
     using PixelIndex = AZStd::pair<int16_t, int16_t>;
 
     //! EBus that can be used to modify the image data for an Image Gradient.
@@ -29,8 +32,40 @@ namespace GradientSignal
         virtual void StartImageModification() = 0;
 
         //! Finish an image modification session.
-        //! Currently does nothing, but might eventually need to perform some cleanup logic.
+        //! Clean up any helper structures used during image modification.
         virtual void EndImageModification() = 0;
+
+        //! The following APIs are the high-level image modification APIs.
+        //! These enable image modifications through paintbrush controls.
+
+        //! Start a brush stroke with the given brush settings for color/intensity/opacity.
+        //! @param brushSettings The paintbrush settings containing the color/intensity/opacity to use for the brush stroke.
+        virtual void BeginBrushStroke(const AzFramework::PaintBrushSettings& brushSettings) = 0;
+
+        //! End the current brush stroke.
+        virtual void EndBrushStroke() = 0;
+
+        //! Returns whether or not the brush is currently in a brush stroke.
+        //! @return True if a brush stroke has been started, false if not.
+        virtual bool IsInBrushStroke() const = 0;
+
+        //! Reset the brush tracking so that the next action will be considered the start of a stroke movement instead of a continuation.
+        //! This is useful for handling discontinuous movement (like moving off the edge of the surface on one side and back on from
+        //! a different side).
+        virtual void ResetBrushStrokeTracking() = 0;
+
+        //! Apply a paint color to the underlying data based on brush movement and settings.
+        //! @param brushCenter The current center of the paintbrush.
+        //! @param brushSettings The current paintbrush settings.
+        virtual void PaintToLocation(const AZ::Vector3& brushCenter, const AzFramework::PaintBrushSettings& brushSettings) = 0;
+
+        //! Smooth the underlying data based on brush movement and settings.
+        //! @param brushCenter The current center of the paintbrush.
+        //! @param brushSettings The current paintbrush settings.
+        virtual void SmoothToLocation(const AZ::Vector3& brushCenter, const AzFramework::PaintBrushSettings& brushSettings) = 0;
+
+        //! The following APIs are the low-level image modification APIs. 
+        //! These enable image modifications at the per-pixel level.
 
         //! Given a list of world positions, return a list of pixel indices into the image.
         //! @param positions The list of world positions to query
@@ -75,4 +110,26 @@ namespace GradientSignal
     };
 
     using ImageGradientModificationBus = AZ::EBus<ImageGradientModifications>;
-}
+
+    //! EBus that notifies about the current state of Image Gradient modifications
+    class ImageGradientModificationNotifications : public AZ::ComponentBus
+    {
+    public:
+        // Overrides the default AZ::EBusTraits handler policy to allow only one listener per entity.
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+
+        //! Notify any listeners that a brush stroke has started on this image gradient.
+        virtual void OnImageGradientBrushStrokeBegin() {}
+
+        //! Notify any listeners that a brush stroke has ended on this image gradient.
+        //! @param changedDataBuffer A pointer to the ImageTileBuffer containing the changed data. The buffer will be deleted
+        //! after this notification unless a listener keeps a copy of the pointer (for undo/redo, for example).
+        //! @param dirtyRegion The AABB defining the world space region affected by the brush stroke.
+        virtual void OnImageGradientBrushStrokeEnd(
+            [[maybe_unused]] AZStd::shared_ptr<ImageTileBuffer> changedDataBuffer, [[maybe_unused]] const AZ::Aabb& dirtyRegion)
+        {
+        }
+    };
+
+    using ImageGradientModificationNotificationBus = AZ::EBus<ImageGradientModificationNotifications>;
+} // namespace GradientSignal

--- a/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
@@ -250,7 +250,7 @@ namespace GradientSignal
                 ;
 
             behaviorContext->EBus<ImageGradientRequestBus>("ImageGradientRequestBus")
-                ->Attribute(AZ::Script::Attributes::Category, "Vegetation")
+                ->Attribute(AZ::Script::Attributes::Category, "Vegetation/ImageGradient")
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
                 ->Attribute(AZ::Script::Attributes::Module, "vegetation")
                 ->Event("GetImageAssetPath", &ImageGradientRequestBus::Events::GetImageAssetPath)
@@ -267,11 +267,17 @@ namespace GradientSignal
             ;
 
             behaviorContext->EBus<ImageGradientModificationBus>("ImageGradientModificationBus")
-                ->Attribute(AZ::Script::Attributes::Category, "Vegetation")
-                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
-                ->Attribute(AZ::Script::Attributes::Module, "vegetation")
+                ->Attribute(AZ::Script::Attributes::Category, "Vegetation/ImageGradient/Modifications")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, "vegetation.imageGradient.modifications")
                 ->Event("StartImageModification", &ImageGradientModificationBus::Events::StartImageModification)
                 ->Event("EndImageModification", &ImageGradientModificationBus::Events::EndImageModification)
+                ->Event("BeginBrushStroke", &ImageGradientModificationBus::Events::BeginBrushStroke)
+                ->Event("EndBrushStroke", &ImageGradientModificationBus::Events::EndBrushStroke)
+                ->Event("IsInBrushStroke", &ImageGradientModificationBus::Events::IsInBrushStroke)
+                ->Event("ResetBrushStrokeTracking", &ImageGradientModificationBus::Events::ResetBrushStrokeTracking)
+                ->Event("PaintToLocation", &ImageGradientModificationBus::Events::PaintToLocation)
+                ->Event("SmoothToLocation", &ImageGradientModificationBus::Events::SmoothToLocation)
             ;
         }
     }
@@ -722,9 +728,11 @@ namespace GradientSignal
 
     void ImageGradientComponent::OnAssetReady(AZ::Data::Asset<AZ::Data::AssetData> asset)
     {
-        AZStd::unique_lock lock(m_queryMutex);
-        m_configuration.m_imageAsset = asset;
-        GetSubImageData();
+        {
+            AZStd::unique_lock lock(m_queryMutex);
+            m_configuration.m_imageAsset = asset;
+            GetSubImageData();
+        }
         LmbrCentral::DependencyNotificationBus::Event(GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
     }
 
@@ -741,6 +749,10 @@ namespace GradientSignal
 
     void ImageGradientComponent::StartImageModification()
     {
+        m_imageModifier = AZStd::make_unique<ImageGradientModifier>(AZ::EntityComponentIdPair(GetEntityId(), GetId()));
+        m_paintBrush = AZStd::make_unique<AzFramework::PaintBrush>(AZ::EntityComponentIdPair(GetEntityId(), GetId()));
+        m_paintBrush->BeginPaintMode();
+
         m_configuration.m_imageModificationActive = true;
 
         if (m_modifiedImageData.empty())
@@ -751,8 +763,69 @@ namespace GradientSignal
 
     void ImageGradientComponent::EndImageModification()
     {
+        m_paintBrush->EndPaintMode();
+        m_paintBrush = {};
+        m_imageModifier = {};
         m_configuration.m_imageModificationActive = false;
     }
+
+    void ImageGradientComponent::BeginBrushStroke(const AzFramework::PaintBrushSettings& brushSettings)
+    {
+        AZ_Error("ImageGradientComponent", m_paintBrush, "StartImageModification() needs to be called first to use the paint controls.");
+        if (m_paintBrush)
+        {
+            m_paintBrush->BeginBrushStroke(brushSettings);
+        }
+    }
+
+    void ImageGradientComponent::EndBrushStroke()
+    {
+        AZ_Error("ImageGradientComponent", m_paintBrush, "StartImageModification() needs to be called first to use the paint controls.");
+        if (m_paintBrush)
+        {
+            m_paintBrush->EndBrushStroke();
+        }
+    }
+
+    bool ImageGradientComponent::IsInBrushStroke() const
+    {
+        if (m_paintBrush)
+        {
+            return m_paintBrush->IsInBrushStroke();
+        }
+
+        return false;
+    }
+
+    void ImageGradientComponent::ResetBrushStrokeTracking()
+    {
+        AZ_Error("ImageGradientComponent", m_paintBrush, "StartImageModification() needs to be called first to use the paint controls.");
+        if (m_paintBrush)
+        {
+            m_paintBrush->ResetBrushStrokeTracking();
+        }
+    }
+
+    void ImageGradientComponent::PaintToLocation(
+        const AZ::Vector3& brushCenter, const AzFramework::PaintBrushSettings& brushSettings)
+    {
+        AZ_Error("ImageGradientComponent", m_paintBrush, "StartImageModification() needs to be called first to use the paint controls.");
+        if (m_paintBrush)
+        {
+            m_paintBrush->PaintToLocation(brushCenter, brushSettings);
+        }
+    }
+
+    void ImageGradientComponent::SmoothToLocation(
+        const AZ::Vector3& brushCenter, const AzFramework::PaintBrushSettings& brushSettings)
+    {
+        AZ_Error("ImageGradientComponent", m_paintBrush, "StartImageModification() needs to be called first to use the paint controls.");
+        if (m_paintBrush)
+        {
+            m_paintBrush->SmoothToLocation(brushCenter, brushSettings);
+        }
+    }
+
 
     AZStd::vector<float>* ImageGradientComponent::GetImageModificationBuffer()
     {

--- a/Gems/GradientSignal/Code/Source/Components/ImageGradientModification.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ImageGradientModification.cpp
@@ -152,15 +152,11 @@ namespace GradientSignal
         const AZ::EntityComponentIdPair& entityComponentIdPair)
         : m_ownerEntityComponentId(entityComponentIdPair)
     {
-        AZ::EntityId entityId = m_ownerEntityComponentId.GetEntityId();
-
         AzFramework::PaintBrushNotificationBus::Handler::BusConnect(entityComponentIdPair);
     }
 
     ImageGradientModifier::~ImageGradientModifier()
     {
-        AZ::EntityId entityId = m_ownerEntityComponentId.GetEntityId();
-
         AzFramework::PaintBrushNotificationBus::Handler::BusDisconnect();
     }
 

--- a/Gems/GradientSignal/Code/Source/Components/ImageGradientModification.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ImageGradientModification.cpp
@@ -1,0 +1,410 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <GradientSignal/Components/ImageGradientModification.h>
+#include <GradientSignal/Components/ImageGradientComponent.h>
+#include <LmbrCentral/Dependency/DependencyNotificationBus.h>
+
+namespace GradientSignal
+{
+    ImageTileBuffer::ImageTileBuffer(uint32_t imageWidth, uint32_t imageHeight, AZ::EntityId imageGradientEntityId)
+        : m_imageGradientEntityId(imageGradientEntityId)
+        // Calculate the number of image tiles in each direction that we'll need, rounding up so that we create an image tile
+        // for fractional tiles as well.
+        , m_numTilesX((imageWidth + ImageTileSize - 1) / ImageTileSize)
+        , m_numTilesY((imageHeight + ImageTileSize - 1) / ImageTileSize)
+    {
+        // Create empty entries for every tile. Each entry is just a null pointer at the start, so the memory overhead
+        // of these empty entries at 32x32 pixels per tile, a 1024x1024 image will have 8 KB of overhead.
+        m_paintedImageTiles.resize(m_numTilesX * m_numTilesY);
+    }
+
+    bool ImageTileBuffer::Empty() const
+    {
+        return !m_modifiedAnyPixels;
+    }
+
+    AZStd::pair<float, float> ImageTileBuffer::GetOriginalPixelValueAndOpacity(const PixelIndex& pixelIndex)
+    {
+        uint32_t tileIndex = GetTileIndex(pixelIndex);
+        uint32_t pixelTileIndex = GetPixelTileIndex(pixelIndex);
+
+        // Create the tile if it doesn't already exist.
+        CreateImageTile(tileIndex);
+
+        return { m_paintedImageTiles[tileIndex]->m_unmodifiedData[pixelTileIndex],
+                    m_paintedImageTiles[tileIndex]->m_modifiedDataOpacity[pixelTileIndex] };
+    }
+
+    void ImageTileBuffer::SetModifiedPixelValue(const PixelIndex& pixelIndex, float modifiedValue, float opacity)
+    {
+        uint32_t tileIndex = GetTileIndex(pixelIndex);
+        uint32_t pixelTileIndex = GetPixelTileIndex(pixelIndex);
+
+        AZ_Assert(m_paintedImageTiles[tileIndex], "Cached image tile hasn't been created yet!");
+
+        m_paintedImageTiles[tileIndex]->m_modifiedData[pixelTileIndex] = modifiedValue;
+        m_paintedImageTiles[tileIndex]->m_modifiedDataOpacity[pixelTileIndex] = opacity;
+    }
+
+    void ImageTileBuffer::ApplyChangeBuffer(bool undo)
+    {
+        AZStd::array<PixelIndex, ImageTileSize * ImageTileSize> pixelIndices;
+
+        for (int32_t tileIndex = 0; tileIndex < m_paintedImageTiles.size(); tileIndex++)
+        {
+            // If we never created this tile, skip it and move on.
+            if (m_paintedImageTiles[tileIndex] == nullptr)
+            {
+                continue;
+            }
+
+            // Create an array of pixel indices for every pixel in this tile.
+            PixelIndex startIndex = GetStartPixelIndex(tileIndex);
+            uint32_t index = 0;
+            for (int16_t y = 0; y < ImageTileSize; y++)
+            {
+                for (int16_t x = 0; x < ImageTileSize; x++)
+                {
+                    pixelIndices[index++] =
+                        PixelIndex(aznumeric_cast<int16_t>(startIndex.first + x), aznumeric_cast<int16_t>(startIndex.second + y));
+                }
+            }
+
+            // Set the image gradient values for this tile either to the original or the modified values.
+            // It's possible that not every pixel in the tile was modified, but it's cheaper just to update per-tile
+            // than to track each individual pixel in the tile and set them individually.
+            ImageGradientModificationBus::Event(
+                m_imageGradientEntityId,
+                &ImageGradientModificationBus::Events::SetPixelValuesByPixelIndex,
+                pixelIndices,
+                undo ? m_paintedImageTiles[tileIndex]->m_unmodifiedData : m_paintedImageTiles[tileIndex]->m_modifiedData);
+        }
+    }
+
+    uint32_t ImageTileBuffer::GetTileIndex(const PixelIndex& pixelIndex) const
+    {
+        return ((pixelIndex.second / ImageTileSize) * m_numTilesX) + (pixelIndex.first / ImageTileSize);
+    }
+
+    PixelIndex ImageTileBuffer::GetStartPixelIndex(uint32_t tileIndex) const
+    {
+        return PixelIndex(
+            aznumeric_cast<int16_t>((tileIndex % m_numTilesX) * ImageTileSize),
+            aznumeric_cast<int16_t>((tileIndex / m_numTilesX) * ImageTileSize));
+    }
+
+    uint32_t ImageTileBuffer::GetPixelTileIndex(const PixelIndex& pixelIndex) const
+    {
+        uint32_t xIndex = pixelIndex.first % ImageTileSize;
+        uint32_t yIndex = pixelIndex.second % ImageTileSize;
+
+        return (yIndex * ImageTileSize) + xIndex;
+    }
+
+    void ImageTileBuffer::CreateImageTile(uint32_t tileIndex)
+    {
+        // If it already exists, there's nothing more to do.
+        if (m_paintedImageTiles[tileIndex])
+        {
+            return;
+        }
+
+        auto imageTile = AZStd::make_unique<ImageTile>();
+
+        // Initialize the list of pixel indices for this tile.
+        AZStd::array<PixelIndex, ImageTileSize * ImageTileSize> pixelIndices;
+        PixelIndex startIndex = GetStartPixelIndex(tileIndex);
+        for (int16_t index = 0; index < (ImageTileSize * ImageTileSize); index++)
+        {
+            pixelIndices[index] = PixelIndex(
+                aznumeric_cast<int16_t>(startIndex.first + (index % ImageTileSize)),
+                aznumeric_cast<int16_t>(startIndex.second + (index / ImageTileSize)));
+        }
+
+        AZ_Assert(imageTile->m_unmodifiedData.size() == pixelIndices.size(), "ImageTile and PixelIndices are out of sync.");
+
+        // Read all of the original gradient values into the image tile buffer.
+        ImageGradientModificationBus::Event(
+            m_imageGradientEntityId,
+            &ImageGradientModificationBus::Events::GetPixelValuesByPixelIndex,
+            pixelIndices,
+            imageTile->m_unmodifiedData);
+
+        // Initialize the modified value buffer with the original values. This way we can always undo/redo an entire tile at a time
+        // without tracking which pixels in the tile have been modified.
+        imageTile->m_modifiedData = imageTile->m_unmodifiedData;
+
+        AZStd::fill(imageTile->m_modifiedDataOpacity.begin(), imageTile->m_modifiedDataOpacity.end(), 0.0f);
+
+        m_paintedImageTiles[tileIndex] = AZStd::move(imageTile);
+
+        // If we create a tile, we'll use that as shorthand for tracking that changed data exists.
+        m_modifiedAnyPixels = true;
+    }
+
+    ImageGradientModifier::ImageGradientModifier(
+        const AZ::EntityComponentIdPair& entityComponentIdPair)
+        : m_ownerEntityComponentId(entityComponentIdPair)
+    {
+        AZ::EntityId entityId = m_ownerEntityComponentId.GetEntityId();
+
+        AzFramework::PaintBrushNotificationBus::Handler::BusConnect(entityComponentIdPair);
+    }
+
+    ImageGradientModifier::~ImageGradientModifier()
+    {
+        AZ::EntityId entityId = m_ownerEntityComponentId.GetEntityId();
+
+        AzFramework::PaintBrushNotificationBus::Handler::BusDisconnect();
+    }
+
+    void ImageGradientModifier::OnBrushStrokeBegin(const AZ::Color& color)
+    {
+        AZ::EntityId entityId = m_ownerEntityComponentId.GetEntityId();
+
+        ImageGradientModificationNotificationBus::Event(
+            entityId, &ImageGradientModificationNotificationBus::Events::OnImageGradientBrushStrokeBegin);
+
+        // Get the spacing to map individual pixels to world space positions.
+        AZ::Vector2 imagePixelsPerMeter(0.0f);
+        ImageGradientRequestBus::EventResult(imagePixelsPerMeter, entityId, &ImageGradientRequestBus::Events::GetImagePixelsPerMeter);
+        if ((imagePixelsPerMeter.GetX() <= 0.0f) || (imagePixelsPerMeter.GetY() <= 0.0f))
+        {
+            return;
+        }
+
+        m_paintStrokeData.m_intensity = color.GetR();
+        m_paintStrokeData.m_opacity = color.GetA();
+
+        m_paintStrokeData.m_metersPerPixelX = 1.0f / imagePixelsPerMeter.GetX();
+        m_paintStrokeData.m_metersPerPixelY = 1.0f / imagePixelsPerMeter.GetY();
+
+        uint32_t imageWidth = 0;
+        ImageGradientRequestBus::EventResult(imageWidth, entityId, &ImageGradientRequestBus::Events::GetImageWidth);
+
+        uint32_t imageHeight = 0;
+        ImageGradientRequestBus::EventResult(imageHeight, entityId, &ImageGradientRequestBus::Events::GetImageHeight);
+
+        // Create the buffer for holding all the changes for a single continuous paint brush stroke.
+        // This buffer will get used during the stroke to hold our accumulated stroke opacity layer,
+        // and then after the stroke finishes we'll hand the buffer over to the undo system as an undo/redo buffer.
+        m_paintStrokeData.m_strokeBuffer = AZStd::make_shared<ImageTileBuffer>(imageWidth, imageHeight, entityId);
+    }
+
+    void ImageGradientModifier::OnBrushStrokeEnd()
+    {
+        AZ::EntityId entityId = m_ownerEntityComponentId.GetEntityId();
+
+        if (m_paintStrokeData.m_dirtyRegion.IsValid())
+        {
+            // Expand the dirty region for this brush stroke by one pixel in each direction
+            // to account for any data affected by bilinear filtering as well.
+            m_paintStrokeData.m_dirtyRegion.Expand(
+                AZ::Vector3(m_paintStrokeData.m_metersPerPixelX, m_paintStrokeData.m_metersPerPixelY, 0.0f));
+
+            // Expand the dirty region to encompass the full Z range since image gradients are 2D.
+            auto dirtyRegionMin = m_paintStrokeData.m_dirtyRegion.GetMin();
+            auto dirtyRegionMax = m_paintStrokeData.m_dirtyRegion.GetMax();
+            m_paintStrokeData.m_dirtyRegion.Set(
+                AZ::Vector3(dirtyRegionMin.GetX(), dirtyRegionMin.GetY(), AZStd::numeric_limits<float>::lowest()),
+                AZ::Vector3(dirtyRegionMax.GetX(), dirtyRegionMax.GetY(), AZStd::numeric_limits<float>::max()));
+        }
+
+        ImageGradientModificationNotificationBus::Event(
+            entityId,
+            &ImageGradientModificationNotificationBus::Events::OnImageGradientBrushStrokeEnd,
+            m_paintStrokeData.m_strokeBuffer,
+            m_paintStrokeData.m_dirtyRegion);
+
+        // Make sure we've cleared out our paint stroke data until the next paint stroke begins.
+        m_paintStrokeData = {};
+    }
+
+    AZ::Color ImageGradientModifier::OnGetColor(const AZ::Vector3& brushCenter)
+    {
+        AZ::EntityId entityId = m_ownerEntityComponentId.GetEntityId();
+
+        // Get the gradient value at the given point.
+        // We use "GetPixelValuesByPosition" instead of "GetGradientValue" because we want to select unscaled, unsmoothed values.
+        float gradientValue = 0.0f;
+        ImageGradientModificationBus::Event(
+            entityId,
+            &ImageGradientModificationBus::Events::GetPixelValuesByPosition,
+            AZStd::span<const AZ::Vector3>(&brushCenter, 1),
+            AZStd::span<float>(&gradientValue, 1));
+
+        return AZ::Color(gradientValue, gradientValue, gradientValue, 1.0f);
+    }
+
+    void ImageGradientModifier::OnPaintSmoothInternal(
+        const AZ::Aabb& dirtyArea,
+        ValueLookupFn& valueLookupFn,
+        AZStd::function<float(const AZ::Vector3& worldPosition, float gradientValue, float opacity)> combineFn)
+    {
+        // We're either painting or smoothing new values into our image gradient.
+        // To do this, we need to calculate the set of world space positions that map to individual pixels in the image,
+        // then ask the paint brush for each position what value we should set that pixel to. Finally, we use those modified
+        // values to change the image gradient.
+
+        const AZ::Vector3 minDistances = dirtyArea.GetMin();
+        const AZ::Vector3 maxDistances = dirtyArea.GetMax();
+        const float zMinDistance = minDistances.GetZ();
+
+        const int32_t xPoints = aznumeric_cast<int32_t>((maxDistances.GetX() - minDistances.GetX()) / m_paintStrokeData.m_metersPerPixelX);
+        const int32_t yPoints = aznumeric_cast<int32_t>((maxDistances.GetY() - minDistances.GetY()) / m_paintStrokeData.m_metersPerPixelY);
+
+        // Early out if the dirty area is smaller than our point size.
+        if ((xPoints <= 0) || (yPoints <= 0))
+        {
+            return;
+        }
+
+        // Calculate the minimum set of world space points that map to those pixels.
+        AZStd::vector<AZ::Vector3> points;
+        points.reserve(xPoints * yPoints);
+        for (float y = minDistances.GetY(); y <= maxDistances.GetY(); y += m_paintStrokeData.m_metersPerPixelY)
+        {
+            for (float x = minDistances.GetX(); x <= maxDistances.GetX(); x += m_paintStrokeData.m_metersPerPixelX)
+            {
+                points.emplace_back(x, y, zMinDistance);
+            }
+        }
+
+        // Query the paintbrush with those points to get back the subset of points and brush opacities for each point that's
+        // affected by the brush.
+        AZStd::vector<AZ::Vector3> validPoints;
+        AZStd::vector<float> perPixelOpacities;
+        valueLookupFn(points, validPoints, perPixelOpacities);
+
+        // Early out if none of the points were actually affected by the brush.
+        if (validPoints.empty())
+        {
+            return;
+        }
+
+        AZ::EntityId entityId = m_ownerEntityComponentId.GetEntityId();
+
+        // Get the pixel indices for each position.
+        AZStd::vector<PixelIndex> pixelIndices(validPoints.size());
+        ImageGradientModificationBus::Event(
+            entityId, &ImageGradientModificationBus::Events::GetPixelIndicesForPositions, validPoints, pixelIndices);
+
+        // Create a buffer for all of the modified, blended gradient values.
+        AZStd::vector<float> paintedValues;
+        paintedValues.reserve(pixelIndices.size());
+
+        // For each pixel, accumulate the per-pixel opacity in the stroke layer, then (re)blend the stroke layer with
+        // the original data by using the stroke intensity, stroke opacity, per-pixel opacity, and original pre-stroke gradient value.
+        // The (re)blended value gets sent immediately to the image gradient, as well as getting cached off into the stroke buffer
+        // for easier and faster undo/redo operations.
+        for (size_t index = 0; index < pixelIndices.size(); index++)
+        {
+            // If we have an invalid pixel index, fill in a placeholder value into paintedValues and move on to the next pixel.
+            if ((pixelIndices[index].first < 0) || (pixelIndices[index].second < 0))
+            {
+                paintedValues.emplace_back(0.0f);
+                continue;
+            }
+
+            auto [gradientValue, opacityValue] = m_paintStrokeData.m_strokeBuffer->GetOriginalPixelValueAndOpacity(pixelIndices[index]);
+
+            // Add the new per-pixel opacity to the existing opacity in our stroke layer.
+            opacityValue = AZStd::clamp(opacityValue + (1.0f - opacityValue) * perPixelOpacities[index], 0.0f, 1.0f);
+
+            // Combine the pixel (either paint or smooth) and store the blended pixel and new opacity back into our paint stroke buffer.
+            float blendedValue = combineFn(validPoints[index], gradientValue, opacityValue);
+            m_paintStrokeData.m_strokeBuffer->SetModifiedPixelValue(pixelIndices[index], blendedValue, opacityValue);
+
+            // Also store the blended value into a second buffer that we'll use to immediately modify the image gradient.
+            paintedValues.emplace_back(blendedValue);
+
+            // Track the overall dirty region for everything we modify so that we don't have to recalculate it for undos/redos.
+            m_paintStrokeData.m_dirtyRegion.AddPoint(validPoints[index]);
+        }
+
+        // Modify the image gradient with all of the changed values
+        ImageGradientModificationBus::Event(
+            entityId, &ImageGradientModificationBus::Events::SetPixelValuesByPixelIndex, pixelIndices, paintedValues);
+
+        // Because Image Gradients support bilinear filtering, we need to expand our dirty area by an extra pixel in each direction
+        // so that the effects of the painted values on adjacent pixels are taken into account when refreshing.
+        AZ::Aabb expandedDirtyArea(dirtyArea);
+        expandedDirtyArea.Expand(AZ::Vector3(m_paintStrokeData.m_metersPerPixelX, m_paintStrokeData.m_metersPerPixelY, 0.0f));
+
+        // Expand the dirty region to encompass the full Z range since image gradients are 2D.
+        auto dirtyRegionMin = expandedDirtyArea.GetMin();
+        auto dirtyRegionMax = expandedDirtyArea.GetMax();
+        expandedDirtyArea.Set(
+            AZ::Vector3(dirtyRegionMin.GetX(), dirtyRegionMin.GetY(), AZStd::numeric_limits<float>::lowest()),
+            AZ::Vector3(dirtyRegionMax.GetX(), dirtyRegionMax.GetY(), AZStd::numeric_limits<float>::max()));
+
+        // Notify anything listening to the image gradient that the modified region has changed.
+        LmbrCentral::DependencyNotificationBus::Event(
+            entityId, &LmbrCentral::DependencyNotificationBus::Events::OnCompositionRegionChanged, expandedDirtyArea);
+    }
+
+    void ImageGradientModifier::OnPaint(const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, BlendFn& blendFn)
+    {
+        // For paint notifications, we'll use the given blend function to blend the original value and the paint brush intensity
+        // using the built-up opacity.
+        auto combineFn = [this,
+                          blendFn]([[maybe_unused]] const AZ::Vector3& worldPosition, float gradientValue, float opacityValue) -> float
+        {
+            return blendFn(gradientValue, m_paintStrokeData.m_intensity, opacityValue * m_paintStrokeData.m_opacity);
+        };
+
+        // Perform all the common logic between painting and smoothing to modify our image gradient.
+        OnPaintSmoothInternal(dirtyArea, valueLookupFn, combineFn);
+    }
+
+    void ImageGradientModifier::OnSmooth(
+        const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, AZStd::span<const AZ::Vector3> valuePointOffsets, SmoothFn& smoothFn)
+    {
+        AZ::EntityId entityId = m_ownerEntityComponentId.GetEntityId();
+
+        // Declare our vectors of kernel point locations and values once outside of the combine function so that we
+        // don't keep reallocating them on every point.
+        AZStd::vector<AZ::Vector3> kernelPoints;
+        AZStd::vector<float> kernelValues;
+
+        const AZ::Vector3 valuePointOffsetScale(m_paintStrokeData.m_metersPerPixelX, m_paintStrokeData.m_metersPerPixelY, 0.0f);
+
+        kernelPoints.reserve(valuePointOffsets.size());
+        kernelValues.reserve(valuePointOffsets.size());
+
+        // For smoothing notifications, we'll need to gather all of the neighboring gradient values to feed into the given smoothing
+        // function for our blend operation.
+        auto combineFn = [this, entityId, smoothFn, &valuePointOffsets, valuePointOffsetScale, &kernelPoints, &kernelValues](
+                             const AZ::Vector3& worldPosition, float gradientValue, float opacityValue) -> float
+        {
+            kernelPoints.clear();
+
+            // Calculate all of the world positions around our base position that we'll use for fetching our blurring kernel values.
+            for (auto& valuePointOffset : valuePointOffsets)
+            {
+                kernelPoints.emplace_back(worldPosition + (valuePointOffset * valuePointOffsetScale));
+            }
+
+            kernelValues.assign(kernelPoints.size(), 0.0f);
+
+            // Read all of the original gradient values for the blurring kernel into the buffer.
+            ImageGradientModificationBus::Event(
+                entityId, &ImageGradientModificationBus::Events::GetPixelValuesByPosition, kernelPoints, kernelValues);
+
+            // Blend all the blurring kernel values together and store the blended pixel and new opacity back into our paint stroke buffer.
+            return smoothFn(gradientValue, kernelValues, opacityValue * m_paintStrokeData.m_opacity);
+        };
+
+        // Perform all the common logic between painting and smoothing to modify our image gradient.
+        OnPaintSmoothInternal(dirtyArea, valueLookupFn, combineFn);
+    }
+
+
+
+} // namespace GradientSignal

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.cpp
@@ -661,17 +661,25 @@ namespace GradientSignal
         return true;
     }
 
-    void EditorImageGradientComponent::StartImageModification()
+    AZ::EntityComponentIdPair EditorImageGradientComponent::StartImageModification()
     {
         // While we're editing, we need to set all the configuration properties to read-only and refresh them.
         // Otherwise, the property changes could conflict with the current painted modifications.
         m_configuration.m_imageModificationActive = true;
         AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
             &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_AttributesAndValues);
+
+        ImageGradientModificationBus::Event(GetEntityId(), &ImageGradientModifications::StartImageModification);
+
+        // Return the runtime entity/component ID pair. This is used to hook the component mode's paintbrush to the runtime component
+        // instead of the editor component so that it can modify the image successfully.
+        return { m_component.GetEntityId(), m_component.GetId() };
     }
 
     void EditorImageGradientComponent::EndImageModification()
     {
+        ImageGradientModificationBus::Event(GetEntityId(), &ImageGradientModifications::EndImageModification);
+
         // We're done editing, so set all the configuration properties back to writeable and refresh them.
         m_configuration.m_imageModificationActive = false;
         AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.h
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.h
@@ -83,7 +83,7 @@ namespace GradientSignal
         };
 
         // EditorImageGradientRequestBus overrides ...
-        void StartImageModification() override;
+        AZ::EntityComponentIdPair StartImageModification() override;
         void EndImageModification() override;
         bool SaveImage() override;
 

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.cpp
@@ -20,6 +20,7 @@
 #include <Editor/EditorImageGradientComponentMode.h>
 #include <Editor/EditorImageGradientRequestBus.h>
 
+#include <GradientSignal/Components/ImageGradientModification.h>
 #include <GradientSignal/Ebuses/GradientRequestBus.h>
 #include <GradientSignal/Ebuses/ImageGradientModificationBus.h>
 #include <GradientSignal/Ebuses/ImageGradientRequestBus.h>
@@ -28,201 +29,6 @@
 
 namespace GradientSignal
 {
-    //! Tracks all of the image modifications for a single continuous paint stroke. Since most modifications will only affect a small
-    //! portion of an image, this buffer divides the total image space into fixed-size tiles and only creates an individual tile
-    //! buffer when at least one pixel in that tile's space is modified.
-    //! While painting the paint stroke, this buffer caches all of the unmodified gradient values and the modifications for each
-    //! modified pixel. The buffer is used to create a special "stroke layer" that accumulates opacity for each stroke, which 
-    //! then combines with the stroke opacity, stroke intensity, and blend mode to blend back into the base layer.
-    //! After the paint stroke finishes, the stroke buffer ownership is handed over to the undo/redo system so that it can
-    //! be used to undo/redo each individual paint stroke.
-    class ImageTileBuffer
-    {
-    public:
-        ImageTileBuffer(uint32_t imageWidth, uint32_t imageHeight, AZ::EntityId imageGradientEntityId)
-            : m_imageGradientEntityId(imageGradientEntityId)
-            // Calculate the number of image tiles in each direction that we'll need, rounding up so that we create an image tile
-            // for fractional tiles as well.
-            , m_numTilesX((imageWidth + ImageTileSize - 1) / ImageTileSize)
-            , m_numTilesY((imageHeight + ImageTileSize - 1) / ImageTileSize)
-        {
-            // Create empty entries for every tile. Each entry is just a null pointer at the start, so the memory overhead
-            // of these empty entries at 32x32 pixels per tile, a 1024x1024 image will have 8 KB of overhead.
-            m_paintedImageTiles.resize(m_numTilesX * m_numTilesY);
-        }
-
-        ~ImageTileBuffer() = default;
-
-        //! Returns true if we don't have any pixel modifications, false if we do.
-        bool Empty() const
-        {
-            return !m_modifiedAnyPixels;
-        }
-
-        //! Get the original gradient value for the given pixel index.
-        //! Since we "lazy-cache" our unmodified image as tiles, create it here the first time we request a pixel from a tile.
-        AZStd::pair<float, float> GetOriginalPixelValueAndOpacity(const PixelIndex& pixelIndex)
-        {
-            uint32_t tileIndex = GetTileIndex(pixelIndex);
-            uint32_t pixelTileIndex = GetPixelTileIndex(pixelIndex);
-
-            // Create the tile if it doesn't already exist.
-            CreateImageTile(tileIndex);
-
-            return
-            {
-                m_paintedImageTiles[tileIndex]->m_unmodifiedData[pixelTileIndex],
-                m_paintedImageTiles[tileIndex]->m_modifiedDataOpacity[pixelTileIndex]
-            };
-        }
-
-        //! Set a modified gradient value for the given pixel index.
-        void SetModifiedPixelValue(const PixelIndex& pixelIndex, float modifiedValue, float opacity)
-        {
-            uint32_t tileIndex = GetTileIndex(pixelIndex);
-            uint32_t pixelTileIndex = GetPixelTileIndex(pixelIndex);
-
-            AZ_Assert(m_paintedImageTiles[tileIndex], "Cached image tile hasn't been created yet!");
-
-            m_paintedImageTiles[tileIndex]->m_modifiedData[pixelTileIndex] = modifiedValue;
-            m_paintedImageTiles[tileIndex]->m_modifiedDataOpacity[pixelTileIndex] = opacity;
-        }
-
-        //! For undo/redo operations, apply the buffer of changes back to the image gradient.
-        void ApplyChangeBuffer(bool undo)
-        {
-            AZStd::array<PixelIndex, ImageTileSize * ImageTileSize> pixelIndices;
-
-            for (int32_t tileIndex = 0; tileIndex < m_paintedImageTiles.size(); tileIndex++)
-            {
-                // If we never created this tile, skip it and move on.
-                if (m_paintedImageTiles[tileIndex] == nullptr)
-                {
-                    continue;
-                }
-
-                // Create an array of pixel indices for every pixel in this tile.
-                PixelIndex startIndex = GetStartPixelIndex(tileIndex);
-                uint32_t index = 0;
-                for (int16_t y = 0; y < ImageTileSize; y++)
-                {
-                    for (int16_t x = 0; x < ImageTileSize; x++)
-                    {
-                        pixelIndices[index++] = PixelIndex(
-                            aznumeric_cast<int16_t>(startIndex.first + x), aznumeric_cast<int16_t>(startIndex.second + y));
-                    }
-                }
-
-                // Set the image gradient values for this tile either to the original or the modified values.
-                // It's possible that not every pixel in the tile was modified, but it's cheaper just to update per-tile
-                // than to track each individual pixel in the tile and set them individually.
-                ImageGradientModificationBus::Event(
-                    m_imageGradientEntityId,
-                    &ImageGradientModificationBus::Events::SetPixelValuesByPixelIndex,
-                    pixelIndices,
-                    undo ? m_paintedImageTiles[tileIndex]->m_unmodifiedData : m_paintedImageTiles[tileIndex]->m_modifiedData);
-            }
-        }
-
-    private:
-        //! Given a pixel index, get the tile index that it maps to.
-        uint32_t GetTileIndex(const PixelIndex& pixelIndex) const
-        {
-            return ((pixelIndex.second / ImageTileSize) * m_numTilesX) + (pixelIndex.first / ImageTileSize);
-        }
-
-        //! Given a tile index, get the absolute start pixel index for the upper left corner of the tile.
-        PixelIndex GetStartPixelIndex(uint32_t tileIndex) const
-        {
-            return PixelIndex(
-                aznumeric_cast<int16_t>((tileIndex % m_numTilesX) * ImageTileSize),
-                aznumeric_cast<int16_t>((tileIndex / m_numTilesX) * ImageTileSize));
-        }
-
-        // Given a pixel index, get the relative pixel index within the tile
-        uint32_t GetPixelTileIndex(const PixelIndex& pixelIndex) const
-        {
-            uint32_t xIndex = pixelIndex.first % ImageTileSize;
-            uint32_t yIndex = pixelIndex.second % ImageTileSize;
-
-            return (yIndex * ImageTileSize) + xIndex;
-        }
-
-        //! Create an image tile initialized with the image gradient values if it doesn't already exist.
-        void CreateImageTile(uint32_t tileIndex)
-        {
-            // If it already exists, there's nothing more to do.
-            if (m_paintedImageTiles[tileIndex])
-            {
-                return;
-            }
-
-            auto imageTile = AZStd::make_unique<ImageTile>();
-
-            // Initialize the list of pixel indices for this tile.
-            AZStd::array<PixelIndex, ImageTileSize * ImageTileSize> pixelIndices;
-            PixelIndex startIndex = GetStartPixelIndex(tileIndex);
-            for (int16_t index = 0; index < (ImageTileSize * ImageTileSize); index++)
-            {
-                pixelIndices[index] = PixelIndex(
-                    aznumeric_cast<int16_t>(startIndex.first + (index % ImageTileSize)),
-                    aznumeric_cast<int16_t>(startIndex.second + (index / ImageTileSize)));
-            }
-
-            AZ_Assert(imageTile->m_unmodifiedData.size() == pixelIndices.size(), "ImageTile and PixelIndices are out of sync.");
-
-            // Read all of the original gradient values into the image tile buffer.
-            ImageGradientModificationBus::Event(
-                m_imageGradientEntityId,
-                &ImageGradientModificationBus::Events::GetPixelValuesByPixelIndex,
-                pixelIndices,
-                imageTile->m_unmodifiedData);
-
-            // Initialize the modified value buffer with the original values. This way we can always undo/redo an entire tile at a time
-            // without tracking which pixels in the tile have been modified.
-            imageTile->m_modifiedData = imageTile->m_unmodifiedData;
-
-            AZStd::fill(imageTile->m_modifiedDataOpacity.begin(), imageTile->m_modifiedDataOpacity.end(), 0.0f);
-
-            m_paintedImageTiles[tileIndex] = AZStd::move(imageTile);
-
-            // If we create a tile, we'll use that as shorthand for tracking that changed data exists.
-            m_modifiedAnyPixels = true;
-        }
-
-        //! Size of each modified image tile that we'll cache off.
-        //! This size is chosen somewhat arbitrarily to keep the number of tiles balanced at a reasonable size.
-        static inline constexpr uint32_t ImageTileSize = 32;
-
-        //! Keeps track of all the unmodified and modified gradient values, as well as our paint stroke opacity layer, for an NxN tile.
-        //! We store it a struct of arrays instead of an array of structs for better compatibility with the ImageGradient APIs,
-        //! where we can just pass in a full array of values to update a full tile of values at once.
-        struct ImageTile
-        {
-            AZStd::array<float, ImageTileSize * ImageTileSize> m_unmodifiedData;
-            AZStd::array<float, ImageTileSize * ImageTileSize> m_modifiedData;
-            AZStd::array<float, ImageTileSize * ImageTileSize> m_modifiedDataOpacity;
-        };
-
-        //! A vector of pointers to image tiles.
-        //! All of the tile pointer entries are always expected to exist, even if the pointers are null.
-        using ImageTileList = AZStd::vector<AZStd::unique_ptr<ImageTile>>;
-
-        //! The actual storage for the set of image tile pointers. Image tiles get created on-demand whenever pixels in them change.
-        //! This ultimately contains all of the changes for one continuous brush stroke.
-        ImageTileList m_paintedImageTiles;
-
-        //! The number of tiles we're creating in the X and Y directions to contain a full Image Gradient.
-        const uint32_t m_numTilesX = 0;
-        const uint32_t m_numTilesY = 0;
-
-        //! The entity ID of the Image Gradient that we're modifying.
-        const AZ::EntityId m_imageGradientEntityId;
-
-        //! Track whether or not we've modified any pixels.
-        bool m_modifiedAnyPixels = false;
-    };
-
     //! Class that tracks the data for undoing/redoing a paint stroke.
     class PaintBrushUndoBuffer : public AzToolsFramework::UndoSystem::URSequencePoint
     {
@@ -275,9 +81,9 @@ namespace GradientSignal
             return !m_strokeImageBuffer->Empty();
         }
 
-        void SetUndoBufferAndDirtyArea(AZStd::unique_ptr<ImageTileBuffer>&& buffer, const AZ::Aabb& dirtyArea)
+        void SetUndoBufferAndDirtyArea(AZStd::shared_ptr<ImageTileBuffer> buffer, const AZ::Aabb& dirtyArea)
         {
-            m_strokeImageBuffer = AZStd::move(buffer);
+            m_strokeImageBuffer = buffer;
             m_dirtyArea = dirtyArea;
         }
 
@@ -286,7 +92,7 @@ namespace GradientSignal
         const AZ::EntityId m_entityId;
 
         //! The undo/redo data for the paint strokes.
-        AZStd::unique_ptr<ImageTileBuffer> m_strokeImageBuffer;
+        AZStd::shared_ptr<ImageTileBuffer> m_strokeImageBuffer;
 
         //! Cached dirty area
         AZ::Aabb m_dirtyArea;
@@ -295,13 +101,13 @@ namespace GradientSignal
     EditorImageGradientComponentMode::EditorImageGradientComponentMode(
         const AZ::EntityComponentIdPair& entityComponentIdPair, AZ::Uuid componentType)
         : EditorBaseComponentMode(entityComponentIdPair, componentType)
-        , m_ownerEntityComponentId(entityComponentIdPair)
         , m_anyValuesChanged(false)
     {
-        EditorImageGradientRequestBus::Event(GetEntityId(), &EditorImageGradientRequests::StartImageModification);
-        ImageGradientModificationBus::Event(GetEntityId(), &ImageGradientModifications::StartImageModification);
+        ImageGradientModificationNotificationBus::Handler::BusConnect(entityComponentIdPair.GetEntityId());
 
-        AzFramework::PaintBrushNotificationBus::Handler::BusConnect(entityComponentIdPair);
+        AZ::EntityComponentIdPair runtimeEntityComponentIdPair;
+        EditorImageGradientRequestBus::EventResult(
+            runtimeEntityComponentIdPair, GetEntityId(), &EditorImageGradientRequests::StartImageModification);
 
         // Set our paint brush min/max world size range. The minimum size should be large enough to paint at least one pixel, and
         // the max size is clamped so that we can't paint more than 256 x 256 pixels per brush stamp.
@@ -325,14 +131,15 @@ namespace GradientSignal
         AZ::Transform worldFromLocal = AZ::Transform::CreateIdentity();
         AZ::TransformBus::EventResult(worldFromLocal, GetEntityId(), &AZ::TransformInterface::GetWorldTM);
 
+        // Connect the PaintBrush to the runtime component, not the Editor component, so that we're able to
+        // modify the component successfully.
         m_brushManipulator = AzToolsFramework::PaintBrushManipulator::MakeShared(
-            worldFromLocal, entityComponentIdPair, AzFramework::PaintBrushColorMode::Greyscale);
+            worldFromLocal, runtimeEntityComponentIdPair, AzFramework::PaintBrushColorMode::Greyscale);
         m_brushManipulator->Register(AzToolsFramework::g_mainManipulatorManagerId);
     }
 
     EditorImageGradientComponentMode::~EditorImageGradientComponentMode()
     {
-        AzFramework::PaintBrushNotificationBus::Handler::BusDisconnect();
         m_brushManipulator->Unregister();
         m_brushManipulator.reset();
 
@@ -345,8 +152,9 @@ namespace GradientSignal
             EditorImageGradientRequestBus::Event(GetEntityId(), &EditorImageGradientRequests::SaveImage);
         }
 
-        ImageGradientModificationBus::Event(GetEntityId(), &ImageGradientModifications::EndImageModification);
         EditorImageGradientRequestBus::Event(GetEntityId(), &EditorImageGradientRequests::EndImageModification);
+
+        ImageGradientModificationNotificationBus::Handler::BusDisconnect();
     }
 
     AZStd::vector<AzToolsFramework::ActionOverride> EditorImageGradientComponentMode::PopulateActionsImpl()
@@ -391,242 +199,23 @@ namespace GradientSignal
         }
     }
 
-    void EditorImageGradientComponentMode::OnBrushStrokeBegin(const AZ::Color& color)
+    void EditorImageGradientComponentMode::OnImageGradientBrushStrokeBegin()
     {
         BeginUndoBatch();
-
-        // Get the spacing to map individual pixels to world space positions.
-        AZ::Vector2 imagePixelsPerMeter(0.0f);
-        ImageGradientRequestBus::EventResult(imagePixelsPerMeter, GetEntityId(), &ImageGradientRequestBus::Events::GetImagePixelsPerMeter);
-        if ((imagePixelsPerMeter.GetX() <= 0.0f) || (imagePixelsPerMeter.GetY() <= 0.0f))
-        {
-            return;
-        }
-
-        m_paintStrokeData.m_intensity = color.GetR();
-        m_paintStrokeData.m_opacity = color.GetA();
-
-        m_paintStrokeData.m_metersPerPixelX = 1.0f / imagePixelsPerMeter.GetX();
-        m_paintStrokeData.m_metersPerPixelY = 1.0f / imagePixelsPerMeter.GetY();
-
-        uint32_t imageWidth = 0;
-        ImageGradientRequestBus::EventResult(imageWidth, GetEntityId(), &ImageGradientRequestBus::Events::GetImageWidth);
-
-        uint32_t imageHeight = 0;
-        ImageGradientRequestBus::EventResult(imageHeight, GetEntityId(), &ImageGradientRequestBus::Events::GetImageHeight);
-
-        // Create the buffer for holding all the changes for a single continuous paint brush stroke.
-        // This buffer will get used during the stroke to hold our accumulated stroke opacity layer,
-        // and then after the stroke finishes we'll hand the buffer over to the undo system as an undo/redo buffer.
-        m_paintStrokeData.m_strokeBuffer = AZStd::make_unique<ImageTileBuffer>(imageWidth, imageHeight, GetEntityId());
     }
 
-    void EditorImageGradientComponentMode::OnBrushStrokeEnd()
+    void EditorImageGradientComponentMode::OnImageGradientBrushStrokeEnd(
+        AZStd::shared_ptr<ImageTileBuffer> changedDataBuffer, const AZ::Aabb& dirtyRegion)
     {
         AZ_Assert(m_paintBrushUndoBuffer != nullptr, "Undo batch is expected to exist while painting");
 
-        if (m_paintStrokeData.m_dirtyRegion.IsValid())
-        {
-            // Expand the dirty region for this brush stroke by one pixel in each direction
-            // to account for any data affected by bilinear filtering as well.
-            m_paintStrokeData.m_dirtyRegion.Expand(
-                AZ::Vector3(m_paintStrokeData.m_metersPerPixelX, m_paintStrokeData.m_metersPerPixelY, 0.0f));
-
-            // Expand the dirty region to encompass the full Z range since image gradients are 2D.
-            auto dirtyRegionMin = m_paintStrokeData.m_dirtyRegion.GetMin();
-            auto dirtyRegionMax = m_paintStrokeData.m_dirtyRegion.GetMax();
-            m_paintStrokeData.m_dirtyRegion.Set(
-                AZ::Vector3(dirtyRegionMin.GetX(), dirtyRegionMin.GetY(), AZStd::numeric_limits<float>::lowest()),
-                AZ::Vector3(dirtyRegionMax.GetX(), dirtyRegionMax.GetY(), AZStd::numeric_limits<float>::max()));
-        }
+        // Track if we've changed image values, so we know to prompt to save on exit.
+        m_anyValuesChanged = dirtyRegion.IsValid();
 
         // Hand over ownership of the paint stroke buffer to the undo/redo buffer.
-        m_paintBrushUndoBuffer->SetUndoBufferAndDirtyArea(
-            AZStd::move(m_paintStrokeData.m_strokeBuffer), m_paintStrokeData.m_dirtyRegion);
+        m_paintBrushUndoBuffer->SetUndoBufferAndDirtyArea(changedDataBuffer, dirtyRegion);
 
         EndUndoBatch();
-
-        // Make sure we've cleared out our paint stroke data until the next paint stroke begins.
-        m_paintStrokeData = {};
-    }
-
-    AZ::Color EditorImageGradientComponentMode::OnGetColor(const AZ::Vector3& brushCenter)
-    {
-        // Get the gradient value at the given point.
-        // We use "GetPixelValuesByPosition" instead of "GetGradientValue" because we want to select unscaled, unsmoothed values.
-        float gradientValue = 0.0f;
-        ImageGradientModificationBus::Event(
-            GetEntityId(),
-            &ImageGradientModificationBus::Events::GetPixelValuesByPosition,
-            AZStd::span<const AZ::Vector3>(&brushCenter, 1),
-            AZStd::span<float>(&gradientValue, 1));
-
-        return AZ::Color(gradientValue, gradientValue, gradientValue, 1.0f);
-    }
-
-    void EditorImageGradientComponentMode::OnPaintSmoothInternal(
-        const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn,
-        AZStd::function<float(const AZ::Vector3& worldPosition, float gradientValue, float opacity)> combineFn)
-    {
-        // We're either painting or smoothing new values into our image gradient.
-        // To do this, we need to calculate the set of world space positions that map to individual pixels in the image,
-        // then ask the paint brush for each position what value we should set that pixel to. Finally, we use those modified
-        // values to change the image gradient.
-
-        const AZ::Vector3 minDistances = dirtyArea.GetMin();
-        const AZ::Vector3 maxDistances = dirtyArea.GetMax();
-        const float zMinDistance = minDistances.GetZ();
-
-        const int32_t xPoints = aznumeric_cast<int32_t>((maxDistances.GetX() - minDistances.GetX()) / m_paintStrokeData.m_metersPerPixelX);
-        const int32_t yPoints = aznumeric_cast<int32_t>((maxDistances.GetY() - minDistances.GetY()) / m_paintStrokeData.m_metersPerPixelY);
-
-        // Early out if the dirty area is smaller than our point size.
-        if ((xPoints <= 0) || (yPoints <= 0))
-        {
-            return;
-        }
-
-        // Calculate the minimum set of world space points that map to those pixels.
-        AZStd::vector<AZ::Vector3> points;
-        points.reserve(xPoints * yPoints);
-        for (float y = minDistances.GetY(); y <= maxDistances.GetY(); y += m_paintStrokeData.m_metersPerPixelY)
-        {
-            for (float x = minDistances.GetX(); x <= maxDistances.GetX(); x += m_paintStrokeData.m_metersPerPixelX)
-            {
-                points.emplace_back(x, y, zMinDistance);
-            }
-        }
-
-        // Query the paintbrush with those points to get back the subset of points and brush opacities for each point that's
-        // affected by the brush.
-        AZStd::vector<AZ::Vector3> validPoints;
-        AZStd::vector<float> perPixelOpacities;
-        valueLookupFn(points, validPoints, perPixelOpacities);
-
-        // Early out if none of the points were actually affected by the brush.
-        if (validPoints.empty())
-        {
-            return;
-        }
-
-        AZ::EntityId entityId = GetEntityId();
-
-        // Get the pixel indices for each position.
-        AZStd::vector<PixelIndex> pixelIndices(validPoints.size());
-        ImageGradientModificationBus::Event(
-            entityId, &ImageGradientModificationBus::Events::GetPixelIndicesForPositions, validPoints, pixelIndices);
-
-        // Create a buffer for all of the modified, blended gradient values.
-        AZStd::vector<float> paintedValues;
-        paintedValues.reserve(pixelIndices.size());
-
-        // For each pixel, accumulate the per-pixel opacity in the stroke layer, then (re)blend the stroke layer with
-        // the original data by using the stroke intensity, stroke opacity, per-pixel opacity, and original pre-stroke gradient value.
-        // The (re)blended value gets sent immediately to the image gradient, as well as getting cached off into the stroke buffer
-        // for easier and faster undo/redo operations.
-        for (size_t index = 0; index < pixelIndices.size(); index++)
-        {
-            // If we have an invalid pixel index, fill in a placeholder value into paintedValues and move on to the next pixel.
-            if ((pixelIndices[index].first < 0) || (pixelIndices[index].second < 0))
-            {
-                paintedValues.emplace_back(0.0f);
-                continue;
-            }
-
-            auto [gradientValue, opacityValue] = m_paintStrokeData.m_strokeBuffer->GetOriginalPixelValueAndOpacity(pixelIndices[index]);
-
-            // Add the new per-pixel opacity to the existing opacity in our stroke layer.
-            opacityValue = AZStd::clamp(opacityValue + (1.0f - opacityValue) * perPixelOpacities[index], 0.0f, 1.0f);
-
-            // Combine the pixel (either paint or smooth) and store the blended pixel and new opacity back into our paint stroke buffer.
-            float blendedValue = combineFn(validPoints[index], gradientValue, opacityValue);
-            m_paintStrokeData.m_strokeBuffer->SetModifiedPixelValue(pixelIndices[index], blendedValue, opacityValue);
-
-            // Also store the blended value into a second buffer that we'll use to immediately modify the image gradient.
-            paintedValues.emplace_back(blendedValue);
-
-            // Track the overall dirty region for everything we modify so that we don't have to recalculate it for undos/redos.
-            m_paintStrokeData.m_dirtyRegion.AddPoint(validPoints[index]);
-        }
-
-        // Modify the image gradient with all of the changed values
-        ImageGradientModificationBus::Event(
-            GetEntityId(), &ImageGradientModificationBus::Events::SetPixelValuesByPixelIndex, pixelIndices, paintedValues);
-
-        // Because Image Gradients support bilinear filtering, we need to expand our dirty area by an extra pixel in each direction
-        // so that the effects of the painted values on adjacent pixels are taken into account when refreshing.
-        AZ::Aabb expandedDirtyArea(dirtyArea);
-        expandedDirtyArea.Expand(AZ::Vector3(m_paintStrokeData.m_metersPerPixelX, m_paintStrokeData.m_metersPerPixelY, 0.0f));
-
-        // Expand the dirty region to encompass the full Z range since image gradients are 2D.
-        auto dirtyRegionMin = expandedDirtyArea.GetMin();
-        auto dirtyRegionMax = expandedDirtyArea.GetMax();
-        expandedDirtyArea.Set(
-            AZ::Vector3(dirtyRegionMin.GetX(), dirtyRegionMin.GetY(), AZStd::numeric_limits<float>::lowest()),
-            AZ::Vector3(dirtyRegionMax.GetX(), dirtyRegionMax.GetY(), AZStd::numeric_limits<float>::max()));
-
-        // Notify anything listening to the image gradient that the modified region has changed.
-        LmbrCentral::DependencyNotificationBus::Event(
-            GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionRegionChanged, expandedDirtyArea);
-
-        // Track that we've changed image values, so we should prompt to save on exit.
-        m_anyValuesChanged = true;
-    }
-
-    void EditorImageGradientComponentMode::OnPaint(const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, BlendFn& blendFn)
-    {
-        // For paint notifications, we'll use the given blend function to blend the original value and the paint brush intensity
-        // using the built-up opacity.
-        auto combineFn = [this, blendFn](
-            [[maybe_unused]] const AZ::Vector3& worldPosition, float gradientValue, float opacityValue) -> float
-        {
-            return blendFn(gradientValue, m_paintStrokeData.m_intensity, opacityValue * m_paintStrokeData.m_opacity);
-        };
-
-        // Perform all the common logic between painting and smoothing to modify our image gradient.
-        OnPaintSmoothInternal(dirtyArea, valueLookupFn, combineFn);
-    }
-
-    void EditorImageGradientComponentMode::OnSmooth(
-        const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, AZStd::span<const AZ::Vector3> valuePointOffsets, SmoothFn& smoothFn)
-    {
-        AZ::EntityId entityId = GetEntityId();
-
-        // Declare our vectors of kernel point locations and values once outside of the combine function so that we
-        // don't keep reallocating them on every point.
-        AZStd::vector<AZ::Vector3> kernelPoints;
-        AZStd::vector<float> kernelValues;
-
-        const AZ::Vector3 valuePointOffsetScale(m_paintStrokeData.m_metersPerPixelX, m_paintStrokeData.m_metersPerPixelY, 0.0f);
-
-        kernelPoints.reserve(valuePointOffsets.size());
-        kernelValues.reserve(valuePointOffsets.size());
-
-        // For smoothing notifications, we'll need to gather all of the neighboring gradient values to feed into the given smoothing
-        // function for our blend operation.
-        auto combineFn = [this, entityId, smoothFn, &valuePointOffsets, valuePointOffsetScale, &kernelPoints, &kernelValues](
-                             const AZ::Vector3& worldPosition, float gradientValue, float opacityValue) -> float
-        {
-            kernelPoints.clear();
-
-            // Calculate all of the world positions around our base position that we'll use for fetching our blurring kernel values.
-            for (auto& valuePointOffset : valuePointOffsets)
-            {
-                kernelPoints.emplace_back(worldPosition + (valuePointOffset * valuePointOffsetScale));
-            }
-
-            kernelValues.assign(kernelPoints.size(), 0.0f);
-
-            // Read all of the original gradient values for the blurring kernel into the buffer.
-            ImageGradientModificationBus::Event(
-                entityId, &ImageGradientModificationBus::Events::GetPixelValuesByPosition, kernelPoints, kernelValues);
-
-            // Blend all the blurring kernel values together and store the blended pixel and new opacity back into our paint stroke buffer.
-            return smoothFn(gradientValue, kernelValues, opacityValue * m_paintStrokeData.m_opacity);
-        };
-
-        // Perform all the common logic between painting and smoothing to modify our image gradient.
-        OnPaintSmoothInternal(dirtyArea, valueLookupFn, combineFn);
     }
 
 } // namespace GradientSignal

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.h
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.h
@@ -10,10 +10,10 @@
 
 #include <AzToolsFramework/ComponentMode/EditorBaseComponentMode.h>
 #include <AzToolsFramework/Manipulators/PaintBrushManipulator.h>
-#include <AzFramework/PaintBrush/PaintBrushNotificationBus.h>
 #include <AzToolsFramework/PaintBrush/PaintBrushSubModeCluster.h>
 #include <AzToolsFramework/Undo/UndoSystem.h>
 #include <AzToolsFramework/ViewportUi/ViewportUiRequestBus.h>
+#include <GradientSignal/Ebuses/ImageGradientModificationBus.h>
 
 namespace GradientSignal
 {
@@ -22,66 +22,27 @@ namespace GradientSignal
 
     class EditorImageGradientComponentMode
         : public AzToolsFramework::ComponentModeFramework::EditorBaseComponentMode
-        , private AzFramework::PaintBrushNotificationBus::Handler
+        , private ImageGradientModificationNotificationBus::Handler
     {
     public:
         EditorImageGradientComponentMode(const AZ::EntityComponentIdPair& entityComponentIdPair, AZ::Uuid componentType);
         ~EditorImageGradientComponentMode() override;
 
-        // EditorBaseComponentMode
+        // EditorBaseComponentMode overrides...
         void Refresh() override;
         AZStd::vector<AzToolsFramework::ActionOverride> PopulateActionsImpl() override;
         bool HandleMouseInteraction(const AzToolsFramework::ViewportInteraction::MouseInteractionEvent& mouseInteraction) override;
         AZStd::string GetComponentModeName() const override;
 
     protected:
-        // PaintBrushNotificationBus overrides
-        void OnBrushStrokeBegin(const AZ::Color& color) override;
-        void OnBrushStrokeEnd() override;
-        void OnPaint(const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, BlendFn& blendFn) override;
-        void OnSmooth(
-            const AZ::Aabb& dirtyArea,
-            ValueLookupFn& valueLookupFn,
-            AZStd::span<const AZ::Vector3> valuePointOffsets,
-            SmoothFn& smoothFn) override;
-        AZ::Color OnGetColor(const AZ::Vector3& brushCenter) override;
-
-        void OnPaintSmoothInternal(
-            const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn,
-            AZStd::function<float(const AZ::Vector3& worldPosition, float gradientValue, float opacity)> combineFn);
+        // ImageGradientModificationNotificationBus overrides...
+        void OnImageGradientBrushStrokeBegin() override;
+        void OnImageGradientBrushStrokeEnd(AZStd::shared_ptr<ImageTileBuffer> changedDataBuffer, const AZ::Aabb& dirtyRegion) override;
 
         void BeginUndoBatch();
         void EndUndoBatch();
 
     private:
-        struct PaintStrokeData
-        {
-            //! A buffer to accumulate a single paint stroke into. This buffer is used to ensure that within a single paint stroke,
-            //! we only perform an operation on a pixel once, not multiple times.
-            //! After the paint stroke is complete, this buffer is handed off to the undo/redo batch so that we can undo/redo each stroke.
-            AZStd::unique_ptr<ImageTileBuffer> m_strokeBuffer;
-
-            //! The meters per pixel in each direction for this image gradient.
-            //! These help us query the paintbrush for exactly one world position per image pixel.
-            float m_metersPerPixelX = 0.0f;
-            float m_metersPerPixelY = 0.0f;
-
-            //! The intensity of the paint stroke (0 - 1)
-            float m_intensity = 0.0f;
-
-            //! The opacity of the paint stroke (0 - 1)
-            float m_opacity = 0.0f;
-
-            //! Track the dirty region for each paint stroke so that we can store it in the undo/redo buffer
-            //! to send with change notifications.
-            AZ::Aabb m_dirtyRegion = AZ::Aabb::CreateNull();
-        };
-
-        PaintStrokeData m_paintStrokeData;
-
-        //! The entity/component that owns this paintbrush.
-        AZ::EntityComponentIdPair m_ownerEntityComponentId;
-
         //! The core paintbrush manipulator and painting logic.
         AZStd::shared_ptr<AzToolsFramework::PaintBrushManipulator> m_brushManipulator;
 

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientRequestBus.h
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientRequestBus.h
@@ -20,8 +20,14 @@ namespace GradientSignal
     public:
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
 
-        virtual void StartImageModification() = 0;
+        //! Start the image modification flow for an ImageGradient that has an Editor component as well.
+        //! @return The EntityComponentIdPair for the runtime ImageGradient. This is used with the paintbrush to connect the two together.
+        virtual AZ::EntityComponentIdPair StartImageModification() = 0;
+
+        //! End the image modification flow for an ImageGradient that has an Editor component as well.
         virtual void EndImageModification() = 0;
+
+        //! Save the edited runtime image asset.
         virtual bool SaveImage() = 0;
     };
 

--- a/Gems/GradientSignal/Code/gradientsignal_files.cmake
+++ b/Gems/GradientSignal/Code/gradientsignal_files.cmake
@@ -17,6 +17,7 @@ set(FILES
     Include/GradientSignal/Components/GradientSurfaceDataComponent.h
     Include/GradientSignal/Components/GradientTransformComponent.h
     Include/GradientSignal/Components/ImageGradientComponent.h
+    Include/GradientSignal/Components/ImageGradientModification.h
     Include/GradientSignal/Components/InvertGradientComponent.h
     Include/GradientSignal/Components/LevelsGradientComponent.h
     Include/GradientSignal/Components/MixedGradientComponent.h
@@ -60,6 +61,7 @@ set(FILES
     Source/Components/GradientSurfaceDataComponent.cpp
     Source/Components/GradientTransformComponent.cpp
     Source/Components/ImageGradientComponent.cpp
+    Source/Components/ImageGradientModification.cpp
     Source/Components/InvertGradientComponent.cpp
     Source/Components/LevelsGradientComponent.cpp
     Source/Components/MixedGradientComponent.cpp


### PR DESCRIPTION
## What does this PR do?

This PR finishes the reorganization of the ImageGradient / PaintBrush logic so that ImageGradient painting can now occur through both the Editor via Component Mode and through the runtime via ScriptCanvas / Lua.

The code in ImageGradientModification is pretty much a direct move of the code that used to live in EditorImageGradientComponentMode. The only logical change is that it returns a pointer to the ImageTileBuffer instead of directly tracking the undo/redo buffer. This change allows for a separation in which the runtime code just uses the buffer for managing the paint stroke compositing, and the editor code can then additionally use the buffer for undo/redo after the paint stroke is complete.

## How was this PR tested?

Manually verified that painting in the Editor continues to function the same as before. Also created a Script Canvas script that verified that painting works at runtime.

![image](https://user-images.githubusercontent.com/82224783/205396784-d8e1ed7d-1e87-4dc9-9715-25b200379fd4.png)


https://user-images.githubusercontent.com/82224783/205396972-08b31db6-23a2-4a3f-9c92-5c3ccedb0bfc.mp4

