### PR TITLE
Material Canvas: Support for automatically opening blank graph on startup

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocument.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocument.h
@@ -48,7 +48,7 @@ namespace AtomToolsFramework
         void Clear() override;
         bool IsOpen() const override;
         bool IsModified() const override;
-        bool CanSave() const override;
+        bool CanSaveAsChild() const override;
         bool CanUndo() const override;
         bool CanRedo() const override;
         bool Undo() override;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentRequestBus.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentRequestBus.h
@@ -67,8 +67,8 @@ namespace AtomToolsFramework
         //! Document has changes pending
         virtual bool IsModified() const = 0;
 
-        //! Can the document be saved
-        virtual bool CanSave() const = 0;
+        //! Can the document be saved as a child or derived document
+        virtual bool CanSaveAsChild() const = 0;
 
         //! Returns true if there are reversible modifications to the document
         virtual bool CanUndo() const = 0;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocument.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocument.cpp
@@ -40,7 +40,7 @@ namespace AtomToolsFramework
                 ->Event("SaveAsCopy", &AtomToolsDocumentRequestBus::Events::SaveAsCopy)
                 ->Event("IsOpen", &AtomToolsDocumentRequestBus::Events::IsOpen)
                 ->Event("IsModified", &AtomToolsDocumentRequestBus::Events::IsModified)
-                ->Event("CanSave", &AtomToolsDocumentRequestBus::Events::CanSave)
+                ->Event("CanSaveAsChild", &AtomToolsDocumentRequestBus::Events::CanSaveAsChild)
                 ->Event("CanUndo", &AtomToolsDocumentRequestBus::Events::CanUndo)
                 ->Event("CanRedo", &AtomToolsDocumentRequestBus::Events::CanRedo)
                 ->Event("Undo", &AtomToolsDocumentRequestBus::Events::Undo)
@@ -132,7 +132,7 @@ namespace AtomToolsFramework
 
     bool AtomToolsDocument::Save()
     {
-        if (!CanSave())
+        if (!GetDocumentTypeInfo().IsSupportedExtensionToSave(m_absolutePath))
         {
             AZ_Error("AtomToolsDocument", false, "Document type can not be saved: '%s'.", m_absolutePath.c_str());
             return SaveFailed();
@@ -156,7 +156,7 @@ namespace AtomToolsFramework
 
     bool AtomToolsDocument::SaveAsCopy(const AZStd::string& savePath)
     {
-        if (!CanSave())
+        if (!GetDocumentTypeInfo().IsSupportedExtensionToSave(savePath))
         {
             AZ_Error("AtomToolsDocument", false, "Document type can not be saved: '%s'.", m_absolutePath.c_str());
             return SaveFailed();
@@ -180,6 +180,12 @@ namespace AtomToolsFramework
 
     bool AtomToolsDocument::SaveAsChild(const AZStd::string& savePath)
     {
+        if (!GetDocumentTypeInfo().IsSupportedExtensionToSave(savePath))
+        {
+            AZ_Error("AtomToolsDocument", false, "Document type can not be saved: '%s'.", m_absolutePath.c_str());
+            return SaveFailed();
+        }
+
         m_savePathNormalized = savePath;
         if (!ValidateDocumentPath(m_savePathNormalized))
         {
@@ -235,9 +241,9 @@ namespace AtomToolsFramework
         return false;
     }
 
-    bool AtomToolsDocument::CanSave() const
+    bool AtomToolsDocument::CanSaveAsChild() const
     {
-        return GetDocumentTypeInfo().IsSupportedExtensionToSave(m_absolutePath);
+        return false;
     }
 
     bool AtomToolsDocument::CanUndo() const

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
@@ -189,37 +189,40 @@ namespace AtomToolsFramework
 
     bool AtomToolsDocumentMainWindow::SaveDocument(const AZ::Uuid& documentId)
     {
-        const QString documentPath = GetDocumentPath(documentId);
+        AZStd::string documentPath;
+        AtomToolsDocumentRequestBus::EventResult(documentPath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
+        DocumentTypeInfo documentInfo;
+        AtomToolsDocumentRequestBus::EventResult(documentInfo, documentId, &AtomToolsDocumentRequestBus::Events::GetDocumentTypeInfo);
 
-        // If the file already has a path then it can be saved without user selecting a new one.
-        if (!documentPath.isEmpty())
+        // Attempt to save using the current path if it is not empty and has a supported save extension.
+        if (documentInfo.IsSupportedExtensionToSave(documentPath))
         {
             bool result = false;
             AtomToolsDocumentSystemRequestBus::EventResult(
                 result, m_toolId, &AtomToolsDocumentSystemRequestBus::Events::SaveDocument, documentId);
             if (!result)
             {
-                SetStatusError(tr("Document save failed: %1").arg(documentPath));
+                SetStatusError(tr("Document save failed: %1").arg(documentPath.c_str()));
                 return false;
             }
             return true;
         }
 
-        // If the file does not have a path, meaning it was not previously saved, then we have to do a save as operation.
-        if (const auto& savePath = GetSaveDocumentParams(documentPath.toUtf8().constData(), documentId); !savePath.empty())
+        // If the path is empty or the extension is not valid for saving, do a save as operation, which prompts the user for a path.
+        if (const auto& savePath = GetSaveDocumentParams(documentPath, documentId); !savePath.empty())
         {
             bool result = false;
             AtomToolsDocumentSystemRequestBus::EventResult(
                 result, m_toolId, &AtomToolsDocumentSystemRequestBus::Events::SaveDocumentAsCopy, documentId, savePath);
             if (!result)
             {
-                SetStatusError(tr("Document save failed: %1").arg(documentPath));
+                SetStatusError(tr("Document save failed: %1").arg(documentPath.c_str()));
                 return false;
             }
             return true;
         }
 
-        // save is cancel
+        // Cancel the save if no valid path was selected by this point.
         return false;
     }
 
@@ -299,8 +302,8 @@ namespace AtomToolsFramework
 
         bool isOpen = false;
         AtomToolsDocumentRequestBus::EventResult(isOpen, documentId, &AtomToolsDocumentRequestBus::Events::IsOpen);
-        bool canSave = false;
-        AtomToolsDocumentRequestBus::EventResult(canSave, documentId, &AtomToolsDocumentRequestBus::Events::CanSave);
+        bool canSaveAsChild = false;
+        AtomToolsDocumentRequestBus::EventResult(canSaveAsChild, documentId, &AtomToolsDocumentRequestBus::Events::CanSaveAsChild);
         bool canUndo = false;
         AtomToolsDocumentRequestBus::EventResult(canUndo, documentId, &AtomToolsDocumentRequestBus::Events::CanUndo);
         bool canRedo = false;
@@ -313,9 +316,10 @@ namespace AtomToolsFramework
         m_actionCloseAll->setEnabled(hasTabs);
         m_actionCloseOthers->setEnabled(hasTabs);
 
-        m_actionSave->setEnabled(canSave);
-        m_actionSaveAsCopy->setEnabled(canSave);
-        m_actionSaveAsChild->setEnabled(isOpen);
+        m_actionSave->setEnabled(isOpen);
+        m_actionSaveAsCopy->setEnabled(isOpen);
+        m_actionSaveAsChild->setEnabled(canSaveAsChild);
+        m_actionSaveAsChild->setVisible(canSaveAsChild);
         m_actionSaveAll->setEnabled(hasTabs);
 
         m_actionUndo->setEnabled(canUndo);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
@@ -458,11 +458,18 @@ namespace AtomToolsFramework
         bool result = true;
         for (const auto& documentPair : m_documentMap)
         {
-            bool canSave = false;
-            AtomToolsDocumentRequestBus::EventResult(canSave, documentPair.first, &AtomToolsDocumentRequestBus::Events::CanSave);
-            if (canSave && !SaveDocument(documentPair.first))
+            const auto& documentId = documentPair.first;
+
+            AZStd::string documentPath;
+            AtomToolsDocumentRequestBus::EventResult(documentPath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
+            DocumentTypeInfo documentInfo;
+            AtomToolsDocumentRequestBus::EventResult(documentInfo, documentId, &AtomToolsDocumentRequestBus::Events::GetDocumentTypeInfo);
+            if (documentInfo.IsSupportedExtensionToSave(documentPath))
             {
-                result = false;
+                if (!SaveDocument(documentId))
+                {
+                    result = false;
+                }
             }
         }
 
@@ -474,13 +481,23 @@ namespace AtomToolsFramework
         bool result = true;
         for (const auto& documentPair : m_documentMap)
         {
-            bool isModified = false;
-            AtomToolsDocumentRequestBus::EventResult(isModified, documentPair.first, &AtomToolsDocumentRequestBus::Events::IsModified);
-            bool canSave = false;
-            AtomToolsDocumentRequestBus::EventResult(canSave, documentPair.first, &AtomToolsDocumentRequestBus::Events::CanSave);
-            if (isModified && canSave && !SaveDocument(documentPair.first))
+            const auto& documentId = documentPair.first;
+
+            AZStd::string documentPath;
+            AtomToolsDocumentRequestBus::EventResult(documentPath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
+            DocumentTypeInfo documentInfo;
+            AtomToolsDocumentRequestBus::EventResult(documentInfo, documentId, &AtomToolsDocumentRequestBus::Events::GetDocumentTypeInfo);
+            if (documentInfo.IsSupportedExtensionToSave(documentPath))
             {
-                result = false;
+                bool isModified = false;
+                AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsDocumentRequestBus::Events::IsModified);
+                if (isModified)
+                {
+                    if (!SaveDocument(documentId))
+                    {
+                        result = false;
+                    }
+                }
             }
         }
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphDocument.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphDocument.cpp
@@ -275,6 +275,11 @@ namespace AtomToolsFramework
 
     AZStd::string GraphDocument::GetGraphName() const
     {
+        if (m_absolutePath.empty())
+        {
+            return "untitled";
+        }
+
         // Sanitize the document name to remove any illegal characters that could not be used as symbols in generated code
         AZStd::string documentName;
         AZ::StringFunc::Path::GetFileName(m_absolutePath.c_str(), documentName);

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialGraphCompiler.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialGraphCompiler.h
@@ -43,6 +43,9 @@ namespace MaterialCanvas
         void CompileGraphFailed() const;
         void CompileGraphCompleted() const;
 
+        // Get the graph export path based on the Graph document path or default export path.
+        AZStd::string GetGraphPath() const;
+
         // Convert the template file path into a save file path based on the document name.
         AZStd::string GetOutputPathFromTemplatePath(const AZStd::string& templatePath) const;
 

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
@@ -338,13 +338,18 @@ namespace MaterialCanvas
     void MaterialCanvasApplication::InitDefaultDocument()
     {
         // Create an untitled, empty graph document as soon as the application starts so the user can begin creating immediately.
-        AZ::Uuid documentId = AZ::Uuid::CreateNull();
-        AtomToolsFramework::AtomToolsDocumentSystemRequestBus::EventResult(documentId, m_toolId,
-            &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Handler::CreateDocumentFromTypeName,
-            "Material Graph");
+        if (AtomToolsFramework::GetSettingsValue("/O3DE/Atom/MaterialCanvas/CreateDefaultDocumentOnStart", true))
+        {
+            AZ::Uuid documentId = AZ::Uuid::CreateNull();
+            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::EventResult(
+                documentId,
+                m_toolId,
+                &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Handler::CreateDocumentFromTypeName,
+                "Material Graph");
 
-        AtomToolsFramework::AtomToolsDocumentNotificationBus::Event(
-            m_toolId, &AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler::OnDocumentOpened, documentId);
+            AtomToolsFramework::AtomToolsDocumentNotificationBus::Event(
+                m_toolId, &AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler::OnDocumentOpened, documentId);
+        }
     }
 
     void MaterialCanvasApplication::ApplyShaderBuildSettings()

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.h
@@ -65,6 +65,8 @@ namespace MaterialCanvas
         void InitMaterialGraphDocumentType();
         void InitMaterialGraphNodeDocumentType();
         void InitShaderSourceDataDocumentType();
+        void InitMainWindow();
+        void InitDefaultDocument();
         void ApplyShaderBuildSettings();
 
         AZStd::unique_ptr<MaterialCanvasMainWindow> m_window;

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
@@ -147,14 +147,19 @@ namespace MaterialCanvas
     void MaterialCanvasMainWindow::PopulateSettingsInspector(AtomToolsFramework::InspectorWidget* inspector) const
     {
         m_materialCanvasCompileSettingsGroup = AtomToolsFramework::CreateSettingsPropertyGroup(
-            "Material Canvas Compile Settings",
-            "Material Canvas Compile Settings",
+            "Material Canvas Settings",
+            "Material Canvas Settings",
             { AtomToolsFramework::CreateSettingsPropertyValue(
                 "/O3DE/Atom/MaterialCanvas/EnableMinimalShaderBuilds",
                 "Enable Minimal Shader Builds",
                 "Improve shader and material iteration and preview times by limiting the asset processor and shader compiler to the "
                 "current platform and RHI. Changing this setting requires restarting Material Canvas and the asset processor.",
-                false) });
+                  false),
+              AtomToolsFramework::CreateSettingsPropertyValue(
+                  "/O3DE/Atom/MaterialCanvas/CreateDefaultDocumentOnStart",
+                  "Create Untitled Graph Document On Start",
+                  "Create a default, untitled graph document when Material Canvas starts",
+                  true) });
 
         inspector->AddGroup(
             m_materialCanvasCompileSettingsGroup->m_name,
@@ -166,8 +171,8 @@ namespace MaterialCanvas
                 azrtti_typeid<AtomToolsFramework::DynamicPropertyGroup>()));
 
         inspector->AddGroup(
-            "Material Canvas Graph View Settings",
-            "Material Canvas Graph View Settings",
+            "Graph View Settings",
+            "Graph View Settings",
             "Configuration settings for the graph view interaction, animation, and other behavior.",
             new AtomToolsFramework::InspectorPropertyGroupWidget(
                 m_graphViewSettingsPtr.get(), m_graphViewSettingsPtr.get(), m_graphViewSettingsPtr->RTTI_Type()));

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
@@ -306,6 +306,11 @@ namespace MaterialEditor
         return result;
     }
 
+    bool MaterialDocument::CanSaveAsChild() const
+    {
+        return true;
+    }
+
     bool MaterialDocument::BeginEdit()
     {
         // Save the current properties as a momento for undo before any changes are applied

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.h
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.h
@@ -47,6 +47,7 @@ namespace MaterialEditor
         bool SaveAsCopy(const AZStd::string& savePath) override;
         bool SaveAsChild(const AZStd::string& savePath) override;
         bool IsModified() const override;
+        bool CanSaveAsChild() const override;
         bool BeginEdit() override;
         bool EndEdit() override;
 

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
@@ -243,11 +243,6 @@ namespace ShaderManagementConsole
         return true;
     }
 
-    bool ShaderManagementConsoleDocument::CanSave() const
-    {
-        return true;
-    }
-
     void ShaderManagementConsoleDocument::Clear()
     {
         AtomToolsFramework::AtomToolsDocument::Clear();

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.h
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.h
@@ -45,7 +45,6 @@ namespace ShaderManagementConsole
         bool IsModified() const override;
         bool BeginEdit() override;
         bool EndEdit() override;
-        bool CanSave() const override;
 
         // ShaderManagementConsoleDocumentRequestBus::Handler overridfes...
         void SetShaderVariantListSourceData(const AZ::RPI::ShaderVariantListSourceData& shaderVariantListSourceData) override;

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
@@ -42,12 +42,6 @@ namespace ShaderManagementConsole
         m_documentInspector->SetDocumentId(documentId);
     }
 
-    void ShaderManagementConsoleWindow::UpdateMenus(QMenuBar* menuBar)
-    {
-        Base::UpdateMenus(menuBar);
-        m_actionSaveAsChild->setVisible(false);
-    }
-
     AZStd::string ShaderManagementConsoleWindow::GetSaveDocumentParams(const AZStd::string& initialPath, const AZ::Uuid& documentId) const
     {
         // Get shader file path

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.h
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.h
@@ -29,9 +29,6 @@ namespace ShaderManagementConsole
         // AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler overrides...
         void OnDocumentOpened(const AZ::Uuid& documentId) override;
 
-        // AtomToolsMainWindowRequestBus::Handler overrides...
-        void UpdateMenus(QMenuBar* menuBar) override;
-
         // AtomToolsFramework::AtomToolsDocumentMainWindow overrides...
         AZStd::string GetSaveDocumentParams(const AZStd::string& initialPath, const AZ::Uuid& documentId) const override;
 


### PR DESCRIPTION
## What does this PR do?

This change has material canvas start up with an empty, untitled graph document and view. Nodes can be dragged into the untitled graph and generated files will be saved to a default, generated materials folder in the user's project. Once the graph is saved, the shaders and materials will be generated in that folder instead.

Other changes were made throughout the document system to do more context sensitive checks to determine if a file could be saved without user prompting.

Disabled the “save as child” menu option by default and enabling it in the material editor.

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

_Please describe any testing performed._
