### PR TITLE
Asset Browser breadcrumbs navigation

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -86,7 +86,7 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
     m_ui->setupUi(this);
     m_ui->m_searchWidget->Setup(true, true);
 
-    OnInitToolsMenuButton();
+    CreateToolsMenu();
 
     namespace AzAssetBrowser = AzToolsFramework::AssetBrowser;
 
@@ -235,11 +235,6 @@ void AzAssetBrowserWindow::resizeEvent(QResizeEvent* resizeEvent)
 
     emit SizeChangedSignal(aznumeric_cast<int>(newWidth));
     QWidget::resizeEvent(resizeEvent);
-}
-
-void AzAssetBrowserWindow::OnInitToolsMenuButton()
-{
-    CreateToolsMenu();
 }
 
 void AzAssetBrowserWindow::CreateToolsMenu()

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -393,15 +393,6 @@ void AzAssetBrowserWindow::UpdateBreadcrumbs(const AzToolsFramework::AssetBrowse
     QString entryPath;
     if (selectedEntry)
     {
-        auto folderForEntry = [](const AssetBrowserEntry* entry)
-        {
-            while (entry && entry->GetEntryType() != AssetBrowserEntry::AssetEntryType::Folder)
-            {
-                entry = entry->GetParent();
-            }
-            return entry;
-        };
-
         const AssetBrowserEntry* folderEntry = Utils::FolderForEntry(selectedEntry);
         if (folderEntry)
         {

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.h
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.h
@@ -62,7 +62,6 @@ protected:
     void resizeEvent(QResizeEvent* resizeEvent) override;
 
 private:
-    void OnInitToolsMenuButton();
     void UpdateDisplayInfo();
     void SetNarrowMode(bool narrow);
 

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.h
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.h
@@ -98,6 +98,7 @@ private:
 private Q_SLOTS:
     void CurrentIndexChangedSlot(const QModelIndex& idx) const;
     void DoubleClickedItem(const QModelIndex& element);
+    void BreadcrumbsPathChangedSlot(const QString& path) const;
 };
 
 extern const char* AZ_ASSET_BROWSER_PREVIEW_NAME;

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.h
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.h
@@ -96,7 +96,7 @@ private:
     bool m_inNarrowMode = false;
 
 private Q_SLOTS:
-    void SelectionChangedSlot(const QItemSelection& selected, const QItemSelection& deselected) const;
+    void CurrentIndexChangedSlot(const QModelIndex& idx) const;
     void DoubleClickedItem(const QModelIndex& element);
 };
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.cpp
@@ -34,6 +34,13 @@ namespace AzQtComponents
     static const QString g_plainTextSeparator = QStringLiteral("\u00a0\u00a0\u203a\u00a0\u00a0");
     static constexpr int g_iconWidth = 16;
 
+    QString toCommonSeparators(const QString& path)
+    {
+        QString ret = path;
+        ret.replace(g_windowsSeparator, g_separator);
+        return ret;
+    }
+
     BreadCrumbs::BreadCrumbs(QWidget* parent)
         : QWidget(parent)
         , m_config(defaultConfig())
@@ -91,10 +98,8 @@ namespace AzQtComponents
 
     void BreadCrumbs::setCurrentPath(const QString& newPath)
     {
-        m_currentPath = newPath;
-
         // clean up the path to use all the first separator in the list of separators
-        m_currentPath.replace(g_windowsSeparator, g_separator);
+        m_currentPath = toCommonSeparators(newPath);
 
         // update internals
         m_currentPathSize = m_currentPath.split(g_separator, Qt::SkipEmptyParts).size();
@@ -233,6 +238,12 @@ namespace AzQtComponents
 
     void BreadCrumbs::pushPath(const QString& fullPath)
     {
+        const QString sanitizedPath = toCommonSeparators(fullPath);
+
+        if (sanitizedPath == m_currentPath)
+        {
+            return;
+        }
         BreadCrumbButtonStates buttonStates;
         getButtonStates(buttonStates);
 
@@ -243,7 +254,7 @@ namespace AzQtComponents
 
         m_forwardPaths.clear();
 
-        changePath(fullPath);
+        changePath(sanitizedPath);
 
         emitButtonSignals(buttonStates);
     }
@@ -406,6 +417,10 @@ namespace AzQtComponents
 
     void BreadCrumbs::changePath(const QString& newPath)
     {
+        if (newPath == m_currentPath)
+        {
+            return;
+        }
         setCurrentPath(newPath);
         updateGeometry();
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntryUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntryUtils.cpp
@@ -245,6 +245,15 @@ namespace AzToolsFramework
                 }
                 return nullptr;
             }
-        } 
-    }
-}
+
+            const AssetBrowserEntry* FolderForEntry(const AssetBrowserEntry* entry)
+            {
+                while (entry && entry->GetEntryType() != AssetBrowserEntry::AssetEntryType::Folder)
+                {
+                    entry = entry->GetParent();
+                }
+                return entry;
+            }
+        } // namespace Utils
+    } // namespace AssetBrowser
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntryUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntryUtils.h
@@ -61,6 +61,9 @@ namespace AzToolsFramework
             //! Note that what is being returned is a pointer to the actual entry in the actual Asset Browser tree,
             //! it is not deserializing or creating a new one.
             const AssetBrowserEntry* FindFromString(AZStd::string_view data);
+
+            //! This function returns the folder in which given asset is located or the entry itself if it's already a folder
+            const AssetBrowserEntry* FolderForEntry(const AssetBrowserEntry* entry);
         } 
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -360,8 +360,7 @@ namespace AzToolsFramework
                 auto productEntry = GetEntryFromIndex<ProductAssetBrowserEntry>(rowIdx);
                 if (productEntry && productEntry->GetAssetId() == assetID)
                 {
-                    selectionModel()->clear();
-                    selectionModel()->select(rowIdx, QItemSelectionModel::Select);
+                    selectionModel()->select(rowIdx, QItemSelectionModel::ClearAndSelect);
                     setCurrentIndex(rowIdx);
                     return true;
                 }
@@ -420,8 +419,7 @@ namespace AzToolsFramework
                                 expand(rowIdx);
                             }
 
-                            selectionModel()->clear();
-                            selectionModel()->select(rowIdx, QItemSelectionModel::Select);
+                            selectionModel()->select(rowIdx, QItemSelectionModel::ClearAndSelect);
                             setCurrentIndex(rowIdx);
 
                             return true;


### PR DESCRIPTION
## What does this PR do?

Adds back and forward buttons Next to the breadcrumbs in new Asset Browser Design.

I recommend reviewing commit by commit.

https://user-images.githubusercontent.com/104767/205650015-33b75ff7-ef08-40b9-b131-6997a78250f3.mp4

Fixes o3de/o3de#12859

## How was this PR tested?

Manually
