### PR TITLE
Disabled Editor / AP tests in monolithic builds - fixes periodic build failure

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/CMakeLists.txt
@@ -6,6 +6,9 @@
 #
 #
 
+if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
+## AP Python Tests ##
+
 add_subdirectory(asset_processor_tests)
 add_subdirectory(fbx_tests)
 add_subdirectory(scene_settings_tests)
@@ -15,15 +18,13 @@ add_subdirectory(scene_settings_tests)
         PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite_Periodic.py
         TEST_SUITE periodic
         RUNTIME_DEPENDENCIES
-            AssetProcessor
+            AZ::AssetProcessor
             AutomatedTesting.Assets
-            Editor
+            Legacy::Editor
         COMPONENT
             Atom
     )
 
-if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
-## AP Python Tests ##
     ly_add_pytest(
         NAME AssetPipelineTests.BankInfoParser
         PATH ${CMAKE_CURRENT_LIST_DIR}/wwise_bank_dependency_tests/bank_info_parser_tests.py
@@ -34,3 +35,4 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
     )
    
 endif()
+


### PR DESCRIPTION
Signed-off-by: AMZN-stankowi <4838196+AMZN-stankowi@users.noreply.github.com>

## What does this PR do?

Period builds were failing due to Editor and AP not being defined there. https://jenkins.build.o3de.org/job/O3DE_periodic-incremental-daily/job/development/184/

## How was this PR tested?

Verified build failed locally with this command, without this change:
cmake .. -DLY_3RDPARTY_PATH=C:\3rdParty -DLY_UNITY_BUILD=ON -DLY_MONOLITHIC_GAME=TRUE -DLY_PROJECTS="AutomatedTesting"

Then verified the build succeeded with this change
