### PR TITLE
Added logging to clarify EditorTest framework failures.

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/o3de/multi_test_framework.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/multi_test_framework.py
@@ -1005,9 +1005,14 @@ class MultiTestSuite(object):
             for i in range(total_threads):
                 def make_parallel_test_func(test_spec, index, current_executable):
                     def run(request, workspace, extra_cmdline_args):
-                        results = self._exec_single_test(
-                            request, workspace, current_executable, index + 1, self.log_name, test_spec,
-                            extra_cmdline_args)
+                        try:
+                            results = self._exec_single_test(
+                                request, workspace, current_executable, index + 1, self.log_name, test_spec,
+                                extra_cmdline_args)
+                        except Exception as e:
+                            logger.warning(f"Found exception trying to run Editor tests. Current log name is "
+                                           f"{self.log_name} and test is {str(test_spec)}")
+                            raise e
                         if not results:
                             raise EditorToolsFrameworkException(f"Results not found. Current log name is "
                                                                 f"{self.log_name} and test name is {str(test_spec)}")
@@ -1069,9 +1074,14 @@ class MultiTestSuite(object):
                 def run(request, workspace, extra_cmdline_args):
                     results = None
                     if len(test_spec_list_for_executable) > 0:
-                        results = self._exec_multitest(
-                            request, workspace, current_executable, index + 1, self.log_name,
-                            test_spec_list_for_executable, extra_cmdline_args)
+                        try:
+                            results = self._exec_multitest(
+                                request, workspace, current_executable, index + 1, self.log_name,
+                                test_spec_list_for_executable, extra_cmdline_args)
+                        except Exception as e:
+                            logger.warning(f"Found exception trying to run Editor tests. Current log name is "
+                                           f"{self.log_name} and tests are {str(test_spec_list_for_executable)}")
+                            raise e
                         if not results:
                             raise EditorToolsFrameworkException(f"Results not found. Current log name is "
                                                                 f"{self.log_name} and tests are "


### PR DESCRIPTION
Signed-off-by: scspaldi <scspaldi@amazon.com>

## What does this PR do?
This improves gaps in logging for editor test framework failures. 

## How was this PR tested?
I threw exceptions from every method in core Editor Test files. I then made sure they either provided sufficient debugging information already, or I added logging until it did. I moved the logging up to the location that captured all of the uncovered locations.