### PR TITLE
Improve prefab delete API unit tests and add override tests

### DIFF
--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabDeleteAsOverrideTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabDeleteAsOverrideTests.cpp
@@ -41,12 +41,6 @@ namespace UnitTest
         AZ::EntityId secondCarContainerId = InstantiateEditorPrefab(carPrefabFilepath, GetRootContainerEntityId());
         RenameEntity(secondCarContainerId, secondCarName);
 
-        InstanceAlias firstCarInstanceAlias = FindNestedInstanceAliasInInstance(GetRootContainerEntityId(), firstCarName);
-        ASSERT_FALSE(firstCarInstanceAlias.empty());
-
-        InstanceAlias secondCarInstanceAlias = FindNestedInstanceAliasInInstance(GetRootContainerEntityId(), secondCarName);
-        ASSERT_FALSE(secondCarInstanceAlias.empty());
-
         // Delete the tire entity in the first car.
         // Note: Level root instance is focused by default.
         auto firstCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(firstCarContainerId);
@@ -95,18 +89,11 @@ namespace UnitTest
         AZ::EntityId tireEntityId = CreateEditorEntityUnderRoot(tireEntityName);
         AZ::EntityId wheelContainerId = CreateEditorPrefab(wheelPrefabFilepath, { tireEntityId });
         AZ::EntityId firstCarContainerId = CreateEditorPrefab(carPrefabFilepath, { wheelContainerId });
-        //EntityAlias tireEntityAlias = FindEntityAliasInInstance(firstCarContainerId, tireEntityName);
         RenameEntity(firstCarContainerId, firstCarName);
 
         // Create and rename the second car.
         AZ::EntityId secondCarContainerId = InstantiateEditorPrefab(carPrefabFilepath, GetRootContainerEntityId());
         RenameEntity(secondCarContainerId, secondCarName);
-
-        InstanceAlias firstCarInstanceAlias = FindNestedInstanceAliasInInstance(GetRootContainerEntityId(), firstCarName);
-        ASSERT_FALSE(firstCarInstanceAlias.empty());
-
-        InstanceAlias secondCarInstanceAlias = FindNestedInstanceAliasInInstance(GetRootContainerEntityId(), secondCarName);
-        ASSERT_FALSE(secondCarInstanceAlias.empty());
 
         InstanceAlias wheelInstanceAlias = FindNestedInstanceAliasInInstance(firstCarContainerId, wheelPrefabName);
         ASSERT_FALSE(wheelInstanceAlias.empty());
@@ -171,12 +158,6 @@ namespace UnitTest
         // Create and rename the second car.
         AZ::EntityId secondCarContainerId = InstantiateEditorPrefab(carPrefabFilepath, GetRootContainerEntityId());
         RenameEntity(secondCarContainerId, secondCarName);
-
-        InstanceAlias firstCarInstanceAlias = FindNestedInstanceAliasInInstance(GetRootContainerEntityId(), firstCarName);
-        ASSERT_FALSE(firstCarInstanceAlias.empty());
-
-        InstanceAlias secondCarInstanceAlias = FindNestedInstanceAliasInInstance(GetRootContainerEntityId(), secondCarName);
-        ASSERT_FALSE(secondCarInstanceAlias.empty());
 
         // Delete the tire entity in the first car.
         // Note: Level root instance is focused by default.
@@ -247,12 +228,6 @@ namespace UnitTest
         // Create and rename the second car.
         AZ::EntityId secondCarContainerId = InstantiateEditorPrefab(carPrefabFilepath, GetRootContainerEntityId());
         RenameEntity(secondCarContainerId, secondCarName);
-
-        InstanceAlias firstCarInstanceAlias = FindNestedInstanceAliasInInstance(GetRootContainerEntityId(), firstCarName);
-        ASSERT_FALSE(firstCarInstanceAlias.empty());
-
-        InstanceAlias secondCarInstanceAlias = FindNestedInstanceAliasInInstance(GetRootContainerEntityId(), secondCarName);
-        ASSERT_FALSE(secondCarInstanceAlias.empty());
 
         // Delete the tire entity in the first car.
         // Note: Level root instance is focused by default.

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabDeleteAsOverrideTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabDeleteAsOverrideTests.cpp
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Prefab/PrefabTestFixture.h>
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+
+namespace UnitTest
+{
+    using PrefabDeleteAsOverrideTests = PrefabTestFixture;
+
+    TEST_F(PrefabDeleteAsOverrideTests, DeleteEntitiesAndAllDescendantsInInstance_DeleteSingleEntitySucceeds)
+    {
+        // Level            <-- focused
+        // | Car_1
+        //   | Tire         <-- delete
+        // | Car_2
+        //   | Tire
+
+        const AZStd::string carPrefabName = "CarPrefab";
+        const AZStd::string tireEntityName = "Tire";
+        const AZStd::string firstCarName = "Car_1";
+        const AZStd::string secondCarName = "Car_2";
+
+        AZ::IO::Path engineRootPath;
+        m_settingsRegistryInterface->Get(engineRootPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
+        AZ::IO::Path carPrefabFilepath(engineRootPath);
+        carPrefabFilepath.Append(carPrefabName);
+
+        // Create and rename the first car.
+        AZ::EntityId tireEntityId = CreateEditorEntityUnderRoot(tireEntityName);
+        AZ::EntityId firstCarContainerId = CreateEditorPrefab(carPrefabFilepath, { tireEntityId });
+        EntityAlias tireEntityAlias = FindEntityAliasInInstance(firstCarContainerId, tireEntityName);
+        RenameEntity(firstCarContainerId, firstCarName);
+
+        // Create and rename the second car.
+        AZ::EntityId secondCarContainerId = InstantiateEditorPrefab(carPrefabFilepath, GetRootContainerEntityId());
+        RenameEntity(secondCarContainerId, secondCarName);
+
+        InstanceAlias firstCarInstanceAlias = FindNestedInstanceAliasInInstance(GetRootContainerEntityId(), firstCarName);
+        ASSERT_FALSE(firstCarInstanceAlias.empty());
+
+        InstanceAlias secondCarInstanceAlias = FindNestedInstanceAliasInInstance(GetRootContainerEntityId(), secondCarName);
+        ASSERT_FALSE(secondCarInstanceAlias.empty());
+
+        // Delete the tire entity in the first car.
+        // Note: Level root instance is focused by default.
+        auto firstCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(firstCarContainerId);
+        AZ::EntityId firstTireEntityId = firstCarInstance->get().GetEntityId(tireEntityAlias);
+
+        auto secondCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(secondCarContainerId);
+        AZ::EntityId secondTireEntityId = secondCarInstance->get().GetEntityId(tireEntityAlias);
+
+        PrefabOperationResult result = m_prefabPublicInterface->DeleteEntitiesAndAllDescendantsInInstance({ firstTireEntityId });
+        ASSERT_TRUE(result.IsSuccess());
+
+        // Validate that only the tire in the first car is deleted.
+        AZ::Entity* firstTireEntity = AzToolsFramework::GetEntityById(firstTireEntityId);
+        EXPECT_TRUE(firstTireEntity == nullptr);
+        AZ::Entity* secondTireEntity = AzToolsFramework::GetEntityById(secondTireEntityId);
+        EXPECT_TRUE(secondTireEntity != nullptr);
+
+        ValidateEntityNotUnderInstance(firstCarInstance->get().GetContainerEntityId(), tireEntityAlias);
+        ValidateEntityUnderInstance(secondCarInstance->get().GetContainerEntityId(), tireEntityAlias, tireEntityName);
+    }
+
+    TEST_F(PrefabDeleteAsOverrideTests, DeleteEntitiesAndAllDescendantsInInstance_DeleteSinglePrefabSucceeds)
+    {
+        // Level            <-- focused
+        // | Car_1
+        //   | Wheel        <-- delete
+        //     | Tire
+        // | Car_2
+        //   | Wheel
+        //     | Tire
+
+        const AZStd::string carPrefabName = "CarPrefab";
+        const AZStd::string wheelPrefabName = "WheelPrefab";
+        const AZStd::string tireEntityName = "Tire";
+        const AZStd::string firstCarName = "Car_1";
+        const AZStd::string secondCarName = "Car_2";
+
+        AZ::IO::Path engineRootPath;
+        m_settingsRegistryInterface->Get(engineRootPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
+        AZ::IO::Path carPrefabFilepath(engineRootPath);
+        carPrefabFilepath.Append(carPrefabName);
+        AZ::IO::Path wheelPrefabFilepath(engineRootPath);
+        wheelPrefabFilepath.Append(wheelPrefabName);
+
+        // Create and rename the first car.
+        AZ::EntityId tireEntityId = CreateEditorEntityUnderRoot(tireEntityName);
+        AZ::EntityId wheelContainerId = CreateEditorPrefab(wheelPrefabFilepath, { tireEntityId });
+        AZ::EntityId firstCarContainerId = CreateEditorPrefab(carPrefabFilepath, { wheelContainerId });
+        //EntityAlias tireEntityAlias = FindEntityAliasInInstance(firstCarContainerId, tireEntityName);
+        RenameEntity(firstCarContainerId, firstCarName);
+
+        // Create and rename the second car.
+        AZ::EntityId secondCarContainerId = InstantiateEditorPrefab(carPrefabFilepath, GetRootContainerEntityId());
+        RenameEntity(secondCarContainerId, secondCarName);
+
+        InstanceAlias firstCarInstanceAlias = FindNestedInstanceAliasInInstance(GetRootContainerEntityId(), firstCarName);
+        ASSERT_FALSE(firstCarInstanceAlias.empty());
+
+        InstanceAlias secondCarInstanceAlias = FindNestedInstanceAliasInInstance(GetRootContainerEntityId(), secondCarName);
+        ASSERT_FALSE(secondCarInstanceAlias.empty());
+
+        InstanceAlias wheelInstanceAlias = FindNestedInstanceAliasInInstance(firstCarContainerId, wheelPrefabName);
+        ASSERT_FALSE(wheelInstanceAlias.empty());
+
+        // Delete the wheel instance in the first car.
+        // Note: Level root instance is focused by default.
+        auto firstCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(firstCarContainerId);
+        AZ::EntityId firstWheelContainerId;
+        firstCarInstance->get().GetNestedInstances(
+            [&firstWheelContainerId, wheelInstanceAlias](AZStd::unique_ptr<Instance>& nestedInstance)
+            {
+                if (nestedInstance->GetInstanceAlias() == wheelInstanceAlias)
+                {
+                    firstWheelContainerId = nestedInstance->GetContainerEntityId();
+                    return;
+                }
+            });
+        ASSERT_TRUE(firstWheelContainerId.IsValid()) << "Cannot get wheel container entity id in the first car.";
+
+        auto secondCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(secondCarContainerId);
+
+        PrefabOperationResult result = m_prefabPublicInterface->DeleteEntitiesAndAllDescendantsInInstance({ firstWheelContainerId });
+        ASSERT_TRUE(result.IsSuccess());
+
+        // Validate that only the wheel instance in the first car is deleted.
+        AZ::Entity* firstWheelContainerEntity = AzToolsFramework::GetEntityById(firstWheelContainerId);
+        EXPECT_TRUE(firstWheelContainerEntity == nullptr);
+
+        ValidateNestedInstanceNotUnderInstance(firstCarInstance->get().GetContainerEntityId(), wheelInstanceAlias);
+        ValidateNestedInstanceUnderInstance(secondCarInstance->get().GetContainerEntityId(), wheelInstanceAlias);
+    }
+
+    TEST_F(PrefabDeleteAsOverrideTests, DeleteEntitiesAndAllDescendantsInInstance_DeletingEntityDeletesChildEntityToo)
+    {
+        // Level              <-- focused
+        // | Car_1
+        //   | Tire           <-- delete
+        //     | ChildEntity
+        // | Car_2
+        //   | Tire
+        //     | ChildEntity
+
+        const AZStd::string carPrefabName = "CarPrefab";
+        const AZStd::string tireEntityName = "Tire";
+        const AZStd::string childEntityName = "ChildEntity";
+        const AZStd::string firstCarName = "Car_1";
+        const AZStd::string secondCarName = "Car_2";
+
+        AZ::IO::Path engineRootPath;
+        m_settingsRegistryInterface->Get(engineRootPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
+        AZ::IO::Path carPrefabFilepath(engineRootPath);
+        carPrefabFilepath.Append(carPrefabName);
+
+        // Create and rename the first car.
+        AZ::EntityId tireEntityId = CreateEditorEntityUnderRoot(tireEntityName);
+        AZ::EntityId childEntityId = CreateEditorEntity(childEntityName, tireEntityId);
+        AZ::EntityId firstCarContainerId = CreateEditorPrefab(carPrefabFilepath, { tireEntityId });
+        EntityAlias tireEntityAlias = FindEntityAliasInInstance(firstCarContainerId, tireEntityName);
+        EntityAlias childEntityAlias = FindEntityAliasInInstance(firstCarContainerId, childEntityName);
+        RenameEntity(firstCarContainerId, firstCarName);
+
+        // Create and rename the second car.
+        AZ::EntityId secondCarContainerId = InstantiateEditorPrefab(carPrefabFilepath, GetRootContainerEntityId());
+        RenameEntity(secondCarContainerId, secondCarName);
+
+        InstanceAlias firstCarInstanceAlias = FindNestedInstanceAliasInInstance(GetRootContainerEntityId(), firstCarName);
+        ASSERT_FALSE(firstCarInstanceAlias.empty());
+
+        InstanceAlias secondCarInstanceAlias = FindNestedInstanceAliasInInstance(GetRootContainerEntityId(), secondCarName);
+        ASSERT_FALSE(secondCarInstanceAlias.empty());
+
+        // Delete the tire entity in the first car.
+        // Note: Level root instance is focused by default.
+        auto firstCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(firstCarContainerId);
+        AZ::EntityId firstTireEntityId = firstCarInstance->get().GetEntityId(tireEntityAlias);
+        AZ::EntityId firstChildEntityId = firstCarInstance->get().GetEntityId(childEntityAlias);
+
+        auto secondCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(secondCarContainerId);
+        AZ::EntityId secondTireEntityId = secondCarInstance->get().GetEntityId(tireEntityAlias);
+        AZ::EntityId secondChildEntityId = secondCarInstance->get().GetEntityId(childEntityAlias);
+
+        PrefabOperationResult result = m_prefabPublicInterface->DeleteEntitiesAndAllDescendantsInInstance({ firstTireEntityId });
+        ASSERT_TRUE(result.IsSuccess());
+
+        // Validate that only the tire and its child entity in the first car are deleted.
+        AZ::Entity* firstTireEntity = AzToolsFramework::GetEntityById(firstTireEntityId);
+        EXPECT_TRUE(firstTireEntity == nullptr);
+        AZ::Entity* firstChildEntity = AzToolsFramework::GetEntityById(firstChildEntityId);
+        EXPECT_TRUE(firstChildEntity == nullptr);
+
+        ValidateEntityNotUnderInstance(firstCarInstance->get().GetContainerEntityId(), tireEntityAlias);
+        ValidateEntityNotUnderInstance(firstCarInstance->get().GetContainerEntityId(), childEntityAlias);
+
+        AZ::Entity* secondTireEntity = AzToolsFramework::GetEntityById(secondTireEntityId);
+        EXPECT_TRUE(secondTireEntity != nullptr);
+        AZ::Entity* secondChildEntity = AzToolsFramework::GetEntityById(secondChildEntityId);
+        EXPECT_TRUE(secondChildEntity != nullptr);
+
+        ValidateEntityUnderInstance(secondCarInstance->get().GetContainerEntityId(), tireEntityAlias, tireEntityName);
+        ValidateEntityUnderInstance(secondCarInstance->get().GetContainerEntityId(), childEntityAlias, childEntityName);
+    }
+
+    TEST_F(PrefabDeleteAsOverrideTests, DeleteEntitiesAndAllDescendantsInInstance_DeletingEntityDeletesChildPrefabToo)
+    {
+        // Level              <-- focused
+        // | Car_1
+        //   | Tire           <-- delete
+        //     | ChildPrefab
+        //       | ChildEntity
+        // | Car_2
+        //   | Tire
+        //     | ChildPrefab
+        //       | ChildEntity
+
+        const AZStd::string carPrefabName = "CarPrefab";
+        const AZStd::string tireEntityName = "Tire";
+        const AZStd::string childPrefabName = "ChildPrefab";
+        const AZStd::string childEntityName = "ChildEntity";
+        const AZStd::string firstCarName = "Car_1";
+        const AZStd::string secondCarName = "Car_2";
+
+        AZ::IO::Path engineRootPath;
+        m_settingsRegistryInterface->Get(engineRootPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
+        AZ::IO::Path carPrefabFilepath(engineRootPath);
+        carPrefabFilepath.Append(carPrefabName);
+        AZ::IO::Path childPrefabFilepath(engineRootPath);
+        childPrefabFilepath.Append(childPrefabName);
+
+        // Create and rename the first car.
+        AZ::EntityId tireEntityId = CreateEditorEntityUnderRoot(tireEntityName);
+        AZ::EntityId childEntityId = CreateEditorEntity(childEntityName, tireEntityId);
+        AZ::EntityId childPrefabContainerId = CreateEditorPrefab(childPrefabFilepath, { childEntityId });
+        AZ::EntityId firstCarContainerId = CreateEditorPrefab(carPrefabFilepath, { tireEntityId });
+        EntityAlias tireEntityAlias = FindEntityAliasInInstance(firstCarContainerId, tireEntityName);
+        InstanceAlias childInstanceAlias = FindNestedInstanceAliasInInstance(firstCarContainerId, childPrefabName);
+        RenameEntity(firstCarContainerId, firstCarName);
+
+        // Create and rename the second car.
+        AZ::EntityId secondCarContainerId = InstantiateEditorPrefab(carPrefabFilepath, GetRootContainerEntityId());
+        RenameEntity(secondCarContainerId, secondCarName);
+
+        InstanceAlias firstCarInstanceAlias = FindNestedInstanceAliasInInstance(GetRootContainerEntityId(), firstCarName);
+        ASSERT_FALSE(firstCarInstanceAlias.empty());
+
+        InstanceAlias secondCarInstanceAlias = FindNestedInstanceAliasInInstance(GetRootContainerEntityId(), secondCarName);
+        ASSERT_FALSE(secondCarInstanceAlias.empty());
+
+        // Delete the tire entity in the first car.
+        // Note: Level root instance is focused by default.
+        auto firstCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(firstCarContainerId);
+        AZ::EntityId firstTireEntityId = firstCarInstance->get().GetEntityId(tireEntityAlias);
+        AZ::EntityId firstChildContainerId;
+        firstCarInstance->get().GetNestedInstances(
+            [&firstChildContainerId, childInstanceAlias](AZStd::unique_ptr<Instance>& nestedInstance)
+            {
+                if (nestedInstance->GetInstanceAlias() == childInstanceAlias)
+                {
+                    firstChildContainerId = nestedInstance->GetContainerEntityId();
+                    return;
+                }
+            });
+        ASSERT_TRUE(firstChildContainerId.IsValid()) << "Cannot get child container entity id in the first car.";
+
+        auto secondCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(secondCarContainerId);
+        AZ::EntityId secondTireEntityId = secondCarInstance->get().GetEntityId(tireEntityAlias);
+        AZ::EntityId secondChildContainerId;
+        secondCarInstance->get().GetNestedInstances(
+            [&secondChildContainerId, childInstanceAlias](AZStd::unique_ptr<Instance>& nestedInstance)
+            {
+                if (nestedInstance->GetInstanceAlias() == childInstanceAlias)
+                {
+                    secondChildContainerId = nestedInstance->GetContainerEntityId();
+                    return;
+                }
+            });
+        ASSERT_TRUE(secondChildContainerId.IsValid()) << "Cannot get child container entity id in the second car.";
+
+        PrefabOperationResult result = m_prefabPublicInterface->DeleteEntitiesAndAllDescendantsInInstance({ firstTireEntityId });
+        ASSERT_TRUE(result.IsSuccess());
+
+        // Validate that only the tire and its child prefab instance in the first car are deleted.
+        AZ::Entity* firstTireEntity = AzToolsFramework::GetEntityById(firstTireEntityId);
+        EXPECT_TRUE(firstTireEntity == nullptr);
+        AZ::Entity* firstChildContainerEntity = AzToolsFramework::GetEntityById(firstChildContainerId);
+        EXPECT_TRUE(firstChildContainerEntity == nullptr);
+
+        ValidateEntityNotUnderInstance(firstCarInstance->get().GetContainerEntityId(), tireEntityAlias);
+        ValidateNestedInstanceNotUnderInstance(firstCarInstance->get().GetContainerEntityId(), childInstanceAlias);
+
+        AZ::Entity* secondTireEntity = AzToolsFramework::GetEntityById(secondTireEntityId);
+        EXPECT_TRUE(secondTireEntity != nullptr);
+        AZ::Entity* secondChildContainerEntity = AzToolsFramework::GetEntityById(secondChildContainerId);
+        EXPECT_TRUE(secondChildContainerEntity != nullptr);
+
+        ValidateEntityUnderInstance(secondCarInstance->get().GetContainerEntityId(), tireEntityAlias, tireEntityName);
+        ValidateNestedInstanceUnderInstance(secondCarInstance->get().GetContainerEntityId(), childInstanceAlias);
+    }
+} // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabDeleteAsOverrideTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabDeleteAsOverrideTests.cpp
@@ -43,10 +43,10 @@ namespace UnitTest
 
         // Delete the tire entity in the first car.
         // Note: Level root instance is focused by default.
-        auto firstCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(firstCarContainerId);
+        InstanceOptionalReference firstCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(firstCarContainerId);
         AZ::EntityId firstTireEntityId = firstCarInstance->get().GetEntityId(tireEntityAlias);
 
-        auto secondCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(secondCarContainerId);
+        InstanceOptionalReference secondCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(secondCarContainerId);
         AZ::EntityId secondTireEntityId = secondCarInstance->get().GetEntityId(tireEntityAlias);
 
         PrefabOperationResult result = m_prefabPublicInterface->DeleteEntitiesAndAllDescendantsInInstance({ firstTireEntityId });
@@ -100,7 +100,7 @@ namespace UnitTest
 
         // Delete the wheel instance in the first car.
         // Note: Level root instance is focused by default.
-        auto firstCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(firstCarContainerId);
+        InstanceOptionalReference firstCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(firstCarContainerId);
         AZ::EntityId firstWheelContainerId;
         firstCarInstance->get().GetNestedInstances(
             [&firstWheelContainerId, wheelInstanceAlias](AZStd::unique_ptr<Instance>& nestedInstance)
@@ -113,7 +113,7 @@ namespace UnitTest
             });
         ASSERT_TRUE(firstWheelContainerId.IsValid()) << "Cannot get wheel container entity id in the first car.";
 
-        auto secondCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(secondCarContainerId);
+        InstanceOptionalReference secondCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(secondCarContainerId);
 
         PrefabOperationResult result = m_prefabPublicInterface->DeleteEntitiesAndAllDescendantsInInstance({ firstWheelContainerId });
         ASSERT_TRUE(result.IsSuccess());
@@ -161,11 +161,11 @@ namespace UnitTest
 
         // Delete the tire entity in the first car.
         // Note: Level root instance is focused by default.
-        auto firstCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(firstCarContainerId);
+        InstanceOptionalReference firstCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(firstCarContainerId);
         AZ::EntityId firstTireEntityId = firstCarInstance->get().GetEntityId(tireEntityAlias);
         AZ::EntityId firstChildEntityId = firstCarInstance->get().GetEntityId(childEntityAlias);
 
-        auto secondCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(secondCarContainerId);
+        InstanceOptionalReference secondCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(secondCarContainerId);
         AZ::EntityId secondTireEntityId = secondCarInstance->get().GetEntityId(tireEntityAlias);
         AZ::EntityId secondChildEntityId = secondCarInstance->get().GetEntityId(childEntityAlias);
 
@@ -231,7 +231,7 @@ namespace UnitTest
 
         // Delete the tire entity in the first car.
         // Note: Level root instance is focused by default.
-        auto firstCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(firstCarContainerId);
+        InstanceOptionalReference firstCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(firstCarContainerId);
         AZ::EntityId firstTireEntityId = firstCarInstance->get().GetEntityId(tireEntityAlias);
         AZ::EntityId firstChildContainerId;
         firstCarInstance->get().GetNestedInstances(
@@ -245,7 +245,7 @@ namespace UnitTest
             });
         ASSERT_TRUE(firstChildContainerId.IsValid()) << "Cannot get child container entity id in the first car.";
 
-        auto secondCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(secondCarContainerId);
+        InstanceOptionalReference secondCarInstance = m_instanceEntityMapperInterface->FindOwningInstance(secondCarContainerId);
         AZ::EntityId secondTireEntityId = secondCarInstance->get().GetEntityId(tireEntityAlias);
         AZ::EntityId secondChildContainerId;
         secondCarInstance->get().GetNestedInstances(

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabDeleteAsOverrideTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabDeleteAsOverrideTests.cpp
@@ -162,7 +162,7 @@ namespace UnitTest
 
         // Create and rename the first car.
         AZ::EntityId tireEntityId = CreateEditorEntityUnderRoot(tireEntityName);
-        AZ::EntityId childEntityId = CreateEditorEntity(childEntityName, tireEntityId);
+        CreateEditorEntity(childEntityName, tireEntityId);
         AZ::EntityId firstCarContainerId = CreateEditorPrefab(carPrefabFilepath, { tireEntityId });
         EntityAlias tireEntityAlias = FindEntityAliasInInstance(firstCarContainerId, tireEntityName);
         EntityAlias childEntityAlias = FindEntityAliasInInstance(firstCarContainerId, childEntityName);
@@ -238,7 +238,7 @@ namespace UnitTest
         // Create and rename the first car.
         AZ::EntityId tireEntityId = CreateEditorEntityUnderRoot(tireEntityName);
         AZ::EntityId childEntityId = CreateEditorEntity(childEntityName, tireEntityId);
-        AZ::EntityId childPrefabContainerId = CreateEditorPrefab(childPrefabFilepath, { childEntityId });
+        CreateEditorPrefab(childPrefabFilepath, { childEntityId });
         AZ::EntityId firstCarContainerId = CreateEditorPrefab(carPrefabFilepath, { tireEntityId });
         EntityAlias tireEntityAlias = FindEntityAliasInInstance(firstCarContainerId, tireEntityName);
         InstanceAlias childInstanceAlias = FindNestedInstanceAliasInInstance(firstCarContainerId, childPrefabName);

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabDeleteTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabDeleteTests.cpp
@@ -6,133 +6,107 @@
  *
  */
 
-#include <AzCore/Settings/SettingsRegistryMergeUtils.h>
-#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
-#include <AzToolsFramework/ToolsComponents/TransformComponent.h>
-
-#include <Prefab/PrefabTestComponent.h>
-#include <Prefab/PrefabTestDomUtils.h>
 #include <Prefab/PrefabTestFixture.h>
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 
 namespace UnitTest
 {
-    using PrefabDeleteTest = PrefabTestFixture;
+    using PrefabDeleteTests = PrefabTestFixture;
 
-    TEST_F(PrefabDeleteTest, DeleteEntitiesAndAllDescendantsInInstance_DeleteSingleEntitySucceeds)
+    TEST_F(PrefabDeleteTests, DeleteEntitiesAndAllDescendantsInInstance_DeleteSingleEntitySucceeds)
     {
-        PrefabEntityResult createEntityResult = m_prefabPublicInterface->CreateEntity(AZ::EntityId(), AZ::Vector3());
+        const AZStd::string entityToDeleteName = "EntityToDelete";
 
-        // Verify that a valid entity is created.
-        AZ::EntityId testEntityId = createEntityResult.GetValue();
-        ASSERT_TRUE(testEntityId.IsValid());
-        AZ::Entity* testEntity = AzToolsFramework::GetEntityById(testEntityId);
-        ASSERT_TRUE(testEntity != nullptr);
+        AZ::EntityId entityId = CreateEditorEntityUnderRoot(entityToDeleteName);
+        EntityAlias entityAlias = FindEntityAliasInInstance(GetRootContainerEntityId(), entityToDeleteName);
 
-        m_prefabPublicInterface->DeleteEntitiesAndAllDescendantsInInstance(AzToolsFramework::EntityIdList{ testEntityId });
+        PrefabOperationResult result = m_prefabPublicInterface->DeleteEntitiesAndAllDescendantsInInstance({ entityId });
+        ASSERT_TRUE(result.IsSuccess());
 
         // Verify that entity can't be found after deletion.
-        testEntity = AzToolsFramework::GetEntityById(testEntityId);
-        EXPECT_TRUE(testEntity == nullptr);
+        AZ::Entity* entityToDelete = AzToolsFramework::GetEntityById(entityId);
+        EXPECT_TRUE(entityToDelete == nullptr);
+
+        ValidateEntityNotUnderInstance(GetRootContainerEntityId(), entityAlias);
     }
 
-    TEST_F(PrefabDeleteTest, DeleteEntitiesAndAllDescendantsInInstance_DeleteSinglePrefabSucceeds)
+    TEST_F(PrefabDeleteTests, DeleteEntitiesAndAllDescendantsInInstance_DeleteSinglePrefabSucceeds)
     {
-        // Verify that a valid entity is created.
-        AZ::EntityId createdEntityId = CreateEditorEntityUnderRoot("EntityUnderRootPrefab");
-        ASSERT_TRUE(createdEntityId.IsValid());
-        AZ::Entity* createdEntity = AzToolsFramework::GetEntityById(createdEntityId);
-        ASSERT_TRUE(createdEntity != nullptr);
+        const AZStd::string entityName = "EntityUnderPrefab";
+        const AZStd::string prefabName = "PrefabToDelete";
 
-        // Rather than hardcode a path, use a path from settings registry since that will work on all platforms.
-        AZ::SettingsRegistryInterface* registry = AZ::SettingsRegistry::Get();
-        AZ::IO::FixedMaxPath path;
-        registry->Get(path.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
-        CreatePrefabResult createPrefabResult =
-            m_prefabPublicInterface->CreatePrefabInMemory(AzToolsFramework::EntityIdList{ createdEntityId }, path);
+        AZ::IO::Path engineRootPath;
+        m_settingsRegistryInterface->Get(engineRootPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
+        AZ::IO::Path prefabFilepath(engineRootPath);
+        prefabFilepath.Append(prefabName);
 
-        AZ::EntityId createdPrefabContainerId = createPrefabResult.GetValue();
-        ASSERT_TRUE(createdPrefabContainerId.IsValid());
-        AZ::Entity* prefabContainerEntity = AzToolsFramework::GetEntityById(createdPrefabContainerId);
-        ASSERT_TRUE(prefabContainerEntity != nullptr);
+        AZ::EntityId entityId = CreateEditorEntityUnderRoot(entityName);
+        AZ::EntityId containerEntityId = CreateEditorPrefab(prefabFilepath, { entityId });
+        InstanceAlias prefabInstanceAlias = FindNestedInstanceAliasInInstance(GetRootContainerEntityId(), prefabName);
 
         // Verify that the prefab container entity and the entity within are deleted.
-        m_prefabPublicInterface->DeleteEntitiesAndAllDescendantsInInstance(AzToolsFramework::EntityIdList{ createdPrefabContainerId });
-        prefabContainerEntity = AzToolsFramework::GetEntityById(createdPrefabContainerId);
-        EXPECT_TRUE(prefabContainerEntity == nullptr);
-        createdEntity = AzToolsFramework::GetEntityById(createdEntityId);
-        EXPECT_TRUE(createdEntity == nullptr);
+        PrefabOperationResult result = m_prefabPublicInterface->DeleteEntitiesAndAllDescendantsInInstance({ containerEntityId });
+        ASSERT_TRUE(result.IsSuccess());
+
+        AZ::Entity* containerEntity = AzToolsFramework::GetEntityById(containerEntityId);
+        EXPECT_TRUE(containerEntity == nullptr);
+
+        ValidateNestedInstanceNotUnderInstance(GetRootContainerEntityId(), prefabInstanceAlias);
     }
 
-    TEST_F(PrefabDeleteTest, DeleteEntitiesAndAllDescendantsInInstance_DeletingEntityDeletesChildEntityToo)
+    TEST_F(PrefabDeleteTests, DeleteEntitiesAndAllDescendantsInInstance_DeletingEntityDeletesChildEntityToo)
     {
-        PrefabEntityResult parentEntityCreationResult = m_prefabPublicInterface->CreateEntity(AZ::EntityId(), AZ::Vector3());
+        const AZStd::string parentEntityName = "ParentEntity";
+        const AZStd::string childEntityName = "ChildEntity";
 
-        // Verify that valid parent entity is created.
-        AZ::EntityId parentEntityId = parentEntityCreationResult.GetValue();
-        ASSERT_TRUE(parentEntityId.IsValid());
-        AZ::Entity* parentEntity = AzToolsFramework::GetEntityById(parentEntityId);
-        ASSERT_TRUE(parentEntity != nullptr);
-
-        // Verify that valid child entity is created.
-        PrefabEntityResult childEntityCreationResult = m_prefabPublicInterface->CreateEntity(parentEntityId, AZ::Vector3());
-        AZ::EntityId childEntityId = childEntityCreationResult.GetValue();
-        ASSERT_TRUE(childEntityId.IsValid());
-        AZ::Entity* childEntity = AzToolsFramework::GetEntityById(childEntityId);
-        ASSERT_TRUE(childEntity != nullptr);
-
-        // Parent the child entity under the parent entity.
-        AZ::TransformBus::Event(childEntityId, &AZ::TransformBus::Events::SetParent, parentEntityId);
-
-        // Delete parent entity and its children.
-        m_prefabPublicInterface->DeleteEntitiesAndAllDescendantsInInstance(AzToolsFramework::EntityIdList{ parentEntityId });
-
-        // Verify that both the parent and child entities are deleted.
-        parentEntity = AzToolsFramework::GetEntityById(parentEntityId);
-        EXPECT_TRUE(parentEntity == nullptr);
-        childEntity = AzToolsFramework::GetEntityById(childEntityId);
-        EXPECT_TRUE(childEntity == nullptr);
-    }
-
-    TEST_F(PrefabDeleteTest, DeleteEntitiesAndAllDescendantsInInstance_DeletingEntityDeletesChildPrefabToo)
-    {
-        // Verify that a valid entity is created that will be put in a prefab later.
-        AZ::EntityId entityToBePutUnderPrefabId = CreateEditorEntityUnderRoot("EntityToBePutUnderPrefab");
-        ASSERT_TRUE(entityToBePutUnderPrefabId.IsValid());
-        AZ::Entity* entityToBePutUnderPrefab = AzToolsFramework::GetEntityById(entityToBePutUnderPrefabId);
-        ASSERT_TRUE(entityToBePutUnderPrefab != nullptr);
-
-        // Verify that a valid parent entity is created.
-        PrefabEntityResult parentEntityCreationResult = m_prefabPublicInterface->CreateEntity(AZ::EntityId(), AZ::Vector3());
-        AZ::EntityId parentEntityId = parentEntityCreationResult.GetValue();
-        ASSERT_TRUE(parentEntityId.IsValid());
-        AZ::Entity* parentEntity = AzToolsFramework::GetEntityById(parentEntityId);
-        ASSERT_TRUE(parentEntity != nullptr);
-
-        // Rather than hardcode a path, use a path from settings registry since that will work on all platforms.
-        AZ::SettingsRegistryInterface* registry = AZ::SettingsRegistry::Get();
-        AZ::IO::FixedMaxPath path;
-        registry->Get(path.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
-        CreatePrefabResult createPrefabResult =
-            m_prefabPublicInterface->CreatePrefabInMemory(AzToolsFramework::EntityIdList{ entityToBePutUnderPrefabId }, path);
-
-        // Verify that a valid prefab container entity is created.
-        AZ::EntityId createdPrefabContainerId = createPrefabResult.GetValue();
-        ASSERT_TRUE(createdPrefabContainerId.IsValid());
-        AZ::Entity* prefabContainerEntity = AzToolsFramework::GetEntityById(createdPrefabContainerId);
-        ASSERT_TRUE(prefabContainerEntity != nullptr);
-
-        // Parent the prefab under the parent entity.
-        AZ::TransformBus::Event(createdPrefabContainerId, &AZ::TransformBus::Events::SetParent, parentEntityId);
+        AZ::EntityId parentEntityId = CreateEditorEntityUnderRoot(parentEntityName);
+        AZ::EntityId childEntityId = CreateEditorEntity(childEntityName, parentEntityId);
+        EntityAlias parentEntityAlias = FindEntityAliasInInstance(GetRootContainerEntityId(), parentEntityName);
+        EntityAlias childEntityAlias = FindEntityAliasInInstance(GetRootContainerEntityId(), childEntityName);
 
         // Delete the parent entity.
-        m_prefabPublicInterface->DeleteEntitiesAndAllDescendantsInInstance(AzToolsFramework::EntityIdList{ parentEntityId });
+        PrefabOperationResult result = m_prefabPublicInterface->DeleteEntitiesAndAllDescendantsInInstance({ parentEntityId });
+        ASSERT_TRUE(result.IsSuccess());
 
-        // Validate that the parent and the prefab under it and the entity inside the prefab are all deleted.
-        parentEntity = AzToolsFramework::GetEntityById(parentEntityId);
-        ASSERT_TRUE(parentEntity == nullptr);
-        entityToBePutUnderPrefab = AzToolsFramework::GetEntityById(entityToBePutUnderPrefabId);
-        ASSERT_TRUE(entityToBePutUnderPrefab == nullptr);
-        prefabContainerEntity = AzToolsFramework::GetEntityById(createdPrefabContainerId);
-        EXPECT_TRUE(prefabContainerEntity == nullptr);
+        // Verify that both the parent and its child entity are deleted.
+        AZ::Entity* parentEntity = AzToolsFramework::GetEntityById(parentEntityId);
+        EXPECT_TRUE(parentEntity == nullptr);
+        AZ::Entity* childEntity = AzToolsFramework::GetEntityById(childEntityId);
+        EXPECT_TRUE(childEntity == nullptr);
+
+        ValidateEntityNotUnderInstance(GetRootContainerEntityId(), parentEntityAlias);
+        ValidateEntityNotUnderInstance(GetRootContainerEntityId(), childEntityAlias);
+    }
+
+    TEST_F(PrefabDeleteTests, DeleteEntitiesAndAllDescendantsInInstance_DeletingEntityDeletesChildPrefabToo)
+    {
+        const AZStd::string parentEntityName = "ParentEntity";
+        const AZStd::string childEntityName = "ChildEntity";
+        const AZStd::string childPrefabName = "ChildPrefab";
+
+        AZ::IO::Path engineRootPath;
+        m_settingsRegistryInterface->Get(engineRootPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
+        AZ::IO::Path prefabFilepath(engineRootPath);
+        prefabFilepath.Append(childPrefabName);
+
+        AZ::EntityId parentEntityId = CreateEditorEntityUnderRoot(parentEntityName);
+        EntityAlias parentEntityAlias = FindEntityAliasInInstance(GetRootContainerEntityId(), parentEntityName);
+
+        AZ::EntityId childEntityId = CreateEditorEntity(childEntityName, parentEntityId);
+        AZ::EntityId childContainerId = CreateEditorPrefab(prefabFilepath, { childEntityId });
+        InstanceAlias childInstanceAlias = FindNestedInstanceAliasInInstance(GetRootContainerEntityId(), childPrefabName);
+
+        // Delete the parent entity.
+        PrefabOperationResult result = m_prefabPublicInterface->DeleteEntitiesAndAllDescendantsInInstance({ parentEntityId });
+        ASSERT_TRUE(result.IsSuccess());
+
+        // Validate that the parent and the prefab instance under it are deleted.
+        AZ::Entity* parentEntity = AzToolsFramework::GetEntityById(parentEntityId);
+        EXPECT_TRUE(parentEntity == nullptr);
+        AZ::Entity* childContainerEntity = AzToolsFramework::GetEntityById(childContainerId);
+        EXPECT_TRUE(childContainerEntity == nullptr);
+
+        ValidateEntityNotUnderInstance(GetRootContainerEntityId(), parentEntityAlias);
+        ValidateNestedInstanceNotUnderInstance(GetRootContainerEntityId(), childPrefabName);
     }
 } // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestFixture.cpp
@@ -289,6 +289,17 @@ namespace UnitTest
         return foundInstanceAlias;
     }
 
+    void PrefabTestFixture::RenameEntity(AZ::EntityId entityId, const AZStd::string& newName)
+    {
+        ASSERT_FALSE(newName.empty()) << "Cannot rename an entity to empty string.";
+        AZ::Entity* entityToRename = AzToolsFramework::GetEntityById(entityId);
+        ASSERT_TRUE(entityToRename != nullptr) << "Cannot rename a null entity.";
+
+        entityToRename->SetName(newName);
+        m_prefabPublicInterface->GenerateUndoNodesForEntityChangeAndUpdateCache(entityId, m_undoStack->GetTop());
+        PropagateAllTemplateChanges();
+    }
+
     void PrefabTestFixture::ValidateEntityUnderInstance(
         AZ::EntityId containerEntityId, const EntityAlias& entityAlias, const AZStd::string& entityName)
     {

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestFixture.h
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestFixture.h
@@ -110,6 +110,12 @@ namespace UnitTest
         //! @return Nested instance alias for the given container entity name. Returns "" if not found.
         InstanceAlias FindNestedInstanceAliasInInstance(AZ::EntityId containerEntityId, const AZStd::string& nestedContainerEntityName);
 
+        //! Rename an entity.
+        //! Note: Renaming a container entity would be an override edit on the focused prefab.
+        //! @param entityId Entity id for entity to be renamed.
+        //! @param newName New entity name.
+        void RenameEntity(AZ::EntityId entityId, const AZStd::string& newName);
+
         //! Helper functions for validation.
         //! @{
         void ValidateEntityUnderInstance(AZ::EntityId containerEntityId, const EntityAlias& entityAlias, const AZStd::string& entityName);

--- a/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
+++ b/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
@@ -99,6 +99,7 @@ set(FILES
     Prefab/Overrides/PrefabOverrideTestFixture.cpp
     Prefab/Overrides/PrefabOverrideTestFixture.h
     Prefab/PrefabDeleteTests.cpp
+    Prefab/PrefabDeleteAsOverrideTests.cpp
     Prefab/PrefabDuplicateTests.cpp
     Prefab/PrefabEntityAliasTests.cpp
     Prefab/PrefabInstanceToTemplatePropagatorTests.cpp


### PR DESCRIPTION
Signed-off-by: Junhao Wang [wjunhao@amazon.com](mailto:wjunhao@amazon.com)

## What does this PR do?

This PR improves unit tests for template editing and adds 4 new tests for override editing. All tests are related to the public delete API "DeleteEntitiesAndAllDescendantsInInstance".

**Improve PrefabDeleteTests:**
1. DeleteSingleEntitySucceeds
2. DeleteSinglePrefabSucceeds
3. DeletingEntityDeletesChildEntityToo
4. DeletingEntityDeletesChildPrefabToo

**Add PrefabDeleteAsOverrideTests:**
1. DeleteSingleEntitySucceeds
2. DeleteSinglePrefabSucceeds
3. DeletingEntityDeletesChildEntityToo
4. DeletingEntityDeletesChildPrefabToo

**Update PrefabTestFixture:**
1. Add helper function to rename an entity

Follow-up for: https://github.com/o3de/o3de/pull/13171

## How was this PR tested?

Passed all AzToolsFramework unit tests.