### PR TITLE
Fixed test_TwoAssetsWithSameProductName_ShouldProcessAfterRename in the Asset Pipeline FBX suite.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_batch_tests.py
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_batch_tests.py
@@ -313,13 +313,8 @@ class TestsAssetProcessorBatch_AllPlatforms(object):
     @pytest.mark.BAT
     @pytest.mark.assetpipeline
     @pytest.mark.test_case_id('C1612448')
-    @pytest.mark.SUITE_sandbox
     def test_TwoAssetsWithSameProductName_ShouldProcessAfterRename(self, asset_processor, ap_setup_fixture):
         """
-        Sandboxed: Race condition on AP batch shutdown can cause the failure to not yet be registered even though it's
-        recognized as failing in the logs.  There appears to be a window where the AutoFailJob doesn't complete
-        before the shutdown completes and the failure doesn't end up counting
-
         Tests processing of two assets with the same product name, then verifies that AP will successfully process after
         renaming one of the assets' outputs.
 

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_batch_tests.py
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_batch_tests.py
@@ -13,6 +13,7 @@ from os import listdir
 import pytest
 import logging
 import os
+from pprint import pformat
 import stat
 import shutil
 
@@ -332,11 +333,19 @@ class TestsAssetProcessorBatch_AllPlatforms(object):
         7. Verify that expected product files are in the cache
         """
 
+        def run_ap_debug_skip_atom_output(asset_processor):
+            result, output = asset_processor.batch_process(capture_output=True, extra_params=["--debugOutput",
+                                                                                              "--regset=\"/O3DE/SceneAPI/AssetImporter/SkipAtomOutput=true\""])
+            # If the test fails, it's helpful to have the output from asset processor in the logs, to track the failure down.
+            logger.info(f"Asset Processor Output: {pformat(output)}")
+            return result, output
+
         # Copying test assets to project folder
         asset_processor.prepare_test_environment(ap_setup_fixture["tests_dir"], "test_TwoAssetsWithSameProductName_ShouldProcessAfterRename")
-        # Launching AP, making sure it is failing
-        result, output = asset_processor.batch_process(capture_output=True)
-        assert result == False, f'AssetProcessorBatch should have failed because the generated output products should share the same name, instead output was {output}'
+        # Launching AP, verify it is failing
+        result, output = run_ap_debug_skip_atom_output(asset_processor)
+        assert result == False, \
+            'AssetProcessorBatch should have failed because the generated output products should share the same name.'
 
         # Renaming output files so they won't collide in cache after second processing
         file_to_rename = os.path.join(asset_processor.temp_asset_root(), "AutomatedTesting", "test_TwoAssetsWithSameProductName_ShouldProcessAfterRename", "a.fbx.assetinfo")
@@ -348,7 +357,7 @@ class TestsAssetProcessorBatch_AllPlatforms(object):
         shutil.copyfile(data_for_rename, file_to_rename)
 
         # Reprocessing files and making sure there are no failed jobs
-        result, output = asset_processor.batch_process(capture_output=True)
+        result, output = run_ap_debug_skip_atom_output(asset_processor)
         assert result, "AssetProcessorBatch failed when it should have succeeded after renaming output."
 
         num_failed_assets = asset_processor_utils.get_num_failed_processed_assets(output)

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/test_TwoAssetsWithSameProductName_ShouldProcessAfterRename/a.fbx
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/test_TwoAssetsWithSameProductName_ShouldProcessAfterRename/a.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e32877eab35459499c73ff093df898f93bf3e7379de25eef6875d693be9bec81
+size 18015

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/test_TwoAssetsWithSameProductName_ShouldProcessAfterRename/a.fbx.assetinfo
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/test_TwoAssetsWithSameProductName_ShouldProcessAfterRename/a.fbx.assetinfo
@@ -1,0 +1,78 @@
+{
+    "values": [
+        {
+            "$type": "{5B03C8E6-8CEE-4DA0-A7FA-CD88689DD45B} MeshGroup",
+            "id": "{33DAE204-51BD-55E2-A94C-674CDE91E9E8}",
+            "name": "a",
+            "NodeSelectionList": {
+                "unselectedNodes": [
+                    {},
+                    "RootNode",
+                    "RootNode.cube"
+                ]
+            },
+            "PhysicsMaterialSlots": {
+                "Slots": [
+                    {
+                        "Name": "Entire object"
+                    }
+                ]
+            }
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "a",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    {},
+                    "RootNode",
+                    "RootNode.cube"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MaterialRule"
+                    }
+                ]
+            },
+            "id": "{44614A2D-2AA7-5D01-8EED-A148FA13FABB}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_a_FA2BD759_0D6E_51AF_9CD0_FAB184590211_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.cube"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{FA2BD759-0D6E-51AF-9CD0-FAB184590211}"
+        },
+        {
+            "$type": "PrefabGroup",
+            "name": "Gem/PythonTests/assetpipeline/asset_processor_tests/assets/test_TwoAssetsWithSameProductName_ShouldProcessAfterRename/a_fbx.procprefab",
+            "id": "{C3CAEA0D-97C7-5C5D-AF96-73918E7E74F5}",
+            "createProceduralPrefab": false
+        },
+        {
+            "$type": "ActorGroup",
+            "name": "b",
+            "selectedRootBone": "RootNode",
+            "id": "{E824E05E-D1E2-46AA-A1D5-4D8A4C49E1DC}"
+        }
+    ]
+}

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/test_TwoAssetsWithSameProductName_ShouldProcessAfterRename/b.fbx
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/test_TwoAssetsWithSameProductName_ShouldProcessAfterRename/b.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e32877eab35459499c73ff093df898f93bf3e7379de25eef6875d693be9bec81
+size 18015

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/test_TwoAssetsWithSameProductName_ShouldProcessAfterRename/b.fbx.assetinfo
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/test_TwoAssetsWithSameProductName_ShouldProcessAfterRename/b.fbx.assetinfo
@@ -1,0 +1,77 @@
+{
+    "values": [
+        {
+            "$type": "{5B03C8E6-8CEE-4DA0-A7FA-CD88689DD45B} MeshGroup",
+            "id": "{D43D325F-29D5-5BA0-9C2F-24FEE6CA6FA0}",
+            "name": "b",
+            "NodeSelectionList": {
+                "unselectedNodes": [
+                    {},
+                    "RootNode",
+                    "RootNode.cube"
+                ]
+            },
+            "PhysicsMaterialSlots": {
+                "Slots": [
+                    {
+                        "Name": "Entire object"
+                    }
+                ]
+            }
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "b",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    {},
+                    "RootNode",
+                    "RootNode.cube"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MaterialRule"
+                    }
+                ]
+            },
+            "id": "{76FE8BF8-F1BE-5398-87A8-6092E6132C54}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_b_D09F1B55_4CA0_551D_91D7_194BF6CDF485_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.cube"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{D09F1B55-4CA0-551D-91D7-194BF6CDF485}"
+        },
+        {
+            "$type": "PrefabGroup",
+            "name": "Gem/PythonTests/assetpipeline/asset_processor_tests/assets/test_TwoAssetsWithSameProductName_ShouldProcessAfterRename/b_fbx.procprefab",
+            "id": "{0AFE0331-36CA-5A8E-ACAB-71E44C5E9012}"
+        },
+        {
+            "$type": "ActorGroup",
+            "name": "b",
+            "selectedRootBone": "RootNode",
+            "id": "{2D535F85-A8A3-4347-850A-0F4AE34CC110}"
+        }
+    ]
+}

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/test_TwoAssetsWithSameProductName_ShouldProcessAfterRename/rename.txt
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/assets/test_TwoAssetsWithSameProductName_ShouldProcessAfterRename/rename.txt
@@ -1,0 +1,78 @@
+{
+    "values": [
+        {
+            "$type": "{5B03C8E6-8CEE-4DA0-A7FA-CD88689DD45B} MeshGroup",
+            "id": "{33DAE204-51BD-55E2-A94C-674CDE91E9E8}",
+            "name": "a",
+            "NodeSelectionList": {
+                "unselectedNodes": [
+                    {},
+                    "RootNode",
+                    "RootNode.cube"
+                ]
+            },
+            "PhysicsMaterialSlots": {
+                "Slots": [
+                    {
+                        "Name": "Entire object"
+                    }
+                ]
+            }
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "a",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    {},
+                    "RootNode",
+                    "RootNode.cube"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MaterialRule"
+                    }
+                ]
+            },
+            "id": "{44614A2D-2AA7-5D01-8EED-A148FA13FABB}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_a_FA2BD759_0D6E_51AF_9CD0_FAB184590211_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.cube"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{FA2BD759-0D6E-51AF-9CD0-FAB184590211}"
+        },
+        {
+            "$type": "PrefabGroup",
+            "name": "Gem/PythonTests/assetpipeline/asset_processor_tests/assets/test_TwoAssetsWithSameProductName_ShouldProcessAfterRename/a_fbx.procprefab",
+            "id": "{C3CAEA0D-97C7-5C5D-AF96-73918E7E74F5}",
+            "createProceduralPrefab": false
+        },
+        {
+            "$type": "ActorGroup",
+            "name": "a",
+            "selectedRootBone": "RootNode",
+            "id": "{E824E05E-D1E2-46AA-A1D5-4D8A4C49E1DC}"
+        }
+    ]
+}


### PR DESCRIPTION
Added missing test assets and additional logging.

Signed-off-by: Rosario Cox <lesaelr@amazon.com>

## What does this PR do?
This PR fixes the failing test "_test_TwoAssetsWithSameProductName_ShouldProcessAfterRename_" in asset_processor_batch_tests by adding the missing test assets.

## How was this PR tested?
This PR was tested locally.
