### PR TITLE
Fix python runtime in AWS linux params

### DIFF
--- a/scripts/build/Platform/Linux/build_config.json
+++ b/scripts/build/Platform/Linux/build_config.json
@@ -394,7 +394,7 @@
     "PARAMETERS": {
       "NVM_VERSION": "v0.39.1",
       "CDK_VERSION": "1.179.0",
-      "PYTHON_RUNTIME": "python-3.10.5-rev1-linux"
+      "PYTHON_RUNTIME": "python-3.10.5-rev2-linux"
     }
   },
   "awsi_destruction": {
@@ -406,7 +406,7 @@
     "PARAMETERS": {
       "NVM_VERSION": "v0.39.1",
       "CDK_VERSION": "1.179.0",
-      "PYTHON_RUNTIME": "python-3.10.5-rev1-linux"
+      "PYTHON_RUNTIME": "python-3.10.5-rev2-linux"
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/12487 

Changes AWSI test param for `PYTHON_RUNTIME` to match what is [currently configured](https://github.com/o3de/o3de/blob/f524e0bdb68610bada6648890e1a773ddcf7f7a0/cmake/LYPython.cmake#L25) for Linux.

## How has this been tested? 

It hasn't been tested directly in CI yet, however the current Linux tests are failing to bootstrap with the error `line 32: python: command not found`, so we know its current value is wrong, while the new value matches what is used elsewhere in the engine. 
