### PR TITLE
Block override editing for instantiate, create and detach prefab

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/PrefabTestUtils.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/PrefabTestUtils.py
@@ -122,7 +122,14 @@ def create_linear_nested_prefabs(entities, nested_prefabs_file_name_prefix, nest
         created_prefabs.append(current_prefab)
         created_prefab_instances.append(current_prefab_instance)
         entities = current_prefab_instance.get_direct_child_entities()
+
+        # Focus on the newly created prefab instance before next creation to perform a prefab edit rather than override edit.
+        current_prefab_instance.container_entity.focus_on_owning_prefab()
     
+    # Switch focus back on the originally focused instance.
+    parent_entity = EditorEntity(created_prefab_instances[0].container_entity.get_parent_id())
+    parent_entity.focus_on_owning_prefab()
+
     return created_prefabs, created_prefab_instances
 
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -106,7 +106,8 @@ namespace AzToolsFramework
             }
 
             // Block creating prefab as override since it is not supported.
-            if (commonRootEntityOwningInstance.has_value() && IsOverrideEditing(commonRootEntityOwningInstance->get()))
+            if (commonRootEntityOwningInstance.has_value() &&
+                !m_prefabFocusHandler.IsOwningPrefabBeingFocused(commonRootEntityOwningInstance->get().GetContainerEntityId()))
             {
                 return AZ::Failure<AZStd::string>("Creating prefab as an override edit is currently not supported.\n"
                     "To perform a prefab edit, please first enter Prefab Edit Mode on the direct owning prefab.");
@@ -462,7 +463,7 @@ namespace AzToolsFramework
             }
 
             // Block instantiating prefab as override since it is not supported.
-            if (IsOverrideEditing(instanceToParentUnder->get()))
+            if (!m_prefabFocusHandler.IsOwningPrefabBeingFocused(instanceToParentUnder->get().GetContainerEntityId()))
             {
                 return AZ::Failure<AZStd::string>("Instantiating prefab as an override edit is currently not supported.\n"
                     "To perform a prefab edit, please first enter Prefab Edit Mode on the direct owning prefab.");
@@ -615,16 +616,6 @@ namespace AzToolsFramework
             }
 
             return false;
-        }
-
-        bool PrefabPublicHandler::IsOverrideEditing(const Instance& owningInstance) const
-        {
-            AzFramework::EntityContextId editorEntityContextId = AzFramework::EntityContextId::CreateNull();
-            EditorEntityContextRequestBus::BroadcastResult(editorEntityContextId, &EditorEntityContextRequests::GetEditorEntityContextId);
-            InstanceOptionalReference focusedInstance = m_prefabFocusHandler.GetFocusedPrefabInstance(editorEntityContextId);
-            AZ_Assert(focusedInstance.has_value(), "PrefabPublicHandler::IsOverrideEditing - The focused instance is null.");
-
-            return &(focusedInstance->get()) != &owningInstance;
         }
 
         void PrefabPublicHandler::CreateLink(
@@ -1515,7 +1506,7 @@ namespace AzToolsFramework
                 const auto parentTemplateId = parentInstance.GetTemplateId();
 
                 // Block detaching prefab as override since it is not supported.
-                if (IsOverrideEditing(parentInstance))
+                if (!m_prefabFocusHandler.IsOwningPrefabBeingFocused(parentInstance.GetContainerEntityId()))
                 {
                     return AZ::Failure(AZStd::string("Detaching prefab as an override edit is currently not supported.\n"
                         "To perform a prefab edit, please first enter Prefab Edit Mode on the direct owning prefab."));

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -619,9 +619,9 @@ namespace AzToolsFramework
 
         bool PrefabPublicHandler::IsOverrideEditing(const Instance& owningInstance) const
         {
-            auto editorEntityContextId = AzFramework::EntityContextId::CreateNull();
+            AzFramework::EntityContextId editorEntityContextId = AzFramework::EntityContextId::CreateNull();
             EditorEntityContextRequestBus::BroadcastResult(editorEntityContextId, &EditorEntityContextRequests::GetEditorEntityContextId);
-            auto focusedInstance = m_prefabFocusHandler.GetFocusedPrefabInstance(editorEntityContextId);
+            InstanceOptionalReference focusedInstance = m_prefabFocusHandler.GetFocusedPrefabInstance(editorEntityContextId);
             AZ_Assert(focusedInstance.has_value(), "PrefabPublicHandler::IsOverrideEditing - The focused instance is null.");
 
             return &(focusedInstance->get()) != &owningInstance;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
@@ -171,11 +171,6 @@ namespace AzToolsFramework
             bool IsCyclicalDependencyFound(
                 InstanceOptionalConstReference instance, const AZStd::unordered_set<AZ::IO::Path>& templateSourcePaths);
 
-            //! Checks if it is an override edit on the focused instance.
-            //! \param The given owning instance to be checked.
-            //! \return True if it is an override editing.
-            bool IsOverrideEditing(const Instance& owningInstance) const;
-
             static void Internal_HandleContainerOverride(
                 UndoSystem::URSequencePoint* undoBatch, AZ::EntityId entityId, const PrefabDom& patch,
                 const LinkId linkId);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
@@ -171,6 +171,11 @@ namespace AzToolsFramework
             bool IsCyclicalDependencyFound(
                 InstanceOptionalConstReference instance, const AZStd::unordered_set<AZ::IO::Path>& templateSourcePaths);
 
+            //! Checks if it is an override edit on the focused instance.
+            //! \param The given owning instance to be checked.
+            //! \return True if it is an override editing.
+            bool IsOverrideEditing(const Instance& owningInstance) const;
+
             static void Internal_HandleContainerOverride(
                 UndoSystem::URSequencePoint* undoBatch, AZ::EntityId entityId, const PrefabDom& patch,
                 const LinkId linkId);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
@@ -476,27 +476,31 @@ namespace AzToolsFramework
                         // Also don't allow to create a prefab if any of the selected entities are read-only
                         if (!layerInSelection && !readOnlyEntityInSelection)
                         {
-                            // Do not show the option when it is not a prefab edit.
-                            AZ::EntityId entityToCheck = selectedEntities[0];
-                            if (s_prefabPublicInterface->IsInstanceContainerEntity(entityToCheck))
+                            if (s_prefabPublicInterface->EntitiesBelongToSameInstance(selectedEntities))
                             {
+                                AZ::EntityId entityToCheck = selectedEntities[0];
+
                                 // If it is a container entity, then check its parent entity's owning instance instead.
-                                AZ::TransformBus::EventResult(entityToCheck, entityToCheck, &AZ::TransformBus::Events::GetParentId);
-                            }
+                                if (s_prefabPublicInterface->IsInstanceContainerEntity(entityToCheck))
+                                {
+                                    AZ::TransformBus::EventResult(entityToCheck, entityToCheck, &AZ::TransformBus::Events::GetParentId);
+                                }
 
-                            if (s_prefabFocusPublicInterface->IsOwningPrefabBeingFocused(entityToCheck))
-                            {
-                                QAction* createAction = menu->addAction(QObject::tr("Create Prefab..."));
-                                createAction->setToolTip(QObject::tr("Creates a prefab out of the currently selected entities."));
+                                // Do not show the option when it is not a prefab edit.
+                                if (s_prefabFocusPublicInterface->IsOwningPrefabBeingFocused(entityToCheck))
+                                {
+                                    QAction* createAction = menu->addAction(QObject::tr("Create Prefab..."));
+                                    createAction->setToolTip(QObject::tr("Creates a prefab out of the currently selected entities."));
 
-                                QObject::connect(
-                                    createAction, &QAction::triggered, createAction,
-                                    [this, selectedEntities]
-                                    {
-                                        ContextMenu_CreatePrefab(selectedEntities);
-                                    });
+                                    QObject::connect(
+                                        createAction, &QAction::triggered, createAction,
+                                        [this, selectedEntities]
+                                        {
+                                            ContextMenu_CreatePrefab(selectedEntities);
+                                        });
 
-                                itemWasShown = true;
+                                    itemWasShown = true;
+                                }
                             }
                         }
                     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
@@ -476,18 +476,28 @@ namespace AzToolsFramework
                         // Also don't allow to create a prefab if any of the selected entities are read-only
                         if (!layerInSelection && !readOnlyEntityInSelection)
                         {
-                            QAction* createAction = menu->addAction(QObject::tr("Create Prefab..."));
-                            createAction->setToolTip(QObject::tr("Creates a prefab out of the currently selected entities."));
+                            // Do not show the option when it is not a prefab edit.
+                            AZ::EntityId entityToCheck = selectedEntities[0];
+                            if (s_prefabPublicInterface->IsInstanceContainerEntity(entityToCheck))
+                            {
+                                // If it is a container entity, then check its parent entity's owning instance instead.
+                                AZ::TransformBus::EventResult(entityToCheck, entityToCheck, &AZ::TransformBus::Events::GetParentId);
+                            }
 
-                            QObject::connect(
-                                createAction, &QAction::triggered, createAction,
-                                [this, selectedEntities]
-                                {
-                                    ContextMenu_CreatePrefab(selectedEntities);
-                                }
-                            );
+                            if (s_prefabFocusPublicInterface->IsOwningPrefabBeingFocused(entityToCheck))
+                            {
+                                QAction* createAction = menu->addAction(QObject::tr("Create Prefab..."));
+                                createAction->setToolTip(QObject::tr("Creates a prefab out of the currently selected entities."));
 
-                            itemWasShown = true;
+                                QObject::connect(
+                                    createAction, &QAction::triggered, createAction,
+                                    [this, selectedEntities]
+                                    {
+                                        ContextMenu_CreatePrefab(selectedEntities);
+                                    });
+
+                                itemWasShown = true;
+                            }
                         }
                     }
                 }
@@ -497,20 +507,27 @@ namespace AzToolsFramework
             if (onlySelectedEntityIsClosedPrefabContainer)
             {
                 AZ::EntityId selectedEntityId = selectedEntities.front();
+                AZ::EntityId parentEntityId;
+                AZ::TransformBus::EventResult(parentEntityId, selectedEntityId, &AZ::TransformBus::Events::GetParentId);
 
-                QAction* detachPrefabAction = menu->addAction(QObject::tr("Detach Prefab..."));
-                QObject::connect(
-                    detachPrefabAction, &QAction::triggered, detachPrefabAction,
-                    [this, selectedEntityId]
-                    {
-                        ContextMenu_DetachPrefab(selectedEntityId);
-                    }
-                );
+                // Do not show the option when it is not a prefab edit.
+                if (s_prefabFocusPublicInterface->IsOwningPrefabBeingFocused(parentEntityId))
+                {
+                    QAction* detachPrefabAction = menu->addAction(QObject::tr("Detach Prefab..."));
+                    QObject::connect(
+                        detachPrefabAction, &QAction::triggered, detachPrefabAction,
+                        [this, selectedEntityId]
+                        {
+                            ContextMenu_DetachPrefab(selectedEntityId);
+                        });
+                }
             }
 
             // Instantiate Prefab
-            if (selectedEntities.size() == 0 ||
-                selectedEntities.size() == 1 && !readOnlyEntityInSelection && !onlySelectedEntityIsClosedPrefabContainer)
+            // Do not show the option when it is not a prefab edit.
+            if (selectedEntities.size() == 0 || selectedEntities.size() == 1 &&
+                !readOnlyEntityInSelection && !onlySelectedEntityIsClosedPrefabContainer &&
+                s_prefabFocusPublicInterface->IsOwningPrefabBeingFocused(selectedEntities[0]))
             {
                 QAction* instantiateAction = menu->addAction(QObject::tr("Instantiate Prefab..."));
                 instantiateAction->setToolTip(QObject::tr("Instantiates a prefab file in the scene."));


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

This PR blocks override editing for some prefab-related operations as they are currently not supported. It will show an info dialog to users and direct them to perform a prefab edit instead. But the PR even hides the options in context menu so users won't be able to do so.

![Block_Dialog](https://user-images.githubusercontent.com/11157226/206280162-8386b546-5a2d-4098-8c03-7a50e72a4cd2.png)

Related Workflows:
1. Instantiate Prefab (including Procedural Prefab)
2. Create Prefab
3. Detach Prefab

Current State: Users can perform the operations but they are essentially prefab-editing.
New State: Users cannot perform the operations in the very first place.

## How was this PR tested?

Manually tested in editor:
- [x] Prefab edit workflows are not impacted.
- [x] Override edit workflows are affected.
- [x] Make sure it also works when a nested prefab is being focused (rather than level).
