### PR TITLE
Refactored material property code in preparation for material pipeline support

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPropertySerializer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPropertySerializer.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <Atom/RPI.Edit/Material/MaterialTypeSourceData.h>
 #include <AzCore/Serialization/Json/BaseJsonSerializer.h>
 
 namespace AZ
@@ -17,6 +16,9 @@ namespace AZ
 
     namespace RPI
     {
+        struct MaterialPropertySourceData;
+        class MaterialPropertyValue;
+
         class JsonMaterialPropertySerializer
             : public BaseJsonSerializer
         {
@@ -39,29 +41,29 @@ namespace AZ
 
             //! Loads a property's value fields from JSON, for use with numeric types like int and float, which support range limits.
             template<typename T>
-            JsonSerializationResult::ResultCode LoadNumericValues(MaterialTypeSourceData::PropertyDefinition* intoProperty, const T& defaultValue,
+            JsonSerializationResult::ResultCode LoadNumericValues(MaterialPropertySourceData* intoProperty, const T& defaultValue,
                 const rapidjson::Value& inputValue, JsonDeserializerContext& context);
 
             //! Loads a property's value fields from JSON, for use with non-numeric types like Vector and Color, which don't support range limits.
             template<typename T>
-            JsonSerializationResult::ResultCode LoadNonNumericValues(MaterialTypeSourceData::PropertyDefinition* intoProperty, const T& defaultValue,
+            JsonSerializationResult::ResultCode LoadNonNumericValues(MaterialPropertySourceData* intoProperty, const T& defaultValue,
                 const rapidjson::Value& inputValue, JsonDeserializerContext& context);
 
-            JsonSerializationResult::ResultCode LoadVectorLabels(MaterialTypeSourceData::PropertyDefinition* intoProperty,
+            JsonSerializationResult::ResultCode LoadVectorLabels(MaterialPropertySourceData* intoProperty,
                 const rapidjson::Value& inputValue, JsonDeserializerContext& context);
 
             //! Stores a property's value fields to JSON, for use with numeric types like int and float, which support range limits.
             template<typename T>
             JsonSerializationResult::ResultCode StoreNumericValues(rapidjson::Value& outputValue,
-                const MaterialTypeSourceData::PropertyDefinition* property, const T& defaultValue, JsonSerializerContext& context);
+                const MaterialPropertySourceData* property, const T& defaultValue, JsonSerializerContext& context);
 
             //! Stores a property's value fields to JSON, for use with non-numeric types like Vector and Color, which don't support range limits.
             template<typename T>
             JsonSerializationResult::ResultCode StoreNonNumericValues(rapidjson::Value& outputValue,
-                const MaterialTypeSourceData::PropertyDefinition* property, const T& defaultValue, JsonSerializerContext& context);
+                const MaterialPropertySourceData* property, const T& defaultValue, JsonSerializerContext& context);
 
             JsonSerializationResult::ResultCode StoreVectorLabels(rapidjson::Value& outputValue,
-                const MaterialTypeSourceData::PropertyDefinition* property, JsonSerializerContext& context);
+                const MaterialPropertySourceData* property, JsonSerializerContext& context);
         };
 
     } // namespace RPI

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPropertySourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPropertySourceData.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/RTTI/TypeInfo.h>
+#include <Atom/RPI.Reflect/Base.h>
+#include <Atom/RPI.Reflect/Material/MaterialPropertyDescriptor.h>
+#include <Atom/RPI.Reflect/Material/MaterialDynamicMetadata.h>
+
+namespace AZ
+{
+    class ReflectContext;
+
+    namespace RPI
+    {
+        class JsonMaterialPropertySerializer;
+
+        //! Stores data that defines one material property, for use in JSON source files such as .materialtype and .materialpipeline.
+        struct MaterialPropertySourceData
+        {
+            friend class JsonMaterialPropertySerializer;
+
+            AZ_CLASS_ALLOCATOR(MaterialPropertySourceData, SystemAllocator, 0);
+            AZ_TYPE_INFO(AZ::RPI::MaterialPropertySourceData, "{E0DB3C0D-75DB-4ADB-9E79-30DA63FA18B7}");
+
+            struct Connection
+            {
+            public:
+                AZ_TYPE_INFO(AZ::RPI::MaterialPropertySourceData::Connection, "{C2F37C26-D7EF-4142-A650-EF50BB18610F}");
+
+                Connection() = default;
+                Connection(MaterialPropertyOutputType type, AZStd::string_view name);
+
+                bool operator==(const Connection& rhs) const;
+                bool operator!=(const Connection& rhs) const;
+
+                MaterialPropertyOutputType m_type = MaterialPropertyOutputType::Invalid;
+
+                //! The name of a specific shader setting. This will either be a ShaderResourceGroup input, a ShaderOption, or a shader tag, depending on m_type.
+                AZStd::string m_name;
+            };
+
+            using ConnectionList = AZStd::vector<Connection>;
+
+            static const float DefaultMin;
+            static const float DefaultMax;
+            static const float DefaultStep;
+
+            static void Reflect(ReflectContext* context);
+
+            MaterialPropertySourceData() = default;
+
+            explicit MaterialPropertySourceData(AZStd::string_view name) : m_name(name)
+            {
+            }
+
+            const AZStd::string& GetName() const { return m_name; }
+
+            MaterialPropertyVisibility m_visibility = MaterialPropertyVisibility::Default;
+
+            MaterialPropertyDataType m_dataType = MaterialPropertyDataType::Invalid;
+
+            ConnectionList m_outputConnections; //!< List of connections from material property to shader settings
+
+            MaterialPropertyValue m_value; //!< Value for the property. The type must match the MaterialPropertyDataType.
+
+            AZStd::vector<AZStd::string> m_enumValues; //!< Only used if property is Enum type
+            bool m_enumIsUv = false;  //!< Indicates if the enum value should use m_enumValues or those extracted from m_uvNameMap.
+
+            // Editor metadata ...
+            AZStd::string m_displayName;
+            AZStd::string m_description;
+            AZStd::vector<AZStd::string> m_vectorLabels;
+            MaterialPropertyValue m_min;
+            MaterialPropertyValue m_max;
+            MaterialPropertyValue m_softMin;
+            MaterialPropertyValue m_softMax;
+            MaterialPropertyValue m_step;
+
+        private:
+
+            // We are gradually moving toward having a more proper API for MaterialPropertySourceData code, but we still some public members
+            // like above. However, it's important for m_name to be private because it is used as the key for lookups, collision validation, etc.
+            AZStd::string m_name; //!< The name of the property within the property group. The full property ID will be groupName.propertyName.
+        };
+
+        //using MaterialPropertySourceDataList = AZStd::vector<AZStd::unique_ptr<MaterialPropertySourceData>>;
+
+    } // namespace RPI
+
+} // namespace AZ

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialTypeSourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialTypeSourceData.h
@@ -13,8 +13,10 @@
 #include <Atom/RPI.Reflect/Base.h>
 #include <Atom/RPI.Reflect/Material/MaterialPropertyDescriptor.h>
 #include <Atom/RPI.Reflect/Material/MaterialVersionUpdate.h>
+#include <Atom/RPI.Reflect/Material/MaterialTypeAssetCreator.h>
 #include <Atom/RPI.Edit/Material/MaterialFunctorSourceData.h>
 #include <Atom/RPI.Edit/Material/MaterialPropertyId.h>
+#include <Atom/RPI.Edit/Material/MaterialPropertySourceData.h>
 #include <Atom/RPI.Edit/Shader/ShaderOptionValuesSourceData.h>
 
 namespace AZ
@@ -24,9 +26,7 @@ namespace AZ
     namespace RPI
     {
         class MaterialTypeAsset;
-        class MaterialTypeAssetCreator;
         class MaterialFunctorSourceDataHolder;
-        class JsonMaterialPropertySerializer;
 
         //! This is a simple data structure for serializing in/out .materialtype source files.
         //! The .materialtype file has two slightly different formats: "abstract" and "direct". See enum Format below.
@@ -57,22 +57,6 @@ namespace AZ
                 Direct
             };
 
-            struct PropertyConnection
-            {
-            public:
-                AZ_TYPE_INFO(AZ::RPI::MaterialTypeSourceData::PropertyConnection, "{C2F37C26-D7EF-4142-A650-EF50BB18610F}");
-
-                PropertyConnection() = default;
-                PropertyConnection(MaterialPropertyOutputType type, AZStd::string_view name);
-
-                MaterialPropertyOutputType m_type = MaterialPropertyOutputType::Invalid;
-
-                //! The name of a specific shader setting. This will either be a ShaderResourceGroup input, a ShaderOption, or a shader tag, depending on m_type.
-                AZStd::string m_name;
-            };
-
-            using PropertyConnectionList = AZStd::vector<PropertyConnection>;
-
             struct GroupDefinition
             {
                 AZ_TYPE_INFO(AZ::RPI::MaterialTypeSourceData::GroupDefinition, "{B2D0FC5C-72A3-435E-A194-1BFDABAC253D}");
@@ -84,55 +68,8 @@ namespace AZ
                 AZStd::string m_displayName;
                 AZStd::string m_description;
             };
-
-            struct PropertyDefinition
-            {
-                friend class JsonMaterialPropertySerializer;
-
-                AZ_CLASS_ALLOCATOR(PropertyDefinition, SystemAllocator, 0);
-                AZ_TYPE_INFO(AZ::RPI::MaterialTypeSourceData::PropertyDefinition, "{E0DB3C0D-75DB-4ADB-9E79-30DA63FA18B7}");
                 
-                static const float DefaultMin;
-                static const float DefaultMax;
-                static const float DefaultStep;
-                
-                PropertyDefinition() = default;
-
-                explicit PropertyDefinition(AZStd::string_view name) : m_name(name)
-                {
-                }
-
-                const AZStd::string& GetName() const { return m_name; }
-
-                MaterialPropertyVisibility m_visibility = MaterialPropertyVisibility::Default;
-
-                MaterialPropertyDataType m_dataType = MaterialPropertyDataType::Invalid;
-
-                PropertyConnectionList m_outputConnections; //!< List of connections from material property to shader settings
-
-                MaterialPropertyValue m_value; //!< Value for the property. The type must match the MaterialPropertyDataType.
-
-                AZStd::vector<AZStd::string> m_enumValues; //!< Only used if property is Enum type
-                bool m_enumIsUv = false;  //!< Indicates if the enum value should use m_enumValues or those extracted from m_uvNameMap.
-
-                // Editor metadata ...
-                AZStd::string m_displayName;
-                AZStd::string m_description;
-                AZStd::vector<AZStd::string> m_vectorLabels;
-                MaterialPropertyValue m_min;
-                MaterialPropertyValue m_max;
-                MaterialPropertyValue m_softMin;
-                MaterialPropertyValue m_softMax;
-                MaterialPropertyValue m_step;
-
-            private:
-
-                // We are gradually moving toward having a more proper API for MaterialTypeSourceData code, but we still some public members
-                // like above. However, it's important for m_name to be private because it is used as the key for lookups, collision validation, etc.
-                AZStd::string m_name; //!< The name of the property within the property group. The full property ID will be groupName.propertyName.
-            };
-            
-            using PropertyList = AZStd::vector<AZStd::unique_ptr<PropertyDefinition>>;
+            using PropertyList = AZStd::vector<AZStd::unique_ptr<MaterialPropertySourceData>>;
 
             struct PropertyGroup
             {
@@ -160,8 +97,8 @@ namespace AZ
 
                 //! Add a new property to this PropertyGroup.
                 //! @param name a unique for the property. Must be a C-style identifier.
-                //! @return the new PropertyDefinition, or null if the name was not valid.
-                PropertyDefinition* AddProperty(AZStd::string_view name);
+                //! @return the new MaterialPropertySourceData, or null if the name was not valid.
+                MaterialPropertySourceData* AddProperty(AZStd::string_view name);
                 
                 //! Add a new nested PropertyGroup to this PropertyGroup.
                 //! @param name a unique for the property group. Must be a C-style identifier.
@@ -228,7 +165,7 @@ namespace AZ
                 AZStd::vector<GroupDefinition> m_groupsOld;
 
                 //! @deprecated: Use m_propertyGroups instead
-                AZStd::map<AZStd::string /*group name*/, AZStd::vector<PropertyDefinition>> m_propertiesOld;
+                AZStd::map<AZStd::string /*group name*/, AZStd::vector<MaterialPropertySourceData>> m_propertiesOld;
                 
                 //! Collection of all available user-facing properties
                 AZStd::vector<AZStd::unique_ptr<PropertyGroup>> m_propertyGroups;
@@ -291,8 +228,8 @@ namespace AZ
 
             //! Add a new property to a PropertyGroup.
             //! @param propertyId The ID of the new property, like "layerBlend.factor" or "layer2.roughness.texture". The indicated property group must already exist.
-            //! @return a pointer to the new PropertyDefinition or null if there was a problem (an AZ_Error will be reported).
-            PropertyDefinition* AddProperty(AZStd::string_view propertyId);
+            //! @return a pointer to the new MaterialPropertySourceData or null if there was a problem (an AZ_Error will be reported).
+            MaterialPropertySourceData* AddProperty(AZStd::string_view propertyId);
 
             //! Return the PropertyLayout containing the tree of property groups and property definitions.
             const PropertyLayout& GetPropertyLayout() const { return m_propertyLayout; }
@@ -305,9 +242,9 @@ namespace AZ
             
             //! Find the definition for a property with the given ID.
             //! @param propertyId The full ID of a property to find, like "baseColor.texture".
-            //! @return the found PropertyDefinition or null if it doesn't exist.
-            const PropertyDefinition* FindProperty(AZStd::string_view propertyId) const;
-            PropertyDefinition* FindProperty(AZStd::string_view propertyId);
+            //! @return the found MaterialPropertySourceData or null if it doesn't exist.
+            const MaterialPropertySourceData* FindProperty(AZStd::string_view propertyId) const;
+            MaterialPropertySourceData* FindProperty(AZStd::string_view propertyId);
 
             //! Tokenizes an ID string like "itemA.itemB.itemC" into a vector like ["itemA", "itemB", "itemC"].
             static AZStd::vector<AZStd::string_view> TokenizeId(AZStd::string_view id);
@@ -330,7 +267,7 @@ namespace AZ
             //! Call back function type used with the numeration functions.
             //! Return false to terminate the traversal.
             using EnumeratePropertiesCallback = AZStd::function<bool(
-                const PropertyDefinition*, // the property definition object 
+                const MaterialPropertySourceData*, // the property definition object 
                 const MaterialNameContext& // The name context that the property is in, used to scope properties and shader connections (i.e. "levelA.levelB.")
                 )>;
             
@@ -356,8 +293,8 @@ namespace AZ
             const PropertyGroup* FindPropertyGroup(AZStd::span<const AZStd::string_view> parsedPropertyGroupId, AZStd::span<const AZStd::unique_ptr<PropertyGroup>> inPropertyGroupList) const;
             PropertyGroup* FindPropertyGroup(AZStd::span<AZStd::string_view> parsedPropertyGroupId, AZStd::span<AZStd::unique_ptr<PropertyGroup>> inPropertyGroupList);
             
-            const PropertyDefinition* FindProperty(AZStd::span<const AZStd::string_view> parsedPropertyId, AZStd::span<const AZStd::unique_ptr<PropertyGroup>> inPropertyGroupList) const;
-            PropertyDefinition* FindProperty(AZStd::span<AZStd::string_view> parsedPropertyId, AZStd::span<AZStd::unique_ptr<PropertyGroup>> inPropertyGroupList);
+            const MaterialPropertySourceData* FindProperty(AZStd::span<const AZStd::string_view> parsedPropertyId, AZStd::span<const AZStd::unique_ptr<PropertyGroup>> inPropertyGroupList) const;
+            MaterialPropertySourceData* FindProperty(AZStd::span<AZStd::string_view> parsedPropertyId, AZStd::span<AZStd::unique_ptr<PropertyGroup>> inPropertyGroupList);
             
             // Function overloads for recursion, returns false to indicate that recursion should end.
             bool EnumeratePropertyGroups(const EnumeratePropertyGroupsCallback& callback, PropertyGroupStack& propertyGroupStack, const AZStd::vector<AZStd::unique_ptr<PropertyGroup>>& inPropertyGroupList) const;
@@ -385,7 +322,15 @@ namespace AZ
                 MaterialTypeAssetCreator& materialTypeAssetCreator,
                 MaterialNameContext materialNameContext,
                 const MaterialTypeSourceData::PropertyGroup* propertyGroup) const;
-                            
+
+            //! Adds a single property to a MaterialTypeAssetCreator
+            bool BuildProperty(
+                const AZStd::string& materialTypeSourceFilePath,
+                MaterialTypeAssetCreator& materialTypeAssetCreator,
+                MaterialNameContext materialNameContext,
+                const Name& propertyId,
+                const MaterialPropertySourceData& propertySourceData) const;
+
             //! Construct a complete list of group definitions, including implicit groups, arranged in the same order as the source data.
             //! Groups with the same name will be consolidated into a single entry.
             //! Operates on the old format PropertyLayout::m_groups, used for conversion to the new format.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialFunctor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialFunctor.h
@@ -26,6 +26,7 @@ namespace AZ
         class Image;
         class ShaderResourceGroup;
         class MaterialPropertiesLayout;
+        class MaterialPropertyCollection;
 
         //! Indicates how the material system should respond to any material property changes that
         //! impact Pipeline State Object configuration. This is significant because some platforms
@@ -103,8 +104,8 @@ namespace AZ
                 const MaterialPropertyValue& GetMaterialPropertyValue(const Name& propertyId) const;
                 const MaterialPropertyValue& GetMaterialPropertyValue(const MaterialPropertyIndex& index) const;
 
-                const MaterialPropertiesLayout* GetMaterialPropertiesLayout() const { return m_materialPropertiesLayout.get(); }
-                
+                const MaterialPropertiesLayout* GetMaterialPropertiesLayout() const;
+
                 MaterialPropertyPsoHandling GetMaterialPropertyPsoHandling() const { return m_psoHandling; }
 
                 //! Set the value of a shader option in all applicable shaders, across all material pipelines.
@@ -138,10 +139,9 @@ namespace AZ
                 //! @param renderStatesOverlay a RenderStates struct that will be merged with this shader's RenderStates (using RHI::MergeStateInto())
                 void ApplyShaderRenderStateOverlay(AZStd::size_t shaderIndex, const RHI::RenderStates& renderStatesOverlay);
                 void ApplyShaderRenderStateOverlay(const AZ::Name& shaderTag, const RHI::RenderStates& renderStatesOverlay);
-
+                
                 RuntimeContext(
-                    const AZStd::vector<MaterialPropertyValue>& propertyValues,
-                    RHI::ConstPtr<MaterialPropertiesLayout> materialPropertiesLayout,
+                    const MaterialPropertyCollection& materialProperties,
                     MaterialPipelineShaderCollections* shaderCollections,
                     ShaderResourceGroup* shaderResourceGroup,
                     const MaterialPropertyFlags* materialPropertyDependencies,
@@ -154,8 +154,7 @@ namespace AZ
                 template<typename ValueType>
                 bool SetShaderOptionValueHelper(const Name& name, const ValueType& value);
 
-                const AZStd::vector<MaterialPropertyValue>& m_materialPropertyValues;
-                RHI::ConstPtr<MaterialPropertiesLayout> m_materialPropertiesLayout;
+                const MaterialPropertyCollection& m_materialProperties;
                 ShaderCollection* m_commonShaderCollection;
                 MaterialPipelineShaderCollections* m_allShaderCollections;
                 ShaderResourceGroup* m_shaderResourceGroup;
@@ -182,7 +181,7 @@ namespace AZ
                 const MaterialPropertyValue& GetMaterialPropertyValue(const Name& propertyId) const;
                 const MaterialPropertyValue& GetMaterialPropertyValue(const MaterialPropertyIndex& index) const;
 
-                const MaterialPropertiesLayout* GetMaterialPropertiesLayout() const { return m_materialPropertiesLayout.get(); }
+                const MaterialPropertiesLayout* GetMaterialPropertiesLayout() const;
                 
                 MaterialPropertyPsoHandling GetMaterialPropertyPsoHandling() const { return MaterialPropertyPsoHandling::Allowed; }
 
@@ -211,8 +210,7 @@ namespace AZ
                 // const AZStd::vector<AZStd::any>&, AZStd::unordered_map<MaterialPropertyIndex, Image*>&, RHI::ConstPtr<MaterialPropertiesLayout>
                 // can be all replaced by const Material*, but Material definition is separated in RPI.Public, we can't use it at this point.
                 EditorContext(
-                    const AZStd::vector<MaterialPropertyValue>& propertyValues,
-                    RHI::ConstPtr<MaterialPropertiesLayout> materialPropertiesLayout,
+                    const MaterialPropertyCollection& materialProperties,
                     AZStd::unordered_map<Name, MaterialPropertyDynamicMetadata>& propertyMetadata,
                     AZStd::unordered_map<Name, MaterialPropertyGroupDynamicMetadata>& propertyGroupMetadata,
                     AZStd::unordered_set<Name>& updatedPropertiesOut,
@@ -224,8 +222,7 @@ namespace AZ
                 MaterialPropertyDynamicMetadata* QueryMaterialPropertyMetadata(const Name& propertyId) const;
                 MaterialPropertyGroupDynamicMetadata* QueryMaterialPropertyGroupMetadata(const Name& propertyGroupId) const;
 
-                const AZStd::vector<MaterialPropertyValue>& m_materialPropertyValues;
-                RHI::ConstPtr<MaterialPropertiesLayout> m_materialPropertiesLayout;
+                const MaterialPropertyCollection& m_materialProperties;
                 AZStd::unordered_map<Name, MaterialPropertyDynamicMetadata>& m_propertyMetadata;
                 AZStd::unordered_map<Name, MaterialPropertyGroupDynamicMetadata>& m_propertyGroupMetadata;
                 AZStd::unordered_set<Name>& m_updatedPropertiesOut;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialPropertyCollection.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialPropertyCollection.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RPI.Reflect/Material/MaterialPropertiesLayout.h>
+
+// These classes are not directly referenced in this header only because the Set/GetPropertyValue()
+// functions are templatized. But the API is still specific to these data types so we include them here.
+#include <AzCore/Math/Vector2.h>
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/Math/Vector4.h>
+#include <AzCore/Math/Color.h>
+
+namespace AZ
+{
+    namespace RPI
+    {
+        //! Represents the runtime state of a set of material properties for a given MaterialPropertiesLayout
+        class MaterialPropertyCollection
+        {
+        public:
+            //! Initialize or re-initialize the properties. If reinitializing, any values that were set via
+            //! SetPropertyValue() before will be preserved and re-applied on top of the @defaultValues.
+            //! Note this does not touch the property dirty flags, the calling code must call
+            //! SetAllPropertyDirtyFlags() or ClearAllPropertyDirtyFlags() as needed.
+            bool Init(
+                RHI::ConstPtr<MaterialPropertiesLayout> layout,
+                const AZStd::vector<MaterialPropertyValue>& defaultValues);
+
+            //! Sets the value of a material property. The template data type must match the property's data type.
+            //! @return true if property value was changed
+            template<typename Type>
+            bool SetPropertyValue(MaterialPropertyIndex index, const Type& value);
+
+            //! Gets the value of a material property. The template data type must match the property's data type.
+            template<typename Type>
+            const Type& GetPropertyValue(MaterialPropertyIndex index) const;
+
+            //! Sets the value of a material property. The @value data type must match the property's data type.
+            //! @return true if property value was changed
+            bool SetPropertyValue(MaterialPropertyIndex index, const MaterialPropertyValue& value);
+
+            //! Returns the value of a material property.
+            const MaterialPropertyValue& GetPropertyValue(MaterialPropertyIndex index) const;
+            const AZStd::vector<MaterialPropertyValue>& GetPropertyValues() const;
+
+            //! Gets flags indicating which properties have been modified.
+            const MaterialPropertyFlags& GetPropertyDirtyFlags() const;
+
+            //! Marks all properties as dirty.
+            void SetAllPropertyDirtyFlags();
+
+            //! Marks all properties as not dirty.
+            void ClearAllPropertyDirtyFlags();
+
+            //! Gets the material properties layout.
+            RHI::ConstPtr<MaterialPropertiesLayout> GetMaterialPropertiesLayout() const;
+
+        private:
+            template<typename Type>
+            bool ValidatePropertyAccess(const MaterialPropertyDescriptor* propertyDescriptor) const;
+
+            //! Provides a description of the set of available material properties, cached locally so we don't have to keep fetching it from the MaterialTypeSourceData.
+            RHI::ConstPtr<MaterialPropertiesLayout> m_layout;
+
+            //! Values for all properties in MaterialPropertiesLayout
+            AZStd::vector<MaterialPropertyValue> m_propertyValues;
+
+            //! Flags indicate which properties have been modified so that related functors will update.
+            MaterialPropertyFlags m_propertyDirtyFlags;
+
+            //! Used to track which properties have been modified at runtime so they can be preserved if the material has to reinitialiize.
+            MaterialPropertyFlags m_propertyOverrideFlags;
+
+        };
+
+    } // namespace RPI
+} // namespace AZ

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialPropertyDescriptor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialPropertyDescriptor.h
@@ -87,7 +87,7 @@ namespace AZ
         AZStd::string GetMaterialPropertyDataTypeString(AZ::TypeId typeId);
         
         //! Checks that the TypeId matches the type expected by materialPropertyDescriptor
-        bool ValidateMaterialPropertyDataType(TypeId typeId, const Name& propertyName, const MaterialPropertyDescriptor* materialPropertyDescriptor, AZStd::function<void(const char*)> onError);
+        bool ValidateMaterialPropertyDataType(TypeId typeId, const MaterialPropertyDescriptor* materialPropertyDescriptor, AZStd::function<void(const char*)> onError);
 
         //! A material property is any data input to a material, like a bool, float, Vector, Image, Buffer, etc.
         //! This descriptor defines a single input property, including it's name ID, and how it maps

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialTypeAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialTypeAsset.h
@@ -123,7 +123,7 @@ namespace AZ
             //! The entries in this list align with the entries in the MaterialPropertiesLayout. Each AZStd::any is guaranteed 
             //! to have a value of type that matches the corresponding MaterialPropertyDescriptor.
             //! For images, the value will be of type ImageBinding.
-            AZStd::span<const MaterialPropertyValue> GetDefaultPropertyValues() const;
+            const AZStd::vector<MaterialPropertyValue>& GetDefaultPropertyValues() const;
 
             //! Returns a map from the UV shader inputs to a custom name.
             MaterialUvNameMap GetUvNameMap() const;

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/BuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/BuilderComponent.cpp
@@ -15,6 +15,7 @@
 #include <Atom/RPI.Edit/Material/MaterialSourceData.h>
 #include <Atom/RPI.Edit/Material/MaterialPipelineSourceData.h>
 #include <Atom/RPI.Edit/Material/MaterialPropertyValueSourceData.h>
+#include <Atom/RPI.Edit/Material/MaterialPropertySourceData.h>
 #include <Atom/RPI.Edit/Material/LuaMaterialFunctorSourceData.h>
 #include <Atom/RPI.Edit/Shader/ShaderSourceData.h>
 #include <Atom/RPI.Edit/Shader/ShaderVariantListSourceData.h>
@@ -54,6 +55,7 @@ namespace AZ
                 ;
             }
 
+            MaterialPropertySourceData::Reflect(context);
             MaterialTypeSourceData::Reflect(context);
             MaterialSourceData::Reflect(context);
             MaterialPipelineSourceData::Reflect(context);

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -43,7 +43,7 @@ namespace AZ
         {
             AssetBuilderSDK::AssetBuilderDesc materialBuilderDescriptor;
             materialBuilderDescriptor.m_name = "Material Type Builder";
-            materialBuilderDescriptor.m_version = 22; // Material pipeline filters
+            materialBuilderDescriptor.m_version = 23; // Material property refactoring
             materialBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.materialtype", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             materialBuilderDescriptor.m_busId = azrtti_typeid<MaterialTypeBuilder>();
             materialBuilderDescriptor.m_createJobFunction = AZStd::bind(&MaterialTypeBuilder::CreateJobs, this, AZStd::placeholders::_1, AZStd::placeholders::_2);
@@ -227,7 +227,7 @@ namespace AZ
                 });
 
             materialTypeSourceData.EnumerateProperties(
-                [&request, &response, &outputJobDescriptor](const MaterialTypeSourceData::PropertyDefinition* property, const MaterialNameContext&)
+                [&request, &response, &outputJobDescriptor](const MaterialPropertySourceData* property, const MaterialNameContext&)
                 {
                     if (property->m_dataType == MaterialPropertyDataType::Image && MaterialUtils::LooksLikeImageFileReference(property->m_value))
                     {

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialPropertyConnectionSerializer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialPropertyConnectionSerializer.cpp
@@ -43,12 +43,12 @@ namespace AZ
             namespace JSR = JsonSerializationResult;
             using namespace JsonMaterialPropertyConnectionSerializerInternal;
 
-            AZ_Assert(azrtti_typeid<MaterialTypeSourceData::PropertyConnection>() == outputValueTypeId,
+            AZ_Assert(azrtti_typeid<MaterialPropertySourceData::Connection>() == outputValueTypeId,
                 "Unable to deserialize material property connection to json because the provided type is %s",
                 outputValueTypeId.ToString<AZStd::string>().c_str());
             AZ_UNUSED(outputValueTypeId);
 
-            MaterialTypeSourceData::PropertyConnection* propertyConnection = reinterpret_cast<MaterialTypeSourceData::PropertyConnection*>(outputValue);
+            MaterialPropertySourceData::Connection* propertyConnection = reinterpret_cast<MaterialPropertySourceData::Connection*>(outputValue);
             AZ_Assert(propertyConnection, "Output value for JsonMaterialPropertyConnectionSerializer can't be null.");
 
             JSR::ResultCode result(JSR::Tasks::ReadField);
@@ -90,19 +90,19 @@ namespace AZ
             namespace JSR = JsonSerializationResult;
             using namespace JsonMaterialPropertyConnectionSerializerInternal;
 
-            AZ_Assert(azrtti_typeid<MaterialTypeSourceData::PropertyConnection>() == valueTypeId,
+            AZ_Assert(azrtti_typeid<MaterialPropertySourceData::Connection>() == valueTypeId,
                 "Unable to serialize material property connection to json because the provided type is %s",
                 valueTypeId.ToString<AZStd::string>().c_str());
             AZ_UNUSED(valueTypeId);
 
-            const MaterialTypeSourceData::PropertyConnection* propertyConnection = reinterpret_cast<const MaterialTypeSourceData::PropertyConnection*>(inputValue);
+            const MaterialPropertySourceData::Connection* propertyConnection = reinterpret_cast<const MaterialPropertySourceData::Connection*>(inputValue);
             AZ_Assert(propertyConnection, "Input value for JsonMaterialPropertyConnectionSerializer can't be null.");
             
             JSR::ResultCode result(JSR::Tasks::WriteValue);
 
             outputValue.SetObject();
 
-            MaterialTypeSourceData::PropertyConnection defaultConnection;
+            MaterialPropertySourceData::Connection defaultConnection;
 
             result.Combine(ContinueStoringToJsonObjectField(outputValue, Field::type, &propertyConnection->m_type, &defaultConnection.m_type, azrtti_typeid<MaterialPropertyOutputType>(), context));
             result.Combine(ContinueStoringToJsonObjectField(outputValue, Field::name, &propertyConnection->m_name, &defaultConnection.m_name, azrtti_typeid<AZStd::string>(), context));

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialPropertySerializer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialPropertySerializer.cpp
@@ -9,6 +9,7 @@
 #include <Atom/RPI.Edit/Material/MaterialPropertySerializer.h>
 #include <Atom/RPI.Edit/Material/MaterialPropertyId.h>
 #include <Atom/RPI.Edit/Material/MaterialUtils.h>
+#include <Atom/RPI.Edit/Material/MaterialPropertySourceData.h>
 
 #include <AzCore/Serialization/Json/BaseJsonSerializer.h>
 #include <AzCore/Serialization/Json/JsonSerializationResult.h>
@@ -100,7 +101,7 @@ namespace AZ
 
         template<typename T>
         JsonSerializationResult::ResultCode JsonMaterialPropertySerializer::LoadNumericValues(
-            MaterialTypeSourceData::PropertyDefinition* intoProperty,
+            MaterialPropertySourceData* intoProperty,
             const T& defaultValue,
             const rapidjson::Value& inputValue,
             JsonDeserializerContext& context)
@@ -158,7 +159,7 @@ namespace AZ
 
         template<typename T>
         JsonSerializationResult::ResultCode JsonMaterialPropertySerializer::LoadNonNumericValues(
-            MaterialTypeSourceData::PropertyDefinition* intoProperty,
+            MaterialPropertySourceData* intoProperty,
             const T& defaultValue,
             const rapidjson::Value& inputValue,
             JsonDeserializerContext& context)
@@ -188,12 +189,12 @@ namespace AZ
             namespace JSR = JsonSerializationResult;
             using namespace JsonMaterialPropertySerializerInternal;
 
-            AZ_Assert(azrtti_typeid<MaterialTypeSourceData::PropertyDefinition>() == outputValueTypeId,
+            AZ_Assert(azrtti_typeid<MaterialPropertySourceData>() == outputValueTypeId,
                 "Unable to deserialize material property to json because the provided type is %s",
                 outputValueTypeId.ToString<AZStd::string>().c_str());
             AZ_UNUSED(outputValueTypeId);
 
-            MaterialTypeSourceData::PropertyDefinition* property = reinterpret_cast<MaterialTypeSourceData::PropertyDefinition*>(outputValue);
+            MaterialPropertySourceData* property = reinterpret_cast<MaterialPropertySourceData*>(outputValue);
             AZ_Assert(property, "Output value for JsonMaterialPropertySerializer can't be null.");
 
             JSR::ResultCode result(JSR::Tasks::ReadField);
@@ -294,7 +295,7 @@ namespace AZ
         template<typename T>
         JsonSerializationResult::ResultCode JsonMaterialPropertySerializer::StoreNumericValues(
             rapidjson::Value& outputValue,
-            const MaterialTypeSourceData::PropertyDefinition* property,
+            const MaterialPropertySourceData* property,
             const T& defaultValue,
             JsonSerializerContext& context)
         {
@@ -339,7 +340,7 @@ namespace AZ
         template<typename T>
         JsonSerializationResult::ResultCode JsonMaterialPropertySerializer::StoreNonNumericValues(
             rapidjson::Value& outputValue,
-            const MaterialTypeSourceData::PropertyDefinition* property,
+            const MaterialPropertySourceData* property,
             const T& defaultValue,
             JsonSerializerContext& context)
         {
@@ -363,12 +364,12 @@ namespace AZ
             namespace JSR = JsonSerializationResult;
             using namespace JsonMaterialPropertySerializerInternal;
 
-            AZ_Assert(azrtti_typeid<MaterialTypeSourceData::PropertyDefinition>() == valueTypeId,
+            AZ_Assert(azrtti_typeid<MaterialPropertySourceData>() == valueTypeId,
                 "Unable to serialize material property to json because the provided type is %s",
                 valueTypeId.ToString<AZStd::string>().c_str());
             AZ_UNUSED(valueTypeId);
 
-            const MaterialTypeSourceData::PropertyDefinition* property = reinterpret_cast<const MaterialTypeSourceData::PropertyDefinition*>(inputValue);
+            const MaterialPropertySourceData* property = reinterpret_cast<const MaterialPropertySourceData*>(inputValue);
             AZ_Assert(property, "Input value for JsonMaterialPropertySerializer can't be null.");
             
             JSR::ResultCode result(JSR::Tasks::WriteValue);
@@ -421,7 +422,7 @@ namespace AZ
             result.Combine(ContinueStoringToJsonObjectField(outputValue, Field::visibility, &property->m_visibility, &defaultVisibility, azrtti_typeid(property->m_visibility), context));
 
             // Support loading a "connection" property as a single entry in m_outputConnections
-            MaterialTypeSourceData::PropertyConnection defaultConnection;
+            MaterialPropertySourceData::Connection defaultConnection;
             if (property->m_outputConnections.size() == 1)
             {
                 result.Combine(ContinueStoringToJsonObjectField(outputValue, Field::connection, &property->m_outputConnections.back(), &defaultConnection, azrtti_typeid(property->m_outputConnections.back()), context));
@@ -450,7 +451,7 @@ namespace AZ
             }
         }
 
-        JsonSerializationResult::ResultCode JsonMaterialPropertySerializer::LoadVectorLabels(MaterialTypeSourceData::PropertyDefinition* intoProperty,
+        JsonSerializationResult::ResultCode JsonMaterialPropertySerializer::LoadVectorLabels(MaterialPropertySourceData* intoProperty,
             const rapidjson::Value& inputValue, JsonDeserializerContext& context)
         {
             namespace JSR = JsonSerializationResult;
@@ -467,7 +468,7 @@ namespace AZ
         }
 
         JsonSerializationResult::ResultCode JsonMaterialPropertySerializer::StoreVectorLabels(rapidjson::Value& outputValue,
-            const MaterialTypeSourceData::PropertyDefinition* property, JsonSerializerContext& context)
+            const MaterialPropertySourceData* property, JsonSerializerContext& context)
         {
             AZStd::string emptyString;
             namespace JSR = JsonSerializationResult;

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialPropertySourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialPropertySourceData.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RPI.Edit/Material/MaterialPropertySourceData.h>
+#include <Atom/RPI.Edit/Material/MaterialPropertySerializer.h>
+#include <Atom/RPI.Edit/Material/MaterialPropertyConnectionSerializer.h>
+#include <Atom/RPI.Edit/Material/MaterialPropertyValueSerializer.h>
+#include <AzCore/Serialization/Json/RegistrationContext.h>
+
+namespace AZ
+{
+    namespace RPI
+    {
+        void MaterialPropertySourceData::Reflect(ReflectContext* context)
+        {
+            if (JsonRegistrationContext* jsonContext = azrtti_cast<JsonRegistrationContext*>(context))
+            {
+                jsonContext->Serializer<JsonMaterialPropertySerializer>()->HandlesType<MaterialPropertySourceData>();
+                jsonContext->Serializer<JsonMaterialPropertyConnectionSerializer>()->HandlesType<MaterialPropertySourceData::Connection>();
+                jsonContext->Serializer<JsonMaterialPropertyValueSerializer>()->HandlesType<MaterialPropertyValue>();
+            }
+            else if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
+            {
+                serializeContext->Class<Connection>()->Version(3);
+                serializeContext->Class<MaterialPropertySourceData>()->Version(1);
+
+                serializeContext->RegisterGenericType<AZStd::unique_ptr<MaterialPropertySourceData>>();
+                serializeContext->RegisterGenericType<AZStd::vector<AZStd::unique_ptr<MaterialPropertySourceData>>>();
+                serializeContext->RegisterGenericType<ConnectionList>();
+            }
+        }
+
+        MaterialPropertySourceData::Connection::Connection(MaterialPropertyOutputType type, AZStd::string_view name)
+            : m_type(type)
+            , m_name(name)
+        {
+        }
+
+        bool MaterialPropertySourceData::Connection::operator==(const Connection& rhs) const
+        {
+            return m_type == rhs.m_type && m_name == rhs.m_name;
+        }
+
+        bool MaterialPropertySourceData::Connection::operator!=(const Connection& rhs) const
+        {
+            return!(*this == rhs);
+        }
+
+        const float MaterialPropertySourceData::DefaultMin = std::numeric_limits<float>::lowest();
+        const float MaterialPropertySourceData::DefaultMax = std::numeric_limits<float>::max();
+        const float MaterialPropertySourceData::DefaultStep = 0.1f;
+
+    } // namespace RPI
+} // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
@@ -165,7 +165,7 @@ namespace AZ
                 {
                     // In this case we need to load the material type data in preparation for the material->Finalize() step below.
                     auto materialTypeAssetOutcome = AssetUtils::LoadAsset<MaterialTypeAsset>(
-                        materialTypeAssetId.GetValue(), materialSourceFilePath.c_str(), AssetUtils::TraceLevel::Error, dontLoadImageAssets);
+                        materialTypeAssetId.GetValue(), m_materialType.c_str(), AssetUtils::TraceLevel::Error, dontLoadImageAssets);
                     if (!materialTypeAssetOutcome)
                     {
                         return Failure();

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialTypeSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialTypeSourceData.cpp
@@ -7,12 +7,10 @@
  */
 
 #include <Atom/RPI.Edit/Material/MaterialTypeSourceData.h>
-#include <Atom/RPI.Edit/Material/MaterialPropertySerializer.h>
 #include <Atom/RPI.Edit/Material/MaterialFunctorSourceDataSerializer.h>
-#include <Atom/RPI.Edit/Material/MaterialPropertyConnectionSerializer.h>
 #include <Atom/RPI.Edit/Material/MaterialPropertyGroupSerializer.h>
-#include <Atom/RPI.Edit/Material/MaterialPropertyValueSerializer.h>
 #include <Atom/RPI.Edit/Material/MaterialUtils.h>
+#include <Atom/RPI.Edit/Material/MaterialPropertySourceData.h>
 
 #include <Atom/RPI.Edit/Common/AssetUtils.h>
 #include <Atom/RPI.Reflect/Material/MaterialTypeAssetCreator.h>
@@ -55,22 +53,14 @@ namespace AZ
         {
             if (JsonRegistrationContext* jsonContext = azrtti_cast<JsonRegistrationContext*>(context))
             {
-                jsonContext->Serializer<JsonMaterialPropertySerializer>()->HandlesType<MaterialTypeSourceData::PropertyDefinition>();
-                jsonContext->Serializer<JsonMaterialPropertyConnectionSerializer>()->HandlesType<MaterialTypeSourceData::PropertyConnection>();
                 jsonContext->Serializer<JsonMaterialPropertyGroupSerializer>()->HandlesType<MaterialTypeSourceData::GroupDefinition>();
-                jsonContext->Serializer<JsonMaterialPropertyValueSerializer>()->HandlesType<MaterialPropertyValue>();
             }
             else if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
             {
-                serializeContext->Class<PropertyConnection>()->Version(3);
                 serializeContext->Class<GroupDefinition>()->Version(4);
-                serializeContext->Class<PropertyDefinition>()->Version(1);
 
                 serializeContext->RegisterGenericType<AZStd::unique_ptr<PropertyGroup>>();
-                serializeContext->RegisterGenericType<AZStd::unique_ptr<PropertyDefinition>>();
                 serializeContext->RegisterGenericType<AZStd::vector<AZStd::unique_ptr<PropertyGroup>>>();
-                serializeContext->RegisterGenericType<AZStd::vector<AZStd::unique_ptr<PropertyDefinition>>>();
-                serializeContext->RegisterGenericType<PropertyConnectionList>();
 
                 serializeContext->RegisterGenericType<MaterialVersionUpdate::Action::ActionDefinition>();
                 serializeContext->RegisterGenericType<VersionUpdateActions>();
@@ -132,16 +122,6 @@ namespace AZ
                     ;
             }
         }
-
-        MaterialTypeSourceData::PropertyConnection::PropertyConnection(MaterialPropertyOutputType type, AZStd::string_view name)
-            : m_type(type)
-            , m_name(name)
-        {
-        }
-
-        const float MaterialTypeSourceData::PropertyDefinition::DefaultMin = std::numeric_limits<float>::lowest();
-        const float MaterialTypeSourceData::PropertyDefinition::DefaultMax = std::numeric_limits<float>::max();
-        const float MaterialTypeSourceData::PropertyDefinition::DefaultStep = 0.1f;
 
         /*static*/ MaterialTypeSourceData::PropertyGroup* MaterialTypeSourceData::PropertyGroup::AddPropertyGroup(AZStd::string_view name, AZStd::vector<AZStd::unique_ptr<PropertyGroup>>& toPropertyGroupList)
         {
@@ -216,14 +196,14 @@ namespace AZ
             m_description = description;
         }
 
-        MaterialTypeSourceData::PropertyDefinition* MaterialTypeSourceData::PropertyGroup::AddProperty(AZStd::string_view name)
+        MaterialPropertySourceData* MaterialTypeSourceData::PropertyGroup::AddProperty(AZStd::string_view name)
         {
             if (!MaterialUtils::CheckIsValidPropertyName(name))
             {
                 return nullptr;
             }
 
-            auto propertyIter = AZStd::find_if(m_properties.begin(), m_properties.end(), [name](const AZStd::unique_ptr<PropertyDefinition>& existingProperty)
+            auto propertyIter = AZStd::find_if(m_properties.begin(), m_properties.end(), [name](const AZStd::unique_ptr<MaterialPropertySourceData>& existingProperty)
                 {
                     return existingProperty->GetName() == name;
                 });
@@ -245,13 +225,13 @@ namespace AZ
                 return nullptr;
             }
 
-            m_properties.emplace_back(AZStd::make_unique<PropertyDefinition>(name));
+            m_properties.emplace_back(AZStd::make_unique<MaterialPropertySourceData>(name));
             return m_properties.back().get();
         }
 
         MaterialTypeSourceData::PropertyGroup* MaterialTypeSourceData::PropertyGroup::AddPropertyGroup(AZStd::string_view name)
         {
-            auto iter = AZStd::find_if(m_properties.begin(), m_properties.end(), [name](const AZStd::unique_ptr<PropertyDefinition>& existingProperty)
+            auto iter = AZStd::find_if(m_properties.begin(), m_properties.end(), [name](const AZStd::unique_ptr<MaterialPropertySourceData>& existingProperty)
                 {
                     return existingProperty->GetName() == name;
                 });
@@ -285,7 +265,7 @@ namespace AZ
             return parentPropertyGroup->AddPropertyGroup(splitPropertyGroupId[1]);
         }
 
-        MaterialTypeSourceData::PropertyDefinition* MaterialTypeSourceData::AddProperty(AZStd::string_view propertyId)
+        MaterialPropertySourceData* MaterialTypeSourceData::AddProperty(AZStd::string_view propertyId)
         {
             AZStd::vector<AZStd::string_view> splitPropertyId = SplitId(propertyId);
 
@@ -353,7 +333,7 @@ namespace AZ
             return FindPropertyGroup(tokens, m_propertyLayout.m_propertyGroups);
         }
 
-        const MaterialTypeSourceData::PropertyDefinition* MaterialTypeSourceData::FindProperty(
+        const MaterialPropertySourceData* MaterialTypeSourceData::FindProperty(
             AZStd::span<const AZStd::string_view> parsedPropertyId,
             AZStd::span<const AZStd::unique_ptr<PropertyGroup>> inPropertyGroupList) const
         {
@@ -365,7 +345,7 @@ namespace AZ
 
                     if (subPath.size() == 1)
                     {
-                        for (AZStd::unique_ptr<PropertyDefinition>& property : propertyGroup->m_properties)
+                        for (AZStd::unique_ptr<MaterialPropertySourceData>& property : propertyGroup->m_properties)
                         {
                             if (property->GetName() == subPath[0])
                             {
@@ -375,7 +355,7 @@ namespace AZ
                     }
                     else if(subPath.size() > 1)
                     {
-                        const MaterialTypeSourceData::PropertyDefinition* property = FindProperty(subPath, propertyGroup->m_propertyGroups);
+                        const MaterialPropertySourceData* property = FindProperty(subPath, propertyGroup->m_propertyGroups);
                         if (property)
                         {
                             return property;
@@ -387,18 +367,18 @@ namespace AZ
             return nullptr;
         }
 
-        MaterialTypeSourceData::PropertyDefinition* MaterialTypeSourceData::FindProperty(AZStd::span<AZStd::string_view> parsedPropertyId, AZStd::span<AZStd::unique_ptr<PropertyGroup>> inPropertyGroupList)
+        MaterialPropertySourceData* MaterialTypeSourceData::FindProperty(AZStd::span<AZStd::string_view> parsedPropertyId, AZStd::span<AZStd::unique_ptr<PropertyGroup>> inPropertyGroupList)
         {
-            return const_cast<MaterialTypeSourceData::PropertyDefinition*>(const_cast<const MaterialTypeSourceData*>(this)->FindProperty(parsedPropertyId, inPropertyGroupList));
+            return const_cast<MaterialPropertySourceData*>(const_cast<const MaterialTypeSourceData*>(this)->FindProperty(parsedPropertyId, inPropertyGroupList));
         }
 
-        const MaterialTypeSourceData::PropertyDefinition* MaterialTypeSourceData::FindProperty(AZStd::string_view propertyId) const
+        const MaterialPropertySourceData* MaterialTypeSourceData::FindProperty(AZStd::string_view propertyId) const
         {
             AZStd::vector<AZStd::string_view> tokens = TokenizeId(propertyId);
             return FindProperty(tokens, m_propertyLayout.m_propertyGroups);
         }
 
-        MaterialTypeSourceData::PropertyDefinition* MaterialTypeSourceData::FindProperty(AZStd::string_view propertyId)
+        MaterialPropertySourceData* MaterialTypeSourceData::FindProperty(AZStd::string_view propertyId)
         {
             AZStd::vector<AZStd::string_view> tokens = TokenizeId(propertyId);
             return FindProperty(tokens, m_propertyLayout.m_propertyGroups);
@@ -523,7 +503,7 @@ namespace AZ
                             propertyGroup = m_propertyLayout.m_propertyGroups.back().get();
                         }
 
-                        PropertyDefinition* newProperty = propertyGroup->AddProperty(propertyDefinition.GetName());
+                        MaterialPropertySourceData* newProperty = propertyGroup->AddProperty(propertyDefinition.GetName());
 
                         *newProperty = propertyDefinition;
                     }
@@ -545,13 +525,13 @@ namespace AZ
                 enumValues.push_back(uvNamePair.second);
             }
 
-            EnumerateProperties([&enumValues](const MaterialTypeSourceData::PropertyDefinition* property, const MaterialNameContext&)
+            EnumerateProperties([&enumValues](const MaterialPropertySourceData* property, const MaterialNameContext&)
                 {
                     if (property->m_dataType == AZ::RPI::MaterialPropertyDataType::Enum && property->m_enumIsUv)
                     {
                         // const_cast is safe because this is internal to the MaterialTypeSourceData. It isn't worth complicating things
                         // by adding another version of EnumerateProperties.
-                        const_cast<MaterialTypeSourceData::PropertyDefinition*>(property)->m_enumValues = enumValues;
+                        const_cast<MaterialPropertySourceData*>(property)->m_enumValues = enumValues;
                     }
                     return true;
                 });
@@ -667,6 +647,73 @@ namespace AZ
             return sourceValue;
         }
 
+        bool MaterialTypeSourceData::BuildProperty(
+            const AZStd::string& materialTypeSourceFilePath,
+            MaterialTypeAssetCreator& materialTypeAssetCreator,
+            MaterialNameContext materialNameContext,
+            const Name& propertyId,
+            const MaterialPropertySourceData& propertySourceData) const
+        {
+            materialTypeAssetCreator.BeginMaterialProperty(propertyId, propertySourceData.m_dataType);
+
+            if (propertySourceData.m_dataType == MaterialPropertyDataType::Enum)
+            {
+                materialTypeAssetCreator.SetMaterialPropertyEnumNames(propertySourceData.m_enumValues);
+            }
+
+            for (auto& output : propertySourceData.m_outputConnections)
+            {
+                switch (output.m_type)
+                {
+                case MaterialPropertyOutputType::ShaderInput:
+                {
+                    Name fieldName{output.m_name};
+                    materialNameContext.ContextualizeSrgInput(fieldName);
+                    materialTypeAssetCreator.ConnectMaterialPropertyToShaderInput(fieldName);
+                    break;
+                }
+                case MaterialPropertyOutputType::ShaderOption:
+                {
+                    Name fieldName{output.m_name};
+                    materialNameContext.ContextualizeShaderOption(fieldName);
+                    materialTypeAssetCreator.ConnectMaterialPropertyToShaderOptions(fieldName);
+                    break;
+                }
+                case MaterialPropertyOutputType::ShaderEnabled:
+                {
+                    Name shaderTag{output.m_name};
+                    materialTypeAssetCreator.ConnectMaterialPropertyToShaderEnabled(shaderTag);
+                    break;
+                }
+                case MaterialPropertyOutputType::Invalid:
+                    // Don't add any output mappings, this is the case when material functors are expected to process the property
+                    break;
+                default:
+                    AZ_Assert(false, "Unsupported MaterialPropertyOutputType");
+                    return false;
+                }
+            }
+
+            materialTypeAssetCreator.EndMaterialProperty();
+            
+            // Parse and set the property's value...
+            if (!propertySourceData.m_value.IsValid())
+            {
+                materialTypeAssetCreator.ReportWarning("Default value for material property '%s' is invalid.", propertyId.GetCStr());
+            }
+            else
+            {
+                // Resolve value if needed
+                MaterialPropertyValue resolvedValue = ResolveSourceValue(
+                    propertyId, propertySourceData.m_value, materialTypeSourceFilePath,
+                    materialTypeAssetCreator.GetMaterialPropertiesLayout(),
+                    [&](const char* message) { materialTypeAssetCreator.ReportError("%s", message); });
+                materialTypeAssetCreator.SetPropertyValue(propertyId, resolvedValue);
+            }
+
+            return true;
+        }
+
         bool MaterialTypeSourceData::BuildPropertyList(
             const AZStd::string& materialTypeSourceFilePath,
             MaterialTypeAssetCreator& materialTypeAssetCreator,
@@ -687,7 +734,7 @@ namespace AZ
 
             ExtendNameContext(materialNameContext, *propertyGroup);
 
-            for (const AZStd::unique_ptr<PropertyDefinition>& property : propertyGroup->m_properties)
+            for (const AZStd::unique_ptr<MaterialPropertySourceData>& property : propertyGroup->m_properties)
             {
                 // Register the property...
 
@@ -711,61 +758,9 @@ namespace AZ
                     return false;
                 }
 
-                materialTypeAssetCreator.BeginMaterialProperty(propertyId, property->m_dataType);
-
-                if (property->m_dataType == MaterialPropertyDataType::Enum)
+                if (!BuildProperty(materialTypeSourceFilePath, materialTypeAssetCreator, materialNameContext, propertyId, *property))
                 {
-                    materialTypeAssetCreator.SetMaterialPropertyEnumNames(property->m_enumValues);
-                }
-
-                for (auto& output : property->m_outputConnections)
-                {
-                    switch (output.m_type)
-                    {
-                    case MaterialPropertyOutputType::ShaderInput:
-                    {
-                        Name fieldName{output.m_name};
-                        materialNameContext.ContextualizeSrgInput(fieldName);
-                        materialTypeAssetCreator.ConnectMaterialPropertyToShaderInput(fieldName);
-                        break;
-                    }
-                    case MaterialPropertyOutputType::ShaderOption:
-                    {
-                        Name fieldName{output.m_name};
-                        materialNameContext.ContextualizeShaderOption(fieldName);
-                        materialTypeAssetCreator.ConnectMaterialPropertyToShaderOptions(fieldName);
-                        break;
-                    }
-                    case MaterialPropertyOutputType::ShaderEnabled:
-                    {
-                        Name shaderTag{output.m_name};
-                        materialTypeAssetCreator.ConnectMaterialPropertyToShaderEnabled(shaderTag);
-                        break;
-                    }
-                    case MaterialPropertyOutputType::Invalid:
-                        // Don't add any output mappings, this is the case when material functors are expected to process the property
-                        break;
-                    default:
-                        AZ_Assert(false, "Unsupported MaterialPropertyOutputType");
-                        return false;
-                    }
-                }
-
-                materialTypeAssetCreator.EndMaterialProperty();
-
-                // Parse and set the property's value...
-                if (!property->m_value.IsValid())
-                {
-                    materialTypeAssetCreator.ReportWarning("Default value for material property '%s' is invalid.", propertyId.GetCStr());
-                }
-                else
-                {
-                    // Resolve value if needed
-                    MaterialPropertyValue resolvedValue = ResolveSourceValue(
-                        propertyId, property->m_value, materialTypeSourceFilePath,
-                        materialTypeAssetCreator.GetMaterialPropertiesLayout(),
-                        [&](const char* message){ materialTypeAssetCreator.ReportError("%s", message); });
-                    materialTypeAssetCreator.SetPropertyValue(propertyId, resolvedValue);
+                    return false;
                 }
 
                 // If there were prior failures, continued processing could spam a bunch of irrelevant error messages,

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
@@ -78,16 +78,16 @@ namespace AZ
                     return RHI::ResultCode::Fail;
                 }
             }
+            
+            // Copy the shader collections because the material will make changes, like updating the ShaderVariantId.
+            m_shaderCollections = materialAsset.GetShaderCollections();
 
-            m_layout = m_materialAsset->GetMaterialPropertiesLayout();
-            if (!m_layout)
+            if (!m_materialProperties.Init(m_materialAsset->GetMaterialPropertiesLayout(), materialAsset.GetPropertyValues()))
             {
-                AZ_Error(s_debugTraceName, false, "MaterialAsset did not have a valid MaterialPropertiesLayout");
                 return RHI::ResultCode::Fail;
             }
 
-            // Copy the shader collections because the material will make changes, like updating the ShaderVariantId.
-            m_shaderCollections = materialAsset.GetShaderCollections();
+            m_materialProperties.SetAllPropertyDirtyFlags();
 
             // Register for update events related to Shader instances that own the ShaderAssets inside
             // the shader collection.
@@ -101,57 +101,11 @@ namespace AZ
                 }
             }
 
-            // If this Init() is actually a re-initialize, we need to re-apply any overridden property values
-            // after loading the property values from the asset, so we save that data here.
-            MaterialPropertyFlags prevOverrideFlags = m_propertyOverrideFlags;
-            AZStd::vector<MaterialPropertyValue> prevPropertyValues = m_propertyValues;
-
-            // The property values are cleared to their default state to ensure that SetPropertyValue() does not early-return
-            // when called below. This is important when Init() is actually a re-initialize.
-            m_propertyValues.clear();
-
-            // Initialize the shader runtime data like shader constant buffers and shader variants by applying the 
-            // material's property values. This will feed through the normal runtime material value-change data flow, which may
-            // include custom property change handlers provided by the material type.
-            //
-            // This baking process could be more efficient by doing it at build-time rather than run-time. However, the 
-            // architectural complexity of supporting separate asset/runtime paths for assigning buffers/images is prohibitive.
-            {
-                m_propertyValues.resize(materialAsset.GetPropertyValues().size());
-                AZ_Assert(m_propertyValues.size() == m_layout->GetPropertyCount(), "The number of properties in this material doesn't match the property layout");
-
-                for (size_t i = 0; i < materialAsset.GetPropertyValues().size(); ++i)
-                {
-                    const MaterialPropertyValue& value = materialAsset.GetPropertyValues()[i];
-                    MaterialPropertyIndex propertyIndex{i};
-                    if (!SetPropertyValue(propertyIndex, value))
-                    {
-                        return RHI::ResultCode::Fail;
-                    }
-                }
-
-                AZ_Assert(materialAsset.GetPropertyValues().size() <= Limits::Material::PropertyCountMax,
-                    "Too many material properties. Max is %d.", Limits::Material::PropertyCountMax);
-            }
-
-            // Clear all override flags because we just loaded properties from the asset
-            m_propertyOverrideFlags.reset();
-
-            // Now apply any properties that were overridden before
-            for (size_t i = 0; i < prevPropertyValues.size(); ++i)
-            {
-                if (prevOverrideFlags[i])
-                {
-                    SetPropertyValue(MaterialPropertyIndex{i}, prevPropertyValues[i]);
-                }
-            }
 
             // Usually SetProperties called above will increment this change ID to invalidate
             // the material, but some materials might not have any properties, and we need
             // the material to be invalidated particularly when hot-reloading.
             ++m_currentChangeId;
-            // Set all dirty for the first use.
-            m_propertyDirtyFlags.set();
 
             Compile();
 
@@ -292,25 +246,127 @@ namespace AZ
         }
         ///////////////////////////////////////////////////////////////////
 
+        const MaterialPropertyCollection& Material::GetPropertyCollection() const
+        {
+            return m_materialProperties;
+        }
+
         const MaterialPropertyValue& Material::GetPropertyValue(MaterialPropertyIndex index) const
         {
-            static const MaterialPropertyValue emptyValue;
-            if (m_propertyValues.size() <= index.GetIndex())
-            {
-                AZ_Error("Material", false, "Property index out of range.");
-                return emptyValue;
-            }
-            return m_propertyValues[index.GetIndex()];
+            return m_materialProperties.GetPropertyValue(index);
         }
 
         const AZStd::vector<MaterialPropertyValue>& Material::GetPropertyValues() const
         {
-            return m_propertyValues;
+            return m_materialProperties.GetPropertyValues();
         }
 
         bool Material::NeedsCompile() const
         {
             return m_compiledChangeId != m_currentChangeId;
+        }
+
+        void Material::ProcessDirectConnections()
+        {
+            AZ_PROFILE_SCOPE(RPI, "Material::ProcessDirectConnections()");
+
+            for (size_t i = 0; i < m_materialProperties.GetMaterialPropertiesLayout()->GetPropertyCount(); ++i)
+            {
+                if (!m_materialProperties.GetPropertyDirtyFlags()[i])
+                {
+                    continue;
+                }
+
+                MaterialPropertyIndex propertyIndex{i};
+
+                const MaterialPropertyValue value = m_materialProperties.GetPropertyValue(propertyIndex);
+
+                const MaterialPropertyDescriptor* propertyDescriptor =
+                    m_materialProperties.GetMaterialPropertiesLayout()->GetPropertyDescriptor(propertyIndex);
+
+                for(auto& outputId : propertyDescriptor->GetOutputConnections())
+                {
+                    if (outputId.m_type == MaterialPropertyOutputType::ShaderInput)
+                    {
+                        if (propertyDescriptor->GetDataType() == MaterialPropertyDataType::Image)
+                        {
+                            const Data::Instance<Image>& image = value.GetValue<Data::Instance<Image>>();
+
+                            RHI::ShaderInputImageIndex shaderInputIndex(outputId.m_itemIndex.GetIndex());
+                            m_shaderResourceGroup->SetImage(shaderInputIndex, image);
+                        }
+                        else
+                        {
+                            RHI::ShaderInputConstantIndex shaderInputIndex(outputId.m_itemIndex.GetIndex());
+                            SetShaderConstant(shaderInputIndex, value);
+                        }
+                    }
+                    else if (outputId.m_type == MaterialPropertyOutputType::ShaderOption)
+                    {
+                        ShaderCollection::Item& shaderReference = m_shaderCollections[outputId.m_materialPipelineName][outputId.m_containerIndex.GetIndex()];
+                        SetShaderOption(*shaderReference.GetShaderOptions(), ShaderOptionIndex{outputId.m_itemIndex.GetIndex()}, value);
+                    }
+                    else if (outputId.m_type == MaterialPropertyOutputType::ShaderEnabled)
+                    {
+                        ShaderCollection::Item& shaderReference = m_shaderCollections[outputId.m_materialPipelineName][outputId.m_containerIndex.GetIndex()];
+                        if (value.Is<bool>())
+                        {
+                            shaderReference.SetEnabled(value.GetValue<bool>());
+                        }
+                        else
+                        {
+                            // We should never get here because MaterialTypeAssetCreator and ValidatePropertyAccess ensure savedPropertyValue is a bool.
+                            AZ_Assert(false, "Unsupported data type for MaterialPropertyOutputType::ShaderEnabled");
+                        }
+                    }
+                    else
+                    {
+                        AZ_Assert(false, "Unhandled MaterialPropertyOutputType");
+                    }
+                }
+            }
+        }
+
+        void Material::ProcessMaterialFunctors()
+        {
+            AZ_PROFILE_SCOPE(RPI, "Material::ProcessMaterialFunctors()");
+
+            // On some platforms, PipelineStateObjects must be pre-compiled and shipped with the game; they cannot be compiled at runtime. So at some
+            // point the material system needs to be smart about when it allows PSO changes and when it doesn't. There is a task scheduled to
+            // thoroughly address this in 2022, but for now we just report a warning to alert users who are using the engine in a way that might
+            // not be supported for much longer. PSO changes should only be allowed in developer tools (though we could also expose a way for users to
+            // enable dynamic PSO changes if their project only targets platforms that support this).
+            // PSO modifications are allowed during initialization because that's using the stored asset data, which the asset system can
+            // access to pre-compile the necessary PSOs.
+            MaterialPropertyPsoHandling psoHandling = m_isInitializing ? MaterialPropertyPsoHandling::Allowed : m_psoHandling;
+
+            for (const Ptr<MaterialFunctor>& functor : m_materialAsset->GetMaterialFunctors())
+            {
+                if (functor)
+                {
+                    const MaterialPropertyFlags& materialPropertyDependencies = functor->GetMaterialPropertyDependencies();
+                    // None covers case that the client code doesn't register material properties to dependencies,
+                    // which will later get caught in Process() when trying to access a property.
+                    if (materialPropertyDependencies.none() || functor->NeedsProcess(m_materialProperties.GetPropertyDirtyFlags()))
+                    {
+                        MaterialFunctor::RuntimeContext processContext = MaterialFunctor::RuntimeContext(
+                            m_materialProperties,
+                            &m_shaderCollections,
+                            m_shaderResourceGroup.get(),
+                            &materialPropertyDependencies,
+                            psoHandling
+                        );
+
+                        functor->Process(processContext);
+                    }
+                }
+                else
+                {
+                    // This could happen when the dll containing the functor class is missing. There will likely be more errors
+                    // preceding this one, from the serialization system when loading the material asset.
+                    AZ_Error(s_debugTraceName, false, "Material functor is null.");
+                }
+            }
         }
 
         bool Material::Compile()
@@ -324,48 +380,10 @@ namespace AZ
 
             if (CanCompile())
             {
-                // On some platforms, PipelineStateObjects must be pre-compiled and shipped with the game; they cannot be compiled at runtime. So at some
-                // point the material system needs to be smart about when it allows PSO changes and when it doesn't. There is a task scheduled to
-                // thoroughly address this in 2022, but for now we just report a warning to alert users who are using the engine in a way that might
-                // not be supported for much longer. PSO changes should only be allowed in developer tools (though we could also expose a way for users to
-                // enable dynamic PSO changes if their project only targets platforms that support this).
-                // PSO modifications are allowed during initialization because that's using the stored asset data, which the asset system can
-                // access to pre-compile the necessary PSOs.
-                MaterialPropertyPsoHandling psoHandling = m_isInitializing ? MaterialPropertyPsoHandling::Allowed : m_psoHandling;
+                ProcessDirectConnections();
+                ProcessMaterialFunctors();
 
-
-                AZ_PROFILE_BEGIN(RPI, "Material::Compile() Processing Functors");
-                for (const Ptr<MaterialFunctor>& functor : m_materialAsset->GetMaterialFunctors())
-                {
-                    if (functor)
-                    {
-                        const MaterialPropertyFlags& materialPropertyDependencies = functor->GetMaterialPropertyDependencies();
-                        // None covers case that the client code doesn't register material properties to dependencies,
-                        // which will later get caught in Process() when trying to access a property.
-                        if (materialPropertyDependencies.none() || functor->NeedsProcess(m_propertyDirtyFlags))
-                        {
-                            MaterialFunctor::RuntimeContext processContext = MaterialFunctor::RuntimeContext(
-                                m_propertyValues,
-                                m_layout,
-                                &m_shaderCollections,
-                                m_shaderResourceGroup.get(),
-                                &materialPropertyDependencies,
-                                psoHandling
-                            );
-
-                            functor->Process(processContext);
-                        }
-                    }
-                    else
-                    {
-                        // This could happen when the dll containing the functor class is missing. There will likely be more errors
-                        // preceding this one, from the serialization system when loading the material asset.
-                        AZ_Error(s_debugTraceName, false, "Material functor is null.");
-                    }
-                }
-                AZ_PROFILE_END(RPI);
-
-                m_propertyDirtyFlags.reset();
+                m_materialProperties.ClearAllPropertyDirtyFlags();
 
                 if (m_shaderResourceGroup)
                 {
@@ -392,14 +410,14 @@ namespace AZ
                 *wasRenamed = false;
             }
 
-            MaterialPropertyIndex index = m_layout->FindPropertyIndex(propertyId);
+            MaterialPropertyIndex index = m_materialProperties.GetMaterialPropertiesLayout()->FindPropertyIndex(propertyId);
             if (!index.IsValid())
             {
                 Name renamedId = propertyId;
                 
                 if (m_materialAsset->GetMaterialTypeAsset()->ApplyPropertyRenames(renamedId))
                 {                                
-                    index = m_layout->FindPropertyIndex(renamedId);
+                    index = m_materialProperties.GetMaterialPropertiesLayout()->FindPropertyIndex(renamedId);
 
                     if (wasRenamed)
                     {
@@ -420,242 +438,110 @@ namespace AZ
             return index;
         }
 
-        template<typename Type>
-        bool Material::ValidatePropertyAccess(const MaterialPropertyDescriptor* propertyDescriptor) const
+        bool Material::SetShaderConstant(RHI::ShaderInputConstantIndex shaderInputIndex, const MaterialPropertyValue& value)
         {
-            // Note that we have warnings here instead of errors because this can happen while materials are hot reloading
-            // after a material property layout changes in the MaterialTypeAsset, as there's a brief time when the data
-            // might be out of sync between MaterialAssets and MaterialTypeAssets.
-
-            if (!propertyDescriptor)
+            if (!value.IsValid())
             {
-                AZ_Warning(s_debugTraceName, false, "MaterialPropertyDescriptor is null");
+                AZ_Assert(false, "Empty value found for shader input index %u", shaderInputIndex.GetIndex());
                 return false;
             }
-
-            AZ::TypeId accessDataType = azrtti_typeid<Type>();
-
-            // Must align with the order in MaterialPropertyDataType
-            static const AZStd::array<AZ::TypeId, MaterialPropertyDataTypeCount> types =
-            {{
-                AZ::TypeId{}, // Invalid
-                azrtti_typeid<bool>(),
-                azrtti_typeid<int32_t>(),
-                azrtti_typeid<uint32_t>(),
-                azrtti_typeid<float>(),
-                azrtti_typeid<Vector2>(),
-                azrtti_typeid<Vector3>(),
-                azrtti_typeid<Vector4>(),
-                azrtti_typeid<Color>(),
-                azrtti_typeid<Data::Instance<Image>>(),
-                azrtti_typeid<uint32_t>()
-            }};
-
-            AZ::TypeId actualDataType = types[static_cast<size_t>(propertyDescriptor->GetDataType())];
-
-            if (accessDataType != actualDataType)
+            else if (value.Is<bool>())
             {
-                AZ_Warning(s_debugTraceName, false, "Material property '%s': Accessed as type %s but is type %s",
-                    propertyDescriptor->GetName().GetCStr(),
-                    GetMaterialPropertyDataTypeString(accessDataType).c_str(),
-                    ToString(propertyDescriptor->GetDataType()));
-                return false;
+                return m_shaderResourceGroup->SetConstant(shaderInputIndex, value.GetValue<bool>());
             }
-
-            return true;
-        }
-
-        template<typename Type>
-        void Material::SetShaderConstant(RHI::ShaderInputConstantIndex shaderInputIndex, const Type& value)
-        {
-            m_shaderResourceGroup->SetConstant(shaderInputIndex, value);
-        }
-
-        template<>
-        void Material::SetShaderConstant<Vector3>(RHI::ShaderInputConstantIndex shaderInputIndex, const Vector3& value)
-        {
-            // Vector3 is actually 16 bytes, not 12, so ShaderResourceGroup::SetConstant won't work. We
-            // have to pass the raw data instead.
-            m_shaderResourceGroup->SetConstantRaw(shaderInputIndex, &value, 3 * sizeof(float));
-        }
-
-        template<>
-        void Material::SetShaderConstant<Color>(RHI::ShaderInputConstantIndex shaderInputIndex, const Color& value)
-        {
-            auto transformedColor = AZ::RPI::TransformColor(value, ColorSpaceId::LinearSRGB, ColorSpaceId::ACEScg);
-
-            // Color is special because it could map to either a float3 or a float4
-            auto descriptor = m_shaderResourceGroup->GetLayout()->GetShaderInput(shaderInputIndex);
-            if (descriptor.m_constantByteCount == 3 * sizeof(float))
+            else if (value.Is<int32_t>())
             {
-                m_shaderResourceGroup->SetConstantRaw(shaderInputIndex, &transformedColor, 3 * sizeof(float));
+                return m_shaderResourceGroup->SetConstant(shaderInputIndex, value.GetValue<int32_t>());
+            }
+            else if (value.Is<uint32_t>())
+            {
+                return m_shaderResourceGroup->SetConstant(shaderInputIndex, value.GetValue<uint32_t>());
+            }
+            else if (value.Is<float>())
+            {
+                return m_shaderResourceGroup->SetConstant(shaderInputIndex, value.GetValue<float>());
+            }
+            else if (value.Is<Vector2>())
+            {
+                return m_shaderResourceGroup->SetConstant(shaderInputIndex, value.GetValue<Vector2>());
+            }
+            else if (value.Is<Vector3>())
+            {
+                // Vector3 is actually 16 bytes, not 12, so ShaderResourceGroup::SetConstant won't work. We
+                // have to pass the raw data instead.
+                return m_shaderResourceGroup->SetConstantRaw(shaderInputIndex, &value.GetValue<Vector3>(), 3 * sizeof(float));
+            }
+            else if (value.Is<Vector4>())
+            {
+                return m_shaderResourceGroup->SetConstant(shaderInputIndex, value.GetValue<Vector4>());
+            }
+            else if (value.Is<Color>())
+            {
+                auto transformedColor = AZ::RPI::TransformColor(value.GetValue<Color>(), ColorSpaceId::LinearSRGB, ColorSpaceId::ACEScg);
+
+                // Color is special because it could map to either a float3 or a float4
+                auto descriptor = m_shaderResourceGroup->GetLayout()->GetShaderInput(shaderInputIndex);
+                if (descriptor.m_constantByteCount == 3 * sizeof(float))
+                {
+                    return m_shaderResourceGroup->SetConstantRaw(shaderInputIndex, &transformedColor, 3 * sizeof(float));
+                }
+                else
+                {
+                    return m_shaderResourceGroup->SetConstantRaw(shaderInputIndex, &transformedColor, 4 * sizeof(float));
+                }
+            }
+            else if (value.Is<Data::Instance<Image>>())
+            {
+                return m_shaderResourceGroup->SetConstant(shaderInputIndex, value.GetValue<Data::Instance<Image>>());
+            }
+            else if (value.Is<Data::Asset<ImageAsset>>())
+            {
+                return m_shaderResourceGroup->SetConstant(shaderInputIndex, value.GetValue<Data::Asset<ImageAsset>>());
             }
             else
             {
-                m_shaderResourceGroup->SetConstantRaw(shaderInputIndex, &transformedColor, 4 * sizeof(float));
+                AZ_Assert(false, "Unhandled material property value type");
+                return false;
             }
         }
 
-        template<typename Type>
-        bool Material::SetShaderOption([[maybe_unused]] ShaderOptionGroup& options, [[maybe_unused]] ShaderOptionIndex shaderOptionIndex, [[maybe_unused]] Type value)
+        bool Material::SetShaderOption(ShaderOptionGroup& options, ShaderOptionIndex shaderOptionIndex, const MaterialPropertyValue& value)
         {
-            AZ_Assert(false, "MaterialProperty is incorrectly mapped to a shader option. Data type is incompatible.");
-            return false;
-        }
-
-        template<>
-        bool Material::SetShaderOption<bool>(ShaderOptionGroup& options, ShaderOptionIndex shaderOptionIndex, bool value)
-        {
-            return options.SetValue(shaderOptionIndex, ShaderOptionValue{ value });
-        }
-
-        template<>
-        bool Material::SetShaderOption<uint32_t>(ShaderOptionGroup& options, ShaderOptionIndex shaderOptionIndex, uint32_t value)
-        {
-            return options.SetValue(shaderOptionIndex, ShaderOptionValue{ value });
-        }
-
-        template<>
-        bool Material::SetShaderOption<int32_t>(ShaderOptionGroup& options, ShaderOptionIndex shaderOptionIndex, int32_t value)
-        {
-            return options.SetValue(shaderOptionIndex, ShaderOptionValue{ value });
+            if (!value.IsValid())
+            {
+                AZ_Assert(false, "Empty value found for shader option %u", shaderOptionIndex.GetIndex());
+                return false;
+            }
+            else if (value.Is<bool>())
+            {
+                return options.SetValue(shaderOptionIndex, ShaderOptionValue{value.GetValue<bool>()});
+            }
+            else if (value.Is<int32_t>())
+            {
+                return options.SetValue(shaderOptionIndex, ShaderOptionValue{value.GetValue<int32_t>()});
+            }
+            else if (value.Is<uint32_t>())
+            {
+                return options.SetValue(shaderOptionIndex, ShaderOptionValue{value.GetValue<uint32_t>()});
+            }
+            else
+            {
+                AZ_Assert(false, "MaterialProperty is incorrectly mapped to a shader option. Data type is incompatible.");
+                return false;
+            }
         }
 
         template<typename Type>
         bool Material::SetPropertyValue(MaterialPropertyIndex index, const Type& value)
         {
-            if (!index.IsValid())
+            bool success = m_materialProperties.SetPropertyValue<Type>(index, value);
+
+            if (success)
             {
-                AZ_Assert(false, "SetPropertyValue: Invalid MaterialPropertyIndex");
-                return false;
+                ++m_currentChangeId;
             }
 
-            const MaterialPropertyDescriptor* propertyDescriptor = m_layout->GetPropertyDescriptor(index);
-
-            if (!ValidatePropertyAccess<Type>(propertyDescriptor))
-            {
-                return false;
-            }
-
-            MaterialPropertyValue& savedPropertyValue = m_propertyValues[index.GetIndex()];
-
-            // If the property value didn't actually change, don't waste time running functors and compiling the changes.
-            if (savedPropertyValue == value)
-            {
-                return false;
-            }
-
-            savedPropertyValue = value;
-            m_propertyDirtyFlags.set(index.GetIndex());
-            m_propertyOverrideFlags.set(index.GetIndex());
-
-            for(auto& outputId : propertyDescriptor->GetOutputConnections())
-            {
-                if (outputId.m_type == MaterialPropertyOutputType::ShaderInput)
-                {
-                    if (propertyDescriptor->GetDataType() == MaterialPropertyDataType::Image)
-                    {
-                        const Data::Instance<Image>& image = savedPropertyValue.GetValue<Data::Instance<Image>>();
-
-                        RHI::ShaderInputImageIndex shaderInputIndex(outputId.m_itemIndex.GetIndex());
-                        m_shaderResourceGroup->SetImage(shaderInputIndex, image);
-                    }
-                    else
-                    {
-                        RHI::ShaderInputConstantIndex shaderInputIndex(outputId.m_itemIndex.GetIndex());
-                        SetShaderConstant(shaderInputIndex, value);
-                    }
-                }
-                else if (outputId.m_type == MaterialPropertyOutputType::ShaderOption)
-                {
-                    ShaderCollection::Item& shaderReference = m_shaderCollections[outputId.m_materialPipelineName][outputId.m_containerIndex.GetIndex()];
-                    if (!SetShaderOption(*shaderReference.GetShaderOptions(), ShaderOptionIndex{outputId.m_itemIndex.GetIndex()}, value))
-                    {
-                        return false;
-                    }
-                }
-                else if (outputId.m_type == MaterialPropertyOutputType::ShaderEnabled)
-                {
-                    ShaderCollection::Item& shaderReference = m_shaderCollections[outputId.m_materialPipelineName][outputId.m_containerIndex.GetIndex()];
-                    if (savedPropertyValue.Is<bool>())
-                    {
-                        shaderReference.SetEnabled(savedPropertyValue.GetValue<bool>());
-                    }
-                    else
-                    {
-                        // We should never get here because MaterialTypeAssetCreator and ValidatePropertyAccess ensure savedPropertyValue is a bool.
-                        AZ_Assert(false, "Unsupported data type for MaterialPropertyOutputType::ShaderEnabled");
-                    }
-                }
-                else
-                {
-                    AZ_Assert(false, "Unhandled MaterialPropertyOutputType");
-                    return false;
-                }
-            }
-
-            ++m_currentChangeId;
-
-            return true;
-        }
-
-        template<>
-        bool Material::SetPropertyValue<Data::Asset<ImageAsset>>(MaterialPropertyIndex index, const Data::Asset<ImageAsset>& value)
-        {
-            Data::Asset<ImageAsset> imageAsset = value;
-
-            if (!imageAsset.GetId().IsValid())
-            {
-                // The image asset reference is null so set the property to an empty Image instance so the AZStd::any will not be empty.
-                return SetPropertyValue(index, Data::Instance<Image>());
-            }
-            else
-            {
-                AZ::Data::AssetType assetType = imageAsset.GetType();
-                if (assetType != azrtti_typeid<StreamingImageAsset>() && assetType != azrtti_typeid<AttachmentImageAsset>())
-                {
-                    AZ::Data::AssetInfo assetInfo;
-                    AZ::Data::AssetCatalogRequestBus::BroadcastResult(
-                        assetInfo, &AZ::Data::AssetCatalogRequests::GetAssetInfoById, imageAsset.GetId());
-                    assetType = assetInfo.m_assetType;
-                }
-
-                // There is an issue in the Asset<T>(Asset<U>) copy constructor which is used with the FindOrCreate() calls below.
-                // If the AssetData is valid, then it will get the actual asset type ID from the AssetData. However, if it is null
-                // then it will continue using the original type ID. The InstanceDatabase will end up asking the AssetManager for
-                // the asset using the wrong type (ImageAsset) and will lead to various error messages and in the end the asset
-                // will never be loaded. So we work around this issue by forcing the asset type ID to the correct value first.
-                // See https://github.com/o3de/o3de/issues/12224
-                if (!imageAsset.Get())
-                {
-                    imageAsset = Data::Asset<ImageAsset>{imageAsset.GetId(), assetType, imageAsset.GetHint()};
-                }
-
-                Data::Instance<Image> image = nullptr;
-                if (assetType == azrtti_typeid<StreamingImageAsset>())
-                {
-                    Data::Asset<StreamingImageAsset> streamingImageAsset = imageAsset;
-                    image = StreamingImage::FindOrCreate(streamingImageAsset);
-                }
-                else if (assetType == azrtti_typeid<AttachmentImageAsset>())
-                {
-                    Data::Asset<AttachmentImageAsset> attachmentImageAsset = imageAsset;
-                    image = AttachmentImage::FindOrCreate(attachmentImageAsset);
-                }
-                else
-                {
-                    AZ_Error(s_debugTraceName, false, "Unsupported image asset type: %s", assetType.ToString<AZStd::string>().c_str());
-                    return false;
-                }
-
-                if (!image)
-                {
-                    AZ_Error(s_debugTraceName, false, "Image asset could not be loaded");
-                    return false;
-                }
-
-                return SetPropertyValue(index, image);
-            }
+            return success;
         }
 
         // Using explicit instantiation to restrict SetPropertyValue to the set of types that we support
@@ -672,104 +558,20 @@ namespace AZ
 
         bool Material::SetPropertyValue(MaterialPropertyIndex propertyIndex, const MaterialPropertyValue& value)
         {
-            if (!value.IsValid())
+            bool success = m_materialProperties.SetPropertyValue(propertyIndex, value);
+
+            if (success)
             {
-                auto descriptor = m_layout->GetPropertyDescriptor(propertyIndex);
-                if (descriptor)
-                {
-                    AZ_Assert(false, "Empty value found for material property '%s'", descriptor->GetName().GetCStr());
-                }
-                else
-                {
-                    AZ_Assert(false, "Empty value found for material property [%d], and this property does not have a descriptor.");
-                }
-                return false;
+                ++m_currentChangeId;
             }
-            if (value.Is<bool>())
-            {
-                return SetPropertyValue(propertyIndex, value.GetValue<bool>());
-            }
-            else if (value.Is<int32_t>())
-            {
-                return SetPropertyValue(propertyIndex, value.GetValue<int32_t>());
-            }
-            else if (value.Is<uint32_t>())
-            {
-                return SetPropertyValue(propertyIndex, value.GetValue<uint32_t>());
-            }
-            else if (value.Is<float>())
-            {
-                return SetPropertyValue(propertyIndex, value.GetValue<float>());
-            }
-            else if (value.Is<Vector2>())
-            {
-                return SetPropertyValue(propertyIndex, value.GetValue<Vector2>());
-            }
-            else if (value.Is<Vector3>())
-            {
-                return SetPropertyValue(propertyIndex, value.GetValue<Vector3>());
-            }
-            else if (value.Is<Vector4>())
-            {
-                return SetPropertyValue(propertyIndex, value.GetValue<Vector4>());
-            }
-            else if (value.Is<Color>())
-            {
-                return SetPropertyValue(propertyIndex, value.GetValue<Color>());
-            }
-            else if (value.Is<Data::Instance<Image>>())
-            {
-                return SetPropertyValue(propertyIndex, value.GetValue<Data::Instance<Image>>());
-            }
-            else if (value.Is<Data::Asset<ImageAsset>>())
-            {
-                return SetPropertyValue(propertyIndex, value.GetValue<Data::Asset<ImageAsset>>());
-            }
-            else
-            {
-                AZ_Assert(false, "Unhandled material property value type");
-                return false;
-            }
+
+            return success;
         }
 
         template<typename Type>
         const Type& Material::GetPropertyValue(MaterialPropertyIndex index) const
         {
-            static const Type defaultValue{};
-
-            const MaterialPropertyDescriptor* propertyDescriptor = nullptr;
-            if (Validation::IsEnabled())
-            {
-                if (!index.IsValid())
-                {
-                    AZ_Assert(false, "GetPropertyValue: Invalid MaterialPropertyIndex");
-                    return defaultValue;
-                }
-
-                propertyDescriptor = m_layout->GetPropertyDescriptor(index);
-
-                if (!ValidatePropertyAccess<Type>(propertyDescriptor))
-                {
-                    return defaultValue;
-                }
-            }
-
-            const MaterialPropertyValue& value = m_propertyValues[index.GetIndex()];
-            if (value.Is<Type>())
-            {
-                return value.GetValue<Type>();
-            }
-            else
-            {
-                if (Validation::IsEnabled())
-                {
-                    AZ_Assert(false, "Material property '%s': Stored property value has the wrong data type. Expected %s but is %s.",
-                    propertyDescriptor->GetName().GetCStr(),
-                        azrtti_typeid<Type>().template ToString<AZStd::string>().data(), // 'template' because clang says "error: use 'template' keyword to treat 'ToString' as a dependent template name"
-                        value.GetTypeId().ToString<AZStd::string>().data());
-                }
-                return defaultValue;
-            }
+            return m_materialProperties.GetPropertyValue<Type>(index);
         }
 
         // Using explicit instantiation to restrict GetPropertyValue to the set of types that we support
@@ -783,15 +585,16 @@ namespace AZ
         template const Vector4&  Material::GetPropertyValue<Vector4>  (MaterialPropertyIndex index) const;
         template const Color&    Material::GetPropertyValue<Color>    (MaterialPropertyIndex index) const;
         template const Data::Instance<Image>& Material::GetPropertyValue<Data::Instance<Image>>(MaterialPropertyIndex index) const;
-
+        
         const MaterialPropertyFlags& Material::GetPropertyDirtyFlags() const
         {
-            return m_propertyDirtyFlags;
+            return m_materialProperties.GetPropertyDirtyFlags();
         }
 
         RHI::ConstPtr<MaterialPropertiesLayout> Material::GetMaterialPropertiesLayout() const
         {
-            return m_layout;
+            return m_materialProperties.GetMaterialPropertiesLayout();
         }
+
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialAsset.cpp
@@ -186,7 +186,7 @@ namespace AZ
 
                         MaterialPropertyValue finalValue = value.CastToType(propertyDescriptor->GetStorageDataTypeId());
 
-                        if (ValidateMaterialPropertyDataType(finalValue.GetTypeId(), name, propertyDescriptor, reportError))
+                        if (ValidateMaterialPropertyDataType(finalValue.GetTypeId(), propertyDescriptor, reportError))
                         {
                             finalizedPropertyValues[propertyIndex.GetIndex()] = finalValue;
                         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialPropertyCollection.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialPropertyCollection.cpp
@@ -1,0 +1,383 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RPI.Public/ColorManagement/TransformColor.h>
+#include <Atom/RPI.Public/Material/Material.h>
+#include <Atom/RPI.Reflect/Image/AttachmentImageAsset.h>
+#include <Atom/RPI.Public/Image/AttachmentImage.h>
+#include <Atom/RPI.Public/Image/StreamingImage.h>
+#include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
+#include <Atom/RPI.Public/Shader/ShaderReloadDebugTracker.h>
+#include <Atom/RPI.Public/Shader/Shader.h>
+#include <Atom/RPI.Public/Shader/ShaderSystemInterface.h>
+#include <Atom/RPI.Reflect/Shader/ShaderOptionGroup.h>
+#include <Atom/RPI.Reflect/Material/MaterialAsset.h>
+#include <Atom/RPI.Reflect/Material/MaterialPropertiesLayout.h>
+#include <Atom/RPI.Reflect/Asset/AssetUtils.h>
+#include <Atom/RPI.Reflect/Material/MaterialFunctor.h>
+
+#include <AtomCore/Instance/InstanceDatabase.h>
+#include <AtomCore/Utils/ScopedValue.h>
+
+namespace AZ
+{
+    namespace RPI
+    {
+        bool MaterialPropertyCollection::Init(
+            RHI::ConstPtr<MaterialPropertiesLayout> layout,
+            const AZStd::vector<MaterialPropertyValue>& defaultValues)
+        {
+            m_layout = layout;
+            if (!m_layout)
+            {
+                AZ_Error("MaterialPropertyCollection", false, "MaterialPropertiesLayout is invalid");
+                return false;
+            }
+
+            // If this Init() is actually a re-initialize, we need to re-apply any overridden property values
+            // after loading the default property values, so we save that data here.
+            MaterialPropertyFlags prevOverrideFlags = m_propertyOverrideFlags;
+            AZStd::vector<MaterialPropertyValue> prevPropertyValues = m_propertyValues;
+
+            // The property values are cleared to their default state to ensure that SetPropertyValue() does not early-return
+            // when called below. This is important when Init() is actually a re-initialize.
+            m_propertyValues.clear();
+
+            // Initialize the shader runtime data like shader constant buffers and shader variants by applying the 
+            // material's property values. This will feed through the normal runtime material value-change data flow, which may
+            // include custom property change handlers provided by the material type.
+            //
+            // This baking process could be more efficient by doing it at build-time rather than run-time. However, the 
+            // architectural complexity of supporting separate asset/runtime paths for assigning buffers/images is prohibitive.
+
+            m_propertyValues.resize(defaultValues.size());
+            AZ_Assert(defaultValues.size() == m_layout->GetPropertyCount(), "The number of properties in this material doesn't match the property layout");
+            AZ_Assert(defaultValues.size() <= Limits::Material::PropertyCountMax, "Too many material properties. Max is %d.", Limits::Material::PropertyCountMax);
+
+            for (size_t i = 0; i < defaultValues.size(); ++i)
+            {
+                const MaterialPropertyValue& value = defaultValues[i];
+                MaterialPropertyIndex propertyIndex{i};
+                if (!SetPropertyValue(propertyIndex, value))
+                {
+                    return false;
+                }
+            }
+
+            // Clear all override flags because we just loaded properties from the asset
+            m_propertyOverrideFlags.reset();
+
+            // Now apply any properties that were overridden before
+            for (size_t i = 0; i < prevPropertyValues.size(); ++i)
+            {
+                if (prevOverrideFlags[i])
+                {
+                    SetPropertyValue(MaterialPropertyIndex{i}, prevPropertyValues[i]);
+                }
+            }
+
+            return true;
+        }
+
+        const MaterialPropertyValue& MaterialPropertyCollection::GetPropertyValue(MaterialPropertyIndex index) const
+        {
+            static const MaterialPropertyValue emptyValue;
+            if (m_propertyValues.size() <= index.GetIndex())
+            {
+                AZ_Error("MaterialPropertyCollection", false, "Property index out of range.");
+                return emptyValue;
+            }
+            return m_propertyValues[index.GetIndex()];
+        }
+
+        const AZStd::vector<MaterialPropertyValue>& MaterialPropertyCollection::GetPropertyValues() const
+        {
+            return m_propertyValues;
+        }
+
+        void MaterialPropertyCollection::SetAllPropertyDirtyFlags()
+        {
+            m_propertyDirtyFlags.set();
+        }
+
+        void MaterialPropertyCollection::ClearAllPropertyDirtyFlags()
+        {
+            m_propertyDirtyFlags.reset();
+        }
+
+        template<typename Type>
+        bool MaterialPropertyCollection::SetPropertyValue(MaterialPropertyIndex index, const Type& value)
+        {
+            if (!index.IsValid())
+            {
+                AZ_Assert(false, "SetPropertyValue: Invalid MaterialPropertyIndex");
+                return false;
+            }
+
+            const MaterialPropertyDescriptor* propertyDescriptor = m_layout->GetPropertyDescriptor(index);
+
+            if (!ValidatePropertyAccess<Type>(propertyDescriptor))
+            {
+                return false;
+            }
+
+            MaterialPropertyValue& savedPropertyValue = m_propertyValues[index.GetIndex()];
+
+            // If the property value didn't actually change, don't waste time running functors and compiling the changes.
+            if (savedPropertyValue == value)
+            {
+                return false;
+            }
+
+            savedPropertyValue = value;
+            m_propertyDirtyFlags.set(index.GetIndex());
+            m_propertyOverrideFlags.set(index.GetIndex());
+
+            return true;
+        }
+
+        template<>
+        bool MaterialPropertyCollection::SetPropertyValue<Data::Asset<ImageAsset>>(MaterialPropertyIndex index, const Data::Asset<ImageAsset>& value)
+        {
+            Data::Asset<ImageAsset> imageAsset = value;
+
+            if (!imageAsset.GetId().IsValid())
+            {
+                // The image asset reference is null so set the property to an empty Image instance so the AZStd::any will not be empty.
+                return SetPropertyValue(index, Data::Instance<Image>());
+            }
+            else
+            {
+                AZ::Data::AssetType assetType = imageAsset.GetType();
+                if (assetType != azrtti_typeid<StreamingImageAsset>() && assetType != azrtti_typeid<AttachmentImageAsset>())
+                {
+                    AZ::Data::AssetInfo assetInfo;
+                    AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+                        assetInfo, &AZ::Data::AssetCatalogRequests::GetAssetInfoById, imageAsset.GetId());
+                    assetType = assetInfo.m_assetType;
+                }
+
+                // There is an issue in the Asset<T>(Asset<U>) copy constructor which is used with the FindOrCreate() calls below.
+                // If the AssetData is valid, then it will get the actual asset type ID from the AssetData. However, if it is null
+                // then it will continue using the original type ID. The InstanceDatabase will end up asking the AssetManager for
+                // the asset using the wrong type (ImageAsset) and will lead to various error messages and in the end the asset
+                // will never be loaded. So we work around this issue by forcing the asset type ID to the correct value first.
+                // See https://github.com/o3de/o3de/issues/12224
+                if (!imageAsset.Get())
+                {
+                    imageAsset = Data::Asset<ImageAsset>{imageAsset.GetId(), assetType, imageAsset.GetHint()};
+                }
+
+                Data::Instance<Image> image = nullptr;
+                if (assetType == azrtti_typeid<StreamingImageAsset>())
+                {
+                    Data::Asset<StreamingImageAsset> streamingImageAsset = imageAsset;
+                    image = StreamingImage::FindOrCreate(streamingImageAsset);
+                }
+                else if (assetType == azrtti_typeid<AttachmentImageAsset>())
+                {
+                    Data::Asset<AttachmentImageAsset> attachmentImageAsset = imageAsset;
+                    image = AttachmentImage::FindOrCreate(attachmentImageAsset);
+                }
+                else
+                {
+                    AZ_Error("MaterialPropertyCollection", false, "Unsupported image asset type: %s", assetType.ToString<AZStd::string>().c_str());
+                    return false;
+                }
+
+                if (!image)
+                {
+                    AZ_Error("MaterialPropertyCollection", false, "Image asset could not be loaded");
+                    return false;
+                }
+
+                return SetPropertyValue(index, image);
+            }
+        }
+
+        template bool MaterialPropertyCollection::SetPropertyValue<bool>(MaterialPropertyIndex index, const bool& value);
+        template bool MaterialPropertyCollection::SetPropertyValue<int32_t>(MaterialPropertyIndex index, const int32_t& value);
+        template bool MaterialPropertyCollection::SetPropertyValue<uint32_t>(MaterialPropertyIndex index, const uint32_t& value);
+        template bool MaterialPropertyCollection::SetPropertyValue<float>(MaterialPropertyIndex index, const float& value);
+        template bool MaterialPropertyCollection::SetPropertyValue<Vector2>(MaterialPropertyIndex index, const Vector2& value);
+        template bool MaterialPropertyCollection::SetPropertyValue<Vector3>(MaterialPropertyIndex index, const Vector3& value);
+        template bool MaterialPropertyCollection::SetPropertyValue<Vector4>(MaterialPropertyIndex index, const Vector4& value);
+        template bool MaterialPropertyCollection::SetPropertyValue<Color>(MaterialPropertyIndex index, const Color& value);
+        template bool MaterialPropertyCollection::SetPropertyValue<Data::Instance<Image>>(MaterialPropertyIndex index, const Data::Instance<Image>& value);
+
+        bool MaterialPropertyCollection::SetPropertyValue(MaterialPropertyIndex propertyIndex, const MaterialPropertyValue& value)
+        {
+            if (!value.IsValid())
+            {
+                auto descriptor = m_layout->GetPropertyDescriptor(propertyIndex);
+                if (descriptor)
+                {
+                    AZ_Assert(false, "Empty value found for material property '%s'", descriptor->GetName().GetCStr());
+                }
+                else
+                {
+                    AZ_Assert(false, "Empty value found for material property [%d], and this property does not have a descriptor.");
+                }
+                return false;
+            }
+            if (value.Is<bool>())
+            {
+                return SetPropertyValue(propertyIndex, value.GetValue<bool>());
+            }
+            else if (value.Is<int32_t>())
+            {
+                return SetPropertyValue(propertyIndex, value.GetValue<int32_t>());
+            }
+            else if (value.Is<uint32_t>())
+            {
+                return SetPropertyValue(propertyIndex, value.GetValue<uint32_t>());
+            }
+            else if (value.Is<float>())
+            {
+                return SetPropertyValue(propertyIndex, value.GetValue<float>());
+            }
+            else if (value.Is<Vector2>())
+            {
+                return SetPropertyValue(propertyIndex, value.GetValue<Vector2>());
+            }
+            else if (value.Is<Vector3>())
+            {
+                return SetPropertyValue(propertyIndex, value.GetValue<Vector3>());
+            }
+            else if (value.Is<Vector4>())
+            {
+                return SetPropertyValue(propertyIndex, value.GetValue<Vector4>());
+            }
+            else if (value.Is<Color>())
+            {
+                return SetPropertyValue(propertyIndex, value.GetValue<Color>());
+            }
+            else if (value.Is<Data::Instance<Image>>())
+            {
+                return SetPropertyValue(propertyIndex, value.GetValue<Data::Instance<Image>>());
+            }
+            else if (value.Is<Data::Asset<ImageAsset>>())
+            {
+                return SetPropertyValue(propertyIndex, value.GetValue<Data::Asset<ImageAsset>>());
+            }
+            else
+            {
+                AZ_Assert(false, "Unhandled material property value type");
+                return false;
+            }
+        }
+
+        template<typename Type>
+        const Type& MaterialPropertyCollection::GetPropertyValue(MaterialPropertyIndex index) const
+        {
+            static const Type defaultValue{};
+
+            const MaterialPropertyDescriptor* propertyDescriptor = nullptr;
+            if (Validation::IsEnabled())
+            {
+                if (!index.IsValid())
+                {
+                    AZ_Assert(false, "GetPropertyValue: Invalid MaterialPropertyIndex");
+                    return defaultValue;
+                }
+
+                propertyDescriptor = m_layout->GetPropertyDescriptor(index);
+
+                if (!ValidatePropertyAccess<Type>(propertyDescriptor))
+                {
+                    return defaultValue;
+                }
+            }
+
+            const MaterialPropertyValue& value = m_propertyValues[index.GetIndex()];
+            if (value.Is<Type>())
+            {
+                return value.GetValue<Type>();
+            }
+            else
+            {
+                if (Validation::IsEnabled())
+                {
+                    AZ_Assert(false, "Material property '%s': Stored property value has the wrong data type. Expected %s but is %s.",
+                    propertyDescriptor->GetName().GetCStr(),
+                        azrtti_typeid<Type>().template ToString<AZStd::string>().data(), // 'template' because clang says "error: use 'template' keyword to treat 'ToString' as a dependent template name"
+                        value.GetTypeId().ToString<AZStd::string>().data());
+                }
+                return defaultValue;
+            }
+        }
+
+        // Using explicit instantiation to restrict GetPropertyValue to the set of types that we support
+
+        template const bool&     MaterialPropertyCollection::GetPropertyValue<bool>     (MaterialPropertyIndex index) const;
+        template const int32_t&  MaterialPropertyCollection::GetPropertyValue<int32_t>  (MaterialPropertyIndex index) const;
+        template const uint32_t& MaterialPropertyCollection::GetPropertyValue<uint32_t> (MaterialPropertyIndex index) const;
+        template const float&    MaterialPropertyCollection::GetPropertyValue<float>    (MaterialPropertyIndex index) const;
+        template const Vector2&  MaterialPropertyCollection::GetPropertyValue<Vector2>  (MaterialPropertyIndex index) const;
+        template const Vector3&  MaterialPropertyCollection::GetPropertyValue<Vector3>  (MaterialPropertyIndex index) const;
+        template const Vector4&  MaterialPropertyCollection::GetPropertyValue<Vector4>  (MaterialPropertyIndex index) const;
+        template const Color&    MaterialPropertyCollection::GetPropertyValue<Color>    (MaterialPropertyIndex index) const;
+        template const Data::Instance<Image>& MaterialPropertyCollection::GetPropertyValue<Data::Instance<Image>>(MaterialPropertyIndex index) const;
+
+        const MaterialPropertyFlags& MaterialPropertyCollection::GetPropertyDirtyFlags() const
+        {
+            return m_propertyDirtyFlags;
+        }
+
+        RHI::ConstPtr<MaterialPropertiesLayout> MaterialPropertyCollection::GetMaterialPropertiesLayout() const
+        {
+            return m_layout;
+        }
+
+        template<typename Type>
+        bool MaterialPropertyCollection::ValidatePropertyAccess(const MaterialPropertyDescriptor* propertyDescriptor) const
+        {
+            // Note that we have warnings here instead of errors because this can happen while materials are hot reloading
+            // after a material property layout changes in the MaterialTypeAsset, as there's a brief time when the data
+            // might be out of sync between MaterialAssets and MaterialTypeAssets.
+
+            if (!propertyDescriptor)
+            {
+                AZ_Warning("MaterialPropertyCollection", false, "MaterialPropertyDescriptor is null");
+                return false;
+            }
+
+            AZ::TypeId accessDataType = azrtti_typeid<Type>();
+
+            // Must align with the order in MaterialPropertyDataType
+            static const AZStd::array<AZ::TypeId, MaterialPropertyDataTypeCount> types =
+            {{
+                AZ::TypeId{}, // Invalid
+                azrtti_typeid<bool>(),
+                azrtti_typeid<int32_t>(),
+                azrtti_typeid<uint32_t>(),
+                azrtti_typeid<float>(),
+                azrtti_typeid<Vector2>(),
+                azrtti_typeid<Vector3>(),
+                azrtti_typeid<Vector4>(),
+                azrtti_typeid<Color>(),
+                azrtti_typeid<Data::Instance<Image>>(),
+                azrtti_typeid<uint32_t>()
+            }};
+
+            AZ::TypeId actualDataType = types[static_cast<size_t>(propertyDescriptor->GetDataType())];
+
+            if (accessDataType != actualDataType)
+            {
+                AZ_Warning("MaterialPropertyCollection", false, "Material property '%s': Accessed as type %s but is type %s",
+                    propertyDescriptor->GetName().GetCStr(),
+                    GetMaterialPropertyDataTypeString(accessDataType).c_str(),
+                    ToString(propertyDescriptor->GetDataType()));
+                return false;
+            }
+
+            return true;
+        }
+
+    } // namespace RPI
+} // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialPropertyDescriptor.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialPropertyDescriptor.cpp
@@ -99,7 +99,7 @@ namespace AZ
             }
         }
         
-        bool ValidateMaterialPropertyDataType(TypeId typeId, const Name& propertyName, const MaterialPropertyDescriptor* materialPropertyDescriptor, AZStd::function<void(const char*)> onError)
+        bool ValidateMaterialPropertyDataType(TypeId typeId, const MaterialPropertyDescriptor* materialPropertyDescriptor, AZStd::function<void(const char*)> onError)
         {
             auto toMaterialPropertyDataType = [](TypeId typeId)
             {
@@ -127,7 +127,7 @@ namespace AZ
                 {
                     onError(
                         AZStd::string::format("Material property '%s' is a Enum type, can only accept UInt value, input value is %s",
-                            propertyName.GetCStr(),
+                            materialPropertyDescriptor->GetName().GetCStr(),
                             ToString(actualDataType)
                         ).data());
                     return false;
@@ -139,7 +139,7 @@ namespace AZ
                 {
                     onError(
                         AZStd::string::format("Material property '%s': Type mismatch. Expected %s but was %s",
-                            propertyName.GetCStr(),
+                            materialPropertyDescriptor->GetName().GetCStr(),
                             ToString(expectedDataType),
                             ToString(actualDataType)
                         ).data());

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAsset.cpp
@@ -159,7 +159,7 @@ namespace AZ
             return m_materialPropertiesLayout.get();
         }
 
-        AZStd::span<const MaterialPropertyValue> MaterialTypeAsset::GetDefaultPropertyValues() const
+        const AZStd::vector<MaterialPropertyValue>& MaterialTypeAsset::GetDefaultPropertyValues() const
         {
             return m_propertyValues;
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAssetCreator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAssetCreator.cpp
@@ -478,7 +478,7 @@ namespace AZ
                 return false;
             }
 
-            if (!ValidateMaterialPropertyDataType(typeId, name, materialPropertyDescriptor, [this](const char* message){ReportError("%s", message);}))
+            if (!ValidateMaterialPropertyDataType(typeId, materialPropertyDescriptor, [this](const char* message){ReportError("%s", message);}))
             {
                 return false;
             }

--- a/Gems/Atom/RPI/Code/Tests/Material/LuaMaterialFunctorTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/LuaMaterialFunctorTests.cpp
@@ -757,8 +757,7 @@ namespace UnitTest
         Ptr<MaterialFunctor> functor = testData.GetMaterialTypeAsset()->GetMaterialFunctors()[0];
 
         AZ::RPI::MaterialFunctor::EditorContext context = AZ::RPI::MaterialFunctor::EditorContext(
-            testData.GetMaterial()->GetPropertyValues(),
-            testData.GetMaterial()->GetMaterialPropertiesLayout(),
+            testData.GetMaterial()->GetPropertyCollection(),
             propertyDynamicMetadata,
             propertyGroupDynamicMetadata,
             changedPropertyNames,
@@ -826,8 +825,7 @@ namespace UnitTest
         Ptr<MaterialFunctor> functor = testData.GetMaterialTypeAsset()->GetMaterialFunctors()[0];
 
         AZ::RPI::MaterialFunctor::EditorContext context = AZ::RPI::MaterialFunctor::EditorContext(
-            testData.GetMaterial()->GetPropertyValues(),
-            testData.GetMaterial()->GetMaterialPropertiesLayout(),
+            testData.GetMaterial()->GetPropertyCollection(),
             propertyDynamicMetadata,
             propertyGroupDynamicMetadata,
             changedPropertyNames,
@@ -892,8 +890,7 @@ namespace UnitTest
         Ptr<MaterialFunctor> functor = testData.GetMaterialTypeAsset()->GetMaterialFunctors()[0];
 
         AZ::RPI::MaterialFunctor::EditorContext context = AZ::RPI::MaterialFunctor::EditorContext(
-            testData.GetMaterial()->GetPropertyValues(),
-            testData.GetMaterial()->GetMaterialPropertiesLayout(),
+            testData.GetMaterial()->GetPropertyCollection(),
             propertyDynamicMetadata,
             propertyGroupDynamicMetadata,
             changedPropertyNames,

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialFunctorTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialFunctorTests.cpp
@@ -155,6 +155,8 @@ namespace UnitTest
 
         // Most of this data can be empty since this particular functor doesn't access it.
         AZStd::vector<MaterialPropertyValue> unusedPropertyValues;
+        MaterialPropertyCollection properties;
+        properties.Init(materialTypeAsset->GetMaterialPropertiesLayout(), unusedPropertyValues);
         ShaderResourceGroup* unusedSrg = nullptr;
 
 
@@ -163,8 +165,7 @@ namespace UnitTest
         {
             // Successfully set o_optionA
             MaterialFunctor::RuntimeContext runtimeContext = MaterialFunctor::RuntimeContext{
-                unusedPropertyValues,
-                materialTypeAsset->GetMaterialPropertiesLayout(),
+                properties,
                 &shaderCollectionCopy,
                 unusedSrg,
                 &testFunctorSetOptionA.GetMaterialPropertyDependencies(),
@@ -180,8 +181,7 @@ namespace UnitTest
         {
             // Successfully set o_optionB
             MaterialFunctor::RuntimeContext runtimeContext = MaterialFunctor::RuntimeContext{
-                unusedPropertyValues,
-                materialTypeAsset->GetMaterialPropertiesLayout(),
+                properties,
                 &shaderCollectionCopy,
                 unusedSrg,
                 &testFunctorSetOptionB.GetMaterialPropertyDependencies(),
@@ -198,8 +198,7 @@ namespace UnitTest
             // Fail to set o_optionC because it is not owned by the material type
             AZ_TEST_START_TRACE_SUPPRESSION;
             MaterialFunctor::RuntimeContext runtimeContext = MaterialFunctor::RuntimeContext{
-                unusedPropertyValues,
-                materialTypeAsset->GetMaterialPropertiesLayout(),
+                properties,
                 &shaderCollectionCopy,
                 unusedSrg,
                 &testFunctorSetOptionC.GetMaterialPropertyDependencies(),
@@ -214,8 +213,7 @@ namespace UnitTest
             // Fail to set option index that is out of range
             AZ_TEST_START_TRACE_SUPPRESSION;
             MaterialFunctor::RuntimeContext runtimeContext = MaterialFunctor::RuntimeContext{
-                unusedPropertyValues,
-                materialTypeAsset->GetMaterialPropertiesLayout(),
+                properties,
                 &shaderCollectionCopy,
                 unusedSrg,
                 &testFunctorSetOptionInvalid.GetMaterialPropertyDependencies(),

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialPropertySerializerTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialPropertySerializerTests.cpp
@@ -18,18 +18,20 @@
 namespace JsonSerializationTests
 {
     class MaterialPropertySerializerTestDescription :
-        public JsonSerializerConformityTestDescriptor<AZ::RPI::MaterialTypeSourceData::PropertyDefinition>
+        public JsonSerializerConformityTestDescriptor<AZ::RPI::MaterialPropertySourceData>
     {
     public:
         void Reflect(AZStd::unique_ptr<AZ::SerializeContext>& context) override
         {
             AZ::RPI::MaterialTypeSourceData::Reflect(context.get());
+            AZ::RPI::MaterialPropertySourceData::Reflect(context.get());
             AZ::RPI::MaterialPropertyDescriptor::Reflect(context.get());
             AZ::RPI::ReflectMaterialDynamicMetadata(context.get());
         }
 
         void Reflect(AZStd::unique_ptr<AZ::JsonRegistrationContext>& context) override
         {
+            AZ::RPI::MaterialPropertySourceData::Reflect(context.get());
             AZ::RPI::MaterialTypeSourceData::Reflect(context.get());
         }
 
@@ -38,14 +40,14 @@ namespace JsonSerializationTests
             return AZStd::make_shared<AZ::RPI::JsonMaterialPropertySerializer>();
         }
 
-        AZStd::shared_ptr<AZ::RPI::MaterialTypeSourceData::PropertyDefinition> CreateDefaultInstance() override
+        AZStd::shared_ptr<AZ::RPI::MaterialPropertySourceData> CreateDefaultInstance() override
         {
-            return AZStd::make_shared<AZ::RPI::MaterialTypeSourceData::PropertyDefinition>();
+            return AZStd::make_shared<AZ::RPI::MaterialPropertySourceData>();
         }
 
-        AZStd::shared_ptr<AZ::RPI::MaterialTypeSourceData::PropertyDefinition> CreatePartialDefaultInstance() override
+        AZStd::shared_ptr<AZ::RPI::MaterialPropertySourceData> CreatePartialDefaultInstance() override
         {
-            auto result = AZStd::make_shared<AZ::RPI::MaterialTypeSourceData::PropertyDefinition>("testProperty");
+            auto result = AZStd::make_shared<AZ::RPI::MaterialPropertySourceData>("testProperty");
             result->m_dataType = AZ::RPI::MaterialPropertyDataType::Float;
             result->m_step = 1.0f;
             result->m_value = 0.0f;
@@ -62,9 +64,9 @@ namespace JsonSerializationTests
             })";
         }
 
-        AZStd::shared_ptr<AZ::RPI::MaterialTypeSourceData::PropertyDefinition> CreateFullySetInstance() override
+        AZStd::shared_ptr<AZ::RPI::MaterialPropertySourceData> CreateFullySetInstance() override
         {
-            auto result = AZStd::make_shared<AZ::RPI::MaterialTypeSourceData::PropertyDefinition>("testProperty");
+            auto result = AZStd::make_shared<AZ::RPI::MaterialPropertySourceData>("testProperty");
             result->m_description = "description";
             result->m_displayName = "display_name";
             result->m_dataType = AZ::RPI::MaterialPropertyDataType::Float;
@@ -111,8 +113,8 @@ namespace JsonSerializationTests
         }
 
         bool AreEqual(
-            const AZ::RPI::MaterialTypeSourceData::PropertyDefinition& lhs,
-            const AZ::RPI::MaterialTypeSourceData::PropertyDefinition& rhs) override
+            const AZ::RPI::MaterialPropertySourceData& lhs,
+            const AZ::RPI::MaterialPropertySourceData& rhs) override
         {
             if (lhs.GetName() != rhs.GetName()) { return false; }
             if (lhs.m_description != rhs.m_description) { return false; }
@@ -157,6 +159,7 @@ namespace UnitTest
         void Reflect(ReflectContext* context) override
         {
             RPITestFixture::Reflect(context);
+            MaterialPropertySourceData::Reflect(context);
             MaterialTypeSourceData::Reflect(context);
         }
         
@@ -187,7 +190,7 @@ namespace UnitTest
         }
         )";
 
-        MaterialTypeSourceData::PropertyDefinition propertyData;
+        MaterialPropertySourceData propertyData;
         JsonTestResult loadResult = LoadTestDataFromJson(propertyData, inputJson);
 
         EXPECT_EQ(AZ::JsonSerializationResult::Tasks::ReadField, loadResult.m_jsonResultCode.GetTask());
@@ -220,7 +223,7 @@ namespace UnitTest
         }
         )";
 
-        MaterialTypeSourceData::PropertyDefinition propertyData;
+        MaterialPropertySourceData propertyData;
         JsonTestResult loadResult = LoadTestDataFromJson(propertyData, inputJson);
 
         EXPECT_EQ(AZ::JsonSerializationResult::Tasks::ReadField, loadResult.m_jsonResultCode.GetTask());
@@ -244,7 +247,7 @@ namespace UnitTest
         []
         )";
 
-        MaterialTypeSourceData::PropertyDefinition propertyData;
+        MaterialPropertySourceData propertyData;
         JsonTestResult loadResult = LoadTestDataFromJson(propertyData, inputJson);
 
         EXPECT_EQ(AZ::JsonSerializationResult::Tasks::ReadField, loadResult.m_jsonResultCode.GetTask());
@@ -263,7 +266,7 @@ namespace UnitTest
         }
         )";
 
-        MaterialTypeSourceData::PropertyDefinition propertyData;
+        MaterialPropertySourceData propertyData;
         JsonTestResult loadResult = LoadTestDataFromJson(propertyData, inputJson);
         
         EXPECT_EQ(AZ::JsonSerializationResult::Tasks::ReadField, loadResult.m_jsonResultCode.GetTask());
@@ -313,7 +316,7 @@ namespace UnitTest
         ]
         )";
 
-        AZStd::vector<MaterialTypeSourceData::PropertyDefinition> propertyData;
+        AZStd::vector<MaterialPropertySourceData> propertyData;
         JsonTestResult loadResult = LoadTestDataFromJson(propertyData, inputJson);
 
         EXPECT_EQ(AZ::JsonSerializationResult::Tasks::ReadField, loadResult.m_jsonResultCode.GetTask());
@@ -386,7 +389,7 @@ namespace UnitTest
         ]
         )";
 
-        AZStd::vector<MaterialTypeSourceData::PropertyDefinition> propertyData;
+        AZStd::vector<MaterialPropertySourceData> propertyData;
         JsonTestResult loadResult = LoadTestDataFromJson(propertyData, inputJson);
 
         EXPECT_EQ(AZ::JsonSerializationResult::Tasks::ReadField, loadResult.m_jsonResultCode.GetTask());
@@ -402,7 +405,7 @@ namespace UnitTest
         EXPECT_EQ(MaterialPropertyDataType::UInt, propertyData[2].m_dataType);
         EXPECT_EQ(AZ::RPI::MaterialPropertyValue(0u), propertyData[2].m_value);
 
-        for (const MaterialTypeSourceData::PropertyDefinition& property : propertyData)
+        for (const MaterialPropertySourceData& property : propertyData)
         {
             EXPECT_FALSE(property.m_min.IsValid());
             EXPECT_FALSE(property.m_max.IsValid());
@@ -435,7 +438,7 @@ namespace UnitTest
         ]
         )";
 
-        AZStd::vector<MaterialTypeSourceData::PropertyDefinition> propertyData;
+        AZStd::vector<MaterialPropertySourceData> propertyData;
         JsonTestResult loadResult = LoadTestDataFromJson(propertyData, inputJson);
 
         EXPECT_EQ(AZ::JsonSerializationResult::Tasks::ReadField, loadResult.m_jsonResultCode.GetTask());
@@ -507,7 +510,7 @@ namespace UnitTest
         ]
         )";
 
-        AZStd::vector<MaterialTypeSourceData::PropertyDefinition> propertyData;
+        AZStd::vector<MaterialPropertySourceData> propertyData;
         JsonTestResult loadResult = LoadTestDataFromJson(propertyData, inputJson);
 
         EXPECT_EQ(AZ::JsonSerializationResult::Tasks::ReadField, loadResult.m_jsonResultCode.GetTask());
@@ -556,7 +559,7 @@ namespace UnitTest
         ]
         )";
 
-        AZStd::vector<MaterialTypeSourceData::PropertyDefinition> propertyData;
+        AZStd::vector<MaterialPropertySourceData> propertyData;
         JsonTestResult loadResult = LoadTestDataFromJson(propertyData, inputJson);
 
         EXPECT_EQ(AZ::JsonSerializationResult::Tasks::ReadField, loadResult.m_jsonResultCode.GetTask());
@@ -620,7 +623,7 @@ namespace UnitTest
         ]
         )";
 
-        AZStd::vector<MaterialTypeSourceData::PropertyDefinition> propertyData;
+        AZStd::vector<MaterialPropertySourceData> propertyData;
         JsonTestResult loadResult = LoadTestDataFromJson(propertyData, inputJson);
 
         EXPECT_EQ(AZ::JsonSerializationResult::Tasks::ReadField, loadResult.m_jsonResultCode.GetTask());
@@ -688,7 +691,7 @@ namespace UnitTest
         ]
         )";
 
-        AZStd::vector<MaterialTypeSourceData::PropertyDefinition> propertyData;
+        AZStd::vector<MaterialPropertySourceData> propertyData;
         JsonTestResult loadResult = LoadTestDataFromJson(propertyData, inputJson);
 
         EXPECT_EQ(AZ::JsonSerializationResult::Tasks::ReadField, loadResult.m_jsonResultCode.GetTask());
@@ -750,7 +753,7 @@ namespace UnitTest
         ]
         )";
 
-        AZStd::vector<MaterialTypeSourceData::PropertyDefinition> propertyData;
+        AZStd::vector<MaterialPropertySourceData> propertyData;
         JsonTestResult loadResult = LoadTestDataFromJson(propertyData, inputJson);
 
         EXPECT_EQ(AZ::JsonSerializationResult::Tasks::ReadField, loadResult.m_jsonResultCode.GetTask());
@@ -787,7 +790,7 @@ namespace UnitTest
         }
         )";
 
-        MaterialTypeSourceData::PropertyDefinition propertyData;
+        MaterialPropertySourceData propertyData;
         JsonTestResult loadResult = LoadTestDataFromJson(propertyData, inputJson);
 
         EXPECT_EQ(AZ::JsonSerializationResult::Tasks::ReadField, loadResult.m_jsonResultCode.GetTask());
@@ -819,7 +822,7 @@ namespace UnitTest
         }
         )";
 
-        MaterialTypeSourceData::PropertyDefinition propertyData;
+        MaterialPropertySourceData propertyData;
         JsonTestResult loadResult = LoadTestDataFromJson(propertyData, inputJson);
 
         EXPECT_EQ(AZ::JsonSerializationResult::Tasks::ReadField, loadResult.m_jsonResultCode.GetTask());
@@ -855,7 +858,7 @@ namespace UnitTest
         }
         )";
 
-        MaterialTypeSourceData::PropertyDefinition propertyData;
+        MaterialPropertySourceData propertyData;
         JsonTestResult loadResult = LoadTestDataFromJson(propertyData, inputJson);
 
         EXPECT_EQ(AZ::JsonSerializationResult::Tasks::ReadField, loadResult.m_jsonResultCode.GetTask());
@@ -893,7 +896,7 @@ namespace UnitTest
         }
         )";
 
-        MaterialTypeSourceData::PropertyDefinition propertyData;
+        MaterialPropertySourceData propertyData;
         JsonTestResult loadResult = LoadTestDataFromJson(propertyData, inputJson);
 
         EXPECT_EQ(AZ::JsonSerializationResult::Tasks::ReadField, loadResult.m_jsonResultCode.GetTask());
@@ -922,7 +925,7 @@ namespace UnitTest
         }
         )";
 
-        MaterialTypeSourceData::PropertyDefinition propertyData;
+        MaterialPropertySourceData propertyData;
         JsonTestResult loadResult = LoadTestDataFromJson(propertyData, inputJson);
 
         EXPECT_EQ(AZ::JsonSerializationResult::Tasks::ReadField, loadResult.m_jsonResultCode.GetTask());

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialSourceDataTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialSourceDataTests.cpp
@@ -46,6 +46,7 @@ namespace UnitTest
         void Reflect(AZ::ReflectContext* context) override
         {
             RPITestFixture::Reflect(context);
+            MaterialPropertySourceData::Reflect(context);
             MaterialTypeSourceData::Reflect(context);
             MaterialSourceData::Reflect(context);
         }

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialTypeSourceDataTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialTypeSourceDataTests.cpp
@@ -315,6 +315,7 @@ namespace UnitTest
         {
             RPITestFixture::Reflect(context);
 
+            MaterialPropertySourceData::Reflect(context);
             MaterialTypeSourceData::Reflect(context);
 
             MaterialFunctorSourceDataHolder::Reflect(context);
@@ -413,7 +414,7 @@ namespace UnitTest
 
         //! Checks for a match between source data and MaterialPropertyDescriptor, for only the fields that correspond 1:1.
         //! (Note this function can't be used in every case, because there are cases where output connections will not correspond 1:1)
-        void ValidateCommonDescriptorFields(const MaterialTypeSourceData::PropertyDefinition& expectedValues, const MaterialPropertyDescriptor* propertyDescriptor)
+        void ValidateCommonDescriptorFields(const MaterialPropertySourceData& expectedValues, const MaterialPropertyDescriptor* propertyDescriptor)
         {
             EXPECT_EQ(propertyDescriptor->GetDataType(), expectedValues.m_dataType);
             EXPECT_EQ(propertyDescriptor->GetOutputConnections().size(), expectedValues.m_outputConnections.size());
@@ -441,22 +442,22 @@ namespace UnitTest
         MaterialTypeSourceData::PropertyGroup* layer1_roughness = sourceData.AddPropertyGroup("layer1.roughness");
         MaterialTypeSourceData::PropertyGroup* layer2_roughness = sourceData.AddPropertyGroup("layer2.roughness");
 
-        MaterialTypeSourceData::PropertyDefinition* layer1_baseColor_texture = layer1_baseColor->AddProperty("texture");
-        MaterialTypeSourceData::PropertyDefinition* layer2_baseColor_texture = layer2_baseColor->AddProperty("texture");
+        MaterialPropertySourceData* layer1_baseColor_texture = layer1_baseColor->AddProperty("texture");
+        MaterialPropertySourceData* layer2_baseColor_texture = layer2_baseColor->AddProperty("texture");
         
-        MaterialTypeSourceData::PropertyDefinition* layer1_roughness_texture = sourceData.AddProperty("layer1.roughness.texture");
-        MaterialTypeSourceData::PropertyDefinition* layer2_roughness_texture = sourceData.AddProperty("layer2.roughness.texture");
+        MaterialPropertySourceData* layer1_roughness_texture = sourceData.AddProperty("layer1.roughness.texture");
+        MaterialPropertySourceData* layer2_roughness_texture = sourceData.AddProperty("layer2.roughness.texture");
         
         // We're doing clear coat only on layer2, for brevity
         MaterialTypeSourceData::PropertyGroup* layer2_clearCoat = layer2->AddPropertyGroup("clearCoat");
         MaterialTypeSourceData::PropertyGroup* layer2_clearCoat_roughness = layer2_clearCoat->AddPropertyGroup("roughness");
         MaterialTypeSourceData::PropertyGroup* layer2_clearCoat_normal = layer2_clearCoat->AddPropertyGroup("normal");
-        MaterialTypeSourceData::PropertyDefinition* layer2_clearCoat_enabled = layer2_clearCoat->AddProperty("enabled");
-        MaterialTypeSourceData::PropertyDefinition* layer2_clearCoat_roughness_texture = layer2_clearCoat_roughness->AddProperty("texture");
-        MaterialTypeSourceData::PropertyDefinition* layer2_clearCoat_normal_texture = layer2_clearCoat_normal->AddProperty("texture");
-        MaterialTypeSourceData::PropertyDefinition* layer2_clearCoat_normal_factor = layer2_clearCoat_normal->AddProperty("factor");
+        MaterialPropertySourceData* layer2_clearCoat_enabled = layer2_clearCoat->AddProperty("enabled");
+        MaterialPropertySourceData* layer2_clearCoat_roughness_texture = layer2_clearCoat_roughness->AddProperty("texture");
+        MaterialPropertySourceData* layer2_clearCoat_normal_texture = layer2_clearCoat_normal->AddProperty("texture");
+        MaterialPropertySourceData* layer2_clearCoat_normal_factor = layer2_clearCoat_normal->AddProperty("factor");
 
-        MaterialTypeSourceData::PropertyDefinition* blend_factor = blend->AddProperty("factor");
+        MaterialPropertySourceData* blend_factor = blend->AddProperty("factor");
 
         // Check the available Find functions
 
@@ -534,10 +535,10 @@ namespace UnitTest
         
         struct EnumeratePropertiesResult
         {
-            const MaterialTypeSourceData::PropertyDefinition* m_propertyDefinition;
+            const MaterialPropertySourceData* m_propertyDefinition;
             MaterialNameContext m_materialNameContext;
 
-            void Check(AZStd::string expectedIdContext, const MaterialTypeSourceData::PropertyDefinition* expectedPropertyDefinition)
+            void Check(AZStd::string expectedIdContext, const MaterialPropertySourceData* expectedPropertyDefinition)
             {
                 Name propertyFullId{m_propertyDefinition->GetName()};
                 m_materialNameContext.ContextualizeProperty(propertyFullId);
@@ -550,7 +551,7 @@ namespace UnitTest
         };
         AZStd::vector<EnumeratePropertiesResult> enumeratePropertiesResults;
 
-        sourceData.EnumerateProperties([&enumeratePropertiesResults](const MaterialTypeSourceData::PropertyDefinition* propertyDefinition, const MaterialNameContext& nameContext)
+        sourceData.EnumerateProperties([&enumeratePropertiesResults](const MaterialPropertySourceData* propertyDefinition, const MaterialNameContext& nameContext)
             {
                 enumeratePropertiesResults.push_back(EnumeratePropertiesResult{propertyDefinition, nameContext});
                 return true;
@@ -709,10 +710,10 @@ namespace UnitTest
         sourceData.AddPropertyGroup("c.d");
         sourceData.AddPropertyGroup("c.d.e");
 
-        MaterialTypeSourceData::PropertyDefinition* enum1 = sourceData.AddProperty("a.enum1");
-        MaterialTypeSourceData::PropertyDefinition* enum2 = sourceData.AddProperty("a.b.enum2");
-        MaterialTypeSourceData::PropertyDefinition* enum3 = sourceData.AddProperty("c.d.e.enum3");
-        MaterialTypeSourceData::PropertyDefinition* notEnum = sourceData.AddProperty("c.d.myFloat");
+        MaterialPropertySourceData* enum1 = sourceData.AddProperty("a.enum1");
+        MaterialPropertySourceData* enum2 = sourceData.AddProperty("a.b.enum2");
+        MaterialPropertySourceData* enum3 = sourceData.AddProperty("c.d.e.enum3");
+        MaterialPropertySourceData* notEnum = sourceData.AddProperty("c.d.myFloat");
 
         enum1->m_dataType = MaterialPropertyDataType::Enum;
         enum2->m_dataType = MaterialPropertyDataType::Enum;
@@ -906,12 +907,12 @@ namespace UnitTest
         sourceData.m_shaderCollection.push_back(MaterialTypeSourceData::ShaderVariantReferenceData{ TestShaderFilename });
 
         MaterialTypeSourceData::PropertyGroup* propertyGroup = sourceData.AddPropertyGroup("general");
-        MaterialTypeSourceData::PropertyDefinition* property = propertyGroup->AddProperty("MyBool");
+        MaterialPropertySourceData* property = propertyGroup->AddProperty("MyBool");
         property->m_displayName = "My Bool";
         property->m_description = "This is a bool";
         property->m_dataType = MaterialPropertyDataType::Bool;
         property->m_value = true;
-        property->m_outputConnections.push_back(MaterialTypeSourceData::PropertyConnection{ MaterialPropertyOutputType::ShaderInput, AZStd::string("m_bool") });
+        property->m_outputConnections.push_back(MaterialPropertySourceData::Connection{ MaterialPropertyOutputType::ShaderInput, AZStd::string("m_bool") });
         
         auto materialTypeOutcome = sourceData.CreateMaterialTypeAsset(Uuid::CreateRandom());
         EXPECT_TRUE(materialTypeOutcome.IsSuccess());
@@ -932,7 +933,7 @@ namespace UnitTest
         sourceData.m_shaderCollection.push_back(MaterialTypeSourceData::ShaderVariantReferenceData{ TestShaderFilename });
         
         MaterialTypeSourceData::PropertyGroup* propertyGroup = sourceData.AddPropertyGroup("general");
-        MaterialTypeSourceData::PropertyDefinition* property = propertyGroup->AddProperty("MyFloat");
+        MaterialPropertySourceData* property = propertyGroup->AddProperty("MyFloat");
         property->m_displayName = "My Float";
         property->m_description = "This is a float";
         property->m_min = 0.0f;
@@ -942,7 +943,7 @@ namespace UnitTest
         property->m_value = 0.0f; 
         property->m_step = 0.01f;
         property->m_dataType = MaterialPropertyDataType::Float;
-        property->m_outputConnections.push_back(MaterialTypeSourceData::PropertyConnection{ MaterialPropertyOutputType::ShaderInput, AZStd::string("m_float") });
+        property->m_outputConnections.push_back(MaterialPropertySourceData::Connection{ MaterialPropertyOutputType::ShaderInput, AZStd::string("m_float") });
         
         auto materialTypeOutcome = sourceData.CreateMaterialTypeAsset(Uuid::CreateRandom());
         EXPECT_TRUE(materialTypeOutcome.IsSuccess());
@@ -963,12 +964,12 @@ namespace UnitTest
         sourceData.m_shaderCollection.push_back(MaterialTypeSourceData::ShaderVariantReferenceData{ TestShaderFilename });
         
         MaterialTypeSourceData::PropertyGroup* propertyGroup = sourceData.AddPropertyGroup("general");
-        MaterialTypeSourceData::PropertyDefinition* property = propertyGroup->AddProperty("MyImage");
+        MaterialPropertySourceData* property = propertyGroup->AddProperty("MyImage");
         property->m_displayName = "My Image";
         property->m_description = "This is an image";
         property->m_dataType = MaterialPropertyDataType::Image;
         property->m_value = AZStd::string{};
-        property->m_outputConnections.push_back(MaterialTypeSourceData::PropertyConnection{ MaterialPropertyOutputType::ShaderInput, AZStd::string("m_image") });
+        property->m_outputConnections.push_back(MaterialPropertySourceData::Connection{ MaterialPropertyOutputType::ShaderInput, AZStd::string("m_image") });
         
         auto materialTypeOutcome = sourceData.CreateMaterialTypeAsset(Uuid::CreateRandom());
         EXPECT_TRUE(materialTypeOutcome.IsSuccess());
@@ -989,11 +990,11 @@ namespace UnitTest
         sourceData.m_shaderCollection.push_back(MaterialTypeSourceData::ShaderVariantReferenceData{TestShaderFilename});
         
         MaterialTypeSourceData::PropertyGroup* propertyGroup = sourceData.AddPropertyGroup("general");
-        MaterialTypeSourceData::PropertyDefinition* property = propertyGroup->AddProperty("MyInt");
+        MaterialPropertySourceData* property = propertyGroup->AddProperty("MyInt");
         property->m_displayName = "My Integer";
         property->m_dataType = MaterialPropertyDataType::Int;
         property->m_value = 0;
-        property->m_outputConnections.push_back(MaterialTypeSourceData::PropertyConnection{MaterialPropertyOutputType::ShaderOption, AZStd::string("o_foo")});
+        property->m_outputConnections.push_back(MaterialPropertySourceData::Connection{MaterialPropertyOutputType::ShaderOption, AZStd::string("o_foo")});
         
         auto materialTypeOutcome = sourceData.CreateMaterialTypeAsset(Uuid::CreateRandom());
         EXPECT_TRUE(materialTypeOutcome.IsSuccess());
@@ -1017,17 +1018,17 @@ namespace UnitTest
 
         MaterialTypeSourceData::PropertyGroup* propertyGroup = sourceData.AddPropertyGroup("general");
 
-        MaterialTypeSourceData::PropertyDefinition* property1 = propertyGroup->AddProperty("EnableShader1");
+        MaterialPropertySourceData* property1 = propertyGroup->AddProperty("EnableShader1");
         property1->m_displayName = "Enable Shader 1";
         property1->m_dataType = MaterialPropertyDataType::Bool;
         property1->m_value = true;
-        property1->m_outputConnections.push_back(MaterialTypeSourceData::PropertyConnection { MaterialPropertyOutputType::ShaderEnabled, AZStd::string("first") });
+        property1->m_outputConnections.push_back(MaterialPropertySourceData::Connection { MaterialPropertyOutputType::ShaderEnabled, AZStd::string("first") });
 
-        MaterialTypeSourceData::PropertyDefinition* property2 = propertyGroup->AddProperty("EnableShader2");
+        MaterialPropertySourceData* property2 = propertyGroup->AddProperty("EnableShader2");
         property2->m_displayName = "Enable Shader 2";
         property2->m_dataType = MaterialPropertyDataType::Bool;
         property2->m_value = true;
-        property2->m_outputConnections.push_back(MaterialTypeSourceData::PropertyConnection { MaterialPropertyOutputType::ShaderEnabled, AZStd::string("second") });
+        property2->m_outputConnections.push_back(MaterialPropertySourceData::Connection { MaterialPropertyOutputType::ShaderEnabled, AZStd::string("second") });
 
         auto materialTypeOutcome = sourceData.CreateMaterialTypeAsset(Uuid::CreateRandom());
         EXPECT_TRUE(materialTypeOutcome.IsSuccess());
@@ -1051,9 +1052,9 @@ namespace UnitTest
         sourceData.m_shaderCollection.push_back(MaterialTypeSourceData::ShaderVariantReferenceData{TestShaderFilename});
         
         MaterialTypeSourceData::PropertyGroup* propertyGroup = sourceData.AddPropertyGroup("general");
-        MaterialTypeSourceData::PropertyDefinition* property = propertyGroup->AddProperty("MyInt");
+        MaterialPropertySourceData* property = propertyGroup->AddProperty("MyInt");
         property->m_dataType = MaterialPropertyDataType::Int;
-        property->m_outputConnections.push_back(MaterialTypeSourceData::PropertyConnection{MaterialPropertyOutputType::ShaderOption, AZStd::string("DoesNotExist")});
+        property->m_outputConnections.push_back(MaterialPropertySourceData::Connection{MaterialPropertyOutputType::ShaderOption, AZStd::string("DoesNotExist")});
         
         AZ_TEST_START_TRACE_SUPPRESSION;
         auto materialTypeOutcome = sourceData.CreateMaterialTypeAsset(Uuid::CreateRandom());
@@ -1265,7 +1266,7 @@ namespace UnitTest
         sourceData.m_shaderCollection.push_back(MaterialTypeSourceData::ShaderVariantReferenceData{ "shaderC.shader" });
         
         MaterialTypeSourceData::PropertyGroup* propertyGroup = sourceData.AddPropertyGroup("general");
-        MaterialTypeSourceData::PropertyDefinition* property = propertyGroup->AddProperty("MyInt");
+        MaterialPropertySourceData* property = propertyGroup->AddProperty("MyInt");
 
         property->m_displayName = "Integer";
         property->m_description = "Integer property that is connected to multiple shader settings";
@@ -1273,11 +1274,11 @@ namespace UnitTest
         property->m_value = 0;
 
         // The value maps to m_int in the SRG
-        property->m_outputConnections.push_back(MaterialTypeSourceData::PropertyConnection{ MaterialPropertyOutputType::ShaderInput, AZStd::string("m_int") });
+        property->m_outputConnections.push_back(MaterialPropertySourceData::Connection{ MaterialPropertyOutputType::ShaderInput, AZStd::string("m_int") });
         // The value also maps to m_uint in the SRG
-        property->m_outputConnections.push_back(MaterialTypeSourceData::PropertyConnection{ MaterialPropertyOutputType::ShaderInput, AZStd::string("m_uint") });
+        property->m_outputConnections.push_back(MaterialPropertySourceData::Connection{ MaterialPropertyOutputType::ShaderInput, AZStd::string("m_uint") });
         // This will apply to all shaders that have a "o_efficiency", which means it will create two outputs in the property descriptor.
-        property->m_outputConnections.push_back(MaterialTypeSourceData::PropertyConnection{ MaterialPropertyOutputType::ShaderOption, AZStd::string("o_efficiency") });
+        property->m_outputConnections.push_back(MaterialPropertySourceData::Connection{ MaterialPropertyOutputType::ShaderOption, AZStd::string("o_efficiency") });
         
 
         // Do the actual test...
@@ -1313,7 +1314,7 @@ namespace UnitTest
         MaterialTypeSourceData sourceData;
         
         MaterialTypeSourceData::PropertyGroup* propertyGroup = sourceData.AddPropertyGroup("general");
-        MaterialTypeSourceData::PropertyDefinition* property = propertyGroup->AddProperty("floatForFunctor");
+        MaterialPropertySourceData* property = propertyGroup->AddProperty("floatForFunctor");
 
         property->m_displayName = "Float for Functor";
         property->m_description = "This float is processed by a functor, not with a direct connection";
@@ -1359,8 +1360,8 @@ namespace UnitTest
         sourceData.m_shaderCollection.push_back(MaterialTypeSourceData::ShaderVariantReferenceData{TestShaderFilename});
         
         MaterialTypeSourceData::PropertyGroup* propertyGroup = sourceData.AddPropertyGroup("general");
-        MaterialTypeSourceData::PropertyDefinition* property1 = propertyGroup->AddProperty("EnableSpecialPassA");
-        MaterialTypeSourceData::PropertyDefinition* property2 = propertyGroup->AddProperty("EnableSpecialPassB");
+        MaterialPropertySourceData* property1 = propertyGroup->AddProperty("EnableSpecialPassA");
+        MaterialPropertySourceData* property2 = propertyGroup->AddProperty("EnableSpecialPassB");
 
         property1->m_displayName = property2->m_displayName = "Enable Special Pass";
         property1->m_description = property2->m_description = "This is a bool to enable an extra shader/pass";
@@ -1418,7 +1419,7 @@ namespace UnitTest
         sourceData.m_shaderCollection.push_back(MaterialTypeSourceData::ShaderVariantReferenceData{TestShaderFilename});
         
         MaterialTypeSourceData::PropertyGroup* propertyGroup = sourceData.AddPropertyGroup("general");
-        MaterialTypeSourceData::PropertyDefinition* property = propertyGroup->AddProperty("MyProperty");
+        MaterialPropertySourceData* property = propertyGroup->AddProperty("MyProperty");
 
         property->m_dataType = MaterialPropertyDataType::Bool;
         property->m_value = false;
@@ -1453,7 +1454,7 @@ namespace UnitTest
         MaterialTypeSourceData sourceData;
         
         MaterialTypeSourceData::PropertyGroup* propertyGroup = sourceData.AddPropertyGroup("general");
-        MaterialTypeSourceData::PropertyDefinition* property = propertyGroup->AddProperty("floatForFunctor");
+        MaterialPropertySourceData* property = propertyGroup->AddProperty("floatForFunctor");
 
         property->m_dataType = MaterialPropertyDataType::Float;
         property->m_value = 0.0f;
@@ -1496,9 +1497,9 @@ namespace UnitTest
 
         auto addProperty = [&sourceData](MaterialPropertyDataType dateType, const char* propertyName, const char* srgConstantName, const AZ::RPI::MaterialPropertyValue& value)
         {
-            MaterialTypeSourceData::PropertyDefinition* property = sourceData.AddProperty(propertyName);
+            MaterialPropertySourceData* property = sourceData.AddProperty(propertyName);
             property->m_dataType = dateType;
-            property->m_outputConnections.push_back(MaterialTypeSourceData::PropertyConnection{ MaterialPropertyOutputType::ShaderInput, AZStd::string(srgConstantName) });
+            property->m_outputConnections.push_back(MaterialPropertySourceData::Connection{ MaterialPropertyOutputType::ShaderInput, AZStd::string(srgConstantName) });
             property->m_value = value;
         };
         
@@ -1564,9 +1565,9 @@ namespace UnitTest
 
         auto addSrgProperty = [&sourceData](MaterialPropertyDataType dateType, MaterialPropertyOutputType connectionType, const char* propertyName, const char* srgConstantName, const AZ::RPI::MaterialPropertyValue& value)
         {
-            MaterialTypeSourceData::PropertyDefinition* property = sourceData.AddProperty(propertyName);
+            MaterialPropertySourceData* property = sourceData.AddProperty(propertyName);
             property->m_dataType = dateType;
-            property->m_outputConnections.push_back(MaterialTypeSourceData::PropertyConnection{ connectionType, AZStd::string(srgConstantName) });
+            property->m_outputConnections.push_back(MaterialPropertySourceData::Connection{ connectionType, AZStd::string(srgConstantName) });
             property->m_value = value;
         };
         

--- a/Gems/Atom/RPI/Code/atom_rpi_edit_files.cmake
+++ b/Gems/Atom/RPI/Code/atom_rpi_edit_files.cmake
@@ -20,6 +20,7 @@ set(FILES
     Include/Atom/RPI.Edit/Material/MaterialPropertyConnectionSerializer.h
     Include/Atom/RPI.Edit/Material/MaterialPropertyGroupSerializer.h
     Include/Atom/RPI.Edit/Material/MaterialPropertySerializer.h
+    Include/Atom/RPI.Edit/Material/MaterialPropertySourceData.h
     Include/Atom/RPI.Edit/Material/MaterialPropertyValueSerializer.h
     Include/Atom/RPI.Edit/Material/MaterialPropertyValueSourceData.h
     Include/Atom/RPI.Edit/Material/MaterialPropertyValueSourceDataSerializer.h
@@ -41,6 +42,7 @@ set(FILES
     Source/RPI.Edit/Material/MaterialPropertyGroupSerializer.cpp
     Source/RPI.Edit/Material/MaterialPropertyConnectionSerializer.cpp
     Source/RPI.Edit/Material/MaterialPropertySerializer.cpp
+    Source/RPI.Edit/Material/MaterialPropertySourceData.cpp
     Source/RPI.Edit/Material/MaterialPropertyValueSerializer.cpp
     Source/RPI.Edit/Material/MaterialPropertyValueSourceData.cpp
     Source/RPI.Edit/Material/MaterialPropertyValueSourceDataSerializer.cpp

--- a/Gems/Atom/RPI/Code/atom_rpi_reflect_files.cmake
+++ b/Gems/Atom/RPI/Code/atom_rpi_reflect_files.cmake
@@ -55,6 +55,7 @@ set(FILES
     Include/Atom/RPI.Reflect/Material/MaterialAssetCreator.h
     Include/Atom/RPI.Reflect/Material/MaterialDynamicMetadata.h
     Include/Atom/RPI.Reflect/Material/MaterialNameContext.h
+    Include/Atom/RPI.Reflect/Material/MaterialPropertyCollection.h
     Include/Atom/RPI.Reflect/Material/MaterialPropertyDescriptor.h
     Include/Atom/RPI.Reflect/Material/MaterialPropertiesLayout.h
     Include/Atom/RPI.Reflect/Material/MaterialPropertyValue.h
@@ -139,6 +140,7 @@ set(FILES
     Source/RPI.Reflect/Material/LuaMaterialFunctor.cpp
     Source/RPI.Reflect/Material/LuaScriptUtilities.cpp
     Source/RPI.Reflect/Material/MaterialDynamicMetadata.cpp
+    Source/RPI.Reflect/Material/MaterialPropertyCollection.cpp
     Source/RPI.Reflect/Material/MaterialPropertyDescriptor.cpp
     Source/RPI.Reflect/Material/MaterialPropertiesLayout.cpp
     Source/RPI.Reflect/Material/MaterialTypeAsset.cpp

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/MaterialPropertyUtil.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/MaterialPropertyUtil.h
@@ -22,7 +22,7 @@ namespace AtomToolsFramework
     AZStd::any ConvertToEditableType(const AZ::RPI::MaterialPropertyValue& value);
 
     //! Convert and assign material type source data property definition fields to editor dynamic property configuration 
-    void ConvertToPropertyConfig(AtomToolsFramework::DynamicPropertyConfig& propertyConfig, const AZ::RPI::MaterialTypeSourceData::PropertyDefinition& propertyDefinition);
+    void ConvertToPropertyConfig(AtomToolsFramework::DynamicPropertyConfig& propertyConfig, const AZ::RPI::MaterialPropertySourceData& propertyDefinition);
 
     //! Convert and assign material property meta data fields to editor dynamic property configuration 
     void ConvertToPropertyConfig(AtomToolsFramework::DynamicPropertyConfig& propertyConfig, const AZ::RPI::MaterialPropertyDynamicMetadata& propertyMetaData);
@@ -41,7 +41,7 @@ namespace AtomToolsFramework
     bool ConvertToExportFormat(
         const AZStd::string& exportPath,
         [[maybe_unused]] const AZ::Name& propertyId,
-        const AZ::RPI::MaterialTypeSourceData::PropertyDefinition& propertyDefinition,
+        const AZ::RPI::MaterialPropertySourceData& propertyDefinition,
         AZ::RPI::MaterialPropertyValue& propertyValue);
 
     AZ::RPI::MaterialPropertyDataType GetMaterialPropertyDataTypeFromValue(

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/MaterialPropertyUtil.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/MaterialPropertyUtil.cpp
@@ -32,7 +32,7 @@ namespace AtomToolsFramework
         return AZ::RPI::MaterialPropertyValue::ToAny(value);
     }
 
-    void ConvertToPropertyConfig(AtomToolsFramework::DynamicPropertyConfig& propertyConfig, const AZ::RPI::MaterialTypeSourceData::PropertyDefinition& propertyDefinition)
+    void ConvertToPropertyConfig(AtomToolsFramework::DynamicPropertyConfig& propertyConfig, const AZ::RPI::MaterialPropertySourceData& propertyDefinition)
     {
         propertyConfig.m_name = propertyDefinition.GetName();
         propertyConfig.m_displayName = propertyDefinition.m_displayName;
@@ -132,7 +132,7 @@ namespace AtomToolsFramework
     bool ConvertToExportFormat(
         const AZStd::string& exportPath,
         [[maybe_unused]] const AZ::Name& propertyId,
-        const AZ::RPI::MaterialTypeSourceData::PropertyDefinition& propertyDefinition,
+        const AZ::RPI::MaterialPropertySourceData& propertyDefinition,
         AZ::RPI::MaterialPropertyValue& propertyValue)
     {
         if (propertyDefinition.m_dataType == AZ::RPI::MaterialPropertyDataType::Enum && propertyValue.Is<uint32_t>())

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
@@ -911,7 +911,7 @@ namespace MaterialEditor
             if (materialPropertyDependencies.none() || functor->NeedsProcess(dirtyFlags))
             {
                 AZ::RPI::MaterialFunctor::EditorContext context = AZ::RPI::MaterialFunctor::EditorContext(
-                    m_materialInstance->GetPropertyValues(), m_materialInstance->GetMaterialPropertiesLayout(), propertyDynamicMetadata,
+                    m_materialInstance->GetPropertyCollection(), propertyDynamicMetadata,
                     propertyGroupDynamicMetadata, updatedProperties, updatedPropertyGroups,
                     &materialPropertyDependencies);
                 functor->Process(context);

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
@@ -588,8 +588,7 @@ namespace AZ
                     if (materialPropertyDependencies.none() || functor->NeedsProcess(m_dirtyPropertyFlags))
                     {
                         AZ::RPI::MaterialFunctor::EditorContext context = AZ::RPI::MaterialFunctor::EditorContext(
-                            m_materialInstance->GetPropertyValues(),
-                            m_materialInstance->GetMaterialPropertiesLayout(),
+                            m_materialInstance->GetPropertyCollection(),
                             propertyDynamicMetadata,
                             propertyGroupDynamicMetadata,
                             changedPropertyNames,

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.cpp
@@ -118,7 +118,7 @@ namespace AZ
 
                 // Copy all of the properties from the material asset to the source data that will be exported
                 bool result = true;
-                editData.m_materialTypeSourceData.EnumerateProperties([&](const AZ::RPI::MaterialTypeSourceData::PropertyDefinition* propertyDefinition, const AZ::RPI::MaterialNameContext& nameContext)
+                editData.m_materialTypeSourceData.EnumerateProperties([&](const AZ::RPI::MaterialPropertySourceData* propertyDefinition, const AZ::RPI::MaterialNameContext& nameContext)
                     {
                         AZ::Name propertyId{propertyDefinition->GetName()};
                         nameContext.ContextualizeProperty(propertyId);


### PR DESCRIPTION
## What does this PR do?

Material pipeline functors are going to require their own internal material property list for passing data from the front end to the back end of the material. So here I have factored out MaterialPropertyCollection and MaterialPropertySourceData classes, as well as a MaterialPropertySourceData::BuildProperty function, which will all be used in a subsequent PR to add separate property collections for each render pipeline.

Most of the code changes are strictly moving code around, but there is one significant behavioral change. Before, when you called Material::SetPropertyValue it would immediately process any of the direct "Connections" to update the ShaderResourceGroup, shader option values, and/or shader-enable state. Now, these direct Connections are handled similar to the material functors, by processing them only when Material::Compile is called. SetPropertyValue will only update the front-end MaterialPropertyValue storage, no back-end resource will be updated until the material is compiled. This allows for a clean separation of concerns between material property data in MaterialPropertyCollection, and render resources in Material.

See https://github.com/o3de/sig-graphics-audio/blob/main/rfcs/MaterialPipelineAbstraction.md 

## How was this PR tested?

- Atom RPI unit tests
- AtomSampleViewer full test suite passed on vulkan (only a couple known issues showed up)
- Opened a material in material editor and toggled various settings
- Opened a material graph in Material Canvas and verified that the shaders compiled and the preview updated accordingly.
- Tested material inspector in MaterialComponent, toggled various settings

