### PR TITLE
Fixing natvis for AZ::Outcome<void, *> overload

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/azcore.natvis
+++ b/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/azcore.natvis
@@ -656,6 +656,18 @@
     </Expand>
   </Type>
 
+  <Type Name="AZStd::expected&lt;void,*&gt;">
+      <Intrinsic Name="has_value" Expression="this->m_hasValue"/>
+      <Intrinsic Name="error" Expression="this->m_storage.m_unexpected"/>
+      <DisplayString Condition="has_value()">Value = Success</DisplayString>
+      <DisplayString Condition="!has_value()">Error = {error()}</DisplayString>
+      <Expand>
+          <Item Name="has_value">has_value()</Item>
+          <Item Name="value" Condition="has_value()">Success</Item>
+          <Item Name="error" Condition="!has_value()">error()</Item>
+      </Expand>
+  </Type>
+
   <Type Name="AZ::Outcome&lt;*&gt;">
     <Intrinsic Name="has_value" Expression="this->m_hasValue"/>
     <Intrinsic Name="value"       Expression="this->m_storage.m_value"/>
@@ -668,6 +680,18 @@
       <Item Name="Error" Condition="!has_value()">error()</Item>
     </Expand>
   </Type>
+
+    <Type Name="AZ::Outcome&lt;void,*&gt;">
+        <Intrinsic Name="has_value" Expression="this->m_hasValue"/>
+        <Intrinsic Name="error" Expression="this->m_storage.m_unexpected"/>
+        <DisplayString Condition="has_value()" >{{Value = Success}}</DisplayString>
+        <DisplayString Condition="!has_value()">{{Error = {error()}}}</DisplayString>
+        <Expand>
+            <Item Name="IsSuccess">has_value()</Item>
+            <Item Name="Value" Condition="has_value()">Success</Item>
+            <Item Name="Error" Condition="!has_value()">error()</Item>
+        </Expand>
+    </Type>
 
   <Type Name="AZ::EnvironmentVariable&lt;*&gt;">
     <DisplayString Condition="m_data != nullptr">{*($T1*)&amp;m_data->m_value}</DisplayString>


### PR DESCRIPTION
The `m_storage->m_value` member isn't available when the value_type is void.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Validated the debugger watch window was able to properly visualize an `AZ::Outcome<void, fixed_string<256>`
