### PR TITLE
Event logger script support: Behavior Context reflection

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -662,7 +662,7 @@ namespace AZ
                 fileStream != nullptr && fileStream->IsOpen())
             {
                 // Configure core event logger with the name of "Core"
-                AZ::Metrics::JsonTraceLoggerEventConfig config{ "Core" };
+                AZ::Metrics::JsonTraceEventLoggerConfig config{ "Core" };
                 auto coreEventLogger = AZStd::make_unique<AZ::Metrics::JsonTraceEventLogger>(AZStd::move(fileStream), config);
                 m_eventLoggerFactory->RegisterEventLogger(AZ::Metrics::CoreEventLoggerId, AZStd::move(coreEventLogger));
             }
@@ -756,9 +756,6 @@ namespace AZ
 
         MergeSettingsToRegistry(*m_settingsRegistry);
 
-        // Register the Core metrics Event logger with the IEventLoggerFactory
-        RegisterCoreEventLogger();
-
         m_systemEntity = AZStd::make_unique<AZ::Entity>(SystemEntityId, "SystemEntity");
         CreateCommon();
         AZ_Assert(m_systemEntity, "SystemEntity failed to initialize!");
@@ -790,6 +787,10 @@ namespace AZ
 
         TickBus::AllowFunctionQueuing(true);
         SystemTickBus::AllowFunctionQueuing(true);
+
+        // Register the Core metrics Event logger with the IEventLoggerFactory
+        // after the TickBus has enabled function queuing
+        RegisterCoreEventLogger();
 
         ComponentApplicationBus::Handler::BusConnect();
 

--- a/Code/Framework/AzCore/AzCore/Metrics/EventLoggerReflectUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Metrics/EventLoggerReflectUtils.cpp
@@ -6,12 +6,34 @@
  *
  */
 
-#include <AzCore/Metrics/IEventLogger.h>
+#include <AzCore/Metrics/EventLoggerFactoryImpl.h>
 #include <AzCore/Metrics/EventLoggerReflectUtils.h>
+#include <AzCore/Metrics/EventLoggerUtils.h>
+#include <AzCore/Metrics/IEventLogger.h>
+#include <AzCore/Metrics/IEventLoggerFactory.h>
+#include <AzCore/Metrics/JsonTraceEventLogger.h>
+#include <AzCore/Preprocessor/EnumReflectUtils.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/RTTI/ChronoReflection.h>
+#include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/Settings/SettingsRegistryScriptUtils.h>
+
+namespace AZ
+{
+    AZ_TYPE_INFO_SPECIALIZE(AZ::Metrics::EventLoggerId, "{C7D72622-922A-4A9E-8216-12B0B8149A64}");
+    // Add AzTypeInfo to the EventPhase enum to allow it to be reflected
+    AZ_TYPE_INFO_SPECIALIZE_WITH_NAME(AZ::Metrics::EventPhase, "{FBB53668-D422-4787-B8B3-527D8F4C649A}", "EventPhase");
+    AZ_TYPE_INFO_SPECIALIZE_WITH_NAME(AZ::Metrics::InstantEventScope, "{F396C6ED-225D-44C4-B2C3-AF5A0D06797F}", "InstantEventScope");
+
+    AZ_TYPE_INFO_SPECIALIZE(AZ::Metrics::EventValue, "{7651AE39-D9F3-4F4B-9907-CEA6AD1DE7EC}");
+    AZ_TYPE_INFO_SPECIALIZE(AZ::Metrics::EventField, "{195BA233-37A9-40E1-B9BA-0282F802E4A4}");
+}
 
 namespace AZ::Metrics
 {
+    AZ_ENUM_DEFINE_REFLECT_UTILITIES(EventPhase);
+    AZ_ENUM_DEFINE_REFLECT_UTILITIES(InstantEventScope);
+
     inline namespace Script
     {
         // Script Event Arguments use container types with persistent storage such as AZStd::string
@@ -26,107 +48,113 @@ namespace AZ::Metrics
 
         //! Represents a value of a field in the arguments supplied to Record*Event
         //! It is also used to supply arguments to JSON arrays in event arguments
-        struct ScriptEventValue;
-        //! Represents a field that contains a name and ScriptEventValue for supplying
-        //! arguments to JSON objects in event arguments
-        struct ScriptEventField;
-
-        //! Encapsulates an array structure suitable for storing
-        //! JSON array arguments to supply as part of the event arguments
-        struct ScriptEventArray
-        {
-            AZ_TYPE_INFO(ScriptEventArray, "{830941A8-ECF4-421B-81AC-5C53D9224881}");
-
-            ScriptEventArray() = default;
-            ScriptEventArray(AZStd::vector<ScriptEventValue> value)
-                : m_value(AZStd::move(value))
-            {}
-            AZStd::vector<ScriptEventValue> m_value;
-        };
-
-        //! Encapsulates an array structure suitable for storing
-        //! JSON object arguments to supply as part of the event arguments
-        struct ScriptEventObject
-        {
-            AZ_TYPE_INFO(ScriptEventObject, "{8970F79F-0613-4B54-872B-2B48702EE5AB}");
-
-            ScriptEventObject() = default;
-            ScriptEventObject(AZStd::vector<ScriptEventField> value)
-                : m_value(AZStd::move(value))
-            {}
-
-            AZStd::vector<ScriptEventField> m_value;
-        };
-
         struct ScriptEventValue
         {
             AZ_TYPE_INFO(ScriptEventValue, "{665521F8-C9C3-440E-86CE-3BD1D6471ECE}");
 
+            //! Variant type which is used to provide storage for arguments until the IEventLogger::Record* functions
+            //! can be invoked in C++
+            using EventValueStorageVariant = AZStd::variant<AZStd::monostate, AZStd::string, AZStd::vector<EventValue>, AZStd::vector<EventField>>;
+
             // Need constructors that can initialize a ScriptEventValue for each type of variant
             // in order to use the BehaviorContext::ClassBuilder::Constructor function
             ScriptEventValue() = default;
+
+            //! string instances need storage
             ScriptEventValue(AZStd::string value)
-                : m_value(AZStd::move(value))
+                : m_valueStorage{ EventValueStorageVariant{AZStd::in_place_type<AZStd::string>, AZStd::move(value)} }
+                , m_eventValueMirror{ AZStd::get<AZStd::string>(m_valueStorage.front()) }
             {}
+
+            //! Integral types are stored directly in the AZ::Metrics::EventValue instance
+            //! so no additional storage is needed
             ScriptEventValue(bool value)
-                : m_value(value)
+                : m_eventValueMirror{ value }
             {}
             ScriptEventValue(AZ::s64 value)
-                : m_value(value)
+                : m_eventValueMirror{ value }
             {}
             ScriptEventValue(AZ::u64 value)
-                : m_value(value)
+                : m_eventValueMirror{ value }
             {}
             ScriptEventValue(double value)
-                : m_value(value)
-            {}
-            ScriptEventValue(ScriptEventArray value)
-                : m_value(AZStd::move(value))
-            {}
-            ScriptEventValue(ScriptEventObject value)
-                : m_value(AZStd::move(value))
+                : m_eventValueMirror{ value }
             {}
 
-            using ArgsVariant = AZStd::variant<
-                AZStd::string,
-                bool,
-                AZ::s64,
-                AZ::u64,
-                double,
-                ScriptEventArray,
-                ScriptEventObject
-            >;
+            //! array instances need storage
+            ScriptEventValue(AZStd::vector<EventValue> value)
+                : m_valueStorage{ EventValueStorageVariant{AZStd::in_place_type<AZStd::vector<EventValue>>,  AZStd::move(value)} }
+                , m_eventValueMirror{ EventArray{ AZStd::get<AZStd::vector<EventValue>>(m_valueStorage.front())} }
+            {
+            }
+            //! object instances need storage
+            ScriptEventValue(AZStd::vector<EventField> value)
+                : m_valueStorage{ EventValueStorageVariant{AZStd::in_place_type<AZStd::vector<EventField>>, AZStd::move(value)} }
+                , m_eventValueMirror{ EventObject{ AZStd::get<AZStd::vector<EventField>>(m_valueStorage.front())} }
+            {
+            }
 
-            //! Stores the data associated with an event field
-            ArgsVariant m_value;
+            // Conversion operator for converting to Metrics::EventValue instance
+            // This is a helper function to pass the ScriptEventValue to C++
+            operator EventValue() const
+            {
+                return m_eventValueMirror;
+            }
+
+        private:
+
+            //! Provides persistent storage for event value arguments of strings, arrays and objects for long enough
+            //! to invoke the RecordMetrics function in C++ from script
+            AZStd::vector<EventValueStorageVariant> m_valueStorage;
+
+            //! Mirrors the storage for the m_value member into the C++ EventValue variant type for compatibility
+            //! with accessing C++ functions which accepts an EventValue type
+            EventValue m_eventValueMirror;
         };
 
-        struct ScriptEventField
-        {
-            AZ_TYPE_INFO(ScriptEventField, "{3823CEFA-30BA-41BB-81E6-FD22FA5CBC1B}");
-
-            ScriptEventField() = default;
-
-            ScriptEventField(AZStd::string name, ScriptEventValue value)
-                : m_name(AZStd::move(name))
-                , m_value(AZStd::move(value))
-            {}
-
-            // field name
-            AZStd::string m_name;
-            // field value
-            ScriptEventValue m_value;
-        };
         struct ScriptEventArgs
         {
+            AZ_TYPE_INFO(ScriptEventArgs, "{D79DEBE1-B271-4F93-9685-F19947E78EC4}");
+
             //! name of the event
             AZStd::string m_name;
             //! comma separated list of categories associated with the event
             AZStd::string m_cat;
-            //! Arguments used to fill the "args" field for each trace event
-            AZStd::vector<ScriptEventField> m_args;
-        };
+            //! Id to associate with the event
+            AZStd::optional<AZStd::string> m_id;
 
+            //! Appends an argument to the "args" field
+            void AppendArg(AZStd::string fieldName, ScriptEventValue value)
+            {
+                m_args.emplace_back(AZStd::move(fieldName), AZStd::move(value));
+            }
+
+            //! Callback function to visit each first generation child of the "args" field
+            using ArgVisitCallback = AZStd::function<void(AZStd::string_view fieldName, EventValue fieldValue)>;
+            void VisitArgs(const ArgVisitCallback& visitCallback)
+            {
+                for (const auto& [fieldName, fieldValue] : m_args)
+                {
+                    visitCallback(fieldName, fieldValue);
+                }
+            }
+
+            //! Specifies the duration of the event in microseconds
+            //! For CompleteEvents only
+            AZStd::chrono::microseconds m_dur;
+
+            //! Specifies the scope of the event
+            //! For InstantEvents only
+            InstantEventScope m_scopeKey;
+
+        private:
+            //! Arguments used to fill the "args" field for each trace event
+            using ScriptField = AZStd::pair<AZStd::string, ScriptEventValue>;
+
+            //! Represents a field that contains a name and EventValue which provides persistent storage
+            //! for an EventField type
+            AZStd::vector<ScriptField> m_args;
+        };
 
         //! Represents the module to use when importing the event logger metrics functions
         //! This is used in Python automation. ex. `import azlmbr.metrics`
@@ -134,6 +162,53 @@ namespace AZ::Metrics
         //! Represents the category to organize the event logger classes and functions
         //! witin the ScriptCanvas NodePalette
         static constexpr const char* MetricsCategory = "Metrics";
+
+        //! Wraps a function to return to create an event logger and register it with the Event Logger Factory
+        using SettingsRegistryScriptProxy = AZ::SettingsRegistryScriptUtils::Internal::SettingsRegistryScriptProxy;
+        static bool CreateMetricsLogger(EventLoggerId loggerId, const char* filePath, AZStd::string_view loggerName,
+            SettingsRegistryScriptProxy settingsRegistry = {})
+        {
+            auto eventLoggerFactory = AZ::Metrics::EventLoggerFactory::Get();
+            if (eventLoggerFactory == nullptr)
+            {
+                // An event logger factory is required to register the created Json Metrics logger
+                return false;
+            }
+            if (!settingsRegistry.IsValid())
+            {
+                settingsRegistry = SettingsRegistryScriptProxy{ AZ::SettingsRegistry::Get() };
+            }
+
+            constexpr AZ::IO::OpenMode openMode = AZ::IO::OpenMode::ModeWrite | AZ::IO::OpenMode::ModeCreatePath;
+            auto systemFileStream = AZStd::make_unique<AZ::IO::SystemFileStream>(filePath, openMode);
+            if (!systemFileStream->IsOpen())
+            {
+                return false;
+            }
+
+            AZ::Metrics::JsonTraceEventLoggerConfig config{ loggerName, settingsRegistry.m_settingsRegistry.get()};
+
+            auto jsonTraceEventLogger = AZStd::make_unique<AZ::Metrics::JsonTraceEventLogger>(
+                AZStd::move(systemFileStream), AZStd::move(config));
+
+            auto registerOutcome = eventLoggerFactory->RegisterEventLogger(loggerId, AZStd::move(jsonTraceEventLogger));
+
+            return registerOutcome.IsSuccess();
+        }
+
+        using CreateMetricsLoggerBPOverrides = AZStd::array<AZ::BehaviorParameterOverrides, AZStd::function_traits<decltype(&CreateMetricsLogger)>::arity>;
+        static CreateMetricsLoggerBPOverrides GetCreateMetricsLoggerBPOverrides(AZ::BehaviorContext& behaviorContext)
+        {
+            constexpr size_t settingsRegistryArgIndex = 3;
+            static_assert(AZStd::is_same_v<AZStd::function_traits<decltype(&CreateMetricsLogger)>::get_arg_t<settingsRegistryArgIndex>, SettingsRegistryScriptProxy>,
+                "The `SettingsRegistryScriptProxy` argument index must be updated for the CreateMetricsLogger function");
+
+            CreateMetricsLoggerBPOverrides behaviorParameterOverrides;
+            behaviorParameterOverrides[settingsRegistryArgIndex].m_defaultValue = behaviorContext.MakeDefaultValue(
+                SettingsRegistryScriptProxy{});
+
+            return behaviorParameterOverrides;
+        }
 
         void Reflect(AZ::ReflectContext* context)
         {
@@ -146,7 +221,31 @@ namespace AZ::Metrics
 
         static void ReflectEventDataTypes(AZ::BehaviorContext& behaviorContext)
         {
-            // Reflect the EventValue
+            // Reflect the EventValue type
+            // This type is a passthrough type for scripting and is not meant to be used directort
+            behaviorContext.Class<EventValue>("_OpaqueEventValue")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, MetricsModuleName)
+                ->Attribute(AZ::Script::Attributes::Category, MetricsCategory)
+                ->Constructor()
+                ->Constructor<AZStd::string>()
+                ->Constructor<bool>()
+                ->Constructor<AZ::s64>()
+                ->Constructor<AZ::u64>()
+                ->Constructor<double>()
+                ;
+
+            // Reflect the EventField type
+            // This type is a passthrough type for scripting and is not meant to be used directly
+            behaviorContext.Class<EventField>("_OpaqueEventField")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, MetricsModuleName)
+                ->Attribute(AZ::Script::Attributes::Category, MetricsCategory)
+                ->Constructor()
+                ->Constructor<AZStd::string_view, EventValue>()
+                ;
+
+            // Reflect the ScriptEventValue as the "EventValue" type for scripting
             behaviorContext.Class<ScriptEventValue>("EventValue")
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                 ->Attribute(AZ::Script::Attributes::Module, MetricsModuleName)
@@ -157,42 +256,253 @@ namespace AZ::Metrics
                 ->Constructor<AZ::s64>()
                 ->Constructor<AZ::u64>()
                 ->Constructor<double>()
-                ->Constructor<ScriptEventArray>()
-                ->Constructor<ScriptEventObject>()
+                ->Constructor<AZStd::vector<EventValue>>()
+                ->Constructor<AZStd::vector<EventField>>()
                 ;
 
-            // Reflect the EventField
-            behaviorContext.Class<ScriptEventField>("EventField")
+            // Reflect the EventLoggerId enum class
+            behaviorContext.Class<EventLoggerId>("EventLoggerId")
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                 ->Attribute(AZ::Script::Attributes::Module, MetricsModuleName)
                 ->Attribute(AZ::Script::Attributes::Category, MetricsCategory)
-                ->Constructor()
-                ->Constructor<AZStd::string, ScriptEventValue>()
+                ->Method("CreateIdFromInt", [](AZ::u32 id) { return EventLoggerId(id); })
+                ->Method("CreateIdFromString", [](AZStd::string_view id) {
+                    return EventLoggerId(static_cast<AZ::u32>(AZStd::hash<AZStd::string_view>{}(id))); })
                 ;
 
-            // Reflect the EventArray
-            behaviorContext.Class<ScriptEventArray>("EventArray")
+            // Reflect the event phase values
+            EventPhaseReflect(behaviorContext);
+
+            // Reflect the Instant Event scope enum values
+            InstantEventScopeReflect(behaviorContext);
+
+            // Reflect the ScriptEvent argument wrapper
+            behaviorContext.Class<ScriptEventArgs>("EventArgs")
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                 ->Attribute(AZ::Script::Attributes::Module, MetricsModuleName)
                 ->Attribute(AZ::Script::Attributes::Category, MetricsCategory)
-                ->Constructor()
-                ->Constructor<AZStd::vector<ScriptEventValue>>()
+                ->Method("AppendArg", &ScriptEventArgs::AppendArg)
+                ->Property("m_name", [](const ScriptEventArgs* self) { return self->m_name; },
+                    [](ScriptEventArgs* self, AZStd::string value) { self->m_name = AZStd::move(value); })
+                ->Property("m_cat", [](const ScriptEventArgs* self) { return self->m_cat; },
+                    [](ScriptEventArgs* self, AZStd::string value) { self->m_cat = AZStd::move(value); })
+                ->Property("m_id", [](const ScriptEventArgs* self) { return self->m_id; },
+                    [](ScriptEventArgs* self, AZStd::optional<AZStd::string> value) { self->m_id = AZStd::move(value); })
+                ->Property("m_duration", [](const ScriptEventArgs* self) { return self->m_dur; },
+                    [](ScriptEventArgs* self, AZStd::chrono::microseconds value) { self->m_dur = AZStd::move(value); })
+                ->Property("m_scopeKey", [](const ScriptEventArgs* self) { return self->m_scopeKey; },
+                    [](ScriptEventArgs* self, InstantEventScope value) { self->m_scopeKey = AZStd::move(value); })
                 ;
+        }
 
-            // Reflect the EventObject
-            behaviorContext.Class<ScriptEventObject>("EventObject")
+        static void ReflectCreateMetricsLogger(AZ::BehaviorContext& behaviorContext)
+        {
+            behaviorContext.Method("CreateMetricsLogger", &CreateMetricsLogger, GetCreateMetricsLoggerBPOverrides(behaviorContext))
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                 ->Attribute(AZ::Script::Attributes::Module, MetricsModuleName)
                 ->Attribute(AZ::Script::Attributes::Category, MetricsCategory)
-                ->Constructor()
-                ->Constructor<AZStd::vector<ScriptEventField>>()
+                ;
+        }
 
+        static void ReflectIsEventLoggerRegistered(AZ::BehaviorContext& behaviorContext)
+        {
+            behaviorContext.Class<IEventLoggerFactory>()
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, MetricsModuleName)
+                ->Attribute(AZ::Script::Attributes::Category, MetricsCategory)
+                ->Method("IsRegistered", &IEventLoggerFactory::IsRegistered)
+                ;
+
+            behaviorContext.Class<EventLoggerFactoryImpl>("EventLoggerFactory")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, MetricsModuleName)
+                ->Attribute(AZ::Script::Attributes::Category, MetricsCategory)
+                ->Constructor<>()
+                ->Method("IsRegistered", &EventLoggerFactoryImpl::IsRegistered)
+                ;
+
+            // Static method to retrieve the global AZ::Interface<IEventLoggerFactory> instance
+            auto GetEventLoggerInterface = []()
+            {
+                return EventLoggerFactory::Get();
+            };
+            behaviorContext.Method("GetGlobalEventLoggerFactory", GetEventLoggerInterface)
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, MetricsModuleName)
+                ->Attribute(AZ::Script::Attributes::Category, MetricsCategory)
+                ;
+
+            auto IsEventLoggerRegistered = [](EventLoggerId eventLoggerId, IEventLoggerFactory* eventLoggerFactory = nullptr)
+                -> bool
+            {
+                if (eventLoggerFactory == nullptr)
+                {
+                    eventLoggerFactory = EventLoggerFactory::Get();
+                }
+
+                return eventLoggerFactory != nullptr && eventLoggerFactory->IsRegistered(eventLoggerId);
+            };
+            // Add a default argument for the IEventLoggerFactory parameter in the BehaviorCont3ext
+            AZStd::array<AZ::BehaviorParameterOverrides, AZStd::function_traits<decltype(IsEventLoggerRegistered)>::arity>
+                isEventLoggerRegisteredOverrides;
+            constexpr size_t eventLoggerFactoryArgIndex = 1;
+
+            isEventLoggerRegisteredOverrides[eventLoggerFactoryArgIndex].m_defaultValue = behaviorContext.MakeDefaultValue(
+                static_cast<IEventLoggerFactory*>(nullptr));
+
+            static_assert(AZStd::is_same_v<AZStd::function_traits<
+                decltype(IsEventLoggerRegistered)>::get_arg_t<eventLoggerFactoryArgIndex>, IEventLoggerFactory*>,
+                "The `IEventLoggerFactory*` argument index must be updated for the IsEventLoggerRegistered function");
+
+            behaviorContext.Method("IsEventLoggerRegistered", IsEventLoggerRegistered, isEventLoggerRegisteredOverrides)
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, MetricsModuleName)
+                ->Attribute(AZ::Script::Attributes::Category, MetricsCategory)
+                ;
+        }
+
+        static void ReflectRecordEvent(AZ::BehaviorContext& behaviorContext)
+        {
+            auto RecordEvent = [](EventLoggerId eventLoggerId, EventPhase eventPhase, ScriptEventArgs eventPhaseArgs,
+                IEventLoggerFactory* eventLoggerFactory = nullptr)
+                -> bool
+            {
+                if (eventLoggerFactory == nullptr)
+                {
+                    eventLoggerFactory = EventLoggerFactory::Get();
+                }
+
+                IEventLogger::ResultOutcome recordOutcome(AZStd::unexpect, IEventLogger::ResultOutcome::ErrorType::format(
+                    R"(Invalid eventPhase type %.*s specified)", AZ_STRING_ARG(ToString(eventPhase))));
+
+                switch (eventPhase)
+                {
+                case EventPhase::DurationBegin:
+                case EventPhase::DurationEnd:
+                {
+                    DurationArgs durationArgs;
+                    durationArgs.m_name = eventPhaseArgs.m_name;
+                    durationArgs.m_cat = eventPhaseArgs.m_cat;
+
+                    // The "args" field needs storage in order to last long enough to invoke the RecordEvent function
+                    AZStd::vector<EventField> eventFields;
+                    auto AppendArgFields = [&eventFields](AZStd::string_view fieldName, EventValue fieldValue)
+                    {
+                        eventFields.emplace_back(fieldName, fieldValue);
+                    };
+                    eventPhaseArgs.VisitArgs(AppendArgFields);
+                    durationArgs.m_args = eventFields;
+
+                    durationArgs.m_id = eventPhaseArgs.m_id;
+                    recordOutcome = AZ::Metrics::Utility::RecordEvent(eventLoggerId, eventPhase, durationArgs, eventLoggerFactory);
+                    break;
+                }
+                case EventPhase::Complete:
+                {
+                    CompleteArgs completeArgs;
+                    completeArgs.m_name = eventPhaseArgs.m_name;
+                    completeArgs.m_cat = eventPhaseArgs.m_cat;
+
+                    // The "args" field needs storage in order to last long enough to invoke the RecordEvent function
+                    AZStd::vector<EventField> eventFields;
+                    auto AppendArgFields = [&eventFields](AZStd::string_view fieldName, EventValue fieldValue)
+                    {
+                        eventFields.emplace_back(fieldName, fieldValue);
+                    };
+                    eventPhaseArgs.VisitArgs(AppendArgFields);
+                    completeArgs.m_args = eventFields;
+
+                    completeArgs.m_id = eventPhaseArgs.m_id;
+                    completeArgs.m_dur = eventPhaseArgs.m_dur;
+                    recordOutcome = AZ::Metrics::Utility::RecordEvent(eventLoggerId, eventPhase, completeArgs, eventLoggerFactory);
+                    break;
+                }
+                case EventPhase::Instant:
+                {
+                    InstantArgs instantArgs;
+                    instantArgs.m_name = eventPhaseArgs.m_name;
+                    instantArgs.m_cat = eventPhaseArgs.m_cat;
+
+                    // The "args" field needs storage in order to last long enough to invoke the RecordEvent function
+                    AZStd::vector<EventField> eventFields;
+                    auto AppendArgFields = [&eventFields](AZStd::string_view fieldName, EventValue fieldValue)
+                    {
+                        eventFields.emplace_back(fieldName, fieldValue);
+                    };
+                    eventPhaseArgs.VisitArgs(AppendArgFields);
+                    instantArgs.m_args = eventFields;
+
+                    instantArgs.m_id = eventPhaseArgs.m_id;
+                    instantArgs.m_scope = eventPhaseArgs.m_scopeKey;
+                    recordOutcome = AZ::Metrics::Utility::RecordEvent(eventLoggerId, eventPhase, instantArgs, eventLoggerFactory);
+                    break;
+                }
+                case EventPhase::Counter:
+                {
+                    CounterArgs counterArgs;
+                    counterArgs.m_name = eventPhaseArgs.m_name;
+                    counterArgs.m_cat = eventPhaseArgs.m_cat;
+
+                    // The "args" field needs storage in order to last long enough to invoke the RecordEvent function
+                    AZStd::vector<EventField> eventFields;
+                    auto AppendArgFields = [&eventFields](AZStd::string_view fieldName, EventValue fieldValue)
+                    {
+                        eventFields.emplace_back(fieldName, fieldValue);
+                    };
+                    eventPhaseArgs.VisitArgs(AppendArgFields);
+                    counterArgs.m_args = eventFields;
+
+                    counterArgs.m_id = eventPhaseArgs.m_id;
+                    recordOutcome = AZ::Metrics::Utility::RecordEvent(eventLoggerId, eventPhase, counterArgs, eventLoggerFactory);
+                    break;
+                }
+                case EventPhase::AsyncStart:
+                case EventPhase::AsyncInstant:
+                case EventPhase::AsyncEnd:
+                {
+                    AsyncArgs asyncArgs;
+                    asyncArgs.m_name = eventPhaseArgs.m_name;
+                    asyncArgs.m_cat = eventPhaseArgs.m_cat;
+
+                    // The "args" field needs storage in order to last long enough to invoke the RecordEvent function
+                    AZStd::vector<EventField> eventFields;
+                    auto AppendArgFields = [&eventFields](AZStd::string_view fieldName, EventValue fieldValue)
+                    {
+                        eventFields.emplace_back(fieldName, fieldValue);
+                    };
+                    eventPhaseArgs.VisitArgs(AppendArgFields);
+                    asyncArgs.m_args = eventFields;
+
+                    asyncArgs.m_id = eventPhaseArgs.m_id.value_or(AZStd::string_view{});
+                    recordOutcome = AZ::Metrics::Utility::RecordEvent(eventLoggerId, eventPhase, asyncArgs, eventLoggerFactory);
+                    break;
+                }
+                }
+                return recordOutcome.IsSuccess();
+            };
+
+            // Add a default argument for the IEventLoggerFactory parameter in the BehaviorCont3ext
+            AZStd::array<AZ::BehaviorParameterOverrides, AZStd::function_traits<decltype(RecordEvent)>::arity>
+                recordEventOverrides;
+            constexpr size_t eventLoggerFactoryArgIndex = 3;
+            recordEventOverrides[eventLoggerFactoryArgIndex].m_defaultValue = behaviorContext.MakeDefaultValue(static_cast<IEventLoggerFactory*>(nullptr));
+            static_assert(AZStd::is_same_v<AZStd::function_traits<
+                decltype(RecordEvent)>::get_arg_t<eventLoggerFactoryArgIndex>, IEventLoggerFactory*>,
+                "The `IEventLoggerFactory*` argument index must be updated for the RecordEvent function");
+
+            behaviorContext.Method("RecordEvent", RecordEvent, recordEventOverrides)
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, MetricsModuleName)
+                ->Attribute(AZ::Script::Attributes::Category, MetricsCategory)
                 ;
         }
 
         void ReflectScript(AZ::BehaviorContext& behaviorContext)
         {
             ReflectEventDataTypes(behaviorContext);
+            ReflectCreateMetricsLogger(behaviorContext);
+            ReflectIsEventLoggerRegistered(behaviorContext);
+            ReflectRecordEvent(behaviorContext);
         }
     } // inline namespace Utility
 } // namespace AZ::Metrics

--- a/Code/Framework/AzCore/AzCore/Metrics/EventLoggerReflectUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Metrics/EventLoggerReflectUtils.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Metrics/IEventLogger.h>
+#include <AzCore/Metrics/EventLoggerReflectUtils.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+
+namespace AZ::Metrics
+{
+    inline namespace Script
+    {
+        // Script Event Arguments use container types with persistent storage such as AZStd::string
+        // instead of AZStd::string_view for storing string arguments and
+        // AZStd::vector instead AZStd::span for storing arrays
+        // This persistent storage is needed in script to allow scripters
+        // to not deal with lifetime concerns related to the event argument structures
+        // The C++ event argument structures located in IEventLogger.h uses non-persistent
+        // storage for the EventArg derived structures and expect users to provide a lifetime
+        // for fields supplied to the EventArg structure at least as long as the call
+        // to the `IEventLogger::Record*Event` call.
+
+        //! Represents a value of a field in the arguments supplied to Record*Event
+        //! It is also used to supply arguments to JSON arrays in event arguments
+        struct ScriptEventValue;
+        //! Represents a field that contains a name and ScriptEventValue for supplying
+        //! arguments to JSON objects in event arguments
+        struct ScriptEventField;
+
+        //! Encapsulates an array structure suitable for storing
+        //! JSON array arguments to supply as part of the event arguments
+        struct ScriptEventArray
+        {
+            AZ_TYPE_INFO(ScriptEventArray, "{830941A8-ECF4-421B-81AC-5C53D9224881}");
+
+            ScriptEventArray() = default;
+            ScriptEventArray(AZStd::vector<ScriptEventValue> value)
+                : m_value(AZStd::move(value))
+            {}
+            AZStd::vector<ScriptEventValue> m_value;
+        };
+
+        //! Encapsulates an array structure suitable for storing
+        //! JSON object arguments to supply as part of the event arguments
+        struct ScriptEventObject
+        {
+            AZ_TYPE_INFO(ScriptEventObject, "{8970F79F-0613-4B54-872B-2B48702EE5AB}");
+
+            ScriptEventObject() = default;
+            ScriptEventObject(AZStd::vector<ScriptEventField> value)
+                : m_value(AZStd::move(value))
+            {}
+
+            AZStd::vector<ScriptEventField> m_value;
+        };
+
+        struct ScriptEventValue
+        {
+            AZ_TYPE_INFO(ScriptEventValue, "{665521F8-C9C3-440E-86CE-3BD1D6471ECE}");
+
+            // Need constructors that can initialize a ScriptEventValue for each type of variant
+            // in order to use the BehaviorContext::ClassBuilder::Constructor function
+            ScriptEventValue() = default;
+            ScriptEventValue(AZStd::string value)
+                : m_value(AZStd::move(value))
+            {}
+            ScriptEventValue(bool value)
+                : m_value(value)
+            {}
+            ScriptEventValue(AZ::s64 value)
+                : m_value(value)
+            {}
+            ScriptEventValue(AZ::u64 value)
+                : m_value(value)
+            {}
+            ScriptEventValue(double value)
+                : m_value(value)
+            {}
+            ScriptEventValue(ScriptEventArray value)
+                : m_value(AZStd::move(value))
+            {}
+            ScriptEventValue(ScriptEventObject value)
+                : m_value(AZStd::move(value))
+            {}
+
+            using ArgsVariant = AZStd::variant<
+                AZStd::string,
+                bool,
+                AZ::s64,
+                AZ::u64,
+                double,
+                ScriptEventArray,
+                ScriptEventObject
+            >;
+
+            //! Stores the data associated with an event field
+            ArgsVariant m_value;
+        };
+
+        struct ScriptEventField
+        {
+            AZ_TYPE_INFO(ScriptEventField, "{3823CEFA-30BA-41BB-81E6-FD22FA5CBC1B}");
+
+            ScriptEventField() = default;
+
+            ScriptEventField(AZStd::string name, ScriptEventValue value)
+                : m_name(AZStd::move(name))
+                , m_value(AZStd::move(value))
+            {}
+
+            // field name
+            AZStd::string m_name;
+            // field value
+            ScriptEventValue m_value;
+        };
+        struct ScriptEventArgs
+        {
+            //! name of the event
+            AZStd::string m_name;
+            //! comma separated list of categories associated with the event
+            AZStd::string m_cat;
+            //! Arguments used to fill the "args" field for each trace event
+            AZStd::vector<ScriptEventField> m_args;
+        };
+
+
+        //! Represents the module to use when importing the event logger metrics functions
+        //! This is used in Python automation. ex. `import azlmbr.metrics`
+        static constexpr const char* MetricsModuleName = "metrics";
+        //! Represents the category to organize the event logger classes and functions
+        //! witin the ScriptCanvas NodePalette
+        static constexpr const char* MetricsCategory = "Metrics";
+
+        void Reflect(AZ::ReflectContext* context)
+        {
+            if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context);
+                behaviorContext != nullptr)
+            {
+                ReflectScript(*behaviorContext);
+            }
+        }
+
+        static void ReflectEventDataTypes(AZ::BehaviorContext& behaviorContext)
+        {
+            // Reflect the EventValue
+            behaviorContext.Class<ScriptEventValue>("EventValue")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, MetricsModuleName)
+                ->Attribute(AZ::Script::Attributes::Category, MetricsCategory)
+                ->Constructor()
+                ->Constructor<AZStd::string>()
+                ->Constructor<bool>()
+                ->Constructor<AZ::s64>()
+                ->Constructor<AZ::u64>()
+                ->Constructor<double>()
+                ->Constructor<ScriptEventArray>()
+                ->Constructor<ScriptEventObject>()
+                ;
+
+            // Reflect the EventField
+            behaviorContext.Class<ScriptEventField>("EventField")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, MetricsModuleName)
+                ->Attribute(AZ::Script::Attributes::Category, MetricsCategory)
+                ->Constructor()
+                ->Constructor<AZStd::string, ScriptEventValue>()
+                ;
+
+            // Reflect the EventArray
+            behaviorContext.Class<ScriptEventArray>("EventArray")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, MetricsModuleName)
+                ->Attribute(AZ::Script::Attributes::Category, MetricsCategory)
+                ->Constructor()
+                ->Constructor<AZStd::vector<ScriptEventValue>>()
+                ;
+
+            // Reflect the EventObject
+            behaviorContext.Class<ScriptEventObject>("EventObject")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, MetricsModuleName)
+                ->Attribute(AZ::Script::Attributes::Category, MetricsCategory)
+                ->Constructor()
+                ->Constructor<AZStd::vector<ScriptEventField>>()
+
+                ;
+        }
+
+        void ReflectScript(AZ::BehaviorContext& behaviorContext)
+        {
+            ReflectEventDataTypes(behaviorContext);
+        }
+    } // inline namespace Utility
+} // namespace AZ::Metrics

--- a/Code/Framework/AzCore/AzCore/Metrics/EventLoggerReflectUtils.h
+++ b/Code/Framework/AzCore/AzCore/Metrics/EventLoggerReflectUtils.h
@@ -16,7 +16,7 @@ namespace AZ
 
 namespace AZ::Metrics
 {
-    // Utility namespace contains functions/class to simpilfy calls to record events
+    // Utility namespace contains functions/class to simplify calls to record events
     // It contains functions that can perform a lookup of an EventLogger and a record command in single calls
     inline namespace Script
     {

--- a/Code/Framework/AzCore/AzCore/Metrics/EventLoggerReflectUtils.h
+++ b/Code/Framework/AzCore/AzCore/Metrics/EventLoggerReflectUtils.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+namespace AZ
+{
+    class ReflectContext;
+    class BehaviorContext;
+}
+
+namespace AZ::Metrics
+{
+    // Utility namespace contains functions/class to simpilfy calls to record events
+    // It contains functions that can perform a lookup of an EventLogger and a record command in single calls
+    inline namespace Script
+    {
+        //! Entry point for reflecting the EventLogger API to the reflection context
+        void Reflect(AZ::ReflectContext* context);
+
+        // Reflects the Event Logger API for Scripting
+        // Users will interact with the Event logger using an API similiar
+        // to the EventLoggerUtils functions
+        void ReflectScript(AZ::BehaviorContext& behaviorContext);
+    } // inline namespace Utility
+} // namespace AZ::Metrics

--- a/Code/Framework/AzCore/AzCore/Metrics/IEventLogger.h
+++ b/Code/Framework/AzCore/AzCore/Metrics/IEventLogger.h
@@ -11,6 +11,7 @@
 #include <AzCore/base.h>
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/Platform.h>
+#include <AzCore/Preprocessor/Enum.h>
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/std/chrono/chrono.h>
 #include <AzCore/std/containers/span.h>
@@ -144,10 +145,11 @@ namespace AZ::Metrics
             AZ::s64,
             AZ::u64,
             double,
-            EventArray, // Used to encapsulate a span of <EventAValue> to represent arguments to output to the Google Trace format "args" object
-            EventObject  // Used to encapsulate a span of <EventArgsValue> to represent arguments to output to the Google Trace format "args" object
+            EventArray, // Used to encapsulate a span of <EventValue> to represent arguments to output to the Google Trace format "args" object
+            EventObject  // Used to encapsulate a span of <EventField> to represent arguments to output to the Google Trace format "args" object
         >;
 
+        //! Variant instance for storing the value of an event entry(string, bool integer, double, array, object)
         ArgsVariant m_value;
     };
 
@@ -157,7 +159,9 @@ namespace AZ::Metrics
         constexpr EventField();
         constexpr EventField(AZStd::string_view name, EventValue value);
 
+        //! Name of the field
         AZStd::string_view m_name;
+        //! Value of the field
         EventValue m_value;
     };
 
@@ -166,30 +170,29 @@ namespace AZ::Metrics
     using EventArrayStorage = AZStd::fixed_vector<AZ::Metrics::EventValue, 32>;
     using EventObjectStorage = AZStd::fixed_vector<AZ::Metrics::EventField, 32>;
 
-    enum class EventPhase : char
-    {
-        DurationBegin = 'B',
-        DurationEnd = 'E',
-        Complete = 'X',
-        Instant = 'i',
-        Counter = 'C',
-        AsyncStart = 'b',
-        AsyncInstant = 'n',
-        AsyncEnd = 'e',
-        FlowStart = 's',
-        FlowInstant = 't',
-        FlowEnd = 'f',
-        ObjectCreated = 'N',
-        ObjectSnapshot = 'O',
-        ObjectDestroyed = 'D',
-        Metadata = 'M',
-        MemoryDumpGlobal = 'V',
-        MemoryDumpProcess = 'v',
-        Mark = 'R',
-        ClockSync = 'c',
-        ContextEnter = '(',
-        ContentLeave = ')'
-    };
+    AZ_ENUM_CLASS_WITH_UNDERLYING_TYPE(EventPhase, char,
+        (DurationBegin, 'B'),
+        (DurationEnd, 'E'),
+        (Complete, 'X'),
+        (Instant, 'i'),
+        (Counter, 'C'),
+        (AsyncStart, 'b'),
+        (AsyncInstant, 'n'),
+        (AsyncEnd, 'e'),
+        (FlowStart, 's'),
+        (FlowInstant, 't'),
+        (FlowEnd, 'f'),
+        (ObjectCreated, 'N'),
+        (ObjectSnapshot, 'O'),
+        (ObjectDestroyed, 'D'),
+        (Metadata, 'M'),
+        (MemoryDumpGlobal, 'V'),
+        (MemoryDumpProcess, 'v'),
+        (Mark, 'R'),
+        (ClockSync, 'c'),
+        (ContextEnter, '('),
+        (ContentLeave, ')')
+        );
 
     struct EventDesc
     {
@@ -299,12 +302,11 @@ namespace AZ::Metrics
     };
 
     //! Enums used to populate the scope key for instant events
-    enum class InstantEventScope : char
-    {
-        Global = 'g',
-        Process = 'p',
-        Thread = 't'
-    };
+    AZ_ENUM_CLASS_WITH_UNDERLYING_TYPE(InstantEventScope, char,
+        (Global, 'g'),
+        (Process, 'p'),
+        (Thread, 't')
+    );
 
     //! Structure which represents arguments associated with the complete instant events
     //! Instant events are used to record an event that has no duration associated with it

--- a/Code/Framework/AzCore/AzCore/Metrics/JsonTraceEventLogger.cpp
+++ b/Code/Framework/AzCore/AzCore/Metrics/JsonTraceEventLogger.cpp
@@ -133,18 +133,18 @@ namespace AZ::Metrics
         ResetStream(nullptr);
     }
 
-    JsonTraceEventLogger::JsonTraceEventLogger(JsonTraceLoggerEventConfig config)
+    JsonTraceEventLogger::JsonTraceEventLogger(JsonTraceEventLoggerConfig config)
         : JsonTraceEventLogger(nullptr, AZStd::move(config))
     {
     }
 
     JsonTraceEventLogger::JsonTraceEventLogger(AZStd::unique_ptr<AZ::IO::GenericStream> stream)
-        : JsonTraceEventLogger(AZStd::move(stream), JsonTraceLoggerEventConfig{})
+        : JsonTraceEventLogger(AZStd::move(stream), JsonTraceEventLoggerConfig{})
     {
     }
 
     JsonTraceEventLogger::JsonTraceEventLogger(AZStd::unique_ptr<AZ::IO::GenericStream> stream,
-        JsonTraceLoggerEventConfig config)
+        JsonTraceEventLoggerConfig config)
         : m_stream(AZStd::move(stream))
         , m_name(AZStd::move(config.m_loggerName))
         , m_settingsRegistry{ config.m_settingsRegistry }

--- a/Code/Framework/AzCore/AzCore/Metrics/JsonTraceEventLogger.h
+++ b/Code/Framework/AzCore/AzCore/Metrics/JsonTraceEventLogger.h
@@ -23,7 +23,7 @@ namespace AZ::IO
 namespace AZ::Metrics
 {
     // Contains JsonTraceEventLogger specific configuration
-    struct JsonTraceLoggerEventConfig
+    struct JsonTraceEventLoggerConfig
     {
         //! Name of the JsonTraceEventLogger
         AZStd::string_view m_loggerName;
@@ -39,10 +39,10 @@ namespace AZ::Metrics
     {
     public:
         JsonTraceEventLogger();
-        explicit JsonTraceEventLogger(JsonTraceLoggerEventConfig);
+        explicit JsonTraceEventLogger(JsonTraceEventLoggerConfig);
         //! Generic stream which owned by the JsonEventLogger
         explicit JsonTraceEventLogger(AZStd::unique_ptr<AZ::IO::GenericStream> stream);
-        JsonTraceEventLogger(AZStd::unique_ptr<AZ::IO::GenericStream> stream, JsonTraceLoggerEventConfig);
+        JsonTraceEventLogger(AZStd::unique_ptr<AZ::IO::GenericStream> stream, JsonTraceEventLoggerConfig);
 
         ~JsonTraceEventLogger();
 

--- a/Code/Framework/AzCore/AzCore/Preprocessor/EnumReflectUtils.h
+++ b/Code/Framework/AzCore/AzCore/Preprocessor/EnumReflectUtils.h
@@ -17,7 +17,7 @@
 //! @param EnumTypeName an enum that was defined using one of the AZ_ENUM macros.
 #define AZ_ENUM_DEFINE_REFLECT_UTILITIES(EnumTypeName)                                                                                             \
                                                                                                                                                    \
-    static void AZ_JOIN(EnumTypeName, Reflect)(AZ::SerializeContext& context)                                                                      \
+    inline void AZ_JOIN(EnumTypeName, Reflect)(AZ::SerializeContext& context)                                                                      \
     {                                                                                                                                              \
         auto enumMaker = context.Enum<EnumTypeName>();                                                                                             \
         for (auto&& member : AZ::AzEnumTraits<EnumTypeName>::Members)                                                                              \
@@ -47,7 +47,7 @@
         (AZ_JOIN(EnumTypeName, ReflectValue)<Indices>(context, enumTypeBuilder, typeName), ...);                                                   \
     }                                                                                                                                              \
                                                                                                                                                    \
-    void AZ_JOIN(EnumTypeName, Reflect)(AZ::BehaviorContext& context, AZStd::string_view typeName = {})                                            \
+    inline void AZ_JOIN(EnumTypeName, Reflect)(AZ::BehaviorContext& context, AZStd::string_view typeName = {})                                            \
     {                                                                                                                                              \
         if (typeName.empty())                                                                                                                      \
         {                                                                                                                                          \

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.cpp
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.cpp
@@ -154,6 +154,13 @@ namespace AZ
         }
     }
 
+
+    // BehaviorMethod legacy Call forwarder
+    bool BehaviorMethod::Call(BehaviorArgument* arguments, unsigned int numArguments, BehaviorArgument* result) const
+    {
+        return Call(AZStd::span(arguments, numArguments), result);
+    }
+
     bool BehaviorMethod::AddOverload(BehaviorMethod* overload)
     {
         // \todo add attribute to all overloads
@@ -468,6 +475,43 @@ namespace AZ
         return (classTypeIt != m_typeToClassMap.end());
     }
 
+    // BehaviorContext bound objects query functions
+    const BehaviorMethod* BehaviorContext::FindMethodByReflectedName(AZStd::string_view reflectedName) const
+    {
+        auto methodIt = m_methods.find(reflectedName);
+        return methodIt != m_methods.end() ? methodIt->second : nullptr;
+    }
+    const BehaviorProperty* BehaviorContext::FindPropertyByReflectedName(AZStd::string_view reflectedName) const
+    {
+        auto propertyIt = m_properties.find(reflectedName);
+        return propertyIt != m_properties.end() ? propertyIt->second : nullptr;
+    }
+    const BehaviorMethod* BehaviorContext::FindGetterByReflectedName(AZStd::string_view reflectedName) const
+    {
+        auto propertyIt = m_properties.find(reflectedName);
+        return propertyIt != m_properties.end() && propertyIt->second != nullptr ? propertyIt->second->m_getter : nullptr;
+    }
+    const BehaviorMethod* BehaviorContext::FindSetterByReflectedName(AZStd::string_view reflectedName) const
+    {
+        auto propertyIt = m_properties.find(reflectedName);
+        return propertyIt != m_properties.end() && propertyIt->second != nullptr ? propertyIt->second->m_setter : nullptr;
+    }
+    const BehaviorClass* BehaviorContext::FindClassByReflectedName(AZStd::string_view reflectedName) const
+    {
+        auto classIt = m_classes.find(reflectedName);
+        return classIt != m_classes.end() ? classIt->second : nullptr;
+    }
+    const BehaviorClass* BehaviorContext::FindClassByTypeId(const AZ::TypeId& typeId) const
+    {
+        auto classTypeIt = m_typeToClassMap.find(typeId);
+        return classTypeIt != m_typeToClassMap.end() ? classTypeIt->second : nullptr;
+    }
+    const BehaviorEBus* BehaviorContext::FindEBusByReflectedName(AZStd::string_view reflectedName) const
+    {
+        auto ebusIt = m_ebuses.find(reflectedName);
+        return ebusIt != m_ebuses.end() ? ebusIt->second: nullptr;
+    }
+
     //=========================================================================
     // BehaviorClass
     //=========================================================================
@@ -538,6 +582,132 @@ namespace AZ
         }
 
         return BehaviorObject(address, m_azRtti);
+    }
+
+
+
+    // ScopedBehaviorObject class constructor/destructor definition
+    BehaviorClass::ScopedBehaviorObject::ScopedBehaviorObject() = default;
+    BehaviorClass::ScopedBehaviorObject::ScopedBehaviorObject(AZ::BehaviorObject&& behaviorObject, CleanupFunction cleanupFunction)
+        : m_behaviorObject(behaviorObject)
+        , m_cleanupFunction(AZStd::move(cleanupFunction))
+    {
+
+    }
+
+    // Move assignment needs to deallocate the previous scoped object
+    auto BehaviorClass::ScopedBehaviorObject::operator=(ScopedBehaviorObject&& other) ->ScopedBehaviorObject&
+    {
+        if (this != &other)
+        {
+            // Swap with the other scoped behavior object
+            // When the other object goes out of scope it will cleanup the old BehaviorObject instance.
+            AZStd::swap(m_behaviorObject, other.m_behaviorObject);
+            AZStd::swap(m_cleanupFunction, other.m_cleanupFunction);
+        }
+        return *this;
+    }
+
+    BehaviorClass::ScopedBehaviorObject::~ScopedBehaviorObject()
+    {
+        if (m_cleanupFunction)
+        {
+            m_cleanupFunction(m_behaviorObject);
+        }
+    }
+
+    bool BehaviorClass::ScopedBehaviorObject::IsValid() const
+    {
+        return m_behaviorObject.IsValid();
+    }
+
+    auto BehaviorClass::CreateWithScope() const -> ScopedBehaviorObject
+    {
+        return ScopedBehaviorObject(Create(Allocate()), [this](const AZ::BehaviorObject& behaviorObject)
+            {
+                this->Destroy(behaviorObject);
+            });
+    }
+
+    auto BehaviorClass::CreateWithScope(void* address) const -> ScopedBehaviorObject
+    {
+        return ScopedBehaviorObject(Create(address), [this](const AZ::BehaviorObject& behaviorObject)
+            {
+                if (behaviorObject.m_typeId == m_typeId && this->m_destructor && behaviorObject.m_address)
+                {
+                    this->m_destructor(behaviorObject.m_address, m_userData);
+                }
+            });
+    }
+
+    auto BehaviorClass::CreateWithScope(AZStd::span<BehaviorArgument> arguments) const -> ScopedBehaviorObject
+    {
+        // If the arguments list is empty fallback to using the default constructor overload
+        if (arguments.empty())
+        {
+            return CreateWithScope();
+        }
+
+        AZ::BehaviorObject selfObject(Allocate(), m_azRtti);
+        AZStd::fixed_vector<AZ::BehaviorArgument, 64> addressPlusArguments{ AZ::BehaviorArgument{&selfObject} };
+        addressPlusArguments.append_range(arguments);
+
+        bool constructorInvoked{};
+        for (AZ::BehaviorMethod* constructor : m_constructors)
+        {
+            if (constructor->IsCallable(addressPlusArguments) && constructor->Call(addressPlusArguments))
+            {
+                constructorInvoked = true;
+                break;
+            }
+        }
+
+        if (constructorInvoked)
+        {
+            return ScopedBehaviorObject(AZStd::move(selfObject), [this](const AZ::BehaviorObject& behaviorObject)
+                {
+                    this->Destroy(behaviorObject);
+                });
+        }
+
+        // No the constructor has been invoked, so deallocate the new object instance created in this function
+        Deallocate(selfObject.m_address);
+
+        return {};
+    }
+
+    auto BehaviorClass::CreateWithScope(void* address, AZStd::span<BehaviorArgument> arguments) const -> ScopedBehaviorObject
+    {
+        // If the arguments list is empty fallback to using the default constructor overload with the supplied memory address
+        if (arguments.empty())
+        {
+            return CreateWithScope(address);
+        }
+
+        // Use the supplied memory address to create a new object instance
+        AZ::BehaviorObject selfObject(address, m_azRtti);
+        AZStd::fixed_vector<AZ::BehaviorArgument, 64> addressPlusArguments{ AZ::BehaviorArgument{&selfObject} };
+        addressPlusArguments.append_range(arguments);
+
+        bool constructorInvoked{};
+        for (AZ::BehaviorMethod* constructor : m_constructors)
+        {
+            if (constructor->IsCallable(addressPlusArguments) && constructor->Call(addressPlusArguments))
+            {
+                constructorInvoked = true;
+                break;
+            }
+        }
+
+        if (constructorInvoked)
+        {
+            return ScopedBehaviorObject(AZStd::move(selfObject), [this](const AZ::BehaviorObject& behaviorObject)
+                {
+                    this->Destroy(behaviorObject);
+                });
+        }
+
+        return {};
     }
 
     //=========================================================================
@@ -670,6 +840,25 @@ namespace AZ
     {
         auto methodIter = m_methods.find(name);
         return methodIter != m_methods.end() && methodIter->second->m_overload != nullptr;
+    }
+
+    // Property method query functions implementations
+    const BehaviorProperty* BehaviorClass::FindPropertyByReflectedName(AZStd::string_view reflectedName) const
+    {
+        auto propertyIter = m_properties.find(reflectedName);
+        return propertyIter != m_properties.end() ? propertyIter->second : nullptr;
+    }
+
+    const BehaviorMethod* BehaviorClass::FindGetterByReflectedName(AZStd::string_view reflectedName) const
+    {
+        const BehaviorProperty* behaviorProperty = FindPropertyByReflectedName(reflectedName);
+        return behaviorProperty != nullptr ? behaviorProperty->m_getter : nullptr;
+    }
+
+    const BehaviorMethod* BehaviorClass::FindSetterByReflectedName(AZStd::string_view reflectedName) const
+    {
+        const BehaviorProperty* behaviorProperty = FindPropertyByReflectedName(reflectedName);
+        return behaviorProperty != nullptr ? behaviorProperty->m_setter : nullptr;
     }
 
     //=========================================================================

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.h
@@ -4216,7 +4216,7 @@ namespace AZ
                     BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
                     if (!defaultValue)
                     {
-                        return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                        return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                             "Not enough arguments to make call to method %s. %zu supplied, needed %zu",
                             m_name.c_str(), arguments.size(), newArguments.size()) };
                     }
@@ -4227,7 +4227,7 @@ namespace AZ
             }
             else if (arguments.size() > totalArguments)
             {
-                return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                     "Too many arguments supplied to method '%s'. Expects %zu arguments, provided %zu",
                     m_name.c_str(), totalArguments, arguments.size()) };
             }
@@ -4239,7 +4239,7 @@ namespace AZ
                 bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
                 if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
                 {
-                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                         "Invalid parameter type for method '%s'!"
                         " Can not convert method parameter %zu from %s(%s) to %s(%s)",
                         m_name.c_str(), i - 1,
@@ -4249,7 +4249,7 @@ namespace AZ
                 }
                 else if (isArgumentPointer != isParameterPointer)
                 {
-                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                         R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
                         isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
                         isParameterPointer ? "pointer" : "value", m_parameters[i].m_name) };
@@ -4263,7 +4263,7 @@ namespace AZ
                     (returnParam->m_azRtti != nullptr && returnParam->m_azRtti->IsTypeOf(result->m_typeId));
                     !canStoreResult)
                 {
-                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                         "The behavior argument for the return value cannot store the return type %s",
                         returnParam->m_typeId.ToFixedString().c_str()) };
                 }
@@ -4520,7 +4520,7 @@ namespace AZ
                     BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
                     if (!defaultValue)
                     {
-                        return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                        return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                             "Not enough arguments to make call to method %s. %zu supplied, needed %zu",
                             m_name.c_str(), arguments.size(), newArguments.size()) };
                     }
@@ -4531,14 +4531,14 @@ namespace AZ
             }
             else if (arguments.size() > totalArguments)
             {
-                return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                     "Too many arguments supplied to method '%s'. Expects %zu arguments, provided %zu",
                     m_name.c_str(), totalArguments, arguments.size()) };
             }
 
             if (!arguments[0].ConvertTo(AzTypeInfo<C>::Uuid()))
             {
-                return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                     "First parameter should be the 'this' pointer for the member function! %s", m_name.c_str()) };
             }
 
@@ -4549,7 +4549,7 @@ namespace AZ
                 bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
                 if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
                 {
-                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                         "Invalid parameter type for method '%s'!"
                         " Can not convert method parameter %zu from %s(%s) to %s(%s)",
                         m_name.c_str(), i - 1,
@@ -4559,7 +4559,7 @@ namespace AZ
                 }
                 else if (isArgumentPointer != isParameterPointer)
                 {
-                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                         R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
                         isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
                         isParameterPointer ? "pointer" : "value", m_parameters[i].m_name) };
@@ -4573,7 +4573,7 @@ namespace AZ
                     (returnParam->m_azRtti != nullptr && returnParam->m_azRtti->IsTypeOf(result->m_typeId));
                     !canStoreResult)
                 {
-                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                         "The behavior argument for the return value cannot store the return type %s",
                         returnParam->m_typeId.ToFixedString().c_str()) };
                 }
@@ -4844,7 +4844,7 @@ namespace AZ
                     BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
                     if (!defaultValue)
                     {
-                        return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                        return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                             "Not enough arguments to make call to method %s. %zu supplied, needed %zu",
                             m_name.c_str(), arguments.size(), newArguments.size()) };
                     }
@@ -4855,7 +4855,7 @@ namespace AZ
             }
             else if (arguments.size() > totalArguments)
             {
-                return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                     "Too many arguments supplied to method '%s'. Expects %zu arguments, provided %zu",
                     m_name.c_str(), totalArguments, arguments.size()) };
             }
@@ -4865,7 +4865,7 @@ namespace AZ
                 if (!arguments[0].ConvertTo(m_parameters[1].m_typeId))
                 {
                     AZ_Warning("Behavior", false, "Invalid BusIdType type can't convert! %s -> %s", arguments[0].m_name, m_parameters[1].m_name);
-                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                         "Invalid BusIdType type can't convert! %s -> %s",
                         arguments[0].m_name, m_parameters[1].m_name) };
                 }
@@ -4878,7 +4878,7 @@ namespace AZ
                 bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
                 if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
                 {
-                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                         "Invalid parameter type for method '%s'!"
                         " Can not convert method parameter %zu from %s(%s) to %s(%s)",
                         m_name.c_str(), i - 1,
@@ -4888,7 +4888,7 @@ namespace AZ
                 }
                 else if (isArgumentPointer != isParameterPointer)
                 {
-                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                         R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
                         isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
                         isParameterPointer ? "pointer" : "value", m_parameters[i].m_name) };
@@ -4902,7 +4902,7 @@ namespace AZ
                     (returnParam->m_azRtti != nullptr && returnParam->m_azRtti->IsTypeOf(result->m_typeId));
                     !canStoreResult)
                 {
-                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                         "The behavior argument for the return value cannot store the return type %s",
                         returnParam->m_typeId.ToFixedString().c_str()) };
                 }

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.h
@@ -152,6 +152,9 @@ namespace AZ
      *
      * For reflecting type information of C+++ parameters use \ref BehaviorParameter.
      */
+    struct BehaviorArgumentValueTypeTag_t {};
+    constexpr BehaviorArgumentValueTypeTag_t BehaviorArgumentValueTypeTag;
+
     struct BehaviorArgument : public BehaviorParameter
     {
         BehaviorArgument();
@@ -162,10 +165,12 @@ namespace AZ
 
         /// Special handling for the generic object holder.
         BehaviorArgument(BehaviorObject* value);
+        BehaviorArgument(BehaviorArgumentValueTypeTag_t, BehaviorObject* value);
 
         template<class T>
         void Set(T* value);
         void Set(BehaviorObject* value);
+        void Set(BehaviorArgumentValueTypeTag_t, BehaviorObject* value);
         void Set(const BehaviorParameter& param);
         void Set(const BehaviorArgument& param);
 
@@ -312,6 +317,7 @@ namespace AZ
         : public OnDemandReflectionOwner
     {
     public:
+        using ResultOutcome = AZ::Outcome<void, AZStd::string>;
         BehaviorMethod(BehaviorContext* context);
         ~BehaviorMethod() override;
 
@@ -326,7 +332,13 @@ namespace AZ
         void SetDeprecatedName(const AZStd::string& name) { m_deprecatedName = name; }
         const AZStd::string& GetDeprecatedName() const { return m_deprecatedName; }
 
-        virtual bool Call(BehaviorArgument* arguments, unsigned int numArguments, BehaviorArgument* result = nullptr) const = 0;
+        virtual bool Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result = nullptr) const = 0;
+        bool Call(BehaviorArgument* arguments, unsigned int numArguments, BehaviorArgument* result = nullptr) const;
+
+        //! Returns success if the method is callable with the supplied arguments otherwise an error message
+        //! is returned with the reason the method is not callable
+        virtual ResultOutcome IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result = nullptr) const = 0;
+
         virtual bool HasResult() const = 0;
         /// Returns true if the method is a class member method. If true the first argument should always be the "this"/ClassType pointer.
         virtual bool IsMember() const = 0;
@@ -559,7 +571,7 @@ namespace AZ
         {
         public:
             using FunctionPointer = R(*)(Args...);
-            typedef void ClassType;
+            using ClassType = void;
 
             AZ_CLASS_ALLOCATOR(BehaviorMethodImpl, AZ::SystemAllocator, 0);
 
@@ -568,7 +580,9 @@ namespace AZ
 
             BehaviorMethodImpl(FunctionPointer functionPointer, BehaviorContext* context, const AZStd::string& name = AZStd::string());
 
-            bool Call(BehaviorArgument* arguments, unsigned int numArguments, BehaviorArgument* result) const override;
+            bool Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const override;
+            // The implementation should return true if the method can be called with the specified BehaviorArgument list
+            ResultOutcome IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const override;
 
             bool HasResult() const override;
             bool IsMember() const override;
@@ -592,8 +606,8 @@ namespace AZ
 
             FunctionPointer m_functionPtr;
 
-            BehaviorParameter m_parameters[sizeof...(Args)+s_startNamedArgumentIndex];
-            AZStd::array<BehaviorParameterMetadata, sizeof...(Args)+s_startNamedArgumentIndex> m_metadataParameters; ///< Stores the per parameter metadata which is used to add names, tooltips, trait, default values, etc... to the parameters
+            BehaviorParameter m_parameters[sizeof...(Args) + s_startNamedArgumentIndex];
+            AZStd::array<BehaviorParameterMetadata, sizeof...(Args) + s_startNamedArgumentIndex> m_metadataParameters; ///< Stores the per parameter metadata which is used to add names, tooltips, trait, default values, etc... to the parameters
         };
 
 #if __cpp_noexcept_function_type
@@ -626,7 +640,8 @@ namespace AZ
             BehaviorMethodImpl(FunctionPointer functionPointer, BehaviorContext* context, const AZStd::string& name = AZStd::string());
             BehaviorMethodImpl(FunctionPointerConst functionPointer, BehaviorContext* context, const AZStd::string& name = AZStd::string());
 
-            bool Call(BehaviorArgument* arguments, unsigned int numArguments, BehaviorArgument* result) const override;
+            bool Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const override;
+            ResultOutcome IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const;
 
             bool HasResult() const override;
             bool IsMember() const override;
@@ -648,11 +663,11 @@ namespace AZ
             void OverrideParameterTraits(size_t index, AZ::u32 addTraits, AZ::u32 removeTraits) override;
 
             FunctionPointer m_functionPtr;
-            BehaviorParameter m_parameters[sizeof...(Args)+s_startNamedArgumentIndex];
-            AZStd::array<BehaviorParameterMetadata, sizeof...(Args)+s_startNamedArgumentIndex> m_metadataParameters; ///< Stores the per parameter metadata which is used to add names, tooltips, trait, default values, etc... to the parameters
+            BehaviorParameter m_parameters[sizeof...(Args) + s_startNamedArgumentIndex];
+            AZStd::array<BehaviorParameterMetadata, sizeof...(Args) + s_startNamedArgumentIndex> m_metadataParameters; ///< Stores the per parameter metadata which is used to add names, tooltips, trait, default values, etc... to the parameters
         };
 
- #if __cpp_noexcept_function_type
+#if __cpp_noexcept_function_type
         // C++17 makes exception specifications as part of the type in paper P0012R1
         // Therefore noexcept overloads must be distinguished from non-noexcept overloads
         template<class R, class C, class... Args>
@@ -779,7 +794,8 @@ namespace AZ
 
             BehaviorEBusEvent(FunctionPointer functionPointer, BehaviorContext* context);
 
-            bool Call(BehaviorArgument* arguments, unsigned int numArguments, BehaviorArgument* result) const override;
+            bool Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const override;
+            ResultOutcome IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result = nullptr) const;
             bool HasResult() const override;
             bool IsMember() const override;
             bool HasBusId() const override;
@@ -804,7 +820,7 @@ namespace AZ
             BehaviorParameter m_parameters[sizeof...(Args) + s_startNamedArgumentIndex];
             AZStd::array<BehaviorParameterMetadata, sizeof...(Args) + s_startNamedArgumentIndex>
                 m_metadataParameters; ///< Stores the per parameter metadata which is used to add names, tooltips, trait, default values,
-                                      ///< etc... to the parameters
+            ///< etc... to the parameters
         };
 
 #if __cpp_noexcept_function_type
@@ -843,7 +859,8 @@ namespace AZ
             template<bool IsBusId>
             inline AZStd::enable_if_t<!IsBusId> SetBusIdType();
 
-            bool Call(BehaviorArgument* arguments, unsigned int numArguments, BehaviorArgument* result) const override;
+            bool Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const override;
+            ResultOutcome IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result = nullptr) const;
             bool HasResult() const override;
             bool IsMember() const override;
             bool HasBusId() const override;
@@ -1129,15 +1146,46 @@ namespace AZ
         /// Compare values
         using EqualityComparisonType = bool(*)(const void* lhs, const void* rhs, void* userData);
 
+        struct ScopedBehaviorObject
+        {
+            using CleanupFunction = AZStd::function<void(const AZ::BehaviorObject&)>;
+            ScopedBehaviorObject();
+            // Accepting an rvalue BehaviorObject to imply "ownership" over it
+            // Does not actually use any move semantics
+            ScopedBehaviorObject(AZ::BehaviorObject&& behaviorObject, CleanupFunction cleanupFunction);
+
+            // Prevents copy constructor and copy assignment from being instantiated
+            // which would cause the cleanupFunction to run twice.
+            ScopedBehaviorObject(ScopedBehaviorObject&&) = default;
+            ScopedBehaviorObject& operator=(ScopedBehaviorObject&&);
+            ~ScopedBehaviorObject();
+
+            bool IsValid() const;
+
+            BehaviorObject m_behaviorObject;
+        private:
+            CleanupFunction m_cleanupFunction;
+        };
+
         // Create the object with default constructor if possible otherwise returns an invalid object
         BehaviorObject Create() const;
 
         // Create the object with default constructor in the provided memory if possible otherwise returns an invalid object
         BehaviorObject Create(void* address) const;
 
-        // TODO: Should we do that or just ask users to Allocate and invoke the constructor manually ?
-        //template<class... Args>
-        //BehaviorObject Create();
+        // Create a scoped behavior object using the  default constructor
+        // The scoped object will automatically destruct AND deallocate the created object
+        ScopedBehaviorObject CreateWithScope() const;
+        // Create a scoped behavior object using default constructor in the provided memory if possible.
+        // The scoped object will automatically destruct the created object
+        // This function does not deallocate since the memory was provided by the user
+        ScopedBehaviorObject CreateWithScope(void* address) const;
+
+        // Create the object using the first registered constructor which can accept all the arguments in the provided memory address
+        // The scoped object will automatically destruct AND deallocate the created object
+        ScopedBehaviorObject CreateWithScope(AZStd::span<BehaviorArgument> arguments) const;
+        // Create the object using the first registered constructor which can accept all the arguments in the provided memory address
+        ScopedBehaviorObject CreateWithScope(void* address, AZStd::span<BehaviorArgument> arguments) const;
 
         BehaviorObject Clone(const BehaviorObject& object) const;
         BehaviorObject Move(BehaviorObject&& object) const;
@@ -1164,11 +1212,14 @@ namespace AZ
 
         const BehaviorMethod* FindMethodByReflectedName(const AZStd::string& reflectedName) const;
         bool IsMethodOverloaded(const AZStd::string& string) const;
-        bool IsMethodOverloaded(BehaviorMethod* method) const;
         AZStd::vector<BehaviorMethod*> GetOverloads(const AZStd::string& string) const;
         AZStd::vector<BehaviorMethod*> GetOverloadsIncludeMethod(BehaviorMethod* method) const;
         AZStd::vector<BehaviorMethod*> GetOverloadsExcludeMethod(BehaviorMethod* method) const;
         void PostProcessMethod(BehaviorContext* context, BehaviorMethod& method);
+
+        const BehaviorProperty* FindPropertyByReflectedName(AZStd::string_view reflectedName) const;
+        const BehaviorMethod* FindGetterByReflectedName(AZStd::string_view reflectedName) const;
+        const BehaviorMethod* FindSetterByReflectedName(AZStd::string_view reflectedName) const;
 
         void* m_userData;
         AZStd::string m_name;
@@ -1928,12 +1979,21 @@ namespace AZ
             return uuid == GetVoidTypeId();
         }
 
+        const BehaviorMethod* FindMethodByReflectedName(AZStd::string_view reflectedName) const;
+        const BehaviorProperty* FindPropertyByReflectedName(AZStd::string_view reflectedName) const;
+        const BehaviorMethod* FindGetterByReflectedName(AZStd::string_view reflectedName) const;
+        const BehaviorMethod* FindSetterByReflectedName(AZStd::string_view reflectedName) const;
+        const BehaviorClass* FindClassByReflectedName(AZStd::string_view reflectedName) const;
+        const BehaviorClass* FindClassByTypeId(const AZ::TypeId& typeId) const;
+        const BehaviorEBus* FindEBusByReflectedName(AZStd::string_view reflectedName) const;
 
-        AZStd::unordered_map<AZStd::string, BehaviorMethod*> m_methods; // TODO: make it a set and use the name inside method
-        AZStd::unordered_map<AZStd::string, BehaviorProperty*> m_properties; // TODO: make it a set and use the name inside property
-        AZStd::unordered_map<AZStd::string, BehaviorClass*> m_classes; // TODO: make it a set and use the name inside class
-        AZStd::unordered_map<AZ::Uuid, BehaviorClass*> m_typeToClassMap; // TODO: make it a set and use the UUID inside the class
-        AZStd::unordered_map<AZStd::string, BehaviorEBus*> m_ebuses; // TODO: make it a set and use the name inside EBus
+        //! Prefer to access BehaviorContext methods, properties, classes and EBuses through the Find* functions
+        //! instead of direct member access
+        AZStd::unordered_map<AZStd::string, BehaviorMethod*> m_methods;
+        AZStd::unordered_map<AZStd::string, BehaviorProperty*> m_properties;
+        AZStd::unordered_map<AZStd::string, BehaviorClass*> m_classes;
+        AZStd::unordered_map<AZ::Uuid, BehaviorClass*> m_typeToClassMap;
+        AZStd::unordered_map<AZStd::string, BehaviorEBus*> m_ebuses;
 
         AZStd::unordered_set<ExplicitOverloadInfo> m_explicitOverloads;
         AZStd::unordered_map< const BehaviorMethod*, AZStd::pair<const BehaviorMethod*, const BehaviorClass*>> m_checksByOperations;
@@ -2370,6 +2430,11 @@ namespace AZ
         Set(value);
     }
 
+    inline BehaviorArgument::BehaviorArgument(BehaviorArgumentValueTypeTag_t, BehaviorObject* value)
+    {
+        Set(BehaviorArgumentValueTypeTag, value);
+    }
+
     //////////////////////////////////////////////////////////////////////////
     template<typename T, typename>
     inline void BehaviorArgument::StoreInTempData(T&& value)
@@ -2399,6 +2464,15 @@ namespace AZ
         m_value = &value->m_address;
         m_typeId = value->m_typeId;
         m_traits = BehaviorParameter::TR_POINTER;
+        m_name = value->m_rttiHelper ? value->m_rttiHelper->GetActualTypeName(value->m_address) : nullptr;
+        m_azRtti = value->m_rttiHelper;
+    }
+
+    inline void BehaviorArgument::Set(BehaviorArgumentValueTypeTag_t, BehaviorObject* value)
+    {
+        m_value = value->m_address;
+        m_typeId = value->m_typeId;
+        m_traits = BehaviorParameter::TR_NONE;
         m_name = value->m_rttiHelper ? value->m_rttiHelper->GetActualTypeName(value->m_address) : nullptr;
         m_azRtti = value->m_rttiHelper;
     }
@@ -3167,7 +3241,7 @@ namespace AZ
     {
         if (!Base::m_context->IsRemovingReflection())
         {
-        AZ_Error("BehaviorContext", m_class, "You can set constructors only on valid classes!");
+            AZ_Error("BehaviorContext", m_class, "You can set constructors only on valid classes!");
         }
         if (m_class)
         {
@@ -3186,7 +3260,7 @@ namespace AZ
             " As wrapped types are implicitly reflected by the ScriptContext, this prevents a recursive loop");
         if (!Base::m_context->IsRemovingReflection())
         {
-        AZ_Error("BehaviorContext", m_class, "You can wrap only valid classes!");
+            AZ_Error("BehaviorContext", m_class, "You can wrap only valid classes!");
         }
         if (m_class)
         {
@@ -4063,17 +4137,17 @@ namespace AZ
 
         //////////////////////////////////////////////////////////////////////////
         template<class R, class... Args>
-        bool BehaviorMethodImpl<R(Args...)>::Call(BehaviorArgument* arguments, unsigned int numArguments, BehaviorArgument* result) const
+        bool BehaviorMethodImpl<R(Args...)>::Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const
         {
             size_t totalArguments = GetNumArguments();
-            if (numArguments < totalArguments)
+            if (arguments.size() < totalArguments)
             {
                 // We are cloning all arguments on the stack, since Call is called only from Invoke we can reserve bigger "arguments" array
                 // that can always handle all parameters. So far the don't use default values that ofter, so we will optimize for the common case first.
-                BehaviorArgument* newArguments = reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument)*  totalArguments));
+                AZStd::span<BehaviorArgument> newArguments(reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument) * totalArguments)), totalArguments);
                 // clone the input parameters (we don't need to clone temp buffers, etc. as they will be still on the stack)
                 size_t argIndex = 0;
-                for (; argIndex < numArguments; ++argIndex)
+                for (; argIndex < arguments.size(); ++argIndex)
                 {
                     new(&newArguments[argIndex]) BehaviorArgument(arguments[argIndex]);
                 }
@@ -4084,7 +4158,7 @@ namespace AZ
                     BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
                     if (!defaultValue)
                     {
-                        AZ_Warning("Behavior", false, "Not enough arguments to make a call! %d needed %d", numArguments, totalArguments);
+                        AZ_Warning("Behavior", false, "Not enough arguments to make a call! %d needed %d", arguments.size(), totalArguments);
                         return false;
                     }
                     new(&newArguments[argIndex]) BehaviorArgument(defaultValue->GetValue());
@@ -4095,16 +4169,107 @@ namespace AZ
 
             for (size_t i = s_startArgumentIndex; i < AZ_ARRAY_SIZE(m_parameters); ++i)
             {
+                // Verify that argument is a pointer for pointer type parameters and a value or reference for value type or reference type parameters
+                bool isArgumentPointer = arguments[i - 1].m_traits & BehaviorParameter::Traits::TR_POINTER;
+                bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
                 if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
                 {
-                    AZ_Warning("Behavior", false, "Invalid parameter type for method '%s'! Can not convert method parameter %d from %s(%s) to %s(%s)", m_name.c_str(), i - 1, arguments[i - 1].m_name, arguments[i - 1].m_typeId.template ToString<AZStd::string>().c_str(), m_parameters[i].m_name, m_parameters[i].m_typeId.template ToString<AZStd::string>().c_str());
+                    AZ_Warning("Behavior", false, "Invalid parameter type for method '%s'! Can not convert method parameter %d from %s(%s) to %s(%s)",
+                        m_name.c_str(), i - 1, arguments[i - 1].m_name,
+                        arguments[i - 1].m_typeId.ToFixedString().c_str(),
+                        m_parameters[i].m_name, m_parameters[i].m_typeId.ToFixedString().c_str());
+                    return false;
+                }
+                else if (isArgumentPointer != isParameterPointer)
+                {
+                    AZ_Warning("Behavior", false, R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
+                        isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
+                        isParameterPointer ? "pointer" : "value", m_parameters[i].m_name);
                     return false;
                 }
             }
 
-            CallFunction<R, Args...>::Global(m_functionPtr, arguments, result, AZStd::make_index_sequence<sizeof...(Args)>());
+            CallFunction<R, Args...>::Global(m_functionPtr, arguments.data(), result, AZStd::make_index_sequence<sizeof...(Args)>());
 
             return true;
+        }
+
+        template<class R,  class... Args>
+        auto BehaviorMethodImpl<R(Args...)>::IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const
+            -> ResultOutcome
+        {
+            size_t totalArguments = GetNumArguments();
+            if (arguments.size() < totalArguments)
+            {
+                // Clone the arguments on the stack and validate that the method can be invoked with the arguments
+                AZStd::span<BehaviorArgument> newArguments(reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument) * totalArguments)), totalArguments);
+                // clone the input parameters (we don't need to clone temp buffers, etc. as they will be still on the stack)
+                size_t argIndex = 0;
+                for (; argIndex < arguments.size(); ++argIndex)
+                {
+                    new(&newArguments[argIndex]) BehaviorArgument(arguments[argIndex]);
+                }
+
+                // clone the default parameters if they exist
+                for (; argIndex < totalArguments; ++argIndex)
+                {
+                    BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
+                    if (!defaultValue)
+                    {
+                        return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                            "Not enough arguments to make call to method %s. %zu supplied, needed %zu",
+                            m_name.c_str(), arguments.size(), newArguments.size()) };
+                    }
+                    new(&newArguments[argIndex]) BehaviorArgument(defaultValue->GetValue());
+                }
+
+                arguments = newArguments;
+            }
+            else if (arguments.size() > totalArguments)
+            {
+                return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                    "Too many arguments supplied to method '%s'. Expects %zu arguments, provided %zu",
+                    m_name.c_str(), totalArguments, arguments.size()) };
+            }
+
+            for (size_t i = s_startArgumentIndex; i < AZ_ARRAY_SIZE(m_parameters); ++i)
+            {
+                // Verify that argument is a pointer for pointer type parameters and a value or reference for value type or reference type parameters
+                bool isArgumentPointer = arguments[i - 1].m_traits & BehaviorParameter::Traits::TR_POINTER;
+                bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
+                if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
+                {
+                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                        "Invalid parameter type for method '%s'!"
+                        " Can not convert method parameter %zu from %s(%s) to %s(%s)",
+                        m_name.c_str(), i - 1,
+                        arguments[i - 1].m_name, arguments[i - 1].m_typeId.ToFixedString().c_str(),
+                        m_parameters[i].m_name, m_parameters[i].m_typeId.ToFixedString().c_str()
+                    ) };
+                }
+                else if (isArgumentPointer != isParameterPointer)
+                {
+                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                        R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
+                        isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
+                        isParameterPointer ? "pointer" : "value", m_parameters[i].m_name) };
+                }
+            }
+
+            if (result != nullptr)
+            {
+                const AZ::BehaviorParameter* returnParam = GetResult();
+                if (bool canStoreResult = result->m_typeId.IsNull() || result->m_typeId == returnParam->m_typeId ||
+                    (returnParam->m_azRtti != nullptr && returnParam->m_azRtti->IsTypeOf(result->m_typeId));
+                    !canStoreResult)
+                {
+                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                        "The behavior argument for the return value cannot store the return type %s",
+                        returnParam->m_typeId.ToFixedString().c_str()) };
+                }
+            }
+
+            return AZ::Success();
         }
 
         //////////////////////////////////////////////////////////////////////////
@@ -4267,17 +4432,17 @@ namespace AZ
 
         //////////////////////////////////////////////////////////////////////////
         template<class R, class C, class... Args>
-        bool BehaviorMethodImpl<R(C::*)(Args...)>::Call(BehaviorArgument* arguments, unsigned int numArguments, BehaviorArgument* result) const
+        bool BehaviorMethodImpl<R(C::*)(Args...)>::Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const
         {
             size_t totalArguments = GetNumArguments();
-            if (numArguments < totalArguments)
+            if (arguments.size() < totalArguments)
             {
                 // We are cloning all arguments on the stack, since Call is called only from Invoke we can reserve bigger "arguments" array
                 // that can always handle all parameters. So far the don't use default values that ofter, so we will optimize for the common case first.
-                BehaviorArgument* newArguments = reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument)*  totalArguments));
+                AZStd::span<BehaviorArgument> newArguments(reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument) * totalArguments)), totalArguments);
                 // clone the input parameters (we don't need to clone temp buffers, etc. as they will be still on the stack)
                 size_t argIndex = 0;
-                for (; argIndex < numArguments; ++argIndex)
+                for (; argIndex < arguments.size(); ++argIndex)
                 {
                     new(&newArguments[argIndex]) BehaviorArgument(arguments[argIndex]);
                 }
@@ -4288,7 +4453,7 @@ namespace AZ
                     BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
                     if (!defaultValue)
                     {
-                        AZ_Warning("Behavior", false, "Not enough arguments to make a call! %d needed %d", numArguments, totalArguments);
+                        AZ_Warning("Behavior", false, "Not enough arguments to make a call! %d needed %d", arguments.size(), totalArguments);
                         return false;
                     }
                     new(&newArguments[argIndex]) BehaviorArgument(defaultValue->GetValue());
@@ -4306,18 +4471,115 @@ namespace AZ
 
             for (size_t i = s_startNamedArgumentIndex; i < AZ_ARRAY_SIZE(m_parameters); ++i)
             {
+                // Verify that argument is a pointer for pointer type parameters and a value or reference for value type or reference type parameters
+                bool isArgumentPointer = arguments[i - 1].m_traits & BehaviorParameter::Traits::TR_POINTER;
+                bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
                 if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
                 {
-                    AZ_Warning("Behavior", false, "Invalid parameter type for method '%s'! Can not convert method parameter %d from %s(%s) to %s(%s)", m_name.c_str(), i - 1, arguments[i - 1].m_name, arguments[i - 1].m_typeId.template ToString<AZStd::string>().c_str(), m_parameters[i].m_name, m_parameters[i].m_typeId.template ToString<AZStd::string>().c_str());
+                    AZ_Warning("Behavior", false, "Invalid parameter type for method '%s'! Can not convert method parameter %d from %s(%s) to %s(%s)",
+                        m_name.c_str(), i - 1, arguments[i - 1].m_name,
+                        arguments[i - 1].m_typeId.ToFixedString().c_str(),
+                        m_parameters[i].m_name, m_parameters[i].m_typeId.ToFixedString().c_str());
+                    return false;
+                }
+                else if (isArgumentPointer != isParameterPointer)
+                {
+                    AZ_Warning("Behavior", false, R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
+                        isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
+                        isParameterPointer ? "pointer" : "value", m_parameters[i].m_name);
                     return false;
                 }
             }
 
-            CallFunction<R, Args...>::Member(m_functionPtr, *arguments[0].GetAsUnsafe<C*>(), &arguments[1], result, AZStd::make_index_sequence<sizeof...(Args)>());
+            CallFunction<R, Args...>::Member(m_functionPtr, *arguments[0].GetAsUnsafe<C*>(), arguments.data() + 1, result, AZStd::make_index_sequence<sizeof...(Args)>());
 
             EBUS_EVENT_ID(((void*)(*arguments[0].GetAsUnsafe<C*>())), BehaviorObjectSignals, OnMemberMethodCalled, this);
 
             return true;
+        }
+
+        template<class R, class C, class... Args>
+        auto BehaviorMethodImpl<R(C::*)(Args...)>::IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const
+            -> ResultOutcome
+        {
+            size_t totalArguments = GetNumArguments();
+            if (arguments.size() < totalArguments)
+            {
+                // Clone the arguments on the stack and validate that the method can be invoked with the arguments
+                AZStd::span<BehaviorArgument> newArguments(reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument) * totalArguments)), totalArguments);
+                // clone the input parameters (we don't need to clone temp buffers, etc. as they will be still on the stack)
+                size_t argIndex = 0;
+                for (; argIndex < arguments.size(); ++argIndex)
+                {
+                    new(&newArguments[argIndex]) BehaviorArgument(arguments[argIndex]);
+                }
+
+                // clone the default parameters if they exist
+                for (; argIndex < totalArguments; ++argIndex)
+                {
+                    BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
+                    if (!defaultValue)
+                    {
+                        return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                            "Not enough arguments to make call to method %s. %zu supplied, needed %zu",
+                            m_name.c_str(), arguments.size(), newArguments.size()) };
+                    }
+                    new(&newArguments[argIndex]) BehaviorArgument(defaultValue->GetValue());
+                }
+
+                arguments = newArguments;
+            }
+            else if (arguments.size() > totalArguments)
+            {
+                return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                    "Too many arguments supplied to method '%s'. Expects %zu arguments, provided %zu",
+                    m_name.c_str(), totalArguments, arguments.size()) };
+            }
+
+            if (!arguments[0].ConvertTo(AzTypeInfo<C>::Uuid()))
+            {
+                return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                    "First parameter should be the 'this' pointer for the member function! %s", m_name.c_str()) };
+            }
+
+            for (size_t i = s_startNamedArgumentIndex; i < AZ_ARRAY_SIZE(m_parameters); ++i)
+            {
+                // Verify that argument is a pointer for pointer type parameters and a value or reference for value type or reference type parameters
+                bool isArgumentPointer = arguments[i - 1].m_traits & BehaviorParameter::Traits::TR_POINTER;
+                bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
+                if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
+                {
+                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                        "Invalid parameter type for method '%s'!"
+                        " Can not convert method parameter %zu from %s(%s) to %s(%s)",
+                        m_name.c_str(), i - 1,
+                        arguments[i - 1].m_name, arguments[i - 1].m_typeId.ToFixedString().c_str(),
+                        m_parameters[i].m_name, m_parameters[i].m_typeId.ToFixedString().c_str()
+                    ) };
+                }
+                else if (isArgumentPointer != isParameterPointer)
+                {
+                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                        R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
+                        isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
+                        isParameterPointer ? "pointer" : "value", m_parameters[i].m_name) };
+                }
+            }
+
+            if (result != nullptr)
+            {
+                const AZ::BehaviorParameter* returnParam = GetResult();
+                if (bool canStoreResult = result->m_typeId.IsNull() || result->m_typeId == returnParam->m_typeId ||
+                    (returnParam->m_azRtti != nullptr && returnParam->m_azRtti->IsTypeOf(result->m_typeId));
+                    !canStoreResult)
+                {
+                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                        "The behavior argument for the return value cannot store the return type %s",
+                        returnParam->m_typeId.ToFixedString().c_str()) };
+                }
+            }
+
+            return AZ::Success();
         }
 
         //////////////////////////////////////////////////////////////////////////
@@ -4410,7 +4672,7 @@ namespace AZ
         template<class R, class C, class... Args>
         const AZStd::string* BehaviorMethodImpl<R(C::*)(Args...)>::GetArgumentToolTip(size_t index) const
         {
-            if (index <GetNumArguments())
+            if (index < GetNumArguments())
             {
                 return &m_metadataParameters[index + s_startArgumentIndex].m_toolTip;
             }
@@ -4494,17 +4756,17 @@ namespace AZ
 
         //////////////////////////////////////////////////////////////////////////
         template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        bool BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::Call(BehaviorArgument* arguments, unsigned int numArguments, BehaviorArgument* result) const
+        bool BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const
         {
             size_t totalArguments = GetNumArguments();
-            if (numArguments < totalArguments)
+            if (arguments.size() < totalArguments)
             {
                 // We are cloning all arguments on the stack, since Call is called only from Invoke we can reserve bigger "arguments" array
                 // that can always handle all parameters. So far the don't use default values that ofter, so we will optimize for the common case first.
-                BehaviorArgument* newArguments = reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument)*  totalArguments));
+                AZStd::span<BehaviorArgument> newArguments(reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument) * totalArguments)), totalArguments);
                 // clone the input parameters (we don't need to clone temp buffers, etc. as they will be still on the stack)
                 size_t argIndex = 0;
-                for (; argIndex < numArguments; ++argIndex)
+                for (; argIndex < arguments.size(); ++argIndex)
                 {
                     new(&newArguments[argIndex]) BehaviorArgument(arguments[argIndex]);
                 }
@@ -4515,7 +4777,7 @@ namespace AZ
                     BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
                     if (!defaultValue)
                     {
-                        AZ_Warning("Behavior", false, "Not enough arguments to make a call! %d needed %d", numArguments, totalArguments);
+                        AZ_Warning("Behavior", false, "Not enough arguments to make a call! %d needed %d", arguments.size(), totalArguments);
                         return false;
                     }
                     new(&newArguments[argIndex]) BehaviorArgument(defaultValue->GetValue());
@@ -4535,16 +4797,118 @@ namespace AZ
 
             for (size_t i = s_startNamedArgumentIndex; i < AZ_ARRAY_SIZE(m_parameters); ++i)
             {
+                // Verify that argument is a pointer for pointer type parameters and a value or reference for value type or reference type parameters
+                bool isArgumentPointer = arguments[i - 1].m_traits & BehaviorParameter::Traits::TR_POINTER;
+                bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
                 if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
                 {
-                    AZ_Warning("Behavior", false, "Invalid parameter type for method '%s'! Can not convert method parameter %d from %s(%s) to %s(%s)", m_name.c_str(), i - 1, arguments[i - 1].m_name, arguments[i - 1].m_typeId.template ToString<AZStd::string>().c_str(), m_parameters[i].m_name, m_parameters[i].m_typeId.template ToString<AZStd::string>().c_str());
+                    AZ_Warning("Behavior", false, "Invalid parameter type for method '%s'! Can not convert method parameter %d from %s(%s) to %s(%s)",
+                        m_name.c_str(), i - 1, arguments[i - 1].m_name,
+                        arguments[i - 1].m_typeId.ToFixedString().c_str(),
+                        m_parameters[i].m_name, m_parameters[i].m_typeId.ToFixedString().c_str());
+                    return false;
+                }
+                else if (isArgumentPointer != isParameterPointer)
+                {
+                    AZ_Warning("Behavior", false, R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
+                        isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
+                        isParameterPointer ? "pointer" : "value", m_parameters[i].m_name);
                     return false;
                 }
             }
 
-            AZ::Internal::EBusCaller<EventType, EBus, R, Args...>::Call(m_functionPtr, &arguments[0], result, AZStd::make_index_sequence<sizeof...(Args)>());
+            AZ::Internal::EBusCaller<EventType, EBus, R, Args...>::Call(m_functionPtr, arguments.data(), result, AZStd::make_index_sequence<sizeof...(Args)>());
 
             return true;
+        }
+
+        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
+        auto BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const
+            -> ResultOutcome
+        {
+            size_t totalArguments = GetNumArguments();
+            if (arguments.size() < totalArguments)
+            {
+                // Clone the arguments on the stack and validate that the method can be invoked with the arguments
+                AZStd::span<BehaviorArgument> newArguments(reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument) * totalArguments)), totalArguments);
+                // clone the input parameters (we don't need to clone temp buffers, etc. as they will be still on the stack)
+                size_t argIndex = 0;
+                for (; argIndex < arguments.size(); ++argIndex)
+                {
+                    new(&newArguments[argIndex]) BehaviorArgument(arguments[argIndex]);
+                }
+
+                // clone the default parameters if they exist
+                for (; argIndex < totalArguments; ++argIndex)
+                {
+                    BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
+                    if (!defaultValue)
+                    {
+                        return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                            "Not enough arguments to make call to method %s. %zu supplied, needed %zu",
+                            m_name.c_str(), arguments.size(), newArguments.size()) };
+                    }
+                    new(&newArguments[argIndex]) BehaviorArgument(defaultValue->GetValue());
+                }
+
+                arguments = newArguments;
+            }
+            else if (arguments.size() > totalArguments)
+            {
+                return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                    "Too many arguments supplied to method '%s'. Expects %zu arguments, provided %zu",
+                    m_name.c_str(), totalArguments, arguments.size()) };
+            }
+
+            if constexpr (s_isBusIdParameter)
+            {
+                if (!arguments[0].ConvertTo(m_parameters[1].m_typeId))
+                {
+                    AZ_Warning("Behavior", false, "Invalid BusIdType type can't convert! %s -> %s", arguments[0].m_name, m_parameters[1].m_name);
+                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                        "Invalid BusIdType type can't convert! %s -> %s",
+                        arguments[0].m_name, m_parameters[1].m_name) };
+                }
+            }
+
+            for (size_t i = s_startNamedArgumentIndex; i < AZ_ARRAY_SIZE(m_parameters); ++i)
+            {
+                // Verify that argument is a pointer for pointer type parameters and a value or reference for value type or reference type parameters
+                bool isArgumentPointer = arguments[i - 1].m_traits & BehaviorParameter::Traits::TR_POINTER;
+                bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
+                if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
+                {
+                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                        "Invalid parameter type for method '%s'!"
+                        " Can not convert method parameter %zu from %s(%s) to %s(%s)",
+                        m_name.c_str(), i - 1,
+                        arguments[i - 1].m_name, arguments[i - 1].m_typeId.ToFixedString().c_str(),
+                        m_parameters[i].m_name, m_parameters[i].m_typeId.ToFixedString().c_str()
+                    ) };
+                }
+                else if (isArgumentPointer != isParameterPointer)
+                {
+                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                        R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
+                        isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
+                        isParameterPointer ? "pointer" : "value", m_parameters[i].m_name) };
+                }
+            }
+
+            if (result != nullptr)
+            {
+                const AZ::BehaviorParameter* returnParam = GetResult();
+                if (bool canStoreResult = result->m_typeId.IsNull() || result->m_typeId == returnParam->m_typeId ||
+                    (returnParam->m_azRtti != nullptr && returnParam->m_azRtti->IsTypeOf(result->m_typeId));
+                    !canStoreResult)
+                {
+                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                        "The behavior argument for the return value cannot store the return type %s",
+                        returnParam->m_typeId.ToFixedString().c_str()) };
+                }
+            }
+
+            return AZ::Success();
         }
 
         //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorContextEBusEventRawSignature.inl
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorContextEBusEventRawSignature.inl
@@ -115,7 +115,7 @@ namespace AZ::Internal
                 BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
                 if (!defaultValue)
                 {
-                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                         "Not enough arguments to make call to method %s. %zu supplied, needed %zu",
                         m_name.c_str(), arguments.size(), newArguments.size()) };
                 }
@@ -126,7 +126,7 @@ namespace AZ::Internal
         }
         else if (arguments.size() > totalArguments)
         {
-            return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+            return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                 "Too many arguments supplied to method '%s'. Expects %zu arguments, provided %zu",
                 m_name.c_str(), totalArguments, arguments.size()) };
         }
@@ -136,7 +136,7 @@ namespace AZ::Internal
             if (!arguments[0].ConvertTo(m_parameters[1].m_typeId))
             {
                 AZ_Warning("Behavior", false, "Invalid BusIdType type can't convert! %s -> %s", arguments[0].m_name, m_parameters[1].m_name);
-                return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                     "Invalid BusIdType type can't convert! %s -> %s",
                     arguments[0].m_name, m_parameters[1].m_name) };
             }
@@ -149,7 +149,7 @@ namespace AZ::Internal
             bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
             if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
             {
-                return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                     "Invalid parameter type for method '%s'!"
                     " Can not convert method parameter %zu from %s(%s) to %s(%s)",
                     m_name.c_str(), i - 1,
@@ -159,7 +159,7 @@ namespace AZ::Internal
             }
             else if (isArgumentPointer != isParameterPointer)
             {
-                return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                     R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
                     isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
                     isParameterPointer ? "pointer" : "value", m_parameters[i].m_name) };
@@ -173,7 +173,7 @@ namespace AZ::Internal
                 (returnParam->m_azRtti != nullptr && returnParam->m_azRtti->IsTypeOf(result->m_typeId));
                 !canStoreResult)
             {
-                return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
                     "The behavior argument for the return value cannot store the return type %s",
                     returnParam->m_typeId.ToFixedString().c_str()) };
             }

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorContextEBusEventRawSignature.inl
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorContextEBusEventRawSignature.inl
@@ -26,17 +26,17 @@ namespace AZ::Internal
 
     //////////////////////////////////////////////////////////////////////////
     template<class EBus, BehaviorEventType EventType, class R, class BusType, class... Args>
-    bool BehaviorEBusEvent<EBus, EventType, R(BusType*, Args...)>::Call(BehaviorArgument* arguments, unsigned int numArguments, BehaviorArgument* result) const
+    bool BehaviorEBusEvent<EBus, EventType, R(BusType*, Args...)>::Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const
     {
         size_t totalArguments = GetNumArguments();
-        if (numArguments < totalArguments)
+        if (arguments.size() < totalArguments)
         {
             // We are cloning all arguments on the stack, since Call is called only from Invoke we can reserve bigger "arguments" array
             // that can always handle all parameters. So far the don't use default values that ofter, so we will optimize for the common case first.
-            BehaviorArgument* newArguments = reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument) * totalArguments));
+            AZStd::span<BehaviorArgument> newArguments(reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument) * totalArguments)), totalArguments);
             // clone the input parameters (we don't need to clone temp buffers, etc. as they will be still on the stack)
             size_t argIndex = 0;
-            for (; argIndex < numArguments; ++argIndex)
+            for (; argIndex < arguments.size(); ++argIndex)
             {
                 new(&newArguments[argIndex]) BehaviorArgument(arguments[argIndex]);
             }
@@ -47,7 +47,7 @@ namespace AZ::Internal
                 BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
                 if (!defaultValue)
                 {
-                    AZ_Warning("Behavior", false, "Not enough arguments to make a call! %d needed %d", numArguments, totalArguments);
+                    AZ_Warning("Behavior", false, "Not enough arguments to make a call! %d needed %d", arguments.size(), totalArguments);
                     return false;
                 }
                 new(&newArguments[argIndex]) BehaviorArgument(defaultValue->GetValue());
@@ -67,17 +67,119 @@ namespace AZ::Internal
 
         for (size_t i = s_startNamedArgumentIndex; i < AZ_ARRAY_SIZE(m_parameters); ++i)
         {
+            // Verify that argument is a pointer for pointer type parameters and a value or reference for value type or reference type parameters
+            bool isArgumentPointer = arguments[i - 1].m_traits & BehaviorParameter::Traits::TR_POINTER;
+            bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
             if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
             {
-                AZ_Warning("Behavior", false, "Invalid parameter type for method '%s'! Can not convert method parameter %d from %s(%s) to %s(%s)", m_name.c_str(), i - 1, arguments[i - 1].m_name, arguments[i - 1].m_typeId.template ToString<AZStd::string>().c_str(), m_parameters[i].m_name, m_parameters[i].m_typeId.template ToString<AZStd::string>().c_str());
+                AZ_Warning("Behavior", false, "Invalid parameter type for method '%s'! Can not convert method parameter %d from %s(%s) to %s(%s)",
+                    m_name.c_str(), i - 1, arguments[i - 1].m_name,
+                    arguments[i - 1].m_typeId.ToFixedString().c_str(),
+                    m_parameters[i].m_name, m_parameters[i].m_typeId.ToFixedString().c_str());
+                return false;
+            }
+            else if (isArgumentPointer != isParameterPointer)
+            {
+                AZ_Warning("Behavior", false, R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
+                    isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
+                    isParameterPointer ? "pointer" : "value", m_parameters[i].m_name);
                 return false;
             }
         }
 
         AZ::Internal::EBusCaller<EventType, EBus, R, Args...>::Call(
-            m_functionPtr, arguments, result, AZStd::make_index_sequence<sizeof...(Args)>());
+            m_functionPtr, arguments.data(), result, AZStd::make_index_sequence<sizeof...(Args)>());
 
         return true;
+    }
+
+    template<class EBus, BehaviorEventType EventType, class R, class BusType, class... Args>
+    auto BehaviorEBusEvent<EBus, EventType, R(BusType*, Args...)>::IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const
+        -> ResultOutcome
+    {
+        size_t totalArguments = GetNumArguments();
+        if (arguments.size() < totalArguments)
+        {
+            // Clone the arguments on the stack and validate that the method can be invoked with the arguments
+            AZStd::span<BehaviorArgument> newArguments(reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument) * totalArguments)), totalArguments);
+            // clone the input parameters (we don't need to clone temp buffers, etc. as they will be still on the stack)
+            size_t argIndex = 0;
+            for (; argIndex < arguments.size(); ++argIndex)
+            {
+                new(&newArguments[argIndex]) BehaviorArgument(arguments[argIndex]);
+            }
+
+            // clone the default parameters if they exist
+            for (; argIndex < totalArguments; ++argIndex)
+            {
+                BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
+                if (!defaultValue)
+                {
+                    return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                        "Not enough arguments to make call to method %s. %zu supplied, needed %zu",
+                        m_name.c_str(), arguments.size(), newArguments.size()) };
+                }
+                new(&newArguments[argIndex]) BehaviorArgument(defaultValue->GetValue());
+            }
+
+            arguments = newArguments;
+        }
+        else if (arguments.size() > totalArguments)
+        {
+            return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                "Too many arguments supplied to method '%s'. Expects %zu arguments, provided %zu",
+                m_name.c_str(), totalArguments, arguments.size()) };
+        }
+
+        if constexpr (s_isBusIdParameter)
+        {
+            if (!arguments[0].ConvertTo(m_parameters[1].m_typeId))
+            {
+                AZ_Warning("Behavior", false, "Invalid BusIdType type can't convert! %s -> %s", arguments[0].m_name, m_parameters[1].m_name);
+                return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                    "Invalid BusIdType type can't convert! %s -> %s",
+                    arguments[0].m_name, m_parameters[1].m_name) };
+            }
+        }
+
+        for (size_t i = s_startNamedArgumentIndex; i < AZ_ARRAY_SIZE(m_parameters); ++i)
+        {
+            // Verify that argument is a pointer for pointer type parameters and a value or reference for value type or reference type parameters
+            bool isArgumentPointer = arguments[i - 1].m_traits & BehaviorParameter::Traits::TR_POINTER;
+            bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
+            if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
+            {
+                return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                    "Invalid parameter type for method '%s'!"
+                    " Can not convert method parameter %zu from %s(%s) to %s(%s)",
+                    m_name.c_str(), i - 1,
+                    arguments[i - 1].m_name, arguments[i - 1].m_typeId.ToFixedString().c_str(),
+                    m_parameters[i].m_name, m_parameters[i].m_typeId.ToFixedString().c_str()
+                ) };
+            }
+            else if (isArgumentPointer != isParameterPointer)
+            {
+                return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                    R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
+                    isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
+                    isParameterPointer ? "pointer" : "value", m_parameters[i].m_name) };
+            }
+        }
+
+        if (result != nullptr)
+        {
+            const AZ::BehaviorParameter* returnParam = GetResult();
+            if (bool canStoreResult = result->m_typeId.IsNull() || result->m_typeId == returnParam->m_typeId ||
+                (returnParam->m_azRtti != nullptr && returnParam->m_azRtti->IsTypeOf(result->m_typeId));
+                !canStoreResult)
+            {
+                return ResultOutcome{ AZStd::unexpect, typename ResultOutcome::ErrorType::format(
+                    "The behavior argument for the return value cannot store the return type %s",
+                    returnParam->m_typeId.ToFixedString().c_str()) };
+            }
+        }
+
+        return AZ::Success();
     }
 
     //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzCore/AzCore/RTTI/ChronoReflection.cpp
+++ b/Code/Framework/AzCore/AzCore/RTTI/ChronoReflection.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#pragma once
 
 #include <AzCore/RTTI/ChronoReflection.h>
 #include <AzCore/RTTI/BehaviorContext.h>

--- a/Code/Framework/AzCore/AzCore/RTTI/ChronoReflection.cpp
+++ b/Code/Framework/AzCore/AzCore/RTTI/ChronoReflection.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/RTTI/ChronoReflection.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+
+namespace AZ
+{
+    //! OnDemand reflection for AZStd::chrono::duration
+
+    template<class Rep, class Period>
+    void OnDemandReflection<AZStd::chrono::duration<Rep, Period>>::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto behaviorContext = azrtti_cast<BehaviorContext*>(context);
+            behaviorContext != nullptr)
+        {
+            auto GetDisplayName = []() -> const char*
+            {
+                if constexpr (AZStd::same_as<DurationType, AZStd::chrono::milliseconds>)
+                {
+                    return "nanoseconds";
+                }
+                else if constexpr (AZStd::same_as<DurationType, AZStd::chrono::microseconds>)
+                {
+                    return "microseconds";
+                }
+                else if constexpr (AZStd::same_as<DurationType, AZStd::chrono::milliseconds>)
+                {
+                    return "milliseconds";
+                }
+                else if constexpr (AZStd::same_as<DurationType, AZStd::chrono::seconds>)
+                {
+                    return "seconds";
+                }
+                else
+                {
+                    return "";
+                }
+            };
+            auto GetTooltip = []() -> const char*
+            {
+                if constexpr (AZStd::same_as<DurationType, AZStd::chrono::milliseconds>)
+                {
+                    return "Represents a time interval that counts nanosecond amount of ticks";
+                }
+                else if constexpr (AZStd::same_as<DurationType, AZStd::chrono::microseconds>)
+                {
+                    return "Represents a time interval that counts microsecond amount of ticks";
+                }
+                else if constexpr (AZStd::same_as<DurationType, AZStd::chrono::milliseconds>)
+                {
+                    return "Represents a time interval that counts millisecond amount of ticks";
+                }
+                else if constexpr (AZStd::same_as<DurationType, AZStd::chrono::seconds>)
+                {
+                    return "Represents a time interval that counts second amount of ticks";
+                }
+                else
+                {
+                    return "Represents a time interval that counts the chrono::duration<DurationType> amount of ticks";
+                }
+            };
+
+            behaviorContext->Class<DurationType>()
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, "time")
+                ->Attribute(AZ::Script::Attributes::Category, "Time")
+                ->Attribute(AZ::ScriptCanvasAttributes::PrettyName, GetDisplayName)
+                ->Attribute(AZ::Script::Attributes::ToolTip, GetTooltip)
+                ->template Constructor<typename DurationType::rep>()
+                ->Method("count", &DurationType::count)
+                ->Attribute(AZ::Script::Attributes::ToolTip, "Return the tick count in the representation of the duration type")
+                ;
+        }
+    }
+
+    // Explicit instantations of common second chrono duration types
+    template struct OnDemandReflection<AZStd::chrono::nanoseconds>;
+    template struct OnDemandReflection<AZStd::chrono::microseconds>;
+    template struct OnDemandReflection<AZStd::chrono::milliseconds>;
+    template struct OnDemandReflection<AZStd::chrono::seconds>;
+}
+

--- a/Code/Framework/AzCore/AzCore/RTTI/ChronoReflection.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/ChronoReflection.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/chrono/chrono.h>
+#include <AzCore/RTTI/TypeInfo.h>
+
+namespace AZ
+{
+    class ReflectContext;
+
+    //! OnDemand reflection for AZStd::chrono::duration specializations
+    //! Currently supported specializations are nanoseconds,m milliseconds microseconds and seconds
+    //!
+    //!
+    template<class T>
+    struct OnDemandReflection;
+
+    template<class Rep, class Period>
+    struct OnDemandReflection<AZStd::chrono::duration<Rep, Period>>
+    {
+        using DurationType = AZStd::chrono::duration<Rep, Period>;
+
+        static void Reflect(AZ::ReflectContext* context);
+    };
+
+    // extern common second duration types
+    extern template struct OnDemandReflection<AZStd::chrono::nanoseconds>;
+    extern template struct OnDemandReflection<AZStd::chrono::milliseconds>;
+    extern template struct OnDemandReflection<AZStd::chrono::microseconds>;
+    extern template struct OnDemandReflection<AZStd::chrono::seconds>;
+
+
+    // Specialize AzTypeInfo for the second duration types, so that they can be reflected to the BehaviorContext
+    AZ_TYPE_INFO_SPECIALIZE(AZStd::chrono::nanoseconds, "{5CEA0194-A74C-448A-AC10-3F7A6A8EEFB4}");
+    AZ_TYPE_INFO_SPECIALIZE(AZStd::chrono::microseconds, "{1BF1728B-E0EB-4AA1-9937-7D1D7869E398}");
+    AZ_TYPE_INFO_SPECIALIZE(AZStd::chrono::milliseconds, "{414B61DC-8042-44DC-82A5-C70DFE04CB65}");
+    AZ_TYPE_INFO_SPECIALIZE(AZStd::chrono::seconds, "{63D98FB5-0802-4850-96F6-71046DF38C94}");
+}

--- a/Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h
@@ -623,7 +623,7 @@ namespace AZ
     /**
     * Use this macro outside a class to allow it to be identified across modules and serialized (in different contexts).
     * The expected input is the class and the assigned uuid as a string or an instance of a uuid.
-    * Note that the AZ_TYPE_INFO_SPECIALIZE always has be declared in "namespace AZ".
+    * Note that the AZ_TYPE_INFO_SPECIALIZE always has to be declared in "namespace AZ".
     * Example:
     *   class MyClass
     *   {
@@ -1292,7 +1292,6 @@ namespace AZ
     }
 
     AZ_TYPE_INFO_SPECIALIZE(char, "{3AB0037F-AF8D-48ce-BCA0-A170D18B2C03}");
-    //    AZ_TYPE_INFO_SPECIALIZE(signed char, "{CFD606FE-41B8-4744-B79F-8A6BD97713D8}");
     AZ_TYPE_INFO_SPECIALIZE(AZ::s8, "{58422C0E-1E47-4854-98E6-34098F6FE12D}");
     AZ_TYPE_INFO_SPECIALIZE(short, "{B8A56D56-A10D-4dce-9F63-405EE243DD3C}");
     AZ_TYPE_INFO_SPECIALIZE(int, "{72039442-EB38-4d42-A1AD-CB68F7E0EEF6}");

--- a/Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h
@@ -588,14 +588,18 @@ namespace AZ
         };
     }
     // AzTypeInfo specialization helper for non intrusive TypeInfo
-#define AZ_TYPE_INFO_INTERNAL_SPECIALIZE(_ClassName, _ClassUuid)      \
+#define AZ_TYPE_INFO_INTERNAL_SPECIALIZE(_ClassName, _ClassUuid, _DisplayName) \
     template<>                                                        \
     struct AzTypeInfo<_ClassName, AZStd::is_enum<_ClassName>::value>  \
     {                                                                 \
     private:                                                          \
         static inline constexpr AZ::TypeId s_classUuid{_ClassUuid};   \
     public:                                                           \
-        static constexpr const char* Name() { return #_ClassName; }   \
+        static constexpr const char* Name()                           \
+        {                                                             \
+            constexpr AZStd::string_view name_{_DisplayName };        \
+            return !name_.empty() ? name_.data() : #_ClassName;       \
+        }                                                             \
         template<typename TypeIdResolverTag = CanonicalTypeIdTag>     \
         static constexpr AZ::TypeId Uuid()                            \
         {                                                             \
@@ -615,6 +619,29 @@ namespace AZ
         }                                                             \
         static constexpr bool Specialized() { return true; }          \
     };
+
+    /**
+    * Use this macro outside a class to allow it to be identified across modules and serialized (in different contexts).
+    * The expected input is the class and the assigned uuid as a string or an instance of a uuid.
+    * Note that the AZ_TYPE_INFO_SPECIALIZE always has be declared in "namespace AZ".
+    * Example:
+    *   class MyClass
+    *   {
+    *   public:
+    *       ...
+    *   };
+    *
+    *   namespace AZ
+    *   {
+    *       AZ_TYPE_INFO_SPECIALIZE(MyClass, "{BD5B1568-D232-4EBF-93BD-69DB66E3773F}");
+    *   }
+    */
+#define AZ_TYPE_INFO_SPECIALIZE(_ClassType, _ClassUuid) AZ_TYPE_INFO_INTERNAL_SPECIALIZE(_ClassType, _ClassUuid, #_ClassType)
+
+    // Adds support for specifying a different display name for the Class type being specialized for TypeInfo
+    // This is useful when wanting to remove a namespace from the TypeInfo name such as when reflecting to scripting
+    // i.e AZ_TYPE_INFO_SPECIALIZE_WITH_NAME(AZ::Metrics::MyClass, "{BD5B1568-D232-4EBF-93BD-69DB66E3773F}", MyClass)
+#define AZ_TYPE_INFO_SPECIALIZE_WITH_NAME(_ClassType, _ClassUuid, _DisplayName) AZ_TYPE_INFO_INTERNAL_SPECIALIZE(_ClassType, _ClassUuid, _DisplayName)
 
     // specialize for function pointers
     template<class R, class... Args>
@@ -1264,26 +1291,26 @@ namespace AZ
         static constexpr bool Specialized() { return true; }                                                         \
     }
 
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(char, "{3AB0037F-AF8D-48ce-BCA0-A170D18B2C03}");
-    //    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(signed char, "{CFD606FE-41B8-4744-B79F-8A6BD97713D8}");
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(AZ::s8, "{58422C0E-1E47-4854-98E6-34098F6FE12D}");
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(short, "{B8A56D56-A10D-4dce-9F63-405EE243DD3C}");
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(int, "{72039442-EB38-4d42-A1AD-CB68F7E0EEF6}");
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(long, "{8F24B9AD-7C51-46cf-B2F8-277356957325}");
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(AZ::s64, "{70D8A282-A1EA-462d-9D04-51EDE81FAC2F}");
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(unsigned char, "{72B9409A-7D1A-4831-9CFE-FCB3FADD3426}");
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(unsigned short, "{ECA0B403-C4F8-4b86-95FC-81688D046E40}");
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(unsigned int, "{43DA906B-7DEF-4ca8-9790-854106D3F983}");
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(unsigned long, "{5EC2D6F7-6859-400f-9215-C106F5B10E53}");
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(AZ::u64, "{D6597933-47CD-4fc8-B911-63F3E2B0993A}");
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(float, "{EA2C3E90-AFBE-44d4-A90D-FAAF79BAF93D}");
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(double, "{110C4B14-11A8-4e9d-8638-5051013A56AC}");
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(bool, "{A0CA880C-AFE4-43cb-926C-59AC48496112}");
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(AZ::Uuid, "{E152C105-A133-4d03-BBF8-3D4B2FBA3E2A}");
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(void, "{C0F1AFAD-5CB3-450E-B0F5-ADB5D46B0E22}");
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(Crc32, "{9F4E062E-06A0-46D4-85DF-E0DA96467D3A}");
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(PlatformID, "{0635D08E-DDD2-48DE-A7AE-73CC563C57C3}");
-    AZ_TYPE_INFO_INTERNAL_SPECIALIZE(AZStd::monostate, "{B1E9136B-D77A-4643-BE8E-2ABDA246AE0E}");
+    AZ_TYPE_INFO_SPECIALIZE(char, "{3AB0037F-AF8D-48ce-BCA0-A170D18B2C03}");
+    //    AZ_TYPE_INFO_SPECIALIZE(signed char, "{CFD606FE-41B8-4744-B79F-8A6BD97713D8}");
+    AZ_TYPE_INFO_SPECIALIZE(AZ::s8, "{58422C0E-1E47-4854-98E6-34098F6FE12D}");
+    AZ_TYPE_INFO_SPECIALIZE(short, "{B8A56D56-A10D-4dce-9F63-405EE243DD3C}");
+    AZ_TYPE_INFO_SPECIALIZE(int, "{72039442-EB38-4d42-A1AD-CB68F7E0EEF6}");
+    AZ_TYPE_INFO_SPECIALIZE(long, "{8F24B9AD-7C51-46cf-B2F8-277356957325}");
+    AZ_TYPE_INFO_SPECIALIZE(AZ::s64, "{70D8A282-A1EA-462d-9D04-51EDE81FAC2F}");
+    AZ_TYPE_INFO_SPECIALIZE(unsigned char, "{72B9409A-7D1A-4831-9CFE-FCB3FADD3426}");
+    AZ_TYPE_INFO_SPECIALIZE(unsigned short, "{ECA0B403-C4F8-4b86-95FC-81688D046E40}");
+    AZ_TYPE_INFO_SPECIALIZE(unsigned int, "{43DA906B-7DEF-4ca8-9790-854106D3F983}");
+    AZ_TYPE_INFO_SPECIALIZE(unsigned long, "{5EC2D6F7-6859-400f-9215-C106F5B10E53}");
+    AZ_TYPE_INFO_SPECIALIZE(AZ::u64, "{D6597933-47CD-4fc8-B911-63F3E2B0993A}");
+    AZ_TYPE_INFO_SPECIALIZE(float, "{EA2C3E90-AFBE-44d4-A90D-FAAF79BAF93D}");
+    AZ_TYPE_INFO_SPECIALIZE(double, "{110C4B14-11A8-4e9d-8638-5051013A56AC}");
+    AZ_TYPE_INFO_SPECIALIZE(bool, "{A0CA880C-AFE4-43cb-926C-59AC48496112}");
+    AZ_TYPE_INFO_SPECIALIZE(AZ::Uuid, "{E152C105-A133-4d03-BBF8-3D4B2FBA3E2A}");
+    AZ_TYPE_INFO_SPECIALIZE(void, "{C0F1AFAD-5CB3-450E-B0F5-ADB5D46B0E22}");
+    AZ_TYPE_INFO_SPECIALIZE(Crc32, "{9F4E062E-06A0-46D4-85DF-E0DA96467D3A}");
+    AZ_TYPE_INFO_SPECIALIZE(PlatformID, "{0635D08E-DDD2-48DE-A7AE-73CC563C57C3}");
+    AZ_TYPE_INFO_SPECIALIZE(AZStd::monostate, "{B1E9136B-D77A-4643-BE8E-2ABDA246AE0E}");
 
     AZ_TYPE_INFO_INTERNAL_SPECIALIZE_CV(T, T*, "", "*");
     AZ_TYPE_INFO_INTERNAL_SPECIALIZE_CV(T, T &, "", "&");
@@ -1392,23 +1419,6 @@ namespace AZ
 
 #include <AzCore/RTTI/TypeInfoSimple.h>
 
-/**
-* Use this macro outside a class to allow it to be identified across modules and serialized (in different contexts).
-* The expected input is the class and the assigned uuid as a string or an instance of a uuid.
-* Note that the AZ_TYPE_INFO_SPECIALIZE always has be declared in "namespace AZ".
-* Example:
-*   class MyClass
-*   {
-*   public:
-*       ...
-*   };
-*
-*   namespace AZ
-*   {
-*       AZ_TYPE_INFO_SPECIALIZE(MyClass, "{BD5B1568-D232-4EBF-93BD-69DB66E3773F}");
-*   }
-*/
-#define AZ_TYPE_INFO_SPECIALIZE(_ClassName, _ClassUuid) AZ_TYPE_INFO_INTERNAL_SPECIALIZE(_ClassName, _ClassUuid)
 
 // Used to declare that a template argument is a "typename" with AZ_TYPE_INFO_TEMPLATE.
 #define AZ_TYPE_INFO_TYPENAME AZ_TYPE_INFO_INTERNAL_TYPENAME

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryScriptUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryScriptUtils.cpp
@@ -34,6 +34,10 @@ namespace AZ::SettingsRegistryScriptUtils::Internal
     }
 
     SettingsRegistryScriptProxy::SettingsRegistryScriptProxy() = default;
+    SettingsRegistryScriptProxy::SettingsRegistryScriptProxy(AZStd::nullptr_t)
+        : SettingsRegistryScriptProxy()
+    {}
+
     SettingsRegistryScriptProxy::SettingsRegistryScriptProxy(AZStd::shared_ptr<AZ::SettingsRegistryInterface> settingsRegistry)
         : m_settingsRegistry(AZStd::move(settingsRegistry))
         , m_notifyEventProxy(AZStd::make_shared<NotifyEventProxy>())

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryScriptUtils.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryScriptUtils.h
@@ -32,7 +32,7 @@ namespace AZ::SettingsRegistryScriptUtils::Internal
         AZ_CLASS_ALLOCATOR(SettingsRegistryScriptProxy, AZ::SystemAllocator, 0);
         AZ_TYPE_INFO(SettingsRegistryScriptProxy, "{795C80A0-D243-473B-972A-C32CA487BAA5}");
 
-        // NotifyEventProxy is used to forward an update to an entry in the SettingsRegistry 
+        // NotifyEventProxy is used to forward an update to an entry in the SettingsRegistry
         // using the RegisterNotifier function to the BehaviorContext in order to create
         // a behavior method that returns an AZ::Event reference or pointer
         // This allows ScriptCanvas to create an AZ Event Handler using the information
@@ -45,6 +45,8 @@ namespace AZ::SettingsRegistryScriptUtils::Internal
         };
 
         SettingsRegistryScriptProxy();
+        SettingsRegistryScriptProxy(AZStd::nullptr_t);
+
         // Stores a SettingsRegistryInterface which will use the provided shared_ptr deleter when the reference count hits zero
         SettingsRegistryScriptProxy(AZStd::shared_ptr<AZ::SettingsRegistryInterface> settingsRegistry);
         // Stores a SettingsRegistryInterface which will perform a no-op deleter when the reference count hits zero

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -423,6 +423,8 @@ set(FILES
     Memory/SystemAllocator.h
     Metrics/EventLoggerFactoryImpl.h
     Metrics/EventLoggerFactoryImpl.cpp
+    Metrics/EventLoggerReflectUtils.cpp
+    Metrics/EventLoggerReflectUtils.h
     Metrics/EventLoggerUtils.cpp
     Metrics/EventLoggerUtils.h
     Metrics/JsonTraceEventLogger.h

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -469,13 +469,6 @@ set(FILES
     Preprocessor/Enum.h
     Preprocessor/EnumReflectUtils.h
     Preprocessor/Sequences.h
-    RTTI/RTTI.h
-    RTTI/TypeInfo.h
-    RTTI/TypeInfoSimple.h
-    RTTI/ReflectContext.h
-    RTTI/ReflectContext.cpp
-    RTTI/ReflectionManager.h
-    RTTI/ReflectionManager.cpp
     RTTI/AttributeReader.h
     RTTI/AzStdOnDemandPrettyName.inl
     RTTI/AzStdOnDemandReflection.inl
@@ -484,10 +477,19 @@ set(FILES
     RTTI/BehaviorContext.cpp
     RTTI/BehaviorContext.h
     RTTI/BehaviorContextEBusEventRawSignature.inl
-    RTTI/BehaviorContextUtilities.h
     RTTI/BehaviorContextUtilities.cpp
+    RTTI/BehaviorContextUtilities.h
     RTTI/BehaviorInterfaceProxy.h
     RTTI/BehaviorObjectSignals.h
+    RTTI/ChronoReflection.cpp
+    RTTI/ChronoReflection.h
+    RTTI/ReflectContext.h
+    RTTI/ReflectContext.cpp
+    RTTI/ReflectionManager.h
+    RTTI/ReflectionManager.cpp
+    RTTI/RTTI.h
+    RTTI/TypeInfo.h
+    RTTI/TypeInfoSimple.h
     RTTI/TypeSafeIntegral.h
     Script/lua/lua.h
     Script/ScriptAsset.cpp

--- a/Code/Framework/AzCore/Tests/Metrics/EventLoggerReflectUtilsTests.cpp
+++ b/Code/Framework/AzCore/Tests/Metrics/EventLoggerReflectUtilsTests.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/IO/ByteContainerStream.h>
+#include <AzCore/Metrics/EventLoggerFactoryImpl.h>
+#include <AzCore/Metrics/EventLoggerReflectUtils.h>
+#include <AzCore/Metrics/JsonTraceEventLogger.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/UnitTest/TestTypes.h>
+
+namespace UnitTest::EventLoggerReflectUtilsTests
+{
+    class EventLoggerReflectUtilsFixture
+        : public ScopedAllocatorSetupFixture
+    {
+    public:
+        EventLoggerReflectUtilsFixture()
+        {
+            // Create an event logger factory
+            m_eventLoggerFactory = AZStd::make_unique<AZ::Metrics::EventLoggerFactoryImpl>();
+
+            // Create an byte container stream that allows event logger output to be logged in-memory
+            auto metricsStream = AZStd::make_unique<AZ::IO::ByteContainerStream<AZStd::string>>(&m_metricsOutput);
+            // Create the trace event logger that logs to the Google Trace Event format
+            auto eventLogger = AZStd::make_unique<AZ::Metrics::JsonTraceEventLogger>(AZStd::move(metricsStream));
+
+            // Register the Google Trace Event Logger with the Event Logger Factory
+            EXPECT_TRUE(m_eventLoggerFactory->RegisterEventLogger(m_loggerId, AZStd::move(eventLogger)));
+
+            m_behaviorContext = AZStd::make_unique<AZ::BehaviorContext>();
+            AZ::Metrics::Reflect(m_behaviorContext.get());
+        }
+    protected:
+        AZStd::string m_metricsOutput;
+        AZStd::unique_ptr<AZ::Metrics::IEventLoggerFactory> m_eventLoggerFactory;
+        AZ::Metrics::EventLoggerId m_loggerId{ 1 };
+
+        AZStd::unique_ptr<AZ::BehaviorContext> m_behaviorContext;
+    };
+
+    constexpr const char* EventValueClassName = "EventValue";
+    constexpr const char* EventFieldClassName = "EventField";
+    constexpr const char* EventArrayClassName = "EventArray";
+    constexpr const char* EventObjectClassName = "EventObject";
+
+    TEST_F(EventLoggerReflectUtilsFixture, EventLogger_EventDataTypes_AreAccessibleInScript_Succeeds)
+    {
+        auto classIter = m_behaviorContext->m_classes.find(EventValueClassName);
+        EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
+
+        classIter = m_behaviorContext->m_classes.find(EventFieldClassName);
+        EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
+
+        classIter = m_behaviorContext->m_classes.find(EventArrayClassName);
+        EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
+
+        classIter = m_behaviorContext->m_classes.find(EventObjectClassName);
+        EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
+    }
+
+    TEST_F(EventLoggerReflectUtilsFixture, EventLogger_EventDataTypes_CanBeCreated)
+    {
+        auto classIter = m_behaviorContext->m_classes.find(EventValueClassName);
+        EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
+
+        classIter = m_behaviorContext->m_classes.find(EventFieldClassName);
+        EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
+
+        classIter = m_behaviorContext->m_classes.find(EventArrayClassName);
+        EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
+
+        classIter = m_behaviorContext->m_classes.find(EventObjectClassName);
+        EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
+    }
+
+    TEST_F(EventLoggerReflectUtilsFixture, RecordEvent_CanRecordEventInScript_Succeeds)
+    {
+
+    }
+
+} // namespace UnitTest::EventLoggerReflectUtilsTests

--- a/Code/Framework/AzCore/Tests/Metrics/EventLoggerReflectUtilsTests.cpp
+++ b/Code/Framework/AzCore/Tests/Metrics/EventLoggerReflectUtilsTests.cpp
@@ -16,13 +16,16 @@
 namespace UnitTest::EventLoggerReflectUtilsTests
 {
     class EventLoggerReflectUtilsFixture
-        : public ScopedAllocatorSetupFixture
+        : public LeakDetectionFixture
     {
     public:
         EventLoggerReflectUtilsFixture()
         {
             // Create an event logger factory
             m_eventLoggerFactory = AZStd::make_unique<AZ::Metrics::EventLoggerFactoryImpl>();
+
+            // Register the event logger factory with the global interface
+            AZ::Metrics::EventLoggerFactory::Register(m_eventLoggerFactory.get());
 
             // Create an byte container stream that allows event logger output to be logged in-memory
             auto metricsStream = AZStd::make_unique<AZ::IO::ByteContainerStream<AZStd::string>>(&m_metricsOutput);
@@ -34,6 +37,11 @@ namespace UnitTest::EventLoggerReflectUtilsTests
 
             m_behaviorContext = AZStd::make_unique<AZ::BehaviorContext>();
             AZ::Metrics::Reflect(m_behaviorContext.get());
+        }
+
+        ~EventLoggerReflectUtilsFixture()
+        {
+            AZ::Metrics::EventLoggerFactory::Unregister(m_eventLoggerFactory.get());
         }
     protected:
         AZStd::string m_metricsOutput;
@@ -53,34 +61,237 @@ namespace UnitTest::EventLoggerReflectUtilsTests
         auto classIter = m_behaviorContext->m_classes.find(EventValueClassName);
         EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
 
-        classIter = m_behaviorContext->m_classes.find(EventFieldClassName);
+        classIter = m_behaviorContext->m_classes.find("EventLoggerId");
         EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
 
-        classIter = m_behaviorContext->m_classes.find(EventArrayClassName);
+        classIter = m_behaviorContext->m_classes.find("EventArgs");
         EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
 
-        classIter = m_behaviorContext->m_classes.find(EventObjectClassName);
+        classIter = m_behaviorContext->m_classes.find("EventPhase");
+        EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
+
+        classIter = m_behaviorContext->m_classes.find("InstantEventScope");
         EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
     }
 
     TEST_F(EventLoggerReflectUtilsFixture, EventLogger_EventDataTypes_CanBeCreated)
     {
         auto classIter = m_behaviorContext->m_classes.find(EventValueClassName);
-        EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
+        ASSERT_NE(m_behaviorContext->m_classes.end(), classIter);
+        {
+            AZ::BehaviorClass* eventValueClass = classIter->second;
+            AZ::BehaviorClass::ScopedBehaviorObject eventValueInst = eventValueClass->CreateWithScope();
+            EXPECT_TRUE(eventValueInst.IsValid());
+        }
 
-        classIter = m_behaviorContext->m_classes.find(EventFieldClassName);
-        EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
+        classIter = m_behaviorContext->m_classes.find("EventLoggerId");
+        ASSERT_NE(m_behaviorContext->m_classes.end(), classIter);
+        {
+            AZ::BehaviorClass* eventLoggerIdClass = classIter->second;
+            AZ::BehaviorClass::ScopedBehaviorObject eventLoggerIdInst = eventLoggerIdClass->CreateWithScope();
+            EXPECT_TRUE(eventLoggerIdInst.IsValid());
+        }
 
-        classIter = m_behaviorContext->m_classes.find(EventArrayClassName);
-        EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
+        classIter = m_behaviorContext->m_classes.find("EventArgs");
+        ASSERT_NE(m_behaviorContext->m_classes.end(), classIter);
+        {
+            AZ::BehaviorClass* eventArgsClass = classIter->second;
+            AZ::BehaviorClass::ScopedBehaviorObject eventArgsInst = eventArgsClass->CreateWithScope();
+            EXPECT_TRUE(eventArgsInst.IsValid());
+        }
 
-        classIter = m_behaviorContext->m_classes.find(EventObjectClassName);
-        EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
+        classIter = m_behaviorContext->m_classes.find("EventPhase");
+        ASSERT_NE(m_behaviorContext->m_classes.end(), classIter);
+        {
+            AZ::BehaviorClass* eventPhaseClass = classIter->second;
+            AZ::BehaviorClass::ScopedBehaviorObject eventPhaseInst = eventPhaseClass->CreateWithScope();
+            EXPECT_TRUE(eventPhaseInst.IsValid());
+        }
+
+        classIter = m_behaviorContext->m_classes.find("InstantEventScope");
+        ASSERT_NE(m_behaviorContext->m_classes.end(), classIter);
+        {
+            AZ::BehaviorClass* instantEventScopeClass = classIter->second;
+            AZ::BehaviorClass::ScopedBehaviorObject instantEventScopeInst = instantEventScopeClass->CreateWithScope();
+            EXPECT_TRUE(instantEventScopeInst.IsValid());
+        }
     }
 
-    TEST_F(EventLoggerReflectUtilsFixture, RecordEvent_CanRecordEventInScript_Succeeds)
+    TEST_F(EventLoggerReflectUtilsFixture, EventLogger_CanCreateFromIntOrString_Succeeds)
     {
+        // Create an EventLoggerId instance in script that maps to Id 1
+        auto classIter = m_behaviorContext->m_classes.find("EventLoggerId");
+        ASSERT_NE(m_behaviorContext->m_classes.end(), classIter);
+        {
+            auto methodIter = classIter->second->m_methods.find("CreateIdFromInt");
+            ASSERT_NE(classIter->second->m_methods.end(), methodIter);
+            AZ::Metrics::EventLoggerId loggerId{ AZStd::numeric_limits<AZStd::underlying_type_t<AZ::Metrics::EventLoggerId>>::max() };
+            EXPECT_TRUE(methodIter->second->InvokeResult(loggerId, 1U));
+            EXPECT_EQ(1, static_cast<AZ::u32>(loggerId));
+        }
 
+        {
+            auto methodIter = classIter->second->m_methods.find("CreateIdFromString");
+            ASSERT_NE(classIter->second->m_methods.end(), methodIter);
+            AZ::Metrics::EventLoggerId loggerId{ AZStd::numeric_limits<AZStd::underlying_type_t<AZ::Metrics::EventLoggerId>>::max() };
+            EXPECT_TRUE(methodIter->second->InvokeResult(loggerId, AZStd::string_view("foo")));
+            EXPECT_EQ(static_cast<AZ::u32>(AZStd::hash<AZStd::string_view>{}("foo")), static_cast<AZ::u32>(loggerId));
+        }
     }
 
+    TEST_F(EventLoggerReflectUtilsFixture, RecordEvent_CanRecordDurationEventInScript_Succeeds)
+    {
+        const auto startThreadTime = AZStd::chrono::utc_clock::now();
+
+        const AZ::BehaviorClass* eventArgsClass = m_behaviorContext->FindClassByReflectedName("EventArgs");
+        ASSERT_NE(nullptr, eventArgsClass);
+
+        const AZ::BehaviorClass* eventValueClass = m_behaviorContext->FindClassByReflectedName("EventValue");
+        ASSERT_NE(nullptr, eventValueClass);
+
+        auto eventArgsScopedObj = eventArgsClass->CreateWithScope();
+        EXPECT_TRUE(eventArgsScopedObj.IsValid());
+
+        // Stores arguments for behavior context calls
+        AZStd::fixed_vector<AZ::BehaviorArgument, 8> behaviorArguments;
+
+        // Use the bound behavior context properties and methods to configure the ScriptEventArgs
+        {
+            // Set `ScriptEventArgs::m_name` field
+            const AZ::BehaviorMethod* nameSetter = eventArgsClass->FindSetterByReflectedName("m_name");
+            ASSERT_NE(nullptr, nameSetter);
+            AZStd::string eventName{ "Duration Event" };
+
+            behaviorArguments.emplace_back(&eventArgsScopedObj.m_behaviorObject);
+            behaviorArguments.emplace_back(&eventName);
+            EXPECT_TRUE(nameSetter->Call(behaviorArguments, nullptr));
+        }
+
+        {
+            // Set `ScriptEventArgs::m_cat` field
+            const AZ::BehaviorMethod* nameSetter = eventArgsClass->FindSetterByReflectedName("m_cat");
+            ASSERT_NE(nullptr, nameSetter);
+            behaviorArguments.clear();
+            AZStd::string category{ "Test" };
+
+            behaviorArguments.emplace_back(&eventArgsScopedObj.m_behaviorObject);
+            behaviorArguments.emplace_back(&category);
+            EXPECT_TRUE(nameSetter->Call(behaviorArguments, nullptr));
+        }
+
+        {
+            // Set `ScriptEventArgs::m_id` field
+            const AZ::BehaviorMethod* nameSetter = eventArgsClass->FindSetterByReflectedName("m_id");
+            ASSERT_NE(nullptr, nameSetter);
+            behaviorArguments.clear();
+            AZStd::optional<AZStd::string> eventId{ "0" };
+
+            behaviorArguments.emplace_back(&eventArgsScopedObj.m_behaviorObject);
+            behaviorArguments.emplace_back(&eventId);
+            EXPECT_TRUE(nameSetter->Call(behaviorArguments, nullptr));
+        }
+
+        {
+            // Populate the ScriptEventArgs "args" object field
+            const AZ::BehaviorMethod* appendArgMethod = eventArgsClass->FindMethodByReflectedName("AppendArg");
+            ASSERT_NE(nullptr, appendArgMethod);
+
+            // Create an EventValue instance
+            AZ::u64 intValue{ 20 };
+            behaviorArguments.clear();
+            behaviorArguments.emplace_back(&intValue);
+            auto eventValueClassObj = eventValueClass->CreateWithScope(behaviorArguments);
+            EXPECT_TRUE(eventValueClassObj.IsValid());
+
+            AZStd::string argName{ "Entity Count" };
+
+            behaviorArguments.clear();
+            behaviorArguments.emplace_back(&eventArgsScopedObj.m_behaviorObject);
+            behaviorArguments.emplace_back(&argName);
+            // The AppendArg function accepts an EventValue instance by value, so it needs to be emplaced
+            // with the BehaviorArgumentValueTypeTag
+            behaviorArguments.emplace_back(AZ::BehaviorArgumentValueTypeTag, &eventValueClassObj.m_behaviorObject);
+            EXPECT_TRUE(appendArgMethod->Call(behaviorArguments, nullptr));
+
+            argName = "Entity Group";
+            AZStd::string stringValue{ "Level" };
+            behaviorArguments.clear();
+            behaviorArguments.emplace_back(&stringValue);
+            eventValueClassObj = eventValueClass->CreateWithScope(behaviorArguments);
+            EXPECT_TRUE(eventValueClassObj.IsValid());
+
+            // Invoke the AppendArg method this time with a string value
+            behaviorArguments.clear();
+            behaviorArguments.emplace_back(&eventArgsScopedObj.m_behaviorObject);
+            behaviorArguments.emplace_back(&argName);
+            behaviorArguments.emplace_back(AZ::BehaviorArgumentValueTypeTag, &eventValueClassObj.m_behaviorObject);
+            EXPECT_TRUE(appendArgMethod->Call(behaviorArguments, nullptr));
+        }
+
+        // Finally invoke the RecordEvent function
+        const AZ::BehaviorMethod* recordEventMethod = m_behaviorContext->FindMethodByReflectedName("RecordEvent");
+        ASSERT_NE(nullptr, recordEventMethod);
+
+        constexpr auto durationBeginPhase = AZ::Metrics::EventPhase::DurationBegin;
+        behaviorArguments.clear();
+        behaviorArguments.emplace_back(&m_loggerId);
+        behaviorArguments.emplace_back(&durationBeginPhase);
+        behaviorArguments.emplace_back(AZ::BehaviorArgumentValueTypeTag, &eventArgsScopedObj.m_behaviorObject);
+        // The return value argument needs storage
+        bool returnStorage{};
+        AZ::BehaviorArgument returnValue(&returnStorage);
+        EXPECT_TRUE(recordEventMethod->Call(behaviorArguments, &returnValue));
+
+        ASSERT_EQ(azrtti_typeid<bool>(), returnValue.m_typeId);
+        bool* recordEventResult = returnValue.GetAsUnsafe<bool>();
+        ASSERT_NE(nullptr, recordEventResult);
+        EXPECT_TRUE(*recordEventResult);
+
+        // Validate that the output contains an "Entity Count and an "Entity Group" argument
+        EXPECT_TRUE(m_metricsOutput.contains("Entity Count"));
+        EXPECT_TRUE(m_metricsOutput.contains("Entity Group"));
+    }
+
+    TEST_F(EventLoggerReflectUtilsFixture, RecordEvent_CanCreateMetricsLoggerInScript_Succeeds)
+    {
+        const AZ::BehaviorMethod* createLoggerMethod = m_behaviorContext->FindMethodByReflectedName("CreateMetricsLogger");
+        ASSERT_NE(nullptr, createLoggerMethod);
+
+        constexpr AZ::Metrics::EventLoggerId scriptLoggerId{ 2 };
+        AZ::Test::ScopedAutoTempDirectory tempDirectory;
+        const auto loggerPath = tempDirectory.GetDirectoryAsFixedMaxPath() / "script_logger.json";
+        constexpr AZStd::string_view loggerName = "ScriptLogger";
+        bool createLoggerResult{};
+        EXPECT_TRUE(createLoggerMethod->InvokeResult(createLoggerResult, scriptLoggerId, loggerPath.c_str(), loggerName));
+        EXPECT_TRUE(createLoggerResult);
+
+        // Validate that the event logger created during script is registered with the global event logger factory
+        EXPECT_TRUE(m_eventLoggerFactory->IsRegistered(scriptLoggerId));
+
+        // Also validate that the script IsEventLoggerRegistered function succeeds as well
+        const AZ::BehaviorMethod* isEventLoggerRegisteredMethod = m_behaviorContext->FindMethodByReflectedName("IsEventLoggerRegistered");
+        ASSERT_NE(nullptr, isEventLoggerRegisteredMethod);
+        bool isEventLoggerRegistered{};
+        EXPECT_TRUE(isEventLoggerRegisteredMethod->InvokeResult(isEventLoggerRegistered, scriptLoggerId));
+        EXPECT_TRUE(isEventLoggerRegistered);
+
+        // Finally validate that the EventFactory IsRegistered member function succeeds as well
+        const AZ::BehaviorMethod* getGlobalEventLoggerFactoryMethod = m_behaviorContext->FindMethodByReflectedName("GetGlobalEventLoggerFactory");
+        ASSERT_NE(nullptr, getGlobalEventLoggerFactoryMethod);
+        AZ::Metrics::IEventLoggerFactory* eventLoggerFactory{};
+        EXPECT_TRUE(getGlobalEventLoggerFactoryMethod->InvokeResult(eventLoggerFactory));
+
+        // This event logger factory should be the same address as the member variable
+        ASSERT_EQ(m_eventLoggerFactory.get(), eventLoggerFactory);
+
+        // reset back to false;
+        isEventLoggerRegistered = {};
+        // Lookup the EventLoggerFactory BehaviorClass in order to lookup the IsRegistered member function
+        const AZ::BehaviorClass* eventLoggerFactoryClass = m_behaviorContext->FindClassByReflectedName("EventLoggerFactory");
+        ASSERT_NE(nullptr, eventLoggerFactoryClass);
+        const AZ::BehaviorMethod* isRegisteredMethod = eventLoggerFactoryClass->FindMethodByReflectedName("IsRegistered");
+        ASSERT_NE(nullptr, isRegisteredMethod);
+        EXPECT_TRUE(isRegisteredMethod->InvokeResult(isEventLoggerRegistered, eventLoggerFactory, scriptLoggerId));
+        EXPECT_TRUE(isEventLoggerRegistered);
+    }
 } // namespace UnitTest::EventLoggerReflectUtilsTests

--- a/Code/Framework/AzCore/Tests/Metrics/EventLoggerReflectUtilsTests.cpp
+++ b/Code/Framework/AzCore/Tests/Metrics/EventLoggerReflectUtilsTests.cpp
@@ -55,22 +55,42 @@ namespace UnitTest::EventLoggerReflectUtilsTests
     constexpr const char* EventFieldClassName = "EventField";
     constexpr const char* EventArrayClassName = "EventArray";
     constexpr const char* EventObjectClassName = "EventObject";
+    constexpr const char* EventLoggerIdClassName = "EventLoggerId";
+    constexpr const char* EventArgsClassName = "EventArgs";
+    constexpr const char* EventPhaseClassName = "EventPhase";
+    constexpr const char* InstantEventScopeClassName = "InstantEventScope";
+    constexpr const char* EventLoggerFactoryClassName = "EventLoggerFactory";
+
+    // EventArgs Member Method Names
+    constexpr const char* EventArgsNameMember = "m_name";
+    constexpr const char* EventArgsCategoryMember = "m_cat";
+    constexpr const char* EventArgsIdMember = "m_id";
+    constexpr const char* EventArgsAppendArgMethodName = "AppendArg";
+
+    // EventFactory Member Method Names
+    constexpr const char* EventLoggerFactoryIsRegisteredMethodName = "IsRegistered";
+
+    // Global Method names
+    constexpr const char* RecordEventMethodName = "RecordEvent";
+    constexpr const char* CreateMetricsLoggerMethodName = "CreateMetricsLogger";
+    constexpr const char* IsEventLoggerRegisteredMethodName = "IsEventLoggerRegistered";
+    constexpr const char* GetGlobalEventLoggerFactoryMethodName = "GetGlobalEventLoggerFactory";
 
     TEST_F(EventLoggerReflectUtilsFixture, EventLogger_EventDataTypes_AreAccessibleInScript_Succeeds)
     {
         auto classIter = m_behaviorContext->m_classes.find(EventValueClassName);
         EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
 
-        classIter = m_behaviorContext->m_classes.find("EventLoggerId");
+        classIter = m_behaviorContext->m_classes.find(EventLoggerIdClassName);
         EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
 
-        classIter = m_behaviorContext->m_classes.find("EventArgs");
+        classIter = m_behaviorContext->m_classes.find(EventArgsClassName);
         EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
 
-        classIter = m_behaviorContext->m_classes.find("EventPhase");
+        classIter = m_behaviorContext->m_classes.find(EventPhaseClassName);
         EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
 
-        classIter = m_behaviorContext->m_classes.find("InstantEventScope");
+        classIter = m_behaviorContext->m_classes.find(InstantEventScopeClassName);
         EXPECT_NE(m_behaviorContext->m_classes.end(), classIter);
     }
 
@@ -84,7 +104,7 @@ namespace UnitTest::EventLoggerReflectUtilsTests
             EXPECT_TRUE(eventValueInst.IsValid());
         }
 
-        classIter = m_behaviorContext->m_classes.find("EventLoggerId");
+        classIter = m_behaviorContext->m_classes.find(EventLoggerIdClassName);
         ASSERT_NE(m_behaviorContext->m_classes.end(), classIter);
         {
             AZ::BehaviorClass* eventLoggerIdClass = classIter->second;
@@ -92,7 +112,7 @@ namespace UnitTest::EventLoggerReflectUtilsTests
             EXPECT_TRUE(eventLoggerIdInst.IsValid());
         }
 
-        classIter = m_behaviorContext->m_classes.find("EventArgs");
+        classIter = m_behaviorContext->m_classes.find(EventArgsClassName);
         ASSERT_NE(m_behaviorContext->m_classes.end(), classIter);
         {
             AZ::BehaviorClass* eventArgsClass = classIter->second;
@@ -100,7 +120,7 @@ namespace UnitTest::EventLoggerReflectUtilsTests
             EXPECT_TRUE(eventArgsInst.IsValid());
         }
 
-        classIter = m_behaviorContext->m_classes.find("EventPhase");
+        classIter = m_behaviorContext->m_classes.find(EventPhaseClassName);
         ASSERT_NE(m_behaviorContext->m_classes.end(), classIter);
         {
             AZ::BehaviorClass* eventPhaseClass = classIter->second;
@@ -108,7 +128,7 @@ namespace UnitTest::EventLoggerReflectUtilsTests
             EXPECT_TRUE(eventPhaseInst.IsValid());
         }
 
-        classIter = m_behaviorContext->m_classes.find("InstantEventScope");
+        classIter = m_behaviorContext->m_classes.find(InstantEventScopeClassName);
         ASSERT_NE(m_behaviorContext->m_classes.end(), classIter);
         {
             AZ::BehaviorClass* instantEventScopeClass = classIter->second;
@@ -120,7 +140,7 @@ namespace UnitTest::EventLoggerReflectUtilsTests
     TEST_F(EventLoggerReflectUtilsFixture, EventLogger_CanCreateFromIntOrString_Succeeds)
     {
         // Create an EventLoggerId instance in script that maps to Id 1
-        auto classIter = m_behaviorContext->m_classes.find("EventLoggerId");
+        auto classIter = m_behaviorContext->m_classes.find(EventLoggerIdClassName);
         ASSERT_NE(m_behaviorContext->m_classes.end(), classIter);
         {
             auto methodIter = classIter->second->m_methods.find("CreateIdFromInt");
@@ -141,12 +161,10 @@ namespace UnitTest::EventLoggerReflectUtilsTests
 
     TEST_F(EventLoggerReflectUtilsFixture, RecordEvent_CanRecordDurationEventInScript_Succeeds)
     {
-        const auto startThreadTime = AZStd::chrono::utc_clock::now();
-
-        const AZ::BehaviorClass* eventArgsClass = m_behaviorContext->FindClassByReflectedName("EventArgs");
+        const AZ::BehaviorClass* eventArgsClass = m_behaviorContext->FindClassByReflectedName(EventArgsClassName);
         ASSERT_NE(nullptr, eventArgsClass);
 
-        const AZ::BehaviorClass* eventValueClass = m_behaviorContext->FindClassByReflectedName("EventValue");
+        const AZ::BehaviorClass* eventValueClass = m_behaviorContext->FindClassByReflectedName(EventValueClassName);
         ASSERT_NE(nullptr, eventValueClass);
 
         auto eventArgsScopedObj = eventArgsClass->CreateWithScope();
@@ -158,7 +176,7 @@ namespace UnitTest::EventLoggerReflectUtilsTests
         // Use the bound behavior context properties and methods to configure the ScriptEventArgs
         {
             // Set `ScriptEventArgs::m_name` field
-            const AZ::BehaviorMethod* nameSetter = eventArgsClass->FindSetterByReflectedName("m_name");
+            const AZ::BehaviorMethod* nameSetter = eventArgsClass->FindSetterByReflectedName(EventArgsNameMember);
             ASSERT_NE(nullptr, nameSetter);
             AZStd::string eventName{ "Duration Event" };
 
@@ -169,7 +187,7 @@ namespace UnitTest::EventLoggerReflectUtilsTests
 
         {
             // Set `ScriptEventArgs::m_cat` field
-            const AZ::BehaviorMethod* nameSetter = eventArgsClass->FindSetterByReflectedName("m_cat");
+            const AZ::BehaviorMethod* nameSetter = eventArgsClass->FindSetterByReflectedName(EventArgsCategoryMember);
             ASSERT_NE(nullptr, nameSetter);
             behaviorArguments.clear();
             AZStd::string category{ "Test" };
@@ -181,7 +199,7 @@ namespace UnitTest::EventLoggerReflectUtilsTests
 
         {
             // Set `ScriptEventArgs::m_id` field
-            const AZ::BehaviorMethod* nameSetter = eventArgsClass->FindSetterByReflectedName("m_id");
+            const AZ::BehaviorMethod* nameSetter = eventArgsClass->FindSetterByReflectedName(EventArgsIdMember);
             ASSERT_NE(nullptr, nameSetter);
             behaviorArguments.clear();
             AZStd::optional<AZStd::string> eventId{ "0" };
@@ -193,7 +211,7 @@ namespace UnitTest::EventLoggerReflectUtilsTests
 
         {
             // Populate the ScriptEventArgs "args" object field
-            const AZ::BehaviorMethod* appendArgMethod = eventArgsClass->FindMethodByReflectedName("AppendArg");
+            const AZ::BehaviorMethod* appendArgMethod = eventArgsClass->FindMethodByReflectedName(EventArgsAppendArgMethodName);
             ASSERT_NE(nullptr, appendArgMethod);
 
             // Create an EventValue instance
@@ -229,7 +247,7 @@ namespace UnitTest::EventLoggerReflectUtilsTests
         }
 
         // Finally invoke the RecordEvent function
-        const AZ::BehaviorMethod* recordEventMethod = m_behaviorContext->FindMethodByReflectedName("RecordEvent");
+        const AZ::BehaviorMethod* recordEventMethod = m_behaviorContext->FindMethodByReflectedName(RecordEventMethodName);
         ASSERT_NE(nullptr, recordEventMethod);
 
         constexpr auto durationBeginPhase = AZ::Metrics::EventPhase::DurationBegin;
@@ -254,7 +272,7 @@ namespace UnitTest::EventLoggerReflectUtilsTests
 
     TEST_F(EventLoggerReflectUtilsFixture, RecordEvent_CanCreateMetricsLoggerInScript_Succeeds)
     {
-        const AZ::BehaviorMethod* createLoggerMethod = m_behaviorContext->FindMethodByReflectedName("CreateMetricsLogger");
+        const AZ::BehaviorMethod* createLoggerMethod = m_behaviorContext->FindMethodByReflectedName(CreateMetricsLoggerMethodName);
         ASSERT_NE(nullptr, createLoggerMethod);
 
         constexpr AZ::Metrics::EventLoggerId scriptLoggerId{ 2 };
@@ -269,14 +287,16 @@ namespace UnitTest::EventLoggerReflectUtilsTests
         EXPECT_TRUE(m_eventLoggerFactory->IsRegistered(scriptLoggerId));
 
         // Also validate that the script IsEventLoggerRegistered function succeeds as well
-        const AZ::BehaviorMethod* isEventLoggerRegisteredMethod = m_behaviorContext->FindMethodByReflectedName("IsEventLoggerRegistered");
+        const AZ::BehaviorMethod* isEventLoggerRegisteredMethod = m_behaviorContext->FindMethodByReflectedName(
+            IsEventLoggerRegisteredMethodName);
         ASSERT_NE(nullptr, isEventLoggerRegisteredMethod);
         bool isEventLoggerRegistered{};
         EXPECT_TRUE(isEventLoggerRegisteredMethod->InvokeResult(isEventLoggerRegistered, scriptLoggerId));
         EXPECT_TRUE(isEventLoggerRegistered);
 
         // Finally validate that the EventFactory IsRegistered member function succeeds as well
-        const AZ::BehaviorMethod* getGlobalEventLoggerFactoryMethod = m_behaviorContext->FindMethodByReflectedName("GetGlobalEventLoggerFactory");
+        const AZ::BehaviorMethod* getGlobalEventLoggerFactoryMethod = m_behaviorContext->FindMethodByReflectedName(
+            GetGlobalEventLoggerFactoryMethodName);
         ASSERT_NE(nullptr, getGlobalEventLoggerFactoryMethod);
         AZ::Metrics::IEventLoggerFactory* eventLoggerFactory{};
         EXPECT_TRUE(getGlobalEventLoggerFactoryMethod->InvokeResult(eventLoggerFactory));
@@ -287,9 +307,10 @@ namespace UnitTest::EventLoggerReflectUtilsTests
         // reset back to false;
         isEventLoggerRegistered = {};
         // Lookup the EventLoggerFactory BehaviorClass in order to lookup the IsRegistered member function
-        const AZ::BehaviorClass* eventLoggerFactoryClass = m_behaviorContext->FindClassByReflectedName("EventLoggerFactory");
+        const AZ::BehaviorClass* eventLoggerFactoryClass = m_behaviorContext->FindClassByReflectedName(EventLoggerFactoryClassName);
         ASSERT_NE(nullptr, eventLoggerFactoryClass);
-        const AZ::BehaviorMethod* isRegisteredMethod = eventLoggerFactoryClass->FindMethodByReflectedName("IsRegistered");
+        const AZ::BehaviorMethod* isRegisteredMethod = eventLoggerFactoryClass->FindMethodByReflectedName(
+            EventLoggerFactoryIsRegisteredMethodName);
         ASSERT_NE(nullptr, isRegisteredMethod);
         EXPECT_TRUE(isRegisteredMethod->InvokeResult(isEventLoggerRegistered, eventLoggerFactory, scriptLoggerId));
         EXPECT_TRUE(isEventLoggerRegistered);

--- a/Code/Framework/AzCore/Tests/Metrics/EventLoggerReflectUtilsTests.cpp
+++ b/Code/Framework/AzCore/Tests/Metrics/EventLoggerReflectUtilsTests.cpp
@@ -52,9 +52,6 @@ namespace UnitTest::EventLoggerReflectUtilsTests
     };
 
     constexpr const char* EventValueClassName = "EventValue";
-    constexpr const char* EventFieldClassName = "EventField";
-    constexpr const char* EventArrayClassName = "EventArray";
-    constexpr const char* EventObjectClassName = "EventObject";
     constexpr const char* EventLoggerIdClassName = "EventLoggerId";
     constexpr const char* EventArgsClassName = "EventArgs";
     constexpr const char* EventPhaseClassName = "EventPhase";

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -165,6 +165,7 @@ set(FILES
     Memory/LeakDetection.cpp
     Memory.cpp
     Metrics/EventLoggerFactoryTests.cpp
+    Metrics/EventLoggerReflectUtilsTests.cpp
     Metrics/EventLoggerUtilsTests.cpp
     Metrics/JsonTraceEventLoggerTests.cpp
     Module.cpp

--- a/Gems/Multiplayer/Code/Source/MultiplayerStatSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerStatSystemComponent.cpp
@@ -54,7 +54,7 @@ namespace Multiplayer
             constexpr AZ::IO::OpenMode openMode = AZ::IO::OpenMode::ModeWrite | AZ::IO::OpenMode::ModeCreatePath;
 
             auto stream = AZStd::make_unique<AZ::IO::SystemFileStream>(metricsFilepath.c_str(), openMode);
-            AZ::Metrics::JsonTraceLoggerEventConfig config{ "Multiplayer" };
+            AZ::Metrics::JsonTraceEventLoggerConfig config{ "Multiplayer" };
             auto eventLogger = AZStd::make_unique<AZ::Metrics::JsonTraceEventLogger>(AZStd::move(stream), config);
             eventLoggerFactory->RegisterEventLogger(NetworkingMetricsId, AZStd::move(eventLogger));
         }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
@@ -541,7 +541,7 @@ namespace
 
                 if (categoryPath.empty())
                 {
-                    if (classNamePretty.empty())
+                    if (!classNamePretty.empty())
                     {
                         categoryPath = classNamePretty;
                     }
@@ -975,7 +975,7 @@ namespace
         // Populates the VariablePalette with type registered with the ScriptCanvas DataRegistry
         PopulateVariablePalette();
 
-        // Populates the NodePalette with Behavior Class method nodes 
+        // Populates the NodePalette with Behavior Class method nodes
         PopulateBehaviorContextClassMethods(nodePaletteModel, *behaviorContext);
 
         // Populates the NodePalette with BehaviorContext methods overloaded on the same name
@@ -1232,7 +1232,7 @@ namespace ScriptCanvasEditor
         auto registerIter = m_registeredNodes.find(nodeIdentifier);
 
         if (registerIter == m_registeredNodes.end())
-        {            
+        {
             MethodNodeModelInformation* methodModelInformation = aznew MethodNodeModelInformation();
             methodModelInformation->m_isOverload = isOverload;
             methodModelInformation->m_nodeIdentifier = nodeIdentifier;
@@ -1271,7 +1271,7 @@ namespace ScriptCanvasEditor
             }
 
             m_registeredNodes.emplace(AZStd::make_pair(nodeIdentifier, methodModelInformation));
-        }        
+        }
     }
 
     void NodePaletteModel::RegisterGlobalConstant(const AZ::BehaviorContext&, const AZ::BehaviorProperty* behaviorProperty, const AZ::BehaviorMethod& behaviorMethod)
@@ -1364,7 +1364,7 @@ namespace ScriptCanvasEditor
         if (nodeIter == m_registeredNodes.end())
         {
             EBusHandlerNodeModelInformation* handlerInformation = aznew EBusHandlerNodeModelInformation();
-            
+
             handlerInformation->m_titlePaletteOverride = "HandlerNodeTitlePalette";
             handlerInformation->m_categoryPath = categoryPath;
             handlerInformation->m_nodeIdentifier = nodeIdentifier;
@@ -1439,7 +1439,7 @@ namespace ScriptCanvasEditor
         ScriptCanvas::EBusBusId busId = scriptEventAsset->GetBusId();
 
         AZStd::string category = scriptEvent.GetCategory();
-        
+
         auto methods = scriptEvent.GetMethods();
 
         AZStd::vector<ScriptCanvas::NodeTypeIdentifier> identifiers;
@@ -1469,7 +1469,7 @@ namespace ScriptCanvasEditor
             m_registeredNodes.emplace(AZStd::make_pair(receiverIdentifier, handlerInformation));
 
             ScriptEventSenderNodeModelInformation* senderInformation = aznew ScriptEventSenderNodeModelInformation();
-            
+
             senderInformation->m_titlePaletteOverride = "MethodNodeTitlePalette";
             senderInformation->m_busName = scriptEvent.GetName();
             senderInformation->m_eventName = method.GetName();
@@ -1709,7 +1709,7 @@ namespace ScriptCanvasEditor
                 if (productEntry->GetAssetType() == azrtti_typeid<ScriptEvents::ScriptEventsAsset>())
                 {
                     const AZ::Data::AssetId& assetId = productEntry->GetAssetId();
-                    
+
                     auto busAsset = AZ::Data::AssetManager::Instance().GetAsset(assetId, azrtti_typeid<ScriptEvents::ScriptEventsAsset>(), AZ::Data::AssetLoadBehavior::PreLoad);
                     busAsset.BlockUntilLoadComplete();
 

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventBroadcast.cpp
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventBroadcast.cpp
@@ -71,23 +71,29 @@ namespace ScriptEvents
         //AZ_TracePrintf("Script Events", "Script Broadcast Method: %s %s::%s (Arguments: %zu)\n", m_returnType.ToString<AZStd::string>().c_str(), busName.c_str(), m_name.c_str(), method.GetParameters().size());
     }
 
-    bool ScriptEventBroadcast::Call(AZ::BehaviorArgument* params, unsigned int paramCount, AZ::BehaviorArgument* returnValue) const
+    bool ScriptEventBroadcast::Call(AZStd::span<AZ::BehaviorArgument> params, AZ::BehaviorArgument* returnValue) const
     {
         Internal::BindingRequest::BindingParameters parameters;
         parameters.m_eventName = m_name;
         parameters.m_address = nullptr;
-        parameters.m_parameters = params;
-        parameters.m_parameterCount = paramCount;
+        parameters.m_parameters = params.data();
+        parameters.m_parameterCount = AZ::u32(params.size());
         parameters.m_returnValue = returnValue;
 
         Internal::BindingRequestBus::Event(m_busBindingId, &Internal::BindingRequest::Bind, parameters);
-        
+
         if (returnValue && returnValue->m_onAssignedResult)
         {
             returnValue->m_onAssignedResult();
         }
 
         return true;
+    }
+
+    auto ScriptEventBroadcast::IsCallable([[maybe_unused]] AZStd::span<AZ::BehaviorArgument> params, [[maybe_unused]] AZ::BehaviorArgument* returnValue) const
+        -> ResultOutcome
+    {
+        return AZ::Success();
     }
 
     void ScriptEventBroadcast::ReserveArguments(size_t numArguments)

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventBroadcast.h
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventBroadcast.h
@@ -33,7 +33,8 @@ namespace ScriptEvents
 
         ScriptEventBroadcast(AZ::BehaviorContext* behaviorContext, const ScriptEvent& definition, AZStd::string eventName);
 
-        bool Call(AZ::BehaviorArgument* params, unsigned int paramCount, AZ::BehaviorArgument* returnValue) const override;
+        bool Call(AZStd::span<AZ::BehaviorArgument> params, AZ::BehaviorArgument* returnValue) const override;
+        ResultOutcome IsCallable(AZStd::span<AZ::BehaviorArgument> params, AZ::BehaviorArgument* returnValue) const override;
         bool HasResult() const override { return !m_returnType.IsNull(); }
         bool IsMember() const override { return false; }
 

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventMethod.cpp
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventMethod.cpp
@@ -81,23 +81,29 @@ namespace ScriptEvents
 
     }
 
-    bool ScriptEventMethod::Call(AZ::BehaviorArgument* params, unsigned int paramCount, AZ::BehaviorArgument* returnValue) const
+    bool ScriptEventMethod::Call(AZStd::span<AZ::BehaviorArgument> params, AZ::BehaviorArgument* returnValue) const
     {
         Internal::BindingRequest::BindingParameters parameters;
         parameters.m_eventName = m_name;
         parameters.m_address = &params[0];  // The address is stored in the first parameter
-        parameters.m_parameters = params + 1; 
-        parameters.m_parameterCount = paramCount - 1; // Minus the address
+        parameters.m_parameters = params.data() + 1;
+        parameters.m_parameterCount = AZ::u32(params.size() - 1); // Minus the address
         parameters.m_returnValue = returnValue;
 
         Internal::BindingRequestBus::Event(m_busBindingId, &Internal::BindingRequest::Bind, parameters);
-        
+
         if (returnValue && returnValue->m_onAssignedResult)
         {
             returnValue->m_onAssignedResult();
         }
 
         return true;
+    }
+
+    auto ScriptEventMethod::IsCallable([[maybe_unused]] AZStd::span<AZ::BehaviorArgument> params, [[maybe_unused]] AZ::BehaviorArgument* returnValue) const
+        -> ResultOutcome
+    {
+        return AZ::Success();
     }
 
     void ScriptEventMethod::ReserveArguments(size_t numArguments)
@@ -132,5 +138,5 @@ namespace ScriptEvents
         // Default values for Script Events are not implemented.
         return nullptr;
     }
-    
+
 }

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventMethod.h
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventMethod.h
@@ -33,7 +33,8 @@ namespace ScriptEvents
 
         ScriptEventMethod(AZ::BehaviorContext* behaviorContext, const ScriptEvent& definition, const AZStd::string eventName);
 
-        bool Call(AZ::BehaviorArgument* params, unsigned int paramCount, AZ::BehaviorArgument* returnValue) const override;
+        bool Call(AZStd::span<AZ::BehaviorArgument> params, AZ::BehaviorArgument* returnValue) const override;
+        ResultOutcome IsCallable(AZStd::span<AZ::BehaviorArgument> params, AZ::BehaviorArgument* returnValue) const override;
         bool HasResult() const override { return !m_returnType.IsNull() && m_returnType != azrtti_typeid<void>(); }
         bool IsMember() const override { return false; }
 


### PR DESCRIPTION
## What does this PR do?

 Adding BehaviorContext support for using the EventLogger API

The primary new functions are `CreateMetricsLogger`, `RecordEvent`
`IsEventLoggerRegistered` and `GetGlobalEventLoggerFactory`.

Several wrapper classes have been added to BehaviorContext to help with
recording event data.
The `EventLoggerId` class is used to specify an ID for an event logger.
In script it can be created as such
```
import azlmbr.metrics

eventLoggerId1 = azlmbr.metrics.CreateFromInt(1)
eventLoggerId2 = azlmbr.metrics.CreateFromString("foo")
```

The `EventPhase` class is used to specify the type of event to record
```
import azlmbr.metrics

durationEventPhase = azlmbr.metrics.EventPhase.DurationBegin
```

The `InstantEventScope` class is used to specify the scope values to an
InstantEvent.
```
import azlmbr.metrics

globalScope = azlmbr.metrics.InstantEventScope.Global
```

The `EventValue` class is used to create a value that can be appended to
the `EventArgs` structure for configuring events
```
import azlmbr.metrics

intValue = azlmbr.emtrics.EventValue(42)
stringValue = azlmbr.metrics.EventValue("Hello world")
```

The `EventArgs` class is the primary class used to configure arguments
to record for an event
```
import azlmbr.metrics

myArgs = azlmbr.metrics.EventArgs()
myArgs.m_name = "Duration Event"
myArgs.m_cat = "Test Category"
myArgs.m_id = "0"
myArgs.AppendArg("Entity Count", 20)
myArgs.AppendArg("Entity Group", "level")

loggerId = azlmbr.metrics.CreateFromString("CustomIdValue")
if azlmbr.metrics.RecordEvent(loggerId, azlmbr.metrics.EventPhase.DurationBegin, myArgs):
    print("Success")

```

For completeness the `CreateMetricsLogger` function can be used as
follows
```
import pathlib
import azlmbr.metrics

loggerId = azlmbr.metrics.CreateFromString("CustomFoo")
outputFilePath = pathlib.Path(azlmbr.paths.projectroot) /
"user/Metrics/MyScriptFoo_metrics.json"
loggerName = "LoggerNameIsFoo"
azlmbr.metrics.CreateMetricsLogger(loggerId, outputFilePath.as_posix(), loggerName)
```

Other changes include updating the BehaviorContext and BehaviorClass to
have methods for querying a BehaviorClass, BehaviorMethod,
BehaviorProperty, property setter, property getter, or BehaviorEBus via
name.

A Scoped wrapper for the BehaviorObject has been added which
automatically destructs and optionally deallocates objects created by
the Behavior Context.

The BehaviorMethod class has had a IsCallable function which returns a
boolean that indicates if function could be invoked with a given set of
input arguments. If it cannot an outcome with the error message
detailing the reason is returned.

## How was this PR tested?

Added C++ UnitTest that verifies the new Behavior Context functions for the EventLogger
