### PR TITLE
Implemented MaterialEditor & Canvas menu items with ActionManager

### DIFF
--- a/Code/Editor/Core/LevelEditorMenuHandler.cpp
+++ b/Code/Editor/Core/LevelEditorMenuHandler.cpp
@@ -327,8 +327,6 @@ void LevelEditorMenuHandler::ResetToolsMenus()
 
     CreateMenuOptions(&menuMap, m_toolsMenu, LyViewPane::CategoryTools);
 
-    AzToolsFramework::EditorMenuNotificationBus::Broadcast(&AzToolsFramework::EditorMenuNotificationBus::Handler::OnPopulateToolMenuItems);
-
     m_toolsMenu.AddSeparator();
 
     // Other

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ActionBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ActionBus.h
@@ -204,8 +204,6 @@ namespace AzToolsFramework
         : public AZ::EBusTraits
     {
     public:
-        /// Dispatched when Editor's Tools menu is being populated so that external tools can add their actions.
-        virtual void OnPopulateToolMenuItems() = 0;
 
         /// Dispatched when Editor's Tools menu is cleared.
         virtual void OnResetToolMenuItems() = 0;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -106,7 +106,6 @@ namespace AZ
             EditorMaterialSystemComponentRequestBus::Handler::BusConnect();
             MaterialComponentNotificationBus::Router::BusRouterConnect();
             AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler::BusConnect();
-            AzToolsFramework::EditorMenuNotificationBus::Handler::BusConnect();
             AzToolsFramework::EditorEvents::Bus::Handler::BusConnect();
             AzToolsFramework::ToolsApplicationNotificationBus::Handler::BusConnect();
             AzFramework::AssetCatalogEventBus::Handler::BusConnect();
@@ -128,7 +127,6 @@ namespace AZ
             EditorMaterialSystemComponentRequestBus::Handler::BusDisconnect();
             MaterialComponentNotificationBus::Router::BusRouterDisconnect();
             AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler::BusDisconnect();
-            AzToolsFramework::EditorMenuNotificationBus::Handler::BusDisconnect();
             AzToolsFramework::EditorEvents::Bus::Handler::BusDisconnect(); 
             AzToolsFramework::ToolsApplicationNotificationBus::Handler::BusDisconnect(); 
             AZ::SystemTickBus::Handler::BusDisconnect();
@@ -139,11 +137,6 @@ namespace AZ
             m_materialPreviewRequests.clear();
             m_materialPreviewModelAsset.Release();
             m_materialPreviewLightingPresetAsset.Release();
-
-            delete m_openMaterialEditorAction;
-            m_openMaterialEditorAction = nullptr;
-            delete m_openMaterialCanvasAction;
-            m_openMaterialCanvasAction = nullptr;
         }
 
         void EditorMaterialSystemComponent::OpenMaterialEditor(const AZStd::string& sourcePath)
@@ -341,14 +334,6 @@ namespace AZ
             m_materialPreviews.erase(entityId);
         }
 
-        void EditorMaterialSystemComponent::OnResetToolMenuItems()
-        {
-            delete m_openMaterialEditorAction;
-            m_openMaterialEditorAction = nullptr;
-            delete m_openMaterialCanvasAction;
-            m_openMaterialCanvasAction = nullptr;
-        }
-
         void EditorMaterialSystemComponent::NotifyRegisterViews()
         {
             AzToolsFramework::ViewPaneOptions inspectorOptions;
@@ -417,13 +402,13 @@ namespace AZ
                 {
                     OpenMaterialEditor("");
                 });
-            AZ_Assert(outcome.IsSuccess(), "Failed to RegisterAction %s", MaterialEditorAction);
+            AZ_Assert(outcome.IsSuccess(), "Failed to RegisterAction %s", MaterialEditorAction.data());
 
             outcome = menuManagerInterface->AddActionToMenu(ToolsMenuIdentifier, MaterialEditorAction, 100);
-            AZ_Assert(outcome.IsSuccess(), "Failed to AddAction %s to Menu %s", MaterialEditorAction, ToolsMenuIdentifier);
+            AZ_Assert(outcome.IsSuccess(), "Failed to AddAction %s to Menu %s", MaterialEditorAction.data(), ToolsMenuIdentifier.data());
 
             outcome = hotKeyManagerInterface->SetActionHotKey(MaterialEditorAction, "M");
-            AZ_Assert(outcome.IsSuccess(), "Failed to ActionHotKey for %s", MaterialEditorAction);
+            AZ_Assert(outcome.IsSuccess(), "Failed to ActionHotKey for %s", MaterialEditorAction.data());
 
 
             constexpr AZStd::string_view MaterialCanvasAction = "o3de.tools.material_canvas";

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -419,13 +419,13 @@ namespace AZ
                 {
                     OpenMaterialCanvas("");
                 });
-            AZ_Assert(outcome.IsSuccess(), "Failed to RegisterAction %s", MaterialCanvasAction);
+            AZ_Assert(outcome.IsSuccess(), "Failed to RegisterAction %s", MaterialCanvasAction.data());
 
             outcome = menuManagerInterface->AddActionToMenu(ToolsMenuIdentifier, MaterialCanvasAction, 101);
-            AZ_Assert(outcome.IsSuccess(), "Failed to AddAction %s to Menu %s", MaterialCanvasAction, ToolsMenuIdentifier);
+            AZ_Assert(outcome.IsSuccess(), "Failed to AddAction %s to Menu %s", MaterialCanvasAction.data(), ToolsMenuIdentifier.data());
 
             outcome = hotKeyManagerInterface->SetActionHotKey(MaterialCanvasAction, "Ctrl+Shift+M");
-            AZ_Assert(outcome.IsSuccess(), "Failed to ActionHotKey for %s", MaterialCanvasAction);
+            AZ_Assert(outcome.IsSuccess(), "Failed to ActionHotKey for %s", MaterialCanvasAction.data());
 
         }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
@@ -19,11 +19,13 @@
 #include <AzCore/Component/EntityBus.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzFramework/Asset/AssetCatalogBus.h>
+#include <AzToolsFramework/ActionManager/ActionManagerRegistrationNotificationBus.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
 #include <AzToolsFramework/Viewport/ActionBus.h>
 #include <Material/MaterialBrowserInteractions.h>
 #include <QPixmap>
+
 
 namespace AZ
 {
@@ -42,6 +44,7 @@ namespace AZ
             , public AzToolsFramework::ToolsApplicationNotificationBus::Handler
             , public AZ::SystemTickBus::Handler
             , public AzFramework::AssetCatalogEventBus::Handler
+            , private AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler
         {
         public:
             AZ_COMPONENT(EditorMaterialSystemComponent, "{96652157-DA0B-420F-B49C-0207C585144C}");
@@ -91,7 +94,6 @@ namespace AZ
             AzToolsFramework::AssetBrowser::SourceFileDetails GetSourceFileDetails(const char* fullSourceFileName) override;
 
             // EditorMenuNotificationBus::Handler overrides ...
-            void OnPopulateToolMenuItems() override;
             void OnResetToolMenuItems() override;
 
             // AztoolsFramework::EditorEvents::Bus::Handler overrides...
@@ -99,6 +101,9 @@ namespace AZ
 
             // AzToolsFramework::ToolsApplicationNotificationBus::Handler overrides...
             void AfterEntitySelectionChanged(const AzToolsFramework::EntityIdList& newlySelectedEntities, const AzToolsFramework::EntityIdList&) override;
+
+            // AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler...
+            void OnMenuBindingHook() override;
 
             void PurgePreviews();
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
@@ -39,7 +39,6 @@ namespace AZ
             , public EditorMaterialSystemComponentRequestBus::Handler
             , public MaterialComponentNotificationBus::Router
             , public AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler
-            , public AzToolsFramework::EditorMenuNotificationBus::Handler
             , public AzToolsFramework::EditorEvents::Bus::Handler
             , public AzToolsFramework::ToolsApplicationNotificationBus::Handler
             , public AZ::SystemTickBus::Handler
@@ -93,9 +92,6 @@ namespace AZ
             //! AssetBrowserInteractionNotificationBus::Handler overrides...
             AzToolsFramework::AssetBrowser::SourceFileDetails GetSourceFileDetails(const char* fullSourceFileName) override;
 
-            // EditorMenuNotificationBus::Handler overrides ...
-            void OnResetToolMenuItems() override;
-
             // AztoolsFramework::EditorEvents::Bus::Handler overrides...
             void NotifyRegisterViews() override;
 
@@ -107,8 +103,6 @@ namespace AZ
 
             void PurgePreviews();
 
-            QAction* m_openMaterialEditorAction = nullptr;
-            QAction* m_openMaterialCanvasAction = nullptr;
             AZStd::unique_ptr<MaterialBrowserInteractions> m_materialBrowserInteractions;
             AZStd::unordered_set<AZStd::pair<AZ::EntityId, AZ::Render::MaterialAssignmentId>> m_materialPreviewRequests;
             AZStd::unordered_map<AZ::EntityId, AZStd::unordered_map<AZ::Render::MaterialAssignmentId, QPixmap>> m_materialPreviews;


### PR DESCRIPTION
## What does this PR do?

Migrated the Material Canvas & Material Editor main menu bar items to use the Action Manager

## How was this PR tested?

Built the editor, launched both tools with the menu option and with the key shortcut

Signed-off-by: Luis Sempé <58790905+lsemp3d@users.noreply.github.com>
