### PR TITLE
Fixed material type dependency build failures.

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -43,7 +43,7 @@ namespace AZ
         {
             AssetBuilderSDK::AssetBuilderDesc materialBuilderDescriptor;
             materialBuilderDescriptor.m_name = "Material Type Builder";
-            materialBuilderDescriptor.m_version = 23; // Material property refactoring
+            materialBuilderDescriptor.m_version = 24; // Added missing dependencies on material pipeline related files
             materialBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.materialtype", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             materialBuilderDescriptor.m_busId = azrtti_typeid<MaterialTypeBuilder>();
             materialBuilderDescriptor.m_createJobFunction = AZStd::bind(&MaterialTypeBuilder::CreateJobs, this, AZStd::placeholders::_1, AZStd::placeholders::_2);
@@ -239,6 +239,22 @@ namespace AZ
                     }
                     return true;
                 });
+
+            for (const auto& pipelinePair : materialTypeSourceData.m_pipelineData)
+            {
+                for (auto& shader : pipelinePair.second.m_shaderCollection)
+                {
+                    MaterialBuilderUtils::AddPossibleDependencies(request.m_sourceFile,
+                        shader.m_shaderFilePath,
+                        "Shader Asset",
+                        outputJobDescriptor.m_jobDependencyList,
+                        response.m_sourceFileDependencyList,
+                        false,
+                        0);
+                }
+
+                addFunctorDependencies(pipelinePair.second.m_materialFunctorSourceData);
+            }
 
             // Create the output jobs for each platform
             for (const AssetBuilderSDK::PlatformInfo& platformInfo : request.m_enabledPlatforms)


### PR DESCRIPTION
## What does this PR do?

I added more file references to the material type asset for new material pipeline data, but forgot to add these dependencies.

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>

## How was this PR tested?

Checked the Asset Processor "Dependencies - Out" info before and after to confirm that the .shader files and .lua files are present.
 
![image](https://user-images.githubusercontent.com/55155825/206391676-05055217-a84b-4ba8-be2a-2cefe8717ca8.png)
