### PR TITLE
Fix warning error on Mac

### DIFF
--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/EditorStatePassSystem.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/EditorStatePassSystem.cpp
@@ -195,7 +195,7 @@ namespace AZ::Render
             {
                 const auto entityIds = state->GetMaskedEntities();
                 auto& mask = entityMaskMap[state->GetEntityMaskDrawList()];
-                for (const auto entityId : entityIds)
+                for (const auto& entityId : entityIds)
                 {
                     mask.insert(entityId);
                 }


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

Fixes the following compilation error in mac:

````
/Users/lybuilder/workspace/o3de/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/EditorStatePassSystem.cpp:198:33: error: loop variable 'entityId' of type 'const AZ::EntityId' creates a copy from type 'const AZ::EntityId' [-Werror,-Wrange-loop-analysis]
                for (const auto entityId : entityIds)
                                ^
/Users/lybuilder/workspace/o3de/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/EditorStatePassSystem.cpp:198:22: note: use reference type 'const AZ::EntityId &' to prevent copying
                for (const auto entityId : entityIds)
                     ^~~~~~~~~~~~~~~~~~~~~
                                &
1 error generated.
````
