### PR TITLE
Bug Fix: Using entity picker on a component before entering component mode causes crash.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -500,9 +500,6 @@ namespace AzToolsFramework
 
         initEntityPropertyEditorResources();
 
-        m_componentModeCollection = AZ::Interface<ComponentModeCollectionInterface>::Get();
-        AZ_Assert(m_componentModeCollection, "Could not retrieve component mode collection.");
-
         m_prefabPublicInterface = AZ::Interface<Prefab::PrefabPublicInterface>::Get();
         AZ_Assert(m_prefabPublicInterface != nullptr, "EntityPropertyEditor requires a PrefabPublicInterface instance on Initialize.");
 
@@ -5889,7 +5886,7 @@ namespace AzToolsFramework
         {
             DisableComponentActions(this, m_entityComponentActions);
             SetPropertyEditorState(m_gui, false);
-            const auto componentModeTypes = m_componentModeCollection->GetComponentTypes();
+            const auto componentModeTypes = AZ::Interface<ComponentModeCollectionInterface>::Get()->GetComponentTypes();
             m_disabled = true;
 
             
@@ -5922,7 +5919,7 @@ namespace AzToolsFramework
         {
             EnableComponentActions(this, m_entityComponentActions);
             SetPropertyEditorState(m_gui, true);
-            const auto componentModeTypes = m_componentModeCollection->GetComponentTypes();
+            const auto componentModeTypes = AZ::Interface<ComponentModeCollectionInterface>::Get()->GetComponentTypes();
             m_disabled = false;
 
             for (auto componentEditor : m_componentEditors)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
@@ -660,8 +660,6 @@ namespace AzToolsFramework
         float m_moveFadeSecondsRemaining;
         AZStd::vector<int> m_indexMapOfMovedRow;
 
-        AzToolsFramework::ComponentModeCollectionInterface* m_componentModeCollection = nullptr;
-
         // When m_initiatingPropertyChangeNotification is set to true, it means this EntityPropertyEditor is
         // broadcasting a change to all listeners about a property change for a given entity.  This is needed
         // so that we don't update the values twice for this inspector


### PR DESCRIPTION
Signed-off-by: amzn-ahmadkrm <ahmadkrm@amazon.com>

## What does this PR do?

Fixes issue https://github.com/o3de/o3de/issues/13339

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_

If you used the Entity Picker on a component then enter its component mode, the Editor will crash. This was caused by the EntityPropertyEditor using a cached value of m_componentModeCollection which became a hanging pointer after using the EntityPicker which destroys and recreates EditorDefaultSelection. This change directly calls the current ComponentModeCollection.

## How was this PR tested?
Manual testing
