### PR TITLE
Add VisiblePath variable to the Asset Browser

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -406,7 +406,7 @@ void AzAssetBrowserWindow::UpdateBreadcrumbs(const AzToolsFramework::AssetBrowse
         const AssetBrowserEntry* folderEntry = folderForEntry(selectedEntry);
         if (folderEntry)
         {
-            entryPath = QString::fromUtf8(folderEntry->GetRelativePath().c_str());
+            entryPath = QString::fromUtf8(folderEntry->GetVisiblePath().c_str());
         }
     }
     m_ui->m_pathBreadCrumbs->setCurrentPath(entryPath);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.cpp
@@ -175,6 +175,11 @@ namespace AzToolsFramework
             return m_relativePath.Native();
         }
 
+        const AZStd::string& AssetBrowserEntry::GetVisiblePath() const
+        {
+            return m_visiblePath.Native();
+        }
+
         const AZStd::string AssetBrowserEntry::GetFullPath() const
         {
             // the full path could use a decoding:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.h
@@ -103,6 +103,8 @@ namespace AzToolsFramework
             const QString& GetDisplayPath() const;
             //! Return path relative to scan folder
             const AZStd::string& GetRelativePath() const;
+            //! Return path visible to asset browser
+            const AZStd::string& GetVisiblePath() const;
             //! Return absolute path to this file. Note that this decodes it to native slashes and resolves
             //! any aliases.
             const AZStd::string GetFullPath() const;
@@ -136,6 +138,7 @@ namespace AzToolsFramework
             QString m_displayName;
             QString m_displayPath;
             AZ::IO::Path m_relativePath;
+            AZ::IO::Path m_visiblePath;
             AZ::IO::Path m_fullPath;
             AZStd::vector<AssetBrowserEntry*> m_children;
             AssetBrowserEntry* m_parentAssetEntry = nullptr;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/FolderAssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/FolderAssetBrowserEntry.cpp
@@ -59,6 +59,9 @@ namespace AzToolsFramework
                 child->m_relativePath = (m_relativePath / child->m_name).LexicallyNormal();
             }
 
+            // the visible path of a child is the path that is visible in the asset browser
+            child->m_visiblePath = (m_visiblePath / child->m_name).LexicallyNormal();
+
             // display path is just the relative path without the name:
             AZ::IO::Path parentPath = child->m_relativePath.ParentPath();
             child->m_displayPath = QString::fromUtf8(parentPath.c_str());

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/RootAssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/RootAssetBrowserEntry.cpp
@@ -262,6 +262,7 @@ namespace AzToolsFramework
                 cleanedRelative = storageForLexicallyRelative;
             }
             product->m_relativePath = cleanedRelative;
+            product->m_visiblePath = cleanedRelative;
             product->m_fullPath = (AZ::IO::Path("@products@") / cleanedRelative).LexicallyNormal();
 
             // compute the display data from the above data.
@@ -414,6 +415,7 @@ namespace AzToolsFramework
             // shown root.
             child->m_fullPath = m_fullPath / child->m_name;
             child->m_relativePath = child->m_name;
+            child->m_visiblePath = child->m_name;
 
             // the display path is the relative path without the child's name.  So it is blank here.
             child->m_displayPath = QString();


### PR DESCRIPTION
Signed-off-by: Daniel Tamkin <jotamkin@amazon.com>

## What does this PR do?

The Relative Path variable in the asset browser displays the path to the nearest scan folder, while the Full Path variable displays the entire path from the root of your computer. Therefore, the visible path displays only the path visible in the asset browser.
Resolves #13474 

## How was this PR tested?

Manually
