### PR TITLE
Fixed out of order ebus connect/add_callback, added more context to error message

### DIFF
--- a/AutomatedTesting/TestAssets/test_chunks_builder.py
+++ b/AutomatedTesting/TestAssets/test_chunks_builder.py
@@ -52,8 +52,8 @@ def on_update_manifest(args):
 def main():
     global mySceneJobHandler
     mySceneJobHandler = sceneApi.ScriptBuildingNotificationBusHandler()
-    mySceneJobHandler.add_callback('OnUpdateManifest', on_update_manifest)
     mySceneJobHandler.connect()
+    mySceneJobHandler.add_callback('OnUpdateManifest', on_update_manifest)
 
 if __name__ == "__main__":
     main()

--- a/Gems/EditorPythonBindings/Code/Source/PythonProxyBus.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonProxyBus.cpp
@@ -189,13 +189,18 @@ namespace EditorPythonBindings
             {
                 if (!PyCallable_Check(callback.ptr()))
                 {
-                    AZ_Error("python", false, "The callback needs to be a callable python function.");
+                    AZ_Error("python", false, "The callback for event '%s' on bus %.*s needs to be a callable python function.", eventName.data(), AZ_STRING_ARG(m_ebus->m_name));
                     return false;
                 }
 
                 if (!m_handler)
                 {
-                    AZ_Error("python", false, "No EBus connection detected; missing call or failed call to connect()?");
+                        AZ_Error(
+                            "python",
+                            false,
+                            "No EBus connection detected for event '%s'. Make sure to call to connect() on the %.*s bus, first.",
+                            eventName.data(),
+                            AZ_STRING_ARG(m_ebus->m_name));
                     return false;
                 }
 

--- a/Gems/EditorPythonBindings/Code/Source/PythonProxyBus.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonProxyBus.cpp
@@ -189,18 +189,22 @@ namespace EditorPythonBindings
             {
                 if (!PyCallable_Check(callback.ptr()))
                 {
-                    AZ_Error("python", false, "The callback for event '%s' on bus %.*s needs to be a callable python function.", eventName.data(), AZ_STRING_ARG(m_ebus->m_name));
+                    [[maybe_unused]] AZStd::string ebusName(AZStd::string(m_ebus ? m_ebus->m_name : "invalid ebus"));
+                    AZ_Error("python", false, "The callback for event '%s' on bus '%.*s' needs to be a callable python function.",
+                        eventName.data(),
+                        AZ_STRING_ARG(ebusName));
                     return false;
                 }
 
                 if (!m_handler)
                 {
-                        AZ_Error(
-                            "python",
-                            false,
-                            "No EBus connection detected for event '%s'. Make sure to call to connect() on the %.*s bus, first.",
-                            eventName.data(),
-                            AZ_STRING_ARG(m_ebus->m_name));
+                    [[maybe_unused]] AZStd::string ebusName(m_ebus ? m_ebus->m_name : "invalid ebus");
+                    AZ_Error(
+                        "python",
+                        false,
+                        "No EBus connection detected for event '%s'. Make sure to call to connect() on the %.*s bus, first.",
+                        eventName.data(),
+                        AZ_STRING_ARG(ebusName));
                     return false;
                 }
 


### PR DESCRIPTION
Signed-off-by: AMZN-stankowi <4838196+AMZN-stankowi@users.noreply.github.com>

## What does this PR do?

connect needs to be called before add_callback, this change fixes that, and adds more context to the error message.

## How was this PR tested?

Tested locally.

New error message:
![image](https://user-images.githubusercontent.com/4838196/206500404-d9006be9-6809-422f-abc1-c6d41dba3c41.png)
