### PR TITLE
Switch auto to const auto& to avoid a vector copy

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
@@ -224,7 +224,7 @@ namespace AZ
             // [GFX TODO][ATOM-5625] This really needs to be optimized to put the burden on setting global shader options, not applying global shader options.
             // For example, make the shader system collect a map of all shaders and ShaderVaraintIds, and look up the shader option names at set-time.
             ShaderSystemInterface* shaderSystem = ShaderSystemInterface::Get();
-            for (auto iter : shaderSystem->GetGlobalShaderOptions())
+            for (const auto& iter : shaderSystem->GetGlobalShaderOptions())
             {
                 const Name& shaderOptionName = iter.first;
                 ShaderOptionValue value = iter.second;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -61,9 +61,9 @@ namespace AZ
 
         void MeshDrawPacket::ForValidShaderOptionName(const Name& shaderOptionName, const AZStd::function<bool(const ShaderCollection::Item&, ShaderOptionIndex)>& callback)
         {
-            for (auto shaderCollectionIter : m_material->GetShaderCollections())
+            for (const auto& shaderCollectionIter : m_material->GetShaderCollections())
             {
-                for (auto& shaderItem : shaderCollectionIter.second)
+                for (const auto& shaderItem : shaderCollectionIter.second)
                 {
                     const ShaderOptionGroupLayout* layout = shaderItem.GetShaderOptions()->GetShaderOptionLayout();
                     ShaderOptionIndex index = layout->FindShaderOptionIndex(shaderOptionName);

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.cpp
@@ -52,9 +52,9 @@ namespace AZ::Render
     bool EditorStateMeshDrawPacket::SetShaderOption(const Name& shaderOptionName, RPI::ShaderOptionValue value)
     {
         // check if the material owns this option in any of its shaders, if so it can't be set externally
-        for (auto shaderCollectionIter : m_material->GetShaderCollections())
+        for (const auto& shaderCollectionIter : m_material->GetShaderCollections())
         {
-            for (auto& shaderItem : shaderCollectionIter.second)
+            for (const auto& shaderItem : shaderCollectionIter.second)
             {
                 const RPI::ShaderOptionGroupLayout* layout = shaderItem.GetShaderOptions()->GetShaderOptionLayout();
                 RPI::ShaderOptionIndex index = layout->FindShaderOptionIndex(shaderOptionName);
@@ -68,9 +68,9 @@ namespace AZ::Render
             }
         }
 
-        for (auto shaderCollectionIter : m_material->GetShaderCollections())
+        for (const auto& shaderCollectionIter : m_material->GetShaderCollections())
         {
-            for (auto& shaderItem : shaderCollectionIter.second)
+            for (const auto& shaderItem : shaderCollectionIter.second)
             {
                 const RPI::ShaderOptionGroupLayout* layout = shaderItem.GetShaderOptions()->GetShaderOptionLayout();
                 RPI::ShaderOptionIndex index = layout->FindShaderOptionIndex(shaderOptionName);


### PR DESCRIPTION
Fix for https://github.com/o3de/o3de/issues/13598

Switch from auto to const auto& to avoid a vector copy

Signed-off-by: Tommy Walton <waltont@amazon.com>

## How was this PR tested?

Profiled in PIX using the Performance/10kVegInstancesTest level
