### PR TITLE
Fix iOS linkage issues with libpng library.

### DIFF
--- a/Gems/Microphone/Code/Source/Platform/iOS/MicrophoneSystemComponent_iOS.mm
+++ b/Gems/Microphone/Code/Source/Platform/iOS/MicrophoneSystemComponent_iOS.mm
@@ -271,9 +271,7 @@ private:
         
         // Obtain recorded samples
         
-        OSStatus status;
-        
-        status = AudioUnitRender(impl->m_audioUnit, 
+        AudioUnitRender(impl->m_audioUnit, 
             ioActionFlags, 
             inTimeStamp, 
             inBusNumber, 

--- a/cmake/3rdParty/Platform/iOS/BuiltInPackages_ios.cmake
+++ b/cmake/3rdParty/Platform/iOS/BuiltInPackages_ios.cmake
@@ -26,7 +26,7 @@ ly_associate_package(PACKAGE_NAME PhysX-4.1.2.29882248-rev5-ios  TARGETS PhysX  
 ly_associate_package(PACKAGE_NAME mikkelsen-1.0.0.4-ios          TARGETS mikkelsen       PACKAGE_HASH 976aaa3ccd8582346132a10af253822ccc5d5bcc9ea5ba44d27848f65ee88a8a)
 ly_associate_package(PACKAGE_NAME googletest-1.8.1-rev4-ios      TARGETS googletest      PACKAGE_HASH 2f121ad9784c0ab73dfaa58e1fee05440a82a07cc556bec162eeb407688111a7)
 ly_associate_package(PACKAGE_NAME googlebenchmark-1.5.0-rev2-ios TARGETS GoogleBenchmark PACKAGE_HASH c2ffaed2b658892b1bcf81dee4b44cd1cb09fc78d55584ef5cb8ab87f2d8d1ae)
-ly_associate_package(PACKAGE_NAME png-1.6.37-rev2-ios            TARGETS PNG             PACKAGE_HASH f6a412a761cf3c3076b73a8115911328917b4b4ea6defc78b328a799b7bbed6d)
+ly_associate_package(PACKAGE_NAME png-1.6.37-rev3-ios            TARGETS PNG             PACKAGE_HASH b476f7d3686a08c4adaec6a6e889db1138483863ddf7b0c7b4fafb553951e87c)
 ly_associate_package(PACKAGE_NAME libsamplerate-0.2.1-rev2-ios   TARGETS libsamplerate   PACKAGE_HASH 7656b961697f490d4f9c35d2e61559f6fc38c32102e542a33c212cd618fc2119)
 ly_associate_package(PACKAGE_NAME OpenSSL-1.1.1o-rev1-ios        TARGETS OpenSSL         PACKAGE_HASH 1325bbb2dcc97fe33d8db71e4b0a61e95e9e77558e3ce6767a1b5d330240f78f)
 ly_associate_package(PACKAGE_NAME zlib-1.2.11-rev5-ios           TARGETS ZLIB            PACKAGE_HASH c7f10b4d0fe63192054d926f53b08e852cdf472bc2b18e2f7be5aecac1869f7f)


### PR DESCRIPTION
## What does this PR do?

Fixes #12490

Updated O3DE to use rev3 of libpng package for iOS, which fixes neon linking issues. (https://github.com/o3de/3p-package-source/pull/169)

This PR also fixes a warning error of a variable set but not used discovered while building O3DE to run unit tests in iOS.

## How was this PR tested?

Built iOS successfully.
