### PR TITLE
Shorten AWSI python test project name

### DIFF
--- a/scripts/build/Platform/Windows/deploy_cdk_applications.cmd
+++ b/scripts/build/Platform/Windows/deploy_cdk_applications.cmd
@@ -38,7 +38,7 @@ FOR /f "tokens=1,2,3" %%a IN ('CALL aws sts assume-role --query Credentials.[Sec
 FOR /F "tokens=4 delims=:" %%a IN ("%ASSUME_ROLE_ARN%") DO SET O3DE_AWS_DEPLOY_ACCOUNT=%%a
 
 IF "%O3DE_AWS_PROJECT_NAME%"=="" (
-    SET O3DE_AWS_PROJECT_NAME=%BRANCH_NAME%-%PIPELINE_NAME%-Windows
+    SET O3DE_AWS_PROJECT_NAME=%BRANCH_NAME%-%PIPELINE_NAME%-Win
     SET slashreplace=
     call SET O3DE_AWS_PROJECT_NAME=%%O3DE_AWS_PROJECT_NAME:/=%slashreplace%%%
 )


### PR DESCRIPTION
## What does this PR do?

Related to https://github.com/o3de/o3de/issues/12487

Reduces generated resource name to be <140 chars (138, to be exact) to fix validation errors like seen in: 
https://jenkins-pipeline.agscollab.com/blue/organizations/jenkins/O3DE-LY-Fork-development_periodic-incremental-daily-internal/detail/O3DE-LY-Fork-development_periodic-incremental-daily-internal/575/pipeline/1915