### PR TITLE
Refactored material functor code in preparation for material pipeline functors

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Material/ConvertEmissiveUnitFunctor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/ConvertEmissiveUnitFunctor.cpp
@@ -33,7 +33,7 @@ namespace AZ
             }
         }
 
-        void ConvertEmissiveUnitFunctor::Process(RuntimeContext& context)
+        void ConvertEmissiveUnitFunctor::Process(RPI::MaterialFunctorAPI::RuntimeContext& context)
         {
             // Convert unit on runtime
             float sourceValue = context.GetMaterialPropertyValue<float>(m_intensityPropertyIndex);
@@ -58,7 +58,7 @@ namespace AZ
             context.GetShaderResourceGroup()->SetConstant(m_shaderInputIndex, targetValue);
         }
 
-        void ConvertEmissiveUnitFunctor::Process(EditorContext& context)
+        void ConvertEmissiveUnitFunctor::Process(RPI::MaterialFunctorAPI::EditorContext& context)
         {
             // Update Editor based on selected light unit
             uint32_t lightUnit = context.GetMaterialPropertyValue<uint32_t>(m_lightUnitPropertyIndex);

--- a/Gems/Atom/Feature/Common/Code/Source/Material/ConvertEmissiveUnitFunctor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/ConvertEmissiveUnitFunctor.h
@@ -27,8 +27,9 @@ namespace AZ
 
             static void Reflect(AZ::ReflectContext* context);
 
-            void Process(RuntimeContext& context) override;
-            void Process(EditorContext& context) override;
+            using RPI::MaterialFunctor::Process;
+            void Process(RPI::MaterialFunctorAPI::RuntimeContext& context) override;
+            void Process(RPI::MaterialFunctorAPI::EditorContext& context) override;
         private:
 
             AZ::RPI::MaterialPropertyIndex m_intensityPropertyIndex;

--- a/Gems/Atom/Feature/Common/Code/Source/Material/SubsurfaceTransmissionParameterFunctor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/SubsurfaceTransmissionParameterFunctor.cpp
@@ -41,7 +41,7 @@ namespace AZ
             }
         }
 
-        void SubsurfaceTransmissionParameterFunctor::Process(RuntimeContext& context)
+        void SubsurfaceTransmissionParameterFunctor::Process(RPI::MaterialFunctorAPI::RuntimeContext& context)
         {
             // Build & preprocess all parameters used by subsurface scattering feature
 

--- a/Gems/Atom/Feature/Common/Code/Source/Material/SubsurfaceTransmissionParameterFunctor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/SubsurfaceTransmissionParameterFunctor.h
@@ -27,7 +27,7 @@ namespace AZ
             static void Reflect(ReflectContext* context);
 
             using RPI::MaterialFunctor::Process;
-            void Process(RuntimeContext& context) override;
+            void Process(RPI::MaterialFunctorAPI::RuntimeContext& context) override;
 
         private:
 

--- a/Gems/Atom/Feature/Common/Code/Source/Material/Transform2DFunctor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/Transform2DFunctor.cpp
@@ -40,7 +40,7 @@ namespace AZ
             }
         }
         
-        void Transform2DFunctor::Process(RuntimeContext& context)
+        void Transform2DFunctor::Process(RPI::MaterialFunctorAPI::RuntimeContext& context)
         {
             using namespace RPI;
 

--- a/Gems/Atom/Feature/Common/Code/Source/Material/Transform2DFunctor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/Transform2DFunctor.h
@@ -28,7 +28,7 @@ namespace AZ
             static void Reflect(ReflectContext* context);
 
             using RPI::MaterialFunctor::Process;
-            void Process(RuntimeContext& context) override;
+            void Process(RPI::MaterialFunctorAPI::RuntimeContext& context) override;
 
         private:
 

--- a/Gems/Atom/Feature/Common/Code/Source/Material/UseTextureFunctor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/UseTextureFunctor.cpp
@@ -29,7 +29,7 @@ namespace AZ
             }
         }
 
-        void UseTextureFunctor::Process(RuntimeContext& context)
+        void UseTextureFunctor::Process(RPI::MaterialFunctorAPI::RuntimeContext& context)
         {
             using namespace RPI;
 
@@ -41,7 +41,7 @@ namespace AZ
             context.SetShaderOptionValue(m_useTextureOptionName, useTexture);
         }
 
-        void UseTextureFunctor::Process(EditorContext& context)
+        void UseTextureFunctor::Process(RPI::MaterialFunctorAPI::EditorContext& context)
         {
             const bool useTextureFlag = context.GetMaterialPropertyValue<bool>(m_useTexturePropertyIndex);
             Data::Instance<RPI::Image> image = context.GetMaterialPropertyValue<Data::Instance<RPI::Image>>(m_texturePropertyIndex);

--- a/Gems/Atom/Feature/Common/Code/Source/Material/UseTextureFunctor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/UseTextureFunctor.h
@@ -27,9 +27,9 @@ namespace AZ
 
             static void Reflect(ReflectContext* context);
 
-            void Process(RuntimeContext& context) override;
-
-            void Process(EditorContext& context) override;
+            using RPI::MaterialFunctor::Process;
+            void Process(RPI::MaterialFunctorAPI::RuntimeContext& context) override;
+            void Process(RPI::MaterialFunctorAPI::EditorContext& context) override;
 
         private:
             // Material property inputs...

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialFunctorSourceDataHolder.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialFunctorSourceDataHolder.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/RTTI/TypeInfo.h>
+#include <Atom/RPI.Reflect/Base.h>
+#include <Atom/RPI.Edit/Material/MaterialFunctorSourceData.h>
+
+namespace AZ
+{
+    class ReflectContext;
+
+    namespace RPI
+    {
+        //! The wrapper class for derived material functors.
+        //! It is used in deserialization so that derived material functors can be deserialized by name.
+        class MaterialFunctorSourceDataHolder final
+            : public AZStd::intrusive_base
+        {
+            friend class JsonMaterialFunctorSourceDataSerializer;
+
+        public:
+            AZ_RTTI(MaterialFunctorSourceDataHolder, "{073C98F6-9EA4-411A-A6D2-A47428A0EFD4}");
+            AZ_CLASS_ALLOCATOR(MaterialFunctorSourceDataHolder, AZ::SystemAllocator, 0);
+
+            MaterialFunctorSourceDataHolder() = default;
+            MaterialFunctorSourceDataHolder(Ptr<MaterialFunctorSourceData> actualSourceData);
+            ~MaterialFunctorSourceDataHolder() = default;
+
+            static void Reflect(AZ::ReflectContext* context);
+
+            MaterialFunctorSourceData::FunctorResult CreateFunctor(const MaterialFunctorSourceData::RuntimeContext& runtimeContext) const;
+            MaterialFunctorSourceData::FunctorResult CreateFunctor(const MaterialFunctorSourceData::EditorContext& editorContext) const;
+
+            Ptr<MaterialFunctorSourceData> GetActualSourceData() const;
+        private:
+            Ptr<MaterialFunctorSourceData> m_actualSourceData = nullptr; // The derived material functor instance.
+        };
+    } // namespace RPI
+
+} // namespace AZ

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialTypeSourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialTypeSourceData.h
@@ -17,6 +17,7 @@
 #include <Atom/RPI.Edit/Material/MaterialFunctorSourceData.h>
 #include <Atom/RPI.Edit/Material/MaterialPropertyId.h>
 #include <Atom/RPI.Edit/Material/MaterialPropertySourceData.h>
+#include <Atom/RPI.Edit/Material/MaterialFunctorSourceDataHolder.h>
 #include <Atom/RPI.Edit/Shader/ShaderOptionValuesSourceData.h>
 
 namespace AZ
@@ -26,7 +27,6 @@ namespace AZ
     namespace RPI
     {
         class MaterialTypeAsset;
-        class MaterialFunctorSourceDataHolder;
 
         //! This is a simple data structure for serializing in/out .materialtype source files.
         //! The .materialtype file has two slightly different formats: "abstract" and "direct". See enum Format below.
@@ -351,36 +351,6 @@ namespace AZ
             PropertyLayout m_propertyLayout;
         };
         
-        //! The wrapper class for derived material functors.
-        //! It is used in deserialization so that derived material functors can be deserialized by name.
-        class MaterialFunctorSourceDataHolder final
-            : public AZStd::intrusive_base
-        {
-            friend class JsonMaterialFunctorSourceDataSerializer;
-
-        public:
-            AZ_RTTI(MaterialFunctorSourceDataHolder, "{073C98F6-9EA4-411A-A6D2-A47428A0EFD4}");
-            AZ_CLASS_ALLOCATOR(MaterialFunctorSourceDataHolder, AZ::SystemAllocator, 0);
-
-            MaterialFunctorSourceDataHolder() = default;
-            MaterialFunctorSourceDataHolder(Ptr<MaterialFunctorSourceData> actualSourceData);
-            ~MaterialFunctorSourceDataHolder() = default;
-
-            static void Reflect(AZ::ReflectContext* context);
-
-            MaterialFunctorSourceData::FunctorResult CreateFunctor(const MaterialFunctorSourceData::RuntimeContext& runtimeContext) const
-            {
-                return m_actualSourceData ? m_actualSourceData->CreateFunctor(runtimeContext) : Failure();
-            }
-            MaterialFunctorSourceData::FunctorResult CreateFunctor(const MaterialFunctorSourceData::EditorContext& editorContext) const
-            {
-                return m_actualSourceData ? m_actualSourceData->CreateFunctor(editorContext) : Failure();
-            }
-
-            Ptr<MaterialFunctorSourceData> GetActualSourceData() const { return m_actualSourceData; }
-        private:
-            Ptr<MaterialFunctorSourceData> m_actualSourceData = nullptr; // The derived material functor instance.
-        };
     } // namespace RPI
 
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/LuaMaterialFunctor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/LuaMaterialFunctor.h
@@ -25,6 +25,348 @@ namespace AZ
 
     namespace RPI
     {
+        namespace LuaMaterialFunctorAPI
+        {
+            class CommonRuntimeConfiguration
+            {
+            public:
+                CommonRuntimeConfiguration(
+                    MaterialPropertyPsoHandling psoHandling,
+                    const MaterialPropertyFlags* materialPropertyDependencies,
+                    const MaterialPropertiesLayout* materialPropertiesLayout);
+
+                //! Returns false if PSO changes are not allowed, and may report errors or warnings
+                bool CheckPsoChangesAllowed();
+
+            private:
+                AZStd::string GetMaterialPropertyDependenciesString() const;
+
+                MaterialPropertyPsoHandling m_psoHandling;
+                bool m_psoChangesReported = false; //!< errors/warnings about PSO changes will only be reported once per execution of the functor
+                const MaterialPropertyFlags* m_materialPropertyDependencies = nullptr;
+                const MaterialPropertiesLayout* m_materialPropertiesLayout = nullptr;
+            };
+
+            //! Wraps MaterialFunctorAPI::ReadMaterialPropertyValues for LuaMaterialFunctor access
+            class ReadMaterialPropertyValues
+            {
+            public:
+                AZ_TYPE_INFO(LuaMaterialFunctorAPI::ReadMaterialPropertyValues, "{2CCCB9A9-AD4F-447C-B587-E7A91CEA8088}");
+
+                template<typename LuaApiClass>
+                static void ReflectSubclass(BehaviorContext::ClassBuilder<LuaApiClass>* subclassBuilder);
+
+                ReadMaterialPropertyValues(
+                    MaterialFunctorAPI::ReadMaterialPropertyValues* underlyingApi,
+                    const MaterialNameContext* materialNameContext);
+
+            protected:
+
+                template<typename Type>
+                Type GetMaterialPropertyValue(const char* name) const;
+
+                MaterialPropertyIndex GetMaterialPropertyIndex(const char* name, const char* functionName) const;
+
+                const MaterialPropertyValue& GetMaterialPropertyValue(MaterialPropertyIndex propertyIndex) const;
+
+                bool HasMaterialValue(const char* name) const;
+
+            private:
+
+                const MaterialNameContext* m_materialNameContext;
+                MaterialFunctorAPI::ReadMaterialPropertyValues* m_underlyingApi = nullptr;
+            };
+
+            //! Wraps RHI::RenderStates for LuaMaterialFunctor access
+            class RenderStates
+            {
+            public:
+                AZ_TYPE_INFO(LuaMaterialFunctorAPI::RenderStates, "{DF724568-0579-4E0D-95CB-1CD9AD484D2F}");
+
+                static void Reflect(BehaviorContext* behaviorContext);
+
+                explicit RenderStates(RHI::RenderStates* renderStates) : m_renderStates(renderStates) {}
+
+                // Set MultisampleState...
+
+                void SetMultisampleCustomPosition(AZStd::size_t multisampleCustomLocationIndex, uint8_t x, uint8_t y);
+                void SetMultisampleCustomPositionCount(uint32_t value);
+                void SetMultisampleCount(uint16_t value);
+                void SetMultisampleQuality(uint16_t value);
+
+                // Set RasterState...
+
+                void SetFillMode(RHI::FillMode value);
+                void SetCullMode(RHI::CullMode value);
+                void SetDepthBias(int32_t value);
+                void SetDepthBiasClamp(float value);
+                void SetDepthBiasSlopeScale(float value);
+                void SetMultisampleEnabled(bool value);
+                void SetDepthClipEnabled(bool value);
+                void SetConservativeRasterEnabled(bool value);
+                void SetForcedSampleCount(uint32_t value);
+
+                // Set BlendState...
+
+                void SetAlphaToCoverageEnabled(bool value);
+                void SetIndependentBlendEnabled(bool value);
+
+                void SetBlendEnabled(AZStd::size_t targetIndex, bool value);
+                void SetBlendWriteMask(AZStd::size_t targetIndex, uint32_t value);
+                void SetBlendSource(AZStd::size_t targetIndex, RHI::BlendFactor value);
+                void SetBlendDest(AZStd::size_t targetIndex, RHI::BlendFactor value);
+                void SetBlendOp(AZStd::size_t targetIndex, RHI::BlendOp value);
+                void SetBlendAlphaSource(AZStd::size_t targetIndex, RHI::BlendFactor value);
+                void SetBlendAlphaDest(AZStd::size_t targetIndex, RHI::BlendFactor value);
+                void SetBlendAlphaOp(AZStd::size_t targetIndex, RHI::BlendOp value);
+
+                // Set DepthState...
+
+                void SetDepthEnabled(bool value);
+                void SetDepthWriteMask(RHI::DepthWriteMask value);
+                void SetDepthComparisonFunc(RHI::ComparisonFunc value);
+
+                // Set StencilState...
+
+                void SetStencilEnabled(bool value);
+                void SetStencilReadMask(uint32_t value);
+                void SetStencilWriteMask(uint32_t value);
+                void SetStencilFrontFaceFailOp(RHI::StencilOp value);
+                void SetStencilFrontFaceDepthFailOp(RHI::StencilOp value);
+                void SetStencilFrontFacePassOp(RHI::StencilOp value);
+                void SetStencilFrontFaceFunc(RHI::ComparisonFunc value);
+                void SetStencilBackFaceFailOp(RHI::StencilOp value);
+                void SetStencilBackFaceDepthFailOp(RHI::StencilOp value);
+                void SetStencilBackFacePassOp(RHI::StencilOp value);
+                void SetStencilBackFaceFunc(RHI::ComparisonFunc value);
+
+                // Clear MultisampleState override values...
+
+                void ClearMultisampleCustomPosition(AZStd::size_t multisampleCustomLocationIndex);
+                void ClearMultisampleCustomPositionCount();
+                void ClearMultisampleCount();
+                void ClearMultisampleQuality();
+
+                // Clear RasterState override values...
+
+                void ClearFillMode();
+                void ClearCullMode();
+                void ClearDepthBias();
+                void ClearDepthBiasClamp();
+                void ClearDepthBiasSlopeScale();
+                void ClearMultisampleEnabled();
+                void ClearDepthClipEnabled();
+                void ClearConservativeRasterEnabled();
+                void ClearForcedSampleCount();
+
+                // Clear BlendState override values...
+
+                void ClearAlphaToCoverageEnabled();
+                void ClearIndependentBlendEnabled();
+
+                void ClearBlendEnabled(AZStd::size_t targetIndex);
+                void ClearBlendWriteMask(AZStd::size_t targetIndex);
+                void ClearBlendSource(AZStd::size_t targetIndex);
+                void ClearBlendDest(AZStd::size_t targetIndex);
+                void ClearBlendOp(AZStd::size_t targetIndex);
+                void ClearBlendAlphaSource(AZStd::size_t targetIndex);
+                void ClearBlendAlphaDest(AZStd::size_t targetIndex);
+                void ClearBlendAlphaOp(AZStd::size_t targetIndex);
+
+                // Clear DepthState override values...
+
+                void ClearDepthEnabled();
+                void ClearDepthWriteMask();
+                void ClearDepthComparisonFunc();
+
+                // Clear StencilState override values...
+
+                void ClearStencilEnabled();
+                void ClearStencilReadMask();
+                void ClearStencilWriteMask();
+                void ClearStencilFrontFaceFailOp();
+                void ClearStencilFrontFaceDepthFailOp();
+                void ClearStencilFrontFacePassOp();
+                void ClearStencilFrontFaceFunc();
+                void ClearStencilBackFaceFailOp();
+                void ClearStencilBackFaceDepthFailOp();
+                void ClearStencilBackFacePassOp();
+                void ClearStencilBackFaceFunc();
+
+            private:
+                RHI::RenderStates* m_renderStates = nullptr;
+            };
+
+            class ShaderItem
+            {
+            public:
+                AZ_TYPE_INFO(LuaMaterialFunctorAPI::ShaderItem, "{F5BF0362-AA43-408A-96A8-6F9980A4CF93}");
+
+                static void Reflect(BehaviorContext* behaviorContext);
+
+                ShaderItem() = default;
+
+                ShaderItem(
+                    ShaderCollection::Item* shaderItem,
+                    const MaterialNameContext* materialNameContext,
+                    CommonRuntimeConfiguration* commonRuntimeConfiguration)
+                    : m_commonRuntimeConfiguration(commonRuntimeConfiguration)
+                    , m_shaderItem(shaderItem)
+                    , m_materialNameContext(materialNameContext)
+                {
+                }
+
+                LuaMaterialFunctorAPI::RenderStates GetRenderStatesOverride();
+                void SetEnabled(bool enable);
+                void SetDrawListTagOverride(const char* drawListTag);
+
+                template<typename Type>
+                void SetShaderOptionValue(const char* name, Type value);
+
+            private:
+                void SetShaderOptionValue(const Name& name, AZStd::function<bool(ShaderOptionGroup*, ShaderOptionIndex)> setValueCommand);
+
+                CommonRuntimeConfiguration* m_commonRuntimeConfiguration = nullptr;
+                ShaderCollection::Item* m_shaderItem = nullptr;
+                const MaterialNameContext* m_materialNameContext = nullptr;
+            };
+
+            //! Wraps MaterialFunctorAPI::ConfigureShaders for LuaMaterialFunctor access
+            class ConfigureShaders
+            {
+            public:
+                AZ_TYPE_INFO(LuaMaterialFunctorAPI::ConfigureShaders, "{DD498919-A135-4430-857B-B00146AEB5EC}");
+
+                template<typename LuaApiClass>
+                static void ReflectSubclass(BehaviorContext::ClassBuilder<LuaApiClass>* subclassBuilder);
+
+                ConfigureShaders(
+                    MaterialFunctorAPI::ConfigureShaders* underlyingApi,
+                    const MaterialNameContext* materialNameContext,
+                    CommonRuntimeConfiguration* psoChangeChecker);
+
+            protected:
+
+                //! Set the value of a shader option. Applies to any shader that has an option with this name.
+                //! @param name the name of the shader option to set
+                //! @param value the new value for the shader option
+                template<typename Type>
+                bool SetShaderOptionValue(const char* name, Type value);
+
+                AZStd::size_t GetShaderCount() const;
+                LuaMaterialFunctorAPI::ShaderItem GetShader(AZStd::size_t index);
+                LuaMaterialFunctorAPI::ShaderItem GetShaderByTag(const char* shaderTag);
+                bool HasShaderWithTag(const char* shaderTag);
+
+            private:
+
+                MaterialFunctorAPI::ConfigureShaders* m_underlyingApi = nullptr;
+                CommonRuntimeConfiguration* m_commonRuntimeConfiguration = nullptr;
+                const MaterialNameContext* m_materialNameContext;
+            };
+
+            //! Wraps MaterialFunctorAPI::RuntimeContext with lua bindings
+            class RuntimeContext
+                : public CommonRuntimeConfiguration
+                , public LuaMaterialFunctorAPI::ReadMaterialPropertyValues
+                , public LuaMaterialFunctorAPI::ConfigureShaders
+            {
+            public:
+                AZ_TYPE_INFO(LuaMaterialFunctorAPI::RuntimeContext, "{00FF6AE5-DE0A-41E2-B3F8-FBB9E265C399}");
+
+                static void Reflect(BehaviorContext* behaviorContext);
+
+                RuntimeContext(
+                    MaterialFunctorAPI::RuntimeContext* runtimeContextImpl,
+                    const MaterialPropertyFlags* materialPropertyDependencies,
+                    const MaterialNameContext* materialNameContext);
+
+                //! Sets the value of a constant in the Material ShaderResourceGroup
+                template<typename T>
+                bool SetShaderConstant(const char* name, T value);
+
+                // The subclass must have wrapper functions for the underlying implementations in the base classes,
+                // in order to expose the entire API in lua in a single context class...
+                template<typename Type>
+                Type GetMaterialPropertyValue(const char* name) const;
+                bool HasMaterialValue(const char* name) const;
+                template<typename Type>
+                bool SetShaderOptionValue(const char* name, Type value);
+                AZStd::size_t GetShaderCount() const;
+                LuaMaterialFunctorAPI::ShaderItem GetShader(AZStd::size_t index);
+                LuaMaterialFunctorAPI::ShaderItem GetShaderByTag(const char* shaderTag);
+                bool HasShaderWithTag(const char* shaderTag);
+
+            private:
+
+                RHI::ShaderInputConstantIndex GetShaderInputConstantIndex(const char* name, const char* functionName) const;
+
+                MaterialFunctorAPI::RuntimeContext* m_runtimeContextImpl = nullptr;
+                const MaterialNameContext* m_materialNameContext;
+            };
+
+            //! Wraps MaterialFunctorAPI::EditorContext with lua bindings
+            class EditorContext
+                : public LuaMaterialFunctorAPI::ReadMaterialPropertyValues
+            {
+            public:
+                AZ_TYPE_INFO(LuaMaterialFunctorAPI::EditorContext, "{AAF380F0-9ED2-4BB7-8E60-656992B14B71}");
+
+                static void Reflect(BehaviorContext* behaviorContext);
+
+                EditorContext(
+                    MaterialFunctorAPI::EditorContext* editorContextImpl,
+                    const MaterialNameContext* materialNameContext);
+
+                bool SetMaterialPropertyVisibility(const char* name, MaterialPropertyVisibility visibility);
+
+                template<typename Type>
+                bool SetMaterialPropertyMinValue(const char* name, Type value);
+
+                template<typename Type>
+                bool SetMaterialPropertyMaxValue(const char* name, Type value);
+
+                template<typename Type>
+                bool SetMaterialPropertySoftMinValue(const char* name, Type value);
+
+                template<typename Type>
+                bool SetMaterialPropertySoftMaxValue(const char* name, Type value);
+
+                bool SetMaterialPropertyDescription(const char* name, const char* description);
+
+                bool SetMaterialPropertyGroupVisibility(const char* name, MaterialPropertyGroupVisibility visibility);
+
+                // The subclass must have wrapper functions for the underlying implementations in the base classes,
+                // in order to expose the entire API in lua in a single context class...
+                template<typename Type>
+                Type GetMaterialPropertyValue(const char* name) const;
+                bool HasMaterialValue(const char* name) const;
+
+            private:
+
+                MaterialFunctorAPI::EditorContext* m_editorContextImpl = nullptr;
+                const MaterialNameContext* m_materialNameContext;
+            };
+
+            class Utilities
+            {
+                friend CommonRuntimeConfiguration;
+                friend LuaMaterialFunctorAPI::RuntimeContext;
+                friend LuaMaterialFunctorAPI::EditorContext;
+                friend LuaMaterialFunctorAPI::RenderStates;
+                friend LuaMaterialFunctorAPI::ShaderItem;
+            public:
+                static void Reflect(BehaviorContext* behaviorContext);
+                static constexpr char const DebugName[] = "LuaMaterialFunctor";
+
+            private:
+                static void Script_Error(const AZStd::string& message);
+                static void Script_Warning(const AZStd::string& message);
+                static void Script_Print(const AZStd::string& message);
+            };
+
+        } // namespace LuaMaterialFunctorAPI
+
         //! Materials can use this functor to create custom scripted operations.
         class LuaMaterialFunctor final
             : public RPI::MaterialFunctor
@@ -39,8 +381,8 @@ namespace AZ
 
             LuaMaterialFunctor();
 
-            void Process(RuntimeContext& context) override;
-            void Process(EditorContext& context) override;
+            void Process(MaterialFunctorAPI::RuntimeContext& context) override;
+            void Process(MaterialFunctorAPI::EditorContext& context) override;
 
         private:
 
@@ -70,290 +412,6 @@ namespace AZ
                 Error
             };
             ScriptStatus m_scriptStatus = ScriptStatus::Uninitialized;
-        };
-
-
-        //! Provides some shared code for LuaMaterialFunctorRuntimeContext and LuaMaterialFunctorEditorContext.
-        class LuaMaterialFunctorCommonContext
-        {
-        public:
-            AZ_TYPE_INFO(AZ::RPI::LuaMaterialFunctorCommonContext, "{2CCCB9A9-AD4F-447C-B587-E7A91CEA8088}");
-
-            explicit LuaMaterialFunctorCommonContext(MaterialFunctor::RuntimeContext* runtimeContextImpl,
-                const MaterialPropertyFlags* materialPropertyDependencies,
-                const MaterialNameContext &materialNameContext);
-
-            explicit LuaMaterialFunctorCommonContext(MaterialFunctor::EditorContext* editorContextImpl,
-                const MaterialPropertyFlags* materialPropertyDependencies,
-                const MaterialNameContext &materialNameContext);
-            
-            //! Returns false if PSO changes are not allowed, and may report errors or warnings
-            bool CheckPsoChangesAllowed();
-
-        protected:
-
-            template<typename Type>
-            Type GetMaterialPropertyValue(const char* name) const;
-
-            MaterialPropertyIndex GetMaterialPropertyIndex(const char* name, const char* functionName) const;
-
-            const MaterialPropertyValue& GetMaterialPropertyValue(MaterialPropertyIndex propertyIndex) const;
-            
-            MaterialPropertyPsoHandling GetMaterialPropertyPsoHandling() const;
-
-            RHI::ConstPtr<MaterialPropertiesLayout> GetMaterialPropertiesLayout() const;
-
-            AZStd::string GetMaterialPropertyDependenciesString() const;
-
-            const MaterialNameContext &m_materialNameContext;
-
-        private:
-
-            // Only one of these will be valid
-            MaterialFunctor::RuntimeContext* m_runtimeContextImpl = nullptr;
-            MaterialFunctor::EditorContext* m_editorContextImpl = nullptr;
-            const MaterialPropertyFlags* m_materialPropertyDependencies = nullptr;
-            bool m_psoChangesReported = false; //!< errors/warnings about PSO changes will only be reported once per execution of the functor
-        };
-
-        //! Wraps RHI::RenderStates for LuaMaterialFunctor access
-        class LuaMaterialFunctorRenderStates
-        {
-        public:
-            AZ_TYPE_INFO(AZ::RPI::LuaMaterialFunctorRenderStates, "{DF724568-0579-4E0D-95CB-1CD9AD484D2F}");
-
-            static void Reflect(BehaviorContext* behaviorContext);
-
-            explicit LuaMaterialFunctorRenderStates(RHI::RenderStates* renderStates) : m_renderStates(renderStates) {}
-
-            // Set MultisampleState...
-
-            void SetMultisampleCustomPosition(AZStd::size_t multisampleCustomLocationIndex, uint8_t x, uint8_t y);
-            void SetMultisampleCustomPositionCount(uint32_t value);
-            void SetMultisampleCount(uint16_t value);
-            void SetMultisampleQuality(uint16_t value);
-
-            // Set RasterState...
-
-            void SetFillMode(RHI::FillMode value);
-            void SetCullMode(RHI::CullMode value);
-            void SetDepthBias(int32_t value);
-            void SetDepthBiasClamp(float value);
-            void SetDepthBiasSlopeScale(float value);
-            void SetMultisampleEnabled(bool value);
-            void SetDepthClipEnabled(bool value);
-            void SetConservativeRasterEnabled(bool value);
-            void SetForcedSampleCount(uint32_t value);
-
-            // Set BlendState...
-
-            void SetAlphaToCoverageEnabled(bool value);
-            void SetIndependentBlendEnabled(bool value);
-
-            void SetBlendEnabled(AZStd::size_t targetIndex, bool value);
-            void SetBlendWriteMask(AZStd::size_t targetIndex, uint32_t value);
-            void SetBlendSource(AZStd::size_t targetIndex, RHI::BlendFactor value);
-            void SetBlendDest(AZStd::size_t targetIndex, RHI::BlendFactor value);
-            void SetBlendOp(AZStd::size_t targetIndex, RHI::BlendOp value);
-            void SetBlendAlphaSource(AZStd::size_t targetIndex, RHI::BlendFactor value);
-            void SetBlendAlphaDest(AZStd::size_t targetIndex, RHI::BlendFactor value);
-            void SetBlendAlphaOp(AZStd::size_t targetIndex, RHI::BlendOp value);
-
-            // Set DepthState...
-
-            void SetDepthEnabled(bool value);
-            void SetDepthWriteMask(RHI::DepthWriteMask value);
-            void SetDepthComparisonFunc(RHI::ComparisonFunc value);
-
-            // Set StencilState...
-
-            void SetStencilEnabled(bool value);
-            void SetStencilReadMask(uint32_t value);
-            void SetStencilWriteMask(uint32_t value);
-            void SetStencilFrontFaceFailOp(RHI::StencilOp value);
-            void SetStencilFrontFaceDepthFailOp(RHI::StencilOp value);
-            void SetStencilFrontFacePassOp(RHI::StencilOp value);
-            void SetStencilFrontFaceFunc(RHI::ComparisonFunc value);
-            void SetStencilBackFaceFailOp(RHI::StencilOp value);
-            void SetStencilBackFaceDepthFailOp(RHI::StencilOp value);
-            void SetStencilBackFacePassOp(RHI::StencilOp value);
-            void SetStencilBackFaceFunc(RHI::ComparisonFunc value);
-
-            // Clear MultisampleState override values...
-
-            void ClearMultisampleCustomPosition(AZStd::size_t multisampleCustomLocationIndex);
-            void ClearMultisampleCustomPositionCount();
-            void ClearMultisampleCount();
-            void ClearMultisampleQuality();
-
-            // Clear RasterState override values...
-
-            void ClearFillMode();
-            void ClearCullMode();
-            void ClearDepthBias();
-            void ClearDepthBiasClamp();
-            void ClearDepthBiasSlopeScale();
-            void ClearMultisampleEnabled();
-            void ClearDepthClipEnabled();
-            void ClearConservativeRasterEnabled();
-            void ClearForcedSampleCount();
-
-            // Clear BlendState override values...
-
-            void ClearAlphaToCoverageEnabled();
-            void ClearIndependentBlendEnabled();
-
-            void ClearBlendEnabled(AZStd::size_t targetIndex);
-            void ClearBlendWriteMask(AZStd::size_t targetIndex);
-            void ClearBlendSource(AZStd::size_t targetIndex);
-            void ClearBlendDest(AZStd::size_t targetIndex);
-            void ClearBlendOp(AZStd::size_t targetIndex);
-            void ClearBlendAlphaSource(AZStd::size_t targetIndex);
-            void ClearBlendAlphaDest(AZStd::size_t targetIndex);
-            void ClearBlendAlphaOp(AZStd::size_t targetIndex);
-
-            // Clear DepthState override values...
-
-            void ClearDepthEnabled();
-            void ClearDepthWriteMask();
-            void ClearDepthComparisonFunc();
-
-            // Clear StencilState override values...
-
-            void ClearStencilEnabled();
-            void ClearStencilReadMask();
-            void ClearStencilWriteMask();
-            void ClearStencilFrontFaceFailOp();
-            void ClearStencilFrontFaceDepthFailOp();
-            void ClearStencilFrontFacePassOp();
-            void ClearStencilFrontFaceFunc();
-            void ClearStencilBackFaceFailOp();
-            void ClearStencilBackFaceDepthFailOp();
-            void ClearStencilBackFacePassOp();
-            void ClearStencilBackFaceFunc();
-
-        private:
-            RHI::RenderStates* m_renderStates = nullptr;
-        };
-
-        class LuaMaterialFunctorShaderItem
-        {
-        public:
-            AZ_TYPE_INFO(AZ::RPI::LuaMaterialFunctorShaderItem, "{F5BF0362-AA43-408A-96A8-6F9980A4CF93}");
-
-            static void Reflect(BehaviorContext* behaviorContext);
-
-            LuaMaterialFunctorShaderItem() :
-                m_context(nullptr), m_shaderItem(nullptr) {}
-
-            explicit LuaMaterialFunctorShaderItem(LuaMaterialFunctorCommonContext* context, ShaderCollection::Item* shaderItem) :
-                m_context(context), m_shaderItem(shaderItem) {}
-
-            LuaMaterialFunctorRenderStates GetRenderStatesOverride();
-            void SetEnabled(bool enable);
-            void SetDrawListTagOverride(const char* drawListTag);
-
-            template<typename Type>
-            void SetShaderOptionValue(const char* name, Type value);
-
-        private:
-            void SetShaderOptionValue(const Name& name, AZStd::function<bool(ShaderOptionGroup*, ShaderOptionIndex)> setValueCommand);
-
-            LuaMaterialFunctorCommonContext* m_context = nullptr;
-            ShaderCollection::Item* m_shaderItem = nullptr;
-        };
-
-        //! Wraps MaterialFunctor::RuntimeContext with lua bindings
-        class LuaMaterialFunctorRuntimeContext : public LuaMaterialFunctorCommonContext
-        {
-        public:
-            AZ_TYPE_INFO(AZ::RPI::LuaMaterialFunctorRuntimeContext, "{00FF6AE5-DE0A-41E2-B3F8-FBB9E265C399}");
-
-            static void Reflect(BehaviorContext* behaviorContext);
-
-            explicit LuaMaterialFunctorRuntimeContext(MaterialFunctor::RuntimeContext* runtimeContextImpl,
-                const MaterialPropertyFlags* materialPropertyDependencies,
-                const MaterialNameContext &materialNameContext);
-
-            template<typename Type>
-            Type GetMaterialPropertyValue(const char* name) const;
-
-            bool HasMaterialValue(const char* name) const;
-
-            //! Set the value of a shader option. Applies to any shader that has an option with this name.
-            //! @param name the name of the shader option to set
-            //! @param value the new value for the shader option
-            template<typename Type>
-            bool SetShaderOptionValue(const char* name, Type value);
-
-            template<typename T>
-            bool SetShaderConstant(const char* name, T value);
-
-            AZStd::size_t GetShaderCount() const;
-            LuaMaterialFunctorShaderItem GetShader(AZStd::size_t index);
-            LuaMaterialFunctorShaderItem GetShaderByTag(const char* shaderTag);
-            bool HasShaderWithTag(const char* shaderTag);
-
-        private:
-
-            RHI::ShaderInputConstantIndex GetShaderInputConstantIndex(const char* name, const char* functionName) const;
-
-            MaterialFunctor::RuntimeContext* m_runtimeContextImpl = nullptr;
-        };
-
-        //! Wraps MaterialFunctor::EditorContext with lua bindings
-        class LuaMaterialFunctorEditorContext : public LuaMaterialFunctorCommonContext
-        {
-        public:
-            AZ_TYPE_INFO(AZ::RPI::LuaMaterialFunctorEditorContext, "{AAF380F0-9ED2-4BB7-8E60-656992B14B71}");
-
-            static void Reflect(BehaviorContext* behaviorContext);
-
-            explicit LuaMaterialFunctorEditorContext(MaterialFunctor::EditorContext* editorContextImpl,
-                const MaterialPropertyFlags* materialPropertyDependencies,
-                const MaterialNameContext &materialNameContext);
-
-            template<typename Type>
-            Type GetMaterialPropertyValue(const char* name) const;
-
-            bool SetMaterialPropertyVisibility(const char* name, MaterialPropertyVisibility visibility);
-
-            template<typename Type>
-            bool SetMaterialPropertyMinValue(const char* name, Type value);
-
-            template<typename Type>
-            bool SetMaterialPropertyMaxValue(const char* name, Type value);
-
-            template<typename Type>
-            bool SetMaterialPropertySoftMinValue(const char* name, Type value);
-
-            template<typename Type>
-            bool SetMaterialPropertySoftMaxValue(const char* name, Type value);
-
-            bool SetMaterialPropertyDescription(const char* name, const char* description);
-            
-            bool SetMaterialPropertyGroupVisibility(const char* name, MaterialPropertyGroupVisibility visibility);
-
-        private:
-
-            MaterialFunctor::EditorContext* m_editorContextImpl = nullptr;
-        };
-
-        class LuaMaterialFunctorUtilities
-        {
-            friend LuaMaterialFunctorCommonContext;
-            friend LuaMaterialFunctorRuntimeContext;
-            friend LuaMaterialFunctorEditorContext;
-            friend LuaMaterialFunctorRenderStates;
-            friend LuaMaterialFunctorShaderItem;
-        public:
-            static void Reflect(BehaviorContext* behaviorContext);
-            static constexpr char const DebugName[] = "LuaMaterialFunctor";
-
-        private:
-            static void Script_Error(const AZStd::string& message);
-            static void Script_Warning(const AZStd::string& message);
-            static void Script_Print(const AZStd::string& message);
         };
 
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialFunctor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialFunctor.h
@@ -46,54 +46,36 @@ namespace AZ
             Allowed
         };
 
-        //! MaterialFunctor objects provide custom logic and calculations to configure shaders, render states,
-        //! editor metadata, and more.
-        //! Atom provides a LuaMaterialFunctor subclass that uses a script to define the custom logic
-        //! for a convenient workflow. Developers may also provide their own custom hard-coded implementations
-        //! as an optimization rather than taking the scripted approach.
-        //! Any custom subclasses of MaterialFunctor will also need a corresponding MaterialFunctorSourceData subclass
-        //! to create the functor at build-time. Depending on the builder context, clients can choose to create a runtime
-        //! specific functor, an editor functor or one functor used in both circumstances (see usage examples and MaterialFunctor::Process blow).
-        //! Usage example:
-        //!     (Runtime) Modify the material's ShaderCollections;
-        //!         (This allows a material type to include custom logic that dynamically select shaders variants
-        //!         or disable specific shaders. This can result in changing the performance characteristics
-        //!         of the material by selecting alternate shader variants, or by excluding entries shaders/passes.)
-        //!     (Runtime) Perform client-specified calculations on material property values to produce shader input values;
-        //!         (For example, there may be a "RotationDegrees" material property but the underlying shader requires
-        //!         a rotation matrix, so a MaterialFunctor converts the data.)
-        //!     (Editor) Modify metadata of a property when other related properties have changed their value.
-        //!         (For example, if a flag property use texture is checked, the texture property will show up,
-        //!         otherwise, it should hide.)
-        class MaterialFunctor
-            : public AZStd::intrusive_base
+        namespace LuaMaterialFunctorAPI
         {
-            friend class MaterialFunctorSourceData;
-        private:
-            //! The material properties associated with this functor.
-            //! In another word, it defines what properties should trigger this functor to process.
-            //! Bit position uses MaterialPropertyIndex of the property.
-            MaterialPropertyFlags m_materialPropertyDependencies;
+            class ConfigureShaders;
+        }
 
-        public:
-            AZ_RTTI(AZ::RPI::MaterialFunctor, "{4F2EDF30-71C0-4E00-9CB0-9EA97587712E}");
-            AZ_CLASS_ALLOCATOR(MaterialFunctor, SystemAllocator, 0);
-
-            using ShaderAssetList = AZStd::vector<Data::Asset<ShaderAsset>>;
-
-            static void Reflect(ReflectContext* context);
-
-            //! This execution context operates at a high level, and is not specific to a particular material pipeline.
-            //! It can read material property values.
-            //! It can configure the Material ShaderResourceGroup because there is one for the entire material,
-            //! it's not specific to a material pipeline or particular shader.
-            //! It can configure shaders that are not specific to a particular material pipeline (i.e. the MaterialPipelineNameCommon ShaderCollection).
-            //! It can set shader option values (Note this does impact the material-pipeline-specific shaders in order to automatically
-            //! propagate the values to all shaders in the material).
-            class RuntimeContext
+        namespace MaterialFunctorAPI
+        {
+            //! Provides functions that are common to all runtime execution contexts
+            class CommonRuntimeConfiguration
             {
-                friend class LuaMaterialFunctorRuntimeContext;
             public:
+                virtual ~CommonRuntimeConfiguration() = default;
+
+                MaterialPropertyPsoHandling GetMaterialPropertyPsoHandling() const { return m_psoHandling; }
+
+            protected:
+                CommonRuntimeConfiguration(MaterialPropertyPsoHandling psoHandling) : m_psoHandling(psoHandling)
+                {
+                }
+
+            private:
+                MaterialPropertyPsoHandling m_psoHandling = MaterialPropertyPsoHandling::Error;
+            };
+
+            //! Provides commonly used functions for reading material property values
+            class ReadMaterialPropertyValues
+            {
+            public:
+                virtual ~ReadMaterialPropertyValues() = default;
+
                 //! Get the property value. The type must be one of those in MaterialPropertyValue.
                 //! Otherwise, a compile error will be reported.
                 template<typename Type>
@@ -106,14 +88,27 @@ namespace AZ
 
                 const MaterialPropertiesLayout* GetMaterialPropertiesLayout() const;
 
-                MaterialPropertyPsoHandling GetMaterialPropertyPsoHandling() const { return m_psoHandling; }
+            protected:
+                ReadMaterialPropertyValues(
+                    const MaterialPropertyCollection& materialProperties,
+                    const MaterialPropertyFlags* materialPropertyDependencies
+                );
 
-                //! Set the value of a shader option in all applicable shaders, across all material pipelines.
+                const MaterialPropertyCollection& m_materialProperties;
+                const MaterialPropertyFlags* m_materialPropertyDependencies = nullptr;
+            };
+
+            //! Provides commonly used functions for configuring shaders
+            class ConfigureShaders
+            {
+                friend LuaMaterialFunctorAPI::ConfigureShaders;
+
+            public:
+                virtual ~ConfigureShaders() = default;
+
+                //! Set the value of a shader option in all applicable shaders.
                 bool SetShaderOptionValue(const Name& optionName, ShaderOptionValue value);
                 bool SetShaderOptionValue(const Name& optionName, const Name& value);
-
-                //! Get the shader resource group for editing.
-                ShaderResourceGroup* GetShaderResourceGroup();
 
                 //! Return how many shaders are in the local ShaderCollection.
                 AZStd::size_t GetShaderCount() const;
@@ -139,51 +134,62 @@ namespace AZ
                 //! @param renderStatesOverlay a RenderStates struct that will be merged with this shader's RenderStates (using RHI::MergeStateInto())
                 void ApplyShaderRenderStateOverlay(AZStd::size_t shaderIndex, const RHI::RenderStates& renderStatesOverlay);
                 void ApplyShaderRenderStateOverlay(const AZ::Name& shaderTag, const RHI::RenderStates& renderStatesOverlay);
-                
-                RuntimeContext(
-                    const MaterialPropertyCollection& materialProperties,
-                    MaterialPipelineShaderCollections* shaderCollections,
-                    ShaderResourceGroup* shaderResourceGroup,
-                    const MaterialPropertyFlags* materialPropertyDependencies,
-                    MaterialPropertyPsoHandling psoHandling
+
+            protected:
+                ConfigureShaders(
+                    ShaderCollection* localShaderCollection
                 );
 
-            private:
-                bool SetShaderOptionValue(ShaderCollection::Item& shaderItem, ShaderOptionIndex optionIndex, ShaderOptionValue value);
+                virtual void ForAllShaderItems(AZStd::function<bool(ShaderCollection::Item& shaderItem)> callback);
 
                 template<typename ValueType>
                 bool SetShaderOptionValueHelper(const Name& name, const ValueType& value);
 
-                const MaterialPropertyCollection& m_materialProperties;
-                ShaderCollection* m_commonShaderCollection;
-                MaterialPipelineShaderCollections* m_allShaderCollections;
-                ShaderResourceGroup* m_shaderResourceGroup;
-                const MaterialPropertyFlags* m_materialPropertyDependencies = nullptr;
-                MaterialPropertyPsoHandling m_psoHandling = MaterialPropertyPsoHandling::Error;
+                ShaderCollection* m_localShaderCollection;
             };
 
-            class EditorContext
+            //! This execution context operates at a high level, and is not specific to a particular material pipeline.
+            //! It can read material property values.
+            //! It can configure the Material ShaderResourceGroup because there is one for the entire material,
+            //! it's not specific to a material pipeline or particular shader.
+            //! It can configure shaders that are not specific to a particular material pipeline (i.e. the MaterialPipelineNone ShaderCollection).
+            //! It can set shader option values (Note this does impact the material-pipeline-specific shaders in order to automatically
+            //! propagate the values to all shaders in the material).
+            class RuntimeContext
+                : public CommonRuntimeConfiguration
+                , public ReadMaterialPropertyValues
+                , public ConfigureShaders
             {
-                friend class LuaMaterialFunctorEditorContext;
+            public:
+
+                //! Get the shader resource group for editing.
+                ShaderResourceGroup* GetShaderResourceGroup();
+
+                RuntimeContext(
+                    const MaterialPropertyCollection& materialProperties,
+                    const MaterialPropertyFlags* materialPropertyDependencies,
+                    MaterialPropertyPsoHandling psoHandling,
+                    ShaderResourceGroup* shaderResourceGroup,
+                    MaterialPipelineShaderCollections* shaderCollections
+                );
+
+            private:
+
+                void ForAllShaderItems(AZStd::function<bool(ShaderCollection::Item& shaderItem)> callback) override;
+
+                ShaderResourceGroup* m_shaderResourceGroup;
+                MaterialPipelineShaderCollections* m_allShaderCollections;
+            };
+
+            //! This execution context is used by tools for configuring UI metadata.
+            class EditorContext
+                : public ReadMaterialPropertyValues
+            {
             public:
                 const MaterialPropertyDynamicMetadata* GetMaterialPropertyMetadata(const Name& propertyId) const;
                 const MaterialPropertyDynamicMetadata* GetMaterialPropertyMetadata(const MaterialPropertyIndex& index) const;
 
                 const MaterialPropertyGroupDynamicMetadata* GetMaterialPropertyGroupMetadata(const Name& propertyId) const;
-
-                //! Get the property value. The type must be one of those in MaterialPropertyValue.
-                //! Otherwise, a compile error will be reported.
-                template<typename Type>
-                const Type& GetMaterialPropertyValue(const Name& propertyId) const;
-                template<typename Type>
-                const Type& GetMaterialPropertyValue(const MaterialPropertyIndex& index) const;
-                //! Get the property value. GetMaterialPropertyValue<T>() is equivalent to GetMaterialPropertyValue().GetValue<T>().
-                const MaterialPropertyValue& GetMaterialPropertyValue(const Name& propertyId) const;
-                const MaterialPropertyValue& GetMaterialPropertyValue(const MaterialPropertyIndex& index) const;
-
-                const MaterialPropertiesLayout* GetMaterialPropertiesLayout() const;
-                
-                MaterialPropertyPsoHandling GetMaterialPropertyPsoHandling() const { return MaterialPropertyPsoHandling::Allowed; }
 
                 //! Set the visibility dynamic metadata of a material property.
                 bool SetMaterialPropertyVisibility(const Name& propertyId, MaterialPropertyVisibility visibility);
@@ -222,13 +228,42 @@ namespace AZ
                 MaterialPropertyDynamicMetadata* QueryMaterialPropertyMetadata(const Name& propertyId) const;
                 MaterialPropertyGroupDynamicMetadata* QueryMaterialPropertyGroupMetadata(const Name& propertyGroupId) const;
 
-                const MaterialPropertyCollection& m_materialProperties;
                 AZStd::unordered_map<Name, MaterialPropertyDynamicMetadata>& m_propertyMetadata;
                 AZStd::unordered_map<Name, MaterialPropertyGroupDynamicMetadata>& m_propertyGroupMetadata;
                 AZStd::unordered_set<Name>& m_updatedPropertiesOut;
                 AZStd::unordered_set<Name>& m_updatedPropertyGroupsOut;
-                const MaterialPropertyFlags* m_materialPropertyDependencies = nullptr;
             };
+
+        }
+
+        //! MaterialFunctor objects provide custom logic and calculations to configure shaders, render states,
+        //! editor metadata, and more.
+        //! Atom also provides a LuaMaterialFunctor subclass that uses a script to define the custom logic
+        //! for a convenient workflow. Developers may also provide their own custom hard-coded implementations
+        //! as an optimization rather than taking the scripted approach.
+        //! Any custom subclasses of MaterialFunctor will also need a corresponding MaterialFunctorSourceData subclass
+        //! to create the functor at build-time. Depending on the builder context, clients can choose to create a runtime
+        //! specific functor, an editor functor or one functor used in both circumstances (see usage examples and MaterialFunctor::Process blow).
+        //! Usage example:
+        //!     (Runtime) Modify the material's main ShaderCollection;
+        //!         (This allows a material type to include custom logic that dynamically enables or disables particular shaders,
+        //!          or set shader options)
+        //!     (Runtime) Perform client-specified calculations on material property values to produce shader input values;
+        //!         (For example, there may be a "RotationDegrees" material property but the underlying shader requires
+        //!         a rotation matrix, so a MaterialFunctor converts the data.)
+        //!     (Editor) Modify metadata of a property when other related properties have changed their value.
+        //!         (For example, if a flag property use texture is checked, the texture property will show up,
+        //!         otherwise, it should hide.)
+        class MaterialFunctor :
+            public AZStd::intrusive_base
+        {
+            friend class MaterialFunctorSourceData;
+
+        public:
+            AZ_RTTI(AZ::RPI::MaterialFunctor, "{4F2EDF30-71C0-4E00-9CB0-9EA97587712E}");
+            AZ_CLASS_ALLOCATOR(MaterialFunctor, SystemAllocator, 0);
+
+            static void Reflect(ReflectContext* context);
 
             //! Check if dependent properties are dirty.
             bool NeedsProcess(const MaterialPropertyFlags& propertyDirtyFlags);
@@ -236,18 +271,20 @@ namespace AZ
             //! Get all dependent properties of this functor.
             const MaterialPropertyFlags& GetMaterialPropertyDependencies() const;
 
-            //! Process() is called at runtime to build a ShaderCollection object given some material property values.
-            //! Material properties will be accessed by MaterialPropertyIndex. The corresponding MaterialFunctorSourceData
-            //! should collect the necessary MaterialPropertyIndex values at build-time.
-            //! Or Process() is to process material property values and make changes to shader settings.
-            virtual void Process([[maybe_unused]] RuntimeContext& context) {}
+            //! Process(RuntimeContext) is called at runtime to configure the pipeline-agnostic ShaderCollection and
+            //! material ShaderResourceGroup based on material property values.
+            virtual void Process([[maybe_unused]] MaterialFunctorAPI::RuntimeContext& context) {}
 
-            //! Process metadata used in the editor, such as property visibility.
-            //! While original metadata is stored in MaterialDocument::m_propertyMetadata, this temporary context has a
-            //! a reference to it which can be accessed by MaterialPropertyIndex or property Name,
-            //! both can use the EditorContext API to convert to the other.
-            virtual void Process([[maybe_unused]] EditorContext& context) {}
+            //! Process(EditorContext) is called in tools to configure UI, such as property visibility.
+            virtual void Process([[maybe_unused]] MaterialFunctorAPI::EditorContext& context) {}
+
+        private:
+            //! The material properties associated with this functor.
+            //! It defines what properties should trigger this functor to process.
+            //! Bit position uses MaterialPropertyIndex of the property.
+            MaterialPropertyFlags m_materialPropertyDependencies;
         };
+
 
         using MaterialFunctorList = AZStd::vector<Ptr<MaterialFunctor>>;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -43,7 +43,7 @@ namespace AZ
         {
             AssetBuilderSDK::AssetBuilderDesc materialBuilderDescriptor;
             materialBuilderDescriptor.m_name = "Material Type Builder";
-            materialBuilderDescriptor.m_version = 24; // Added missing dependencies on material pipeline related files
+            materialBuilderDescriptor.m_version = 25; // Refactored material functor code
             materialBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.materialtype", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             materialBuilderDescriptor.m_busId = azrtti_typeid<MaterialTypeBuilder>();
             materialBuilderDescriptor.m_createJobFunction = AZStd::bind(&MaterialTypeBuilder::CreateJobs, this, AZStd::placeholders::_1, AZStd::placeholders::_2);

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialFunctorSourceDataHolder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialFunctorSourceDataHolder.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RPI.Edit/Material/MaterialFunctorSourceDataHolder.h>
+
+namespace AZ
+{
+    namespace RPI
+    {
+        MaterialFunctorSourceDataHolder::MaterialFunctorSourceDataHolder(Ptr<MaterialFunctorSourceData> actualSourceData)
+            : m_actualSourceData(actualSourceData)
+        {
+        }
+
+        void MaterialFunctorSourceDataHolder::Reflect(AZ::ReflectContext* context)
+        {
+            if (JsonRegistrationContext* jsonContext = azrtti_cast<JsonRegistrationContext*>(context))
+            {
+                jsonContext->Serializer<JsonMaterialFunctorSourceDataSerializer>()->HandlesType<MaterialFunctorSourceDataHolder>();
+            }
+            else if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+            {
+                serializeContext->Class<MaterialFunctorSourceDataHolder>();
+            }
+        }
+
+        MaterialFunctorSourceData::FunctorResult MaterialFunctorSourceDataHolder::CreateFunctor(const MaterialFunctorSourceData::RuntimeContext& runtimeContext) const
+        {
+            return m_actualSourceData ? m_actualSourceData->CreateFunctor(runtimeContext) : Failure();
+        }
+
+        MaterialFunctorSourceData::FunctorResult MaterialFunctorSourceDataHolder::CreateFunctor(const MaterialFunctorSourceData::EditorContext& editorContext) const
+        {
+            return m_actualSourceData ? m_actualSourceData->CreateFunctor(editorContext) : Failure();
+        }
+
+        Ptr<MaterialFunctorSourceData> MaterialFunctorSourceDataHolder::GetActualSourceData() const
+        {
+            return m_actualSourceData;
+        }
+    } // namespace RPI
+} // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialTypeSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialTypeSourceData.cpp
@@ -33,22 +33,6 @@ namespace AZ
             [[maybe_unused]] static constexpr char const MaterialTypeSourceDataDebugName[] = "MaterialTypeSourceData";
         }
 
-        MaterialFunctorSourceDataHolder::MaterialFunctorSourceDataHolder(Ptr<MaterialFunctorSourceData> actualSourceData)
-            : m_actualSourceData(actualSourceData)
-        {}
-
-        void MaterialFunctorSourceDataHolder::Reflect(AZ::ReflectContext* context)
-        {
-            if (JsonRegistrationContext* jsonContext = azrtti_cast<JsonRegistrationContext*>(context))
-            {
-                jsonContext->Serializer<JsonMaterialFunctorSourceDataSerializer>()->HandlesType<MaterialFunctorSourceDataHolder>();
-            }
-            else if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
-            {
-                serializeContext->Class<MaterialFunctorSourceDataHolder>();
-            }
-        }
-
         void MaterialTypeSourceData::Reflect(ReflectContext* context)
         {
             if (JsonRegistrationContext* jsonContext = azrtti_cast<JsonRegistrationContext*>(context))

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
@@ -349,12 +349,12 @@ namespace AZ
                     // which will later get caught in Process() when trying to access a property.
                     if (materialPropertyDependencies.none() || functor->NeedsProcess(m_materialProperties.GetPropertyDirtyFlags()))
                     {
-                        MaterialFunctor::RuntimeContext processContext = MaterialFunctor::RuntimeContext(
+                        MaterialFunctorAPI::RuntimeContext processContext = MaterialFunctorAPI::RuntimeContext(
                             m_materialProperties,
-                            &m_shaderCollections,
-                            m_shaderResourceGroup.get(),
                             &materialPropertyDependencies,
-                            psoHandling
+                            psoHandling,
+                            m_shaderResourceGroup.get(),
+                            &m_shaderCollections
                         );
 
                         functor->Process(processContext);

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/LuaMaterialFunctor.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/LuaMaterialFunctor.cpp
@@ -60,11 +60,11 @@ namespace AZ
             MaterialPropertyDescriptor::Reflect(behaviorContext);
             ReflectMaterialDynamicMetadata(behaviorContext);
 
-            LuaMaterialFunctorRenderStates::Reflect(behaviorContext);
-            LuaMaterialFunctorShaderItem::Reflect(behaviorContext);
+            LuaMaterialFunctorAPI::RenderStates::Reflect(behaviorContext);
+            LuaMaterialFunctorAPI::ShaderItem::Reflect(behaviorContext);
             LuaScriptUtilities::Reflect(behaviorContext);
-            LuaMaterialFunctorRuntimeContext::Reflect(behaviorContext);
-            LuaMaterialFunctorEditorContext::Reflect(behaviorContext);
+            LuaMaterialFunctorAPI::RuntimeContext::Reflect(behaviorContext);
+            LuaMaterialFunctorAPI::EditorContext::Reflect(behaviorContext);
         }
 
         const AZStd::vector<char>& LuaMaterialFunctor::GetScriptBuffer() const
@@ -119,7 +119,7 @@ namespace AZ
             }
         }
 
-        void LuaMaterialFunctor::Process(RuntimeContext& context)
+        void LuaMaterialFunctor::Process(MaterialFunctorAPI::RuntimeContext& context)
         {
             AZ_PROFILE_FUNCTION(RPI);
 
@@ -127,7 +127,7 @@ namespace AZ
 
             if (m_scriptStatus == ScriptStatus::Ready)
             {
-                LuaMaterialFunctorRuntimeContext luaContext{&context, &GetMaterialPropertyDependencies(), m_materialNameContext};
+                LuaMaterialFunctorAPI::RuntimeContext luaContext{&context, &GetMaterialPropertyDependencies(), &m_materialNameContext};
                 AZ::ScriptDataContext call;
                 if (m_scriptContext->Call("Process", call))
                 {
@@ -137,7 +137,7 @@ namespace AZ
             }
         }
 
-        void LuaMaterialFunctor::Process(EditorContext& context)
+        void LuaMaterialFunctor::Process(MaterialFunctorAPI::EditorContext& context)
         {
             AZ_PROFILE_FUNCTION(RPI);
 
@@ -145,7 +145,7 @@ namespace AZ
 
             if (m_scriptStatus == ScriptStatus::Ready)
             {
-                LuaMaterialFunctorEditorContext luaContext{&context, &GetMaterialPropertyDependencies(), m_materialNameContext};
+                LuaMaterialFunctorAPI::EditorContext luaContext{&context, &m_materialNameContext};
                 AZ::ScriptDataContext call;
                 if (m_scriptContext->Call("ProcessEditor", call))
                 {
@@ -155,56 +155,24 @@ namespace AZ
             }
         }
 
-        LuaMaterialFunctorCommonContext::LuaMaterialFunctorCommonContext(MaterialFunctor::RuntimeContext* runtimeContextImpl,
+        LuaMaterialFunctorAPI::CommonRuntimeConfiguration::CommonRuntimeConfiguration(
+            MaterialPropertyPsoHandling psoHandling,
             const MaterialPropertyFlags* materialPropertyDependencies,
-            const MaterialNameContext& materialNameContext)
-            : m_runtimeContextImpl(runtimeContextImpl)
+            const MaterialPropertiesLayout* materialPropertiesLayout)
+            : m_psoHandling(psoHandling)
             , m_materialPropertyDependencies(materialPropertyDependencies)
-            , m_materialNameContext(materialNameContext)
+            , m_materialPropertiesLayout(materialPropertiesLayout)
         {
         }
 
-        LuaMaterialFunctorCommonContext::LuaMaterialFunctorCommonContext(MaterialFunctor::EditorContext* editorContextImpl,
-            const MaterialPropertyFlags* materialPropertyDependencies,
-            const MaterialNameContext& materialNameContext)
-            : m_editorContextImpl(editorContextImpl)
-            , m_materialPropertyDependencies(materialPropertyDependencies)
-            , m_materialNameContext(materialNameContext)
-        {
-        }
-        
-        MaterialPropertyPsoHandling LuaMaterialFunctorCommonContext::GetMaterialPropertyPsoHandling() const
-        {
-            if (m_runtimeContextImpl)
-            {
-                return m_runtimeContextImpl->GetMaterialPropertyPsoHandling();
-            }
-            else
-            {
-                return m_editorContextImpl->GetMaterialPropertyPsoHandling();
-            }
-        }
-
-        RHI::ConstPtr<MaterialPropertiesLayout> LuaMaterialFunctorCommonContext::GetMaterialPropertiesLayout() const
-        {
-            if (m_runtimeContextImpl)
-            {
-                return m_runtimeContextImpl->GetMaterialPropertiesLayout();
-            }
-            else
-            {
-                return m_editorContextImpl->GetMaterialPropertiesLayout();
-            }
-        }
-
-        AZStd::string LuaMaterialFunctorCommonContext::GetMaterialPropertyDependenciesString() const
+        AZStd::string LuaMaterialFunctorAPI::CommonRuntimeConfiguration::GetMaterialPropertyDependenciesString() const
         {
             AZStd::vector<AZStd::string> propertyList;
             for (size_t i = 0; i < m_materialPropertyDependencies->size(); ++i)
             {
                 if ((*m_materialPropertyDependencies)[i])
                 {
-                    propertyList.push_back(GetMaterialPropertiesLayout()->GetPropertyDescriptor(MaterialPropertyIndex{i})->GetName().GetStringView());
+                    propertyList.push_back(m_materialPropertiesLayout->GetPropertyDescriptor(MaterialPropertyIndex{i})->GetName().GetStringView());
                 }
             }
 
@@ -213,10 +181,10 @@ namespace AZ
 
             return propertyListString;
         }
-        
-        bool LuaMaterialFunctorCommonContext::CheckPsoChangesAllowed()
+
+        bool LuaMaterialFunctorAPI::CommonRuntimeConfiguration::CheckPsoChangesAllowed()
         {
-            if (GetMaterialPropertyPsoHandling() == MaterialPropertyPsoHandling::Error)
+            if (m_psoHandling == MaterialPropertyPsoHandling::Error)
             {
                 if (!m_psoChangesReported)
                 {
@@ -229,7 +197,7 @@ namespace AZ
 
                 return false;
             }
-            else if (GetMaterialPropertyPsoHandling() == MaterialPropertyPsoHandling::Warning)
+            else if (m_psoHandling == MaterialPropertyPsoHandling::Warning)
             {
                 if (!m_psoChangesReported)
                 {
@@ -244,14 +212,22 @@ namespace AZ
             return true;
         }
 
-        MaterialPropertyIndex LuaMaterialFunctorCommonContext::GetMaterialPropertyIndex(const char* name, const char* functionName) const
+        LuaMaterialFunctorAPI::ReadMaterialPropertyValues::ReadMaterialPropertyValues(
+            MaterialFunctorAPI::ReadMaterialPropertyValues* underlyingApi,
+            const MaterialNameContext* materialNameContext)
+            : m_underlyingApi(underlyingApi)
+            , m_materialNameContext(materialNameContext)
+        {
+        }
+
+        MaterialPropertyIndex LuaMaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyIndex(const char* name, const char* functionName) const
         {
             MaterialPropertyIndex propertyIndex;
 
             Name propertyFullName{name};
-            m_materialNameContext.ContextualizeProperty(propertyFullName);
+            m_materialNameContext->ContextualizeProperty(propertyFullName);
             
-            propertyIndex = GetMaterialPropertiesLayout()->FindPropertyIndex(propertyFullName);
+            propertyIndex = m_underlyingApi->GetMaterialPropertiesLayout()->FindPropertyIndex(propertyFullName);
 
             if (!propertyIndex.IsValid())
             {
@@ -261,26 +237,13 @@ namespace AZ
             return propertyIndex;
         }
 
-        const MaterialPropertyValue& LuaMaterialFunctorCommonContext::GetMaterialPropertyValue(MaterialPropertyIndex propertyIndex) const
+        const MaterialPropertyValue& LuaMaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue(MaterialPropertyIndex propertyIndex) const
         {
-            if (m_runtimeContextImpl)
-            {
-                return m_runtimeContextImpl->GetMaterialPropertyValue(propertyIndex);
-            }
-            else if (m_editorContextImpl)
-            {
-                return m_editorContextImpl->GetMaterialPropertyValue(propertyIndex);
-            }
-            else
-            {
-                AZ_Assert(false, "Context not initialized properly");
-                static MaterialPropertyValue defaultValue;
-                return defaultValue;
-            }
+            return m_underlyingApi->GetMaterialPropertyValue(propertyIndex);
         }
 
         template<typename Type>
-        Type LuaMaterialFunctorCommonContext::GetMaterialPropertyValue(const char* name) const
+        Type LuaMaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue(const char* name) const
         {
             MaterialPropertyIndex index = GetMaterialPropertyIndex(name, "GetMaterialPropertyValue");
 
@@ -310,94 +273,103 @@ namespace AZ
         // The script can then check the result for nil without calling "get()".
         // For example, "GetMaterialPropertyValue_Image(name) == nil" rather than "GetMaterialPropertyValue_Image(name):get() == nil"
         template<>
-        Image* LuaMaterialFunctorCommonContext::GetMaterialPropertyValue(const char* name) const
+        Image* LuaMaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue(const char* name) const
         {
             return GetMaterialPropertyValue<Data::Instance<Image>>(name).get();
         }
 
-        // Explicit specialization must be declared before expanding it in LuaMaterialFunctorRuntimeContext::Reflect()
-        template<>
-        bool LuaMaterialFunctorRuntimeContext::SetShaderOptionValue(const char* name, const char* value);
-
-        void LuaMaterialFunctorRuntimeContext::Reflect(BehaviorContext* behaviorContext)
+        template<typename LuaApiClass>
+        void LuaMaterialFunctorAPI::ReadMaterialPropertyValues::ReflectSubclass(BehaviorContext::ClassBuilder<LuaApiClass>* subclassBuilder)
         {
-            behaviorContext->Class<LuaMaterialFunctorRuntimeContext>()
-                ->Method("GetMaterialPropertyValue_bool", &LuaMaterialFunctorRuntimeContext::GetMaterialPropertyValue<bool>)
-                ->Method("GetMaterialPropertyValue_int", &LuaMaterialFunctorRuntimeContext::GetMaterialPropertyValue<int32_t>)
-                ->Method("GetMaterialPropertyValue_uint", &LuaMaterialFunctorRuntimeContext::GetMaterialPropertyValue<uint32_t>)
-                ->Method("GetMaterialPropertyValue_enum", &LuaMaterialFunctorRuntimeContext::GetMaterialPropertyValue<uint32_t>)
-                ->Method("GetMaterialPropertyValue_float", &LuaMaterialFunctorRuntimeContext::GetMaterialPropertyValue<float>)
-                ->Method("GetMaterialPropertyValue_Vector2", &LuaMaterialFunctorRuntimeContext::GetMaterialPropertyValue<Vector2>)
-                ->Method("GetMaterialPropertyValue_Vector3", &LuaMaterialFunctorRuntimeContext::GetMaterialPropertyValue<Vector3>)
-                ->Method("GetMaterialPropertyValue_Vector4", &LuaMaterialFunctorRuntimeContext::GetMaterialPropertyValue<Vector4>)
-                ->Method("GetMaterialPropertyValue_Color", &LuaMaterialFunctorRuntimeContext::GetMaterialPropertyValue<Color>)
-                ->Method("GetMaterialPropertyValue_Image", &LuaMaterialFunctorRuntimeContext::GetMaterialPropertyValue<Image*>)
-                ->Method("HasMaterialProperty", &LuaMaterialFunctorRuntimeContext::HasMaterialValue)
-                ->Method("SetShaderConstant_bool", &LuaMaterialFunctorRuntimeContext::SetShaderConstant<bool>)
-                ->Method("SetShaderConstant_int", &LuaMaterialFunctorRuntimeContext::SetShaderConstant<int32_t>)
-                ->Method("SetShaderConstant_uint", &LuaMaterialFunctorRuntimeContext::SetShaderConstant<uint32_t>)
-                ->Method("SetShaderConstant_float", &LuaMaterialFunctorRuntimeContext::SetShaderConstant<float>)
-                ->Method("SetShaderConstant_Vector2", &LuaMaterialFunctorRuntimeContext::SetShaderConstant<Vector2>)
-                ->Method("SetShaderConstant_Vector3", &LuaMaterialFunctorRuntimeContext::SetShaderConstant<Vector3>)
-                ->Method("SetShaderConstant_Vector4", &LuaMaterialFunctorRuntimeContext::SetShaderConstant<Vector4>)
-                ->Method("SetShaderConstant_Color", &LuaMaterialFunctorRuntimeContext::SetShaderConstant<Color>)
-                ->Method("SetShaderConstant_Matrix3x3", &LuaMaterialFunctorRuntimeContext::SetShaderConstant<Matrix3x3>)
-                ->Method("SetShaderConstant_Matrix4x4", &LuaMaterialFunctorRuntimeContext::SetShaderConstant<Matrix4x4>)
-                ->Method("SetShaderOptionValue_bool", &LuaMaterialFunctorRuntimeContext::SetShaderOptionValue<bool>)
-                ->Method("SetShaderOptionValue_uint", &LuaMaterialFunctorRuntimeContext::SetShaderOptionValue<uint32_t>)
-                ->Method("SetShaderOptionValue_enum", &LuaMaterialFunctorRuntimeContext::SetShaderOptionValue<const char*>)
-                ->Method("GetShaderCount", &LuaMaterialFunctorRuntimeContext::GetShaderCount)
-                ->Method("GetShader", &LuaMaterialFunctorRuntimeContext::GetShader)
-                ->Method("GetShaderByTag", &LuaMaterialFunctorRuntimeContext::GetShaderByTag)
-                ->Method("HasShaderWithTag", &LuaMaterialFunctorRuntimeContext::HasShaderWithTag)
+            subclassBuilder
+                ->Method("GetMaterialPropertyValue_bool", &LuaApiClass::template GetMaterialPropertyValue<bool>)
+                ->Method("GetMaterialPropertyValue_int", &LuaApiClass::template GetMaterialPropertyValue<int32_t>)
+                ->Method("GetMaterialPropertyValue_uint", &LuaApiClass::template GetMaterialPropertyValue<uint32_t>)
+                ->Method("GetMaterialPropertyValue_enum", &LuaApiClass::template GetMaterialPropertyValue<uint32_t>)
+                ->Method("GetMaterialPropertyValue_float", &LuaApiClass::template GetMaterialPropertyValue<float>)
+                ->Method("GetMaterialPropertyValue_Vector2", &LuaApiClass::template GetMaterialPropertyValue<Vector2>)
+                ->Method("GetMaterialPropertyValue_Vector3", &LuaApiClass::template GetMaterialPropertyValue<Vector3>)
+                ->Method("GetMaterialPropertyValue_Vector4", &LuaApiClass::template GetMaterialPropertyValue<Vector4>)
+                ->Method("GetMaterialPropertyValue_Color", &LuaApiClass::template GetMaterialPropertyValue<Color>)
+                ->Method("GetMaterialPropertyValue_Image", &LuaApiClass::template GetMaterialPropertyValue<Image*>)
+                ->Method("HasMaterialProperty", &LuaApiClass::template HasMaterialValue)
                 ;
         }
 
-        LuaMaterialFunctorRuntimeContext::LuaMaterialFunctorRuntimeContext(MaterialFunctor::RuntimeContext* runtimeContextImpl,
-            const MaterialPropertyFlags* materialPropertyDependencies,
-            const MaterialNameContext& materialNameContext)
-            : LuaMaterialFunctorCommonContext(runtimeContextImpl, materialPropertyDependencies, materialNameContext)
-            , m_runtimeContextImpl(runtimeContextImpl)
+        void LuaMaterialFunctorAPI::RuntimeContext::Reflect(BehaviorContext* behaviorContext)
+        {
+            auto builder = behaviorContext->Class<LuaMaterialFunctorAPI::RuntimeContext>()
+                ->Method("SetShaderConstant_bool", &LuaMaterialFunctorAPI::RuntimeContext::SetShaderConstant<bool>)
+                ->Method("SetShaderConstant_int", &LuaMaterialFunctorAPI::RuntimeContext::SetShaderConstant<int32_t>)
+                ->Method("SetShaderConstant_uint", &LuaMaterialFunctorAPI::RuntimeContext::SetShaderConstant<uint32_t>)
+                ->Method("SetShaderConstant_float", &LuaMaterialFunctorAPI::RuntimeContext::SetShaderConstant<float>)
+                ->Method("SetShaderConstant_Vector2", &LuaMaterialFunctorAPI::RuntimeContext::SetShaderConstant<Vector2>)
+                ->Method("SetShaderConstant_Vector3", &LuaMaterialFunctorAPI::RuntimeContext::SetShaderConstant<Vector3>)
+                ->Method("SetShaderConstant_Vector4", &LuaMaterialFunctorAPI::RuntimeContext::SetShaderConstant<Vector4>)
+                ->Method("SetShaderConstant_Color", &LuaMaterialFunctorAPI::RuntimeContext::SetShaderConstant<Color>)
+                ->Method("SetShaderConstant_Matrix3x3", &LuaMaterialFunctorAPI::RuntimeContext::SetShaderConstant<Matrix3x3>)
+                ->Method("SetShaderConstant_Matrix4x4", &LuaMaterialFunctorAPI::RuntimeContext::SetShaderConstant<Matrix4x4>)
+                ;
+
+            LuaMaterialFunctorAPI::ReadMaterialPropertyValues::ReflectSubclass<LuaMaterialFunctorAPI::RuntimeContext>(builder);
+            LuaMaterialFunctorAPI::ConfigureShaders::ReflectSubclass<LuaMaterialFunctorAPI::RuntimeContext>(builder);
+        }
+
+        template<typename LuaApiClass>
+        void LuaMaterialFunctorAPI::ConfigureShaders::ReflectSubclass(BehaviorContext::ClassBuilder<LuaApiClass>* subclassBuilder)
+        {
+            subclassBuilder
+                ->Method("SetShaderOptionValue_bool", &LuaApiClass::template SetShaderOptionValue<bool>)
+                ->Method("SetShaderOptionValue_uint", &LuaApiClass::template SetShaderOptionValue<uint32_t>)
+                ->Method("SetShaderOptionValue_enum", &LuaApiClass::template SetShaderOptionValue<const char*>)
+                ->Method("GetShaderCount", &LuaApiClass::template GetShaderCount)
+                ->Method("GetShader", &LuaApiClass::template GetShader)
+                ->Method("GetShaderByTag", &LuaApiClass::template GetShaderByTag)
+                ->Method("HasShaderWithTag", &LuaApiClass::template HasShaderWithTag)
+                ;
+        }
+
+        LuaMaterialFunctorAPI::ConfigureShaders::ConfigureShaders(
+            MaterialFunctorAPI::ConfigureShaders* underlyingApi,
+            const MaterialNameContext* materialNameContext,
+            CommonRuntimeConfiguration* commonRuntimeConfiguration)
+            : m_underlyingApi(underlyingApi)
+            , m_materialNameContext(materialNameContext)
+            , m_commonRuntimeConfiguration(commonRuntimeConfiguration)
         {
         }
 
-        template<typename Type>
-        Type LuaMaterialFunctorRuntimeContext::GetMaterialPropertyValue(const char* name) const
-        {
-            return LuaMaterialFunctorCommonContext::GetMaterialPropertyValue<Type>(name);
-        }
-
-        bool LuaMaterialFunctorRuntimeContext::HasMaterialValue(const char* name) const
+        bool LuaMaterialFunctorAPI::ReadMaterialPropertyValues::HasMaterialValue(const char* name) const
         {
             Name propertyFullName{name};
-            m_materialNameContext.ContextualizeProperty(propertyFullName);
-            
-            MaterialPropertyIndex propertyIndex = GetMaterialPropertiesLayout()->FindPropertyIndex(propertyFullName);
+            m_materialNameContext->ContextualizeProperty(propertyFullName);
+
+            MaterialPropertyIndex propertyIndex = m_underlyingApi->GetMaterialPropertiesLayout()->FindPropertyIndex(propertyFullName);
             return propertyIndex.IsValid();
         }
 
         template<>
-        bool LuaMaterialFunctorRuntimeContext::SetShaderOptionValue(const char* name, const char* value)
+        bool LuaMaterialFunctorAPI::ConfigureShaders::SetShaderOptionValue(const char* name, const char* value)
         {
             Name optionName{name};
-            m_materialNameContext.ContextualizeShaderOption(optionName);
-            return m_runtimeContextImpl->SetShaderOptionValue(optionName, Name{value});
+            m_materialNameContext->ContextualizeShaderOption(optionName);
+            return m_underlyingApi->SetShaderOptionValue(optionName, Name{value});
         }
 
         template<typename Type>
-        bool LuaMaterialFunctorRuntimeContext::SetShaderOptionValue(const char* name, Type value)
+        bool LuaMaterialFunctorAPI::ConfigureShaders::SetShaderOptionValue(const char* name, Type value)
         {
             Name optionName{name};
-            m_materialNameContext.ContextualizeShaderOption(optionName);
-            return m_runtimeContextImpl->SetShaderOptionValue(optionName, ShaderOptionValue{value});
+            m_materialNameContext->ContextualizeShaderOption(optionName);
+            return m_underlyingApi->SetShaderOptionValue(optionName, ShaderOptionValue{value});
         }
 
-        RHI::ShaderInputConstantIndex LuaMaterialFunctorRuntimeContext::GetShaderInputConstantIndex(const char* name, const char* functionName) const
+        RHI::ShaderInputConstantIndex LuaMaterialFunctorAPI::RuntimeContext::GetShaderInputConstantIndex(const char* name, const char* functionName) const
         {
             Name fullInputName{name};
-            m_materialNameContext.ContextualizeSrgInput(fullInputName);
+            m_materialNameContext->ContextualizeSrgInput(fullInputName);
 
-            RHI::ShaderInputConstantIndex index = m_runtimeContextImpl->m_shaderResourceGroup->FindShaderInputConstantIndex(fullInputName);
+            RHI::ShaderInputConstantIndex index = m_runtimeContextImpl->GetShaderResourceGroup()->FindShaderInputConstantIndex(fullInputName);
 
             if (!index.IsValid())
             {
@@ -408,27 +380,27 @@ namespace AZ
         }
 
         template<typename Type>
-        bool LuaMaterialFunctorRuntimeContext::SetShaderConstant(const char* name, Type value)
+        bool LuaMaterialFunctorAPI::RuntimeContext::SetShaderConstant(const char* name, Type value)
         {
             RHI::ShaderInputConstantIndex index = GetShaderInputConstantIndex(name, "SetShaderConstant");
             if (index.IsValid())
             {
-                return m_runtimeContextImpl->m_shaderResourceGroup->SetConstant(index, value);
+                return m_runtimeContextImpl->GetShaderResourceGroup()->SetConstant(index, value);
             }
 
             return false;
         }
 
-        AZStd::size_t LuaMaterialFunctorRuntimeContext::GetShaderCount() const
+        AZStd::size_t LuaMaterialFunctorAPI::ConfigureShaders::GetShaderCount() const
         {
-            return m_runtimeContextImpl->GetShaderCount();
+            return m_underlyingApi->GetShaderCount();
         }
 
-        LuaMaterialFunctorShaderItem LuaMaterialFunctorRuntimeContext::GetShader(AZStd::size_t index)
+        LuaMaterialFunctorAPI::ShaderItem LuaMaterialFunctorAPI::ConfigureShaders::GetShader(AZStd::size_t index)
         {
             if (index < GetShaderCount())
             {
-                return LuaMaterialFunctorShaderItem{this, &(*m_runtimeContextImpl->m_commonShaderCollection)[index]};
+                return LuaMaterialFunctorAPI::ShaderItem{&(*m_underlyingApi->m_localShaderCollection)[index], m_materialNameContext, m_commonRuntimeConfiguration};
             }
             else
             {
@@ -437,12 +409,12 @@ namespace AZ
             }
         }
 
-        LuaMaterialFunctorShaderItem LuaMaterialFunctorRuntimeContext::GetShaderByTag(const char* shaderTag)
+        LuaMaterialFunctorAPI::ShaderItem LuaMaterialFunctorAPI::ConfigureShaders::GetShaderByTag(const char* shaderTag)
         {
             const AZ::Name tag{shaderTag};
-            if (m_runtimeContextImpl->m_commonShaderCollection->HasShaderTag(tag))
+            if (m_underlyingApi->m_localShaderCollection->HasShaderTag(tag))
             {
-                return LuaMaterialFunctorShaderItem{this, &(*m_runtimeContextImpl->m_commonShaderCollection)[tag]};
+                return LuaMaterialFunctorAPI::ShaderItem{&(*m_underlyingApi->m_localShaderCollection)[tag], m_materialNameContext, m_commonRuntimeConfiguration};
             }
             else
             {
@@ -451,59 +423,106 @@ namespace AZ
                 return {};
             }
         }
-        
-        bool LuaMaterialFunctorRuntimeContext::HasShaderWithTag(const char* shaderTag)
+
+        bool LuaMaterialFunctorAPI::ConfigureShaders::HasShaderWithTag(const char* shaderTag)
         {
-            return m_runtimeContextImpl->m_commonShaderCollection->HasShaderTag(AZ::Name{shaderTag});
+            return m_underlyingApi->m_localShaderCollection->HasShaderTag(AZ::Name{shaderTag});
         }
 
-        void LuaMaterialFunctorEditorContext::LuaMaterialFunctorEditorContext::Reflect(BehaviorContext* behaviorContext)
-        {
-            behaviorContext->Class<LuaMaterialFunctorEditorContext>()
-                ->Method("GetMaterialPropertyValue_bool", &LuaMaterialFunctorEditorContext::GetMaterialPropertyValue<bool>)
-                ->Method("GetMaterialPropertyValue_int", &LuaMaterialFunctorEditorContext::GetMaterialPropertyValue<int32_t>)
-                ->Method("GetMaterialPropertyValue_uint", &LuaMaterialFunctorEditorContext::GetMaterialPropertyValue<uint32_t>)
-                ->Method("GetMaterialPropertyValue_enum", &LuaMaterialFunctorEditorContext::GetMaterialPropertyValue<uint32_t>)
-                ->Method("GetMaterialPropertyValue_float", &LuaMaterialFunctorEditorContext::GetMaterialPropertyValue<float>)
-                ->Method("GetMaterialPropertyValue_Vector2", &LuaMaterialFunctorEditorContext::GetMaterialPropertyValue<Vector2>)
-                ->Method("GetMaterialPropertyValue_Vector3", &LuaMaterialFunctorEditorContext::GetMaterialPropertyValue<Vector3>)
-                ->Method("GetMaterialPropertyValue_Vector4", &LuaMaterialFunctorEditorContext::GetMaterialPropertyValue<Vector4>)
-                ->Method("GetMaterialPropertyValue_Color", &LuaMaterialFunctorEditorContext::GetMaterialPropertyValue<Color>)
-                ->Method("GetMaterialPropertyValue_Image", &LuaMaterialFunctorEditorContext::GetMaterialPropertyValue<Image*>)
-                ->Method("SetMaterialPropertyVisibility", &LuaMaterialFunctorEditorContext::SetMaterialPropertyVisibility)
-                ->Method("SetMaterialPropertyDescription", &LuaMaterialFunctorEditorContext::SetMaterialPropertyDescription)
-                ->Method("SetMaterialPropertyMinValue_int", &LuaMaterialFunctorEditorContext::SetMaterialPropertyMinValue<int32_t>)
-                ->Method("SetMaterialPropertyMinValue_uint", &LuaMaterialFunctorEditorContext::SetMaterialPropertyMinValue<uint32_t>)
-                ->Method("SetMaterialPropertyMinValue_float", &LuaMaterialFunctorEditorContext::SetMaterialPropertyMinValue<float>)
-                ->Method("SetMaterialPropertyMaxValue_int", &LuaMaterialFunctorEditorContext::SetMaterialPropertyMaxValue<int32_t>)
-                ->Method("SetMaterialPropertyMaxValue_uint", &LuaMaterialFunctorEditorContext::SetMaterialPropertyMaxValue<uint32_t>)
-                ->Method("SetMaterialPropertyMaxValue_float", &LuaMaterialFunctorEditorContext::SetMaterialPropertyMaxValue<float>)
-                ->Method("SetMaterialPropertySoftMinValue_int", &LuaMaterialFunctorEditorContext::SetMaterialPropertySoftMinValue<int32_t>)
-                ->Method("SetMaterialPropertySoftMinValue_uint", &LuaMaterialFunctorEditorContext::SetMaterialPropertySoftMinValue<uint32_t>)
-                ->Method("SetMaterialPropertySoftMinValue_float", &LuaMaterialFunctorEditorContext::SetMaterialPropertySoftMinValue<float>)
-                ->Method("SetMaterialPropertySoftMaxValue_int", &LuaMaterialFunctorEditorContext::SetMaterialPropertySoftMaxValue<int32_t>)
-                ->Method("SetMaterialPropertySoftMaxValue_uint", &LuaMaterialFunctorEditorContext::SetMaterialPropertySoftMaxValue<uint32_t>)
-                ->Method("SetMaterialPropertySoftMaxValue_float", &LuaMaterialFunctorEditorContext::SetMaterialPropertySoftMaxValue<float>)
-                ->Method("SetMaterialPropertyGroupVisibility", &LuaMaterialFunctorEditorContext::SetMaterialPropertyGroupVisibility)
-                ;
-        }
-
-        LuaMaterialFunctorEditorContext::LuaMaterialFunctorEditorContext(MaterialFunctor::EditorContext* editorContextImpl,
+        LuaMaterialFunctorAPI::RuntimeContext::RuntimeContext(
+            MaterialFunctorAPI::RuntimeContext* runtimeContextImpl,
             const MaterialPropertyFlags* materialPropertyDependencies,
-            const MaterialNameContext& materialNameContext)
-            : LuaMaterialFunctorCommonContext(editorContextImpl, materialPropertyDependencies, materialNameContext)
+            const MaterialNameContext* materialNameContext)
+            : LuaMaterialFunctorAPI::CommonRuntimeConfiguration(runtimeContextImpl->GetMaterialPropertyPsoHandling(), materialPropertyDependencies, runtimeContextImpl->GetMaterialPropertiesLayout())
+            , LuaMaterialFunctorAPI::ReadMaterialPropertyValues(runtimeContextImpl, materialNameContext)
+            , LuaMaterialFunctorAPI::ConfigureShaders(runtimeContextImpl, materialNameContext, this)
+            , m_runtimeContextImpl(runtimeContextImpl)
+            , m_materialNameContext(materialNameContext)
+        {
+        }
+
+        template<typename Type>
+        Type LuaMaterialFunctorAPI::RuntimeContext::GetMaterialPropertyValue(const char* name) const
+        {
+            return LuaMaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<Type>(name);
+        }
+
+        bool LuaMaterialFunctorAPI::RuntimeContext::HasMaterialValue(const char* name) const
+        {
+            return LuaMaterialFunctorAPI::ReadMaterialPropertyValues::HasMaterialValue(name);
+        }
+
+        template<typename Type>
+        bool LuaMaterialFunctorAPI::RuntimeContext::SetShaderOptionValue(const char* name, Type value)
+        {
+            return LuaMaterialFunctorAPI::ConfigureShaders::SetShaderOptionValue(name, value);
+        }
+
+        AZStd::size_t LuaMaterialFunctorAPI::RuntimeContext::GetShaderCount() const
+        {
+            return LuaMaterialFunctorAPI::ConfigureShaders::GetShaderCount();
+        }
+
+        LuaMaterialFunctorAPI::ShaderItem LuaMaterialFunctorAPI::RuntimeContext::GetShader(AZStd::size_t index)
+        {
+            return LuaMaterialFunctorAPI::ConfigureShaders::GetShader(index);
+        }
+
+        LuaMaterialFunctorAPI::ShaderItem LuaMaterialFunctorAPI::RuntimeContext::GetShaderByTag(const char* shaderTag)
+        {
+            return LuaMaterialFunctorAPI::ConfigureShaders::GetShaderByTag(shaderTag);
+        }
+        
+        bool LuaMaterialFunctorAPI::RuntimeContext::HasShaderWithTag(const char* shaderTag)
+        {
+            return LuaMaterialFunctorAPI::ConfigureShaders::HasShaderWithTag(shaderTag);
+        }
+
+        void LuaMaterialFunctorAPI::EditorContext::EditorContext::Reflect(BehaviorContext* behaviorContext)
+        {
+            auto builder = behaviorContext->Class<LuaMaterialFunctorAPI::EditorContext>()
+                ->Method("SetMaterialPropertyVisibility", &LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertyVisibility)
+                ->Method("SetMaterialPropertyDescription", &LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertyDescription)
+                ->Method("SetMaterialPropertyMinValue_int", &LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertyMinValue<int32_t>)
+                ->Method("SetMaterialPropertyMinValue_uint", &LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertyMinValue<uint32_t>)
+                ->Method("SetMaterialPropertyMinValue_float", &LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertyMinValue<float>)
+                ->Method("SetMaterialPropertyMaxValue_int", &LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertyMaxValue<int32_t>)
+                ->Method("SetMaterialPropertyMaxValue_uint", &LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertyMaxValue<uint32_t>)
+                ->Method("SetMaterialPropertyMaxValue_float", &LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertyMaxValue<float>)
+                ->Method("SetMaterialPropertySoftMinValue_int", &LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertySoftMinValue<int32_t>)
+                ->Method("SetMaterialPropertySoftMinValue_uint", &LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertySoftMinValue<uint32_t>)
+                ->Method("SetMaterialPropertySoftMinValue_float", &LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertySoftMinValue<float>)
+                ->Method("SetMaterialPropertySoftMaxValue_int", &LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertySoftMaxValue<int32_t>)
+                ->Method("SetMaterialPropertySoftMaxValue_uint", &LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertySoftMaxValue<uint32_t>)
+                ->Method("SetMaterialPropertySoftMaxValue_float", &LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertySoftMaxValue<float>)
+                ->Method("SetMaterialPropertyGroupVisibility", &LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertyGroupVisibility)
+                ;
+
+            LuaMaterialFunctorAPI::ReadMaterialPropertyValues::ReflectSubclass<LuaMaterialFunctorAPI::EditorContext>(builder);
+        }
+
+        LuaMaterialFunctorAPI::EditorContext::EditorContext(
+            MaterialFunctorAPI::EditorContext* editorContextImpl,
+            const MaterialNameContext* materialNameContext)
+            : LuaMaterialFunctorAPI::ReadMaterialPropertyValues(editorContextImpl, materialNameContext)
             , m_editorContextImpl(editorContextImpl)
+            , m_materialNameContext(materialNameContext)
         {
         }
 
         template<typename Type>
-        Type LuaMaterialFunctorEditorContext::GetMaterialPropertyValue(const char* name) const
+        Type LuaMaterialFunctorAPI::EditorContext::GetMaterialPropertyValue(const char* name) const
         {
-            return LuaMaterialFunctorCommonContext::GetMaterialPropertyValue<Type>(name);
+            return LuaMaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<Type>(name);
+        }
+
+        bool LuaMaterialFunctorAPI::EditorContext::HasMaterialValue(const char* name) const
+        {
+            return LuaMaterialFunctorAPI::ReadMaterialPropertyValues::HasMaterialValue(name);
         }
 
         template<typename Type>
-        bool LuaMaterialFunctorEditorContext::SetMaterialPropertyMinValue(const char* name, Type value)
+        bool LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertyMinValue(const char* name, Type value)
         {
             const char* functionName = "SetMaterialPropertyMinValue";
 
@@ -517,7 +536,7 @@ namespace AZ
         }
 
         template<typename Type>
-        bool LuaMaterialFunctorEditorContext::SetMaterialPropertyMaxValue(const char* name, Type value)
+        bool LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertyMaxValue(const char* name, Type value)
         {
             const char* functionName = "SetMaterialPropertyMaxValue";
 
@@ -531,7 +550,7 @@ namespace AZ
         }
 
         template<typename Type>
-        bool LuaMaterialFunctorEditorContext::SetMaterialPropertySoftMinValue(const char* name, Type value)
+        bool LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertySoftMinValue(const char* name, Type value)
         {
             const char* functionName = "SetMaterialPropertySoftMinValue";
 
@@ -545,7 +564,7 @@ namespace AZ
         }
 
         template<typename Type>
-        bool LuaMaterialFunctorEditorContext::SetMaterialPropertySoftMaxValue(const char* name, Type value)
+        bool LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertySoftMaxValue(const char* name, Type value)
         {
             const char* functionName = "SetMaterialPropertySoftMaxValue";
 
@@ -558,68 +577,68 @@ namespace AZ
             return m_editorContextImpl->SetMaterialPropertySoftMaxValue(index, value);
         }
         
-        bool LuaMaterialFunctorEditorContext::SetMaterialPropertyGroupVisibility(const char* name, MaterialPropertyGroupVisibility visibility)
+        bool LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertyGroupVisibility(const char* name, MaterialPropertyGroupVisibility visibility)
         {
             if (m_editorContextImpl)
             {
                 Name fullName{name};
-                m_materialNameContext.ContextualizeProperty(fullName);
+                m_materialNameContext->ContextualizeProperty(fullName);
                 return m_editorContextImpl->SetMaterialPropertyGroupVisibility(fullName, visibility);
             }
             return false;
         }
 
-        bool LuaMaterialFunctorEditorContext::SetMaterialPropertyVisibility(const char* name, MaterialPropertyVisibility visibility)
+        bool LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertyVisibility(const char* name, MaterialPropertyVisibility visibility)
         {
             if (m_editorContextImpl)
             {
                 Name fullName{name};
-                m_materialNameContext.ContextualizeProperty(fullName);
+                m_materialNameContext->ContextualizeProperty(fullName);
                 return m_editorContextImpl->SetMaterialPropertyVisibility(fullName, visibility);
             }
             return false;
         }
 
-        bool LuaMaterialFunctorEditorContext::SetMaterialPropertyDescription(const char* name, const char* description)
+        bool LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertyDescription(const char* name, const char* description)
         {
             if (m_editorContextImpl)
             {
                 Name fullName{name};
-                m_materialNameContext.ContextualizeProperty(fullName);
+                m_materialNameContext->ContextualizeProperty(fullName);
                 return m_editorContextImpl->SetMaterialPropertyDescription(fullName, description);
             }
             return false;
         }
 
         template<>
-        void LuaMaterialFunctorShaderItem::SetShaderOptionValue(const char* name, const char* value);
+        void LuaMaterialFunctorAPI::ShaderItem::SetShaderOptionValue(const char* name, const char* value);
 
-        void LuaMaterialFunctorShaderItem::Reflect(AZ::BehaviorContext* behaviorContext)
+        void LuaMaterialFunctorAPI::ShaderItem::Reflect(AZ::BehaviorContext* behaviorContext)
         {
-            behaviorContext->Class<LuaMaterialFunctorShaderItem>()
-                ->Method("GetRenderStatesOverride", &LuaMaterialFunctorShaderItem::GetRenderStatesOverride)
-                ->Method("SetEnabled", &LuaMaterialFunctorShaderItem::SetEnabled)
-                ->Method("SetDrawListTagOverride", &LuaMaterialFunctorShaderItem::SetDrawListTagOverride)
-                ->Method("SetShaderOptionValue_bool", &LuaMaterialFunctorShaderItem::SetShaderOptionValue<bool>)
-                ->Method("SetShaderOptionValue_uint", &LuaMaterialFunctorShaderItem::SetShaderOptionValue<uint32_t>)
-                ->Method("SetShaderOptionValue_enum", &LuaMaterialFunctorShaderItem::SetShaderOptionValue<const char*>)
+            behaviorContext->Class<LuaMaterialFunctorAPI::ShaderItem>()
+                ->Method("GetRenderStatesOverride", &LuaMaterialFunctorAPI::ShaderItem::GetRenderStatesOverride)
+                ->Method("SetEnabled", &LuaMaterialFunctorAPI::ShaderItem::SetEnabled)
+                ->Method("SetDrawListTagOverride", &LuaMaterialFunctorAPI::ShaderItem::SetDrawListTagOverride)
+                ->Method("SetShaderOptionValue_bool", &LuaMaterialFunctorAPI::ShaderItem::SetShaderOptionValue<bool>)
+                ->Method("SetShaderOptionValue_uint", &LuaMaterialFunctorAPI::ShaderItem::SetShaderOptionValue<uint32_t>)
+                ->Method("SetShaderOptionValue_enum", &LuaMaterialFunctorAPI::ShaderItem::SetShaderOptionValue<const char*>)
                 ;
         }
 
-        LuaMaterialFunctorRenderStates LuaMaterialFunctorShaderItem::GetRenderStatesOverride()
+        LuaMaterialFunctorAPI::RenderStates LuaMaterialFunctorAPI::ShaderItem::GetRenderStatesOverride()
         {
-            if (m_context && m_context->CheckPsoChangesAllowed() && m_shaderItem)
+            if (m_commonRuntimeConfiguration->CheckPsoChangesAllowed() && m_shaderItem)
             {
-                return LuaMaterialFunctorRenderStates{m_shaderItem->GetRenderStatesOverlay()};
+                return LuaMaterialFunctorAPI::RenderStates{m_shaderItem->GetRenderStatesOverlay()};
             }
             else
             {
                 static RHI::RenderStates dummyRenderStates;
-                return LuaMaterialFunctorRenderStates{&dummyRenderStates};
+                return LuaMaterialFunctorAPI::RenderStates{&dummyRenderStates};
             }
         }
 
-        void LuaMaterialFunctorShaderItem::SetEnabled(bool enable)
+        void LuaMaterialFunctorAPI::ShaderItem::SetEnabled(bool enable)
         {
             if (m_shaderItem)
             {
@@ -627,7 +646,7 @@ namespace AZ
             }
         }
 
-        void LuaMaterialFunctorShaderItem::SetDrawListTagOverride(const char* drawListTag)
+        void LuaMaterialFunctorAPI::ShaderItem::SetDrawListTagOverride(const char* drawListTag)
         {
             if (m_shaderItem)
             {
@@ -635,7 +654,7 @@ namespace AZ
             }
         }
 
-        void LuaMaterialFunctorShaderItem::SetShaderOptionValue(
+        void LuaMaterialFunctorAPI::ShaderItem::SetShaderOptionValue(
             const Name& name, AZStd::function<bool(ShaderOptionGroup*, ShaderOptionIndex)> setValueCommand)
         {
             ShaderOptionGroup* shaderOptionGroup = m_shaderItem->GetShaderOptions();
@@ -659,7 +678,7 @@ namespace AZ
         }
 
         template<>
-        void LuaMaterialFunctorShaderItem::SetShaderOptionValue(const char* name, const char* value)
+        void LuaMaterialFunctorAPI::ShaderItem::SetShaderOptionValue(const char* name, const char* value)
         {
             if (m_shaderItem)
             {
@@ -670,7 +689,7 @@ namespace AZ
         }
 
         template<typename Type>
-        void LuaMaterialFunctorShaderItem::SetShaderOptionValue(const char* name, Type value)
+        void LuaMaterialFunctorAPI::ShaderItem::SetShaderOptionValue(const char* name, Type value)
         {
             if (m_shaderItem)
             {
@@ -680,15 +699,15 @@ namespace AZ
             }
         }
 
-        void LuaMaterialFunctorRenderStates::Reflect(AZ::BehaviorContext* behaviorContext)
+        void LuaMaterialFunctorAPI::RenderStates::Reflect(AZ::BehaviorContext* behaviorContext)
         {
             RHI::ReflectRenderStateEnums(behaviorContext);
 
-            auto classBuilder = behaviorContext->Class<LuaMaterialFunctorRenderStates>();
+            auto classBuilder = behaviorContext->Class<LuaMaterialFunctorAPI::RenderStates>();
 
             #define TEMP_REFLECT_RENDERSTATE_METHODS(PropertyName) \
-                classBuilder->Method("Set" AZ_STRINGIZE(PropertyName), AZ_JOIN(&LuaMaterialFunctorRenderStates::Set, PropertyName)); \
-                classBuilder->Method("Clear" AZ_STRINGIZE(PropertyName), AZ_JOIN(&LuaMaterialFunctorRenderStates::Clear, PropertyName));
+                classBuilder->Method("Set" AZ_STRINGIZE(PropertyName), AZ_JOIN(&LuaMaterialFunctorAPI::RenderStates::Set, PropertyName)); \
+                classBuilder->Method("Clear" AZ_STRINGIZE(PropertyName), AZ_JOIN(&LuaMaterialFunctorAPI::RenderStates::Clear, PropertyName));
 
             TEMP_REFLECT_RENDERSTATE_METHODS(MultisampleCustomPosition)
             TEMP_REFLECT_RENDERSTATE_METHODS(MultisampleCustomPositionCount)
@@ -732,17 +751,17 @@ namespace AZ
         }
 
         #define TEMP_DEFINE_RENDERSTATE_METHODS_COMMON(PropertyName, DataType, Field, InvalidValue) \
-            void AZ_JOIN(LuaMaterialFunctorRenderStates::Set, PropertyName)(DataType value)         \
+            void AZ_JOIN(LuaMaterialFunctorAPI::RenderStates::Set, PropertyName)(DataType value)         \
             {                                                                                       \
                 Field = value;                                                                      \
             }                                                                                       \
-            void AZ_JOIN(LuaMaterialFunctorRenderStates::Clear, PropertyName)()                     \
+            void AZ_JOIN(LuaMaterialFunctorAPI::RenderStates::Clear, PropertyName)()                     \
             {                                                                                       \
                 Field = InvalidValue;                                                               \
             }
 
         #define TEMP_DEFINE_RENDERSTATE_METHODS_BLENDSTATETARGET(PropertyName, DataType, Field, InvalidValue)           \
-            void AZ_JOIN(LuaMaterialFunctorRenderStates::Set, PropertyName)(AZStd::size_t targetIndex, DataType value)  \
+            void AZ_JOIN(LuaMaterialFunctorAPI::RenderStates::Set, PropertyName)(AZStd::size_t targetIndex, DataType value)  \
             {                                                                                                           \
                 if (targetIndex < RHI::Limits::Pipeline::AttachmentColorCountMax)                                       \
                 {                                                                                                       \
@@ -755,7 +774,7 @@ namespace AZ
                         targetIndex, RHI::Limits::Pipeline::AttachmentColorCountMax));                                  \
                 }                                                                                                       \
             }                                                                                                           \
-            void AZ_JOIN(LuaMaterialFunctorRenderStates::Clear, PropertyName)(AZStd::size_t targetIndex)                \
+            void AZ_JOIN(LuaMaterialFunctorAPI::RenderStates::Clear, PropertyName)(AZStd::size_t targetIndex)                \
             {                                                                                                           \
                 if (targetIndex < RHI::Limits::Pipeline::AttachmentColorCountMax)                                       \
                 {                                                                                                       \
@@ -769,7 +788,7 @@ namespace AZ
                 }                                                                                                       \
             }
 
-        void LuaMaterialFunctorRenderStates::SetMultisampleCustomPosition(AZStd::size_t multisampleCustomLocationIndex, uint8_t x, uint8_t y)
+        void LuaMaterialFunctorAPI::RenderStates::SetMultisampleCustomPosition(AZStd::size_t multisampleCustomLocationIndex, uint8_t x, uint8_t y)
         {
             if (multisampleCustomLocationIndex < RHI::Limits::Pipeline::MultiSampleCustomLocationsCountMax)
             {
@@ -783,7 +802,7 @@ namespace AZ
             }
         }
 
-        void LuaMaterialFunctorRenderStates::ClearMultisampleCustomPosition(AZStd::size_t multisampleCustomLocationIndex)
+        void LuaMaterialFunctorAPI::RenderStates::ClearMultisampleCustomPosition(AZStd::size_t multisampleCustomLocationIndex)
         {
             if (multisampleCustomLocationIndex < RHI::Limits::Pipeline::MultiSampleCustomLocationsCountMax)
             {
@@ -797,7 +816,7 @@ namespace AZ
             }
         }
 
-        void LuaMaterialFunctorRenderStates::SetMultisampleCustomPositionCount(uint32_t value)
+        void LuaMaterialFunctorAPI::RenderStates::SetMultisampleCustomPositionCount(uint32_t value)
         {
             if (value == RHI::RenderStates_InvalidUInt || value < RHI::Limits::Pipeline::MultiSampleCustomLocationsCountMax)
             {
@@ -810,7 +829,7 @@ namespace AZ
             }
         }
 
-        void LuaMaterialFunctorRenderStates::ClearMultisampleCustomPositionCount()
+        void LuaMaterialFunctorAPI::RenderStates::ClearMultisampleCustomPositionCount()
         {                                                                                      
             m_renderStates->m_multisampleState.m_customPositionsCount = RHI::RenderStates_InvalidUInt;
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialFunctor.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialFunctor.cpp
@@ -31,40 +31,29 @@ namespace AZ
             }
         }
 
-        MaterialFunctor::RuntimeContext::RuntimeContext(
-            const MaterialPropertyCollection& materialProperties,
-            MaterialPipelineShaderCollections* shaderCollections,
-            ShaderResourceGroup* shaderResourceGroup,
-            const MaterialPropertyFlags* materialPropertyDependencies,
-            MaterialPropertyPsoHandling psoHandling
-        )
-            : m_materialProperties(materialProperties)
-            , m_allShaderCollections(shaderCollections)
-            , m_shaderResourceGroup(shaderResourceGroup)
-            , m_materialPropertyDependencies(materialPropertyDependencies)
-            , m_psoHandling(psoHandling)
+        MaterialFunctorAPI::ConfigureShaders::ConfigureShaders(ShaderCollection* localShaderCollection)
+            : m_localShaderCollection(localShaderCollection)
         {
-            static ShaderCollection EmptyShaderCollection;
+        }
 
-            auto iter = m_allShaderCollections->find(MaterialPipelineNameCommon);
-            if (iter != m_allShaderCollections->end())
+        void MaterialFunctorAPI::ConfigureShaders::ForAllShaderItems(AZStd::function<bool(ShaderCollection::Item& shaderItem)> callback)
+        {
+            for (ShaderCollection::Item& shaderItem : *m_localShaderCollection)
             {
-                m_commonShaderCollection = &iter->second;
-            }
-            else
-            {
-                m_commonShaderCollection = &EmptyShaderCollection;
+                if (!callback(shaderItem))
+                {
+                    return;
+                }
             }
         }
 
         template<typename ValueType>
-        bool MaterialFunctor::RuntimeContext::SetShaderOptionValueHelper(const Name& name, const ValueType& value)
+        bool MaterialFunctorAPI::ConfigureShaders::SetShaderOptionValueHelper(const Name& name, const ValueType& value)
         {
             bool didSetOne = false;
+            bool materialOwnsOption = false;
 
-            for (auto& shaderCollectionPair : *m_allShaderCollections)
-            {
-                for (ShaderCollection::Item& shaderItem : shaderCollectionPair.second)
+            ForAllShaderItems([&](ShaderCollection::Item& shaderItem)
                 {
                     ShaderOptionGroup* shaderOptionGroup = shaderItem.GetShaderOptions();
                     const ShaderOptionGroupLayout* layout = shaderOptionGroup->GetShaderOptionLayout();
@@ -72,24 +61,29 @@ namespace AZ
 
                     if (!optionIndex.IsValid())
                     {
-                        continue;
+                        return true; // skip this and continue
                     }
 
                     if (!shaderItem.MaterialOwnsShaderOption(optionIndex))
                     {
-                        AZ_Error("MaterialFunctor", false, "Shader option '%s' is not owned by this material.", name.GetCStr());
-                        AZ_Assert(!didSetOne, "The material build pipeline should have ensured that MaterialOwnsShaderOption is consistent across all shaders.");
-                        return false;
+                        materialOwnsOption = true;
+                        return false; // break;
                     }
 
                     if (shaderOptionGroup->SetValue(optionIndex, value))
                     {
                         didSetOne = true;
                     }
-                }
-            }
 
-            if (!didSetOne)
+                    return true; // continue
+                });
+
+            if (materialOwnsOption)
+            {
+                AZ_Error("MaterialFunctor", false, "Shader option '%s' is not owned by this material.", name.GetCStr());
+                AZ_Assert(!didSetOne, "The material build pipeline should have ensured that MaterialOwnsShaderOption is consistent across all shaders.");
+            }
+            else if (!didSetOne)
             {
                 AZ_Error("MaterialFunctor", false, "Shader option '%s' not found.", name.GetCStr());
             }
@@ -97,57 +91,87 @@ namespace AZ
             return didSetOne;
         }
 
-        bool MaterialFunctor::RuntimeContext::SetShaderOptionValue(const Name& optionName, ShaderOptionValue value)
+        bool MaterialFunctorAPI::ConfigureShaders::SetShaderOptionValue(const Name& optionName, ShaderOptionValue value)
         {
             return SetShaderOptionValueHelper(optionName, value);
         }
 
-        bool MaterialFunctor::RuntimeContext::SetShaderOptionValue(const Name& optionName, const Name& value)
+        bool MaterialFunctorAPI::ConfigureShaders::SetShaderOptionValue(const Name& optionName, const Name& value)
         {
             return SetShaderOptionValueHelper(optionName, value);
         }
 
-        ShaderResourceGroup* MaterialFunctor::RuntimeContext::GetShaderResourceGroup()
+        AZStd::size_t MaterialFunctorAPI::ConfigureShaders::GetShaderCount() const
+        {
+            return m_localShaderCollection->size();
+        }
+
+        void MaterialFunctorAPI::ConfigureShaders::SetShaderEnabled(AZStd::size_t shaderIndex, bool enabled)
+        {
+            (*m_localShaderCollection)[shaderIndex].SetEnabled(enabled);
+        }
+
+        void MaterialFunctorAPI::ConfigureShaders::SetShaderEnabled(const AZ::Name& shaderTag, bool enabled)
+        {
+            (*m_localShaderCollection)[shaderTag].SetEnabled(enabled);
+        }
+
+        void MaterialFunctorAPI::ConfigureShaders::SetShaderDrawListTagOverride(AZStd::size_t shaderIndex, const Name& drawListTagName)
+        {
+            (*m_localShaderCollection)[shaderIndex].SetDrawListTagOverride(drawListTagName);
+        }
+
+        void MaterialFunctorAPI::ConfigureShaders::SetShaderDrawListTagOverride(const AZ::Name& shaderTag, const Name& drawListTagName)
+        {
+            (*m_localShaderCollection)[shaderTag].SetDrawListTagOverride(drawListTagName);
+        }
+
+        void MaterialFunctorAPI::ConfigureShaders::ApplyShaderRenderStateOverlay(AZStd::size_t shaderIndex, const RHI::RenderStates& renderStatesOverlay)
+        {
+            RHI::MergeStateInto(renderStatesOverlay, *((*m_localShaderCollection)[shaderIndex].GetRenderStatesOverlay()));
+        }
+
+        void MaterialFunctorAPI::ConfigureShaders::ApplyShaderRenderStateOverlay(const AZ::Name& shaderTag, const RHI::RenderStates& renderStatesOverlay)
+        {
+            RHI::MergeStateInto(renderStatesOverlay, *((*m_localShaderCollection)[shaderTag].GetRenderStatesOverlay()));
+        }
+
+        MaterialFunctorAPI::RuntimeContext::RuntimeContext(
+            const MaterialPropertyCollection& materialProperties,
+            const MaterialPropertyFlags* materialPropertyDependencies,
+            MaterialPropertyPsoHandling psoHandling,
+            ShaderResourceGroup* shaderResourceGroup,
+            MaterialPipelineShaderCollections* shaderCollections
+        )
+            : MaterialFunctorAPI::CommonRuntimeConfiguration(psoHandling)
+            , MaterialFunctorAPI::ReadMaterialPropertyValues(materialProperties, materialPropertyDependencies)
+            , MaterialFunctorAPI::ConfigureShaders(&(*shaderCollections)[MaterialPipelineNameCommon])
+            , m_shaderResourceGroup(shaderResourceGroup)
+            , m_allShaderCollections(shaderCollections)
+        {
+        }
+
+        void MaterialFunctorAPI::RuntimeContext::ForAllShaderItems(AZStd::function<bool(ShaderCollection::Item& shaderItem)> callback)
+        {
+            MaterialFunctorAPI::ConfigureShaders::ForAllShaderItems(callback);
+
+            for (auto& materialPipelinePair : *m_allShaderCollections)
+            {
+                for (ShaderCollection::Item& shaderItem : materialPipelinePair.second)
+                {
+                    if (!callback(shaderItem))
+                    {
+                        return;
+                    }
+                }
+            }
+        }
+        ShaderResourceGroup* MaterialFunctorAPI::RuntimeContext::GetShaderResourceGroup()
         {
             return m_shaderResourceGroup;
         }
 
-        AZStd::size_t MaterialFunctor::RuntimeContext::GetShaderCount() const
-        {
-            return m_commonShaderCollection->size();
-        }
-
-        void MaterialFunctor::RuntimeContext::SetShaderEnabled(AZStd::size_t shaderIndex, bool enabled)
-        {
-            (*m_commonShaderCollection)[shaderIndex].SetEnabled(enabled);
-        }
-
-        void MaterialFunctor::RuntimeContext::SetShaderEnabled(const AZ::Name& shaderTag, bool enabled)
-        {
-            (*m_commonShaderCollection)[shaderTag].SetEnabled(enabled);
-        }
-
-        void MaterialFunctor::RuntimeContext::SetShaderDrawListTagOverride(AZStd::size_t shaderIndex, const Name& drawListTagName)
-        {
-            (*m_commonShaderCollection)[shaderIndex].SetDrawListTagOverride(drawListTagName);
-        }
-
-        void MaterialFunctor::RuntimeContext::SetShaderDrawListTagOverride(const AZ::Name& shaderTag, const Name& drawListTagName)
-        {
-            (*m_commonShaderCollection)[shaderTag].SetDrawListTagOverride(drawListTagName);
-        }
-
-        void MaterialFunctor::RuntimeContext::ApplyShaderRenderStateOverlay(AZStd::size_t shaderIndex, const RHI::RenderStates& renderStatesOverlay)
-        {
-            RHI::MergeStateInto(renderStatesOverlay, *((*m_commonShaderCollection)[shaderIndex].GetRenderStatesOverlay()));
-        }
-
-        void MaterialFunctor::RuntimeContext::ApplyShaderRenderStateOverlay(const AZ::Name& shaderTag, const RHI::RenderStates& renderStatesOverlay)
-        {
-            RHI::MergeStateInto(renderStatesOverlay, *((*m_commonShaderCollection)[shaderTag].GetRenderStatesOverlay()));
-        }
-
-        MaterialFunctor::EditorContext::EditorContext(
+        MaterialFunctorAPI::EditorContext::EditorContext(
             const MaterialPropertyCollection& materialProperties,
             AZStd::unordered_map<Name, MaterialPropertyDynamicMetadata>& propertyMetadata,
             AZStd::unordered_map<Name, MaterialPropertyGroupDynamicMetadata>& propertyGroupMetadata,
@@ -155,31 +179,30 @@ namespace AZ
             AZStd::unordered_set<Name>& updatedPropertyGroupsOut,
             const MaterialPropertyFlags* materialPropertyDependencies
         )
-            : m_materialProperties(materialProperties)
+            : MaterialFunctorAPI::ReadMaterialPropertyValues(materialProperties, materialPropertyDependencies)
             , m_propertyMetadata(propertyMetadata)
             , m_propertyGroupMetadata(propertyGroupMetadata)
             , m_updatedPropertiesOut(updatedPropertiesOut)
             , m_updatedPropertyGroupsOut(updatedPropertyGroupsOut)
-            , m_materialPropertyDependencies(materialPropertyDependencies)
         {}
 
-        const MaterialPropertyDynamicMetadata* MaterialFunctor::EditorContext::GetMaterialPropertyMetadata(const Name& propertyId) const
+        const MaterialPropertyDynamicMetadata* MaterialFunctorAPI::EditorContext::GetMaterialPropertyMetadata(const Name& propertyId) const
         {
             return QueryMaterialPropertyMetadata(propertyId);
         }
 
-        const MaterialPropertyDynamicMetadata* MaterialFunctor::EditorContext::GetMaterialPropertyMetadata(const MaterialPropertyIndex& index) const
+        const MaterialPropertyDynamicMetadata* MaterialFunctorAPI::EditorContext::GetMaterialPropertyMetadata(const MaterialPropertyIndex& index) const
         {
             const Name& name = m_materialProperties.GetMaterialPropertiesLayout()->GetPropertyDescriptor(index)->GetName();
             return GetMaterialPropertyMetadata(name);
         }
         
-        const MaterialPropertyGroupDynamicMetadata* MaterialFunctor::EditorContext::GetMaterialPropertyGroupMetadata(const Name& propertyId) const
+        const MaterialPropertyGroupDynamicMetadata* MaterialFunctorAPI::EditorContext::GetMaterialPropertyGroupMetadata(const Name& propertyId) const
         {
             return QueryMaterialPropertyGroupMetadata(propertyId);
         }
         
-        bool MaterialFunctor::EditorContext::SetMaterialPropertyGroupVisibility(const Name& propertyGroupName, MaterialPropertyGroupVisibility visibility)
+        bool MaterialFunctorAPI::EditorContext::SetMaterialPropertyGroupVisibility(const Name& propertyGroupName, MaterialPropertyGroupVisibility visibility)
         {
             MaterialPropertyGroupDynamicMetadata* metadata = QueryMaterialPropertyGroupMetadata(propertyGroupName);
             if (!metadata)
@@ -196,7 +219,7 @@ namespace AZ
             return true;
         }
 
-        bool MaterialFunctor::EditorContext::SetMaterialPropertyVisibility(const Name& propertyId, MaterialPropertyVisibility visibility)
+        bool MaterialFunctorAPI::EditorContext::SetMaterialPropertyVisibility(const Name& propertyId, MaterialPropertyVisibility visibility)
         {
             MaterialPropertyDynamicMetadata* metadata = QueryMaterialPropertyMetadata(propertyId);
             if (!metadata)
@@ -213,13 +236,13 @@ namespace AZ
             return true;
         }
 
-        bool MaterialFunctor::EditorContext::SetMaterialPropertyVisibility(const MaterialPropertyIndex& index, MaterialPropertyVisibility visibility)
+        bool MaterialFunctorAPI::EditorContext::SetMaterialPropertyVisibility(const MaterialPropertyIndex& index, MaterialPropertyVisibility visibility)
         {
             const Name& name = m_materialProperties.GetMaterialPropertiesLayout()->GetPropertyDescriptor(index)->GetName();
             return SetMaterialPropertyVisibility(name, visibility);
         }
 
-        bool MaterialFunctor::EditorContext::SetMaterialPropertyDescription(const Name& propertyId, AZStd::string description)
+        bool MaterialFunctorAPI::EditorContext::SetMaterialPropertyDescription(const Name& propertyId, AZStd::string description)
         {
             MaterialPropertyDynamicMetadata* metadata = QueryMaterialPropertyMetadata(propertyId);
             if (!metadata)
@@ -236,13 +259,13 @@ namespace AZ
             return true;
         }
 
-        bool MaterialFunctor::EditorContext::SetMaterialPropertyDescription(const MaterialPropertyIndex& index, AZStd::string description)
+        bool MaterialFunctorAPI::EditorContext::SetMaterialPropertyDescription(const MaterialPropertyIndex& index, AZStd::string description)
         {
             const Name& name = m_materialProperties.GetMaterialPropertiesLayout()->GetPropertyDescriptor(index)->GetName();
             return SetMaterialPropertyDescription(name, description);
         }
 
-        bool MaterialFunctor::EditorContext::SetMaterialPropertyMinValue(const Name& propertyId, const MaterialPropertyValue& min)
+        bool MaterialFunctorAPI::EditorContext::SetMaterialPropertyMinValue(const Name& propertyId, const MaterialPropertyValue& min)
         {
             MaterialPropertyDynamicMetadata* metadata = QueryMaterialPropertyMetadata(propertyId);
             if (!metadata)
@@ -259,13 +282,13 @@ namespace AZ
             return true;
         }
 
-        bool MaterialFunctor::EditorContext::SetMaterialPropertyMinValue(const MaterialPropertyIndex& index, const MaterialPropertyValue& min)
+        bool MaterialFunctorAPI::EditorContext::SetMaterialPropertyMinValue(const MaterialPropertyIndex& index, const MaterialPropertyValue& min)
         {
             const Name& name = m_materialProperties.GetMaterialPropertiesLayout()->GetPropertyDescriptor(index)->GetName();
             return SetMaterialPropertyMinValue(name, min);
         }
 
-        bool MaterialFunctor::EditorContext::SetMaterialPropertyMaxValue(const Name& propertyId, const MaterialPropertyValue& max)
+        bool MaterialFunctorAPI::EditorContext::SetMaterialPropertyMaxValue(const Name& propertyId, const MaterialPropertyValue& max)
         {
             MaterialPropertyDynamicMetadata* metadata = QueryMaterialPropertyMetadata(propertyId);
             if (!metadata)
@@ -282,13 +305,13 @@ namespace AZ
             return true;
         }
 
-        bool MaterialFunctor::EditorContext::SetMaterialPropertyMaxValue(const MaterialPropertyIndex& index, const MaterialPropertyValue& max)
+        bool MaterialFunctorAPI::EditorContext::SetMaterialPropertyMaxValue(const MaterialPropertyIndex& index, const MaterialPropertyValue& max)
         {
             const Name& name = m_materialProperties.GetMaterialPropertiesLayout()->GetPropertyDescriptor(index)->GetName();
             return SetMaterialPropertyMaxValue(name, max);
         }
 
-        bool MaterialFunctor::EditorContext::SetMaterialPropertySoftMinValue(const Name& propertyId, const MaterialPropertyValue& min)
+        bool MaterialFunctorAPI::EditorContext::SetMaterialPropertySoftMinValue(const Name& propertyId, const MaterialPropertyValue& min)
         {
             MaterialPropertyDynamicMetadata* metadata = QueryMaterialPropertyMetadata(propertyId);
             if (!metadata)
@@ -305,13 +328,13 @@ namespace AZ
             return true;
         }
 
-        bool MaterialFunctor::EditorContext::SetMaterialPropertySoftMinValue(const MaterialPropertyIndex& index, const MaterialPropertyValue& min)
+        bool MaterialFunctorAPI::EditorContext::SetMaterialPropertySoftMinValue(const MaterialPropertyIndex& index, const MaterialPropertyValue& min)
         {
             const Name& name = m_materialProperties.GetMaterialPropertiesLayout()->GetPropertyDescriptor(index)->GetName();
             return SetMaterialPropertySoftMinValue(name, min);
         }
 
-        bool MaterialFunctor::EditorContext::SetMaterialPropertySoftMaxValue(const Name& propertyId, const MaterialPropertyValue& max)
+        bool MaterialFunctorAPI::EditorContext::SetMaterialPropertySoftMaxValue(const Name& propertyId, const MaterialPropertyValue& max)
         {
             MaterialPropertyDynamicMetadata* metadata = QueryMaterialPropertyMetadata(propertyId);
             if (!metadata)
@@ -328,13 +351,13 @@ namespace AZ
             return true;
         }
 
-        bool MaterialFunctor::EditorContext::SetMaterialPropertySoftMaxValue(const MaterialPropertyIndex& index, const MaterialPropertyValue& max)
+        bool MaterialFunctorAPI::EditorContext::SetMaterialPropertySoftMaxValue(const MaterialPropertyIndex& index, const MaterialPropertyValue& max)
         {
             const Name& name = m_materialProperties.GetMaterialPropertiesLayout()->GetPropertyDescriptor(index)->GetName();
             return SetMaterialPropertySoftMaxValue(name, max);
         }
 
-        MaterialPropertyDynamicMetadata* MaterialFunctor::EditorContext::QueryMaterialPropertyMetadata(const Name& propertyId) const
+        MaterialPropertyDynamicMetadata* MaterialFunctorAPI::EditorContext::QueryMaterialPropertyMetadata(const Name& propertyId) const
         {
             auto it = m_propertyMetadata.find(propertyId);
             if (it == m_propertyMetadata.end())
@@ -346,7 +369,7 @@ namespace AZ
             return &it->second;
         }
         
-        MaterialPropertyGroupDynamicMetadata* MaterialFunctor::EditorContext::QueryMaterialPropertyGroupMetadata(const Name& propertyGroupId) const
+        MaterialPropertyGroupDynamicMetadata* MaterialFunctorAPI::EditorContext::QueryMaterialPropertyGroupMetadata(const Name& propertyGroupId) const
         {
             auto it = m_propertyGroupMetadata.find(propertyGroupId);
             if (it == m_propertyGroupMetadata.end())
@@ -358,72 +381,47 @@ namespace AZ
             return &it->second;
         }
 
+        MaterialFunctorAPI::ReadMaterialPropertyValues::ReadMaterialPropertyValues(
+            const MaterialPropertyCollection& materialProperties,
+            const MaterialPropertyFlags* materialPropertyDependencies
+        )
+            : m_materialProperties(materialProperties)
+            , m_materialPropertyDependencies(materialPropertyDependencies)
+        { }
+
         template<typename Type>
-        const Type& MaterialFunctor::RuntimeContext::GetMaterialPropertyValue(const MaterialPropertyIndex& index) const
+        const Type& MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue(const MaterialPropertyIndex& index) const
         {
             return GetMaterialPropertyValue(index).GetValue<Type>();
         }
 
         // explicit template instantiation
-        template const bool&     MaterialFunctor::RuntimeContext::GetMaterialPropertyValue<bool>     (const Name& propertyId) const;
-        template const int32_t&  MaterialFunctor::RuntimeContext::GetMaterialPropertyValue<int32_t>  (const Name& propertyId) const;
-        template const uint32_t& MaterialFunctor::RuntimeContext::GetMaterialPropertyValue<uint32_t> (const Name& propertyId) const;
-        template const float&    MaterialFunctor::RuntimeContext::GetMaterialPropertyValue<float>    (const Name& propertyId) const;
-        template const Vector2&  MaterialFunctor::RuntimeContext::GetMaterialPropertyValue<Vector2>  (const Name& propertyId) const;
-        template const Vector3&  MaterialFunctor::RuntimeContext::GetMaterialPropertyValue<Vector3>  (const Name& propertyId) const;
-        template const Vector4&  MaterialFunctor::RuntimeContext::GetMaterialPropertyValue<Vector4>  (const Name& propertyId) const;
-        template const Color&    MaterialFunctor::RuntimeContext::GetMaterialPropertyValue<Color>    (const Name& propertyId) const;
-        template const Data::Instance<Image>& MaterialFunctor::RuntimeContext::GetMaterialPropertyValue<Data::Instance<Image>>(const Name& propertyId) const;
+        template const bool&     MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<bool>     (const Name& propertyId) const;
+        template const int32_t&  MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<int32_t>  (const Name& propertyId) const;
+        template const uint32_t& MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<uint32_t> (const Name& propertyId) const;
+        template const float&    MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<float>    (const Name& propertyId) const;
+        template const Vector2&  MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<Vector2>  (const Name& propertyId) const;
+        template const Vector3&  MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<Vector3>  (const Name& propertyId) const;
+        template const Vector4&  MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<Vector4>  (const Name& propertyId) const;
+        template const Color&    MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<Color>    (const Name& propertyId) const;
+        template const Data::Instance<Image>& MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<Data::Instance<Image>>(const Name& propertyId) const;
 
         template<typename Type>
-        const Type& MaterialFunctor::RuntimeContext::GetMaterialPropertyValue(const Name& propertyId) const
+        const Type& MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue(const Name& propertyId) const
         {
             return GetMaterialPropertyValue(propertyId).GetValue<Type>();
         }
 
         // explicit template instantiation
-        template const bool&     MaterialFunctor::RuntimeContext::GetMaterialPropertyValue<bool>     (const MaterialPropertyIndex& index) const;
-        template const int32_t&  MaterialFunctor::RuntimeContext::GetMaterialPropertyValue<int32_t>  (const MaterialPropertyIndex& index) const;
-        template const uint32_t& MaterialFunctor::RuntimeContext::GetMaterialPropertyValue<uint32_t> (const MaterialPropertyIndex& index) const;
-        template const float&    MaterialFunctor::RuntimeContext::GetMaterialPropertyValue<float>    (const MaterialPropertyIndex& index) const;
-        template const Vector2&  MaterialFunctor::RuntimeContext::GetMaterialPropertyValue<Vector2>  (const MaterialPropertyIndex& index) const;
-        template const Vector3&  MaterialFunctor::RuntimeContext::GetMaterialPropertyValue<Vector3>  (const MaterialPropertyIndex& index) const;
-        template const Vector4&  MaterialFunctor::RuntimeContext::GetMaterialPropertyValue<Vector4>  (const MaterialPropertyIndex& index) const;
-        template const Color&    MaterialFunctor::RuntimeContext::GetMaterialPropertyValue<Color>    (const MaterialPropertyIndex& index) const;
-        template const Data::Instance<Image>& MaterialFunctor::RuntimeContext::GetMaterialPropertyValue<Data::Instance<Image>> (const MaterialPropertyIndex& index) const;
-
-        template<typename Type>
-        const Type& MaterialFunctor::EditorContext::GetMaterialPropertyValue(const MaterialPropertyIndex& index) const
-        {
-            return GetMaterialPropertyValue(index).GetValue<Type>();
-        }
-
-        // explicit template instantiation
-        template const bool&     MaterialFunctor::EditorContext::GetMaterialPropertyValue<bool>     (const Name& propertyId) const;
-        template const int32_t&  MaterialFunctor::EditorContext::GetMaterialPropertyValue<int32_t>  (const Name& propertyId) const;
-        template const uint32_t& MaterialFunctor::EditorContext::GetMaterialPropertyValue<uint32_t> (const Name& propertyId) const;
-        template const float&    MaterialFunctor::EditorContext::GetMaterialPropertyValue<float>    (const Name& propertyId) const;
-        template const Vector2&  MaterialFunctor::EditorContext::GetMaterialPropertyValue<Vector2>  (const Name& propertyId) const;
-        template const Vector3&  MaterialFunctor::EditorContext::GetMaterialPropertyValue<Vector3>  (const Name& propertyId) const;
-        template const Vector4&  MaterialFunctor::EditorContext::GetMaterialPropertyValue<Vector4>  (const Name& propertyId) const;
-        template const Color&    MaterialFunctor::EditorContext::GetMaterialPropertyValue<Color>    (const Name& propertyId) const;
-
-        template<typename Type>
-        const Type& MaterialFunctor::EditorContext::GetMaterialPropertyValue(const Name& propertyId) const
-        {
-            return GetMaterialPropertyValue(propertyId).GetValue<Type>();
-        }
-
-        // explicit template instantiation
-        template const bool&     MaterialFunctor::EditorContext::GetMaterialPropertyValue<bool>     (const MaterialPropertyIndex& index) const;
-        template const int32_t&  MaterialFunctor::EditorContext::GetMaterialPropertyValue<int32_t>  (const MaterialPropertyIndex& index) const;
-        template const uint32_t& MaterialFunctor::EditorContext::GetMaterialPropertyValue<uint32_t> (const MaterialPropertyIndex& index) const;
-        template const float&    MaterialFunctor::EditorContext::GetMaterialPropertyValue<float>    (const MaterialPropertyIndex& index) const;
-        template const Vector2&  MaterialFunctor::EditorContext::GetMaterialPropertyValue<Vector2>  (const MaterialPropertyIndex& index) const;
-        template const Vector3&  MaterialFunctor::EditorContext::GetMaterialPropertyValue<Vector3>  (const MaterialPropertyIndex& index) const;
-        template const Vector4&  MaterialFunctor::EditorContext::GetMaterialPropertyValue<Vector4>  (const MaterialPropertyIndex& index) const;
-        template const Color&    MaterialFunctor::EditorContext::GetMaterialPropertyValue<Color>    (const MaterialPropertyIndex& index) const;
-        template const Data::Instance<Image>& MaterialFunctor::EditorContext::GetMaterialPropertyValue<Data::Instance<Image>> (const MaterialPropertyIndex& index) const;
+        template const bool&     MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<bool>     (const MaterialPropertyIndex& index) const;
+        template const int32_t&  MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<int32_t>  (const MaterialPropertyIndex& index) const;
+        template const uint32_t& MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<uint32_t> (const MaterialPropertyIndex& index) const;
+        template const float&    MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<float>    (const MaterialPropertyIndex& index) const;
+        template const Vector2&  MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<Vector2>  (const MaterialPropertyIndex& index) const;
+        template const Vector3&  MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<Vector3>  (const MaterialPropertyIndex& index) const;
+        template const Vector4&  MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<Vector4>  (const MaterialPropertyIndex& index) const;
+        template const Color&    MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<Color>    (const MaterialPropertyIndex& index) const;
+        template const Data::Instance<Image>& MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue<Data::Instance<Image>> (const MaterialPropertyIndex& index) const;
 
         void CheckPropertyAccess([[maybe_unused]] const MaterialPropertyIndex& index, [[maybe_unused]] const MaterialPropertyFlags& materialPropertyDependencies, [[maybe_unused]] const MaterialPropertiesLayout& materialPropertiesLayout)
         {
@@ -437,40 +435,22 @@ namespace AZ
 #endif
         }
 
-        const MaterialPropertiesLayout* MaterialFunctor::RuntimeContext::GetMaterialPropertiesLayout() const
+        const MaterialPropertiesLayout* MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertiesLayout() const
         {
             return m_materialProperties.GetMaterialPropertiesLayout().get();
         }
 
-        const MaterialPropertyValue& MaterialFunctor::RuntimeContext::GetMaterialPropertyValue(const MaterialPropertyIndex& index) const
+        const MaterialPropertyValue& MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue(const MaterialPropertyIndex& index) const
         {
             CheckPropertyAccess(index, *m_materialPropertyDependencies, *GetMaterialPropertiesLayout());
 
             return m_materialProperties.GetPropertyValue(index);
         }
 
-        const MaterialPropertyValue& MaterialFunctor::RuntimeContext::GetMaterialPropertyValue(const Name& propertyId) const
+        const MaterialPropertyValue& MaterialFunctorAPI::ReadMaterialPropertyValues::GetMaterialPropertyValue(const Name& propertyId) const
         {
             MaterialPropertyIndex index = GetMaterialPropertiesLayout()->FindPropertyIndex(propertyId);
             return GetMaterialPropertyValue(index);
-        }
-
-        const MaterialPropertyValue& MaterialFunctor::EditorContext::GetMaterialPropertyValue(const MaterialPropertyIndex& index) const
-        {
-            CheckPropertyAccess(index, *m_materialPropertyDependencies, *GetMaterialPropertiesLayout());
-
-            return m_materialProperties.GetPropertyValue(index);
-        }
-
-        const MaterialPropertyValue& MaterialFunctor::EditorContext::GetMaterialPropertyValue(const Name& propertyId) const
-        {
-            MaterialPropertyIndex index = GetMaterialPropertiesLayout()->FindPropertyIndex(propertyId);
-            return GetMaterialPropertyValue(index);
-        }
-
-        const MaterialPropertiesLayout* MaterialFunctor::EditorContext::GetMaterialPropertiesLayout() const
-        {
-            return m_materialProperties.GetMaterialPropertiesLayout().get();
         }
 
         bool MaterialFunctor::NeedsProcess(const MaterialPropertyFlags& propertyDirtyFlags)
@@ -482,5 +462,6 @@ namespace AZ
         {
             return m_materialPropertyDependencies;
         }
+
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Tests/Material/LuaMaterialFunctorTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/LuaMaterialFunctorTests.cpp
@@ -756,7 +756,7 @@ namespace UnitTest
 
         Ptr<MaterialFunctor> functor = testData.GetMaterialTypeAsset()->GetMaterialFunctors()[0];
 
-        AZ::RPI::MaterialFunctor::EditorContext context = AZ::RPI::MaterialFunctor::EditorContext(
+        AZ::RPI::MaterialFunctorAPI::EditorContext context = AZ::RPI::MaterialFunctorAPI::EditorContext(
             testData.GetMaterial()->GetPropertyCollection(),
             propertyDynamicMetadata,
             propertyGroupDynamicMetadata,
@@ -824,7 +824,7 @@ namespace UnitTest
 
         Ptr<MaterialFunctor> functor = testData.GetMaterialTypeAsset()->GetMaterialFunctors()[0];
 
-        AZ::RPI::MaterialFunctor::EditorContext context = AZ::RPI::MaterialFunctor::EditorContext(
+        AZ::RPI::MaterialFunctorAPI::EditorContext context = AZ::RPI::MaterialFunctorAPI::EditorContext(
             testData.GetMaterial()->GetPropertyCollection(),
             propertyDynamicMetadata,
             propertyGroupDynamicMetadata,
@@ -889,7 +889,7 @@ namespace UnitTest
 
         Ptr<MaterialFunctor> functor = testData.GetMaterialTypeAsset()->GetMaterialFunctors()[0];
 
-        AZ::RPI::MaterialFunctor::EditorContext context = AZ::RPI::MaterialFunctor::EditorContext(
+        AZ::RPI::MaterialFunctorAPI::EditorContext context = AZ::RPI::MaterialFunctorAPI::EditorContext(
             testData.GetMaterial()->GetPropertyCollection(),
             propertyDynamicMetadata,
             propertyGroupDynamicMetadata,

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialFunctorTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialFunctorTests.cpp
@@ -43,7 +43,7 @@ namespace UnitTest
             }
 
             using MaterialFunctor::Process;
-            void Process(MaterialFunctor::RuntimeContext& context) override
+            void Process(MaterialFunctorAPI::RuntimeContext& context) override
             {
                 m_processResult = context.SetShaderOptionValue(m_shaderOptionName, m_shaderOptionValue);
             }
@@ -67,7 +67,7 @@ namespace UnitTest
             MOCK_METHOD0(ProcessCalled, void());
 
             using MaterialFunctor::Process;
-            void Process(RuntimeContext& context) override
+            void Process(MaterialFunctorAPI::RuntimeContext& context) override
             {
                 ProcessCalled();
 
@@ -164,12 +164,12 @@ namespace UnitTest
 
         {
             // Successfully set o_optionA
-            MaterialFunctor::RuntimeContext runtimeContext = MaterialFunctor::RuntimeContext{
+            MaterialFunctorAPI::RuntimeContext runtimeContext = MaterialFunctorAPI::RuntimeContext{
                 properties,
-                &shaderCollectionCopy,
+                & testFunctorSetOptionA.GetMaterialPropertyDependencies(),
+                AZ::RPI::MaterialPropertyPsoHandling::Allowed,
                 unusedSrg,
-                &testFunctorSetOptionA.GetMaterialPropertyDependencies(),
-                AZ::RPI::MaterialPropertyPsoHandling::Allowed
+                & shaderCollectionCopy
             };
             testFunctorSetOptionA.Process(runtimeContext);
             EXPECT_TRUE(testFunctorSetOptionA.GetProcessResult());
@@ -180,12 +180,12 @@ namespace UnitTest
 
         {
             // Successfully set o_optionB
-            MaterialFunctor::RuntimeContext runtimeContext = MaterialFunctor::RuntimeContext{
+            MaterialFunctorAPI::RuntimeContext runtimeContext = MaterialFunctorAPI::RuntimeContext{
                 properties,
-                &shaderCollectionCopy,
-                unusedSrg,
                 &testFunctorSetOptionB.GetMaterialPropertyDependencies(),
-                AZ::RPI::MaterialPropertyPsoHandling::Allowed
+                AZ::RPI::MaterialPropertyPsoHandling::Allowed,
+                unusedSrg,
+                &shaderCollectionCopy
             };
             testFunctorSetOptionB.Process(runtimeContext);
             EXPECT_TRUE(testFunctorSetOptionB.GetProcessResult());
@@ -197,12 +197,12 @@ namespace UnitTest
         {
             // Fail to set o_optionC because it is not owned by the material type
             AZ_TEST_START_TRACE_SUPPRESSION;
-            MaterialFunctor::RuntimeContext runtimeContext = MaterialFunctor::RuntimeContext{
+            MaterialFunctorAPI::RuntimeContext runtimeContext = MaterialFunctorAPI::RuntimeContext{
                 properties,
-                &shaderCollectionCopy,
-                unusedSrg,
                 &testFunctorSetOptionC.GetMaterialPropertyDependencies(),
-                AZ::RPI::MaterialPropertyPsoHandling::Allowed
+                AZ::RPI::MaterialPropertyPsoHandling::Allowed,
+                unusedSrg,
+                &shaderCollectionCopy
             };
             testFunctorSetOptionC.Process(runtimeContext);
             EXPECT_FALSE(testFunctorSetOptionC.GetProcessResult());
@@ -212,12 +212,12 @@ namespace UnitTest
         {
             // Fail to set option index that is out of range
             AZ_TEST_START_TRACE_SUPPRESSION;
-            MaterialFunctor::RuntimeContext runtimeContext = MaterialFunctor::RuntimeContext{
+            MaterialFunctorAPI::RuntimeContext runtimeContext = MaterialFunctorAPI::RuntimeContext{
                 properties,
-                &shaderCollectionCopy,
+                & testFunctorSetOptionInvalid.GetMaterialPropertyDependencies(),
+                AZ::RPI::MaterialPropertyPsoHandling::Allowed,
                 unusedSrg,
-                &testFunctorSetOptionInvalid.GetMaterialPropertyDependencies(),
-                AZ::RPI::MaterialPropertyPsoHandling::Allowed
+                &shaderCollectionCopy
             };
             testFunctorSetOptionInvalid.Process(runtimeContext);
             EXPECT_FALSE(testFunctorSetOptionInvalid.GetProcessResult());

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialTypeAssetTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialTypeAssetTests.cpp
@@ -50,7 +50,7 @@ namespace UnitTest
             }
 
             using AZ::RPI::MaterialFunctor::Process;
-            void Process(AZ::RPI::MaterialFunctor::RuntimeContext& context) override
+            void Process(AZ::RPI::MaterialFunctorAPI::RuntimeContext& context) override
             {
                 // This code isn't actually called in the unit test, but we include it here just to demonstrate what a real functor might look like.
                 float f = context.GetMaterialPropertyValue(m_floatIndex).GetValue<float>();
@@ -78,7 +78,7 @@ namespace UnitTest
             }
 
             using AZ::RPI::MaterialFunctor::Process;
-            void Process(AZ::RPI::MaterialFunctor::RuntimeContext& context) override
+            void Process(AZ::RPI::MaterialFunctorAPI::RuntimeContext& context) override
             {
                 // This code isn't actually called in the unit test, but we include it here just to demonstrate what a real functor might look like.
 

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialTypeSourceDataTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialTypeSourceDataTests.cpp
@@ -79,7 +79,7 @@ namespace UnitTest
             }
 
             using AZ::RPI::MaterialFunctor::Process;
-            void Process(AZ::RPI::MaterialFunctor::RuntimeContext& context) override
+            void Process(AZ::RPI::MaterialFunctorAPI::RuntimeContext& context) override
             {
                 // This code isn't actually called in the unit test, but we include it here just to demonstrate what a real functor might look like.
                 float f = context.GetMaterialPropertyValue(m_floatIndex).GetValue<float>();
@@ -149,7 +149,7 @@ namespace UnitTest
             }
 
             using AZ::RPI::MaterialFunctor::Process;
-            void Process(AZ::RPI::MaterialFunctor::RuntimeContext& context) override
+            void Process(AZ::RPI::MaterialFunctorAPI::RuntimeContext& context) override
             {
                 // This code isn't actually called in the unit test, but we include it here just to demonstrate what a real functor might look like.
 
@@ -213,7 +213,7 @@ namespace UnitTest
             }
 
             using AZ::RPI::MaterialFunctor::Process;
-            void Process(AZ::RPI::MaterialFunctor::RuntimeContext& context) override
+            void Process(AZ::RPI::MaterialFunctorAPI::RuntimeContext& context) override
             {
                 // This code isn't actually called in the unit test, but we include it here just to demonstrate what a real functor might look like.
                 context.SetShaderOptionValue(Name{"o_foo"}, ShaderOptionValue{1});
@@ -274,7 +274,7 @@ namespace UnitTest
             }
 
             using AZ::RPI::MaterialFunctor::Process;
-            void Process(AZ::RPI::MaterialFunctor::RuntimeContext&) override
+            void Process(AZ::RPI::MaterialFunctorAPI::RuntimeContext&) override
             {
                 // Intentionally empty, this is where the functor would do it's normal processing,
                 // but all this test functor does is store the MaterialNameContext.

--- a/Gems/Atom/RPI/Code/atom_rpi_edit_files.cmake
+++ b/Gems/Atom/RPI/Code/atom_rpi_edit_files.cmake
@@ -26,6 +26,7 @@ set(FILES
     Include/Atom/RPI.Edit/Material/MaterialPropertyValueSourceDataSerializer.h
     Include/Atom/RPI.Edit/Material/MaterialSourceData.h
     Include/Atom/RPI.Edit/Material/MaterialFunctorSourceData.h
+    Include/Atom/RPI.Edit/Material/MaterialFunctorSourceDataHolder.h
     Include/Atom/RPI.Edit/Material/MaterialFunctorSourceDataSerializer.h
     Include/Atom/RPI.Edit/Material/MaterialFunctorSourceDataRegistration.h
     Include/Atom/RPI.Edit/Material/MaterialPipelineSourceData.h
@@ -48,6 +49,7 @@ set(FILES
     Source/RPI.Edit/Material/MaterialPropertyValueSourceDataSerializer.cpp
     Source/RPI.Edit/Material/MaterialSourceData.cpp
     Source/RPI.Edit/Material/MaterialFunctorSourceData.cpp
+    Source/RPI.Edit/Material/MaterialFunctorSourceDataHolder.cpp
     Source/RPI.Edit/Material/MaterialFunctorSourceDataSerializer.cpp
     Source/RPI.Edit/Material/MaterialFunctorSourceDataRegistration.cpp
     Source/RPI.Edit/Material/MaterialPipelineSourceData.cpp

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
@@ -910,7 +910,7 @@ namespace MaterialEditor
             // which will later get caught in Process() when trying to access a property.
             if (materialPropertyDependencies.none() || functor->NeedsProcess(dirtyFlags))
             {
-                AZ::RPI::MaterialFunctor::EditorContext context = AZ::RPI::MaterialFunctor::EditorContext(
+                AZ::RPI::MaterialFunctorAPI::EditorContext context = AZ::RPI::MaterialFunctorAPI::EditorContext(
                     m_materialInstance->GetPropertyCollection(), propertyDynamicMetadata,
                     propertyGroupDynamicMetadata, updatedProperties, updatedPropertyGroups,
                     &materialPropertyDependencies);

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
@@ -587,7 +587,7 @@ namespace AZ
                     // which will later get caught in Process() when trying to access a property.
                     if (materialPropertyDependencies.none() || functor->NeedsProcess(m_dirtyPropertyFlags))
                     {
-                        AZ::RPI::MaterialFunctor::EditorContext context = AZ::RPI::MaterialFunctor::EditorContext(
+                        AZ::RPI::MaterialFunctorAPI::EditorContext context = AZ::RPI::MaterialFunctorAPI::EditorContext(
                             m_materialInstance->GetPropertyCollection(),
                             propertyDynamicMetadata,
                             propertyGroupDynamicMetadata,


### PR DESCRIPTION
## What does this PR do?

There are no behavioral changes here, only reogranizing code. These changes will prevent code duplication when I introduce material pipeline functors, and will make those changes easier to understand as well.

- Moved MaterialFunctorSourceDataHolder to its own file. This will eventually be used by MaterialPipelineSourceData in addition to MaterialTypeSourceData.
- Moved MaterialFunctor's execution "context" code out into a MaterialFunctorAPI namespace, so the MaterialFunctor class isn't so cluttered with nested classes. Similarly moved LuaMaterialFunctor code into a LuaMaterialFunctorAPI namespace.
- Split MaterialFunctor's execution "context" code into a couple extra base classes, for better sharing between RuntimeContext, EditorContext, and the eventual PipelineRuntimeContext. Similarly split LuaMaterialFunctor code into a couple extra base classes.
- I was able to factor out some duplicate BehaviorContext reflection code in LuaMaterialFunctor's context classes, using template functions.
- I happened to reorder the execution "context" class constructor parameters.

## How was this PR tested?

- Atom RPI unit tests
- Ran Material Editor, opened a couple materials, and flipped settings that are connected to material functors.
- AtomSampleViewer full test suite on vulkan

