### PR TITLE
EMFX: Fix the  time track widget mouse wheel event

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphStateTransition.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphStateTransition.cpp
@@ -1047,7 +1047,7 @@ namespace EMotionFX
             ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
             ->DataElement(AZ::Edit::UIHandlers::Default, &AnimGraphStateTransition::m_isDisabled, "Disabled", "Is disabled? If yes the transition will not be used by the state machine.")
             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AnimGraphStateTransition::SyncVisualObject)
-            ->DataElement(AZ::Edit::UIHandlers::Default, &AnimGraphStateTransition::m_priority, "Priority", "The priority level of the transition.")
+            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &AnimGraphStateTransition::m_priority, "Priority", "The priority level of the transition. Smaller values mean lower priority.")
             ->Attribute(AZ::Edit::Attributes::Min, 0)
             ->Attribute(AZ::Edit::Attributes::Max, std::numeric_limits<AZ::s32>::max())
             ->DataElement(AZ_CRC("TransitionStateFilterLocal", 0x7c4000ff), &AnimGraphStateTransition::m_allowTransitionsFrom, "Allow transitions from", "States and groups of states from which the wildcard transition can get activated.")

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackDataWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackDataWidget.cpp
@@ -1598,6 +1598,11 @@ namespace EMStudio
     // the mouse wheel is adjusted
     void TrackDataWidget::DoWheelEvent(QWheelEvent* event, TimeViewPlugin* plugin)
     {
+        if (m_dragging)
+        {
+            return;
+        }
+
         plugin->SetRedrawFlag();
 
         // Vertical
@@ -1608,27 +1613,6 @@ namespace EMStudio
 
             double zoomDelta = delta * 4 * MCore::Clamp(plugin->GetTimeScale() / 2.0, 1.0, 22.0);
             plugin->SetScale(plugin->GetTimeScale() + zoomDelta);
-        }
-
-        // Horizontal
-        {
-            const int numDegrees    = event->angleDelta().x() / 8;
-            const int numSteps      = numDegrees / 15;
-            float delta             = numSteps / 10.0f;
-
-            if (EMotionFX::GetRecorder().GetIsRecording() == false)
-            {
-                if (delta > 0)
-                {
-                    delta = 1;
-                }
-                else
-                {
-                    delta = -1;
-                }
-
-                plugin->DeltaScrollX(-delta * 600);
-            }
         }
     }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackDataWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackDataWidget.cpp
@@ -1598,7 +1598,7 @@ namespace EMStudio
     // the mouse wheel is adjusted
     void TrackDataWidget::DoWheelEvent(QWheelEvent* event, TimeViewPlugin* plugin)
     {
-        if (m_dragging)
+        if (m_isScrolling || m_dragging || m_resizing)
         {
             return;
         }

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackDataWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackDataWidget.h
@@ -43,9 +43,6 @@ namespace EMStudio
         TrackDataWidget(TimeViewPlugin* plugin, QWidget* parent = nullptr);
         ~TrackDataWidget();
 
-        static void DoWheelEvent(QWheelEvent* event, TimeViewPlugin* plugin);
-        static void DoMouseYMoveZoom(int32 deltaY, TimeViewPlugin* plugin);
-
         void initializeGL() override;
         void resizeGL(int w, int h) override;
         void paintGL() override;
@@ -96,6 +93,8 @@ namespace EMStudio
         void SetPausedTime(float timeValue, bool emitTimeChangeStart=false);
         void ClearState();
 
+        void DoWheelEvent(QWheelEvent* event, TimeViewPlugin* plugin);
+        void DoMouseYMoveZoom(int32 deltaY, TimeViewPlugin* plugin);
         void wheelEvent(QWheelEvent* event) override;
         void DoPaste(bool useLocation);
         void PaintRecorder(QPainter& painter, const QRect& rect);


### PR DESCRIPTION
## What does this PR do?

Fixed the wheelMouse event for time track widget.
Basically skip the wheel event when it is dragging/resizing. This avoid multiple mouse move event triggered at same time.

## How was this PR tested?

https://user-images.githubusercontent.com/69218254/206630767-399ccbe1-f7b0-4c87-bf01-5ad1ea0f9add.mp4

Fixes https://github.com/o3de/o3de/issues/13535


