### PR TITLE
Prefab | Remove link id in source template

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.cpp
@@ -610,7 +610,7 @@ namespace AzToolsFramework
             }
 
             PrefabDom storedPrefabDom(&loadedTemplateDom->get().GetAllocator());
-            if (!PrefabDomUtils::StoreInstanceInPrefabDom(loadedPrefabInstance, storedPrefabDom))
+            if (!PrefabDomUtils::StoreInstanceInPrefabDom(loadedPrefabInstance, storedPrefabDom, PrefabDomUtils::StoreFlags::StripLinkIds))
             {
                 return false;
             }


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

Fix https://github.com/o3de/o3de/issues/13434

```
[Warning] (Prefab) - Source template from link with id '4' shouldn't contains key 'LinkId'
```

The cause is described in the issue. This PR removes the invalid link id stored in source template DOM. The link id was created in prefab loader when the template is sanitized.

It is okay that we remove it as when comparing between source template DOM and linked instance DOM, we already make sure link id is removed.

## How was this PR tested?

Manually tested and the warning is gone. Passed all tests.