### PR TITLE
Math test matchers

### DIFF
--- a/Code/Framework/AzCore/Tests/Math/AabbTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/AabbTests.cpp
@@ -30,32 +30,32 @@ namespace UnitTest
         Aabb aabb = Aabb::CreateFromPoint(Vector3(0.0f));
         EXPECT_TRUE(aabb.IsValid());
         EXPECT_TRUE(aabb.IsFinite());
-        EXPECT_TRUE(aabb.GetMin().IsClose(aabb.GetMax()));
+        EXPECT_THAT(aabb.GetMin(), IsClose(aabb.GetMax()));
     }
 
     TEST(MATH_Aabb, TestCreateFromMinMax)
     {
         Aabb aabb = Aabb::CreateFromMinMax(Vector3(0.0f), Vector3(1.0f));
         EXPECT_TRUE(aabb.IsValid());
-        EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(0.0f)));
-        EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(1.0f)));
+        EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(0.0f)));
+        EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(1.0f)));
     }
 
     TEST(MATH_Aabb, TestCreateCenterHalfExtents)
     {
         Aabb aabb = Aabb::CreateCenterHalfExtents(Vector3(1.0f), Vector3(1.0f));
         EXPECT_TRUE(aabb.IsValid());
-        EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(0.0f)));
-        EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(2.0f)));
-        EXPECT_TRUE(aabb.GetCenter().IsClose(Vector3(1.0f)));
+        EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(0.0f)));
+        EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(2.0f)));
+        EXPECT_THAT(aabb.GetCenter(), IsClose(Vector3(1.0f)));
     }
 
     TEST(MATH_Aabb, TestCreateCenterRadius)
     {
         Aabb aabb = Aabb::CreateCenterRadius(Vector3(4.0f), 2.0f);
-        EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(2.0f)));
-        EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(6.0f)));
-        EXPECT_TRUE(aabb.GetExtents().IsClose(Vector3(4.0f)));
+        EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(2.0f)));
+        EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(6.0f)));
+        EXPECT_THAT(aabb.GetExtents(), IsClose(Vector3(4.0f)));
     }
 
     TEST(MATH_Aabb, TestCreatePoints)
@@ -68,8 +68,8 @@ namespace UnitTest
             Vector3(0.0f, -10.0f, 10.0f)
         };
         Aabb aabb = Aabb::CreatePoints(points, numPoints);
-        EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(-10.0f)));
-        EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(10.0f)));
+        EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(-10.0f)));
+        EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(10.0f)));
     }
 
     TEST(MATH_Aabb, TestCreatePointsSlice)
@@ -81,8 +81,8 @@ namespace UnitTest
             Vector3(0.0f, -10.0f, 10.0f)
         };
         Aabb aabb = Aabb::CreatePoints(points);
-        EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(-10.0f)));
-        EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(10.0f)));
+        EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(-10.0f)));
+        EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(10.0f)));
     }
 
     TEST(MATH_Aabb, TestCreatePointsEmpty)
@@ -105,48 +105,48 @@ namespace UnitTest
         const Vector3 halfLengths = Vector3::CreateOne();
         const Obb obb = Obb::CreateFromPositionRotationAndHalfLengths(position, rotation, halfLengths);
         Aabb aabb = Aabb::CreateFromObb(obb);
-        EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(-0.414f, -0.414f, 0.0f)));
-        EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(2.414f, 2.414f, 2.0f)));
-        EXPECT_TRUE(aabb.GetCenter().IsClose(Vector3(1.0f, 1.0f, 1.0f)));
+        EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(-0.414f, -0.414f, 0.0f)));
+        EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(2.414f, 2.414f, 2.0f)));
+        EXPECT_THAT(aabb.GetCenter(), IsClose(Vector3(1.0f, 1.0f, 1.0f)));
     }
 
     TEST(MATH_Aabb, TestSetters)
     {
         Aabb aabb = Aabb::CreateFromMinMax(Vector3(1.0f), Vector3(4.0f));
 
-        EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(1.0f)));
-        EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(4.0f)));
+        EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(1.0f)));
+        EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(4.0f)));
 
         aabb.SetMin(Vector3(0.0f));
-        EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(0.0f)));
-        EXPECT_TRUE(aabb.GetCenter().IsClose(Vector3(2.0f)));
+        EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(0.0f)));
+        EXPECT_THAT(aabb.GetCenter(), IsClose(Vector3(2.0f)));
 
         aabb.SetMax(Vector3(6.0f));
-        EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(6.0f)));
-        EXPECT_TRUE(aabb.GetCenter().IsClose(Vector3(3.0f)));
+        EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(6.0f)));
+        EXPECT_THAT(aabb.GetCenter(), IsClose(Vector3(3.0f)));
     }
 
     TEST(MATH_Aabb, TestGetExtents)
     {
         Aabb aabb = Aabb::CreateFromMinMax(Vector3(0.0f), Vector3(1.0f, 2.0f, 3.0f));
 
-        EXPECT_TRUE(AZ::IsClose(aabb.GetXExtent(), 1.0f));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetYExtent(), 2.0f));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetZExtent(), 3.0f));
+        EXPECT_NEAR(aabb.GetXExtent(), 1.0f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetYExtent(), 2.0f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetZExtent(), 3.0f, AZ::Constants::Tolerance);
     }
 
     TEST(MATH_Aabb, TestSupport)
     {
         Aabb aabb = Aabb::CreateFromMinMax(Vector3(0.0f), Vector3(1.0f));
 
-        EXPECT_TRUE(aabb.GetSupport(Vector3( 0.5774,  0.5774,  0.5774)).IsClose(Vector3(0.0f, 0.0f, 0.0f)));
-        EXPECT_TRUE(aabb.GetSupport(Vector3( 0.5774,  0.5774, -0.5774)).IsClose(Vector3(0.0f, 0.0f, 1.0f)));
-        EXPECT_TRUE(aabb.GetSupport(Vector3( 0.5774, -0.5774,  0.5774)).IsClose(Vector3(0.0f, 1.0f, 0.0f)));
-        EXPECT_TRUE(aabb.GetSupport(Vector3( 0.5774, -0.5774, -0.5774)).IsClose(Vector3(0.0f, 1.0f, 1.0f)));
-        EXPECT_TRUE(aabb.GetSupport(Vector3(-0.5774,  0.5774,  0.5774)).IsClose(Vector3(1.0f, 0.0f, 0.0f)));
-        EXPECT_TRUE(aabb.GetSupport(Vector3(-0.5774,  0.5774, -0.5774)).IsClose(Vector3(1.0f, 0.0f, 1.0f)));
-        EXPECT_TRUE(aabb.GetSupport(Vector3(-0.5774, -0.5774,  0.5774)).IsClose(Vector3(1.0f, 1.0f, 0.0f)));
-        EXPECT_TRUE(aabb.GetSupport(Vector3(-0.5774, -0.5774, -0.5774)).IsClose(Vector3(1.0f, 1.0f, 1.0f)));
+        EXPECT_THAT(aabb.GetSupport(Vector3( 0.5774,  0.5774,  0.5774)), IsClose(Vector3(0.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(aabb.GetSupport(Vector3( 0.5774,  0.5774, -0.5774)), IsClose(Vector3(0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(aabb.GetSupport(Vector3( 0.5774, -0.5774,  0.5774)), IsClose(Vector3(0.0f, 1.0f, 0.0f)));
+        EXPECT_THAT(aabb.GetSupport(Vector3( 0.5774, -0.5774, -0.5774)), IsClose(Vector3(0.0f, 1.0f, 1.0f)));
+        EXPECT_THAT(aabb.GetSupport(Vector3(-0.5774,  0.5774,  0.5774)), IsClose(Vector3(1.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(aabb.GetSupport(Vector3(-0.5774,  0.5774, -0.5774)), IsClose(Vector3(1.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(aabb.GetSupport(Vector3(-0.5774, -0.5774,  0.5774)), IsClose(Vector3(1.0f, 1.0f, 0.0f)));
+        EXPECT_THAT(aabb.GetSupport(Vector3(-0.5774, -0.5774, -0.5774)), IsClose(Vector3(1.0f, 1.0f, 1.0f)));
     }
 
     TEST(MATH_Aabb, TestGetAsSphere)
@@ -156,8 +156,8 @@ namespace UnitTest
         Vector3 center;
         float radius;
         aabb.GetAsSphere(center, radius);
-        EXPECT_TRUE(center.IsClose(Vector3(0.0f)));
-        EXPECT_TRUE(AZ::IsClose(radius, 2.0f));
+        EXPECT_THAT(center, IsClose(Vector3(0.0f)));
+        EXPECT_NEAR(radius, 2.0f, AZ::Constants::Tolerance);
     }
 
     TEST(MATH_Aabb, TestContains)
@@ -203,9 +203,9 @@ namespace UnitTest
         Aabb aabb = Aabb::CreateFromMinMax(Vector3(0.0f), Vector3(2.0f));
 
         aabb.Expand(Vector3(1.0f));
-        EXPECT_TRUE(aabb.GetCenter().IsClose(Vector3(1.0f)));
-        EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(-1.0f)));
-        EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(3.0f)));
+        EXPECT_THAT(aabb.GetCenter(), IsClose(Vector3(1.0f)));
+        EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(-1.0f)));
+        EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(3.0f)));
     }
 
     TEST(MATH_Aabb, TestGetExpanded)
@@ -213,8 +213,8 @@ namespace UnitTest
         Aabb aabb = Aabb::CreateFromMinMax(Vector3(-1.0f), Vector3(1.0f));
 
         aabb = aabb.GetExpanded(Vector3(9.0f));
-        EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(-10.0f)));
-        EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(10.0f)));
+        EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(-10.0f)));
+        EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(10.0f)));
     }
 
     TEST(MATH_Aabb, TestAddPoint)
@@ -222,11 +222,11 @@ namespace UnitTest
         Aabb aabb = Aabb::CreateFromMinMax(Vector3(-1.0f), Vector3(1.0f));
 
         aabb.AddPoint(Vector3(1.0f));
-        EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(-1.0f)));
-        EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(1.0f)));
+        EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(-1.0f)));
+        EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(1.0f)));
         aabb.AddPoint(Vector3(2.0f));
-        EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(-1.0f)));
-        EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(2.0f)));
+        EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(-1.0f)));
+        EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(2.0f)));
     }
 
     TEST(MATH_Aabb, TestAddAabb)
@@ -235,26 +235,26 @@ namespace UnitTest
         Aabb aabb2 = Aabb::CreateFromMinMax(Vector3(-2.0f), Vector3(0.0f));
 
         aabb.AddAabb(aabb2);
-        EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(-2.0f)));
-        EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(2.0f)));
+        EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(-2.0f)));
+        EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(2.0f)));
     }
 
     TEST(MATH_Aabb, TestGetDistance)
     {
         Aabb aabb = Aabb::CreateFromMinMax(Vector3(-1.0f), Vector3(1.0f));
 
-        EXPECT_TRUE(AZ::IsClose(aabb.GetDistance(Vector3(2.0f, 0.0f, 0.0f)), 1.0f));
+        EXPECT_NEAR(aabb.GetDistance(Vector3(2.0f, 0.0f, 0.0f)), 1.0f, AZ::Constants::Tolerance);
         // make sure a point inside the box returns zero, even if that point isn't the center.
-        EXPECT_TRUE(AZ::IsClose(aabb.GetDistance(Vector3(0.5f, 0.0f, 0.0f)), 0.0f));
+        EXPECT_NEAR(aabb.GetDistance(Vector3(0.5f, 0.0f, 0.0f)), 0.0f, AZ::Constants::Tolerance);
     }
 
     TEST(MATH_Aabb, TestGetDistanceSq)
     {
         Aabb aabb = Aabb::CreateFromMinMax(Vector3(-1.0f), Vector3(1.0f));
 
-        EXPECT_TRUE(AZ::IsClose(aabb.GetDistanceSq(Vector3(0.0f, 3.0f, 0.0f)), 4.0f));
+        EXPECT_NEAR(aabb.GetDistanceSq(Vector3(0.0f, 3.0f, 0.0f)), 4.0f, AZ::Constants::Tolerance);
         // make sure a point inside the box returns zero, even if that point isn't the center.
-        EXPECT_TRUE(AZ::IsClose(aabb.GetDistanceSq(Vector3(0.0f, 0.5f, 0.0f)), 0.0f));
+        EXPECT_NEAR(aabb.GetDistanceSq(Vector3(0.0f, 0.5f, 0.0f)), 0.0f, AZ::Constants::Tolerance);
     }
 
     TEST(MATH_Aabb, TestGetMaxDistance)
@@ -262,25 +262,25 @@ namespace UnitTest
         Aabb aabb = Aabb::CreateFromMinMax(Vector3(-1.0f), Vector3(1.0f));
 
         // The max distance for all of the following should be the square root of (4^2 + 3^2 + 2^2)
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistance(Vector3(3.0f, 2.0f, 1.0f)), sqrtf(16.0f + 9.0f + 4.0f)));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistance(Vector3(3.0f, 2.0f, -1.0f)), sqrtf(16.0f + 9.0f + 4.0f)));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistance(Vector3(3.0f, -2.0f, 1.0f)), sqrtf(16.0f + 9.0f + 4.0f)));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistance(Vector3(3.0f, -2.0f, -1.0f)), sqrtf(16.0f + 9.0f + 4.0f)));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistance(Vector3(-3.0f, 2.0f, 1.0f)), sqrtf(16.0f + 9.0f + 4.0f)));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistance(Vector3(-3.0f, 2.0f, -1.0f)), sqrtf(16.0f + 9.0f + 4.0f)));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistance(Vector3(-3.0f, -2.0f, 1.0f)), sqrtf(16.0f + 9.0f + 4.0f)));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistance(Vector3(-3.0f, -2.0f, -1.0f)), sqrtf(16.0f + 9.0f + 4.0f)));
+        EXPECT_NEAR(aabb.GetMaxDistance(Vector3(3.0f, 2.0f, 1.0f)), sqrtf(16.0f + 9.0f + 4.0f), AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistance(Vector3(3.0f, 2.0f, -1.0f)), sqrtf(16.0f + 9.0f + 4.0f), AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistance(Vector3(3.0f, -2.0f, 1.0f)), sqrtf(16.0f + 9.0f + 4.0f), AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistance(Vector3(3.0f, -2.0f, -1.0f)), sqrtf(16.0f + 9.0f + 4.0f), AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistance(Vector3(-3.0f, 2.0f, 1.0f)), sqrtf(16.0f + 9.0f + 4.0f), AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistance(Vector3(-3.0f, 2.0f, -1.0f)), sqrtf(16.0f + 9.0f + 4.0f), AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistance(Vector3(-3.0f, -2.0f, 1.0f)), sqrtf(16.0f + 9.0f + 4.0f), AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistance(Vector3(-3.0f, -2.0f, -1.0f)), sqrtf(16.0f + 9.0f + 4.0f), AZ::Constants::Tolerance);
         // make sure points inside the box return a correct max distance as well - sqrt of (1.5^2 + 1.5^2 + 1.5^2)
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistance(Vector3(0.5f, 0.5f, 0.5f)), sqrtf(2.25f + 2.25f + 2.25f)));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistance(Vector3(0.5f, 0.5f, -0.5f)), sqrtf(2.25f + 2.25f + 2.25f)));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistance(Vector3(0.5f, -0.5f, 0.5f)), sqrtf(2.25f + 2.25f + 2.25f)));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistance(Vector3(0.5f, -0.5f, -0.5f)), sqrtf(2.25f + 2.25f + 2.25f)));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistance(Vector3(-0.5f, 0.5f, 0.5f)), sqrtf(2.25f + 2.25f + 2.25f)));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistance(Vector3(-0.5f, 0.5f, -0.5f)), sqrtf(2.25f + 2.25f + 2.25f)));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistance(Vector3(-0.5f, -0.5f, 0.5f)), sqrtf(2.25f + 2.25f + 2.25f)));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistance(Vector3(-0.5f, -0.5f, -0.5f)), sqrtf(2.25f + 2.25f + 2.25f)));
+        EXPECT_NEAR(aabb.GetMaxDistance(Vector3(0.5f, 0.5f, 0.5f)), sqrtf(2.25f + 2.25f + 2.25f), AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistance(Vector3(0.5f, 0.5f, -0.5f)), sqrtf(2.25f + 2.25f + 2.25f), AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistance(Vector3(0.5f, -0.5f, 0.5f)), sqrtf(2.25f + 2.25f + 2.25f), AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistance(Vector3(0.5f, -0.5f, -0.5f)), sqrtf(2.25f + 2.25f + 2.25f), AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistance(Vector3(-0.5f, 0.5f, 0.5f)), sqrtf(2.25f + 2.25f + 2.25f), AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistance(Vector3(-0.5f, 0.5f, -0.5f)), sqrtf(2.25f + 2.25f + 2.25f), AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistance(Vector3(-0.5f, -0.5f, 0.5f)), sqrtf(2.25f + 2.25f + 2.25f), AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistance(Vector3(-0.5f, -0.5f, -0.5f)), sqrtf(2.25f + 2.25f + 2.25f), AZ::Constants::Tolerance);
         // make sure the center returns our minimal max distance (1^2 + 1^2 + 1^2)
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistance(Vector3(0.0f, 0.0f, 0.0f)), sqrtf(1.0f + 1.0f + 1.0f)));
+        EXPECT_NEAR(aabb.GetMaxDistance(Vector3(0.0f, 0.0f, 0.0f)), sqrtf(1.0f + 1.0f + 1.0f), AZ::Constants::Tolerance);
     }
 
     TEST(MATH_Aabb, TestGetMaxDistanceSq)
@@ -288,25 +288,25 @@ namespace UnitTest
         Aabb aabb = Aabb::CreateFromMinMax(Vector3(-1.0f), Vector3(1.0f));
 
         // The max distance for all of the following should be (4^2 + 3^2 + 2^2)
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistanceSq(Vector3(3.0f, 2.0f, 1.0f)), 16.0f + 9.0f + 4.0f));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistanceSq(Vector3(3.0f, 2.0f, -1.0f)), 16.0f + 9.0f + 4.0f));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistanceSq(Vector3(3.0f, -2.0f, 1.0f)), 16.0f + 9.0f + 4.0f));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistanceSq(Vector3(3.0f, -2.0f, -1.0f)), 16.0f + 9.0f + 4.0f));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistanceSq(Vector3(-3.0f, 2.0f, 1.0f)), 16.0f + 9.0f + 4.0f));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistanceSq(Vector3(-3.0f, 2.0f, -1.0f)), 16.0f + 9.0f + 4.0f));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistanceSq(Vector3(-3.0f, -2.0f, 1.0f)), 16.0f + 9.0f + 4.0f));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistanceSq(Vector3(-3.0f, -2.0f, -1.0f)), 16.0f + 9.0f + 4.0f));
+        EXPECT_NEAR(aabb.GetMaxDistanceSq(Vector3(3.0f, 2.0f, 1.0f)), 16.0f + 9.0f + 4.0f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistanceSq(Vector3(3.0f, 2.0f, -1.0f)), 16.0f + 9.0f + 4.0f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistanceSq(Vector3(3.0f, -2.0f, 1.0f)), 16.0f + 9.0f + 4.0f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistanceSq(Vector3(3.0f, -2.0f, -1.0f)), 16.0f + 9.0f + 4.0f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistanceSq(Vector3(-3.0f, 2.0f, 1.0f)), 16.0f + 9.0f + 4.0f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistanceSq(Vector3(-3.0f, 2.0f, -1.0f)), 16.0f + 9.0f + 4.0f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistanceSq(Vector3(-3.0f, -2.0f, 1.0f)), 16.0f + 9.0f + 4.0f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistanceSq(Vector3(-3.0f, -2.0f, -1.0f)), 16.0f + 9.0f + 4.0f, AZ::Constants::Tolerance);
         // make sure points inside the box return a correct max distance as well: (1.5^2 + 1.5^2 + 1.5^2)
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistanceSq(Vector3(0.5f, 0.5f, 0.5f)), 2.25f + 2.25f + 2.25f));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistanceSq(Vector3(0.5f, 0.5f, -0.5f)), 2.25f + 2.25f + 2.25f));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistanceSq(Vector3(0.5f, -0.5f, 0.5f)), 2.25f + 2.25f + 2.25f));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistanceSq(Vector3(0.5f, -0.5f, -0.5f)), 2.25f + 2.25f + 2.25f));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistanceSq(Vector3(-0.5f, 0.5f, 0.5f)), 2.25f + 2.25f + 2.25f));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistanceSq(Vector3(-0.5f, 0.5f, -0.5f)), 2.25f + 2.25f + 2.25f));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistanceSq(Vector3(-0.5f, -0.5f, 0.5f)), 2.25f + 2.25f + 2.25f));
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistanceSq(Vector3(-0.5f, -0.5f, -0.5f)), 2.25f + 2.25f + 2.25f));
+        EXPECT_NEAR(aabb.GetMaxDistanceSq(Vector3(0.5f, 0.5f, 0.5f)), 2.25f + 2.25f + 2.25f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistanceSq(Vector3(0.5f, 0.5f, -0.5f)), 2.25f + 2.25f + 2.25f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistanceSq(Vector3(0.5f, -0.5f, 0.5f)), 2.25f + 2.25f + 2.25f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistanceSq(Vector3(0.5f, -0.5f, -0.5f)), 2.25f + 2.25f + 2.25f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistanceSq(Vector3(-0.5f, 0.5f, 0.5f)), 2.25f + 2.25f + 2.25f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistanceSq(Vector3(-0.5f, 0.5f, -0.5f)), 2.25f + 2.25f + 2.25f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistanceSq(Vector3(-0.5f, -0.5f, 0.5f)), 2.25f + 2.25f + 2.25f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(aabb.GetMaxDistanceSq(Vector3(-0.5f, -0.5f, -0.5f)), 2.25f + 2.25f + 2.25f, AZ::Constants::Tolerance);
         // make sure the center returns our minimal max distance (1^2 + 1^2 + 1^2)
-        EXPECT_TRUE(AZ::IsClose(aabb.GetMaxDistanceSq(Vector3(0.0f, 0.0f, 0.0f)), 1.0f + 1.0f + 1.0f));
+        EXPECT_NEAR(aabb.GetMaxDistanceSq(Vector3(0.0f, 0.0f, 0.0f)), 1.0f + 1.0f + 1.0f, AZ::Constants::Tolerance);
     }
 
     TEST(MATH_Aabb, TestGetClamped)
@@ -315,8 +315,8 @@ namespace UnitTest
         Aabb aabb2 = Aabb::CreateFromMinMax(Vector3(1.0f), Vector3(4.0f));
 
         aabb = aabb.GetClamped(aabb2);
-        EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(1.0f)));
-        EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(2.0f)));
+        EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(1.0f)));
+        EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(2.0f)));
     }
 
     TEST(MATH_Aabb, TestClamp)
@@ -325,8 +325,8 @@ namespace UnitTest
         Aabb aabb2 = Aabb::CreateFromMinMax(Vector3(-2.0f), Vector3(1.0f));
 
         aabb.Clamp(aabb2);
-        EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(0.0f)));
-        EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(1.0f)));
+        EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(0.0f)));
+        EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(1.0f)));
     }
 
     TEST(MATH_Aabb, TestSetNull)
@@ -342,8 +342,8 @@ namespace UnitTest
         Aabb aabb = Aabb::CreateFromMinMax(Vector3(-1.0f), Vector3(1.0f));
 
         aabb.Translate(Vector3(2.0f));
-        EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(1.0f)));
-        EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(3.0f)));
+        EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(1.0f)));
+        EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(3.0f)));
     }
 
     TEST(MATH_Aabb, TestGetTranslated)
@@ -351,8 +351,8 @@ namespace UnitTest
         Aabb aabb = Aabb::CreateFromMinMax(Vector3(1.0f), Vector3(3.0f));
 
         aabb = aabb.GetTranslated(Vector3(-2.0f));
-        EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(-1.0f)));
-        EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(1.0f)));
+        EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(-1.0f)));
+        EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(1.0f)));
     }
 
     TEST(MATH_Aabb, TestGetSurfaceArea)
@@ -404,10 +404,10 @@ namespace UnitTest
         aabb.ApplyTransform(tm);
 
         // compare the transformations
-        EXPECT_TRUE(transAabb.GetMin().IsClose(transAabb2.GetMin()));
-        EXPECT_TRUE(transAabb.GetMax().IsClose(transAabb2.GetMax()));
-        EXPECT_TRUE(aabb.GetMin().IsClose(transAabb.GetMin()));
-        EXPECT_TRUE(aabb.GetMax().IsClose(transAabb.GetMax()));
+        EXPECT_THAT(transAabb.GetMin(), IsClose(transAabb2.GetMin()));
+        EXPECT_THAT(transAabb.GetMax(), IsClose(transAabb2.GetMax()));
+        EXPECT_THAT(aabb.GetMin(), IsClose(transAabb.GetMin()));
+        EXPECT_THAT(aabb.GetMax(), IsClose(transAabb.GetMax()));
     }
 
     TEST(MATH_AabbTransform, GetTransformedAabbCorrectResult)

--- a/Code/Framework/AzCore/Tests/Math/CapsuleTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/CapsuleTests.cpp
@@ -57,7 +57,7 @@ namespace UnitTest
         const float radius = 2.0f;
         AZ::Capsule capsuleA(firstHemisphereCenter, secondHemisphereCenter, radius);
         AZ::Capsule capsuleB(firstHemisphereCenter, secondHemisphereCenter, radius);
-        EXPECT_TRUE(capsuleA.IsClose(capsuleB));
+        EXPECT_THAT(capsuleA, IsClose(capsuleB));
     }
 
     TEST(MATH_Capsule, IsCloseReversedEnds)
@@ -67,7 +67,7 @@ namespace UnitTest
         const float radius = 2.0f;
         AZ::Capsule capsuleA(firstHemisphereCenter, secondHemisphereCenter, radius);
         AZ::Capsule capsuleB(secondHemisphereCenter, firstHemisphereCenter, radius);
-        EXPECT_TRUE(capsuleA.IsClose(capsuleB));
+        EXPECT_THAT(capsuleA, IsClose(capsuleB));
     }
 
     TEST(MATH_Capsule, IsCloseDifferentRadius)
@@ -78,7 +78,7 @@ namespace UnitTest
         const float radiusB = 1.5f;
         AZ::Capsule capsuleA(firstHemisphereCenter, secondHemisphereCenter, radiusA);
         AZ::Capsule capsuleB(firstHemisphereCenter, secondHemisphereCenter, radiusB);
-        EXPECT_FALSE(capsuleA.IsClose(capsuleB));
+        EXPECT_THAT(capsuleA, testing::Not(IsClose(capsuleB)));
     }
 
     TEST(MATH_Capsule, IsCloseDifferentCenter)
@@ -113,6 +113,6 @@ namespace UnitTest
         const float radius = 2.0f;
         const AZ::Capsule capsuleFromLineSegment(lineSegment, radius);
         const AZ::Capsule capsule(start, end, radius);
-        EXPECT_TRUE(capsuleFromLineSegment.IsClose(capsule));
+        EXPECT_THAT(capsuleFromLineSegment, IsClose(capsule));
     }
 } // namespace UnitTest

--- a/Code/Framework/AzCore/Tests/Math/CapsuleTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/CapsuleTests.cpp
@@ -57,7 +57,7 @@ namespace UnitTest
         const float radius = 2.0f;
         AZ::Capsule capsuleA(firstHemisphereCenter, secondHemisphereCenter, radius);
         AZ::Capsule capsuleB(firstHemisphereCenter, secondHemisphereCenter, radius);
-        EXPECT_THAT(capsuleA, IsClose(capsuleB));
+        EXPECT_TRUE(capsuleA.IsClose(capsuleB));
     }
 
     TEST(MATH_Capsule, IsCloseReversedEnds)
@@ -67,7 +67,7 @@ namespace UnitTest
         const float radius = 2.0f;
         AZ::Capsule capsuleA(firstHemisphereCenter, secondHemisphereCenter, radius);
         AZ::Capsule capsuleB(secondHemisphereCenter, firstHemisphereCenter, radius);
-        EXPECT_THAT(capsuleA, IsClose(capsuleB));
+        EXPECT_TRUE(capsuleA.IsClose(capsuleB));
     }
 
     TEST(MATH_Capsule, IsCloseDifferentRadius)
@@ -78,7 +78,7 @@ namespace UnitTest
         const float radiusB = 1.5f;
         AZ::Capsule capsuleA(firstHemisphereCenter, secondHemisphereCenter, radiusA);
         AZ::Capsule capsuleB(firstHemisphereCenter, secondHemisphereCenter, radiusB);
-        EXPECT_THAT(capsuleA, testing::Not(IsClose(capsuleB)));
+        EXPECT_FALSE(capsuleA.IsClose(capsuleB));
     }
 
     TEST(MATH_Capsule, IsCloseDifferentCenter)

--- a/Code/Framework/AzCore/Tests/Math/ColorTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/ColorTests.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Vector4.h>
 #include <AzCore/UnitTest/TestTypes.h>
+#include <AZTestShared/Math/MathTestHelpers.h>
 
 using namespace AZ;
 
@@ -25,15 +26,15 @@ namespace UnitTest
         // Vector4 constructor
         const Vector4 vectorColor(0.5f, 0.6f, 0.7f, 1.0f);
         const Color colorFromVector(vectorColor);
-        EXPECT_TRUE(colorFromVector.GetAsVector4().IsClose(vectorColor));
+        EXPECT_THAT(colorFromVector.GetAsVector4(), IsClose(vectorColor));
 
         // Single float constructor
         const Color colorFromFloat(1.0f);
-        EXPECT_TRUE(colorFromFloat.GetAsVector4().IsClose(Vector4(1.0f, 1.0f, 1.0f, 1.0f)));
+        EXPECT_THAT(colorFromFloat.GetAsVector4(), IsClose(Vector4(1.0f, 1.0f, 1.0f, 1.0f)));
 
         // Four individual floats constructor
         const Color colorFromFloats(0.5f, 0.6f, 0.7f, 1.0f);
-        EXPECT_TRUE(colorFromFloats.GetAsVector4().IsClose(vectorColor));
+        EXPECT_THAT(colorFromFloats.GetAsVector4(), IsClose(vectorColor));
 
         // Four individual uint8s constructor
         const Color colorFronUints((u8)0x7F, (u8)0x9F, (u8)0xBF, (u8)0xFF);
@@ -44,25 +45,25 @@ namespace UnitTest
     {
         // Zero color
         const Color colorZero = Color::CreateZero();
-        EXPECT_TRUE(colorZero.GetAsVector4().IsClose(Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(colorZero.GetAsVector4(), IsClose(Vector4(0.0f, 0.0f, 0.0f, 0.0f)));
 
         // OneColor
         const Color colorOne = Color::CreateOne();
-        EXPECT_TRUE(colorOne.GetAsVector4().IsClose(Vector4(1.0f, 1.0f, 1.0f, 1.0f)));
+        EXPECT_THAT(colorOne.GetAsVector4(), IsClose(Vector4(1.0f, 1.0f, 1.0f, 1.0f)));
 
         // From Float4
         const float float4Color[4] = { 0.3f, 0.4f, 0.5f, 0.8f };
         const Color colorFrom4Floats = Color::CreateFromFloat4(float4Color);
-        EXPECT_TRUE(colorFrom4Floats.GetAsVector4().IsClose(Vector4(0.3f, 0.4f, 0.5f, 0.8f)));
+        EXPECT_THAT(colorFrom4Floats.GetAsVector4(), IsClose(Vector4(0.3f, 0.4f, 0.5f, 0.8f)));
 
         // From Vector3
         const Vector3 vector3Color(0.6f, 0.7f, 0.8f);
         const Color colorFromVector3 = Color::CreateFromVector3(vector3Color);
-        EXPECT_TRUE(colorFromVector3.GetAsVector4().IsClose(Vector4(0.6f, 0.7f, 0.8f, 1.0f)));
+        EXPECT_THAT(colorFromVector3.GetAsVector4(), IsClose(Vector4(0.6f, 0.7f, 0.8f, 1.0f)));
 
         // From Vector 3 and float
         const Color colorFromVector3AndFloat = Color::CreateFromVector3AndFloat(vector3Color, 0.5f);
-        EXPECT_TRUE(colorFromVector3AndFloat.GetAsVector4().IsClose(Vector4(0.6f, 0.7f, 0.8f, 0.5f)));
+        EXPECT_THAT(colorFromVector3AndFloat.GetAsVector4(), IsClose(Vector4(0.6f, 0.7f, 0.8f, 0.5f)));
     }
 
     TEST(MATH_Color, Store)
@@ -122,20 +123,20 @@ namespace UnitTest
     {
         // Vector3 getter
         const Color vectorColor = Color(0.3f, 0.4f, 0.5f, 0.7f);
-        EXPECT_TRUE(vectorColor.GetAsVector3().IsClose(Vector3(0.3f, 0.4f, 0.5f)));
+        EXPECT_THAT(vectorColor.GetAsVector3(), IsClose(Vector3(0.3f, 0.4f, 0.5f)));
 
         // Vector 4 getter
-        EXPECT_TRUE(vectorColor.GetAsVector4().IsClose(Vector4(0.3f, 0.4f, 0.5f, 0.7f)));
+        EXPECT_THAT(vectorColor.GetAsVector4(), IsClose(Vector4(0.3f, 0.4f, 0.5f, 0.7f)));
 
         // Set from single float
         Color singleValue;
         singleValue.Set(0.75f);
-        EXPECT_TRUE(singleValue.GetAsVector4().IsClose(Vector4(0.75f, 0.75f, 0.75f, 0.75f)));
+        EXPECT_THAT(singleValue.GetAsVector4(), IsClose(Vector4(0.75f, 0.75f, 0.75f, 0.75f)));
 
         // Set from 4 floats
         Color separateValues;
         separateValues.Set(0.23f, 0.45f, 0.67f, 0.89f);
-        EXPECT_TRUE(separateValues.GetAsVector4().IsClose(Vector4(0.23f, 0.45f, 0.67f, 0.89f)));
+        EXPECT_THAT(separateValues.GetAsVector4(), IsClose(Vector4(0.23f, 0.45f, 0.67f, 0.89f)));
 
         // Set from a float[4]
         float floatArray[4] = { 0.87f, 0.65f, 0.43f, 0.21f };
@@ -146,12 +147,12 @@ namespace UnitTest
         // Set from Vector3, Alpha should be set to 1.0f
         Color vector3Color;
         vector3Color.Set(Vector3(0.2f, 0.4f, 0.6f));
-        EXPECT_TRUE(vector3Color.GetAsVector4().IsClose(Vector4(0.2f, 0.4f, 0.6f, 1.0f)));
+        EXPECT_THAT(vector3Color.GetAsVector4(), IsClose(Vector4(0.2f, 0.4f, 0.6f, 1.0f)));
 
         // Set from Vector3 +_ alpha
         Color vector4Color;
         vector4Color.Set(Vector3(0.1f, 0.3f, 0.5f), 0.7f);
-        EXPECT_TRUE(vector4Color.GetAsVector4().IsClose(Vector4(0.1f, 0.3f, 0.5f, 0.7f)));
+        EXPECT_THAT(vector4Color.GetAsVector4(), IsClose(Vector4(0.1f, 0.3f, 0.5f, 0.7f)));
 
         // Oddly lacking a Set() from Vector4...
     }
@@ -162,75 +163,75 @@ namespace UnitTest
 
         // Check first sexant (0-60 degrees) with 0 hue, full saturation and value = red.
         fromHSV.SetFromHSVRadians(0.0f, 1.0f, 1.0f);
-        EXPECT_TRUE(fromHSV.IsClose(Color(1.0f, 0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(fromHSV, IsClose(Color(1.0f, 0.0f, 0.0f, 1.0f)));
 
         // Check the second sexant (60-120 degrees)
         fromHSV.SetFromHSVRadians(AZ::DegToRad(72.0f), 1.0f, 1.0f);
-        EXPECT_TRUE(fromHSV.IsClose(Color(0.8f, 1.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(fromHSV, IsClose(Color(0.8f, 1.0f, 0.0f, 1.0f)));
 
         // Check the third sexant (120-180 degrees)
         fromHSV.SetFromHSVRadians(AZ::DegToRad(144.0f), 1.0f, 1.0f);
-        EXPECT_TRUE(fromHSV.IsClose(Color(0.0f, 1.0f, 0.4f, 1.0f)));
+        EXPECT_THAT(fromHSV, IsClose(Color(0.0f, 1.0f, 0.4f, 1.0f)));
 
         // Check the fourth sexant (180-240 degrees)
         fromHSV.SetFromHSVRadians(AZ::DegToRad(216.0f), 1.0f, 1.0f);
-        EXPECT_TRUE(fromHSV.IsClose(Color(0.0f, 0.4f, 1.0f, 1.0f)));
+        EXPECT_THAT(fromHSV, IsClose(Color(0.0f, 0.4f, 1.0f, 1.0f)));
 
         // Check the fifth sexant (240-300 degrees)
         fromHSV.SetFromHSVRadians(AZ::DegToRad(252.0f), 1.0f, 1.0f);
-        EXPECT_TRUE(fromHSV.IsClose(Color(0.2f, 0.0f, 1.0f, 1.0f)));
+        EXPECT_THAT(fromHSV, IsClose(Color(0.2f, 0.0f, 1.0f, 1.0f)));
 
         // Check the sixth sexant (300-360 degrees)
         fromHSV.SetFromHSVRadians(AZ::DegToRad(324.0f), 1.0f, 1.0f);
-        EXPECT_TRUE(fromHSV.IsClose(Color(1.0f, 0.0f, 0.6f, 1.0f)));
+        EXPECT_THAT(fromHSV, IsClose(Color(1.0f, 0.0f, 0.6f, 1.0f)));
 
         // Check the upper limit of the hue
         fromHSV.SetFromHSVRadians(AZ::Constants::TwoPi, 1.0f, 1.0f);
-        EXPECT_TRUE(fromHSV.IsClose(Color(1.0f, 0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(fromHSV, IsClose(Color(1.0f, 0.0f, 0.0f, 1.0f)));
 
         // Check that zero saturation causes RGB to all be value.
         fromHSV.SetFromHSVRadians(AZ::DegToRad(90.0f), 0.0f, 0.75f);
-        EXPECT_TRUE(fromHSV.IsClose(Color(0.75f, 0.75f, 0.75f, 1.0f)));
+        EXPECT_THAT(fromHSV, IsClose(Color(0.75f, 0.75f, 0.75f, 1.0f)));
 
         // Check that zero value causes the color to be black.
         fromHSV.SetFromHSVRadians(AZ::DegToRad(180.0f), 1.0f, 0.0f);
-        EXPECT_TRUE(fromHSV.IsClose(Color(0.0f, 0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(fromHSV, IsClose(Color(0.0f, 0.0f, 0.0f, 1.0f)));
 
         // Check a non-zero, non-one saturation
         fromHSV.SetFromHSVRadians(AZ::DegToRad(252.0f), 0.5f, 1.0f);
-        EXPECT_TRUE(fromHSV.IsClose(Color(0.6f, 0.5f, 1.0f, 1.0f)));
+        EXPECT_THAT(fromHSV, IsClose(Color(0.6f, 0.5f, 1.0f, 1.0f)));
 
         // Check a non-zero, non-one value
         fromHSV.SetFromHSVRadians(AZ::DegToRad(216.0f), 1.0f, 0.5f);
-        EXPECT_TRUE(fromHSV.IsClose(Color(0.0f, 0.2f, 0.5f, 1.0f)));
+        EXPECT_THAT(fromHSV, IsClose(Color(0.0f, 0.2f, 0.5f, 1.0f)));
 
         // Check a non-zero, non-one value and saturation
         fromHSV.SetFromHSVRadians(AZ::DegToRad(144.0f), 0.25f, 0.75f);
-        EXPECT_TRUE(fromHSV.IsClose(Color(143.44f / 255.0f, 191.25f / 255.0f, 162.56f / 255.0f, 1.0f)));
+        EXPECT_THAT(fromHSV, IsClose(Color(143.44f / 255.0f, 191.25f / 255.0f, 162.56f / 255.0f, 1.0f)));
 
         // Check that negative hue is handled correctly (only fractional value, +1 to be positive)
         fromHSV.SetFromHSVRadians(AZ::DegToRad(-396.0f), 1.0f, 1.0f);
-        EXPECT_TRUE(fromHSV.IsClose(Color(1.0f, 0.0f, 0.6f, 1.0f)));
+        EXPECT_THAT(fromHSV, IsClose(Color(1.0f, 0.0f, 0.6f, 1.0f)));
 
         // Check that negative saturation is clamped to 0
         fromHSV.SetFromHSVRadians(AZ::DegToRad(324.0f), -1.0f, 1.0f);
-        EXPECT_TRUE(fromHSV.IsClose(Color(1.0f, 1.0f, 1.0f, 1.0f)));
+        EXPECT_THAT(fromHSV, IsClose(Color(1.0f, 1.0f, 1.0f, 1.0f)));
 
         // Check that negative value is clamped to 0
         fromHSV.SetFromHSVRadians(AZ::Constants::Pi, 1.0f, -1.0f);
-        EXPECT_TRUE(fromHSV.IsClose(Color(0.0f, 0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(fromHSV, IsClose(Color(0.0f, 0.0f, 0.0f, 1.0f)));
 
         // Check that > 1 saturation is clamped to 1
         fromHSV.SetFromHSVRadians(AZ::DegToRad(324.0f), 2.0f, 1.0f);
-        EXPECT_TRUE(fromHSV.IsClose(Color(1.0f, 0.0f, 0.6f, 1.0f)));
+        EXPECT_THAT(fromHSV, IsClose(Color(1.0f, 0.0f, 0.6f, 1.0f)));
 
         // Check that > 1 value is clamped to 1
         fromHSV.SetFromHSVRadians(AZ::DegToRad(324.0f), 1.0f, 2.0f);
-        EXPECT_TRUE(fromHSV.IsClose(Color(1.0f, 0.0f, 0.6f, 1.0f)));
+        EXPECT_THAT(fromHSV, IsClose(Color(1.0f, 0.0f, 0.6f, 1.0f)));
 
         // Check a large hue.
         fromHSV.SetFromHSVRadians(AZ::DegToRad(3744.0f), 1.0f, 1.0f);
-        EXPECT_TRUE(fromHSV.IsClose(Color(0.0f, 1.0f, 0.4f, 1.0f)));
+        EXPECT_THAT(fromHSV, IsClose(Color(0.0f, 1.0f, 0.4f, 1.0f)));
     }
 
     TEST(MATH_Color, EqualityComparisons)
@@ -240,9 +241,9 @@ namespace UnitTest
         Color color2(0.1f, 0.2f, 0.3f, 0.4f);
         Color color3(0.12f, 0.22f, 0.32f, 0.42f);
 
-        EXPECT_TRUE(color1.IsClose(color2));
+        EXPECT_THAT(color1, IsClose(color2));
         EXPECT_FALSE(color1.IsClose(color3));
-        EXPECT_TRUE(color1.IsClose(color3, 0.03f));
+        EXPECT_THAT(color1, IsCloseTolerance(color3, 0.03f));
         EXPECT_FALSE(color1.IsClose(color3, 0.01f));
 
         // Zero check within tolerance
@@ -344,14 +345,14 @@ namespace UnitTest
     TEST(MATH_Color, VectorConversions)
     {
         Vector3 vec3FromColor(Color(0.4f, 0.6f, 0.8f, 1.0f));
-        EXPECT_TRUE(vec3FromColor.IsClose(Vector3(0.4f, 0.6f, 0.8f)));
+        EXPECT_THAT(vec3FromColor, IsClose(Vector3(0.4f, 0.6f, 0.8f)));
 
         Vector4 vec4FromColor(Color(0.4f, 0.6f, 0.8f, 1.0f));
-        EXPECT_TRUE(vec4FromColor.IsClose(Vector4(0.4f, 0.6f, 0.8f, 1.0f)));
+        EXPECT_THAT(vec4FromColor, IsClose(Vector4(0.4f, 0.6f, 0.8f, 1.0f)));
 
         Color ColorfromVec3;
         ColorfromVec3 = Vector3(0.3f, 0.4f, 0.5f);
-        EXPECT_TRUE(ColorfromVec3.GetAsVector4().IsClose(Vector4(0.3f, 0.4f, 0.5f, 1.0f)));
+        EXPECT_THAT(ColorfromVec3.GetAsVector4(), IsClose(Vector4(0.3f, 0.4f, 0.5f, 1.0f)));
     }
 
     TEST(MATH_Color, LinearToGamma)
@@ -360,29 +361,29 @@ namespace UnitTest
         Color reallyDarkLinear(0.001234f, 0.000123f, 0.001010f, 0.5f);
         Color reallyDarkGamma = reallyDarkLinear.LinearToGamma();
         Color reallyDarkGammaCheck(0.01594328f, 0.00158916f, 0.0130492f, 0.5f);
-        EXPECT_TRUE(reallyDarkGamma.IsClose(reallyDarkGammaCheck, 0.00001f));
+        EXPECT_THAT(reallyDarkGamma, IsCloseTolerance(reallyDarkGammaCheck, 0.00001f));
 
         // Normal values
         Color normalLinear(0.123456f, 0.345678f, 0.567890f, 0.8f);
         Color normalGamma = normalLinear.LinearToGamma();
         Color normalGammaCheck(0.386281658744f, 0.622691988496f, 0.77841737783f, 0.8f);
-        EXPECT_TRUE(normalGamma.IsClose(normalGammaCheck, 0.00001f));
+        EXPECT_THAT(normalGamma, IsCloseTolerance(normalGammaCheck, 0.00001f));
 
         // Bright values
         Color brightLinear(1.234567f, 3.456789f, 5.678901f, 1.0f);
         Color brightGamma = brightLinear.LinearToGamma();
         Color brightGammaCheck(1.09681722689f, 1.71388455271f, 2.12035054203f, 1.0f);
-        EXPECT_TRUE(brightGamma.IsClose(brightGammaCheck, 0.00001f));
+        EXPECT_THAT(brightGamma, IsCloseTolerance(brightGammaCheck, 0.00001f));
 
         // Zero should stay the same
         Color zeroColor = Color::CreateZero();
         Color zeroColorGamma = zeroColor.LinearToGamma();
-        EXPECT_TRUE(zeroColorGamma.IsClose(zeroColor, 0.00001f));
+        EXPECT_THAT(zeroColorGamma, IsCloseTolerance(zeroColor, 0.00001f));
 
         // One should stay the same
         Color oneColor = Color::CreateOne();
         Color oneColorGamma = oneColor.LinearToGamma();
-        EXPECT_TRUE(oneColorGamma.IsClose(oneColor, 0.00001f));
+        EXPECT_THAT(oneColorGamma, IsCloseTolerance(oneColor, 0.00001f));
     }
 
     TEST(MATH_Color, GammaToLinear)
@@ -391,29 +392,29 @@ namespace UnitTest
         Color reallyDarkGamma(0.001234f, 0.000123f, 0.001010f, 0.5f);
         Color reallyDarkLinear = reallyDarkGamma.GammaToLinear();
         Color reallyDarkLinearCheck(0.0000955108359133f, 0.00000952012383901f, 0.000078173374613f, 0.5f);
-        EXPECT_TRUE(reallyDarkLinear.IsClose(reallyDarkLinearCheck, 0.00001f));
+        EXPECT_THAT(reallyDarkLinear, IsCloseTolerance(reallyDarkLinearCheck, 0.00001f));
 
         // Normal values
         Color normalGamma(0.123456f, 0.345678f, 0.567890f, 0.8f);
         Color normalLinear = normalGamma.GammaToLinear();
         Color normalLinearCheck(0.0140562303977f, 0.097927189487f, 0.282345816828f, 0.8f);
-        EXPECT_TRUE(normalLinear.IsClose(normalLinearCheck, 0.00001f));
+        EXPECT_THAT(normalLinear, IsCloseTolerance(normalLinearCheck, 0.00001f));
 
         // Bright values
         Color brightGamma(1.234567f, 3.456789f, 5.678901f, 1.0f);
         Color brightLinear = brightGamma.GammaToLinear();
         Color brightLinearCheck(1.61904710087f, 17.9251290437f, 58.1399365547f, 1.0f);
-        EXPECT_TRUE(brightLinear.IsClose(brightLinearCheck, 0.00001f));
+        EXPECT_THAT(brightLinear, IsCloseTolerance(brightLinearCheck, 0.00001f));
 
         // Zero should stay the same
         Color zeroColor = Color::CreateZero();
         Color zeroColorLinear = zeroColor.GammaToLinear();
-        EXPECT_TRUE(zeroColorLinear.IsClose(zeroColor, 0.00001f));
+        EXPECT_THAT(zeroColorLinear, IsCloseTolerance(zeroColor, 0.00001f));
 
         // One should stay the same
         Color oneColor = Color::CreateOne();
         Color oneColorLinear = oneColor.GammaToLinear();
-        EXPECT_TRUE(oneColorLinear.IsClose(oneColor, 0.00001f));
+        EXPECT_THAT(oneColorLinear, IsCloseTolerance(oneColor, 0.00001f));
     }
 
     TEST(MATH_Color, UintConversions)
@@ -425,7 +426,7 @@ namespace UnitTest
         // Convert from u32
         Color colorFromU32;
         colorFromU32.FromU32(0xFFE08C3A);
-        EXPECT_TRUE(colorFromU32.IsClose(Color(0.22745098039f, 0.549019607843f, 0.87843137254f, 1.0f), 0.00001f));
+        EXPECT_THAT(colorFromU32, IsCloseTolerance(Color(0.22745098039f, 0.549019607843f, 0.87843137254f, 1.0f), 0.00001f));
 
         // Convert to u32 and change to gamma space at the same time.
         Color colorToU32Gamma(0.23f, 0.55f, 0.88f, 0.5f);
@@ -434,7 +435,7 @@ namespace UnitTest
         // Convert from u32 and change to linear space at the same time.
         Color colorFromU32Gamma;
         colorFromU32Gamma.FromU32GammaToLinear(0x7FF1C383);
-        EXPECT_TRUE(colorFromU32Gamma.IsClose(Color(0.22696587351f, 0.54572446137f, 0.879622396888f, 0.498039215686f), 0.00001f));
+        EXPECT_THAT(colorFromU32Gamma, IsCloseTolerance(Color(0.22696587351f, 0.54572446137f, 0.879622396888f, 0.498039215686f), 0.00001f));
     }
 
     TEST(MATH_Color, Lerp)
@@ -443,7 +444,7 @@ namespace UnitTest
         Color colorDest(0.0f, 1.0f, 0.8f, 0.2f);
 
         AZ_TEST_ASSERT(colorSrc.Lerp(colorDest, 0.0f).IsClose(colorSrc));
-        EXPECT_TRUE(colorSrc.Lerp(colorDest, 0.5f).IsClose(Color(0.5f, 0.5f, 0.5f, 0.5f), 0.00001f));
+        EXPECT_THAT(colorSrc.Lerp(colorDest, 0.5f), IsCloseTolerance(Color(0.5f, 0.5f, 0.5f, 0.5f), 0.00001f));
         AZ_TEST_ASSERT(colorSrc.Lerp(colorDest, 1.0f).IsClose(colorDest));
     }
 
@@ -468,10 +469,10 @@ namespace UnitTest
         Color color2(0.5f, 0.7f, 0.3f, 0.8f);
         Color colorSum(1.1f, 1.1f, 0.6f, 0.9f);
 
-        EXPECT_TRUE(colorSum.IsClose(color1 + color2, 0.0001f));
+        EXPECT_THAT(colorSum, IsCloseTolerance(color1 + color2, 0.0001f));
 
         color1 += color2;
-        EXPECT_TRUE(colorSum.IsClose(color1, 0.0001f));
+        EXPECT_THAT(colorSum, IsCloseTolerance(color1, 0.0001f));
     }
 
     TEST(MATH_Color, Subtraction)
@@ -480,10 +481,10 @@ namespace UnitTest
         Color color2(0.5f, 0.7f, 0.3f, 0.8f);
         Color colorDiff(0.1f, -0.3f, 0.0f, -0.7f);
 
-        EXPECT_TRUE(colorDiff.IsClose(color1 - color2, 0.0001f));
+        EXPECT_THAT(colorDiff, IsCloseTolerance(color1 - color2, 0.0001f));
 
         color1 -= color2;
-        EXPECT_TRUE(colorDiff.IsClose(color1, 0.0001f));
+        EXPECT_THAT(colorDiff, IsCloseTolerance(color1, 0.0001f));
     }
 
     TEST(MATH_Color, Multiplication)
@@ -494,18 +495,18 @@ namespace UnitTest
         Color color2Double(1.0f, 1.4f, 0.6f, 1.6f);
 
         // Product of two colors
-        EXPECT_TRUE(colorProduct.IsClose(color1 * color2, 0.0001f));
+        EXPECT_THAT(colorProduct, IsCloseTolerance(color1 * color2, 0.0001f));
 
         // Multiply-assignment
         color1 *= color2;
-        EXPECT_TRUE(colorProduct.IsClose(color1, 0.0001f));
+        EXPECT_THAT(colorProduct, IsCloseTolerance(color1, 0.0001f));
 
         // Product of color and float
-        EXPECT_TRUE(color2Double.IsClose(color2 * 2.0f));
+        EXPECT_THAT(color2Double, IsClose(color2 * 2.0f));
 
         // Multiply-assignment with single float
         color2 *= 2.0f;
-        EXPECT_TRUE(color2Double.IsClose(color2));
+        EXPECT_THAT(color2Double, IsClose(color2));
     }
 
     TEST(MATH_Color, Division)
@@ -516,17 +517,17 @@ namespace UnitTest
         Color color2Half(0.25f, 0.4f, 0.15f, 0.4f);
 
         // Product of two colors
-        EXPECT_TRUE(colorQuotient.IsClose(color1 / color2, 0.0001f));
+        EXPECT_THAT(colorQuotient, IsCloseTolerance(color1 / color2, 0.0001f));
 
         // Multiply-assignment
         color1 /= color2;
-        EXPECT_TRUE(colorQuotient.IsClose(color1, 0.0001f));
+        EXPECT_THAT(colorQuotient, IsCloseTolerance(color1, 0.0001f));
 
         // Product of color and float
-        EXPECT_TRUE(color2Half.IsClose(color2 / 2.0f));
+        EXPECT_THAT(color2Half, IsClose(color2 / 2.0f));
 
         // Multiply-assignment with single float
         color2 /= 2.0f;
-        EXPECT_TRUE(color2Half.IsClose(color2));
+        EXPECT_THAT(color2Half, IsClose(color2));
     }
 }

--- a/Code/Framework/AzCore/Tests/Math/ColorTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/ColorTests.cpp
@@ -443,9 +443,9 @@ namespace UnitTest
         Color colorSrc(1.0f, 0.0f, 0.2f, 0.8f);
         Color colorDest(0.0f, 1.0f, 0.8f, 0.2f);
 
-        AZ_TEST_ASSERT(colorSrc.Lerp(colorDest, 0.0f).IsClose(colorSrc));
+        EXPECT_THAT(colorSrc.Lerp(colorDest, 0.0f), IsClose(colorSrc));
         EXPECT_THAT(colorSrc.Lerp(colorDest, 0.5f), IsCloseTolerance(Color(0.5f, 0.5f, 0.5f, 0.5f), 0.00001f));
-        AZ_TEST_ASSERT(colorSrc.Lerp(colorDest, 1.0f).IsClose(colorDest));
+        EXPECT_THAT(colorSrc.Lerp(colorDest, 1.0f), IsClose(colorDest));
     }
 
     TEST(MATH_Color, DotProduct)

--- a/Code/Framework/AzCore/Tests/Math/FrustumTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/FrustumTests.cpp
@@ -313,9 +313,9 @@ namespace UnitTest
         AZ::Plane bottom1 = AZ::Plane::CreateFromNormalAndPoint(AZ::Vector3(0.f, 0.f, 1.f), AZ::Vector3(0.f, 0.f, -2.f));
         AZ::Frustum frustum1(near1, far1, left1, right1, top1, bottom1);
 
-        EXPECT_FALSE(frustum.IsClose(frustum1));
+        EXPECT_THAT(frustum, testing::Not(IsClose(frustum1)));
         frustum.Set(frustum1);
-        EXPECT_TRUE(frustum.IsClose(frustum1));
+        EXPECT_THAT(frustum, IsClose(frustum1));
 
         frustum.SetPlane(AZ::Frustum::PlaneId::Near, near_value);
         frustum.SetPlane(AZ::Frustum::PlaneId::Far, far_value);
@@ -332,7 +332,7 @@ namespace UnitTest
         EXPECT_TRUE(frustum.GetPlane(AZ::Frustum::PlaneId::Bottom) == bottom);
 
         frustum = frustum1;
-        EXPECT_TRUE(frustum.IsClose(frustum1));
+        EXPECT_THAT(frustum, IsClose(frustum1));
     }
 
     // TODO: Test frustum creation from View-Projection Matrices

--- a/Code/Framework/AzCore/Tests/Math/FrustumTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/FrustumTests.cpp
@@ -26,11 +26,11 @@ namespace UnitTest
         // Test a sphere in front of the near clip with a radius too small to intersect
         {
             AZ::IntersectResult result = testFrustum1.IntersectSphere(AZ::Vector3::CreateZero(), 0.5f);
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Exterior);
+            EXPECT_EQ(result, AZ::IntersectResult::Exterior);
         }
         {
             AZ::IntersectResult result = testFrustum2.IntersectSphere(AZ::Vector3(0.0f, 9.0f, 0.0f), 0.5f);
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Exterior);
+            EXPECT_EQ(result, AZ::IntersectResult::Exterior);
         }
     }
 
@@ -39,11 +39,11 @@ namespace UnitTest
         // Test a sphere beyond the far clip
         {
             AZ::IntersectResult result = testFrustum1.IntersectSphere(AZ::Vector3(0.0f, 102.0f, 0.0f), 1.0f);
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Exterior);
+            EXPECT_EQ(result, AZ::IntersectResult::Exterior);
         }
         {
             AZ::IntersectResult result = testFrustum2.IntersectSphere(AZ::Vector3(0.0f, 92.0f, 0.0f), 1.0f);
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Exterior);
+            EXPECT_EQ(result, AZ::IntersectResult::Exterior);
         }
     }
 
@@ -52,11 +52,11 @@ namespace UnitTest
         // Test a sphere in front of the near clip with a radius large enough to intersect
         {
             AZ::IntersectResult result = testFrustum1.IntersectSphere(AZ::Vector3::CreateZero(), 1.5f);
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
         {
             AZ::IntersectResult result = testFrustum2.IntersectSphere(AZ::Vector3(0.0f, 9.0f, 0.0f), 1.5f);
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
     }
 
@@ -65,11 +65,11 @@ namespace UnitTest
         // Test a sphere on the left clip plane
         {
             AZ::IntersectResult result = testFrustum1.IntersectSphere(AZ::Vector3(-50.0f, 50.0f, 0.0f), 1.0f);
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
         {
             AZ::IntersectResult result = testFrustum2.IntersectSphere(AZ::Vector3(-25.0f, 50.0f, 0.0f), 1.0f);
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
     }
 
@@ -78,11 +78,11 @@ namespace UnitTest
         // Test a sphere on the right clip plane
         {
             AZ::IntersectResult result = testFrustum1.IntersectSphere(AZ::Vector3(50.0f, 50.0f, 0.0f), 1.0f);
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
         {
             AZ::IntersectResult result = testFrustum2.IntersectSphere(AZ::Vector3(25.0f, 50.0f, 0.0f), 1.0f);
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
     }
 
@@ -91,11 +91,11 @@ namespace UnitTest
         // Test a sphere on the top clip plane
         {
             AZ::IntersectResult result = testFrustum1.IntersectSphere(AZ::Vector3(0.0f, 50.0f, 50.0f), 1.0f);
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
         {
             AZ::IntersectResult result = testFrustum2.IntersectSphere(AZ::Vector3(0.0f, 50.0f, 25.0f), 1.0f);
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
     }
 
@@ -104,11 +104,11 @@ namespace UnitTest
         // Test a sphere on the bottom clip plane
         {
             AZ::IntersectResult result = testFrustum1.IntersectSphere(AZ::Vector3(0.0f, 50.0f, -50.0f), 1.0f);
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
         {
             AZ::IntersectResult result = testFrustum2.IntersectSphere(AZ::Vector3(0.0f, 50.0f, -25.0f), 1.0f);
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
     }
 
@@ -117,11 +117,11 @@ namespace UnitTest
         // Test a sphere near the middle of the frustum
         {
             AZ::IntersectResult result = testFrustum1.IntersectSphere(AZ::Vector3(0.0f, 50.0f, 0.0f), 1.0f);
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Interior);
+            EXPECT_EQ(result, AZ::IntersectResult::Interior);
         }
         {
             AZ::IntersectResult result = testFrustum2.IntersectSphere(AZ::Vector3(0.0f, 50.0f, 0.0f), 1.0f);
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Interior);
+            EXPECT_EQ(result, AZ::IntersectResult::Interior);
         }
     }
 
@@ -131,12 +131,12 @@ namespace UnitTest
         {
             AZ::Vector3 center = AZ::Vector3::CreateZero();
             AZ::IntersectResult result = testFrustum1.IntersectAabb(center - AZ::Vector3(0.5f), center + AZ::Vector3(0.5f));
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Exterior);
+            EXPECT_EQ(result, AZ::IntersectResult::Exterior);
         }
         {
             AZ::Vector3 center = AZ::Vector3(0.0f, 9.0f, 0.0f);
             AZ::IntersectResult result = testFrustum2.IntersectAabb(center - AZ::Vector3(0.5f, 0.5f, 0.5f), center + AZ::Vector3(0.5f, 0.5f, 0.5f));
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Exterior);
+            EXPECT_EQ(result, AZ::IntersectResult::Exterior);
         }
     }
 
@@ -146,12 +146,12 @@ namespace UnitTest
         {
             AZ::Vector3 center = AZ::Vector3(0.0f, 102.0f, 0.0f);
             AZ::IntersectResult result = testFrustum1.IntersectAabb(center - AZ::Vector3(1.0f), center + AZ::Vector3(1.0f));
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Exterior);
+            EXPECT_EQ(result, AZ::IntersectResult::Exterior);
         }
         {
             AZ::Vector3 center = AZ::Vector3(0.0f, 92.0f, 0.0f);
             AZ::IntersectResult result = testFrustum2.IntersectAabb(center - AZ::Vector3(1.0f), center + AZ::Vector3(1.0f));
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Exterior);
+            EXPECT_EQ(result, AZ::IntersectResult::Exterior);
         }
     }
 
@@ -161,12 +161,12 @@ namespace UnitTest
         {
             AZ::Vector3 center = AZ::Vector3::CreateZero();
             AZ::IntersectResult result = testFrustum1.IntersectAabb(center - AZ::Vector3(1.5f), center + AZ::Vector3(1.5f));
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
         {
             AZ::Vector3 center = AZ::Vector3(0.0f, 9.0f, 0.0f);
             AZ::IntersectResult result = testFrustum2.IntersectAabb(center - AZ::Vector3(1.5f, 1.5f, 1.5f), center + AZ::Vector3(1.5f, 1.5f, 1.5f));
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
     }
 
@@ -176,12 +176,12 @@ namespace UnitTest
         {
             AZ::Vector3 center = AZ::Vector3(-50.0f, 50.0f, 0.0f);
             AZ::IntersectResult result = testFrustum1.IntersectAabb(center - AZ::Vector3(1.0f), center + AZ::Vector3(1.0f));
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
         {
             AZ::Vector3 center = AZ::Vector3(-25.0f, 50.0f, 0.0f);
             AZ::IntersectResult result = testFrustum2.IntersectAabb(center - AZ::Vector3(1.0f), center + AZ::Vector3(1.0f));
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
     }
 
@@ -191,12 +191,12 @@ namespace UnitTest
         {
             AZ::Vector3 center = AZ::Vector3(50.0f, 50.0f, 0.0f);
             AZ::IntersectResult result = testFrustum1.IntersectAabb(center - AZ::Vector3(1.0f), center + AZ::Vector3(1.0f));
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
         {
             AZ::Vector3 center = AZ::Vector3(25.0f, 50.0f, 0.0f);
             AZ::IntersectResult result = testFrustum2.IntersectAabb(center - AZ::Vector3(1.0f), center + AZ::Vector3(1.0f));
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
     }
 
@@ -206,12 +206,12 @@ namespace UnitTest
         {
             AZ::Vector3 center = AZ::Vector3(0.0f, 50.0f, 50.0f);
             AZ::IntersectResult result = testFrustum1.IntersectAabb(center - AZ::Vector3(1.0f), center + AZ::Vector3(1.0f));
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
         {
             AZ::Vector3 center = AZ::Vector3(0.0f, 50.0f, 25.0f);
             AZ::IntersectResult result = testFrustum2.IntersectAabb(center - AZ::Vector3(1.0f), center + AZ::Vector3(1.0f));
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
     }
 
@@ -221,12 +221,12 @@ namespace UnitTest
         {
             AZ::Vector3 center = AZ::Vector3(0.0f, 50.0f, -50.0f);
             AZ::IntersectResult result = testFrustum1.IntersectAabb(center - AZ::Vector3(1.0f), center + AZ::Vector3(1.0f));
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
         {
             AZ::Vector3 center = AZ::Vector3(0.0f, 50.0f, -25.0f);
             AZ::IntersectResult result = testFrustum2.IntersectAabb(center - AZ::Vector3(1.0f), center + AZ::Vector3(1.0f));
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(result, AZ::IntersectResult::Overlaps);
         }
     }
 
@@ -236,12 +236,12 @@ namespace UnitTest
         {
             AZ::Vector3 center = AZ::Vector3(0.0f, 50.0f, 0.0f);
             AZ::IntersectResult result = testFrustum1.IntersectAabb(center - AZ::Vector3(1.0f), center + AZ::Vector3(1.0f));
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Interior);
+            EXPECT_EQ(result, AZ::IntersectResult::Interior);
         }
         {
             AZ::Vector3 center = AZ::Vector3(0.0f, 50.0f, 0.0f);
             AZ::IntersectResult result = testFrustum2.IntersectAabb(center - AZ::Vector3(1.0f), center + AZ::Vector3(1.0f));
-            AZ_TEST_ASSERT(result == AZ::IntersectResult::Interior);
+            EXPECT_EQ(result, AZ::IntersectResult::Interior);
         }
     }
 

--- a/Code/Framework/AzCore/Tests/Math/IntersectionTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/IntersectionTests.cpp
@@ -472,8 +472,8 @@ namespace UnitTest
                     else if (!outNormal[0].IsClose(outNormal[1]) || !outNormal[0].IsClose(outNormal[2]))
                     {
                         numDifferentHits++;
-                        EXPECT_TRUE(outNormal[0].IsClose(outNormal[1]));
-                        EXPECT_TRUE(outNormal[0].IsClose(outNormal[2]));
+                        EXPECT_THAT(outNormal[0], IsClose(outNormal[1]));
+                        EXPECT_THAT(outNormal[0], IsClose(outNormal[2]));
                     }
                 }
             }
@@ -591,7 +591,7 @@ namespace UnitTest
 
             EXPECT_EQ(test.m_shouldHit, result);
             EXPECT_NEAR(test.m_hitDistance, outDistance, 0.0001f);
-            EXPECT_TRUE(test.m_hitNormal.IsClose(outNormal));
+            EXPECT_THAT(test.m_hitNormal, IsClose(outNormal));
         }
     }
 

--- a/Code/Framework/AzCore/Tests/Math/IntersectionTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/IntersectionTests.cpp
@@ -37,9 +37,9 @@ namespace UnitTest
             Intersect::ClosestSegmentSegment(line1Start, line1End, line2Start, line2End, line1Proportion, line2Proportion, line1ClosestPoint, line2ClosestPoint);
             float pointDifference = (line2ClosestPoint - line1ClosestPoint).GetLength();
 
-            EXPECT_TRUE(pointDifference == 5.0f);
-            EXPECT_TRUE(line1Proportion == 1.0f);
-            EXPECT_TRUE(line2Proportion == 0.0f);
+            EXPECT_NEAR(pointDifference, 5.0f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(line1Proportion, 1.0f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(line2Proportion, 0.0f, AZ::Constants::Tolerance);
         }
 
         // line2 halfway over the top of the line1 (overlap, parallel)
@@ -56,9 +56,9 @@ namespace UnitTest
             Intersect::ClosestSegmentSegment(line1Start, line1End, line2Start, line2End, line1Proportion, line2Proportion, line1ClosestPoint, line2ClosestPoint);
             float pointDifference = (line2ClosestPoint - line1ClosestPoint).GetLength();
 
-            EXPECT_TRUE(pointDifference == 3.0f);
-            EXPECT_TRUE(line1Proportion == 0.5f);
-            EXPECT_TRUE(line2Proportion == 0.0f);
+            EXPECT_NEAR(pointDifference, 3.0f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(line1Proportion, 0.5f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(line2Proportion, 0.0f, AZ::Constants::Tolerance);
         }
 
         // line2 over the top of the line1 (inside, parallel)
@@ -75,9 +75,9 @@ namespace UnitTest
             Intersect::ClosestSegmentSegment(line1Start, line1End, line2Start, line2End, line1Proportion, line2Proportion, line1ClosestPoint, line2ClosestPoint);
             float pointDifference = (line2ClosestPoint - line1ClosestPoint).GetLength();
 
-            EXPECT_TRUE(pointDifference == 3.0f);
-            EXPECT_TRUE(line1Proportion == 0.25f);
-            EXPECT_TRUE(line2Proportion == 0.0f);
+            EXPECT_NEAR(pointDifference, 3.0f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(line1Proportion, 0.25f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(line2Proportion, 0.0f, AZ::Constants::Tolerance);
         }
 
         // line2 over the top of the line1 (overlap, skew (cross))
@@ -94,9 +94,9 @@ namespace UnitTest
             Intersect::ClosestSegmentSegment(line1Start, line1End, line2Start, line2End, line1Proportion, line2Proportion, line1ClosestPoint, line2ClosestPoint);
             float pointDifference = (line2ClosestPoint - line1ClosestPoint).GetLength();
 
-            EXPECT_TRUE(pointDifference == 4.0f);
-            EXPECT_TRUE(line1Proportion == 0.5f);
-            EXPECT_TRUE(line2Proportion == 0.5f);
+            EXPECT_NEAR(pointDifference, 4.0f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(line1Proportion, 0.5f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(line2Proportion, 0.5f, AZ::Constants::Tolerance);
         }
 
         // line2 flat diagonal to line1 (no overlap, skew)
@@ -113,9 +113,9 @@ namespace UnitTest
             Intersect::ClosestSegmentSegment(line1Start, line1End, line2Start, line2End, line1Proportion, line2Proportion, line1ClosestPoint, line2ClosestPoint);
             float pointDifference = (line2ClosestPoint - line1ClosestPoint).GetLength();
 
-            EXPECT_TRUE(pointDifference == 2.0f);
-            EXPECT_TRUE(line1Proportion == 1.0f);
-            EXPECT_TRUE(line2Proportion == 1.0f);
+            EXPECT_NEAR(pointDifference, 2.0f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(line1Proportion, 1.0f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(line2Proportion, 1.0f, AZ::Constants::Tolerance);
         }
 
         // line2 perpendicular to line1 (skew, no overlap)
@@ -132,9 +132,9 @@ namespace UnitTest
             Intersect::ClosestSegmentSegment(line1Start, line1End, line2Start, line2End, line1Proportion, line2Proportion, line1ClosestPoint, line2ClosestPoint);
             float pointDifference = (line2ClosestPoint - line1ClosestPoint).GetLength();
 
-            EXPECT_TRUE(pointDifference == 1.0f);
-            EXPECT_TRUE(line1Proportion == 0.5f);
-            EXPECT_TRUE(line2Proportion == 0.0f);
+            EXPECT_NEAR(pointDifference, 1.0f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(line1Proportion, 0.5f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(line2Proportion, 0.0f, AZ::Constants::Tolerance);
         }
 
         // line 1 degenerates to point
@@ -151,9 +151,9 @@ namespace UnitTest
             Intersect::ClosestSegmentSegment(line1Start, line1End, line2Start, line2End, line1Proportion, line2Proportion, line1ClosestPoint, line2ClosestPoint);
             float pointDifference = (line2ClosestPoint - line1ClosestPoint).GetLength();
 
-            EXPECT_TRUE(pointDifference == 2.0f);
-            EXPECT_TRUE(line1Proportion == 0.0f);
-            EXPECT_TRUE(line2Proportion == 0.5f);
+            EXPECT_NEAR(pointDifference, 2.0f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(line1Proportion, 0.0f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(line2Proportion, 0.5f, AZ::Constants::Tolerance);
         }
 
         // line 2 degenerates to point
@@ -170,9 +170,9 @@ namespace UnitTest
             Intersect::ClosestSegmentSegment(line1Start, line1End, line2Start, line2End, line1Proportion, line2Proportion, line1ClosestPoint, line2ClosestPoint);
             float pointDifference = (line2ClosestPoint - line1ClosestPoint).GetLength();
 
-            EXPECT_TRUE(pointDifference == 1.0f);
-            EXPECT_TRUE(line1Proportion == 0.5f);
-            EXPECT_TRUE(line2Proportion == 0.0f);
+            EXPECT_NEAR(pointDifference, 1.0f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(line1Proportion, 0.5f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(line2Proportion, 0.0f, AZ::Constants::Tolerance);
         }
 
         // both lines degenerate to points
@@ -191,9 +191,9 @@ namespace UnitTest
 
             // (10, 10, 10) - (5, 5, 5) == (5, 5, 5)
             // |(5,5,5)| == sqrt(5*5+5*5+5*5) == sqrt(75)
-            EXPECT_TRUE(pointDifference == sqrtf(75.0f));
-            EXPECT_TRUE(line1Proportion == 0.0f);
-            EXPECT_TRUE(line2Proportion == 0.0f);
+            EXPECT_NEAR(pointDifference, sqrtf(75.0f), AZ::Constants::Tolerance);
+            EXPECT_NEAR(line1Proportion, 0.0f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(line2Proportion, 0.0f, AZ::Constants::Tolerance);
         }
     }
 
@@ -211,8 +211,8 @@ namespace UnitTest
 
             float pointDifference = (lineClosestPoint - point).GetLength();
 
-            EXPECT_TRUE(pointDifference == 2.0f);
-            EXPECT_TRUE(lineProportion == 0.5f);
+            EXPECT_NEAR(pointDifference, 2.0f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(lineProportion, 0.5f, AZ::Constants::Tolerance);
         }
 
         // point same height behind line
@@ -227,8 +227,8 @@ namespace UnitTest
 
             float pointDifference = (lineClosestPoint - point).GetLength();
 
-            EXPECT_TRUE(pointDifference == 2.0f);
-            EXPECT_TRUE(lineProportion == 0.0f);
+            EXPECT_NEAR(pointDifference, 2.0f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(lineProportion, 0.0f, AZ::Constants::Tolerance);
         }
 
         // point passed end of line
@@ -243,8 +243,8 @@ namespace UnitTest
 
             float pointDifference = (lineClosestPoint - point).GetLength();
 
-            EXPECT_TRUE(pointDifference == 5.0f);
-            EXPECT_TRUE(lineProportion == 1.0f);
+            EXPECT_NEAR(pointDifference, 5.0f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(lineProportion, 1.0f, AZ::Constants::Tolerance);
         }
 
         // point above part way along line
@@ -259,8 +259,8 @@ namespace UnitTest
 
             float pointDifference = (lineClosestPoint - point).GetLength();
 
-            EXPECT_TRUE(pointDifference == 1.0f);
-            EXPECT_TRUE(lineProportion == 0.75f);
+            EXPECT_NEAR(pointDifference, 1.0f, AZ::Constants::Tolerance);
+            EXPECT_NEAR(lineProportion, 0.75f, AZ::Constants::Tolerance);
         }
     }
 

--- a/Code/Framework/AzCore/Tests/Math/Matrix3x3Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Matrix3x3Tests.cpp
@@ -23,217 +23,217 @@ namespace UnitTest
     TEST(MATH_Matrix3x3, TestCreateIdentity)
     {
         Matrix3x3 m1 = Matrix3x3::CreateIdentity();
-        AZ_TEST_ASSERT(m1.GetRow(0) == Vector3(1.0f, 0.0f, 0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(1) == Vector3(0.0f, 1.0f, 0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(2) == Vector3(0.0f, 0.0f, 1.0f));
+        EXPECT_THAT(m1.GetRow(0), IsCloseTolerance(Vector3(1.0f, 0.0f, 0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(1), IsCloseTolerance(Vector3(0.0f, 1.0f, 0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(2), IsCloseTolerance(Vector3(0.0f, 0.0f, 1.0f), 1e-6f));
     }
 
     TEST(MATH_Matrix3x3, TestCreateZero)
     {
         Matrix3x3 m1 = Matrix3x3::CreateZero();
-        AZ_TEST_ASSERT(m1.GetRow(0) == Vector3(0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(1) == Vector3(0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(2) == Vector3(0.0f));
+        EXPECT_THAT(m1.GetRow(0), IsCloseTolerance(Vector3(0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(1), IsCloseTolerance(Vector3(0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(2), IsCloseTolerance(Vector3(0.0f), 1e-6f));
     }
 
     TEST(MATH_Matrix3x3, TestCreateFromValue)
     {
         Matrix3x3 m1 = Matrix3x3::CreateFromValue(2.0f);
-        AZ_TEST_ASSERT(m1.GetRow(0) == Vector3(2.0f));
-        AZ_TEST_ASSERT(m1.GetRow(1) == Vector3(2.0f));
-        AZ_TEST_ASSERT(m1.GetRow(2) == Vector3(2.0f));
+        EXPECT_THAT(m1.GetRow(0), IsCloseTolerance(Vector3(2.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(1), IsCloseTolerance(Vector3(2.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(2), IsCloseTolerance(Vector3(2.0f), 1e-6f));
     }
 
     TEST(MATH_Matrix3x3, TestCreateFromRowMajorFloat9)
     {
         Matrix3x3 m1 = Matrix3x3::CreateFromRowMajorFloat9(testFloats);
-        AZ_TEST_ASSERT(m1.GetRow(0) == Vector3(1.0f, 2.0f, 3.0f));
-        AZ_TEST_ASSERT(m1.GetRow(1) == Vector3(4.0f, 5.0f, 6.0f));
-        AZ_TEST_ASSERT(m1.GetRow(2) == Vector3(7.0f, 8.0f, 9.0f));
+        EXPECT_THAT(m1.GetRow(0), IsCloseTolerance(Vector3(1.0f, 2.0f, 3.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(1), IsCloseTolerance(Vector3(4.0f, 5.0f, 6.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(2), IsCloseTolerance(Vector3(7.0f, 8.0f, 9.0f), 1e-6f));
         m1.StoreToRowMajorFloat9(testFloatsMtx);
-        AZ_TEST_ASSERT(memcmp(testFloatsMtx, testFloats, sizeof(testFloatsMtx)) == 0);
+        EXPECT_EQ(memcmp(testFloatsMtx, testFloats, sizeof(testFloatsMtx)), 0);
     }
 
     TEST(MATH_Matrix3x3, TestCreateFromColumnMajorFloat9)
     {
         Matrix3x3 m1 = Matrix3x3::CreateFromColumnMajorFloat9(testFloats);
-        AZ_TEST_ASSERT(m1.GetRow(0) == Vector3(1.0f, 4.0f, 7.0f));
-        AZ_TEST_ASSERT(m1.GetRow(1) == Vector3(2.0f, 5.0f, 8.0f));
-        AZ_TEST_ASSERT(m1.GetRow(2) == Vector3(3.0f, 6.0f, 9.0f));
+        EXPECT_THAT(m1.GetRow(0), IsCloseTolerance(Vector3(1.0f, 4.0f, 7.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(1), IsCloseTolerance(Vector3(2.0f, 5.0f, 8.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(2), IsCloseTolerance(Vector3(3.0f, 6.0f, 9.0f), 1e-6f));
         m1.StoreToColumnMajorFloat9(testFloatsMtx);
-        AZ_TEST_ASSERT(memcmp(testFloatsMtx, testFloats, sizeof(testFloatsMtx)) == 0);
+        EXPECT_EQ(memcmp(testFloatsMtx, testFloats, sizeof(testFloatsMtx)), 0);
     }
 
     TEST(MATH_Matrix3x3, TestCreateRotationX)
     {
         Matrix3x3 m1 = Matrix3x3::CreateRotationX(DegToRad(30.0f));
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector3(1.0f, 0.0f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector3(0.0f, 0.866f, -0.5f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector3(0.0f, 0.5f, 0.866f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector3(1.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector3(0.0f, 0.866f, -0.5f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector3(0.0f, 0.5f, 0.866f)));
     }
 
     TEST(MATH_Matrix3x3, TestCreateRotationY)
     {
         Matrix3x3 m1 = Matrix3x3::CreateRotationY(DegToRad(30.0f));
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector3(0.866f, 0.0f, 0.5f)));
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector3(0.0f, 1.0f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector3(-0.5f, 0.0f, 0.866f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector3(0.866f, 0.0f, 0.5f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector3(0.0f, 1.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector3(-0.5f, 0.0f, 0.866f)));
     }
 
     TEST(MATH_Matrix3x3, TestCreateRotationZ)
     {
         Matrix3x3 m1 = Matrix3x3::CreateRotationZ(DegToRad(30.0f));
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector3(0.866f, -0.5f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector3(0.5f, 0.866f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector3(0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector3(0.866f, -0.5f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector3(0.5f, 0.866f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector3(0.0f, 0.0f, 1.0f)));
     }
 
     TEST(MATH_Matrix3x3, TestCreateFromTransform)
     {
         Matrix3x3 m1 = Matrix3x3::CreateFromTransform(Transform::CreateRotationX(DegToRad(30.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector3(1.0f, 0.0f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector3(0.0f, 0.866f, -0.5f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector3(0.0f, 0.5f, 0.866f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector3(1.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector3(0.0f, 0.866f, -0.5f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector3(0.0f, 0.5f, 0.866f)));
     }
 
     TEST(MATH_Matrix3x3, TestCreateFromMatrix4x4)
     {
         Matrix3x3 m1 = Matrix3x3::CreateFromMatrix4x4(Matrix4x4::CreateRotationX(DegToRad(30.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector3(1.0f, 0.0f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector3(0.0f, 0.866f, -0.5f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector3(0.0f, 0.5f, 0.866f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector3(1.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector3(0.0f, 0.866f, -0.5f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector3(0.0f, 0.5f, 0.866f)));
     }
 
     TEST(MATH_Matrix3x3, TestCreateFromQuaternion)
     {
         Matrix3x3 m1 = Matrix3x3::CreateFromQuaternion(AZ::Quaternion::CreateRotationX(DegToRad(30.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector3(1.0f, 0.0f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector3(0.0f, 0.866f, -0.5f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector3(0.0f, 0.5f, 0.866f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector3(1.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector3(0.0f, 0.866f, -0.5f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector3(0.0f, 0.5f, 0.866f)));
     }
 
     TEST(MATH_Matrix3x3, TestCreateScale)
     {
         Matrix3x3 m1 = Matrix3x3::CreateScale(Vector3(1.0f, 2.0f, 3.0f));
-        AZ_TEST_ASSERT(m1.GetRow(0) == Vector3(1.0f, 0.0f, 0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(1) == Vector3(0.0f, 2.0f, 0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(2) == Vector3(0.0f, 0.0f, 3.0f));
+        EXPECT_THAT(m1.GetRow(0), IsCloseTolerance(Vector3(1.0f, 0.0f, 0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(1), IsCloseTolerance(Vector3(0.0f, 2.0f, 0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(2), IsCloseTolerance(Vector3(0.0f, 0.0f, 3.0f), 1e-6f));
     }
 
     TEST(MATH_Matrix3x3, TestCreateDiagonal)
     {
         Matrix3x3 m1 = Matrix3x3::CreateDiagonal(Vector3(2.0f, 3.0f, 4.0f));
-        AZ_TEST_ASSERT(m1.GetRow(0) == Vector3(2.0f, 0.0f, 0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(1) == Vector3(0.0f, 3.0f, 0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(2) == Vector3(0.0f, 0.0f, 4.0f));
+        EXPECT_THAT(m1.GetRow(0), IsCloseTolerance(Vector3(2.0f, 0.0f, 0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(1), IsCloseTolerance(Vector3(0.0f, 3.0f, 0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(2), IsCloseTolerance(Vector3(0.0f, 0.0f, 4.0f), 1e-6f));
     }
 
     TEST(MATH_Matrix3x3, TestCreateCrossProduct)
     {
         Matrix3x3 m1 = Matrix3x3::CreateCrossProduct(Vector3(1.0f, 2.0f, 3.0f));
-        AZ_TEST_ASSERT(m1.GetRow(0) == Vector3(0.0f, -3.0f, 2.0f));
-        AZ_TEST_ASSERT(m1.GetRow(1) == Vector3(3.0f, 0.0f, -1.0f));
-        AZ_TEST_ASSERT(m1.GetRow(2) == Vector3(-2.0f, 1.0f, 0.0f));
+        EXPECT_THAT(m1.GetRow(0), IsCloseTolerance(Vector3(0.0f, -3.0f, 2.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(1), IsCloseTolerance(Vector3(3.0f, 0.0f, -1.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(2), IsCloseTolerance(Vector3(-2.0f, 1.0f, 0.0f), 1e-6f));
     }
 
     TEST(MATH_Matrix3x3, TestElementAccess)
     {
         Matrix3x3 m1 = Matrix3x3::CreateRotationX(DegToRad(30.0f));
-        AZ_TEST_ASSERT_FLOAT_CLOSE(m1.GetElement(1, 2), -0.5f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(m1.GetElement(2, 2), 0.866f);
+        EXPECT_NEAR(m1.GetElement(1, 2), -0.5f, 2e-3f);
+        EXPECT_NEAR(m1.GetElement(2, 2), 0.866f, 2e-3f);
         m1.SetElement(2, 1, 5.0f);
-        AZ_TEST_ASSERT(m1.GetElement(2, 1) == 5.0f);
+        EXPECT_NEAR(m1.GetElement(2, 1), 5.0f, 1e-6f);
 
-        AZ_TEST_ASSERT_FLOAT_CLOSE(m1(1, 2), -0.5f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(m1(2, 2), 0.866f);
+        EXPECT_NEAR(m1(1, 2), -0.5f, 2e-3f);
+        EXPECT_NEAR(m1(2, 2), 0.866f, 2e-3f);
         m1.SetElement(2, 1, 15.0f);
-        AZ_TEST_ASSERT(m1(2, 1) == 15.0f);
+        EXPECT_NEAR(m1(2, 1), 15.0f, 1e-6f);
     }
 
     TEST(MATH_Matrix3x3, TestRowAccess)
     {
         Matrix3x3 m1 = Matrix3x3::CreateRotationX(DegToRad(30.0f));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector3(0.0f, 0.5f, 0.866f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector3(0.0f, 0.5f, 0.866f)));
         m1.SetRow(0, 1.0f, 2.0f, 3.0f);
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector3(1.0f, 2.0f, 3.0f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector3(1.0f, 2.0f, 3.0f)));
         m1.SetRow(1, Vector3(4.0f, 5.0f, 6.0f));
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector3(4.0f, 5.0f, 6.0f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector3(4.0f, 5.0f, 6.0f)));
         m1.SetRow(2, Vector3(7.0f, 8.0f, 9.0f));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector3(7.0f, 8.0f, 9.0f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector3(7.0f, 8.0f, 9.0f)));
 
         // test GetRow with non-constant, we have different implementations for constants and variables
-        AZ_TEST_ASSERT(m1.GetRow(testIndices3x3[0]).IsClose(Vector3(1.0f, 2.0f, 3.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(testIndices3x3[1]).IsClose(Vector3(4.0f, 5.0f, 6.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(testIndices3x3[2]).IsClose(Vector3(7.0f, 8.0f, 9.0f)));
+        EXPECT_THAT(m1.GetRow(testIndices3x3[0]), IsClose(Vector3(1.0f, 2.0f, 3.0f)));
+        EXPECT_THAT(m1.GetRow(testIndices3x3[1]), IsClose(Vector3(4.0f, 5.0f, 6.0f)));
+        EXPECT_THAT(m1.GetRow(testIndices3x3[2]), IsClose(Vector3(7.0f, 8.0f, 9.0f)));
         Vector3 row0, row1, row2;
         m1.GetRows(&row0, &row1, &row2);
-        AZ_TEST_ASSERT(row0.IsClose(Vector3(1.0f, 2.0f, 3.0f)));
-        AZ_TEST_ASSERT(row1.IsClose(Vector3(4.0f, 5.0f, 6.0f)));
-        AZ_TEST_ASSERT(row2.IsClose(Vector3(7.0f, 8.0f, 9.0f)));
+        EXPECT_THAT(row0, IsClose(Vector3(1.0f, 2.0f, 3.0f)));
+        EXPECT_THAT(row1, IsClose(Vector3(4.0f, 5.0f, 6.0f)));
+        EXPECT_THAT(row2, IsClose(Vector3(7.0f, 8.0f, 9.0f)));
         m1.SetRows(Vector3(10.0f, 11.0f, 12.0f), Vector3(13.0f, 14.0f, 15.0f), Vector3(16.0f, 17.0f, 18.0f));
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector3(10.0f, 11.0f, 12.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector3(13.0f, 14.0f, 15.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector3(16.0f, 17.0f, 18.0f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector3(10.0f, 11.0f, 12.0f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector3(13.0f, 14.0f, 15.0f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector3(16.0f, 17.0f, 18.0f)));
     }
 
     TEST(MATH_Matrix3x3, TestColumnAccess)
     {
         Matrix3x3 m1 = Matrix3x3::CreateRotationX(DegToRad(30.0f));
-        AZ_TEST_ASSERT(m1.GetColumn(1).IsClose(Vector3(0.0f, 0.866f, 0.5f)));
+        EXPECT_THAT(m1.GetColumn(1), IsClose(Vector3(0.0f, 0.866f, 0.5f)));
         m1.SetColumn(2, 1.0f, 2.0f, 3.0f);
-        AZ_TEST_ASSERT(m1.GetColumn(2).IsClose(Vector3(1.0f, 2.0f, 3.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector3(1.0f, 0.0f, 1.0f)));  // checking all components in case others get messed up with the shuffling
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector3(0.0f, 0.866f, 2.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector3(0.0f, 0.5f, 3.0f)));
+        EXPECT_THAT(m1.GetColumn(2), IsClose(Vector3(1.0f, 2.0f, 3.0f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector3(1.0f, 0.0f, 1.0f)));  // checking all components in case others get messed up with the shuffling
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector3(0.0f, 0.866f, 2.0f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector3(0.0f, 0.5f, 3.0f)));
         m1.SetColumn(0, Vector3(2.0f, 3.0f, 4.0f));
-        AZ_TEST_ASSERT(m1.GetColumn(0).IsClose(Vector3(2.0f, 3.0f, 4.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector3(2.0f, 0.0f, 1.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector3(3.0f, 0.866f, 2.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector3(4.0f, 0.5f, 3.0f)));
+        EXPECT_THAT(m1.GetColumn(0), IsClose(Vector3(2.0f, 3.0f, 4.0f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector3(2.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector3(3.0f, 0.866f, 2.0f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector3(4.0f, 0.5f, 3.0f)));
 
         // test GetColumn with non-constant, we have different implementations for constants and variables
-        AZ_TEST_ASSERT(m1.GetColumn(testIndices3x3[0]).IsClose(Vector3(2.0f, 3.0f, 4.0f)));
-        AZ_TEST_ASSERT(m1.GetColumn(testIndices3x3[1]).IsClose(Vector3(0.0f, 0.866f, 0.5f)));
-        AZ_TEST_ASSERT(m1.GetColumn(testIndices3x3[2]).IsClose(Vector3(1.0f, 2.0f, 3.0f)));
+        EXPECT_THAT(m1.GetColumn(testIndices3x3[0]), IsClose(Vector3(2.0f, 3.0f, 4.0f)));
+        EXPECT_THAT(m1.GetColumn(testIndices3x3[1]), IsClose(Vector3(0.0f, 0.866f, 0.5f)));
+        EXPECT_THAT(m1.GetColumn(testIndices3x3[2]), IsClose(Vector3(1.0f, 2.0f, 3.0f)));
         Vector3 col0, col1, col2;
         m1.GetColumns(&col0, &col1, &col2);
-        AZ_TEST_ASSERT(col0.IsClose(Vector3(2.0f, 3.0f, 4.0f)));
-        AZ_TEST_ASSERT(col1.IsClose(Vector3(0.0f, 0.866f, 0.5f)));
-        AZ_TEST_ASSERT(col2.IsClose(Vector3(1.0f, 2.0f, 3.0f)));
+        EXPECT_THAT(col0, IsClose(Vector3(2.0f, 3.0f, 4.0f)));
+        EXPECT_THAT(col1, IsClose(Vector3(0.0f, 0.866f, 0.5f)));
+        EXPECT_THAT(col2, IsClose(Vector3(1.0f, 2.0f, 3.0f)));
         m1.SetColumns(Vector3(10.0f, 11.0f, 12.0f), Vector3(13.0f, 14.0f, 15.0f), Vector3(16.0f, 17.0f, 18.0f));
-        AZ_TEST_ASSERT(m1.GetColumn(0).IsClose(Vector3(10.0f, 11.0f, 12.0f)));
-        AZ_TEST_ASSERT(m1.GetColumn(1).IsClose(Vector3(13.0f, 14.0f, 15.0f)));
-        AZ_TEST_ASSERT(m1.GetColumn(2).IsClose(Vector3(16.0f, 17.0f, 18.0f)));
+        EXPECT_THAT(m1.GetColumn(0), IsClose(Vector3(10.0f, 11.0f, 12.0f)));
+        EXPECT_THAT(m1.GetColumn(1), IsClose(Vector3(13.0f, 14.0f, 15.0f)));
+        EXPECT_THAT(m1.GetColumn(2), IsClose(Vector3(16.0f, 17.0f, 18.0f)));
     }
 
     TEST(MATH_Matrix3x3, TestBasisAccess)
     {
         Matrix3x3 m1 = Matrix3x3::CreateRotationX(DegToRad(30.0f));
-        AZ_TEST_ASSERT(m1.GetBasisX().IsClose(Vector3(1.0f, 0.0f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetBasisY().IsClose(Vector3(0.0f, 0.866f, 0.5f)));
-        AZ_TEST_ASSERT(m1.GetBasisZ().IsClose(Vector3(0.0f, -0.5f, 0.866f)));
+        EXPECT_THAT(m1.GetBasisX(), IsClose(Vector3(1.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(m1.GetBasisY(), IsClose(Vector3(0.0f, 0.866f, 0.5f)));
+        EXPECT_THAT(m1.GetBasisZ(), IsClose(Vector3(0.0f, -0.5f, 0.866f)));
         m1.SetBasisX(1.0f, 2.0f, 3.0f);
-        AZ_TEST_ASSERT(m1.GetBasisX().IsClose(Vector3(1.0f, 2.0f, 3.0f)));
+        EXPECT_THAT(m1.GetBasisX(), IsClose(Vector3(1.0f, 2.0f, 3.0f)));
         m1.SetBasisY(4.0f, 5.0f, 6.0f);
-        AZ_TEST_ASSERT(m1.GetBasisY().IsClose(Vector3(4.0f, 5.0f, 6.0f)));
+        EXPECT_THAT(m1.GetBasisY(), IsClose(Vector3(4.0f, 5.0f, 6.0f)));
         m1.SetBasisZ(7.0f, 8.0f, 9.0f);
-        AZ_TEST_ASSERT(m1.GetBasisZ().IsClose(Vector3(7.0f, 8.0f, 9.0f)));
+        EXPECT_THAT(m1.GetBasisZ(), IsClose(Vector3(7.0f, 8.0f, 9.0f)));
         m1.SetBasisX(Vector3(10.0f, 11.0f, 12.0f));
-        AZ_TEST_ASSERT(m1.GetBasisX().IsClose(Vector3(10.0f, 11.0f, 12.0f)));
+        EXPECT_THAT(m1.GetBasisX(), IsClose(Vector3(10.0f, 11.0f, 12.0f)));
         m1.SetBasisY(Vector3(13.0f, 14.0f, 15.0f));
-        AZ_TEST_ASSERT(m1.GetBasisY().IsClose(Vector3(13.0f, 14.0f, 15.0f)));
+        EXPECT_THAT(m1.GetBasisY(), IsClose(Vector3(13.0f, 14.0f, 15.0f)));
         m1.SetBasisZ(Vector3(16.0f, 17.0f, 18.0f));
-        AZ_TEST_ASSERT(m1.GetBasisZ().IsClose(Vector3(16.0f, 17.0f, 18.0f)));
+        EXPECT_THAT(m1.GetBasisZ(), IsClose(Vector3(16.0f, 17.0f, 18.0f)));
 
         Vector3 basis0, basis1, basis2;
         m1.GetBasis(&basis0, &basis1, &basis2);
-        AZ_TEST_ASSERT(basis0.IsClose(Vector3(10.0f, 11.0f, 12.0f)));
-        AZ_TEST_ASSERT(basis1.IsClose(Vector3(13.0f, 14.0f, 15.0f)));
-        AZ_TEST_ASSERT(basis2.IsClose(Vector3(16.0f, 17.0f, 18.0f)));
+        EXPECT_THAT(basis0, IsClose(Vector3(10.0f, 11.0f, 12.0f)));
+        EXPECT_THAT(basis1, IsClose(Vector3(13.0f, 14.0f, 15.0f)));
+        EXPECT_THAT(basis2, IsClose(Vector3(16.0f, 17.0f, 18.0f)));
         m1.SetBasis(Vector3(1.0f, 2.0f, 3.0f), Vector3(4.0f, 5.0f, 6.0f), Vector3(7.0f, 8.0f, 9.0f));
-        AZ_TEST_ASSERT(m1.GetBasisX().IsClose(Vector3(1.0f, 2.0f, 3.0f)));
-        AZ_TEST_ASSERT(m1.GetBasisY().IsClose(Vector3(4.0f, 5.0f, 6.0f)));
-        AZ_TEST_ASSERT(m1.GetBasisZ().IsClose(Vector3(7.0f, 8.0f, 9.0f)));
+        EXPECT_THAT(m1.GetBasisX(), IsClose(Vector3(1.0f, 2.0f, 3.0f)));
+        EXPECT_THAT(m1.GetBasisY(), IsClose(Vector3(4.0f, 5.0f, 6.0f)));
+        EXPECT_THAT(m1.GetBasisZ(), IsClose(Vector3(7.0f, 8.0f, 9.0f)));
     }
 
     TEST(MATH_Matrix3x3, TestMatrixMultiplication)
@@ -399,29 +399,29 @@ namespace UnitTest
         m1.SetRow(1, 4.0f, 5.0f, 6.0f);
         m1.SetRow(2, 7.0f, 8.0f, 9.0f);
         Matrix3x3 m2 = m1.GetTranspose();
-        AZ_TEST_ASSERT(m2.GetRow(0).IsClose(Vector3(1.0f, 4.0f, 7.0f)));
-        AZ_TEST_ASSERT(m2.GetRow(1).IsClose(Vector3(2.0f, 5.0f, 8.0f)));
-        AZ_TEST_ASSERT(m2.GetRow(2).IsClose(Vector3(3.0f, 6.0f, 9.0f)));
+        EXPECT_THAT(m2.GetRow(0), IsClose(Vector3(1.0f, 4.0f, 7.0f)));
+        EXPECT_THAT(m2.GetRow(1), IsClose(Vector3(2.0f, 5.0f, 8.0f)));
+        EXPECT_THAT(m2.GetRow(2), IsClose(Vector3(3.0f, 6.0f, 9.0f)));
         m2 = m1;
         m2.Transpose();
-        AZ_TEST_ASSERT(m2.GetRow(0).IsClose(Vector3(1.0f, 4.0f, 7.0f)));
-        AZ_TEST_ASSERT(m2.GetRow(1).IsClose(Vector3(2.0f, 5.0f, 8.0f)));
-        AZ_TEST_ASSERT(m2.GetRow(2).IsClose(Vector3(3.0f, 6.0f, 9.0f)));
+        EXPECT_THAT(m2.GetRow(0), IsClose(Vector3(1.0f, 4.0f, 7.0f)));
+        EXPECT_THAT(m2.GetRow(1), IsClose(Vector3(2.0f, 5.0f, 8.0f)));
+        EXPECT_THAT(m2.GetRow(2), IsClose(Vector3(3.0f, 6.0f, 9.0f)));
     }
 
     TEST(MATH_Matrix3x3, TestFastInverse)
     {
         // orthogonal matrix only
         Matrix3x3 m1 = Matrix3x3::CreateRotationX(1.0f);
-        AZ_TEST_ASSERT((m1 * m1.GetInverseFast()).IsClose(Matrix3x3::CreateIdentity(), 0.02f));
+        EXPECT_THAT((m1 * m1.GetInverseFast()), IsCloseTolerance(Matrix3x3::CreateIdentity(), 0.02f));
         Matrix3x3 m2 = Matrix3x3::CreateRotationZ(2.0f) * Matrix3x3::CreateRotationX(1.0f);
         Matrix3x3 m3 = m2.GetInverseFast();
 
         // allow a little bigger threshold, because of the 2 rot matrices (sin,cos differences)
-        AZ_TEST_ASSERT((m2 * m3).IsClose(Matrix3x3::CreateIdentity(), 0.1f));
-        AZ_TEST_ASSERT(m3.GetRow(0).IsClose(Vector3(-0.420f, 0.909f, 0.0f), 0.06f));
-        AZ_TEST_ASSERT(m3.GetRow(1).IsClose(Vector3(-0.493f, -0.228f, 0.841f), 0.06f));
-        AZ_TEST_ASSERT(m3.GetRow(2).IsClose(Vector3(0.765f, 0.353f, 0.542f), 0.06f));
+        EXPECT_THAT((m2 * m3), IsCloseTolerance(Matrix3x3::CreateIdentity(), 0.1f));
+        EXPECT_THAT(m3.GetRow(0), IsCloseTolerance(Vector3(-0.420f, 0.909f, 0.0f), 0.06f));
+        EXPECT_THAT(m3.GetRow(1), IsCloseTolerance(Vector3(-0.493f, -0.228f, 0.841f), 0.06f));
+        EXPECT_THAT(m3.GetRow(2), IsCloseTolerance(Vector3(0.765f, 0.353f, 0.542f), 0.06f));
     }
 
     TEST(MATH_Matrix3x3, TestFullInverse)
@@ -430,7 +430,7 @@ namespace UnitTest
         m1.SetRow(0, -1.0f, 2.0f, 3.0f);
         m1.SetRow(1, 4.0f, 5.0f, 6.0f);
         m1.SetRow(2, 7.0f, 8.0f, -9.0f);
-        AZ_TEST_ASSERT((m1 * m1.GetInverseFull()).IsClose(Matrix3x3::CreateIdentity()));
+        EXPECT_THAT((m1 * m1.GetInverseFull()), IsClose(Matrix3x3::CreateIdentity()));
     }
 
     TEST(MATH_Matrix3x3, TestScaleAccess)
@@ -470,12 +470,12 @@ namespace UnitTest
         Matrix3x3 m1 = Matrix3x3::CreateRotationX(DegToRad(30.0f));
         Matrix3x3 m2 = Matrix3x3::CreateScale(Vector3(5.0f, 6.0f, 7.0f));
         Matrix3x3 m3 = m1 * m2;
-        AZ_TEST_ASSERT(m3.GetPolarDecomposition().IsClose(m1));
+        EXPECT_THAT(m3.GetPolarDecomposition(), IsClose(m1));
         Matrix3x3 m4, m5;
         m3.GetPolarDecomposition(&m4, &m5);
-        AZ_TEST_ASSERT((m4 * m5).IsClose(m3));
-        AZ_TEST_ASSERT(m4.IsClose(m1));
-        AZ_TEST_ASSERT(m5.IsClose(m2, 0.01f));
+        EXPECT_THAT((m4 * m5), IsClose(m3));
+        EXPECT_THAT(m4, IsClose(m1));
+        EXPECT_THAT(m5, IsCloseTolerance(m2, 0.01f));
     }
 
     TEST(MATH_Matrix3x3, TestOrthogonalize)
@@ -493,30 +493,30 @@ namespace UnitTest
         EXPECT_THAT(m2.GetRow(1).Cross(m2.GetRow(2)), IsClose(m2.GetRow(0)));
         EXPECT_THAT(m2.GetRow(2).Cross(m2.GetRow(0)), IsClose(m2.GetRow(1)));
         m1.Orthogonalize();
-        AZ_TEST_ASSERT(m1.IsClose(m2));
+        EXPECT_THAT(m1, IsClose(m2));
     }
 
     TEST(MATH_Matrix3x3, TestOrthogonal)
     {
         Matrix3x3 m1 = Matrix3x3::CreateRotationX(AZ::DegToRad(30.0f));
-        AZ_TEST_ASSERT(m1.IsOrthogonal(0.05f));
+        EXPECT_TRUE(m1.IsOrthogonal(0.05f));
         m1.SetRow(1, m1.GetRow(1) * 2.0f);
-        AZ_TEST_ASSERT(!m1.IsOrthogonal(0.05f));
+        EXPECT_FALSE(m1.IsOrthogonal(0.05f));
         m1 = Matrix3x3::CreateRotationX(AZ::DegToRad(30.0f));
         m1.SetRow(1, Vector3(0.0f, 1.0f, 0.0f));
-        AZ_TEST_ASSERT(!m1.IsOrthogonal(0.05f));
+        EXPECT_FALSE(m1.IsOrthogonal(0.05f));
     }
 
     TEST(MATH_Matrix3x3, TestIsClose)
     {
         Matrix3x3 m1 = Matrix3x3::CreateRotationX(DegToRad(30.0f));
         Matrix3x3 m2 = m1;
-        AZ_TEST_ASSERT(m1.IsClose(m2));
+        EXPECT_TRUE(m1.IsClose(m2));
         m2.SetElement(0, 0, 2.0f);
-        AZ_TEST_ASSERT(!m1.IsClose(m2));
+        EXPECT_FALSE(m1.IsClose(m2));
         m2 = m1;
         m2.SetElement(0, 2, 2.0f);
-        AZ_TEST_ASSERT(!m1.IsClose(m2));
+        EXPECT_FALSE(m1.IsClose(m2));
     }
 
     TEST(MATH_Matrix3x3, TestGetDiagonal)
@@ -525,7 +525,7 @@ namespace UnitTest
         m1.SetRow(0, 1.0f, 2.0f, 3.0f);
         m1.SetRow(1, 4.0f, 5.0f, 6.0f);
         m1.SetRow(2, 7.0f, 8.0f, 9.0f);
-        AZ_TEST_ASSERT(m1.GetDiagonal() == Vector3(1.0f, 5.0f, 9.0f));
+        EXPECT_THAT(m1.GetDiagonal(), IsCloseTolerance(Vector3(1.0f, 5.0f, 9.0f), 1e-6f));
     }
 
     TEST(MATH_Matrix3x3, TestDeterminant)
@@ -544,8 +544,8 @@ namespace UnitTest
         m1.SetRow(1, 4.0f, 5.0f, 6.0f);
         m1.SetRow(2, 7.0f, 8.0f, 9.0f);
         Matrix3x3 m2 = m1.GetAdjugate();
-        AZ_TEST_ASSERT(m2.GetRow(0).IsClose(Vector3(-3.0f, 6.0f, -3.0f)));
-        AZ_TEST_ASSERT(m2.GetRow(1).IsClose(Vector3(6.0f, -12.0f, 6.0f)));
-        AZ_TEST_ASSERT(m2.GetRow(2).IsClose(Vector3(-3.0f, 6.0f, -3.0f)));
+        EXPECT_THAT(m2.GetRow(0), IsClose(Vector3(-3.0f, 6.0f, -3.0f)));
+        EXPECT_THAT(m2.GetRow(1), IsClose(Vector3(6.0f, -12.0f, 6.0f)));
+        EXPECT_THAT(m2.GetRow(2), IsClose(Vector3(-3.0f, 6.0f, -3.0f)));
     }
 }

--- a/Code/Framework/AzCore/Tests/Math/Matrix3x3Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Matrix3x3Tests.cpp
@@ -483,15 +483,15 @@ namespace UnitTest
         Matrix3x3 m1 = Matrix3x3::CreateRotationX(AZ::DegToRad(30.0f)) * Matrix3x3::CreateScale(Vector3(2.0f, 3.0f, 4.0f));
         m1.SetElement(0, 1, 0.2f);
         Matrix3x3 m2 = m1.GetOrthogonalized();
-        AZ_TEST_ASSERT(AZ::IsClose(m2.GetRow(0).GetLength(), 1.0f));
-        AZ_TEST_ASSERT(AZ::IsClose(m2.GetRow(1).GetLength(), 1.0f));
-        AZ_TEST_ASSERT(AZ::IsClose(m2.GetRow(2).GetLength(), 1.0f));
-        AZ_TEST_ASSERT(AZ::IsClose(m2.GetRow(0).Dot(m2.GetRow(1)), 0.0f));
-        AZ_TEST_ASSERT(AZ::IsClose(m2.GetRow(0).Dot(m2.GetRow(2)), 0.0f));
-        AZ_TEST_ASSERT(AZ::IsClose(m2.GetRow(1).Dot(m2.GetRow(2)), 0.0f));
-        AZ_TEST_ASSERT(m2.GetRow(0).Cross(m2.GetRow(1)).IsClose(m2.GetRow(2)));
-        AZ_TEST_ASSERT(m2.GetRow(1).Cross(m2.GetRow(2)).IsClose(m2.GetRow(0)));
-        AZ_TEST_ASSERT(m2.GetRow(2).Cross(m2.GetRow(0)).IsClose(m2.GetRow(1)));
+        EXPECT_NEAR(m2.GetRow(0).GetLength(), 1.0f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(m2.GetRow(1).GetLength(), 1.0f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(m2.GetRow(2).GetLength(), 1.0f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(m2.GetRow(0).Dot(m2.GetRow(1)), 0.0f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(m2.GetRow(0).Dot(m2.GetRow(2)), 0.0f, AZ::Constants::Tolerance);
+        EXPECT_NEAR(m2.GetRow(1).Dot(m2.GetRow(2)), 0.0f, AZ::Constants::Tolerance);
+        EXPECT_THAT(m2.GetRow(0).Cross(m2.GetRow(1)), IsClose(m2.GetRow(2)));
+        EXPECT_THAT(m2.GetRow(1).Cross(m2.GetRow(2)), IsClose(m2.GetRow(0)));
+        EXPECT_THAT(m2.GetRow(2).Cross(m2.GetRow(0)), IsClose(m2.GetRow(1)));
         m1.Orthogonalize();
         AZ_TEST_ASSERT(m1.IsClose(m2));
     }
@@ -534,7 +534,7 @@ namespace UnitTest
         m1.SetRow(0, -1.0f, 2.0f, 3.0f);
         m1.SetRow(1, 4.0f, 5.0f, 6.0f);
         m1.SetRow(2, 7.0f, 8.0f, -9.0f);
-        AZ_TEST_ASSERT(AZ::IsClose(m1.GetDeterminant(), 240.0f));
+        EXPECT_NEAR(m1.GetDeterminant(), 240.0f, AZ::Constants::Tolerance);
     }
 
     TEST(MATH_Matrix3x3, TestAdjugate)

--- a/Code/Framework/AzCore/Tests/Math/Matrix3x4Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Matrix3x4Tests.cpp
@@ -117,7 +117,7 @@ namespace UnitTest
         const AZ::Vector3 vector(1.5f, -0.2f, 2.7f);
         const AZ::Vector3 rotatedVector = matrix.TransformVector(vector);
         // rotating a vector should not affect its length
-        EXPECT_TRUE(AZ::IsClose(rotatedVector.GetLengthSq(), vector.GetLengthSq()));
+        EXPECT_NEAR(rotatedVector.GetLengthSq(), vector.GetLengthSq(), AZ::Constants::Tolerance);
 
         // rotating about the X axis should not affect the X component
         EXPECT_NEAR(rotatedVector.GetX(), vector.GetX(), AZ::Constants::Tolerance);
@@ -138,7 +138,7 @@ namespace UnitTest
         const AZ::Vector3 vector(1.5f, -0.2f, 2.7f);
         const AZ::Vector3 rotatedVector = matrix.TransformVector(vector);
         // rotating a vector should not affect its length
-        EXPECT_TRUE(AZ::IsClose(rotatedVector.GetLengthSq(), vector.GetLengthSq()));
+        EXPECT_NEAR(rotatedVector.GetLengthSq(), vector.GetLengthSq(), AZ::Constants::Tolerance);
 
         // rotating about the Y axis should not affect the Y component
         EXPECT_NEAR(rotatedVector.GetY(), vector.GetY(), AZ::Constants::Tolerance);
@@ -159,7 +159,7 @@ namespace UnitTest
         const AZ::Vector3 vector(1.5f, -0.2f, 2.7f);
         const AZ::Vector3 rotatedVector = matrix.TransformVector(vector);
         // rotating a vector should not affect its length
-        EXPECT_TRUE(AZ::IsClose(rotatedVector.GetLengthSq(), vector.GetLengthSq()));
+        EXPECT_NEAR(rotatedVector.GetLengthSq(), vector.GetLengthSq(), AZ::Constants::Tolerance);
 
         // rotating about the Z axis should not affect the Z component
         EXPECT_NEAR(rotatedVector.GetZ(), vector.GetZ(), AZ::Constants::Tolerance);
@@ -474,7 +474,7 @@ namespace UnitTest
         const AZ::Vector3 from(2.5f, 0.2f, 3.6f);
         // to and from are the same, should generate an error
         AZ_TEST_START_TRACE_SUPPRESSION;
-        EXPECT_TRUE(AZ::Matrix3x4::CreateLookAt(from, from).IsClose(AZ::Matrix3x4::Identity()));
+        EXPECT_THAT(AZ::Matrix3x4::CreateLookAt(from, from), IsClose(AZ::Matrix3x4::Identity()));
         AZ_TEST_STOP_TRACE_SUPPRESSION(1);
 
         // to - from is parallel to usual up direction
@@ -713,7 +713,7 @@ namespace UnitTest
         const AZ::Vector3 vector(0.9f, 3.2f, -1.4f);
         EXPECT_THAT((inverse * matrix) * vector, IsClose(vector));
         EXPECT_THAT((matrix * inverse) * vector, IsClose(vector));
-        EXPECT_TRUE((inverse * matrix).IsClose(AZ::Matrix3x4::Identity()));
+        EXPECT_THAT((inverse * matrix), IsClose(AZ::Matrix3x4::Identity()));
     }
 
     TEST_P(Matrix3x4InvertFullFixture, InvertFull)
@@ -724,7 +724,7 @@ namespace UnitTest
         const AZ::Vector3 vector(2.8f, -1.3f, 2.6f);
         EXPECT_THAT((inverse * matrix) * vector, IsClose(vector));
         EXPECT_THAT((matrix * inverse) * vector, IsClose(vector));
-        EXPECT_TRUE((inverse * matrix).IsClose(AZ::Matrix3x4::Identity()));
+        EXPECT_THAT((inverse * matrix), IsClose(AZ::Matrix3x4::Identity()));
     }
 
     INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4InvertFullFixture, ::testing::ValuesIn(MathTestData::NonOrthogonalMatrix3x4s));
@@ -753,8 +753,8 @@ namespace UnitTest
         const AZ::Vector3 vector(0.9f, 3.2f, -1.4f);
         EXPECT_THAT((inverseFast * matrix) * vector, IsClose(vector));
         EXPECT_THAT((matrix * inverseFast) * vector, IsClose(vector));
-        EXPECT_TRUE((inverseFast * matrix).IsClose(AZ::Matrix3x4::Identity()));
-        EXPECT_TRUE(inverseFast.IsClose(inverseFull));
+        EXPECT_THAT((inverseFast * matrix), IsClose(AZ::Matrix3x4::Identity()));
+        EXPECT_THAT(inverseFast, IsClose(inverseFull));
     }
 
     TEST_P(Matrix3x4InvertFastFixture, InvertFast)
@@ -767,8 +767,8 @@ namespace UnitTest
         const AZ::Vector3 vector(2.8f, -1.3f, 2.6f);
         EXPECT_THAT((inverseFast * matrix) * vector, IsClose(vector));
         EXPECT_THAT((matrix * inverseFast) * vector, IsClose(vector));
-        EXPECT_TRUE((inverseFast * matrix).IsClose(AZ::Matrix3x4::Identity()));
-        EXPECT_TRUE(inverseFast.IsClose(inverseFull));
+        EXPECT_THAT((inverseFast * matrix), IsClose(AZ::Matrix3x4::Identity()));
+        EXPECT_THAT(inverseFast, IsClose(inverseFull));
     }
 
     INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4InvertFastFixture, ::testing::ValuesIn(MathTestData::OrthogonalMatrix3x4s));
@@ -856,7 +856,7 @@ namespace UnitTest
         // a matrix which is already orthogonal should be unchanged
         const AZ::Matrix3x4 orthogonalMatrix = AZ::Matrix3x4::CreateRotationZ(0.7f);
         EXPECT_TRUE(orthogonalMatrix.IsOrthogonal());
-        EXPECT_TRUE(orthogonalMatrix.GetOrthogonalized().IsClose(orthogonalMatrix));
+        EXPECT_THAT(orthogonalMatrix.GetOrthogonalized(), IsClose(orthogonalMatrix));
 
         // a matrix which isn't already orthogonal should be made orthogonal
         const AZ::Matrix3x4 nonOrthogonalMatrix = AZ::Matrix3x4::CreateScale(AZ::Vector3(3.0f, 4.0f, 5.0f));
@@ -870,7 +870,7 @@ namespace UnitTest
         AZ::Matrix3x4 orthogonalMatrix = AZ::Matrix3x4::CreateRotationY(-0.2f);
         EXPECT_TRUE(orthogonalMatrix.IsOrthogonal());
         orthogonalMatrix.Orthogonalize();
-        EXPECT_TRUE(orthogonalMatrix.IsClose(AZ::Matrix3x4::CreateRotationY(-0.2f)));
+        EXPECT_THAT(orthogonalMatrix, IsClose(AZ::Matrix3x4::CreateRotationY(-0.2f)));
 
         // a matrix which isn't already orthogonal should be made orthogonal
         AZ::Matrix3x4 nonOrthogonalMatrix = AZ::Matrix3x4::CreateScale(AZ::Vector3(0.7f, 0.7f, 0.2f));
@@ -887,11 +887,11 @@ namespace UnitTest
         );
 
         AZ::Matrix3x4 matrix2 = matrix1;
-        EXPECT_TRUE(matrix2.IsClose(matrix1, 1e-6f));
+        EXPECT_THAT(matrix2, IsCloseTolerance(matrix1, 1e-6f));
         matrix2.SetElement(0, 2, matrix2(0, 2) + 1e-2f);
         matrix2.SetElement(2, 3, matrix2(2, 3) + 1e-4f);
         matrix2.SetElement(1, 1, matrix2(1, 1) - 1e-6f);
-        EXPECT_TRUE(matrix2.IsClose(matrix1, 1e-1f));
+        EXPECT_THAT(matrix2, IsCloseTolerance(matrix1, 1e-1f));
         EXPECT_FALSE(matrix2.IsClose(matrix1, 1e-3f));
         EXPECT_FALSE(matrix2.IsClose(matrix1, 1e-5f));
         EXPECT_FALSE(matrix2.IsClose(matrix1, 1e-7f));
@@ -930,7 +930,7 @@ namespace UnitTest
         const AZ::Matrix3x4 rotX = AZ::Matrix3x4::CreateRotationX(eulerRadians.GetX());
         const AZ::Matrix3x4 rotY = AZ::Matrix3x4::CreateRotationY(eulerRadians.GetY());
         const AZ::Matrix3x4 rotZ = AZ::Matrix3x4::CreateRotationZ(eulerRadians.GetZ());
-        EXPECT_TRUE(matrix.IsClose(rotX * rotY * rotZ));
+        EXPECT_THAT(matrix, IsClose(rotX * rotY * rotZ));
     }
 
     INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4SetFromEulerDegreesFixture, ::testing::ValuesIn(MathTestData::EulerAnglesDegrees));
@@ -945,7 +945,7 @@ namespace UnitTest
         const AZ::Matrix3x4 rotX = AZ::Matrix3x4::CreateRotationX(eulerRadians.GetX());
         const AZ::Matrix3x4 rotY = AZ::Matrix3x4::CreateRotationY(eulerRadians.GetY());
         const AZ::Matrix3x4 rotZ = AZ::Matrix3x4::CreateRotationZ(eulerRadians.GetZ());
-        EXPECT_TRUE(matrix.IsClose(rotX * rotY * rotZ));
+        EXPECT_THAT(matrix, IsClose(rotX * rotY * rotZ));
     }
 
     INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4SetFromEulerRadiansFixture, ::testing::ValuesIn(MathTestData::EulerAnglesRadians));
@@ -962,11 +962,11 @@ namespace UnitTest
         const AZ::Vector3 eulerDegrees = matrix.GetEulerDegrees();
         AZ::Matrix3x4 eulerMatrix;
         eulerMatrix.SetFromEulerDegrees(eulerDegrees);
-        EXPECT_TRUE(eulerMatrix.IsClose(matrix));
+        EXPECT_THAT(eulerMatrix, IsClose(matrix));
         const AZ::Vector3 eulerRadians = matrix.GetEulerRadians();
         eulerMatrix = AZ::Matrix3x4::Identity();
         eulerMatrix.SetFromEulerRadians(eulerRadians);
-        EXPECT_TRUE(eulerMatrix.IsClose(matrix));
+        EXPECT_THAT(eulerMatrix, IsClose(matrix));
     }
 
     INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4GetEulerFixture, ::testing::ValuesIn(MathTestData::OrthogonalMatrix3x4s));

--- a/Code/Framework/AzCore/Tests/Math/Matrix4x4Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Matrix4x4Tests.cpp
@@ -22,35 +22,35 @@ namespace UnitTest
     TEST(MATH_Matrix4x4, TestCreate)
     {
         Matrix4x4 m1 = Matrix4x4::CreateIdentity();
-        AZ_TEST_ASSERT(m1.GetRow(0) == Vector4(1.0f, 0.0f, 0.0f, 0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(1) == Vector4(0.0f, 1.0f, 0.0f, 0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(2) == Vector4(0.0f, 0.0f, 1.0f, 0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(3) == Vector4(0.0f, 0.0f, 0.0f, 1.0f));
+        EXPECT_THAT(m1.GetRow(0), IsCloseTolerance(Vector4(1.0f, 0.0f, 0.0f, 0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(1), IsCloseTolerance(Vector4(0.0f, 1.0f, 0.0f, 0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(2), IsCloseTolerance(Vector4(0.0f, 0.0f, 1.0f, 0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(3), IsCloseTolerance(Vector4(0.0f, 0.0f, 0.0f, 1.0f), 1e-6f));
         m1 = Matrix4x4::CreateZero();
-        AZ_TEST_ASSERT(m1.GetRow(0) == Vector4(0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(1) == Vector4(0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(2) == Vector4(0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(3) == Vector4(0.0f));
+        EXPECT_THAT(m1.GetRow(0), IsCloseTolerance(Vector4(0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(1), IsCloseTolerance(Vector4(0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(2), IsCloseTolerance(Vector4(0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(3), IsCloseTolerance(Vector4(0.0f), 1e-6f));
         m1 = Matrix4x4::CreateFromValue(2.0f);
-        AZ_TEST_ASSERT(m1.GetRow(0) == Vector4(2.0f));
-        AZ_TEST_ASSERT(m1.GetRow(1) == Vector4(2.0f));
-        AZ_TEST_ASSERT(m1.GetRow(2) == Vector4(2.0f));
-        AZ_TEST_ASSERT(m1.GetRow(3) == Vector4(2.0f));
+        EXPECT_THAT(m1.GetRow(0), IsCloseTolerance(Vector4(2.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(1), IsCloseTolerance(Vector4(2.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(2), IsCloseTolerance(Vector4(2.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(3), IsCloseTolerance(Vector4(2.0f), 1e-6f));
         m1 = Matrix4x4::CreateScale(Vector3(1.0f, 2.0f, 3.0f));
-        AZ_TEST_ASSERT(m1.GetRow(0) == Vector4(1.0f, 0.0f, 0.0f, 0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(1) == Vector4(0.0f, 2.0f, 0.0f, 0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(2) == Vector4(0.0f, 0.0f, 3.0f, 0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(3) == Vector4(0.0f, 0.0f, 0.0f, 1.0f));
+        EXPECT_THAT(m1.GetRow(0), IsCloseTolerance(Vector4(1.0f, 0.0f, 0.0f, 0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(1), IsCloseTolerance(Vector4(0.0f, 2.0f, 0.0f, 0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(2), IsCloseTolerance(Vector4(0.0f, 0.0f, 3.0f, 0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(3), IsCloseTolerance(Vector4(0.0f, 0.0f, 0.0f, 1.0f), 1e-6f));
         m1 = Matrix4x4::CreateDiagonal(Vector4(2.0f, 3.0f, 4.0f, 5.0f));
-        AZ_TEST_ASSERT(m1.GetRow(0) == Vector4(2.0f, 0.0f, 0.0f, 0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(1) == Vector4(0.0f, 3.0f, 0.0f, 0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(2) == Vector4(0.0f, 0.0f, 4.0f, 0.0f));
-        AZ_TEST_ASSERT(m1.GetRow(3) == Vector4(0.0f, 0.0f, 0.0f, 5.0f));
+        EXPECT_THAT(m1.GetRow(0), IsCloseTolerance(Vector4(2.0f, 0.0f, 0.0f, 0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(1), IsCloseTolerance(Vector4(0.0f, 3.0f, 0.0f, 0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(2), IsCloseTolerance(Vector4(0.0f, 0.0f, 4.0f, 0.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(3), IsCloseTolerance(Vector4(0.0f, 0.0f, 0.0f, 5.0f), 1e-6f));
         m1 = Matrix4x4::CreateTranslation(Vector3(1.0f, 2.0f, 3.0f));
-        AZ_TEST_ASSERT(m1.GetRow(0) == Vector4(1.0f, 0.0f, 0.0f, 1.0f));
-        AZ_TEST_ASSERT(m1.GetRow(1) == Vector4(0.0f, 1.0f, 0.0f, 2.0f));
-        AZ_TEST_ASSERT(m1.GetRow(2) == Vector4(0.0f, 0.0f, 1.0f, 3.0f));
-        AZ_TEST_ASSERT(m1.GetRow(3) == Vector4(0.0f, 0.0f, 0.0f, 1.0f));
+        EXPECT_THAT(m1.GetRow(0), IsCloseTolerance(Vector4(1.0f, 0.0f, 0.0f, 1.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(1), IsCloseTolerance(Vector4(0.0f, 1.0f, 0.0f, 2.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(2), IsCloseTolerance(Vector4(0.0f, 0.0f, 1.0f, 3.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(3), IsCloseTolerance(Vector4(0.0f, 0.0f, 0.0f, 1.0f), 1e-6f));
     }
 
     TEST(MATH_Matrix4x4, TestCreateFrom)
@@ -64,19 +64,19 @@ namespace UnitTest
         };
         float testFloatMtx[16];
         Matrix4x4 m1 = Matrix4x4::CreateFromRowMajorFloat16(thisTestFloats);
-        AZ_TEST_ASSERT(m1.GetRow(0) == Vector4(1.0f, 2.0f, 3.0f, 4.0f));
-        AZ_TEST_ASSERT(m1.GetRow(1) == Vector4(5.0f, 6.0f, 7.0f, 8.0f));
-        AZ_TEST_ASSERT(m1.GetRow(2) == Vector4(9.0f, 10.0f, 11.0f, 12.0f));
-        AZ_TEST_ASSERT(m1.GetRow(3) == Vector4(13.0f, 14.0f, 15.0f, 16.0f));
+        EXPECT_THAT(m1.GetRow(0), IsCloseTolerance(Vector4(1.0f, 2.0f, 3.0f, 4.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(1), IsCloseTolerance(Vector4(5.0f, 6.0f, 7.0f, 8.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(2), IsCloseTolerance(Vector4(9.0f, 10.0f, 11.0f, 12.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(3), IsCloseTolerance(Vector4(13.0f, 14.0f, 15.0f, 16.0f), 1e-6f));
         m1.StoreToRowMajorFloat16(testFloatMtx);
-        AZ_TEST_ASSERT(memcmp(testFloatMtx, thisTestFloats, sizeof(testFloatMtx)) == 0);
+        EXPECT_EQ(memcmp(testFloatMtx, thisTestFloats, sizeof(testFloatMtx)), 0);
         m1 = Matrix4x4::CreateFromColumnMajorFloat16(thisTestFloats);
-        AZ_TEST_ASSERT(m1.GetRow(0) == Vector4(1.0f, 5.0f, 9.0f, 13.0f));
-        AZ_TEST_ASSERT(m1.GetRow(1) == Vector4(2.0f, 6.0f, 10.0f, 14.0f));
-        AZ_TEST_ASSERT(m1.GetRow(2) == Vector4(3.0f, 7.0f, 11.0f, 15.0f));
-        AZ_TEST_ASSERT(m1.GetRow(3) == Vector4(4.0f, 8.0f, 12.0f, 16.0f));
+        EXPECT_THAT(m1.GetRow(0), IsCloseTolerance(Vector4(1.0f, 5.0f, 9.0f, 13.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(1), IsCloseTolerance(Vector4(2.0f, 6.0f, 10.0f, 14.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(2), IsCloseTolerance(Vector4(3.0f, 7.0f, 11.0f, 15.0f), 1e-6f));
+        EXPECT_THAT(m1.GetRow(3), IsCloseTolerance(Vector4(4.0f, 8.0f, 12.0f, 16.0f), 1e-6f));
         m1.StoreToColumnMajorFloat16(testFloatMtx);
-        AZ_TEST_ASSERT(memcmp(testFloatMtx, thisTestFloats, sizeof(testFloatMtx)) == 0);
+        EXPECT_EQ(memcmp(testFloatMtx, thisTestFloats, sizeof(testFloatMtx)), 0);
     }
 
     TEST(MATH_Matrix4x4, TestCreateFromMatrix3x4)
@@ -108,125 +108,125 @@ namespace UnitTest
     TEST(MATH_Matrix4x4, TestCreateRotation)
     {
         Matrix4x4 m1 = Matrix4x4::CreateRotationX(DegToRad(30.0f));
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector4(1.0f, 0.0f, 0.0f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector4(0.0f, 0.866f, -0.5f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector4(0.0f, 0.5f, 0.866f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(3).IsClose(Vector4(0.0f, 0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector4(1.0f, 0.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector4(0.0f, 0.866f, -0.5f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector4(0.0f, 0.5f, 0.866f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(3), IsClose(Vector4(0.0f, 0.0f, 0.0f, 1.0f)));
         m1 = Matrix4x4::CreateRotationY(DegToRad(30.0f));
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector4(0.866f, 0.0f, 0.5f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector4(0.0f, 1.0f, 0.0f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector4(-0.5f, 0.0f, 0.866f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(3).IsClose(Vector4(0.0f, 0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector4(0.866f, 0.0f, 0.5f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector4(0.0f, 1.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector4(-0.5f, 0.0f, 0.866f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(3), IsClose(Vector4(0.0f, 0.0f, 0.0f, 1.0f)));
         m1 = Matrix4x4::CreateRotationZ(DegToRad(30.0f));
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector4(0.866f, -0.5f, 0.0f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector4(0.5f, 0.866f, 0.0f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector4(0.0f, 0.0f, 1.0f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(3).IsClose(Vector4(0.0f, 0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector4(0.866f, -0.5f, 0.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector4(0.5f, 0.866f, 0.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector4(0.0f, 0.0f, 1.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(3), IsClose(Vector4(0.0f, 0.0f, 0.0f, 1.0f)));
         m1 = Matrix4x4::CreateFromQuaternion(AZ::Quaternion::CreateRotationX(DegToRad(30.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector4(1.0f, 0.0f, 0.0f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector4(0.0f, 0.866f, -0.5f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector4(0.0f, 0.5f, 0.866f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(3).IsClose(Vector4(0.0f, 0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector4(1.0f, 0.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector4(0.0f, 0.866f, -0.5f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector4(0.0f, 0.5f, 0.866f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(3), IsClose(Vector4(0.0f, 0.0f, 0.0f, 1.0f)));
         m1 = Matrix4x4::CreateFromQuaternionAndTranslation(AZ::Quaternion::CreateRotationX(DegToRad(30.0f)), Vector3(1.0f, 2.0f, 3.0f));
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector4(1.0f, 0.0f, 0.0f, 1.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector4(0.0f, 0.866f, -0.5f, 2.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector4(0.0f, 0.5f, 0.866f, 3.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(3).IsClose(Vector4(0.0f, 0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector4(1.0f, 0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector4(0.0f, 0.866f, -0.5f, 2.0f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector4(0.0f, 0.5f, 0.866f, 3.0f)));
+        EXPECT_THAT(m1.GetRow(3), IsClose(Vector4(0.0f, 0.0f, 0.0f, 1.0f)));
     }
 
     TEST(MATH_Matrix4x4, TestCreateProjection)
     {
         Matrix4x4 m1 = Matrix4x4::CreateProjection(DegToRad(30.0f), 16.0f / 9.0f, 1.0f, 1000.0f);
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector4(-2.099279f, 0.0f, 0.0f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector4(0.0f, 3.732f, 0.0f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector4(0.0f, 0.0f, 1.002f, -2.002f)));
-        AZ_TEST_ASSERT(m1.GetRow(3).IsClose(Vector4(0.0f, 0.0f, 1.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector4(-2.099279f, 0.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector4(0.0f, 3.732f, 0.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector4(0.0f, 0.0f, 1.002f, -2.002f)));
+        EXPECT_THAT(m1.GetRow(3), IsClose(Vector4(0.0f, 0.0f, 1.0f, 0.0f)));
         m1 = Matrix4x4::CreateProjectionFov(DegToRad(30.0f), DegToRad(60.0f), 1.0f, 1000.0f);
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector4(-3.732f, 0.0f, 0.0f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector4(0.0f, 1.732f, 0.0f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector4(0.0f, 0.0f, 1.002f, -2.002f)));
-        AZ_TEST_ASSERT(m1.GetRow(3).IsClose(Vector4(0.0f, 0.0f, 1.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector4(-3.732f, 0.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector4(0.0f, 1.732f, 0.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector4(0.0f, 0.0f, 1.002f, -2.002f)));
+        EXPECT_THAT(m1.GetRow(3), IsClose(Vector4(0.0f, 0.0f, 1.0f, 0.0f)));
         m1 = Matrix4x4::CreateProjectionOffset(0.5f, 1.0f, 0.0f, 0.5f, 1.0f, 1000.0f);
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector4(-4.0f, 0.0f, -3.0f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector4(0.0f, 4.0f, -1.0f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector4(0.0f, 0.0f, 1.002f, -2.002f)));
-        AZ_TEST_ASSERT(m1.GetRow(3).IsClose(Vector4(0.0f, 0.0f, 1.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector4(-4.0f, 0.0f, -3.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector4(0.0f, 4.0f, -1.0f, 0.0f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector4(0.0f, 0.0f, 1.002f, -2.002f)));
+        EXPECT_THAT(m1.GetRow(3), IsClose(Vector4(0.0f, 0.0f, 1.0f, 0.0f)));
     }
 
     TEST(MATH_Matrix4x4, TestElementAccess)
     {
         Matrix4x4 m1 = Matrix4x4::CreateRotationX(DegToRad(30.0f));
-        AZ_TEST_ASSERT_FLOAT_CLOSE(m1.GetElement(1, 2), -0.5f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(m1.GetElement(2, 2), 0.866f);
+        EXPECT_NEAR(m1.GetElement(1, 2), -0.5f, 2e-3f);
+        EXPECT_NEAR(m1.GetElement(2, 2), 0.866f, 2e-3f);
         m1.SetElement(2, 1, 5.0f);
-        AZ_TEST_ASSERT(m1.GetElement(2, 1) == 5.0f);
+        EXPECT_NEAR(m1.GetElement(2, 1), 5.0f, 2e-3f);
     }
 
     TEST(MATH_Matrix4x4, TestIndexAccessors)
     {
         Matrix4x4 m1 = Matrix4x4::CreateRotationX(DegToRad(30.0f));
-        AZ_TEST_ASSERT_FLOAT_CLOSE(m1(1, 2), -0.5f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(m1(2, 2), 0.866f);
+        EXPECT_NEAR(m1(1, 2), -0.5f, 2e-3f);
+        EXPECT_NEAR(m1(2, 2), 0.866f, 2e-3f);
         m1.SetElement(2, 1, 15.0f);
-        AZ_TEST_ASSERT(m1(2, 1) == 15.0f);
+        EXPECT_NEAR(m1(2, 1), 15.0f, 1e-6f);
     }
 
     TEST(MATH_Matrix4x4, TestRowAccess)
     {
         Matrix4x4 m1 = Matrix4x4::CreateRotationX(DegToRad(30.0f));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector4(0.0f, 0.5f, 0.866f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetRowAsVector3(2).IsClose(Vector3(0.0f, 0.5f, 0.866f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector4(0.0f, 0.5f, 0.866f, 0.0f)));
+        EXPECT_THAT(m1.GetRowAsVector3(2), IsClose(Vector3(0.0f, 0.5f, 0.866f)));
         m1.SetRow(0, 1.0f, 2.0f, 3.0f, 4.0f);
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector4(1.0f, 2.0f, 3.0f, 4.0f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector4(1.0f, 2.0f, 3.0f, 4.0f)));
         m1.SetRow(1, Vector3(5.0f, 6.0f, 7.0f), 8.0f);
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector4(5.0f, 6.0f, 7.0f, 8.0f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector4(5.0f, 6.0f, 7.0f, 8.0f)));
         m1.SetRow(2, Vector4(3.0f, 4.0f, 5.0f, 6.0));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector4(3.0f, 4.0f, 5.0f, 6.0f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector4(3.0f, 4.0f, 5.0f, 6.0f)));
         m1.SetRow(3, Vector4(7.0f, 8.0f, 9.0f, 10.0));
-        AZ_TEST_ASSERT(m1.GetRow(3).IsClose(Vector4(7.0f, 8.0f, 9.0f, 10.0f)));
+        EXPECT_THAT(m1.GetRow(3), IsClose(Vector4(7.0f, 8.0f, 9.0f, 10.0f)));
         //test GetRow with non-constant, we have different implementations for constants and variables
-        AZ_TEST_ASSERT(m1.GetRow(testIndices4x4[0]).IsClose(Vector4(1.0f, 2.0f, 3.0f, 4.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(testIndices4x4[1]).IsClose(Vector4(5.0f, 6.0f, 7.0f, 8.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(testIndices4x4[2]).IsClose(Vector4(3.0f, 4.0f, 5.0f, 6.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(testIndices4x4[3]).IsClose(Vector4(7.0f, 8.0f, 9.0f, 10.0f)));
+        EXPECT_THAT(m1.GetRow(testIndices4x4[0]), IsClose(Vector4(1.0f, 2.0f, 3.0f, 4.0f)));
+        EXPECT_THAT(m1.GetRow(testIndices4x4[1]), IsClose(Vector4(5.0f, 6.0f, 7.0f, 8.0f)));
+        EXPECT_THAT(m1.GetRow(testIndices4x4[2]), IsClose(Vector4(3.0f, 4.0f, 5.0f, 6.0f)));
+        EXPECT_THAT(m1.GetRow(testIndices4x4[3]), IsClose(Vector4(7.0f, 8.0f, 9.0f, 10.0f)));
     }
 
     TEST(MATH_Matrix4x4, TestColumnAccess)
     {
         Matrix4x4 m1 = Matrix4x4::CreateRotationX(DegToRad(30.0f));
-        AZ_TEST_ASSERT(m1.GetColumn(1).IsClose(Vector4(0.0f, 0.866f, 0.5f, 0.0f)));
+        EXPECT_THAT(m1.GetColumn(1), IsClose(Vector4(0.0f, 0.866f, 0.5f, 0.0f)));
         m1.SetColumn(3, 1.0f, 2.0f, 3.0f, 4.0f);
-        AZ_TEST_ASSERT(m1.GetColumn(3).IsClose(Vector4(1.0f, 2.0f, 3.0f, 4.0f)));
-        AZ_TEST_ASSERT(m1.GetColumnAsVector3(3).IsClose(Vector3(1.0f, 2.0f, 3.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector4(1.0f, 0.0f, 0.0f, 1.0f))); //checking all components in case others get messed up with the shuffling
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector4(0.0f, 0.866f, -0.5f, 2.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector4(0.0f, 0.5f, 0.866f, 3.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(3).IsClose(Vector4(0.0f, 0.0f, 0.0f, 4.0f)));
+        EXPECT_THAT(m1.GetColumn(3), IsClose(Vector4(1.0f, 2.0f, 3.0f, 4.0f)));
+        EXPECT_THAT(m1.GetColumnAsVector3(3), IsClose(Vector3(1.0f, 2.0f, 3.0f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector4(1.0f, 0.0f, 0.0f, 1.0f))); //checking all components in case others get messed up with the shuffling
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector4(0.0f, 0.866f, -0.5f, 2.0f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector4(0.0f, 0.5f, 0.866f, 3.0f)));
+        EXPECT_THAT(m1.GetRow(3), IsClose(Vector4(0.0f, 0.0f, 0.0f, 4.0f)));
         m1.SetColumn(0, Vector4(2.0f, 3.0f, 4.0f, 5.0f));
-        AZ_TEST_ASSERT(m1.GetColumn(0).IsClose(Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector4(2.0f, 0.0f, 0.0f, 1.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector4(3.0f, 0.866f, -0.5f, 2.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector4(4.0f, 0.5f, 0.866f, 3.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(3).IsClose(Vector4(5.0f, 0.0f, 0.0f, 4.0f)));
+        EXPECT_THAT(m1.GetColumn(0), IsClose(Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector4(2.0f, 0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector4(3.0f, 0.866f, -0.5f, 2.0f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector4(4.0f, 0.5f, 0.866f, 3.0f)));
+        EXPECT_THAT(m1.GetRow(3), IsClose(Vector4(5.0f, 0.0f, 0.0f, 4.0f)));
         //test GetColumn with non-constant, we have different implementations for constants and variables
-        AZ_TEST_ASSERT(m1.GetColumn(testIndices4x4[0]).IsClose(Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
-        AZ_TEST_ASSERT(m1.GetColumn(testIndices4x4[1]).IsClose(Vector4(0.0f, 0.866f, 0.5f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetColumn(testIndices4x4[2]).IsClose(Vector4(0.0f, -0.5f, 0.866f, 0.0f)));
-        AZ_TEST_ASSERT(m1.GetColumn(testIndices4x4[3]).IsClose(Vector4(1.0f, 2.0f, 3.0f, 4.0f)));
+        EXPECT_THAT(m1.GetColumn(testIndices4x4[0]), IsClose(Vector4(2.0f, 3.0f, 4.0f, 5.0f)));
+        EXPECT_THAT(m1.GetColumn(testIndices4x4[1]), IsClose(Vector4(0.0f, 0.866f, 0.5f, 0.0f)));
+        EXPECT_THAT(m1.GetColumn(testIndices4x4[2]), IsClose(Vector4(0.0f, -0.5f, 0.866f, 0.0f)));
+        EXPECT_THAT(m1.GetColumn(testIndices4x4[3]), IsClose(Vector4(1.0f, 2.0f, 3.0f, 4.0f)));
     }
 
     TEST(MATH_Matrix4x4, TestTranslationAccess)
     {
         Matrix4x4 m1 = Matrix4x4::CreateTranslation(Vector3(5.0f, 6.0f, 7.0f));
-        AZ_TEST_ASSERT(m1.GetTranslation().IsClose(Vector3(5.0f, 6.0f, 7.0f)));
+        EXPECT_THAT(m1.GetTranslation(), IsClose(Vector3(5.0f, 6.0f, 7.0f)));
         m1.SetTranslation(1.0f, 2.0f, 3.0f);
-        AZ_TEST_ASSERT(m1.GetTranslation().IsClose(Vector3(1.0f, 2.0f, 3.0f)));
+        EXPECT_THAT(m1.GetTranslation(), IsClose(Vector3(1.0f, 2.0f, 3.0f)));
         m1.SetTranslation(Vector3(2.0f, 3.0f, 4.0f));
-        AZ_TEST_ASSERT(m1.GetTranslation().IsClose(Vector3(2.0f, 3.0f, 4.0f)));
+        EXPECT_THAT(m1.GetTranslation(), IsClose(Vector3(2.0f, 3.0f, 4.0f)));
         m1.SetTranslation(4.0f, 5.0f, 6.0f);
-        AZ_TEST_ASSERT(m1.GetTranslation().IsClose(Vector3(4.0f, 5.0f, 6.0f)));
+        EXPECT_THAT(m1.GetTranslation(), IsClose(Vector3(4.0f, 5.0f, 6.0f)));
         m1.SetTranslation(Vector3(2.0f, 3.0f, 4.0f));
-        AZ_TEST_ASSERT(m1.GetTranslation().IsClose(Vector3(2.0f, 3.0f, 4.0f)));
+        EXPECT_THAT(m1.GetTranslation(), IsClose(Vector3(2.0f, 3.0f, 4.0f)));
     }
 
     TEST(MATH_Matrix4x4, TestMatrixMultiplication)
@@ -413,16 +413,16 @@ namespace UnitTest
         m1.SetRow(2, 9.0f, 10.0f, 11.0f, 12.0f);
         m1.SetRow(3, 13.0f, 14.0f, 15.0f, 16.0f);
         Matrix4x4 m2 = m1.GetTranspose();
-        AZ_TEST_ASSERT(m2.GetRow(0).IsClose(Vector4(1.0f, 5.0f, 9.0f, 13.0f)));
-        AZ_TEST_ASSERT(m2.GetRow(1).IsClose(Vector4(2.0f, 6.0f, 10.0f, 14.0f)));
-        AZ_TEST_ASSERT(m2.GetRow(2).IsClose(Vector4(3.0f, 7.0f, 11.0f, 15.0f)));
-        AZ_TEST_ASSERT(m2.GetRow(3).IsClose(Vector4(4.0f, 8.0f, 12.0f, 16.0f)));
+        EXPECT_THAT(m2.GetRow(0), IsClose(Vector4(1.0f, 5.0f, 9.0f, 13.0f)));
+        EXPECT_THAT(m2.GetRow(1), IsClose(Vector4(2.0f, 6.0f, 10.0f, 14.0f)));
+        EXPECT_THAT(m2.GetRow(2), IsClose(Vector4(3.0f, 7.0f, 11.0f, 15.0f)));
+        EXPECT_THAT(m2.GetRow(3), IsClose(Vector4(4.0f, 8.0f, 12.0f, 16.0f)));
         m2 = m1;
         m2.Transpose();
-        AZ_TEST_ASSERT(m2.GetRow(0).IsClose(Vector4(1.0f, 5.0f, 9.0f, 13.0f)));
-        AZ_TEST_ASSERT(m2.GetRow(1).IsClose(Vector4(2.0f, 6.0f, 10.0f, 14.0f)));
-        AZ_TEST_ASSERT(m2.GetRow(2).IsClose(Vector4(3.0f, 7.0f, 11.0f, 15.0f)));
-        AZ_TEST_ASSERT(m2.GetRow(3).IsClose(Vector4(4.0f, 8.0f, 12.0f, 16.0f)));
+        EXPECT_THAT(m2.GetRow(0), IsClose(Vector4(1.0f, 5.0f, 9.0f, 13.0f)));
+        EXPECT_THAT(m2.GetRow(1), IsClose(Vector4(2.0f, 6.0f, 10.0f, 14.0f)));
+        EXPECT_THAT(m2.GetRow(2), IsClose(Vector4(3.0f, 7.0f, 11.0f, 15.0f)));
+        EXPECT_THAT(m2.GetRow(3), IsClose(Vector4(4.0f, 8.0f, 12.0f, 16.0f)));
     }
 
     TEST(MATH_Matrix4x4, TestFastInverse)
@@ -430,16 +430,16 @@ namespace UnitTest
         Matrix4x4 m1;
         m1 = Matrix4x4::CreateRotationX(1.0f);
         m1.SetTranslation(Vector3(10.0f, -3.0f, 5.0f));
-        AZ_TEST_ASSERT((m1 * m1.GetInverseFast()).IsClose(Matrix4x4::CreateIdentity(), 0.02f));
+        EXPECT_THAT((m1 * m1.GetInverseFast()), IsCloseTolerance(Matrix4x4::CreateIdentity(), 0.02f));
         Matrix4x4 m2 = Matrix4x4::CreateRotationZ(2.0f) * Matrix4x4::CreateRotationX(1.0f);
         m2.SetTranslation(Vector3(-5.0f, 4.2f, -32.0f));
         Matrix4x4 m3 = m2.GetInverseFast();
         // allow a little bigger threshold, because of the 2 rot matrices (sin,cos differences)
-        AZ_TEST_ASSERT((m2 * m3).IsClose(Matrix4x4::CreateIdentity(), 0.1f));
-        AZ_TEST_ASSERT(m3.GetRow(0).IsClose(Vector4(-0.420f, 0.909f, 0.0f, -5.920f), 0.06f));
-        AZ_TEST_ASSERT(m3.GetRow(1).IsClose(Vector4(-0.493f, -0.228f, 0.841f, 25.418f), 0.06f));
-        AZ_TEST_ASSERT(m3.GetRow(2).IsClose(Vector4(0.765f, 0.353f, 0.542f, 19.703f), 0.06f));
-        AZ_TEST_ASSERT(m3.GetRow(3).IsClose(Vector4(0.0f, 0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT((m2 * m3), IsCloseTolerance(Matrix4x4::CreateIdentity(), 0.1f));
+        EXPECT_THAT(m3.GetRow(0), IsCloseTolerance(Vector4(-0.420f, 0.909f, 0.0f, -5.920f), 0.06f));
+        EXPECT_THAT(m3.GetRow(1), IsCloseTolerance(Vector4(-0.493f, -0.228f, 0.841f, 25.418f), 0.06f));
+        EXPECT_THAT(m3.GetRow(2), IsCloseTolerance(Vector4(0.765f, 0.353f, 0.542f, 19.703f), 0.06f));
+        EXPECT_THAT(m3.GetRow(3), IsClose(Vector4(0.0f, 0.0f, 0.0f, 1.0f)));
     }
 
     TEST(MATH_Matrix4x4, TestTransformInverse)
@@ -449,7 +449,7 @@ namespace UnitTest
         m1 = Matrix4x4::CreateRotationX(1.0f);
         m1.SetTranslation(Vector3(10.0f, -3.0f, 5.0f));
         m1.SetElement(0, 1, 23.1234f);
-        AZ_TEST_ASSERT((m1 * m1.GetInverseTransform()).IsClose(Matrix4x4::CreateIdentity(), 0.01f));
+        EXPECT_THAT((m1 * m1.GetInverseTransform()), IsCloseTolerance(Matrix4x4::CreateIdentity(), 0.01f));
     }
 
     TEST(MATH_Matrix4x4, TestFullInverse)
@@ -459,19 +459,19 @@ namespace UnitTest
         m1.SetRow(1, 3.0f, 4.0f, 5.0f, 6.0f);
         m1.SetRow(2, 9.0f, 10.0f, 11.0f, 12.0f);
         m1.SetRow(3, 13.0f, 14.0f, 15.0f, -16.0f);
-        AZ_TEST_ASSERT((m1 * m1.GetInverseFull()).IsClose(Matrix4x4::CreateIdentity()));
+        EXPECT_THAT((m1 * m1.GetInverseFull()), IsClose(Matrix4x4::CreateIdentity()));
     }
 
     TEST(MATH_Matrix4x4, TestIsClose)
     {
         Matrix4x4 m1 = Matrix4x4::CreateRotationX(DegToRad(30.0f));
         Matrix4x4 m2 = m1;
-        AZ_TEST_ASSERT(m1.IsClose(m2));
+        EXPECT_TRUE(m1.IsClose(m2));
         m2.SetElement(0, 0, 2.0f);
-        AZ_TEST_ASSERT(!m1.IsClose(m2));
+        EXPECT_FALSE(m1.IsClose(m2));
         m2 = m1;
         m2.SetElement(0, 3, 2.0f);
-        AZ_TEST_ASSERT(!m1.IsClose(m2));
+        EXPECT_FALSE(m1.IsClose(m2));
     }
 
     TEST(MATH_Matrix4x4, TestSetRotationPart)
@@ -479,10 +479,10 @@ namespace UnitTest
         Matrix4x4 m1 = Matrix4x4::CreateTranslation(Vector3(1.0f, 2.0f, 3.0f));
         m1.SetRow(3, 5.0f, 6.0f, 7.0f, 8.0f);
         m1.SetRotationPartFromQuaternion(AZ::Quaternion::CreateRotationX(DegToRad(30.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(0).IsClose(Vector4(1.0f, 0.0f, 0.0f, 1.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(1).IsClose(Vector4(0.0f, 0.866f, -0.5f, 2.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(2).IsClose(Vector4(0.0f, 0.5f, 0.866f, 3.0f)));
-        AZ_TEST_ASSERT(m1.GetRow(3).IsClose(Vector4(5.0f, 6.0f, 7.0f, 8.0f)));
+        EXPECT_THAT(m1.GetRow(0), IsClose(Vector4(1.0f, 0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(m1.GetRow(1), IsClose(Vector4(0.0f, 0.866f, -0.5f, 2.0f)));
+        EXPECT_THAT(m1.GetRow(2), IsClose(Vector4(0.0f, 0.5f, 0.866f, 3.0f)));
+        EXPECT_THAT(m1.GetRow(3), IsClose(Vector4(5.0f, 6.0f, 7.0f, 8.0f)));
     }
 
     TEST(MATH_Matrix4x4, TestGetDiagonal)
@@ -492,7 +492,7 @@ namespace UnitTest
         m1.SetRow(1, 5.0f, 6.0f, 7.0f, 8.0f);
         m1.SetRow(2, 9.0f, 10.0f, 11.0f, 12.0f);
         m1.SetRow(3, 13.0f, 14.0f, 15.0f, 16.0f);
-        AZ_TEST_ASSERT(m1.GetDiagonal() == Vector4(1.0f, 6.0f, 11.0f, 16.0f));
+        EXPECT_THAT(m1.GetDiagonal(), IsCloseTolerance(Vector4(1.0f, 6.0f, 11.0f, 16.0f), 1e-6f));
     }
 
     TEST(MATH_Matrix4x4, TestScaleAccess)

--- a/Code/Framework/AzCore/Tests/Math/MatrixUtilsTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/MatrixUtilsTests.cpp
@@ -36,12 +36,12 @@ namespace UnitTest
         // point on near plane
         Vector3 nearPos(0, 0, -near_value);
         Vector3 result = MatrixTransformPosition(matrix, nearPos);
-        EXPECT_TRUE(AZ::IsClose(result.GetZ(), 0, floatEpsilon));
+        EXPECT_NEAR(result.GetZ(), 0, floatEpsilon);
 
         // point on far plane
         Vector3 farPos(0, 0, -far_value);
         result = MatrixTransformPosition(matrix, farPos);
-        EXPECT_TRUE(AZ::IsClose(result.GetZ(), 1, floatEpsilon));
+        EXPECT_NEAR(result.GetZ(), 1, floatEpsilon);
 
         // point further than far plane
         Vector3 furtherFarPos(0, 0, -far_value - 1000);
@@ -85,9 +85,9 @@ namespace UnitTest
         // create a reverse depth perspective projection matrix
         MakePerspectiveFovMatrixRH(matrix, fovY, aspectRatio, near_value, far_value, true);
         result = MatrixTransformPosition(matrix, nearPos);
-        EXPECT_TRUE(AZ::IsClose(result.GetZ(), 1, floatEpsilon));
+        EXPECT_NEAR(result.GetZ(), 1, floatEpsilon);
         result = MatrixTransformPosition(matrix, farPos);
-        EXPECT_TRUE(AZ::IsClose(result.GetZ(), 0, floatEpsilon));
+        EXPECT_NEAR(result.GetZ(), 0, floatEpsilon);
         result = MatrixTransformPosition(matrix, furtherFarPos);
         EXPECT_TRUE(result.GetZ() < 0.f);
         result = MatrixTransformPosition(matrix, closerNearPos);
@@ -139,21 +139,21 @@ namespace UnitTest
 
         // center position
         result = MatrixTransformPosition(matrix, Vector3(-50, 150, -500));
-        EXPECT_TRUE(AZ::IsClose(result.GetX(), 0, floatEpsilon));
-        EXPECT_TRUE(AZ::IsClose(result.GetY(), 0, floatEpsilon));
-        EXPECT_TRUE(AZ::IsClose(result.GetZ(), 0.5f, floatEpsilon));
+        EXPECT_NEAR(result.GetX(), 0, floatEpsilon);
+        EXPECT_NEAR(result.GetY(), 0, floatEpsilon);
+        EXPECT_NEAR(result.GetZ(), 0.5f, floatEpsilon);
 
         // left top and far
         result = MatrixTransformPosition(matrix, Vector3(-100, 200, -1000));
-        EXPECT_TRUE(AZ::IsClose(result.GetX(), -1, floatEpsilon));
-        EXPECT_TRUE(AZ::IsClose(result.GetY(), 1, floatEpsilon));
-        EXPECT_TRUE(AZ::IsClose(result.GetZ(), 1, floatEpsilon));
+        EXPECT_NEAR(result.GetX(), -1, floatEpsilon);
+        EXPECT_NEAR(result.GetY(), 1, floatEpsilon);
+        EXPECT_NEAR(result.GetZ(), 1, floatEpsilon);
 
         // right bottom and near
         result = MatrixTransformPosition(matrix, Vector3(0, 100, 0));
-        EXPECT_TRUE(AZ::IsClose(result.GetX(), 1, floatEpsilon));
-        EXPECT_TRUE(AZ::IsClose(result.GetY(), -1, floatEpsilon));
-        EXPECT_TRUE(AZ::IsClose(result.GetZ(), 0, floatEpsilon));
+        EXPECT_NEAR(result.GetX(), 1, floatEpsilon);
+        EXPECT_NEAR(result.GetY(), -1, floatEpsilon);
+        EXPECT_NEAR(result.GetZ(), 0, floatEpsilon);
 
         // further than far
         result = MatrixTransformPosition(matrix, Vector3(-50, 150, -2000));
@@ -177,21 +177,21 @@ namespace UnitTest
         // left top and near
         Vector3 leftTopNear(-100, 200, -1);
         result = MatrixTransformPosition(matrix, leftTopNear);
-        EXPECT_TRUE(AZ::IsClose(result.GetX(), -1, floatEpsilon));
-        EXPECT_TRUE(AZ::IsClose(result.GetY(), 1, floatEpsilon));
-        EXPECT_TRUE(AZ::IsClose(result.GetZ(), 0, floatEpsilon));
+        EXPECT_NEAR(result.GetX(), -1, floatEpsilon);
+        EXPECT_NEAR(result.GetY(), 1, floatEpsilon);
+        EXPECT_NEAR(result.GetZ(), 0, floatEpsilon);
 
         // right bottom and near
         Vector3 rightBottomNear(0, 100, -1);
         result = MatrixTransformPosition(matrix, rightBottomNear);
-        EXPECT_TRUE(AZ::IsClose(result.GetX(), 1, floatEpsilon));
-        EXPECT_TRUE(AZ::IsClose(result.GetY(), -1, floatEpsilon));
-        EXPECT_TRUE(AZ::IsClose(result.GetZ(), 0, floatEpsilon));
+        EXPECT_NEAR(result.GetX(), 1, floatEpsilon);
+        EXPECT_NEAR(result.GetY(), -1, floatEpsilon);
+        EXPECT_NEAR(result.GetZ(), 0, floatEpsilon);
 
         // further than far
         Vector3 far_value(-50, 150, -1000);
         result = MatrixTransformPosition(matrix, far_value);
-        EXPECT_TRUE(AZ::IsClose(result.GetZ(), 1, floatEpsilon));
+        EXPECT_NEAR(result.GetZ(), 1, floatEpsilon);
         Vector3 furtherFar(-50, 150, -2000);
         result = MatrixTransformPosition(matrix, furtherFar);
         EXPECT_TRUE(result.GetZ() > 1);
@@ -204,14 +204,14 @@ namespace UnitTest
         // reverse depth
         MakeFrustumMatrixRH(matrix, -100, 0, 100, 200, 1, 1000, true);
         result = MatrixTransformPosition(matrix, leftTopNear);
-        EXPECT_TRUE(AZ::IsClose(result.GetX(), -1, floatEpsilon));
-        EXPECT_TRUE(AZ::IsClose(result.GetY(), 1, floatEpsilon));
+        EXPECT_NEAR(result.GetX(), -1, floatEpsilon);
+        EXPECT_NEAR(result.GetY(), 1, floatEpsilon);
         result = MatrixTransformPosition(matrix, rightBottomNear);
-        EXPECT_TRUE(AZ::IsClose(result.GetX(), 1, floatEpsilon));
-        EXPECT_TRUE(AZ::IsClose(result.GetY(), -1, floatEpsilon));
-        EXPECT_TRUE(AZ::IsClose(result.GetZ(), 1, floatEpsilon));
+        EXPECT_NEAR(result.GetX(), 1, floatEpsilon);
+        EXPECT_NEAR(result.GetY(), -1, floatEpsilon);
+        EXPECT_NEAR(result.GetZ(), 1, floatEpsilon);
         result = MatrixTransformPosition(matrix, far_value);
-        EXPECT_TRUE(AZ::IsClose(result.GetZ(), 0, floatEpsilon));
+        EXPECT_NEAR(result.GetZ(), 0, floatEpsilon);
 
         // bad input
         UnitTest::TestRunner::Instance().StartAssertTests();

--- a/Code/Framework/AzCore/Tests/Math/MatrixUtilsTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/MatrixUtilsTests.cpp
@@ -24,105 +24,105 @@ namespace UnitTest
     {
         Matrix4x4 matrix;
 
-        constexpr float near_value = 10;
-        constexpr float far_value = 1000;
+        constexpr float near_value = 10.0f;
+        constexpr float far_value = 1000.0f;
         float fovY = Constants::HalfPi;
-        float aspectRatio = 1.f;
+        float aspectRatio = 1.0f;
         auto matPtr = MakePerspectiveFovMatrixRH(matrix, fovY, aspectRatio, near_value, far_value);
         EXPECT_NE(matPtr, nullptr);
         EXPECT_EQ(matPtr, &matrix);
 
         // transform some positions and valid the output
         // point on near plane
-        Vector3 nearPos(0, 0, -near_value);
+        Vector3 nearPos(0.0f, 0.0f, -near_value);
         Vector3 result = MatrixTransformPosition(matrix, nearPos);
-        EXPECT_NEAR(result.GetZ(), 0, floatEpsilon);
+        EXPECT_NEAR(result.GetZ(), 0.0f, floatEpsilon);
 
         // point on far plane
-        Vector3 farPos(0, 0, -far_value);
+        Vector3 farPos(0.0f, 0.0f, -far_value);
         result = MatrixTransformPosition(matrix, farPos);
-        EXPECT_NEAR(result.GetZ(), 1, floatEpsilon);
+        EXPECT_NEAR(result.GetZ(), 1.0f, floatEpsilon);
 
         // point further than far plane
-        Vector3 furtherFarPos(0, 0, -far_value - 1000);
+        Vector3 furtherFarPos(0.0f, 0.0f, -far_value - 1000.0f);
         result = MatrixTransformPosition(matrix, furtherFarPos);
-        EXPECT_TRUE(result.GetZ() > 1.f);
+        EXPECT_GT(result.GetZ(), 1.0f);
 
         // point closer then near plane
-        Vector3 closerNearPos(0, 0, -near_value + 5);
+        Vector3 closerNearPos(0.0f, 0.0f, -near_value + 5.0f);
         result = MatrixTransformPosition(matrix, closerNearPos);
-        EXPECT_TRUE(result.GetZ() < 0.f);
+        EXPECT_LT(result.GetZ(), 0.0f);
 
         // point between near and far
-        Vector3 betweenPos(0, 0, -(far_value + near_value) / 2);
+        Vector3 betweenPos(0.0f, 0.0f, -(far_value + near_value) / 2.0f);
         result = MatrixTransformPosition(matrix, betweenPos);
-        EXPECT_TRUE(result.GetZ() > 0.f);
-        EXPECT_TRUE(result.GetZ() < 1.f);
+        EXPECT_GT(result.GetZ(), 0.0f);
+        EXPECT_LT(result.GetZ(), 1.0f);
 
         // x and y value
-        Vector3 insideLeftTopPos(-900, 900, -far_value);
-        Vector3 insideRightBottomPos(900, -900, -far_value);
-        Vector3 outsideLeftTopPos(-1100, 1100, -far_value);
-        Vector3 outsideRightBottomPos(1100, -1100, -far_value);
+        Vector3 insideLeftTopPos(-900.0f, 900.0f, -far_value);
+        Vector3 insideRightBottomPos(900.0f, -900.0f, -far_value);
+        Vector3 outsideLeftTopPos(-1100.0f, 1100.0f, -far_value);
+        Vector3 outsideRightBottomPos(1100.0f, -1100.0f, -far_value);
 
         result = MatrixTransformPosition(matrix, insideLeftTopPos);
-        EXPECT_TRUE(result.GetX() < 0);
-        EXPECT_TRUE(result.GetX() > -1);
-        EXPECT_TRUE(result.GetY() > 0);
-        EXPECT_TRUE(result.GetY() < 1);
+        EXPECT_LT(result.GetX(), 0.0f);
+        EXPECT_GT(result.GetX(), -1.0f);
+        EXPECT_GT(result.GetY(), 0.0f);
+        EXPECT_LT(result.GetY(), 1.0f);
         result = MatrixTransformPosition(matrix, insideRightBottomPos);
-        EXPECT_TRUE(result.GetX() > 0);
-        EXPECT_TRUE(result.GetX() < 1);
-        EXPECT_TRUE(result.GetY() < 0);
-        EXPECT_TRUE(result.GetY() > -1);
+        EXPECT_GT(result.GetX(), 0.0f);
+        EXPECT_LT(result.GetX(), 1.0f);
+        EXPECT_LT(result.GetY(), 0.0f);
+        EXPECT_GT(result.GetY(), -1.0f);
         result = MatrixTransformPosition(matrix, outsideLeftTopPos);
-        EXPECT_TRUE(result.GetX() < -1);
-        EXPECT_TRUE(result.GetY() > 1);
+        EXPECT_LT(result.GetX(), -1.0f);
+        EXPECT_GT(result.GetY(), 1.0f);
         result = MatrixTransformPosition(matrix, outsideRightBottomPos);
-        EXPECT_TRUE(result.GetX() > 1);
-        EXPECT_TRUE(result.GetY() < -1);
+        EXPECT_GT(result.GetX(), 1.0f);
+        EXPECT_LT(result.GetY(), -1.0f);
 
         // create a reverse depth perspective projection matrix
         MakePerspectiveFovMatrixRH(matrix, fovY, aspectRatio, near_value, far_value, true);
         result = MatrixTransformPosition(matrix, nearPos);
-        EXPECT_NEAR(result.GetZ(), 1, floatEpsilon);
+        EXPECT_NEAR(result.GetZ(), 1.0f, floatEpsilon);
         result = MatrixTransformPosition(matrix, farPos);
-        EXPECT_NEAR(result.GetZ(), 0, floatEpsilon);
+        EXPECT_NEAR(result.GetZ(), 0.0f, floatEpsilon);
         result = MatrixTransformPosition(matrix, furtherFarPos);
-        EXPECT_TRUE(result.GetZ() < 0.f);
+        EXPECT_LT(result.GetZ(), 0.0f);
         result = MatrixTransformPosition(matrix, closerNearPos);
-        EXPECT_TRUE(result.GetZ() > 1.f);
+        EXPECT_GT(result.GetZ(), 1.0f);
         result = MatrixTransformPosition(matrix, betweenPos);
-        EXPECT_TRUE(result.GetZ() > 0.f);
-        EXPECT_TRUE(result.GetZ() < 1.f);
+        EXPECT_GT(result.GetZ(), 0.0f);
+        EXPECT_LT(result.GetZ(), 1.0f);
         result = MatrixTransformPosition(matrix, insideLeftTopPos);
-        EXPECT_TRUE(result.GetX() < 0);
-        EXPECT_TRUE(result.GetX() > -1);
-        EXPECT_TRUE(result.GetY() > 0);
-        EXPECT_TRUE(result.GetY() < 1);
+        EXPECT_LT(result.GetX(), 0.0f);
+        EXPECT_GT(result.GetX(), -1.0f);
+        EXPECT_GT(result.GetY(), 0.0f);
+        EXPECT_LT(result.GetY(), 1.0f);
         result = MatrixTransformPosition(matrix, insideRightBottomPos);
-        EXPECT_TRUE(result.GetX() > 0);
-        EXPECT_TRUE(result.GetX() < 1);
-        EXPECT_TRUE(result.GetY() < 0);
-        EXPECT_TRUE(result.GetY() > -1);
+        EXPECT_GT(result.GetX(), 0.0f);
+        EXPECT_LT(result.GetX(), 1.0f);
+        EXPECT_LT(result.GetY(), 0.0f);
+        EXPECT_GT(result.GetY(), -1.0f);
         result = MatrixTransformPosition(matrix, outsideLeftTopPos);
-        EXPECT_TRUE(result.GetX() < -1);
-        EXPECT_TRUE(result.GetY() > 1);
+        EXPECT_LT(result.GetX(), -1.0f);
+        EXPECT_GT(result.GetY(), 1.0f);
         result = MatrixTransformPosition(matrix, outsideRightBottomPos);
-        EXPECT_TRUE(result.GetX() > 1);
-        EXPECT_TRUE(result.GetY() < -1);
+        EXPECT_GT(result.GetX(), 1.0f);
+        EXPECT_LT(result.GetY(), -1.0f);
 
         // bad input
         UnitTest::TestRunner::Instance().StartAssertTests();
-        EXPECT_FALSE(MakePerspectiveFovMatrixRH(matrix, fovY, -1, near_value, far_value));
+        EXPECT_FALSE(MakePerspectiveFovMatrixRH(matrix, fovY, -1.0f, near_value, far_value));
         EXPECT_EQ(1, UnitTest::TestRunner::Instance().m_numAssertsFailed);
-        EXPECT_FALSE(MakePerspectiveFovMatrixRH(matrix, 0, aspectRatio, near_value, far_value));
+        EXPECT_FALSE(MakePerspectiveFovMatrixRH(matrix, 0.0f, aspectRatio, near_value, far_value));
         EXPECT_EQ(2, UnitTest::TestRunner::Instance().m_numAssertsFailed);
         EXPECT_FALSE(MakePerspectiveFovMatrixRH(matrix, fovY, aspectRatio, -near_value, far_value));
         EXPECT_EQ(3, UnitTest::TestRunner::Instance().m_numAssertsFailed);
         EXPECT_FALSE(MakePerspectiveFovMatrixRH(matrix, fovY, aspectRatio, near_value, -far_value));
         EXPECT_EQ(4, UnitTest::TestRunner::Instance().m_numAssertsFailed);
-        EXPECT_FALSE(MakePerspectiveFovMatrixRH(matrix, fovY, aspectRatio, 0, far_value));
+        EXPECT_FALSE(MakePerspectiveFovMatrixRH(matrix, fovY, aspectRatio, 0.0f, far_value));
         EXPECT_EQ(5, UnitTest::TestRunner::Instance().m_numAssertsFailed);
         UnitTest::TestRunner::Instance().StopAssertTests();
     }
@@ -131,92 +131,92 @@ namespace UnitTest
     {
         Matrix4x4 matrix;
 
-        auto ptr = MakeOrthographicMatrixRH(matrix, -100, 0, 100, 200, 0, 1000);
+        auto ptr = MakeOrthographicMatrixRH(matrix, -100.0f, 0.0f, 100.0f, 200.0f, 0.0f, 1000.0f);
         EXPECT_NE(ptr, nullptr);
         EXPECT_EQ(ptr, &matrix);
 
         Vector3 result;
 
         // center position
-        result = MatrixTransformPosition(matrix, Vector3(-50, 150, -500));
-        EXPECT_NEAR(result.GetX(), 0, floatEpsilon);
-        EXPECT_NEAR(result.GetY(), 0, floatEpsilon);
+        result = MatrixTransformPosition(matrix, Vector3(-50.0f, 150.0f, -500.0f));
+        EXPECT_NEAR(result.GetX(), 0.0f, floatEpsilon);
+        EXPECT_NEAR(result.GetY(), 0.0f, floatEpsilon);
         EXPECT_NEAR(result.GetZ(), 0.5f, floatEpsilon);
 
         // left top and far
-        result = MatrixTransformPosition(matrix, Vector3(-100, 200, -1000));
-        EXPECT_NEAR(result.GetX(), -1, floatEpsilon);
-        EXPECT_NEAR(result.GetY(), 1, floatEpsilon);
-        EXPECT_NEAR(result.GetZ(), 1, floatEpsilon);
+        result = MatrixTransformPosition(matrix, Vector3(-100.0f, 200.0f, -1000.0f));
+        EXPECT_NEAR(result.GetX(), -1.0f, floatEpsilon);
+        EXPECT_NEAR(result.GetY(), 1.0f, floatEpsilon);
+        EXPECT_NEAR(result.GetZ(), 1.0f, floatEpsilon);
 
         // right bottom and near
-        result = MatrixTransformPosition(matrix, Vector3(0, 100, 0));
-        EXPECT_NEAR(result.GetX(), 1, floatEpsilon);
-        EXPECT_NEAR(result.GetY(), -1, floatEpsilon);
-        EXPECT_NEAR(result.GetZ(), 0, floatEpsilon);
+        result = MatrixTransformPosition(matrix, Vector3(0.0f, 100.0f, 0.0f));
+        EXPECT_NEAR(result.GetX(), 1.0f, floatEpsilon);
+        EXPECT_NEAR(result.GetY(), -1.0f, floatEpsilon);
+        EXPECT_NEAR(result.GetZ(), 0.0f, floatEpsilon);
 
         // further than far
-        result = MatrixTransformPosition(matrix, Vector3(-50, 150, -2000));
-        EXPECT_TRUE(result.GetZ() > 1);
+        result = MatrixTransformPosition(matrix, Vector3(-50.0f, 150.0f, -2000.0f));
+        EXPECT_GT(result.GetZ(), 1.0f);
 
         // closer than near
-        result = MatrixTransformPosition(matrix, Vector3(-50, 150, 200));
-        EXPECT_TRUE(result.GetZ() < 0);
+        result = MatrixTransformPosition(matrix, Vector3(-50.0f, 150.0f, 200.0f));
+        EXPECT_LT(result.GetZ(), 0.0f);
     }
 
     TEST_F(MatrixUtilsTests, FrustumMatrixRH)
     {
         Matrix4x4 matrix;
 
-        auto ptr = MakeFrustumMatrixRH(matrix, -100, 0, 100, 200, 1, 1000);
+        auto ptr = MakeFrustumMatrixRH(matrix, -100.0f, 0.0f, 100.0f, 200.0f, 1.0f, 1000.0f);
         EXPECT_NE(ptr, nullptr);
         EXPECT_EQ(ptr, &matrix);
 
         Vector3 result;
 
         // left top and near
-        Vector3 leftTopNear(-100, 200, -1);
+        Vector3 leftTopNear(-100.0f, 200.0f, -1.0f);
         result = MatrixTransformPosition(matrix, leftTopNear);
-        EXPECT_NEAR(result.GetX(), -1, floatEpsilon);
-        EXPECT_NEAR(result.GetY(), 1, floatEpsilon);
-        EXPECT_NEAR(result.GetZ(), 0, floatEpsilon);
+        EXPECT_NEAR(result.GetX(), -1.0f, floatEpsilon);
+        EXPECT_NEAR(result.GetY(), 1.0f, floatEpsilon);
+        EXPECT_NEAR(result.GetZ(), 0.0f, floatEpsilon);
 
         // right bottom and near
-        Vector3 rightBottomNear(0, 100, -1);
+        Vector3 rightBottomNear(0.0f, 100.0f, -1.0f);
         result = MatrixTransformPosition(matrix, rightBottomNear);
-        EXPECT_NEAR(result.GetX(), 1, floatEpsilon);
-        EXPECT_NEAR(result.GetY(), -1, floatEpsilon);
-        EXPECT_NEAR(result.GetZ(), 0, floatEpsilon);
+        EXPECT_NEAR(result.GetX(), 1.0f, floatEpsilon);
+        EXPECT_NEAR(result.GetY(), -1.0f, floatEpsilon);
+        EXPECT_NEAR(result.GetZ(), 0.0f, floatEpsilon);
 
         // further than far
-        Vector3 far_value(-50, 150, -1000);
+        Vector3 far_value(-50.0f, 150.0f, -1000.0f);
         result = MatrixTransformPosition(matrix, far_value);
-        EXPECT_NEAR(result.GetZ(), 1, floatEpsilon);
-        Vector3 furtherFar(-50, 150, -2000);
+        EXPECT_NEAR(result.GetZ(), 1.0f, floatEpsilon);
+        Vector3 furtherFar(-50.0f, 150.0f, -2000.0f);
         result = MatrixTransformPosition(matrix, furtherFar);
-        EXPECT_TRUE(result.GetZ() > 1);
+        EXPECT_GT(result.GetZ(), 1.0f);
 
         // closer than near
-        Vector3 closerNear(-50, 150, -0.5f);
+        Vector3 closerNear(-50.0f, 150.0f, -0.5f);
         result = MatrixTransformPosition(matrix, closerNear);
-        EXPECT_TRUE(result.GetZ() < 0);
+        EXPECT_LT(result.GetZ(), 0.0f);
 
         // reverse depth
-        MakeFrustumMatrixRH(matrix, -100, 0, 100, 200, 1, 1000, true);
+        MakeFrustumMatrixRH(matrix, -100.0f, 0.0f, 100.0f, 200.0f, 1.0f, 1000.0f, true);
         result = MatrixTransformPosition(matrix, leftTopNear);
-        EXPECT_NEAR(result.GetX(), -1, floatEpsilon);
-        EXPECT_NEAR(result.GetY(), 1, floatEpsilon);
+        EXPECT_NEAR(result.GetX(), -1.0f, floatEpsilon);
+        EXPECT_NEAR(result.GetY(), 1.0f, floatEpsilon);
         result = MatrixTransformPosition(matrix, rightBottomNear);
-        EXPECT_NEAR(result.GetX(), 1, floatEpsilon);
-        EXPECT_NEAR(result.GetY(), -1, floatEpsilon);
-        EXPECT_NEAR(result.GetZ(), 1, floatEpsilon);
+        EXPECT_NEAR(result.GetX(), 1.0f, floatEpsilon);
+        EXPECT_NEAR(result.GetY(), -1.0f, floatEpsilon);
+        EXPECT_NEAR(result.GetZ(), 1.0f, floatEpsilon);
         result = MatrixTransformPosition(matrix, far_value);
-        EXPECT_NEAR(result.GetZ(), 0, floatEpsilon);
+        EXPECT_NEAR(result.GetZ(), 0.0f, floatEpsilon);
 
         // bad input
         UnitTest::TestRunner::Instance().StartAssertTests();
         // near = 0
-        EXPECT_FALSE(MakeFrustumMatrixRH(matrix, -100, 0, 100, 200, 0, 1000));
+        EXPECT_FALSE(MakeFrustumMatrixRH(matrix, -100.0f, 0.0f, 100.0f, 200.0f, 0.0f, 1000.0f));
         EXPECT_EQ(1, UnitTest::TestRunner::Instance().m_numAssertsFailed);
         UnitTest::TestRunner::Instance().StopAssertTests();
     }

--- a/Code/Framework/AzCore/Tests/Math/PlaneTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/PlaneTests.cpp
@@ -12,6 +12,7 @@
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Vector4.h>
 #include <AzCore/UnitTest/TestTypes.h>
+#include <AZTestShared/Math/MathTestHelpers.h>
 #include <Math/MathTest.h>
 
 using namespace AZ;
@@ -21,28 +22,28 @@ namespace UnitTest
     TEST(MATH_Plane, TestCreateFromNormalAndDistance)
     {
         Plane pl = Plane::CreateFromNormalAndDistance(Vector3(1.0f, 0.0f, 0.0f), -100.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetDistance(), -100.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetX(), 1.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetY(), 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetZ(), 0.0f);
+        EXPECT_NEAR(pl.GetDistance(), -100.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetX(), 1.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetY(), 0.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetZ(), 0.0f, 2e-3f);
     }
 
     TEST(MATH_Plane, TestCreateFromNormalAndPoint)
     {
         Plane pl = Plane::CreateFromNormalAndPoint(Vector3(0.0f, 1.0f, 0.0f), Vector3(10, 10, 10));
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetDistance(), -10.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetX(), 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetY(), 1.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetZ(), 0.0f);
+        EXPECT_NEAR(pl.GetDistance(), -10.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetX(), 0.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetY(), 1.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetZ(), 0.0f, 2e-3f);
     }
 
     TEST(MATH_Plane, TestCreateFromCoefficients)
     {
         Plane pl = Plane::CreateFromCoefficients(0.0f, -1.0f, 0.0f, -5.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetDistance(), -5.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetX(), 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetY(), -1.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetZ(), 0.0f);
+        EXPECT_NEAR(pl.GetDistance(), -5.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetX(), 0.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetY(), -1.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetZ(), 0.0f, 2e-3f);
     }
 
     TEST(MATH_Plane, TestSet)
@@ -51,10 +52,10 @@ namespace UnitTest
         AZ_MATH_TEST_START_TRACE_SUPPRESSION;
         pl.Set(12.0f, 13.0f, 14.0f, 15.0f);
         AZ_MATH_TEST_STOP_TRACE_SUPPRESSION(1);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetDistance(), 15.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetX(), 12.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetY(), 13.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetZ(), 14.0f);
+        EXPECT_NEAR(pl.GetDistance(), 15.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetX(), 12.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetY(), 13.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetZ(), 14.0f, 2e-3f);
     }
 
     TEST(MATH_Plane, TestSetVector3)
@@ -63,37 +64,37 @@ namespace UnitTest
         AZ_MATH_TEST_START_TRACE_SUPPRESSION;
         pl.Set(Vector3(22.0f, 23.0f, 24.0f), 25.0f);
         AZ_MATH_TEST_STOP_TRACE_SUPPRESSION(1);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetDistance(), 25.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetX(), 22.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetY(), 23.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetZ(), 24.0f);
+        EXPECT_NEAR(pl.GetDistance(), 25.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetX(), 22.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetY(), 23.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetZ(), 24.0f, 2e-3f);
     }
 
     TEST(MATH_Plane, TestSetVector4)
     {
         Plane pl;
         pl.Set(Vector4(32.0f, 33.0f, 34.0f, 35.0f));
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetDistance(), 35.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetX(), 32.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetY(), 33.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetZ(), 34.0f);
+        EXPECT_NEAR(pl.GetDistance(), 35.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetX(), 32.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetY(), 33.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetZ(), 34.0f, 2e-3f);
     }
 
     TEST(MATH_Plane, TestSetNormalAndDistance)
     {
         Plane pl;
         pl.SetNormal(Vector3(0.0f, 0.0f, 1.0f));
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetX(), 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetY(), 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetNormal().GetZ(), 1.0f);
+        EXPECT_NEAR(pl.GetNormal().GetX(), 0.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetY(), 0.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetNormal().GetZ(), 1.0f, 2e-3f);
 
         pl.SetDistance(55.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetDistance(), 55.0f);
+        EXPECT_NEAR(pl.GetDistance(), 55.0f, 2e-3f);
 
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetPlaneEquationCoefficients().GetW(), 55.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetPlaneEquationCoefficients().GetX(), 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetPlaneEquationCoefficients().GetY(), 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetPlaneEquationCoefficients().GetZ(), 1.0f);
+        EXPECT_NEAR(pl.GetPlaneEquationCoefficients().GetW(), 55.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetPlaneEquationCoefficients().GetX(), 0.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetPlaneEquationCoefficients().GetY(), 0.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetPlaneEquationCoefficients().GetZ(), 1.0f, 2e-3f);
     }
 
     TEST(MATH_Plane, TestGetTransform)
@@ -103,13 +104,13 @@ namespace UnitTest
 
         Transform tm = Transform::CreateRotationY(DegToRad(90.0f));
         pl = pl.GetTransform(tm);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetPlaneEquationCoefficients().GetW(), 55.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetPlaneEquationCoefficients().GetX(), 1.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetPlaneEquationCoefficients().GetY(), 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetPlaneEquationCoefficients().GetZ(), 0.0f);
+        EXPECT_NEAR(pl.GetPlaneEquationCoefficients().GetW(), 55.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetPlaneEquationCoefficients().GetX(), 1.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetPlaneEquationCoefficients().GetY(), 0.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetPlaneEquationCoefficients().GetZ(), 0.0f, 2e-3f);
 
         float dist = pl.GetPointDist(Vector3(10.0f, 0.0f, 0.0f));
-        AZ_TEST_ASSERT_FLOAT_CLOSE(dist, 65.0f);  // 55 + 10
+        EXPECT_NEAR(dist, 65.0f, 2e-3f);  // 55 + 10
     }
 
     TEST(MATH_Plane, TestApplyTransform)
@@ -121,10 +122,10 @@ namespace UnitTest
         Transform tm2 = Transform::CreateRotationZ(DegToRad(45.0f));
         pl.ApplyTransform(tm1);
         pl.ApplyTransform(tm2);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetPlaneEquationCoefficients().GetW(), 55.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetPlaneEquationCoefficients().GetX(), 0.707f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetPlaneEquationCoefficients().GetY(), 0.707f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(pl.GetPlaneEquationCoefficients().GetZ(), 0.0f);
+        EXPECT_NEAR(pl.GetPlaneEquationCoefficients().GetW(), 55.0f, 2e-3f);
+        EXPECT_NEAR(pl.GetPlaneEquationCoefficients().GetX(), 0.707f, 2e-3f);
+        EXPECT_NEAR(pl.GetPlaneEquationCoefficients().GetY(), 0.707f, 2e-3f);
+        EXPECT_NEAR(pl.GetPlaneEquationCoefficients().GetZ(), 0.0f, 2e-3f);
     }
 
     TEST(MATH_Plane, TestGetProjected)
@@ -132,7 +133,7 @@ namespace UnitTest
         Plane pl;
         pl.Set(Vector3(0.0f, 0.0f, 1.0f), 55.0f);
         Vector3 v1 = pl.GetProjected(Vector3(10.0f, 15.0f, 20.0f));
-        AZ_TEST_ASSERT(v1 == Vector3(10.0f, 15.0f, 0.0f));
+        EXPECT_THAT(v1, IsCloseTolerance(Vector3(10.0f, 15.0f, 0.0f), 1e-6f));
     }
 
     TEST(MATH_Plane, TestCastRay)
@@ -142,18 +143,18 @@ namespace UnitTest
         Plane pl;
         pl.Set(0.0f, 0.0f, 1.0f, 10.0f);
         bool hit = pl.CastRay(Vector3(0.0f, 0.0f, 0.0f), Vector3(0.0f, 0.0f, 1.0f), hitPoint);
-        AZ_TEST_ASSERT(hit == true);
-        AZ_TEST_ASSERT(hitPoint.IsClose(Vector3(0.0f, 0.0f, -10.0f)));
+        EXPECT_TRUE(hit);
+        EXPECT_THAT(hitPoint, IsClose(Vector3(0.0f, 0.0f, -10.0f)));
 
         pl.Set(0.0f, 1.0f, 0.0f, 10.0f);
         float time;
         hit = pl.CastRay(Vector3(0.0f, 1.0f, 0.0f), Vector3(0.0f, -1.0f, 0.0f), time);
-        AZ_TEST_ASSERT(hit == true);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(time, 10.999f);
+        EXPECT_TRUE(hit);
+        EXPECT_NEAR(time, 10.999f, 2e-3f);
 
         pl.Set(1.0f, 0.0f, 0.0f, 5.0f);
         hit = pl.CastRay(Vector3(0.0f, 1.0f, 0.0f), Vector3(0.0f, -1.0f, 0.0f), time);
-        AZ_TEST_ASSERT(hit == false);
+        EXPECT_FALSE(hit);
     }
 
     TEST(MATH_Plane, TestIntersectSegment)
@@ -162,30 +163,30 @@ namespace UnitTest
         Plane pl;
         pl.Set(1.0f, 0.0f, 0.0f, 0.0f);
         bool hit = pl.IntersectSegment(Vector3(-1.0f, 0.0f, 0.0f), Vector3(1.0f, 0.0f, 0.0f), hitPoint);
-        AZ_TEST_ASSERT(hit == true);
-        AZ_TEST_ASSERT(hitPoint.IsClose(Vector3(0.0f, 0.0f, 0.0f)));
+        EXPECT_TRUE(hit);
+        EXPECT_THAT(hitPoint, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
 
         float time;
         pl.Set(0.0f, 1.0f, 0.0f, 0.0f);
         hit = pl.IntersectSegment(Vector3(0.0f, -10.0f, 0.0f), Vector3(0.0f, 10.0f, 0.0f), time);
-        AZ_TEST_ASSERT(hit == true);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(time, 0.5f);
+        EXPECT_TRUE(hit);
+        EXPECT_NEAR(time, 0.5f, 2e-3f);
 
         pl.Set(0.0f, 1.0f, 0.0f, 20.0f);
         hit = pl.IntersectSegment(Vector3(-1.0f, 0.0f, 0.0f), Vector3(1.0f, 0.0f, 0.0f), time);
-        AZ_TEST_ASSERT(hit == false);
+        EXPECT_FALSE(hit);
     }
 
     TEST(MATH_Plane, TestIsFinite)
     {
         Plane pl;
         pl.Set(1.0f, 0.0f, 0.0f, 0.0f);
-        AZ_TEST_ASSERT(pl.IsFinite());
+        EXPECT_TRUE(pl.IsFinite());
         const float infinity = std::numeric_limits<float>::infinity();
         AZ_MATH_TEST_START_TRACE_SUPPRESSION;
         pl.Set(infinity, infinity, infinity, infinity);
         AZ_MATH_TEST_STOP_TRACE_SUPPRESSION(1);
-        AZ_TEST_ASSERT(!pl.IsFinite());
+        EXPECT_FALSE(pl.IsFinite());
     }
 
     TEST(MATH_Plane, CreateFromVectorCoefficients_IsEquivalentToCreateFromCoefficients)

--- a/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
@@ -49,43 +49,43 @@ namespace UnitTest
         AZ::Quaternion q6 = AZ::Quaternion::CreateFromVector3(Vector3(1.0f, 2.0f, 3.0f));
         EXPECT_TRUE((q6.GetX() == 1.0f) && (q6.GetY() == 2.0f) && (q6.GetZ() == 3.0f) && (q6.GetW() == 0.0f));
         AZ::Quaternion q7 = AZ::Quaternion::CreateFromAxisAngle(Vector3::CreateAxisZ(), DegToRad(45.0f));
-        EXPECT_TRUE(q7.IsClose(AZ::Quaternion::CreateRotationZ(DegToRad(45.0f))));
+        EXPECT_THAT(q7, IsClose(AZ::Quaternion::CreateRotationZ(DegToRad(45.0f))));
 
         AZ::Quaternion q8 = Transform::CreateRotationX(DegToRad(60.0f)).GetRotation();
-        EXPECT_TRUE(q8.IsClose(AZ::Quaternion(0.5f, 0.0f, 0.0f, 0.866f)));
+        EXPECT_THAT(q8, IsClose(AZ::Quaternion(0.5f, 0.0f, 0.0f, 0.866f)));
         AZ::Quaternion q9 = AZ::Quaternion::CreateFromMatrix3x3(Matrix3x3::CreateRotationX(DegToRad(120.0f)));
-        EXPECT_TRUE(q9.IsClose(AZ::Quaternion(0.866f, 0.0f, 0.0f, 0.5f)));
+        EXPECT_THAT(q9, IsClose(AZ::Quaternion(0.866f, 0.0f, 0.0f, 0.5f)));
         AZ::Quaternion q10 = AZ::Quaternion::CreateFromMatrix4x4(Matrix4x4::CreateRotationX(DegToRad(120.0f)));
-        EXPECT_TRUE(q10.IsClose(AZ::Quaternion(0.866f, 0.0f, 0.0f, 0.5f)));
+        EXPECT_THAT(q10, IsClose(AZ::Quaternion(0.866f, 0.0f, 0.0f, 0.5f)));
         AZ::Quaternion q11 = AZ::Quaternion::CreateFromMatrix3x3(Matrix3x3::CreateRotationX(DegToRad(-60.0f)));
-        EXPECT_TRUE(q11.IsClose(AZ::Quaternion(-0.5f, 0.0f, 0.0f, 0.866f)));
+        EXPECT_THAT(q11, IsClose(AZ::Quaternion(-0.5f, 0.0f, 0.0f, 0.866f)));
         AZ::Quaternion q12 = AZ::Quaternion::CreateFromMatrix4x4(Matrix4x4::CreateRotationX(DegToRad(-60.0f)));
-        EXPECT_TRUE(q12.IsClose(AZ::Quaternion(-0.5f, 0.0f, 0.0f, 0.866f)));
+        EXPECT_THAT(q12, IsClose(AZ::Quaternion(-0.5f, 0.0f, 0.0f, 0.866f)));
         AZ::Quaternion q13 = AZ::Quaternion::CreateFromMatrix3x3(Matrix3x3::CreateRotationY(DegToRad(120.0f)));
-        EXPECT_TRUE(q13.IsClose(AZ::Quaternion(0.0f, 0.866f, 0.0f, 0.5f)));
+        EXPECT_THAT(q13, IsClose(AZ::Quaternion(0.0f, 0.866f, 0.0f, 0.5f)));
         AZ::Quaternion q14 = AZ::Quaternion::CreateFromMatrix4x4(Matrix4x4::CreateRotationY(DegToRad(120.0f)));
-        EXPECT_TRUE(q14.IsClose(AZ::Quaternion(0.0f, 0.866f, 0.0f, 0.5f)));
+        EXPECT_THAT(q14, IsClose(AZ::Quaternion(0.0f, 0.866f, 0.0f, 0.5f)));
         AZ::Quaternion q15 = AZ::Quaternion::CreateFromMatrix3x3(Matrix3x3::CreateRotationY(DegToRad(-60.0f)));
-        EXPECT_TRUE(q15.IsClose(AZ::Quaternion(0.0f, -0.5f, 0.0f, 0.866f)));
+        EXPECT_THAT(q15, IsClose(AZ::Quaternion(0.0f, -0.5f, 0.0f, 0.866f)));
         AZ::Quaternion q16 = AZ::Quaternion::CreateFromMatrix4x4(Matrix4x4::CreateRotationY(DegToRad(-60.0f)));
-        EXPECT_TRUE(q16.IsClose(AZ::Quaternion(0.0f, -0.5f, 0.0f, 0.866f)));
+        EXPECT_THAT(q16, IsClose(AZ::Quaternion(0.0f, -0.5f, 0.0f, 0.866f)));
         AZ::Quaternion q17 = AZ::Quaternion::CreateFromMatrix3x3(Matrix3x3::CreateRotationZ(DegToRad(120.0f)));
-        EXPECT_TRUE(q17.IsClose(AZ::Quaternion(0.0f, 0.0f, 0.866f, 0.5f)));
+        EXPECT_THAT(q17, IsClose(AZ::Quaternion(0.0f, 0.0f, 0.866f, 0.5f)));
         AZ::Quaternion q18 = AZ::Quaternion::CreateFromMatrix4x4(Matrix4x4::CreateRotationZ(DegToRad(120.0f)));
-        EXPECT_TRUE(q18.IsClose(AZ::Quaternion(0.0f, 0.0f, 0.866f, 0.5f)));
+        EXPECT_THAT(q18, IsClose(AZ::Quaternion(0.0f, 0.0f, 0.866f, 0.5f)));
         AZ::Quaternion q19 = AZ::Quaternion::CreateFromMatrix3x3(Matrix3x3::CreateRotationZ(DegToRad(-60.0f)));
-        EXPECT_TRUE(q19.IsClose(AZ::Quaternion(0.0f, 0.0f, -0.5f, 0.866f)));
+        EXPECT_THAT(q19, IsClose(AZ::Quaternion(0.0f, 0.0f, -0.5f, 0.866f)));
         AZ::Quaternion q20 = AZ::Quaternion::CreateFromMatrix4x4(Matrix4x4::CreateRotationZ(DegToRad(-60.0f)));
-        EXPECT_TRUE(q20.IsClose(AZ::Quaternion(0.0f, 0.0f, -0.5f, 0.866f)));
+        EXPECT_THAT(q20, IsClose(AZ::Quaternion(0.0f, 0.0f, -0.5f, 0.866f)));
     }
 
     TEST(MATH_Quaternion, TestCreate)
     {
         EXPECT_TRUE(AZ::Quaternion::CreateIdentity() == AZ::Quaternion(0.0f, 0.0f, 0.0f, 1.0f));
         EXPECT_TRUE(AZ::Quaternion::CreateZero() == AZ::Quaternion(0.0f));
-        EXPECT_TRUE(AZ::Quaternion::CreateRotationX(DegToRad(60.0f)).IsClose(AZ::Quaternion(0.5f, 0.0f, 0.0f, 0.866f)));
-        EXPECT_TRUE(AZ::Quaternion::CreateRotationY(DegToRad(60.0f)).IsClose(AZ::Quaternion(0.0f, 0.5f, 0.0f, 0.866f)));
-        EXPECT_TRUE(AZ::Quaternion::CreateRotationZ(DegToRad(60.0f)).IsClose(AZ::Quaternion(0.0f, 0.0f, 0.5f, 0.866f)));
+        EXPECT_THAT(AZ::Quaternion::CreateRotationX(DegToRad(60.0f)), IsClose(AZ::Quaternion(0.5f, 0.0f, 0.0f, 0.866f)));
+        EXPECT_THAT(AZ::Quaternion::CreateRotationY(DegToRad(60.0f)), IsClose(AZ::Quaternion(0.0f, 0.5f, 0.0f, 0.866f)));
+        EXPECT_THAT(AZ::Quaternion::CreateRotationZ(DegToRad(60.0f)), IsClose(AZ::Quaternion(0.0f, 0.0f, 0.5f, 0.866f)));
     }
 
     TEST(MATH_Quaternion, TestConcatenate)
@@ -93,7 +93,7 @@ namespace UnitTest
         Quaternion q1(1.0f, 2.0f, 3.0f, 4.0f);
         Quaternion q2(-1.0f, -2.0f, -3.0f, -4.0f);
         Quaternion result = q1 * q2;
-        EXPECT_TRUE(result.IsClose(Quaternion(-8.0f, -16.0f, -24.0f, -2.0f)));
+        EXPECT_THAT(result, IsClose(Quaternion(-8.0f, -16.0f, -24.0f, -2.0f)));
     }
 
     TEST(MATH_Quaternion, TestShortestArc)
@@ -101,16 +101,16 @@ namespace UnitTest
         Vector3 v1 = Vector3(1.0f, 2.0f, 3.0f).GetNormalized();
         Vector3 v2 = Vector3(-2.0f, 7.0f, -1.0f).GetNormalized();
         Quaternion q3 = AZ::Quaternion::CreateShortestArc(v1, v2); //q3 should transform v1 into v2
-        EXPECT_TRUE(v2.IsClose(q3.TransformVector(v1), 1e-3f));
+        EXPECT_THAT(v2, IsCloseTolerance(q3.TransformVector(v1), 1e-3f));
         Quaternion q4 = AZ::Quaternion::CreateShortestArc(Vector3(1.0f, 0.0f, 0.0f), Vector3(0.0f, 1.0f, 0.0f));
-        EXPECT_TRUE((q4.TransformVector(Vector3(0.0f, 0.0f, 1.0f))).IsClose(Vector3(0.0f, 0.0f, 1.0f), 1e-3f));  //perpendicular vector should be unaffected
-        EXPECT_TRUE((q4.TransformVector(Vector3(0.0f, -1.0f, 0.0f))).IsClose(Vector3(1.0f, 0.0f, 0.0f), 1e-3f)); //make sure we rotate the right direction, i.e. actually shortest arc
+        EXPECT_THAT((q4.TransformVector(Vector3(0.0f, 0.0f, 1.0f))), IsCloseTolerance(Vector3(0.0f, 0.0f, 1.0f), 1e-3f));  //perpendicular vector should be unaffected
+        EXPECT_THAT((q4.TransformVector(Vector3(0.0f, -1.0f, 0.0f))), IsCloseTolerance(Vector3(1.0f, 0.0f, 0.0f), 1e-3f)); //make sure we rotate the right direction, i.e. actually shortest arc
         v2 = (v1 + Vector3(1e-5f, 1e-5f, 1e-5f)).GetNormalized(); // test almost parallel vectors
         Quaternion q5 = AZ::Quaternion::CreateShortestArc(v1, v2);
-        EXPECT_TRUE(v2.IsClose(q5.TransformVector(v1), 1e-3f));
+        EXPECT_THAT(v2, IsCloseTolerance(q5.TransformVector(v1), 1e-3f));
         v2 = (-v1 + Vector3(1e-5f, 1e-5f, 1e-5f)).GetNormalized(); // test almost anti-parallel vectors
         Quaternion q6 = AZ::Quaternion::CreateShortestArc(v1, v2);
-        EXPECT_TRUE(v2.IsClose(q6.TransformVector(v1), 1e-3f));
+        EXPECT_THAT(v2, IsCloseTolerance(q6.TransformVector(v1), 1e-3f));
     }
 
     TEST(MATH_Quaternion, TestGetSet)
@@ -171,20 +171,20 @@ namespace UnitTest
     TEST(MATH_Quaternion, TestInverse)
     {
         Quaternion q1 = AZ::Quaternion::CreateRotationX(DegToRad(25.0f)) * AZ::Quaternion::CreateRotationY(DegToRad(70.0f));
-        EXPECT_TRUE((q1 * q1.GetInverseFast()).IsClose(AZ::Quaternion::CreateIdentity()));
+        EXPECT_THAT((q1 * q1.GetInverseFast()), IsClose(AZ::Quaternion::CreateIdentity()));
         Quaternion q2 = q1;
         q2.InvertFast();
         EXPECT_TRUE(q1.GetX() == -q2.GetX());
         EXPECT_TRUE(q1.GetY() == -q2.GetY());
         EXPECT_TRUE(q1.GetZ() == -q2.GetZ());
         EXPECT_TRUE(q1.GetW() == q2.GetW());
-        EXPECT_TRUE((q1 * q2).IsClose(AZ::Quaternion::CreateIdentity()));
+        EXPECT_THAT((q1 * q2), IsClose(AZ::Quaternion::CreateIdentity()));
     }
 
     TEST(MATH_Quaternion, TestGetInverseFull)
     {
         Quaternion q1(1.0f, 2.0f, 3.0f, 4.0f);
-        EXPECT_TRUE((q1 * q1.GetInverseFull()).IsClose(AZ::Quaternion::CreateIdentity()));
+        EXPECT_THAT((q1 * q1.GetInverseFull()), IsClose(AZ::Quaternion::CreateIdentity()));
     }
 
     TEST(MATH_Quaternion, TestDot)
@@ -200,51 +200,51 @@ namespace UnitTest
 
     TEST(MATH_Quaternion, TestNormalize)
     {
-        EXPECT_TRUE(AZ::Quaternion(0.0f, -4.0f, 2.0f, 4.0f).GetNormalized().IsClose(AZ::Quaternion(0.0f, -0.66666f, 0.33333f, 0.66666f)));
+        EXPECT_THAT(AZ::Quaternion(0.0f, -4.0f, 2.0f, 4.0f).GetNormalized(), IsClose(AZ::Quaternion(0.0f, -0.66666f, 0.33333f, 0.66666f)));
         Quaternion q1(2.0f, 0.0f, 4.0f, -4.0f);
         q1.Normalize();
-        EXPECT_TRUE(q1.IsClose(AZ::Quaternion(0.33333f, 0.0f, 0.66666f, -0.66666f)));
+        EXPECT_THAT(q1, IsClose(AZ::Quaternion(0.33333f, 0.0f, 0.66666f, -0.66666f)));
         q1.Set(2.0f, 0.0f, 4.0f, -4.0f);
         float length = q1.NormalizeWithLength();
         EXPECT_NEAR(length, 6.0f, normalizeEpsilon);
-        EXPECT_TRUE(q1.IsClose(AZ::Quaternion(0.33333f, 0.0f, 0.66666f, -0.66666f)));
+        EXPECT_THAT(q1, IsClose(AZ::Quaternion(0.33333f, 0.0f, 0.66666f, -0.66666f)));
     }
 
     TEST(MATH_Quaternion, TestInterpolation)
     {
-        EXPECT_TRUE(AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f).Lerp(AZ::Quaternion(2.0f, 3.0f, 4.0f, 5.0f), 0.5f).IsClose(AZ::Quaternion(1.5f, 2.5f, 3.5f, 4.5f)));
-        EXPECT_TRUE(AZ::Quaternion::CreateRotationX(DegToRad(10.0f)).Slerp(AZ::Quaternion::CreateRotationY(DegToRad(60.0f)), 0.5f).IsClose(AZ::Quaternion(0.045f, 0.259f, 0.0f, 0.965f), 1e-3f));
-        EXPECT_TRUE(AZ::Quaternion::CreateRotationX(DegToRad(10.0f)).Squad(AZ::Quaternion::CreateRotationY(DegToRad(60.0f)), AZ::Quaternion::CreateRotationZ(DegToRad(35.0f)), AZ::Quaternion::CreateRotationX(DegToRad(80.0f)), 0.5f).IsClose(AZ::Quaternion(0.2f, 0.132f, 0.083f, 0.967f), 1e-3f));
+        EXPECT_THAT(AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f).Lerp(AZ::Quaternion(2.0f, 3.0f, 4.0f, 5.0f), 0.5f), IsClose(AZ::Quaternion(1.5f, 2.5f, 3.5f, 4.5f)));
+        EXPECT_THAT(AZ::Quaternion::CreateRotationX(DegToRad(10.0f)).Slerp(AZ::Quaternion::CreateRotationY(DegToRad(60.0f)), 0.5f), IsCloseTolerance(AZ::Quaternion(0.045f, 0.259f, 0.0f, 0.965f), 1e-3f));
+        EXPECT_THAT(AZ::Quaternion::CreateRotationX(DegToRad(10.0f)).Squad(AZ::Quaternion::CreateRotationY(DegToRad(60.0f)), AZ::Quaternion::CreateRotationZ(DegToRad(35.0f)), AZ::Quaternion::CreateRotationX(DegToRad(80.0f)), 0.5f), IsCloseTolerance(AZ::Quaternion(0.2f, 0.132f, 0.083f, 0.967f), 1e-3f));
     }
 
     TEST(MATH_Quaternion, TestClose)
     {
-        EXPECT_TRUE(AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f).IsClose(AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f)));
-        EXPECT_TRUE(!AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f).IsClose(AZ::Quaternion(1.0f, 2.0f, 3.0f, 5.0f)));
-        EXPECT_TRUE(AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f).IsClose(AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.4f), 0.5f));
+        EXPECT_THAT(AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f), IsClose(AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f)));
+        EXPECT_THAT(AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f), testing::Not(IsClose(AZ::Quaternion(1.0f, 2.0f, 3.0f, 5.0f))));
+        EXPECT_THAT(AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f), IsCloseTolerance(AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.4f), 0.5f));
     }
 
     TEST(MATH_Quaternion, TestOperators)
     {
         EXPECT_TRUE((-AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f)) == AZ::Quaternion(-1.0f, -2.0f, -3.0f, -4.0f));
-        EXPECT_TRUE((AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f) + AZ::Quaternion(2.0f, 3.0f, 5.0f, -1.0f)).IsClose(AZ::Quaternion(3.0f, 5.0f, 8.0f, 3.0f)));
-        EXPECT_TRUE((AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f) - AZ::Quaternion(2.0f, 3.0f, 5.0f, -1.0f)).IsClose(AZ::Quaternion(-1.0f, -1.0f, -2.0f, 5.0f)));
-        EXPECT_TRUE((AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f) * AZ::Quaternion(2.0f, 3.0f, 5.0f, -1.0f)).IsClose(AZ::Quaternion(8.0f, 11.0f, 16.0f, -27.0f)));
-        EXPECT_TRUE((AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f) * 2.0f).IsClose(AZ::Quaternion(2.0f, 4.0f, 6.0f, 8.0f)));
-        EXPECT_TRUE((2.0f * AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f)).IsClose(AZ::Quaternion(2.0f, 4.0f, 6.0f, 8.0f)));
-        EXPECT_TRUE((AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f) / 2.0f).IsClose(AZ::Quaternion(0.5f, 1.0f, 1.5f, 2.0f)));
+        EXPECT_THAT((AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f) + AZ::Quaternion(2.0f, 3.0f, 5.0f, -1.0f)), IsClose(AZ::Quaternion(3.0f, 5.0f, 8.0f, 3.0f)));
+        EXPECT_THAT((AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f) - AZ::Quaternion(2.0f, 3.0f, 5.0f, -1.0f)), IsClose(AZ::Quaternion(-1.0f, -1.0f, -2.0f, 5.0f)));
+        EXPECT_THAT((AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f) * AZ::Quaternion(2.0f, 3.0f, 5.0f, -1.0f)), IsClose(AZ::Quaternion(8.0f, 11.0f, 16.0f, -27.0f)));
+        EXPECT_THAT((AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f) * 2.0f), IsClose(AZ::Quaternion(2.0f, 4.0f, 6.0f, 8.0f)));
+        EXPECT_THAT((2.0f * AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f)), IsClose(AZ::Quaternion(2.0f, 4.0f, 6.0f, 8.0f)));
+        EXPECT_THAT((AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f) / 2.0f), IsClose(AZ::Quaternion(0.5f, 1.0f, 1.5f, 2.0f)));
         Quaternion q1(1.0f, 2.0f, 3.0f, 4.0f);
         q1 += AZ::Quaternion(5.0f, 6.0f, 7.0f, 8.0f);
-        EXPECT_TRUE(q1.IsClose(AZ::Quaternion(6.0f, 8.0f, 10.0f, 12.0f)));
+        EXPECT_THAT(q1, IsClose(AZ::Quaternion(6.0f, 8.0f, 10.0f, 12.0f)));
         q1 -= AZ::Quaternion(3.0f, -1.0f, 5.0f, 7.0f);
-        EXPECT_TRUE(q1.IsClose(AZ::Quaternion(3.0f, 9.0f, 5.0f, 5.0f)));
+        EXPECT_THAT(q1, IsClose(AZ::Quaternion(3.0f, 9.0f, 5.0f, 5.0f)));
         q1.Set(1.0f, 2.0f, 3.0f, 4.0f);
         q1 *= AZ::Quaternion(2.0f, 3.0f, 5.0f, -1.0f);
-        EXPECT_TRUE(q1.IsClose(AZ::Quaternion(8.0f, 11.0f, 16.0f, -27.0f)));
+        EXPECT_THAT(q1, IsClose(AZ::Quaternion(8.0f, 11.0f, 16.0f, -27.0f)));
         q1 *= 2.0f;
-        EXPECT_TRUE(q1.IsClose(AZ::Quaternion(16.0f, 22.0f, 32.0f, -54.0f)));
+        EXPECT_THAT(q1, IsClose(AZ::Quaternion(16.0f, 22.0f, 32.0f, -54.0f)));
         q1 /= 4.0f;
-        EXPECT_TRUE(q1.IsClose(AZ::Quaternion(4.0f, 5.5f, 8.0f, -13.5f)));
+        EXPECT_THAT(q1, IsClose(AZ::Quaternion(4.0f, 5.5f, 8.0f, -13.5f)));
     }
 
     TEST(MATH_Quaternion, TestEquality)
@@ -258,7 +258,7 @@ namespace UnitTest
 
     TEST(MATH_Quaternion, TestVectorTransform)
     {
-        EXPECT_TRUE((AZ::Quaternion::CreateRotationX(DegToRad(45.0f)).TransformVector(Vector3(4.0f, 1.0f, 0.0f))).IsClose(Vector3(4.0f, 0.7071f, 0.7071f)));
+        EXPECT_THAT((AZ::Quaternion::CreateRotationX(DegToRad(45.0f)).TransformVector(Vector3(4.0f, 1.0f, 0.0f))), IsClose(Vector3(4.0f, 0.7071f, 0.7071f)));
     }
 
     TEST(MATH_Quaternion, TestGetImaginary)
@@ -270,7 +270,7 @@ namespace UnitTest
     TEST(MATH_Quaternion, TestGetAngle)
     {
         Quaternion q1 = AZ::Quaternion::CreateRotationX(DegToRad(35.0f));
-        EXPECT_TRUE(AZ::IsClose(q1.GetAngle(), DegToRad(35.0f)));
+        EXPECT_NEAR(q1.GetAngle(), DegToRad(35.0f), AZ::Constants::Tolerance);
     }
 
     TEST(MATH_Quaternion, TestConcatenation)
@@ -278,7 +278,7 @@ namespace UnitTest
         Quaternion q1 = AZ::Quaternion::CreateRotationZ(DegToRad(90.0f));
         Quaternion q2 = AZ::Quaternion::CreateRotationX(DegToRad(90.0f));
         Vector3 v = (q2 * q1).TransformVector(Vector3(1.0f, 0.0f, 0.0f));
-        EXPECT_TRUE(v.IsClose(Vector3(0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(v, IsClose(Vector3(0.0f, 0.0f, 1.0f)));
     }
 
     TEST(MATH_Quaternion, ToEulerDegrees)
@@ -288,10 +288,10 @@ namespace UnitTest
         float cos = cosf(halfAngle);
         AZ::Quaternion testQuat = AZ::Quaternion::CreateFromVector3AndValue(sin * AZ::Vector3::CreateAxisX(), cos);
         AZ::Vector3 resultVector = testQuat.GetEulerDegrees();
-        EXPECT_TRUE(resultVector.IsClose(AZ::Vector3(45.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(resultVector, IsClose(AZ::Vector3(45.0f, 0.0f, 0.0f)));
 
         resultVector = ConvertQuaternionToEulerDegrees(testQuat);
-        EXPECT_TRUE(resultVector.IsClose(AZ::Vector3(45.0f, 0.0f, 0.0f)));
+        EXPECT_THAT(resultVector, IsClose(AZ::Vector3(45.0f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Quaternion, ToEulerRadians)
@@ -367,7 +367,7 @@ namespace UnitTest
         const AZ::Vector3 testDegrees(45.0f, 45.0f, 45.0f);
         AZ::Quaternion testQuat;
         testQuat.SetFromEulerDegrees(testDegrees);
-        EXPECT_TRUE(testQuat.IsClose(AZ::Quaternion(0.46193981170654296875f, 0.1913417130708694458f, 0.46193981170654296875f, 0.73253774642944335938f), 0.0000001f));
+        EXPECT_THAT(testQuat, IsCloseTolerance(AZ::Quaternion(0.46193981170654296875f, 0.1913417130708694458f, 0.46193981170654296875f, 0.73253774642944335938f), 0.0000001f));
     }
 
     TEST(MATH_Quaternion, FromEulerRadians)
@@ -375,20 +375,20 @@ namespace UnitTest
         const AZ::Vector3 testRadians(Constants::QuarterPi, Constants::QuarterPi, Constants::QuarterPi);
         AZ::Quaternion testQuat;
         testQuat.SetFromEulerRadians(testRadians);
-        EXPECT_TRUE(testQuat.IsClose(AZ::Quaternion(0.46193981170654296875f, 0.1913417130708694458f, 0.46193981170654296875f, 0.73253774642944335938f), 0.0000001f));
+        EXPECT_THAT(testQuat, IsCloseTolerance(AZ::Quaternion(0.46193981170654296875f, 0.1913417130708694458f, 0.46193981170654296875f, 0.73253774642944335938f), 0.0000001f));
     }
 
 
     TEST(MATH_Quaternion, FromAxisAngle)
     {
         AZ::Quaternion q10 = AZ::Quaternion::CreateFromAxisAngle(AZ::Vector3::CreateAxisZ(), Constants::QuarterPi);
-        EXPECT_TRUE(q10.IsClose(AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)));
+        EXPECT_THAT(q10, IsClose(AZ::Quaternion::CreateRotationZ(Constants::QuarterPi)));
 
         q10 = AZ::Quaternion::CreateFromAxisAngle(AZ::Vector3::CreateAxisY(), Constants::HalfPi);
-        EXPECT_TRUE(q10.IsClose(AZ::Quaternion::CreateRotationY(Constants::HalfPi)));
+        EXPECT_THAT(q10, IsClose(AZ::Quaternion::CreateRotationY(Constants::HalfPi)));
 
         q10 = AZ::Quaternion::CreateFromAxisAngle(AZ::Vector3::CreateAxisX(), Constants::TwoPi / 3.0f);
-        EXPECT_TRUE(q10.IsClose(AZ::Quaternion::CreateRotationX(Constants::TwoPi / 3.0f)));
+        EXPECT_THAT(q10, IsClose(AZ::Quaternion::CreateRotationX(Constants::TwoPi / 3.0f)));
     }
 
     TEST(MATH_Quaternion, ToAxisAngle)
@@ -399,7 +399,7 @@ namespace UnitTest
         Vector3 resultAxis = Vector3::CreateZero();
         float resultAngle{};
         testQuat.ConvertToAxisAngle(resultAxis, resultAngle);
-        EXPECT_TRUE(resultAxis.IsClose(Vector3::CreateAxisY()));
+        EXPECT_THAT(resultAxis, IsClose(Vector3::CreateAxisY()));
         EXPECT_NEAR(0.0f, resultAngle, axisAngleEpsilon);
     }
 
@@ -490,7 +490,7 @@ namespace UnitTest
 
         // Compare the scaled result to the version from the helper that directly converts it to scaled axis-angle.
         AZ::Vector3 scaledResult = axis*angle;
-        EXPECT_TRUE(scaledResult.IsClose(scaledAxisAngle, 1e-5f));
+        EXPECT_THAT(scaledResult, IsCloseTolerance(scaledAxisAngle, 1e-5f));
     }
 
     TEST_P(QuaternionScaledAxisAngleConversionFixture, CompareScaledAxisAngleConversionTests)

--- a/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
@@ -27,11 +27,11 @@ namespace UnitTest
         // a positive rotation around z should transform the x axis to the y axis
         Matrix4x4 matrix = Matrix4x4::CreateRotationZ(DegToRad(90.0f));
         Vector3 v = matrix * Vector3(1.0f, 0.0f, 0.0f);
-        AZ_TEST_ASSERT(v.IsClose(Vector3(0.0f, 1.0f, 0.0f)));
+        EXPECT_THAT(v, IsClose(Vector3(0.0f, 1.0f, 0.0f)));
 
         AZ::Quaternion quat = AZ::Quaternion::CreateRotationZ(DegToRad(90.0f));
         v = quat.TransformVector(Vector3(1.0f, 0.0f, 0.0f));
-        AZ_TEST_ASSERT(v.IsClose(Vector3(0.0f, 1.0f, 0.0f)));
+        EXPECT_THAT(v, IsClose(Vector3(0.0f, 1.0f, 0.0f)));
     }
 
     TEST(MATH_Quaternion, TestConstruction)
@@ -409,10 +409,10 @@ namespace UnitTest
         AZ::Quaternion rotQuat = AZ::Quaternion::CreateRotationZ(DegToRad(90.0f));
 
         AZ::Quaternion q = AZ::Quaternion::CreateFromMatrix4x4(rotMatrix);
-        AZ_TEST_ASSERT(q.IsClose(rotQuat));
+        EXPECT_THAT(q, IsClose(rotQuat));
 
         Matrix4x4 m = Matrix4x4::CreateFromQuaternion(rotQuat);
-        AZ_TEST_ASSERT(m.IsClose(rotMatrix));
+        EXPECT_THAT(m, IsClose(rotMatrix));
     }
 
     class QuaternionScaledAxisAngleConversionFixture

--- a/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
@@ -81,8 +81,8 @@ namespace UnitTest
 
     TEST(MATH_Quaternion, TestCreate)
     {
-        EXPECT_TRUE(AZ::Quaternion::CreateIdentity() == AZ::Quaternion(0.0f, 0.0f, 0.0f, 1.0f));
-        EXPECT_TRUE(AZ::Quaternion::CreateZero() == AZ::Quaternion(0.0f));
+        EXPECT_THAT(AZ::Quaternion::CreateIdentity(), IsClose(AZ::Quaternion(0.0f, 0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(AZ::Quaternion::CreateZero(), IsClose(AZ::Quaternion(0.0f)));
         EXPECT_THAT(AZ::Quaternion::CreateRotationX(DegToRad(60.0f)), IsClose(AZ::Quaternion(0.5f, 0.0f, 0.0f, 0.866f)));
         EXPECT_THAT(AZ::Quaternion::CreateRotationY(DegToRad(60.0f)), IsClose(AZ::Quaternion(0.0f, 0.5f, 0.0f, 0.866f)));
         EXPECT_THAT(AZ::Quaternion::CreateRotationZ(DegToRad(60.0f)), IsClose(AZ::Quaternion(0.0f, 0.0f, 0.5f, 0.866f)));
@@ -117,19 +117,19 @@ namespace UnitTest
     {
         Quaternion q1;
         q1.SetX(10.0f);
-        EXPECT_TRUE(q1.GetX() == 10.0f);
+        EXPECT_NEAR(q1.GetX(), 10.0f, 1e-6f);
         q1.SetY(11.0f);
-        EXPECT_TRUE(q1.GetY() == 11.0f);
+        EXPECT_NEAR(q1.GetY(), 11.0f, 1e-6f);
         q1.SetZ(12.0f);
-        EXPECT_TRUE(q1.GetZ() == 12.0f);
+        EXPECT_NEAR(q1.GetZ(), 12.0f, 1e-6f);
         q1.SetW(13.0f);
-        EXPECT_TRUE(q1.GetW() == 13.0f);
+        EXPECT_NEAR(q1.GetW(), 13.0f, 1e-6f);
         q1.Set(15.0f);
-        EXPECT_TRUE(q1 == AZ::Quaternion(15.0f));
+        EXPECT_THAT(q1, IsClose(AZ::Quaternion(15.0f)));
         q1.Set(2.0f, 3.0f, 4.0f, 5.0f);
-        EXPECT_TRUE(q1 == AZ::Quaternion(2.0f, 3.0f, 4.0f, 5.0f));
+        EXPECT_THAT(q1, IsClose(AZ::Quaternion(2.0f, 3.0f, 4.0f, 5.0f)));
         q1.Set(Vector3(5.0f, 6.0f, 7.0f), 8.0f);
-        EXPECT_TRUE(q1 == AZ::Quaternion(5.0f, 6.0f, 7.0f, 8.0f));
+        EXPECT_THAT(q1, IsClose(AZ::Quaternion(5.0f, 6.0f, 7.0f, 8.0f)));
         q1.Set(values);
         EXPECT_TRUE((q1.GetX() == 10.0f) && (q1.GetY() == 20.0f) && (q1.GetZ() == 30.0f) && (q1.GetW() == 40.0f));
     }
@@ -141,19 +141,19 @@ namespace UnitTest
         q1.SetElement(1, 2.0f);
         q1.SetElement(2, 3.0f);
         q1.SetElement(3, 4.0f);
-        EXPECT_TRUE(q1.GetElement(0) == 1.0f);
-        EXPECT_TRUE(q1.GetElement(1) == 2.0f);
-        EXPECT_TRUE(q1.GetElement(2) == 3.0f);
-        EXPECT_TRUE(q1.GetElement(3) == 4.0f);
+        EXPECT_NEAR(q1.GetElement(0), 1.0f, 1e-6f);
+        EXPECT_NEAR(q1.GetElement(1), 2.0f, 1e-6f);
+        EXPECT_NEAR(q1.GetElement(2), 3.0f, 1e-6f);
+        EXPECT_NEAR(q1.GetElement(3), 4.0f, 1e-6f);
     }
 
     TEST(MATH_Quaternion, TestIndexOperators)
     {
         Quaternion q1(1.0f, 2.0f, 3.0f, 4.0f);
-        EXPECT_TRUE(q1(0) == 1.0f);
-        EXPECT_TRUE(q1(1) == 2.0f);
-        EXPECT_TRUE(q1(2) == 3.0f);
-        EXPECT_TRUE(q1(3) == 4.0f);
+        EXPECT_NEAR(q1(0), 1.0f, 1e-6f);
+        EXPECT_NEAR(q1(1), 2.0f, 1e-6f);
+        EXPECT_NEAR(q1(2), 3.0f, 1e-6f);
+        EXPECT_NEAR(q1(3), 4.0f, 1e-6f);
     }
 
     TEST(MATH_Quaternion, TestIsIdentity)
@@ -165,7 +165,7 @@ namespace UnitTest
     TEST(MATH_Quaternion, TestConjugate)
     {
         Quaternion q1(1.0f, 2.0f, 3.0f, 4.0f);
-        EXPECT_TRUE(q1.GetConjugate() == AZ::Quaternion(-1.0f, -2.0f, -3.0f, 4.0f));
+        EXPECT_THAT(q1.GetConjugate(), IsClose(AZ::Quaternion(-1.0f, -2.0f, -3.0f, 4.0f)));
     }
 
     TEST(MATH_Quaternion, TestInverse)
@@ -174,10 +174,10 @@ namespace UnitTest
         EXPECT_THAT((q1 * q1.GetInverseFast()), IsClose(AZ::Quaternion::CreateIdentity()));
         Quaternion q2 = q1;
         q2.InvertFast();
-        EXPECT_TRUE(q1.GetX() == -q2.GetX());
-        EXPECT_TRUE(q1.GetY() == -q2.GetY());
-        EXPECT_TRUE(q1.GetZ() == -q2.GetZ());
-        EXPECT_TRUE(q1.GetW() == q2.GetW());
+        EXPECT_NEAR(q1.GetX(), -q2.GetX(), 1e-6f);
+        EXPECT_NEAR(q1.GetY(), -q2.GetY(), 1e-6f);
+        EXPECT_NEAR(q1.GetZ(), -q2.GetZ(), 1e-6f);
+        EXPECT_NEAR(q1.GetW(), q2.GetW(), 1e-6f);
         EXPECT_THAT((q1 * q2), IsClose(AZ::Quaternion::CreateIdentity()));
     }
 
@@ -226,7 +226,7 @@ namespace UnitTest
 
     TEST(MATH_Quaternion, TestOperators)
     {
-        EXPECT_TRUE((-AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f)) == AZ::Quaternion(-1.0f, -2.0f, -3.0f, -4.0f));
+        EXPECT_THAT((-AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f)), IsClose(AZ::Quaternion(-1.0f, -2.0f, -3.0f, -4.0f)));
         EXPECT_THAT((AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f) + AZ::Quaternion(2.0f, 3.0f, 5.0f, -1.0f)), IsClose(AZ::Quaternion(3.0f, 5.0f, 8.0f, 3.0f)));
         EXPECT_THAT((AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f) - AZ::Quaternion(2.0f, 3.0f, 5.0f, -1.0f)), IsClose(AZ::Quaternion(-1.0f, -1.0f, -2.0f, 5.0f)));
         EXPECT_THAT((AZ::Quaternion(1.0f, 2.0f, 3.0f, 4.0f) * AZ::Quaternion(2.0f, 3.0f, 5.0f, -1.0f)), IsClose(AZ::Quaternion(8.0f, 11.0f, 16.0f, -27.0f)));
@@ -264,7 +264,7 @@ namespace UnitTest
     TEST(MATH_Quaternion, TestGetImaginary)
     {
         Quaternion q1(21.0f, 22.0f, 23.0f, 24.0f);
-        EXPECT_TRUE(q1.GetImaginary() == Vector3(21.0f, 22.0f, 23.0f));
+        EXPECT_THAT(q1.GetImaginary(), IsClose(Vector3(21.0f, 22.0f, 23.0f)));
     }
 
     TEST(MATH_Quaternion, TestGetAngle)

--- a/Code/Framework/AzCore/Tests/Math/ShapeIntersectionTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/ShapeIntersectionTests.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Math/Frustum.h>
 #include <AzCore/Math/Sphere.h>
 #include <AzCore/Math/ShapeIntersection.h>
+#include <AZTestShared/Math/MathTestHelpers.h>
 
 namespace UnitTest
 {
@@ -50,14 +51,14 @@ namespace UnitTest
         {
             AZ::Vector3 intersectionPoint;
             EXPECT_TRUE(AZ::ShapeIntersection::IntersectThreePlanes(near_value, left, bottom, intersectionPoint));
-            EXPECT_TRUE(intersectionPoint.IsClose(AZ::Vector3(-5.f, -5.f, -5.f)));
+            EXPECT_THAT(intersectionPoint, IsClose(AZ::Vector3(-5.f, -5.f, -5.f)));
             EXPECT_FALSE(AZ::ShapeIntersection::IntersectThreePlanes(near_value, far_value, bottom, intersectionPoint));
         }
 
         {
             AZ::Vector3 intersectionPoint;
             EXPECT_TRUE(AZ::ShapeIntersection::IntersectThreePlanes(near_value, left, bottom, intersectionPoint));
-            EXPECT_TRUE(intersectionPoint.IsClose(AZ::Vector3(-5.f, -5.f, -5.f)));
+            EXPECT_THAT(intersectionPoint, IsClose(AZ::Vector3(-5.f, -5.f, -5.f)));
             EXPECT_FALSE(AZ::ShapeIntersection::IntersectThreePlanes(near_value, far_value, bottom, intersectionPoint));
         }
 

--- a/Code/Framework/AzCore/Tests/Math/ShapeIntersectionTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/ShapeIntersectionTests.cpp
@@ -109,13 +109,13 @@ namespace UnitTest
             AZ::Sphere s1(AZ::Vector3(0.0f, -5.1f, 0.0f), 0.5f);
             AZ::Sphere s2(AZ::Vector3(0.0f, -5.6f, 0.0f), 0.5f);
 
-            EXPECT_TRUE(AZ::ShapeIntersection::Classify(near_value, s) ==  AZ::IntersectResult::Interior);
-            EXPECT_TRUE(AZ::ShapeIntersection::Classify(near_value, s1) == AZ::IntersectResult::Overlaps);
-            EXPECT_TRUE(AZ::ShapeIntersection::Classify(near_value, s2) == AZ::IntersectResult::Exterior);
+            EXPECT_EQ(AZ::ShapeIntersection::Classify(near_value, s), AZ::IntersectResult::Interior);
+            EXPECT_EQ(AZ::ShapeIntersection::Classify(near_value, s1), AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(AZ::ShapeIntersection::Classify(near_value, s2), AZ::IntersectResult::Exterior);
 
-            EXPECT_TRUE(AZ::ShapeIntersection::Classify(frustum, s) ==  AZ::IntersectResult::Interior);
-            EXPECT_TRUE(AZ::ShapeIntersection::Classify(frustum, s1) == AZ::IntersectResult::Overlaps);
-            EXPECT_TRUE(AZ::ShapeIntersection::Classify(frustum, s2) == AZ::IntersectResult::Exterior);
+            EXPECT_EQ(AZ::ShapeIntersection::Classify(frustum, s), AZ::IntersectResult::Interior);
+            EXPECT_EQ(AZ::ShapeIntersection::Classify(frustum, s1), AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(AZ::ShapeIntersection::Classify(frustum, s2), AZ::IntersectResult::Exterior);
         }
 
         {
@@ -125,9 +125,9 @@ namespace UnitTest
                 AZ::Vector3(0.0f, -5.1f, 0.0f), AZ::Quaternion::CreateIdentity(), AZ::Vector3::CreateOne());
             AZ::Obb obb2 = AZ::Obb::CreateFromPositionRotationAndHalfLengths(
                 AZ::Vector3(0.0f, -6.1f, 0.0f), AZ::Quaternion::CreateIdentity(), AZ::Vector3::CreateOne());
-            EXPECT_TRUE(AZ::ShapeIntersection::Classify(near_value, obb) ==  AZ::IntersectResult::Interior);
-            EXPECT_TRUE(AZ::ShapeIntersection::Classify(near_value, obb1) == AZ::IntersectResult::Overlaps);
-            EXPECT_TRUE(AZ::ShapeIntersection::Classify(near_value, obb2) == AZ::IntersectResult::Exterior);
+            EXPECT_EQ(AZ::ShapeIntersection::Classify(near_value, obb), AZ::IntersectResult::Interior);
+            EXPECT_EQ(AZ::ShapeIntersection::Classify(near_value, obb1), AZ::IntersectResult::Overlaps);
+            EXPECT_EQ(AZ::ShapeIntersection::Classify(near_value, obb2), AZ::IntersectResult::Exterior);
         }
 
         //Test a bunch of different rotations with the OBBs

--- a/Code/Framework/AzCore/Tests/Math/SimdMathTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/SimdMathTests.cpp
@@ -340,11 +340,11 @@ namespace UnitTest
         switch (VectorType::ElementCount)
         {
         case 4:
-            EXPECT_TRUE(AZ::IsClose(testStoreValues[3], 4.0f, 0.01f));
+            EXPECT_NEAR(testStoreValues[3], 4.0f, 0.01f);
         case 3:
             EXPECT_TRUE(std::isnan(testStoreValues[2]));
         case 2:
-            EXPECT_TRUE(AZ::IsClose(testStoreValues[1], -4.0f, 0.01f));
+            EXPECT_NEAR(testStoreValues[1], -4.0f, 0.01f);
         case 1:
             EXPECT_TRUE(std::isnan(testStoreValues[0]));
             break;
@@ -1056,7 +1056,7 @@ namespace UnitTest
             float results[4] = { 0.5f, 0.25f, 0.125f, 1.0f };
             for (int32_t i = 0; i < VectorType::ElementCount; ++i)
             {
-                EXPECT_TRUE(AZ::IsClose(testStoreValues[i], results[i], 0.01f));
+                EXPECT_NEAR(testStoreValues[i], results[i], 0.01f);
             }
         }
 
@@ -1068,7 +1068,7 @@ namespace UnitTest
             float results[4] = { 0.5f, 0.25f, 0.125f, 1.0f };
             for (int32_t i = 0; i < VectorType::ElementCount; ++i)
             {
-                EXPECT_TRUE(AZ::IsClose(testStoreValues[i], results[i], 0.01f));
+                EXPECT_NEAR(testStoreValues[i], results[i], 0.01f);
             }
         }
     }

--- a/Code/Framework/AzCore/Tests/Math/SimdMathTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/SimdMathTests.cpp
@@ -25,7 +25,7 @@ namespace UnitTest
 
         for (int32_t i = 0; i < VectorType::ElementCount; ++i)
         {
-            EXPECT_TRUE(testLoadValues[i] == testStoreValues[i]);
+            EXPECT_NEAR(testLoadValues[i], testStoreValues[i], 1e-6f);
         }
     }
 
@@ -40,7 +40,7 @@ namespace UnitTest
 
         for (int32_t i = 0; i < VectorType::ElementCount; ++i)
         {
-            EXPECT_TRUE(testLoadValues[i] == testStoreValues[i]);
+            EXPECT_NEAR(testLoadValues[i], testStoreValues[i], 1e-6f);
         }
     }
 
@@ -52,7 +52,7 @@ namespace UnitTest
         typename VectorType::FloatType testVector = VectorType::LoadUnaligned(testLoadValues);
         const float firstFloat = VectorType::SelectFirst(testVector);
 
-        EXPECT_TRUE(testLoadValues[0] == firstFloat);
+        EXPECT_NEAR(testLoadValues[0], firstFloat, 1e-6f);
     }
 
     template <typename VectorType>
@@ -63,7 +63,7 @@ namespace UnitTest
         typename VectorType::FloatType testVector = VectorType::LoadUnaligned(testLoadValues);
         const float firstFloat = VectorType::SelectSecond(testVector);
 
-        EXPECT_TRUE(testLoadValues[1] == firstFloat);
+        EXPECT_NEAR(testLoadValues[1], firstFloat, 1e-6f);
     }
 
     template <typename VectorType>
@@ -74,7 +74,7 @@ namespace UnitTest
         typename VectorType::FloatType testVector = VectorType::LoadUnaligned(testLoadValues);
         const float firstFloat = VectorType::SelectThird(testVector);
 
-        EXPECT_TRUE(testLoadValues[2] == firstFloat);
+        EXPECT_NEAR(testLoadValues[2], firstFloat, 1e-6f);
     }
 
     template <typename VectorType>
@@ -85,7 +85,7 @@ namespace UnitTest
         typename VectorType::FloatType testVector = VectorType::LoadUnaligned(testLoadValues);
         const float firstFloat = VectorType::SelectFourth(testVector);
 
-        EXPECT_TRUE(testLoadValues[3] == firstFloat);
+        EXPECT_NEAR(testLoadValues[3], firstFloat, 1e-6f);
     }
 
     template <typename VectorType>

--- a/Code/Framework/AzCore/Tests/Math/SimdMathTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/SimdMathTests.cpp
@@ -1089,11 +1089,11 @@ namespace UnitTest
             switch (VectorType::ElementCount)
             {
             case 4:
-                AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[3], 0.0f);
+                EXPECT_NEAR(testStoreValues[3], 0.0f, 0.002f);
             case 3:
-                AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 1.0f);
+                EXPECT_NEAR(testStoreValues[2], 1.0f, 0.002f);
             case 2:
-                AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 4.0f);
+                EXPECT_NEAR(testStoreValues[1], 4.0f, 0.002f);
             case 1:
                 EXPECT_TRUE(std::isnan(testStoreValues[0]));
                 break;
@@ -1110,9 +1110,9 @@ namespace UnitTest
             case 4:
                 EXPECT_TRUE(std::isnan(testStoreValues[3]) || std::isinf(testStoreValues[3]));
             case 3:
-                AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 1.0f);
+                EXPECT_NEAR(testStoreValues[2], 1.0f, 0.002f);
             case 2:
-                AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 0.25f);
+                EXPECT_NEAR(testStoreValues[1], 0.25f, 0.002f);
             case 1:
                 EXPECT_TRUE(std::isnan(testStoreValues[0]));
                 break;
@@ -1139,13 +1139,13 @@ namespace UnitTest
             switch (VectorType::ElementCount)
             {
             case 4:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[3], 0.0f, precision);
+                EXPECT_NEAR(testStoreValues1[3], 0.0f, precision);
             case 3:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[2], 1.0f, precision);
+                EXPECT_NEAR(testStoreValues1[2], 1.0f, precision);
             case 2:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[1], 0.5f, precision);
+                EXPECT_NEAR(testStoreValues1[1], 0.5f, precision);
             case 1:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[0], 0.0f, precision);
+                EXPECT_NEAR(testStoreValues1[0], 0.0f, precision);
             }
         }
 
@@ -1156,13 +1156,13 @@ namespace UnitTest
             switch (VectorType::ElementCount)
             {
             case 4:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues2[3], 0.0f, precision);
+                EXPECT_NEAR(testStoreValues2[3], 0.0f, precision);
             case 3:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues2[2], -1.0f, precision);
+                EXPECT_NEAR(testStoreValues2[2], -1.0f, precision);
             case 2:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues2[1], -0.8660254f, precision);
+                EXPECT_NEAR(testStoreValues2[1], -0.8660254f, precision);
             case 1:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues2[0], 0.0f, precision);
+                EXPECT_NEAR(testStoreValues2[0], 0.0f, precision);
             }
         }
     }
@@ -1186,13 +1186,13 @@ namespace UnitTest
             switch (VectorType::ElementCount)
             {
             case 4:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[3], -1.0f, precision);
+                EXPECT_NEAR(testStoreValues1[3], -1.0f, precision);
             case 3:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[2], 0.0f, precision);
+                EXPECT_NEAR(testStoreValues1[2], 0.0f, precision);
             case 2:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[1], 0.8660254f, precision);
+                EXPECT_NEAR(testStoreValues1[1], 0.8660254f, precision);
             case 1:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[0], 1.0f, precision);
+                EXPECT_NEAR(testStoreValues1[0], 1.0f, precision);
             }
         }
 
@@ -1203,13 +1203,13 @@ namespace UnitTest
             switch (VectorType::ElementCount)
             {
             case 4:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues2[3], -1.0f, precision);
+                EXPECT_NEAR(testStoreValues2[3], -1.0f, precision);
             case 3:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues2[2], 0.0f, precision);
+                EXPECT_NEAR(testStoreValues2[2], 0.0f, precision);
             case 2:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues2[1], -0.5f, precision);
+                EXPECT_NEAR(testStoreValues2[1], -0.5f, precision);
             case 1:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues2[0], -1.0f, precision);
+                EXPECT_NEAR(testStoreValues2[0], -1.0f, precision);
             }
         }
     }
@@ -1233,13 +1233,13 @@ namespace UnitTest
             switch (VectorType::ElementCount)
             {
             case 4:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[3], Constants::HalfPi, precision);
+                EXPECT_NEAR(testStoreValues1[3], Constants::HalfPi, precision);
             case 3:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[2], 2 * Constants::Pi / 3.0f, precision);
+                EXPECT_NEAR(testStoreValues1[2], 2 * Constants::Pi / 3.0f, precision);
             case 2:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[1], 5 * Constants::Pi / 6.0f, precision);
+                EXPECT_NEAR(testStoreValues1[1], 5 * Constants::Pi / 6.0f, precision);
             case 1:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[0], Constants::Pi, precision);
+                EXPECT_NEAR(testStoreValues1[0], Constants::Pi, precision);
             }
         }
 
@@ -1254,9 +1254,9 @@ namespace UnitTest
             case 3:
                 EXPECT_TRUE(std::isnan(testStoreValues2[2]));
             case 2:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues2[1], 0.0f, precision);
+                EXPECT_NEAR(testStoreValues2[1], 0.0f, precision);
             case 1:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues2[0], Constants::QuarterPi, precision);
+                EXPECT_NEAR(testStoreValues2[0], Constants::QuarterPi, precision);
             }
         }
     }
@@ -1280,13 +1280,13 @@ namespace UnitTest
             switch (VectorType::ElementCount)
             {
             case 4:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[3], 1.569796f, precision);
+                EXPECT_NEAR(testStoreValues1[3], 1.569796f, precision);
             case 3:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[2], Constants::Pi / 4.0f, precision);
+                EXPECT_NEAR(testStoreValues1[2], Constants::Pi / 4.0f, precision);
             case 2:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[1], Constants::Pi / 6.0f, precision);
+                EXPECT_NEAR(testStoreValues1[1], Constants::Pi / 6.0f, precision);
             case 1:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[0], 0.0f, precision);
+                EXPECT_NEAR(testStoreValues1[0], 0.0f, precision);
             }
         }
 
@@ -1297,13 +1297,13 @@ namespace UnitTest
             switch (VectorType::ElementCount)
             {
             case 4:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues2[3], -1.569796f, precision);
+                EXPECT_NEAR(testStoreValues2[3], -1.569796f, precision);
             case 3:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues2[2], -Constants::Pi / 4.0f, precision);
+                EXPECT_NEAR(testStoreValues2[2], -Constants::Pi / 4.0f, precision);
             case 2:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues2[1], -Constants::Pi / 6.0f, precision);
+                EXPECT_NEAR(testStoreValues2[1], -Constants::Pi / 6.0f, precision);
             case 1:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues2[0], 0.0f, precision);
+                EXPECT_NEAR(testStoreValues2[0], 0.0f, precision);
             }
         }
     }
@@ -1333,13 +1333,13 @@ namespace UnitTest
             switch (VectorType::ElementCount)
             {
             case 4:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[3], Constants::Pi / 4.0f, precision);
+                EXPECT_NEAR(testStoreValues1[3], Constants::Pi / 4.0f, precision);
             case 3:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[2], -Constants::HalfPi, precision);
+                EXPECT_NEAR(testStoreValues1[2], -Constants::HalfPi, precision);
             case 2:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[1], Constants::HalfPi, precision);
+                EXPECT_NEAR(testStoreValues1[1], Constants::HalfPi, precision);
             case 1:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues1[0], 0.0f, precision);
+                EXPECT_NEAR(testStoreValues1[0], 0.0f, precision);
             }
         }
 
@@ -1350,13 +1350,13 @@ namespace UnitTest
             switch (VectorType::ElementCount)
             {
             case 4:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues2[3], 0.0f, precision);
+                EXPECT_NEAR(testStoreValues2[3], 0.0f, precision);
             case 3:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues2[2], -3 * Constants::Pi / 4.0f, precision);
+                EXPECT_NEAR(testStoreValues2[2], -3 * Constants::Pi / 4.0f, precision);
             case 2:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues2[1], 3 * Constants::Pi / 4.0f, precision);
+                EXPECT_NEAR(testStoreValues2[1], 3 * Constants::Pi / 4.0f, precision);
             case 1:
-                AZ_TEST_ASSERT_CLOSE(testStoreValues2[0], Constants::Pi, precision);
+                EXPECT_NEAR(testStoreValues2[0], Constants::Pi, precision);
             }
         }
     }
@@ -1496,13 +1496,13 @@ namespace UnitTest
             switch (VectorType::ElementCount)
             {
             case 4:
-                AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[3], 4.0f);
+                EXPECT_NEAR(testStoreValues[3], 4.0f, 0.002f);
             case 3:
-                AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 2.0f);
+                EXPECT_NEAR(testStoreValues[2], 2.0f, 0.002f);
             case 2:
-                AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 0.0f);
+                EXPECT_NEAR(testStoreValues[1], 0.0f, 0.002f);
             case 1:
-                AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], -1.0f);
+                EXPECT_NEAR(testStoreValues[0], -1.0f, 0.002f);
                 break;
             }
         }
@@ -1523,7 +1523,7 @@ namespace UnitTest
         EXPECT_TRUE(std::isnan(testStoreFloatValues[0]));
         if constexpr (VectorType::ElementCount > 1)
         {
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreFloatValues[1], 0.0f);
+            EXPECT_NEAR(testStoreFloatValues[1], 0.0f, 0.002f);
         }
 
         typename VectorType::Int32Type testVector2 = VectorType::CastToInt(testVector1);
@@ -2371,7 +2371,7 @@ namespace UnitTest
         Simd::Vec1::FloatType testDot = Simd::Vec2::Dot(sourceVector1, sourceVector2);
         Simd::Vec1::StoreUnaligned(testStoreValues, testDot);
 
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 257.0f);
+        EXPECT_NEAR(testStoreValues[0], 257.0f, 0.002f);
     }
 
     TEST(MATH_SimdMath, TestDotFloatVec3)
@@ -2384,7 +2384,7 @@ namespace UnitTest
         Simd::Vec1::FloatType testDot = Simd::Vec3::Dot(sourceVector1, sourceVector2);
         Simd::Vec1::StoreUnaligned(testStoreValues, testDot);
 
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 258.0f);
+        EXPECT_NEAR(testStoreValues[0], 258.0f, 0.002f);
     }
 
     TEST(MATH_SimdMath, TestDotFloatVec4)
@@ -2397,7 +2397,7 @@ namespace UnitTest
         Simd::Vec1::FloatType testDot = Simd::Vec4::Dot(sourceVector1, sourceVector2);
         Simd::Vec1::StoreUnaligned(testStoreValues, testDot);
 
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 257.0f);
+        EXPECT_NEAR(testStoreValues[0], 257.0f, 0.002f);
     }
 
     TEST(MATH_SimdMath, TestCrossFloatVec3)
@@ -2412,30 +2412,30 @@ namespace UnitTest
             Simd::Vec3::FloatType testVector = Simd::Vec3::Cross(sourceVector1, sourceVector2);
             Simd::Vec3::StoreUnaligned(testStoreValues, testVector);
 
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 0.0f);
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 0.0f);
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 1.0f);
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[3], 0.0f);
+            EXPECT_NEAR(testStoreValues[0], 0.0f, 0.002f);
+            EXPECT_NEAR(testStoreValues[1], 0.0f, 0.002f);
+            EXPECT_NEAR(testStoreValues[2], 1.0f, 0.002f);
+            EXPECT_NEAR(testStoreValues[3], 0.0f, 0.002f);
         }
 
         {
             Simd::Vec3::FloatType testVector = Simd::Vec3::Cross(sourceVector2, sourceVector3);
             Simd::Vec3::StoreUnaligned(testStoreValues, testVector);
 
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 1.0f);
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 0.0f);
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 0.0f);
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[3], 0.0f);
+            EXPECT_NEAR(testStoreValues[0], 1.0f, 0.002f);
+            EXPECT_NEAR(testStoreValues[1], 0.0f, 0.002f);
+            EXPECT_NEAR(testStoreValues[2], 0.0f, 0.002f);
+            EXPECT_NEAR(testStoreValues[3], 0.0f, 0.002f);
         }
 
         {
             Simd::Vec3::FloatType testVector = Simd::Vec3::Cross(sourceVector3, sourceVector1);
             Simd::Vec3::StoreUnaligned(testStoreValues, testVector);
 
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 0.0f);
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 1.0f);
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 0.0f);
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[3], 0.0f);
+            EXPECT_NEAR(testStoreValues[0], 0.0f, 0.002f);
+            EXPECT_NEAR(testStoreValues[1], 1.0f, 0.002f);
+            EXPECT_NEAR(testStoreValues[2], 0.0f, 0.002f);
+            EXPECT_NEAR(testStoreValues[3], 0.0f, 0.002f);
         }
     }
 
@@ -2451,19 +2451,19 @@ namespace UnitTest
         Simd::Vec3::Mat3x3Inverse(rows, rows);
 
         Simd::Vec3::StoreUnaligned(testStoreValues, rows[0]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 0.5f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 0.0f);
+        EXPECT_NEAR(testStoreValues[0], 0.5f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], 0.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], 0.0f, 0.002f);
 
         Simd::Vec3::StoreUnaligned(testStoreValues, rows[1]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 0.5f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 0.0f);
+        EXPECT_NEAR(testStoreValues[0], 0.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], 0.5f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], 0.0f, 0.002f);
 
         Simd::Vec3::StoreUnaligned(testStoreValues, rows[2]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 0.5f);
+        EXPECT_NEAR(testStoreValues[0], 0.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], 0.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], 0.5f, 0.002f);
     }
 
     TEST(MATH_SimdMath, TestMat3x3Adjugate)
@@ -2478,19 +2478,19 @@ namespace UnitTest
         Simd::Vec3::Mat3x3Adjugate(rows, rows);
 
         Simd::Vec3::StoreUnaligned(testStoreValues, rows[0]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], -1.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], -1.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2],  2.0f);
+        EXPECT_NEAR(testStoreValues[0], -1.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], -1.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2],  2.0f, 0.002f);
 
         Simd::Vec3::StoreUnaligned(testStoreValues, rows[1]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], -5.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1],  5.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2],  5.0f);
+        EXPECT_NEAR(testStoreValues[0], -5.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1],  5.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2],  5.0f, 0.002f);
 
         Simd::Vec3::StoreUnaligned(testStoreValues, rows[2]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0],  2.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], -3.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], -4.0f);
+        EXPECT_NEAR(testStoreValues[0],  2.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], -3.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], -4.0f, 0.002f);
     }
 
     TEST(MATH_SimdMath, TestMat3x3Transpose)
@@ -2505,19 +2505,19 @@ namespace UnitTest
         Simd::Vec3::Mat3x3Transpose(rows, rows);
 
         Simd::Vec3::StoreUnaligned(testStoreValues, rows[0]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 1.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 4.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 7.0f);
+        EXPECT_NEAR(testStoreValues[0], 1.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], 4.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], 7.0f, 0.002f);
 
         Simd::Vec3::StoreUnaligned(testStoreValues, rows[1]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 2.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 5.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 8.0f);
+        EXPECT_NEAR(testStoreValues[0], 2.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], 5.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], 8.0f, 0.002f);
 
         Simd::Vec3::StoreUnaligned(testStoreValues, rows[2]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 3.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 6.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 9.0f);
+        EXPECT_NEAR(testStoreValues[0], 3.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], 6.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], 9.0f, 0.002f);
     }
 
     TEST(MATH_SimdMath, TestMat3x3Multiply)
@@ -2538,19 +2538,19 @@ namespace UnitTest
         Simd::Vec3::Mat3x3Multiply(rowsA, rowsB, out);
 
         Simd::Vec3::StoreUnaligned(testStoreValues, out[0]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 1.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 0.0f);
+        EXPECT_NEAR(testStoreValues[0], 1.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], 0.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], 0.0f, 0.002f);
 
         Simd::Vec3::StoreUnaligned(testStoreValues, out[1]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 1.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 0.0f);
+        EXPECT_NEAR(testStoreValues[0], 0.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], 1.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], 0.0f, 0.002f);
 
         Simd::Vec3::StoreUnaligned(testStoreValues, out[2]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 1.0f);
+        EXPECT_NEAR(testStoreValues[0], 0.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], 0.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], 1.0f, 0.002f);
     }
 
     TEST(MATH_SimdMath, TestMat3x3TransposeMultiply)
@@ -2571,19 +2571,19 @@ namespace UnitTest
         Simd::Vec3::Mat3x3TransposeMultiply(rowsA, rowsB, out);
 
         Simd::Vec3::StoreUnaligned(testStoreValues, out[0]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 1.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 0.0f);
+        EXPECT_NEAR(testStoreValues[0], 1.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], 0.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], 0.0f, 0.002f);
 
         Simd::Vec3::StoreUnaligned(testStoreValues, out[1]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 1.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 0.0f);
+        EXPECT_NEAR(testStoreValues[0], 0.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], 1.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], 0.0f, 0.002f);
 
         Simd::Vec3::StoreUnaligned(testStoreValues, out[2]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 1.0f);
+        EXPECT_NEAR(testStoreValues[0], 0.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], 0.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], 1.0f, 0.002f);
     }
 
     TEST(MATH_SimdMath, TestQuaternion)
@@ -2639,16 +2639,16 @@ namespace UnitTest
             Simd::Vec4::FloatType planeVec = Simd::Vec4::ConstructPlane(normalVec, pointVec);
             Simd::Vec4::StoreUnaligned(testStoreValues, planeVec);
 
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 0.0f);
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 1.0f);
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 0.0f);
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[3], 0.0f);
+            EXPECT_NEAR(testStoreValues[0], 0.0f, 0.002f);
+            EXPECT_NEAR(testStoreValues[1], 1.0f, 0.002f);
+            EXPECT_NEAR(testStoreValues[2], 0.0f, 0.002f);
+            EXPECT_NEAR(testStoreValues[3], 0.0f, 0.002f);
 
             Simd::Vec3::FloatType testPoint = Simd::Vec3::LoadImmediate(0.0f, 10.0f, 0.0f);
             Simd::Vec1::FloatType testDist = Simd::Vec4::PlaneDistance(planeVec, testPoint);
             Simd::Vec1::StoreUnaligned(testStoreValues, testDist);
 
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 10.0f);
+            EXPECT_NEAR(testStoreValues[0], 10.0f, 0.002f);
         }
 
         // Point offset along the plane normal, offset should be preserved in distance calculations
@@ -2659,16 +2659,16 @@ namespace UnitTest
             Simd::Vec4::FloatType planeVec = Simd::Vec4::ConstructPlane(normalVec, pointVec);
             Simd::Vec4::StoreUnaligned(testStoreValues, planeVec);
 
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 0.0f);
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 1.0f);
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 0.0f);
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[3], -10.0f);
+            EXPECT_NEAR(testStoreValues[0], 0.0f, 0.002f);
+            EXPECT_NEAR(testStoreValues[1], 1.0f, 0.002f);
+            EXPECT_NEAR(testStoreValues[2], 0.0f, 0.002f);
+            EXPECT_NEAR(testStoreValues[3], -10.0f, 0.002f);
 
             Simd::Vec3::FloatType testPoint = Simd::Vec3::LoadImmediate(0.0f, -5.0f, 0.0f);
             Simd::Vec1::FloatType testDist = Simd::Vec4::PlaneDistance(planeVec, testPoint);
             Simd::Vec1::StoreUnaligned(testStoreValues, testDist);
 
-            AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], -15.0f);
+            EXPECT_NEAR(testStoreValues[0], -15.0f, 0.002f);
         }
     }
 
@@ -2684,22 +2684,22 @@ namespace UnitTest
         Simd::Vec4::Mat3x4Transpose(rows, rows);
 
         Simd::Vec4::StoreUnaligned(testStoreValues, rows[0]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 4.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 8.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[3], 0.0f);
+        EXPECT_NEAR(testStoreValues[0], 0.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], 4.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], 8.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[3], 0.0f, 0.002f);
 
         Simd::Vec4::StoreUnaligned(testStoreValues, rows[1]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 1.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 5.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 9.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[3], 0.0f);
+        EXPECT_NEAR(testStoreValues[0], 1.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], 5.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], 9.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[3], 0.0f, 0.002f);
 
         Simd::Vec4::StoreUnaligned(testStoreValues, rows[2]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 2.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 6.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], -1.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[3], 0.0f);
+        EXPECT_NEAR(testStoreValues[0], 2.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], 6.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], -1.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[3], 0.0f, 0.002f);
     }
 
     TEST(MATH_SimdMath, TestMat4x4Transpose)
@@ -2715,28 +2715,28 @@ namespace UnitTest
         Simd::Vec4::Mat4x4Transpose(rows, rows);
 
         Simd::Vec4::StoreUnaligned(testStoreValues, rows[0]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 0.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 4.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 8.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[3], -1.0f);
+        EXPECT_NEAR(testStoreValues[0], 0.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], 4.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], 8.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[3], -1.0f, 0.002f);
 
         Simd::Vec4::StoreUnaligned(testStoreValues, rows[1]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 1.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 5.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 9.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[3], -2.0f);
+        EXPECT_NEAR(testStoreValues[0], 1.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], 5.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], 9.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[3], -2.0f, 0.002f);
 
         Simd::Vec4::StoreUnaligned(testStoreValues, rows[2]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 2.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 6.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 9.1f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[3], -3.0f);
+        EXPECT_NEAR(testStoreValues[0], 2.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], 6.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], 9.1f, 0.002f);
+        EXPECT_NEAR(testStoreValues[3], -3.0f, 0.002f);
 
         Simd::Vec4::StoreUnaligned(testStoreValues, rows[3]);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[0], 3.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[1], 7.0f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[2], 9.9f);
-        AZ_TEST_ASSERT_FLOAT_CLOSE(testStoreValues[3], -4.0f);
+        EXPECT_NEAR(testStoreValues[0], 3.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[1], 7.0f, 0.002f);
+        EXPECT_NEAR(testStoreValues[2], 9.9f, 0.002f);
+        EXPECT_NEAR(testStoreValues[3], -4.0f, 0.002f);
     }
 
     TEST(MATH_SimdMath, TestConvertToIntVec1)

--- a/Code/Framework/AzCore/Tests/Math/SplineTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/SplineTests.cpp
@@ -34,25 +34,25 @@ namespace UnitTest
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = linearSpline.GetNearestAddressPosition(Vector3(7.5f, 2.5f, 0.0f));
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = linearSpline.GetNearestAddressPosition(Vector3(-1.0f, -1.0f, 0.0f));
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentIndex == 0);
+                    EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 0);
                     EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.0f);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = linearSpline.GetNearestAddressPosition(Vector3(-1.0f, 6.0f, 0.0f));
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentIndex == 2);
+                    EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 2);
                     EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = linearSpline.GetNearestAddressPosition(Vector3(2.5f, 6.0f, 0.0f));
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentIndex == 2);
+                    EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 2);
                     EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
                 }
             }
@@ -69,13 +69,13 @@ namespace UnitTest
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = linearSpline.GetNearestAddressPosition(Vector3(-2.0f, 2.5f, 0.0f));
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentIndex == 3);
+                    EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 3);
                     EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = linearSpline.GetNearestAddressPosition(Vector3(-2.0f, 4.0f, 0.0f));
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentIndex == 3);
+                    EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 3);
                     EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.2f);
                 }
             }
@@ -94,25 +94,25 @@ namespace UnitTest
 
                 {
                     RaySplineQueryResult raySplineQueryResult = linearSpline.GetNearestAddressRay(Vector3(2.5f, -2.5f, 1.0f), Vector3(0.0f, 1.0f, 0.0f));
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentIndex == 0);
+                    EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 0);
                     EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
                 }
 
                 {
                     RaySplineQueryResult raySplineQueryResult = linearSpline.GetNearestAddressRay(Vector3(2.5f, -10.0f, 0.0f), Vector3(1.0f, 1.0f, 0.0f));
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentIndex == 0);
+                    EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 0);
                     EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
                 }
 
                 {
                     RaySplineQueryResult raySplineQueryResult = linearSpline.GetNearestAddressRay(Vector3(7.5f, 2.5f, 0.0f), Vector3(-1.0f, 1.0f, 0.0f));
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
                 }
 
                 {
                     RaySplineQueryResult raySplineQueryResult = linearSpline.GetNearestAddressRay(Vector3(-2.5f, 2.5f, -1.0f), Vector3(1.0f, 1.0f, 0.0f));
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentIndex == 2);
+                    EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 2);
                     EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
                 }
             }
@@ -129,13 +129,13 @@ namespace UnitTest
 
                 {
                     RaySplineQueryResult raySplineQueryResult = linearSpline.GetNearestAddressRay(Vector3(-2.5f, 2.5f, 0.0f), Vector3(0.0f, 0.0f, -1.0f));
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentIndex == 3);
+                    EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 3);
                     EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
                 }
 
                 {
                     RaySplineQueryResult raySplineQueryResult = linearSpline.GetNearestAddressRay(Vector3(-2.5f, 2.5f, 0.0f), Vector3(1.0f, 0.0f, 0.0f));
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentIndex == 3);
+                    EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 3);
                     EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
                 }
             }
@@ -154,43 +154,43 @@ namespace UnitTest
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByDistance(7.5f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.5f);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByDistance(15.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 2);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 2);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByDistance(0.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 0);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 0);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByDistance(11.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 2);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 2);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.2f);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByDistance(3.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 0);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 0);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.6f);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByDistance(20.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 2);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 2);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByDistance(-5.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 0);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 0);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
                 }
             }
@@ -207,13 +207,13 @@ namespace UnitTest
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByDistance(17.5f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 3);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 3);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.5f);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByDistance(20.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 3);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 3);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
                 }
             }
@@ -232,43 +232,43 @@ namespace UnitTest
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(0.5f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.5f);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(1.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 2);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 2);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(0.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 0);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 0);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(0.6f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.8f);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(0.2f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 0);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 0);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.6f);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(1.5f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 2);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 2);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(-0.5f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 0);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 0);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
                 }
             }
@@ -285,19 +285,19 @@ namespace UnitTest
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(0.5f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 2);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 2);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(1.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 3);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 3);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(0.8f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 3);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 3);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.2f);
                 }
             }
@@ -722,25 +722,25 @@ namespace UnitTest
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = catmullRomSpline.GetNearestAddressPosition(Vector3(7.5f, 2.5f, 0.0f));
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = catmullRomSpline.GetNearestAddressPosition(Vector3(-1.0f, -1.0f, 0.0f));
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.0f);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = catmullRomSpline.GetNearestAddressPosition(Vector3(-1.0f, 6.0f, 0.0f));
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = catmullRomSpline.GetNearestAddressPosition(Vector3(2.5f, 6.0f, 0.0f));
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
                 }
             }
@@ -757,7 +757,7 @@ namespace UnitTest
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = catmullRomSpline.GetNearestAddressPosition(Vector3(5.0f, -2.5f, 0.0f));
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentIndex == 3);
+                    EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 3);
                     EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
                 }
             }
@@ -776,25 +776,25 @@ namespace UnitTest
 
                 {
                     RaySplineQueryResult raySplineQueryResult = catmullRomSpline.GetNearestAddressRay(Vector3(2.5f, -2.5f, 1.0f), Vector3(0.0f, 1.0f, 0.0f));
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.0f);
                 }
 
                 {
                     RaySplineQueryResult raySplineQueryResult = catmullRomSpline.GetNearestAddressRay(Vector3(2.5f, -10.0f, 0.0f), Vector3(1.0f, 1.0f, 0.0f));
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.0f);
                 }
 
                 {
                     RaySplineQueryResult raySplineQueryResult = catmullRomSpline.GetNearestAddressRay(Vector3(7.5f, 2.5f, 0.0f), Vector3(-1.0f, 0.0f, 0.0f));
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
                 }
 
                 {
                     RaySplineQueryResult raySplineQueryResult = catmullRomSpline.GetNearestAddressRay(Vector3(-2.5f, 7.5f, -1.0f), Vector3(1.0f, 0.0f, 0.0f));
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
                 }
             }
@@ -811,7 +811,7 @@ namespace UnitTest
 
                 {
                     RaySplineQueryResult raySplineQueryResult = catmullRomSpline.GetNearestAddressRay(Vector3(-2.5f, 2.5f, 0.0f), Vector3(0.0f, 1.0f, 0.0f));
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentIndex == 3);
+                    EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 3);
                     EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
                 }
             }
@@ -856,26 +856,26 @@ namespace UnitTest
 
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByDistance(20.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
                 }
 
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByDistance(0.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
                 }
 
                 {
                     // note: spline length is approx 10.49176
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByDistance(5.24588f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 1);
                     EXPECT_NEAR(0.5f, splineAddress.m_segmentFraction, 0.0001f);
                 }
 
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByDistance(-10.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
                 }
             }
@@ -892,13 +892,13 @@ namespace UnitTest
 
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByDistance(50.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 3);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 3);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
                 }
 
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByDistance(0.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 0);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 0);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
                 }
             }
@@ -917,25 +917,25 @@ namespace UnitTest
 
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByFraction(0.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
                 }
 
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByFraction(1.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
                 }
 
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByFraction(0.5f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.5f);
                 }
 
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByFraction(0.75f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.75f);
                 }
             }
@@ -952,19 +952,19 @@ namespace UnitTest
 
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByFraction(0.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 0);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 0);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
                 }
 
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByFraction(1.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 3);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 3);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
                 }
 
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByFraction(0.5f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 2);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 2);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
                 }
             }
@@ -1363,19 +1363,19 @@ namespace UnitTest
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = bezierSpline.GetNearestAddressPosition(Vector3(-1.0f, -1.0f, 0.0f));
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentIndex == 0);
+                    EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 0);
                     EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.0f);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = bezierSpline.GetNearestAddressPosition(Vector3(5.0f, 12.0f, 0.0f));
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = bezierSpline.GetNearestAddressPosition(Vector3(12.0f, -1.0f, 0.0f));
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentIndex == 2);
+                    EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 2);
                     EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
                 }
             }
@@ -1392,13 +1392,13 @@ namespace UnitTest
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = bezierSpline.GetNearestAddressPosition(Vector3(5.0f, -12.0f, 0.0f));
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentIndex == 3);
+                    EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 3);
                     EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = bezierSpline.GetNearestAddressPosition(Vector3(12.0f, 12.0f, 0.0f));
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
                 }
             }
@@ -1417,19 +1417,19 @@ namespace UnitTest
 
                 {
                     RaySplineQueryResult raySplineQueryResult = bezierSpline.GetNearestAddressRay(Vector3(-1.0f, -1.0f, 0.0f), Vector3(-1.0f, 1.0f, 0.0f));
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentIndex == 0);
+                    EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 0);
                     EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.0f);
                 }
 
                 {
                     RaySplineQueryResult raySplineQueryResult = bezierSpline.GetNearestAddressRay(Vector3(5.0f, 12.0f, 0.0f), Vector3(0.0f, -1.0f, 0.0f));
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 1);
                     EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
                 }
 
                 {
                     RaySplineQueryResult raySplineQueryResult = bezierSpline.GetNearestAddressRay(Vector3(12.0f, -1.0f, 0.0f), Vector3(1.0f, 1.0f, 0.0f));
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentIndex == 2);
+                    EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 2);
                     EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
                 }
             }
@@ -1446,7 +1446,7 @@ namespace UnitTest
 
                 {
                     RaySplineQueryResult raySplineQueryResult = bezierSpline.GetNearestAddressRay(Vector3(-10.0f, -10.0f, 0.0f), Vector3(1.0f, 0.0f, 0.0f));
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentIndex == 3);
+                    EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 3);
                     EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
                 }
             }
@@ -1465,19 +1465,19 @@ namespace UnitTest
 
                 {
                     SplineAddress splineAddress = bezierSpline.GetAddressByDistance(0.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 0);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 0);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
                 }
 
                 {
                     SplineAddress splineAddress = bezierSpline.GetAddressByDistance(-5.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 0);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 0);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
                 }
 
                 {
                     SplineAddress splineAddress = bezierSpline.GetAddressByDistance(100.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 2);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 2);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
                 }
             }
@@ -1494,7 +1494,7 @@ namespace UnitTest
 
                 {
                     SplineAddress splineAddress = bezierSpline.GetAddressByDistance(100.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 3);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 3);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
                 }
             }
@@ -1513,31 +1513,31 @@ namespace UnitTest
 
                 {
                     SplineAddress splineAddress = bezierSpline.GetAddressByFraction(0.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 0);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 0);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
                 }
 
                 {
                     SplineAddress splineAddress = bezierSpline.GetAddressByFraction(-0.5f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 0);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 0);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
                 }
 
                 {
                     SplineAddress splineAddress = bezierSpline.GetAddressByFraction(2.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 2);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 2);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
                 }
 
                 {
                     SplineAddress splineAddress = bezierSpline.GetAddressByFraction(1.0f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 2);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 2);
                     EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
                 }
 
                 {
                     SplineAddress splineAddress = bezierSpline.GetAddressByFraction(0.5f);
-                    EXPECT_TRUE(splineAddress.m_segmentIndex == 1);
+                    EXPECT_EQ(splineAddress.m_segmentIndex, 1);
                     EXPECT_NEAR(splineAddress.m_segmentFraction, 0.5f, Constants::Tolerance);
                 }
             }
@@ -2019,9 +2019,9 @@ namespace UnitTest
             bezierSplineSetLValueCopy.m_vertexContainer.SetVertices(bezierSplineSetLValue.GetVertices());
 
             EXPECT_TRUE(bezierSpline.GetBezierData().size() == bezierSplineSetLValue.GetBezierData().size());
-            EXPECT_TRUE(bezierSplineSetLValue.GetBezierData().size() == 4);
+            EXPECT_EQ(bezierSplineSetLValue.GetBezierData().size(), 4);
             EXPECT_TRUE(bezierSplineSetLValue.GetBezierData().size() == bezierSplineSetRValue.GetBezierData().size());
-            EXPECT_TRUE(bezierSplineSetLValueCopy.GetBezierData().size() == 4);
+            EXPECT_EQ(bezierSplineSetLValueCopy.GetBezierData().size(), 4);
             EXPECT_TRUE(bezierSplineSetLValueCopy.GetVertexCount() == vertices.size());
         }
     };

--- a/Code/Framework/AzCore/Tests/Math/SplineTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/SplineTests.cpp
@@ -35,25 +35,25 @@ namespace UnitTest
                 {
                     PositionSplineQueryResult posSplineQueryResult = linearSpline.GetNearestAddressPosition(Vector3(7.5f, 2.5f, 0.0f));
                     EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
+                    EXPECT_NEAR(posSplineQueryResult.m_splineAddress.m_segmentFraction, 0.5f, AZ::Constants::Tolerance);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = linearSpline.GetNearestAddressPosition(Vector3(-1.0f, -1.0f, 0.0f));
                     EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 0);
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(posSplineQueryResult.m_splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = linearSpline.GetNearestAddressPosition(Vector3(-1.0f, 6.0f, 0.0f));
                     EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 2);
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(posSplineQueryResult.m_splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = linearSpline.GetNearestAddressPosition(Vector3(2.5f, 6.0f, 0.0f));
                     EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 2);
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
+                    EXPECT_NEAR(posSplineQueryResult.m_splineAddress.m_segmentFraction, 0.5f, AZ::Constants::Tolerance);
                 }
             }
 
@@ -70,13 +70,13 @@ namespace UnitTest
                 {
                     PositionSplineQueryResult posSplineQueryResult = linearSpline.GetNearestAddressPosition(Vector3(-2.0f, 2.5f, 0.0f));
                     EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 3);
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
+                    EXPECT_NEAR(posSplineQueryResult.m_splineAddress.m_segmentFraction, 0.5f, AZ::Constants::Tolerance);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = linearSpline.GetNearestAddressPosition(Vector3(-2.0f, 4.0f, 0.0f));
                     EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 3);
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.2f);
+                    EXPECT_NEAR(posSplineQueryResult.m_splineAddress.m_segmentFraction, 0.2f, AZ::Constants::Tolerance);
                 }
             }
         }
@@ -95,25 +95,25 @@ namespace UnitTest
                 {
                     RaySplineQueryResult raySplineQueryResult = linearSpline.GetNearestAddressRay(Vector3(2.5f, -2.5f, 1.0f), Vector3(0.0f, 1.0f, 0.0f));
                     EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 0);
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
+                    EXPECT_NEAR(raySplineQueryResult.m_splineAddress.m_segmentFraction, 0.5f, AZ::Constants::Tolerance);
                 }
 
                 {
                     RaySplineQueryResult raySplineQueryResult = linearSpline.GetNearestAddressRay(Vector3(2.5f, -10.0f, 0.0f), Vector3(1.0f, 1.0f, 0.0f));
                     EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 0);
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(raySplineQueryResult.m_splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     RaySplineQueryResult raySplineQueryResult = linearSpline.GetNearestAddressRay(Vector3(7.5f, 2.5f, 0.0f), Vector3(-1.0f, 1.0f, 0.0f));
                     EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(raySplineQueryResult.m_splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     RaySplineQueryResult raySplineQueryResult = linearSpline.GetNearestAddressRay(Vector3(-2.5f, 2.5f, -1.0f), Vector3(1.0f, 1.0f, 0.0f));
                     EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 2);
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(raySplineQueryResult.m_splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
             }
 
@@ -130,13 +130,13 @@ namespace UnitTest
                 {
                     RaySplineQueryResult raySplineQueryResult = linearSpline.GetNearestAddressRay(Vector3(-2.5f, 2.5f, 0.0f), Vector3(0.0f, 0.0f, -1.0f));
                     EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 3);
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
+                    EXPECT_NEAR(raySplineQueryResult.m_splineAddress.m_segmentFraction, 0.5f, AZ::Constants::Tolerance);
                 }
 
                 {
                     RaySplineQueryResult raySplineQueryResult = linearSpline.GetNearestAddressRay(Vector3(-2.5f, 2.5f, 0.0f), Vector3(1.0f, 0.0f, 0.0f));
                     EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 3);
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
+                    EXPECT_NEAR(raySplineQueryResult.m_splineAddress.m_segmentFraction, 0.5f, AZ::Constants::Tolerance);
                 }
             }
         }
@@ -155,43 +155,43 @@ namespace UnitTest
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByDistance(7.5f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.5f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.5f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByDistance(15.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 2);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByDistance(0.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 0);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByDistance(11.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 2);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.2f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.2f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByDistance(3.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 0);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.6f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.6f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByDistance(20.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 2);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByDistance(-5.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 0);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
             }
 
@@ -208,13 +208,13 @@ namespace UnitTest
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByDistance(17.5f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 3);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.5f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.5f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByDistance(20.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 3);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
             }
         }
@@ -233,43 +233,43 @@ namespace UnitTest
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(0.5f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.5f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.5f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(1.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 2);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(0.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 0);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(0.6f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.8f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.8f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(0.2f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 0);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.6f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.6f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(1.5f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 2);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(-0.5f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 0);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
             }
 
@@ -286,19 +286,19 @@ namespace UnitTest
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(0.5f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 2);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(1.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 3);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = linearSpline.GetAddressByFraction(0.8f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 3);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.2f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.2f, AZ::Constants::Tolerance);
                 }
             }
         }
@@ -316,33 +316,33 @@ namespace UnitTest
 
                 {
                     Vector3 position = linearSpline.GetPosition(linearSpline.GetAddressByFraction(0.5f));
-                    EXPECT_TRUE(position == Vector3(5.0f, 2.5f, 0.0f));
+                    EXPECT_THAT(position, IsClose(Vector3(5.0f, 2.5f, 0.0f)));
                 }
 
                 {
                     Vector3 position = linearSpline.GetPosition(SplineAddress());
-                    EXPECT_TRUE(position == Vector3(0.0f, 0.0f, 0.0f));
+                    EXPECT_THAT(position, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
                 }
 
                 {
                     Vector3 position = linearSpline.GetPosition(SplineAddress(linearSpline.GetSegmentCount() - 1, 1.0f));
-                    EXPECT_TRUE(position == Vector3(0.0f, 5.0f, 0.0f));
+                    EXPECT_THAT(position, IsClose(Vector3(0.0f, 5.0f, 0.0f)));
                 }
 
                 {
                     Vector3 position = linearSpline.GetPosition(linearSpline.GetAddressByDistance(4.0f));
-                    EXPECT_TRUE(position == Vector3(4.0f, 0.0f, 0.0f));
+                    EXPECT_THAT(position, IsClose(Vector3(4.0f, 0.0f, 0.0f)));
                 }
 
                 {
                     Vector3 position = linearSpline.GetPosition(SplineAddress(3, 0.0f));
-                    EXPECT_TRUE(position == Vector3(0.0f, 5.0f, 0.0f));
+                    EXPECT_THAT(position, IsClose(Vector3(0.0f, 5.0f, 0.0f)));
                 }
 
                 {
                     // out of bounds access (return position of last vertex - clamped)
                     Vector3 position = linearSpline.GetPosition(SplineAddress(5, 0.0f));
-                    EXPECT_TRUE(position == Vector3(0.0f, 5.0f, 0.0f));
+                    EXPECT_THAT(position, IsClose(Vector3(0.0f, 5.0f, 0.0f)));
                 }
             }
 
@@ -392,28 +392,28 @@ namespace UnitTest
 
                 {
                     Vector3 normal = linearSpline.GetNormal(linearSpline.GetAddressByFraction(0.5f));
-                    EXPECT_TRUE(normal == Vector3(0.0f, 1.0f, 0.0f));
+                    EXPECT_THAT(normal, IsClose(Vector3(0.0f, 1.0f, 0.0f)));
                 }
 
                 {
                     Vector3 normal = linearSpline.GetNormal(SplineAddress());
-                    EXPECT_TRUE(normal == Vector3(-1.0f, 0.0f, 0.0f));
+                    EXPECT_THAT(normal, IsClose(Vector3(-1.0f, 0.0f, 0.0f)));
                 }
 
                 {
                     Vector3 normal = linearSpline.GetNormal(SplineAddress(linearSpline.GetSegmentCount() - 1, 1.0f));
-                    EXPECT_TRUE(normal == Vector3(1.0f, 0.0f, 0.0f));
+                    EXPECT_THAT(normal, IsClose(Vector3(1.0f, 0.0f, 0.0f)));
                 }
 
                 {
                     Vector3 normal = linearSpline.GetNormal(linearSpline.GetAddressByDistance(4.0f));
-                    EXPECT_TRUE(normal == Vector3(-1.0f, 0.0f, 0.0f));
+                    EXPECT_THAT(normal, IsClose(Vector3(-1.0f, 0.0f, 0.0f)));
                 }
 
                 {
                     // out of bounds access (return normal of last vertex - clamped)
                     Vector3 normal = linearSpline.GetNormal(SplineAddress(5, 0.0f));
-                    EXPECT_TRUE(normal == Vector3(1.0f, 0.0f, 0.0f));
+                    EXPECT_THAT(normal, IsClose(Vector3(1.0f, 0.0f, 0.0f)));
                 }
             }
 
@@ -427,7 +427,7 @@ namespace UnitTest
                 linearSpline.m_vertexContainer.AddVertex(Vector3(0.0f, 5.0f, 0.0f));
 
                 Vector3 normal = linearSpline.GetNormal(linearSpline.GetAddressByDistance(4.0f));
-                EXPECT_TRUE(normal == Vector3(0.0f, 0.0f, 0.0f));
+                EXPECT_THAT(normal, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
             }
 
             {
@@ -442,12 +442,12 @@ namespace UnitTest
 
                 {
                     Vector3 normal = linearSpline.GetNormal(linearSpline.GetAddressByDistance(20.0f));
-                    EXPECT_TRUE(normal == Vector3(0.0f, -1.0f, 0.0f));
+                    EXPECT_THAT(normal, IsClose(Vector3(0.0f, -1.0f, 0.0f)));
                 }
 
                 {
                     Vector3 normal = linearSpline.GetNormal(linearSpline.GetAddressByFraction(0.8f));
-                    EXPECT_TRUE(normal == Vector3(0.0f, -1.0f, 0.0f));
+                    EXPECT_THAT(normal, IsClose(Vector3(0.0f, -1.0f, 0.0f)));
                 }
             }
         }
@@ -465,22 +465,22 @@ namespace UnitTest
 
                 {
                     Vector3 tangent = linearSpline.GetTangent(linearSpline.GetAddressByFraction(0.5f));
-                    EXPECT_TRUE(tangent == Vector3(0.0f, 1.0f, 0.0f));
+                    EXPECT_THAT(tangent, IsClose(Vector3(0.0f, 1.0f, 0.0f)));
                 }
 
                 {
                     Vector3 tangent = linearSpline.GetTangent(SplineAddress());
-                    EXPECT_TRUE(tangent == Vector3(1.0f, 0.0f, 0.0f));
+                    EXPECT_THAT(tangent, IsClose(Vector3(1.0f, 0.0f, 0.0f)));
                 }
 
                 {
                     Vector3 tangent = linearSpline.GetTangent(SplineAddress(linearSpline.GetSegmentCount() - 1, 1.0f));
-                    EXPECT_TRUE(tangent == Vector3(-1.0f, 0.0f, 0.0f));
+                    EXPECT_THAT(tangent, IsClose(Vector3(-1.0f, 0.0f, 0.0f)));
                 }
 
                 {
                     Vector3 tangent = linearSpline.GetTangent(linearSpline.GetAddressByDistance(4.0f));
-                    EXPECT_TRUE(tangent == Vector3(1.0f, 0.0f, 0.0f));
+                    EXPECT_THAT(tangent, IsClose(Vector3(1.0f, 0.0f, 0.0f)));
                 }
             }
 
@@ -496,12 +496,12 @@ namespace UnitTest
 
                 {
                     Vector3 tangent = linearSpline.GetTangent(SplineAddress(linearSpline.GetSegmentCount() - 1, 1.0f));
-                    EXPECT_TRUE(tangent == Vector3(0.0f, -1.0f, 0.0f));
+                    EXPECT_THAT(tangent, IsClose(Vector3(0.0f, -1.0f, 0.0f)));
                 }
 
                 {
                     Vector3 tangent = linearSpline.GetTangent(linearSpline.GetAddressByDistance(16.0f));
-                    EXPECT_TRUE(tangent == Vector3(0.0f, -1.0f, 0.0f));
+                    EXPECT_THAT(tangent, IsClose(Vector3(0.0f, -1.0f, 0.0f)));
                 }
             }
         }
@@ -519,22 +519,22 @@ namespace UnitTest
 
                 {
                     float splineLength = linearSpline.GetSplineLength();
-                    EXPECT_TRUE(splineLength == 15.0f);
+                    EXPECT_NEAR(splineLength, 15.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     float segmentLength = linearSpline.GetSegmentLength(0);
-                    EXPECT_TRUE(segmentLength == 5.0f);
+                    EXPECT_NEAR(segmentLength, 5.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     float segmentLength = linearSpline.GetSegmentLength(2);
-                    EXPECT_TRUE(segmentLength == 5.0f);
+                    EXPECT_NEAR(segmentLength, 5.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     float segmentLength = linearSpline.GetSegmentLength(4);
-                    EXPECT_TRUE(segmentLength == 0.0f);
+                    EXPECT_NEAR(segmentLength, 0.0f, AZ::Constants::Tolerance);
                 }
             }
 
@@ -550,17 +550,17 @@ namespace UnitTest
 
                 {
                     float splineLength = linearSpline.GetSplineLength();
-                    EXPECT_TRUE(splineLength == 14.0f);
+                    EXPECT_NEAR(splineLength, 14.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     float segmentLength = linearSpline.GetSegmentLength(0);
-                    EXPECT_TRUE(segmentLength == 2.0f);
+                    EXPECT_NEAR(segmentLength, 2.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     float segmentLength = linearSpline.GetSegmentLength(3);
-                    EXPECT_TRUE(segmentLength == 7.0f);
+                    EXPECT_NEAR(segmentLength, 7.0f, AZ::Constants::Tolerance);
                 }
             }
 
@@ -576,12 +576,12 @@ namespace UnitTest
 
                 {
                     float splineLength = linearSpline.GetSplineLength();
-                    EXPECT_TRUE(splineLength == 20.0f);
+                    EXPECT_NEAR(splineLength, 20.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     float segmentLength = linearSpline.GetSegmentLength(3);
-                    EXPECT_TRUE(segmentLength == 5.0f);
+                    EXPECT_NEAR(segmentLength, 5.0f, AZ::Constants::Tolerance);
                 }
             }
 
@@ -595,12 +595,12 @@ namespace UnitTest
 
                 {
                     float splineLength = linearSpline.GetSplineLength();
-                    EXPECT_TRUE(splineLength == 20.0f);
+                    EXPECT_NEAR(splineLength, 20.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     float segmentLength = linearSpline.GetSegmentLength(1);
-                    EXPECT_TRUE(segmentLength == 10.0f);
+                    EXPECT_NEAR(segmentLength, 10.0f, AZ::Constants::Tolerance);
                 }
             }
         }
@@ -723,25 +723,25 @@ namespace UnitTest
                 {
                     PositionSplineQueryResult posSplineQueryResult = catmullRomSpline.GetNearestAddressPosition(Vector3(7.5f, 2.5f, 0.0f));
                     EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
+                    EXPECT_NEAR(posSplineQueryResult.m_splineAddress.m_segmentFraction, 0.5f, AZ::Constants::Tolerance);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = catmullRomSpline.GetNearestAddressPosition(Vector3(-1.0f, -1.0f, 0.0f));
                     EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(posSplineQueryResult.m_splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = catmullRomSpline.GetNearestAddressPosition(Vector3(-1.0f, 6.0f, 0.0f));
                     EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(posSplineQueryResult.m_splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = catmullRomSpline.GetNearestAddressPosition(Vector3(2.5f, 6.0f, 0.0f));
                     EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(posSplineQueryResult.m_splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
             }
 
@@ -758,7 +758,7 @@ namespace UnitTest
                 {
                     PositionSplineQueryResult posSplineQueryResult = catmullRomSpline.GetNearestAddressPosition(Vector3(5.0f, -2.5f, 0.0f));
                     EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 3);
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
+                    EXPECT_NEAR(posSplineQueryResult.m_splineAddress.m_segmentFraction, 0.5f, AZ::Constants::Tolerance);
                 }
             }
         }
@@ -777,25 +777,25 @@ namespace UnitTest
                 {
                     RaySplineQueryResult raySplineQueryResult = catmullRomSpline.GetNearestAddressRay(Vector3(2.5f, -2.5f, 1.0f), Vector3(0.0f, 1.0f, 0.0f));
                     EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(raySplineQueryResult.m_splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     RaySplineQueryResult raySplineQueryResult = catmullRomSpline.GetNearestAddressRay(Vector3(2.5f, -10.0f, 0.0f), Vector3(1.0f, 1.0f, 0.0f));
                     EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(raySplineQueryResult.m_splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     RaySplineQueryResult raySplineQueryResult = catmullRomSpline.GetNearestAddressRay(Vector3(7.5f, 2.5f, 0.0f), Vector3(-1.0f, 0.0f, 0.0f));
                     EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
+                    EXPECT_NEAR(raySplineQueryResult.m_splineAddress.m_segmentFraction, 0.5f, AZ::Constants::Tolerance);
                 }
 
                 {
                     RaySplineQueryResult raySplineQueryResult = catmullRomSpline.GetNearestAddressRay(Vector3(-2.5f, 7.5f, -1.0f), Vector3(1.0f, 0.0f, 0.0f));
                     EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(raySplineQueryResult.m_splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
             }
 
@@ -812,7 +812,7 @@ namespace UnitTest
                 {
                     RaySplineQueryResult raySplineQueryResult = catmullRomSpline.GetNearestAddressRay(Vector3(-2.5f, 2.5f, 0.0f), Vector3(0.0f, 1.0f, 0.0f));
                     EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 3);
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
+                    EXPECT_NEAR(raySplineQueryResult.m_splineAddress.m_segmentFraction, 0.5f, AZ::Constants::Tolerance);
                 }
             }
         }
@@ -857,13 +857,13 @@ namespace UnitTest
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByDistance(20.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByDistance(0.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
 
                 {
@@ -876,7 +876,7 @@ namespace UnitTest
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByDistance(-10.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
             }
 
@@ -893,13 +893,13 @@ namespace UnitTest
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByDistance(50.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 3);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByDistance(0.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 0);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
             }
         }
@@ -918,25 +918,25 @@ namespace UnitTest
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByFraction(0.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByFraction(1.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByFraction(0.5f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.5f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.5f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByFraction(0.75f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.75f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.75f, AZ::Constants::Tolerance);
                 }
             }
 
@@ -953,19 +953,19 @@ namespace UnitTest
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByFraction(0.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 0);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByFraction(1.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 3);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = catmullRomSpline.GetAddressByFraction(0.5f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 2);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
             }
         }
@@ -1008,13 +1008,13 @@ namespace UnitTest
 
                 {
                     Vector3 position = catmullRomSpline.GetPosition(SplineAddress(2, 0.0f));
-                    EXPECT_TRUE(position == Vector3(10.0f, 10.0f, 0.0f));
+                    EXPECT_THAT(position, IsClose(Vector3(10.0f, 10.0f, 0.0f)));
                 }
 
                 {
                     // out of bounds access (return position of last vertex that is not a control point - clamped)
                     Vector3 position = catmullRomSpline.GetPosition(SplineAddress(5, 0.0f));
-                    EXPECT_TRUE(position == Vector3(10.0f, 10.0f, 0.0f));
+                    EXPECT_THAT(position, IsClose(Vector3(10.0f, 10.0f, 0.0f)));
                 }
             }
 
@@ -1050,13 +1050,13 @@ namespace UnitTest
 
                 {
                     Vector3 position = catmullRomSpline.GetPosition(SplineAddress(0, 0.5f));
-                    EXPECT_TRUE(position == Vector3(-1.25f, 5.0f, 0.0f));
+                    EXPECT_THAT(position, IsClose(Vector3(-1.25f, 5.0f, 0.0f)));
                 }
 
                 {
                     // out of bounds access (return position of first/last vertex - clamped)
                     Vector3 position = catmullRomSpline.GetPosition(SplineAddress(5, 0.0f));
-                    EXPECT_TRUE(position == Vector3(0.0f, 0.0f, 0.0f));
+                    EXPECT_THAT(position, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
                 }
             }
         }
@@ -1224,7 +1224,7 @@ namespace UnitTest
 
                 {
                     float length = catmullRomSpline.GetSegmentLength(0);
-                    EXPECT_TRUE(length == 0.0f);
+                    EXPECT_NEAR(length, 0.0f, AZ::Constants::Tolerance);
                 }
 
                 {
@@ -1234,12 +1234,12 @@ namespace UnitTest
 
                 {
                     float length = catmullRomSpline.GetSegmentLength((size_t)-1);
-                    EXPECT_TRUE(length == 0.0f);
+                    EXPECT_NEAR(length, 0.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     float length = catmullRomSpline.GetSegmentLength(10);
-                    EXPECT_TRUE(length == 0.0f);
+                    EXPECT_NEAR(length, 0.0f, AZ::Constants::Tolerance);
                 }
             }
 
@@ -1364,19 +1364,19 @@ namespace UnitTest
                 {
                     PositionSplineQueryResult posSplineQueryResult = bezierSpline.GetNearestAddressPosition(Vector3(-1.0f, -1.0f, 0.0f));
                     EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 0);
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(posSplineQueryResult.m_splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = bezierSpline.GetNearestAddressPosition(Vector3(5.0f, 12.0f, 0.0f));
                     EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
+                    EXPECT_NEAR(posSplineQueryResult.m_splineAddress.m_segmentFraction, 0.5f, AZ::Constants::Tolerance);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = bezierSpline.GetNearestAddressPosition(Vector3(12.0f, -1.0f, 0.0f));
                     EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 2);
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(posSplineQueryResult.m_splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
             }
 
@@ -1393,13 +1393,13 @@ namespace UnitTest
                 {
                     PositionSplineQueryResult posSplineQueryResult = bezierSpline.GetNearestAddressPosition(Vector3(5.0f, -12.0f, 0.0f));
                     EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 3);
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
+                    EXPECT_NEAR(posSplineQueryResult.m_splineAddress.m_segmentFraction, 0.5f, AZ::Constants::Tolerance);
                 }
 
                 {
                     PositionSplineQueryResult posSplineQueryResult = bezierSpline.GetNearestAddressPosition(Vector3(12.0f, 12.0f, 0.0f));
                     EXPECT_EQ(posSplineQueryResult.m_splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(posSplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(posSplineQueryResult.m_splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
             }
         }
@@ -1418,19 +1418,19 @@ namespace UnitTest
                 {
                     RaySplineQueryResult raySplineQueryResult = bezierSpline.GetNearestAddressRay(Vector3(-1.0f, -1.0f, 0.0f), Vector3(-1.0f, 1.0f, 0.0f));
                     EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 0);
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(raySplineQueryResult.m_splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     RaySplineQueryResult raySplineQueryResult = bezierSpline.GetNearestAddressRay(Vector3(5.0f, 12.0f, 0.0f), Vector3(0.0f, -1.0f, 0.0f));
                     EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 1);
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
+                    EXPECT_NEAR(raySplineQueryResult.m_splineAddress.m_segmentFraction, 0.5f, AZ::Constants::Tolerance);
                 }
 
                 {
                     RaySplineQueryResult raySplineQueryResult = bezierSpline.GetNearestAddressRay(Vector3(12.0f, -1.0f, 0.0f), Vector3(1.0f, 1.0f, 0.0f));
                     EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 2);
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(raySplineQueryResult.m_splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
             }
 
@@ -1447,7 +1447,7 @@ namespace UnitTest
                 {
                     RaySplineQueryResult raySplineQueryResult = bezierSpline.GetNearestAddressRay(Vector3(-10.0f, -10.0f, 0.0f), Vector3(1.0f, 0.0f, 0.0f));
                     EXPECT_EQ(raySplineQueryResult.m_splineAddress.m_segmentIndex, 3);
-                    EXPECT_TRUE(raySplineQueryResult.m_splineAddress.m_segmentFraction == 0.5f);
+                    EXPECT_NEAR(raySplineQueryResult.m_splineAddress.m_segmentFraction, 0.5f, AZ::Constants::Tolerance);
                 }
             }
         }
@@ -1466,19 +1466,19 @@ namespace UnitTest
                 {
                     SplineAddress splineAddress = bezierSpline.GetAddressByDistance(0.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 0);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = bezierSpline.GetAddressByDistance(-5.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 0);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = bezierSpline.GetAddressByDistance(100.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 2);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
             }
 
@@ -1495,7 +1495,7 @@ namespace UnitTest
                 {
                     SplineAddress splineAddress = bezierSpline.GetAddressByDistance(100.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 3);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
             }
         }
@@ -1514,25 +1514,25 @@ namespace UnitTest
                 {
                     SplineAddress splineAddress = bezierSpline.GetAddressByFraction(0.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 0);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = bezierSpline.GetAddressByFraction(-0.5f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 0);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 0.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 0.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = bezierSpline.GetAddressByFraction(2.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 2);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     SplineAddress splineAddress = bezierSpline.GetAddressByFraction(1.0f);
                     EXPECT_EQ(splineAddress.m_segmentIndex, 2);
-                    EXPECT_TRUE(splineAddress.m_segmentFraction == 1.0f);
+                    EXPECT_NEAR(splineAddress.m_segmentFraction, 1.0f, AZ::Constants::Tolerance);
                 }
 
                 {
@@ -1581,23 +1581,23 @@ namespace UnitTest
 
                 {
                     Vector3 position = bezierSpline.GetPosition(bezierSpline.GetAddressByFraction(1.0f));
-                    EXPECT_TRUE(position == Vector3(10.0f, 0.0f, 0.0f));
+                    EXPECT_THAT(position, IsClose(Vector3(10.0f, 0.0f, 0.0f)));
                 }
 
                 {
                     Vector3 position = bezierSpline.GetPosition(SplineAddress());
-                    EXPECT_TRUE(position == Vector3(0.0f, 0.0f, 0.0f));
+                    EXPECT_THAT(position, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
                 }
 
                 {
                     Vector3 position = bezierSpline.GetPosition(SplineAddress(bezierSpline.GetSegmentCount() - 1, 1.0f));
-                    EXPECT_TRUE(position == Vector3(10.0f, 0.0f, 0.0f));
+                    EXPECT_THAT(position, IsClose(Vector3(10.0f, 0.0f, 0.0f)));
                 }
 
                 {
                     // out of bounds access (return position of last vertex - clamped)
                     Vector3 position = bezierSpline.GetPosition(SplineAddress(5, 0.5f));
-                    EXPECT_TRUE(position == Vector3(10.0f, 0.0f, 0.0f));
+                    EXPECT_THAT(position, IsClose(Vector3(10.0f, 0.0f, 0.0f)));
                 }
             }
 
@@ -1613,18 +1613,18 @@ namespace UnitTest
 
                 {
                     Vector3 position = bezierSpline.GetPosition(SplineAddress());
-                    EXPECT_TRUE(position == Vector3(0.0f, 0.0f, 0.0f));
+                    EXPECT_THAT(position, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
                 }
 
                 {
                     Vector3 position = bezierSpline.GetPosition(SplineAddress(bezierSpline.GetSegmentCount() - 1, 1.0f));
-                    EXPECT_TRUE(position == Vector3(0.0f, 0.0f, 0.0f));
+                    EXPECT_THAT(position, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
                 }
 
                 {
                     // out of bounds access (return position of last/first vertex - clamped)
                     Vector3 position = bezierSpline.GetPosition(SplineAddress(5, 0.5f));
-                    EXPECT_TRUE(position == Vector3(0.0f, 0.0f, 0.0f));
+                    EXPECT_THAT(position, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
                 }
             }
         }
@@ -1795,12 +1795,12 @@ namespace UnitTest
 
                 {
                     float splineLength = bezierSpline.GetSplineLength();
-                    EXPECT_TRUE(splineLength == 20.0f);
+                    EXPECT_NEAR(splineLength, 20.0f, AZ::Constants::Tolerance);
                 }
 
                 {
                     float segmentLength = bezierSpline.GetSegmentLength(1);
-                    EXPECT_TRUE(segmentLength == 10.0f);
+                    EXPECT_NEAR(segmentLength, 10.0f, AZ::Constants::Tolerance);
                 }
             }
         }
@@ -1898,78 +1898,78 @@ namespace UnitTest
                 LinearSpline linearSpline;
 
                 PositionSplineQueryResult posSplineQuery = linearSpline.GetNearestAddressPosition(Vector3::CreateZero());
-                EXPECT_TRUE(posSplineQuery.m_splineAddress == SplineAddress());
-                EXPECT_TRUE(posSplineQuery.m_distanceSq == std::numeric_limits<float>::max());
+                EXPECT_EQ(posSplineQuery.m_splineAddress, SplineAddress());
+                EXPECT_NEAR(posSplineQuery.m_distanceSq, std::numeric_limits<float>::max(), AZ::Constants::Tolerance);
                 RaySplineQueryResult raySplineQuery = linearSpline.GetNearestAddressRay(Vector3::CreateZero(), Vector3::CreateZero());
-                EXPECT_TRUE(raySplineQuery.m_splineAddress == SplineAddress());
-                EXPECT_TRUE(raySplineQuery.m_distanceSq == std::numeric_limits<float>::max());
-                EXPECT_TRUE(raySplineQuery.m_rayDistance == std::numeric_limits<float>::max());
+                EXPECT_EQ(raySplineQuery.m_splineAddress, SplineAddress());
+                EXPECT_NEAR(raySplineQuery.m_distanceSq, std::numeric_limits<float>::max(), AZ::Constants::Tolerance);
+                EXPECT_NEAR(raySplineQuery.m_rayDistance, std::numeric_limits<float>::max(), AZ::Constants::Tolerance);
                 SplineAddress linearAddressDistance = linearSpline.GetAddressByDistance(2.0f);
-                EXPECT_TRUE(linearAddressDistance == SplineAddress());
+                EXPECT_EQ(linearAddressDistance, SplineAddress());
                 SplineAddress linearAddressFraction = linearSpline.GetAddressByFraction(0.0f);
-                EXPECT_TRUE(linearAddressFraction == SplineAddress());
+                EXPECT_EQ(linearAddressFraction, SplineAddress());
                 Vector3 linearPosition = linearSpline.GetPosition(SplineAddress(0, 0.5f));
-                EXPECT_TRUE(linearPosition == Vector3::CreateZero());
+                EXPECT_THAT(linearPosition, IsClose(Vector3::CreateZero()));
                 Vector3 linearNormal = linearSpline.GetNormal(SplineAddress(1, 0.5f));
-                EXPECT_TRUE(linearNormal == Vector3::CreateAxisX());
+                EXPECT_THAT(linearNormal, IsClose(Vector3::CreateAxisX()));
                 Vector3 linearTangent = linearSpline.GetTangent(SplineAddress(2, 0.5f));
-                EXPECT_TRUE(linearTangent == Vector3::CreateAxisX());
+                EXPECT_THAT(linearTangent, IsClose(Vector3::CreateAxisX()));
                 float linearSegmentLength = linearSpline.GetSegmentLength(2);
-                EXPECT_TRUE(linearSegmentLength == 0.0f);
+                EXPECT_NEAR(linearSegmentLength, 0.0f, AZ::Constants::Tolerance);
                 float linearSplineLength = linearSpline.GetSplineLength();
-                EXPECT_TRUE(linearSplineLength == 0.0f);
+                EXPECT_NEAR(linearSplineLength, 0.0f, AZ::Constants::Tolerance);
             }
 
             {
                 CatmullRomSpline catmullRomSpline;
 
                 PositionSplineQueryResult posSplineQuery = catmullRomSpline.GetNearestAddressPosition(Vector3::CreateZero());
-                EXPECT_TRUE(posSplineQuery.m_splineAddress == SplineAddress());
-                EXPECT_TRUE(posSplineQuery.m_distanceSq == std::numeric_limits<float>::max());
+                EXPECT_EQ(posSplineQuery.m_splineAddress, SplineAddress());
+                EXPECT_NEAR(posSplineQuery.m_distanceSq, std::numeric_limits<float>::max(), AZ::Constants::Tolerance);
                 RaySplineQueryResult raySplineQuery = catmullRomSpline.GetNearestAddressRay(Vector3::CreateZero(), Vector3::CreateZero());
-                EXPECT_TRUE(raySplineQuery.m_splineAddress == SplineAddress());
-                EXPECT_TRUE(raySplineQuery.m_distanceSq == std::numeric_limits<float>::max());
-                EXPECT_TRUE(raySplineQuery.m_rayDistance == std::numeric_limits<float>::max());
+                EXPECT_EQ(raySplineQuery.m_splineAddress, SplineAddress());
+                EXPECT_NEAR(raySplineQuery.m_distanceSq, std::numeric_limits<float>::max(), AZ::Constants::Tolerance);
+                EXPECT_NEAR(raySplineQuery.m_rayDistance, std::numeric_limits<float>::max(), AZ::Constants::Tolerance);
                 SplineAddress catmullRomAddressDistance = catmullRomSpline.GetAddressByDistance(2.0f);
-                EXPECT_TRUE(catmullRomAddressDistance == SplineAddress());
+                EXPECT_EQ(catmullRomAddressDistance, SplineAddress());
                 SplineAddress catmullRomAddressFraction = catmullRomSpline.GetAddressByFraction(0.0f);
-                EXPECT_TRUE(catmullRomAddressFraction == SplineAddress());
+                EXPECT_EQ(catmullRomAddressFraction, SplineAddress());
                 Vector3 catmullRomPosition = catmullRomSpline.GetPosition(SplineAddress(0, 0.5f));
-                EXPECT_TRUE(catmullRomPosition == Vector3::CreateZero());
+                EXPECT_THAT(catmullRomPosition, IsClose(Vector3::CreateZero()));
                 Vector3 catmullRomNormal = catmullRomSpline.GetNormal(SplineAddress(1, 0.5f));
-                EXPECT_TRUE(catmullRomNormal == Vector3::CreateAxisX());
+                EXPECT_THAT(catmullRomNormal, IsClose(Vector3::CreateAxisX()));
                 Vector3 catmullRomTangent = catmullRomSpline.GetTangent(SplineAddress(2, 0.5f));
-                EXPECT_TRUE(catmullRomTangent == Vector3::CreateAxisX());
+                EXPECT_THAT(catmullRomTangent, IsClose(Vector3::CreateAxisX()));
                 float catmullRomSegmentLength = catmullRomSpline.GetSegmentLength(2);
-                EXPECT_TRUE(catmullRomSegmentLength == 0.0f);
+                EXPECT_NEAR(catmullRomSegmentLength, 0.0f, AZ::Constants::Tolerance);
                 float catmullRomSplineLength = catmullRomSpline.GetSplineLength();
-                EXPECT_TRUE(catmullRomSplineLength == 0.0f);
+                EXPECT_NEAR(catmullRomSplineLength, 0.0f, AZ::Constants::Tolerance);
             }
 
             {
                 BezierSpline bezierSpline;
 
                 PositionSplineQueryResult posSplineQuery = bezierSpline.GetNearestAddressPosition(Vector3::CreateZero());
-                EXPECT_TRUE(posSplineQuery.m_splineAddress == SplineAddress());
-                EXPECT_TRUE(posSplineQuery.m_distanceSq == std::numeric_limits<float>::max());
+                EXPECT_EQ(posSplineQuery.m_splineAddress, SplineAddress());
+                EXPECT_NEAR(posSplineQuery.m_distanceSq, std::numeric_limits<float>::max(), AZ::Constants::Tolerance);
                 RaySplineQueryResult raySplineQuery = bezierSpline.GetNearestAddressRay(Vector3::CreateZero(), Vector3::CreateZero());
-                EXPECT_TRUE(raySplineQuery.m_splineAddress == SplineAddress());
-                EXPECT_TRUE(raySplineQuery.m_distanceSq == std::numeric_limits<float>::max());
-                EXPECT_TRUE(raySplineQuery.m_rayDistance == std::numeric_limits<float>::max());
+                EXPECT_EQ(raySplineQuery.m_splineAddress, SplineAddress());
+                EXPECT_NEAR(raySplineQuery.m_distanceSq, std::numeric_limits<float>::max(), AZ::Constants::Tolerance);
+                EXPECT_NEAR(raySplineQuery.m_rayDistance, std::numeric_limits<float>::max(), AZ::Constants::Tolerance);
                 SplineAddress bezierAddressDistance = bezierSpline.GetAddressByDistance(2.0f);
-                EXPECT_TRUE(bezierAddressDistance == SplineAddress());
+                EXPECT_EQ(bezierAddressDistance, SplineAddress());
                 SplineAddress bezierAddressFraction = bezierSpline.GetAddressByFraction(0.0f);
-                EXPECT_TRUE(bezierAddressFraction == SplineAddress());
+                EXPECT_EQ(bezierAddressFraction, SplineAddress());
                 Vector3 bezierPosition = bezierSpline.GetPosition(SplineAddress(0, 0.5f));
-                EXPECT_TRUE(bezierPosition == Vector3::CreateZero());
+                EXPECT_THAT(bezierPosition, IsClose(Vector3::CreateZero()));
                 Vector3 bezierNormal = bezierSpline.GetNormal(SplineAddress(1, 0.5f));
-                EXPECT_TRUE(bezierNormal == Vector3::CreateAxisX());
+                EXPECT_THAT(bezierNormal, IsClose(Vector3::CreateAxisX()));
                 Vector3 bezierTangent = bezierSpline.GetTangent(SplineAddress(2, 0.5f));
-                EXPECT_TRUE(bezierTangent == Vector3::CreateAxisX());
+                EXPECT_THAT(bezierTangent, IsClose(Vector3::CreateAxisX()));
                 float bezierSegmentLength = bezierSpline.GetSegmentLength(2);
-                EXPECT_TRUE(bezierSegmentLength == 0.0f);
+                EXPECT_NEAR(bezierSegmentLength, 0.0f, AZ::Constants::Tolerance);
                 float bezierSplineLength = bezierSpline.GetSplineLength();
-                EXPECT_TRUE(bezierSplineLength == 0.0f);
+                EXPECT_NEAR(bezierSplineLength, 0.0f, AZ::Constants::Tolerance);
             }
         }
 
@@ -1996,10 +1996,10 @@ namespace UnitTest
             LinearSpline linearSplineSetLValueCopy;
             linearSplineSetLValueCopy.m_vertexContainer.SetVertices(linearSplineSetLValue.GetVertices());
 
-            EXPECT_TRUE(linearSpline.GetVertexCount() == linearSplineSetLValue.GetVertexCount());
-            EXPECT_TRUE(linearSpline.GetVertexCount() == linearSplineSetRValue.GetVertexCount());
-            EXPECT_TRUE(linearSplineSetLValue.GetVertexCount() == linearSplineSetRValue.GetVertexCount());
-            EXPECT_TRUE(linearSplineSetLValueCopy.GetVertexCount() == vertices.size());
+            EXPECT_EQ(linearSpline.GetVertexCount(), linearSplineSetLValue.GetVertexCount());
+            EXPECT_EQ(linearSpline.GetVertexCount(), linearSplineSetRValue.GetVertexCount());
+            EXPECT_EQ(linearSplineSetLValue.GetVertexCount(), linearSplineSetRValue.GetVertexCount());
+            EXPECT_EQ(linearSplineSetLValueCopy.GetVertexCount(), vertices.size());
 
             BezierSpline bezierSpline;
 
@@ -2018,11 +2018,11 @@ namespace UnitTest
             BezierSpline bezierSplineSetLValueCopy;
             bezierSplineSetLValueCopy.m_vertexContainer.SetVertices(bezierSplineSetLValue.GetVertices());
 
-            EXPECT_TRUE(bezierSpline.GetBezierData().size() == bezierSplineSetLValue.GetBezierData().size());
+            EXPECT_EQ(bezierSpline.GetBezierData().size(), bezierSplineSetLValue.GetBezierData().size());
             EXPECT_EQ(bezierSplineSetLValue.GetBezierData().size(), 4);
-            EXPECT_TRUE(bezierSplineSetLValue.GetBezierData().size() == bezierSplineSetRValue.GetBezierData().size());
+            EXPECT_EQ(bezierSplineSetLValue.GetBezierData().size(), bezierSplineSetRValue.GetBezierData().size());
             EXPECT_EQ(bezierSplineSetLValueCopy.GetBezierData().size(), 4);
-            EXPECT_TRUE(bezierSplineSetLValueCopy.GetVertexCount() == vertices.size());
+            EXPECT_EQ(bezierSplineSetLValueCopy.GetVertexCount(), vertices.size());
         }
     };
 

--- a/Code/Framework/AzCore/Tests/Math/SplineTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/SplineTests.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Math/Matrix3x3.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/UnitTest/TestTypes.h>
+#include <AZTestShared/Math/MathTestHelpers.h>
 
 using namespace AZ;
 
@@ -357,23 +358,23 @@ namespace UnitTest
 
                 {
                     Vector3 position = linearSpline.GetPosition(linearSpline.GetAddressByFraction(0.5f));
-                    EXPECT_TRUE(position.IsClose(Vector3(5.0f, 5.0f, 0.0f)));
+                    EXPECT_THAT(position, IsClose(Vector3(5.0f, 5.0f, 0.0f)));
                 }
 
                 {
                     Vector3 position = linearSpline.GetPosition(linearSpline.GetAddressByDistance(20.0f));
-                    EXPECT_TRUE(position.IsClose(Vector3(0.0f, 0.0f, 0.0f)));
+                    EXPECT_THAT(position, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
                 }
 
                 {
                     Vector3 position = linearSpline.GetPosition(linearSpline.GetAddressByDistance(18.0f));
-                    EXPECT_TRUE(position.IsClose(Vector3(0.0f, 2.0f, 0.0f)));
+                    EXPECT_THAT(position, IsClose(Vector3(0.0f, 2.0f, 0.0f)));
                 }
 
                 {
                     // out of bounds access (return position of last/first vertex - clamped)
                     Vector3 position = linearSpline.GetPosition(SplineAddress(5, 0.0f));
-                    EXPECT_TRUE(position.IsClose(Vector3(0.0f, 0.0f, 0.0f)));
+                    EXPECT_THAT(position, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
                 }
             }
         }
@@ -618,8 +619,8 @@ namespace UnitTest
                 AZ::Aabb aabb;
                 linearSpline.GetAabb(aabb);
 
-                EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(0.0f, 0.0f, 0.0f)));
-                EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(10.0f, 10.0f, 0.0f)));
+                EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(0.0f, 0.0f, 0.0f)));
+                EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(10.0f, 10.0f, 0.0f)));
             }
 
             {
@@ -635,8 +636,8 @@ namespace UnitTest
                 AZ::Aabb aabb;
                 linearSpline.GetAabb(aabb);
 
-                EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(0.0f, 0.0f, 0.0f)));
-                EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(10.0f, 10.0f, 0.0f)));
+                EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(0.0f, 0.0f, 0.0f)));
+                EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(10.0f, 10.0f, 0.0f)));
             }
 
             {
@@ -652,8 +653,8 @@ namespace UnitTest
                 AZ::Aabb aabb;
                 linearSpline.GetAabb(aabb, translation);
 
-                EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(25.0f, 25.0f, 0.0f)));
-                EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(35.0f, 35.0f, 0.0f)));
+                EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(25.0f, 25.0f, 0.0f)));
+                EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(35.0f, 35.0f, 0.0f)));
             }
         }
 
@@ -982,27 +983,27 @@ namespace UnitTest
 
                 {
                     Vector3 position = catmullRomSpline.GetPosition(SplineAddress(1, 0.125f));
-                    EXPECT_TRUE(position.IsClose(Vector3(0.83984375f, 10.546875f, 0.0f)));
+                    EXPECT_THAT(position, IsClose(Vector3(0.83984375f, 10.546875f, 0.0f)));
                 }
 
                 {
                     Vector3 position = catmullRomSpline.GetPosition(SplineAddress(1, 0.625f));
-                    EXPECT_TRUE(position.IsClose(Vector3(6.54296875f, 11.171875f, 0.0f)));
+                    EXPECT_THAT(position, IsClose(Vector3(6.54296875f, 11.171875f, 0.0f)));
                 }
 
                 {
                     Vector3 position = catmullRomSpline.GetPosition(SplineAddress(3, 0.5f));
-                    EXPECT_TRUE(position.IsClose(Vector3(10.0f, 10.0f, 0.0f)));
+                    EXPECT_THAT(position, IsClose(Vector3(10.0f, 10.0f, 0.0f)));
                 }
 
                 {
                     Vector3 position = catmullRomSpline.GetPosition(SplineAddress(0, 0.0f));
-                    EXPECT_TRUE(position.IsClose(Vector3(0.0f, 10.0f, 0.0f)));
+                    EXPECT_THAT(position, IsClose(Vector3(0.0f, 10.0f, 0.0f)));
                 }
 
                 {
                     Vector3 position = catmullRomSpline.GetPosition(SplineAddress(1, 0.0f));
-                    EXPECT_TRUE(position.IsClose(Vector3(0.0f, 10.0f, 0.0f)));
+                    EXPECT_THAT(position, IsClose(Vector3(0.0f, 10.0f, 0.0f)));
                 }
 
                 {
@@ -1029,22 +1030,22 @@ namespace UnitTest
 
                 {
                     Vector3 position = catmullRomSpline.GetPosition(SplineAddress(1, 0.125f));
-                    EXPECT_TRUE(position.IsClose(Vector3(0.83984375f, 10.546875f, 0.0f)));
+                    EXPECT_THAT(position, IsClose(Vector3(0.83984375f, 10.546875f, 0.0f)));
                 }
 
                 {
                     Vector3 position = catmullRomSpline.GetPosition(SplineAddress(1, 0.625f));
-                    EXPECT_TRUE(position.IsClose(Vector3(6.54296875f, 11.171875f, 0.0f)));
+                    EXPECT_THAT(position, IsClose(Vector3(6.54296875f, 11.171875f, 0.0f)));
                 }
 
                 {
                     Vector3 position = catmullRomSpline.GetPosition(SplineAddress(0, 0.0f));
-                    EXPECT_TRUE(position.IsClose(Vector3(0.0f, 0.0f, 0.0f)));
+                    EXPECT_THAT(position, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
                 }
 
                 {
                     Vector3 position = catmullRomSpline.GetPosition(SplineAddress(3, 1.0f));
-                    EXPECT_TRUE(position.IsClose(Vector3(0.0f, 0.0f, 0.0f)));
+                    EXPECT_THAT(position, IsClose(Vector3(0.0f, 0.0f, 0.0f)));
                 }
 
                 {
@@ -1073,38 +1074,38 @@ namespace UnitTest
 
                 {
                     Vector3 normal = catmullRomSpline.GetNormal(SplineAddress());
-                    EXPECT_TRUE(normal.IsClose(Vector3(-5.0f, 5.0f, 0.0f).GetNormalized()));
+                    EXPECT_THAT(normal, IsClose(Vector3(-5.0f, 5.0f, 0.0f).GetNormalized()));
                 }
 
                 {
                     Vector3 normal = catmullRomSpline.GetNormal(SplineAddress(1, 0.0f));
-                    EXPECT_TRUE(normal.IsClose(Vector3(-5.0f, 5.0f, 0.0f).GetNormalized()));
+                    EXPECT_THAT(normal, IsClose(Vector3(-5.0f, 5.0f, 0.0f).GetNormalized()));
                 }
 
                 {
                     Vector3 normal = catmullRomSpline.GetNormal(SplineAddress(1, 1.0f));
-                    EXPECT_TRUE(normal.IsClose(Vector3(5.0f, 5.0f, 0.0f).GetNormalized()));
+                    EXPECT_THAT(normal, IsClose(Vector3(5.0f, 5.0f, 0.0f).GetNormalized()));
                 }
 
                 {
                     Vector3 normal = catmullRomSpline.GetNormal(SplineAddress(1, 0.5f));
-                    EXPECT_TRUE(normal.IsClose(Vector3(0.0f, 12.5f, 0.0f).GetNormalized()));
+                    EXPECT_THAT(normal, IsClose(Vector3(0.0f, 12.5f, 0.0f).GetNormalized()));
                 }
 
                 {
                     Vector3 normal = catmullRomSpline.GetNormal(SplineAddress(2, 0.0f));
-                    EXPECT_TRUE(normal.IsClose(Vector3(5.0f, 5.0f, 0.0f).GetNormalized()));
+                    EXPECT_THAT(normal, IsClose(Vector3(5.0f, 5.0f, 0.0f).GetNormalized()));
                 }
 
                 {
                     Vector3 normal = catmullRomSpline.GetNormal(SplineAddress(3, 0.5f));
-                    EXPECT_TRUE(normal.IsClose(Vector3(5.0f, 5.0f, 0.0f).GetNormalized()));
+                    EXPECT_THAT(normal, IsClose(Vector3(5.0f, 5.0f, 0.0f).GetNormalized()));
                 }
 
                 {
                     // out of bounds access (return normal of last vertex that is not a control point - clamped)
                     Vector3 normal = catmullRomSpline.GetNormal(SplineAddress(5, 0.0f));
-                    EXPECT_TRUE(normal.IsClose(Vector3(5.0f, 5.0f, 0.0f).GetNormalized()));
+                    EXPECT_THAT(normal, IsClose(Vector3(5.0f, 5.0f, 0.0f).GetNormalized()));
                 }
             }
 
@@ -1120,23 +1121,23 @@ namespace UnitTest
 
                 {
                     Vector3 normal = catmullRomSpline.GetNormal(SplineAddress());
-                    EXPECT_TRUE(normal.IsClose(Vector3(-5.0f, -5.0f, 0.0f).GetNormalized()));
+                    EXPECT_THAT(normal, IsClose(Vector3(-5.0f, -5.0f, 0.0f).GetNormalized()));
                 }
 
                 {
                     Vector3 normal = catmullRomSpline.GetNormal(SplineAddress(1, 0.5f));
-                    EXPECT_TRUE(normal.IsClose(Vector3(0.0f, 1.0f, 0.0f)));
+                    EXPECT_THAT(normal, IsClose(Vector3(0.0f, 1.0f, 0.0f)));
                 }
 
                 {
                     Vector3 normal = catmullRomSpline.GetNormal(SplineAddress(3, 0.5f));
-                    EXPECT_TRUE(normal.IsClose(Vector3(0.0f, -1.0f, 0.0f)));
+                    EXPECT_THAT(normal, IsClose(Vector3(0.0f, -1.0f, 0.0f)));
                 }
 
                 {
                     // out of bounds access (return normal of last vertex that is not a control point - clamped)
                     Vector3 normal = catmullRomSpline.GetNormal(SplineAddress(5, 0.0f));
-                    EXPECT_TRUE(normal.IsClose(Vector3(-5.0f, -5.0f, 0.0f).GetNormalized()));
+                    EXPECT_THAT(normal, IsClose(Vector3(-5.0f, -5.0f, 0.0f).GetNormalized()));
                 }
             }
         }
@@ -1154,27 +1155,27 @@ namespace UnitTest
 
                 {
                     Vector3 tangent = catmullRomSpline.GetTangent(SplineAddress(1, 0.0f));
-                    EXPECT_TRUE(tangent.IsClose(Vector3(5.0f, 5.0f, 0.0f).GetNormalized()));
+                    EXPECT_THAT(tangent, IsClose(Vector3(5.0f, 5.0f, 0.0f).GetNormalized()));
                 }
 
                 {
                     Vector3 tangent = catmullRomSpline.GetTangent(SplineAddress(1, 1.0f));
-                    EXPECT_TRUE(tangent.IsClose(Vector3(5.0f, -5.0f, 0.0f).GetNormalized()));
+                    EXPECT_THAT(tangent, IsClose(Vector3(5.0f, -5.0f, 0.0f).GetNormalized()));
                 }
 
                 {
                     Vector3 tangent = catmullRomSpline.GetTangent(SplineAddress(1, 0.5f));
-                    EXPECT_TRUE(tangent.IsClose(Vector3(12.5f, 0.0f, 0.0f).GetNormalized()));
+                    EXPECT_THAT(tangent, IsClose(Vector3(12.5f, 0.0f, 0.0f).GetNormalized()));
                 }
 
                 {
                     Vector3 tangent = catmullRomSpline.GetTangent(SplineAddress(2, 0.0f));
-                    EXPECT_TRUE(tangent.IsClose(Vector3(5.0f, -5.0f, 0.0f).GetNormalized()));
+                    EXPECT_THAT(tangent, IsClose(Vector3(5.0f, -5.0f, 0.0f).GetNormalized()));
                 }
 
                 {
                     Vector3 tangent = catmullRomSpline.GetTangent(SplineAddress(3, 0.5f));
-                    EXPECT_TRUE(tangent.IsClose(Vector3(5.0f, -5.0f, 0.0f).GetNormalized()));
+                    EXPECT_THAT(tangent, IsClose(Vector3(5.0f, -5.0f, 0.0f).GetNormalized()));
                 }
             }
 
@@ -1190,17 +1191,17 @@ namespace UnitTest
 
                 {
                     Vector3 tangent = catmullRomSpline.GetTangent(SplineAddress(3, 0.5f));
-                    EXPECT_TRUE(tangent.IsClose(Vector3(-1.0f, 0.0f, 0.0f)));
+                    EXPECT_THAT(tangent, IsClose(Vector3(-1.0f, 0.0f, 0.0f)));
                 }
 
                 {
                     Vector3 tangent = catmullRomSpline.GetTangent(SplineAddress(1, 0.5f));
-                    EXPECT_TRUE(tangent.IsClose(Vector3(1.0f, 0.0f, 0.0f)));
+                    EXPECT_THAT(tangent, IsClose(Vector3(1.0f, 0.0f, 0.0f)));
                 }
 
                 {
                     Vector3 tangent = catmullRomSpline.GetTangent(SplineAddress(3, 1.0f));
-                    EXPECT_TRUE(tangent.IsClose(Vector3(-5.0f, 5.0f, 0.0f).GetNormalized()));
+                    EXPECT_THAT(tangent, IsClose(Vector3(-5.0f, 5.0f, 0.0f).GetNormalized()));
                 }
             }
         }
@@ -1278,8 +1279,8 @@ namespace UnitTest
                 AZ::Aabb aabb;
                 catmullRomSpline.GetAabb(aabb);
 
-                EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(0.0f, 10.0f, 0.0f)));
-                EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(10.0f, 11.25f, 0.0f)));
+                EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(0.0f, 10.0f, 0.0f)));
+                EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(10.0f, 11.25f, 0.0f)));
             }
 
             {
@@ -1295,8 +1296,8 @@ namespace UnitTest
                 AZ::Aabb aabb;
                 catmullRomSpline.GetAabb(aabb);
 
-                EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(-1.25f, -1.25f, 0.0f)));
-                EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(11.25f, 11.25f, 0.0f)));
+                EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(-1.25f, -1.25f, 0.0f)));
+                EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(11.25f, 11.25f, 0.0f)));
             }
         }
 
@@ -1641,23 +1642,23 @@ namespace UnitTest
 
                 {
                     Vector3 normal = bezierSpline.GetNormal(SplineAddress(1, 0.5f));
-                    EXPECT_TRUE(normal.IsClose(Vector3(0.0f, 1.0f, 0.0f)));
+                    EXPECT_THAT(normal, IsClose(Vector3(0.0f, 1.0f, 0.0f)));
                 }
 
                 {
                     Vector3 normal = bezierSpline.GetNormal(SplineAddress(0, 0.0f));
-                    EXPECT_TRUE(normal.IsClose(Vector3(-0.955f, -0.294f, 0.0f), 1e-3f));
+                    EXPECT_THAT(normal, IsCloseTolerance(Vector3(-0.955f, -0.294f, 0.0f), 1e-3f));
                 }
 
                 {
                     Vector3 normal = bezierSpline.GetNormal(SplineAddress(3, 0.0f));
-                    EXPECT_TRUE(normal.IsClose(Vector3(0.955f, -0.294f, 0.0f), 1e-3f));
+                    EXPECT_THAT(normal, IsCloseTolerance(Vector3(0.955f, -0.294f, 0.0f), 1e-3f));
                 }
 
                 {
                     // out of bounds access (return normal of last vertex - clamped)
                     Vector3 normal = bezierSpline.GetNormal(SplineAddress(5, 0.5f));
-                    EXPECT_TRUE(normal.IsClose(Vector3(0.955f, -0.294f, 0.0f), 1e-3f));
+                    EXPECT_THAT(normal, IsCloseTolerance(Vector3(0.955f, -0.294f, 0.0f), 1e-3f));
                 }
             }
 
@@ -1673,28 +1674,28 @@ namespace UnitTest
 
                 {
                     Vector3 normal = bezierSpline.GetNormal(SplineAddress(3, 0.5f));
-                    EXPECT_TRUE(normal.IsClose(Vector3(0.0f, -1.0f, 0.0f)));
+                    EXPECT_THAT(normal, IsClose(Vector3(0.0f, -1.0f, 0.0f)));
                 }
 
                 {
                     Vector3 normal = bezierSpline.GetNormal(SplineAddress(0, 0.0f));
-                    EXPECT_TRUE(normal.IsClose(Vector3(-0.7071f, -0.7071f, 0.0f)));
+                    EXPECT_THAT(normal, IsClose(Vector3(-0.7071f, -0.7071f, 0.0f)));
                 }
 
                 {
                     Vector3 normal = bezierSpline.GetNormal(SplineAddress(3, 0.0f));
-                    EXPECT_TRUE(normal.IsClose(Vector3(0.7071f, -0.7071f, 0.0f)));
+                    EXPECT_THAT(normal, IsClose(Vector3(0.7071f, -0.7071f, 0.0f)));
                 }
 
                 {
                     Vector3 normal = bezierSpline.GetNormal(SplineAddress(3, 1.0f));
-                    EXPECT_TRUE(normal.IsClose(Vector3(-0.7071f, -0.7071f, 0.0f)));
+                    EXPECT_THAT(normal, IsClose(Vector3(-0.7071f, -0.7071f, 0.0f)));
                 }
 
                 {
                     // out of bounds access (return normal of last vertex - clamped)
                     Vector3 normal = bezierSpline.GetNormal(SplineAddress(5, 0.5f));
-                    EXPECT_TRUE(normal.IsClose(Vector3(-0.7071f, -0.7071f, 0.0f)));
+                    EXPECT_THAT(normal, IsClose(Vector3(-0.7071f, -0.7071f, 0.0f)));
                 }
             }
         }
@@ -1712,7 +1713,7 @@ namespace UnitTest
 
                 {
                     Vector3 tangent = bezierSpline.GetTangent(SplineAddress(1, 0.5f));
-                    EXPECT_TRUE(tangent.IsClose(Vector3(1.0f, 0.0f, 0.0f)));
+                    EXPECT_THAT(tangent, IsClose(Vector3(1.0f, 0.0f, 0.0f)));
                 }
             }
 
@@ -1728,12 +1729,12 @@ namespace UnitTest
 
                 {
                     Vector3 tangent = bezierSpline.GetTangent(SplineAddress(3, 0.5f));
-                    EXPECT_TRUE(tangent.IsClose(Vector3(-1.0f, 0.0f, 0.0f)));
+                    EXPECT_THAT(tangent, IsClose(Vector3(-1.0f, 0.0f, 0.0f)));
                 }
 
                 {
                     Vector3 tangent = bezierSpline.GetTangent(SplineAddress(2, 0.5f));
-                    EXPECT_TRUE(tangent.IsClose(Vector3(0.0f, -1.0f, 0.0f)));
+                    EXPECT_THAT(tangent, IsClose(Vector3(0.0f, -1.0f, 0.0f)));
                 }
             }
         }
@@ -1869,8 +1870,8 @@ namespace UnitTest
                 AZ::Aabb aabb;
                 bezierSpline.GetAabb(aabb);
 
-                EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(-1.2948f, 0.0f, 0.0f)));
-                EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(11.2948f, 11.7677f, 0.0f)));
+                EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(-1.2948f, 0.0f, 0.0f)));
+                EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(11.2948f, 11.7677f, 0.0f)));
             }
 
             {
@@ -1886,8 +1887,8 @@ namespace UnitTest
                 AZ::Aabb aabb;
                 bezierSpline.GetAabb(aabb);
 
-                EXPECT_TRUE(aabb.GetMin().IsClose(Vector3(-1.7677f, -1.7677f, 0.0f)));
-                EXPECT_TRUE(aabb.GetMax().IsClose(Vector3(11.7677f, 11.7677f, 0.0f)));
+                EXPECT_THAT(aabb.GetMin(), IsClose(Vector3(-1.7677f, -1.7677f, 0.0f)));
+                EXPECT_THAT(aabb.GetMax(), IsClose(Vector3(11.7677f, 11.7677f, 0.0f)));
             }
         }
 

--- a/Code/Framework/AzCore/Tests/Math/TransformTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/TransformTests.cpp
@@ -53,7 +53,7 @@ namespace UnitTest
         const AZ::Vector3 vector(1.5f, -0.2f, 2.7f);
         const AZ::Vector3 rotatedVector = transform.TransformPoint(vector);
         // rotating a vector should not affect its length
-        EXPECT_TRUE(AZ::IsClose(rotatedVector.GetLengthSq(), vector.GetLengthSq(), AZ::Constants::Tolerance * vector.GetLengthSq()));
+        EXPECT_NEAR(rotatedVector.GetLengthSq(), vector.GetLengthSq(), AZ::Constants::Tolerance * vector.GetLengthSq());
 
         // rotating about the X axis should not affect the X component
         EXPECT_NEAR(rotatedVector.GetX(), vector.GetX(), AZ::Constants::Tolerance);
@@ -74,7 +74,7 @@ namespace UnitTest
         const AZ::Vector3 vector(1.5f, -0.2f, 2.7f);
         const AZ::Vector3 rotatedVector = transform.TransformPoint(vector);
         // rotating a vector should not affect its length
-        EXPECT_TRUE(AZ::IsClose(rotatedVector.GetLengthSq(), vector.GetLengthSq(), AZ::Constants::Tolerance * vector.GetLengthSq()));
+        EXPECT_NEAR(rotatedVector.GetLengthSq(), vector.GetLengthSq(), AZ::Constants::Tolerance * vector.GetLengthSq());
 
         // rotating about the Y axis should not affect the Y component
         EXPECT_NEAR(rotatedVector.GetY(), vector.GetY(), AZ::Constants::Tolerance);
@@ -95,7 +95,7 @@ namespace UnitTest
         const AZ::Vector3 vector(1.5f, -0.2f, 2.7f);
         const AZ::Vector3 rotatedVector = transform.TransformPoint(vector);
         // rotating a vector should not affect its length
-        EXPECT_TRUE(AZ::IsClose(rotatedVector.GetLengthSq(), vector.GetLengthSq(), AZ::Constants::Tolerance * vector.GetLengthSq()));
+        EXPECT_NEAR(rotatedVector.GetLengthSq(), vector.GetLengthSq(), AZ::Constants::Tolerance * vector.GetLengthSq());
 
         // rotating about the Z axis should not affect the Z component
         EXPECT_NEAR(rotatedVector.GetZ(), vector.GetZ(), AZ::Constants::Tolerance);
@@ -191,7 +191,7 @@ namespace UnitTest
         const AZ::Vector3 from(2.5f, 0.2f, 3.6f);
         // to and from are the same, should generate an error
         AZ_TEST_START_TRACE_SUPPRESSION;
-        EXPECT_TRUE(AZ::Transform::CreateLookAt(from, from).IsClose(AZ::Transform::Identity()));
+        EXPECT_THAT(AZ::Transform::CreateLookAt(from, from), IsClose(AZ::Transform::Identity()));
         AZ_TEST_STOP_TRACE_SUPPRESSION(1);
 
         // to - from is parallel to usual up direction
@@ -217,11 +217,11 @@ namespace UnitTest
         AZ::Transform transform5 = transform1;
         transform5 *= transform4;
         const AZ::Vector3 vector(1.9f, 2.3f, 0.2f);
-        EXPECT_TRUE((transform1 * (transform2 * transform3)).IsClose((transform1 * transform2) * transform3));
+        EXPECT_THAT((transform1 * (transform2 * transform3)), IsClose((transform1 * transform2) * transform3));
         EXPECT_THAT((transform3 * transform4).TransformPoint(vector), IsClose(transform3.TransformPoint((transform4.TransformPoint(vector)))));
-        EXPECT_TRUE((transform2 * AZ::Transform::Identity()).IsClose(transform2));
-        EXPECT_TRUE((transform3 * AZ::Transform::Identity()).IsClose(AZ::Transform::Identity() * transform3));
-        EXPECT_TRUE(transform5.IsClose(transform1 * transform4));
+        EXPECT_THAT((transform2 * AZ::Transform::Identity()), IsClose(transform2));
+        EXPECT_THAT((transform3 * AZ::Transform::Identity()), IsClose(AZ::Transform::Identity() * transform3));
+        EXPECT_THAT(transform5, IsClose(transform1 * transform4));
     }
 
     TEST(MATH_Transform, TranslationCorrectInTransformHierarchy)
@@ -289,7 +289,7 @@ namespace UnitTest
         const AZ::Vector3 vector(0.9f, 3.2f, -1.4f);
         EXPECT_THAT((inverse * transform).TransformPoint(vector), IsClose(vector));
         EXPECT_THAT((transform * inverse).TransformPoint(vector), IsClose(vector));
-        EXPECT_TRUE((inverse * transform).IsClose(AZ::Transform::Identity()));
+        EXPECT_THAT((inverse * transform), IsClose(AZ::Transform::Identity()));
     }
 
     TEST_P(TransformInvertFixture, Invert)
@@ -300,7 +300,7 @@ namespace UnitTest
         const AZ::Vector3 vector(2.8f, -1.3f, 2.6f);
         EXPECT_THAT((inverse * transform).TransformPoint(vector), IsClose(vector));
         EXPECT_THAT((transform * inverse).TransformPoint(vector), IsClose(vector));
-        EXPECT_TRUE((inverse * transform).IsClose(AZ::Transform::Identity()));
+        EXPECT_THAT((inverse * transform), IsClose(AZ::Transform::Identity()));
     }
 
     INSTANTIATE_TEST_CASE_P(MATH_Transform, TransformInvertFixture, ::testing::ValuesIn(MathTestData::OrthogonalTransforms));
@@ -344,9 +344,9 @@ namespace UnitTest
         const AZ::Transform rotX = AZ::Transform::CreateRotationX(eulerRadians.GetX());
         const AZ::Transform rotY = AZ::Transform::CreateRotationY(eulerRadians.GetY());
         const AZ::Transform rotZ = AZ::Transform::CreateRotationZ(eulerRadians.GetZ());
-        EXPECT_TRUE(transform.IsClose(rotX * rotY * rotZ));
+        EXPECT_THAT(transform, IsClose(rotX * rotY * rotZ));
         transform.SetFromEulerDegrees(eulerDegrees);
-        EXPECT_TRUE(transform.IsClose(rotX * rotY * rotZ));
+        EXPECT_THAT(transform, IsClose(rotX * rotY * rotZ));
     }
 
     INSTANTIATE_TEST_CASE_P(MATH_Transform, TransformSetFromEulerDegreesFixture, ::testing::ValuesIn(MathTestData::EulerAnglesDegrees));
@@ -361,7 +361,7 @@ namespace UnitTest
         const AZ::Transform rotX = AZ::Transform::CreateRotationX(eulerRadians.GetX());
         const AZ::Transform rotY = AZ::Transform::CreateRotationY(eulerRadians.GetY());
         const AZ::Transform rotZ = AZ::Transform::CreateRotationZ(eulerRadians.GetZ());
-        EXPECT_TRUE(transform.IsClose(rotX * rotY * rotZ));
+        EXPECT_THAT(transform, IsClose(rotX * rotY * rotZ));
     }
 
     INSTANTIATE_TEST_CASE_P(MATH_Transform, TransformSetFromEulerRadiansFixture, ::testing::ValuesIn(MathTestData::EulerAnglesRadians));
@@ -378,11 +378,11 @@ namespace UnitTest
         const AZ::Vector3 eulerDegrees = transform.GetEulerDegrees();
         AZ::Transform eulerTransform;
         eulerTransform.SetFromEulerDegrees(eulerDegrees);
-        EXPECT_TRUE(eulerTransform.IsClose(transform));
+        EXPECT_THAT(eulerTransform, IsClose(transform));
         const AZ::Vector3 eulerRadians = transform.GetEulerRadians();
         eulerTransform = AZ::Transform::Identity();
         eulerTransform.SetFromEulerRadians(eulerRadians);
-        EXPECT_TRUE(eulerTransform.IsClose(transform));
+        EXPECT_THAT(eulerTransform, IsClose(transform));
     }
 
     INSTANTIATE_TEST_CASE_P(MATH_Transform, TransformGetEulerFixture, ::testing::ValuesIn(MathTestData::OrthogonalTransforms));

--- a/Code/Framework/AzCore/Tests/Math/Vector2Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector2Tests.cpp
@@ -103,18 +103,18 @@ namespace UnitTest
     {
         AZ::Vector2 vA(2.0f, 3.0f);
 
-        EXPECT_TRUE(vA == AZ::Vector2(2.0f, 3.0f));
+        EXPECT_THAT(vA, IsClose(AZ::Vector2(2.0f, 3.0f)));
         EXPECT_FLOAT_EQ(vA.GetX(), 2.0f);
         EXPECT_FLOAT_EQ(vA.GetY(), 3.0f);
 
         vA.SetX(10.0f);
-        EXPECT_TRUE(vA == AZ::Vector2(10.0f, 3.0f));
+        EXPECT_THAT(vA, IsClose(AZ::Vector2(10.0f, 3.0f)));
 
         vA.SetY(11.0f);
-        EXPECT_TRUE(vA == AZ::Vector2(10.0f, 11.0f));
+        EXPECT_THAT(vA, IsClose(AZ::Vector2(10.0f, 11.0f)));
 
         vA.Set(15.0f);
-        EXPECT_TRUE(vA == AZ::Vector2(15.0f));
+        EXPECT_THAT(vA, IsClose(AZ::Vector2(15.0f)));
 
         vA.SetElement(0, 20.0f);
         EXPECT_FLOAT_EQ(vA.GetX(), 20.0f);

--- a/Code/Framework/AzCore/Tests/Math/Vector3Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector3Tests.cpp
@@ -410,9 +410,9 @@ namespace UnitTest
         v1.BuildTangentBasis(v2, v3);
         EXPECT_TRUE(v2.IsNormalized());
         EXPECT_TRUE(v3.IsNormalized());
-        EXPECT_TRUE(fabsf(v2.Dot(v1)) < 0.001f);
-        EXPECT_TRUE(fabsf(v3.Dot(v1)) < 0.001f);
-        EXPECT_TRUE(fabsf(v2.Dot(v3)) < 0.001f);
+        EXPECT_LT(fabsf(v2.Dot(v1)), 0.001f);
+        EXPECT_LT(fabsf(v3.Dot(v1)), 0.001f);
+        EXPECT_LT(fabsf(v2.Dot(v3)), 0.001f);
     }
 
     TEST(MATH_Vector3, TestMadd)

--- a/Code/Framework/AzCore/Tests/Math/Vector3Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector3Tests.cpp
@@ -548,14 +548,14 @@ namespace UnitTest
 
         // compare equal
         AZ::Vector3 rEq = AZ::Vector3::CreateSelectCmpEqual(vA, vB, AZ::Vector3(1.0f), AZ::Vector3(0.0f));
-        EXPECT_TRUE(rEq.IsClose(AZ::Vector3(0.0f, 0.0f, 1.0f)));
+        EXPECT_THAT(rEq, IsClose(AZ::Vector3(0.0f, 0.0f, 1.0f)));
 
         // compare greater equal
         AZ::Vector3 rGr = AZ::Vector3::CreateSelectCmpGreaterEqual(vA, vB, AZ::Vector3(1.0f), AZ::Vector3(0.0f));
-        EXPECT_TRUE(rGr.IsClose(AZ::Vector3(0.0f, 1.0f, 1.0f)));
+        EXPECT_THAT(rGr, IsClose(AZ::Vector3(0.0f, 1.0f, 1.0f)));
 
         // compare greater
         AZ::Vector3 rGrEq = AZ::Vector3::CreateSelectCmpGreater(vA, vB, AZ::Vector3(1.0f), AZ::Vector3(0.0f));
-        EXPECT_TRUE(rGrEq.IsClose(AZ::Vector3(0.0f, 1.0f, 0.0f)));
+        EXPECT_THAT(rGrEq, IsClose(AZ::Vector3(0.0f, 1.0f, 0.0f)));
     }
 }

--- a/Code/Framework/AzCore/Tests/Math/Vector3Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector3Tests.cpp
@@ -285,10 +285,10 @@ namespace UnitTest
     TEST(MATH_Vector3, TestEquality)
     {
         AZ::Vector3 v3(1.0f, 2.0f, 3.0f);
-        AZ_TEST_ASSERT(v3 == AZ::Vector3(1.0f, 2.0f, 3.0f));
-        AZ_TEST_ASSERT(!(v3 == AZ::Vector3(1.0f, 2.0f, 4.0f)));
-        AZ_TEST_ASSERT(v3 != AZ::Vector3(1.0f, 2.0f, 5.0f));
-        AZ_TEST_ASSERT(!(v3 != AZ::Vector3(1.0f, 2.0f, 3.0f)));
+        EXPECT_TRUE(v3 == AZ::Vector3(1.0f, 2.0f, 3.0f));
+        EXPECT_FALSE((v3 == AZ::Vector3(1.0f, 2.0f, 4.0f)));
+        EXPECT_TRUE(v3 != AZ::Vector3(1.0f, 2.0f, 5.0f));
+        EXPECT_FALSE((v3 != AZ::Vector3(1.0f, 2.0f, 3.0f)));
     }
 
     TEST(MATH_Vector3, TestIsLessThan)

--- a/Code/Framework/AzCore/Tests/Math/Vector4Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector4Tests.cpp
@@ -303,9 +303,9 @@ namespace UnitTest
 
     TEST(MATH_Vector4, TestLerpSlerpNLerp)
     {
-        EXPECT_TRUE(AZ::Vector4(4.0f, 5.0f, 6.0f, 7.0f).Lerp(AZ::Vector4(5.0f, 10.0f, 2.0f, 1.0f), 0.5f).IsClose(AZ::Vector4(4.5f, 7.5f, 4.0f, 4.0f)));
-        EXPECT_TRUE(AZ::Vector4(1.0f, 0.0f, 0.0f, 0.0f).Slerp(AZ::Vector4(0.0f, 1.0f, 0.0f, 0.0f), 0.5f).IsClose(AZ::Vector4(0.7071f, 0.7071f, 0.0f, 0.0f)));
-        EXPECT_TRUE(AZ::Vector4(1.0f, 0.0f, 0.0f, 0.0f).Nlerp(AZ::Vector4(0.0f, 1.0f, 0.0f, 0.0f), 0.5f).IsClose(AZ::Vector4(0.7071f, 0.7071f, 0.0f, 0.0f)));
+        EXPECT_THAT(AZ::Vector4(4.0f, 5.0f, 6.0f, 7.0f).Lerp(AZ::Vector4(5.0f, 10.0f, 2.0f, 1.0f), 0.5f), IsClose(AZ::Vector4(4.5f, 7.5f, 4.0f, 4.0f)));
+        EXPECT_THAT(AZ::Vector4(1.0f, 0.0f, 0.0f, 0.0f).Slerp(AZ::Vector4(0.0f, 1.0f, 0.0f, 0.0f), 0.5f), IsClose(AZ::Vector4(0.7071f, 0.7071f, 0.0f, 0.0f)));
+        EXPECT_THAT(AZ::Vector4(1.0f, 0.0f, 0.0f, 0.0f).Nlerp(AZ::Vector4(0.0f, 1.0f, 0.0f, 0.0f), 0.5f), IsClose(AZ::Vector4(0.7071f, 0.7071f, 0.0f, 0.0f)));
     }
 
     TEST(MATH_Vector4, TestDot)


### PR DESCRIPTION
## What does this PR do?
Rewrites AzCore/Math tests to use matchers as much as possible, to provide more useful output if the tests fail.

## How was this PR tested?
Ran AzCore tests.