### PR TITLE
Fix Mac compilation issue

### DIFF
--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestDataUtils.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestDataUtils.cpp
@@ -83,7 +83,7 @@ namespace UnitTest
         {
             PrefabDom linkDom;
             actualLink.GetLinkDom(linkDom, linkDom.GetAllocator());
-            PrefabDomValueConstReference patchesReference = PrefabDomUtils::FindPrefabDomValue(linkDom, PrefabDomUtils::PatchesName);
+            PrefabDomValueReference patchesReference = PrefabDomUtils::FindPrefabDomValue(linkDom, PrefabDomUtils::PatchesName);
 
             if (!expectedTemplatePatches.IsNull())
             {


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

Fixed the following Mac compilation error:

````
[2022-12-12T09:42:04.556Z] /Users/lybuilder/workspace/o3de/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestDataUtils.cpp:86:42: error: no viable conversion from 'optional<reference_wrapper<GenericValue<...>>>' to 'optional<reference_wrapper<const GenericValue<...>>>'
[2022-12-12T09:42:04.556Z]             PrefabDomValueConstReference patchesReference = PrefabDomUtils::FindPrefabDomValue(linkDom, PrefabDomUtils::PatchesName);
[2022-12-12T09:42:04.556Z]                                          ^                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[2022-12-12T09:42:04.556Z] In file included from /Users/lybuilder/workspace/o3de/build/mac/Code/Framework/AzToolsFramework/CMakeFiles/AzToolsFramework.Tests.dir/Unity/unity_10_cxx.cxx:3:
[2022-12-12T09:42:04.556Z] In file included from /Users/lybuilder/workspace/o3de/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestDataUtils.cpp:9:
[2022-12-12T09:42:04.556Z] In file included from /Users/lybuilder/workspace/o3de/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestDataUtils.h:11:
[2022-12-12T09:42:04.556Z] In file included from /Users/lybuilder/workspace/o3de/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestData.h:11:
[2022-12-12T09:42:04.556Z] In file included from /Users/lybuilder/workspace/o3de/Code/Framework/AzCore/AzCore/IO/Path/Path.h:12:
[2022-12-12T09:42:04.557Z] In file included from /Users/lybuilder/workspace/o3de/Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h:11:
[2022-12-12T09:42:04.557Z] In file included from /Users/lybuilder/workspace/o3de/Code/Framework/AzCore/AzCore/Preprocessor/Enum.h:54:
[2022-12-12T09:42:04.557Z] In file included from /Users/lybuilder/workspace/o3de/Code/Framework/AzCore/AzCore/std/optional.h:11:
[2022-12-12T09:42:04.557Z] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/optional:688:41: note: candidate constructor not viable: no known conversion from 'AzToolsFramework::Prefab::PrefabDomValueReference' (aka 'optional<reference_wrapper<GenericValue<UTF8<> > > >') to 'const std::__1::optional<std::__1::reference_wrapper<const rapidjson_ly::GenericValue<rapidjson_ly::UTF8<char>, rapidjson_ly::CrtAllocator> > > &' for 1st argument
[2022-12-12T09:42:04.557Z]     _LIBCPP_INLINE_VISIBILITY constexpr optional(const optional&) = default;
[2022-12-12T09:42:04.557Z]                                         ^
[2022-12-12T09:42:04.557Z] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/optional:689:41: note: candidate constructor not viable: no known conversion from 'AzToolsFramework::Prefab::PrefabDomValueReference' (aka 'optional<reference_wrapper<GenericValue<UTF8<> > > >') to 'std::__1::optional<std::__1::reference_wrapper<const rapidjson_ly::GenericValue<rapidjson_ly::UTF8<char>, rapidjson_ly::CrtAllocator> > > &&' for 1st argument
[2022-12-12T09:42:04.557Z]     _LIBCPP_INLINE_VISIBILITY constexpr optional(optional&&) = default;
[2022-12-12T09:42:04.557Z]                                         ^
[2022-12-12T09:42:04.557Z] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/optional:690:41: note: candidate constructor not viable: no known conversion from 'AzToolsFramework::Prefab::PrefabDomValueReference' (aka 'optional<reference_wrapper<GenericValue<UTF8<> > > >') to 'std::__1::nullopt_t' for 1st argument
[2022-12-12T09:42:04.557Z]     _LIBCPP_INLINE_VISIBILITY constexpr optional(nullopt_t) noexcept {}
[2022-12-12T09:42:04.557Z]                                         ^
[2022-12-12T09:42:04.557Z] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/optional:714:15: note: candidate template ignored: substitution failure [with _Up = std::__1::optional<std::__1::reference_wrapper<rapidjson_ly::GenericValue<rapidjson_ly::UTF8<char>, rapidjson_ly::CrtAllocator> > >]: no member named '_EnableIfImpl' in 'std::__1::_MetaBase<false>'
[2022-12-12T09:42:04.557Z]     constexpr optional(_Up&& __v)
[2022-12-12T09:42:04.557Z]               ^
[2022-12-12T09:42:04.557Z] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/optional:729:5: note: candidate template ignored: substitution failure [with _Up = std::__1::reference_wrapper<rapidjson_ly::GenericValue<rapidjson_ly::UTF8<char>, rapidjson_ly::CrtAllocator> >]: no member named '_EnableIfImpl' in 'std::__1::_MetaBase<false>'
[2022-12-12T09:42:04.557Z]     optional(const optional<_Up>& __v)
[2022-12-12T09:42:04.557Z]     ^
[2022-12-12T09:42:04.557Z] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/optional:747:5: note: candidate template ignored: substitution failure [with _Up = std::__1::reference_wrapper<rapidjson_ly::GenericValue<rapidjson_ly::UTF8<char>, rapidjson_ly::CrtAllocator> >]: no member named '_EnableIfImpl' in 'std::__1::_MetaBase<false>'
[2022-12-12T09:42:04.557Z]     optional(optional<_Up>&& __v)
[2022-12-12T09:42:04.557Z]     ^
````
