### PR TITLE
Fix clang compile and add extra flags feature

### DIFF
--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Link/SingleInstanceMultiplePatchesBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Link/SingleInstanceMultiplePatchesBenchmarks.cpp
@@ -95,7 +95,7 @@ namespace Benchmark
 
     BENCHMARK_DEFINE_F(SingleInstanceMultiplePatchesBenchmarks, GetLinkDom)(benchmark::State& state)
     {
-        for (auto _ : state)
+        for ([[maybe_unused]] auto _ : state)
         {
             LinkReference link = m_prefabSystemComponent->FindLink(m_linkId);
             AZ_Assert(link.has_value(), "Link between prefabs is missing.");
@@ -107,7 +107,7 @@ namespace Benchmark
 
     BENCHMARK_DEFINE_F(SingleInstanceMultiplePatchesBenchmarks, SetLinkDom)(benchmark::State& state)
     {
-        for (auto _ : state)
+        for ([[maybe_unused]] auto _ : state)
         {
             LinkReference link = m_prefabSystemComponent->FindLink(m_linkId);
             AZ_Assert(link.has_value(), "Link between prefabs is missing.");

--- a/Gems/Atom/RHI/Code/Tests/TagRegistryTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/TagRegistryTests.cpp
@@ -61,7 +61,7 @@ namespace UnitTest
     {
         auto tagRegistry = RHI::TagRegistry<IndexType, 32>::Create();
         EXPECT_EQ(tagRegistry->GetAllocatedTagCount(), 0);
-        auto tagA = tagRegistry->AcquireTag(Name("A"));
+        [[maybe_unused]] auto tagA = tagRegistry->AcquireTag(Name("A"));
         EXPECT_EQ(tagRegistry->GetAllocatedTagCount(), 1);
         tagRegistry->Reset();
         EXPECT_EQ(tagRegistry->GetAllocatedTagCount(), 0);
@@ -163,7 +163,7 @@ namespace UnitTest
     {
         auto tagBitRegistry = RHI::TagBitRegistry<IndexType>::Create();
         EXPECT_EQ(tagBitRegistry->GetAllocatedTagCount(), 0);
-        auto tagA = tagBitRegistry->AcquireTag(Name("A"));
+        [[maybe_unused]] auto tagA = tagBitRegistry->AcquireTag(Name("A"));
         EXPECT_EQ(tagBitRegistry->GetAllocatedTagCount(), 1);
         tagBitRegistry->Reset();
         EXPECT_EQ(tagBitRegistry->GetAllocatedTagCount(), 0);

--- a/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
+++ b/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
@@ -21,7 +21,7 @@ ly_associate_package(PACKAGE_NAME xxhash-0.7.4-rev1-multiplatform               
 # platform-specific:
 ly_associate_package(PACKAGE_NAME expat-2.4.2-rev2-windows                              TARGETS expat                       PACKAGE_HASH 748d08f21f5339757059a7887e72b52d15e954c549245c638b0b05bd5961e307)
 ly_associate_package(PACKAGE_NAME assimp-5.1.6-rev1-windows                             TARGETS assimplib                   PACKAGE_HASH 299d8a3c70657d74af8841650538e9d083fda9356f6782416edbec0ef5a0493e)
-ly_associate_package(PACKAGE_NAME OpenEXR-3.1.3-rev4-windows                            TARGETS OpenEXR Imath               PACKAGE_HASH c850268e849171751cdaefdab1952333ac38afbb771b999e99d67f9761706d98)
+ly_associate_package(PACKAGE_NAME OpenEXR-3.1.3-rev5-windows                            TARGETS OpenEXR Imath               PACKAGE_HASH bff6dc78412bb1b04ded243753bee36e9229fdaf9a9e1fa85b1059238fba4c9b)
 ly_associate_package(PACKAGE_NAME AWSGameLiftServerSDK-3.4.2-rev1-windows               TARGETS AWSGameLiftServerSDK        PACKAGE_HASH 9d30eb265adc8b46a7f6a9ad122c2d3c8820ca16961533a3cc994734e264969a)
 ly_associate_package(PACKAGE_NAME DirectXShaderCompilerDxc-1.6.2112-o3de-rev1-windows   TARGETS DirectXShaderCompilerDxc    PACKAGE_HASH fdcdc081e67abcfdc8172866258a9c36f1fd0d7b963ba5378ca01cb4fcdbf9c7)
 ly_associate_package(PACKAGE_NAME SPIRVCross-2021.04.29-rev1-windows                    TARGETS SPIRVCross                  PACKAGE_HASH 7d601ea9d625b1d509d38bd132a1f433d7e895b16adab76bac6103567a7a6817)

--- a/cmake/Platform/Common/Configurations_common.cmake
+++ b/cmake/Platform/Common/Configurations_common.cmake
@@ -12,14 +12,21 @@
 # each platform include them
 
 # Clear all
-ly_set(CMAKE_C_FLAGS "")
-ly_set(CMAKE_CXX_FLAGS "")
-ly_set(LINK_OPTIONS "")
+set(O3DE_EXTRA_C_FLAGS ""       CACHE STRING "Additional C Compiler flags to apply globally")
+set(O3DE_EXTRA_CXX_FLAGS ""     CACHE STRING "Additional Cxx Compiler flags to apply globally")
+set(O3DE_EXTRA_LINK_OPTIONS ""  CACHE STRING "Additional link options to apply globally")
+
+ly_set(CMAKE_C_FLAGS "${O3DE_EXTRA_C_FLAGS}")
+ly_set(CMAKE_CXX_FLAGS "${O3DE_EXTRA_CXX_FLAGS}")
+ly_set(LINK_OPTIONS "${O3DE_EXTRA_LINK_OPTIONS}")
 foreach(conf ${CMAKE_CONFIGURATION_TYPES})
     string(TOUPPER ${conf} UCONF)
-    ly_set(CMAKE_C_FLAGS_${UCONF} "")
-    ly_set(CMAKE_CXX_FLAGS_${UCONF} "")
-    ly_set(LINK_OPTIONS_${UCONF} "")
+    set(O3DE_EXTRA_C_FLAGS_${UCONF} ""       CACHE STRING "Additional C Compiler flags to add globally when compiling in ${conf}")
+    set(O3DE_EXTRA_CXX_FLAGS_${UCONF} ""     CACHE STRING "Additional Cxx Compiler flags to add globally when compiling in ${conf}")
+    set(O3DE_EXTRA_LINK_OPTIONS_${UCONF} ""  CACHE STRING "Additional link options to add globally when linking in ${conf}")
+    ly_set(CMAKE_C_FLAGS_${UCONF} "${O3DE_EXTRA_C_FLAGS_${UCONF}}")
+    ly_set(CMAKE_CXX_FLAGS_${UCONF} "${O3DE_EXTRA_CXX_FLAGS_${UCONF}}")
+    ly_set(LINK_OPTIONS_${UCONF} "${O3DE_EXTRA_LINK_OPTIONS_${UCONF}}")
     ly_set(LY_BUILD_CONFIGURATION_TYPE_${UCONF} ${conf})
 endforeach()
 

--- a/cmake/Platform/Windows/Configurations_windows.cmake
+++ b/cmake/Platform/Windows/Configurations_windows.cmake
@@ -6,9 +6,8 @@
 #
 #
 
-ly_set(CMAKE_RC_FLAGS /nologo)
-
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    ly_set(CMAKE_RC_FLAGS /nologo)   
     
     include(cmake/Platform/Common/MSVC/Configurations_msvc.cmake)
 


### PR DESCRIPTION
## What does this PR do?

Fixes compilation errors with clang, and adds a feature mainly meant for clang tools like the clang build analyzer and others (which require adding flags to compiler).

It also fixes the OpenEXR package to no longer set "/EHsc" (a MSVC-only flag) on Windows, instead, it sets it only when in MSVC.

## How was this PR tested?

Building this with MSVC, as well as building it with clang on windows.

to build it on windows with clang, make sure llvm clang is installed and on the path, and set the CMAKE_C_COMPILER and CMAKE_CXX_COMPILER  variables in cmake to both be clang++

You need to be inside a visual studio command prompt to do this, since some tools still invoke 'link' from vs.


