### PR TITLE
Added BC4_UNORM support to runtime-decodable formats.

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/BlockCompression.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/BlockCompression.h
@@ -89,6 +89,112 @@ namespace AZ
             }
         };
 
+        // Helper structure for decoding BC4 block compression.
+        // BC4 consists of 8-byte blocks that encode 16 pixels arranged in a 4x4 square. The first 2 bytes are 2 8-bit greyscale values,
+        // and the next 6 bytes contain 6 3-bit indices that represent individual pixels.
+        // The 3-bit index values of 000 and 111 directly reference the two greyscale values. The other 6 values either
+        // represent 6 interpolated values between the two greyscale values or 4 interpolated values plus black and white.
+        struct BC4Block
+        {
+            union
+            {
+                uint64_t m_block;
+
+                struct UnpackedData
+                {
+                    uint8_t m_color0;
+                    uint8_t m_color1;
+                    uint8_t m_colorIndices[6];
+                } m_unpackedData;
+            };
+
+            // Each block is 8 bytes in size.
+            static constexpr size_t BlockBytes = 8;
+
+            // Each block is 4x4 pixels in size.
+            static constexpr size_t BlockPixelWidth = 4;
+            static constexpr size_t BlockPixelHeight = 4;
+
+            // Given an image width, and an XY location, return a pair of indices.
+            // The first index is a block index when walking through an array of blocks.
+            // The second index is the specific pixel index (0-15) within that block.
+            static AZStd::pair<size_t, size_t> GetBlockIndices(uint32_t width, uint32_t x, uint32_t y)
+            {
+                size_t blockWidth = width / BlockPixelWidth;
+                uint32_t blockX = x / BlockPixelWidth;
+                uint32_t blockY = y / BlockPixelHeight;
+
+                size_t blockIndex = (blockY * blockWidth + blockX);
+                size_t pixelIndex = ((y % BlockPixelHeight) * BlockPixelHeight) + (x % BlockPixelWidth);
+                return AZStd::pair<size_t, size_t>(blockIndex, pixelIndex);
+            }
+
+            // Given an index into the 4x4 block, return the color value in the 0-1 range.
+            AZ::Color GetBlockColor(size_t pixelIndex) const
+            {
+                AZ_Assert(pixelIndex < 16, "Unsupported pixel index for BC4: %zu", pixelIndex);
+                // Pull out the correct 3 bits from the BC4 block for this pixel.
+                // The "16 +" is to skip over the two bytes of palette data to get to the start of the first pixel.
+                uint8_t colorIndex = (m_block >> (16 + (3 * (pixelIndex & 0x0F)))) & 0x07;
+
+                auto extractColor = [](uint8_t color) -> AZ::Color
+                {
+                    return AZ::Color(color / 255.0f, color / 255.0f, color / 255.0f, 1.0f);
+                };
+
+                if (m_unpackedData.m_color0 > m_unpackedData.m_color1)
+                {
+                    // When the first color palette entry is larger, the first two indices are the two palette entries,
+                    // and the remaining 5 are interpolations from 1/7 to 6/7 between the palette entries.
+                    switch (colorIndex)
+                    {
+                    case 0:
+                        return extractColor(m_unpackedData.m_color0);
+                    case 1:
+                        return extractColor(m_unpackedData.m_color1);
+                    case 2:
+                    case 3:
+                    case 4:
+                    case 5:
+                    case 6:
+                    case 7:
+                        // Index 2-7 lerps from 1/7 - 6/7 between color0 and color1
+                        return extractColor(m_unpackedData.m_color0)
+                            .Lerp(extractColor(m_unpackedData.m_color1), aznumeric_cast<float>(colorIndex - 1) / 7.0f);
+                    }
+                }
+                else
+                {
+                    // When the second color palette entry is larger, the first two indices are the two palette entries,
+                    // the next 4 are interpolations from 1/5 to 4/5 between the palette entries, and the last two are transparent
+                    // black and opaque white.
+                    switch (colorIndex)
+                    {
+                    case 0:
+                        return extractColor(m_unpackedData.m_color0);
+                    case 1:
+                        return extractColor(m_unpackedData.m_color1);
+                    case 2:
+                    case 3:
+                    case 4:
+                    case 5:
+                        // Index 2-5 lerps from 1/5 - 4/5 between color0 and color1
+                        return extractColor(m_unpackedData.m_color0)
+                            .Lerp(extractColor(m_unpackedData.m_color1), aznumeric_cast<float>(colorIndex - 1) / 5.0f);
+                    case 6:
+                        // Index 6 returns transparent black
+                        return AZ::Color::CreateZero();
+                    case 7:
+                        // Index 7 returns opaque white
+                        return AZ::Color::CreateOne();
+                    }
+                }
+
+                return AZ::Color::CreateZero();
+            }
+        };
+
+
     }   // namespace RPI
 }   // namespace AZ
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/BlockCompression.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/BlockCompression.h
@@ -100,12 +100,12 @@ namespace AZ
             {
                 uint64_t m_block;
 
-                struct UnpackedData
+                struct
                 {
                     uint8_t m_color0;
                     uint8_t m_color1;
                     uint8_t m_colorIndices[6];
-                } m_unpackedData;
+                };
             };
 
             // Each block is 8 bytes in size.
@@ -142,16 +142,16 @@ namespace AZ
                     return AZ::Color(color / 255.0f, color / 255.0f, color / 255.0f, 1.0f);
                 };
 
-                if (m_unpackedData.m_color0 > m_unpackedData.m_color1)
+                if (m_color0 > m_color1)
                 {
                     // When the first color palette entry is larger, the first two indices are the two palette entries,
                     // and the remaining 5 are interpolations from 1/7 to 6/7 between the palette entries.
                     switch (colorIndex)
                     {
                     case 0:
-                        return extractColor(m_unpackedData.m_color0);
+                        return extractColor(m_color0);
                     case 1:
-                        return extractColor(m_unpackedData.m_color1);
+                        return extractColor(m_color1);
                     case 2:
                     case 3:
                     case 4:
@@ -159,8 +159,8 @@ namespace AZ
                     case 6:
                     case 7:
                         // Index 2-7 lerps from 1/7 - 6/7 between color0 and color1
-                        return extractColor(m_unpackedData.m_color0)
-                            .Lerp(extractColor(m_unpackedData.m_color1), aznumeric_cast<float>(colorIndex - 1) / 7.0f);
+                        return extractColor(m_color0)
+                            .Lerp(extractColor(m_color1), aznumeric_cast<float>(colorIndex - 1) / 7.0f);
                     }
                 }
                 else
@@ -171,16 +171,16 @@ namespace AZ
                     switch (colorIndex)
                     {
                     case 0:
-                        return extractColor(m_unpackedData.m_color0);
+                        return extractColor(m_color0);
                     case 1:
-                        return extractColor(m_unpackedData.m_color1);
+                        return extractColor(m_color1);
                     case 2:
                     case 3:
                     case 4:
                     case 5:
                         // Index 2-5 lerps from 1/5 - 4/5 between color0 and color1
-                        return extractColor(m_unpackedData.m_color0)
-                            .Lerp(extractColor(m_unpackedData.m_color1), aznumeric_cast<float>(colorIndex - 1) / 5.0f);
+                        return extractColor(m_color0)
+                            .Lerp(extractColor(m_color1), aznumeric_cast<float>(colorIndex - 1) / 5.0f);
                     case 6:
                         // Index 6 returns transparent black
                         return AZ::Color::CreateZero();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPIUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPIUtils.cpp
@@ -224,6 +224,11 @@ namespace AZ
                         float color = actualMem[indices.first].GetBlockColor(indices.second).GetElement(componentIndex);
                         return s_SrgbGammaToLinearLookupTable[aznumeric_cast<uint8_t>(color * AZStd::numeric_limits<AZ::u8>::max())];
                     }
+                case AZ::RHI::Format::BC4_UNORM:
+                    {
+                        auto actualMem = reinterpret_cast<const BC4Block*>(mem);
+                        return actualMem[indices.first].GetBlockColor(indices.second).GetElement(componentIndex);
+                    }
                 default:
                     AZ_Assert(false, "Unsupported pixel format: %s", AZ::RHI::ToString(format));
                     return 0.0f;
@@ -427,6 +432,11 @@ namespace AZ
                             s_SrgbGammaToLinearLookupTable[aznumeric_cast<uint8_t>(color.GetB() * AZStd::numeric_limits<AZ::u8>::max())],
                             s_SrgbGammaToLinearLookupTable[aznumeric_cast<uint8_t>(color.GetA() * AZStd::numeric_limits<AZ::u8>::max())]);
                     }
+                case AZ::RHI::Format::BC4_UNORM:
+                    {
+                        auto actualMem = reinterpret_cast<const BC4Block*>(mem);
+                        return actualMem[indices.first].GetBlockColor(indices.second);
+                    }
                 default:
                     AZ_Assert(false, "Unsupported pixel format: %s", AZ::RHI::ToString(format));
                     return AZ::Color::CreateZero();
@@ -518,6 +528,8 @@ namespace AZ
                 case AZ::RHI::Format::BC1_UNORM:
                 case AZ::RHI::Format::BC1_UNORM_SRGB:
                     return BC1Block::GetBlockIndices(width, x, y);
+                case AZ::RHI::Format::BC4_UNORM:
+                    return BC4Block::GetBlockIndices(width, x, y);
                 default:
                     return AZStd::pair<size_t, size_t>((y * width + x) * numComponents, 0);
                 }
@@ -827,6 +839,7 @@ namespace AZ
             // Compressed types
             case AZ::RHI::Format::BC1_UNORM:
             case AZ::RHI::Format::BC1_UNORM_SRGB:
+            case AZ::RHI::Format::BC4_UNORM:
                 return true;
             }
 


### PR DESCRIPTION
## What does this PR do?

This adds BC4_UNORM to the set of image formats that can get decoded at runtime.

The specific use case is that with this support, we can easily take material displacement maps that default to BC4_UNORM encoding and use them on an Image Gradient as a heightmap, and then take the material basecolor texture and use it as a terrain macro material. It's not expected to be a normal use case, especially since it only supports 256 different height values, but it's a novel thing to do that isn't hard to support.

## How was this PR tested?

Loaded a texture and displacement map onto the terrain. Also verified with low mips of the displacement map that the pixel values match the dds when loaded into Visual Studio.

![image](https://user-images.githubusercontent.com/82224783/207467884-7105ed52-2648-4f38-9782-eb1567876e86.png)
![image](https://user-images.githubusercontent.com/82224783/207467951-0923fcd0-e188-42b8-9b61-55c8abb4536c.png)
![image](https://user-images.githubusercontent.com/82224783/207468061-dc284c90-458c-4041-83d2-066b7fa65e80.png)

