### PR TITLE
[Terrain] Misc TQO Bugfixes

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/PaintBrushManipulator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/PaintBrushManipulator.cpp
@@ -51,6 +51,14 @@ namespace AzToolsFramework
         AZ::ConsoleFunctorFlags::Null,
         "The color of the paintbrush manipulator.");
 
+    AZ_CVAR(
+        float,
+        ed_paintBrushRayCastMeters,
+        4096.0f,
+        nullptr,
+        AZ::ConsoleFunctorFlags::Null,
+        "The number of meters to raycast to look for a valid surface to paint onto.");
+
     namespace
     {
         static constexpr AZ::Crc32 PaintbrushIncreaseSize = AZ_CRC_CE("org.o3de.action.paintbrush.increase_size");
@@ -239,7 +247,7 @@ namespace AzToolsFramework
     {
         // Ray cast into the screen to find the closest collision point for the current mouse location.
         auto worldSurfacePosition =
-            AzToolsFramework::FindClosestPickIntersection(viewportId, screenCoordinates, AzToolsFramework::EditorPickRayLength);
+            AzToolsFramework::FindClosestPickIntersection(viewportId, screenCoordinates, ed_paintBrushRayCastMeters);
 
         // If the mouse isn't colliding with anything, don't move the paintbrush, just leave it at its last location
         // and don't perform any brush actions. We'll reset the stroke movement tracking though so that we don't draw unintended lines

--- a/Gems/GradientSignal/Code/CMakeLists.txt
+++ b/Gems/GradientSignal/Code/CMakeLists.txt
@@ -75,6 +75,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
             PRIVATE
                 3rdParty::OpenImageIO
                 Gem::LmbrCentral.Editor
+                Gem::Atom_RPI.Edit
             PUBLIC
                 3rdParty::Qt::Widgets
                 AZ::AzCore

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <Editor/EditorImageGradientComponent.h>
+#include <Atom/RPI.Edit/Common/AssetUtils.h>
 #include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Preprocessor/EnumReflectUtils.h>
@@ -755,7 +756,8 @@ namespace GradientSignal
             settingsRegistry->Get(defaultPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath);
         }
 
-        defaultPath /= AZ::IO::FixedMaxPathString::format(AZ_STRING_FORMAT "_gsi.tif", AZ_STRING_ARG(GetEntity()->GetName()));
+        defaultPath /= AZ::IO::FixedMaxPathString::format(
+            AZ_STRING_FORMAT "_gsi.tif", AZ_STRING_ARG(AZ::RPI::AssetUtils::SanitizeFileName(GetEntity()->GetName())));
 
         return defaultPath.Native();
     }

--- a/Gems/Terrain/Code/Source/Components/TerrainLayerSpawnerComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainLayerSpawnerComponent.cpp
@@ -49,7 +49,7 @@ namespace Terrain
                     ->DataElement(AZ::Edit::UIHandlers::Slider, &TerrainLayerSpawnerConfig::m_priority, "Sub Priority", "Defines order terrain spawners are applied within a layer.  Larger numbers = higher priority")
                     ->Attribute(AZ::Edit::Attributes::Min, AreaConstants::s_priorityMin)
                     ->Attribute(AZ::Edit::Attributes::Max, AreaConstants::s_priorityMax)
-                    ->Attribute(AZ::Edit::Attributes::SoftMin, AreaConstants::s_priorityMin)
+                    ->Attribute(AZ::Edit::Attributes::SoftMin, AreaConstants::s_prioritySoftMin)
                     ->Attribute(AZ::Edit::Attributes::SoftMax, AreaConstants::s_prioritySoftMax)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &TerrainLayerSpawnerConfig::m_useGroundPlane, "Use Ground Plane", "Determines whether or not to provide a default ground plane")
                     ;

--- a/Gems/Terrain/Code/Source/Components/TerrainWorldDebuggerComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainWorldDebuggerComponent.cpp
@@ -274,9 +274,6 @@ namespace Terrain
             debugDisplay.SetColor(dirtyRegionColor);
             debugDisplay.DrawSolidBox(m_lastDirtyRegion.GetMin(), m_lastDirtyRegion.GetMax());
         }
-
-        // Clear it out until something goes dirty again.
-        m_lastDirtyRegion = AZ::Aabb::CreateNull();
     }
 
     void TerrainWorldDebuggerComponent::DrawWorldBounds(AzFramework::DebugDisplayRequests& debugDisplay)
@@ -654,10 +651,7 @@ namespace Terrain
         if (dataChangedMask & (TerrainDataChangedMask::Settings | TerrainDataChangedMask::HeightData))
         {
             MarkDirtySectors(dirtyRegion);
-        }
 
-        if (dataChangedMask & TerrainDataChangedMask::Settings)
-        {
             // Any time the world bounds potentially changes, notify that the terrain debugger's visibility bounds also changed.
             AzFramework::IEntityBoundsUnionRequestBus::Broadcast(
                 &AzFramework::IEntityBoundsUnionRequestBus::Events::RefreshEntityLocalBoundsUnion, GetEntityId());


### PR DESCRIPTION
## What does this PR do?

This fixes a few bugs that were found while testing terrain:
* Terrain debug drawing sometimes culled out because the AABBs weren't being updated with the visibility system when terrain spawners were dragged around the level. Now the AABBs update correctly. (closes #13654 )
* Terrain Layer Spawner was using Min instead of SoftMin for the lower bounds by mistake. Switched to the correct SoftMin constant.(closes #13656 )
* Image Gradient would propose potentially invalid file names if the Entity name has invalid characters in it (spaces, slashes, etc). It now sanitizes the entity name before using it as a default file name.
* Painting didn't work when the camera is pulled back more than 1000 meters from the surface. This is because the raycast was hardcoded to only go 1000 meters. The fix (for now) is to add a cvar that makes this distance user-configurable. Eventually, this will hopefully get fixed by having the user select which entity they're painting on. (closes #13589 ).

I also switched the behavior of the Terrain debug drawing feature that draws the last dirty region to keep the region persistent. I kept changing the feature locally to do this every time I used it, so it seems like the more useful way for the feature to behave.

## How was this PR tested?

Ran through the testing steps for all of the above bugs.
