### PR TITLE
Remove squish-ccr from the EditorLib BUILD_DEPENDENCIES

### DIFF
--- a/Code/Editor/CMakeLists.txt
+++ b/Code/Editor/CMakeLists.txt
@@ -103,7 +103,6 @@ ly_add_target(
             3rdParty::Qt::Widgets
             3rdParty::Qt::Concurrent
             3rdParty::TIFF
-            3rdParty::squish-ccr
             Legacy::CryCommon
             Legacy::EditorCommon
             AZ::AzCore


### PR DESCRIPTION
Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>

## What does this PR do?

The 3P library `squish-ccr` is listed as a build dependency of `EditorLib`, which it is not. The package is only a dependency of `ImageProcessingAtom.Editor.Static`. This removes this unnecessary dependency.

## How was this PR tested?

The Editor for AutomatedTesting was built and ran on Windows and Ubuntu Linux
