### PR TITLE
Disable TestCLIToolPythonBindingsExampleWorkst that fails periodically

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/smoke/test_CLITool_PythonBindingsExample_Works.py
+++ b/AutomatedTesting/Gem/PythonTests/smoke/test_CLITool_PythonBindingsExample_Works.py
@@ -14,7 +14,7 @@ import pytest
 import subprocess
 
 
-@pytest.mark.SUITE_smoke
+@pytest.mark.skip(reason="GHI #13693: Test Periodically Fails")
 class TestCLIToolPythonBindingsExampleWorks(object):
     def test_CLITool_PythonBindingsExample_Works(self, build_directory):
         file_path = os.path.join(build_directory, "PythonBindingsExample")


### PR DESCRIPTION
Signed-off-by: Tom Hulton-Harrop <82228511+hultonha@users.noreply.github.com>

## What does this PR do?

Disables `TestCLIToolPythonBindingsExampleWorks` which has been failing repeatedly on unrelated AR runs.

3/5 AR runs failed on this test for no reason, please see https://github.com/o3de/o3de/issues/13693 for more details and logs.

## How was this PR tested?

Ran AR
