### PR TITLE
Editable breadcrumbs for asset browser

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.ui
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.ui
@@ -98,7 +98,7 @@
              <number>0</number>
             </property>
             <property name="rightMargin">
-             <number>0</number>
+             <number>5</number>
             </property>
             <property name="bottomMargin">
              <number>0</number>
@@ -110,6 +110,9 @@
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
+              </property>
+              <property name="editable" stdset="0">
+               <bool>true</bool>
               </property>
              </widget>
             </item>

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.cpp
@@ -13,14 +13,17 @@
 #include <AzQtComponents/Components/Style.h>
 
 AZ_PUSH_DISABLE_WARNING(4244 4251, "-Wunknown-warning-option") // 4251: 'QLayoutItem::align': class 'QFlags<Qt::AlignmentFlag>' needs to have dll-interface to be used by clients of class 'QLayoutItem'
-#include <QtMath>
-#include <QToolButton>
-#include <QToolBar>
-#include <QSettings>
-#include <QResizeEvent>
-#include <QMenu>
-#include <QLabel>
 #include <QHBoxLayout>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMenu>
+#include <QResizeEvent>
+#include <QSettings>
+#include <QStackedWidget>
+#include <QToolBar>
+#include <QToolButton>
+#include <QtMath>
 AZ_POP_DISABLE_WARNING
 
 namespace AzQtComponents
@@ -33,6 +36,12 @@ namespace AzQtComponents
     // non-breaking spaces
     static const QString g_plainTextSeparator = QStringLiteral("\u00a0\u00a0\u203a\u00a0\u00a0");
     static constexpr int g_iconWidth = 16;
+    static constexpr int g_leftMargin = 5;
+    //! This reserved space is used to make sure that for editable breadcrumbs user has at least some empty space to click and initiate the
+    //! editing.
+    static constexpr double g_reservedEmptySpace = 30.0;
+    //! This should be in sync with border width in BreadCrumbs.qss
+    static constexpr double g_borderWidthWhenEditable = 1.0;
 
     QString toCommonSeparators(const QString& path)
     {
@@ -41,15 +50,28 @@ namespace AzQtComponents
         return ret;
     }
 
+    //! @class AzQtComponents::BreadCrumbs
+    //!
+    //! @internal
+    //! ## Editable BreadCrumbs implementation
+    //!
+    //! Editable breadcrumbs are implemented as two widgets:
+    //!  - A QLabel that shows the nicely formatted breadcrumbs with links when not being edited
+    //!  - A QLineEdit that is shown when editing happens, due to user's interaction or calling startEditing()
+    //!
+    //!  These two widgets are inside the QStackLayout and are brought to front as needed. The interaction patterns
+    //!  are implemented in BreadCrumbs::eventFilter.
+    //! @endinternal
+
     BreadCrumbs::BreadCrumbs(QWidget* parent)
-        : QWidget(parent)
+        : QFrame(parent)
         , m_config(defaultConfig())
     {
         // WARNING: If you add any any new widget to the layout, make sure that it's accounted for in ::sizeHint() and ::fillLabel()
         
         // create the layout
         QHBoxLayout* boxLayout = new QHBoxLayout(this);
-        boxLayout->setContentsMargins(0, 0, 0, 0);
+        boxLayout->setContentsMargins(g_leftMargin, 0, 0, 0);
 
         m_menuButton = new QToolButton(this);
         m_menuButton->setObjectName(g_buttonName);
@@ -57,17 +79,33 @@ namespace AzQtComponents
         boxLayout->addWidget(m_menuButton);
         connect(m_menuButton, &QToolButton::clicked, this, &BreadCrumbs::showTruncatedPathsMenu);
 
+        m_labelEditStack = new QStackedWidget(this);
+        // This needs to be done because QStackWidget by default expands, regardless
+        // of what is inside it.
+        m_labelEditStack->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Maximum);
+
         // create the label
-        m_label = new QLabel(this);
+        m_label = new QLabel();
         m_label->setObjectName(g_labelName);
         m_label->setTextFormat(Qt::RichText);
+        m_label->installEventFilter(this);
+        m_labelEditStack->addWidget(m_label);
+
+        // create the line edit for editable breadcrumbs
+        m_lineEdit = new QLineEdit();
+        m_lineEdit->installEventFilter(this);
+        connect(m_lineEdit, &QLineEdit::returnPressed, this, &BreadCrumbs::confirmEdit);
+        Style::flagToIgnore(m_lineEdit);
+        m_labelEditStack->addWidget(m_lineEdit);
+
         // We need to explicitly set indent. Otherwise the calculations are not correct because the
         // style causes the frame to be positive in size (but invisible) which gives us the effective indent
         // described in https://doc.qt.io/qt-5/qlabel.html#indent-prop
         m_label->setIndent(0);
-        boxLayout->addWidget(m_label);
+        boxLayout->addWidget(m_labelEditStack);
         // Horizontal policy deliberately ignored, we manage the width ourselves see ::sizeHint() and ::fillLabel()
         m_label->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+        m_lineEdit->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
         connect(m_label, &QLabel::linkActivated, this, &BreadCrumbs::onLinkActivated);
     }
 
@@ -100,6 +138,8 @@ namespace AzQtComponents
     {
         // clean up the path to use all the first separator in the list of separators
         m_currentPath = toCommonSeparators(newPath);
+
+        m_lineEdit->setText(newPath);
 
         // update internals
         m_currentPathSize = m_currentPath.split(g_separator, Qt::SkipEmptyParts).size();
@@ -134,6 +174,16 @@ namespace AzQtComponents
         }
 
         return QIcon(m_currentPathIcons[index]);
+    }
+
+    bool BreadCrumbs::isEditable() const
+    {
+        return m_editable;
+    }
+
+    void BreadCrumbs::setEditable(bool editable)
+    {
+        m_editable = editable;
     }
 
     bool BreadCrumbs::getPushPathOnLinkActivation() const
@@ -185,8 +235,11 @@ namespace AzQtComponents
             }
         );
 
-        QSize sh = QWidget::sizeHint();
-        sh.rwidth() = qCeil(noSeparatorsWidth + separatorsOnlyWidth + numIcons * iconWidth);
+        const qreal borderWidth = isEditable() ? 2 * g_borderWidthWhenEditable : 0.0;
+        const qreal reservedWidth = isEditable() ? g_reservedEmptySpace : 0.0;
+
+        QSize sh = QFrame::sizeHint();
+        sh.rwidth() = qCeil(g_leftMargin + reservedWidth + borderWidth + noSeparatorsWidth + separatorsOnlyWidth + numIcons * iconWidth);
         return sh;
     }
 
@@ -309,7 +362,86 @@ namespace AzQtComponents
             m_menuButton->setVisible(needsMenu);
             fillLabel();
         }
-        QWidget::resizeEvent(event);
+        QFrame::resizeEvent(event);
+    }
+
+    bool BreadCrumbs::eventFilter(QObject* obj, QEvent* ev)
+    {
+        if (obj == m_label)
+        {
+            // HACK: QLabel doesn't have any API that would answer the question "are we currently hovering a link?" so we query the
+            // cursor shape to detect it. Without this, we would always start editing and not let the user click the breadcrumbs links.
+            // This will fail on touch device so maybe breadcrumbs could be rewritten to a series of buttons instead of rich text links
+            bool linkHovered = m_label->cursor().shape() == Qt::PointingHandCursor;
+            if (ev->type() == QEvent::MouseButtonRelease && isEditable() && !linkHovered)
+            {
+                startEditing();
+                return true;
+            }
+        }
+
+        if (obj == m_lineEdit)
+        {
+            // Esc key does the ::focusOut() on the lineEdit and the actual cancellation will happen through FocusOut event. If
+            // Esc did cancellation directly, we would get a recursive FocusOut event because cancellation swaps the line edit for
+            // label which causes FocusOut for the line edit.
+            switch (ev->type())
+            {
+            case QEvent::ShortcutOverride:
+                // If we're currently editing, Esc should always discard editing. Thus, we need to override any Esc shortcut. Such as one
+                // in the editor main window.
+                if (const auto* keyEvent = static_cast<QKeyEvent*>(ev); keyEvent->key() == Qt::Key_Escape && m_lineEdit->hasFocus())
+                {
+                    m_lineEdit->clearFocus();
+                    return true;
+                }
+                break;
+            case QEvent::FocusOut:
+                cancelEdit();
+                return true;
+            case QEvent::KeyPress:
+                if (const auto* keyEvent = static_cast<QKeyEvent*>(ev); keyEvent->key() == Qt::Key_Escape)
+                {
+                    m_lineEdit->clearFocus();
+                    return true;
+                }
+                break;
+            default:;
+            }
+        }
+        return QFrame::eventFilter(obj, ev);
+    }
+
+    void BreadCrumbs::startEditing()
+    {
+        if (!isEditable() || isEditing())
+        {
+            return;
+        }
+        m_labelEditStack->setCurrentWidget(m_lineEdit);
+        m_lineEdit->selectAll();
+        m_lineEdit->setFocus();
+    }
+
+    void BreadCrumbs::confirmEdit()
+    {
+        if (!isEditing())
+        {
+            return;
+        }
+        const QString requestedPath = m_lineEdit->text();
+        m_lineEdit->setText(m_currentPath);
+        if (requestedPath != m_currentPath)
+        {
+            Q_EMIT pathEdited(requestedPath);
+        }
+        m_labelEditStack->setCurrentWidget(m_label);
+    }
+
+    void BreadCrumbs::cancelEdit()
+    {
+        m_lineEdit->setText(m_currentPath);
+        m_labelEditStack->setCurrentWidget(m_label);
     }
 
     QString BreadCrumbs::generateIconHtml(int index)
@@ -340,9 +472,10 @@ namespace AzQtComponents
         m_truncatedPaths = fullPath;
 
         // used to measure the width used by the path.
-        const int availableWidth = width() -
+        const int availableWidth = width() - g_leftMargin
+            - (isEditable() ? g_borderWidthWhenEditable*2.0 + g_reservedEmptySpace: 0)
             // using sizeHint() because width() will be the QWidget's default 100px before the first layouting
-            (m_menuButton->isVisible() ? m_menuButton->sizeHint().width() + layout()->spacing() : 0);
+            - (m_menuButton->isVisible() ? m_menuButton->sizeHint().width() + layout()->spacing() : 0);
 
         const QFontMetricsF fm(m_label->font());
 
@@ -522,6 +655,11 @@ namespace AzQtComponents
 
         const auto position = m_menuButton->mapToGlobal(m_menuButton->geometry().bottomLeft());
         hiddenPaths.exec(position);
+    }
+
+    bool BreadCrumbs::isEditing() const
+    {
+        return m_labelEditStack->currentWidget() == m_lineEdit;
     }
 } // namespace AzQtComponents
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.h
@@ -15,13 +15,15 @@
 #include <QString>
 #include <QStyle>
 #include <QVector>
-#include <QWidget>
+#include <QFrame>
 
 #endif
 
 class QSettings;
 class QToolButton;
 class QLabel;
+class QLineEdit;
+class QStackedWidget;
 
 namespace AzQtComponents
 {
@@ -50,10 +52,12 @@ namespace AzQtComponents
     //! Can be styled by modifying BreadCrumbs.qss and BreadCrumbsConfig.ini.
     //! Note that Qt doesn't handle HTML embedded in QLabel widgets gracefully - stylesheets are not shared between those
     //! and Qt objects. As a result, the color of the HTML styled links in the BreadCrumbs is specified in BreadCrumbsConfig.ini.
+
     class AZ_QT_COMPONENTS_API BreadCrumbs
-        : public QWidget
+        : public QFrame
     {
         Q_OBJECT
+        Q_PROPERTY(bool editable READ isEditable WRITE setEditable)
 
     public:
         //! Style configuration for the Breadcrumbs class.
@@ -83,6 +87,9 @@ namespace AzQtComponents
         void setIconAt(int index, const QString& iconPath);
         //! Gets the icon for the path element at index.
         QIcon iconAt(int index);
+
+        bool isEditable() const;
+        void setEditable(bool editable);
 
         //! Returns true if activating a link should automatically push a new path to the navigation stack.
         bool getPushPathOnLinkActivation() const;
@@ -121,11 +128,23 @@ namespace AzQtComponents
         bool back();
         //! Restores the next breadcrumb path from the navigation stack if it exists.
         bool forward();
+        //! Initiate editing of the path in BreadCrumbs.
+        //!
+        //! This could be called when e.g. user presses some combination like Ctrl+L in
+        //! an appropriate context.
+        //! It will work only for editable instances (@see isEditable()).
+        //! Calling this on BreadCrumbs that are already edited is a no-op.
+        void startEditing();
 
     Q_SIGNALS:
         //! Triggered when the currently displayed path changes via any of the slots.
         //! @return fullPath The new path after the change.
         void pathChanged(const QString& fullPath);
+        //! Triggered after user changes the path in editable BreadCrumbs.
+        //!
+        //! @warning the actual path won't be pushed and the BreadCrumbs won't change. It's up to the user of this class to first check
+        //! the validity of the path provided by the user and call e.g. pushPath() to actually change what is stored in the breadcrumbs
+        void pathEdited(const QString& requestedPath);
         //! Triggered when a link is clicked.
         //! @param linkPath The path of the clicked link.
         //! @param linkIndex The index of the link.
@@ -139,9 +158,12 @@ namespace AzQtComponents
 
     protected:
         void resizeEvent(QResizeEvent* event) override;
+        bool eventFilter(QObject* obj, QEvent* ev) override;
 
     private Q_SLOTS:
         void onLinkActivated(const QString& link);
+        void confirmEdit();
+        void cancelEdit();
 
     private:
         QString generateIconHtml(int index);
@@ -152,11 +174,15 @@ namespace AzQtComponents
         void emitButtonSignals(BreadCrumbButtonStates previousButtonStates);
 
         void showTruncatedPathsMenu();
+        bool isEditing() const;
 
         static QString buildPathFromList(const QStringList& fullPath, int pos);
 
+
         QLabel* m_label = nullptr;
+        QLineEdit* m_lineEdit = nullptr;
         QToolButton* m_menuButton = nullptr;
+        QStackedWidget* m_labelEditStack = nullptr;
 
         QString m_currentPath;
         AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 4251: 'AzQtComponents::BreadCrumbs::m_backPaths': class 'QStack<QString>' needs to have dll-interface to be used by clients of class 'AzQtComponents::BreadCrumbs'
@@ -166,6 +192,7 @@ namespace AzQtComponents
         QStringList m_truncatedPaths;
         AZ_POP_DISABLE_WARNING
         bool m_pushPathOnLinkActivation = true;
+        bool m_editable = false;
         int m_currentPathSize = 0;
 
         QString m_defaultIcon;

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.qss
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.qss
@@ -22,3 +22,16 @@ AzQtComponents--BreadCrumbs #MenuButton
     qproperty-icon: url(:/Breadcrumb/img/UI20/Breadcrumb/dot-dot-dot_with_arrow.svg);
     qproperty-iconSize: 22px 11px;
 }
+
+AzQtComponents--BreadCrumbs QLineEdit
+{
+    border: 0px;
+    background: transparent;
+    color: white;
+}
+
+AzQtComponents--BreadCrumbs[editable="true"]
+{
+    border: 1px solid #2f2f2f;
+    border-radius: 2px;
+}

--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/BreadCrumbsPage.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/BreadCrumbsPage.cpp
@@ -28,6 +28,7 @@ BreadCrumbsPage::BreadCrumbsPage(QWidget* parent)
 
     // Seed the bread crumbs with an arbitrary path, to make the example obvious
     breadCrumbs->pushPath("C:/Documents/SubDirectory1/SubDirectory2/SubDirectory3");
+    breadCrumbs->setEditable(true);
 
     // Have the bread crumb widget create the right buttons for us and we just lay them out
     ui->horizontalLayout->addWidget(breadCrumbs->createBackForwardToolBar());
@@ -81,6 +82,14 @@ connect(breadCrumbs, &AzQtComponents::BreadCrumbs::pathChanged, this, [](const Q
 
 // To get the current path:
 QString currentPath = breadCrumbs->currentPath();
+
+// To make breadcrumbs editable by the user.
+breadCrumbs->setEditable(true);
+connect(breadCrumbs, &AzQtComponents::BreadCrumbs::pathEdited, this, [breadCrumbs](const QString& requestedPath){
+    // Handle user request
+    // WARNING: breadcrumbs themselves won't change the path. If user request is valid, set the path:
+    breadCrumbs->pushPath(requestedPath);
+});
 
 // Create auto-connected navigation buttons and layout everything in a group widget:
 QWidget* group = new QWidget(this);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Asset/AssetManagerBus.h>
 #include <AzCore/Math/Crc.h>
 #include <AzCore/std/containers/vector.h>
+#include <AzCore/std/ranges/split_view.h>
 #include <AzCore/StringFunc/StringFunc.h>
 
 #include <AzFramework/StringFunc/StringFunc.h>
@@ -323,6 +324,40 @@ namespace AzToolsFramework
                     curIndex = indexBelow(curIndex);
                 }
             }
+        }
+
+        const AssetBrowserEntry* AssetBrowserTreeView::GetEntryByPath(QStringView path)
+        {
+            QModelIndex current;
+            for (auto token : AZStd::ranges::split_view(path, '/'))
+            {
+                QStringView pathPart{ token.begin(), token.end() };
+                const int rows = model()->rowCount(current);
+                bool rowFound = false;
+                for (int row=0; row < rows; ++row)
+                {
+                    QModelIndex rowIdx = model()->index(row, 0, current);
+                    auto rowEntry = GetEntryFromIndex<AssetBrowserEntry>(rowIdx);
+                    if (rowEntry)
+                    {
+                        if (rowEntry->GetDisplayName() == pathPart)
+                        {
+                            current = rowIdx;
+                            rowFound = true;
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        return nullptr;
+                    }
+                }
+                if (!rowFound)
+                {
+                    return nullptr;
+                }
+            }
+            return GetEntryFromIndex<AssetBrowserEntry>(current);
         }
 
         bool AssetBrowserTreeView::IsIndexExpandedByDefault(const QModelIndex& index) const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
@@ -94,6 +94,8 @@ namespace AzToolsFramework
             template <class TEntryType>
             const TEntryType* GetEntryFromIndex(const QModelIndex& index) const;
 
+            const AssetBrowserEntry* GetEntryByPath(QStringView path);
+
             bool IsIndexExpandedByDefault(const QModelIndex& index) const override;
 
         Q_SIGNALS:


### PR DESCRIPTION
## What does this PR do?

Implements editable breadcrumbs in the Asset Browser. Fixes #12854 

https://user-images.githubusercontent.com/104767/207630758-4e8bbb03-092d-45eb-a440-417d7dedb854.mp4

Some notes:
- If an incorrect url is pasted, nothing happens
- If an url to files is pasted, the folder in which the file is located is selected
- Esc or a focus change aborts the editing
- Enter confirms editing

Potential ideas for follow-up tasks:
- validator to show if the current url is incorrect
- completer that suggest folder names at the current level

## How was this PR tested?
Manually and by running the editor test suite in AutomatedTesting