### PR TITLE
Add function context copy when updating the Vulkan instance

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/Vulkan/XRVkDescriptors.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/Vulkan/XRVkDescriptors.h
@@ -35,6 +35,7 @@ namespace AZ::Vulkan
         struct 
         {
             VkInstance m_xrVkInstance = VK_NULL_HANDLE;
+            GladVulkanContext m_context;
         } m_outputData;
 
     };

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
@@ -330,6 +330,8 @@ namespace AZ
 
                 //Update the native object from the passed by the XR module
                 m_instance = xrInstanceDescriptor->m_outputData.m_xrVkInstance;
+                //Update the context from the passed by the XR module
+                m_context = xrInstanceDescriptor->m_outputData.m_context;
 
                 //Re-add support for validation with the updated VkInstance
                 CreateDebugMessenger();


### PR DESCRIPTION
Signed-off-by: Akio Gaule <10719597+akioCL@users.noreply.github.com>

## What does this PR do?

Adds a missing copy of the function loader context from the OpenXR to the Vulkan instance.
This change is for enabling this PR change https://github.com/o3de/o3de-extras/pull/78

## How was this PR tested?

Run Features/OpenXR sample on the Quest2
