### PR TITLE
Remove the revert overrides outliner option

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
@@ -644,29 +644,6 @@ namespace AzToolsFramework
                 );
             }
 
-            // Revert Overrides
-            {
-                if (IsPrefabOverridesUxEnabled() && selectedEntities.size() == 1)
-                {
-                    AZ::EntityId selectedEntity = selectedEntities[0];
-                    if (!s_prefabPublicInterface->IsInstanceContainerEntity(selectedEntity) &&
-                        m_prefabOverridePublicInterface->AreOverridesPresent(selectedEntity))
-                    {
-                        QAction* revertAction = menu->addAction(QObject::tr("Revert Overrides"));
-                        QObject::connect(
-                            revertAction,
-                            &QAction::triggered,
-                            revertAction,
-                            [this, selectedEntity]
-                            {
-                                ContextMenu_RevertOverrides(selectedEntity);
-                            });
-
-                        menu->addSeparator();
-                    }
-                }
-            }
-
             menu->addSeparator();
         }
 


### PR DESCRIPTION
Signed-off-by: michabr <82236305+michabr@users.noreply.github.com>

## What does this PR do?

This PR removes the context menu option of reverting overrides on an entity in the outliner. The main reason is the added complexity caused by the sort order component which currently sits on a child's parent. So reverting overrides on a parent that has a child added as an override, or reverting overrides on an added child would cause the sort order component of the parent to be in an invalid state.

## How was this PR tested?

Manual testing in editor.