### PR TITLE
Update PyTyest, custom plugin, and remove unused dependency

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/editor_test_testing/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/editor_test_testing/TestSuite_Main.py
@@ -46,12 +46,24 @@ class TestEditorTest:
         for arg in sys.argv:
             if not arg.endswith(".py"):
                 TestEditorTest.args.append(arg)
-        try:
-            build_dir_arg_index = TestEditorTest.args.index("--build-directory")
-        except ValueError:
-            raise ValueError("Must pass --build-directory argument in order to run this test")
 
-        TestEditorTest.args[build_dir_arg_index+1] = os.path.abspath(TestEditorTest.args[build_dir_arg_index+1])
+        if "--build-directory" in TestEditorTest.args:
+            # passed as two args, flag and value
+            build_dir_arg_index = TestEditorTest.args.index("--build-directory")
+            TestEditorTest.args[build_dir_arg_index + 1] = os.path.abspath(
+                TestEditorTest.args[build_dir_arg_index + 1])
+        else:
+            # may instead be passed as one arg which includes equals-sign between flag and value
+            build_dir_arg_index = 0
+            for arg in TestEditorTest.args:
+                if arg.startswith("--build-directory"):
+                    first, second = arg.split("=", maxsplit=1)
+                    TestEditorTest.args[build_dir_arg_index] = f'{first}={os.path.abspath(second)}'
+                    break
+                build_dir_arg_index += 1
+        if build_dir_arg_index == len(TestEditorTest.args):
+            raise ValueError(f"Must pass --build-directory argument in order to run this test. Found args: {TestEditorTest.args}")
+
         TestEditorTest.args.append("-s")
         TestEditorTest.path = os.path.dirname(os.path.abspath(__file__))
         cls._asset_processor = None

--- a/Tools/LyTestTools/setup.py
+++ b/Tools/LyTestTools/setup.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
             'pluggy',
             'psutil',
             'pyscreenshot',
-            'pytest',
+            'pytest>=7.2.0',
             'pytest-mock',
             'pytest-timeout',
             'six',

--- a/Tools/LyTestTools/tests/integ/__init__.py
+++ b/Tools/LyTestTools/tests/integ/__init__.py
@@ -1,6 +1,10 @@
-"""
+r"""
 Copyright (c) Contributors to the Open 3D Engine Project.
 For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
+
+Tests in this directory require setting the `build-directory` parameter, examples:
+python -m pytest --build-directory="c:\git\o3de\build\bin\profile"
+python -m pytest --build-directory="~/git/o3de/build/bin/profile"
 """

--- a/Tools/LyTestTools/tests/unit/test_o3de_multi_test_framework.py
+++ b/Tools/LyTestTools/tests/unit/test_o3de_multi_test_framework.py
@@ -1197,9 +1197,7 @@ class TestMultiTestCollector(unittest.TestCase):
         mock_run.obj.marks = {"run_type": 'run_shared'}
         mock_run_2 = mock.MagicMock()
         mock_run_2.obj.marks = {"run_type": 'result'}
-        mock_instance = mock.MagicMock()
-        mock_instance.collect.return_value = [mock_run, mock_run_2]
-        mock_collect.return_value = [mock_instance]
+        mock_collect.return_value = [mock_run_2]
 
         collection = self.mock_test_class.collect()
         assert collection == [mock_run_2]
@@ -1222,13 +1220,10 @@ class TestMultiTestCollector(unittest.TestCase):
         mock_run_2 = mock.MagicMock()
         mock_run_2.obj.marks = {"run_type": 'result'}
         mock_run_2.function.marks = {"runner": mock_runner_2}
-        mock_instance = mock.MagicMock()
-        mock_instance.collect.return_value = [mock_run, mock_run_2]
-        mock_collect.return_value = [mock_instance]
+        mock_collect.return_value = [mock_run_2]
 
         self.mock_test_class.collect()
 
-        assert mock_runner.run_pytestfunc == mock_run
         assert mock_run_2 in mock_runner_2.result_pytestfuncs
 
     @mock.patch('ly_test_tools.o3de.multi_test_framework.isinstance', mock.MagicMock())

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -39,6 +39,8 @@ easyprocess==0.2.8 \
     --hash=sha256:da7f67a006e2eb63d86a8f3f4baa9d6752dab9676009a67193a4e433f2f41c2a \
     --hash=sha256:e8258e8fafddc97a9780bafa83a0b7a7223e3679478ebc7a64cb320d434354e5 \
     # via pyscreenshot
+exceptiongroup=1.0.4 \
+    --hash=sha256:542adf9dea4055530d6e1279602fa5cb11dab2395fa650b8674eaec35fc4a828
 gitdb2==2.0.6 \
     --hash=sha256:1b6df1433567a51a4a9c1a5a0de977aa351a405cc56d7d35f3388bad1f630350 \
     --hash=sha256:96bbb507d765a7f51eb802554a9cfe194a174582f772e0d89f4e87288c288b7b \

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -39,7 +39,7 @@ easyprocess==0.2.8 \
     --hash=sha256:da7f67a006e2eb63d86a8f3f4baa9d6752dab9676009a67193a4e433f2f41c2a \
     --hash=sha256:e8258e8fafddc97a9780bafa83a0b7a7223e3679478ebc7a64cb320d434354e5 \
     # via pyscreenshot
-exceptiongroup=1.0.4 \
+exceptiongroup==1.0.4 \
     --hash=sha256:542adf9dea4055530d6e1279602fa5cb11dab2395fa650b8674eaec35fc4a828
 gitdb2==2.0.6 \
     --hash=sha256:1b6df1433567a51a4a9c1a5a0de977aa351a405cc56d7d35f3388bad1f630350 \

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -219,10 +219,6 @@ psutil==5.8.0 \
     --hash=sha256:f4634b033faf0d968bb9220dd1c793b897ab7f1189956e1aa9eae752527127d3 \
     --hash=sha256:fcc01e900c1d7bee2a37e5d6e4f9194760a93597c97fee89c4ae51701de03563
     # via requirements.txt
-py==1.11.0 \
-    --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
-    --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378 \
-    # via -r requirements.txt
 pyparsing==2.4.7 \
     --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
     --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b \
@@ -239,9 +235,8 @@ pytest-timeout==2.1.0 \
     --hash=sha256:c07ca07404c612f8abbe22294b23c368e2e5104b521c1790195561f37e1ac3d9 \
     --hash=sha256:f6f50101443ce70ad325ceb4473c4255e9d74e3c7cd0ef827309dfa4c0d975c6
     # via requirements.txt
-pytest==6.2.5 \
-    --hash=sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89 \
-    --hash=sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134
+pytest==7.2.0 \
+    --hash=sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71
     # via requirements.txt, pytest-mock, pytest-timeout
 python-dateutil==2.8.1 \
     --hash=sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c \


### PR DESCRIPTION
Signed-off-by: sweeneys <sweeneys@amazon.com>

## What does this PR do?

Resolves https://github.com/o3de/o3de/issues/10588 and https://github.com/o3de/o3de/issues/12685 by updating to the latest version of PyTest. Also includes minor updates to make it easier to run tests locally.

## How was this PR tested?

Tests pass when running the following command with CWD in o3de/build:
`ctest -C profile -L "(SUITE_smoke|SUITE_main)" --no-tests=error --parallel 12 --output-on-failure`
