### PR TITLE
Only propagate previous focused instance if necessary

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
@@ -352,7 +352,11 @@ namespace AzToolsFramework::Prefab
         // Queuing the previous focus before the new one saves some time in the propagation loop on average.
         if (previousFocusedInstance.has_value())
         {
-            m_instanceUpdateExecutorInterface->AddInstanceToQueue(previousFocusedInstance);
+            // No need to update the previous focused instance if it's a descendant of the newly focused instance
+            if (!PrefabInstanceUtils::IsDescendantInstance(*previousFocusedInstance, *focusedInstance))
+            {
+                m_instanceUpdateExecutorInterface->AddInstanceToQueue(previousFocusedInstance);
+            }
         }
         m_instanceUpdateExecutorInterface->AddInstanceToQueue(focusedInstance);
 


### PR DESCRIPTION
Signed-off-by: michabr <82236305+michabr@users.noreply.github.com>

## What does this PR do?

When the focus changes, only propagate changes on the previous focused instance if it's not a descendant of the new focused instance. Otherwise, the propagation of the new focused instance will automatically handle the previous focused instance.

This solves an assert that occurred when the focus changes to the root instance from a nested instance that the root has deleted as an override (because the DOM for the deleted instance doesn't exist when seen from the root).

## How was this PR tested?

Manual testing in editor.