### PR TITLE
[Terrain] Painting fixes with non-standard gradient transforms

### DIFF
--- a/Gems/GradientSignal/Code/Include/GradientSignal/GradientTransform.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/GradientTransform.h
@@ -121,9 +121,19 @@ namespace GradientSignal
         //! Return the frequency zoom for this GradientTransform
         float GetFrequencyZoom() const;
 
-        AZ::Matrix3x4 GetTransform() const;
+        //! Get the transform matrix used by this gradient transform.
+        AZ::Matrix3x4 GetTransformMatrix() const;
+
+        //! Get the UVW values at the min and max corners of the shape's local bounds.
+        //! @param minUvw [output] The UVW values at the min corner of the local bounds.
+        //! @param maxUvw [output] The UVW values at the max corner of the local bounds.
+        void GetMinMaxUvwValues(AZ::Vector3& minUvw, AZ::Vector3& maxUvw) const;
+        void GetMinMaxUvwValuesNormalized(AZ::Vector3& minUvw, AZ::Vector3& maxUvw) const;
 
     private:
+
+        void TransformLocalPositionToUVW(const AZ::Vector3& inLocalPosition, AZ::Vector3& outUVW, bool& wasPointRejected) const;
+        void TransformLocalPositionToUVWNormalized(const AZ::Vector3& inLocalPosition, AZ::Vector3& outUVW, bool& wasPointRejected) const;
 
         //! These are the various transformations that will be performed, based on wrapping type.
         static AZ::Vector3 NoTransform(const AZ::Vector3& point, const AZ::Aabb& bounds);

--- a/Gems/GradientSignal/Code/Source/GradientTransform.cpp
+++ b/Gems/GradientSignal/Code/Source/GradientTransform.cpp
@@ -49,10 +49,10 @@ namespace GradientSignal
             AZ::IsClose(0.0f, m_shapeBounds.GetZExtent()) ? 0.0f : (1.0f / m_shapeBounds.GetZExtent()));
     }
 
-    void GradientTransform::TransformPositionToUVW(const AZ::Vector3& inPosition, AZ::Vector3& outUVW, bool& wasPointRejected) const
+    void GradientTransform::TransformLocalPositionToUVW(
+        const AZ::Vector3& inLocalPosition, AZ::Vector3& outUVW, bool& wasPointRejected) const
     {
-        // Transform coordinate into "local" relative space of shape bounds, and set W to 0 if this is a 2D gradient.
-        outUVW = m_inverseTransform * inPosition;
+        outUVW = inLocalPosition;
 
         // For most wrapping types, we always accept the point, but for ClampToZero we only accept it if it's within
         // the shape bounds. We don't use m_shapeBounds.Contains() here because Contains() is inclusive on all edges.
@@ -85,13 +85,31 @@ namespace GradientSignal
         outUVW *= m_frequencyZoom;
     }
 
-    void GradientTransform::TransformPositionToUVWNormalized(const AZ::Vector3& inPosition, AZ::Vector3& outUVW, bool& wasPointRejected) const
+    void GradientTransform::TransformLocalPositionToUVWNormalized(
+        const AZ::Vector3& inLocalPosition, AZ::Vector3& outUVW, bool& wasPointRejected) const
     {
-        TransformPositionToUVW(inPosition, outUVW, wasPointRejected);
+        TransformLocalPositionToUVW(inLocalPosition, outUVW, wasPointRejected);
 
         // This effectively does AZ::LerpInverse(bounds.GetMin(), bounds.GetMax(), point) if shouldNormalize is true,
         // and just returns outUVW if shouldNormalize is false.
         outUVW = m_normalizeExtentsReciprocal * (outUVW - m_shapeBounds.GetMin());
+    }
+
+    void GradientTransform::TransformPositionToUVW(const AZ::Vector3& inPosition, AZ::Vector3& outUVW, bool& wasPointRejected) const
+    {
+        // Transform coordinate into "local" relative space of shape bounds, and set W to 0 if this is a 2D gradient.
+        AZ::Vector3 inLocalPosition = m_inverseTransform * inPosition;
+
+        TransformLocalPositionToUVW(inLocalPosition, outUVW, wasPointRejected);
+    }
+
+    void GradientTransform::TransformPositionToUVWNormalized(
+        const AZ::Vector3& inPosition, AZ::Vector3& outUVW, bool& wasPointRejected) const
+    {
+        // Transform coordinate into "local" relative space of shape bounds, and set W to 0 if this is a 2D gradient.
+        AZ::Vector3 inLocalPosition = m_inverseTransform * inPosition;
+
+        TransformLocalPositionToUVWNormalized(inLocalPosition, outUVW, wasPointRejected);
     }
 
     WrappingType GradientTransform::GetWrappingType() const
@@ -114,9 +132,25 @@ namespace GradientSignal
         return m_frequencyZoom;
     }
 
-    AZ::Matrix3x4 GradientTransform::GetTransform() const
+    AZ::Matrix3x4 GradientTransform::GetTransformMatrix() const
     {
         return m_transform;
+    }
+
+    void GradientTransform::GetMinMaxUvwValues(AZ::Vector3& minUvw, AZ::Vector3& maxUvw) const
+    {
+        // Get the UVW values at the min & max corners.
+        bool wasPointRejected;
+        TransformLocalPositionToUVW(m_shapeBounds.GetMin(), minUvw, wasPointRejected);
+        TransformLocalPositionToUVW(m_shapeBounds.GetMax(), maxUvw, wasPointRejected);
+    }
+
+    void GradientTransform::GetMinMaxUvwValuesNormalized(AZ::Vector3& minUvw, AZ::Vector3& maxUvw) const
+    {
+        // Get the normalized UVW values at the min & max corners.
+        bool wasPointRejected;
+        TransformLocalPositionToUVWNormalized(m_shapeBounds.GetMin(), minUvw, wasPointRejected);
+        TransformLocalPositionToUVWNormalized(m_shapeBounds.GetMax(), maxUvw, wasPointRejected);
     }
 
     AZ::Vector3 GradientTransform::NoTransform(const AZ::Vector3& point, const AZ::Aabb& /*bounds*/)


### PR DESCRIPTION
## What does this PR do?

When painting on an image gradient with non-standard gradient transforms or tiling values, the dirty region wasn't getting calculated correctly and the set of pixels to modify wasn't accounting for rotation and scale. This PR fixes all of the issues I could find:
- Tiled images now have dirty regions that account for all of the repeated pixels affected by painting.
- ClampToEdge now stretches the dirty region to infinity when a pixel that affects the edge is modified.
- Repeat/Mirror/Unbounded now always create an infinite dirty region for changes.
- The dirty regions for modifying pixels now account for the entire volume of the pixel, not just the corner.
- The dirty region takes rotation / translation / scale into account.
- Pixels are now walked through based on their centers, not their corners. This solves the problem where painting on a single pixel would fail because the corners would query the paintbrush and get 0-opacity values, because the paintbrush is a circle that's fitted inside that square. Querying at the center gets a more expected brush value.
- Pixels are now walked through in local space and translated back. Previously, when walking through them in world space, it was possible to miss some pixels because the pixel-walking wasn't accounting for the transformations.

This closes #13683 and #13586 .

At a high level, the changes below involved exposing a method in GradientTransform to get the local space UVW values from the min and max corners of the shape bounds, and then modifying the ImageModification class to extract the dirty region calculations into its own little class that handles the more complicated transform math.

## How was this PR tested?

Ran through a variety of different combinations of transform settings, scale settings, and tiling settings.

The before/after videos below demonstrate how previously the repeats weren't taken into account and modification of edge pixels wasn't taken into account. At the end, it shows how painting a large solid circle on a rotated image didn't produce solid results. The after video shows all of these fixed.

Before:
https://user-images.githubusercontent.com/82224783/208151860-acb3afc4-bacd-480d-83e3-22c734b84c67.mp4

After:
https://user-images.githubusercontent.com/82224783/208152273-f0060ac5-369e-4ab1-8793-ee5a8c14b8e3.mp4
