### PR TITLE
Change the screenshot python tests to use outcome as return value.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_tools_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_tools_utils.py
@@ -291,15 +291,16 @@ class ScreenshotHelper(object):
         """
         self.done = False
         self.captured_screenshot = False
-        frame_capture_id = azlmbr.atom.FrameCaptureRequestBus(azlmbr.bus.Broadcast, "CaptureScreenshot", filename)
-        if frame_capture_id != -1:
+        outcome = azlmbr.atom.FrameCaptureRequestBus(azlmbr.bus.Broadcast, "CaptureScreenshot", filename)
+
+        if outcome.IsSuccess():
             self.handler = azlmbr.atom.FrameCaptureNotificationBusHandler()
-            self.handler.connect(frame_capture_id)
+            self.handler.connect(outcome.GetValue())
             self.handler.add_callback("OnCaptureFinished", self.on_screenshot_captured)
             self.wait_until_screenshot()
             print("Screenshot taken.")
         else:
-            print("screenshot failed")
+            print(f"Screenshot failed. {outcome.GetError().ErrorMessage}")
         return self.captured_screenshot
 
     def on_screenshot_captured(self, parameters: tuple[any, any]) -> None:

--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/screenshot_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/screenshot_utils.py
@@ -127,17 +127,3 @@ def compare_screenshots(imageA, imageB, min_diff_filter=0.01):
     assert outcome.IsSuccess(), f"Image comparison failed. {outcome.GetError().ErrorMessage}"
 
     return outcome.GetValue()
-
-def screenshot_compare_result_code_to_string(result_code):
-    """
-    Convert the ImageDiffResult.result_code from value to string for debugging purpose.
-    :param result_code: the value form of the result code.
-    :return: the string form of the result code.
-    """
-    value_to_string = {
-        azlmbr.utils.ImageDiffResultCode_FormatMismatch : "FormatMismatch",
-        azlmbr.utils.ImageDiffResultCode_UnsupportedFormat : "UnsupportedFormat",
-        azlmbr.utils.ImageDiffResultCode_Success : "Success",
-        azlmbr.utils.ImageDiffResultCode_SizeMismatch : "SizeMismatch"}
-
-    return value_to_string[result_code];

--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/screenshot_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/screenshot_utils.py
@@ -67,7 +67,7 @@ class ScreenshotHelper(object):
             self.wait_until_screenshot()
             general.log("Screenshot taken.")
         else:
-            general.log("Screenshot failed")
+            general.log(f"Screenshot failed. {outcome.GetError().ErrorMessage}")
         return self.capturedScreenshot
 
     def on_screenshot_captured(self, parameters):
@@ -124,9 +124,7 @@ def compare_screenshots(imageA, imageB, min_diff_filter=0.01):
     outcome = azlmbr.atom.FrameCaptureTestRequestBus(
         azlmbr.bus.Broadcast, "CompareScreenshots", imageA, imageB, min_diff_filter)
 
-    if not outcome.IsSuccess():
-        error = screenshot_compare_result_code_to_string(outcome.GetError())
-        assert False, f"Failed to comparison because of {error} for {imageA} and {imageB}"
+    assert outcome.IsSuccess(), f"Image comparison failed. {outcome.GetError().ErrorMessage}"
 
     return outcome.GetValue()
 

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomGPU_AreaLightScreenshotTest.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomGPU_AreaLightScreenshotTest.py
@@ -86,7 +86,7 @@ def AtomGPU_LightComponent_AreaLightScreenshotsMatchGoldenImages():
         enter_exit_game_mode_take_screenshot,
         compare_screenshot_to_golden_image)
 
-    from Atom.atom_utils.screenshot_utils import (FOLDER_PATH, screenshot_compare_result_code_to_string)
+    from Atom.atom_utils.screenshot_utils import FOLDER_PATH
 
     DEGREE_RADIAN_FACTOR = 0.0174533
 
@@ -206,8 +206,7 @@ def AtomGPU_LightComponent_AreaLightScreenshotsMatchGoldenImages():
             image_diff_result = compare_screenshot_to_golden_image(FOLDER_PATH, screenshot_name, screenshot_name)
             screenshot_compare_execution = (
                     f"Screenshot {screenshot_name} comparison succeeded.",
-                    f"Screenshot {screenshot_name} comparison failed due to "
-                    + f"{screenshot_compare_result_code_to_string(image_diff_result.result_code)}.");
+                    f"Screenshot {screenshot_name} comparison failed.");
             Report.result(
                 screenshot_compare_execution,
                 image_diff_result.result_code == azlmbr.utils.ImageDiffResultCode_Success

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomGPU_BasicLevelSetup.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomGPU_BasicLevelSetup.py
@@ -129,7 +129,7 @@ def AtomGPU_BasicLevelSetup_SetsUpLevel():
     from Atom.atom_utils.atom_component_helper import (
         enter_exit_game_mode_take_screenshot, compare_screenshot_to_golden_image)
 
-    from Atom.atom_utils.screenshot_utils import (FOLDER_PATH, screenshot_compare_result_code_to_string)
+    from Atom.atom_utils.screenshot_utils import FOLDER_PATH
 
     DEGREE_RADIAN_FACTOR = 0.0174533
 
@@ -314,8 +314,7 @@ def AtomGPU_BasicLevelSetup_SetsUpLevel():
             image_diff_result = compare_screenshot_to_golden_image(FOLDER_PATH, screenshot_name, screenshot_name)
             screenshot_compare_execution = (
                     f"Screenshot {screenshot_name} comparison succeeded.",
-                    f"Screenshot {screenshot_name} comparison failed due to "
-                    + f"{screenshot_compare_result_code_to_string(image_diff_result.result_code)}.");
+                    f"Screenshot {screenshot_name} comparison failed.");
             Report.result(
                 screenshot_compare_execution,
                 image_diff_result.result_code == azlmbr.utils.ImageDiffResultCode_Success

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomGPU_SpotLightScreenshotTest.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomGPU_SpotLightScreenshotTest.py
@@ -105,7 +105,7 @@ def AtomGPU_LightComponent_SpotLightScreenshotsMatchGoldenImages():
     from Atom.atom_utils.atom_component_helper import (
         initial_viewport_setup, create_basic_atom_rendering_scene, enter_exit_game_mode_take_screenshot, compare_screenshot_to_golden_image)
 
-    from Atom.atom_utils.screenshot_utils import (FOLDER_PATH, screenshot_compare_result_code_to_string)
+    from Atom.atom_utils.screenshot_utils import FOLDER_PATH
 
     DEGREE_RADIAN_FACTOR = 0.0174533
 
@@ -253,8 +253,7 @@ def AtomGPU_LightComponent_SpotLightScreenshotsMatchGoldenImages():
             image_diff_result = compare_screenshot_to_golden_image(FOLDER_PATH, screenshot_name, screenshot_name)
             screenshot_compare_execution = (
                     f"Screenshot {screenshot_name} comparison succeeded.",
-                    f"Screenshot {screenshot_name} comparison failed due to "
-                    + f"{screenshot_compare_result_code_to_string(image_diff_result.result_code)}.");
+                    f"Screenshot {screenshot_name} comparison failed.");
             Report.result(
                 screenshot_compare_execution,
                 image_diff_result.result_code == azlmbr.utils.ImageDiffResultCode_Success

--- a/Code/Editor/TrackView/AtomOutputFrameCapture.cpp
+++ b/Code/Editor/TrackView/AtomOutputFrameCapture.cpp
@@ -94,13 +94,13 @@ namespace TrackView
         m_captureFinishedCallback = AZStd::move(captureFinishedCallback);
 
         // note: "Output" (slot name) maps to MainPipeline.pass CopyToSwapChain
-        AZ::Render::FrameCaptureId frameCaptureId = AZ::Render::InvalidFrameCaptureId;
+        AZ::Outcome<AZ::Render::FrameCaptureId, AZ::Render::FrameCaptureId> captureOutcome;
         AZ::Render::FrameCaptureRequestBus::BroadcastResult(
-            frameCaptureId, &AZ::Render::FrameCaptureRequestBus::Events::CapturePassAttachmentWithCallback, m_passHierarchy,
+            captureOutcome, &AZ::Render::FrameCaptureRequestBus::Events::CapturePassAttachmentWithCallback, m_passHierarchy,
             AZStd::string("Output"), attachmentReadbackCallback, AZ::RPI::PassAttachmentReadbackOption::Output);
-        if (frameCaptureId != AZ::Render::InvalidFrameCaptureId)
+        if (captureOutcome.IsSuccess())
         {
-            AZ::Render::FrameCaptureNotificationBus::Handler::BusConnect(frameCaptureId);
+            AZ::Render::FrameCaptureNotificationBus::Handler::BusConnect(captureOutcome.GetValue());
             return true;
         }
 

--- a/Code/Editor/TrackView/AtomOutputFrameCapture.cpp
+++ b/Code/Editor/TrackView/AtomOutputFrameCapture.cpp
@@ -94,7 +94,7 @@ namespace TrackView
         m_captureFinishedCallback = AZStd::move(captureFinishedCallback);
 
         // note: "Output" (slot name) maps to MainPipeline.pass CopyToSwapChain
-        AZ::Outcome<AZ::Render::FrameCaptureId, AZ::Render::FrameCaptureId> captureOutcome;
+        AZ::Outcome<AZ::Render::FrameCaptureId, AZ::Render::FrameCaptureError> captureOutcome;
         AZ::Render::FrameCaptureRequestBus::BroadcastResult(
             captureOutcome, &AZ::Render::FrameCaptureRequestBus::Events::CapturePassAttachmentWithCallback, m_passHierarchy,
             AZStd::string("Output"), attachmentReadbackCallback, AZ::RPI::PassAttachmentReadbackOption::Output);
@@ -104,6 +104,8 @@ namespace TrackView
             return true;
         }
 
+        AZ_Error("AtomOutputFrameCapture", captureOutcome.IsSuccess(),
+            "Frame capture initialization failed. %s", captureOutcome.GetError().m_errorMessage.c_str());
         return false;
     }
 

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/FrameCaptureBus.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/FrameCaptureBus.h
@@ -19,14 +19,15 @@ namespace AZ
 {
     namespace Render
     {
-        AZ_ENUM_CLASS(FrameCaptureResult,
-            None,
-            Success,
-            FileWriteError,
-            InvalidArgument,
-            UnsupportedFormat,
-            InternalError
-        )
+        //! The errors met in initializing the frame capture.
+        //! It used for script Ebus calls to provide a richer debug environment.
+        struct FrameCaptureError
+        {
+            AZ_TYPE_INFO(FrameCaptureError, "{9459AC1D-B0EE-4D89-9EEC-6A65790C76BF}");
+            static void Reflect(ReflectContext* context);
+
+            AZStd::string m_errorMessage;
+        };
 
         using FrameCaptureId = uint32_t;
         constexpr FrameCaptureId InvalidFrameCaptureId = aznumeric_cast<FrameCaptureId>(-1);
@@ -47,18 +48,18 @@ namespace AZ
             //! @param filepath The output file path. 
             //! @param windowHandle The handle to the AzFrameWork::NativeWindow that is being captured
             //! @return value is the frame capture Id, on failure it will return InvalidFrameCaptureId
-            virtual AZ::Outcome<FrameCaptureId, FrameCaptureId> CaptureScreenshotForWindow(const AZStd::string& filePath, AzFramework::NativeWindowHandle windowHandle) = 0;
+            virtual AZ::Outcome<FrameCaptureId, FrameCaptureError> CaptureScreenshotForWindow(const AZStd::string& filePath, AzFramework::NativeWindowHandle windowHandle) = 0;
 
             //! Similar to CaptureScreenshotForWindow except it's capturing the screen shot for default window 
             //! @param filepath The output file path. 
             //! @return value is the frame capture Id, on failure it will return InvalidFrameCaptureId
-            virtual AZ::Outcome<FrameCaptureId, FrameCaptureId> CaptureScreenshot(const AZStd::string& filePath) = 0;
+            virtual AZ::Outcome<FrameCaptureId, FrameCaptureError> CaptureScreenshot(const AZStd::string& filePath) = 0;
 
             //! Capture a screenshot and save it to a file if the pass image attachment preview is enabled.
             //! It will return InvalidFrameCaptureId if the preview is not enabled.
             //! @param outputFilePath The output file path. 
             //! @return value is the frame capture Id, on failure it will return InvalidFrameCaptureId
-            virtual AZ::Outcome<FrameCaptureId, FrameCaptureId> CaptureScreenshotWithPreview(const AZStd::string& outputFilePath) = 0;
+            virtual AZ::Outcome<FrameCaptureId, FrameCaptureError> CaptureScreenshotWithPreview(const AZStd::string& outputFilePath) = 0;
             
             //! Save a buffer attachment or a image attachment binded to a pass's slot to a data file.
             //! @param passHierarchy For finding the pass by using a pass hierarchy filter. Check PassFilter::CreateWithPassHierarchy() function for detail
@@ -67,7 +68,7 @@ namespace AZ
             //!               and use PassAttachmentReadbackOption::Output to capture the output state
             //! @param outputFilePath The output file path. 
             //! @return value is the frame capture Id, on failure it will return InvalidFrameCaptureId
-            virtual AZ::Outcome<FrameCaptureId, FrameCaptureId> CapturePassAttachment(const AZStd::vector<AZStd::string>& passHierarchy, const AZStd::string& slotName
+            virtual AZ::Outcome<FrameCaptureId, FrameCaptureError> CapturePassAttachment(const AZStd::vector<AZStd::string>& passHierarchy, const AZStd::string& slotName
                 , const AZStd::string& outputFilePath, RPI::PassAttachmentReadbackOption option) = 0;
 
             //! Similar to CapturePassAttachment. But instead of saving the read back result to a file, it will call the callback function provide
@@ -78,10 +79,19 @@ namespace AZ
             //! @param option Only valid for an InputOutput attachment. Use PassAttachmentReadbackOption::Input to capture the input state
             //!               and use PassAttachmentReadbackOption::Output to capture the output state
             //! @return value is the frame capture Id, on failure it will return InvalidFrameCaptureId
-            virtual AZ::Outcome<FrameCaptureId, FrameCaptureId> CapturePassAttachmentWithCallback(const AZStd::vector<AZStd::string>& passHierarchy, const AZStd::string& slotName
+            virtual AZ::Outcome<FrameCaptureId, FrameCaptureError> CapturePassAttachmentWithCallback(const AZStd::vector<AZStd::string>& passHierarchy, const AZStd::string& slotName
                 , RPI::AttachmentReadback::CallbackFunction callback, RPI::PassAttachmentReadbackOption option) = 0;
         };
         using FrameCaptureRequestBus = EBus<FrameCaptureRequests>;
+
+        AZ_ENUM_CLASS(FrameCaptureResult,
+            None,
+            Success,
+            FileWriteError,
+            InvalidArgument,
+            UnsupportedFormat,
+            InternalError
+        )
 
         class FrameCaptureNotifications
             : public EBusTraits

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/FrameCaptureBus.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/FrameCaptureBus.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AzCore/EBus/EBus.h>
+#include <AzCore/Outcome/Outcome.h>
 #include <AzCore/Preprocessor/Enum.h>
 #include <AzFramework/Windowing/WindowBus.h>
 
@@ -46,18 +47,18 @@ namespace AZ
             //! @param filepath The output file path. 
             //! @param windowHandle The handle to the AzFrameWork::NativeWindow that is being captured
             //! @return value is the frame capture Id, on failure it will return InvalidFrameCaptureId
-            virtual FrameCaptureId CaptureScreenshotForWindow(const AZStd::string& filePath, AzFramework::NativeWindowHandle windowHandle) = 0;
+            virtual AZ::Outcome<FrameCaptureId, FrameCaptureId> CaptureScreenshotForWindow(const AZStd::string& filePath, AzFramework::NativeWindowHandle windowHandle) = 0;
 
             //! Similar to CaptureScreenshotForWindow except it's capturing the screen shot for default window 
             //! @param filepath The output file path. 
             //! @return value is the frame capture Id, on failure it will return InvalidFrameCaptureId
-            virtual FrameCaptureId CaptureScreenshot(const AZStd::string& filePath) = 0;
+            virtual AZ::Outcome<FrameCaptureId, FrameCaptureId> CaptureScreenshot(const AZStd::string& filePath) = 0;
 
             //! Capture a screenshot and save it to a file if the pass image attachment preview is enabled.
             //! It will return InvalidFrameCaptureId if the preview is not enabled.
             //! @param outputFilePath The output file path. 
             //! @return value is the frame capture Id, on failure it will return InvalidFrameCaptureId
-            virtual FrameCaptureId CaptureScreenshotWithPreview(const AZStd::string& outputFilePath) = 0;
+            virtual AZ::Outcome<FrameCaptureId, FrameCaptureId> CaptureScreenshotWithPreview(const AZStd::string& outputFilePath) = 0;
             
             //! Save a buffer attachment or a image attachment binded to a pass's slot to a data file.
             //! @param passHierarchy For finding the pass by using a pass hierarchy filter. Check PassFilter::CreateWithPassHierarchy() function for detail
@@ -66,7 +67,7 @@ namespace AZ
             //!               and use PassAttachmentReadbackOption::Output to capture the output state
             //! @param outputFilePath The output file path. 
             //! @return value is the frame capture Id, on failure it will return InvalidFrameCaptureId
-            virtual FrameCaptureId CapturePassAttachment(const AZStd::vector<AZStd::string>& passHierarchy, const AZStd::string& slotName
+            virtual AZ::Outcome<FrameCaptureId, FrameCaptureId> CapturePassAttachment(const AZStd::vector<AZStd::string>& passHierarchy, const AZStd::string& slotName
                 , const AZStd::string& outputFilePath, RPI::PassAttachmentReadbackOption option) = 0;
 
             //! Similar to CapturePassAttachment. But instead of saving the read back result to a file, it will call the callback function provide
@@ -77,7 +78,7 @@ namespace AZ
             //! @param option Only valid for an InputOutput attachment. Use PassAttachmentReadbackOption::Input to capture the input state
             //!               and use PassAttachmentReadbackOption::Output to capture the output state
             //! @return value is the frame capture Id, on failure it will return InvalidFrameCaptureId
-            virtual FrameCaptureId CapturePassAttachmentWithCallback(const AZStd::vector<AZStd::string>& passHierarchy, const AZStd::string& slotName
+            virtual AZ::Outcome<FrameCaptureId, FrameCaptureId> CapturePassAttachmentWithCallback(const AZStd::vector<AZStd::string>& passHierarchy, const AZStd::string& slotName
                 , RPI::AttachmentReadback::CallbackFunction callback, RPI::PassAttachmentReadbackOption option) = 0;
         };
         using FrameCaptureRequestBus = EBus<FrameCaptureRequests>;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/FrameCaptureTestBus.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/FrameCaptureTestBus.h
@@ -41,24 +41,24 @@ namespace AZ
             //! Build the screenshot file path: screenshotFolder + envPath + imageName
             //! @imageName the image name of the screenshot; when empty string is passed, returns the folder.
             //! @return the full path of the screenshot.
-            virtual AZStd::string BuildScreenshotFilePath(const AZStd::string& imageName, bool useEnvPath) = 0;
+            virtual AZ::Outcome<AZStd::string> BuildScreenshotFilePath(const AZStd::string& imageName, bool useEnvPath) = 0;
 
             //! Build the screenshot file path: officialBaselineImageFolder + imageName
             //! @param imageName the image name of the screenshot; when empty string is passed, returns the folder.
             //! @return the full path of the screenshot.
-            virtual AZStd::string BuildOfficialBaselineFilePath(const AZStd::string& imageName, bool useEnvPath) = 0;
+            virtual AZ::Outcome<AZStd::string> BuildOfficialBaselineFilePath(const AZStd::string& imageName, bool useEnvPath) = 0;
 
             //! Build the screenshot file path: localBaselineImageFolder + envPath + imageName
             //! @param imageName the image name of the screenshot; when empty string is passed, returns the folder.
             //! @return the full path of the screenshot.
-            virtual AZStd::string BuildLocalBaselineFilePath(const AZStd::string& imageName, bool useEnvPath) = 0;
+            virtual AZ::Outcome<AZStd::string> BuildLocalBaselineFilePath(const AZStd::string& imageName, bool useEnvPath) = 0;
 
             //! Compare 2 screenshots files and give scores (using root mean square RMS) for the difference.
             //! @param filePathA the full path of screenshot A
             //! @param filePathB the full path of screenshot B
             //! @param minDiffFilter diff values less than this will be filtered out before calculating ImageDiffResult::m_filteredDiffScore.
             //! @return the result code, diff score and filtered diff score.
-            virtual Utils::ImageDiffResult CompareScreenshots(
+            virtual AZ::Outcome<Utils::ImageDiffResult, Utils::ImageDiffResultCode> CompareScreenshots(
                 const AZStd::string& filePathA,
                 const AZStd::string& filePathB,
                 float minDiffFilter) = 0;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/FrameCaptureTestBus.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/FrameCaptureTestBus.h
@@ -15,6 +15,14 @@ namespace AZ
 {
     namespace Render
     {
+        struct FrameCaptureTestError
+        {
+            AZ_TYPE_INFO(FrameCaptureError, "{C96D1649-6B7C-42AE-87C3-3253EA5214E2}");
+            static void Reflect(ReflectContext* context);
+
+            AZStd::string m_errorMessage;
+        };
+
         class FrameCaptureTestRequests
             : public EBusTraits
         {
@@ -41,24 +49,27 @@ namespace AZ
             //! Build the screenshot file path: screenshotFolder + envPath + imageName
             //! @imageName the image name of the screenshot; when empty string is passed, returns the folder.
             //! @return the full path of the screenshot.
-            virtual AZ::Outcome<AZStd::string> BuildScreenshotFilePath(const AZStd::string& imageName, bool useEnvPath) = 0;
+            virtual AZ::Outcome<AZStd::string, FrameCaptureTestError> BuildScreenshotFilePath(
+                const AZStd::string& imageName, bool useEnvPath) = 0;
 
             //! Build the screenshot file path: officialBaselineImageFolder + imageName
             //! @param imageName the image name of the screenshot; when empty string is passed, returns the folder.
             //! @return the full path of the screenshot.
-            virtual AZ::Outcome<AZStd::string> BuildOfficialBaselineFilePath(const AZStd::string& imageName, bool useEnvPath) = 0;
+            virtual AZ::Outcome<AZStd::string, FrameCaptureTestError> BuildOfficialBaselineFilePath(
+                const AZStd::string& imageName, bool useEnvPath) = 0;
 
             //! Build the screenshot file path: localBaselineImageFolder + envPath + imageName
             //! @param imageName the image name of the screenshot; when empty string is passed, returns the folder.
             //! @return the full path of the screenshot.
-            virtual AZ::Outcome<AZStd::string> BuildLocalBaselineFilePath(const AZStd::string& imageName, bool useEnvPath) = 0;
+            virtual AZ::Outcome<AZStd::string, FrameCaptureTestError> BuildLocalBaselineFilePath(
+                const AZStd::string& imageName, bool useEnvPath) = 0;
 
             //! Compare 2 screenshots files and give scores (using root mean square RMS) for the difference.
             //! @param filePathA the full path of screenshot A
             //! @param filePathB the full path of screenshot B
             //! @param minDiffFilter diff values less than this will be filtered out before calculating ImageDiffResult::m_filteredDiffScore.
             //! @return the result code, diff score and filtered diff score.
-            virtual AZ::Outcome<Utils::ImageDiffResult, Utils::ImageDiffResultCode> CompareScreenshots(
+            virtual AZ::Outcome<Utils::ImageDiffResult, FrameCaptureTestError> CompareScreenshots(
                 const AZStd::string& filePathA,
                 const AZStd::string& filePathB,
                 float minDiffFilter) = 0;

--- a/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.h
+++ b/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.h
@@ -41,12 +41,12 @@ namespace AZ
 
             // FrameCaptureRequestBus overrides ...
             bool CanCapture() const override;
-            AZ::Outcome<FrameCaptureId, FrameCaptureId> CaptureScreenshot(const AZStd::string& filePath) override;
-            AZ::Outcome<FrameCaptureId, FrameCaptureId> CaptureScreenshotForWindow(const AZStd::string& filePath, AzFramework::NativeWindowHandle windowHandle) override;
-            AZ::Outcome<FrameCaptureId, FrameCaptureId> CaptureScreenshotWithPreview(const AZStd::string& outputFilePath) override;
-            AZ::Outcome<FrameCaptureId, FrameCaptureId> CapturePassAttachment(const AZStd::vector<AZStd::string>& passHierarchy, const AZStd::string& slotName, const AZStd::string& outputFilePath,
+            AZ::Outcome<FrameCaptureId, FrameCaptureError> CaptureScreenshot(const AZStd::string& filePath) override;
+            AZ::Outcome<FrameCaptureId, FrameCaptureError> CaptureScreenshotForWindow(const AZStd::string& filePath, AzFramework::NativeWindowHandle windowHandle) override;
+            AZ::Outcome<FrameCaptureId, FrameCaptureError> CaptureScreenshotWithPreview(const AZStd::string& outputFilePath) override;
+            AZ::Outcome<FrameCaptureId, FrameCaptureError> CapturePassAttachment(const AZStd::vector<AZStd::string>& passHierarchy, const AZStd::string& slotName, const AZStd::string& outputFilePath,
                 RPI::PassAttachmentReadbackOption option) override;
-            AZ::Outcome<FrameCaptureId, FrameCaptureId> CapturePassAttachmentWithCallback(const AZStd::vector<AZStd::string>& passHierarchy, const AZStd::string& slotName
+            AZ::Outcome<FrameCaptureId, FrameCaptureError> CapturePassAttachmentWithCallback(const AZStd::vector<AZStd::string>& passHierarchy, const AZStd::string& slotName
                 , RPI::AttachmentReadback::CallbackFunction callback, RPI::PassAttachmentReadbackOption option) override;
 
             // FrameCaptureTestRequestBus overrides ...
@@ -54,10 +54,12 @@ namespace AZ
             void SetTestEnvPath(const AZStd::string& envPath) override;
             void SetOfficialBaselineImageFolder(const AZStd::string& baselineFolder) override;
             void SetLocalBaselineImageFolder(const AZStd::string& baselineFolder) override;
-            AZ::Outcome<AZStd::string> BuildScreenshotFilePath(const AZStd::string& imageName, bool useEnvPath) override;
-            AZ::Outcome<AZStd::string> BuildOfficialBaselineFilePath(const AZStd::string& imageName, bool useEnvPath) override;
-            AZ::Outcome<AZStd::string> BuildLocalBaselineFilePath(const AZStd::string& imageName, bool useEnvPath) override;
-            AZ::Outcome<Utils::ImageDiffResult, Utils::ImageDiffResultCode> CompareScreenshots(
+            AZ::Outcome<AZStd::string, FrameCaptureTestError> BuildScreenshotFilePath(const AZStd::string& imageName, bool useEnvPath) override;
+            AZ::Outcome<AZStd::string, FrameCaptureTestError> BuildOfficialBaselineFilePath(
+                const AZStd::string& imageName, bool useEnvPath) override;
+            AZ::Outcome<AZStd::string, FrameCaptureTestError> BuildLocalBaselineFilePath(
+                const AZStd::string& imageName, bool useEnvPath) override;
+            AZ::Outcome<Utils::ImageDiffResult, FrameCaptureTestError> CompareScreenshots(
                 const AZStd::string& filePathA,
                 const AZStd::string& filePathB,
                 float minDiffFilter) override;

--- a/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.h
+++ b/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.h
@@ -41,12 +41,12 @@ namespace AZ
 
             // FrameCaptureRequestBus overrides ...
             bool CanCapture() const override;
-            FrameCaptureId CaptureScreenshot(const AZStd::string& filePath) override;
-            FrameCaptureId CaptureScreenshotForWindow(const AZStd::string& filePath, AzFramework::NativeWindowHandle windowHandle) override;
-            FrameCaptureId CaptureScreenshotWithPreview(const AZStd::string& outputFilePath) override;
-            FrameCaptureId CapturePassAttachment(const AZStd::vector<AZStd::string>& passHierarchy, const AZStd::string& slotName, const AZStd::string& outputFilePath,
+            AZ::Outcome<FrameCaptureId, FrameCaptureId> CaptureScreenshot(const AZStd::string& filePath) override;
+            AZ::Outcome<FrameCaptureId, FrameCaptureId> CaptureScreenshotForWindow(const AZStd::string& filePath, AzFramework::NativeWindowHandle windowHandle) override;
+            AZ::Outcome<FrameCaptureId, FrameCaptureId> CaptureScreenshotWithPreview(const AZStd::string& outputFilePath) override;
+            AZ::Outcome<FrameCaptureId, FrameCaptureId> CapturePassAttachment(const AZStd::vector<AZStd::string>& passHierarchy, const AZStd::string& slotName, const AZStd::string& outputFilePath,
                 RPI::PassAttachmentReadbackOption option) override;
-            FrameCaptureId CapturePassAttachmentWithCallback(const AZStd::vector<AZStd::string>& passHierarchy, const AZStd::string& slotName
+            AZ::Outcome<FrameCaptureId, FrameCaptureId> CapturePassAttachmentWithCallback(const AZStd::vector<AZStd::string>& passHierarchy, const AZStd::string& slotName
                 , RPI::AttachmentReadback::CallbackFunction callback, RPI::PassAttachmentReadbackOption option) override;
 
             // FrameCaptureTestRequestBus overrides ...
@@ -54,10 +54,10 @@ namespace AZ
             void SetTestEnvPath(const AZStd::string& envPath) override;
             void SetOfficialBaselineImageFolder(const AZStd::string& baselineFolder) override;
             void SetLocalBaselineImageFolder(const AZStd::string& baselineFolder) override;
-            AZStd::string BuildScreenshotFilePath(const AZStd::string& imageName, bool useEnvPath) override;
-            AZStd::string BuildOfficialBaselineFilePath(const AZStd::string& imageName, bool useEnvPath) override;
-            AZStd::string BuildLocalBaselineFilePath(const AZStd::string& imageName, bool useEnvPath) override;
-            Utils::ImageDiffResult CompareScreenshots(
+            AZ::Outcome<AZStd::string> BuildScreenshotFilePath(const AZStd::string& imageName, bool useEnvPath) override;
+            AZ::Outcome<AZStd::string> BuildOfficialBaselineFilePath(const AZStd::string& imageName, bool useEnvPath) override;
+            AZ::Outcome<AZStd::string> BuildLocalBaselineFilePath(const AZStd::string& imageName, bool useEnvPath) override;
+            AZ::Outcome<Utils::ImageDiffResult, Utils::ImageDiffResultCode> CompareScreenshots(
                 const AZStd::string& filePathA,
                 const AZStd::string& filePathB,
                 float minDiffFilter) override;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
@@ -234,10 +234,13 @@ namespace AtomToolsFramework
 
         m_renderPipeline->AddToRenderTickOnce();
 
-        AZ::Render::FrameCaptureId frameCaptureId = AZ::Render::InvalidFrameCaptureId;
+        AZ::Outcome<AZ::Render::FrameCaptureId, AZ::Render::FrameCaptureId> captureOutcome;
         AZ::Render::FrameCaptureRequestBus::BroadcastResult(
-            frameCaptureId, &AZ::Render::FrameCaptureRequestBus::Events::CapturePassAttachmentWithCallback, m_passHierarchy,
+            captureOutcome, &AZ::Render::FrameCaptureRequestBus::Events::CapturePassAttachmentWithCallback, m_passHierarchy,
             AZStd::string("Output"), captureCallback, AZ::RPI::PassAttachmentReadbackOption::Output);
+
+        AZ::Render::FrameCaptureId frameCaptureId = captureOutcome.IsSuccess() ? captureOutcome.GetValue() : captureOutcome.GetError();
+
         return frameCaptureId;
     }
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
@@ -234,12 +234,15 @@ namespace AtomToolsFramework
 
         m_renderPipeline->AddToRenderTickOnce();
 
-        AZ::Outcome<AZ::Render::FrameCaptureId, AZ::Render::FrameCaptureId> captureOutcome;
+        AZ::Outcome<AZ::Render::FrameCaptureId, AZ::Render::FrameCaptureError> captureOutcome;
         AZ::Render::FrameCaptureRequestBus::BroadcastResult(
             captureOutcome, &AZ::Render::FrameCaptureRequestBus::Events::CapturePassAttachmentWithCallback, m_passHierarchy,
             AZStd::string("Output"), captureCallback, AZ::RPI::PassAttachmentReadbackOption::Output);
 
-        AZ::Render::FrameCaptureId frameCaptureId = captureOutcome.IsSuccess() ? captureOutcome.GetValue() : captureOutcome.GetError();
+        AZ_Error("PreviewRenderer", captureOutcome.IsSuccess(),
+            "Frame capture initialization failed. %s", captureOutcome.GetError().m_errorMessage.c_str());
+
+        AZ::Render::FrameCaptureId frameCaptureId = captureOutcome.IsSuccess() ? captureOutcome.GetValue() : AZ::Render::InvalidFrameCaptureId;
 
         return frameCaptureId;
     }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/ColorGrading/EditorHDRColorGradingComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/ColorGrading/EditorHDRColorGradingComponent.cpp
@@ -273,7 +273,7 @@ namespace AZ
             AzFramework::StringFunc::Path::GetFolderPath(resolvedOutputFilePath, lutGenerationCacheFolder);
             AZ::IO::SystemFile::CreateDir(lutGenerationCacheFolder.c_str());
 
-            AZ::Outcome<AZ::Render::FrameCaptureId, AZ::Render::FrameCaptureId> outcome;
+            AZ::Outcome<AZ::Render::FrameCaptureId, AZ::Render::FrameCaptureError> outcome;
             AZ::Render::FrameCaptureRequestBus::BroadcastResult(
                 outcome,
                 &AZ::Render::FrameCaptureRequestBus::Events::CapturePassAttachment,
@@ -287,6 +287,9 @@ namespace AZ
                 AZ::Render::FrameCaptureNotificationBus::Handler::BusConnect(outcome.GetValue());
                 AZ::TickBus::Handler::BusDisconnect();
             }
+
+            AZ_Error("EditorHDRColorGradingComponent", outcome.IsSuccess(),
+                "Frame capture initialization failed. %s", outcome.GetError().m_errorMessage.c_str());
         }
 
         void EditorHDRColorGradingComponent::OnFrameCaptureFinished([[maybe_unused]] AZ::Render::FrameCaptureResult result, [[maybe_unused]]const AZStd::string& info)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/ColorGrading/EditorHDRColorGradingComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/ColorGrading/EditorHDRColorGradingComponent.cpp
@@ -273,18 +273,18 @@ namespace AZ
             AzFramework::StringFunc::Path::GetFolderPath(resolvedOutputFilePath, lutGenerationCacheFolder);
             AZ::IO::SystemFile::CreateDir(lutGenerationCacheFolder.c_str());
 
-            AZ::Render::FrameCaptureId frameCaptureId = AZ::Render::InvalidFrameCaptureId;
+            AZ::Outcome<AZ::Render::FrameCaptureId, AZ::Render::FrameCaptureId> outcome;
             AZ::Render::FrameCaptureRequestBus::BroadcastResult(
-                frameCaptureId,
+                outcome,
                 &AZ::Render::FrameCaptureRequestBus::Events::CapturePassAttachment,
                 LutGenerationPassHierarchy,
                 AZStd::string(LutAttachment),
                 m_currentTiffFilePath,
                 AZ::RPI::PassAttachmentReadbackOption::Output);
 
-            if (frameCaptureId != AZ::Render::InvalidFrameCaptureId)
+            if (outcome.IsSuccess())
             {
-                AZ::Render::FrameCaptureNotificationBus::Handler::BusConnect(frameCaptureId);
+                AZ::Render::FrameCaptureNotificationBus::Handler::BusConnect(outcome.GetValue());
                 AZ::TickBus::Handler::BusDisconnect();
             }
         }

--- a/Gems/ScriptAutomation/Code/Source/ScriptAutomationScriptBindings.cpp
+++ b/Gems/ScriptAutomation/Code/Source/ScriptAutomationScriptBindings.cpp
@@ -276,9 +276,16 @@ namespace ScriptAutomation
 
         bool PrepareForScreenCapture(const AZStd::string& imageName)
         {
-            AZStd::string fullFilePath;
+            AZ::Outcome<AZStd::string> pathOutcome;
             AZ::Render::FrameCaptureTestRequestBus::BroadcastResult(
-                fullFilePath, &AZ::Render::FrameCaptureTestRequestBus::Events::BuildScreenshotFilePath, imageName, true);
+                pathOutcome, &AZ::Render::FrameCaptureTestRequestBus::Events::BuildScreenshotFilePath, imageName, true);
+
+            if (!pathOutcome.IsSuccess())
+            {
+                return false;
+            }
+
+            AZStd::string fullFilePath = pathOutcome.GetValue();
 
             if (!AZ::IO::PathView(fullFilePath).IsRelativeTo(Utils::ResolvePath("@user@")))
             {
@@ -355,16 +362,21 @@ namespace ScriptAutomation
                 // Note this will pause the script until the capture is complete
                 if (PrepareForScreenCapture(imageName))
                 {
-                    AZStd::string screenshotFilePath;
+                    AZ::Outcome<AZStd::string> pathOutcome;
                     AZ::Render::FrameCaptureTestRequestBus::BroadcastResult(
-                        screenshotFilePath, &AZ::Render::FrameCaptureTestRequestBus::Events::BuildScreenshotFilePath, imageName, true);
+                        pathOutcome, &AZ::Render::FrameCaptureTestRequestBus::Events::BuildScreenshotFilePath, imageName, true);
+
+                    AZ_Assert(pathOutcome.IsSuccess(), "Path check should already be done in PrepareForScreenCapture().");
+                    AZStd::string screenshotFilePath = pathOutcome.GetValue();
 
                     auto scriptAutomationInterface = ScriptAutomationInterface::Get();
-                    AZ::Render::FrameCaptureId frameCaptureId = AZ::Render::InvalidFrameCaptureId;
-                    AZ::Render::FrameCaptureRequestBus::BroadcastResult(frameCaptureId, &AZ::Render::FrameCaptureRequestBus::Events::CaptureScreenshot, screenshotFilePath);
-                    if (frameCaptureId != AZ::Render::InvalidFrameCaptureId)
+
+                    AZ::Outcome<AZ::Render::FrameCaptureId, AZ::Render::FrameCaptureId> captureOutcome;
+                    AZ::Render::FrameCaptureRequestBus::BroadcastResult(captureOutcome, &AZ::Render::FrameCaptureRequestBus::Events::CaptureScreenshot, screenshotFilePath);
+
+                    if (captureOutcome.IsSuccess())
                     {
-                        scriptAutomationInterface->SetFrameCaptureId(frameCaptureId);
+                        scriptAutomationInterface->SetFrameCaptureId(captureOutcome.GetValue());
                     }
                     else
                     {
@@ -384,16 +396,21 @@ namespace ScriptAutomation
                 // Note this will pause the script until the capture is complete
                 if (PrepareForScreenCapture(imageName))
                 {
-                    AZStd::string screenshotFilePath;
+                    AZ::Outcome<AZStd::string> pathOutcome;
                     AZ::Render::FrameCaptureTestRequestBus::BroadcastResult(
-                        screenshotFilePath, &AZ::Render::FrameCaptureTestRequestBus::Events::BuildScreenshotFilePath, imageName, true);
+                        pathOutcome, &AZ::Render::FrameCaptureTestRequestBus::Events::BuildScreenshotFilePath, imageName, true);
+
+                    AZ_Assert(pathOutcome.IsSuccess(), "Path check should already be done in PrepareForScreenCapture().");
+                    AZStd::string screenshotFilePath = pathOutcome.GetValue();
 
                     auto scriptAutomationInterface = ScriptAutomationInterface::Get();
-                    AZ::Render::FrameCaptureId frameCaptureId = AZ::Render::InvalidFrameCaptureId;
-                    AZ::Render::FrameCaptureRequestBus::BroadcastResult(frameCaptureId, &AZ::Render::FrameCaptureRequestBus::Events::CaptureScreenshotWithPreview, screenshotFilePath);
-                    if (frameCaptureId != AZ::Render::InvalidFrameCaptureId)
+
+                    AZ::Outcome<AZ::Render::FrameCaptureId, AZ::Render::FrameCaptureId> captureOutcome;
+                    AZ::Render::FrameCaptureRequestBus::BroadcastResult(captureOutcome, &AZ::Render::FrameCaptureRequestBus::Events::CaptureScreenshotWithPreview, screenshotFilePath);
+
+                    if (captureOutcome.IsSuccess())
                     {
-                        scriptAutomationInterface->SetFrameCaptureId(frameCaptureId);
+                        scriptAutomationInterface->SetFrameCaptureId(captureOutcome.GetValue());
                     }
                     else
                     {
@@ -487,16 +504,19 @@ namespace ScriptAutomation
                 // Note this will pause the script until the capture is complete
                 if (PrepareForScreenCapture(imageName))
                 {
-                    AZStd::string screenshotFilePath;
+                    AZ::Outcome<AZStd::string> pathOutcome;
                     AZ::Render::FrameCaptureTestRequestBus::BroadcastResult(
-                        screenshotFilePath, &AZ::Render::FrameCaptureTestRequestBus::Events::BuildScreenshotFilePath, imageName, true);
+                        pathOutcome, &AZ::Render::FrameCaptureTestRequestBus::Events::BuildScreenshotFilePath, imageName, true);
+
+                    AZ_Assert(pathOutcome.IsSuccess(), "Path check should already be done in PrepareForScreenCapture().");
+                    AZStd::string screenshotFilePath = pathOutcome.GetValue();
 
                     auto scriptAutomationInterface = ScriptAutomationInterface::Get();
-                    AZ::Render::FrameCaptureId frameCaptureId = AZ::Render::InvalidFrameCaptureId;
-                    AZ::Render::FrameCaptureRequestBus::BroadcastResult(frameCaptureId, &AZ::Render::FrameCaptureRequestBus::Events::CapturePassAttachment, passHierarchy, slot, screenshotFilePath, readbackOption);
-                    if (frameCaptureId != AZ::Render::InvalidFrameCaptureId)
+                    AZ::Outcome<AZ::Render::FrameCaptureId, AZ::Render::FrameCaptureId> captureOutcome;
+                    AZ::Render::FrameCaptureRequestBus::BroadcastResult(captureOutcome, &AZ::Render::FrameCaptureRequestBus::Events::CapturePassAttachment, passHierarchy, slot, screenshotFilePath, readbackOption);
+                    if (captureOutcome.IsSuccess())
                     {
-                        scriptAutomationInterface->SetFrameCaptureId(frameCaptureId);
+                        scriptAutomationInterface->SetFrameCaptureId(captureOutcome.GetValue());
                     }
                     else
                     {
@@ -516,26 +536,26 @@ namespace ScriptAutomation
                 AZStd::string resolvedPathA = ResolvePath(filePathA);
                 AZStd::string resolvedPathB = ResolvePath(filePathB);
 
-                AZ::Utils::ImageDiffResult result;
+                AZ::Outcome<AZ::Utils::ImageDiffResult, AZ::Utils::ImageDiffResultCode> outcome;
                 AZ::Render::FrameCaptureTestRequestBus::BroadcastResult(
-                    result,
+                    outcome,
                     &AZ::Render::FrameCaptureTestRequestBus::Events::CompareScreenshots,
                     resolvedPathA,
                     resolvedPathB,
                     minDiffFilter);
 
-                if (result.m_resultCode == AZ::Utils::ImageDiffResultCode::Success)
+                if (outcome.IsSuccess())
                 {
                     AZ_Printf(
                         "ScriptAutomation",
                         "Diff score is %.5f from %s and %s.",
-                        result.m_diffScore,
+                        outcome.GetValue().m_diffScore,
                         resolvedPathA.c_str(),
                         resolvedPathB.c_str());
                     AZ_Printf(
                         "ScriptAutomation",
                         "Filtered diff score is %.5f from %s and %s.",
-                        result.m_filteredDiffScore,
+                        outcome.GetValue().m_filteredDiffScore,
                         resolvedPathA.c_str(),
                         resolvedPathB.c_str());
                 }


### PR DESCRIPTION
## What does this PR do?

Screenshot APIs (including taking screenshot/image comparison/path building) now return AZ::Outcome

## How was this PR tested?

Tested ASV for lua (it should not be affected, for stability)
Tested python hydra tests in Atom (they are skipped, force enabled for testing purpose.)