### PR TITLE
Prefab Overrides | New edit-entity undo node for improving performance

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.h
@@ -153,6 +153,14 @@ namespace AzToolsFramework
              */
             void AddLinkIdToInstanceDom(PrefabDomValue& instanceDomValue);
 
+            //! Generates a DOM prefix subtree that contains the provided override patches for an entity.
+            //! Paths in patches should be subpath from an entity's perspective, eg: /Components/Component_[123].
+            //! @param subpathPatches The override patches for an entity that include subpaths.
+            //! @param pathToEntity The override path to an entity that will be used to construct patch paths.
+            //! @return DOM prefix tree that contains override patches.
+            AZ::Dom::DomPrefixTree<PrefabOverrideMetadata> GenerateOverrideSubTreeForEntity(
+                const PrefabDomValue& subpathPatches, const AZStd::string& pathToEntity);
+
         private:
 
             /**
@@ -185,7 +193,11 @@ namespace AzToolsFramework
             // Name of the nested instance of target Template.
             AZStd::string m_instanceName;
 
+            // Identifier for the link.
             LinkId m_id = InvalidLinkId;
+
+            // Index counter for generating patches.
+            AZ::u32 m_patchIndexCounter = 0u;
 
             PrefabSystemComponentInterface* m_prefabSystemComponentInterface = nullptr;
         };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.cpp
@@ -13,6 +13,7 @@
 #include <AzToolsFramework/Prefab/Undo/PrefabUndoAddEntityAsOverride.h>
 #include <AzToolsFramework/Prefab/Undo/PrefabUndoDelete.h>
 #include <AzToolsFramework/Prefab/Undo/PrefabUndoDeleteAsOverride.h>
+#include <AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.h>
 
 namespace AzToolsFramework
 {
@@ -101,6 +102,18 @@ namespace AzToolsFramework
                 PrefabUndoEntityUpdate* state = aznew PrefabUndoEntityUpdate("Undo Updating Entity");
                 state->SetParent(undoBatch);
                 state->Capture(entityDomBeforeUpdatingEntity, entityDomAfterUpdatingEntity, entityId);
+                state->Redo();
+            }
+
+            void UpdateEntityListAsOverride(
+                const AZStd::vector<const AZ::Entity*>& entityList,
+                Instance& owningInstance,
+                const Instance& focusedInstance,
+                UndoSystem::URSequencePoint* undoBatch)
+            {
+                PrefabUndoEntityOverrides* state = aznew PrefabUndoEntityOverrides("Undo Updating Entity List As Override");
+                state->SetParent(undoBatch);
+                state->Capture(entityList, owningInstance, focusedInstance);
                 state->Redo();
             }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.h
@@ -60,6 +60,17 @@ namespace AzToolsFramework
                 AZ::EntityId entityId,
                 UndoSystem::URSequencePoint* undoBatch);
 
+            //! Helper function for updating entities as overrides to focused template with undo-redo support.
+            //! @param entityList Entity list for entities to be updated in focused template.
+            //! @param owningInstance The common owning prefab instance of all inputs.
+            //! @param focusedInstance The current focused prefab instance.
+            //! @param undoBatch The undo batch node to register the update-entity undo node to.
+            void UpdateEntityListAsOverride(
+                const AZStd::vector<const AZ::Entity*>& entityList,
+                Instance& owningInstance,
+                const Instance& focusedInstance,
+                UndoSystem::URSequencePoint* undoBatch);
+
             //! Helper function for deleting entities and update parents to prefab template with undo-redo support.
             //! Note: It includes updating relevant parent entities.
             //! @param entityAliasPathList The alias path list for entities that will be removed.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzToolsFramework/Prefab/Instance/InstanceToTemplateInterface.h>
+#include <AzToolsFramework/Prefab/Link/Link.h>
+#include <AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.h>
+#include <AzToolsFramework/Prefab/Undo/PrefabUndoUtils.h>
+#include <AzToolsFramework/Prefab/PrefabInstanceUtils.h>
+#include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
+
+namespace AzToolsFramework
+{
+    namespace Prefab
+    {
+        PrefabUndoEntityOverrides::PrefabUndoEntityOverrides(const AZStd::string& undoOperationName)
+            : UndoSystem::URSequencePoint(undoOperationName)
+            , m_linkId(InvalidLinkId)
+            , m_changed(true)
+        {
+            m_prefabSystemComponentInterface = AZ::Interface<PrefabSystemComponentInterface>::Get();
+            AZ_Assert(m_prefabSystemComponentInterface, "PrefabUndoEntityOverrides - Failed to grab prefab system component interface.");
+
+            m_instanceToTemplateInterface = AZ::Interface<InstanceToTemplateInterface>::Get();
+            AZ_Assert(m_instanceToTemplateInterface, "PrefabUndoEntityOverrides - Could not get instance to template interface.");
+        }
+
+        bool PrefabUndoEntityOverrides::Changed() const
+        {
+            return m_changed;
+        }
+
+        void PrefabUndoEntityOverrides::Capture(
+            const AZStd::vector<const AZ::Entity*>& entityList,
+            Instance& owningInstance,
+            const Instance& focusedInstance)
+        {
+            InstanceClimbUpResult climbUpResult = PrefabInstanceUtils::ClimbUpToTargetOrRootInstance(owningInstance, &focusedInstance);
+            AZ_Assert(climbUpResult.m_isTargetInstanceReached, "PrefabUndoEntityOverrides::Capture - "
+                "Owning prefab instance should be a descendant of the focused prefab instance.");
+
+            m_linkId = climbUpResult.m_climbedInstances.back()->GetLinkId();
+            AZ_Assert(m_linkId != InvalidLinkId, "PrefabUndoEntityOverrides::Capture - "
+                "Could not get the link id between focused instance and top instance.");
+
+            LinkReference link = m_prefabSystemComponentInterface->FindLink(m_linkId);
+            if (!link.has_value())
+            {
+                AZ_Error("Prefab", false, "PrefabUndoEntityOverrides::Capture - Could not get the link for override editing.");
+                return;
+            }
+
+            PrefabDomReference cachedOwningInstanceDom = owningInstance.GetCachedInstanceDom();
+
+            const AZStd::string overridePatchPathToOwningInstance = PrefabInstanceUtils::GetRelativePathFromClimbedInstances(
+                climbUpResult.m_climbedInstances, true); // skip top instance
+
+            for (const AZ::Entity* entity : entityList)
+            {
+                if (!entity)
+                {
+                    AZ_Error("Prefab", false, "PrefabUndoEntityOverrides::Capture - Found a null entity. Skipping it.");
+                    continue;
+                }
+
+                // Hierarchy Example: Level (focused) -> Car (top) -> ... -> Wheel (owning) -> Tire (override)
+                // Path seen from focused: /Instances/Instance_[Car]/.../Instances/Instance_[Wheel]/Entities/Entity_[Tire]
+                //                                   (top instance)               (owning instance)         (entity to update)
+                // Note: Override patch path is the path seen from top without top instance alias path.
+                const AZStd::string entityAliasPath = m_instanceToTemplateInterface->GenerateEntityAliasPath(entity->GetId());
+                const AZStd::string entityPathFromTopInstance = overridePatchPathToOwningInstance + entityAliasPath;
+                PrefabDomPath entityDomPathFromTopInstance(entityPathFromTopInstance.c_str());
+
+                // Get the after-state entity DOM.
+                PrefabDom entityDomAfterUpdate;
+                m_instanceToTemplateInterface->GenerateDomForEntity(entityDomAfterUpdate, *entity);
+
+                // Get the before-state entity DOM inside the source template DOM of the top instance.
+                const TemplateId topTemplateId = link->get().GetSourceTemplateId();
+                const PrefabDom& topTemplateDom = m_prefabSystemComponentInterface->FindTemplateDom(topTemplateId);
+
+                PrefabDom overridePatches;
+                {
+                    // This scope is added to limit their usage and ensure DOM is not modified when it is being used.
+                    // DOM value pointers can't be relied upon if the original DOM gets modified after pointer creation.
+                    const PrefabDomValue* entityDomInTopTemplate = entityDomPathFromTopInstance.Get(topTemplateDom);
+
+                    if (entityDomInTopTemplate)
+                    {
+                        m_instanceToTemplateInterface->GeneratePatch(overridePatches, *entityDomInTopTemplate, entityDomAfterUpdate);
+                    }
+                    else
+                    {
+                        // Merge patches to an entity DOM as add-entity override.
+                        // Path is empty because there is no subpath for add-entity override patch like "/Components/Component_[123]".
+                        overridePatches.SetArray();
+                        PrefabUndoUtils::AppendAddEntityPatch(overridePatches, entityDomAfterUpdate, "");
+                    }
+                }
+
+                PrefabOverridePrefixTree overrideSubTree = link->get().GenerateOverrideSubTreeForEntity(
+                    overridePatches, entityPathFromTopInstance);
+                m_overrideSubTrees[AZ::Dom::Path(entityPathFromTopInstance)] = AZStd::move(overrideSubTree);
+
+                // Preemptively updates the cached DOM to prevent reloading instance DOM.
+                if (cachedOwningInstanceDom.has_value())
+                {
+                    PrefabUndoUtils::UpdateEntityInInstanceDom(cachedOwningInstanceDom, entityDomAfterUpdate, entityAliasPath);
+                }
+            }
+        }
+
+        void PrefabUndoEntityOverrides::Undo()
+        {
+            UpdateLink();
+        }
+
+        void PrefabUndoEntityOverrides::Redo()
+        {
+            UpdateLink();
+        }
+
+        void PrefabUndoEntityOverrides::UpdateLink()
+        {
+            LinkReference link = m_prefabSystemComponentInterface->FindLink(m_linkId);
+            if (link.has_value())
+            {
+                for (auto& [pathToSubTree, overrideSubTree] : m_overrideSubTrees)
+                {
+                    PrefabOverridePrefixTree prevSubTree = AZStd::move(link->get().RemoveOverrides(pathToSubTree));
+                    link->get().AddOverrides(pathToSubTree, AZStd::move(overrideSubTree));
+                    overrideSubTree = AZStd::move(prevSubTree);
+                }
+
+                link->get().UpdateTarget();
+                m_prefabSystemComponentInterface->SetTemplateDirtyFlag(link->get().GetTargetTemplateId(), true);
+                m_prefabSystemComponentInterface->PropagateTemplateChanges(link->get().GetTargetTemplateId());
+            }
+        }
+    } // namespace Prefab
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzToolsFramework/Undo/UndoSystem.h>
+
+namespace AzToolsFramework::Prefab
+{
+    class PrefabSystemComponentInterface;
+    class InstanceToTemplateInterface;
+
+    //! Undo class for handling updating entity list to an instance as override of focused instance.
+    class PrefabUndoEntityOverrides
+        : public UndoSystem::URSequencePoint
+    {
+    public:
+        AZ_RTTI(PrefabUndoEntityOverrides, "{97F210B2-86BE-4A16-9B3E-6ADAFD9BCDA3}", UndoSystem::URSequencePoint);
+        AZ_CLASS_ALLOCATOR(PrefabUndoEntityOverrides, AZ::SystemAllocator, 0);
+
+        explicit PrefabUndoEntityOverrides(const AZStd::string& undoOperationName);
+
+        bool Changed() const override;
+        void Undo() override;
+        void Redo() override;
+
+        // The function to generate undo/redo an override subtree for updating the provided entity list as overrides.
+        void Capture(const AZStd::vector<const AZ::Entity*>& entityList, Instance& owningInstance, const Instance& focusedInstance);
+
+        // The function to update link during undo and redo.
+        void UpdateLink();
+
+    private:
+        // Map that stores entities' override patch paths and override subtrees.
+        AZStd::unordered_map<AZ::Dom::Path, PrefabOverridePrefixTree> m_overrideSubTrees;
+
+        // Link that connects the linked instance and the focused instance.
+        LinkId m_linkId;
+        bool m_changed;
+
+        PrefabSystemComponentInterface* m_prefabSystemComponentInterface = nullptr;
+        InstanceToTemplateInterface* m_instanceToTemplateInterface = nullptr;
+    };
+} // namespace AzToolsFramework::Prefab

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -869,6 +869,8 @@ set(FILES
     Prefab/Undo/PrefabUndoBase.cpp
     Prefab/Undo/PrefabUndoRevertOverrides.h
     Prefab/Undo/PrefabUndoRevertOverrides.cpp
+    Prefab/Undo/PrefabUndoEntityOverrides.h
+    Prefab/Undo/PrefabUndoEntityOverrides.cpp
     Prefab/Undo/PrefabUndoUpdateLink.h
     Prefab/Undo/PrefabUndoUpdateLink.cpp
     Prefab/Undo/PrefabUndoUtils.h


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

This PR introduces a new edit-entity undo node for override editing. This node is a more selective version of avoid comparing instance DOMs to generate patches. As a result, it would increase the editor performance for override editing as mentioned in https://github.com/o3de/o3de/issues/11401.

This PR depends on https://github.com/o3de/o3de/pull/13640 to add override subtree successfully.

| Performance Improvement | Base | This PR | Change % |
| :---    |  ---: | ---: | ---: |
| Edit entity in 10k-entity prefab (Single-Edit) |  4,000 ms |  2,700 ms | -32.5% |
| Toggle lock on 1k-entity prefab (Multi-Edit) |  56,000 ms |  8,000 ms | -85.7% |

#### Major Changes
1. New undo node for edit-entity override that supports batch processing, merging override patches to add-entity patch. It can even be used for add-entity override workflow in the future.
2. Add patch index counter and functionality to generate subtree in Link class.
3. Update edit-entity workflow to partially adopt this undo node

#### What's Next

1. Further improvement in edit-entity workflow:
    1. Batch processing dirty entities in edit-entity workflow (improvement is noted in the GitHub issue)
    1. Can use this undo node for reparent editing as well
1. Can use this undo node for add-entity workflow (improvement is not obvious though)

## How was this PR tested?

- [x] Manually testing in editor.
- [x] Passed all tests.
- [x] Ran performance check. See improvement.
- [ ] Add some new unit tests for the new undo node