### PR TITLE
Materials reference the original material type

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialTypeSourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialTypeSourceData.h
@@ -38,6 +38,8 @@ namespace AZ
 
             static constexpr const char Extension[] = "materialtype";
 
+            static constexpr AZ::u32 IntermediateMaterialTypeSubId = 0;
+
             static void Reflect(ReflectContext* context);
 
             //! The .materialtype file has two slightly different formats, in most cases users will want to author content in the abstract format, which is 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialUtils.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialUtils.h
@@ -91,6 +91,28 @@ namespace AZ
             bool CheckIsValidPropertyName(AZStd::string_view name);
             bool CheckIsValidGroupName(AZStd::string_view name);
 
+            //! Returns the file path that would be used for an intermediate .materialtype, if there were one, for the given .materialtype path.
+            //! @param originalMaterialTypeSourcePath the path to the .materialtype
+            //! @param referencingFilePath The @originalMaterialTypeSourcePath can be relative to this path in addition to the asset root.
+            AZStd::string PredictIntermediateMaterialTypeSourcePath(const AZStd::string& originalMaterialTypeSourcePath);
+            AZStd::string PredictIntermediateMaterialTypeSourcePath(const AZStd::string& referencingFilePath, const AZStd::string& originalMaterialTypeSourcePath);
+
+            //! Checks to see if there is an intermediate .materialtype for the given .materialtype path, and returns its path.
+            AZStd::string GetIntermediateMaterialTypeSourcePath(const AZStd::string& forOriginalMaterialTypeSourcePath);
+
+            //! Returns the path of the final .materialtype path, which may be the same as the original path, or could be a different path if there is
+            //! an intermediate .materialtype file associated with this one.
+            //! @param originalMaterialTypeSourcePath the path to the .materialtype
+            //! @param referencingFilePath The @originalMaterialTypeSourcePath can be relative to this path in addition to the asset root.
+            AZStd::string GetFinalMaterialTypeSourcePath(const AZStd::string& referencingFilePath, const AZStd::string& originalMaterialTypeSourcePath);
+
+            //! Returns AssetId of the MaterialTypeAsset from the given .materialtype source file path. This will account for the possibility that there
+            //! is an intermediate .materialtype file associated with the given .materialtype.
+            //! @param originalMaterialTypeSourcePath the path to the .materialtype
+            //! @param referencingFilePath The @originalMaterialTypeSourcePath can be relative to this path in addition to the asset root.
+            Outcome<Data::AssetId> GetFinalMaterialTypeAssetId(const AZStd::string& referencingFilePath, const AZStd::string& originalMaterialTypeSourcePath);
+
+
         }
     }
 }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialTypeAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialTypeAsset.h
@@ -65,6 +65,8 @@ namespace AZ
             static const char* Group;
             static const char* Extension;
 
+            static constexpr AZ::u32 SubId = 0;
+
             static constexpr uint32_t InvalidShaderIndex = static_cast<uint32_t>(-1);
 
             //! Provides data about how to render the material in a particular render pipeline.

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -43,7 +43,7 @@ namespace AZ
         {
             AssetBuilderSDK::AssetBuilderDesc materialBuilderDescriptor;
             materialBuilderDescriptor.m_name = "Material Type Builder";
-            materialBuilderDescriptor.m_version = 36; // pipeline material functors
+            materialBuilderDescriptor.m_version = 38; // material type indirect references
             materialBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.materialtype", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             materialBuilderDescriptor.m_busId = azrtti_typeid<MaterialTypeBuilder>();
             materialBuilderDescriptor.m_createJobFunction = AZStd::bind(&MaterialTypeBuilder::CreateJobs, this, AZStd::placeholders::_1, AZStd::placeholders::_2);
@@ -364,7 +364,7 @@ namespace AZ
         {
             const AZStd::string materialTypeName = AZ::IO::Path{request.m_sourceFile}.Stem().Native();
 
-            AZ::u32 nextProductSubID = 0;
+            AZ::u32 nextProductSubID = MaterialTypeSourceData::IntermediateMaterialTypeSubId + 1;
 
             auto materialTypeLoadResult = MaterialUtils::LoadMaterialTypeSourceData(request.m_fullPath);
             if (!materialTypeLoadResult.IsSuccess())
@@ -582,7 +582,8 @@ namespace AZ
                 AssetBuilderSDK::JobProduct product;
                 product.m_outputFlags = AssetBuilderSDK::ProductOutputFlags::IntermediateAsset;
                 product.m_productFileName = outputMaterialTypeFilePath.String();
-                product.m_productSubID = nextProductSubID++;
+                product.m_productAssetType = azrtti_typeid<RPI::MaterialTypeSourceData>();
+                product.m_productSubID = MaterialTypeSourceData::IntermediateMaterialTypeSubId;
                 response.m_outputProducts.push_back(AZStd::move(product));
             }
             else

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.h
@@ -74,8 +74,8 @@ namespace AZ
 
                 enum class MaterialTypeProductSubId : u32
                 {
-                    MaterialTypeAsset = 0,
-                    AllPropertiesMaterialSourceFile = 1
+                    MaterialTypeAsset = MaterialTypeAsset::SubId,
+                    AllPropertiesMaterialSourceFile
                 };
 
             } m_finalStage;

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
@@ -130,7 +130,7 @@ namespace AZ
                 return Failure();
             }
 
-            Outcome<Data::AssetId> materialTypeAssetId = AssetUtils::MakeAssetId(materialSourceFilePath, m_materialType, 0);
+            Outcome<Data::AssetId> materialTypeAssetId = MaterialUtils::GetFinalMaterialTypeAssetId(materialSourceFilePath, m_materialType);
             if (!materialTypeAssetId)
             {
                 return Failure();
@@ -270,11 +270,12 @@ namespace AZ
                 return Failure();
             }
 
-            const auto materialTypeSourcePath = AssetUtils::ResolvePathReference(materialSourceFilePath, m_materialType);
-            const auto materialTypeAssetId = AssetUtils::MakeAssetId(materialTypeSourcePath, 0);
-            if (!materialTypeAssetId.IsSuccess())
+            const AZStd::string materialTypeSourcePath = MaterialUtils::GetFinalMaterialTypeSourcePath(materialSourceFilePath, m_materialType);
+            const auto materialTypeAssetId = MaterialUtils::GetFinalMaterialTypeAssetId(materialSourceFilePath, m_materialType);
+
+            if (!materialTypeAssetId.IsSuccess() || materialTypeSourcePath.empty())
             {
-                AZ_Error("MaterialSourceData", false, "Failed to create material type asset ID: '%s'.", materialTypeSourcePath.c_str());
+                AZ_Error("MaterialSourceData", false, "Could not find material type file: '%s'.", m_materialType.c_str());
                 return Failure();
             }
 
@@ -325,7 +326,7 @@ namespace AZ
                 MaterialSourceData parentSourceData = loadParentResult.TakeValue();
 
                 // Make sure that all materials in the hierarchy share the same material type
-                const auto parentTypeAssetId = AssetUtils::MakeAssetId(parentSourceAbsPath, parentSourceData.m_materialType, 0);
+                const auto parentTypeAssetId = MaterialUtils::GetFinalMaterialTypeAssetId(parentSourceAbsPath, parentSourceData.m_materialType);
                 if (!parentTypeAssetId)
                 {
                     AZ_Error("MaterialSourceData", false, "Parent material asset ID wasn't found: '%s'.", parentSourceAbsPath.c_str());

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialSourceDataTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialSourceDataTests.cpp
@@ -721,6 +721,7 @@ namespace UnitTest
         
         errorMessageFinder.Reset();
         errorMessageFinder.AddExpectedErrorMessage("Could not find asset for source file [DoesNotExist.materialtype]");
+        errorMessageFinder.AddIgnoredErrorMessage("Could not find material type file", true);
         errorMessageFinder.AddIgnoredErrorMessage("Failed to create material type asset ID", true);
         result = material.CreateMaterialAssetFromSourceData(AZ::Uuid::CreateRandom(), "test.material", elevateWarnings);
         EXPECT_FALSE(result.IsSuccess());


### PR DESCRIPTION
## What does this PR do?

Materials reference the original material type even when intermediate material types are involved.

This allows Material Editor to create new materials based on the original .materialtype file and both Material Editor and Material Builder understand the indirect reference to the final MaterialTypeAsset.

Also fixed a bug where child materials weren't always reprocessed when they should be, if a .materialtype is changed. See https://github.com/o3de/o3de/issues/13766

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>

## How was this PR tested?
AtomSampleViewer material screenshot test script
Created new materials in material editor, using both StandardPBR and the new pipeline based equivalent material type. Also a child material. These are processed successfully by the AP and opened successfully my Material Editor.
Tested removing and adding the pipeline test .materialtype files, saw the corresponding .material files fail, and then replaced the missing .materialtype files and saw the .material files pass again.

The only issue is that some materials will now report a warning about a missing job dependency, like this:
```
No job was found to match the job dependency criteria declared by file D:/o3de/AtomSampleViewer/Assets/NewStandardPipelineChild.material. (File: D:/o3de/Gems/Atom/TestData/TestData/Materials/Types/MaterialPipelineTest_Standard.materialtype, JobKey: Material Type Builder (Final Stage), Platform: pc)
```
Everything should still function properly. I think we can have a separate PR to address this issue. (We could use a wildcard dependency on like "StandardPBR*.materialtype", but I'd rather not do that as it would pick up other material types beyond just "StandardPBR.materialtype" and "standardpbr_generated.materialtype". Also that might not work on Linux because of the difference in case between the source file and the intermediate file. A cleaner and simpler option that I think would work would be to use the same job key for both stages of the material builder instead of separate "Material Type Builder (Pipeline Stage)" and "Material Type Builder (Final Stage)" keys.