### PR TITLE
'Be this camera' incremental improvements

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
@@ -158,7 +158,6 @@ namespace AtomToolsFramework
 
         AzFramework::Camera m_camera; //!< The current camera state (pitch/yaw/position/look-distance).
         AzFramework::Camera m_targetCamera; //!< The target (next) camera state that m_camera is catching up to.
-        AzFramework::Camera m_previousCamera; //!< The state of the camera from the previous frame.
         AZStd::optional<AzFramework::Camera> m_storedCamera; //!< A potentially stored camera for when a transform is being tracked.
         AzFramework::CameraSystem m_cameraSystem; //!< The camera system responsible for managing all CameraInputs.
         AzFramework::CameraProps m_cameraProps; //!< Camera properties to control rotate and translate smoothness.

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
@@ -139,6 +139,9 @@ namespace AtomToolsFramework
         //! transform (this is usually zero).
         AZ::Transform CombinedCameraTransform() const;
 
+        //!
+        void ReconnectViewMatrixChangeHandler();
+
         //! The current mode the camera controller is in.
         enum class CameraMode
         {

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
@@ -139,7 +139,8 @@ namespace AtomToolsFramework
         //! transform (this is usually zero).
         AZ::Transform CombinedCameraTransform() const;
 
-        //!
+        //! Reconnect the current view matrix change handler after the viewport context view group has changed.
+        //! @note: This happens after switching to track a different camera/viewport transform.
         void ReconnectViewMatrixChangeHandler();
 
         //! The current mode the camera controller is in.

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
@@ -172,13 +172,11 @@ namespace AtomToolsFramework
         controller->SetupCameraControllerPriority(m_priorityFn);
         controller->SetupCameraControllerViewportContext(m_modularCameraViewportContext);
 
-        auto handleCameraChange = [this]([[maybe_unused]] const AZ::Matrix4x4& cameraView)
+        auto handleCameraChangeFn = [this]([[maybe_unused]] const AZ::Matrix4x4& cameraView)
         {
             // ignore these updates if the camera is being updated internally
             if (!m_updatingTransformInternally)
             {
-                m_previousCamera = m_targetCamera;
-
                 const AZ::Transform transform = m_modularCameraViewportContext->GetCameraTransform();
                 const AZ::Vector3 eulerAngles = AzFramework::EulerAngles(AZ::Matrix3x3::CreateFromTransform(transform));
                 UpdateCameraFromTranslationAndRotation(m_targetCamera, transform.GetTranslation(), eulerAngles);
@@ -189,7 +187,7 @@ namespace AtomToolsFramework
             }
         };
 
-        m_cameraViewMatrixChangeHandler = AZ::RPI::MatrixChangedEvent::Handler(handleCameraChange);
+        m_cameraViewMatrixChangeHandler = AZ::RPI::MatrixChangedEvent::Handler(handleCameraChangeFn);
         m_modularCameraViewportContext->ConnectViewMatrixChangedHandler(m_cameraViewMatrixChangeHandler);
 
         ModularViewportCameraControllerRequestBus::Handler::BusConnect(viewportId);
@@ -381,7 +379,7 @@ namespace AtomToolsFramework
     {
         if (!m_storedCamera.has_value())
         {
-            m_storedCamera = m_previousCamera;
+            m_storedCamera = m_targetCamera;
         }
 
         const auto angles = AzFramework::EulerAngles(AZ::Matrix3x3::CreateFromQuaternion(worldFromLocal.GetRotation()));
@@ -390,6 +388,9 @@ namespace AtomToolsFramework
         m_targetCamera.m_offset = AZ::Vector3::CreateZero();
         m_targetCamera.m_pivot = worldFromLocal.GetTranslation();
         m_targetRoll = angles.GetY();
+
+        m_cameraViewMatrixChangeHandler.Disconnect();
+        m_modularCameraViewportContext->ConnectViewMatrixChangedHandler(m_cameraViewMatrixChangeHandler);
     }
 
     void ModularViewportCameraControllerInstance::StopTrackingTransform()
@@ -401,6 +402,9 @@ namespace AtomToolsFramework
         }
 
         m_storedCamera.reset();
+
+        m_cameraViewMatrixChangeHandler.Disconnect();
+        m_modularCameraViewportContext->ConnectViewMatrixChangedHandler(m_cameraViewMatrixChangeHandler);
     }
 
     bool ModularViewportCameraControllerInstance::IsTrackingTransform() const

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
@@ -196,6 +196,7 @@ namespace AtomToolsFramework
 
     ModularViewportCameraControllerInstance::~ModularViewportCameraControllerInstance()
     {
+        m_cameraViewMatrixChangeHandler.Disconnect();
         AzToolsFramework::ViewportInteraction::ViewportInteractionNotificationBus::Handler::BusDisconnect();
         ModularViewportCameraControllerRequestBus::Handler::BusDisconnect();
     }
@@ -389,8 +390,7 @@ namespace AtomToolsFramework
         m_targetCamera.m_pivot = worldFromLocal.GetTranslation();
         m_targetRoll = angles.GetY();
 
-        m_cameraViewMatrixChangeHandler.Disconnect();
-        m_modularCameraViewportContext->ConnectViewMatrixChangedHandler(m_cameraViewMatrixChangeHandler);
+        ReconnectViewMatrixChangeHandler();
     }
 
     void ModularViewportCameraControllerInstance::StopTrackingTransform()
@@ -403,8 +403,7 @@ namespace AtomToolsFramework
 
         m_storedCamera.reset();
 
-        m_cameraViewMatrixChangeHandler.Disconnect();
-        m_modularCameraViewportContext->ConnectViewMatrixChangedHandler(m_cameraViewMatrixChangeHandler);
+        ReconnectViewMatrixChangeHandler();
     }
 
     bool ModularViewportCameraControllerInstance::IsTrackingTransform() const
@@ -415,6 +414,12 @@ namespace AtomToolsFramework
     void ModularViewportCameraControllerInstance::OnViewportFocusOut()
     {
         ResetCameras();
+    }
+
+    void ModularViewportCameraControllerInstance::ReconnectViewMatrixChangeHandler()
+    {
+        m_cameraViewMatrixChangeHandler.Disconnect();
+        m_modularCameraViewportContext->ConnectViewMatrixChangedHandler(m_cameraViewMatrixChangeHandler);
     }
 
     AZ::Transform PlaceholderModularCameraViewportContextImpl::GetCameraTransform() const

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
@@ -390,6 +390,9 @@ namespace AtomToolsFramework
         m_targetCamera.m_pivot = worldFromLocal.GetTranslation();
         m_targetRoll = angles.GetY();
 
+        m_camera = m_targetCamera;
+        m_roll = m_targetRoll;
+
         ReconnectViewMatrixChangeHandler();
     }
 
@@ -399,6 +402,9 @@ namespace AtomToolsFramework
         {
             m_targetCamera = m_storedCamera.value();
             m_targetRoll = 0.0f;
+
+            m_camera = m_targetCamera;
+            m_roll = m_targetRoll;
         }
 
         m_storedCamera.reset();

--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -139,13 +139,7 @@ namespace Camera
 
     void CameraComponentController::DeactivateAtomView()
     {
-        if (!IsActiveView())
-        {
-            return;
-        }
-
-        auto atomViewportRequests = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get();
-        if (atomViewportRequests)
+        if (auto atomViewportRequests = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get())
         {
             const AZ::Name contextName = atomViewportRequests->GetDefaultViewportContextName();
             atomViewportRequests->PopViewGroup(contextName, m_atomCameraViewGroup);
@@ -283,8 +277,7 @@ namespace Camera
         AZ::TransformNotificationBus::Handler::BusDisconnect(m_entityId);
         CameraRequestBus::Handler::BusDisconnect(m_entityId);
 
-        auto atomViewportRequests = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get();
-        if (atomViewportRequests)
+        if (auto atomViewportRequests = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get())
         {
             AZ::RPI::ViewProviderBus::Handler::BusDisconnect(m_entityId);
             m_atomCameraViewGroup->Deactivate();
@@ -306,8 +299,8 @@ namespace Camera
 
     AZ::RPI::ViewportContextPtr CameraComponentController::GetViewportContext()
     {
-        auto atomViewportRequests = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get();
-        if (m_atomCameraViewGroup && atomViewportRequests)
+        if (auto atomViewportRequests = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get();
+            m_atomCameraViewGroup && atomViewportRequests)
         {
             return atomViewportRequests->GetDefaultViewportContext();
         }

--- a/Gems/Camera/Code/Source/ViewportCameraSelectorWindow.cpp
+++ b/Gems/Camera/Code/Source/ViewportCameraSelectorWindow.cpp
@@ -230,8 +230,6 @@ namespace Camera
             }
         }
 
-        //////////////////////////////////////////////////////////////////////////
-        /// AzToolsFramework::EditorEntityContextRequestBus::Handler
         // make sure we can only use this window while in Edit mode
         void ViewportCameraSelectorWindow::OnStartPlayInEditor()
         {


### PR DESCRIPTION
## What does this PR do?

Fixes #13525
Fixes #13763

This PR is an incremental improvement and does not fix all issues with 'Be this camera', it does however make things dramatically better (see above issues). There are still several unfortunate problems with the behavior of the `ViewportCameraSelector` and `EditorCameraComponent`. After investigating it seemed like it was going to be a longer thing to investigate and fix (likely not happening in 2022) so I wanted to get this incremental PR posted to make things a bit better in the interim. I'll do my best to return to this in the new year along with more tests to verify the behavior.

## How was this PR tested?

Tested manually in the Editor. There are several tests that cover related functionality, more will be added in future.

Note: There are still problems when you go to Game Mode while still being in 'Be this camera', and there are problems when being in 'Be this camera' and opening a new level (see https://github.com/o3de/o3de/issues/13744).

Tagging [@Darking](https://github.com/Darkinggq) for visibility as well.