### PR TITLE
fix build error in FileWatcher_linux.cpp

### DIFF
--- a/Code/Tools/AssetProcessor/Platform/Linux/native/FileWatcher/FileWatcher_linux.cpp
+++ b/Code/Tools/AssetProcessor/Platform/Linux/native/FileWatcher/FileWatcher_linux.cpp
@@ -315,8 +315,8 @@ void FileWatcher::PlatformStop()
 void FileWatcher::WatchFolderLoop()
 {
     char eventBuffer[s_inotifyReadBufferSize];
-    
-    int cycleCount = 0;
+
+    [[maybe_unused]] int cycleCount = 0;
 
     constexpr const nfds_t nfds = 2;
     struct pollfd fds[nfds];


### PR DESCRIPTION
The cycleCount variable is only read when the
ALLOW_FILEWATCHER_DEBUG_SPAM definition is 1, but it is 0 by default. Otherwise cycleCount is only assigned to, but never read.

```
o3de/Code/Tools/AssetProcessor/Platform/Linux/native/FileWatcher/FileWatcher_linux.cpp:319:9: error: variable 'cycleCount' set but not used [-Werror,-Wunused-but-set-variable]
    int cycleCount = 0;
        ^
1 error generated.
```

Signed-off-by: Be Wilson <be.wilson@kdab.com>