### PR TITLE
Fix for the MetadataManagerTests failure

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Metadata/MetadataManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Metadata/MetadataManager.cpp
@@ -92,7 +92,7 @@ namespace AzToolsFramework
         }
 
         outValue = rapidjson::Document(); // Make sure to release any existing memory if the document happens to be non-empty
-        outValue.CopyFrom(*value, document.GetAllocator());
+        outValue.CopyFrom(*value, outValue.GetAllocator());
         return true;
     }
 


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?

Fix the MetadataManagerTests failure caused by a merge.

## How was this PR tested?

MetadataManagerTests passed locally:
```
[==========] Running 11 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 11 tests from MetadataManagerTests
[ RUN      ] MetadataManagerTests.Get_FileDoesNotExist_ReturnsFalse
[       OK ] MetadataManagerTests.Get_FileDoesNotExist_ReturnsFalse (1 ms)
[ RUN      ] MetadataManagerTests.Get_EmptyFile_ReturnsFalse
[       OK ] MetadataManagerTests.Get_EmptyFile_ReturnsFalse (1 ms)
[ RUN      ] MetadataManagerTests.Get_InvalidFile_ReturnsFalse
[       OK ] MetadataManagerTests.Get_InvalidFile_ReturnsFalse (1 ms)
[ RUN      ] MetadataManagerTests.Get_InvalidKey_ReturnsFalse
[       OK ] MetadataManagerTests.Get_InvalidKey_ReturnsFalse (0 ms)
[ RUN      ] MetadataManagerTests.Set_ReturnsTrue
[       OK ] MetadataManagerTests.Set_ReturnsTrue (0 ms)
[ RUN      ] MetadataManagerTests.Set_InvalidKey_ReturnsFalse
[       OK ] MetadataManagerTests.Set_InvalidKey_ReturnsFalse (0 ms)
[ RUN      ] MetadataManagerTests.SetGet_ReadsValueCorrectly
[       OK ] MetadataManagerTests.SetGet_ReadsValueCorrectly (0 ms)
[ RUN      ] MetadataManagerTests.Get_FileExists_KeyDoesNotExist_ReturnsFalse
[       OK ] MetadataManagerTests.Get_FileExists_KeyDoesNotExist_ReturnsFalse (0 ms)
[ RUN      ] MetadataManagerTests.Get_FileVersion_ReturnsTrue
[       OK ] MetadataManagerTests.Get_FileVersion_ReturnsTrue (1 ms)
[ RUN      ] MetadataManagerTests.Set_InvalidMetadataFile_ReturnsFalse
[       OK ] MetadataManagerTests.Set_InvalidMetadataFile_ReturnsFalse (0 ms)
[ RUN      ] MetadataManagerTests.Get_OldVersion
[       OK ] MetadataManagerTests.Get_OldVersion (0 ms)
[----------] 11 tests from MetadataManagerTests (12 ms total)

[----------] Global test environment tear-down
[==========] 11 tests from 1 test case ran. (16 ms total)
[  PASSED  ] 11 tests.
```