### PR TITLE
Revert "Prefab | Remove link id in template DOM during prefab creation"

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
@@ -346,8 +346,7 @@ namespace AzToolsFramework
             HandleEntitiesAdded({ m_rootInstance->m_containerEntity.get() });
 
             AzToolsFramework::Prefab::PrefabDom dom;
-            bool success = AzToolsFramework::Prefab::PrefabDomUtils::StoreInstanceInPrefabDom(*m_rootInstance, dom,
-                AzToolsFramework::Prefab::PrefabDomUtils::StoreFlags::StripLinkIds);
+            bool success = AzToolsFramework::Prefab::PrefabDomUtils::StoreInstanceInPrefabDom(*m_rootInstance, dom);
             if (!success)
             {
                 AZ_Error(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
@@ -449,7 +449,7 @@ namespace AzToolsFramework
 
             // Convert our instance into a serialized template dom
             PrefabDom serializedInstance;
-            if (!PrefabDomUtils::StoreInstanceInPrefabDom(instance, serializedInstance, PrefabDomUtils::StoreFlags::StripLinkIds))
+            if (!PrefabDomUtils::StoreInstanceInPrefabDom(instance, serializedInstance))
             {
                 return InvalidTemplateId;
             }

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestDataUtils.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestDataUtils.cpp
@@ -57,9 +57,6 @@ namespace UnitTest
             EXPECT_EQ(expectedTemplateData.m_isValid, actualTemplate.IsValid());
             EXPECT_EQ(expectedTemplateData.m_isLoadedWithErrors, actualTemplate.IsLoadedWithErrors());
 
-            auto& actualTemplateDom = actualTemplate.GetPrefabDom();
-            EXPECT_FALSE(actualTemplateDom.HasMember(PrefabDomUtils::LinkIdName));
-
             auto& actualInstancesLinkIds = actualTemplate.GetLinks();
             EXPECT_EQ(expectedTemplateData.m_instancesData.size(), actualInstancesLinkIds.size());
             for (auto& actualLinkId : actualInstancesLinkIds)

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestFixture.cpp
@@ -225,12 +225,12 @@ namespace UnitTest
         AzToolsFramework::Prefab::PrefabDom prefabDomB;
         ASSERT_TRUE(AzToolsFramework::Prefab::PrefabDomUtils::StoreInstanceInPrefabDom(instanceB, prefabDomB));
 
-        // Validate that both instances match when serialized.
-        PrefabTestDomUtils::ComparePrefabDoms(prefabDomA, prefabDomB, shouldCompareLinkIds, shouldCompareContainerEntities);
+        // Validate that both instances match when serialized
+        PrefabTestDomUtils::ComparePrefabDoms(prefabDomA, prefabDomB, true, shouldCompareContainerEntities);
 
         // Validate that the serialized instances match the shared template when serialized
-        // Note: We do not compare the link ids. The template DOM is not supposed to have this member.
-        PrefabTestDomUtils::ComparePrefabDoms(templateA->get().GetPrefabDom(), prefabDomB, false, shouldCompareContainerEntities);
+        PrefabTestDomUtils::ComparePrefabDoms(templateA->get().GetPrefabDom(), prefabDomB, shouldCompareLinkIds,
+            shouldCompareContainerEntities);
     }
 
     void PrefabTestFixture::DeleteInstances(const InstanceList& instancesToDelete)

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestFixture.h
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestFixture.h
@@ -91,11 +91,6 @@ namespace UnitTest
         //! After prefab template is updated, we need to propagate the changes to all prefab instances.
         void PropagateAllTemplateChanges();
 
-        //! Helper function to compare two instances and asserts will be thrown if two instances are not identical.
-        //! @param instanceA The given first instance.
-        //! @param instanceB The given second instance.
-        //! @param shouldCompareLinkIds Flag of whether it compares two link ids.
-        //! @param shouldCompareContainerEntities Flag of whether it compares two container entities.
         void CompareInstances(const Instance& instanceA, const Instance& instanceB, bool shouldCompareLinkIds = true,
             bool shouldCompareContainerEntities = true);
 


### PR DESCRIPTION
Reverts o3de/o3de#13662

The AR failure is caused by a combo of this reverted PR and https://github.com/o3de/o3de/pull/13151.

Still investigating root cause...