### PR TITLE
Restore removal of 'SkipLinkIds' flag during template sanitization

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Metadata/MetadataManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Metadata/MetadataManager.cpp
@@ -92,7 +92,7 @@ namespace AzToolsFramework
         }
 
         outValue = rapidjson::Document(); // Make sure to release any existing memory if the document happens to be non-empty
-        outValue.CopyFrom(*value, document.GetAllocator());
+        outValue.CopyFrom(*value, outValue.GetAllocator());
         return true;
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.cpp
@@ -595,7 +595,8 @@ namespace AzToolsFramework
             // Prefabs are stored to disk with default values stripped. However, while in memory, we need those default values to be
             // present to make patches work consistently. To accomplish this, we'll instantiate the Dom, then serialize the instance
             // back into a Dom with all of the default values preserved.
-            // Note that this is the default behavior in Prefab serialization, so we don't need to specify StoreInstanceFlags.
+            // Note that this is the default behavior in Prefab serialization, so we don't need to specify any StoreInstanceFlags
+            // except StripLinkIds that is needed to remove link ids from template DOM.
 
             if (!loadedTemplateDom)
             {
@@ -619,8 +620,9 @@ namespace AzToolsFramework
 
             // Now that the Instance has been created, convert it back into a Prefab DOM.  Because we
             // don't specify to skip default fields in the call to StoreInstanceInPrefabDom,
-            // this new DOM will have all fields from all classes.
-            if (!PrefabDomUtils::StoreInstanceInPrefabDom(loadedPrefabInstance, loadedTemplateDomRef))
+            // this new DOM will have all fields from all classes except link ids.
+            if (!PrefabDomUtils::StoreInstanceInPrefabDom(
+                    loadedPrefabInstance, loadedTemplateDomRef, PrefabDomUtils::StoreFlags::StripLinkIds))
             {
                 return false;
             }


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

Fix AR failure in development branch.

This PR restores a flag change introduced in https://github.com/o3de/o3de/pull/13629. It was reverted during rebase in https://github.com/o3de/o3de/pull/13151.

***Why did the prefab unit tests fail?***

Between the above 2 PRs, I updated existing unit tests to check link ids in prefab template DOM in https://github.com/o3de/o3de/pull/13662. So the tests failed because of a previous bugfix reverted.

## How was this PR tested?

Passed all unit tests, automated tests.