### PR TITLE
MATH_ShapeIntersection.Test passes on Android using NEON

### DIFF
--- a/Code/Framework/AzCore/Tests/Math/ShapeIntersectionTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/ShapeIntersectionTests.cpp
@@ -15,11 +15,7 @@
 
 namespace UnitTest
 {
-#if AZ_TRAIT_DISABLE_FAILED_MATH_TESTS
-    TEST(MATH_ShapeIntersection, DISABLED_Test)
-#else
     TEST(MATH_ShapeIntersection, Test)
-#endif
     {
         //Assumes +x runs to the 'right', +y runs 'out' and +z points 'up'
 


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

`MATH_ShapeIntersection.Test` passes on Android using NEON (which is enabled by default), so enabling the test.

This test will fail on Android using Scalars when AABB dimensions are -FLT_MAX, FLT_MAX due to the usage of --ffast-math where [this trick](https://github.com/o3de/o3de/blob/development/Code/Framework/AzCore/AzCore/Math/ShapeIntersection.inl#L181-L184) doesn't work since it's optimized away.

After discussing some potential ways to address this it was concluded that it'd be better to not trying to workaround `--ffast-math` by doing some less performant solution without being absolutely necessary and since the default SIMD set in Android is NEON now and it passes, it will be left as is for the time being. If in the future this test starts failing in the same spot we can reevaluate options.

## How was this PR tested?

`MATH_ShapeIntersection.Test` passes on Android.

````
[ RUN      ] MATH_ShapeIntersection.Test
[       OK ] MATH_ShapeIntersection.Test (0 ms)
````