### PR TITLE
Fix Compile Bug

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasViewportContent.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasViewportContent.cpp
@@ -68,7 +68,7 @@ namespace MaterialCanvas
 
         // Avoid z-fighting with the cube model when double-sided rendering is enabled
         AZ::TransformBus::Event(
-            GetShadowCatcherEntityId(), &AZ::TransformInterface::SetWorldZ, -0.01);
+            GetShadowCatcherEntityId(), &AZ::TransformInterface::SetWorldZ, -0.01f);
 
         AZ::Render::MeshComponentRequestBus::Event(
             GetShadowCatcherEntityId(), &AZ::Render::MeshComponentRequestBus::Events::SetModelAssetId,

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorViewportContent.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorViewportContent.cpp
@@ -66,7 +66,7 @@ namespace MaterialEditor
 
         // Avoid z-fighting with the cube model when double-sided rendering is enabled
         AZ::TransformBus::Event(
-            GetShadowCatcherEntityId(), &AZ::TransformInterface::SetWorldZ, -0.01);
+            GetShadowCatcherEntityId(), &AZ::TransformInterface::SetWorldZ, -0.01f);
 
         AZ::Render::MeshComponentRequestBus::Event(
             GetShadowCatcherEntityId(), &AZ::Render::MeshComponentRequestBus::Events::SetModelAssetId,

--- a/Gems/Atom/Tools/PassCanvas/Code/Source/Window/PassCanvasViewportContent.cpp
+++ b/Gems/Atom/Tools/PassCanvas/Code/Source/Window/PassCanvasViewportContent.cpp
@@ -68,7 +68,7 @@ namespace PassCanvas
 
         // Avoid z-fighting with the cube model when double-sided rendering is enabled
         AZ::TransformBus::Event(
-            GetShadowCatcherEntityId(), &AZ::TransformInterface::SetWorldZ, -0.01);
+            GetShadowCatcherEntityId(), &AZ::TransformInterface::SetWorldZ, -0.01f);
 
         AZ::Render::MeshComponentRequestBus::Event(
             GetShadowCatcherEntityId(), &AZ::Render::MeshComponentRequestBus::Events::SetModelAssetId,


### PR DESCRIPTION
Signed-off-by: John Jones-Steele <82226755+jjjoness@users.noreply.github.com>

This fixes a problem with VS2022 17.4.3 that gives a warning about converting double to float which in turn generates an error. Giving a specific float as an argument fixes this.

## How was this PR tested?

Compiles correctly.
