### PR TITLE
remove deprecated functions from BoxManipulatorRequestBus

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/BoxManipulatorRequestBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/BoxManipulatorRequestBus.h
@@ -26,26 +26,8 @@ namespace AzToolsFramework
         virtual AZ::Vector3 GetDimensions() = 0;
         //! Set the X/Y/Z dimensions of the box shape/collider.
         virtual void SetDimensions(const AZ::Vector3& dimensions) = 0;
-        // O3DE_DEPRECATION_NOTICE(GHI-7572)
-        //! @deprecated Because non-uniform scale effects can be complex, it is recommended to separately use
-        //! AZ::TransformBus::Events::GetWorldTM, AZ::NonUniformScaleRequests::GetScale and GetCurrentLocalTransform
-        //! and combine their effects.
-        //! Get the transform of the box shape/collider.
-        //! This is used by \ref BoxComponentMode instead of the \ref \AZ::TransformBus
-        //! because a collider may have an additional translation/orientation offset from
-        //! the Entity transform.
-        virtual AZ::Transform GetCurrentTransform() = 0;
         //! Get the transform of the box relative to the entity.
         virtual AZ::Transform GetCurrentLocalTransform() = 0;
-        // O3DE_DEPRECATION_NOTICE(GHI-7572)
-        //! @deprecated Because non-uniform scale effects can be complex, it is recommended to separately use
-        //! AZ::TransformBus::Events::GetWorldTM, AZ::NonUniformScaleRequests::GetScale and GetCurrentLocalTransform
-        //! and combine their effects.
-        //! Get the scale currently applied to the box.
-        //! With the Box Shape, the largest x/y/z component is taken
-        //! so scale is always uniform, with colliders the scale may
-        //! be different per component.
-        virtual AZ::Vector3 GetBoxScale() = 0;
 
     protected:
         ~BoxManipulatorRequests() = default;

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorAxisAlignedBoxShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorAxisAlignedBoxShapeComponent.cpp
@@ -157,19 +157,9 @@ namespace LmbrCentral
         return m_aaboxShape.SetBoxDimensions(dimensions);
     }
 
-    AZ::Transform EditorAxisAlignedBoxShapeComponent::GetCurrentTransform()
-    {
-        return AzToolsFramework::TransformNormalizedScale(m_aaboxShape.GetCurrentTransform());
-    }
-
     AZ::Transform EditorAxisAlignedBoxShapeComponent::GetCurrentLocalTransform()
     {
         return AZ::Transform::CreateIdentity();
-    }
-
-    AZ::Vector3 EditorAxisAlignedBoxShapeComponent::GetBoxScale()
-    {
-        return AZ::Vector3(m_aaboxShape.GetCurrentTransform().GetUniformScale());
     }
 
     AZ::Aabb EditorAxisAlignedBoxShapeComponent::GetLocalBounds()

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorAxisAlignedBoxShapeComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorAxisAlignedBoxShapeComponent.h
@@ -58,9 +58,7 @@ namespace LmbrCentral
         // AzToolsFramework::BoxManipulatorRequestBus
         AZ::Vector3 GetDimensions() override;
         void SetDimensions(const AZ::Vector3& dimensions) override;
-        AZ::Transform GetCurrentTransform() override;
         AZ::Transform GetCurrentLocalTransform() override;
-        AZ::Vector3 GetBoxScale() override;
 
         void ConfigurationChanged();        
 

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorBoxShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorBoxShapeComponent.cpp
@@ -162,18 +162,8 @@ namespace LmbrCentral
         return m_boxShape.SetBoxDimensions(dimensions);
     }
 
-    AZ::Transform EditorBoxShapeComponent::GetCurrentTransform()
-    {
-        return AzToolsFramework::TransformNormalizedScale(m_boxShape.GetCurrentTransform());
-    }
-
     AZ::Transform EditorBoxShapeComponent::GetCurrentLocalTransform()
     {
         return AZ::Transform::CreateIdentity();
-    }
-
-    AZ::Vector3 EditorBoxShapeComponent::GetBoxScale()
-    {
-        return AZ::Vector3(m_boxShape.GetCurrentTransform().GetUniformScale() * m_boxShape.GetCurrentNonUniformScale());
     }
 } // namespace LmbrCentral

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorBoxShapeComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorBoxShapeComponent.h
@@ -56,9 +56,7 @@ namespace LmbrCentral
         // AzToolsFramework::BoxManipulatorRequestBus
         AZ::Vector3 GetDimensions() override;
         void SetDimensions(const AZ::Vector3& dimensions) override;
-        AZ::Transform GetCurrentTransform() override;
         AZ::Transform GetCurrentLocalTransform() override;
-        AZ::Vector3 GetBoxScale() override;
 
         void ConfigurationChanged();        
 

--- a/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
@@ -1133,19 +1133,9 @@ namespace PhysX
         CreateStaticEditorCollider();
     }
 
-    AZ::Transform EditorColliderComponent::GetCurrentTransform()
-    {
-        return GetWorldTM();
-    }
-
     AZ::Transform EditorColliderComponent::GetCurrentLocalTransform()
     {
         return GetColliderLocalTransform();
-    }
-
-    AZ::Vector3 EditorColliderComponent::GetBoxScale()
-    {
-        return AZ::Vector3::CreateOne();
     }
 
     void EditorColliderComponent::OnTransformChanged(const AZ::Transform& /*local*/, const AZ::Transform& world)

--- a/Gems/PhysX/Code/Source/EditorColliderComponent.h
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.h
@@ -198,9 +198,7 @@ namespace PhysX
         // AzToolsFramework::BoxManipulatorRequestBus
         AZ::Vector3 GetDimensions() override;
         void SetDimensions(const AZ::Vector3& dimensions) override;
-        AZ::Transform GetCurrentTransform() override;
         AZ::Transform GetCurrentLocalTransform() override;
-        AZ::Vector3 GetBoxScale() override;
 
         // AZ::Render::MeshComponentNotificationBus
         void OnModelReady(const AZ::Data::Asset<AZ::RPI::ModelAsset>& modelAsset,


### PR DESCRIPTION
Signed-off-by: greerdv <greerdv@amazon.com>

## What does this PR do?
Removes deprecated functions from BoxManipulatorRequestBus (#7572). The functions were marked with O3DE_DEPRECATION_NOTICE in #7463, prior to the 2210 release. The bus has very light usage, so moving directly to deleting the functions rather than marking with AZ_DEPRECATED.

## How was this PR tested?
Ran LmbrCentral and PhysX tests and editor tests.