### PR TITLE
Fix to prevent crash on drawing arc with negative sweep.

### DIFF
--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.cpp
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.cpp
@@ -182,7 +182,7 @@ namespace AZ::AtomBridge
         int estimatedNumLineSegments
         )
     {
-        m_points.reserve(estimatedNumLineSegments * 2);
+        m_points.reserve(AZStd::abs(estimatedNumLineSegments) * 2);
     }
 
     void SingleColorDynamicSizeLineHelper::AddLineSegment(


### PR DESCRIPTION
Signed-off-by: Michał Pełka <michal.pelka@robotec.ai>

## What does this PR do?

This PR prevents a crash on the allocation SingleColorDynamicSizeLineHelper constructor.

## How was this PR tested?

Manual testing.
