### PR TITLE
ScriptCanvas behavior class method context translation standardization

### DIFF
--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AWSScriptBehaviorDynamoDB.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AWSScriptBehaviorDynamoDB.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetItem",
-                    "context": "AWSScriptBehaviorDynamoDB",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetItem"
@@ -41,7 +40,6 @@
                 },
                 {
                     "base": "GetItemRaw",
-                    "context": "AWSScriptBehaviorDynamoDB",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetItemRaw"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AWSScriptBehaviorLambda.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AWSScriptBehaviorLambda.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "Invoke",
-                    "context": "AWSScriptBehaviorLambda",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Invoke"
@@ -40,7 +39,6 @@
                 },
                 {
                     "base": "InvokeRaw",
-                    "context": "AWSScriptBehaviorLambda",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke InvokeRaw"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AWSScriptBehaviorS3.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AWSScriptBehaviorS3.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetObject",
-                    "context": "AWSScriptBehaviorS3",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetObject"
@@ -46,7 +45,6 @@
                 },
                 {
                     "base": "GetObjectRaw",
-                    "context": "AWSScriptBehaviorS3",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetObjectRaw"
@@ -87,7 +85,6 @@
                 },
                 {
                     "base": "HeadObject",
-                    "context": "AWSScriptBehaviorS3",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke HeadObject"
@@ -116,7 +113,6 @@
                 },
                 {
                     "base": "HeadObjectRaw",
-                    "context": "AWSScriptBehaviorS3",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke HeadObjectRaw"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AZ__SceneAPI__Containers__SceneGraph.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AZ__SceneAPI__Containers__SceneGraph.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetNodeChild",
-                    "context": "AZ::SceneAPI::Containers::SceneGraph",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Node Child"
@@ -48,7 +47,6 @@
                 },
                 {
                     "base": "FindWithPath",
-                    "context": "AZ::SceneAPI::Containers::SceneGraph",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Find With Path"
@@ -85,7 +83,6 @@
                 },
                 {
                     "base": "HasNodeChild",
-                    "context": "AZ::SceneAPI::Containers::SceneGraph",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Has Node Child"
@@ -122,7 +119,6 @@
                 },
                 {
                     "base": "HasNodeParent",
-                    "context": "AZ::SceneAPI::Containers::SceneGraph",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Has Node Parent"
@@ -159,7 +155,6 @@
                 },
                 {
                     "base": "GetNodeSibling",
-                    "context": "AZ::SceneAPI::Containers::SceneGraph",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Node Sibling"
@@ -196,7 +191,6 @@
                 },
                 {
                     "base": "HasNodeSibling",
-                    "context": "AZ::SceneAPI::Containers::SceneGraph",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Has Node Sibling"
@@ -233,7 +227,6 @@
                 },
                 {
                     "base": "IsNodeEndPoint",
-                    "context": "AZ::SceneAPI::Containers::SceneGraph",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Node End Point"
@@ -270,7 +263,6 @@
                 },
                 {
                     "base": "GetNodeCount",
-                    "context": "AZ::SceneAPI::Containers::SceneGraph",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Node Count"
@@ -301,7 +293,6 @@
                 },
                 {
                     "base": "HasNodeContent",
-                    "context": "AZ::SceneAPI::Containers::SceneGraph",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Has Node Content"
@@ -338,7 +329,6 @@
                 },
                 {
                     "base": "GetNodeContent",
-                    "context": "AZ::SceneAPI::Containers::SceneGraph",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Node Content"
@@ -375,7 +365,6 @@
                 },
                 {
                     "base": "GetNodeName",
-                    "context": "AZ::SceneAPI::Containers::SceneGraph",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Node Name"
@@ -412,7 +401,6 @@
                 },
                 {
                     "base": "GetRoot",
-                    "context": "AZ::SceneAPI::Containers::SceneGraph",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Root"
@@ -443,7 +431,6 @@
                 },
                 {
                     "base": "GetNodeSeperationCharacter",
-                    "context": "AZ::SceneAPI::Containers::SceneGraph",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Node Separation Character"
@@ -466,7 +453,6 @@
                 },
                 {
                     "base": "GetNodeParent",
-                    "context": "AZ::SceneAPI::Containers::SceneGraph",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Node Parent"
@@ -503,7 +489,6 @@
                 },
                 {
                     "base": "FindWithRootAndPath",
-                    "context": "AZ::SceneAPI::Containers::SceneGraph",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Find With Root And Path"
@@ -546,7 +531,6 @@
                 },
                 {
                     "base": "IsValidName",
-                    "context": "AZ::SceneAPI::Containers::SceneGraph",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Valid Name"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AZ__SceneAPI__DataTypes__IMeshData__Face.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AZ__SceneAPI__DataTypes__IMeshData__Face.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetVertexIndex",
-                    "context": "AZ::SceneAPI::DataTypes::IMeshData::Face",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Vertex Index"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AcesParameterOverrides.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AcesParameterOverrides.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "LoadPreset",
-                    "context": "AcesParameterOverrides",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Load Preset"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AssetData.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AssetData.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetUseCount",
-                    "context": "AssetData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Use Count"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "IsLoading",
-                    "context": "AssetData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Loading"
@@ -80,7 +78,6 @@
                 },
                 {
                     "base": "IsError",
-                    "context": "AssetData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Error"
@@ -111,7 +108,6 @@
                 },
                 {
                     "base": "IsReady",
-                    "context": "AssetData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Ready"
@@ -142,7 +138,6 @@
                 },
                 {
                     "base": "GetId",
-                    "context": "AssetData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Id"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AssetId.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/AssetId.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "CreateString",
-                    "context": "AssetId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke CreateString"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "IsValid",
-                    "context": "AssetId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsValid"
@@ -73,7 +71,6 @@
                 },
                 {
                     "base": "ToString",
-                    "context": "AssetId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ToString"
@@ -104,7 +101,6 @@
                 },
                 {
                     "base": "IsEqual",
-                    "context": "AssetId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsEqual"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/BlendShapeData.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/BlendShapeData.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetUV",
-                    "context": "BlendShapeData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get UV"
@@ -54,7 +53,6 @@
                 },
                 {
                     "base": "GetTangent",
-                    "context": "BlendShapeData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Tangent"
@@ -91,7 +89,6 @@
                 },
                 {
                     "base": "GetBitangent",
-                    "context": "BlendShapeData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Bitangent"
@@ -128,7 +125,6 @@
                 },
                 {
                     "base": "GetColor",
-                    "context": "BlendShapeData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Color"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/BlendShapeDataFace.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/BlendShapeDataFace.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetVertexIndex",
-                    "context": "BlendShapeDataFace",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Vertex Index"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/CollisionEvent.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/CollisionEvent.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "GetBody1EntityId",
-                    "context": "CollisionEvent",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Body 1 Entity Id"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "GetBody2EntityId",
-                    "context": "CollisionEvent",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Body 2 Entity Id"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/ComponentId.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/ComponentId.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "IsValid",
-                    "context": "ComponentId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Valid"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "Equal",
-                    "context": "ComponentId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Equal"
@@ -79,7 +77,6 @@
                 },
                 {
                     "base": "ToString",
-                    "context": "ComponentId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke To String"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/DisplaySettingsState.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/DisplaySettingsState.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "ToString",
-                    "context": "DisplaySettingsState",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ToString"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/EditorLayerComponent.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/EditorLayerComponent.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "CreateLayerEntityFromName",
-                    "context": "EditorLayerComponent",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke CreateLayerEntityFromName"
@@ -43,7 +42,6 @@
                 },
                 {
                     "base": "RecoverLayer",
-                    "context": "EditorLayerComponent",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RecoverLayer"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Entity.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Entity.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetComponentName",
-                    "context": "Entity",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Component Name"
@@ -50,7 +49,6 @@
                 },
                 {
                     "base": "GetComponentType",
-                    "context": "Entity",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Component Type"
@@ -89,7 +87,6 @@
                 },
                 {
                     "base": "CreateComponent",
-                    "context": "Entity",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Create Component"
@@ -134,7 +131,6 @@
                 },
                 {
                     "base": "DestroyComponent",
-                    "context": "Entity",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Destroy Component"
@@ -173,7 +169,6 @@
                 },
                 {
                     "base": "FindComponentOfType",
-                    "context": "Entity",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Find Component Of Type"
@@ -212,7 +207,6 @@
                 },
                 {
                     "base": "SetComponentConfiguration",
-                    "context": "Entity",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Component Configuration"
@@ -257,7 +251,6 @@
                 },
                 {
                     "base": "IsValid",
-                    "context": "Entity",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Valid"
@@ -290,7 +283,6 @@
                 },
                 {
                     "base": "GetId",
-                    "context": "Entity",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetId"
@@ -324,7 +316,6 @@
                 },
                 {
                     "base": "GetOwningContextId",
-                    "context": "Entity",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetOwningContextId"
@@ -356,7 +347,6 @@
                 },
                 {
                     "base": "GetComponents",
-                    "context": "Entity",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Components"
@@ -389,7 +379,6 @@
                 },
                 {
                     "base": "FindAllComponentsOfType",
-                    "context": "Entity",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Find All Components Of Type"
@@ -428,7 +417,6 @@
                 },
                 {
                     "base": "GetComponentConfiguration",
-                    "context": "Entity",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Component Configuration"
@@ -473,7 +461,6 @@
                 },
                 {
                     "base": "SetName",
-                    "context": "Entity",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Name"
@@ -504,7 +491,6 @@
                 },
                 {
                     "base": "IsActivated",
-                    "context": "Entity",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Activated"
@@ -537,7 +523,6 @@
                 },
                 {
                     "base": "Activate",
-                    "context": "Entity",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Activate"
@@ -562,7 +547,6 @@
                 },
                 {
                     "base": "Deactivate",
-                    "context": "Entity",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Deactivate"
@@ -587,7 +571,6 @@
                 },
                 {
                     "base": "GetName",
-                    "context": "Entity",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Name"
@@ -620,7 +603,6 @@
                 },
                 {
                     "base": "Exists",
-                    "context": "Entity",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Exists"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/EntityComponentIdPair.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/EntityComponentIdPair.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "GetEntityId",
-                    "context": "EntityComponentIdPair",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetEntityId"
@@ -43,7 +42,6 @@
                 },
                 {
                     "base": "Equal",
-                    "context": "EntityComponentIdPair",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Equal"
@@ -81,7 +79,6 @@
                 },
                 {
                     "base": "ToString",
-                    "context": "EntityComponentIdPair",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ToString"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/EntityEntity_VM.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/EntityEntity_VM.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "ToString",
-                    "context": "EntityEntity_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ToString"
@@ -43,7 +42,6 @@
                 },
                 {
                     "base": "IsValid",
-                    "context": "EntityEntity_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsValid"
@@ -76,7 +74,6 @@
                 },
                 {
                     "base": "GetEntityForward",
-                    "context": "EntityEntity_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetEntityForward"
@@ -115,7 +112,6 @@
                 },
                 {
                     "base": "IsActive",
-                    "context": "EntityEntity_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsActive"
@@ -148,7 +144,6 @@
                 },
                 {
                     "base": "GetEntityRight",
-                    "context": "EntityEntity_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetEntityRight"
@@ -187,7 +182,6 @@
                 },
                 {
                     "base": "GetEntityUp",
-                    "context": "EntityEntity_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetEntityUp"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/EntityTransform.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/EntityTransform.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "Rotate",
-                    "context": "Entity Transform",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Rotate"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/ExportProductList.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/ExportProductList.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "AddProduct",
-                    "context": "ExportProductList",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Add Product"
@@ -40,7 +39,6 @@
                 },
                 {
                     "base": "GetProducts",
-                    "context": "ExportProductList",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Products"
@@ -63,7 +61,6 @@
                 },
                 {
                     "base": "AddDependencyToProduct",
-                    "context": "ExportProductList",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Add Dependency To Product"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/GameplayNotificationId.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/GameplayNotificationId.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "ToString",
-                    "context": "GameplayNotificationId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ToString"
@@ -43,7 +42,6 @@
                 },
                 {
                     "base": "Equal",
-                    "context": "GameplayNotificationId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Equal"
@@ -81,7 +79,6 @@
                 },
                 {
                     "base": "Clone",
-                    "context": "GameplayNotificationId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Clone"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/GradientSurfaceDataConfig.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/GradientSurfaceDataConfig.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "GetNumTags",
-                    "context": "GradientSurfaceDataConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetNumTags"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "GetTag",
-                    "context": "GradientSurfaceDataConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetTag"
@@ -80,7 +78,6 @@
                 },
                 {
                     "base": "RemoveTag",
-                    "context": "GradientSurfaceDataConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RemoveTag"
@@ -110,7 +107,6 @@
                 },
                 {
                     "base": "AddTag",
-                    "context": "GradientSurfaceDataConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke AddTag"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/IAnimationData.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/IAnimationData.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetKeyFrameCount",
-                    "context": "IAnimationData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Key Frame Count"
@@ -34,7 +33,6 @@
                 },
                 {
                     "base": "GetKeyFrame",
-                    "context": "IAnimationData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Key Frame"
@@ -65,7 +63,6 @@
                 },
                 {
                     "base": "GetTimeStepBetweenFrames",
-                    "context": "IAnimationData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Time Step Between Frames"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/IBlendShapeAnimationData.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/IBlendShapeAnimationData.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetBlendShapeName",
-                    "context": "IBlendShapeAnimationData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Blend Shape Name"
@@ -34,7 +33,6 @@
                 },
                 {
                     "base": "GetKeyFrameCount",
-                    "context": "IBlendShapeAnimationData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Key Frame Count"
@@ -57,7 +55,6 @@
                 },
                 {
                     "base": "GetKeyFrame",
-                    "context": "IBlendShapeAnimationData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Key Frame"
@@ -88,7 +85,6 @@
                 },
                 {
                     "base": "GetTimeStepBetweenFrames",
-                    "context": "IBlendShapeAnimationData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Time Step Between Frames"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/IBlendShapeData.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/IBlendShapeData.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetNormal",
-                    "context": "IBlendShapeData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Normal"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "GetFaceVertexIndex",
-                    "context": "IBlendShapeData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Face Vertex Index"
@@ -79,7 +77,6 @@
                 },
                 {
                     "base": "GetFaceInfo",
-                    "context": "IBlendShapeData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Face Info"
@@ -110,7 +107,6 @@
                 },
                 {
                     "base": "GetPosition",
-                    "context": "IBlendShapeData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Position"
@@ -141,7 +137,6 @@
                 },
                 {
                     "base": "GetUsedPointIndexForControlPoint",
-                    "context": "IBlendShapeData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Used Point Index For Control Point"
@@ -172,7 +167,6 @@
                 },
                 {
                     "base": "GetVertexCount",
-                    "context": "IBlendShapeData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Vertex Count"
@@ -195,7 +189,6 @@
                 },
                 {
                     "base": "GetFaceCount",
-                    "context": "IBlendShapeData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Face Count"
@@ -218,7 +211,6 @@
                 },
                 {
                     "base": "GetControlPointIndex",
-                    "context": "IBlendShapeData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Control Point Index"
@@ -249,7 +241,6 @@
                 },
                 {
                     "base": "GetUsedControlPointCount",
-                    "context": "IBlendShapeData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Used Control Point Count"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/IMeshData.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/IMeshData.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetUnitSizeInMeters",
-                    "context": "IMeshData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Unit Size In Meters"
@@ -34,7 +33,6 @@
                 },
                 {
                     "base": "GetOriginalUnitSizeInMeters",
-                    "context": "IMeshData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Original Unit Size In Meters"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/InputEventNotificationId.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/InputEventNotificationId.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "ToString",
-                    "context": "InputEventNotificationId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke To String"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "Equal",
-                    "context": "InputEventNotificationId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Equal"
@@ -79,7 +77,6 @@
                 },
                 {
                     "base": "Clone",
-                    "context": "InputEventNotificationId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Clone"
@@ -110,7 +107,6 @@
                 },
                 {
                     "base": "CreateInputEventNotificationId",
-                    "context": "InputEventNotificationId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Create Input Event Notification Id"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MaterialAssignment.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MaterialAssignment.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "ToString",
-                    "context": "MaterialAssignment",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke To String"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MaterialAssignmentId.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MaterialAssignmentId.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "ToString",
-                    "context": "MaterialAssignmentId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke To String"
@@ -34,7 +33,6 @@
                 },
                 {
                     "base": "IsAssetOnly",
-                    "context": "MaterialAssignmentId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Asset Only"
@@ -57,7 +55,6 @@
                 },
                 {
                     "base": "IsSlotIdOnly",
-                    "context": "MaterialAssignmentId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Slot Id Only"
@@ -80,7 +77,6 @@
                 },
                 {
                     "base": "IsLodAndSlotId",
-                    "context": "MaterialAssignmentId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Lod And Slot Id"
@@ -103,7 +99,6 @@
                 },
                 {
                     "base": "IsDefault",
-                    "context": "MaterialAssignmentId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Default"
@@ -126,7 +121,6 @@
                 },
                 {
                     "base": "IsLodAndAsset",
-                    "context": "MaterialAssignmentId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Lod And Asset"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MaterialData.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MaterialData.names
@@ -33,7 +33,6 @@
                 },
                 {
                     "base": "GetUseRoughnessMap",
-                    "context": "MaterialData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Use Roughness Map"
@@ -56,7 +55,6 @@
                 },
                 {
                     "base": "GetShininess",
-                    "context": "MaterialData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Shininess"
@@ -79,7 +77,6 @@
                 },
                 {
                     "base": "GetUseEmissiveMap",
-                    "context": "MaterialData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Use Emissive Map"
@@ -102,7 +99,6 @@
                 },
                 {
                     "base": "GetEmissiveColor",
-                    "context": "MaterialData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Emissive Color"
@@ -125,7 +121,6 @@
                 },
                 {
                     "base": "GetSpecularColor",
-                    "context": "MaterialData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Specular Color"
@@ -148,7 +143,6 @@
                 },
                 {
                     "base": "GetUniqueId",
-                    "context": "MaterialData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Unique Id"
@@ -171,7 +165,6 @@
                 },
                 {
                     "base": "GetDiffuseColor",
-                    "context": "MaterialData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Diffuse Color"
@@ -194,7 +187,6 @@
                 },
                 {
                     "base": "GetEmissiveIntensity",
-                    "context": "MaterialData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Emissive Intensity"
@@ -217,7 +209,6 @@
                 },
                 {
                     "base": "GetMaterialName",
-                    "context": "MaterialData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Material Name"
@@ -240,7 +231,6 @@
                 },
                 {
                     "base": "GetUseMetallicMap",
-                    "context": "MaterialData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Use Metallic Map"
@@ -263,7 +253,6 @@
                 },
                 {
                     "base": "GetMetallicFactor",
-                    "context": "MaterialData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Metallic Factor"
@@ -286,7 +275,6 @@
                 },
                 {
                     "base": "GetRoughnessFactor",
-                    "context": "MaterialData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Roughness Factor"
@@ -309,7 +297,6 @@
                 },
                 {
                     "base": "GetUseAOMap",
-                    "context": "MaterialData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get UseAO Map"
@@ -332,7 +319,6 @@
                 },
                 {
                     "base": "GetTexture",
-                    "context": "MaterialData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Texture"
@@ -363,7 +349,6 @@
                 },
                 {
                     "base": "IsNoDraw",
-                    "context": "MaterialData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is No Draw"
@@ -386,7 +371,6 @@
                 },
                 {
                     "base": "GetOpacity",
-                    "context": "MaterialData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Opacity"
@@ -409,7 +393,6 @@
                 },
                 {
                     "base": "GetUseColorMap",
-                    "context": "MaterialData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Use Color Map"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Math.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Math.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "DivideByNumber",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke DivideByNumber"
@@ -49,7 +48,6 @@
                 },
                 {
                     "base": "Round",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Round"
@@ -81,7 +79,6 @@
                 },
                 {
                     "base": "Sqrt",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Sqrt"
@@ -113,7 +110,6 @@
                 },
                 {
                     "base": "Mod",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Mod"
@@ -151,7 +147,6 @@
                 },
                 {
                     "base": "Ceil",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Ceil"
@@ -183,7 +178,6 @@
                 },
                 {
                     "base": "IsEven",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsEven"
@@ -215,7 +209,6 @@
                 },
                 {
                     "base": "IsClose",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsClose"
@@ -259,7 +252,6 @@
                 },
                 {
                     "base": "ArcSin",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ArcSin"
@@ -291,7 +283,6 @@
                 },
                 {
                     "base": "ArcTan",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ArcTan"
@@ -323,7 +314,6 @@
                 },
                 {
                     "base": "Max",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Max"
@@ -361,7 +351,6 @@
                 },
                 {
                     "base": "Tan",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Tan"
@@ -393,7 +382,6 @@
                 },
                 {
                     "base": "ArcTan2",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ArcTan2"
@@ -431,7 +419,6 @@
                 },
                 {
                     "base": "Floor",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Floor"
@@ -463,7 +450,6 @@
                 },
                 {
                     "base": "Min",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Min"
@@ -501,7 +487,6 @@
                 },
                 {
                     "base": "Lerp",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Lerp"
@@ -545,7 +530,6 @@
                 },
                 {
                     "base": "LerpInverse",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke LerpInverse"
@@ -589,7 +573,6 @@
                 },
                 {
                     "base": "IsOdd",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsOdd"
@@ -621,7 +604,6 @@
                 },
                 {
                     "base": "Abs",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Abs"
@@ -652,7 +634,6 @@
                 },
                 {
                     "base": "RadToDeg",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RadToDeg"
@@ -684,7 +665,6 @@
                 },
                 {
                     "base": "Sin",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Sin"
@@ -716,7 +696,6 @@
                 },
                 {
                     "base": "Cos",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Cos"
@@ -748,7 +727,6 @@
                 },
                 {
                     "base": "ArcCos",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ArcCos"
@@ -780,7 +758,6 @@
                 },
                 {
                     "base": "Sign",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Sign"
@@ -812,7 +789,6 @@
                 },
                 {
                     "base": "Clamp",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Clamp"
@@ -856,7 +832,6 @@
                 },
                 {
                     "base": "GetSinCos",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetSinCos"
@@ -892,7 +867,6 @@
                 },
                 {
                     "base": "DegToRad",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke DegToRad"
@@ -924,7 +898,6 @@
                 },
                 {
                     "base": "Pow",
-                    "context": "Math",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Pow"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathAABB_VM.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathAABB_VM.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "Overlaps",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Overlaps"
@@ -48,7 +47,6 @@
                 },
                 {
                     "base": "SurfaceArea",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke SurfaceArea"
@@ -80,7 +78,6 @@
                 },
                 {
                     "base": "ToSphere",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ToSphere"
@@ -112,7 +109,6 @@
                 },
                 {
                     "base": "FromOBB",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromOBB"
@@ -144,7 +140,6 @@
                 },
                 {
                     "base": "Translate",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Translate"
@@ -182,7 +177,6 @@
                 },
                 {
                     "base": "ContainsVector3",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ContainsVector3"
@@ -220,7 +214,6 @@
                 },
                 {
                     "base": "Distance",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Distance"
@@ -258,7 +251,6 @@
                 },
                 {
                     "base": "FromPoint",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromPoint"
@@ -290,7 +282,6 @@
                 },
                 {
                     "base": "Null",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Null"
@@ -314,7 +305,6 @@
                 },
                 {
                     "base": "YExtent",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke YExtent"
@@ -346,7 +336,6 @@
                 },
                 {
                     "base": "Clamp",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Clamp"
@@ -384,7 +373,6 @@
                 },
                 {
                     "base": "ContainsAABB",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ContainsAABB"
@@ -422,7 +410,6 @@
                 },
                 {
                     "base": "Expand",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Expand"
@@ -460,7 +447,6 @@
                 },
                 {
                     "base": "Extents",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Extents"
@@ -492,7 +478,6 @@
                 },
                 {
                     "base": "FromCenterHalfExtents",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromCenterHalfExtents"
@@ -530,7 +515,6 @@
                 },
                 {
                     "base": "GetMin",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetMin"
@@ -562,7 +546,6 @@
                 },
                 {
                     "base": "ApplyTransform",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ApplyTransform"
@@ -600,7 +583,6 @@
                 },
                 {
                     "base": "Center",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Center"
@@ -632,7 +614,6 @@
                 },
                 {
                     "base": "FromMinMax",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromMinMax"
@@ -670,7 +651,6 @@
                 },
                 {
                     "base": "IsFinite",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsFinite"
@@ -702,7 +682,6 @@
                 },
                 {
                     "base": "IsValid",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsValid"
@@ -734,7 +713,6 @@
                 },
                 {
                     "base": "GetMax",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetMax"
@@ -766,7 +744,6 @@
                 },
                 {
                     "base": "XExtent",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke XExtent"
@@ -798,7 +775,6 @@
                 },
                 {
                     "base": "AddPoint",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke AddPoint"
@@ -836,7 +812,6 @@
                 },
                 {
                     "base": "AddAABB",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke AddAABB"
@@ -874,7 +849,6 @@
                 },
                 {
                     "base": "FromCenterRadius",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromCenterRadius"
@@ -912,7 +886,6 @@
                 },
                 {
                     "base": "ZExtent",
-                    "context": "MathAABB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ZExtent"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathColor_VM.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathColor_VM.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "One",
-                    "context": "MathColor_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke One"
@@ -34,7 +33,6 @@
                 },
                 {
                     "base": "LinearToGamma",
-                    "context": "MathColor_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke LinearToGamma"
@@ -66,7 +64,6 @@
                 },
                 {
                     "base": "FromVector3",
-                    "context": "MathColor_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromVector3"
@@ -98,7 +95,6 @@
                 },
                 {
                     "base": "MultiplyByNumber",
-                    "context": "MathColor_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyByNumber"
@@ -136,7 +132,6 @@
                 },
                 {
                     "base": "Negate",
-                    "context": "MathColor_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Negate"
@@ -168,7 +163,6 @@
                 },
                 {
                     "base": "Dot3",
-                    "context": "MathColor_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Dot3"
@@ -206,7 +200,6 @@
                 },
                 {
                     "base": "Dot",
-                    "context": "MathColor_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Dot"
@@ -244,7 +237,6 @@
                 },
                 {
                     "base": "FromValues",
-                    "context": "MathColor_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromValues"
@@ -294,7 +286,6 @@
                 },
                 {
                     "base": "DivideByNumber",
-                    "context": "MathColor_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke DivideByNumber"
@@ -332,7 +323,6 @@
                 },
                 {
                     "base": "FromVector3AndNumber",
-                    "context": "MathColor_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromVector3AndNumber"
@@ -370,7 +360,6 @@
                 },
                 {
                     "base": "GammaToLinear",
-                    "context": "MathColor_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GammaToLinear"
@@ -402,7 +391,6 @@
                 },
                 {
                     "base": "IsClose",
-                    "context": "MathColor_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsClose"
@@ -446,7 +434,6 @@
                 },
                 {
                     "base": "IsZero",
-                    "context": "MathColor_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsZero"
@@ -484,7 +471,6 @@
                 },
                 {
                     "base": "MultiplyByColor",
-                    "context": "MathColor_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyByColor"
@@ -522,7 +508,6 @@
                 },
                 {
                     "base": "Add",
-                    "context": "MathColor_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Add"
@@ -560,7 +545,6 @@
                 },
                 {
                     "base": "Subtract",
-                    "context": "MathColor_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Subtract"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathCrc32_VM.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathCrc32_VM.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "FromString",
-                    "context": "MathCrc32_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromString"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathMatrix3x3_VM.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathMatrix3x3_VM.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "Transpose",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Transpose"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "Zero",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Zero"
@@ -66,7 +64,6 @@
                 },
                 {
                     "base": "Subtract",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Subtract"
@@ -104,7 +101,6 @@
                 },
                 {
                     "base": "GetElement",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetElement"
@@ -148,7 +144,6 @@
                 },
                 {
                     "base": "Invert",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Invert"
@@ -180,7 +175,6 @@
                 },
                 {
                     "base": "GetDiagonal",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetDiagonal"
@@ -212,7 +206,6 @@
                 },
                 {
                     "base": "GetColumn",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetColumn"
@@ -250,7 +243,6 @@
                 },
                 {
                     "base": "MultiplyByVector",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyByVector"
@@ -288,7 +280,6 @@
                 },
                 {
                     "base": "Add",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Add"
@@ -326,7 +317,6 @@
                 },
                 {
                     "base": "IsFinite",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsFinite"
@@ -358,7 +348,6 @@
                 },
                 {
                     "base": "DivideByNumber",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke DivideByNumber"
@@ -396,7 +385,6 @@
                 },
                 {
                     "base": "ToAdjugate",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ToAdjugate"
@@ -428,7 +416,6 @@
                 },
                 {
                     "base": "IsClose",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsClose"
@@ -472,7 +459,6 @@
                 },
                 {
                     "base": "MultiplyByMatrix",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyByMatrix"
@@ -510,7 +496,6 @@
                 },
                 {
                     "base": "IsOrthogonal",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsOrthogonal"
@@ -542,7 +527,6 @@
                 },
                 {
                     "base": "Orthogonalize",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Orthogonalize"
@@ -574,7 +558,6 @@
                 },
                 {
                     "base": "GetRows",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetRows"
@@ -606,7 +589,6 @@
                 },
                 {
                     "base": "FromCrossProduct",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromCrossProduct"
@@ -638,7 +620,6 @@
                 },
                 {
                     "base": "GetColumns",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetColumns"
@@ -670,7 +651,6 @@
                 },
                 {
                     "base": "FromTransform",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromTransform"
@@ -702,7 +682,6 @@
                 },
                 {
                     "base": "FromScale",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromScale"
@@ -734,7 +713,6 @@
                 },
                 {
                     "base": "ToScale",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ToScale"
@@ -766,7 +744,6 @@
                 },
                 {
                     "base": "FromQuaternion",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromQuaternion"
@@ -798,7 +775,6 @@
                 },
                 {
                     "base": "MultiplyByNumber",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyByNumber"
@@ -836,7 +812,6 @@
                 },
                 {
                     "base": "GetRow",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetRow"
@@ -874,7 +849,6 @@
                 },
                 {
                     "base": "FromRotationYDegrees",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromRotationYDegrees"
@@ -906,7 +880,6 @@
                 },
                 {
                     "base": "FromRows",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromRows"
@@ -950,7 +923,6 @@
                 },
                 {
                     "base": "FromDiagonal",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromDiagonal"
@@ -982,7 +954,6 @@
                 },
                 {
                     "base": "FromRotationZDegrees",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromRotationZDegrees"
@@ -1014,7 +985,6 @@
                 },
                 {
                     "base": "FromMatrix4x4",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromMatrix4x4"
@@ -1046,7 +1016,6 @@
                 },
                 {
                     "base": "FromColumns",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromColumns"
@@ -1090,7 +1059,6 @@
                 },
                 {
                     "base": "FromRotationXDegrees",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromRotationXDegrees"
@@ -1122,7 +1090,6 @@
                 },
                 {
                     "base": "ToDeterminant",
-                    "context": "MathMatrix3x3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ToDeterminant"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathMatrix4x4_VM.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathMatrix4x4_VM.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "GetRow",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetRow"
@@ -48,7 +47,6 @@
                 },
                 {
                     "base": "FromRotationXDegrees",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromRotationXDegrees"
@@ -80,7 +78,6 @@
                 },
                 {
                     "base": "FromRotationZDegrees",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromRotationZDegrees"
@@ -112,7 +109,6 @@
                 },
                 {
                     "base": "FromRows",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromRows"
@@ -162,7 +158,6 @@
                 },
                 {
                     "base": "ToScale",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ToScale"
@@ -194,7 +189,6 @@
                 },
                 {
                     "base": "FromQuaternion",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromQuaternion"
@@ -226,7 +220,6 @@
                 },
                 {
                     "base": "FromScale",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromScale"
@@ -258,7 +251,6 @@
                 },
                 {
                     "base": "FromTransform",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromTransform"
@@ -290,7 +282,6 @@
                 },
                 {
                     "base": "GetTranslation",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetTranslation"
@@ -322,7 +313,6 @@
                 },
                 {
                     "base": "FromQuaternionAndTranslation",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromQuaternionAndTranslation"
@@ -360,7 +350,6 @@
                 },
                 {
                     "base": "GetColumn",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetColumn"
@@ -398,7 +387,6 @@
                 },
                 {
                     "base": "GetDiagonal",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetDiagonal"
@@ -430,7 +418,6 @@
                 },
                 {
                     "base": "Invert",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Invert"
@@ -462,7 +449,6 @@
                 },
                 {
                     "base": "IsClose",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsClose"
@@ -506,7 +492,6 @@
                 },
                 {
                     "base": "FromMatrix3x3",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromMatrix3x3"
@@ -538,7 +523,6 @@
                 },
                 {
                     "base": "GetColumns",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetColumns"
@@ -570,7 +554,6 @@
                 },
                 {
                     "base": "GetRows",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetRows"
@@ -602,7 +585,6 @@
                 },
                 {
                     "base": "MultiplyByMatrix",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyByMatrix"
@@ -640,7 +622,6 @@
                 },
                 {
                     "base": "FromDiagonal",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromDiagonal"
@@ -672,7 +653,6 @@
                 },
                 {
                     "base": "FromRotationYDegrees",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromRotationYDegrees"
@@ -704,7 +684,6 @@
                 },
                 {
                     "base": "GetElement",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetElement"
@@ -748,7 +727,6 @@
                 },
                 {
                     "base": "Transpose",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Transpose"
@@ -780,7 +758,6 @@
                 },
                 {
                     "base": "FromColumns",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromColumns"
@@ -830,7 +807,6 @@
                 },
                 {
                     "base": "FromTranslation",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromTranslation"
@@ -862,7 +838,6 @@
                 },
                 {
                     "base": "IsFinite",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsFinite"
@@ -894,7 +869,6 @@
                 },
                 {
                     "base": "MultiplyByVector",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyByVector"
@@ -932,7 +906,6 @@
                 },
                 {
                     "base": "Zero",
-                    "context": "MathMatrix4x4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Zero"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathOBB_VM.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathOBB_VM.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "GetPosition",
-                    "context": "MathOBB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetPosition"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "GetAxisY",
-                    "context": "MathOBB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetAxisY"
@@ -74,7 +72,6 @@
                 },
                 {
                     "base": "GetAxisX",
-                    "context": "MathOBB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetAxisX"
@@ -106,7 +103,6 @@
                 },
                 {
                     "base": "FromAabb",
-                    "context": "MathOBB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromAabb"
@@ -138,7 +134,6 @@
                 },
                 {
                     "base": "FromPositionRotationAndHalfLengths",
-                    "context": "MathOBB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromPositionRotationAndHalfLengths"
@@ -182,7 +177,6 @@
                 },
                 {
                     "base": "GetAxisZ",
-                    "context": "MathOBB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetAxisZ"
@@ -214,7 +208,6 @@
                 },
                 {
                     "base": "IsFinite",
-                    "context": "MathOBB_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsFinite"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathPlane_VM.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathPlane_VM.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "GetPlaneEquationCoefficients",
-                    "context": "MathPlane_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetPlaneEquationCoefficients"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "GetDistance",
-                    "context": "MathPlane_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetDistance"
@@ -74,7 +72,6 @@
                 },
                 {
                     "base": "Project",
-                    "context": "MathPlane_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Project"
@@ -112,7 +109,6 @@
                 },
                 {
                     "base": "FromNormalAndPoint",
-                    "context": "MathPlane_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromNormalAndPoint"
@@ -150,7 +146,6 @@
                 },
                 {
                     "base": "IsFinite",
-                    "context": "MathPlane_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsFinite"
@@ -182,7 +177,6 @@
                 },
                 {
                     "base": "Transform",
-                    "context": "MathPlane_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Transform"
@@ -220,7 +214,6 @@
                 },
                 {
                     "base": "DistanceToPoint",
-                    "context": "MathPlane_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke DistanceToPoint"
@@ -258,7 +251,6 @@
                 },
                 {
                     "base": "FromCoefficients",
-                    "context": "MathPlane_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromCoefficients"
@@ -308,7 +300,6 @@
                 },
                 {
                     "base": "FromNormalAndDistance",
-                    "context": "MathPlane_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromNormalAndDistance"
@@ -346,7 +337,6 @@
                 },
                 {
                     "base": "GetNormal",
-                    "context": "MathPlane_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetNormal"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathQuaternion_VM.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathQuaternion_VM.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "Subtract",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Subtract"
@@ -48,7 +47,6 @@
                 },
                 {
                     "base": "RotationYDegrees",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RotationYDegrees"
@@ -80,7 +78,6 @@
                 },
                 {
                     "base": "Normalize",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Normalize"
@@ -112,7 +109,6 @@
                 },
                 {
                     "base": "LengthReciprocal",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke LengthReciprocal"
@@ -144,7 +140,6 @@
                 },
                 {
                     "base": "CreateFromEulerAngles",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke CreateFromEulerAngles"
@@ -188,7 +183,6 @@
                 },
                 {
                     "base": "IsIdentity",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsIdentity"
@@ -226,7 +220,6 @@
                 },
                 {
                     "base": "FromTransform",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromTransform"
@@ -258,7 +251,6 @@
                 },
                 {
                     "base": "Lerp",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Lerp"
@@ -302,7 +294,6 @@
                 },
                 {
                     "base": "RotationZDegrees",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RotationZDegrees"
@@ -334,7 +325,6 @@
                 },
                 {
                     "base": "ConvertTransformToRotation",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ConvertTransformToRotation"
@@ -366,7 +356,6 @@
                 },
                 {
                     "base": "ShortestArc",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ShortestArc"
@@ -404,7 +393,6 @@
                 },
                 {
                     "base": "RotationXDegrees",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RotationXDegrees"
@@ -436,7 +424,6 @@
                 },
                 {
                     "base": "IsZero",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsZero"
@@ -474,7 +461,6 @@
                 },
                 {
                     "base": "IsClose",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsClose"
@@ -518,7 +504,6 @@
                 },
                 {
                     "base": "Length",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Length"
@@ -550,7 +535,6 @@
                 },
                 {
                     "base": "Conjugate",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Conjugate"
@@ -582,7 +566,6 @@
                 },
                 {
                     "base": "ToAngleDegrees",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ToAngleDegrees"
@@ -614,7 +597,6 @@
                 },
                 {
                     "base": "Dot",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Dot"
@@ -652,7 +634,6 @@
                 },
                 {
                     "base": "Negate",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Negate"
@@ -684,7 +665,6 @@
                 },
                 {
                     "base": "Add",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Add"
@@ -722,7 +702,6 @@
                 },
                 {
                     "base": "MultiplyByNumber",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyByNumber"
@@ -760,7 +739,6 @@
                 },
                 {
                     "base": "Slerp",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Slerp"
@@ -804,7 +782,6 @@
                 },
                 {
                     "base": "InvertFull",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke InvertFull"
@@ -836,7 +813,6 @@
                 },
                 {
                     "base": "FromMatrix4x4",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromMatrix4x4"
@@ -868,7 +844,6 @@
                 },
                 {
                     "base": "RotateVector3",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RotateVector3"
@@ -906,7 +881,6 @@
                 },
                 {
                     "base": "FromMatrix3x3",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromMatrix3x3"
@@ -938,7 +912,6 @@
                 },
                 {
                     "base": "Squad",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Squad"
@@ -994,7 +967,6 @@
                 },
                 {
                     "base": "FromAxisAngleDegrees",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromAxisAngleDegrees"
@@ -1032,7 +1004,6 @@
                 },
                 {
                     "base": "LengthSquared",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke LengthSquared"
@@ -1064,7 +1035,6 @@
                 },
                 {
                     "base": "IsFinite",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsFinite"
@@ -1096,7 +1066,6 @@
                 },
                 {
                     "base": "DivideByNumber",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke DivideByNumber"
@@ -1134,7 +1103,6 @@
                 },
                 {
                     "base": "MultiplyByRotation",
-                    "context": "MathQuaternion_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyByRotation"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathRandom_VM.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathRandom_VM.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "RandomPointOnSphere",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomPointOnSphere"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "RandomPointInCircle",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomPointInCircle"
@@ -74,7 +72,6 @@
                 },
                 {
                     "base": "RandomPointInSquare",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomPointInSquare"
@@ -106,7 +103,6 @@
                 },
                 {
                     "base": "RandomUnitVector2",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomUnitVector2"
@@ -130,7 +126,6 @@
                 },
                 {
                     "base": "RandomVector2",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomVector2"
@@ -168,7 +163,6 @@
                 },
                 {
                     "base": "RandomPointInCylinder",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomPointInCylinder"
@@ -206,7 +200,6 @@
                 },
                 {
                     "base": "RandomQuaternion",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomQuaternion"
@@ -244,7 +237,6 @@
                 },
                 {
                     "base": "RandomVector4",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomVector4"
@@ -282,7 +274,6 @@
                 },
                 {
                     "base": "RandomPointInBox",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomPointInBox"
@@ -314,7 +305,6 @@
                 },
                 {
                     "base": "RandomPointOnCircle",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomPointOnCircle"
@@ -346,7 +336,6 @@
                 },
                 {
                     "base": "RandomPointInEllipsoid",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomPointInEllipsoid"
@@ -378,7 +367,6 @@
                 },
                 {
                     "base": "RandomInteger",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomInteger"
@@ -416,7 +404,6 @@
                 },
                 {
                     "base": "RandomPointInWedge",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomPointInWedge"
@@ -478,7 +465,6 @@
                 },
                 {
                     "base": "RandomGrayscale",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomGrayscale"
@@ -516,7 +502,6 @@
                 },
                 {
                     "base": "RandomPointInCone",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomPointInCone"
@@ -554,7 +539,6 @@
                 },
                 {
                     "base": "RandomColor",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomColor"
@@ -592,7 +576,6 @@
                 },
                 {
                     "base": "RandomNumber",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomNumber"
@@ -630,7 +613,6 @@
                 },
                 {
                     "base": "RandomPointInSphere",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomPointInSphere"
@@ -662,7 +644,6 @@
                 },
                 {
                     "base": "RandomUnitVector3",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomUnitVector3"
@@ -686,7 +667,6 @@
                 },
                 {
                     "base": "RandomVector3",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomVector3"
@@ -724,7 +704,6 @@
                 },
                 {
                     "base": "RandomPointInArc",
-                    "context": "MathRandom_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RandomPointInArc"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathTransform_VM.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathTransform_VM.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "RotationZDegrees",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RotationZDegrees"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "GetUp",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetUp"
@@ -80,7 +78,6 @@
                 },
                 {
                     "base": "GetForward",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetForward"
@@ -118,7 +115,6 @@
                 },
                 {
                     "base": "IsClose",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsClose"
@@ -162,7 +158,6 @@
                 },
                 {
                     "base": "RotationXDegrees",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RotationXDegrees"
@@ -194,7 +189,6 @@
                 },
                 {
                     "base": "FromTranslation",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromTranslation"
@@ -226,7 +220,6 @@
                 },
                 {
                     "base": "IsFinite",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsFinite"
@@ -258,7 +251,6 @@
                 },
                 {
                     "base": "MultiplyByUniformScale",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyByUniformScale"
@@ -296,7 +288,6 @@
                 },
                 {
                     "base": "MultiplyByTransform",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyByTransform"
@@ -334,7 +325,6 @@
                 },
                 {
                     "base": "FromRotation",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromRotation"
@@ -366,7 +356,6 @@
                 },
                 {
                     "base": "RotationYDegrees",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RotationYDegrees"
@@ -398,7 +387,6 @@
                 },
                 {
                     "base": "FromRotationAndTranslation",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromRotationAndTranslation"
@@ -436,7 +424,6 @@
                 },
                 {
                     "base": "MultiplyByVector3",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyByVector3"
@@ -474,7 +461,6 @@
                 },
                 {
                     "base": "MultiplyByVector4",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyByVector4"
@@ -512,7 +498,6 @@
                 },
                 {
                     "base": "ToScale",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ToScale"
@@ -544,7 +529,6 @@
                 },
                 {
                     "base": "FromMatrix3x3",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromMatrix3x3"
@@ -576,7 +560,6 @@
                 },
                 {
                     "base": "GetRight",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetRight"
@@ -614,7 +597,6 @@
                 },
                 {
                     "base": "IsOrthogonal",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsOrthogonal"
@@ -652,7 +634,6 @@
                 },
                 {
                     "base": "Orthogonalize",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Orthogonalize"
@@ -684,7 +665,6 @@
                 },
                 {
                     "base": "FromMatrix3x3AndTranslation",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromMatrix3x3AndTranslation"
@@ -722,7 +702,6 @@
                 },
                 {
                     "base": "FromScale",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromScale"
@@ -754,7 +733,6 @@
                 },
                 {
                     "base": "GetTranslation",
-                    "context": "MathTransform_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetTranslation"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathUtils.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathUtils.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "ConvertEulerDegreesToQuaternion",
-                    "context": "MathUtils",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Convert Euler Angles To Quaternion"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "ConvertEulerDegreesToTransformPrecise",
-                    "context": "MathUtils",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Convert Euler Angles To Transform (Precise)"
@@ -74,7 +72,6 @@
                 },
                 {
                     "base": "ConvertEulerDegreesToTransform",
-                    "context": "MathUtils",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Convert Euler Angles To Transform"
@@ -105,7 +102,6 @@
                 },
                 {
                     "base": "ConvertQuaternionToEulerRadians",
-                    "context": "MathUtils",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Convert Quaternion To Euler Angles (Radians)"
@@ -136,7 +132,6 @@
                 },
                 {
                     "base": "CreateLookAt",
-                    "context": "MathUtils",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Create Look At"
@@ -180,7 +175,6 @@
                 },
                 {
                     "base": "ConvertTransformToEulerRadians",
-                    "context": "MathUtils",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Convert Transform To Euler Angles (Radians)"
@@ -211,7 +205,6 @@
                 },
                 {
                     "base": "ConvertQuaternionToEulerDegrees",
-                    "context": "MathUtils",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Convert Quaternion To Euler Angles (Degrees)"
@@ -242,7 +235,6 @@
                 },
                 {
                     "base": "ConvertTransformToEulerDegrees",
-                    "context": "MathUtils",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Convert Transform To Euler Angles (Degrees)"
@@ -273,7 +265,6 @@
                 },
                 {
                     "base": "ConvertEulerRadiansToQuaternion",
-                    "context": "MathUtils",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Convert Euler Angles (Radians) To Quaternion"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathVector2_VM.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathVector2_VM.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "DirectionTo",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke DirectionTo"
@@ -54,7 +53,6 @@
                 },
                 {
                     "base": "Subtract",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Subtract"
@@ -92,7 +90,6 @@
                 },
                 {
                     "base": "Project",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Project"
@@ -130,7 +127,6 @@
                 },
                 {
                     "base": "Distance",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Distance"
@@ -168,7 +164,6 @@
                 },
                 {
                     "base": "FromValues",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromValues"
@@ -206,7 +201,6 @@
                 },
                 {
                     "base": "Dot",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Dot"
@@ -244,7 +238,6 @@
                 },
                 {
                     "base": "Angle",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Angle"
@@ -276,7 +269,6 @@
                 },
                 {
                     "base": "Negate",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Negate"
@@ -308,7 +300,6 @@
                 },
                 {
                     "base": "MultiplyByVector",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyByVector"
@@ -346,7 +337,6 @@
                 },
                 {
                     "base": "Add",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Add"
@@ -384,7 +374,6 @@
                 },
                 {
                     "base": "Clamp",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Clamp"
@@ -428,7 +417,6 @@
                 },
                 {
                     "base": "MultiplyByNumber",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyByNumber"
@@ -466,7 +454,6 @@
                 },
                 {
                     "base": "Slerp",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Slerp"
@@ -510,7 +497,6 @@
                 },
                 {
                     "base": "IsZero",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsZero"
@@ -548,7 +534,6 @@
                 },
                 {
                     "base": "SetY",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke SetY"
@@ -586,7 +571,6 @@
                 },
                 {
                     "base": "IsClose",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsClose"
@@ -630,7 +614,6 @@
                 },
                 {
                     "base": "DivideByNumber",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke DivideByNumber"
@@ -668,7 +651,6 @@
                 },
                 {
                     "base": "IsNormalized",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsNormalized"
@@ -706,7 +688,6 @@
                 },
                 {
                     "base": "LengthSquared",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke LengthSquared"
@@ -738,7 +719,6 @@
                 },
                 {
                     "base": "IsFinite",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsFinite"
@@ -770,7 +750,6 @@
                 },
                 {
                     "base": "ToPerpendicular",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ToPerpendicular"
@@ -802,7 +781,6 @@
                 },
                 {
                     "base": "Normalize",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Normalize"
@@ -834,7 +812,6 @@
                 },
                 {
                     "base": "Max",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Max"
@@ -872,7 +849,6 @@
                 },
                 {
                     "base": "GetElement",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetElement"
@@ -910,7 +886,6 @@
                 },
                 {
                     "base": "Absolute",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Absolute"
@@ -942,7 +917,6 @@
                 },
                 {
                     "base": "SetX",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke SetX"
@@ -980,7 +954,6 @@
                 },
                 {
                     "base": "Min",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Min"
@@ -1018,7 +991,6 @@
                 },
                 {
                     "base": "DivideByVector",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke DivideByVector"
@@ -1056,7 +1028,6 @@
                 },
                 {
                     "base": "DistanceSquared",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke DistanceSquared"
@@ -1094,7 +1065,6 @@
                 },
                 {
                     "base": "Length",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Length"
@@ -1126,7 +1096,6 @@
                 },
                 {
                     "base": "Lerp",
-                    "context": "MathVector2_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Lerp"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathVector3_VM.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathVector3_VM.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "Reciprocal",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Reciprocal"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "Subtract",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Subtract"
@@ -80,7 +78,6 @@
                 },
                 {
                     "base": "Project",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Project"
@@ -118,7 +115,6 @@
                 },
                 {
                     "base": "Normalize",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Normalize"
@@ -150,7 +146,6 @@
                 },
                 {
                     "base": "Distance",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Distance"
@@ -188,7 +183,6 @@
                 },
                 {
                     "base": "SetZ",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke SetZ"
@@ -226,7 +220,6 @@
                 },
                 {
                     "base": "Max",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Max"
@@ -264,7 +257,6 @@
                 },
                 {
                     "base": "GetElement",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetElement"
@@ -302,7 +294,6 @@
                 },
                 {
                     "base": "Absolute",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Absolute"
@@ -334,7 +325,6 @@
                 },
                 {
                     "base": "BuildTangentBasis",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke BuildTangentBasis"
@@ -366,7 +356,6 @@
                 },
                 {
                     "base": "Clamp",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Clamp"
@@ -410,7 +399,6 @@
                 },
                 {
                     "base": "MultiplyByNumber",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyByNumber"
@@ -448,7 +436,6 @@
                 },
                 {
                     "base": "Slerp",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Slerp"
@@ -492,7 +479,6 @@
                 },
                 {
                     "base": "IsZero",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsZero"
@@ -530,7 +516,6 @@
                 },
                 {
                     "base": "SetY",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke SetY"
@@ -568,7 +553,6 @@
                 },
                 {
                     "base": "IsClose",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsClose"
@@ -612,7 +596,6 @@
                 },
                 {
                     "base": "Cross",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Cross"
@@ -650,7 +633,6 @@
                 },
                 {
                     "base": "DirectionTo",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke DirectionTo"
@@ -694,7 +676,6 @@
                 },
                 {
                     "base": "MultiplyByVector",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyByVector"
@@ -732,7 +713,6 @@
                 },
                 {
                     "base": "Negate",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Negate"
@@ -764,7 +744,6 @@
                 },
                 {
                     "base": "Add",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Add"
@@ -802,7 +781,6 @@
                 },
                 {
                     "base": "IsPerpendicular",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsPerpendicular"
@@ -846,7 +824,6 @@
                 },
                 {
                     "base": "IsFinite",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsFinite"
@@ -878,7 +855,6 @@
                 },
                 {
                     "base": "DivideByNumber",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke DivideByNumber"
@@ -916,7 +892,6 @@
                 },
                 {
                     "base": "IsNormalized",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsNormalized"
@@ -954,7 +929,6 @@
                 },
                 {
                     "base": "LengthSquared",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke LengthSquared"
@@ -986,7 +960,6 @@
                 },
                 {
                     "base": "FromValues",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromValues"
@@ -1030,7 +1003,6 @@
                 },
                 {
                     "base": "Dot",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Dot"
@@ -1068,7 +1040,6 @@
                 },
                 {
                     "base": "SetX",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke SetX"
@@ -1106,7 +1077,6 @@
                 },
                 {
                     "base": "LengthReciprocal",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke LengthReciprocal"
@@ -1138,7 +1108,6 @@
                 },
                 {
                     "base": "Min",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Min"
@@ -1176,7 +1145,6 @@
                 },
                 {
                     "base": "DistanceSquared",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke DistanceSquared"
@@ -1214,7 +1182,6 @@
                 },
                 {
                     "base": "Length",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Length"
@@ -1246,7 +1213,6 @@
                 },
                 {
                     "base": "DivideByVector",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke DivideByVector"
@@ -1284,7 +1250,6 @@
                 },
                 {
                     "base": "Lerp",
-                    "context": "MathVector3_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Lerp"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathVector4_VM.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MathVector4_VM.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "SetW",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke SetW"
@@ -48,7 +47,6 @@
                 },
                 {
                     "base": "SetX",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke SetX"
@@ -86,7 +84,6 @@
                 },
                 {
                     "base": "IsNormalized",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsNormalized"
@@ -124,7 +121,6 @@
                 },
                 {
                     "base": "LengthSquared",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke LengthSquared"
@@ -156,7 +152,6 @@
                 },
                 {
                     "base": "MultiplyByNumber",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyByNumber"
@@ -194,7 +189,6 @@
                 },
                 {
                     "base": "Negate",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Negate"
@@ -226,7 +220,6 @@
                 },
                 {
                     "base": "Dot",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Dot"
@@ -264,7 +257,6 @@
                 },
                 {
                     "base": "FromValues",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke FromValues"
@@ -314,7 +306,6 @@
                 },
                 {
                     "base": "IsFinite",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsFinite"
@@ -346,7 +337,6 @@
                 },
                 {
                     "base": "Length",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Length"
@@ -378,7 +368,6 @@
                 },
                 {
                     "base": "MultiplyByVector",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyByVector"
@@ -416,7 +405,6 @@
                 },
                 {
                     "base": "DirectionTo",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke DirectionTo"
@@ -460,7 +448,6 @@
                 },
                 {
                     "base": "DivideByVector",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke DivideByVector"
@@ -498,7 +485,6 @@
                 },
                 {
                     "base": "LengthReciprocal",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke LengthReciprocal"
@@ -530,7 +516,6 @@
                 },
                 {
                     "base": "SetZ",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke SetZ"
@@ -568,7 +553,6 @@
                 },
                 {
                     "base": "Normalize",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Normalize"
@@ -600,7 +584,6 @@
                 },
                 {
                     "base": "DivideByNumber",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke DivideByNumber"
@@ -638,7 +621,6 @@
                 },
                 {
                     "base": "IsClose",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsClose"
@@ -682,7 +664,6 @@
                 },
                 {
                     "base": "IsZero",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsZero"
@@ -720,7 +701,6 @@
                 },
                 {
                     "base": "Add",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Add"
@@ -758,7 +738,6 @@
                 },
                 {
                     "base": "GetElement",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetElement"
@@ -796,7 +775,6 @@
                 },
                 {
                     "base": "Reciprocal",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Reciprocal"
@@ -828,7 +806,6 @@
                 },
                 {
                     "base": "Subtract",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Subtract"
@@ -866,7 +843,6 @@
                 },
                 {
                     "base": "Absolute",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Absolute"
@@ -898,7 +874,6 @@
                 },
                 {
                     "base": "SetY",
-                    "context": "MathVector4_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke SetY"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Math_VM.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Math_VM.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "ThreeGeneric",
-                    "context": "Math_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ThreeGeneric"
@@ -54,7 +53,6 @@
                 },
                 {
                     "base": "MultiplyAndAdd",
-                    "context": "Math_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke MultiplyAndAdd"
@@ -98,7 +96,6 @@
                 },
                 {
                     "base": "StringToNumber",
-                    "context": "Math_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke StringToNumber"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MeshData.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MeshData.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetVertexIndex",
-                    "context": "MeshData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Vertex Index"
@@ -48,7 +47,6 @@
                 },
                 {
                     "base": "GetPosition",
-                    "context": "MeshData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Position"
@@ -79,7 +77,6 @@
                 },
                 {
                     "base": "GetFaceInfo",
-                    "context": "MeshData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Face Info"
@@ -110,7 +107,6 @@
                 },
                 {
                     "base": "HasNormalData",
-                    "context": "MeshData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Has Normal Data"
@@ -133,7 +129,6 @@
                 },
                 {
                     "base": "GetNormal",
-                    "context": "MeshData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Normal"
@@ -164,7 +159,6 @@
                 },
                 {
                     "base": "GetUsedPointIndexForControlPoint",
-                    "context": "MeshData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Used Point Index For Control Point"
@@ -195,7 +189,6 @@
                 },
                 {
                     "base": "GetVertexCount",
-                    "context": "MeshData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Vertex Count"
@@ -218,7 +211,6 @@
                 },
                 {
                     "base": "GetFaceCount",
-                    "context": "MeshData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Face Count"
@@ -241,7 +233,6 @@
                 },
                 {
                     "base": "GetUsedControlPointCount",
-                    "context": "MeshData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Used Control Point Count"
@@ -264,7 +255,6 @@
                 },
                 {
                     "base": "GetFaceMaterialId",
-                    "context": "MeshData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Face Material Id"
@@ -295,7 +285,6 @@
                 },
                 {
                     "base": "GetControlPointIndex",
-                    "context": "MeshData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Control Point Index"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MeshVertexBitangentData.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MeshVertexBitangentData.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetCount",
-                    "context": "MeshVertexBitangentData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Count"
@@ -34,7 +33,6 @@
                 },
                 {
                     "base": "GetBitangent",
-                    "context": "MeshVertexBitangentData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Bitangent"
@@ -65,7 +63,6 @@
                 },
                 {
                     "base": "GetBitangentSetIndex",
-                    "context": "MeshVertexBitangentData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Bitangent Set Index"
@@ -88,7 +85,6 @@
                 },
                 {
                     "base": "GetGenerationMethod",
-                    "context": "MeshVertexBitangentData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Generation Method"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MeshVertexColorData.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MeshVertexColorData.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetCustomName",
-                    "context": "MeshVertexColorData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Custom Name"
@@ -34,7 +33,6 @@
                 },
                 {
                     "base": "GetCount",
-                    "context": "MeshVertexColorData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Count"
@@ -57,7 +55,6 @@
                 },
                 {
                     "base": "GetColor",
-                    "context": "MeshVertexColorData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Color"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MeshVertexTangentData.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MeshVertexTangentData.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetCount",
-                    "context": "MeshVertexTangentData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Count"
@@ -34,7 +33,6 @@
                 },
                 {
                     "base": "GetTangent",
-                    "context": "MeshVertexTangentData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Tangent"
@@ -65,7 +63,6 @@
                 },
                 {
                     "base": "GetTangentSetIndex",
-                    "context": "MeshVertexTangentData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Tangent Set Index"
@@ -88,7 +85,6 @@
                 },
                 {
                     "base": "GetGenerationMethod",
-                    "context": "MeshVertexTangentData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Generation Method"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MeshVertexUVData.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MeshVertexUVData.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetCustomName",
-                    "context": "MeshVertexUVData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Custom Name"
@@ -34,7 +33,6 @@
                 },
                 {
                     "base": "GetCount",
-                    "context": "MeshVertexUVData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Count"
@@ -57,7 +55,6 @@
                 },
                 {
                     "base": "GetUV",
-                    "context": "MeshVertexUVData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetUV"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MixedGradientConfig.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MixedGradientConfig.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "GetNumLayers",
-                    "context": "MixedGradientConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetNumLayers"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "AddLayer",
-                    "context": "MixedGradientConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke AddLayer"
@@ -66,7 +64,6 @@
                 },
                 {
                     "base": "RemoveLayer",
-                    "context": "MixedGradientConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RemoveLayer"
@@ -96,7 +93,6 @@
                 },
                 {
                     "base": "GetLayer",
-                    "context": "MixedGradientConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetLayer"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MultiplayerSystemComponent.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/MultiplayerSystemComponent.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "GetOnClientDisconnectedEvent",
-                    "context": "MultiplayerSystemComponent",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get On Client Disconnected Event"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Name.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Name.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "ToString",
-                    "context": "Name",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke To String"
@@ -34,7 +33,6 @@
                 },
                 {
                     "base": "Set",
-                    "context": "Name",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set"
@@ -63,7 +61,6 @@
                 },
                 {
                     "base": "IsEmpty",
-                    "context": "Name",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Empty"
@@ -86,7 +83,6 @@
                 },
                 {
                     "base": "Equal",
-                    "context": "Name",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Equal"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/NetBindComponent.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/NetBindComponent.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "IsNetEntityRoleAuthority",
-                    "context": "NetBindComponent",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Net Entity Role Authority"
@@ -44,7 +43,6 @@
                 },
                 {
                     "base": "IsNetEntityRoleAutonomous",
-                    "context": "NetBindComponent",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsNetEntityRoleAutonomous"
@@ -77,7 +75,6 @@
                 },
                 {
                     "base": "IsNetEntityRoleClient",
-                    "context": "NetBindComponent",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Role Client"
@@ -110,7 +107,6 @@
                 },
                 {
                     "base": "IsNetEntityRoleServer",
-                    "context": "NetBindComponent",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Role Server"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/NodeIndex.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/NodeIndex.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "Equal",
-                    "context": "NodeIndex",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Equal"
@@ -41,7 +40,6 @@
                 },
                 {
                     "base": "ToString",
-                    "context": "NodeIndex",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke To String"
@@ -64,7 +62,6 @@
                 },
                 {
                     "base": "IsValid",
-                    "context": "NodeIndex",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Valid"
@@ -87,7 +84,6 @@
                 },
                 {
                     "base": "Distance",
-                    "context": "NodeIndex",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Distance"
@@ -118,7 +114,6 @@
                 },
                 {
                     "base": "AsNumber",
-                    "context": "NodeIndex",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke As Number"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/PhysicsScene.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/PhysicsScene.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "GetOnGravityChangeEvent",
-                    "context": "PhysicsScene",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get On Gravity Change Event"
@@ -41,7 +40,6 @@
                 },
                 {
                     "base": "QueryScene",
-                    "context": "PhysicsScene",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Query Scene"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/PhysicsSystemInterface.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/PhysicsSystemInterface.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetOnPresimulateEvent",
-                    "context": "PhysicsSystemInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get On Pre Simulate Event"
@@ -34,7 +33,6 @@
                 },
                 {
                     "base": "GetOnPostsimulateEvent",
-                    "context": "PhysicsSystemInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get On Post Simulate Event"
@@ -57,7 +55,6 @@
                 },
                 {
                     "base": "GetSceneHandle",
-                    "context": "PhysicsSystemInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Scene Handle"
@@ -94,7 +91,6 @@
                 },
                 {
                     "base": "GetScene",
-                    "context": "PhysicsSystemInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Scene"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Platform.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Platform.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetName",
-                    "context": "Platform",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Name"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/PropertyTreeEditor.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/PropertyTreeEditor.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "ResetContainer",
-                    "context": "PropertyTreeEditor",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ResetContainer"
@@ -48,7 +47,6 @@
                 },
                 {
                     "base": "CompareProperty",
-                    "context": "PropertyTreeEditor",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke CompareProperty"
@@ -92,7 +90,6 @@
                 },
                 {
                     "base": "IsContainer",
-                    "context": "PropertyTreeEditor",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsContainer"
@@ -130,7 +127,6 @@
                 },
                 {
                     "base": "GetContainerCount",
-                    "context": "PropertyTreeEditor",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetContainerCount"
@@ -168,7 +164,6 @@
                 },
                 {
                     "base": "SetProperty",
-                    "context": "PropertyTreeEditor",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke SetProperty"
@@ -212,7 +207,6 @@
                 },
                 {
                     "base": "AppendContainerItem",
-                    "context": "PropertyTreeEditor",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke AppendContainerItem"
@@ -256,7 +250,6 @@
                 },
                 {
                     "base": "GetProperty",
-                    "context": "PropertyTreeEditor",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetProperty"
@@ -294,7 +287,6 @@
                 },
                 {
                     "base": "AddContainerItem",
-                    "context": "PropertyTreeEditor",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke AddContainerItem"
@@ -344,7 +336,6 @@
                 },
                 {
                     "base": "RemoveContainerItem",
-                    "context": "PropertyTreeEditor",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RemoveContainerItem"
@@ -388,7 +379,6 @@
                 },
                 {
                     "base": "BuildPathsListWithTypes",
-                    "context": "PropertyTreeEditor",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke BuildPathsListWithTypes"
@@ -420,7 +410,6 @@
                 },
                 {
                     "base": "HasAttribute",
-                    "context": "PropertyTreeEditor",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke HasAttribute"
@@ -464,7 +453,6 @@
                 },
                 {
                     "base": "BuildPathsList",
-                    "context": "PropertyTreeEditor",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke BuildPathsList"
@@ -496,7 +484,6 @@
                 },
                 {
                     "base": "SetVisibleEnforcement",
-                    "context": "PropertyTreeEditor",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke SetVisibleEnforcement"
@@ -526,7 +513,6 @@
                 },
                 {
                     "base": "UpdateContainerItem",
-                    "context": "PropertyTreeEditor",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke UpdateContainerItem"
@@ -576,7 +562,6 @@
                 },
                 {
                     "base": "GetContainerItem",
-                    "context": "PropertyTreeEditor",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetContainerItem"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/RuntimeData.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/RuntimeData.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "GetRequiredAssets",
-                    "context": "RuntimeData",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Required Assets"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Scene.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Scene.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetOriginalSceneOrientation",
-                    "context": "Scene",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Original Scene Orientation"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SceneGraphName.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SceneGraphName.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetPath",
-                    "context": "SceneGraphName",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Path"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "GetName",
-                    "context": "SceneGraphName",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Name"
@@ -73,7 +71,6 @@
                 },
                 {
                     "base": "ToString",
-                    "context": "SceneGraphName",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke To String"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SceneManifest.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SceneManifest.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "ImportFromJson",
-                    "context": "SceneManifest",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Import From Json"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "ExportToJson",
-                    "context": "SceneManifest",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Export To Json"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SceneQueries.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SceneQueries.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "CreateRayCastRequest",
-                    "context": "SceneQueries",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke CreateRayCastRequest"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/ScriptTimePoint.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/ScriptTimePoint.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "ToString",
-                    "context": "ScriptTimePoint",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke To String"
@@ -34,7 +33,6 @@
                 },
                 {
                     "base": "GetSeconds",
-                    "context": "ScriptTimePoint",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Seconds"
@@ -57,7 +55,6 @@
                 },
                 {
                     "base": "GetMilliseconds",
-                    "context": "ScriptTimePoint",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Milliseconds"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SettingsRegistryInterface.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SettingsRegistryInterface.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetFloat",
-                    "context": "SettingsRegistryInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Float"
@@ -48,7 +47,6 @@
                 },
                 {
                     "base": "SetFloat",
-                    "context": "SettingsRegistryInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Float"
@@ -91,7 +89,6 @@
                 },
                 {
                     "base": "RemoveKey",
-                    "context": "SettingsRegistryInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Remove Key"
@@ -128,7 +125,6 @@
                 },
                 {
                     "base": "SetInt",
-                    "context": "SettingsRegistryInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Int"
@@ -171,7 +167,6 @@
                 },
                 {
                     "base": "SetUInt",
-                    "context": "SettingsRegistryInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set UInt"
@@ -214,7 +209,6 @@
                 },
                 {
                     "base": "GetBool",
-                    "context": "SettingsRegistryInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Bool"
@@ -251,7 +245,6 @@
                 },
                 {
                     "base": "GetInt",
-                    "context": "SettingsRegistryInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Int"
@@ -288,7 +281,6 @@
                 },
                 {
                     "base": "GetUInt",
-                    "context": "SettingsRegistryInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get UInt"
@@ -325,7 +317,6 @@
                 },
                 {
                     "base": "GetNotifyEvent",
-                    "context": "SettingsRegistryInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Notify Event"
@@ -356,7 +347,6 @@
                 },
                 {
                     "base": "MergeSettings",
-                    "context": "SettingsRegistryInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Merge Settings"
@@ -400,7 +390,6 @@
                 },
                 {
                     "base": "MergeSettingsFile",
-                    "context": "SettingsRegistryInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Merge Settings File"
@@ -450,7 +439,6 @@
                 },
                 {
                     "base": "GetString",
-                    "context": "SettingsRegistryInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get String"
@@ -487,7 +475,6 @@
                 },
                 {
                     "base": "IsValid",
-                    "context": "SettingsRegistryInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Valid"
@@ -518,7 +505,6 @@
                 },
                 {
                     "base": "MergeSettingsFolder",
-                    "context": "SettingsRegistryInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Merge Settings Folder"
@@ -567,7 +553,6 @@
                 },
                 {
                     "base": "SetBool",
-                    "context": "SettingsRegistryInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Bool"
@@ -610,7 +595,6 @@
                 },
                 {
                     "base": "SetString",
-                    "context": "SettingsRegistryInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set String"
@@ -653,7 +637,6 @@
                 },
                 {
                     "base": "DumpSettings",
-                    "context": "SettingsRegistryInterface",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Dump Settings"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/ShaderCollectionItem.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/ShaderCollectionItem.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "GetShaderAsset",
-                    "context": "ShaderCollectionItem",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetShaderAsset"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "GetShaderAssetId",
-                    "context": "ShaderCollectionItem",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetShaderAssetId"
@@ -74,7 +72,6 @@
                 },
                 {
                     "base": "GetShaderVariantId",
-                    "context": "ShaderCollectionItem",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetShaderVariantId"
@@ -106,7 +103,6 @@
                 },
                 {
                     "base": "GetShaderOptionGroup",
-                    "context": "ShaderCollectionItem",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetShaderOptionGroup"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/ShaderOptionGroup.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/ShaderOptionGroup.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "GetValueByOptionName",
-                    "context": "ShaderOptionGroup",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetValueByOptionName"
@@ -48,7 +47,6 @@
                 },
                 {
                     "base": "GetShaderOptionDescriptors",
-                    "context": "ShaderOptionGroup",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetShaderOptionDescriptors"
@@ -80,7 +78,6 @@
                 },
                 {
                     "base": "GetShaderVariantId",
-                    "context": "ShaderOptionGroup",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetShaderVariantId"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/ShaderSemantic.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/ShaderSemantic.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "ToString",
-                    "context": "ShaderSemantic",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke To String"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/ShaderVariantId.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/ShaderVariantId.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "Equal",
-                    "context": "ShaderVariantId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Equal"
@@ -48,7 +47,6 @@
                 },
                 {
                     "base": "IsEmpty",
-                    "context": "ShaderVariantId",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsEmpty"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SimpleAssetReferenceBase.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SimpleAssetReferenceBase.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "SetAssetPath",
-                    "context": "SimpleAssetReferenceBase",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Asset Path"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SimulatedBody.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SimulatedBody.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "GetOnCollisionEndEvent",
-                    "context": "SimulatedBody",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get On Collision End Event"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "GetOnCollisionPersistEvent",
-                    "context": "SimulatedBody",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get On Collision Persist Event"
@@ -74,7 +72,6 @@
                 },
                 {
                     "base": "GetOnTriggerEnterEvent",
-                    "context": "SimulatedBody",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get On Trigger Enter Event"
@@ -106,7 +103,6 @@
                 },
                 {
                     "base": "GetOnCollisionBeginEvent",
-                    "context": "SimulatedBody",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get On Collision Begin Event"
@@ -138,7 +134,6 @@
                 },
                 {
                     "base": "GetOnTriggerExitEvent",
-                    "context": "SimulatedBody",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get On Trigger Exit Event"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SliceInstanceAddress.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SliceInstanceAddress.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "IsValid",
-                    "context": "SliceInstanceAddress",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke IsValid"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SliceInstantiationTicket.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SliceInstantiationTicket.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "Equal",
-                    "context": "SliceInstantiationTicket",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Equal"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "ToString",
-                    "context": "SliceInstantiationTicket",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke To String"
@@ -65,7 +63,6 @@
                 },
                 {
                     "base": "IsValid",
-                    "context": "SliceInstantiationTicket",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Valid"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Specializations.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Specializations.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "GetPriority",
-                    "context": "Specializations",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Priority"
@@ -49,7 +48,6 @@
                 },
                 {
                     "base": "GetCount",
-                    "context": "Specializations",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Count"
@@ -80,7 +78,6 @@
                 },
                 {
                     "base": "Contains",
-                    "context": "Specializations",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Contains"
@@ -117,7 +114,6 @@
                 },
                 {
                     "base": "Append",
-                    "context": "Specializations",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Append"
@@ -154,7 +150,6 @@
                 },
                 {
                     "base": "GetSpecialization",
-                    "context": "Specializations",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Specialization"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/String.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/String.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "ReplaceString",
-                    "context": "String",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Replace String"
@@ -57,7 +56,6 @@
                 },
                 {
                     "base": "Join",
-                    "context": "String",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Join"
@@ -89,7 +87,6 @@
                 },
                 {
                     "base": "StartsWith",
-                    "context": "String",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Starts With"
@@ -128,7 +125,6 @@
                 },
                 {
                     "base": "ContainsString",
-                    "context": "String",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Contains String"
@@ -174,7 +170,6 @@
                 },
                 {
                     "base": "Split",
-                    "context": "String",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Split"
@@ -206,7 +201,6 @@
                 },
                 {
                     "base": "IsValidFindPosition",
-                    "context": "String",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Valid Find Position"
@@ -229,7 +223,6 @@
                 },
                 {
                     "base": "EndsWith",
-                    "context": "String",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Ends With"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/String_VM.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/String_VM.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "ToLower",
-                    "context": "String_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ToLower"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "ToUpper",
-                    "context": "String_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke ToUpper"
@@ -74,7 +72,6 @@
                 },
                 {
                     "base": "Substring",
-                    "context": "String_VM",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Substring"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SurfaceAltitudeGradientConfig.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SurfaceAltitudeGradientConfig.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "GetNumTags",
-                    "context": "SurfaceAltitudeGradientConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetNumTags"
@@ -43,7 +42,6 @@
                 },
                 {
                     "base": "GetTag",
-                    "context": "SurfaceAltitudeGradientConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetTag"
@@ -82,7 +80,6 @@
                 },
                 {
                     "base": "RemoveTag",
-                    "context": "SurfaceAltitudeGradientConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RemoveTag"
@@ -113,7 +110,6 @@
                 },
                 {
                     "base": "AddTag",
-                    "context": "SurfaceAltitudeGradientConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke AddTag"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SurfaceMaskGradientConfig.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SurfaceMaskGradientConfig.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "GetNumTags",
-                    "context": "SurfaceMaskGradientConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetNumTags"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "GetTag",
-                    "context": "SurfaceMaskGradientConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetTag"
@@ -80,7 +78,6 @@
                 },
                 {
                     "base": "RemoveTag",
-                    "context": "SurfaceMaskGradientConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RemoveTag"
@@ -110,7 +107,6 @@
                 },
                 {
                     "base": "AddTag",
-                    "context": "SurfaceMaskGradientConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke AddTag"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SurfaceSlopeGradientConfig.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/SurfaceSlopeGradientConfig.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "GetNumTags",
-                    "context": "SurfaceSlopeGradientConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetNumTags"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "GetTag",
-                    "context": "SurfaceSlopeGradientConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke GetTag"
@@ -80,7 +78,6 @@
                 },
                 {
                     "base": "RemoveTag",
-                    "context": "SurfaceSlopeGradientConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke RemoveTag"
@@ -110,7 +107,6 @@
                 },
                 {
                     "base": "AddTag",
-                    "context": "SurfaceSlopeGradientConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke AddTag"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/TestTupleMethods.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/TestTupleMethods.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "Three",
-                    "context": "TestTupleMethods",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Three"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/TransformConfig.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/TransformConfig.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "SetTransform",
-                    "context": "TransformConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Transform"
@@ -40,7 +39,6 @@
                 },
                 {
                     "base": "SetLocalAndWorldTransform",
-                    "context": "TransformConfig",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Local And World Transform"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/TriggerEvent.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/TriggerEvent.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "GetTriggerEntityId",
-                    "context": "TriggerEvent",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Trigger Entity Id"
@@ -43,7 +42,6 @@
                 },
                 {
                     "base": "GetOtherEntityId",
-                    "context": "TriggerEvent",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Get Other Entity Id"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/TypeExposition.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/TypeExposition.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "Reflect_AZStd__array_AZ__Vector3_2",
-                    "context": "TypeExposition",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Reflect_AZStd__array_AZ__Vector3_2"
@@ -42,7 +41,6 @@
                 },
                 {
                     "base": "Reflect_AZ__Outcome_AZ__Vector3_void",
-                    "context": "TypeExposition",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Reflect_AZ__Outcome_AZ__Vector3_void"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/UVCoords.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/UVCoords.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "SetUVCoords",
-                    "context": "UVCoords",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke SetUV Coords"
@@ -58,7 +57,6 @@
                 },
                 {
                     "base": "SetBottom",
-                    "context": "UVCoords",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Bottom"
@@ -87,7 +85,6 @@
                 },
                 {
                     "base": "SetRight",
-                    "context": "UVCoords",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Right"
@@ -116,7 +113,6 @@
                 },
                 {
                     "base": "SetTop",
-                    "context": "UVCoords",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Top"
@@ -145,7 +141,6 @@
                 },
                 {
                     "base": "SetLeft",
-                    "context": "UVCoords",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Left"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/UiAnchors.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/UiAnchors.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "SetBottom",
-                    "context": "UiAnchors",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Bottom"
@@ -40,7 +39,6 @@
                 },
                 {
                     "base": "SetRight",
-                    "context": "UiAnchors",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Right"
@@ -69,7 +67,6 @@
                 },
                 {
                     "base": "SetTop",
-                    "context": "UiAnchors",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Top"
@@ -98,7 +95,6 @@
                 },
                 {
                     "base": "SetLeft",
-                    "context": "UiAnchors",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Left"
@@ -127,7 +123,6 @@
                 },
                 {
                     "base": "SetAnchors",
-                    "context": "UiAnchors",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Anchors"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/UiOffsets.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/UiOffsets.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "SetBottom",
-                    "context": "UiOffsets",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Bottom"
@@ -40,7 +39,6 @@
                 },
                 {
                     "base": "SetRight",
-                    "context": "UiOffsets",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Right"
@@ -69,7 +67,6 @@
                 },
                 {
                     "base": "SetOffsets",
-                    "context": "UiOffsets",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Offsets"
@@ -116,7 +113,6 @@
                 },
                 {
                     "base": "SetTop",
-                    "context": "UiOffsets",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Top"
@@ -145,7 +141,6 @@
                 },
                 {
                     "base": "SetLeft",
-                    "context": "UiOffsets",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Left"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/UiPadding.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/UiPadding.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "SetPadding",
-                    "context": "UiPadding",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Padding"
@@ -58,7 +57,6 @@
                 },
                 {
                     "base": "SetBottom",
-                    "context": "UiPadding",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Bottom"
@@ -87,7 +85,6 @@
                 },
                 {
                     "base": "SetRight",
-                    "context": "UiPadding",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Right"
@@ -116,7 +113,6 @@
                 },
                 {
                     "base": "SetTop",
-                    "context": "UiPadding",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Top"
@@ -145,7 +141,6 @@
                 },
                 {
                     "base": "SetLeft",
-                    "context": "UiPadding",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Set Left"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/UnitTesting.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/UnitTesting.names
@@ -10,7 +10,6 @@
             "methods": [
                 {
                     "base": "ExpectLessThanEqual",
-                    "context": "Unit Testing",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Expect Less Than Equal"
@@ -55,7 +54,6 @@
                 },
                 {
                     "base": "ExpectGreaterThanEqual",
-                    "context": "Unit Testing",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Expect Greater Than Equal"
@@ -100,7 +98,6 @@
                 },
                 {
                     "base": "MarkComplete",
-                    "context": "Unit Testing",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Mark Complete"
@@ -131,7 +128,6 @@
                 },
                 {
                     "base": "ExpectTrue",
-                    "context": "Unit Testing",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Expect True"
@@ -169,7 +165,6 @@
                 },
                 {
                     "base": "Checkpoint",
-                    "context": "Unit Testing",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Checkpoint"
@@ -200,7 +195,6 @@
                 },
                 {
                     "base": "ExpectFalse",
-                    "context": "Unit Testing",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Expect False"
@@ -238,7 +232,6 @@
                 },
                 {
                     "base": "ExpectEqual",
-                    "context": "Unit Testing",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Expect Equal"
@@ -283,7 +276,6 @@
                 },
                 {
                     "base": "ExpectLessThan",
-                    "context": "Unit Testing",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Expect Less Than"
@@ -328,7 +320,6 @@
                 },
                 {
                     "base": "AddSuccess",
-                    "context": "Unit Testing",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Add Success"
@@ -359,7 +350,6 @@
                 },
                 {
                     "base": "ExpectNotEqual",
-                    "context": "Unit Testing",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Expect Not Equal"
@@ -404,7 +394,6 @@
                 },
                 {
                     "base": "ExpectGreaterThan",
-                    "context": "Unit Testing",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Expect Greater Than"
@@ -449,7 +438,6 @@
                 },
                 {
                     "base": "AddFailure",
-                    "context": "Unit Testing",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Add Failure"

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Uuid.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Uuid.names
@@ -11,7 +11,6 @@
             "methods": [
                 {
                     "base": "CreateRandom",
-                    "context": "Uuid",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Create Random"
@@ -34,7 +33,6 @@
                 },
                 {
                     "base": "CreateNull",
-                    "context": "Uuid",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Create Null"
@@ -57,7 +55,6 @@
                 },
                 {
                     "base": "Create",
-                    "context": "Uuid",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Create"
@@ -80,7 +77,6 @@
                 },
                 {
                     "base": "CreateName",
-                    "context": "Uuid",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Create Name"
@@ -111,7 +107,6 @@
                 },
                 {
                     "base": "Clone",
-                    "context": "Uuid",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Clone"
@@ -142,7 +137,6 @@
                 },
                 {
                     "base": "LessThan",
-                    "context": "Uuid",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Less Than"
@@ -179,7 +173,6 @@
                 },
                 {
                     "base": "IsNull",
-                    "context": "Uuid",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Is Null"
@@ -210,7 +203,6 @@
                 },
                 {
                     "base": "CreateString",
-                    "context": "Uuid",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Create String"
@@ -247,7 +239,6 @@
                 },
                 {
                     "base": "ToString",
-                    "context": "Uuid",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke To String"
@@ -278,7 +269,6 @@
                 },
                 {
                     "base": "Equal",
-                    "context": "Uuid",
                     "entry": {
                         "name": "In",
                         "tooltip": "When signaled, this will invoke Equal"

--- a/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.cpp
+++ b/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.cpp
@@ -1125,7 +1125,10 @@ namespace ScriptCanvasEditorTools
                     if (!methodSource.m_context.empty())
                     {
                         value.SetString(methodSource.m_context.c_str(), document.GetAllocator());
-                        theMethod.AddMember(GraphCanvas::Schema::Field::context, value, document.GetAllocator());
+                        if (value == "Getter" or value == "Setter")
+                        {
+                            theMethod.AddMember(GraphCanvas::Schema::Field::context, value, document.GetAllocator());
+                        }
                     }
 
                     if (!methodSource.m_entry.m_name.empty())

--- a/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.cpp
+++ b/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.cpp
@@ -1125,7 +1125,7 @@ namespace ScriptCanvasEditorTools
                     if (!methodSource.m_context.empty())
                     {
                         value.SetString(methodSource.m_context.c_str(), document.GetAllocator());
-                        if (value == "Getter" or value == "Setter")
+                        if (value == "Getter" || value == "Setter")
                         {
                             theMethod.AddMember(GraphCanvas::Schema::Field::context, value, document.GetAllocator());
                         }


### PR DESCRIPTION
## What does this PR do?
Standardizes "context" fields for methods in behaviour classes in translation files. Previously, some methods had a "context" value equal to their class name, others had no context value. This change removes all the context entries, except for if they are "Getter" or "Setter", and modifies the automatic translation generation to avoid adding the class name as the context value.
 
## How was this PR tested?
Manual testing in Node Palette and Graph Editor.
Turned on s_traceMissingItems setting and inspected output. With this change, 307 fewer values fail to be found in the translation database, and 0 new failures occur.
Created a translation file and verified the context fields for methods.