### PR TITLE
Monkeypatch pytest xml file race condition

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/_internal/pytest_plugin/test_tools_fixtures.py
+++ b/Tools/LyTestTools/ly_test_tools/_internal/pytest_plugin/test_tools_fixtures.py
@@ -468,4 +468,4 @@ def monkeypatch_pytest():
             logfile.write(ET.tostring(testsuites, encoding="unicode"))
 
     # override
-    _pytest.junitxml.LogXML.pytest_sessionfinish = types.MethodType(pytest_sessionfinish, _pytest.junitxml.LogXML)
+    _pytest.junitxml.LogXML.pytest_sessionfinish = pytest_sessionfinish

--- a/Tools/LyTestTools/ly_test_tools/_internal/pytest_plugin/test_tools_fixtures.py
+++ b/Tools/LyTestTools/ly_test_tools/_internal/pytest_plugin/test_tools_fixtures.py
@@ -55,6 +55,9 @@ def pytest_configure(config):
     ly_test_tools._internal.pytest_plugin.build_directory = _get_build_directory(config)
     ly_test_tools._internal.pytest_plugin.output_path = _get_output_path(config)
 
+    # patch to work around TODO GHI
+    monkeypatch_pytest()
+
 
 def _get_build_directory(config):
     """
@@ -413,3 +416,56 @@ def _asset_processor_platform(request):
         raise ValueError(
             f'asset_processor_platform: "{ap_platform}" is not valid. '
             f'Please select from one of the following: {ALL_PLATFORM_OPTIONS}')
+
+
+def monkeypatch_pytest():
+    """
+    Patches a file creation race condition in _pytest.junitxml.LogXML.pytest_sessionfinish
+    """
+    import types
+    import _pytest.junitxml
+    import platform
+    import xml.etree.ElementTree as ET
+    from _pytest import timing
+
+    # patch code from pytest 7.2.0, fetched at commit 7431750
+    def pytest_sessionfinish(self) -> None:
+        dirname = os.path.dirname(os.path.abspath(self.logfile))
+        if not os.path.isdir(dirname):
+            os.makedirs(dirname, exist_ok=True)  # our patch
+
+        with open(self.logfile, "w", encoding="utf-8") as logfile:
+            suite_stop_time = timing.time()
+            suite_time_delta = suite_stop_time - self.suite_start_time
+
+            numtests = (
+                    self.stats["passed"]
+                    + self.stats["failure"]
+                    + self.stats["skipped"]
+                    + self.stats["error"]
+                    - self.cnt_double_fail_tests
+            )
+            logfile.write('<?xml version="1.0" encoding="utf-8"?>')
+
+            suite_node = ET.Element(
+                "testsuite",
+                name=self.suite_name,
+                errors=str(self.stats["error"]),
+                failures=str(self.stats["failure"]),
+                skipped=str(self.stats["skipped"]),
+                tests=str(numtests),
+                time="%.3f" % suite_time_delta,
+                timestamp=datetime.fromtimestamp(self.suite_start_time).isoformat(),
+                hostname=platform.node(),
+            )
+            global_properties = self._get_global_properties_node()
+            if global_properties is not None:
+                suite_node.append(global_properties)
+            for node_reporter in self.node_reporters_ordered:
+                suite_node.append(node_reporter.to_xml())
+            testsuites = ET.Element("testsuites")
+            testsuites.append(suite_node)
+            logfile.write(ET.tostring(testsuites, encoding="unicode"))
+
+    # override
+    _pytest.junitxml.LogXML.pytest_sessionfinish = types.MethodType(pytest_sessionfinish, _pytest.junitxml.LogXML)

--- a/Tools/LyTestTools/ly_test_tools/_internal/pytest_plugin/test_tools_fixtures.py
+++ b/Tools/LyTestTools/ly_test_tools/_internal/pytest_plugin/test_tools_fixtures.py
@@ -55,7 +55,7 @@ def pytest_configure(config):
     ly_test_tools._internal.pytest_plugin.build_directory = _get_build_directory(config)
     ly_test_tools._internal.pytest_plugin.output_path = _get_output_path(config)
 
-    # patch to work around TODO GHI
+    # patch to work around https://github.com/pytest-dev/pytest/issues/10604
     monkeypatch_pytest()
 
 


### PR DESCRIPTION
Signed-off-by: sweeneys <sweeneys@amazon.com>

## What does this PR do?

Attempts a new workaround to resolve a filesystem race condition in pytest https://github.com/o3de/o3de/issues/13720 . The race condition most frequently appears when running multiple instances of pytest in parallel, or when invoking pytest inside another instance of pytest.

The change copies existing pytest code from https://github.com/pytest-dev/pytest/blob/7.2.x/src/_pytest/junitxml.py#L646 and modifies a single line to include `exist_ok=True`. This notably does not work around another edge case where the user requests creating a file at `grandparent/parent/file.xml` but a non-directory file already exists at `grandparent/parent` . That case does not appear to be reproducing in O3DE, should be very uncommon, and would likely require renaming the user's requested file path.

This fix was hooked into the pytest plugin for configuration because it cannot be done in an autouse pytest fixture. Unfortunately all fixtures are instantiated after pytest initializes a LogXML object.

A better fix would be to directly fix pytest itself. After proving stability, this fix will be recommended to the pytest maintainers.

## How was this PR tested?

Executed the unit tests of LyTestTools with the --junitxml flag set, to make sure the patched method is being called. Manually set a breakpoint and manually recreated the race condition of the file structure changing between `os.path.isdir` and `os.makedirs`.

Will use Jenkins runs to collect additional data on whether we continue to encounter race conditions here.