### PR TITLE
Re-enable Atom_Main_Null_Render_02 test, move Mesh & Hair component portions of test to sandbox for fixing.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/Atom/CMakeLists.txt
@@ -35,7 +35,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED)
     )
     ly_add_pytest(
         NAME AutomatedTesting::Atom_Main_Null_Render_02
-        TEST_SUITE periodic
+        TEST_SUITE main
         PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite_Main_Null_Render_Component_02.py
         TEST_SERIAL
         TIMEOUT 600

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Component_02.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Component_02.py
@@ -21,10 +21,6 @@ class TestAutomation(EditorTestSuite):
     class AtomEditorComponents_GridAdded(EditorBatchedTest):
         from Atom.tests import hydra_AtomEditorComponents_GridAdded as test_module
 
-    @pytest.mark.test_case_id("C36553404")
-    class AtomEditorComponents_HairAdded(EditorBatchedTest):
-        from Atom.tests import hydra_AtomEditorComponents_HairAdded as test_module
-
     @pytest.mark.test_case_id("C36525671")
     class AtomEditorComponents_HDRColorGradingAdded(EditorBatchedTest):
         from Atom.tests import hydra_AtomEditorComponents_HDRColorGradingAdded as test_module
@@ -44,10 +40,6 @@ class TestAutomation(EditorTestSuite):
     @pytest.mark.test_case_id("C32078123")
     class AtomEditorComponents_MaterialAdded(EditorBatchedTest):
         from Atom.tests import hydra_AtomEditorComponents_MaterialAdded as test_module
-
-    @pytest.mark.test_case_id("C32078124")
-    class AtomEditorComponents_MeshAdded(EditorBatchedTest):
-        from Atom.tests import hydra_AtomEditorComponents_MeshAdded as test_module
 
     @pytest.mark.test_case_id("C36525663")
     class AtomEditorComponents_OcclusionCullingPlaneAdded(EditorBatchedTest):

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Sandbox.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Sandbox.py
@@ -9,7 +9,7 @@ import os
 
 import pytest
 
-from ly_test_tools.o3de.editor_test import EditorSharedTest, EditorTestSuite
+from ly_test_tools.o3de.editor_test import EditorBatchedTest, EditorSharedTest, EditorTestSuite
 
 logger = logging.getLogger(__name__)
 TEST_DIRECTORY = os.path.join(os.path.dirname(__file__), "tests")
@@ -28,3 +28,13 @@ class TestAutomation(EditorTestSuite):
     @pytest.mark.test_case_id("C36529679")
     class AtomLevelLoadTest_Editor_Sandbox(EditorSharedTest):
         from Atom.tests import hydra_Atom_LevelLoadTest_Sandbox as test_module
+
+    # GHI: https://github.com/o3de/o3de/issues/13819
+    @pytest.mark.test_case_id("C36553404")
+    class AtomEditorComponents_HairAdded(EditorBatchedTest):
+        from Atom.tests import hydra_AtomEditorComponents_HairAdded as test_module
+
+    # GHI: https://github.com/o3de/o3de/issues/13818
+    @pytest.mark.test_case_id("C32078124")
+    class AtomEditorComponents_MeshAdded(EditorBatchedTest):
+        from Atom.tests import hydra_AtomEditorComponents_MeshAdded as test_module


### PR DESCRIPTION
## What does this PR do?
1. Re-enables the component test previously disabled in https://github.com/o3de/o3de/pull/13679 
2. Moves the 2 components causing the test to intermittently fail into sandbox suite (Mesh & Hair components caused it).
3. GHI for Hair component failure: https://github.com/o3de/o3de/issues/13819 
4. GHI for Mesh component failure: https://github.com/o3de/o3de/issues/13818 

## How was this PR tested?
1. Ran this command many times (at least 200) with different permutations of disabled/enabled components in the test.
2. Only the Mesh and Hair components triggered asserts every 20 to 30 runs or so. Removing them made the test pass 100 times in a row.
5. Since I can't include all output, here's an example output from 1 run below:
```py
# Example of the Material component passing.
Starting test AtomEditorComponents_Material_AddedToEntity...
Test AtomEditorComponents_Material_AddedToEntity finished.
Report:
[SUCCESS] Success: Material Entity successfully created
[SUCCESS] Success: Entity has a Material component
[SUCCESS] Success: UNDO Entity creation success
[SUCCESS] Success: REDO Entity creation success
[SUCCESS] Success: Material component disabled
[SUCCESS] Success: Entity has an Actor component
[SUCCESS] Success: Material component enabled
[SUCCESS] Success: Entity Actor component gone
[SUCCESS] Success: Material component disabled
[SUCCESS] Success: Entity has a Mesh component
[SUCCESS] Success: Material component enabled
[SUCCESS] Success: Model Asset set
[SUCCESS] Success: Model Material count is 5 as expected
[SUCCESS] Success: Model Material zero index is labeled lambert0
[SUCCESS] Success: Asset path of the Material Model index zero is as expected
[SUCCESS] Success: Enable LOD Materials property set to True
[SUCCESS] Success: LOD Material count is 5 as expected
[SUCCESS] Success: Asset path of LOD Material index zero first item is as expected
[SUCCESS] Success: LOD material zero is set to metal_gold.azmaterial id
[SUCCESS] Success: LOD material zero is set to metal_gold.azmaterial id
[SUCCESS] Success: Asset path of LOD Material index zero first item is as expected
[SUCCESS] Success: Default Material set to metal_gold.azmaterial
[SUCCESS] Success: Default Material cleared with MaterialComponentRequestBus
[SUCCESS] Success: Default Material set to metal_gold.azmaterial
[SUCCESS] Success: Entered game mode
[SUCCESS] Success: Exited game mode
[SUCCESS] Success: Entity is hidden
[SUCCESS] Success: Entity is visible
[SUCCESS] Success: Entity deleted
[SUCCESS] Success: UNDO deletion success
[SUCCESS] Success: REDO deletion success
Test result:  SUCCESS

# Example of all tests passing after removing Hair and Mesh components from test.
=== 8 passed in 36.85s ===
```