### PR TITLE
[AWSCore] Fix loading of the resource mapping tool on Windows

### DIFF
--- a/Gems/AWSCore/Code/Tools/ResourceMappingTool/.gitignore
+++ b/Gems/AWSCore/Code/Tools/ResourceMappingTool/.gitignore
@@ -1,0 +1,3 @@
+.env/
+.venv/
+.idea/

--- a/Gems/AWSCore/Code/Tools/ResourceMappingTool/README.md
+++ b/Gems/AWSCore/Code/Tools/ResourceMappingTool/README.md
@@ -38,20 +38,20 @@ Follow cmake instructions to configure your project, for example:
    * Windows
       * release mode
       ```
-      $ python\python.cmd Gems\AWSCore\Code\Tools\ResourceMappingTool\resource_mapping_tool.py --binaries_path <PATH_TO_BUILD_FOLDER>\bin\profile\AWSCoreEditorQtBin
+      $ python\python.cmd Gems\AWSCore\Code\Tools\ResourceMappingTool\resource_mapping_tool.py --binaries-path <PATH_TO_BUILD_FOLDER>\bin\profile\AWSCoreEditorQtBin
       ```
       * debug mode
       ```
-      $ python\python.cmd debug Gems\AWSCore\Code\Tools\ResourceMappingTool\resource_mapping_tool.py --binaries_path <PATH_TO_BUILD_FOLDER>\bin\debug\AWSCoreEditorQtBin
+      $ python\python.cmd debug Gems\AWSCore\Code\Tools\ResourceMappingTool\resource_mapping_tool.py --binaries-path <PATH_TO_BUILD_FOLDER>\bin\debug\AWSCoreEditorQtBin
       ```
    * Linux
       * release mode
       ```
-      $ python/python.sh Gems/AWSCore/Code/Tools/ResourceMappingTool/resource_mapping_tool.py --binaries_path <PATH_TO_BUILD_FOLDER>/bin/profile/AWSCoreEditorQtBin
+      $ python/python.sh Gems/AWSCore/Code/Tools/ResourceMappingTool/resource_mapping_tool.py --binaries-path <PATH_TO_BUILD_FOLDER>/bin/profile/AWSCoreEditorQtBin
       ```
       * debug mode
       ```
-      $ python/python.sh Gems/AWSCore/Code/Tools/ResourceMappingTool/resource_mapping_tool.py --binaries_path <PATH_TO_BUILD_FOLDER>/bin/debug/AWSCoreEditorQtBin
+      $ python/python.sh Gems/AWSCore/Code/Tools/ResourceMappingTool/resource_mapping_tool.py --binaries-path <PATH_TO_BUILD_FOLDER>/bin/debug/AWSCoreEditorQtBin
       ```
       
 * Note - the engine Editor is integrated with the same python environment used to launch the Resource Mapping Tool. If the tool fails to launch from the Editor, please double check that you have completed all of the above steps and that the expected scripts and binaries are present in the expected directories.

--- a/Gems/AWSCore/Code/Tools/ResourceMappingTool/requirements.txt
+++ b/Gems/AWSCore/Code/Tools/ResourceMappingTool/requirements.txt
@@ -1,5 +1,6 @@
 PySide2>=5.15.2
 boto3>=1.17.30
+botocore>=1.19.18
 pytest>=5.3.2
 
 

--- a/Gems/AWSCore/Code/Tools/ResourceMappingTool/tests/unit/utils/test_environment_utils.py
+++ b/Gems/AWSCore/Code/Tools/ResourceMappingTool/tests/unit/utils/test_environment_utils.py
@@ -6,12 +6,8 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
 import platform
-from typing import List
 from unittest import TestCase
 from unittest.mock import (ANY, call, MagicMock, patch)
-
-from model import constants
-from model.basic_resource_attributes import (BasicResourceAttributes, BasicResourceAttributesBuilder)
 from utils import environment_utils
 
 
@@ -28,6 +24,10 @@ class TestEnvironmentUtils(TestCase):
         self.addCleanup(os_pathsep_patcher.stop)
         self._mock_os_pathsep: MagicMock = os_pathsep_patcher.start()
 
+        os_add_dll_directory_patcher: patch = patch("os.add_dll_directory")
+        self.addCleanup(os_add_dll_directory_patcher.stop)
+        self._mock_os_dll_directory: MagicMock = os_add_dll_directory_patcher.start()
+
     @patch('os.path.exists')
     @patch('ctypes.CDLL')
     def test_setup_qt_environment_global_flag_is_set(self, mock_os_path_exists, mock_ctype_cdll) -> None:
@@ -35,6 +35,7 @@ class TestEnvironmentUtils(TestCase):
         environment_utils.setup_qt_environment("dummy")
         self._mock_os_environ.copy.assert_called_once()
         self._mock_os_pathsep.join.assert_called_once()
+        self._mock_os_dll_directory.assert_called_once()
         assert environment_utils.is_qt_linked() is True
         if platform.system() == 'Linux':
             mock_os_path_exists.assert_called()
@@ -49,3 +50,4 @@ class TestEnvironmentUtils(TestCase):
         assert environment_utils.is_qt_linked() is False
         if platform.system() == 'Linux':
             mock_os_path_exists.assert_called()
+        self._mock_os_dll_directory.assert_called_once()

--- a/Gems/AWSCore/Code/Tools/ResourceMappingTool/tests/unit/utils/test_environment_utils.py
+++ b/Gems/AWSCore/Code/Tools/ResourceMappingTool/tests/unit/utils/test_environment_utils.py
@@ -35,10 +35,11 @@ class TestEnvironmentUtils(TestCase):
         environment_utils.setup_qt_environment("dummy")
         self._mock_os_environ.copy.assert_called_once()
         self._mock_os_pathsep.join.assert_called_once()
-        self._mock_os_dll_directory.assert_called_once()
         assert environment_utils.is_qt_linked() is True
         if platform.system() == 'Linux':
             mock_os_path_exists.assert_called()
+        elif platform.system() == 'Windows':
+            self._mock_os_dll_directory.assert_called_once()
 
     @patch('os.path.exists')
     @patch('ctypes.CDLL')
@@ -50,4 +51,5 @@ class TestEnvironmentUtils(TestCase):
         assert environment_utils.is_qt_linked() is False
         if platform.system() == 'Linux':
             mock_os_path_exists.assert_called()
-        self._mock_os_dll_directory.assert_called_once()
+        elif platform.system() == 'Windows':
+            self._mock_os_dll_directory.assert_called_once()

--- a/Gems/AWSCore/Code/Tools/ResourceMappingTool/utils/environment_utils.py
+++ b/Gems/AWSCore/Code/Tools/ResourceMappingTool/utils/environment_utils.py
@@ -38,7 +38,8 @@ def setup_qt_environment(bin_path: str) -> None:
     # and directories added with add_dll_directory() are searched for load-time dependencies.
     # Specifically, PATH and the current working directory are no longer used, and modifications to these
     # will no longer have any effect on normal DLL resolution.
-    os.add_dll_directory(binaries_path)
+    if platform.system() == 'Windows':
+        os.add_dll_directory(binaries_path)
 
     os.environ["QT_PLUGIN_PATH"] = binaries_path
 

--- a/Gems/AWSCore/Code/Tools/ResourceMappingTool/utils/environment_utils.py
+++ b/Gems/AWSCore/Code/Tools/ResourceMappingTool/utils/environment_utils.py
@@ -23,7 +23,7 @@ old_os_env: Dict[str, str] = os.environ.copy()
 
 def setup_qt_environment(bin_path: str) -> None:
     """
-    Setup Qt binaries for o3de python runtime environment
+    Setup Qt binaries for O3DE python runtime environment
     :param bin_path: The path of Qt binaries
     """
     if is_qt_linked():
@@ -32,6 +32,14 @@ def setup_qt_environment(bin_path: str) -> None:
     global old_os_env
     old_os_env = os.environ.copy()
     binaries_path: str = file_utils.normalize_file_path(bin_path)
+
+    # Python 3.8 DLL dependencies for extension modules and DLLs loaded with ctypes on Windows
+    # are now resolved more securely. Only the system paths, the directory containing the DLL or PYD file,
+    # and directories added with add_dll_directory() are searched for load-time dependencies.
+    # Specifically, PATH and the current working directory are no longer used, and modifications to these
+    # will no longer have any effect on normal DLL resolution.
+    os.add_dll_directory(binaries_path)
+
     os.environ["QT_PLUGIN_PATH"] = binaries_path
 
     path = os.environ['PATH']
@@ -67,7 +75,7 @@ def is_qt_linked() -> bool:
 
 def cleanup_qt_environment() -> None:
     """
-    Clean up the linked Qt binaries in o3de python runtime environment
+    Clean up the linked Qt binaries in O3DE python runtime environment
     """
     if not is_qt_linked():
         logger.info("Qt binaries have not been linked, skip Qt uninstall")


### PR DESCRIPTION
## What does this PR do?

Fix for https://github.com/o3de/o3de/issues/13798 

* Python loading of DLLs has changed on windows, change will fix discovery of the QT libraries
* Linux loading requires further work to fix discovery of Shiboken2 

## How was this PR tested?

* Launched tool from Editor menu and command line, tool opens on Windoes
* Ran all unit tests via ```python -m pytest -vv .``` all passed
