### PR TITLE
Fix validation error with depth/stencil RT in bindless pool

### DIFF
--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/ImageView.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/ImageView.cpp
@@ -93,11 +93,12 @@ namespace AZ
 
             // If a depth stencil image does not have depth or aspect flag set it is probably going to be used as
             // a render target and do not need to be added to the bindless heap
-            bool isReadOnlyDSView = viewDescriptor.m_aspectFlags == RHI::ImageAspectFlags::Depth ||
-                                    viewDescriptor.m_aspectFlags == RHI::ImageAspectFlags::Stencil;
+            bool isDSRendertarget = RHI::CheckBitsAny(image.GetDescriptor().m_bindFlags, RHI::ImageBindFlags::DepthStencil) &&
+                                    viewDescriptor.m_aspectFlags != RHI::ImageAspectFlags::Depth &&
+                                    viewDescriptor.m_aspectFlags != RHI::ImageAspectFlags::Stencil;
                         
             // Cache the read and readwrite index of the view withn the global Bindless Argument buffer
-            if (!viewDescriptor.m_isArray && !viewDescriptor.m_isCubemap && !isReadOnlyDSView)
+            if (!viewDescriptor.m_isArray && !viewDescriptor.m_isCubemap && !isDSRendertarget)
             {
                 if (RHI::CheckBitsAll(image.GetDescriptor().m_bindFlags, RHI::ImageBindFlags::ShaderRead))
                 {

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImageView.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImageView.cpp
@@ -112,10 +112,11 @@ namespace AZ
 
             // If a depth stencil image does not have depth or aspect flag set it is probably going to be used as
             // a render target and do not need to be added to the bindless heap
-            bool isReadOnlyDSView = viewDescriptor.m_aspectFlags == RHI::ImageAspectFlags::Depth ||
-                                    viewDescriptor.m_aspectFlags == RHI::ImageAspectFlags::Stencil;
+            bool isDSRendertarget = RHI::CheckBitsAny(image.GetDescriptor().m_bindFlags, RHI::ImageBindFlags::DepthStencil) &&
+                                    viewDescriptor.m_aspectFlags != RHI::ImageAspectFlags::Depth &&
+                                    viewDescriptor.m_aspectFlags != RHI::ImageAspectFlags::Stencil;
 
-            if (!viewDescriptor.m_isArray && !viewDescriptor.m_isCubemap && !isReadOnlyDSView)
+            if (!viewDescriptor.m_isArray && !viewDescriptor.m_isCubemap && !isDSRendertarget)
             {
                 if (RHI::CheckBitsAll(image.GetDescriptor().m_bindFlags, RHI::ImageBindFlags::ShaderRead))
                 {


### PR DESCRIPTION
Signed-off-by: Akio Gaule <10719597+akioCL@users.noreply.github.com>

## What does this PR do?

Fix a validation error on Vulkan and Metal when incorrectly adding a depth/stencil rendertarget in the bindless pool

## How was this PR tested?

Run ASV bindless sample
