### PR TITLE
Includes CTest in top level CMakeLists to create the CTest config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ endif()
 ################################################################################
 # Initialize
 ################################################################################
+include(CTest)
 include(cmake/GeneralSettings.cmake)
 include(cmake/FileUtil.cmake)
 include(cmake/PAL.cmake)


### PR DESCRIPTION
Signed-off-by: Chiang <evanchia@amazon.com>

## What does this PR do?

Adds the include(CTest) option to the top level CMakeLists file to create the CTest DartConfiguration file. No actual config is being added, this change is merely to remove the "Cannot find file: ~/o3de/build/windows/DartConfiguration.tcl" warning.

## How was this PR tested?

Tested by configuring locally and running CTest