### PR TITLE
[Terrain] Fix paint brush settings when used with a color.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/PaintBrush/PaintBrushSettings.cpp
+++ b/Code/Framework/AzFramework/AzFramework/PaintBrush/PaintBrushSettings.cpp
@@ -54,23 +54,6 @@ namespace AzFramework
         }
     }
 
-    // The following settings are visible but read-only when in the Eyedropper mode
-
-    bool PaintBrushSettings::GetColorReadOnly() const
-    {
-        return (m_brushMode == PaintBrushMode::Eyedropper);
-    }
-
-    bool PaintBrushSettings::GetIntensityReadOnly() const
-    {
-        return (m_brushMode == PaintBrushMode::Eyedropper);
-    }
-
-    bool PaintBrushSettings::GetOpacityReadOnly() const
-    {
-        return (m_brushMode == PaintBrushMode::Eyedropper);
-    }
-
     // The following settings aren't visible in Eyedropper mode, but are available in Paint / Smooth modes
 
     bool PaintBrushSettings::GetSizeVisibility() const

--- a/Code/Framework/AzFramework/AzFramework/PaintBrush/PaintBrushSettings.h
+++ b/Code/Framework/AzFramework/AzFramework/PaintBrush/PaintBrushSettings.h
@@ -196,10 +196,6 @@ namespace AzFramework
         AZ::u32 OnIntensityChanged();
         AZ::u32 OnOpacityChanged();
 
-        bool GetColorReadOnly() const;
-        bool GetIntensityReadOnly() const;
-        bool GetOpacityReadOnly() const;
-
         bool GetSizeVisibility() const;
         bool GetColorVisibility() const;
         bool GetIntensityVisibility() const;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrush/GlobalPaintBrushSettings.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrush/GlobalPaintBrushSettings.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzToolsFramework/PaintBrush/GlobalPaintBrushSettings.h>
 #include <AzToolsFramework/PaintBrush/GlobalPaintBrushSettingsNotificationBus.h>
+#include <AzToolsFramework/PaintBrush/GlobalPaintBrushSettingsRequestBus.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.hxx>
 
 namespace AzToolsFramework
@@ -49,8 +50,12 @@ namespace AzToolsFramework
                     ->DataElement(AZ::Edit::UIHandlers::Default, &PaintBrushSettings::m_brushColor, "Color", "Color of the paint brush.")
                     ->Attribute(
                         "ColorEditorConfiguration",
-                        [](PaintBrushSettings* handler) -> AzToolsFramework::ColorEditorConfiguration
+                        []([[maybe_unused]] void* voidHandler) -> AzToolsFramework::ColorEditorConfiguration
                         {
+                            AzFramework::PaintBrushColorMode colorMode = AzFramework::PaintBrushColorMode::SRGB;
+                            GlobalPaintBrushSettingsRequestBus::BroadcastResult(
+                                colorMode, &GlobalPaintBrushSettingsRequests::GetBrushColorMode);
+
                             enum ColorSpace : uint32_t
                             {
                                 LinearSRGB,
@@ -62,8 +67,7 @@ namespace AzToolsFramework
 
                             // The property is in either SRGB or linear, depending on paintbrush settings, but we should display the colors
                             // using SRGB.
-                            configuration.m_propertyColorSpaceId =
-                                (handler->GetColorMode() == AzFramework::PaintBrushColorMode::SRGB)
+                            configuration.m_propertyColorSpaceId = (colorMode == AzFramework::PaintBrushColorMode::SRGB)
                                 ? ColorSpace::SRGB : ColorSpace::LinearSRGB;
                             configuration.m_colorPickerDialogColorSpaceId = ColorSpace::SRGB;
                             configuration.m_colorSwatchColorSpaceId = ColorSpace::SRGB;
@@ -95,7 +99,6 @@ namespace AzToolsFramework
 
                             return configuration;
                         })
-                        ->Attribute(AZ::Edit::Attributes::ReadOnly, &PaintBrushSettings::GetColorReadOnly)
                         ->Attribute(AZ::Edit::Attributes::Visibility, &PaintBrushSettings::GetColorVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PaintBrushSettings::OnColorChanged)
                     ->DataElement(
@@ -108,7 +111,6 @@ namespace AzToolsFramework
                         ->Attribute(AZ::Edit::Attributes::Step, 0.5f)
                         ->Attribute(AZ::Edit::Attributes::DisplayDecimals, 1)
                         ->Attribute(AZ::Edit::Attributes::Suffix, " %")
-                        ->Attribute(AZ::Edit::Attributes::ReadOnly, &PaintBrushSettings::GetIntensityReadOnly)
                         ->Attribute(AZ::Edit::Attributes::Visibility, &PaintBrushSettings::GetIntensityVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PaintBrushSettings::OnIntensityChanged)
                     ->DataElement(
@@ -121,7 +123,6 @@ namespace AzToolsFramework
                         ->Attribute(AZ::Edit::Attributes::Step, 0.5f)
                         ->Attribute(AZ::Edit::Attributes::DisplayDecimals, 1)
                         ->Attribute(AZ::Edit::Attributes::Suffix, " %")
-                        ->Attribute(AZ::Edit::Attributes::ReadOnly, &PaintBrushSettings::GetOpacityReadOnly)
                         ->Attribute(AZ::Edit::Attributes::Visibility, &PaintBrushSettings::GetOpacityVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PaintBrushSettings::OnOpacityChanged)
                     ->DataElement(


### PR DESCRIPTION
## What does this PR do?

This fixes two problems discovered while testing the Paint Brush Settings with color painting:
1. The lambda for setting the color space wasn't getting called due to the wrong function signature. (See #13830 ) This was causing the color field to display the colors in the wrong color space.
2. By setting the color field to readonly when using the eyedropper, the color is greyed out, making it hard to see the color the eyedropper is picking. There's no harm in leaving these fields writeable, so this removes the readonly flags on them.

## How was this PR tested?

I used these changes with local modifications for doing color painting and verified that the color picker is much more usable.
