### PR TITLE
Changed codeowners test to not fail if o3de text is not in path.

### DIFF
--- a/Tools/LyTestTools/tests/integ/test_o3de_codeowners.py
+++ b/Tools/LyTestTools/tests/integ/test_o3de_codeowners.py
@@ -14,7 +14,7 @@ import ly_test_tools.cli.codeowners_hint as hint
 def test_FindCodeowners_ThisCWD_FindForO3DE():
     codeowners_path = hint.find_github_codeowners(os.path.abspath(__file__))
     assert codeowners_path
-    assert "o3de" in str(codeowners_path), "codeowners file has been tampered with, or test unexpectedly migrated"
+    assert ".github" in str(codeowners_path), "codeowners file has been tampered with, or test unexpectedly migrated"
 
 
 def test_FindCodeowners_ThisFilesystemRoot_NotFound():


### PR DESCRIPTION
Signed-off-by: scspaldi <scspaldi@amazon.com>

## What does this PR do?
https://github.com/o3de/o3de/issues/13304
Fixes a test to make it not rely on "o3de" being in the file path unnecessarily.

## How was this PR tested?
Ran the test locally.