### PR TITLE
Updated ImGuiPassTree to use ScriptableImGui for the color range sliders

### DIFF
--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiPassTree.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiPassTree.inl
@@ -87,7 +87,7 @@ namespace AZ::Render
 
             if (m_showAttachments)
             {
-                ImGui::SliderFloat2("Color Range", m_attachmentColorTranformRange, 0.0f, 1.0f);
+                Scriptable_ImGui::SliderFloat2("Color Range", m_attachmentColorTranformRange, 0.0f, 1.0f);
             }
 
             if (Scriptable_ImGui::Button("Save Attachment"))


### PR DESCRIPTION
## What does this PR do?

Updated ImGuiPassTree to use ScriptableImGui for the color range sliders. This allows the range to be adjusted in AtomSampleViewer test scripts.

## How was this PR tested?

Tested together with WIP changes to add a new test script that modifies this color range.
