### PR TITLE
Fix crash on outliner tree collapse

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
@@ -564,8 +564,14 @@ namespace AzToolsFramework
 
         if (m_prefabFocusPublicInterface->IsOwningPrefabBeingFocused(entityId))
         {
-            // Close this prefab and focus on the parent
-            m_prefabFocusPublicInterface->FocusOnParentOfFocusedPrefab(s_editorEntityContextId);
+            // Close this prefab and focus on the parent.
+            // This is deferred to the end of the message queue to allow Qt code to continue
+            // working with unaltered tree indices after it has sent the "on collapsed" event.
+            // Changing focus can remove/add tree rows which would invalidate any tree indices
+            // used by Qt when returning from the handler
+            QTimer::singleShot(0, [this] {
+                m_prefabFocusPublicInterface->FocusOnParentOfFocusedPrefab(AzToolsFramework::PrefabUiHandler::s_editorEntityContextId);
+            });
         }
     }
 


### PR DESCRIPTION
Signed-off-by: michabr <82236305+michabr@users.noreply.github.com>

## What does this PR do?

This PR fixes a crash that occurs when the left arrow key is used to collapse a tree row in the outliner that represents a focused prefab container. The issue is that after Qt sends the "on collapsed" callback, it expects the tree rows to be unaltered as it continues to manipulate tree indices. When the focus changes to another prefab, rows can be added or removed from the tree, causing the old tree indices to become invalid.

The fix is to move the focus handling to the end of the message queue to allow Qt to finish its own "on collapsed" logic before we perform ours.

Fixes #13796.

## How was this PR tested?

Manual testing in editor.
