### PR TITLE
Fixed Matrix3x4::GetInverseFull() and FBX processing.

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x4.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x4.cpp
@@ -433,7 +433,7 @@ namespace AZ
         // calculate the determinant
         const float determinant = result.m_rows[0].Dot3(GetColumn(0));
 
-        if (!AZ::IsClose(determinant, 0.0f))
+        if (!AZ::IsClose(determinant, 0.0f, Constants::FloatEpsilon))
         {
             float determinantInv = 1.0f / determinant;
             result.m_rows[0] *= determinantInv;

--- a/Code/Framework/AzCore/Tests/Math/Matrix3x4Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Matrix3x4Tests.cpp
@@ -739,6 +739,21 @@ namespace UnitTest
         EXPECT_THAT(inverse.GetTranslation(), IsClose(AZ::Vector3(-1.4f)));
     }
 
+    TEST(MATH_Matrix3x4, GetInverseFullSmallDeterminant)
+    {
+        // This is a regression test for a specific case that was broken by some changes to Matrix3x4::GetInverseFull()
+
+        const AZ::Matrix3x4 matrix = AZ::Matrix3x4::CreateFromRows(
+            AZ::Vector4(-0.0162572227f, 6.21248771e-17f, 1.42125156e-09f, 0.0f),
+            AZ::Vector4(1.42125156e-09f, 7.10625780e-10f, 0.0162572227f, 0.0f),
+            AZ::Vector4(0.0f, 0.0162572227f, -7.10625780e-10f, 0.0f)
+        );
+        const AZ::Matrix3x4 inverse = matrix.GetInverseFull();
+        EXPECT_THAT(inverse.GetRow(0), IsClose(AZ::Vector4(-61.5111237f, 5.37747292e-06f, 0.0f, 0.0f)));
+        EXPECT_THAT(inverse.GetRow(1), IsClose(AZ::Vector4(2.35056820e-13f, 2.68873646e-06f, 61.5111237f, 0.0f)));
+        EXPECT_THAT(inverse.GetRow(2), IsClose(AZ::Vector4(5.37747292e-06f, 61.5111237f, -2.68873646e-06f, 0.0f)));
+    }
+
     using Matrix3x4InvertFastFixture = ::testing::TestWithParam<AZ::Matrix3x4>;
 
     TEST_P(Matrix3x4InvertFastFixture, GetInverseFast)

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
@@ -114,7 +114,7 @@ namespace AZ
             if (auto* serialize = azrtti_cast<SerializeContext*>(context))
             {
                 serialize->Class<ModelAssetBuilderComponent, SceneAPI::SceneCore::ExportingComponent>()
-                    ->Version(34);  // Fix vertex welding
+                    ->Version(35);  // Fix vertex welding
             }
         }
 


### PR DESCRIPTION

## What does this PR do?

Fixed Matrix3x4::GetInverseFull() and FBX processing.
This bug was introduced at https://github.com/o3de/o3de/pull/13739 It messed up the normal vectors on some models, which caused many AtomSampleViewer screenshot tests to fail. The tests are passing again.

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>

## How was this PR tested?

AtomSampleViewer full test suite on vulkan.
