### PR TITLE
AssetProcessor: Fix new startup scan skip mode, update UX and rename tools to settings

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -3351,6 +3351,7 @@ namespace AssetProcessor
             m_fileModTimes.clear();
             m_fileHashes.clear();
 
+            QueueIdleCheck();
             m_initialScanSkippingFeature = false;
             return;
         }

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
@@ -240,7 +240,7 @@ void MainWindow::Activate()
     ui->buttonList->addTab(QStringLiteral("Logs"));
     ui->buttonList->addTab(QStringLiteral("Connections"));
     ui->buttonList->addTab(QStringLiteral("Builders"));
-    ui->buttonList->addTab(QStringLiteral("Tools"));
+    ui->buttonList->addTab(QStringLiteral("Settings"));
     ui->buttonList->addTab(QStringLiteral("Shared Cache"));
 
     connect(ui->buttonList, &AzQtComponents::SegmentBar::currentChanged, ui->dialogStack, &QStackedWidget::setCurrentIndex);
@@ -591,7 +591,7 @@ void MainWindow::Activate()
         &BuilderData::OnCreateJobsDurationChanged);
     connect(m_builderData, &BuilderData::DurationChanged, m_builderInfoMetrics, &BuilderInfoMetricsModel::OnDurationChanged);
 
-    // Tools tab:
+    // Settings tab:
     connect(ui->fullScanButton, &QPushButton::clicked, this, &MainWindow::OnRescanButtonClicked);
 
     AzQtComponents::CheckBox::applyToggleSwitchStyle(ui->modtimeSkippingCheckBox);

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.h
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.h
@@ -112,7 +112,7 @@ public:
 
     explicit MainWindow(GUIApplicationManager* guiApplicationManager, QWidget* parent = 0);
     void Activate();
-    ~MainWindow();
+    ~MainWindow() override;
 
 public Q_SLOTS:
     void ShowWindow();

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
@@ -1464,10 +1464,10 @@
              </layout>
             </widget>
            </widget>
-          </item>
+          </item>dis
          </layout>
         </widget>
-        <widget class="QWidget" name="ToolsPage">
+        <widget class="QWidget" name="SettingsPage">
          <layout class="QVBoxLayout" name="verticalLayout_3">
           <item>
            <layout class="QVBoxLayout" name="fullScanLayout">
@@ -1771,7 +1771,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;Disable Startup Scan&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;Skip Startup Scan&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                </widget>
               </item>
@@ -1840,7 +1840,7 @@
               <item>
                <widget class="QLabel" name="skipinitialdatabaseDescription">
                 <property name="text">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This mode disables the startup scan (modified file changes while the asset processor wasn't running won't be detected).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This mode skips startup checks for assets modified while AssetProcessor was closed. (Use this mode to improve Editor launch times when assets are not changing. Skipping these startup checks may result in unexpected behavior if assets are modified while Asset Processor is not running).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="scaledContents">
                  <bool>false</bool>

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
@@ -1464,7 +1464,7 @@
              </layout>
             </widget>
            </widget>
-          </item>dis
+          </item>
          </layout>
         </widget>
         <widget class="QWidget" name="SettingsPage">

--- a/Code/Tools/AssetProcessor/native/ui/ProductAssetTreeModel.h
+++ b/Code/Tools/AssetProcessor/native/ui/ProductAssetTreeModel.h
@@ -18,7 +18,7 @@ namespace AssetProcessor
     {
     public:
         ProductAssetTreeModel(AZStd::shared_ptr<AzToolsFramework::AssetDatabase::AssetDatabaseConnection> sharedDbConnection, QObject *parent = nullptr);
-        virtual ~ProductAssetTreeModel();
+        ~ProductAssetTreeModel() override;
 
         // AssetDatabaseNotificationBus::Handler
         void OnProductFileChanged(const AzToolsFramework::AssetDatabase::ProductDatabaseEntry& entry) override;

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -804,7 +804,7 @@ void ApplicationManagerBase::InitAssetRequestHandler(AssetProcessor::AssetReques
         {
             if (!m_assetProcessorManagerIsReady)
             {
-                if (m_remainingAPMJobs == newNum)
+                if ((m_remainingAPMJobs == newNum) && m_remainingAPMJobs)
                 {
                     return;
                 }

--- a/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.h
+++ b/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.h
@@ -52,7 +52,7 @@ class GUIApplicationManager
     Q_OBJECT
 public:
     explicit GUIApplicationManager(int* argc, char*** argv, QObject* parent = 0);
-    virtual ~GUIApplicationManager();
+    ~GUIApplicationManager() override;
 
     ApplicationManager::BeforeRunStatus BeforeRun() override;
     IniConfiguration* GetIniConfiguration() const;


### PR DESCRIPTION
Signed-off-by: Pip Potter <61438964+lmbr-pip@users.noreply.github.com>

## What does this PR do?

Will consider splitting into seperate PRs

1. Fixes new startup scan mode so AP correct signals that its Idle.  Ensures that `m_isAssetProcessorReady` flag is correctly set when entering Idle after skipping startup scan.
3. Update UX for startup scan mode to new language discussed with sig/ui-ux
4. Rename Tools tab -> settings
5. Fix missing or incorrect virtuals noticed in code

![Screenshot 2022-12-29 125957](https://user-images.githubusercontent.com/61438964/210012340-bff8f355-ab38-4a73-827c-0b4027c03e04.png)



## How was this PR tested?

* Ran all unit tests
* Ran AP with new startup scan and ensured that once AP goes Idle, Editor gets a correct response from `RequestAssetProcessorStatus`
