### PR TITLE
show secondary asset browser from context menu

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
@@ -9,6 +9,7 @@
 
 #include "EditorDefs.h"
 
+#include "AzAssetBrowser/AzAssetBrowserWindow.h"
 #include "AzAssetBrowserRequestHandler.h"
 
 // Qt
@@ -508,6 +509,17 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
                         OpenWithOS(fullFilePath);
                     });
             }
+
+            menu->addAction(QObject::tr("Open in another Asset Browser"), [fullFilePath, treeView](){
+                auto* browser1 = qobject_cast<AzAssetBrowserWindow*>(QtViewPaneManager::instance()->OpenPane(LyViewPane::AssetBrowser)->Widget());
+                const QString name2 = QString("%1 (2)").arg(LyViewPane::AssetBrowser);
+                auto* browser2 = qobject_cast<AzAssetBrowserWindow*>(QtViewPaneManager::instance()->OpenPane(name2)->Widget());
+                if (browser1->TreeViewBelongsTo(treeView)) {
+                    browser2->SelectAsset(fullFilePath.c_str());
+                } else {
+                    browser1->SelectAsset(fullFilePath.c_str());
+                }
+            });
 
             AZStd::vector<const ProductAssetBrowserEntry*> products;
             entry->GetChildrenRecursively<ProductAssetBrowserEntry>(products);

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -10,6 +10,8 @@
 
 #include "AzAssetBrowserWindow.h"
 
+#include <AssetBrowser/Views/AssetBrowserTreeView.h>
+
 // AzToolsFramework
 #include <AzCore/Console/IConsole.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
@@ -310,6 +312,10 @@ void AzAssetBrowserWindow::RegisterViewClass()
     AzToolsFramework::ViewPaneOptions options;
     options.preferedDockingArea = Qt::LeftDockWidgetArea;
     AzToolsFramework::RegisterViewPane<AzAssetBrowserWindow>(LyViewPane::AssetBrowser, LyViewPane::CategoryTools, options);
+
+    options.showInMenu = false;
+    const QString name = QString("%1 (2)").arg(LyViewPane::AssetBrowser);
+    AzToolsFramework::RegisterViewPane<AzAssetBrowserWindow>(qPrintable(name), LyViewPane::CategoryTools, options);
 }
 
 QObject* AzAssetBrowserWindow::createListenerForShowAssetEditorEvent(QObject* parent)
@@ -318,6 +324,10 @@ QObject* AzAssetBrowserWindow::createListenerForShowAssetEditorEvent(QObject* pa
 
     // the listener is attached to the parent and will get cleaned up then
     return listener;
+}
+
+bool AzAssetBrowserWindow::TreeViewBelongsTo(AzToolsFramework::AssetBrowser::AssetBrowserTreeView* treeView) {
+    return m_ui->m_assetBrowserTreeViewWidget == treeView;
 }
 
 void AzAssetBrowserWindow::resizeEvent(QResizeEvent* resizeEvent)

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.h
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.h
@@ -11,6 +11,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 
 #include <QWidget>
+#include <QMenu>
 #endif
 
 class QItemSelection;
@@ -29,6 +30,7 @@ namespace AzToolsFramework
         class AssetBrowserTableModel;
         class AssetBrowserModel;
         class AssetBrowserTableFilterModel;
+        class AssetBrowserTreeView;
 
         enum class AssetBrowserDisplayState : int
         {
@@ -54,6 +56,7 @@ public:
 
     static QObject* createListenerForShowAssetEditorEvent(QObject* parent);
 
+    bool TreeViewBelongsTo(AzToolsFramework::AssetBrowser::AssetBrowserTreeView* treeView);
 
 Q_SIGNALS:
     void SizeChangedSignal(int newWidth);


### PR DESCRIPTION
This adds a secondary asset browser, which is not shown in the Tools menu, that can be opened by right clicking assets in the asset browser.

This partially fixes https://github.com/o3de/o3de/issues/12870. Dragging and dropping between the two asset browsers is not implemented yet.

Signed-off-by: Be Wilson <be.wilson@kdab.com>


https://user-images.githubusercontent.com/9455094/210030961-69a04fe2-c962-41f6-889e-383f00c5f3bb.mp4

