### PR TITLE
[Terrain] Support multiple generic runtime paint sessions

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
@@ -54,6 +54,7 @@
 #include <AzFramework/IO/LocalFileIO.h>
 #include <AzFramework/IO/RemoteStorageDrive.h>
 #include <AzFramework/PaintBrush/PaintBrushSettings.h>
+#include <AzFramework/PaintBrush/PaintBrushSystemComponent.h>
 #include <AzFramework/Physics/Utils.h>
 #include <AzFramework/Physics/Material/PhysicsMaterialSystemComponent.h>
 #include <AzFramework/Render/GameIntersectorComponent.h>
@@ -365,6 +366,7 @@ namespace AzFramework
             azrtti_typeid<AzFramework::RenderGeometry::GameIntersectorComponent>(),
             azrtti_typeid<AzFramework::AssetSystem::AssetSystemComponent>(),
             azrtti_typeid<AzFramework::InputSystemComponent>(),
+            azrtti_typeid<AzFramework::PaintBrushSystemComponent>(),
             azrtti_typeid<AzFramework::StreamingInstall::StreamingInstallSystemComponent>(),
             azrtti_typeid<AzFramework::SpawnableSystemComponent>(),
             azrtti_typeid<Physics::MaterialSystemComponent>(),

--- a/Code/Framework/AzFramework/AzFramework/AzFrameworkModule.cpp
+++ b/Code/Framework/AzFramework/AzFramework/AzFrameworkModule.cpp
@@ -18,6 +18,7 @@
 #include <AzFramework/FileTag/FileTagComponent.h>
 #include <AzFramework/Input/Contexts/InputContextComponent.h>
 #include <AzFramework/Input/System/InputSystemComponent.h>
+#include <AzFramework/PaintBrush/PaintBrushSystemComponent.h>
 #include <AzFramework/Render/GameIntersectorComponent.h>
 #include <AzFramework/Scene/SceneSystemComponent.h>
 #include <AzFramework/Script/ScriptComponent.h>
@@ -46,6 +47,7 @@ namespace AzFramework
             AzFramework::AssetSystem::AssetSystemComponent::CreateDescriptor(),
             AzFramework::InputSystemComponent::CreateDescriptor(),
             AzFramework::InputContextComponent::CreateDescriptor(),
+            AzFramework::PaintBrushSystemComponent::CreateDescriptor(),
 
     #if !defined(AZCORE_EXCLUDE_LUA)
             AzFramework::ScriptComponent::CreateDescriptor(),

--- a/Code/Framework/AzFramework/AzFramework/PaintBrush/PaintBrush.cpp
+++ b/Code/Framework/AzFramework/AzFramework/PaintBrush/PaintBrush.cpp
@@ -438,7 +438,8 @@ namespace AzFramework
         // values at specific world positions, and provide the blendFn to perform blending operations based on the provided base and
         // paint brush values.
         PaintBrushNotificationBus::Event(
-            m_ownerEntityComponentId, &PaintBrushNotificationBus::Events::OnPaint, strokeRegion, valueLookupFn, blendFn);
+            m_ownerEntityComponentId, &PaintBrushNotificationBus::Events::OnPaint,
+            brushSettings.GetColor(), strokeRegion, valueLookupFn, blendFn);
     }
 
     void PaintBrush::SmoothToLocation(
@@ -564,6 +565,7 @@ namespace AzFramework
         PaintBrushNotificationBus::Event(
             m_ownerEntityComponentId,
             &PaintBrushNotificationBus::Events::OnSmooth,
+            brushSettings.GetColor(),
             strokeRegion,
             valueLookupFn,
             valuePointOffsets,

--- a/Code/Framework/AzFramework/AzFramework/PaintBrush/PaintBrushNotificationBus.h
+++ b/Code/Framework/AzFramework/AzFramework/PaintBrush/PaintBrushNotificationBus.h
@@ -86,17 +86,27 @@ namespace AzFramework
         //! 2. The listener calls the paintbrush value callback for each position in the region that it cares about.
         //! 3. The paintbrush responds with the specific painted values for each of those positions based on the brush shape and settings.
         //! 4. The listener uses the blendFn to blend values together using the paint brush blending method.
+        //! @param color The color of the paint stroke, including opacity
         //! @param dirtyArea The AABB of the area that has been painted in.
         //! @param valueLookupFn The paintbrush value callback to use to get the intensities / opacities / valid flags for
         //! specific positions.
         //! @param blendFn The paintbrush callback to use to blend values together.
-        virtual void OnPaint(const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, BlendFn& blendFn) = 0;
+        virtual void OnPaint(
+            [[maybe_unused]] const AZ::Color& color,
+            [[maybe_unused]] const AZ::Aabb& dirtyArea,
+            [[maybe_unused]] ValueLookupFn& valueLookupFn,
+            [[maybe_unused]] BlendFn& blendFn)
+        {
+        }
 
         //! Notifies listeners that the paintbrush eyedropper has requested a color from a point.
         //! This will get called in each frame that the paintbrush continues its brush stroke and the brush has moved.
         //! @param brushCenterPoint the point to get the color from.
         //! @return The color stored in the data source at that point.
-        virtual AZ::Color OnGetColor([[maybe_unused]] const AZ::Vector3& brushCenterPoint) = 0;
+        virtual AZ::Color OnGetColor([[maybe_unused]] const AZ::Vector3& brushCenterPoint)
+        {
+            return AZ::Color(0.0f, 0.0f, 0.0f, 1.0f);
+        }
 
         //! Notifies listeners that the paintbrush is smoothing a region.
         //! This will get called in each frame that the paintbrush continues to smooth and the brush has moved.
@@ -107,14 +117,20 @@ namespace AzFramework
         //! 3. The paintbrush responds with the specific brush values for each of those positions based on the brush shape and settings.
         //! 4. The listener gets an NxN set of values around each valid brush position.
         //! 4. The listener uses the smoothFn to smooth those values together using the paint brush smoothing method.
+        //! @param color The color of the paint stroke, including opacity
         //! @param dirtyArea The AABB of the area that has been painted in.
         //! @param valueLookupFn The paintbrush value callback to use to get the intensities / opacities / valid flags for
         //! specific positions.
         //! @param valuePointOffsets A vector of relative positional offsets to use for looking up all the values to pass into smoothFn
         //! @param smoothFn The paintbrush callback to use to smooth values together.
         virtual void OnSmooth(
-            const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn,
-            AZStd::span<const AZ::Vector3> valuePointOffsets, SmoothFn& smoothFn) = 0;
+            [[maybe_unused]] const AZ::Color& color,
+            [[maybe_unused]] const AZ::Aabb& dirtyArea,
+            [[maybe_unused]] ValueLookupFn& valueLookupFn,
+            [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,
+            [[maybe_unused]] SmoothFn& smoothFn)
+        {
+        }
     };
 
     using PaintBrushNotificationBus = AZ::EBus<PaintBrushNotifications>;

--- a/Code/Framework/AzFramework/AzFramework/PaintBrush/PaintBrushSessionBus.h
+++ b/Code/Framework/AzFramework/AzFramework/PaintBrush/PaintBrushSessionBus.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/Math/Uuid.h>
+#include <AzFramework/PaintBrush/PaintBrushSettings.h>
+
+namespace AzFramework
+{
+    //! EBus that supports the painting API at runtime.
+    //! This is exposed to the Behavior Context and provides a common runtime interface for any paintable component.
+    class PaintBrushSession : public AZ::EBusTraits
+    {
+    public:
+        // Overrides the default AZ::EBusTraits handler policy to allow only one listener.
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        //! Start an image modification session.
+        //! This will create a modification buffer that contains an uncompressed copy of the current image data.
+        //! @param paintableEntityId The entity to connect with a paintbrush session.
+        virtual AZ::Uuid StartPaintSession(const AZ::EntityId& paintableEntityId) = 0;
+
+        //! Finish an image modification session.
+        //! Clean up any helper structures used during image modification.
+        virtual void EndPaintSession(const AZ::Uuid& sessionId) = 0;
+
+        //! The following APIs are the high-level image modification APIs.
+        //! These enable image modifications through paintbrush controls.
+
+        //! Start a brush stroke with the given brush settings for color/intensity/opacity.
+        //! @param brushSettings The paintbrush settings containing the color/intensity/opacity to use for the brush stroke.
+        virtual void BeginBrushStroke(const AZ::Uuid& sessionId, const AzFramework::PaintBrushSettings& brushSettings) = 0;
+
+        //! End the current brush stroke.
+        virtual void EndBrushStroke(const AZ::Uuid& sessionId) = 0;
+
+        //! Returns whether or not the brush is currently in a brush stroke.
+        //! @return True if a brush stroke has been started, false if not.
+        virtual bool IsInBrushStroke(const AZ::Uuid& sessionId) const = 0;
+
+        //! Reset the brush tracking so that the next action will be considered the start of a stroke movement instead of a continuation.
+        //! This is useful for handling discontinuous movement (like moving off the edge of the surface on one side and back on from
+        //! a different side).
+        virtual void ResetBrushStrokeTracking(const AZ::Uuid& sessionId) = 0;
+
+        //! Apply a paint color to the underlying data based on brush movement and settings.
+        //! @param brushCenter The current center of the paintbrush.
+        //! @param brushSettings The current paintbrush settings.
+        virtual void PaintToLocation(
+            const AZ::Uuid& sessionId, const AZ::Vector3& brushCenter, const AzFramework::PaintBrushSettings& brushSettings) = 0;
+
+        //! Smooth the underlying data based on brush movement and settings.
+        //! @param brushCenter The current center of the paintbrush.
+        //! @param brushSettings The current paintbrush settings.
+        virtual void SmoothToLocation(
+            const AZ::Uuid& sessionId, const AZ::Vector3& brushCenter, const AzFramework::PaintBrushSettings& brushSettings) = 0;
+    };
+
+    using PaintBrushSessionBus = AZ::EBus<PaintBrushSession>;
+
+} // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/PaintBrush/PaintBrushSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/PaintBrush/PaintBrushSystemComponent.cpp
@@ -53,9 +53,8 @@ namespace AzFramework
     {
         AZ::EntityComponentIdPair entityComponentPair;
 
-        // To find the component associated with this entity id, visit every paintbrush notification bus and look for the ones
-        // that match the entity id. 
-        // Visit every paintbrush notification bus.
+        // To find the paintable component associated with this entity id, visit every paintbrush notification bus handler
+        // and look for the first one that matches the entity id. 
         AzFramework::PaintBrushNotificationBus::EnumerateHandlers(
             [entityId, &entityComponentPair]([[maybe_unused]]AzFramework::PaintBrushNotifications* handler) -> bool
             {
@@ -71,6 +70,7 @@ namespace AzFramework
                 return true;
             });
 
+        // If we found a match, create a new paint session for this entity/component pair.
         if (entityComponentPair.GetEntityId().IsValid())
         {
             auto paintBrush = AZStd::make_shared<AzFramework::PaintBrush>(entityComponentPair);

--- a/Code/Framework/AzFramework/AzFramework/PaintBrush/PaintBrushSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/PaintBrush/PaintBrushSystemComponent.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzFramework/PaintBrush/PaintBrushSystemComponent.h>
+
+namespace AzFramework
+{
+    void PaintBrushSystemComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<PaintBrushSystemComponent, AZ::Component>()
+                ->Version(1)
+                ;
+        }
+
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->EBus<PaintBrushSessionBus>("PaintBrushSessionBus")
+                ->Attribute(AZ::Script::Attributes::Category, "PaintBrush")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, "paintbrush")
+                ->Event("StartPaintSession", &PaintBrushSessionBus::Events::StartPaintSession)
+                ->Event("EndPaintSession", &PaintBrushSessionBus::Events::EndPaintSession)
+                ->Event("BeginBrushStroke", &PaintBrushSessionBus::Events::BeginBrushStroke)
+                ->Event("EndBrushStroke", &PaintBrushSessionBus::Events::EndBrushStroke)
+                ->Event("IsInBrushStroke", &PaintBrushSessionBus::Events::IsInBrushStroke)
+                ->Event("ResetBrushStrokeTracking", &PaintBrushSessionBus::Events::ResetBrushStrokeTracking)
+                ->Event("PaintToLocation", &PaintBrushSessionBus::Events::PaintToLocation)
+                ->Event("SmoothToLocation", &PaintBrushSessionBus::Events::SmoothToLocation);
+        }
+    }
+
+    void PaintBrushSystemComponent::Activate()
+    {
+        PaintBrushSessionBus::Handler::BusConnect();
+    }
+
+    void PaintBrushSystemComponent::Deactivate()
+    {
+        PaintBrushSessionBus::Handler::BusDisconnect();
+    }
+
+    AZ::Uuid PaintBrushSystemComponent::StartPaintSession(const AZ::EntityId& entityId)
+    {
+        AZ::EntityComponentIdPair entityComponentPair;
+
+        // To find the component associated with this entity id, visit every paintbrush notification bus and look for the ones
+        // that match the entity id. 
+        // Visit every paintbrush notification bus.
+        AzFramework::PaintBrushNotificationBus::EnumerateHandlers(
+            [entityId, &entityComponentPair]([[maybe_unused]]AzFramework::PaintBrushNotifications* handler) -> bool
+            {
+                auto handlerEntityComponentPair = *(AzFramework::PaintBrushNotificationBus::GetCurrentBusId());
+
+                if (handlerEntityComponentPair.GetEntityId() == entityId)
+                {
+                    entityComponentPair = handlerEntityComponentPair;
+                    return false;
+                }
+
+                // Haven't found a match yet, so keep enumerating.
+                return true;
+            });
+
+        if (entityComponentPair.GetEntityId().IsValid())
+        {
+            auto paintBrush = AZStd::make_shared<AzFramework::PaintBrush>(entityComponentPair);
+            auto sessionId = AZ::Uuid::CreateRandom();
+
+            paintBrush->BeginPaintMode();
+
+            m_brushSessions.emplace(sessionId, AZStd::move(paintBrush));
+            return sessionId;
+        }
+
+        AZ_Error("PaintBrushSystemComponent", false, "Entity doesn't have a paintable component.");
+        return AZ::Uuid::CreateNull();
+    }
+
+    void PaintBrushSystemComponent::EndPaintSession(const AZ::Uuid& sessionId)
+    {
+        auto paintBrushItr = m_brushSessions.find(sessionId);
+        AZ_Error("PaintBrushSystemComponent", paintBrushItr != m_brushSessions.end(), "Paint Brush Session ID isn't valid.");
+
+        if (paintBrushItr != m_brushSessions.end())
+        {
+            paintBrushItr->second->EndPaintMode();
+            m_brushSessions.erase(sessionId);
+        }
+    }
+
+    void PaintBrushSystemComponent::BeginBrushStroke(const AZ::Uuid& sessionId, const AzFramework::PaintBrushSettings& brushSettings)
+    {
+        auto paintBrushItr = m_brushSessions.find(sessionId);
+        AZ_Error("PaintBrushSystemComponent", paintBrushItr != m_brushSessions.end(), "Paint Brush Session ID isn't valid.");
+
+        if (paintBrushItr != m_brushSessions.end())
+        {
+            paintBrushItr->second->BeginBrushStroke(brushSettings);
+        }
+    }
+
+    void PaintBrushSystemComponent::EndBrushStroke(const AZ::Uuid& sessionId)
+    {
+        auto paintBrushItr = m_brushSessions.find(sessionId);
+        AZ_Error("PaintBrushSystemComponent", paintBrushItr != m_brushSessions.end(), "Paint Brush Session ID isn't valid.");
+
+        if (paintBrushItr != m_brushSessions.end())
+        {
+            paintBrushItr->second->EndBrushStroke();
+        }
+    }
+
+    bool PaintBrushSystemComponent::IsInBrushStroke(const AZ::Uuid& sessionId) const
+    {
+        auto paintBrushItr = m_brushSessions.find(sessionId);
+        AZ_Error("PaintBrushSystemComponent", paintBrushItr != m_brushSessions.end(), "Paint Brush Session ID isn't valid.");
+
+        if (paintBrushItr != m_brushSessions.end())
+        {
+            return paintBrushItr->second->IsInBrushStroke();
+        }
+
+        return false;
+    }
+
+    void PaintBrushSystemComponent::ResetBrushStrokeTracking(const AZ::Uuid& sessionId)
+    {
+        auto paintBrushItr = m_brushSessions.find(sessionId);
+        AZ_Error("PaintBrushSystemComponent", paintBrushItr != m_brushSessions.end(), "Paint Brush Session ID isn't valid.");
+
+        if (paintBrushItr != m_brushSessions.end())
+        {
+            paintBrushItr->second->ResetBrushStrokeTracking();
+        }
+    }
+
+    void PaintBrushSystemComponent::PaintToLocation(
+        const AZ::Uuid& sessionId, const AZ::Vector3& brushCenter, const AzFramework::PaintBrushSettings& brushSettings)
+    {
+        auto paintBrushItr = m_brushSessions.find(sessionId);
+        AZ_Error("PaintBrushSystemComponent", paintBrushItr != m_brushSessions.end(), "Paint Brush Session ID isn't valid.");
+
+        if (paintBrushItr != m_brushSessions.end())
+        {
+            paintBrushItr->second->PaintToLocation(brushCenter, brushSettings);
+        }
+    }
+
+    void PaintBrushSystemComponent::SmoothToLocation(
+        const AZ::Uuid& sessionId, const AZ::Vector3& brushCenter, const AzFramework::PaintBrushSettings& brushSettings)
+    {
+        auto paintBrushItr = m_brushSessions.find(sessionId);
+        AZ_Error("PaintBrushSystemComponent", paintBrushItr != m_brushSessions.end(), "Paint Brush Session ID isn't valid.");
+
+        if (paintBrushItr != m_brushSessions.end())
+        {
+            paintBrushItr->second->SmoothToLocation(brushCenter, brushSettings);
+        }
+    }
+
+} // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/PaintBrush/PaintBrushSystemComponent.h
+++ b/Code/Framework/AzFramework/AzFramework/PaintBrush/PaintBrushSystemComponent.h
@@ -48,10 +48,10 @@ namespace AzFramework
         void SmoothToLocation(
             const AZ::Uuid& sessionId, const AZ::Vector3& brushCenter, const AzFramework::PaintBrushSettings& brushSettings) override;
 
-        //! Instances of a PaintBrush for image modifications that exist for use with the high-level paint APIs exposed
-        //! on the PaintBrushSession. This is *only* used by the paint APIs on the bus - the Editor has its own instance
-        //! of a PaintBrush that it uses in conjunction with mouse tracking, manipulator drawing, etc.
-        //! These are only created and active between StartPaintSession / EndPaintSession calls.
+        //! Tracks one PaintBrush instance per paint session. These are only used to support the PaintBrushSessionBus.
+        //! When painting in the Editor, the Editor tracks its own PaintBrush instance that gets used in conjunction with
+        //! mouse tracking, manipulator drawing, etc.
+        //! These PaintBrush instances only exist between StartPaintSession and EndPaintSession.
         AZStd::unordered_map<AZ::Uuid, AZStd::shared_ptr<AzFramework::PaintBrush>> m_brushSessions;
     };
 }; // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/PaintBrush/PaintBrushSystemComponent.h
+++ b/Code/Framework/AzFramework/AzFramework/PaintBrush/PaintBrushSystemComponent.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/Entity.h>
+#include <AzCore/Math/Uuid.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzFramework/PaintBrush/PaintBrush.h>
+#include <AzFramework/PaintBrush/PaintBrushSessionBus.h>
+
+namespace AzFramework
+{
+    //! PaintBrushSystemComponent generically manages runtime paint brush sessions for any components that support runtime painting.
+    class PaintBrushSystemComponent
+        : public AZ::Component
+        , protected AzFramework::PaintBrushSessionBus::Handler
+    {
+    public:
+        AZ_COMPONENT(PaintBrushSystemComponent, "{EB1CDA1E-A2FD-4AEF-AFBF-B39ED18463AE}");
+
+        PaintBrushSystemComponent() = default;
+        ~PaintBrushSystemComponent() override = default;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+    protected:
+        void Activate() override;
+        void Deactivate() override;
+
+        // PaintBrushSessionBus overrides...
+        AZ::Uuid StartPaintSession(const AZ::EntityId& paintableEntityId) override;
+        void EndPaintSession(const AZ::Uuid& sessionId) override;
+        void BeginBrushStroke(const AZ::Uuid& sessionId, const AzFramework::PaintBrushSettings& brushSettings) override;
+        void EndBrushStroke(const AZ::Uuid& sessionId) override;
+        bool IsInBrushStroke(const AZ::Uuid& sessionId) const override;
+        void ResetBrushStrokeTracking(const AZ::Uuid& sessionId) override;
+        void PaintToLocation(
+            const AZ::Uuid& sessionId, const AZ::Vector3& brushCenter, const AzFramework::PaintBrushSettings& brushSettings) override;
+        void SmoothToLocation(
+            const AZ::Uuid& sessionId, const AZ::Vector3& brushCenter, const AzFramework::PaintBrushSettings& brushSettings) override;
+
+        //! Instances of a PaintBrush for image modifications that exist for use with the high-level paint APIs exposed
+        //! on the PaintBrushSession. This is *only* used by the paint APIs on the bus - the Editor has its own instance
+        //! of a PaintBrush that it uses in conjunction with mouse tracking, manipulator drawing, etc.
+        //! These are only created and active between StartPaintSession / EndPaintSession calls.
+        AZStd::unordered_map<AZ::Uuid, AZStd::shared_ptr<AzFramework::PaintBrush>> m_brushSessions;
+    };
+}; // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
+++ b/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
@@ -222,6 +222,9 @@ set(FILES
     PaintBrush/PaintBrush.cpp
     PaintBrush/PaintBrush.h
     PaintBrush/PaintBrushNotificationBus.h
+    PaintBrush/PaintBrushSessionBus.h
+    PaintBrush/PaintBrushSystemComponent.cpp
+    PaintBrush/PaintBrushSystemComponent.h
     PaintBrush/PaintBrushSettings.cpp
     PaintBrush/PaintBrushSettings.h
     Physics/Collision/CollisionEvents.h

--- a/Code/Framework/AzFramework/Tests/PaintBrush/MockPaintBrushNotificationHandler.h
+++ b/Code/Framework/AzFramework/Tests/PaintBrush/MockPaintBrushNotificationHandler.h
@@ -33,9 +33,10 @@ namespace UnitTest
         MOCK_METHOD0(OnPaintModeEnd, void());
         MOCK_METHOD1(OnBrushStrokeBegin, void(const AZ::Color& color));
         MOCK_METHOD0(OnBrushStrokeEnd, void());
-        MOCK_METHOD3(OnPaint, void(const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, BlendFn& blendFn));
+        MOCK_METHOD4(OnPaint, void(const AZ::Color& color, const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, BlendFn& blendFn));
         MOCK_METHOD1(OnGetColor, AZ::Color(const AZ::Vector3& brushCenterPoint));
-        MOCK_METHOD4(OnSmooth, void(
+        MOCK_METHOD5(OnSmooth, void(
+            const AZ::Color& color,
             const AZ::Aabb& dirtyArea,
             ValueLookupFn& valueLookupFn,
             AZStd::span<const AZ::Vector3> valuePointOffsets,

--- a/Code/Framework/AzFramework/Tests/PaintBrush/PaintBrushPaintLocationTests.cpp
+++ b/Code/Framework/AzFramework/Tests/PaintBrush/PaintBrushPaintLocationTests.cpp
@@ -44,11 +44,12 @@ namespace UnitTest
         const float TestBrushRadius = 1.0f;
         m_settings.SetSize(TestBrushRadius * 2.0f);
 
-        EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_)).Times(1);
+        EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
 
         ON_CALL(mockHandler, OnPaint)
             .WillByDefault(
-                [=](const AZ::Aabb& dirtyArea,
+                [=]([[maybe_unused]] const AZ::Color& color,
+                    const AZ::Aabb& dirtyArea,
                     AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     AzFramework::PaintBrushNotifications::BlendFn& blendFn)
                 {
@@ -138,7 +139,7 @@ namespace UnitTest
 
         // We expect to get called only once for our initial PaintToLocation(); the second PaintToLocation() won't
         // have moved far enough to trigger a second OnPaint call.
-        EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_)).Times(1);
+        EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
 
         paintBrush.BeginPaintMode();
         paintBrush.BeginBrushStroke(m_settings);
@@ -150,7 +151,7 @@ namespace UnitTest
         // Try the test again, this time moving exactly the amount we need to so that we trigger a second call.
         // (We do this to verify that we've correctly identified the threshold under which we should not trigger another OnPaint)
         const AZ::Vector3 largeEnoughSecondLocation = TestBrushCenter + AZ::Vector3(DistanceToTriggerSecondCall, 0.0f, 0.0f);
-        EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_)).Times(2);
+        EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(2);
 
         paintBrush.BeginPaintMode();
         paintBrush.BeginBrushStroke(m_settings);
@@ -187,14 +188,14 @@ namespace UnitTest
         const AZ::Vector3 secondLocation = TestBrushCenter + AZ::Vector3(TestBrushSize * 3.0f, 0.0f, 0.0f);
 
         // We expect to get two OnPaint calls.
-        EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_)).Times(2);
+        EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(2);
 
         paintBrush.BeginPaintMode();
         paintBrush.BeginBrushStroke(m_settings);
 
         ON_CALL(mockHandler, OnPaint)
             .WillByDefault(
-                [=](const AZ::Aabb& dirtyArea,
+                [=]([[maybe_unused]] const AZ::Color& color, const AZ::Aabb& dirtyArea,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::BlendFn& blendFn)
                 {
@@ -207,7 +208,7 @@ namespace UnitTest
 
         ON_CALL(mockHandler, OnPaint)
             .WillByDefault(
-                [=](const AZ::Aabb& dirtyArea,
+                [=]([[maybe_unused]] const AZ::Color& color, const AZ::Aabb& dirtyArea,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::BlendFn& blendFn)
                 {
@@ -243,11 +244,11 @@ namespace UnitTest
         AZ::Vector3 secondLocation = TestBrushCenter + AZ::Vector3(TestBrushSize * 2.0f, 0.0f, 0.0f);
 
         // We expect to get two OnPaint calls.
-        EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_)).Times(2);
+        EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(2);
 
         ON_CALL(mockHandler, OnPaint)
             .WillByDefault(
-                [=](const AZ::Aabb& dirtyArea,
+                [=]([[maybe_unused]] const AZ::Color& color, const AZ::Aabb& dirtyArea,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::BlendFn& blendFn)
                 {
@@ -296,14 +297,14 @@ namespace UnitTest
         const AZ::Vector3 secondLocation = TestBrushCenter + AZ::Vector3(TestBrushSize * 10.0f, 0.0f, 0.0f);
 
         // We expect to get two OnPaint calls.
-        EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_)).Times(2);
+        EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(2);
 
         paintBrush.BeginPaintMode();
         paintBrush.BeginBrushStroke(m_settings);
 
         ON_CALL(mockHandler, OnPaint)
             .WillByDefault(
-                [=](const AZ::Aabb& dirtyArea,
+                [=]([[maybe_unused]] const AZ::Color& color, const AZ::Aabb& dirtyArea,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::BlendFn& blendFn)
                 {
@@ -319,7 +320,7 @@ namespace UnitTest
 
         ON_CALL(mockHandler, OnPaint)
             .WillByDefault(
-                [=](const AZ::Aabb& dirtyArea,
+                [=]([[maybe_unused]] const AZ::Color& color, const AZ::Aabb& dirtyArea,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::BlendFn& blendFn)
                 {

--- a/Code/Framework/AzFramework/Tests/PaintBrush/PaintBrushPaintSettingsTests.cpp
+++ b/Code/Framework/AzFramework/Tests/PaintBrush/PaintBrushPaintSettingsTests.cpp
@@ -36,8 +36,8 @@ namespace UnitTest
             AzFramework::PaintBrush paintBrush(EntityComponentIdPair);
             ::testing::NiceMock<MockPaintBrushNotificationBusHandler> mockHandler(EntityComponentIdPair);
 
-            EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_)).Times(0);
-            EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(0);
+            EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(0);
+            EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(0);
 
             paintBrush.BeginPaintMode();
 
@@ -72,10 +72,11 @@ namespace UnitTest
             paintBrush.BeginBrushStroke(m_settings);
             for (size_t index = 0; index < locations.size(); index++)
             {
-                EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_)).Times(1);
+                EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
                 ON_CALL(mockHandler, OnPaint)
                     .WillByDefault(
-                        [=](const AZ::Aabb& dirtyArea,
+                        [=]([[maybe_unused]] const AZ::Color& color,
+                            const AZ::Aabb& dirtyArea,
                             AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                             [[maybe_unused]] AzFramework::PaintBrushNotifications::BlendFn& blendFn)
                         {
@@ -90,10 +91,11 @@ namespace UnitTest
             paintBrush.BeginBrushStroke(m_settings);
             for (size_t index = 0; index < locations.size(); index++)
             {
-                EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
+                EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
                 ON_CALL(mockHandler, OnSmooth)
                     .WillByDefault(
-                        [=](const AZ::Aabb& dirtyArea,
+                        [=]([[maybe_unused]] const AZ::Color& color,
+                            const AZ::Aabb& dirtyArea,
                             AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                             [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,
                             [[maybe_unused]] AzFramework::PaintBrushNotifications::SmoothFn& smoothFn)
@@ -127,10 +129,11 @@ namespace UnitTest
 
             // Test the blend mode with PaintToLocation()
 
-            EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_)).Times(1);
+            EXPECT_CALL(mockHandler, OnPaint(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
             ON_CALL(mockHandler, OnPaint)
                 .WillByDefault(
-                    [=]([[maybe_unused]] const AZ::Aabb& dirtyArea,
+                    [=]([[maybe_unused]] const AZ::Color& color,
+                        [[maybe_unused]] const AZ::Aabb& dirtyArea,
                         [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                         AzFramework::PaintBrushNotifications::BlendFn& blendFn)
                     {
@@ -153,10 +156,11 @@ namespace UnitTest
 
             // Test the blend mode with SmoothToLocation()
 
-            EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
+            EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
             ON_CALL(mockHandler, OnSmooth)
                 .WillByDefault(
-                    [=]([[maybe_unused]] const AZ::Aabb& dirtyArea,
+                    [=]([[maybe_unused]] const AZ::Color& color,
+                        [[maybe_unused]] const AZ::Aabb& dirtyArea,
                         [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                         [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,
                         AzFramework::PaintBrushNotifications::SmoothFn& smoothFn)
@@ -663,10 +667,11 @@ namespace UnitTest
         {
             m_settings.SetSmoothingRadius(radius);
 
-            EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
+            EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
             ON_CALL(mockHandler, OnSmooth)
                 .WillByDefault(
-                    [=]([[maybe_unused]] const AZ::Aabb& dirtyArea,
+                    [=]([[maybe_unused]] const AZ::Color& color,
+                        [[maybe_unused]] const AZ::Aabb& dirtyArea,
                         [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                         AZStd::span<const AZ::Vector3> valuePointOffsets,
                         AzFramework::PaintBrushNotifications::SmoothFn& smoothFn)
@@ -721,10 +726,11 @@ namespace UnitTest
 
         paintBrush.BeginPaintMode();
 
-        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
+        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
         ON_CALL(mockHandler, OnSmooth)
             .WillByDefault(
-                [=]([[maybe_unused]] const AZ::Aabb& dirtyArea,
+                [=]([[maybe_unused]] const AZ::Color& color,
+                    [[maybe_unused]] const AZ::Aabb& dirtyArea,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,
                     AzFramework::PaintBrushNotifications::SmoothFn& smoothFn)
@@ -769,10 +775,11 @@ namespace UnitTest
 
         paintBrush.BeginPaintMode();
 
-        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
+        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
         ON_CALL(mockHandler, OnSmooth)
             .WillByDefault(
-                [=]([[maybe_unused]] const AZ::Aabb& dirtyArea,
+                [=]([[maybe_unused]] const AZ::Color& color,
+                    [[maybe_unused]] const AZ::Aabb& dirtyArea,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,
                     AzFramework::PaintBrushNotifications::SmoothFn& smoothFn)
@@ -811,10 +818,10 @@ namespace UnitTest
 
         paintBrush.BeginPaintMode();
 
-        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
+        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
         ON_CALL(mockHandler, OnSmooth)
             .WillByDefault(
-                [=]([[maybe_unused]] const AZ::Aabb& dirtyArea,
+                [=]([[maybe_unused]] const AZ::Color& color, [[maybe_unused]] const AZ::Aabb& dirtyArea,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,
                     AzFramework::PaintBrushNotifications::SmoothFn& smoothFn)

--- a/Code/Framework/AzFramework/Tests/PaintBrush/PaintBrushSmoothLocationTests.cpp
+++ b/Code/Framework/AzFramework/Tests/PaintBrush/PaintBrushSmoothLocationTests.cpp
@@ -47,11 +47,12 @@ namespace UnitTest
         // We'll set the smooth mode to "Mean" just so that it's easy to verify that the smoothFn trivially works.
         m_settings.SetSmoothMode(AzFramework::PaintBrushSmoothMode::Mean);
 
-        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
+        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
 
         ON_CALL(mockHandler, OnSmooth)
             .WillByDefault(
-                [=](const AZ::Aabb& dirtyArea,
+                [=]([[maybe_unused]] const AZ::Color& color,
+                    const AZ::Aabb& dirtyArea,
                     AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     AZStd::span<const AZ::Vector3> valuePointOffsets,
                     AzFramework::PaintBrushNotifications::SmoothFn& smoothFn)
@@ -160,7 +161,7 @@ namespace UnitTest
 
         // We expect to get called only once for our initial SmoothToLocation(); the second SmoothToLocation() won't
         // have moved far enough to trigger a second OnSmooth call.
-        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
+        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
 
         paintBrush.BeginPaintMode();
         paintBrush.BeginBrushStroke(m_settings);
@@ -172,7 +173,7 @@ namespace UnitTest
         // Try the test again, this time moving exactly the amount we need to so that we trigger a second call.
         // (We do this to verify that we've correctly identified the threshold under which we should not trigger another OnSmooth)
         const AZ::Vector3 largeEnoughSecondLocation = TestBrushCenter + AZ::Vector3(DistanceToTriggerSecondCall, 0.0f, 0.0f);
-        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(2);
+        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(2);
 
         paintBrush.BeginPaintMode();
         paintBrush.BeginBrushStroke(m_settings);
@@ -209,14 +210,15 @@ namespace UnitTest
         const AZ::Vector3 secondLocation = TestBrushCenter + AZ::Vector3(TestBrushSize * 3.0f, 0.0f, 0.0f);
 
         // We expect to get two OnSmooth calls.
-        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(2);
+        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(2);
 
         paintBrush.BeginPaintMode();
         paintBrush.BeginBrushStroke(m_settings);
 
         ON_CALL(mockHandler, OnSmooth)
             .WillByDefault(
-                [=](const AZ::Aabb& dirtyArea,
+                [=]([[maybe_unused]] const AZ::Color& color,
+                    const AZ::Aabb& dirtyArea,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::SmoothFn& smoothFn)
@@ -230,7 +232,8 @@ namespace UnitTest
 
         ON_CALL(mockHandler, OnSmooth)
             .WillByDefault(
-                [=](const AZ::Aabb& dirtyArea,
+                [=]([[maybe_unused]] const AZ::Color& color,
+                    const AZ::Aabb& dirtyArea,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::SmoothFn& smoothFn)
@@ -267,11 +270,12 @@ namespace UnitTest
         AZ::Vector3 secondLocation = TestBrushCenter + AZ::Vector3(TestBrushSize * 2.0f, 0.0f, 0.0f);
 
         // We expect to get two OnSmooth calls.
-        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(2);
+        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(2);
 
         ON_CALL(mockHandler, OnSmooth)
             .WillByDefault(
-                [=](const AZ::Aabb& dirtyArea,
+                [=]([[maybe_unused]] const AZ::Color& color,
+                    const AZ::Aabb& dirtyArea,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::SmoothFn& smoothFn)
@@ -321,14 +325,15 @@ namespace UnitTest
         const AZ::Vector3 secondLocation = TestBrushCenter + AZ::Vector3(TestBrushSize * 10.0f, 0.0f, 0.0f);
 
         // We expect to get two OnSmooth calls.
-        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(2);
+        EXPECT_CALL(mockHandler, OnSmooth(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(2);
 
         paintBrush.BeginPaintMode();
         paintBrush.BeginBrushStroke(m_settings);
 
         ON_CALL(mockHandler, OnSmooth)
             .WillByDefault(
-                [=](const AZ::Aabb& dirtyArea,
+                [=]([[maybe_unused]] const AZ::Color& color,
+                    const AZ::Aabb& dirtyArea,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::SmoothFn& smoothFn)
@@ -345,7 +350,8 @@ namespace UnitTest
 
         ON_CALL(mockHandler, OnSmooth)
             .WillByDefault(
-                [=](const AZ::Aabb& dirtyArea,
+                [=]([[maybe_unused]] const AZ::Color& color,
+                    const AZ::Aabb& dirtyArea,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::SmoothFn& smoothFn)

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientComponent.h
@@ -16,6 +16,7 @@
 #include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <AzCore/std/parallel/shared_mutex.h>
 #include <AzFramework/PaintBrush/PaintBrush.h>
+#include <AzFramework/PaintBrush/PaintBrushNotificationBus.h>
 #include <GradientSignal/Components/ImageGradientModification.h>
 #include <GradientSignal/Ebuses/GradientRequestBus.h>
 #include <GradientSignal/Ebuses/GradientTransformRequestBus.h>
@@ -102,8 +103,8 @@ namespace GradientSignal
 
         // Non-serialized properties used by the Editor for display purposes.
 
-        //! True if we're currently modifying the image, false if not.
-        bool m_imageModificationActive = false;
+        //! The number of active image modification sessions.
+        int m_numImageModificationsActive = 0;
 
         //! Label to use for the image asset. This gets modified to show current asset loading/processing state.
         AZStd::string m_imageAssetPropertyLabel = "Image Asset";
@@ -120,6 +121,7 @@ namespace GradientSignal
         , private GradientRequestBus::Handler
         , private ImageGradientRequestBus::Handler
         , private ImageGradientModificationBus::Handler
+        , private AzFramework::PaintBrushNotificationBus::Handler
         , private GradientTransformNotificationBus::Handler
     {
     public:
@@ -162,28 +164,24 @@ namespace GradientSignal
         void StartImageModification() override;
         void EndImageModification() override;
         void GetPixelValuesByPosition(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
-        void SetPixelValueByPosition(const AZ::Vector3& position, float value) override;
         void SetPixelValuesByPosition(AZStd::span<const AZ::Vector3> positions, AZStd::span<const float> values) override;
 
         void GetPixelIndicesForPositions(AZStd::span<const AZ::Vector3> positions, AZStd::span<PixelIndex> outIndices) const override;
         void GetPixelValuesByPixelIndex(AZStd::span<const PixelIndex> positions, AZStd::span<float> outValues) const override;
-        void SetPixelValueByPixelIndex(const PixelIndex& position, float value) override;
         void SetPixelValuesByPixelIndex(AZStd::span<const PixelIndex> positions, AZStd::span<const float> values) override;
 
-        void BeginBrushStroke(const AzFramework::PaintBrushSettings& brushSettings) override;
-        void EndBrushStroke() override;
-        bool IsInBrushStroke() const override;
-        void ResetBrushStrokeTracking() override;
-        void PaintToLocation(const AZ::Vector3& brushCenter, const AzFramework::PaintBrushSettings& brushSettings) override;
-        void SmoothToLocation(const AZ::Vector3& brushCenter, const AzFramework::PaintBrushSettings& brushSettings) override;
-
-        AZStd::vector<float>* GetImageModificationBuffer();
         bool ImageIsModified() const;
 
+    protected:
         AZ::Data::Asset<AZ::RPI::StreamingImageAsset> GetImageAsset() const;
         void SetImageAsset(const AZ::Data::Asset<AZ::RPI::StreamingImageAsset>& asset);
 
-    protected:
+        AZStd::vector<float>* GetImageModificationBuffer();
+
+        // PaintBrushNotificationBus overrides...
+        void OnPaintModeBegin() override;
+        void OnPaintModeEnd() override;
+
         // GradientTransformNotificationBus overrides...
         void OnGradientTransformChanged(const GradientTransform& newTransform) override;
 
@@ -266,13 +264,7 @@ namespace GradientSignal
         bool m_imageIsModified = false;
 
         //! Logic for handling image modification requests from PaintBrush instances.
-        //! This is only created and active between StartImageModification / EndImageModification calls.
+        //! This is only created and active between StartPaintSession / EndPaintSession calls.
         AZStd::unique_ptr<ImageGradientModifier> m_imageModifier;
-
-        //! An instance of a PaintBrush for image modifications that exists for use with the high-level paint APIs exposed
-        //! on the ImageGradientModificationBus. This is *only* used by the paint APIs on the bus - the Editor has its own instance
-        //! of a PaintBrush that it uses in conjunction with mouse tracking, manipulator drawing, etc.
-        //! This is only created and active between StartImageModification / EndImageModification calls.
-        AZStd::unique_ptr<AzFramework::PaintBrush> m_paintBrush;
     };
 }

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientModification.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientModification.h
@@ -130,12 +130,6 @@ namespace GradientSignal
         //! we only perform an operation on a pixel once, not multiple times.
         //! After the paint stroke is complete, this buffer is handed off to the undo/redo batch so that we can undo/redo each stroke.
         AZStd::shared_ptr<ImageTileBuffer> m_strokeBuffer;
-
-        //! The intensity of the paint stroke (0 - 1)
-        float m_intensity = 0.0f;
-
-        //! The opacity of the paint stroke (0 - 1)
-        float m_opacity = 0.0f;
     };
 
     //! Handles all of the calculations for figuring out the dirty region AABB for the image gradient based on all its settings.
@@ -195,8 +189,9 @@ namespace GradientSignal
         // PaintBrushNotificationBus overrides
         void OnBrushStrokeBegin(const AZ::Color& color) override;
         void OnBrushStrokeEnd() override;
-        void OnPaint(const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, BlendFn& blendFn) override;
+        void OnPaint(const AZ::Color& color, const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, BlendFn& blendFn) override;
         void OnSmooth(
+            const AZ::Color& color,
             const AZ::Aabb& dirtyArea,
             ValueLookupFn& valueLookupFn,
             AZStd::span<const AZ::Vector3> valuePointOffsets,

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Ebuses/ImageGradientModificationBus.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Ebuses/ImageGradientModificationBus.h
@@ -9,9 +9,7 @@
 #pragma once
 
 #include <AzCore/Component/ComponentBus.h>
-#include <AzFramework/PaintBrush/PaintBrushSettings.h>
-#include <GradientSignal/Util.h>
-
+#include <AzCore/Math/Aabb.h>
 
 namespace GradientSignal
 {
@@ -20,6 +18,7 @@ namespace GradientSignal
     using PixelIndex = AZStd::pair<int16_t, int16_t>;
 
     //! EBus that can be used to modify the image data for an Image Gradient.
+    //! The following APIs are the low-level image modification APIs that enable image modifications at the per-pixel level.
     class ImageGradientModifications
         : public AZ::ComponentBus
     {
@@ -34,38 +33,6 @@ namespace GradientSignal
         //! Finish an image modification session.
         //! Clean up any helper structures used during image modification.
         virtual void EndImageModification() = 0;
-
-        //! The following APIs are the high-level image modification APIs.
-        //! These enable image modifications through paintbrush controls.
-
-        //! Start a brush stroke with the given brush settings for color/intensity/opacity.
-        //! @param brushSettings The paintbrush settings containing the color/intensity/opacity to use for the brush stroke.
-        virtual void BeginBrushStroke(const AzFramework::PaintBrushSettings& brushSettings) = 0;
-
-        //! End the current brush stroke.
-        virtual void EndBrushStroke() = 0;
-
-        //! Returns whether or not the brush is currently in a brush stroke.
-        //! @return True if a brush stroke has been started, false if not.
-        virtual bool IsInBrushStroke() const = 0;
-
-        //! Reset the brush tracking so that the next action will be considered the start of a stroke movement instead of a continuation.
-        //! This is useful for handling discontinuous movement (like moving off the edge of the surface on one side and back on from
-        //! a different side).
-        virtual void ResetBrushStrokeTracking() = 0;
-
-        //! Apply a paint color to the underlying data based on brush movement and settings.
-        //! @param brushCenter The current center of the paintbrush.
-        //! @param brushSettings The current paintbrush settings.
-        virtual void PaintToLocation(const AZ::Vector3& brushCenter, const AzFramework::PaintBrushSettings& brushSettings) = 0;
-
-        //! Smooth the underlying data based on brush movement and settings.
-        //! @param brushCenter The current center of the paintbrush.
-        //! @param brushSettings The current paintbrush settings.
-        virtual void SmoothToLocation(const AZ::Vector3& brushCenter, const AzFramework::PaintBrushSettings& brushSettings) = 0;
-
-        //! The following APIs are the low-level image modification APIs. 
-        //! These enable image modifications at the per-pixel level.
 
         //! Given a list of world positions, return a list of pixel indices into the image.
         //! @param positions The list of world positions to query
@@ -87,16 +54,6 @@ namespace GradientSignal
         //! @param positions The list of pixel indices to query
         //! @param outValues [out] The list of output values. This list is expected to be the same size as the positions list.
         virtual void GetPixelValuesByPixelIndex(AZStd::span<const PixelIndex> indices, AZStd::span<float> outValues) const = 0;
-
-        //! Set the value at the given world position.
-        //! @param position The world position to set the value at.
-        //! @param value The value to set it to.
-        virtual void SetPixelValueByPosition(const AZ::Vector3& position, float value) = 0;
-
-        //! Set the value at the given pixel index.
-        //! @param index The pixel index to set the value at.
-        //! @param value The value to set it to.
-        virtual void SetPixelValueByPixelIndex(const PixelIndex& index, float value) = 0;
 
         //! Given a list of world positions, set the pixels at those positions to the given values.
         //! @param positions The list of world positions to set the values for.

--- a/Gems/GradientSignal/Code/Source/Components/ImageGradientModification.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ImageGradientModification.cpp
@@ -436,7 +436,7 @@ namespace GradientSignal
         AzFramework::PaintBrushNotificationBus::Handler::BusDisconnect();
     }
 
-    void ImageGradientModifier::OnBrushStrokeBegin(const AZ::Color& color)
+    void ImageGradientModifier::OnBrushStrokeBegin([[maybe_unused]] const AZ::Color& color)
     {
         AZ::EntityId entityId = m_ownerEntityComponentId.GetEntityId();
 
@@ -448,9 +448,6 @@ namespace GradientSignal
         {
             return;
         }
-
-        m_paintStrokeData.m_intensity = color.GetR();
-        m_paintStrokeData.m_opacity = color.GetA();
 
         // Create the buffer for holding all the changes for a single continuous paint brush stroke.
         // This buffer will get used during the stroke to hold our accumulated stroke opacity layer,
@@ -603,14 +600,17 @@ namespace GradientSignal
         }
     }
 
-    void ImageGradientModifier::OnPaint(const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, BlendFn& blendFn)
+    void ImageGradientModifier::OnPaint(const AZ::Color& color, const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, BlendFn& blendFn)
     {
+        const float intensity = color.GetR();
+        const float opacity = color.GetA();
+
         // For paint notifications, we'll use the given blend function to blend the original value and the paint brush intensity
         // using the built-up opacity.
-        auto combineFn = [this,
-                          blendFn]([[maybe_unused]] const AZ::Vector3& worldPosition, float gradientValue, float opacityValue) -> float
+        auto combineFn = [intensity, opacity, blendFn](
+            [[maybe_unused]] const AZ::Vector3& worldPosition, float gradientValue, float opacityValue) -> float
         {
-            return blendFn(gradientValue, m_paintStrokeData.m_intensity, opacityValue * m_paintStrokeData.m_opacity);
+            return blendFn(gradientValue, intensity, opacityValue * opacity);
         };
 
         // Perform all the common logic between painting and smoothing to modify our image gradient.
@@ -618,8 +618,14 @@ namespace GradientSignal
     }
 
     void ImageGradientModifier::OnSmooth(
-        const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, AZStd::span<const AZ::Vector3> valuePointOffsets, SmoothFn& smoothFn)
+        const AZ::Color& color,
+        const AZ::Aabb& dirtyArea,
+        ValueLookupFn& valueLookupFn,
+        AZStd::span<const AZ::Vector3> valuePointOffsets,
+        SmoothFn& smoothFn)
     {
+        const float opacity = color.GetA();
+
         AZ::EntityId entityId = m_ownerEntityComponentId.GetEntityId();
 
         // Declare our vectors of kernel point locations and values once outside of the combine function so that we
@@ -634,7 +640,7 @@ namespace GradientSignal
 
         // For smoothing notifications, we'll need to gather all of the neighboring gradient values to feed into the given smoothing
         // function for our blend operation.
-        auto combineFn = [this, entityId, smoothFn, &valuePointOffsets, valuePointOffsetScale, &kernelPoints, &kernelValues](
+        auto combineFn = [entityId, opacity, smoothFn, &valuePointOffsets, valuePointOffsetScale, &kernelPoints, &kernelValues](
                              const AZ::Vector3& worldPosition, float gradientValue, float opacityValue) -> float
         {
             kernelPoints.clear();
@@ -652,7 +658,7 @@ namespace GradientSignal
                 entityId, &ImageGradientModificationBus::Events::GetPixelValuesByPosition, kernelPoints, kernelValues);
 
             // Blend all the blurring kernel values together and store the blended pixel and new opacity back into our paint stroke buffer.
-            return smoothFn(gradientValue, kernelValues, opacityValue * m_paintStrokeData.m_opacity);
+            return smoothFn(gradientValue, kernelValues, opacityValue * opacity);
         };
 
         // Perform all the common logic between painting and smoothing to modify our image gradient.

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.cpp
@@ -316,21 +316,28 @@ namespace GradientSignal
 
     void EditorImageGradientComponent::OnPaintModeBegin()
     {
+        m_configuration.m_numImageModificationsActive++;
+
+        // Forward the paint brush notification to the runtime component.
+        AzFramework::PaintBrushNotificationBus::Event(
+            { m_component.GetEntityId(), m_component.GetId() }, &AzFramework::PaintBrushNotificationBus::Events::OnPaintModeBegin);
+
         // While we're editing, we need to set all the configuration properties to read-only and refresh them.
         // Otherwise, the property changes could conflict with the current painted modifications.
-        m_configuration.m_imageModificationActive = true;
         AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
             &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_AttributesAndValues);
 
-        ImageGradientModificationBus::Event(GetEntityId(), &ImageGradientModifications::StartImageModification);
     }
 
     void EditorImageGradientComponent::OnPaintModeEnd()
     {
-        ImageGradientModificationBus::Event(GetEntityId(), &ImageGradientModifications::EndImageModification);
+        // Forward the paint brush notification to the runtime component.
+        AzFramework::PaintBrushNotificationBus::Event(
+            { m_component.GetEntityId(), m_component.GetId() }, &AzFramework::PaintBrushNotificationBus::Events::OnPaintModeEnd);
+
+        m_configuration.m_numImageModificationsActive--;
 
         // We're done editing, so set all the configuration properties back to writeable and refresh them.
-        m_configuration.m_imageModificationActive = false;
         AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
             &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_AttributesAndValues);
 
@@ -358,15 +365,17 @@ namespace GradientSignal
             { m_component.GetEntityId(), m_component.GetId() }, &AzFramework::PaintBrushNotificationBus::Events::OnBrushStrokeEnd);
     }
 
-    void EditorImageGradientComponent::OnPaint(const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, BlendFn& blendFn)
+    void EditorImageGradientComponent::OnPaint(
+        const AZ::Color& color, const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, BlendFn& blendFn)
     {
         // Forward the paint brush notification to the runtime component.
         AzFramework::PaintBrushNotificationBus::Event(
             { m_component.GetEntityId(), m_component.GetId() }, &AzFramework::PaintBrushNotificationBus::Events::OnPaint,
-            dirtyArea, valueLookupFn, blendFn);
+            color, dirtyArea, valueLookupFn, blendFn);
     }
 
     void EditorImageGradientComponent::OnSmooth(
+        const AZ::Color& color,
         const AZ::Aabb& dirtyArea,
         ValueLookupFn& valueLookupFn,
         AZStd::span<const AZ::Vector3> valuePointOffsets,
@@ -375,7 +384,7 @@ namespace GradientSignal
         // Forward the paint brush notification to the runtime component.
         AzFramework::PaintBrushNotificationBus::Event(
             { m_component.GetEntityId(), m_component.GetId() }, &AzFramework::PaintBrushNotificationBus::Events::OnSmooth,
-            dirtyArea, valueLookupFn, valuePointOffsets, smoothFn);
+            color, dirtyArea, valueLookupFn, valuePointOffsets, smoothFn);
     }
 
     AZ::Color EditorImageGradientComponent::OnGetColor(const AZ::Vector3& brushCenter)

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.h
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.h
@@ -66,8 +66,9 @@ namespace GradientSignal
         void OnPaintModeEnd() override;
         void OnBrushStrokeBegin(const AZ::Color& color) override;
         void OnBrushStrokeEnd() override;
-        void OnPaint(const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, BlendFn& blendFn) override;
+        void OnPaint(const AZ::Color& color, const AZ::Aabb& dirtyArea, ValueLookupFn& valueLookupFn, BlendFn& blendFn) override;
         void OnSmooth(
+            const AZ::Color& color,
             const AZ::Aabb& dirtyArea,
             ValueLookupFn& valueLookupFn,
             AZStd::span<const AZ::Vector3> valuePointOffsets,


### PR DESCRIPTION
## What does this PR do?

This extracts the runtime API for painting on an Image Gradient and moves it to a generic PaintBrush runtime API. The generic API makes it possible to use the same Script Canvas script for painting onto Image Gradients and Terrain Macro Material Components, depending on which entity is targeted. It also adds API support for multiple simultaneous paint sessions, so that multiple painting script instances can run in parallel.

The changes consist of the following:
* Extracted the PaintBrush instance management, wrapper code, and EBus from Image Gradient and moves it to a new PaintBrushSystemComponent.
* Added multiple instances to PaintBrushSystemComponent by adding a sessionId to the API.
* Changed the PaintBrushNotificationBus to include the brush color on every call, not just OnBrushStrokeBegin. The Image Gradient was caching the brush color, which didn't work with multiple simultaneous sessions. By passing it on every call, it doesn't need to be cached, and everything "just works".

## How was this PR tested?

Ran multiple paint sessions in parallel in-game.
https://user-images.githubusercontent.com/82224783/210110058-c77a362c-75a2-4bd6-84e8-73f63bde72b8.mp4

![image](https://user-images.githubusercontent.com/82224783/210110083-9b8807f7-1499-4a1a-be2c-3fce50fa5da8.png)

![image](https://user-images.githubusercontent.com/82224783/210110167-9ab76dba-80b2-47e8-b37c-addde6696122.png)

