### PR TITLE
[Terrain] Change enum to use bit operators and added colorized debug dirty region.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.h
@@ -347,7 +347,7 @@ namespace AzFramework
             static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
             //////////////////////////////////////////////////////////////////////////
 
-            enum TerrainDataChangedMask : uint8_t
+            enum class TerrainDataChangedMask : uint8_t
             {
                 None        = 0b00000000,
                 Settings    = 0b00000001,
@@ -389,6 +389,9 @@ namespace AzFramework
             };
         };
         using TerrainDataNotificationBus = AZ::EBus<TerrainDataNotifications>;
+
+        AZ_DEFINE_ENUM_BITWISE_OPERATORS(TerrainDataNotifications::TerrainDataChangedMask);
+
     } // namespace Terrain
 } // namespace AzFramework
 

--- a/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.h
@@ -353,7 +353,8 @@ namespace AzFramework
                 Settings    = 0b00000001,
                 HeightData  = 0b00000010,
                 ColorData   = 0b00000100,
-                SurfaceData = 0b00001000
+                SurfaceData = 0b00001000,
+                All         = 0b00001111
             };
 
             virtual void OnTerrainDataCreateBegin() {}

--- a/Gems/Terrain/Code/Source/Components/TerrainHeightGradientListComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainHeightGradientListComponent.cpp
@@ -134,7 +134,7 @@ namespace Terrain
         // Since this height data will no longer exist, notify the terrain system to refresh the area.
         TerrainSystemServiceRequestBus::Broadcast(
             &TerrainSystemServiceRequestBus::Events::RefreshArea, GetEntityId(),
-            AzFramework::Terrain::TerrainDataNotifications::HeightData);
+            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData);
     }
 
     bool TerrainHeightGradientListComponent::ReadInConfig(const AZ::ComponentConfig* baseConfig)
@@ -309,7 +309,7 @@ namespace Terrain
                 TerrainSystemServiceRequestBus::Broadcast(
                     &TerrainSystemServiceRequestBus::Events::RefreshRegion,
                     clampedDirtyRegion,
-                    AzFramework::Terrain::TerrainDataNotifications::HeightData);
+                    AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData);
             }
         }
         else
@@ -317,13 +317,13 @@ namespace Terrain
             TerrainSystemServiceRequestBus::Broadcast(
                 &TerrainSystemServiceRequestBus::Events::RefreshArea,
                 GetEntityId(),
-                AzFramework::Terrain::TerrainDataNotifications::HeightData);
+                AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData);
         }
     }
 
     void TerrainHeightGradientListComponent::OnTerrainDataChanged(const AZ::Aabb& dirtyRegion, TerrainDataChangedMask dataChangedMask)
     {
-        if (dataChangedMask & TerrainDataChangedMask::Settings)
+        if ((dataChangedMask & TerrainDataChangedMask::Settings) == TerrainDataChangedMask::Settings)
         {
             // If the terrain system settings changed, it's possible that the world bounds have changed, which can affect our height data.
             // Refresh the min/max heights and notify that the height data for this area needs to be refreshed.

--- a/Gems/Terrain/Code/Source/Components/TerrainLayerSpawnerComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainLayerSpawnerComponent.cpp
@@ -172,8 +172,8 @@ namespace Terrain
 
         // Notify the terrain system that the entire layer has changed, so both height and surface data can be affected.
         TerrainSystemServiceRequestBus::Broadcast(
-            &TerrainSystemServiceRequestBus::Events::RefreshArea, GetEntityId(),
-            static_cast<Terrain::TerrainDataChangedMask>(Terrain::HeightData | Terrain::SurfaceData)
-        );
+            &TerrainSystemServiceRequestBus::Events::RefreshArea,
+            GetEntityId(),
+            Terrain::TerrainDataChangedMask::HeightData | Terrain::TerrainDataChangedMask::SurfaceData);
     }
 }

--- a/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.cpp
@@ -41,17 +41,17 @@ namespace Terrain
 
         HeightfieldProviderNotifications::HeightfieldChangeMask result = HeightfieldProviderNotifications::HeightfieldChangeMask::None;
 
-        if (mask & TerrainDataNotifications::Settings)
+        if ((mask & TerrainDataNotifications::TerrainDataChangedMask::Settings) == TerrainDataNotifications::TerrainDataChangedMask::Settings)
         {
             result |= HeightfieldProviderNotifications::HeightfieldChangeMask::Settings;
         }
 
-        if (mask & TerrainDataNotifications::HeightData)
+        if ((mask & TerrainDataNotifications::TerrainDataChangedMask::HeightData) == TerrainDataNotifications::TerrainDataChangedMask::HeightData)
         {
             result |= HeightfieldProviderNotifications::HeightfieldChangeMask::HeightData;
         }
 
-        if (mask & TerrainDataNotifications::SurfaceData)
+        if ((mask & TerrainDataNotifications::TerrainDataChangedMask::SurfaceData) == TerrainDataNotifications::TerrainDataChangedMask::SurfaceData)
         {
             result |= HeightfieldProviderNotifications::HeightfieldChangeMask::SurfaceData;
         }

--- a/Gems/Terrain/Code/Source/Components/TerrainSurfaceGradientListComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainSurfaceGradientListComponent.cpp
@@ -124,7 +124,7 @@ namespace Terrain
         // Since this surface data will no longer exist, notify the terrain system to refresh the area.
         TerrainSystemServiceRequestBus::Broadcast(
             &TerrainSystemServiceRequestBus::Events::RefreshArea, GetEntityId(),
-            AzFramework::Terrain::TerrainDataNotifications::SurfaceData);
+            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::SurfaceData);
     }
 
     bool TerrainSurfaceGradientListComponent::ReadInConfig(const AZ::ComponentConfig* baseConfig)
@@ -220,14 +220,14 @@ namespace Terrain
             TerrainSystemServiceRequestBus::Broadcast(
                 &TerrainSystemServiceRequestBus::Events::RefreshRegion,
                 dirtyRegion,
-                AzFramework::Terrain::TerrainDataNotifications::SurfaceData);
+                AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::SurfaceData);
         }
         else
         {
             TerrainSystemServiceRequestBus::Broadcast(
                 &TerrainSystemServiceRequestBus::Events::RefreshArea,
                 GetEntityId(),
-                AzFramework::Terrain::TerrainDataNotifications::SurfaceData);
+                AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::SurfaceData);
         }
     }
 

--- a/Gems/Terrain/Code/Source/Components/TerrainWorldDebuggerComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainWorldDebuggerComponent.cpp
@@ -261,13 +261,19 @@ namespace Terrain
 
     void TerrainWorldDebuggerComponent::DrawLastDirtyRegion(AzFramework::DebugDisplayRequests& debugDisplay)
     {
+        using DataChangedMask = AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask;
+
         if (!m_configuration.m_drawLastDirtyRegion)
         {
             return;
         }
 
         // Draw a translucent box around the terrain dirty region
-        const AZ::Color dirtyRegionColor(1.0f, 0.0f, 1.0f, 0.25f);
+        const AZ::Color dirtyRegionColor(
+            (m_lastDirtyData & (DataChangedMask::HeightData | DataChangedMask::Settings)) != DataChangedMask::None ? 1.0f : 0.0f,
+            (m_lastDirtyData & (DataChangedMask::SurfaceData | DataChangedMask::Settings)) != DataChangedMask::None ? 1.0f : 0.0f,
+            (m_lastDirtyData & (DataChangedMask::ColorData | DataChangedMask::Settings)) != DataChangedMask::None ? 1.0f : 0.0f,
+            0.25f);
 
         if (m_lastDirtyRegion.IsValid())
         {
@@ -647,8 +653,9 @@ namespace Terrain
     void TerrainWorldDebuggerComponent::OnTerrainDataChanged(const AZ::Aabb& dirtyRegion, TerrainDataChangedMask dataChangedMask)
     {
         m_lastDirtyRegion = dirtyRegion;
+        m_lastDirtyData = dataChangedMask;
 
-        if (dataChangedMask & (TerrainDataChangedMask::Settings | TerrainDataChangedMask::HeightData))
+        if ((dataChangedMask & (TerrainDataChangedMask::Settings | TerrainDataChangedMask::HeightData)) != TerrainDataChangedMask::None)
         {
             MarkDirtySectors(dirtyRegion);
 

--- a/Gems/Terrain/Code/Source/Components/TerrainWorldDebuggerComponent.h
+++ b/Gems/Terrain/Code/Source/Components/TerrainWorldDebuggerComponent.h
@@ -181,5 +181,7 @@ namespace Terrain
         int32_t m_sectorGridSize{ 0 };
 
         AZ::Aabb m_lastDirtyRegion{ AZ::Aabb::CreateNull() };
+        AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask m_lastDirtyData =
+            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::None;
     };
 }

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
@@ -291,11 +291,11 @@ namespace Terrain
 
     void TerrainDetailMaterialManager::OnTerrainDataChanged(const AZ::Aabb& dirtyRegion, TerrainDataChangedMask dataChangedMask)
     {
-        if ((dataChangedMask & TerrainDataChangedMask::SurfaceData) != 0)
+        if ((dataChangedMask & TerrainDataChangedMask::SurfaceData) == TerrainDataChangedMask::SurfaceData)
         {
             m_dirtyDetailRegion.AddAabb(dirtyRegion);
         }
-        if ((dataChangedMask & TerrainDataChangedMask::Settings) != 0)
+        if ((dataChangedMask & TerrainDataChangedMask::Settings) == TerrainDataChangedMask::Settings)
         {
             InitializeTextureParams();
         }

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.cpp
@@ -69,7 +69,7 @@ namespace Terrain
         }
 
         OnTerrainDataChanged(
-            AZ::Aabb::CreateNull(), TerrainDataChangedMask(TerrainDataChangedMask::HeightData | TerrainDataChangedMask::Settings));
+            AZ::Aabb::CreateNull(), TerrainDataChangedMask::HeightData | TerrainDataChangedMask::Settings);
         m_meshManager.Initialize(*GetParentScene());
     }
 
@@ -125,7 +125,7 @@ namespace Terrain
     
     void TerrainFeatureProcessor::OnTerrainDataChanged([[maybe_unused]] const AZ::Aabb& dirtyRegion, TerrainDataChangedMask dataChangedMask)
     {
-        if ((dataChangedMask & TerrainDataChangedMask::Settings) != 0)
+        if ((dataChangedMask & TerrainDataChangedMask::Settings) == TerrainDataChangedMask::Settings)
         {
             AzFramework::Terrain::TerrainDataRequestBus::BroadcastResult(
                 m_zBounds, &AzFramework::Terrain::TerrainDataRequests::GetTerrainHeightBounds);

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
@@ -551,7 +551,7 @@ namespace Terrain
 
     void TerrainMeshManager::OnTerrainDataChanged([[maybe_unused]] const AZ::Aabb& dirtyRegion, TerrainDataChangedMask dataChangedMask)
     {
-        if ((dataChangedMask & (TerrainDataChangedMask::HeightData | TerrainDataChangedMask::Settings)) != 0)
+        if ((dataChangedMask & (TerrainDataChangedMask::HeightData | TerrainDataChangedMask::Settings)) != TerrainDataChangedMask::None)
         {
             AzFramework::Terrain::FloatRange heightBounds = AzFramework::Terrain::FloatRange::CreateNull();
             AzFramework::Terrain::TerrainDataRequestBus::BroadcastResult(

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
@@ -85,9 +85,10 @@ void TerrainSystem::Activate()
         &AzFramework::Terrain::TerrainDataNotificationBus::Events::OnTerrainDataCreateBegin);
 
     m_dirtyRegion = AZ::Aabb::CreateNull();
-    m_terrainHeightDirty = true;
-    m_terrainSettingsDirty = true;
-    m_terrainSurfacesDirty = true;
+    m_terrainDirtyMask = AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings |
+        AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::ColorData |
+        AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::SurfaceData |
+        AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData;
     m_requestedSettings.m_systemActive = true;
     m_cachedAreaBounds = AZ::Aabb::CreateNull();
 
@@ -138,9 +139,10 @@ void TerrainSystem::Deactivate()
     }
 
     m_dirtyRegion = AZ::Aabb::CreateNull();
-    m_terrainHeightDirty = true;
-    m_terrainSettingsDirty = true;
-    m_terrainSurfacesDirty = true;
+    m_terrainDirtyMask = AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings |
+        AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::ColorData |
+        AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::SurfaceData |
+        AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData;
     m_requestedSettings.m_systemActive = false;
 
     AzFramework::Terrain::TerrainDataNotificationBus::Broadcast(
@@ -150,7 +152,7 @@ void TerrainSystem::Deactivate()
 void TerrainSystem::SetTerrainHeightBounds(const AzFramework::Terrain::FloatRange& heightRange)
 {   
     m_requestedSettings.m_heightRange = heightRange;
-    m_terrainSettingsDirty = true;
+    m_terrainDirtyMask |= AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings;
 }
 
 bool TerrainSystem::TerrainAreaExistsInBounds(const AZ::Aabb& bounds) const
@@ -168,13 +170,13 @@ bool TerrainSystem::TerrainAreaExistsInBounds(const AZ::Aabb& bounds) const
 void TerrainSystem::SetTerrainHeightQueryResolution(float queryResolution)
 {
     m_requestedSettings.m_heightQueryResolution = queryResolution;
-    m_terrainSettingsDirty = true;
+    m_terrainDirtyMask |= AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings;
 }
 
 void TerrainSystem::SetTerrainSurfaceDataQueryResolution(float queryResolution)
 {
     m_requestedSettings.m_surfaceDataQueryResolution = queryResolution;
-    m_terrainSettingsDirty = true;
+    m_terrainDirtyMask |= AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings;
 }
 
 AZ::Aabb TerrainSystem::GetTerrainAabb() const
@@ -1690,8 +1692,8 @@ void TerrainSystem::RegisterArea(AZ::EntityId areaId)
 
     m_registeredAreas[areaId] = { aabb, useGroundPlane };
     m_dirtyRegion.AddAabb(aabb);
-    m_terrainHeightDirty = true;
-    m_terrainSurfacesDirty = true;
+    m_terrainDirtyMask |= AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData |
+        AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::SurfaceData;
     m_cachedAreaBounds.AddAabb(aabb);
 }
 
@@ -1710,8 +1712,8 @@ void TerrainSystem::UnregisterArea(AZ::EntityId areaId)
             if (areaId == entityId)
             {
                 m_dirtyRegion.AddAabb(areaData.m_areaBounds);
-                m_terrainHeightDirty = true;
-                m_terrainSurfacesDirty = true;
+                m_terrainDirtyMask |= AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData |
+                    AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::SurfaceData;
 
                 if (ContainedAabbTouchesEdge(m_cachedAreaBounds, areaData.m_areaBounds))
                 {
@@ -1768,10 +1770,7 @@ void TerrainSystem::RefreshRegion(
     m_dirtyRegion.AddAabb(dirtyRegion);
 
     // Keep track of which types of data have changed so that we can send out the appropriate notifications later.
-
-    m_terrainHeightDirty = m_terrainHeightDirty || ((changeMask & Terrain::HeightData) == Terrain::HeightData);
-
-    m_terrainSurfacesDirty = m_terrainSurfacesDirty || ((changeMask & Terrain::SurfaceData) == Terrain::SurfaceData);
+    m_terrainDirtyMask |= changeMask;
 }
 
 void TerrainSystem::OnTick(float /*deltaTime*/, AZ::ScriptTimePoint /*time*/)
@@ -1780,10 +1779,11 @@ void TerrainSystem::OnTick(float /*deltaTime*/, AZ::ScriptTimePoint /*time*/)
 
     bool terrainSettingsChanged = false;
 
-    if (m_terrainSettingsDirty)
+    if ((m_terrainDirtyMask & AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings) ==
+        AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings)
     {
         terrainSettingsChanged = true;
-        m_terrainSettingsDirty = false;
+        m_terrainDirtyMask &= ~AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings;
         if (m_currentSettings.m_heightRange.IsValid())
         {
             m_dirtyRegion = ClampZBoundsToHeightBounds(m_cachedAreaBounds);
@@ -1793,8 +1793,8 @@ void TerrainSystem::OnTick(float /*deltaTime*/, AZ::ScriptTimePoint /*time*/)
         // terrain layer areas to request the current world bounds.
         if (m_requestedSettings.m_heightRange != m_requestedSettings.m_heightRange)
         {
-            m_terrainHeightDirty = true;
-            m_terrainSurfacesDirty = true;
+            m_terrainDirtyMask |= AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData |
+                AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::SurfaceData;
             m_currentSettings.m_heightRange = m_requestedSettings.m_heightRange;
 
             // Add the cached area bounds clamped to the new range, so both the old and new range are included.
@@ -1803,40 +1803,30 @@ void TerrainSystem::OnTick(float /*deltaTime*/, AZ::ScriptTimePoint /*time*/)
 
         if (m_requestedSettings.m_heightQueryResolution != m_currentSettings.m_heightQueryResolution)
         {
-            m_terrainHeightDirty = true;
+            m_terrainDirtyMask |= AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData;
         }
 
         if (m_requestedSettings.m_surfaceDataQueryResolution != m_currentSettings.m_surfaceDataQueryResolution)
         {
-            m_terrainSurfacesDirty = true;
+            m_terrainDirtyMask |= AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::SurfaceData;
         }
 
         m_currentSettings = m_requestedSettings;
     }
 
-    if (terrainSettingsChanged || m_terrainHeightDirty || m_terrainSurfacesDirty)
+    if (terrainSettingsChanged || (m_terrainDirtyMask != AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::None))
     {
-        Terrain::TerrainDataChangedMask changeMask = Terrain::TerrainDataChangedMask::None;
+        Terrain::TerrainDataChangedMask changeMask = m_terrainDirtyMask;
 
         if (terrainSettingsChanged)
         {
-            changeMask = static_cast<Terrain::TerrainDataChangedMask>(changeMask | Terrain::TerrainDataChangedMask::Settings);
-        }
-        if (m_terrainHeightDirty)
-        {
-            changeMask = static_cast<Terrain::TerrainDataChangedMask>(changeMask | Terrain::TerrainDataChangedMask::HeightData);
-        }
-
-        if (m_terrainSurfacesDirty)
-        {
-            changeMask = static_cast<Terrain::TerrainDataChangedMask>(changeMask | Terrain::TerrainDataChangedMask::SurfaceData);
+            changeMask |= Terrain::TerrainDataChangedMask::Settings;
         }
 
         // Make sure to set these *before* calling OnTerrainDataChanged, since it's possible that subsystems reacting to that call will
         // cause the data to become dirty again.
         AZ::Aabb dirtyRegion = ClampZBoundsToHeightBounds(m_dirtyRegion);
-        m_terrainHeightDirty = false;
-        m_terrainSurfacesDirty = false;
+        m_terrainDirtyMask = AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::None;
         m_dirtyRegion = AZ::Aabb::CreateNull();
 
         AzFramework::Terrain::TerrainDataNotificationBus::Broadcast(

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
@@ -85,10 +85,7 @@ void TerrainSystem::Activate()
         &AzFramework::Terrain::TerrainDataNotificationBus::Events::OnTerrainDataCreateBegin);
 
     m_dirtyRegion = AZ::Aabb::CreateNull();
-    m_terrainDirtyMask = AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings |
-        AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::ColorData |
-        AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::SurfaceData |
-        AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData;
+    m_terrainDirtyMask = AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::All;
     m_requestedSettings.m_systemActive = true;
     m_cachedAreaBounds = AZ::Aabb::CreateNull();
 
@@ -139,10 +136,7 @@ void TerrainSystem::Deactivate()
     }
 
     m_dirtyRegion = AZ::Aabb::CreateNull();
-    m_terrainDirtyMask = AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings |
-        AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::ColorData |
-        AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::SurfaceData |
-        AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData;
+    m_terrainDirtyMask = AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::All;
     m_requestedSettings.m_systemActive = false;
 
     AzFramework::Terrain::TerrainDataNotificationBus::Broadcast(

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
@@ -1765,8 +1765,6 @@ void TerrainSystem::RefreshArea(AZ::EntityId areaId, AzFramework::Terrain::Terra
 void TerrainSystem::RefreshRegion(
     const AZ::Aabb& dirtyRegion, AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask changeMask)
 {
-    using Terrain = AzFramework::Terrain::TerrainDataNotifications;
-
     m_dirtyRegion.AddAabb(dirtyRegion);
 
     // Keep track of which types of data have changed so that we can send out the appropriate notifications later.

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.h
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.h
@@ -297,9 +297,8 @@ namespace Terrain
         TerrainSystemSettings m_currentSettings;
         TerrainSystemSettings m_requestedSettings;
 
-        bool m_terrainSettingsDirty = true;
-        bool m_terrainHeightDirty = false;
-        bool m_terrainSurfacesDirty = false;
+        AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask m_terrainDirtyMask =
+            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings;
         AZ::Aabb m_dirtyRegion;
         AZ::Aabb m_cachedAreaBounds;
 


### PR DESCRIPTION
## What does this PR do?

While adding support for broadcasting dirty terrain color data and changing the terrain debug dirty region to support different colors based on which types of data are dirty, I also added the bit operators to the TerrainDataChangedMask enum and cleaned up the dirty data tracking in TerrainSystem to use the flags.

This PR doesn't include the changes for broadcasting the dirty terrain color data, it just includes the enum cleanup and the colorization of the terrain debug dirty region.

## How was this PR tested?

Ran the changes in the Editor and was surprised to discover that surface changes also cause a height data refresh. sigh. But that's exactly the sort of reason _why_ I wanted the debug colorization change. :) 
