### PR TITLE
Sandbox the failed ApplicationManagerTest

### DIFF
--- a/Code/Tools/AssetProcessor/CMakeLists.txt
+++ b/Code/Tools/AssetProcessor/CMakeLists.txt
@@ -272,6 +272,10 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
     ly_add_googletest(NAME AZ::AssetProcessor.Tests.Periodic
         TARGET AZ::AssetProcessor.Tests 
         TEST_SUITE periodic)
+    # Sandbox the tests that fail intermittently
+    ly_add_googletest(NAME AZ::AssetProcessor.Tests.Sandbox
+        TARGET AZ::AssetProcessor.Tests 
+        TEST_SUITE sandbox)
 
     ly_add_googlebenchmark(
         NAME AZ::AssetProcessor.Benchmarks

--- a/Code/Tools/AssetProcessor/native/tests/ApplicationManagerTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/ApplicationManagerTests.cpp
@@ -96,7 +96,7 @@ namespace UnitTests
         EXPECT_TRUE(fileStateCache->Exists((assetRootDir / "test").c_str()));
     }
 
-    TEST_F(ApplicationManagerTest, FileWatcherEventsTriggered_ProperlySignalledOnCorrectThread)
+    TEST_F(ApplicationManagerTest, FileWatcherEventsTriggered_ProperlySignalledOnCorrectThread_SUITE_sandbox)
     {
         AZ::IO::Path assetRootDir(m_databaseLocationListener.GetAssetRootDir());
 


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?

Move ApplicationManagerTest.FileWatcherEventsTriggered_ProperlySignalledOnCorrectThread to the sandbox since it fails intermittently. The issue is tracked at https://github.com/o3de/o3de/issues/12638.

## How was this PR tested?
```
D:\github\o3de>build\windows\bin\profile\AzTestRunner.exe build\windows\bin\profile\AssetProcessor.Tests.dll AzRunUnitTests --gtest_filter=*SUITE_sandbox*
cwd = D:\github\o3de
LIB: build\windows\bin\profile\AssetProcessor.Tests.dll
Loading: build\windows\bin\profile\AssetProcessor.Tests.dll
OKAY Library loaded: build\windows\bin\profile\AssetProcessor.Tests.dll
OKAY Symbol found: AzRunUnitTests
Note: Google Test filter = *SUITE_sandbox*
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from ApplicationManagerTest
[ RUN      ] ApplicationManagerTest.FileWatcherEventsTriggered_ProperlySignalledOnCorrectThread_SUITE_sandbox
...
[       OK ] ApplicationManagerTest.FileWatcherEventsTriggered_ProperlySignalledOnCorrectThread_SUITE_sandbox (88 ms)
[----------] 1 test from ApplicationManagerTest (89 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (90 ms total)
[  PASSED  ] 1 test.
OKAY AzRunUnitTests() returned 0
Returning code: 0
```

Will verify on AR and update here.
