### PR TITLE
Action Manager | Reflect 3 more Component Modes to work correctly with the new setup

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -23,6 +23,7 @@
 #include <AzToolsFramework/Application/ToolsApplication.h>
 #include <AzToolsFramework/Commands/EntityStateCommand.h>
 #include <AzToolsFramework/Commands/SelectionCommand.h>
+#include <AzToolsFramework/ComponentModes/BoxComponentMode.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.h>
 #include <AzToolsFramework/ToolsComponents/AzToolsFrameworkConfigurationSystemComponent.h>
 #include <AzToolsFramework/ToolsComponents/EditorAssetMimeDataContainer.h>
@@ -391,6 +392,8 @@ namespace AzToolsFramework
 
         ComponentModeFramework::ComponentModeDelegate::Reflect(context);
         ComponentModeFramework::EditorBaseComponentMode::Reflect(context);
+
+        BoxComponentMode::Reflect(context);
 
         ViewportInteraction::ViewportInteractionReflect(context);
         ViewportEditorModeNotifications::Reflect(context);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentModes/BoxComponentMode.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentModes/BoxComponentMode.cpp
@@ -12,6 +12,11 @@ namespace AzToolsFramework
 {
     AZ_CLASS_ALLOCATOR_IMPL(BoxComponentMode, AZ::SystemAllocator, 0)
 
+    void BoxComponentMode::Reflect(AZ::ReflectContext* context)
+    {
+        AzToolsFramework::ComponentModeFramework::ReflectEditorBaseComponentModeDescendant<BoxComponentMode>(context);
+    }
+
     BoxComponentMode::BoxComponentMode(
         const AZ::EntityComponentIdPair& entityComponentIdPair, const AZ::Uuid componentType)
         : EditorBaseComponentMode(entityComponentIdPair, componentType)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentModes/BoxComponentMode.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentModes/BoxComponentMode.h
@@ -21,6 +21,9 @@ namespace AzToolsFramework
     {
     public:
         AZ_CLASS_ALLOCATOR_DECL
+        AZ_RTTI(BoxComponentMode, "{8E09B2C1-ED99-4945-A0B1-C4AFE6FE2FA9}", EditorBaseComponentMode)
+
+        static void Reflect(AZ::ReflectContext* context);
 
         BoxComponentMode(
             const AZ::EntityComponentIdPair& entityComponentIdPair, AZ::Uuid componentType);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorNonUniformScaleComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorNonUniformScaleComponent.cpp
@@ -24,6 +24,8 @@ namespace AzToolsFramework
 
         void EditorNonUniformScaleComponent::Reflect(AZ::ReflectContext* context)
         {
+            NonUniformScaleComponentMode::Reflect(context);
+
             if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
             {
                 serializeContext->Class<EditorNonUniformScaleComponent, EditorComponentBase>()
@@ -61,8 +63,6 @@ namespace AzToolsFramework
                     ->Attribute(AZ::Script::Attributes::Module, "editor")
                     ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation);
             }
-
-            NonUniformScaleComponentMode::Reflect(context);
         }
 
         void EditorNonUniformScaleComponent::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorNonUniformScaleComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorNonUniformScaleComponent.cpp
@@ -61,6 +61,8 @@ namespace AzToolsFramework
                     ->Attribute(AZ::Script::Attributes::Module, "editor")
                     ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation);
             }
+
+            NonUniformScaleComponentMode::Reflect(context);
         }
 
         void EditorNonUniformScaleComponent::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorNonUniformScaleComponentMode.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorNonUniformScaleComponentMode.cpp
@@ -16,6 +16,11 @@ namespace AzToolsFramework
 {
     namespace Components
     {
+        void NonUniformScaleComponentMode::Reflect(AZ::ReflectContext* context)
+        {
+            AzToolsFramework::ComponentModeFramework::ReflectEditorBaseComponentModeDescendant<NonUniformScaleComponentMode>(context);
+        }
+
         NonUniformScaleComponentMode::NonUniformScaleComponentMode(
             const AZ::EntityComponentIdPair& entityComponentIdPair, AZ::Uuid componentType)
             : EditorBaseComponentMode(entityComponentIdPair, componentType)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorNonUniformScaleComponentMode.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorNonUniformScaleComponentMode.h
@@ -15,10 +15,14 @@ namespace AzToolsFramework
 {
     namespace Components
     {
-        class NonUniformScaleComponentMode : public AzToolsFramework::ComponentModeFramework::EditorBaseComponentMode
+        class NonUniformScaleComponentMode
+            : public AzToolsFramework::ComponentModeFramework::EditorBaseComponentMode
         {
         public:
             AZ_CLASS_ALLOCATOR(NonUniformScaleComponentMode, AZ::SystemAllocator, 0)
+            AZ_RTTI(NonUniformScaleComponentMode, "{E7D16788-DE62-4D13-8899-28A7C5DCA039}", EditorBaseComponentMode)
+
+            static void Reflect(AZ::ReflectContext* context);
 
             NonUniformScaleComponentMode(const AZ::EntityComponentIdPair& entityComponentIdPair, AZ::Uuid componentType);
             NonUniformScaleComponentMode(const NonUniformScaleComponentMode&) = delete;

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorPolygonPrismShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorPolygonPrismShapeComponent.cpp
@@ -172,6 +172,8 @@ namespace LmbrCentral
                         ;
             }
         }
+
+        EditorPolygonPrismShapeComponentMode::Reflect(context);
     }
 
     void EditorPolygonPrismShapeComponent::DisplayEntityViewport(

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorPolygonPrismShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorPolygonPrismShapeComponent.cpp
@@ -145,6 +145,8 @@ namespace LmbrCentral
 
     void EditorPolygonPrismShapeComponent::Reflect(AZ::ReflectContext* context)
     {
+        EditorPolygonPrismShapeComponentMode::Reflect(context);
+
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<EditorPolygonPrismShapeComponent, EditorBaseShapeComponent>()
@@ -172,8 +174,6 @@ namespace LmbrCentral
                         ;
             }
         }
-
-        EditorPolygonPrismShapeComponentMode::Reflect(context);
     }
 
     void EditorPolygonPrismShapeComponent::DisplayEntityViewport(

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorPolygonPrismShapeComponentMode.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorPolygonPrismShapeComponentMode.cpp
@@ -20,6 +20,11 @@ namespace LmbrCentral
 {
     AZ_CLASS_ALLOCATOR_IMPL(EditorPolygonPrismShapeComponentMode, AZ::SystemAllocator, 0)
 
+    void EditorPolygonPrismShapeComponentMode::Reflect(AZ::ReflectContext* context)
+    {
+        AzToolsFramework::ComponentModeFramework::ReflectEditorBaseComponentModeDescendant<EditorPolygonPrismShapeComponentMode>(context);
+    }
+
     /// Util to calculate central position of prism (to draw the height manipulator)
     static AZ::Vector3 CalculateHeightManipulatorPosition(const AZ::PolygonPrism& polygonPrism)
     {

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorPolygonPrismShapeComponentMode.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorPolygonPrismShapeComponentMode.h
@@ -31,6 +31,9 @@ namespace LmbrCentral
     {
     public:
         AZ_CLASS_ALLOCATOR_DECL
+        AZ_RTTI(EditorPolygonPrismShapeComponentMode, "{010CC49A-477A-4F1A-812F-60F7C4E420D5}", EditorBaseComponentMode)
+
+        static void Reflect(AZ::ReflectContext* context);
 
         EditorPolygonPrismShapeComponentMode(
             const AZ::EntityComponentIdPair& entityComponentIdPair, AZ::Uuid componentType);


### PR DESCRIPTION
## What does this PR do?

Reflects these Component Modes to Serialize Context:
- Box Component Mode
- Non-Uniform Scale Component Mode
- Polygon Prism Shape Component Mode

This allows them to be picked up by the new setup that allows Component Modes to register actions and switch them correctly in the file menu of the Editor using the new Action Manager.

## How was this PR tested?

Tested locally, verified that switching to these Component Modes changes the menu items correctly.
