### PR TITLE
Fix ambiguous Dom::Value ctor error for Linux

### DIFF
--- a/Code/Framework/AzCore/AzCore/DOM/DomValue.cpp
+++ b/Code/Framework/AzCore/AzCore/DOM/DomValue.cpp
@@ -164,47 +164,57 @@ namespace AZ::Dom
     }
 
     Value::Value(int8_t value)
-        : m_value(aznumeric_cast<int64_t>(value))
+        : m_value(static_cast<int64_t>(value))
     {
     }
 
     Value::Value(uint8_t value)
-        : m_value(aznumeric_cast<uint64_t>(value))
+        : m_value(static_cast<uint64_t>(value))
     {
     }
 
     Value::Value(int16_t value)
-        : m_value(aznumeric_cast<int64_t>(value))
+        : m_value(static_cast<int64_t>(value))
     {
     }
 
     Value::Value(uint16_t value)
-        : m_value(aznumeric_cast<uint64_t>(value))
+        : m_value(static_cast<uint64_t>(value))
     {
     }
 
     Value::Value(int32_t value)
-        : m_value(aznumeric_cast<int64_t>(value))
+        : m_value(static_cast<int64_t>(value))
     {
     }
 
     Value::Value(uint32_t value)
-        : m_value(aznumeric_cast<uint64_t>(value))
+        : m_value(static_cast<uint64_t>(value))
     {
     }
 
-    Value::Value(int64_t value)
-        : m_value(value)
+    Value::Value(long value)
+        : m_value(static_cast<int64_t>(value))
     {
     }
 
-    Value::Value(uint64_t value)
-        : m_value(value)
+    Value::Value(unsigned long value)
+        : m_value(static_cast<uint64_t>(value))
+    {
+    }
+
+    Value::Value(long long value)
+        : m_value(static_cast<int64_t>(value))
+    {
+    }
+
+    Value::Value(unsigned long long value)
+        : m_value(static_cast<uint64_t>(value))
     {
     }
 
     Value::Value(float value)
-        : m_value(aznumeric_cast<double>(value))
+        : m_value(static_cast<double>(value))
     {
     }
 
@@ -923,9 +933,9 @@ namespace AZ::Dom
         case GetTypeIndex<int64_t>():
             return AZStd::get<int64_t>(m_value);
         case GetTypeIndex<uint64_t>():
-            return aznumeric_cast<int64_t>(AZStd::get<uint64_t>(m_value));
+            return static_cast<int64_t>(AZStd::get<uint64_t>(m_value));
         case GetTypeIndex<double>():
-            return aznumeric_cast<int64_t>(AZStd::get<double>(m_value));
+            return static_cast<int64_t>(AZStd::get<double>(m_value));
         }
         AZ_Assert(false, "AZ::Dom::Value: Called GetInt on a non-numeric type");
         return {};
@@ -941,11 +951,11 @@ namespace AZ::Dom
         switch (m_value.index())
         {
         case GetTypeIndex<int64_t>():
-            return aznumeric_cast<uint64_t>(AZStd::get<int64_t>(m_value));
+            return static_cast<uint64_t>(AZStd::get<int64_t>(m_value));
         case GetTypeIndex<uint64_t>():
             return AZStd::get<uint64_t>(m_value);
         case GetTypeIndex<double>():
-            return aznumeric_cast<uint64_t>(AZStd::get<double>(m_value));
+            return static_cast<uint64_t>(AZStd::get<double>(m_value));
         }
         AZ_Assert(false, "AZ::Dom::Value: Called GetInt on a non-numeric type");
         return {};
@@ -976,9 +986,9 @@ namespace AZ::Dom
         switch (m_value.index())
         {
         case GetTypeIndex<int64_t>():
-            return aznumeric_cast<double>(AZStd::get<int64_t>(m_value));
+            return static_cast<double>(AZStd::get<int64_t>(m_value));
         case GetTypeIndex<uint64_t>():
-            return aznumeric_cast<double>(AZStd::get<uint64_t>(m_value));
+            return static_cast<double>(AZStd::get<uint64_t>(m_value));
         case GetTypeIndex<double>():
             return AZStd::get<double>(m_value);
         }

--- a/Code/Framework/AzCore/AzCore/DOM/DomValue.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomValue.h
@@ -200,8 +200,10 @@ namespace AZ::Dom
         explicit Value(uint16_t value);
         explicit Value(int32_t value);
         explicit Value(uint32_t value);
-        explicit Value(int64_t value);
-        explicit Value(uint64_t value);
+        explicit Value(long value);
+        explicit Value(unsigned long value);
+        explicit Value(long long value);
+        explicit Value(unsigned long long value);
         explicit Value(float value);
         explicit Value(double value);
         explicit Value(bool value);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -265,8 +265,7 @@ namespace AZ::DocumentPropertyEditor
         {
             Dom::Value result(Dom::Type::Object);
             result[EntryDescriptionKey] = Dom::Value(attribute.m_description, true);
-            result[EntryValueKey] = Dom::Value();
-            result[EntryValueKey].SetUint64(attribute.m_value);
+            result[EntryValueKey] = Dom::Value(attribute.m_value);
             return result;
         }
 


### PR DESCRIPTION
**Description**
Prior to this PR, it was possible for builds to fail on Linux systems when certain integral types were being passed to the `Dom::Value` constructor due to an explicit constructor for long, unsigned long, long long, and unsigned long long being missing. Linux systems do not have the same integral types specified for uint64_t and int64_t which resulted in intended constructor ambiguity.

This PR removes the uint64_t and int64_t and replaces them with explicit constructors for long, unsigned long, long long, and unsigned long long.

**Testing**
- Ran AzCore Dom::Value tests
- Verified editor builds without error on Windows
- Verified reflected enums correctly populate comboboxes in the standalone DPE app when using enums of underlying types affected by this PR

Signed-off-by: amzn-tmryan <104796591+amzn-tmryan@users.noreply.github.com>