### PR TITLE
Action Manager | Reflect Collider Component Mode to work correctly with the new setup

### DIFF
--- a/Gems/PhysX/Code/Editor/ColliderComponentMode.cpp
+++ b/Gems/PhysX/Code/Editor/ColliderComponentMode.cpp
@@ -18,12 +18,19 @@
 #include <PhysX/EditorColliderComponentRequestBus.h>
 
 #include <AzFramework/Physics/ShapeConfiguration.h>
+#include <AzToolsFramework/ActionManager/Action/ActionManagerInterface.h>
+#include <AzToolsFramework/ActionManager/Menu/MenuManagerInterface.h>
+#include <AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h>
+#include <AzToolsFramework/API/ComponentModeCollectionInterface.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/ComponentModes/BoxComponentMode.h>
 #include <AzToolsFramework/ComponentModes/BoxViewportEdit.h>
 
 namespace PhysX
 {
+    static constexpr AZStd::string_view EditorMainWindowActionContextIdentifier = "o3de.context.editor.mainwindow";
+    static constexpr AZStd::string_view EditMenuIdentifier = "o3de.menu.editor.edit";
+
     namespace
     {
         //! Uri's for shortcut actions.
@@ -34,6 +41,168 @@ namespace PhysX
     } // namespace
 
     AZ_CLASS_ALLOCATOR_IMPL(ColliderComponentMode, AZ::SystemAllocator, 0);
+
+    void ColliderComponentMode::Reflect(AZ::ReflectContext* context)
+    {
+        AzToolsFramework::ComponentModeFramework::ReflectEditorBaseComponentModeDescendant<ColliderComponentMode>(context);
+    }
+
+    void ColliderComponentMode::RegisterActions()
+    {
+        auto actionManagerInterface = AZ::Interface<AzToolsFramework::ActionManagerInterface>::Get();
+        AZ_Assert(actionManagerInterface, "ColliderComponentMode - could not get ActionManagerInterface on RegisterActions.");
+
+        auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get();
+        AZ_Assert(hotKeyManagerInterface, "EditorVertexSelection - could not get HotKeyManagerInterface on RegisterActions.");
+
+        // Set Offset Sub-Mode
+        {
+            constexpr AZStd::string_view actionIdentifier = "o3de.action.colliderComponentMode.setOffsetSubMode";
+            AzToolsFramework::ActionProperties actionProperties;
+            actionProperties.m_name = "Set Offset Mode";
+            actionProperties.m_description = "Set Offset Mode";
+            actionProperties.m_category = "Collider Component Mode";
+
+            actionManagerInterface->RegisterAction(
+                EditorMainWindowActionContextIdentifier,
+                actionIdentifier,
+                actionProperties,
+                []
+                {
+                    auto componentModeCollectionInterface = AZ::Interface<AzToolsFramework::ComponentModeCollectionInterface>::Get();
+                    AZ_Assert(componentModeCollectionInterface, "Could not retrieve component mode collection.");
+
+                    componentModeCollectionInterface->EnumerateActiveComponents(
+                        [](const AZ::EntityComponentIdPair& entityComponentIdPair, const AZ::Uuid&)
+                        {
+                            ColliderComponentModeRequestBus::Event(
+                                entityComponentIdPair, &ColliderComponentModeRequests::SetCurrentMode, SubMode::Offset);
+                        }
+                    );
+                }
+            );
+
+            hotKeyManagerInterface->SetActionHotKey(actionIdentifier, "1");
+        }
+
+        // Set Rotation Sub-Mode
+        {
+            constexpr AZStd::string_view actionIdentifier = "o3de.action.colliderComponentMode.setRotationSubMode";
+            AzToolsFramework::ActionProperties actionProperties;
+            actionProperties.m_name = "Set Rotation Mode";
+            actionProperties.m_description = "Set Rotation Mode";
+            actionProperties.m_category = "Collider Component Mode";
+
+            actionManagerInterface->RegisterAction(
+                EditorMainWindowActionContextIdentifier,
+                actionIdentifier,
+                actionProperties,
+                []
+                {
+                    auto componentModeCollectionInterface = AZ::Interface<AzToolsFramework::ComponentModeCollectionInterface>::Get();
+                    AZ_Assert(componentModeCollectionInterface, "Could not retrieve component mode collection.");
+
+                    componentModeCollectionInterface->EnumerateActiveComponents(
+                        [](const AZ::EntityComponentIdPair& entityComponentIdPair, const AZ::Uuid&)
+                        {
+                            ColliderComponentModeRequestBus::Event(
+                                entityComponentIdPair, &ColliderComponentModeRequests::SetCurrentMode, SubMode::Rotation);
+                        }
+                    );
+                }
+            );
+
+            hotKeyManagerInterface->SetActionHotKey(actionIdentifier, "2");
+        }
+
+        // Set Resize Sub-Mode
+        {
+            constexpr AZStd::string_view actionIdentifier = "o3de.action.colliderComponentMode.setResizeSubMode";
+            AzToolsFramework::ActionProperties actionProperties;
+            actionProperties.m_name = "Set Resize Mode";
+            actionProperties.m_description = "Set Resize Mode";
+            actionProperties.m_category = "Collider Component Mode";
+
+            actionManagerInterface->RegisterAction(
+                EditorMainWindowActionContextIdentifier,
+                actionIdentifier,
+                actionProperties,
+                []
+                {
+                    auto componentModeCollectionInterface = AZ::Interface<AzToolsFramework::ComponentModeCollectionInterface>::Get();
+                    AZ_Assert(componentModeCollectionInterface, "Could not retrieve component mode collection.");
+
+                    componentModeCollectionInterface->EnumerateActiveComponents(
+                        [](const AZ::EntityComponentIdPair& entityComponentIdPair, const AZ::Uuid&)
+                        {
+                            ColliderComponentModeRequestBus::Event(
+                                entityComponentIdPair, &ColliderComponentModeRequests::SetCurrentMode, SubMode::Dimensions);
+                        }
+                    );
+                }
+            );
+
+            hotKeyManagerInterface->SetActionHotKey(actionIdentifier, "3");
+        }
+
+        // Reset Current Mode
+        {
+            constexpr AZStd::string_view actionIdentifier = "o3de.action.colliderComponentMode.resetCurrentMode";
+            AzToolsFramework::ActionProperties actionProperties;
+            actionProperties.m_name = "Reset Current Mode";
+            actionProperties.m_description = "Reset Current Mode";
+            actionProperties.m_category = "Collider Component Mode";
+
+            actionManagerInterface->RegisterAction(
+                EditorMainWindowActionContextIdentifier,
+                actionIdentifier,
+                actionProperties,
+                []
+                {
+                    auto componentModeCollectionInterface = AZ::Interface<AzToolsFramework::ComponentModeCollectionInterface>::Get();
+                    AZ_Assert(componentModeCollectionInterface, "Could not retrieve component mode collection.");
+
+                    componentModeCollectionInterface->EnumerateActiveComponents(
+                        [](const AZ::EntityComponentIdPair& entityComponentIdPair, const AZ::Uuid&)
+                        {
+                            ColliderComponentModeRequestBus::Event(
+                                entityComponentIdPair, &ColliderComponentModeRequests::ResetCurrentMode);
+                        }
+                    );
+                }
+            );
+
+            hotKeyManagerInterface->SetActionHotKey(actionIdentifier, "R");
+        }
+    }
+
+    void ColliderComponentMode::BindActionsToModes()
+    {
+        auto actionManagerInterface = AZ::Interface<AzToolsFramework::ActionManagerInterface>::Get();
+        AZ_Assert(actionManagerInterface, "ColliderComponentMode - could not get ActionManagerInterface on RegisterActions.");
+
+        AZ::SerializeContext* serializeContext = nullptr;
+        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
+
+        AZStd::string modeIdentifier = AZStd::string::format(
+            "o3de.context.mode.%s", serializeContext->FindClassData(azrtti_typeid<ColliderComponentMode>())->m_name);
+
+        actionManagerInterface->AssignModeToAction(modeIdentifier, "o3de.action.colliderComponentMode.setOffsetSubMode");
+        actionManagerInterface->AssignModeToAction(modeIdentifier, "o3de.action.colliderComponentMode.setRotationSubMode");
+        actionManagerInterface->AssignModeToAction(modeIdentifier, "o3de.action.colliderComponentMode.setResizeSubMode");
+        actionManagerInterface->AssignModeToAction(modeIdentifier, "o3de.action.colliderComponentMode.resetCurrentMode");
+    }
+
+    void ColliderComponentMode::BindActionsToMenus()
+    {
+        auto menuManagerInterface = AZ::Interface<AzToolsFramework::MenuManagerInterface>::Get();
+        AZ_Assert(menuManagerInterface, "ColliderComponentMode - could not get MenuManagerInterface on BindActionsToMenus.");
+
+        menuManagerInterface->AddActionToMenu(EditMenuIdentifier, "o3de.action.colliderComponentMode.setOffsetSubMode", 6000);
+        menuManagerInterface->AddActionToMenu(EditMenuIdentifier, "o3de.action.colliderComponentMode.setRotationSubMode", 6001);
+        menuManagerInterface->AddActionToMenu(EditMenuIdentifier, "o3de.action.colliderComponentMode.setResizeSubMode", 6002);
+        menuManagerInterface->AddActionToMenu(EditMenuIdentifier, "o3de.action.colliderComponentMode.resetCurrentMode", 6003);
+    }
 
     ColliderComponentMode::ColliderComponentMode(const AZ::EntityComponentIdPair& entityComponentIdPair, AZ::Uuid componentType)
         : AzToolsFramework::ComponentModeFramework::EditorBaseComponentMode(entityComponentIdPair, componentType)

--- a/Gems/PhysX/Code/Editor/ColliderComponentMode.h
+++ b/Gems/PhysX/Code/Editor/ColliderComponentMode.h
@@ -25,11 +25,17 @@ namespace PhysX
         , public ColliderComponentModeUiRequestBus::Handler
     {
     public:
-
         AZ_CLASS_ALLOCATOR_DECL;
+        AZ_RTTI(ColliderComponentMode, "{07DA4C6A-743E-4703-8A31-98E276903C75}", EditorBaseComponentMode)
 
         ColliderComponentMode(const AZ::EntityComponentIdPair& entityComponentIdPair, AZ::Uuid componentType);
         ~ColliderComponentMode();
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        static void RegisterActions();
+        static void BindActionsToModes();
+        static void BindActionsToMenus();
 
         // EditorBaseComponentMode overrides ...
         void Refresh() override;
@@ -39,6 +45,7 @@ namespace PhysX
         // ColliderComponentModeBus overrides ...
         SubMode GetCurrentMode() override;
         void SetCurrentMode(SubMode index) override;
+        void ResetCurrentMode() override;
 
         // ColliderComponentModeUiBus overrides ...
         AzToolsFramework::ViewportUi::ButtonId GetOffsetButtonId() const override;
@@ -54,7 +61,6 @@ namespace PhysX
         // AzToolsFramework::ViewportInteraction::ViewportSelectionRequests ...
         bool HandleMouseInteraction(const AzToolsFramework::ViewportInteraction::MouseInteractionEvent& mouseInteraction) override;
         void CreateSubModes();
-        void ResetCurrentMode();
 
         AZStd::unordered_map<SubMode, AZStd::unique_ptr<PhysXSubComponentModeBase>> m_subModes;
         SubMode m_subMode = SubMode::Dimensions;

--- a/Gems/PhysX/Code/Editor/ColliderComponentModeBus.h
+++ b/Gems/PhysX/Code/Editor/ColliderComponentModeBus.h
@@ -32,6 +32,9 @@ namespace PhysX
         /// Sets the current sub collider component mode.
         /// @param mode The new mode to set.
         virtual void SetCurrentMode(SubMode mode) = 0;
+
+        /// Resets the current sub collider component mode's UI.
+        virtual void ResetCurrentMode() = 0;
     };
 
     //! Provides access to Component Mode specific UI options

--- a/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.cpp
@@ -17,6 +17,7 @@
 
 #include <IEditor.h>
 
+#include <Editor/ColliderComponentMode.h>
 #include <Editor/EditorJointConfiguration.h>
 #include <Editor/EditorWindow.h>
 #include <Editor/PropertyTypes.h>
@@ -28,6 +29,7 @@ namespace PhysX
 {
     void EditorSystemComponent::Reflect(AZ::ReflectContext* context)
     {
+        ColliderComponentMode::Reflect(context);
         EditorJointLimitConfig::Reflect(context);
         EditorJointLimitPairConfig::Reflect(context);
         EditorJointLimitLinearPairConfig::Reflect(context);
@@ -106,10 +108,12 @@ namespace PhysX
 
         AzToolsFramework::EditorEvents::Bus::Handler::BusConnect();
         AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusConnect();
+        AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler::BusConnect();
     }
 
     void EditorSystemComponent::Deactivate()
     {
+        AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::EditorEvents::Bus::Handler::BusDisconnect();
         AzToolsFramework::EditorContextMenuBus::Handler::BusDisconnect();
@@ -129,6 +133,21 @@ namespace PhysX
     AzPhysics::SceneHandle EditorSystemComponent::GetEditorSceneHandle() const
     {
         return m_editorWorldSceneHandle;
+    }
+
+    void EditorSystemComponent::OnActionRegistrationHook()
+    {
+        ColliderComponentMode::RegisterActions();
+    }
+
+    void EditorSystemComponent::OnActionContextModeBindingHook()
+    {
+        ColliderComponentMode::BindActionsToModes();
+    }
+
+    void EditorSystemComponent::OnMenuBindingHook()
+    {
+        ColliderComponentMode::BindActionsToMenus();
     }
 
     void EditorSystemComponent::OnStartPlayInEditorBegin()

--- a/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.h
+++ b/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.h
@@ -14,6 +14,7 @@
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzFramework/Physics/Common/PhysicsEvents.h>
 #include <AzFramework/Physics/SystemBus.h>
+#include <AzToolsFramework/ActionManager/ActionManagerRegistrationNotificationBus.h>
 #include <AzToolsFramework/Editor/EditorContextMenuBus.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <Editor/Source/Material/PhysXEditorMaterialAssetBuilder.h>
@@ -35,6 +36,7 @@ namespace PhysX
         , private AzToolsFramework::EditorEntityContextNotificationBus::Handler
         , private AzToolsFramework::EditorEvents::Bus::Handler
         , private AzToolsFramework::EditorContextMenuBus::Handler
+        , public AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler
     {
     public:
         AZ_COMPONENT(EditorSystemComponent, "{560F08DC-94F5-4D29-9AD4-CDFB3B57C654}");
@@ -55,6 +57,11 @@ namespace PhysX
 
         // Physics::EditorWorldBus overrides...
         AzPhysics::SceneHandle GetEditorSceneHandle() const override;
+
+        // ActionManagerRegistrationNotificationBus overrides ...
+        void OnActionRegistrationHook() override;
+        void OnActionContextModeBindingHook() override;
+        void OnMenuBindingHook() override;
 
     private:
         // AzToolsFramework::EditorEntityContextNotificationBus overrides...


### PR DESCRIPTION
Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>

## What does this PR do?

Reflects the Collider Component Mode to Serialize Context:
This allows it to be picked up by the new setup that allows Component Modes to register actions and switch them correctly in the file menu of the Editor using the new Action Manager.

## How was this PR tested?

Manual testing
