### PR TITLE
GHI-13371 Freshly imported .exr files can crash the Editor when attempting to Edit Texture Settings

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/EditorCommon.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/EditorCommon.cpp
@@ -143,7 +143,10 @@ namespace ImageProcessingAtomEditor
     EditorTextureSetting::EditorTextureSetting(const AZ::Uuid& sourceTextureId)
     {
         const AzToolsFramework::AssetBrowser::SourceAssetBrowserEntry* fullDetails = AzToolsFramework::AssetBrowser::SourceAssetBrowserEntry::GetSourceByUuid(sourceTextureId);
-        InitFromPath(fullDetails->GetFullPath());
+        if (fullDetails)
+        {
+            InitFromPath(fullDetails->GetFullPath());
+        }
     }
 
     EditorTextureSetting::EditorTextureSetting(const AZStd::string& texturePath)

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageProcessingSystemComponent.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageProcessingSystemComponent.cpp
@@ -189,11 +189,13 @@ namespace ImageProcessingAtom
             }
 
             AZ::Uuid sourceId = source->GetSourceUuid();
-
-            menu->addAction("Edit Texture Settings...", [sourceId, this]()
-                {
-                    OpenSourceTextureFile(sourceId);
-                });
+            if (!sourceId.IsNull())
+            {
+                menu->addAction("Edit Texture Settings...", [sourceId, this]()
+                    {
+                        OpenSourceTextureFile(sourceId);
+                    });
+            }
         }
         else if ((*entryIt)->GetEntryType() == AssetBrowserEntry::AssetEntryType::Product)
         {


### PR DESCRIPTION
## What does this PR do?
https://github.com/o3de/o3de/issues/13771

The asset source id can be empty when the exr was just added to the asset folder. Change the code so it only adds context menu when the asset source id is valid.

## How was this PR tested?

Follow the repro steps mentioned in the [GHI](https://github.com/o3de/o3de/issues/13771)
