### PR TITLE
Fixes for Mac compilation errors

### DIFF
--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUndoDeleteTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUndoDeleteTests.cpp
@@ -205,7 +205,7 @@ namespace UnitTest
         PrefabDom patchesCopyForUndoSupport;
         PrefabDom wheelInstanceLinkDom;
         firstWheelLink->get().GetLinkDom(wheelInstanceLinkDom, wheelInstanceLinkDom.GetAllocator());
-        PrefabDomValueConstReference wheelInstanceLinkPatches =
+        PrefabDomValueReference wheelInstanceLinkPatches =
             PrefabDomUtils::FindPrefabDomValue(wheelInstanceLinkDom, PrefabDomUtils::PatchesName);
         if (wheelInstanceLinkPatches.has_value())
         {

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/BufferMemoryAllocator.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/BufferMemoryAllocator.cpp
@@ -108,7 +108,7 @@ namespace AZ
                 {
                     AZStd::lock_guard<AZStd::mutex> lock(m_allocatorMutex);
                     RHI::HeapMemoryUsage& heapMemoryUsage = *m_descriptor.m_getHeapMemoryUsageFunction();
-                    heapMemoryUsage.m_usedResidentInBytes -= bufferMemoryView.GetSize();
+                    heapMemoryUsage.m_usedResidentInBytes -= memoryView.GetSize();
                     m_subAllocator.DeAllocate(memoryView.m_memoryAllocation);
                 }
                 break;


### PR DESCRIPTION
Signed-off-by: spham <82231385+spham-amzn@users.noreply.github.com>

## What does this PR do?

Fixes the following mac compilation errors:

```
In file included from /Users/spham/github/o3de/build/mac/External/Metal-3248c6c3/Code/CMakeFiles/Atom_RHI_Metal.Private.Static.dir/Unity/unity_0_cxx.cxx:11:
/Users/spham/github/o3de/Gems/Atom/RHI/Metal/Code/Source/RHI/BufferMemoryAllocator.cpp:111:62: error: use of undeclared identifier 'bufferMemoryView'
                    heapMemoryUsage.m_usedResidentInBytes -= bufferMemoryView.GetSize();
```

and 

```
In file included from /Users/spham/github/o3de/build/mac/Code/Framework/AzToolsFramework/CMakeFiles/AzToolsFramework.Tests.dir/Unity/unity_10_cxx.cxx:15:
/Users/spham/github/o3de/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUndoDeleteTests.cpp:208:38: error: no viable conversion from
      'optional<reference_wrapper<GenericValue<...>>>' to 'optional<reference_wrapper<const GenericValue<...>>>'
        PrefabDomValueConstReference wheelInstanceLinkPatches =

```

## How was this PR tested?

Built successfully on Mac
 
