### PR TITLE
Make CCD read only when kinematic is enabled and vice versa

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/RigidBodyConfiguration.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/RigidBodyConfiguration.cpp
@@ -105,13 +105,23 @@ namespace AzPhysics
         }
     }
 
-    const AZStd::string kinematicDescription =
+    constexpr AZStd::string_view kinematicDescription =
         "When active, the rigid body is not affected by gravity or other forces and is moved by script. ";
 
-    const AZStd::string ccdDescription =
+    constexpr AZStd::string_view kinematicDescriptionReadOnly =
+        "When active, the rigid body is not affected by gravity or other forces and is moved by script. "
+        "<b>The rigid body cannot be set as Kinematic if CCD is enabled, disable CCD to allow changes to be made.</b>";
+
+    constexpr AZStd::string_view ccdDescription =
         "When active, the rigid body has continuous collision detection (CCD). Use this to ensure accurate "
         "collision detection, particularly for fast moving rigid bodies. CCD must be activated in the global PhysX "
         "configuration. ";
+
+    constexpr AZStd::string_view ccdDescriptionReadOnly =
+        "When active, the rigid body has continuous collision detection (CCD). Use this to ensure accurate "
+        "collision detection, particularly for fast moving rigid bodies. CCD must be activated in the global PhysX "
+        "configuration. <b>CCD cannot be enabled if the rigid body is kinematic, set the rigid body as non-kinematic"
+        "to allow changes to be made.</b>";
 
     AZ_CLASS_ALLOCATOR_IMPL(RigidBodyConfiguration, AZ::SystemAllocator, 0);
 
@@ -202,24 +212,14 @@ namespace AzPhysics
         return m_kinematic;
     }
 
-    AZStd::string RigidBodyConfiguration::GetCcdTooltip() const
+    AZStd::string_view RigidBodyConfiguration::GetCcdTooltip() const
     {
-        if (m_kinematic)
-        {
-            return ccdDescription +
-                "<b>CCD cannot be enabled if the rigid body is kinematic, set the rigid body as non-kinematic to allow changes to be made.</b>";
-        }
-        return ccdDescription;
+        return (m_kinematic) ? ccdDescriptionReadOnly : ccdDescription;
     }
 
-    AZStd::string RigidBodyConfiguration::GetKinematicTooltip() const
+    AZStd::string_view RigidBodyConfiguration::GetKinematicTooltip() const
     {
-        if (m_ccdEnabled)
-        {
-            return kinematicDescription +
-                "<b>The rigid body cannot be set as Kinematic if CCD is enabled, disable CCD to allow changes to be made.</b>";
-        }
-        return kinematicDescription;
+        return (m_ccdEnabled) ? kinematicDescriptionReadOnly : kinematicDescription;
     }
 
     AZ::Crc32 RigidBodyConfiguration::GetInitialVelocitiesVisibility() const

--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/RigidBodyConfiguration.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/RigidBodyConfiguration.cpp
@@ -12,6 +12,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzFramework/Physics/Shape.h>
+#include <AzFramework/Physics/PhysicsSystem.h>
 
 namespace AzPhysics
 {
@@ -104,6 +105,14 @@ namespace AzPhysics
         }
     }
 
+    const AZStd::string kinematicDescription =
+        "When active, the rigid body is not affected by gravity or other forces and is moved by script. ";
+
+    const AZStd::string ccdDescription =
+        "When active, the rigid body has continuous collision detection (CCD). Use this to ensure accurate "
+        "collision detection, particularly for fast moving rigid bodies. CCD must be activated in the global PhysX "
+        "configuration. ";
+
     AZ_CLASS_ALLOCATOR_IMPL(RigidBodyConfiguration, AZ::SystemAllocator, 0);
 
     void RigidBodyConfiguration::Reflect(AZ::ReflectContext* context)
@@ -182,6 +191,35 @@ namespace AzPhysics
     bool RigidBodyConfiguration::IsCcdEnabled() const
     {
         return m_ccdEnabled;
+    }
+
+    bool RigidBodyConfiguration::CcdReadOnly() const
+    {
+        if (auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get())
+        {
+            return !physicsSystem->GetDefaultSceneConfiguration().m_enableCcd || m_kinematic;
+        }
+        return m_kinematic;
+    }
+
+    AZStd::string RigidBodyConfiguration::GetCcdTooltip() const
+    {
+        if (m_kinematic)
+        {
+            return ccdDescription +
+                "<b>CCD cannot be enabled if the rigid body is kinematic, set the rigid body as non-kinematic to allow changes to be made.</b>";
+        }
+        return ccdDescription;
+    }
+
+    AZStd::string RigidBodyConfiguration::GetKinematicTooltip() const
+    {
+        if (m_ccdEnabled)
+        {
+            return kinematicDescription +
+                "<b>The rigid body cannot be set as Kinematic if CCD is enabled, disable CCD to allow changes to be made.</b>";
+        }
+        return kinematicDescription;
     }
 
     AZ::Crc32 RigidBodyConfiguration::GetInitialVelocitiesVisibility() const

--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/RigidBodyConfiguration.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/RigidBodyConfiguration.cpp
@@ -105,19 +105,19 @@ namespace AzPhysics
         }
     }
 
-    constexpr AZStd::string_view kinematicDescription =
+    constexpr AZStd::string_view KinematicDescription =
         "When active, the rigid body is not affected by gravity or other forces and is moved by script. ";
 
-    constexpr AZStd::string_view kinematicDescriptionReadOnly =
+    constexpr AZStd::string_view KinematicDescriptionReadOnly =
         "When active, the rigid body is not affected by gravity or other forces and is moved by script. "
         "<b>The rigid body cannot be set as Kinematic if CCD is enabled, disable CCD to allow changes to be made.</b>";
 
-    constexpr AZStd::string_view ccdDescription =
+    constexpr AZStd::string_view CcdDescription =
         "When active, the rigid body has continuous collision detection (CCD). Use this to ensure accurate "
         "collision detection, particularly for fast moving rigid bodies. CCD must be activated in the global PhysX "
         "configuration. ";
 
-    constexpr AZStd::string_view ccdDescriptionReadOnly =
+    constexpr AZStd::string_view CcdDescriptionReadOnly =
         "When active, the rigid body has continuous collision detection (CCD). Use this to ensure accurate "
         "collision detection, particularly for fast moving rigid bodies. CCD must be activated in the global PhysX "
         "configuration. <b>CCD cannot be enabled if the rigid body is kinematic, set the rigid body as non-kinematic"
@@ -214,12 +214,12 @@ namespace AzPhysics
 
     AZStd::string_view RigidBodyConfiguration::GetCcdTooltip() const
     {
-        return (m_kinematic) ? ccdDescriptionReadOnly : ccdDescription;
+        return m_kinematic ? CcdDescriptionReadOnly : CcdDescription;
     }
 
     AZStd::string_view RigidBodyConfiguration::GetKinematicTooltip() const
     {
-        return (m_ccdEnabled) ? kinematicDescriptionReadOnly : kinematicDescription;
+        return m_ccdEnabled ? KinematicDescriptionReadOnly : KinematicDescription;
     }
 
     AZ::Crc32 RigidBodyConfiguration::GetInitialVelocitiesVisibility() const

--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/RigidBodyConfiguration.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/RigidBodyConfiguration.h
@@ -37,8 +37,8 @@ namespace AzPhysics
 
         bool IsCcdEnabled() const;
         bool CcdReadOnly() const;
-        AZStd::string GetCcdTooltip() const;
-        AZStd::string GetKinematicTooltip() const;
+        AZStd::string_view GetCcdTooltip() const;
+        AZStd::string_view GetKinematicTooltip() const;
 
         // Basic initial settings.
         AZ::Vector3 m_initialLinearVelocity = AZ::Vector3::CreateZero();

--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/RigidBodyConfiguration.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/RigidBodyConfiguration.h
@@ -36,6 +36,9 @@ namespace AzPhysics
         void SetMassComputeFlags(MassComputeFlags flags);
 
         bool IsCcdEnabled() const;
+        bool CcdReadOnly() const;
+        AZStd::string GetCcdTooltip() const;
+        AZStd::string GetKinematicTooltip() const;
 
         // Basic initial settings.
         AZ::Vector3 m_initialLinearVelocity = AZ::Vector3::CreateZero();

--- a/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
@@ -178,6 +178,8 @@ namespace PhysX
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_kinematic,
                         "Kinematic", "When active, the rigid body is not affected by gravity or other forces and is moved by script.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetKinematicVisibility)
+                        ->Attribute(AZ::Edit::Attributes::ReadOnly, &AzPhysics::RigidBodyConfiguration::m_ccdEnabled)
+                        ->Attribute(AZ::Edit::Attributes::DescriptionTextOverride, &AzPhysics::RigidBodyConfiguration::GetKinematicTooltip)
 
                     // Linear axis locking properties
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Linear Axis Locking")
@@ -212,7 +214,8 @@ namespace PhysX
                         "CCD enabled", "When active, the rigid body has continuous collision detection (CCD). Use this to ensure accurate "
                         "collision detection, particularly for fast moving rigid bodies. CCD must be activated in the global PhysX configuration.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetCcdVisibility)
-                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &IsSceneCcdDisabled)
+                        ->Attribute(AZ::Edit::Attributes::DescriptionTextOverride, &AzPhysics::RigidBodyConfiguration::GetCcdTooltip)
+                        ->Attribute(AZ::Edit::Attributes::ReadOnly, &AzPhysics::RigidBodyConfiguration::CcdReadOnly)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_ccdMinAdvanceCoefficient,
                         "Min advance coefficient", "Lower values reduce clipping but can affect simulation smoothness.")


### PR DESCRIPTION
Signed-off-by: amzn-ahmadkrm <ahmadkrm@amazon.com>

## What does this PR do?

This PR updates the UI to disallow the user to set a Rigid Body Component to Kinematic mode while CCD is enabled and vice versa, these are not compatible in PhysX and results in a warning. This PR makes it so it doesn't get to the point of the PhysX warning and informs the user that only one setting can be used at once.

![devenv_C9X5GRLxQv](https://user-images.githubusercontent.com/105638312/210534551-4fc65dcb-10cd-4769-b54e-776ad5f5e633.png)
![devenv_LlneAyonsK](https://user-images.githubusercontent.com/105638312/210534567-2ef6729e-5920-4eb6-882f-ea46a9900ef8.png)

## How was this PR tested?

Manual testing.
_Please describe any testing performed._
