### PR TITLE
make sure all joint component submodes are handled during component m…

### DIFF
--- a/Gems/PhysX/Code/Editor/Source/ComponentModes/Joints/JointsComponentMode.cpp
+++ b/Gems/PhysX/Code/Editor/Source/ComponentModes/Joints/JointsComponentMode.cpp
@@ -416,6 +416,9 @@ namespace PhysX
                     }
                 }
                 break;
+            case JointsComponentModeCommon::SubComponentModes::ModeType::SnapPosition:
+            case JointsComponentModeCommon::SubComponentModes::ModeType::SnapRotation:
+                break;
             default:
                 AZ_Error("Joints", false, "Joints component mode cluster UI setup found unknown sub mode.");
                 break;


### PR DESCRIPTION
…ode setup

Signed-off-by: greerdv <greerdv@amazon.com>

## What does this PR do?
Makes sure all joint component submodes are handled during component mode setup. Fixes #9972 

## How was this PR tested?
Manual testing in the editor