### PR TITLE
Restore rapidjson fixes

### DIFF
--- a/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsContainer.cpp
+++ b/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsContainer.cpp
@@ -301,7 +301,7 @@ namespace ProjectSettingsTool
         return nullptr;
     }
 
-    rapidjson::RAPIDJSON_DEFAULT_ALLOCATOR& ProjectSettingsContainer::GetProjectJsonAllocator()
+    rapidjson::Document::AllocatorType& ProjectSettingsContainer::GetProjectJsonAllocator()
     {
         return m_projectJson.m_document->GetAllocator();
     }

--- a/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsContainer.h
+++ b/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsContainer.h
@@ -109,7 +109,7 @@ namespace ProjectSettingsTool
         AZStd::unique_ptr<PlistDictionary> CreatePlistDictionary(const Platform& plat);
 
         // Returns the allocator used by ProjectJson
-        rapidjson::RAPIDJSON_DEFAULT_ALLOCATOR& GetProjectJsonAllocator();
+        rapidjson::Document::AllocatorType& GetProjectJsonAllocator();
 
         static AZ::Outcome<rapidjson::Value*, void> GetJsonValue(rapidjson::Document& settings, const char* key);
 

--- a/Code/Framework/AzCore/AzCore/JSON/RapidJsonAllocator.h
+++ b/Code/Framework/AzCore/AzCore/JSON/RapidJsonAllocator.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Memory/ChildAllocatorSchema.h>
+#include <AzCore/Memory/OSAllocator.h>
+
+namespace AZ::JSON
+{
+    class RapidJSONAllocator : public AZ::ChildAllocatorSchema<AZ::OSAllocator>
+    {
+    public:
+        AZ_TYPE_INFO(RapidJSONAllocator, "{CCD24805-0E41-48CC-B92E-DB77F10FBEE3}");
+    };
+} // namespace AZ::JSON
+
+

--- a/Code/Framework/AzCore/AzCore/JSON/rapidjson.cpp
+++ b/Code/Framework/AzCore/AzCore/JSON/rapidjson.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/JSON/rapidjson.h>
+#include <AzCore/JSON/RapidJsonAllocator.h>
+
+#if USING_AZCORE_RAPIDJSON_ALLOCATION_OVERRIDES
+    namespace AZ::JSON
+    {
+        pointer_type do_malloc(
+            size_type byteSize,
+            size_type alignment,
+            int flags,
+            const char* name,
+            const char* fileName,
+            int lineNum,
+            unsigned int suppressStackRecord)
+        {
+            return AllocatorInstance<RapidJSONAllocator>::Get().Allocate(
+                byteSize, alignment, flags, name, fileName, lineNum, suppressStackRecord);
+        }
+
+        pointer_type do_realloc(pointer_type ptr, size_type newSize, size_type newAlignment)
+        {
+            return AllocatorInstance<RapidJSONAllocator>::Get().ReAllocate(ptr, newSize, newAlignment);
+        }
+
+        void do_free(pointer_type ptr)
+        {
+            return AllocatorInstance<RapidJSONAllocator>::Get().DeAllocate(ptr);
+        }
+    } // namespace AZ::JSON
+
+#endif // USING_AZCORE_RAPIDJSON_ALLOCATION_OVERRIDES
+

--- a/Code/Framework/AzCore/AzCore/JSON/rapidjson.h
+++ b/Code/Framework/AzCore/AzCore/JSON/rapidjson.h
@@ -8,52 +8,97 @@
 
 #pragma once
 
-#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/base.h>
 
-// Skip the error as we are including the recommended way.
-#define RAPIDJSON_SKIP_AZCORE_ERROR
-
-#if defined(AZ_ENABLE_TRACING)
-#   define RAPIDJSON_ASSERT(x) AZ_Assert(x, "Assert[rapidjson]: " #x)
-#else
-#   define RAPIDJSON_ASSERT(x) (void)(0)
+#if defined(RAPIDJSON_RAPIDJSON_H_)
+// if this happens, someone has alrady included the default rapidjson.h already, which is a bad idea as it won't
+// include any customizations such as memory management.
+#error vanilla rapidjson was included before including <AzCore/JSON/rapidjson.h>
 #endif
-#define RAPIDJSON_STATIC_ASSERT(x) static_assert(x, "Assert[rapidjson]: " #x)
-#define RAPIDJSON_HAS_CXX11_TYPETRAITS 1
-#define RAPIDJSON_HAS_CXX11_RVALUE_REFS 1
 
-namespace rapidjson_ly_internal
-{
-    template<typename T>
-    void Delete(T* instance)
+// Only override RAPIDJSON_ customization macros which are not already defined.
+// This allows the user to pre-define these before including O3DE if they want to use default values
+// or their own values.
+
+#if !defined(RAPIDJSON_ASSERT)
+#   if defined(AZ_ENABLE_TRACING)
+#       define RAPIDJSON_ASSERT(x) AZ_Assert(x, "Assert[rapidjson]: " #x)
+#   else
+#       define RAPIDJSON_ASSERT(x) (void)(0)
+#   endif
+#endif
+
+#if !defined(RAPIDJSON_STATIC_ASSERT)
+   #define RAPIDJSON_STATIC_ASSERT(x) static_assert(x, "Assert[rapidjson]: " #x)
+#endif
+
+#if !defined(RAPIDJSON_HAS_CXX11_TYPETRAITS)
+#   define RAPIDJSON_HAS_CXX11_TYPETRAITS 1
+#endif
+
+#if !defined(RAPIDJSON_HAS_CXX11_RVALUE_REFS)
+#   define RAPIDJSON_HAS_CXX11_RVALUE_REFS 1
+#endif
+
+// note for future maintainers:
+// RapidJSON allows you to customize the default allocator type for documents by overriding with RAPIDJSON_DEFAULT_ALLOCATOR.
+// However, customizing the default type of rapidjson::Document and rapidjson::Value in that way will cause incompatibilities
+// with external software libraries that use unmodified RapidJSON.   It is not thus recommended
+// to actually set the value of RAPIDJSON_DEFAULT_ALLOCATOR or redefine what a rapidjson::Document itself is.
+// The other way to get a 'custom' allocator installed in RapidJSON is to make your own Document/Value/Pointer type, since it's templated
+// on allocator type - for example, implement your own allocator and do
+// using MyDocument = rapidjson::GenericDocument<rapidjson::UTF8<char>, MyAllocator, MyAllocator> and then use MyDocument in your code
+// instead of RapidJSON::Document.  Note GenericDocument<> customized must use customized GenericValue<> and GenericPointer<>
+// or else you haven't acutally plugged into all the places where memory is allocated and will lose some.
+// 
+// Unfortunately, rapidjson::Pointer can't deal with these customized values or documents due to a bug in the code where functions
+// like Set/Get/Create use the default template parameter instead of deducing it:
+// ie, they are set up like somefunction<T>(GenericValue<char> val) which will only accept default GenericValue<char, CrtAllocator>.
+// correct form: somefunction<T>(GenericValue<char, T::AllocatorType> val, which would allow MyValue<char, MyAllocator> to be passed in.
+// thus, it is not recommended to use customized documents, values, or pointers either, (until that bug is fixed).
+
+// this leaves just one avenue for customization of memory of Rapidjson - overriding the macros RAPIDJSON_xxxx (new,delete, malloc, realloc..)
+
+// forward all allocations to our own allocators.  But preferrably without acutally having to drag our allocators into this header:
+
+// note that we cannot partially define allocation forwarding - for example, it is not okay to just override new, but not delete.
+// So either we define them all, or we define none.  If a user has defined any of them, we don't define any of them:
+// Users can manually switch the entire system off by setting USING_AZCORE_RAPIDJSON_ALLOCATION_OVERRIDES 0
+
+#if !defined(USING_AZCORE_RAPIDJSON_ALLOCATION_OVERRIDES)
+#   if  !defined(RAPIDJSON_MALLOC) && !defined(RAPIDJSON_REALLOC) && !defined(RAPIDJSON_FREE) && !defined(RAPIDJSON_NEW) && !defined(RAPIDJSON_DELETE)
+#       define USING_AZCORE_RAPIDJSON_ALLOCATION_OVERRIDES 1
+#   else
+#       define USING_AZCORE_RAPIDJSON_ALLOCATION_OVERRIDES 0
+#   endif
+#endif
+
+#if USING_AZCORE_RAPIDJSON_ALLOCATION_OVERRIDES
+
+    namespace AZ::JSON
     {
-        if (instance)
-        {
-            instance->~T();
-            azfree(instance, AZ::SystemAllocator);
-        }
+        typedef void* pointer_type;
+        typedef size_t size_type;
+
+        pointer_type do_malloc(size_type byteSize, size_type alignment, int flags, const char* name, const char* fileName, int lineNum, unsigned int suppressStackRecord);
+        pointer_type do_realloc(pointer_type ptr, size_type newSize, size_type newAlignment);
+        void do_free(pointer_type ptr);
+    } 
+
+#   define RAPIDJSON_MALLOC(_size)         AZ::JSON::do_malloc(_size, 16, 0, "RapidJSON", __FILE__, __LINE__, 0)
+#   define RAPIDJSON_REALLOC(_ptr, _size)  AZ::JSON::do_realloc(_ptr, _size, 16)
+#   define RAPIDJSON_FREE(_ptr)            AZ::JSON::do_free(_ptr)
+#   define RAPIDJSON_NEW(x)           new (AZ::JSON::do_malloc(sizeof(x), alignof(x), 0, "RapidJSON", __FILE__, __LINE__, 0)) x
+#   define RAPIDJSON_DELETE(x)                 \
+    {                                          \
+        if (x)                                 \
+        {                                      \
+            std::destroy_at(x);                \
+            AZ::JSON::do_free(x);              \
+        }                                      \
     }
-}
 
-
-#define RAPIDJSON_NEW(x)  new(azmalloc(sizeof(x), alignof(x), AZ::SystemAllocator)) x
-#define RAPIDJSON_DELETE(x) rapidjson_ly_internal::Delete(x)
-#define RAPIDJSON_MALLOC(_size) AZ::AllocatorInstance<AZ::SystemAllocator>::Get().allocate(_size, 16)
-#define RAPIDJSON_REALLOC(_ptr, _newSize) _ptr ? AZ::AllocatorInstance<AZ::SystemAllocator>::Get().reallocate(_ptr, _newSize, 16) : RAPIDJSON_MALLOC(_newSize)
-#define RAPIDJSON_FREE(_ptr) if (_ptr) { AZ::AllocatorInstance<AZ::SystemAllocator>::Get().deallocate(_ptr, 0, 0); }
-#define RAPIDJSON_CLASS_ALLOCATOR(_class) AZ_CLASS_ALLOCATOR(_class, AZ::SystemAllocator, 0)
-
-// By default, RapidJSON uses its own pooling allocator that allocates in 64k chunks and then uses the
-// contents of those chunks internally.
-// However, O3DE defines the above macros, which redirect the RapidJSON allocations into the O3DE system
-// allocator, which itself is a also a chunk-based pooling allocator (HPHA).
-// This double-chunking would be wasteful, so tell RapidJSON to directly ask for allocations instead
-// of attempting to pool them.  The rapidjson::CrtAllocator just passes allocation and deallocation to the above
-// macros.
-#define RAPIDJSON_DEFAULT_ALLOCATOR CrtAllocator
-
-// Set custom namespace for AzCore's rapidjson to avoid various collisions.
-#define RAPIDJSON_NAMESPACE rapidjson_ly
+#endif // USING_AZCORE_RAPIDJSON_ALLOCATION_OVERRIDES
 
 #if AZ_TRAIT_JSON_CLANG_IGNORE_UNKNOWN_WARNING && defined(AZ_COMPILER_CLANG)
 #pragma clang diagnostic push
@@ -94,5 +139,6 @@ namespace rapidjson_ly_internal
 #pragma clang diagnostic pop
 #endif
 
-// Allow our existing code to continue use "rapidjson::"
-#define rapidjson RAPIDJSON_NAMESPACE
+// retain backward compatibility by aliasing rapidjson_ly to rapidjson
+namespace rapidjson_ly = rapidjson;
+

--- a/Code/Framework/AzCore/AzCore/JSON/rapidjson.h
+++ b/Code/Framework/AzCore/AzCore/JSON/rapidjson.h
@@ -11,7 +11,7 @@
 #include <AzCore/base.h>
 
 #if defined(RAPIDJSON_RAPIDJSON_H_)
-// if this happens, someone has alrady included the default rapidjson.h already, which is a bad idea as it won't
+// if this happens, someone has already included the default rapidjson.h already, which is a bad idea as it won't
 // include any customizations such as memory management.
 #error vanilla rapidjson was included before including <AzCore/JSON/rapidjson.h>
 #endif
@@ -49,7 +49,7 @@
 // on allocator type - for example, implement your own allocator and do
 // using MyDocument = rapidjson::GenericDocument<rapidjson::UTF8<char>, MyAllocator, MyAllocator> and then use MyDocument in your code
 // instead of RapidJSON::Document.  Note GenericDocument<> customized must use customized GenericValue<> and GenericPointer<>
-// or else you haven't acutally plugged into all the places where memory is allocated and will lose some.
+// or else you haven't actually plugged into all the places where memory is allocated and will lose some.
 // 
 // Unfortunately, rapidjson::Pointer can't deal with these customized values or documents due to a bug in the code where functions
 // like Set/Get/Create use the default template parameter instead of deducing it:
@@ -59,7 +59,7 @@
 
 // this leaves just one avenue for customization of memory of Rapidjson - overriding the macros RAPIDJSON_xxxx (new,delete, malloc, realloc..)
 
-// forward all allocations to our own allocators.  But preferrably without acutally having to drag our allocators into this header:
+// forward all allocations to our own allocators.  But preferably without actually having to drag our allocators into this header:
 
 // note that we cannot partially define allocation forwarding - for example, it is not okay to just override new, but not delete.
 // So either we define them all, or we define none.  If a user has defined any of them, we don't define any of them:

--- a/Code/Framework/AzCore/AzCore/JSON/rapidjson.h
+++ b/Code/Framework/AzCore/AzCore/JSON/rapidjson.h
@@ -131,14 +131,25 @@
     #endif
 #endif
 
+// Push all of rapidjson into a different namespace (rapidjson_ly for backward compatibility, as this is what
+// it used to be at some point).  
+// The risk of using the default namespace is that during library search, the linker might find other versions
+// of rapidjson from other 3rd party libraries that have the same mangled function names and use those when 
+// linking the code in.  The problem with that is different versions of rapidjson have different struct layouts
+// and thus even though the signature of the function is the same, the actual implementation is not compatible,
+// leading to mystery crashes.
+
+#define RAPIDJSON_NAMESPACE rapidjson_ly
+
 // Now that all of the above is declared, bring the RapidJSON headers in.
 // If you add additional definitions or configuration options, add them above.
 #include <rapidjson/rapidjson.h>
 
+// After using this header file, any use of 'rapidjson' points at O3DE's rapidjson.  This will also cause
+// compiler errors and warnings about redefinition if you happen to ever use this file and another rapidjson
+// in the same compile unit somehow.
+namespace rapidjson = rapidjson_ly;
+
 #if AZ_TRAIT_JSON_CLANG_IGNORE_UNKNOWN_WARNING && defined(AZ_COMPILER_CLANG)
 #pragma clang diagnostic pop
 #endif
-
-// retain backward compatibility by aliasing rapidjson_ly to rapidjson
-namespace rapidjson_ly = rapidjson;
-

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -252,6 +252,8 @@ set(FILES
     JSON/pointer.h
     JSON/prettywriter.h
     JSON/rapidjson.h
+    JSON/rapidjson.cpp
+    JSON/RapidJsonAllocator.h
     JSON/RapidjsonAllocatorAdapter.h
     JSON/reader.h
     JSON/schema.h

--- a/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/rapidjson.natvis
+++ b/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/rapidjson.natvis
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
 	<!-- rapidjson::GenericValue - basic support -->
-	<Type Name="rapidjson_ly::GenericValue&lt;*,*&gt;">
+	<Type Name="rapidjson::GenericValue&lt;*,*&gt;">
 		<DisplayString Condition="(data_.f.flags &amp; kTypeMask) == kNullType">null</DisplayString>
 		<DisplayString Condition="data_.f.flags == kTrueFlag">true</DisplayString>
 		<DisplayString Condition="data_.f.flags == kFalseFlag">false</DisplayString>
@@ -20,7 +20,7 @@
 			<ArrayItems Condition="data_.f.flags == kObjectType">
 				<Size>data_.o.size</Size>
 				<!-- NOTE: Rapidjson stores some extra data in the high bits of pointers, which is why the mask -->
-				<ValuePointer>(rapidjson_ly::GenericMember&lt;$T1,$T2&gt;*)(((size_t)data_.o.members) &amp; 0x0000FFFFFFFFFFFF)</ValuePointer>
+				<ValuePointer>(rapidjson::GenericMember&lt;$T1,$T2&gt;*)(((size_t)data_.o.members) &amp; 0x0000FFFFFFFFFFFF)</ValuePointer>
 			</ArrayItems>
 
 			<Item Condition="data_.f.flags == kArrayType" Name="[size]">data_.a.size</Item>
@@ -28,7 +28,7 @@
 			<ArrayItems Condition="data_.f.flags == kArrayType">
 				<Size>data_.a.size</Size>
 				<!-- NOTE: Rapidjson stores some extra data in the high bits of pointers, which is why the mask -->
-				<ValuePointer>(rapidjson_ly::GenericValue&lt;$T1,$T2&gt;*)(((size_t)data_.a.elements) &amp; 0x0000FFFFFFFFFFFF)</ValuePointer>
+				<ValuePointer>(rapidjson::GenericValue&lt;$T1,$T2&gt;*)(((size_t)data_.a.elements) &amp; 0x0000FFFFFFFFFFFF)</ValuePointer>
 			</ArrayItems>
 
 		</Expand>

--- a/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/rapidjson.natvis
+++ b/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/rapidjson.natvis
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
 	<!-- rapidjson::GenericValue - basic support -->
-	<Type Name="rapidjson::GenericValue&lt;*,*&gt;">
+	<Type Name="rapidjson_ly::GenericValue&lt;*,*&gt;">
 		<DisplayString Condition="(data_.f.flags &amp; kTypeMask) == kNullType">null</DisplayString>
 		<DisplayString Condition="data_.f.flags == kTrueFlag">true</DisplayString>
 		<DisplayString Condition="data_.f.flags == kFalseFlag">false</DisplayString>
@@ -20,7 +20,7 @@
 			<ArrayItems Condition="data_.f.flags == kObjectType">
 				<Size>data_.o.size</Size>
 				<!-- NOTE: Rapidjson stores some extra data in the high bits of pointers, which is why the mask -->
-				<ValuePointer>(rapidjson::GenericMember&lt;$T1,$T2&gt;*)(((size_t)data_.o.members) &amp; 0x0000FFFFFFFFFFFF)</ValuePointer>
+				<ValuePointer>(rapidjson_ly::GenericMember&lt;$T1,$T2&gt;*)(((size_t)data_.o.members) &amp; 0x0000FFFFFFFFFFFF)</ValuePointer>
 			</ArrayItems>
 
 			<Item Condition="data_.f.flags == kArrayType" Name="[size]">data_.a.size</Item>
@@ -28,7 +28,7 @@
 			<ArrayItems Condition="data_.f.flags == kArrayType">
 				<Size>data_.a.size</Size>
 				<!-- NOTE: Rapidjson stores some extra data in the high bits of pointers, which is why the mask -->
-				<ValuePointer>(rapidjson::GenericValue&lt;$T1,$T2&gt;*)(((size_t)data_.a.elements) &amp; 0x0000FFFFFFFFFFFF)</ValuePointer>
+				<ValuePointer>(rapidjson_ly::GenericValue&lt;$T1,$T2&gt;*)(((size_t)data_.a.elements) &amp; 0x0000FFFFFFFFFFFF)</ValuePointer>
 			</ArrayItems>
 
 		</Expand>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EntityUtilityComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EntityUtilityComponent.cpp
@@ -8,6 +8,8 @@
 
 #include <sstream>
 #include <AzCore/JSON/rapidjson.h>
+#include <AzCore/JSON/document.h>
+
 #include <AzCore/Serialization/Json/JsonSerialization.h>
 #include <AzCore/Serialization/Json/JsonSerializationSettings.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>
@@ -15,7 +17,6 @@
 #include <AzFramework/FileFunc/FileFunc.h>
 #include <AzToolsFramework/Entity/EntityUtilityComponent.h>
 #include <Entity/EditorEntityContextBus.h>
-#include <rapidjson/document.h>
 
 namespace AzToolsFramework
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Metadata/MetadataManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Metadata/MetadataManager.cpp
@@ -28,7 +28,7 @@ namespace AzToolsFramework
 
     bool MetadataManager::GetValue(AZ::IO::PathView file, AZStd::string_view key, void* outValue, AZ::Uuid typeId)
     {
-        rapidjson_ly::Document value;
+        rapidjson::Document value;
 
         if (!GetJson(file, key, value))
         {
@@ -41,12 +41,12 @@ namespace AzToolsFramework
         return resultCode.GetProcessing() != AZ::JsonSerializationResult::Processing::Halted;
     }
 
-    bool MetadataManager::GetJson(AZ::IO::PathView file, AZStd::string_view key, rapidjson_ly::Document& outValue)
+    bool MetadataManager::GetJson(AZ::IO::PathView file, AZStd::string_view key, rapidjson::Document& outValue)
     {
         auto path = ToMetadataPath(file);
 
         // Make a JSONPath pointer and validate it
-        rapidjson_ly::Pointer pointer(key.data(), key.length());
+        rapidjson::Pointer pointer(key.data(), key.length());
 
         if (!pointer.IsValid())
         {
@@ -84,21 +84,21 @@ namespace AzToolsFramework
         auto& document = result.GetValue();
 
         // Use the pointer to find the value we're trying to read
-        rapidjson_ly::Value* value = pointer.Get(document);
+        rapidjson::Value* value = pointer.Get(document);
 
         if (!value)
         {
             return false;
         }
 
-        outValue = rapidjson_ly::Document(); // Make sure to release any existing memory if the document happens to be non-empty
+        outValue = rapidjson::Document(); // Make sure to release any existing memory if the document happens to be non-empty
         outValue.CopyFrom(*value, outValue.GetAllocator());
         return true;
     }
 
     bool MetadataManager::GetValueVersion(AZ::IO::PathView file, AZStd::string_view key, int& version)
     {
-        rapidjson_ly::Document value;
+        rapidjson::Document value;
         if (!GetJson(file, key, value))
         {
             return false;
@@ -137,8 +137,8 @@ namespace AzToolsFramework
         auto path = ToMetadataPath(file);
 
         // Make a JSONPath pointer and validate it
-        rapidjson_ly::Pointer pointer(key.data(), key.length());
-        rapidjson_ly::Pointer versionPointer(MetadataVersionKey);
+        rapidjson::Pointer pointer(key.data(), key.length());
+        rapidjson::Pointer versionPointer(MetadataVersionKey);
 
         if (!pointer.IsValid())
         {
@@ -155,7 +155,7 @@ namespace AzToolsFramework
         // Otherwise, just start a new, blank document
         auto result = AZ::JsonSerializationUtils::ReadJsonFile(path.Native());
 
-        rapidjson_ly::Document document;
+        rapidjson::Document document;
 
         if (result)
         {
@@ -208,11 +208,11 @@ namespace AzToolsFramework
         };
 
         // Encode the version into JSON
-        rapidjson_ly::Value serializedVersion;
+        rapidjson::Value serializedVersion;
         AZ::JsonSerialization::Store(serializedVersion, document.GetAllocator(), &MetadataVersion, nullptr, azrtti_typeid<int>(), settings);
 
         // Encode the value into JSON
-        rapidjson_ly::Value serializedValue;
+        rapidjson::Value serializedValue;
         auto resultCode = AZ::JsonSerialization::Store(serializedValue, document.GetAllocator(), inValue, nullptr, typeId, settings);
 
         // Try to insert the version of the type being serialized into the serialized data
@@ -230,10 +230,10 @@ namespace AzToolsFramework
             }
             else
             {
-                rapidjson_ly::Value versionValue;
+                rapidjson::Value versionValue;
                 versionValue.SetInt(currentVersion);
                 serializedValue.GetObject().AddMember(
-                    rapidjson_ly::Value(MetadataObjectVersionField, document.GetAllocator()).Move(), versionValue, document.GetAllocator());
+                    rapidjson::Value(MetadataObjectVersionField, document.GetAllocator()).Move(), versionValue, document.GetAllocator());
             }
         }
 
@@ -242,11 +242,11 @@ namespace AzToolsFramework
             // Create the file version JSON entry in the document and store the encoded value
             // This will update the saved version to the current version
             // Note that this is the version of the entire saved document (the metadata version), not the version of the type being saved
-            rapidjson_ly::Value& versionStore = versionPointer.Create(document, document.GetAllocator());
+            rapidjson::Value& versionStore = versionPointer.Create(document, document.GetAllocator());
             versionStore = AZStd::move(serializedVersion);
 
             // Create the user JSON entry in the document and store the encoded value
-            rapidjson_ly::Value& store = pointer.Create(document, document.GetAllocator());
+            rapidjson::Value& store = pointer.Create(document, document.GetAllocator());
             store = AZStd::move(serializedValue);
 
             // Save JSON to disk

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Metadata/MetadataManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Metadata/MetadataManager.h
@@ -42,7 +42,7 @@ namespace AzToolsFramework
         //! @param file Absolute path to the file (or metadata file).
         //! @param key JSONPath formatted key for the metadata value to read.  Ex: /Settings/Platform/pc.
         //! @return True if metadata file and key exists and was successfully read, false otherwise.
-        virtual bool GetJson(AZ::IO::PathView file, AZStd::string_view key, rapidjson_ly::Document& outValue) = 0;
+        virtual bool GetJson(AZ::IO::PathView file, AZStd::string_view key, rapidjson::Document& outValue) = 0;
 
         //! Gets the version for a stored key/value from the metadata file associated with the file.
         //! @param file Absolute path to the file (or metadata file).
@@ -91,7 +91,7 @@ namespace AzToolsFramework
 
     public:
         bool GetValue(AZ::IO::PathView file, AZStd::string_view key, void* outValue, AZ::Uuid typeId) override;
-        bool GetJson(AZ::IO::PathView file, AZStd::string_view key, rapidjson_ly::Document& outValue) override;
+        bool GetJson(AZ::IO::PathView file, AZStd::string_view key, rapidjson::Document& outValue) override;
         bool GetValueVersion(AZ::IO::PathView file, AZStd::string_view key, int& version) override;
         bool SetValue(AZ::IO::PathView file, AZStd::string_view key, const void* inValue, AZ::Uuid typeId) override;
 

--- a/Code/Framework/AzToolsFramework/Tests/MetadataManagerTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/MetadataManagerTests.cpp
@@ -310,7 +310,7 @@ namespace UnitTest
         EXPECT_TRUE(m_metadata->GetValueVersion("mockfile", "/Test", version));
         EXPECT_EQ(version, 1);
 
-        rapidjson_ly::Document inValue;
+        rapidjson::Document inValue;
         EXPECT_TRUE(m_metadata->GetJson("mockfile", "/Test", inValue));
 
         auto intItr = inValue.FindMember("int");

--- a/Gems/AWSCore/Code/Include/Framework/JsonWriter.h
+++ b/Gems/AWSCore/Code/Include/Framework/JsonWriter.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/std/string/string.h>
+#include <AzCore/std/containers/vector.h>
 #include <AzCore/JSON/writer.h>
 #include <aws/core/utils/memory/stl/AWSStreamFwd.h>
 

--- a/Gems/GraphCanvas/Code/Source/Translation/TranslationDatabase.h
+++ b/Gems/GraphCanvas/Code/Source/Translation/TranslationDatabase.h
@@ -14,9 +14,9 @@
 #include <AzFramework/Asset/GenericAssetHandler.h>
 #include <AzFramework/Asset/AssetCatalogBus.h>
 
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/prettywriter.h>
-#include <rapidjson/rapidjson.h>
+#include <AzCore/JSON/stringbuffer.h>
+#include <AzCore/JSON/prettywriter.h>
+#include <AzCore/JSON/rapidjson.h>
 
 namespace GraphCanvas
 {

--- a/Gems/PhysX/Code/Editor/Source/Material/Conversion/LegacyPhysicsMaterialPrefabConversion.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Material/Conversion/LegacyPhysicsMaterialPrefabConversion.cpp
@@ -170,7 +170,7 @@ namespace PhysX
         // Fix terrain mappings, which is an array of legacy material ids, which will be converted to new material assets.
         if (auto* mappingMember = Physics::Utils::FindMemberChainInPrefabComponent({ "Configuration", "Mappings" }, component); mappingMember != nullptr)
         {
-            for (rapidjson_ly::SizeType i = 0; i < mappingMember->Size(); ++i)
+            for (rapidjson::SizeType i = 0; i < mappingMember->Size(); ++i)
             {
                 if (FixPhysicsMaterialId(prefabInfo, (*mappingMember)[i], legacyMaterialIdToNewAssetIdMap,
                     { "Material" }, { "MaterialAsset" }))

--- a/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
+++ b/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
@@ -38,7 +38,7 @@
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
-#include <rapidjson/pointer.h>
+#include <AzCore/JSON/pointer.h>
 #include <SceneBuilder/SceneBuilderWorker.h>
 #include <SceneBuilder/TraceMessageHook.h>
 

--- a/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.cpp
+++ b/Gems/ScriptCanvas/Code/Tools/TranslationGeneration.cpp
@@ -10,10 +10,10 @@
 
 #include <Source/Translation/TranslationBus.h>
 
-#include <rapidjson/rapidjson.h>
-#include <rapidjson/document.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/prettywriter.h>
+#include <AzCore/JSON/rapidjson.h>
+#include <AzCore/JSON/document.h>
+#include <AzCore/JSON/stringbuffer.h>
+#include <AzCore/JSON/prettywriter.h>
 
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/IO/SystemFile.h>
@@ -1082,15 +1082,15 @@ namespace ScriptCanvasEditorTools
 
     void TranslationGeneration::SaveJSONData(const AZStd::string& filename, TranslationFormat& translationRoot)
     {
-        rapidjson_ly::Document document;
+        rapidjson::Document document;
         document.SetObject();
-        rapidjson_ly::Value entries(rapidjson_ly::kArrayType);
+        rapidjson::Value entries(rapidjson::kArrayType);
 
         // Here I'll need to parse translationRoot myself and produce the JSON
         for (const auto& entrySource : translationRoot.m_entries)
         {
-            rapidjson_ly::Value entry(rapidjson_ly::kObjectType);
-            rapidjson_ly::Value value(rapidjson_ly::kStringType);
+            rapidjson::Value entry(rapidjson::kObjectType);
+            rapidjson::Value value(rapidjson::kStringType);
 
             value.SetString(entrySource.m_key.c_str(), document.GetAllocator());
             entry.AddMember(GraphCanvas::Schema::Field::key, value, document.GetAllocator());
@@ -1101,7 +1101,7 @@ namespace ScriptCanvasEditorTools
             value.SetString(entrySource.m_variant.c_str(), document.GetAllocator());
             entry.AddMember(GraphCanvas::Schema::Field::variant, value, document.GetAllocator());
 
-            rapidjson_ly::Value details(rapidjson_ly::kObjectType);
+            rapidjson::Value details(rapidjson::kObjectType);
             value.SetString(entrySource.m_details.m_name.c_str(), document.GetAllocator());
             details.AddMember("name", value, document.GetAllocator());
 
@@ -1113,11 +1113,11 @@ namespace ScriptCanvasEditorTools
 
             if (!entrySource.m_methods.empty())
             {
-                rapidjson_ly::Value methods(rapidjson_ly::kArrayType);
+                rapidjson::Value methods(rapidjson::kArrayType);
 
                 for (const auto& methodSource : entrySource.m_methods)
                 {
-                    rapidjson_ly::Value theMethod(rapidjson_ly::kObjectType);
+                    rapidjson::Value theMethod(rapidjson::kObjectType);
 
                     value.SetString(methodSource.m_key.c_str(), document.GetAllocator());
                     theMethod.AddMember(GraphCanvas::Schema::Field::key, value, document.GetAllocator());
@@ -1133,7 +1133,7 @@ namespace ScriptCanvasEditorTools
 
                     if (!methodSource.m_entry.m_name.empty())
                     {
-                        rapidjson_ly::Value entrySlot(rapidjson_ly::kObjectType);
+                        rapidjson::Value entrySlot(rapidjson::kObjectType);
                         value.SetString(methodSource.m_entry.m_name.c_str(), document.GetAllocator());
                         entrySlot.AddMember("name", value, document.GetAllocator());
 
@@ -1144,7 +1144,7 @@ namespace ScriptCanvasEditorTools
 
                     if (!methodSource.m_exit.m_name.empty())
                     {
-                        rapidjson_ly::Value exitSlot(rapidjson_ly::kObjectType);
+                        rapidjson::Value exitSlot(rapidjson::kObjectType);
                         value.SetString(methodSource.m_exit.m_name.c_str(), document.GetAllocator());
                         exitSlot.AddMember("name", value, document.GetAllocator());
 
@@ -1153,7 +1153,7 @@ namespace ScriptCanvasEditorTools
                         theMethod.AddMember("exit", exitSlot, document.GetAllocator());
                     }
 
-                    rapidjson_ly::Value methodDetails(rapidjson_ly::kObjectType);
+                    rapidjson::Value methodDetails(rapidjson::kObjectType);
 
                     value.SetString(methodSource.m_details.m_name.c_str(), document.GetAllocator());
                     methodDetails.AddMember("name", value, document.GetAllocator());
@@ -1165,13 +1165,13 @@ namespace ScriptCanvasEditorTools
 
                     if (!methodSource.m_arguments.empty())
                     {
-                        rapidjson_ly::Value methodArguments(rapidjson_ly::kArrayType);
+                        rapidjson::Value methodArguments(rapidjson::kArrayType);
 
                         [[maybe_unused]] size_t index = 0;
                         for (const auto& argSource : methodSource.m_arguments)
                         {
-                            rapidjson_ly::Value argument(rapidjson_ly::kObjectType);
-                            rapidjson_ly::Value argumentDetails(rapidjson_ly::kObjectType);
+                            rapidjson::Value argument(rapidjson::kObjectType);
+                            rapidjson::Value argumentDetails(rapidjson::kObjectType);
 
                             value.SetString(argSource.m_typeId.c_str(), document.GetAllocator());
                             argument.AddMember("typeid", value, document.GetAllocator());
@@ -1195,12 +1195,12 @@ namespace ScriptCanvasEditorTools
 
                     if (!methodSource.m_results.empty())
                     {
-                        rapidjson_ly::Value methodArguments(rapidjson_ly::kArrayType);
+                        rapidjson::Value methodArguments(rapidjson::kArrayType);
 
                         for (const auto& argSource : methodSource.m_results)
                         {
-                            rapidjson_ly::Value argument(rapidjson_ly::kObjectType);
-                            rapidjson_ly::Value argumentDetails(rapidjson_ly::kObjectType);
+                            rapidjson::Value argument(rapidjson::kObjectType);
+                            rapidjson::Value argumentDetails(rapidjson::kObjectType);
 
                             value.SetString(argSource.m_typeId.c_str(), document.GetAllocator());
                             argument.AddMember("typeid", value, document.GetAllocator());
@@ -1229,16 +1229,16 @@ namespace ScriptCanvasEditorTools
 
             if (!entrySource.m_slots.empty())
             {
-                rapidjson_ly::Value slotsArray(rapidjson_ly::kArrayType);
+                rapidjson::Value slotsArray(rapidjson::kArrayType);
 
                 for (const auto& slotSource : entrySource.m_slots)
                 {
-                    rapidjson_ly::Value theSlot(rapidjson_ly::kObjectType);
+                    rapidjson::Value theSlot(rapidjson::kObjectType);
 
                     value.SetString(slotSource.m_key.c_str(), document.GetAllocator());
                     theSlot.AddMember(GraphCanvas::Schema::Field::key, value, document.GetAllocator());
 
-                    rapidjson_ly::Value sloDetails(rapidjson_ly::kObjectType);
+                    rapidjson::Value sloDetails(rapidjson::kObjectType);
                     if (!slotSource.m_details.m_name.empty())
                     {
                         Helpers::WriteString(sloDetails, "name", slotSource.m_details.m_name, document);
@@ -1248,7 +1248,7 @@ namespace ScriptCanvasEditorTools
 
                     if (!slotSource.m_data.m_details.m_name.empty())
                     {
-                        rapidjson_ly::Value slotDataDetails(rapidjson_ly::kObjectType);
+                        rapidjson::Value slotDataDetails(rapidjson::kObjectType);
                         Helpers::WriteString(slotDataDetails, "name", slotSource.m_data.m_details.m_name, document);
                         theSlot.AddMember("details", slotDataDetails, document.GetAllocator());
                     }
@@ -1296,9 +1296,9 @@ namespace ScriptCanvasEditorTools
             return;
         }
 
-        rapidjson_ly::StringBuffer scratchBuffer;
+        rapidjson::StringBuffer scratchBuffer;
 
-        rapidjson_ly::PrettyWriter<rapidjson_ly::StringBuffer> writer(scratchBuffer);
+        rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(scratchBuffer);
         document.Accept(writer);
 
         outputFile.Write(scratchBuffer.GetString(), scratchBuffer.GetSize());
@@ -1403,17 +1403,17 @@ namespace ScriptCanvasEditorTools
             return { typeID };
         }
 
-        void WriteString(rapidjson_ly::Value& owner, const AZStd::string& key, const AZStd::string& value, rapidjson_ly::Document& document)
+        void WriteString(rapidjson::Value& owner, const AZStd::string& key, const AZStd::string& value, rapidjson::Document& document)
         {
             if (key.empty() || value.empty())
             {
                 return;
             }
 
-            rapidjson_ly::Value item(rapidjson_ly::kStringType);
+            rapidjson::Value item(rapidjson::kStringType);
             item.SetString(value.c_str(), document.GetAllocator());
 
-            rapidjson_ly::Value keyVal(rapidjson_ly::kStringType);
+            rapidjson::Value keyVal(rapidjson::kStringType);
             keyVal.SetString(key.c_str(), document.GetAllocator());
 
             owner.AddMember(keyVal, item, document.GetAllocator());


### PR DESCRIPTION
## What does this PR do?

The fixes to the memory allocators in rapidjson caused crashes on linux which turned out to be from linker choosing symbols from the assimp static library which used a different version of the rapidjson library than the rest of the engine.

Because of those crashes, the changes were reverted.  

This PR reverts the revert, and then adds one additional change which fixes the problem, by putting o3de's rapidjson into a namespace (One which it used to be in, so as to retain backward compat).  This fixes the problem, as the linker will only use the o3de rapidjson symbols that come from that namespace instead of matching them with other versions of rapidjson embedded in other third party static libraries.

## How was it tested?
Tested manually on linux and windows by compiling all assets with it.

## Other notes
Note that it contains 2 commits - the first commit was the already approved (and then reverted) changes to rapidjson.  
The second commit is the fixup that moves it into its own namespace and aliases that namespace with the old namespace to make it backward compatible.  

This is basically a "proper" fix for https://github.com/o3de/o3de/issues/13803 that does not revert the rapidjson changes (since they are still valuable to have and prevent other problems, including memory usage)

