### PR TITLE
Corrected output variable name used to contain gem root path.

### DIFF
--- a/Gems/Multiplayer/Multiplayer_ScriptCanvas/CMakeLists.txt
+++ b/Gems/Multiplayer/Multiplayer_ScriptCanvas/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 # Query the gem name from the gem.json file if possible
 # otherwise fallback to using ${Name}
-o3de_find_ancestor_gem_root(gempath gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
+o3de_find_ancestor_gem_root(gem_path gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
 if (NOT gem_name)
     set(gem_name "${Name}")
 endif()

--- a/Templates/DefaultGem/Template/CMakeLists.txt
+++ b/Templates/DefaultGem/Template/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 # Query the gem name from the gem.json file if possible
 # otherwise fallback to using ${Name}
-o3de_find_ancestor_gem_root(gempath gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
+o3de_find_ancestor_gem_root(gem_path gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
 if (NOT gem_name)
     set(gem_name "${Name}")
 endif()

--- a/Templates/DefaultProject/Template/Gem/CMakeLists.txt
+++ b/Templates/DefaultProject/Template/Gem/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 # Query the gem name from the gem.json file if possible
 # otherwise fallback to using ${Name}
-o3de_find_ancestor_gem_root(gempath gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
+o3de_find_ancestor_gem_root(gem_path gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
 if (NOT gem_name)
     set(gem_name "${Name}")
 endif()

--- a/Templates/MinimalProject/Template/Gem/CMakeLists.txt
+++ b/Templates/MinimalProject/Template/Gem/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 # Query the gem name from the gem.json file if possible
 # otherwise fallback to using ${Name}
-o3de_find_ancestor_gem_root(gempath gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
+o3de_find_ancestor_gem_root(gem_path gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
 if (NOT gem_name)
     set(gem_name "${Name}")
 endif()

--- a/Templates/PrebuiltGem/Template/CMakeLists.txt
+++ b/Templates/PrebuiltGem/Template/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 # Query the gem name from the gem.json file if possible
 # otherwise fallback to using ${Name}
-o3de_find_ancestor_gem_root(gempath gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
+o3de_find_ancestor_gem_root(gem_path gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
 if (NOT gem_name)
     set(gem_name "${Name}")
 endif()

--- a/Templates/PythonToolGem/Template/CMakeLists.txt
+++ b/Templates/PythonToolGem/Template/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 # Query the gem name from the gem.json file if possible
 # otherwise fallback to using ${Name}
-o3de_find_ancestor_gem_root(gempath gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
+o3de_find_ancestor_gem_root(gem_path gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
 if (NOT gem_name)
     set(gem_name "${Name}")
 endif()


### PR DESCRIPTION
The `o3de_find_ancestor_gem_root` function in the Gem templates were storing the output gem path in a variable called "gempath", but were checking a variable called "gem_path".

Corrected the code to store the output gem path in the `gem_path` variable.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

