### PR TITLE
Bug fix: Switcher crash on undo + select other component

### DIFF
--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -1818,7 +1818,7 @@ void SandboxIntegrationManager::GetSelectedOrHighlightedEntities(AzToolsFramewor
     }
 }
 
-AZStd::string SandboxIntegrationManager::GetComponentEditorIcon(const AZ::Uuid& componentType, AZ::Component* component)
+AZStd::string SandboxIntegrationManager::GetComponentEditorIcon(const AZ::Uuid& componentType, const AZ::Component* component)
 {
     AZStd::string iconPath = GetComponentIconPath(componentType, AZ::Edit::Attributes::Icon, component);
     return iconPath;
@@ -1830,7 +1830,7 @@ AZStd::string SandboxIntegrationManager::GetComponentTypeEditorIcon(const AZ::Uu
 }
 
 AZStd::string SandboxIntegrationManager::GetComponentIconPath(const AZ::Uuid& componentType,
-    AZ::Crc32 componentIconAttrib, AZ::Component* component)
+    AZ::Crc32 componentIconAttrib, const AZ::Component* component)
 {
     AZ_PROFILE_FUNCTION(AzToolsFramework);
     if (componentIconAttrib != AZ::Edit::Attributes::Icon

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.h
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.h
@@ -234,9 +234,9 @@ private:
         return m_defaultEntityIconLocation;
     }
 
-    AZStd::string GetComponentEditorIcon(const AZ::Uuid& componentType, AZ::Component* component) override;
+    AZStd::string GetComponentEditorIcon(const AZ::Uuid& componentType, const AZ::Component* component) override;
     AZStd::string GetComponentTypeEditorIcon(const AZ::Uuid& componentType) override;
-    AZStd::string GetComponentIconPath(const AZ::Uuid& componentType, AZ::Crc32 componentIconAttrib, AZ::Component* component) override;
+    AZStd::string GetComponentIconPath(const AZ::Uuid& componentType, AZ::Crc32 componentIconAttrib, const AZ::Component* component) override;
 
     //////////////////////////////////////////////////////////////////////////
     // IUndoManagerListener

--- a/Code/Framework/AzCore/AzCore/RTTI/ReflectContext.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/ReflectContext.h
@@ -238,7 +238,7 @@ namespace AZ
         template<class U>
         explicit AttributeData(U&& data)
             : m_data(AZStd::forward<U>(data)) {}
-        virtual const T& Get(void* instance) const { (void)instance; return m_data; }
+        virtual const T& Get(const void* instance) const { (void)instance; return m_data; }
         T& operator = (T& data) { m_data = data; return m_data; }
         T& operator = (const T& data) { m_data = data; return m_data; }
 
@@ -276,7 +276,7 @@ namespace AZ
         explicit AttributeMemberData(DataPtr p)
             : AttributeData<T>(T())
             , m_dataPtr(p) {}
-        const T& Get(void* instance) const override { return (reinterpret_cast<C*>(instance)->*m_dataPtr); }
+        const T& Get(const void* instance) const override { return (reinterpret_cast<const C*>(instance)->*m_dataPtr); }
         DataPtr GetMemberDataPtr() const { return m_dataPtr; }
 
         AZ::Dom::Value GetAsDomValue(void* instance) override

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
@@ -821,7 +821,7 @@ namespace AzToolsFramework
 
         /// Return path to icon for component.
         /// Path will be empty if component should have no icon.
-        virtual AZStd::string GetComponentEditorIcon(const AZ::Uuid& /*componentType*/, AZ::Component* /*component*/) { return AZStd::string(); }
+        virtual AZStd::string GetComponentEditorIcon(const AZ::Uuid& /*componentType*/, const AZ::Component* /*component*/) { return AZStd::string(); }
 
         //! Return path to icon for component type.
         //! Path will be empty if component type should have no icon.
@@ -833,7 +833,7 @@ namespace AzToolsFramework
          * \param componentIconAttrib   edit attribute describing where the icon is used, it could be one of Icon, Viewport and HidenIcon
          * \return the path of the icon image
          */
-        virtual AZStd::string GetComponentIconPath(const AZ::Uuid& /*componentType*/, AZ::Crc32 /*componentIconAttrib*/, AZ::Component* /*component*/) { return AZStd::string(); }
+        virtual AZStd::string GetComponentIconPath(const AZ::Uuid& /*componentType*/, AZ::Crc32 /*componentIconAttrib*/, const AZ::Component* /*component*/) { return AZStd::string(); }
 
         /**
          * Calculate the navigation 2D radius in units of an agent given its Navigation Type Name

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
@@ -22,9 +22,7 @@ namespace AzToolsFramework::ComponentModeFramework
     ComponentData::ComponentData(AZ::EntityComponentIdPair pairId)
         : m_pairId(pairId)
     {
-        AZ::Entity* entity = AzToolsFramework::GetEntityById(pairId.GetEntityId());
-
-        AZ::Component* component = entity->FindComponent(pairId.GetComponentId());
+        AZ::Component* component = GetComponent();
         m_componentName = AzToolsFramework::GetFriendlyComponentName(component);
 
         AzToolsFramework::EditorRequestBus::BroadcastResult(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
@@ -22,7 +22,7 @@ namespace AzToolsFramework::ComponentModeFramework
     ComponentData::ComponentData(AZ::EntityComponentIdPair pairId)
         : m_pairId(pairId)
     {
-        AZ::Component* component = GetComponent();
+        AZ::Component* component = FindComponent();
         m_componentName = AzToolsFramework::GetFriendlyComponentName(component);
 
         AzToolsFramework::EditorRequestBus::BroadcastResult(
@@ -32,7 +32,7 @@ namespace AzToolsFramework::ComponentModeFramework
             component);
     }
 
-    AZ::Component* ComponentData::GetComponent() const
+    AZ::Component* ComponentData::FindComponent() const
     {
         AZ::Entity* entity = AzToolsFramework::GetEntityById(m_pairId.GetEntityId());
         return entity->FindComponent(m_pairId.GetComponentId());
@@ -183,7 +183,7 @@ namespace AzToolsFramework::ComponentModeFramework
                 m_addedComponents,
                 [newComponentData](const ComponentData& componentInfo)
                 {
-                    return componentInfo.GetComponent()->RTTI_GetType() == newComponentData.GetComponent()->RTTI_GetType();
+                    return componentInfo.FindComponent()->RTTI_GetType() == newComponentData.FindComponent()->RTTI_GetType();
                 });
             componentDataIt == m_addedComponents.end())
         {
@@ -265,12 +265,13 @@ namespace AzToolsFramework::ComponentModeFramework
         if (InComponentMode())
         {
             AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequestBus::Broadcast(
-                &ComponentModeSystemRequests::ChangeComponentMode, componentData->GetComponent()->GetUnderlyingComponentType());
+                &ComponentModeSystemRequests::ChangeComponentMode, componentData->FindComponent()->GetUnderlyingComponentType());
         }
         else
         {
             AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequestBus::Broadcast(
-                &ComponentModeSystemRequests::AddSelectedComponentModesOfType, componentData->GetComponent()->GetUnderlyingComponentType());
+                &ComponentModeSystemRequests::AddSelectedComponentModesOfType,
+                componentData->FindComponent()->GetUnderlyingComponentType());
         }
     }
 
@@ -312,7 +313,7 @@ namespace AzToolsFramework::ComponentModeFramework
                             isComponentActive,
                             &ComponentModeSystemRequestBus::Events::AddedToComponentMode,
                             componentData.m_pairId,
-                            componentData.GetComponent()->GetUnderlyingComponentType());
+                            componentData.FindComponent()->GetUnderlyingComponentType());
                         return isComponentActive;
                     });
                 componentDataIt != m_addedComponents.end())
@@ -323,7 +324,7 @@ namespace AzToolsFramework::ComponentModeFramework
                     m_switcherId,
                     componentDataIt->m_buttonId);
 
-                m_activeSwitcherComponent = componentDataIt->GetComponent();
+                m_activeSwitcherComponent = componentDataIt->FindComponent();
             }
         }
     }
@@ -339,10 +340,10 @@ namespace AzToolsFramework::ComponentModeFramework
 
         for (AZStd::vector<ComponentData>::reverse_iterator it = m_addedComponents.rbegin(); it != m_addedComponents.rend(); ++it)
         {
-            if (!componentIds.contains(it->GetComponent()->RTTI_GetType()))
-                {
-                    RemoveComponentButton(it->m_pairId);
-                }
+            if (!componentIds.contains(it->FindComponent()->RTTI_GetType()))
+            {
+                RemoveComponentButton(it->m_pairId);
+            }
         }
     }
 
@@ -435,7 +436,7 @@ namespace AzToolsFramework::ComponentModeFramework
                 m_addedComponents,
                 [componentType](const ComponentData& componentInfo)
                 {
-                    return componentInfo.GetComponent()->RTTI_GetType() == componentType;
+                    return componentInfo.FindComponent()->RTTI_GetType() == componentType;
                 });
             componentDataIt != m_addedComponents.end())
         {
@@ -445,7 +446,7 @@ namespace AzToolsFramework::ComponentModeFramework
                 m_switcherId,
                 componentDataIt->m_buttonId);
 
-            m_activeSwitcherComponent = componentDataIt->GetComponent();
+            m_activeSwitcherComponent = componentDataIt->FindComponent();
         }
     }
 } // namespace AzToolsFramework::ComponentModeFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.cpp
@@ -22,7 +22,7 @@ namespace AzToolsFramework::ComponentModeFramework
     ComponentData::ComponentData(AZ::EntityComponentIdPair pairId)
         : m_pairId(pairId)
     {
-        AZ::Component* component = FindComponent();
+        const AZ::Component* component = FindComponent();
         m_componentName = AzToolsFramework::GetFriendlyComponentName(component);
 
         AzToolsFramework::EditorRequestBus::BroadcastResult(
@@ -32,7 +32,7 @@ namespace AzToolsFramework::ComponentModeFramework
             component);
     }
 
-    AZ::Component* ComponentData::FindComponent() const
+    const AZ::Component* ComponentData::FindComponent() const
     {
         AZ::Entity* entity = AzToolsFramework::GetEntityById(m_pairId.GetEntityId());
         return entity->FindComponent(m_pairId.GetComponentId());

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.h
@@ -38,7 +38,7 @@ namespace AzToolsFramework
             AZStd::string m_iconPath; //!< Path of component icon.
             ViewportUi::ButtonId m_buttonId; //!< Button Id of switcher component.
 
-            AZ::Component* FindComponent() const;
+            const AZ::Component* FindComponent() const;
         };
 
         //! Handles all aspects of the ViewportUi Switcher related to Component Mode.
@@ -115,7 +115,7 @@ namespace AzToolsFramework
             void ActiveComponentModeChanged(const AZ::Uuid& componentType) override;
 
             // Member variables
-            AZ::Component* m_activeSwitcherComponent = nullptr; //!< The component that is currently in component mode
+            const AZ::Component* m_activeSwitcherComponent = nullptr; //!< The component that is currently in component mode
             AZStd::vector<ComponentData> m_addedComponents; //!< Vector of ComponentData elements..
             ViewportUi::ButtonId m_transformButtonId; //!< Id of the default button of the switcher, used to exit component mode.
             AZ::Event<ViewportUi::ButtonId>::Handler m_handler; //!< Handler for onclick of switcher buttons, activates component mode.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.h
@@ -34,8 +34,6 @@ namespace AzToolsFramework
 
             // Member variables
             AZ::EntityComponentIdPair m_pairId; //!< Id of entity component pair.
-            //AZ::Entity* m_entity = nullptr; //!< Pointer to entity associated with pairId.
-            //AZ::Component* m_component = nullptr; //!< Pointer to component associated with pairId.
             AZStd::string m_componentName; //!< Friendly name of component.
             AZStd::string m_iconPath; //!< Path of component icon.
             ViewportUi::ButtonId m_buttonId; //!< Button Id of switcher component.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.h
@@ -65,11 +65,6 @@ namespace AzToolsFramework
                 return m_activeSwitcherComponent;
             }
 
-            AZ::Component* GetActiveComponent()
-            {
-                return m_activeSwitcherComponent;
-            }
-
             ViewportUi::SwitcherId GetSwitcherId() const
             {
                 return m_switcherId;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.h
@@ -34,11 +34,13 @@ namespace AzToolsFramework
 
             // Member variables
             AZ::EntityComponentIdPair m_pairId; //!< Id of entity component pair.
-            AZ::Entity* m_entity = nullptr; //!< Pointer to entity associated with pairId.
-            AZ::Component* m_component = nullptr; //!< Pointer to component associated with pairId.
+            //AZ::Entity* m_entity = nullptr; //!< Pointer to entity associated with pairId.
+            //AZ::Component* m_component = nullptr; //!< Pointer to component associated with pairId.
             AZStd::string m_componentName; //!< Friendly name of component.
             AZStd::string m_iconPath; //!< Path of component icon.
             ViewportUi::ButtonId m_buttonId; //!< Button Id of switcher component.
+
+            AZ::Component* GetComponent() const;
         };
 
         //! Handles all aspects of the ViewportUi Switcher related to Component Mode.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeSwitcher.h
@@ -38,7 +38,7 @@ namespace AzToolsFramework
             AZStd::string m_iconPath; //!< Path of component icon.
             ViewportUi::ButtonId m_buttonId; //!< Button Id of switcher component.
 
-            AZ::Component* GetComponent() const;
+            AZ::Component* FindComponent() const;
         };
 
         //! Handles all aspects of the ViewportUi Switcher related to Component Mode.


### PR DESCRIPTION
Signed-off-by: amzn-ahmadkrm <ahmadkrm@amazon.com>

## What does this PR do?
Fixes issue: https://github.com/o3de/o3de/issues/13873

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_

The problem was that when a user hits Undo the component is destroyed and recreated but the pointer does not update. The crash happens when it was trying to access the pointer when another entity was added to the selection. This fix stops using a pointer for the component and uses FindComponent instead.

## How was this PR tested?

Manual testing.
