### PR TITLE
Add unit tests for instance DOM generator

### DIFF
--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTestFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTestFixture.cpp
@@ -17,7 +17,7 @@ namespace UnitTest
         PrefabTestFixture::SetUpEditorFixtureImpl();
 
         m_instanceDomGeneratorInterface = AZ::Interface<InstanceDomGeneratorInterface>::Get();
-        EXPECT_TRUE(m_instanceDomGeneratorInterface);
+        ASSERT_TRUE(m_instanceDomGeneratorInterface);
 
         m_prefabFocusPublicInterface = AZ::Interface<PrefabFocusPublicInterface>::Get();
         ASSERT_TRUE(m_prefabFocusPublicInterface);
@@ -38,10 +38,8 @@ namespace UnitTest
 
         AZ::IO::Path engineRootPath;
         m_settingsRegistryInterface->Get(engineRootPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
-        AZ::IO::Path carPrefabFilepath(engineRootPath);
-        carPrefabFilepath.Append(carPrefabName);
-        AZ::IO::Path wheelPrefabFilepath(engineRootPath);
-        wheelPrefabFilepath.Append(wheelPrefabName);
+        AZ::IO::Path carPrefabFilepath = engineRootPath / carPrefabName;
+        AZ::IO::Path wheelPrefabFilepath = engineRootPath / wheelPrefabName;
 
         // Create the car hierarchy
         AZ::EntityId tireEntityId = CreateEditorEntityUnderRoot(tireEntityName);
@@ -198,7 +196,7 @@ namespace UnitTest
             instanceFromDom, generatedInstanceDom, PrefabDomUtils::LoadFlags::UseSelectiveDeserialization));
 
         // Verify that the worldX value of the provided child entity is coming from the correct template
-        EntityOptionalReference childEntity = FindEntityInNestedInstances(instanceFromDom, entityAlias);
+        EntityOptionalReference childEntity = FindEntityInInstanceHierarchy(instanceFromDom, entityAlias);
         ASSERT_TRUE(childEntity.has_value());
         childEntity->get().Init();
         childEntity->get().Activate(); // to connect to buses such as transform bus
@@ -216,7 +214,7 @@ namespace UnitTest
         EXPECT_TRUE(parentEntityId.IsValid());
     }
 
-    EntityOptionalReference PrefabInstanceDomGeneratorTestFixture::FindEntityInNestedInstances(
+    EntityOptionalReference PrefabInstanceDomGeneratorTestFixture::FindEntityInInstanceHierarchy(
         Instance& instance,
         EntityAlias entityAlias)
     {

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTestFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTestFixture.cpp
@@ -90,7 +90,7 @@ namespace UnitTest
 
         // Generate a patch that will alter the Wheel's container entity
         PrefabDom containerPatch;
-        GenerateWorldXEntityPatch("", m_containerOverrideValueOnLevel, *m_wheelInstance, containerPatch);
+        GenerateWorldXEntityPatch("", m_wheelContainerOverrideValueOnLevel, *m_wheelInstance, containerPatch);
 
         // Apply the Wheel container patch to the Root template (level)
         ApplyEntityPatchToTemplate(containerPatch, "", *m_wheelInstance, rootInstance);

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTestFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTestFixture.cpp
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Prefab/PrefabInstanceDomGeneratorTestFixture.h>
+#include <Prefab/PrefabTestDomUtils.h>
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+
+namespace UnitTest
+{
+    void PrefabInstanceDomGeneratorTestFixture::SetUpEditorFixtureImpl()
+    {
+        PrefabTestFixture::SetUpEditorFixtureImpl();
+
+        m_instanceDomGeneratorInterface = AZ::Interface<InstanceDomGeneratorInterface>::Get();
+        EXPECT_TRUE(m_instanceDomGeneratorInterface);
+
+        m_prefabFocusPublicInterface = AZ::Interface<PrefabFocusPublicInterface>::Get();
+        ASSERT_TRUE(m_prefabFocusPublicInterface);
+
+        SetUpInstanceHierarchy();
+    }
+
+    void PrefabInstanceDomGeneratorTestFixture::SetUpInstanceHierarchy()
+    {
+        // Level        <-- override WorldX of Tire and WorldX of Wheel container
+        // | Car        <-- override WorldX of Tire
+        //   | Wheel
+        //     | Tire
+
+        const AZStd::string carPrefabName = "CarPrefab";
+        const AZStd::string wheelPrefabName = "WheelPrefab";
+        const AZStd::string tireEntityName = "Tire";
+
+        AZ::IO::Path engineRootPath;
+        m_settingsRegistryInterface->Get(engineRootPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
+        AZ::IO::Path carPrefabFilepath(engineRootPath);
+        carPrefabFilepath.Append(carPrefabName);
+        AZ::IO::Path wheelPrefabFilepath(engineRootPath);
+        wheelPrefabFilepath.Append(wheelPrefabName);
+
+        // Create the car hierarchy
+        AZ::EntityId tireEntityId = CreateEditorEntityUnderRoot(tireEntityName);
+        AZ::EntityId wheelContainerId = CreateEditorPrefab(wheelPrefabFilepath, { tireEntityId });
+
+        m_wheelInstance = m_instanceEntityMapperInterface->FindOwningInstance(wheelContainerId);
+        ASSERT_TRUE(m_wheelInstance.has_value());
+        // Save the tire alias for further testing
+        AZStd::vector<EntityAlias> entityAliases = m_wheelInstance->get().GetEntityAliases();
+        ASSERT_TRUE(!entityAliases.empty());
+        m_tireAlias = entityAliases[0];
+
+        // Save the Wheel instance alias before the Car prefab is created
+        InstanceAlias wheelInstanceAlias = m_wheelInstance->get().GetInstanceAlias();
+
+        AZ::EntityId carContainerId = CreateEditorPrefab(carPrefabFilepath, { wheelContainerId });
+        m_carInstance = m_instanceEntityMapperInterface->FindOwningInstance(carContainerId);
+        ASSERT_TRUE(m_carInstance.has_value());
+
+        // Reassign the Wheel instance now that it's been recreated by propagation
+        m_wheelInstance = m_carInstance->get().FindNestedInstance(wheelInstanceAlias);
+        ASSERT_TRUE(m_wheelInstance.has_value());
+
+        // Activate the container entity of the Wheel instance
+        m_wheelInstance->get().ActivateContainerEntity();
+
+        InitializePrefabTemplates();
+    }
+
+    void PrefabInstanceDomGeneratorTestFixture::InitializePrefabTemplates()
+    {
+        const Instance& rootInstance = *m_prefabEditorEntityOwnershipInterface->GetRootPrefabInstance();
+
+        // Generate a patch that will alter the Tire
+        PrefabDom entityPatch;
+        GenerateWorldXEntityPatch(m_tireAlias, m_entityOverrideValueOnLevel, *m_wheelInstance, entityPatch);
+
+        // Apply the Tire patch to the Root template (level)
+        ApplyEntityPatchToTemplate(entityPatch, m_tireAlias, *m_wheelInstance, rootInstance);
+
+        // Update the Tire patch and apply it to the Car template
+        UpdateWorldXEntityPatch(entityPatch, m_entityOverrideValueOnCar);
+        ApplyEntityPatchToTemplate(entityPatch, m_tireAlias, *m_wheelInstance, m_carInstance->get());
+
+        // Update the Tire patch and apply it to the Wheel template
+        UpdateWorldXEntityPatch(entityPatch, m_entityValueOnWheel);
+        ApplyEntityPatchToTemplate(entityPatch, m_tireAlias, *m_wheelInstance, *m_wheelInstance);
+
+        // Generate a patch that will alter the Wheel's container entity
+        PrefabDom containerPatch;
+        GenerateWorldXEntityPatch("", m_containerOverrideValueOnLevel, *m_wheelInstance, containerPatch);
+
+        // Apply the Wheel container patch to the Root template (level)
+        ApplyEntityPatchToTemplate(containerPatch, "", *m_wheelInstance, rootInstance);
+    }
+
+    void PrefabInstanceDomGeneratorTestFixture::GenerateWorldXEntityPatch(
+        const EntityAlias& entityAlias,
+        float updatedXValue,
+        Instance& owningInstance,
+        PrefabDom& patchOut)
+    {
+        EntityOptionalReference childEntity = entityAlias.empty() ? owningInstance.GetContainerEntity() : owningInstance.GetEntity(entityAlias);
+        ASSERT_TRUE(childEntity.has_value());
+
+        // Create document with before change snapshot
+        PrefabDom entityDomBeforeUpdate;
+        m_instanceToTemplateInterface->GenerateDomForEntity(entityDomBeforeUpdate, *childEntity);
+
+        // Change the entity
+        float prevXValue = 0.0f;
+        AZ::TransformBus::EventResult(prevXValue, childEntity->get().GetId(), &AZ::TransformInterface::GetWorldX);
+        AZ::TransformBus::Event(childEntity->get().GetId(), &AZ::TransformInterface::SetWorldX, updatedXValue);
+        float curXValue = 0.0f;
+        AZ::TransformBus::EventResult(curXValue, childEntity->get().GetId(), &AZ::TransformInterface::GetWorldX);
+        EXPECT_EQ(curXValue, updatedXValue);
+
+        // Create document with after change snapshot
+        PrefabDom entityDomAfterUpdate;
+        m_instanceToTemplateInterface->GenerateDomForEntity(entityDomAfterUpdate, *childEntity);
+
+        // Generate patch
+        m_instanceToTemplateInterface->GeneratePatch(patchOut, entityDomBeforeUpdate, entityDomAfterUpdate);
+
+        // Revert the change to the entity
+        AZ::TransformBus::Event(childEntity->get().GetId(), &AZ::TransformInterface::SetWorldX, prevXValue);
+    }
+
+    void PrefabInstanceDomGeneratorTestFixture::UpdateWorldXEntityPatch(
+        PrefabDom& patch,
+        double newValue)
+    {
+        PrefabDomValue::MemberIterator patchEntryIterator = patch[0].FindMember("value");
+        ASSERT_TRUE(patchEntryIterator != patch[0].MemberEnd());
+        patchEntryIterator->value.SetDouble(newValue);
+    }
+
+    void PrefabInstanceDomGeneratorTestFixture::ApplyEntityPatchToTemplate(
+        PrefabDom& patch,
+        const EntityAlias& entityAlias,
+        const Instance& owningInstance,
+        const Instance& targetInstance)
+    {
+        // We need to generate a patch prefix so that the path of the patches correctly reflects the hierarchy path
+        // from the entity to the instance where the patch needs to be added.
+        AZStd::string patchPrefix;
+        if (entityAlias.empty())
+        {
+            patchPrefix.insert(0, "/ContainerEntity");
+        }
+        else
+        {
+            patchPrefix.insert(0, "/Entities/" + entityAlias);
+        }
+
+        auto instanceToAddPatches = m_prefabEditorEntityOwnershipInterface->GetRootPrefabInstance();
+        const Instance* curInstance = &owningInstance;
+        while (curInstance != &targetInstance)
+        {
+            patchPrefix.insert(0, "/Instances/" + curInstance->GetInstanceAlias());
+            InstanceOptionalConstReference parentInstance = curInstance->GetParentInstance();
+            ASSERT_TRUE(parentInstance.has_value());
+            curInstance = &parentInstance->get();
+        }
+
+        PrefabDomValueReference patchPathReference = PrefabDomUtils::FindPrefabDomValue(patch[0], "path");
+        ASSERT_TRUE(patchPathReference.has_value());
+        AZStd::string patchPathStringBefore = patchPathReference->get().GetString();
+        AZStd::string patchPathString = patchPathStringBefore;
+        patchPathString.insert(0, patchPrefix);
+        patchPathReference->get().SetString(patchPathString.c_str(), patch.GetAllocator());
+
+        // Apply the patch
+        TemplateId targetTemplateId = targetInstance.GetTemplateId();
+        PrefabDom& targetTemplateDomReference = m_prefabSystemComponent->FindTemplateDom(targetTemplateId);
+        AZ::JsonSerializationResult::ResultCode result =
+            PrefabDomUtils::ApplyPatches(targetTemplateDomReference, targetTemplateDomReference.GetAllocator(), patch);
+        ASSERT_TRUE(result.GetOutcome() == AZ::JsonSerializationResult::Outcomes::Success);
+
+        // Revert back to previous path
+        patchPathReference->get().SetString(patchPathStringBefore.c_str(), patch.GetAllocator());
+    }
+
+    void PrefabInstanceDomGeneratorTestFixture::GenerateAndValidateInstanceDom(
+        const Instance& instance, EntityAlias entityAlias, float expectedValue)
+    {
+        // Generate a prefab DOM for the provided instance
+        PrefabDom generatedInstanceDom;
+        m_instanceDomGeneratorInterface->GenerateInstanceDom(generatedInstanceDom, instance);
+
+        // Create an instance from the generated prefab DOM for validation
+        Instance instanceFromDom;
+        ASSERT_TRUE(PrefabDomUtils::LoadInstanceFromPrefabDom(
+            instanceFromDom, generatedInstanceDom, PrefabDomUtils::LoadFlags::UseSelectiveDeserialization));
+
+        // Verify that the worldX value of the provided child entity is coming from the correct template
+        EntityOptionalReference childEntity = FindEntityInNestedInstances(instanceFromDom, entityAlias);
+        ASSERT_TRUE(childEntity.has_value());
+        childEntity->get().Init();
+        childEntity->get().Activate(); // to connect to buses such as transform bus
+        float curXValue = 0.0f;
+        AZ::TransformBus::EventResult(curXValue, childEntity->get().GetId(), &AZ::TransformInterface::GetWorldX);
+        EXPECT_EQ(curXValue, expectedValue);
+
+        // Verify that the parent of the container entity is a valid entity
+        EntityOptionalReference containerEntity = instanceFromDom.GetContainerEntity();
+        ASSERT_TRUE(containerEntity.has_value());
+        containerEntity->get().Init();
+        containerEntity->get().Activate(); // to connect to buses such as transform bus
+        AZ::EntityId parentEntityId;
+        AZ::TransformBus::EventResult(parentEntityId, containerEntity->get().GetId(), &AZ::TransformInterface::GetParentId);
+        EXPECT_TRUE(parentEntityId.IsValid());
+    }
+
+    EntityOptionalReference PrefabInstanceDomGeneratorTestFixture::FindEntityInNestedInstances(
+        Instance& instance,
+        EntityAlias entityAlias)
+    {
+        AZStd::queue<InstanceOptionalReference> instanceQueue;
+        instanceQueue.push(instance);
+        EntityOptionalReference foundEntity;
+        while (!instanceQueue.empty())
+        {
+            InstanceOptionalReference currentInstance = instanceQueue.front();
+            instanceQueue.pop();
+
+            if (currentInstance.has_value())
+            {
+                foundEntity = currentInstance->get().GetEntity(entityAlias);
+                if (foundEntity.has_value())
+                {
+                    break;
+                }
+
+                currentInstance->get().GetNestedInstances(
+                    [&](AZStd::unique_ptr<Instance>& nestedInstance)
+                    {
+                        instanceQueue.push(*nestedInstance.get());
+                    });
+            }
+        }
+
+        return foundEntity;
+    }
+
+    void PrefabInstanceDomGeneratorTestFixture::GenerateAndValidateEntityDom(const AZ::Entity& entity, float expectedValue)
+    {
+        // Generate an entity DOM for the provided entity
+        PrefabDom generatedEntityDom;
+        m_instanceDomGeneratorInterface->GenerateEntityDom(generatedEntityDom, entity);
+        EXPECT_TRUE(generatedEntityDom.IsObject());
+
+        // Create an entity from the generated entity DOM for validation
+        AZ::Entity entityFromDom;
+        AZ::JsonSerializationResult::ResultCode result = AZ::JsonSerialization::Load(entityFromDom, generatedEntityDom);
+        ASSERT_TRUE(result.GetProcessing() != AZ::JsonSerializationResult::Processing::Halted);
+
+        // Verify that the worldX value is coming from the correct template
+        entityFromDom.Init();
+        entityFromDom.Activate(); // to connect to buses such as transform bus
+        float curXValue = 0.0f;
+        AZ::TransformBus::EventResult(curXValue, entityFromDom.GetId(), &AZ::TransformInterface::GetWorldX);
+        EXPECT_EQ(curXValue, expectedValue);
+    }
+} // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTestFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTestFixture.cpp
@@ -155,7 +155,6 @@ namespace UnitTest
             patchPrefix.insert(0, "/Entities/" + entityAlias);
         }
 
-        auto instanceToAddPatches = m_prefabEditorEntityOwnershipInterface->GetRootPrefabInstance();
         const Instance* curInstance = &owningInstance;
         while (curInstance != &targetInstance)
         {

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTestFixture.h
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTestFixture.h
@@ -28,7 +28,7 @@ namespace UnitTest
         const float m_entityOverrideValueOnLevel = 1.0f;
         const float m_entityOverrideValueOnCar = 2.0f;
         const float m_entityValueOnWheel = 3.0f;
-        const float m_containerOverrideValueOnLevel = 1.0f;
+        const float m_wheelContainerOverrideValueOnLevel = 1.0f;
 
         InstanceOptionalReference m_carInstance;
         InstanceOptionalReference m_wheelInstance;

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTestFixture.h
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTestFixture.h
@@ -14,7 +14,7 @@ namespace UnitTest
 {
     using namespace AzToolsFramework::Prefab;
 
-    // Fixture for testing instance DOM generation based on the focused prefab via existing template DOMS
+    //! Fixture for testing instance DOM generation based on the focused prefab via existing template DOMS
     class PrefabInstanceDomGeneratorTestFixture
         : public PrefabTestFixture
     {
@@ -39,11 +39,13 @@ namespace UnitTest
     private:
         void SetUpInstanceHierarchy();
         void InitializePrefabTemplates();
-        EntityOptionalReference FindEntityInNestedInstances(
+
+        //! Finds an entity in the provided instance by recursing through its nested prefab hierarchy
+        EntityOptionalReference FindEntityInInstanceHierarchy(
             Instance& instance,
             EntityAlias entityAlias);
 
-        // Helpers that apply patches to in-memory template DOMs to simulate overrides
+        //! Helpers that apply patches to in-memory template DOMs to simulate overrides
         void GenerateWorldXEntityPatch(
             const EntityAlias& entityAlias,
             float updatedXValue,

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTestFixture.h
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTestFixture.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Prefab/PrefabTestFixture.h>
+
+namespace UnitTest
+{
+    using namespace AzToolsFramework::Prefab;
+
+    // Fixture for testing instance DOM generation based on the focused prefab via existing template DOMS
+    class PrefabInstanceDomGeneratorTestFixture
+        : public PrefabTestFixture
+    {
+    protected:
+        void SetUpEditorFixtureImpl() override;
+
+        void GenerateAndValidateInstanceDom(const Instance& instance, EntityAlias entityAlias, float expectedValue);
+        void GenerateAndValidateEntityDom(const AZ::Entity& entity, float expectedValue);
+
+        // Protected members
+        const float m_entityOverrideValueOnLevel = 1.0f;
+        const float m_entityOverrideValueOnCar = 2.0f;
+        const float m_entityValueOnWheel = 3.0f;
+        const float m_containerOverrideValueOnLevel = 1.0f;
+
+        InstanceOptionalReference m_carInstance;
+        InstanceOptionalReference m_wheelInstance;
+        EntityAlias m_tireAlias;
+
+        PrefabFocusPublicInterface* m_prefabFocusPublicInterface = nullptr;
+
+    private:
+        void SetUpInstanceHierarchy();
+        void InitializePrefabTemplates();
+        EntityOptionalReference FindEntityInNestedInstances(
+            Instance& instance,
+            EntityAlias entityAlias);
+
+        // Helpers that apply patches to in-memory template DOMs to simulate overrides
+        void GenerateWorldXEntityPatch(
+            const EntityAlias& entityAlias,
+            float updatedXValue,
+            Instance& owningInstance,
+            PrefabDom& patchOut);
+        void UpdateWorldXEntityPatch(PrefabDom& patch, double newValue);
+        void ApplyEntityPatchToTemplate(
+            PrefabDom& patch,
+            const EntityAlias& entityAlias,
+            const Instance& owningInstance,
+            const Instance& targetInstance);
+
+        // Private members
+        InstanceDomGeneratorInterface* m_instanceDomGeneratorInterface = nullptr;
+    };
+}

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTests.cpp
@@ -6,284 +6,54 @@
  *
  */
 
-#include <Prefab/PrefabTestFixture.h>
-#include <Prefab/PrefabTestDomUtils.h>
-#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+#include <Prefab/PrefabInstanceDomGeneratorTestFixture.h>
 
 namespace UnitTest
 {
-    // Fixture for testing instance DOM generation based on the focused prefab via existing template DOMS
-    class PrefabInstanceDomGeneratorTests : public PrefabTestFixture
-    {
-    public:
-        void SetUpEditorFixtureImpl() override
-        {
-            PrefabTestFixture::SetUpEditorFixtureImpl();
+    using PrefabInstanceDomGeneratorTests = PrefabInstanceDomGeneratorTestFixture;
 
-            m_instanceDomGeneratorInterface = AZ::Interface<InstanceDomGeneratorInterface>::Get();
-            EXPECT_TRUE(m_instanceDomGeneratorInterface);
-
-            m_prefabFocusPublicInterface = AZ::Interface<PrefabFocusPublicInterface>::Get();
-            ASSERT_TRUE(m_prefabFocusPublicInterface);
-
-            SetUpInstanceHierarchy();
-        }
-
-        void SetUpInstanceHierarchy()
-        {
-            // Level
-            // | Car
-            //   | Wheel
-            //     | Tire
-
-            const AZStd::string carPrefabName = "CarPrefab";
-            const AZStd::string wheelPrefabName = "WheelPrefab";
-            const AZStd::string tireEntityName = "Tire";
-
-            AZ::IO::Path engineRootPath;
-            m_settingsRegistryInterface->Get(engineRootPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
-            AZ::IO::Path carPrefabFilepath(engineRootPath);
-            carPrefabFilepath.Append(carPrefabName);
-            AZ::IO::Path wheelPrefabFilepath(engineRootPath);
-            wheelPrefabFilepath.Append(wheelPrefabName);
-
-            // Create the car hierarchy
-            AZ::EntityId tireEntityId = CreateEditorEntityUnderRoot(tireEntityName);
-            AZ::EntityId wheelContainerId = CreateEditorPrefab(wheelPrefabFilepath, { tireEntityId });
-
-            m_wheelInstance = m_instanceEntityMapperInterface->FindOwningInstance(wheelContainerId);
-            ASSERT_TRUE(m_wheelInstance.has_value());
-            // Save the tire alias for further testing
-            AZStd::vector<EntityAlias> entityAliases = m_wheelInstance->get().GetEntityAliases();
-            ASSERT_TRUE(!entityAliases.empty());
-            m_tireAlias = entityAliases[0];
-
-            // Save the Wheel instance alias before the Car prefab is created
-            InstanceAlias wheelInstanceAlias = m_wheelInstance->get().GetInstanceAlias();
-
-            AZ::EntityId carContainerId = CreateEditorPrefab(carPrefabFilepath, { wheelContainerId });
-            m_carInstance = m_instanceEntityMapperInterface->FindOwningInstance(carContainerId);
-            ASSERT_TRUE(m_carInstance.has_value());
-
-            // Reassign the Wheel instance now that it's been recreated by propagation
-            m_wheelInstance = m_carInstance->get().FindNestedInstance(wheelInstanceAlias);
-            ASSERT_TRUE(m_wheelInstance.has_value());
-
-            // Activate the container entity of the Wheel instance
-            m_wheelInstance->get().ActivateContainerEntity();
-
-            // Generate a patch that will alter the tire
-            GenerateWorldXEntityPatch(m_tireAlias, m_overrideValueOnLevel, *m_wheelInstance, m_patch);
-
-            // Apply the tire patch to the Root template (level)
-            ApplyEntityPatchToTemplate(m_patch, m_tireAlias, *m_wheelInstance, *m_prefabEditorEntityOwnershipInterface->GetRootPrefabInstance());
-
-            // Generate a patch that will alter the container entity of the Wheel
-            GenerateWorldXEntityPatch("", m_overrideValueOnLevel, *m_wheelInstance, m_containerPatch);
-
-            // Apply the container patch to the Root template (level)
-            ApplyEntityPatchToTemplate(m_containerPatch, "", *m_wheelInstance, *m_prefabEditorEntityOwnershipInterface->GetRootPrefabInstance());
-
-            // Update and apply the tire patch to the Wheel template
-            UpdateWorldXEntityPatch(m_patch, m_overrideValueOnWheel);
-            ApplyEntityPatchToTemplate(m_patch, m_tireAlias, *m_wheelInstance, *m_wheelInstance);
-
-            // Update and apply the tire patch to the Car template
-            UpdateWorldXEntityPatch(m_patch, m_overrideValueOnCar);
-            ApplyEntityPatchToTemplate(m_patch, m_tireAlias, *m_wheelInstance, m_carInstance->get());
-        }
-
-        void TearDownEditorFixtureImpl() override
-        {
-            PrefabTestFixture::TearDownEditorFixtureImpl();
-        }
-
-        void GenerateWorldXEntityPatch(
-            const EntityAlias& entityAlias,
-            float updatedXValue,
-            Instance& owningInstance,
-            PrefabDom& patchOut)
-        {
-            EntityOptionalReference childEntity = entityAlias.empty() ? owningInstance.GetContainerEntity() : owningInstance.GetEntity(entityAlias);
-            ASSERT_TRUE(childEntity.has_value());
-
-            // Create document with before change snapshot
-            PrefabDom entityDomBeforeUpdate;
-            m_instanceToTemplateInterface->GenerateDomForEntity(entityDomBeforeUpdate, *childEntity);
-
-            // Change the entity
-            float prevXValue = 0.0f;
-            AZ::TransformBus::EventResult(prevXValue, childEntity->get().GetId(), &AZ::TransformInterface::GetWorldX);
-            AZ::TransformBus::Event(childEntity->get().GetId(), &AZ::TransformInterface::SetWorldX, updatedXValue);
-            float curXValue = 0.0f;
-            AZ::TransformBus::EventResult(curXValue, childEntity->get().GetId(), &AZ::TransformInterface::GetWorldX);
-            EXPECT_EQ(curXValue, updatedXValue);
-
-            // Create document with after change snapshot
-            PrefabDom entityDomAfterUpdate;
-            m_instanceToTemplateInterface->GenerateDomForEntity(entityDomAfterUpdate, *childEntity);
-
-            // Generate patch
-            m_instanceToTemplateInterface->GeneratePatch(patchOut, entityDomBeforeUpdate, entityDomAfterUpdate);
-
-            // Revert the change to the entity
-            AZ::TransformBus::Event(childEntity->get().GetId(), &AZ::TransformInterface::SetWorldX, prevXValue);
-        }
-
-        void UpdateWorldXEntityPatch(
-            PrefabDom& patch,
-            double newValue)
-        {
-            PrefabDomValue::MemberIterator patchEntryIterator = patch[0].FindMember("value");
-            ASSERT_TRUE(patchEntryIterator != patch[0].MemberEnd());
-            patchEntryIterator->value.SetDouble(newValue);
-        }
-
-        void ApplyEntityPatchToTemplate(
-            PrefabDom& patch,
-            const EntityAlias& entityAlias,
-            const Instance& owningInstance,
-            const Instance& targetInstance)
-        {
-            // We need to generate a patch prefix so that the path of the patches correctly refelects the hierarchy path
-            // from the entity to the instance where the patch needs to be added.
-            AZStd::string patchPrefix;
-            if (entityAlias.empty())
-            {
-                patchPrefix.insert(0, "/ContainerEntity");
-            }
-            else
-            {
-                patchPrefix.insert(0, "/Entities/" + entityAlias);
-            }
-
-            auto instanceToAddPatches = m_prefabEditorEntityOwnershipInterface->GetRootPrefabInstance();
-            const Instance* curInstance = &owningInstance;
-            while (curInstance != &targetInstance)
-            {
-                patchPrefix.insert(0, "/Instances/" + curInstance->GetInstanceAlias());
-                InstanceOptionalConstReference parentInstance = curInstance->GetParentInstance();
-                ASSERT_TRUE(parentInstance.has_value());
-                curInstance = &parentInstance->get();
-            }
-
-            PrefabDomValueReference patchPathReference = PrefabDomUtils::FindPrefabDomValue(patch[0], "path");
-            ASSERT_TRUE(patchPathReference.has_value());
-            AZStd::string patchPathStringBefore = patchPathReference->get().GetString();
-            AZStd::string patchPathString = patchPathStringBefore;
-            patchPathString.insert(0, patchPrefix);
-            patchPathReference->get().SetString(patchPathString.c_str(), patch.GetAllocator());
-
-            // Apply the patch
-            TemplateId targetTemplateId = targetInstance.GetTemplateId();
-            PrefabDom& targetTemplateDomReference = m_prefabSystemComponent->FindTemplateDom(targetTemplateId);
-            AZ::JsonSerializationResult::ResultCode result =
-                PrefabDomUtils::ApplyPatches(targetTemplateDomReference, targetTemplateDomReference.GetAllocator(), patch);
-            ASSERT_TRUE(result.GetOutcome() == AZ::JsonSerializationResult::Outcomes::Success);
-
-            // Revert back to previous path
-            patchPathReference->get().SetString(patchPathStringBefore.c_str(), patch.GetAllocator());
-        }
-
-        void GenerateAndValidateInstanceDom(const Instance& instance, EntityAlias entityAlias, float expectedValue)
-        {
-            // Generate a prefab DOM for the provided instance
-            PrefabDom generatedInstanceDom;
-            m_instanceDomGeneratorInterface->GenerateInstanceDom(generatedInstanceDom, instance);
-
-            // Create an instance from the generated prefab DOM for validation
-            Instance instanceFromDom;
-            ASSERT_TRUE(PrefabDomUtils::LoadInstanceFromPrefabDom(
-                instanceFromDom, generatedInstanceDom, PrefabDomUtils::LoadFlags::UseSelectiveDeserialization));
-
-            // Verify that the worldX value of the provided child entity is coming from the correct template
-            EntityOptionalReference childEntity = instanceFromDom.GetEntity(entityAlias);
-            childEntity->get().Init();
-            childEntity->get().Activate(); // to connect to buses such as transform bus
-            float curXValue = 0.0f;
-            AZ::TransformBus::EventResult(curXValue, childEntity->get().GetId(), &AZ::TransformInterface::GetWorldX);
-            EXPECT_EQ(curXValue, expectedValue);
-
-            // Verify that the parent of the container entity is a valid entity
-            EntityOptionalReference containerEntity = instanceFromDom.GetContainerEntity();
-            containerEntity->get().Init();
-            containerEntity->get().Activate(); // to connect to buses such as transform bus
-            AZ::EntityId parentEntityId;
-            AZ::TransformBus::EventResult(parentEntityId, containerEntity->get().GetId(), &AZ::TransformInterface::GetParentId);
-            EXPECT_TRUE(parentEntityId.IsValid());
-        }
-
-        void GenerateAndValidateEntityDom(const AZ::Entity& entity, float expectedValue)
-        {
-            // Generate an entity DOM for the provided entity
-            PrefabDom generatedEntityDom;
-            m_instanceDomGeneratorInterface->GenerateEntityDom(generatedEntityDom, entity);
-            EXPECT_TRUE(generatedEntityDom.IsObject());
-
-            // Create an entity from the generated entity DOM for validation
-            AZ::Entity entityFromDom;
-            AZ::JsonSerializationResult::ResultCode result = AZ::JsonSerialization::Load(entityFromDom, generatedEntityDom);
-            ASSERT_TRUE(result.GetProcessing() != AZ::JsonSerializationResult::Processing::Halted);
-
-            // Verify that the worldX value is coming from the correct template
-            entityFromDom.Init();
-            entityFromDom.Activate(); // to connect to buses such as transform bus
-            float curXValue = 0.0f;
-            AZ::TransformBus::EventResult(curXValue, entityFromDom.GetId(), &AZ::TransformInterface::GetWorldX);
-            EXPECT_EQ(curXValue, expectedValue);
-        }
-
-    protected:
-        const float m_overrideValueOnLevel = 1.0f;
-        const float m_overrideValueOnCar = 2.0f;
-        const float m_overrideValueOnWheel = 3.0f;
-
-        InstanceOptionalReference m_carInstance;
-        InstanceOptionalReference m_wheelInstance;
-        EntityAlias m_tireAlias;
-        PrefabDom m_patch;
-        PrefabDom m_containerPatch;
-
-        InstanceDomGeneratorInterface* m_instanceDomGeneratorInterface = nullptr;
-        PrefabFocusPublicInterface* m_prefabFocusPublicInterface = nullptr;
-    };
-
-    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDom_DescendantOfFocusedOrRoot_Succeeds)
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDom_TESTMEDescendantOfFocusedOrRoot_Succeeds)
     {
         // Generate a prefab DOM for the Wheel instance while the Level is in focus
-        GenerateAndValidateInstanceDom(m_wheelInstance->get(), m_tireAlias, m_overrideValueOnLevel);
+        GenerateAndValidateInstanceDom(m_wheelInstance->get(), m_tireAlias, m_entityOverrideValueOnLevel);
     }
 
-    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDom_Focused_Succeeds)
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDom_TESTMEFocused_Succeeds)
     {
         // Generate a prefab DOM for the Wheel instance while the Wheel instance is in focus
         m_prefabFocusPublicInterface->FocusOnOwningPrefab(m_wheelInstance->get().GetContainerEntityId());
-
-        GenerateAndValidateInstanceDom(m_wheelInstance->get(), m_tireAlias, m_overrideValueOnWheel);
+        GenerateAndValidateInstanceDom(m_wheelInstance->get(), m_tireAlias, m_entityValueOnWheel);
     }
 
-    TEST_F(PrefabInstanceDomGeneratorTests, GenerateEntityDom_NotContainerEntity_Succeeds)
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDom_TESTMEAncestorOfFocused_Succeeds)
+    {
+        // Generate a prefab DOM for the Car instance while the Wheel instance is in focus
+        m_prefabFocusPublicInterface->FocusOnOwningPrefab(m_wheelInstance->get().GetContainerEntityId());
+        GenerateAndValidateInstanceDom(m_carInstance->get(), m_tireAlias, m_entityValueOnWheel);
+    }
+
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateEntityDom_TESTMENotContainerEntity_Succeeds)
     {
         const AZ::Entity& tireEntity = m_wheelInstance->get().GetEntity(m_tireAlias)->get();
 
         // Focus is on Level by default
-        GenerateAndValidateEntityDom(tireEntity, m_overrideValueOnLevel);
+        GenerateAndValidateEntityDom(tireEntity, m_entityOverrideValueOnLevel);
 
         // Change focus to Car
         m_prefabFocusPublicInterface->FocusOnOwningPrefab(m_carInstance->get().GetContainerEntityId());
-        GenerateAndValidateEntityDom(tireEntity, m_overrideValueOnCar);
+        GenerateAndValidateEntityDom(tireEntity, m_entityOverrideValueOnCar);
 
         // Change focus to Wheel
         m_prefabFocusPublicInterface->FocusOnOwningPrefab(m_wheelInstance->get().GetContainerEntityId());
-        GenerateAndValidateEntityDom(tireEntity, m_overrideValueOnWheel);
+        GenerateAndValidateEntityDom(tireEntity, m_entityValueOnWheel);
     }
 
-    TEST_F(PrefabInstanceDomGeneratorTests, GenerateEntityDom_ContainerEntity_Succeeds)
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateEntityDom_TESTMEContainerEntity_Succeeds)
     {
         const AZ::Entity& containerEntity = m_wheelInstance->get().GetContainerEntity()->get();
 
         // Change focus to Wheel, so the container entity DOM should come from the root
         m_prefabFocusPublicInterface->FocusOnOwningPrefab(m_wheelInstance->get().GetContainerEntityId());
-        GenerateAndValidateEntityDom(containerEntity, m_overrideValueOnLevel);
+        GenerateAndValidateEntityDom(containerEntity, m_containerOverrideValueOnLevel);
     }
 } // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTests.cpp
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Prefab/PrefabTestFixture.h>
+#include <Prefab/PrefabTestDomUtils.h>
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+
+namespace UnitTest
+{
+    // Fixture for testing instance DOM generation based on the focused prefab via existing template DOMS
+    class PrefabInstanceDomGeneratorTests : public PrefabTestFixture
+    {
+    public:
+        void SetUpEditorFixtureImpl() override
+        {
+            PrefabTestFixture::SetUpEditorFixtureImpl();
+
+            m_instanceDomGeneratorInterface = AZ::Interface<InstanceDomGeneratorInterface>::Get();
+            EXPECT_TRUE(m_instanceDomGeneratorInterface);
+
+            m_prefabFocusPublicInterface = AZ::Interface<PrefabFocusPublicInterface>::Get();
+            ASSERT_TRUE(m_prefabFocusPublicInterface);
+
+            SetUpInstanceHierarchy();
+        }
+
+        void SetUpInstanceHierarchy()
+        {
+            // Level
+            // | Car
+            //   | Wheel
+            //     | Tire
+
+            const AZStd::string carPrefabName = "CarPrefab";
+            const AZStd::string wheelPrefabName = "WheelPrefab";
+            const AZStd::string tireEntityName = "Tire";
+
+            AZ::IO::Path engineRootPath;
+            m_settingsRegistryInterface->Get(engineRootPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
+            AZ::IO::Path carPrefabFilepath(engineRootPath);
+            carPrefabFilepath.Append(carPrefabName);
+            AZ::IO::Path wheelPrefabFilepath(engineRootPath);
+            wheelPrefabFilepath.Append(wheelPrefabName);
+
+            // Create the car hierarchy
+            AZ::EntityId tireEntityId = CreateEditorEntityUnderRoot(tireEntityName);
+            AZ::EntityId wheelContainerId = CreateEditorPrefab(wheelPrefabFilepath, { tireEntityId });
+
+            m_wheelInstance = m_instanceEntityMapperInterface->FindOwningInstance(wheelContainerId);
+            ASSERT_TRUE(m_wheelInstance.has_value());
+            // Save the tire alias for further testing
+            AZStd::vector<EntityAlias> entityAliases = m_wheelInstance->get().GetEntityAliases();
+            ASSERT_TRUE(!entityAliases.empty());
+            m_tireAlias = entityAliases[0];
+
+            // Save the Wheel instance alias before the Car prefab is created
+            InstanceAlias wheelInstanceAlias = m_wheelInstance->get().GetInstanceAlias();
+
+            AZ::EntityId carContainerId = CreateEditorPrefab(carPrefabFilepath, { wheelContainerId });
+            m_carInstance = m_instanceEntityMapperInterface->FindOwningInstance(carContainerId);
+            ASSERT_TRUE(m_carInstance.has_value());
+
+            // Reassign the Wheel instance now that it's been recreated by propagation
+            m_wheelInstance = m_carInstance->get().FindNestedInstance(wheelInstanceAlias);
+            ASSERT_TRUE(m_wheelInstance.has_value());
+
+            // Activate the container entity of the Wheel instance
+            m_wheelInstance->get().ActivateContainerEntity();
+
+            // Generate a patch that will alter the tire
+            GenerateWorldXEntityPatch(m_tireAlias, m_overrideValueOnLevel, *m_wheelInstance, m_patch);
+
+            // Apply the tire patch to the Root template (level)
+            ApplyEntityPatchToTemplate(m_patch, m_tireAlias, *m_wheelInstance, *m_prefabEditorEntityOwnershipInterface->GetRootPrefabInstance());
+
+            // Generate a patch that will alter the container entity of the Wheel
+            GenerateWorldXEntityPatch("", m_overrideValueOnLevel, *m_wheelInstance, m_containerPatch);
+
+            // Apply the container patch to the Root template (level)
+            ApplyEntityPatchToTemplate(m_containerPatch, "", *m_wheelInstance, *m_prefabEditorEntityOwnershipInterface->GetRootPrefabInstance());
+
+            // Update and apply the tire patch to the Wheel template
+            UpdateWorldXEntityPatch(m_patch, m_overrideValueOnWheel);
+            ApplyEntityPatchToTemplate(m_patch, m_tireAlias, *m_wheelInstance, *m_wheelInstance);
+
+            // Update and apply the tire patch to the Car template
+            UpdateWorldXEntityPatch(m_patch, m_overrideValueOnCar);
+            ApplyEntityPatchToTemplate(m_patch, m_tireAlias, *m_wheelInstance, m_carInstance->get());
+        }
+
+        void TearDownEditorFixtureImpl() override
+        {
+            PrefabTestFixture::TearDownEditorFixtureImpl();
+        }
+
+        void GenerateWorldXEntityPatch(
+            const EntityAlias& entityAlias,
+            float updatedXValue,
+            Instance& owningInstance,
+            PrefabDom& patchOut)
+        {
+            EntityOptionalReference childEntity = entityAlias.empty() ? owningInstance.GetContainerEntity() : owningInstance.GetEntity(entityAlias);
+            ASSERT_TRUE(childEntity.has_value());
+
+            // Create document with before change snapshot
+            PrefabDom entityDomBeforeUpdate;
+            m_instanceToTemplateInterface->GenerateDomForEntity(entityDomBeforeUpdate, *childEntity);
+
+            // Change the entity
+            float prevXValue = 0.0f;
+            AZ::TransformBus::EventResult(prevXValue, childEntity->get().GetId(), &AZ::TransformInterface::GetWorldX);
+            AZ::TransformBus::Event(childEntity->get().GetId(), &AZ::TransformInterface::SetWorldX, updatedXValue);
+            float curXValue = 0.0f;
+            AZ::TransformBus::EventResult(curXValue, childEntity->get().GetId(), &AZ::TransformInterface::GetWorldX);
+            EXPECT_EQ(curXValue, updatedXValue);
+
+            // Create document with after change snapshot
+            PrefabDom entityDomAfterUpdate;
+            m_instanceToTemplateInterface->GenerateDomForEntity(entityDomAfterUpdate, *childEntity);
+
+            // Generate patch
+            m_instanceToTemplateInterface->GeneratePatch(patchOut, entityDomBeforeUpdate, entityDomAfterUpdate);
+
+            // Revert the change to the entity
+            AZ::TransformBus::Event(childEntity->get().GetId(), &AZ::TransformInterface::SetWorldX, prevXValue);
+        }
+
+        void UpdateWorldXEntityPatch(
+            PrefabDom& patch,
+            double newValue)
+        {
+            PrefabDomValue::MemberIterator patchEntryIterator = patch[0].FindMember("value");
+            ASSERT_TRUE(patchEntryIterator != patch[0].MemberEnd());
+            patchEntryIterator->value.SetDouble(newValue);
+        }
+
+        void ApplyEntityPatchToTemplate(
+            PrefabDom& patch,
+            const EntityAlias& entityAlias,
+            const Instance& owningInstance,
+            const Instance& targetInstance)
+        {
+            // We need to generate a patch prefix so that the path of the patches correctly refelects the hierarchy path
+            // from the entity to the instance where the patch needs to be added.
+            AZStd::string patchPrefix;
+            if (entityAlias.empty())
+            {
+                patchPrefix.insert(0, "/ContainerEntity");
+            }
+            else
+            {
+                patchPrefix.insert(0, "/Entities/" + entityAlias);
+            }
+
+            auto instanceToAddPatches = m_prefabEditorEntityOwnershipInterface->GetRootPrefabInstance();
+            const Instance* curInstance = &owningInstance;
+            while (curInstance != &targetInstance)
+            {
+                patchPrefix.insert(0, "/Instances/" + curInstance->GetInstanceAlias());
+                InstanceOptionalConstReference parentInstance = curInstance->GetParentInstance();
+                ASSERT_TRUE(parentInstance.has_value());
+                curInstance = &parentInstance->get();
+            }
+
+            PrefabDomValueReference patchPathReference = PrefabDomUtils::FindPrefabDomValue(patch[0], "path");
+            ASSERT_TRUE(patchPathReference.has_value());
+            AZStd::string patchPathStringBefore = patchPathReference->get().GetString();
+            AZStd::string patchPathString = patchPathStringBefore;
+            patchPathString.insert(0, patchPrefix);
+            patchPathReference->get().SetString(patchPathString.c_str(), patch.GetAllocator());
+
+            // Apply the patch
+            TemplateId targetTemplateId = targetInstance.GetTemplateId();
+            PrefabDom& targetTemplateDomReference = m_prefabSystemComponent->FindTemplateDom(targetTemplateId);
+            AZ::JsonSerializationResult::ResultCode result =
+                PrefabDomUtils::ApplyPatches(targetTemplateDomReference, targetTemplateDomReference.GetAllocator(), patch);
+            ASSERT_TRUE(result.GetOutcome() == AZ::JsonSerializationResult::Outcomes::Success);
+
+            // Revert back to previous path
+            patchPathReference->get().SetString(patchPathStringBefore.c_str(), patch.GetAllocator());
+        }
+
+        void GenerateAndValidateInstanceDom(const Instance& instance, EntityAlias entityAlias, float expectedValue)
+        {
+            // Generate a prefab DOM for the provided instance
+            PrefabDom generatedInstanceDom;
+            m_instanceDomGeneratorInterface->GenerateInstanceDom(generatedInstanceDom, instance);
+
+            // Create an instance from the generated prefab DOM for validation
+            Instance instanceFromDom;
+            ASSERT_TRUE(PrefabDomUtils::LoadInstanceFromPrefabDom(
+                instanceFromDom, generatedInstanceDom, PrefabDomUtils::LoadFlags::UseSelectiveDeserialization));
+
+            // Verify that the worldX value of the provided child entity is coming from the correct template
+            EntityOptionalReference childEntity = instanceFromDom.GetEntity(entityAlias);
+            childEntity->get().Init();
+            childEntity->get().Activate(); // to connect to buses such as transform bus
+            float curXValue = 0.0f;
+            AZ::TransformBus::EventResult(curXValue, childEntity->get().GetId(), &AZ::TransformInterface::GetWorldX);
+            EXPECT_EQ(curXValue, expectedValue);
+
+            // Verify that the parent of the container entity is a valid entity
+            EntityOptionalReference containerEntity = instanceFromDom.GetContainerEntity();
+            containerEntity->get().Init();
+            containerEntity->get().Activate(); // to connect to buses such as transform bus
+            AZ::EntityId parentEntityId;
+            AZ::TransformBus::EventResult(parentEntityId, containerEntity->get().GetId(), &AZ::TransformInterface::GetParentId);
+            EXPECT_TRUE(parentEntityId.IsValid());
+        }
+
+        void GenerateAndValidateEntityDom(const AZ::Entity& entity, float expectedValue)
+        {
+            // Generate an entity DOM for the provided entity
+            PrefabDom generatedEntityDom;
+            m_instanceDomGeneratorInterface->GenerateEntityDom(generatedEntityDom, entity);
+            EXPECT_TRUE(generatedEntityDom.IsObject());
+
+            // Create an entity from the generated entity DOM for validation
+            AZ::Entity entityFromDom;
+            AZ::JsonSerializationResult::ResultCode result = AZ::JsonSerialization::Load(entityFromDom, generatedEntityDom);
+            ASSERT_TRUE(result.GetProcessing() != AZ::JsonSerializationResult::Processing::Halted);
+
+            // Verify that the worldX value is coming from the correct template
+            entityFromDom.Init();
+            entityFromDom.Activate(); // to connect to buses such as transform bus
+            float curXValue = 0.0f;
+            AZ::TransformBus::EventResult(curXValue, entityFromDom.GetId(), &AZ::TransformInterface::GetWorldX);
+            EXPECT_EQ(curXValue, expectedValue);
+        }
+
+    protected:
+        const float m_overrideValueOnLevel = 1.0f;
+        const float m_overrideValueOnCar = 2.0f;
+        const float m_overrideValueOnWheel = 3.0f;
+
+        InstanceOptionalReference m_carInstance;
+        InstanceOptionalReference m_wheelInstance;
+        EntityAlias m_tireAlias;
+        PrefabDom m_patch;
+        PrefabDom m_containerPatch;
+
+        InstanceDomGeneratorInterface* m_instanceDomGeneratorInterface = nullptr;
+        PrefabFocusPublicInterface* m_prefabFocusPublicInterface = nullptr;
+    };
+
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDom_DescendantOfFocusedOrRoot_Succeeds)
+    {
+        // Generate a prefab DOM for the Wheel instance while the Level is in focus
+        GenerateAndValidateInstanceDom(m_wheelInstance->get(), m_tireAlias, m_overrideValueOnLevel);
+    }
+
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDom_Focused_Succeeds)
+    {
+        // Generate a prefab DOM for the Wheel instance while the Wheel instance is in focus
+        m_prefabFocusPublicInterface->FocusOnOwningPrefab(m_wheelInstance->get().GetContainerEntityId());
+
+        GenerateAndValidateInstanceDom(m_wheelInstance->get(), m_tireAlias, m_overrideValueOnWheel);
+    }
+
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateEntityDom_NotContainerEntity_Succeeds)
+    {
+        const AZ::Entity& tireEntity = m_wheelInstance->get().GetEntity(m_tireAlias)->get();
+
+        // Focus is on Level by default
+        GenerateAndValidateEntityDom(tireEntity, m_overrideValueOnLevel);
+
+        // Change focus to Car
+        m_prefabFocusPublicInterface->FocusOnOwningPrefab(m_carInstance->get().GetContainerEntityId());
+        GenerateAndValidateEntityDom(tireEntity, m_overrideValueOnCar);
+
+        // Change focus to Wheel
+        m_prefabFocusPublicInterface->FocusOnOwningPrefab(m_wheelInstance->get().GetContainerEntityId());
+        GenerateAndValidateEntityDom(tireEntity, m_overrideValueOnWheel);
+    }
+
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateEntityDom_ContainerEntity_Succeeds)
+    {
+        const AZ::Entity& containerEntity = m_wheelInstance->get().GetContainerEntity()->get();
+
+        // Change focus to Wheel, so the container entity DOM should come from the root
+        m_prefabFocusPublicInterface->FocusOnOwningPrefab(m_wheelInstance->get().GetContainerEntityId());
+        GenerateAndValidateEntityDom(containerEntity, m_overrideValueOnLevel);
+    }
+} // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTests.cpp
@@ -12,27 +12,27 @@ namespace UnitTest
 {
     using PrefabInstanceDomGeneratorTests = PrefabInstanceDomGeneratorTestFixture;
 
-    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDom_TESTMEDescendantOfFocusedOrRoot_Succeeds)
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDom_DescendantOfFocusedOrRootSucceeds)
     {
         // Generate a prefab DOM for the Wheel instance while the Level is in focus
         GenerateAndValidateInstanceDom(m_wheelInstance->get(), m_tireAlias, m_entityOverrideValueOnLevel);
     }
 
-    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDom_TESTMEFocused_Succeeds)
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDom_FocusedSucceeds)
     {
         // Generate a prefab DOM for the Wheel instance while the Wheel instance is in focus
         m_prefabFocusPublicInterface->FocusOnOwningPrefab(m_wheelInstance->get().GetContainerEntityId());
         GenerateAndValidateInstanceDom(m_wheelInstance->get(), m_tireAlias, m_entityValueOnWheel);
     }
 
-    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDom_TESTMEAncestorOfFocused_Succeeds)
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDom_AncestorOfFocusedSucceeds)
     {
         // Generate a prefab DOM for the Car instance while the Wheel instance is in focus
         m_prefabFocusPublicInterface->FocusOnOwningPrefab(m_wheelInstance->get().GetContainerEntityId());
         GenerateAndValidateInstanceDom(m_carInstance->get(), m_tireAlias, m_entityValueOnWheel);
     }
 
-    TEST_F(PrefabInstanceDomGeneratorTests, GenerateEntityDom_TESTMENotContainerEntity_Succeeds)
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateEntityDom_NotContainerEntitySucceeds)
     {
         const AZ::Entity& tireEntity = m_wheelInstance->get().GetEntity(m_tireAlias)->get();
 
@@ -48,7 +48,7 @@ namespace UnitTest
         GenerateAndValidateEntityDom(tireEntity, m_entityValueOnWheel);
     }
 
-    TEST_F(PrefabInstanceDomGeneratorTests, GenerateEntityDom_TESTMEContainerEntity_Succeeds)
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateEntityDom_ContainerEntitySucceeds)
     {
         const AZ::Entity& containerEntity = m_wheelInstance->get().GetContainerEntity()->get();
 

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTests.cpp
@@ -12,27 +12,27 @@ namespace UnitTest
 {
     using PrefabInstanceDomGeneratorTests = PrefabInstanceDomGeneratorTestFixture;
 
-    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDomDescendantOfFocusedOrRootSucceeds)
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDomForDescendantOfFocusedLevel)
     {
         // Generate a prefab DOM for the Wheel instance while the Level is in focus
         GenerateAndValidateInstanceDom(m_wheelInstance->get(), m_tireAlias, m_entityOverrideValueOnLevel);
     }
 
-    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDomFocusedSucceeds)
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDomForFocusedPrefab)
     {
         // Generate a prefab DOM for the Wheel instance while the Wheel instance is in focus
         m_prefabFocusPublicInterface->FocusOnOwningPrefab(m_wheelInstance->get().GetContainerEntityId());
         GenerateAndValidateInstanceDom(m_wheelInstance->get(), m_tireAlias, m_entityValueOnWheel);
     }
 
-    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDomAncestorOfFocusedSucceeds)
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDomForAncestorOfFocusedPrefab)
     {
         // Generate a prefab DOM for the Car instance while the Wheel instance is in focus
         m_prefabFocusPublicInterface->FocusOnOwningPrefab(m_wheelInstance->get().GetContainerEntityId());
         GenerateAndValidateInstanceDom(m_carInstance->get(), m_tireAlias, m_entityValueOnWheel);
     }
 
-    TEST_F(PrefabInstanceDomGeneratorTests, GenerateEntityDomNotContainerSucceeds)
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateEntityDomForDescendantOfFocusedPrefab)
     {
         const AZ::Entity& tireEntity = m_wheelInstance->get().GetEntity(m_tireAlias)->get();
 
@@ -48,12 +48,12 @@ namespace UnitTest
         GenerateAndValidateEntityDom(tireEntity, m_entityValueOnWheel);
     }
 
-    TEST_F(PrefabInstanceDomGeneratorTests, GenerateEntityDomContainerSucceeds)
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateEntityDomForContainerOfFocusedPrefab)
     {
         const AZ::Entity& containerEntity = m_wheelInstance->get().GetContainerEntity()->get();
 
         // Change focus to Wheel, so the container entity DOM should come from the root
         m_prefabFocusPublicInterface->FocusOnOwningPrefab(m_wheelInstance->get().GetContainerEntityId());
-        GenerateAndValidateEntityDom(containerEntity, m_containerOverrideValueOnLevel);
+        GenerateAndValidateEntityDom(containerEntity, m_wheelContainerOverrideValueOnLevel);
     }
 } // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTests.cpp
@@ -12,27 +12,27 @@ namespace UnitTest
 {
     using PrefabInstanceDomGeneratorTests = PrefabInstanceDomGeneratorTestFixture;
 
-    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDom_DescendantOfFocusedOrRootSucceeds)
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDomDescendantOfFocusedOrRootSucceeds)
     {
         // Generate a prefab DOM for the Wheel instance while the Level is in focus
         GenerateAndValidateInstanceDom(m_wheelInstance->get(), m_tireAlias, m_entityOverrideValueOnLevel);
     }
 
-    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDom_FocusedSucceeds)
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDomFocusedSucceeds)
     {
         // Generate a prefab DOM for the Wheel instance while the Wheel instance is in focus
         m_prefabFocusPublicInterface->FocusOnOwningPrefab(m_wheelInstance->get().GetContainerEntityId());
         GenerateAndValidateInstanceDom(m_wheelInstance->get(), m_tireAlias, m_entityValueOnWheel);
     }
 
-    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDom_AncestorOfFocusedSucceeds)
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateInstanceDomAncestorOfFocusedSucceeds)
     {
         // Generate a prefab DOM for the Car instance while the Wheel instance is in focus
         m_prefabFocusPublicInterface->FocusOnOwningPrefab(m_wheelInstance->get().GetContainerEntityId());
         GenerateAndValidateInstanceDom(m_carInstance->get(), m_tireAlias, m_entityValueOnWheel);
     }
 
-    TEST_F(PrefabInstanceDomGeneratorTests, GenerateEntityDom_NotContainerEntitySucceeds)
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateEntityDomNotContainerSucceeds)
     {
         const AZ::Entity& tireEntity = m_wheelInstance->get().GetEntity(m_tireAlias)->get();
 
@@ -48,7 +48,7 @@ namespace UnitTest
         GenerateAndValidateEntityDom(tireEntity, m_entityValueOnWheel);
     }
 
-    TEST_F(PrefabInstanceDomGeneratorTests, GenerateEntityDom_ContainerEntitySucceeds)
+    TEST_F(PrefabInstanceDomGeneratorTests, GenerateEntityDomContainerSucceeds)
     {
         const AZ::Entity& containerEntity = m_wheelInstance->get().GetContainerEntity()->get();
 

--- a/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
+++ b/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
@@ -102,6 +102,8 @@ set(FILES
     Prefab/PrefabDeleteAsOverrideTests.cpp
     Prefab/PrefabDuplicateTests.cpp
     Prefab/PrefabEntityAliasTests.cpp
+    Prefab/PrefabInstanceDomGeneratorTestFixture.cpp
+    Prefab/PrefabInstanceDomGeneratorTestFixture.h
     Prefab/PrefabInstanceDomGeneratorTests.cpp
     Prefab/PrefabInstanceToTemplatePropagatorTests.cpp
     Prefab/PrefabInstantiateTests.cpp

--- a/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
+++ b/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
@@ -102,6 +102,7 @@ set(FILES
     Prefab/PrefabDeleteAsOverrideTests.cpp
     Prefab/PrefabDuplicateTests.cpp
     Prefab/PrefabEntityAliasTests.cpp
+    Prefab/PrefabInstanceDomGeneratorTests.cpp
     Prefab/PrefabInstanceToTemplatePropagatorTests.cpp
     Prefab/PrefabInstantiateTests.cpp
     Prefab/PrefabAssetFixupTests.cpp


### PR DESCRIPTION
Signed-off-by: michabr <82236305+michabr@users.noreply.github.com>

## What does this PR do?

Add unit tests for generating instance and entity DOMs based on the currently focused prefab and existing template DOMs.

## How was this PR tested?

Ran new unit tests and checked that they passed.
