### PR TITLE
Added a new error message for Erroneous Assets 

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/InMemorySpawnableAssetContainer.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/InMemorySpawnableAssetContainer.cpp
@@ -201,6 +201,19 @@ namespace AzFramework
                         return false;
                     }
 
+                    if (asset->GetStatus() == AZ::Data::AssetData::AssetStatus::Error)
+                    {
+                        AZ_Error(
+                            "Prefab",
+                            false,
+                            "Asset '%s' (%s) of type '%s' failed to load while entering game mode",
+                            asset->GetHint().c_str(),
+                            asset->GetId().ToFixedString().c_str(),
+                            classData->m_name);
+
+                        return false;
+                    }
+
                     if (asset->GetStatus() != AZ::Data::AssetData::AssetStatus::NotLoaded)
                     {
                         // Already loaded so no need to do anything.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -951,38 +951,59 @@ namespace AzToolsFramework
     // Functionality to use the default asset when no asset is selected has to be implemented on the component side.
     void PropertyAssetCtrl::SetDefaultAssetID(const AZ::Data::AssetId& defaultID)
     {
-        m_defaultAssetID = defaultID;
-
-        AZ::Data::AssetInfo assetInfo;
-        AZStd::string rootFilePath;
-        AZStd::string assetPath;
-
-        if (m_showProductAssetName)
+        if (defaultID.IsValid())
         {
-            AZ::Data::AssetCatalogRequestBus::BroadcastResult(assetPath, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, m_defaultAssetID);
+            m_defaultAssetID = defaultID;
+
+            AZ::Data::AssetInfo assetInfo;
+            AZStd::string rootFilePath;
+            AZStd::string assetPath;
+
+            if (m_showProductAssetName)
+            {
+                AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+                    assetPath, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, m_defaultAssetID);
+            }
+            else
+            {
+                const AZStd::string platformName = ""; // Empty for default
+                for (const auto& assetType : GetSelectableAssetTypes())
+                {
+                    bool result = false;
+                    AssetSystemRequestBus::BroadcastResult(
+                        result,
+                        &AssetSystem::AssetSystemRequest::GetAssetInfoById,
+                        defaultID,
+                        assetType,
+                        platformName,
+                        assetInfo,
+                        rootFilePath);
+                    if (result)
+                    {
+                        assetPath = assetInfo.m_relativePath;
+                        break;
+                    }
+                }
+            }
+
+            if (!assetPath.empty())
+            {
+                AzFramework::StringFunc::Path::GetFileName(assetPath.c_str(), m_defaultAssetHint);
+            }
+            m_browseEdit->setPlaceholderText((m_defaultAssetHint + m_DefaultSuffix).c_str());
         }
         else
         {
-            const AZStd::string platformName = ""; // Empty for default
-            for (const auto& assetType : GetSelectableAssetTypes())
+            if (m_selectedAssetID.IsValid())
             {
-                bool result = false;
-                AssetSystemRequestBus::BroadcastResult(
-                    result, &AssetSystem::AssetSystemRequest::GetAssetInfoById, defaultID, assetType, platformName, assetInfo,
-                    rootFilePath);
-                if (result)
-                {
-                    assetPath = assetInfo.m_relativePath;
-                    break;
-                }
+                ClearErrorButton();
+            }
+            else
+            {
+                UpdateErrorButtonWithMessage(AZStd::string("Default asset is invalid"));
+                m_browseEdit->setPlaceholderText("Invalid");
             }
         }
-
-        if (!assetPath.empty())
-        {
-            AzFramework::StringFunc::Path::GetFileName(assetPath.c_str(), m_defaultAssetHint);
-        }
-        m_browseEdit->setPlaceholderText((m_defaultAssetHint + m_DefaultSuffix).c_str());
 
         UpdateEditButton();
     }
@@ -1002,101 +1023,104 @@ namespace AzToolsFramework
         {
             const AZ::Data::AssetId assetID = GetCurrentAssetID();
 
-            AZ::Outcome<AssetSystem::JobInfoContainer> jobOutcome = AZ::Failure();
-            AssetSystemJobRequestBus::BroadcastResult(jobOutcome, &AssetSystemJobRequestBus::Events::GetAssetJobsInfoByAssetID, assetID, false, false);
-
-            if (jobOutcome.IsSuccess())
+            if (assetID.IsValid())
             {
-                AZStd::string assetPath;
-                AssetSystem::JobInfoContainer& jobs = jobOutcome.GetValue();
+                AZ::Outcome<AssetSystem::JobInfoContainer> jobOutcome = AZ::Failure();
+                AssetSystemJobRequestBus::BroadcastResult(jobOutcome, &AssetSystemJobRequestBus::Events::GetAssetJobsInfoByAssetID, assetID, false, false);
 
-                // Get the asset relative path
-                AssetSystem::JobStatus assetStatus = AssetSystem::JobStatus::Completed;
-
-                if (!jobs.empty())
+                if (jobOutcome.IsSuccess())
                 {
-                    // The default behavior is to show the source filename.
-                    assetPath = jobs[0].m_sourceFile;
+                    AZStd::string assetPath;
+                    AssetSystem::JobInfoContainer& jobs = jobOutcome.GetValue();
 
-                    AZStd::string errorLog;
+                    // Get the asset relative path
+                    AssetSystem::JobStatus assetStatus = AssetSystem::JobStatus::Completed;
 
-                    for (const auto& jobInfo : jobs)
+                    if (!jobs.empty())
                     {
-                        // If the job has failed, mark the asset as failed, and collect the log.
-                        switch (jobInfo.m_status)
+                        // The default behavior is to show the source filename.
+                        assetPath = jobs[0].m_sourceFile;
+
+                        AZStd::string errorLog;
+
+                        for (const auto& jobInfo : jobs)
                         {
+                            // If the job has failed, mark the asset as failed, and collect the log.
+                            switch (jobInfo.m_status)
+                            {
                             case AssetSystem::JobStatus::Failed:
                             case AssetSystem::JobStatus::Failed_InvalidSourceNameExceedsMaxLimit:
-                            {
-                                assetStatus = AssetSystem::JobStatus::Failed;
-
-                                AZ::Outcome<AZStd::string> logOutcome = AZ::Failure();
-                                AssetSystemJobRequestBus::BroadcastResult(logOutcome, &AssetSystemJobRequestBus::Events::GetJobLog, jobInfo.m_jobRunKey);
-                                if (logOutcome.IsSuccess())
                                 {
-                                    errorLog += logOutcome.TakeValue();
-                                    errorLog += '\n';
+                                    assetStatus = AssetSystem::JobStatus::Failed;
+
+                                    AZ::Outcome<AZStd::string> logOutcome = AZ::Failure();
+                                    AssetSystemJobRequestBus::BroadcastResult(logOutcome, &AssetSystemJobRequestBus::Events::GetJobLog, jobInfo.m_jobRunKey);
+                                    if (logOutcome.IsSuccess())
+                                    {
+                                        errorLog += logOutcome.TakeValue();
+                                        errorLog += '\n';
+                                    }
                                 }
-                            }
-                            break;
+                                break;
 
                             // If the job is in progress, mark the asset as in progress
                             case AssetSystem::JobStatus::InProgress:
-                            {
-                                // Only mark asset in progress if it isn't already in progress, or marked as an error
-                                if (assetStatus == AssetSystem::JobStatus::Completed)
                                 {
-                                    assetStatus = AssetSystem::JobStatus::InProgress;
+                                    // Only mark asset in progress if it isn't already in progress, or marked as an error
+                                    if (assetStatus == AssetSystem::JobStatus::Completed)
+                                    {
+                                        assetStatus = AssetSystem::JobStatus::InProgress;
+                                    }
                                 }
+                                break;
+                            }
+                        }
+
+                        switch (assetStatus)
+                        {
+                        // In case of failure, render failure icon
+                        case AssetSystem::JobStatus::Failed:
+                            {
+                                UpdateErrorButtonWithLog(errorLog);
+                            }
+                            break;
+
+                        // In case of success, remove error elements
+                        case AssetSystem::JobStatus::Completed:
+                            {
+                                ClearErrorButton();
                             }
                             break;
                         }
                     }
-
-                    switch (assetStatus)
+                    else
                     {
-                        // In case of failure, render failure icon
-                        case AssetSystem::JobStatus::Failed:
+                        // If there aren't any jobs and the asset ID is valid, the asset must have been removed.
+                        if (assetID.IsValid())
                         {
-                            UpdateErrorButtonWithLog(errorLog);
+                            UpdateErrorButtonWithMessage(AZStd::string::format(
+                                "Asset has been removed.\n\nID: %s\nHint:%s",
+                                assetID.ToString<AZStd::string>().c_str(),
+                                GetCurrentAssetHint().c_str()));
                         }
-                        break;
+                    }
 
-                        // In case of success, remove error elements
-                        case AssetSystem::JobStatus::Completed:
-                        {
-                            ClearErrorButton();
-                        }
-                        break;
+                    // This can be turned on with an attribute in EditContext
+                    if (m_showProductAssetName)
+                    {
+                        AZ::Data::AssetCatalogRequestBus::BroadcastResult(assetPath, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, assetID);
+                    }
+
+                    // Only change the asset name if the asset not found or there's no last known good name for it
+                    if (!assetPath.empty() && (assetStatus != AssetSystem::JobStatus::Completed || m_currentAssetHint != assetPath))
+                    {
+                        m_currentAssetHint = assetPath;
                     }
                 }
                 else
                 {
-                    // If there aren't any jobs and the asset ID is valid, the asset must have been removed.
-                    if (assetID.IsValid())
-                    {
-                        UpdateErrorButtonWithMessage(AZStd::string::format(
-                            "Asset has been removed.\n\nID: %s\nHint:%s",
-                            assetID.ToString<AZStd::string>().c_str(),
-                            GetCurrentAssetHint().c_str()));
-                    }
+                    UpdateErrorButtonWithMessage(AZStd::string::format("Asset is missing.\n\nID: %s\nHint:%s", assetID.ToString<AZStd::string>().c_str(), GetCurrentAssetHint().c_str()));
                 }
-
-                // This can be turned on with an attribute in EditContext
-                if (m_showProductAssetName)
-                {
-                    AZ::Data::AssetCatalogRequestBus::BroadcastResult(assetPath, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, assetID);
-                }
-
-                // Only change the asset name if the asset not found or there's no last known good name for it
-                if (!assetPath.empty() && (assetStatus != AssetSystem::JobStatus::Completed || m_currentAssetHint != assetPath))
-                {
-                    m_currentAssetHint = assetPath;
-                }
-            }
-            else
-            {
-                UpdateErrorButtonWithMessage(AZStd::string::format("Asset is missing.\n\nID: %s\nHint:%s", assetID.ToString<AZStd::string>().c_str(), GetCurrentAssetHint().c_str()));
             }
         }
 
@@ -1108,13 +1132,9 @@ namespace AzToolsFramework
         }
 
         setToolTip(m_currentAssetHint.c_str());
-
+        
         // If no asset is selected but a default asset id is, show the default name.
-        if (!m_selectedAssetID.IsValid() && m_defaultAssetID.IsValid())
-        {
-            m_browseEdit->setText("");
-        }
-        else
+        if (m_selectedAssetID.IsValid())
         {
             m_browseEdit->setText(assetName.c_str());
         }


### PR DESCRIPTION
Signed-off-by: Nikhil Raktale <raktalen@amazon.com>

## What does this PR do?

Fixes : https://github.com/o3de/o3de/issues/4934

- Adds better error messaging for assets that were deleted on disk after being referenced
- Adds better iconography and messaging for assets that are supposed to have valid defaults, but the defaults are missing

## How was this PR tested?

Tested in editor
