### PR TITLE
Fix the scene setting issue when selected or the unselected node list is not provided

### DIFF
--- a/Code/Tools/SceneAPI/SceneCore/Tests/Utilities/SceneGraphSelectorTests.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Tests/Utilities/SceneGraphSelectorTests.cpp
@@ -129,18 +129,13 @@ namespace AZ
                 NiceMock<TestNodeSelectionList> m_testNodeSelectionList;
             };
 
-            TEST_F(SceneGraphSelectorTest, GenerateTargetNodes_EmptySelectedAndEmptyUnselectedNodes_AllTargetNodes)
+            TEST_F(SceneGraphSelectorTest, GenerateTargetNodes_EmptySelectedAndEmptyUnselectedNodes_NoTargetNodes)
             {
                 AZStd::vector<AZStd::string> selectedNodes;
                 AZStd::vector<AZStd::string> unselectedNodes;
                 CreateMeshGroup(selectedNodes, unselectedNodes);
                 auto targetNodes = SceneGraphSelector::GenerateTargetNodes(m_graph, m_testNodeSelectionList, IsValidTestNodeType);
-                EXPECT_EQ(targetNodes.size(), 5);
-                EXPECT_STREQ("A", targetNodes[0].c_str());
-                EXPECT_STREQ("A.B", targetNodes[1].c_str());
-                EXPECT_STREQ("A.C", targetNodes[2].c_str());
-                EXPECT_STREQ("A.D", targetNodes[3].c_str());
-                EXPECT_STREQ("A.D.E", targetNodes[4].c_str());
+                EXPECT_EQ(targetNodes.size(), 0);
             }
 
             TEST_F(SceneGraphSelectorTest, GenerateTargetNodes_OnlySelectedRootNode_AllNodesInTargetNodes)
@@ -166,7 +161,7 @@ namespace AZ
                 EXPECT_TRUE(targetNodes.empty());
             }
 
-            TEST_F(SceneGraphSelectorTest, GenerateTargetNodes_NonemptySelectedAndEmptyUnselectedNodes_AllNodesInTargetNodes)
+            TEST_F(SceneGraphSelectorTest, GenerateTargetNodes_NonemptySelectedIncludingRootNodeAndEmptyUnselectedNodes_AllNodesInTargetNodes)
             {
                 AZStd::vector<AZStd::string> selectedNodes = { "A", "A.B", "A.D" };
                 AZStd::vector<AZStd::string> unselectedNodes;
@@ -180,13 +175,49 @@ namespace AZ
                 EXPECT_STREQ("A.D.E", targetNodes[4].c_str());
             }
 
-            TEST_F(SceneGraphSelectorTest, GenerateTargetNodes_EmptySelectedAndNonemptyUnselectedNodes_NoTargetNodes)
+            TEST_F(SceneGraphSelectorTest, GenerateTargetNodes_NonemptySelectedExcludingRootNodeAndEmptyUnselectedNodes_NodeAandADandADE)
+            {
+                AZStd::vector<AZStd::string> selectedNodes = { "A.B", "A.D" };
+                AZStd::vector<AZStd::string> unselectedNodes;
+                CreateMeshGroup(selectedNodes, unselectedNodes);
+                auto targetNodes = SceneGraphSelector::GenerateTargetNodes(m_graph, m_testNodeSelectionList, IsValidTestNodeType);
+                EXPECT_EQ(targetNodes.size(), 3);
+                EXPECT_STREQ("A.B", targetNodes[0].c_str());
+                EXPECT_STREQ("A.D", targetNodes[1].c_str());
+                EXPECT_STREQ("A.D.E", targetNodes[2].c_str());
+            }
+
+            TEST_F(SceneGraphSelectorTest, GenerateTargetNodes_EmptySelectedAndNonemptyUnselectedNodesIncludingRootNode_NoTargetNodes)
             {
                 AZStd::vector<AZStd::string> selectedNodes;
                 AZStd::vector<AZStd::string> unselectedNodes = { "A", "A.B", "A.D" };
                 CreateMeshGroup(selectedNodes, unselectedNodes);
                 auto targetNodes = SceneGraphSelector::GenerateTargetNodes(m_graph, m_testNodeSelectionList, IsValidTestNodeType);
                 EXPECT_TRUE(targetNodes.empty());
+            }
+
+            TEST_F(SceneGraphSelectorTest, GenerateTargetNodes_EmptySelectedAndNonemptyUnselectedNodesExcludingRootNode_NodeAandAC)
+            {
+                AZStd::vector<AZStd::string> selectedNodes;
+                AZStd::vector<AZStd::string> unselectedNodes = { "A.B", "A.D" };
+                CreateMeshGroup(selectedNodes, unselectedNodes);
+                auto targetNodes = SceneGraphSelector::GenerateTargetNodes(m_graph, m_testNodeSelectionList, IsValidTestNodeType);
+                EXPECT_EQ(targetNodes.size(), 2);
+                EXPECT_STREQ("A", targetNodes[0].c_str());
+                EXPECT_STREQ("A.C", targetNodes[1].c_str());
+            }
+
+            TEST_F(SceneGraphSelectorTest, GenerateTargetNodes_DuplicateNodeRemovedFromSelected_MissNodeADotD)
+            {
+                AZStd::vector<AZStd::string> selectedNodes = { "A", "A.B", "A.C", "A.D", "A.D.E" };
+                AZStd::vector<AZStd::string> unselectedNodes = { "A.D" };
+                CreateMeshGroup(selectedNodes, unselectedNodes);
+                auto targetNodes = SceneGraphSelector::GenerateTargetNodes(m_graph, m_testNodeSelectionList, IsValidTestNodeType);
+                EXPECT_EQ(targetNodes.size(), 4);
+                EXPECT_STREQ("A", targetNodes[0].c_str());
+                EXPECT_STREQ("A.B", targetNodes[1].c_str());
+                EXPECT_STREQ("A.C", targetNodes[2].c_str());
+                EXPECT_STREQ("A.D.E", targetNodes[3].c_str());
             }
 
             TEST_F(SceneGraphSelectorTest, GenerateTargetNodes_SelectedParentNodeUnselectedChildNode_NodeAandAB)
@@ -296,11 +327,11 @@ namespace AZ
                 CreateMeshGroup(selectedNodes, unselectedNodes);
 
                 SceneGraphSelector::UpdateNodeSelection(m_graph, m_testNodeSelectionList);
-                EXPECT_EQ(5, selectedNodes.size());
-                EXPECT_EQ(0, unselectedNodes.size());
+                EXPECT_EQ(0, selectedNodes.size());
+                EXPECT_EQ(5, unselectedNodes.size());
             }
 
-            TEST_F(SceneGraphSelectorTest, UpdateNodeSelection_UnselectedNodeA_AllNodesUnselectedExceptRoot)
+            TEST_F(SceneGraphSelectorTest, UpdateNodeSelection_UnselectedNodeA_AllNodesInUnselected)
             {
                 AZStd::vector<AZStd::string> selectedNodes;
                 AZStd::vector<AZStd::string> unselectedNodes = { "A" };
@@ -309,6 +340,49 @@ namespace AZ
                 SceneGraphSelector::UpdateNodeSelection(m_graph, m_testNodeSelectionList);
                 EXPECT_EQ(0, selectedNodes.size());
                 EXPECT_EQ(5, unselectedNodes.size());
+            }
+
+            TEST_F(SceneGraphSelectorTest, UpdateNodeSelection_NonemptySelectedExcludingRootNodeAndEmptyUnselectedNodes__ABandADandADEFoundInSelectedNodes)
+            {
+                AZStd::vector<AZStd::string> selectedNodes = { "A.B", "A.D" };
+                AZStd::vector<AZStd::string> unselectedNodes;
+                CreateMeshGroup(selectedNodes, unselectedNodes);
+
+                SceneGraphSelector::UpdateNodeSelection(m_graph, m_testNodeSelectionList);
+                EXPECT_EQ(3, selectedNodes.size());
+                EXPECT_EQ(2, unselectedNodes.size());
+                EXPECT_STREQ("A.B", selectedNodes[0].c_str());
+                EXPECT_STREQ("A.D", selectedNodes[1].c_str());
+                EXPECT_STREQ("A.D.E", selectedNodes[2].c_str());
+                EXPECT_STREQ("A", unselectedNodes[0].c_str());
+                EXPECT_STREQ("A.C", unselectedNodes[1].c_str());
+            }
+
+            TEST_F(SceneGraphSelectorTest, UpdateNodeSelection_EmptySelectedAndNonemptyUnselectedNodesIncludingRootNode_AllNodesInUnselected)
+            {
+                AZStd::vector<AZStd::string> selectedNodes;
+                AZStd::vector<AZStd::string> unselectedNodes = { "A", "A.B", "A.D" };
+                CreateMeshGroup(selectedNodes, unselectedNodes);
+
+                SceneGraphSelector::UpdateNodeSelection(m_graph, m_testNodeSelectionList);
+                EXPECT_EQ(0, selectedNodes.size());
+                EXPECT_EQ(5, unselectedNodes.size());
+            }
+
+            TEST_F(SceneGraphSelectorTest, UpdateNodeSelection_EmptySelectedAndNonemptyUnselectedNodesExcludingRootNode_AandACFoundInSelectedNodes)
+            {
+                AZStd::vector<AZStd::string> selectedNodes;
+                AZStd::vector<AZStd::string> unselectedNodes = { "A.B", "A.D" };
+                CreateMeshGroup(selectedNodes, unselectedNodes);
+
+                SceneGraphSelector::UpdateNodeSelection(m_graph, m_testNodeSelectionList);
+                EXPECT_EQ(2, selectedNodes.size());
+                EXPECT_EQ(3, unselectedNodes.size());
+                EXPECT_STREQ("A", selectedNodes[0].c_str());
+                EXPECT_STREQ("A.C", selectedNodes[1].c_str());
+                EXPECT_STREQ("A.B", unselectedNodes[0].c_str());
+                EXPECT_STREQ("A.D", unselectedNodes[1].c_str());
+                EXPECT_STREQ("A.D.E", unselectedNodes[2].c_str());
             }
 
             TEST_F(SceneGraphSelectorTest, UpdateNodeSelection_DuplicateEntryRemovedFromSelected_ADotDNotFoundInSelectedNodes)

--- a/Code/Tools/SceneAPI/SceneCore/Utilities/SceneGraphSelector.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Utilities/SceneGraphSelector.cpp
@@ -312,15 +312,27 @@ namespace AZ
             void SceneGraphSelector::CorrectRootNode(const Containers::SceneGraph& graph,
                 AZStd::set<AZStd::string>& selected, AZStd::set<AZStd::string>& unselected)
             {
+                // If both of the unselected and selected node lists are empty or don't exist, deselect all the nodes
+                // in the graph by deselecting the root node.
+                // 
+                // If only the unselected node list is empty or doesn't exist, deselect the root node (which will deselect
+                // all the nodes in the graph) by default and then reselect nodes based on the selected node list.
+                // 
+                // Otherwise select the root node (which will select all the nodes in the graph) by default and then
+                // remove selected nodes based on the deselected list.
+                bool selectRootNode = !unselected.empty();
                 AZStd::string rootNodeName = graph.GetNodeName(graph.GetRoot()).GetPath();
-                if (selected.find(rootNodeName) == selected.end())
+                AZStd::set<AZStd::string>& nodeSetToAdd = selectRootNode ? selected : unselected;
+                AZStd::set<AZStd::string>& nodeSetToRemove = selectRootNode ? unselected : selected;
+
+                if (nodeSetToAdd.find(rootNodeName) == nodeSetToAdd.end())
                 {
-                    selected.insert(rootNodeName);
+                    nodeSetToAdd.insert(rootNodeName);
                 }
-                auto root = unselected.find(rootNodeName);
-                if (root != unselected.end())
+                auto root = nodeSetToRemove.find(rootNodeName);
+                if (root != nodeSetToRemove.end())
                 {
-                    unselected.erase(root);
+                    nodeSetToRemove.erase(root);
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?

This PR changes the behavior for loading selected/unselected node lists from scene settings. It addresses a few existing issues:
- Issue 1: All the nodes are selected by default when the selected node list contains part of all nodes and the unselected node list is missing. 
    - After this change, only the nodes included in the selected node list (and their children) will be selected by default.
- Issue 2: All the nodes are selected by default when both of the selected and unselected node lists are empty (e.g. by default, a new LOD slot will say "All lod meshes selected" even if nothing is selected).
    - After this change, no nodes will be selected by default when add a new LOD.
- Behavior Update: If both of the selected and unselected node lists are empty (or don't exist), all the nodes will be selected by default.
    -  After this change, no nodes will be selected by default under this scenario.

## How was this PR tested?
- All the existing and new unit tests passed
- All the existing python automation tests for FBX and SceneSettings passed
- Removed the selected/unselected node list from scene settings file. FBX could be processed successfully and proper nodes are selected in the Scene Settings UI
- Added a new LOD in the Scene Settings UI, no node is selected by default

**Example 1:**
.assetinfo file:
```
...
{
    "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule",
    "nodeSelectionList": [
        {
            "selectedNodes": [
                "RootNode.RootNode.LOD_Group_1.LOD_1.Alpha_Joints",
                "RootNode.RootNode.LOD_Group_1.LOD_1.Alpha_Surface"
            ]
        }
    ]
}
...
```
SceneSettings:
![image](https://user-images.githubusercontent.com/68558268/211110956-d7faf425-5ace-49a3-9da5-47acb2591789.png)

**Example 2:**
.assetinfo file:
```
...
{
    "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule",
    "nodeSelectionList": [
        {
            "unselectedNodes": [
                "RootNode.RootNode.LOD_Group_1.LOD_1.Alpha_Joints",
                "RootNode.RootNode.LOD_Group_1.LOD_1.Alpha_Surface"
            ]
        }
    ]
}
...
```
SceneSettings:
![image](https://user-images.githubusercontent.com/68558268/211110716-0c9bc757-9bb4-4c50-90b2-27fdfb7bd35a.png)

**Example 3:**
.assetinfo file:
```
...
{
    "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule",
    "nodeSelectionList": [
        {
        }
    ]
}
...
```
SceneSettings:
![image](https://user-images.githubusercontent.com/68558268/211111092-472ed5ec-8a8c-47d6-bf9f-edee51079afe.png)

**Example 4:**
Add new LOD mesh:
![image](https://user-images.githubusercontent.com/68558268/211110626-00dc7c11-18da-4ade-aa95-62e117162294.png)


## Note
This PR doesn't change some of the existing behaviors below:
- There're conflicts in the selected and unselected node lists (i.e. same node appear in both list). The node will be unselected by default in this case
