### PR TITLE
Prefab - Fix cached instance DOM update in undo delete

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.cpp
@@ -121,7 +121,7 @@ namespace AzToolsFramework
                 const AZStd::vector<AZStd::string>& instanceAliasPathList,
                 const AZStd::vector<const AZ::Entity*> parentEntityList,
                 Instance& owningInstance,
-                Instance& focusedInstance,
+                const Instance& focusedInstance,
                 UndoSystem::URSequencePoint* undoBatch)
             {
                 AZ_Assert(&owningInstance != &focusedInstance,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.h
@@ -84,7 +84,7 @@ namespace AzToolsFramework
                 const AZStd::vector<AZStd::string>& instanceAliasPathList,
                 const AZStd::vector<const AZ::Entity*> parentEntityList,
                 Instance& owningInstance,
-                Instance& focusedInstance,
+                const Instance& focusedInstance,
                 UndoSystem::URSequencePoint* undoBatch);
         }
     } // namespace Prefab

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDeleteAsOverride.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDeleteAsOverride.cpp
@@ -27,8 +27,8 @@ namespace AzToolsFramework
             const AZStd::vector<AZStd::string>& entityAliasPathList,
             const AZStd::vector<AZStd::string>& instanceAliasPathList,
             const AZStd::vector<const AZ::Entity*> parentEntityList,
-            const Instance& owningInstance,
-            Instance& focusedInstance)
+            Instance& owningInstance,
+            const Instance& focusedInstance)
         {
             m_templateId = focusedInstance.GetTemplateId();
             m_redoPatch.SetArray();
@@ -36,7 +36,7 @@ namespace AzToolsFramework
 
             PrefabDom& focusedTempalteDom = m_prefabSystemComponentInterface->FindTemplateDom(m_templateId);
 
-            PrefabDomReference cachedOwningInstanceDom = focusedInstance.GetCachedInstanceDom();
+            PrefabDomReference cachedOwningInstanceDom = owningInstance.GetCachedInstanceDom();
 
             // Generates override patch path to owning instance.
             InstanceClimbUpResult climbUpResult = PrefabInstanceUtils::ClimbUpToTargetOrRootInstance(owningInstance, &focusedInstance);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDeleteAsOverride.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDeleteAsOverride.h
@@ -29,8 +29,8 @@ namespace AzToolsFramework
                 const AZStd::vector<AZStd::string>& entityAliasPathList,
                 const AZStd::vector<AZStd::string>& instanceAliasPathList,
                 const AZStd::vector<const AZ::Entity*> parentEntityList,
-                const Instance& owningInstance,
-                Instance& focusedInstance);
+                Instance& owningInstance,
+                const Instance& focusedInstance);
         };
     } // namespace Prefab
 } // namespace AzToolsFramework


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

This PR changes to update cached instance DOM in owning instance rather than the focused instance for deletion overrides.

<img src="https://user-images.githubusercontent.com/11157226/211642223-23bdc8b2-a335-4918-8e85-ab4076f9c582.png" height=200px>

We should update the cached instance DOM that is stored in the owning instance. Otherwise, the Entity 1 container entity would be unnecessarily reloaded due to sort order update.

## How was this PR tested?

Passed all tests.