### PR TITLE
Fix mac/linux compilation errors

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/std/time_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/std/time_UnixLike.cpp
@@ -59,7 +59,7 @@ namespace AZStd
     {
         struct timespec ts;
         errno = 0;
-        int result = clock_gettime(CLOCK_THREAD_CPUTIME_ID , &ts);
+        [[maybe_unused]] int result = clock_gettime(CLOCK_THREAD_CPUTIME_ID , &ts);
 
         AZ_Assert(result != -1, "clock_gettime error using CLOCK_THREAD_CPUTIME_ID: %s\n", strerror(errno));
         return AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(AZStd::chrono::seconds(ts.tv_sec) + AZStd::chrono::nanoseconds(ts.tv_nsec));

--- a/Code/Framework/AzFramework/Tests/FileIO.cpp
+++ b/Code/Framework/AzFramework/Tests/FileIO.cpp
@@ -176,7 +176,7 @@ namespace UnitTest
             void SetUp() override
             {
                 // lets use a random temp folder name
-                srand(clock());
+                srand(static_cast<unsigned int>(clock()));
                 m_randomFolderKey = rand();
 
                 LocalFileIO local;

--- a/Gems/PhysX/Code/Source/HingeJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/HingeJointComponent.cpp
@@ -112,8 +112,7 @@ namespace PhysX
         auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
         AZ_Assert(sceneInterface, "No sceneInterface");
         const auto joint = sceneInterface->GetJointFromHandle(m_jointSceneOwner, m_jointHandle);
-        const auto type = joint->GetNativeType();
-        AZ_Assert(type == PhysX::NativeTypeIdentifiers::HingeJoint, "It is not PhysXHingeJoint");
+        AZ_Assert(joint->GetNativeType() == PhysX::NativeTypeIdentifiers::HingeJoint, "It is not PhysXHingeJoint");
         physx::PxJoint* nativeJoint = static_cast<physx::PxJoint*>(joint->GetNativePointer());
         physx::PxRevoluteJoint* native = nativeJoint->is<physx::PxRevoluteJoint>();
         AZ_Assert(native, "It is not PxRevoluteJoint");


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

Fixes #13697 

Fixed the following compilation errors:

````
/Users/macpro15/o3de/Code/Framework/AzFramework/Tests/FileIO.cpp:179:23: error: implicit conversion loses integer precision: 'clock_t' (aka 'unsigned long') to 'unsigned int' [-Werror,-Wshorten-64-to-32]
                srand(clock());
                ~~~~~ ^~~~~~~
1 error generated.
````

````
/data/workspace/o3de/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/std/time_UnixLike.cpp:62:13: error: unused variable 'result' [-Werror,-Wunused-variable]
        int result = clock_gettime(CLOCK_THREAD_CPUTIME_ID , &ts);
            ^
1 error generated.
````

````
/Users/lybuilder/workspace/o3de/Gems/PhysX/Code/Source/HingeJointComponent.cpp:115:20: error: unused variable 'type' [-Werror,-Wunused-variable]
        const auto type = joint->GetNativeType();
                   ^
1 error generated.
````

