### PR TITLE
Small startup performance improvement for AssetProcessor

### DIFF
--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
@@ -1761,13 +1761,18 @@ namespace AssetProcessor
 
         // first, check for an EXACT match.  If there's an exact match, this must be the one returned!
         // this is to catch the case where the actual path of a scan folder is fed in to this.
+
+        // because exact matches are preferred over less exact, we first check exact matches:
         for (int pathIdx = 0; pathIdx < m_scanFolders.size(); ++pathIdx)
         {
             QString scanFolderName = m_scanFolders[pathIdx].ScanPath();
-            if (normalized.compare(scanFolderName, Qt::CaseInsensitive) == 0)
+            if (scanFolderName.length() == normalized.length())
             {
-                // if its an exact match, we're basically done
-                return &m_scanFolders[pathIdx];
+                if (normalized.compare(scanFolderName, Qt::CaseInsensitive) == 0)
+                {
+                    // if its an exact match, we're basically done
+                    return &m_scanFolders[pathIdx];
+                }
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

This function is one of the very hot-path functions when AP is doing its fast scan.

QStrings cache the length of the string - so we don't need to compare the watch folder unless they're exactly he same length.  This saves about 5 seconds (22 down to 17) in a full run on multiplayer sample.

Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>


## How was this PR tested?

Manual testing.