### PR TITLE
Fix the processing failure for script_reinsert.fbx and bump up the scene builder version

### DIFF
--- a/AutomatedTesting/Assets/ap_test_assets/script_reinsert.py
+++ b/AutomatedTesting/Assets/ap_test_assets/script_reinsert.py
@@ -59,7 +59,7 @@ def on_update_manifest(args):
             {
                 "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
                 "name": "fake",
-                "nodeSelectionList": { "selectedNodes": ["fake_node"] }
+                "nodeSelectionList": { "selectedNodes": ["RootNode"] }
             }
         ]
     }"""

--- a/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderComponent.cpp
+++ b/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderComponent.cpp
@@ -44,7 +44,7 @@ namespace SceneBuilder
         builderDescriptor.m_createJobFunction = AZStd::bind(&SceneBuilderWorker::CreateJobs, &m_sceneBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
         builderDescriptor.m_processJobFunction = AZStd::bind(&SceneBuilderWorker::ProcessJob, &m_sceneBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
 
-        builderDescriptor.m_version = 7; // bump this to rebuild everything.
+        builderDescriptor.m_version = 8; // bump this to rebuild everything.
         builderDescriptor.m_analysisFingerprint = m_sceneBuilder.GetFingerprint(); // bump this to at least re-analyze everything.
 
         m_sceneBuilder.BusConnect(builderDescriptor.m_busId);


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?
AutomatedTesting/Assets/ap_test_assets/script_reinsert.fbx fails to be processed after https://github.com/o3de/o3de/pull/13965 is merged since https://github.com/o3de/o3de/pull/13965 changes how the selected and unselected nodes from the scene settings are parsed. This PR updated the node list to match the previous selection for script_reinsert.fbx. 

This PR also bump up the scene builder version to trigger the reprocess of all the FBX files due to scene settings change.

## How was this PR tested?

Verified that script_reinsert.fbx could be processed successfully. All the other FBX files were reprocessed as well.
