### PR TITLE
Added ScriptCanvas schema for nodeables and updated template

### DIFF
--- a/Gems/ScriptCanvas/Code/CMakeLists.txt
+++ b/Gems/ScriptCanvas/Code/CMakeLists.txt
@@ -6,8 +6,6 @@
 #
 #
 
-add_subdirectory(sc_test)
-
 set(SCRIPT_CANVAS_COMMON_DEFINES 
     SCRIPTCANVAS
     ENABLE_EXTENDED_MATH_SUPPORT=0

--- a/Gems/ScriptCanvas/Code/CMakeLists.txt
+++ b/Gems/ScriptCanvas/Code/CMakeLists.txt
@@ -6,6 +6,8 @@
 #
 #
 
+add_subdirectory(sc_test)
+
 set(SCRIPT_CANVAS_COMMON_DEFINES 
     SCRIPTCANVAS
     ENABLE_EXTENDED_MATH_SUPPORT=0

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable.xsd
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable.xsd
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:element name="ScriptCanvas">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Class">
+					<xs:complexType mixed="true">
+						<xs:sequence>
+							<xs:element maxOccurs="unbounded" minOccurs="0" name="Input">
+								<xs:complexType>
+									<xs:sequence minOccurs="0" maxOccurs="unbounded" >
+										<xs:element maxOccurs="unbounded" name="Parameter">
+											<xs:complexType>
+												<xs:attribute name="Name" type="xs:string" use="required" />
+												<xs:attribute name="Type" type="xs:string" use="required" />
+												<xs:attribute name="DefaultValue" type="xs:string" use="optional" />
+												<xs:attribute name="Description" type="xs:string" use="required" />
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+									<xs:attribute name="Name" type="xs:string" use="required" />
+									<xs:attribute name="Description" type="xs:string" use="required" />
+									<xs:attribute name="OutputName" type="xs:string" use="optional" />
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="Output" minOccurs="0" maxOccurs="unbounded" >
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element minOccurs="0" maxOccurs="unbounded" name="Parameter">
+											<xs:complexType>
+												<xs:attribute name="Name" type="xs:string" use="required" />
+												<xs:attribute name="Type" type="xs:string" use="required" />
+												<xs:attribute name="Description" type="xs:string" use="required" />
+												<xs:attribute name="DefaultValue" type="xs:string" use="optional" />
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+									<xs:attribute name="Name" type="xs:string" use="required" />
+									<xs:attribute name="Description" type="xs:string" use="required" />
+								</xs:complexType>
+							</xs:element>
+							<xs:element maxOccurs="unbounded" minOccurs="0" name="PropertyInterface">
+								<xs:complexType>
+									<xs:attribute name="Name" type="xs:string" use="required" />
+									<xs:attribute name="Description" type="xs:string" use="required" />
+									<xs:attribute name="Property" type="xs:string" use="required" />
+									<xs:attribute name="Type" type="xs:string" use="required" />
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="Name" type="xs:string" use="required" />
+						<xs:attribute name="QualifiedName" type="xs:string" use="required" />
+						<xs:attribute name="PreferredClassName" type="xs:string" use="required" />
+						<xs:attribute name="Uuid" type="xs:string" use="optional" />
+						<xs:attribute name="Category" type="xs:string" use="required" />
+						<xs:attribute name="Namespace" type="xs:string" use="required" />
+						<xs:attribute name="Description" type="xs:string" use="required" />
+						<xs:attribute name="Base" type="xs:string" use="optional" />
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="Include" type="xs:string" use="required" />
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/CreateSpawnTicketNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/CreateSpawnTicketNodeable.ScriptCanvasNodeable.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Spawning/CreateSpawnTicketNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Spawning/CreateSpawnTicketNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			  xsi:noNamespaceSchemaLocation="../../AutoGen/ScriptCanvasNodeable.xsd">
+	
     <Class Name="CreateSpawnTicketNodeable"
         QualifiedName="Nodeables::Spawning::CreateSpawnTicketNodeable"
         PreferredClassName="CreateSpawnTicket"
@@ -13,6 +15,7 @@
             <Parameter Name="Prefab" Type="const AzFramework::Scripts::SpawnableScriptAssetRef&amp;" Description="Prefab source asset to spawn"/>
             <Return Name="SpawnTicket" Type="AzFramework::EntitySpawnTicket" Shared="true"/>
         </Input>
+		
     </Class>
 </ScriptCanvas>
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/DespawnNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/DespawnNodeable.ScriptCanvasNodeable.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Spawning/DespawnNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Spawning/DespawnNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			  xsi:noNamespaceSchemaLocation="../../AutoGen/ScriptCanvasNodeable.xsd">
     <Class Name="DespawnNodeable"
         QualifiedName="Nodeables::Spawning::DespawnNodeable"
         PreferredClassName="Despawn"
@@ -8,7 +9,7 @@
         Namespace="ScriptCanvas"
         Description="Despawns a selected prefab">
 
-        <Input Name="Request Despawn" OutputName="Despawn Requested">
+        <Input Name="Request Despawn" OutputName="Despawn Requested" Description="">
             <Parameter Name="SpawnTicket" Type="AzFramework::EntitySpawnTicket" Description="Ticket instance assosiated with spawnable asset."/>
         </Input>
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/SpawnNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/SpawnNodeable.ScriptCanvasNodeable.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Spawning/SpawnNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Spawning/SpawnNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			  xsi:noNamespaceSchemaLocation="../../AutoGen/ScriptCanvasNodeable.xsd">
     <Class Name="SpawnNodeable"
         QualifiedName="Nodeables::Spawning::SpawnNodeable"
         PreferredClassName="Spawn"
@@ -8,7 +9,7 @@
         Namespace="ScriptCanvas"
         Description="Spawns a selected prefab">
 
-        <Input Name="Request Spawn" OutputName="Spawn Requested">
+        <Input Name="Request Spawn" OutputName="Spawn Requested" Description="">
             <Parameter Name="SpawnTicket" Type="AzFramework::EntitySpawnTicket" Description="Ticket instance assosiated with spawnable asset."/>
             <Parameter Name="ParentId" Type="AZ::EntityId" Description="Optional parent to assign spawned container entity to."/>
             <Parameter Name="Local Translation" Type="Data::Vector3Type" Description="Position to spawn."/>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/DelayNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/DelayNodeable.ScriptCanvasNodeable.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Time/DelayNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Time/DelayNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			  xsi:noNamespaceSchemaLocation="../../AutoGen/ScriptCanvasNodeable.xsd">
     <Class Name="DelayNodeable"
         QualifiedName="ScriptCanvas::Nodeables::Time::DelayNodeable"
         PreferredClassName="Delay"

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/DurationNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/DurationNodeable.ScriptCanvasNodeable.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Time/DurationNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Time/DurationNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			  xsi:noNamespaceSchemaLocation="../../AutoGen/ScriptCanvasNodeable.xsd">
     <Class Name="DurationNodeable"
         QualifiedName="ScriptCanvas::Nodeables::Time::DurationNodeable"
         PreferredClassName="Duration"

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/HeartBeatNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/HeartBeatNodeable.ScriptCanvasNodeable.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Time/HeartBeatNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Time/HeartBeatNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			  xsi:noNamespaceSchemaLocation="../../AutoGen/ScriptCanvasNodeable.xsd">
     <Class Name="HeartBeatNodeable"
         QualifiedName="Nodeables::Time::HeartBeatNodeable"
         PreferredClassName="HeartBeat"
@@ -13,7 +14,7 @@
             <Parameter Name="Interval" Type="Data::NumberType" DefaultValue="0.0" Description="The amount of time between pulses"/>
         </Input>
 
-        <Input Name="Stop"/>
+        <Input Name="Stop" Description=""/>
 
         <Output Name="Pulse" Description="Signaled at each specified interval." />
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/RepeaterNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/RepeaterNodeable.ScriptCanvasNodeable.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Time/RepeaterNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Time/RepeaterNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			  xsi:noNamespaceSchemaLocation="../../AutoGen/ScriptCanvasNodeable.xsd">
     <Class Name="RepeaterNodeable"
         QualifiedName="ScriptCanvas::Nodeables::Core::RepeaterNodeable"
         PreferredClassName="Repeater"

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/TimeDelayNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/TimeDelayNodeable.ScriptCanvasNodeable.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Time/TimeDelayNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Time/TimeDelayNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			  xsi:noNamespaceSchemaLocation="../../AutoGen/ScriptCanvasNodeable.xsd">
     <Class Name="TimeDelayNodeable"
         QualifiedName="Nodeables::Time::TimeDelayNodeable"
         PreferredClassName="Time Delay"

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/TimerNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/TimerNodeable.ScriptCanvasNodeable.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Time/TimerNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Time/TimerNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			  xsi:noNamespaceSchemaLocation="../../AutoGen/ScriptCanvasNodeable.xsd">
     <Class Name="TimerNodeable"
         QualifiedName="Nodeables::Time::TimerNodeable"
         PreferredClassName="Timer"

--- a/Templates/ScriptCanvasNode/Template/${Name}_files.cmake
+++ b/Templates/ScriptCanvasNode/Template/${Name}_files.cmake
@@ -21,4 +21,6 @@ set(FILES
     Include/${Name}.h
     Source/${Name}.ScriptCanvasNodeable.xml
     Source/${Name}.cpp
+
+    Source/AutoGen/ScriptCanvasNodeable.xsd
 )

--- a/Templates/ScriptCanvasNode/Template/Source/${Name}.ScriptCanvasNodeable.xml
+++ b/Templates/ScriptCanvasNode/Template/Source/${Name}.ScriptCanvasNodeable.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<ScriptCanvas Include="${Name}.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<ScriptCanvas Include="${Name}.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+              xsi:noNamespaceSchemaLocation="AutoGen/ScriptCanvasNodeable.xsd">
+
     <Class Name="${SanitizedCppName}"
         QualifiedName="ScriptCanvas::Nodes::${SanitizedCppName}"
         PreferredClassName="${SanitizedCppName}"

--- a/Templates/ScriptCanvasNode/Template/Source/AutoGen/ScriptCanvasNodeable.xsd
+++ b/Templates/ScriptCanvasNode/Template/Source/AutoGen/ScriptCanvasNodeable.xsd
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:element name="ScriptCanvas">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Class">
+					<xs:complexType mixed="true">
+						<xs:sequence>
+							<xs:element maxOccurs="unbounded" minOccurs="0" name="Input">
+								<xs:complexType>
+									<xs:sequence minOccurs="0" maxOccurs="unbounded" >
+										<xs:element maxOccurs="unbounded" name="Parameter">
+											<xs:complexType>
+												<xs:attribute name="Name" type="xs:string" use="required" />
+												<xs:attribute name="Type" type="xs:string" use="required" />
+												<xs:attribute name="DefaultValue" type="xs:string" use="optional" />
+												<xs:attribute name="Description" type="xs:string" use="required" />
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+									<xs:attribute name="Name" type="xs:string" use="required" />
+									<xs:attribute name="Description" type="xs:string" use="required" />
+									<xs:attribute name="OutputName" type="xs:string" use="optional" />
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="Output" minOccurs="0" maxOccurs="unbounded" >
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element minOccurs="0" maxOccurs="unbounded" name="Parameter">
+											<xs:complexType>
+												<xs:attribute name="Name" type="xs:string" use="required" />
+												<xs:attribute name="Type" type="xs:string" use="required" />
+												<xs:attribute name="Description" type="xs:string" use="required" />
+												<xs:attribute name="DefaultValue" type="xs:string" use="optional" />
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+									<xs:attribute name="Name" type="xs:string" use="required" />
+									<xs:attribute name="Description" type="xs:string" use="required" />
+								</xs:complexType>
+							</xs:element>
+							<xs:element maxOccurs="unbounded" minOccurs="0" name="PropertyInterface">
+								<xs:complexType>
+									<xs:attribute name="Name" type="xs:string" use="required" />
+									<xs:attribute name="Description" type="xs:string" use="required" />
+									<xs:attribute name="Property" type="xs:string" use="required" />
+									<xs:attribute name="Type" type="xs:string" use="required" />
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="Name" type="xs:string" use="required" />
+						<xs:attribute name="QualifiedName" type="xs:string" use="required" />
+						<xs:attribute name="PreferredClassName" type="xs:string" use="required" />
+						<xs:attribute name="Uuid" type="xs:string" use="optional" />
+						<xs:attribute name="Category" type="xs:string" use="required" />
+						<xs:attribute name="Namespace" type="xs:string" use="required" />
+						<xs:attribute name="Description" type="xs:string" use="required" />
+						<xs:attribute name="Base" type="xs:string" use="optional" />
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="Include" type="xs:string" use="required" />
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/Templates/ScriptCanvasNode/template.json
+++ b/Templates/ScriptCanvasNode/template.json
@@ -27,6 +27,10 @@
             "isTemplated": true
         },
         {
+            "file": "Source/AutoGen/ScriptCanvasNodeable.xsd",
+            "isTemplated": false
+        },
+        {
             "file": "${Name}_files.cmake",
             "isTemplated": true
         },


### PR DESCRIPTION
Signed-off-by: Luis Sempé <58790905+lsemp3d@users.noreply.github.com>

## What does this PR do?

The .xsd schema provides autocompletion and validation capabilities in Visual Studio when authoring or editing ScriptCanvas nodeable XML files.

Also added the same .xsd for nodeable targets generated from the ScriptCanvasNode template

## How was this PR tested?
Verified that no errors or warnings were emitted in Visual Studio 