### PR TITLE
avoid a crash with texture arrays

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroupData.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroupData.h
@@ -355,6 +355,15 @@ namespace AZ
             }
 
             const TShaderInputDescriptor& shaderInputImage = GetLayout()->GetShaderInput(inputIndex);
+
+            if (!imageView)
+            {
+                AZ_Error("ShaderResourceGroupData", false,
+                    "Image Array Input '%s[%d]' is null.",
+                    shaderInputImage.m_name.GetCStr(), arrayIndex);
+                return false;
+            }
+
             const ImageViewDescriptor& imageViewDescriptor = imageView->GetDescriptor();
             const Image& image = imageView->GetImage();
             const ImageDescriptor& imageDescriptor = image.GetDescriptor();


### PR DESCRIPTION
Signed-off-by: Karl Haubenwallner <karl.haubenwallner@huawei.com>

## What does this PR do?

Fixes a crash during validation when a texture in an array used for SetImageViewUnboundedArray() is a nullptr.

## How was this PR tested?

Windows & Vulkan, using an unbound ImageArray where single views are nullptrs.