### PR TITLE
check if the raytracing pass needs the RayTracingSceneSrg

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
@@ -125,6 +125,9 @@ namespace AZ
             const auto& rayTracingMaterialSrgLayout = m_rayGenerationShader->FindShaderResourceGroupLayout(RayTracingMaterialSrgBindingSlot);
             m_requiresRayTracingMaterialSrg = (rayTracingMaterialSrgLayout != nullptr);
 
+            const auto& rayTracingSceneSrgLayout = m_rayGenerationShader->FindShaderResourceGroupLayout(RayTracingSceneSrgBindingSlot);
+            m_requiresRayTracingSceneSrg = (rayTracingSceneSrgLayout != nullptr);
+
             // build the ray tracing pipeline state descriptor
             RHI::RayTracingPipelineStateDescriptor descriptor;
             descriptor.Build()
@@ -312,11 +315,12 @@ namespace AZ
 
             // bind RayTracingGlobal, RayTracingScene, and View Srgs
             // [GFX TODO][ATOM-15610] Add RenderPass::SetSrgsForRayTracingDispatch
-            AZStd::vector<RHI::ShaderResourceGroup*> shaderResourceGroups =
+            AZStd::vector<RHI::ShaderResourceGroup*> shaderResourceGroups = { m_shaderResourceGroup->GetRHIShaderResourceGroup() };
+
+            if (m_requiresRayTracingSceneSrg)
             {
-                m_shaderResourceGroup->GetRHIShaderResourceGroup(),
-                rayTracingFeatureProcessor->GetRayTracingSceneSrg()->GetRHIShaderResourceGroup()
-            };
+                shaderResourceGroups.push_back(rayTracingFeatureProcessor->GetRayTracingSceneSrg()->GetRHIShaderResourceGroup());
+            }
 
             if (m_requiresViewSrg)
             {

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.h
@@ -74,6 +74,7 @@ namespace AZ
             bool m_requiresViewSrg = false;
             bool m_requiresSceneSrg = false;
             bool m_requiresRayTracingMaterialSrg = false;
+            bool m_requiresRayTracingSceneSrg = false;
         };
     }   // namespace RPI
 }   // namespace AZ


### PR DESCRIPTION
Signed-off-by: Karl Haubenwallner <karl.haubenwallner@huawei.com>

## What does this PR do?

Adds a check if the RayGeneration - Shader actually needs the RayTracingSceneSrg, instead of always providing it unchecked.

## How was this PR tested?

Windows & Vulkan, with a Fullscreen Raytracing pass that uses an entirely custom TLAS/BLAS to trace against
