### PR TITLE
add GetMeshScene() to the MeshFeatureProcessorInterface

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
@@ -216,6 +216,7 @@ namespace AZ
             bool GetRayTracingEnabled(const MeshHandle& meshHandle) const override;
             void SetVisible(const MeshHandle& meshHandle, bool visible) override;
             bool GetVisible(const MeshHandle& meshHandle) const override;
+            RPI::Scene* GetMeshScene(const MeshHandle& meshHandle) const override;
             void SetUseForwardPassIblSpecular(const MeshHandle& meshHandle, bool useForwardPassIblSpecular) override;
 
             RHI::Ptr <FlagRegistry> GetShaderOptionFlagRegistry();

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
@@ -133,6 +133,9 @@ namespace AZ
             //! Returns the visibility state of the mesh.
             //! This only refers to whether or not the mesh has been explicitly hidden, and is not related to view frustum visibility.
             virtual bool GetVisible(const MeshHandle& meshHandle) const = 0;
+            //! Returns the scene of the MeshHandle. It's possible this is a different scene than the Parent-Scene of the
+            //! MeshFeatureProcessor.
+            virtual RPI::Scene* GetMeshScene(const MeshHandle& meshHandle) const = 0;
             //! Sets the mesh to render IBL specular in the forward pass.
             virtual void SetUseForwardPassIblSpecular(const MeshHandle& meshHandle, bool useForwardPassIblSpecular) = 0;
         };

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -655,6 +655,15 @@ namespace AZ
             }
         }
 
+        RPI::Scene* MeshFeatureProcessor::GetMeshScene(const MeshHandle& meshHandle) const
+        {
+            if (meshHandle.IsValid())
+            {
+                return meshHandle->m_scene;
+            }
+            return nullptr;
+        }
+
         void MeshFeatureProcessor::SetUseForwardPassIblSpecular(const MeshHandle& meshHandle, bool useForwardPassIblSpecular)
         {
             if (meshHandle.IsValid())


### PR DESCRIPTION
Signed-off-by: Karl Haubenwallner <karl.haubenwallner@huawei.com>

## What does this PR do?

Adds the interface-function `GetMeshScene()` to the MeshFeatureProcessorInterface, to get access to the `RPI::Scene` of a `MeshHandle`.

This is somewhat of a workaround when broadcasting `MeshHandleStateRequestBus::Events::GetMeshHandle()`, since that Ebus does not offer a way to limit which mesh-handles are returned, which means you will also get mesh-handles from the Preview-Scene, created and stored by a different MeshFeatureProcessor.

## How was this PR tested?

Windows & Vulkan. Explicitly collecting all mesh-handles in a component and sorting out mesh-handles from the Preview-Scene.