### PR TITLE
Fix Mac warnings as errors

### DIFF
--- a/Code/Framework/AzCore/Tests/AZStd/Bitset.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Bitset.cpp
@@ -24,7 +24,7 @@ namespace UnitTest
     protected:
         void SetUp() override
         {
-            m_unsignedLong = GetParam();
+            m_unsignedLong = static_cast<AZ::u32>(GetParam());
             m_bitset = AZStd::bitset<32>(m_unsignedLong);
         }
 

--- a/Code/Framework/AzCore/Tests/JSON.cpp
+++ b/Code/Framework/AzCore/Tests/JSON.cpp
@@ -121,7 +121,7 @@ namespace UnitTest
                 char lbuffer[10];
                 int len = azsnprintf(lbuffer, AZ_ARRAY_SIZE(lbuffer), "%s %s", "Milo", "Yip");  // synthetic example of dynamically created string.
 
-                author.SetString(lbuffer, static_cast<size_t>(len), document.GetAllocator());
+                author.SetString(lbuffer, static_cast<rapidjson_ly::SizeType>(len), document.GetAllocator());
                 // Shorter but slower version:
                 // document["hello"].SetString(buffer, document.GetAllocator());
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h
@@ -40,7 +40,9 @@
 
 #include <ostream>
 
-AZ_PUSH_DISABLE_WARNING(4127, "-Wunknown-warning-option") // warning suppressed: constant used in conditional expression
+// MSVC: warning suppressed: constant used in conditional expression
+// CLANG: warning suppressed: implicit conversion loses integer precision
+AZ_PUSH_DISABLE_WARNING(4127, "-Wshorten-64-to-32")
 #include <QtTest/QtTest>
 AZ_POP_DISABLE_WARNING
 

--- a/Code/Tools/AssetProcessor/native/unittests/FileWatcherUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/FileWatcherUnitTests.cpp
@@ -300,10 +300,10 @@ namespace FileWatcherTests
         {
             QString filename = QDir(m_assetRootPath).absoluteFilePath(QString("test%1.tif").arg(fileIndex));
             filename = QDir::toNativeSeparators(filename);
-            EXPECT_STREQ(m_filesAdded[fileIndex].toUtf8().constData(), filename.toUtf8().constData());
+            EXPECT_STREQ(m_filesAdded[static_cast<unsigned int>(fileIndex)].toUtf8().constData(), filename.toUtf8().constData());
             // there may be more modifications than expected but we should at least see each one, once.
             EXPECT_TRUE(m_filesModified.contains(filename));
-            EXPECT_STREQ(m_filesRemoved[fileIndex].toUtf8().constData(), filename.toUtf8().constData());
+            EXPECT_STREQ(m_filesRemoved[static_cast<unsigned int>(fileIndex)].toUtf8().constData(), filename.toUtf8().constData());
         }
     }
 

--- a/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomation/EditorAutomationActions/EditorKeyActions.cpp
+++ b/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomation/EditorAutomationActions/EditorKeyActions.cpp
@@ -6,6 +6,8 @@
  *
  */
 
+#include <AzCore/PlatformIncl.h>
+
 #include <QApplication>
 #include <QKeyEvent>
 #include <QWidget>

--- a/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomation/EditorAutomationActions/EditorKeyActions.cpp
+++ b/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomation/EditorAutomationActions/EditorKeyActions.cpp
@@ -8,8 +8,13 @@
 
 #include <QApplication>
 #include <QKeyEvent>
-#include <QtTest/qtest.h>
 #include <QWidget>
+
+// MSVC: warning suppressed: constant used in conditional expression
+// CLANG: warning suppressed: implicit conversion loses integer precision
+AZ_PUSH_DISABLE_WARNING(4127, "-Wshorten-64-to-32")
+#include <QtTest/qtest.h>
+AZ_POP_DISABLE_WARNING
 
 #include <ScriptCanvasDeveloperEditor/EditorAutomation/EditorAutomationActions/EditorKeyActions.h>
 

--- a/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomation/EditorAutomationActions/EditorMouseActions.cpp
+++ b/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomation/EditorAutomationActions/EditorMouseActions.cpp
@@ -12,8 +12,13 @@
 #include <QCursor>
 #include <QMainWindow>
 #include <QMouseEvent>
-#include <QtTest/qtest.h>
 #include <QWidget>
+
+// MSVC: warning suppressed: constant used in conditional expression
+// CLANG: warning suppressed: implicit conversion loses integer precision
+AZ_PUSH_DISABLE_WARNING(4127, "-Wshorten-64-to-32")
+#include <QtTest/qtest.h>
+AZ_POP_DISABLE_WARNING
 
 #include <ScriptCanvasDeveloperEditor/EditorAutomation/EditorAutomationActions/EditorMouseActions.h>
 


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

Fixes #13697

Fixes for the following compilation errors:

````
/Users/macpro/Desktop/build/o3de/Code/Framework/AzCore/Tests/AZStd/Bitset.cpp:27:30: error: implicit conversion loses integer precision: 'const testing::WithParamInterface<unsigned long>::ParamType' (aka 'const unsigned long') to 'AZ::u32' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]
            m_unsignedLong = GetParam();
                           ~ ^~~~~~~~~~
1 error generated.
````

````
/Users/moraaar/Amazon/o3de/Code/Framework/AzCore/Tests/JSON.cpp:124:43: error: implicit conversion loses integer precision: 'size_t'
      (aka 'unsigned long') to 'rapidjson_ly::SizeType' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]
                author.SetString(lbuffer, static_cast<size_t>(len), document.GetAllocator());
                       ~~~~~~~~~          ^~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
````

````
In file included from /Users/moraaar/Amazon/o3de/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h:46:
In file included from /Users/moraaar/.o3de/3rdParty/packages/qt-5.15.2-rev8-mac/qt/lib/QtTest.framework/Headers/QtTest:11:
/Users/moraaar/.o3de/3rdParty/packages/qt-5.15.2-rev8-mac/qt/lib/QtTest.framework/Headers/qtest.h:100:34: error: implicit conversion
      loses integer precision: 'qsizetype' (aka 'long long') to 'int' [-Werror,-Wshorten-64-to-32]
        str[i] = "01"[ba.testBit(i)];
                         ~~~~~~~ ^
````

````
In file included from /Users/moraaar/Amazon/o3de/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomation/EditorAutomationActions/EditorKeyActions.cpp:11:
In file included from /Users/moraaar/Amazon/o3de/AutomatedTesting/build/mac/bin/profile/QtTest.framework/Headers/qtest.h:449:
In file included from /Users/moraaar/Amazon/o3de/AutomatedTesting/build/mac/bin/profile/QtTest.framework/Headers/qtestsystem.h:45:
/Users/moraaar/Amazon/o3de/AutomatedTesting/build/mac/bin/profile/QtCore.framework/Headers/qtestsupport_core.h:79:30: error: implicit
      conversion loses integer precision: 'qint64' (aka 'long long') to 'int' [-Werror,-Wshorten-64-to-32]
        remaining = deadline.remainingTime();
                  ~ ~~~~~~~~~^~~~~~~~~~~~~~~
````

````
/Users/moraaar/Amazon/o3de/Code/Tools/AssetProcessor/native/unittests/FileWatcherUnitTests.cpp:303:39: error: implicit conversion
      loses integer precision: 'unsigned long' to 'int' [-Werror,-Wshorten-64-to-32]
            EXPECT_STREQ(m_filesAdded[fileIndex].toUtf8().constData(), filename.toUtf8().constData());
                         ~~~~~~~~~~~~ ^~~~~~~~~
````

## How was this PR tested?

Built Mac ALL_BUILD target.
