### PR TITLE
GHI-13115 Atom: Editor can crash on startup in ShaderResourceGroupLayout.cpp

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
@@ -123,6 +123,16 @@ namespace AZ
             settingsRegistry->GetObject(m_rpiDescriptor, settingPath);
 
             m_rpiSystem.Initialize(m_rpiDescriptor);
+
+            // Part of RPI system initialization requires asset system to be ready
+            // which happens after the game system started
+            // Use the tick bus to delay this initialization
+            AZ::TickBus::QueueFunction(
+                [this]()
+                {
+                    m_rpiSystem.InitializeSystemAssets();
+                });
+
             AZ::SystemTickBus::Handler::BusConnect();
             AZ::RHI::RHISystemNotificationBus::Handler::BusConnect();
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -379,7 +379,6 @@ namespace AZ
         {
             if (m_systemAssetsInitialized)
             {
-                AZ_Warning("RPISystem", false , "InitializeSystemAssets should only be called once'");
                 return;
             }
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererSystemComponent.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererSystemComponent.cpp
@@ -36,6 +36,11 @@ namespace AtomToolsFramework
     {
         provided.push_back(AZ_CRC_CE("PreviewRendererSystem"));
     }
+    
+    void PreviewRendererSystemComponent::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)
+    {
+        dependent.push_back(AZ_CRC("RPISystem", 0xf2add773));
+    }
 
     void PreviewRendererSystemComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
     {

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererSystemComponent.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererSystemComponent.cpp
@@ -39,7 +39,7 @@ namespace AtomToolsFramework
     
     void PreviewRendererSystemComponent::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)
     {
-        dependent.push_back(AZ_CRC("RPISystem", 0xf2add773));
+        dependent.push_back(AZ_CRC_CE("RPISystem"));
     }
 
     void PreviewRendererSystemComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererSystemComponent.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererSystemComponent.h
@@ -28,6 +28,7 @@ namespace AtomToolsFramework
 
         static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
         static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
 
     protected:
         // AZ::Component interface overrides...


### PR DESCRIPTION
## What does this PR do?

Changes include:
- Move RPISystem::InitializeSystemAssets to after all system components are activated.
- Add initialize dependency of RPISystem to PrevewRendererSystemComponent.
- Move BootstrapSystemComponent's initalize function to after all system components are activated. 
 
The RPISystem initialization with assets was relying on "CriticalAssetsCompiled" event. If by any chance the event wasn't triggered, it may lead to the crash in the RHI. The changes in this commit remove that dependency. Instead, it adds the initialization all system components are activated and when the AZ::TickBus::ExecuteQueuedEvents() is called.

https://github.com/o3de/o3de/issues/13115
https://github.com/o3de/o3de/issues/6139

## How was this PR tested?
Tested with Editor (AutomatedTesting); AutomatedTesting.GameLauncher; ASV standalone; Material Editor
