### PR TITLE
Allow adjusting scan folder priority for project-relative Gems

### DIFF
--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.h
@@ -247,7 +247,7 @@ namespace AZ
         //! Register a post-merge hahndler with the PostMergeEvent.
         //! The handler will be called after a file is merged.
         //! @param handler The handler to register with the PostmergeEVent.
-        virtual void RegisterPostMergeEvent(PostMergeEventHandler& hanlder) = 0;
+        virtual void RegisterPostMergeEvent(PostMergeEventHandler& handler) = 0;
 
         //! Gets the boolean value at the provided path.
         //! @param result The target to write the result to.
@@ -278,7 +278,7 @@ namespace AZ
         //! @param resultTypeId The type id of the target that's being written to.
         //! @param path The path to the value.
         //! @return Whether or not the value was stored. An invalid path will return false;
-        virtual bool GetObject(void* result, AZ::Uuid resultTypeID, AZStd::string_view path) const = 0;
+        virtual bool GetObject(void* result, AZ::Uuid resultTypeId, AZStd::string_view path) const = 0;
         //! Gets the json object value at the provided path serialized to the target struct/class. Classes retrieved
         //! through this call needs to be registered with the Serialize Context.
         //! @param result The target to write the result to.
@@ -322,13 +322,13 @@ namespace AZ
         //! @param value The new value to store.
         //! @param valueTypeId The type id of the target that's being stored.
         //! @return Whether or not the value was stored. An invalid path will return false;
-        virtual bool SetObject(AZStd::string_view path, const void* value, AZ::Uuid valueTypeID) = 0;
-        template<typename T>
+        virtual bool SetObject(AZStd::string_view path, const void* value, AZ::Uuid valueTypeId) = 0;
         //! Sets the value at the provided path to the serialized version of the provided struct/class.
         //! Classes used for this call need to be registered with the Serialize Context.
         //! @param path The path to the value.
         //! @param value The new value to store.
         //! @return Whether or not the value was stored. An invalid path will return false;
+        template<typename T>
         bool SetObject(AZStd::string_view path, const T& value) { return SetObject(path, &value, azrtti_typeid(value)); }
 
         //! Remove the value at the provided path 

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
@@ -1611,7 +1611,7 @@ namespace AssetProcessor
         auto* fileStateInterface = AZ::Interface<AssetProcessor::IFileStateRequests>::Get();
 
         // Only compute the intermediate assets folder path if we are going to search for and skip it.
-       
+
         if (skipIntermediateScanFolder)
         {
             if (m_intermediateAssetScanFolderId == -1)
@@ -1619,13 +1619,13 @@ namespace AssetProcessor
                 CacheIntermediateAssetsScanFolderId();
             }
         }
-        
+
         QString absolutePath; // avoid allocating memory repeatedly here by reusing absolutePath each scan folder.
         absolutePath.reserve(AZ_MAX_PATH_LEN);
 
         QFileInfo details(relativeName); // note that this does not actually hit the actual storage medium until you query something
         bool isAbsolute = details.isAbsolute(); // note that this looks at the file name string only, it does not hit storage.
-        
+
         for (int pathIdx = 0; pathIdx < m_scanFolders.size(); ++pathIdx)
         {
             const AssetProcessor::ScanFolderInfo& scanFolderInfo = m_scanFolders[pathIdx];
@@ -1879,16 +1879,11 @@ namespace AssetProcessor
 
     void PlatformConfiguration::AddGemScanFolders(const AZStd::vector<AzFramework::GemInfo>& gemInfoList)
     {
-        // Determine if a Gem is from the project.
-        // Cross-check gem paths against visited project gem paths.
-        // If the gem is project-relative, make adjustments to it's priority order.
-        // Registry Settings:
+        // Determine if a Gem is relative to the project. Cross-check gem paths against visited project gem paths.
+        // If the gem is project-relative, make adjustments to it's priority order based on registry settings:
         // /Amazon/AssetProcessor/Settings/GemScanFolderStartingPriorityOrder
-        //      The starting gem priority order
         // /Amazon/AssetProcessor/Settings/ProjectRelativeGemsScanFolderPriority
-        //      "none" - any project Gem scan folder priority will be incremented from the "GemScanFolderStartingPriorityOrder" value.
-        //      "lower" - each project Gem scan folder will be set to lower priority (higher numeric value) than the project scan folder.
-        //      "higher" - each project Gem scan folder will be set to higher priority (lower numeric value) than the project scan folder.
+        // See <o3de-root>/Registry/AssetProcessorPlatformConfig.setreg for more information.
 
         AZ::s64 gemStartingOrder = 100;
         AZStd::string projectGemPrioritySetting{};

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
@@ -1879,16 +1879,14 @@ namespace AssetProcessor
 
     void PlatformConfiguration::AddGemScanFolders(const AZStd::vector<AzFramework::GemInfo>& gemInfoList)
     {
-        // Default order should be:
-        // Project Gems > Project > Engine and External Gems
-        // Query the Project/Assets scan order.
         // Determine if a Gem is from the project.
-        // Cross-check gem name against the gemInfo name.
+        // Cross-check gem paths against visited project gem paths.
+        // If the gem is project-relative, make adjustments to it's priority order.
         // Registry Settings:
-        // /Amazon/AssetProcessor/Settings/GemScanFolderPriorityStart
-        //      The starting gem order
-        // /Amazon/AssetProcessor/Settings/ProjectGemsRelativeScanFolderPriority
-        //      "none" - any project Gem scan folder priority will be incremented from the "GemScanFolderPriorityStart" value.
+        // /Amazon/AssetProcessor/Settings/GemScanFolderStartingPriorityOrder
+        //      The starting gem priority order
+        // /Amazon/AssetProcessor/Settings/ProjectRelativeGemsScanFolderPriority
+        //      "none" - any project Gem scan folder priority will be incremented from the "GemScanFolderStartingPriorityOrder" value.
         //      "lower" - each project Gem scan folder will be set to lower priority (higher numeric value) than the project scan folder.
         //      "higher" - each project Gem scan folder will be set to higher priority (lower numeric value) than the project scan folder.
 
@@ -1903,10 +1901,10 @@ namespace AssetProcessor
         if (settingsRegistry != nullptr)
         {
             settingsRegistry->Get(gemStartingOrder,
-                AZ::SettingsRegistryInterface::FixedValueString(AssetProcessorSettingsKey) + "/GemScanFolderPriorityStart");
+                AZ::SettingsRegistryInterface::FixedValueString(AssetProcessorSettingsKey) + "/GemScanFolderStartingPriorityOrder");
 
             settingsRegistry->Get(projectGemPrioritySetting,
-                AZ::SettingsRegistryInterface::FixedValueString(AssetProcessorSettingsKey) + "/ProjectGemsRelativeScanFolderPriority");
+                AZ::SettingsRegistryInterface::FixedValueString(AssetProcessorSettingsKey) + "/ProjectRelativeGemsScanFolderPriority");
             AZStd::to_lower(projectGemPrioritySetting.begin(), projectGemPrioritySetting.end());
 
             auto projectGemCallback = [&projectGemPaths]([[maybe_unused]] AZStd::string_view manifestObjectKey,

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
@@ -1872,7 +1872,7 @@ namespace AssetProcessor
 
     void PlatformConfiguration::AddGemScanFolders(const AZStd::vector<AzFramework::GemInfo>& gemInfoList)
     {
-        // If the gem is project-relative, make adjustments to it's priority order based on registry settings:
+        // If the gem is project-relative, make adjustments to its priority order based on registry settings:
         // /Amazon/AssetProcessor/Settings/GemScanFolderStartingPriorityOrder
         // /Amazon/AssetProcessor/Settings/ProjectRelativeGemsScanFolderPriority
         // See <o3de-root>/Registry/AssetProcessorPlatformConfig.setreg for more information.

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
@@ -21,11 +21,6 @@
 
 #include <AzCore/Serialization/SerializeContext.h>
 
-namespace
-{
-    // the starting order in the file for gems.
-    const int g_gemStartingOrder = 100;
-}
 
 namespace AssetProcessor
 {

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.h
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.h
@@ -196,7 +196,8 @@ namespace AssetProcessor
 
         //! Retrieve the scan folder at a given index.
         const AssetProcessor::ScanFolderInfo& GetScanFolderAt(int index) const;
-
+        //! Retrieve the scan folder found by a boolean predicate function, when the predicate returns true, the current scan folder info is returned.
+        const AssetProcessor::ScanFolderInfo* FindScanFolder(AZStd::function<bool(const AssetProcessor::ScanFolderInfo&)> predicate) const;
         const AssetProcessor::ScanFolderInfo* GetScanFolderById(AZ::s64 id) const override;
 
         //!  Manually add a scan folder.  Also used for testing.
@@ -262,11 +263,11 @@ namespace AssetProcessor
         //! c:/dev/engine/models/box01.mdl
         //! ----> [models/box01.mdl] found under[c:/dev/engine]
         //! note that this does return a database source path by default
-        bool ConvertToRelativePath(QString fullFileName, QString& databaseSourceName, QString& scanFolderName) const;
+        bool ConvertToRelativePath(QString fullFileName, QString& databaseSourceName, QString& scanFolderName) const override;
         static bool ConvertToRelativePath(const QString& fullFileName, const ScanFolderInfo* scanFolderInfo, QString& databaseSourceName);
 
         //! given a full file name (assumed already fed through the normalization funciton), return the first matching scan folder
-        const AssetProcessor::ScanFolderInfo* GetScanFolderForFile(const QString& fullFileName) const;
+        const AssetProcessor::ScanFolderInfo* GetScanFolderForFile(const QString& fullFileName) const override;
 
         //! Given a scan folder path, get its complete info
         const AssetProcessor::ScanFolderInfo* GetScanFolderByPath(const QString& scanFolderPath) const;
@@ -316,6 +317,8 @@ namespace AssetProcessor
         void ReadEnabledPlatformsFromSettingsRegistry();
         bool ReadRecognizersFromSettingsRegistry(const QString& assetRoot, bool skipScanFolders = false, QStringList scanFolderPatterns = QStringList() );
         void ReadMetaDataFromSettingsRegistry();
+
+        int GetProjectScanFolderOrder() const;
 
     private:
         AZStd::vector<AssetBuilderSDK::PlatformInfo> m_enabledPlatforms;

--- a/Registry/AssetProcessorPlatformConfig.setreg
+++ b/Registry/AssetProcessorPlatformConfig.setreg
@@ -154,8 +154,9 @@
                     "order": 40000
                 },
 
-                // Configurable starting prioirity for all Gem scan folders to use.
+                // Configurable starting priority for all Gem scan folders to use.
                 // Each Gem scan folder added will increment this.
+                // NOTE: Each successive gem priority will be lower than the last.
                 "GemScanFolderStartingPriorityOrder": 100,
 
                 // Control how project-relative Gem scan folders are prioritized against the project's main scan folder (key: "Project/Assets", alias: @PROJECTROOT@).

--- a/Registry/AssetProcessorPlatformConfig.setreg
+++ b/Registry/AssetProcessorPlatformConfig.setreg
@@ -156,13 +156,13 @@
 
                 // Configurable starting prioirity for all Gem scan folders to use.
                 // Each Gem scan folder added will increment this.
-                "GemScanFolderPriorityStart": 100,
+                "GemScanFolderStartingPriorityOrder": 100,
 
                 // Control how project-relative Gem scan folders are prioritized against the project's main scan folder (key: "Project/Assets", alias: @PROJECTROOT@).
-                //  "none" - any project Gem scan folder priority will be incremented from the "GemScanFolderPriorityStart" value (default behavior).
+                //  "none" - any project Gem scan folder priority will be incremented from the "GemScanFolderStartingPriorityOrder" value (default behavior).
                 //  "lower" - each project Gem scan folder will be set to lower priority (higher numeric value) than the project scan folder.
                 //  "higher" - each project Gem scan folder will be set to higher priority (lower numeric value) than the project scan folder.
-                "ProjectGemsRelativeScanFolderPriority": "none",
+                "ProjectRelativeGemsScanFolderPriority": "none",
 
                 // Excludes files that match the pattern or glob.
                 // the input string will be the relative path from the scan folder the file was found in.

--- a/Registry/AssetProcessorPlatformConfig.setreg
+++ b/Registry/AssetProcessorPlatformConfig.setreg
@@ -1,5 +1,5 @@
 {
-    // ---- Enable/Disable platforms for the entire project. AssetProcessor will automatically add the current platform by default. 
+    // ---- Enable/Disable platforms for the entire project. AssetProcessor will automatically add the current platform by default.
 
     // PLATFORM DEFINITIONS
     // [Platform (unique identifier)]
@@ -53,7 +53,7 @@
                 "Platform mac": {
                     "tags": "tools,renderer,metal,null"
                 },
-                // this is an example of a headless platform that has no renderer.   
+                // this is an example of a headless platform that has no renderer.
                 // To use this you would still need to make sure 'assetplatform' in your startup params in your main() chooses this 'server' platform as your server 'assets' flavor
                 "Platform server": {
                     "tags": "server,dx12,vulkan"
@@ -89,7 +89,7 @@
                 // however if your metafile REPLACES the extension (for example, if you have the file blah.i_caf and its metafile is blah.exportsettings)
                 // then you specify the original extension here to narrow the scope.
                 // If a relative path to a specific file is provided instead of an extension, a change to the file will change all files
-                // with the associated extension (e.g. Animations/SkeletonList.xml=i_caf will cause all i_caf files to recompile when 
+                // with the associated extension (e.g. Animations/SkeletonList.xml=i_caf will cause all i_caf files to recompile when
                 // Animations/SkeletonList.xml within the current game project changes)
 
                 "MetaDataTypes": {
@@ -104,21 +104,21 @@
                 },
 
                 // ---- add any folders to scan here.  The priority order is the order they appear here
-                // available macros are 
+                // available macros are
                 // @ROOT@ - the location of asset root
-                // @PROJECTROOT@ - the location of the project root, for example 'Q:\MyProjects\RPGSample' 
+                // @PROJECTROOT@ - the location of the project root, for example 'Q:\MyProjects\RPGSample'
                 // note that they are sorted by their 'order' value, and the lower the order the more important an asset is
                 // lower order numbers override higher ones.
                 // If specified, output will be prepended to every path found in that recognizer's watch folder.
                 // Note that you can also make the scan folder platform specific by using the keywords include and exclude.
                 // Both include and exclude can contain either platform tags, platform identifiers or both.
                 // if no include is specified, all currently enabled platforms are included by default.
-                // If includes ARE specified, it will be filtered down by the list of currently enabled platforms. 
+                // If includes ARE specified, it will be filtered down by the list of currently enabled platforms.
                 // "ScanFolder (unique identifier)": {
                 //  "include": "(comma seperated platform tags or identifiers)",
                 //  "exclude": "(comma seperated platform tags or identifiers)"
                 // }
-                // For example if you want to include a scan folder only for platforms that have the platform tags tools and renderer 
+                // For example if you want to include a scan folder only for platforms that have the platform tags tools and renderer
                 // but omit it for platform mac, you will have a scanfolder rule like
                 // "ScanFolder (unique identifier)": {
                 // "watch": "@ROOT@/foo",
@@ -132,7 +132,6 @@
                     "recursive": 1,
                     "order": 0
                 },
-                // gems will be auto-added from 100 onwards
                 "ScanFolder Root": {
                     "watch": "@ROOT@",
                     "recursive": 0,
@@ -154,6 +153,16 @@
                     "recursive": 1,
                     "order": 40000
                 },
+
+                // Configurable starting prioirity for all Gem scan folders to use.
+                // Each Gem scan folder added will increment this.
+                "GemScanFolderPriorityStart": 100,
+
+                // Control how project-relative Gem scan folders are prioritized against the project's main scan folder (key: "Project/Assets", alias: @PROJECTROOT@).
+                //  "none" - any project Gem scan folder priority will be incremented from the "GemScanFolderPriorityStart" value (default behavior).
+                //  "lower" - each project Gem scan folder will be set to lower priority (higher numeric value) than the project scan folder.
+                //  "higher" - each project Gem scan folder will be set to higher priority (lower numeric value) than the project scan folder.
+                "ProjectGemsRelativeScanFolderPriority": "none",
 
                 // Excludes files that match the pattern or glob.
                 // the input string will be the relative path from the scan folder the file was found in.
@@ -239,14 +248,14 @@
                 // so ensure start your patterns with .* or as appropriate.
                 // Also, any rules which match will apply - so if you have two rules which both apply to PNG files for example
                 // but you only want one, you might want to use exclusion patterns:
-                 
+
                 //Example: copy everything EXCEPT the ones in the libs/ui
                 // "RC png-normal": {
                 //  "pattern": "(?!.*libs\\\\/ui\\\\/).*\\.png",
                 //  "params": "copy"
                 //}
 
-                //Example:  Process everything in the libs/ui folder 
+                //Example:  Process everything in the libs/ui folder
                 // "RC png-ui": {
                 //  "pattern": "(.*libs\\\\/ui\\\\/).*\\.png",
                 //  "params": "copy"


### PR DESCRIPTION
## What does this PR do?

It may be desirable to have the scan folders of any project-relative Gems (Gems that reside within the project folder) be prioritized before the main Project scan folder.  By default, the project scan folder is priority 0, and all Gem scan folders start incrementing from starting value of 100, so Gem scan folders are always at a lower priority than the project.

This introduces two settings registry keys that can be used to tweak relative priorities:
`"/Amazon/AssetProcessor/Settings/GemScanFolderStartingPriorityOrder": 100`
This setting will define the starting priority order for all Gems.  The first Gem scan folder will be assigned 101 and increase value from there.

`"/Amazon/AssetProcessor/Settings/ProjectRelativeGemsScanFolderPriority": "none"`
This setting determines how you want project-relative Gem scan folders to be prioritized against the main project scan folder.
`"none"` (default): This means don't do anything special.  All project-relative Gem scan folders will be assigned priority order using the 'running value' that starts at the value defined in the above setting.
`"lower"`: All project-relative Gem scan folders will have a priority that is lower than the project.  Users could configure the priority order of the project's main scan folder to be lower than all Gems, but having a setting of "lower" here would force project-relative Gem scan folders to be lower than the project.
`"higher"`: All project-relative Gem scan folders will have a priority that is higher than the project.  Again, by default Gems have lower priority than the project, but having a setting of "higher" here would force project-relative Gem scan folders to be higher than the project.

fixes #8480 

## How was this PR tested?

Followed instructions from the GHI.  Was able to tweak relative priorities and get the assets in project-relative Gems to scan and be picked up.  More testing ongoing.
