### PR TITLE
Fix RELEASE build issues introduced by Client/Server split

### DIFF
--- a/AutomatedTesting/Gem/Code/CMakeLists.txt
+++ b/AutomatedTesting/Gem/Code/CMakeLists.txt
@@ -41,6 +41,8 @@ ly_create_alias(NAME AutomatedTesting.Builders NAMESPACE Gem TARGETS Gem::Automa
 ly_create_alias(NAME AutomatedTesting.Tools    NAMESPACE Gem TARGETS Gem::AutomatedTesting)
 ly_create_alias(NAME AutomatedTesting.Clients  NAMESPACE Gem TARGETS Gem::AutomatedTesting)
 ly_create_alias(NAME AutomatedTesting.Servers  NAMESPACE Gem TARGETS Gem::AutomatedTesting)
+ly_create_alias(NAME AutomatedTesting.Unified  NAMESPACE Gem TARGETS Gem::AutomatedTesting)
+
 
 ################################################################################
 # Gem dependencies

--- a/Gems/Multiplayer/Code/CMakeLists.txt
+++ b/Gems/Multiplayer/Code/CMakeLists.txt
@@ -189,7 +189,7 @@ ly_add_target(
 )
 
 ly_add_target(
-    NAME Multiplayer.Debug ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
+    NAME Multiplayer.Debug.Client ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
     NAMESPACE Gem
     FILES_CMAKE
         multiplayer_debug_files.cmake
@@ -210,8 +210,30 @@ ly_add_target(
             Gem::ImGui.Static
 )
 
+ly_add_target(
+    NAME Multiplayer.Debug ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
+    NAMESPACE Gem
+    FILES_CMAKE
+        multiplayer_debug_files.cmake
+    INCLUDE_DIRECTORIES
+        PRIVATE
+            Source
+            .
+        PUBLIC
+            Include
+    BUILD_DEPENDENCIES
+        PRIVATE
+            AZ::AzCore
+            AZ::AtomCore
+            AZ::AzFramework
+            AZ::AzNetworking
+            Gem::Atom_Feature_Common.Static
+            Gem::Multiplayer.Unified.Static
+            Gem::ImGui.Static
+)
+
 # The "Multiplayer" target is used by clients and servers, Debug is used only on clients.
-ly_create_alias(NAME Multiplayer.Clients NAMESPACE Gem TARGETS Gem::Multiplayer.Client Gem::Multiplayer.Debug)
+ly_create_alias(NAME Multiplayer.Clients NAMESPACE Gem TARGETS Gem::Multiplayer.Client Gem::Multiplayer.Debug.Client)
 ly_create_alias(NAME Multiplayer.Servers NAMESPACE Gem TARGETS Gem::Multiplayer.Server)
 ly_create_alias(NAME Multiplayer.Unified NAMESPACE Gem TARGETS Gem::Multiplayer Gem::Multiplayer.Debug)
 

--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugModule.cpp
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugModule.cpp
@@ -31,4 +31,7 @@ namespace Multiplayer
     }
 }
 
+#if defined(AZ_MONOLITHIC_BUILD)
+AZ_DECLARE_MODULE_CLASS(Gem_Multiplayer_Debug_Client, Multiplayer::MultiplayerDebugModule);
+#endif
 AZ_DECLARE_MODULE_CLASS(Gem_Multiplayer_Debug, Multiplayer::MultiplayerDebugModule);

--- a/Gems/Multiplayer/Code/Source/MultiplayerGem.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerGem.cpp
@@ -48,5 +48,9 @@ namespace Multiplayer
 } // namespace Multiplayer
 
 #if !defined(MULTIPLAYER_EDITOR)
+#if defined(AZ_MONOLITHIC_BUILD)
+AZ_DECLARE_MODULE_CLASS(Gem_Multiplayer_Client, Multiplayer::MultiplayerModule);
+AZ_DECLARE_MODULE_CLASS(Gem_Multiplayer_Server, Multiplayer::MultiplayerModule);
+#endif
 AZ_DECLARE_MODULE_CLASS(Gem_Multiplayer, Multiplayer::MultiplayerModule);
 #endif

--- a/Gems/Multiplayer/Multiplayer_ScriptCanvas/Code/Source/ScriptCanvasMultiplayerModule.cpp
+++ b/Gems/Multiplayer/Multiplayer_ScriptCanvas/Code/Source/ScriptCanvasMultiplayerModule.cpp
@@ -43,4 +43,4 @@ namespace ScriptCanvasMultiplayer
 // DO NOT MODIFY THIS LINE UNLESS YOU RENAME THE GEM
 // The first parameter should be GemName_GemIdLower
 // The second should be the fully qualified name of the class above
-AZ_DECLARE_MODULE_CLASS(Gem_ScriptCanvasMultiplayer, ScriptCanvasMultiplayer::ScriptCanvasMultiplayerModule)
+AZ_DECLARE_MODULE_CLASS(Gem_Multiplayer_ScriptCanvas, ScriptCanvasMultiplayer::ScriptCanvasMultiplayerModule)


### PR DESCRIPTION
## What does this PR do?

This change addresses build issues in RELEASE builds introduced with the Multiplayer Client Server split change. The specific issue here is that `AZ_DECLARE_MODULE_CLASS` functions differently in RELEASE builds.

The issue here is for any Gem that specifies different targets for the Client, Server or Unified aliases. In this case, Multiplayer specifies `Multiplayer.Client`, `Multiplayer.Server` and `Multiplayer` respectively. In RELEASE, this requires module declarations for `Gem_Multiplayer_Client`, `Gem_Multiplayer_Server` and `Gem_Multiplayer`. This is not an issue outside of RELEASE builds.

There were two potential fixes here.

1. Modify build instructions so that the convention broadly used by split Gems would be honored by default. I did not want to go this route as I have concerns it'd be prone to error.
2. Update affected Module cases in RELEASE mode only with the necessary additional defines.

This change also corrects Multiplayer_ScriptCanvas's module name and adds a Multiplayer.Debug.Client target to untangle the UnifiedLauncher build from Multiplayer.Client.

## How was this PR tested?

I built RELEASE builds of MultiplayerSample's GameLauncher, ServerLauncher and UnifiedLauncher.