### PR TITLE
Prefab | Rename prefab DOM generator functions

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.cpp
@@ -54,15 +54,15 @@ namespace AzToolsFramework
             AZ::Interface<InstanceDomGeneratorInterface>::Unregister(this);
         }
 
-        void InstanceDomGenerator::GenerateInstanceDomFromTemplate(PrefabDom& instanceDom, const Instance& instance) const
+        void InstanceDomGenerator::GetInstanceDomFromTemplate(PrefabDom& instanceDom, const Instance& instance) const
         {
-            AZ_Assert(instanceDom.IsNull(), "GenerateInstanceDomFromTemplate must be called with an empty instance to generate into.");
+            AZ_Assert(instanceDom.IsNull(), "GetInstanceDomFromTemplate must be called with an empty instance to generate into.");
 
             // Retrieves the focused instance.
             auto prefabFocusInterface = AZ::Interface<PrefabFocusInterface>::Get();
             if (!prefabFocusInterface)
             {
-                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateInstanceDomFromTemplate - "
+                AZ_Assert(false, "Prefab - InstanceDomGenerator::GetInstanceDomFromTemplate - "
                     "PrefabFocusInterface could not be found.");
                 return;
             }
@@ -70,7 +70,7 @@ namespace AzToolsFramework
             InstanceOptionalReference focusedInstance = prefabFocusInterface->GetFocusedPrefabInstance(s_editorEntityContextId);
             if (!focusedInstance.has_value())
             {
-                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateInstanceDomFromTemplate - "
+                AZ_Assert(false, "Prefab - InstanceDomGenerator::GetInstanceDomFromTemplate - "
                     "Could not get the focused instance. It should not be null.");
                 return;
             }
@@ -80,7 +80,7 @@ namespace AzToolsFramework
             const Instance* focusedOrRootInstance = climbUpResult.m_reachedInstance;
             if (!focusedOrRootInstance)
             {
-                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateInstanceDomFromTemplate - "
+                AZ_Assert(false, "Prefab - InstanceDomGenerator::GetInstanceDomFromTemplate - "
                     "Could not get the focused or root instance. It should not be null.");
                 return;
             }
@@ -94,7 +94,7 @@ namespace AzToolsFramework
             {
                 AZ_Assert(
                     false,
-                    "Prefab - InstanceDomGenerator::GenerateInstanceDomFromTemplate - "
+                    "Prefab - InstanceDomGenerator::GetInstanceDomFromTemplate - "
                     "Could not get the instance DOM stored in the focused or root template DOM.");
                 return;
             }
@@ -134,14 +134,14 @@ namespace AzToolsFramework
             // the focused instance has no hierarchy relation with the given instance.
         }
 
-        void InstanceDomGenerator::GenerateEntityDomFromTemplate(PrefabDom& entityDom, const AZ::Entity& entity) const
+        void InstanceDomGenerator::GetEntityDomFromTemplate(PrefabDom& entityDom, const AZ::Entity& entity) const
         {
-            AZ_Assert(entityDom.IsNull(), "GenerateEntityDomFromTemplate must be called with an empty entityDom to fill.");
+            AZ_Assert(entityDom.IsNull(), "GetEntityDomFromTemplate must be called with an empty entityDom to fill.");
             // Retrieves the focused instance.
             auto prefabFocusInterface = AZ::Interface<PrefabFocusInterface>::Get();
             if (!prefabFocusInterface)
             {
-                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateEntityDomFromTemplate - "
+                AZ_Assert(false, "Prefab - InstanceDomGenerator::GetEntityDomFromTemplate - "
                     "PrefabFocusInterface could not be found.");
                 return;
             }
@@ -149,7 +149,7 @@ namespace AzToolsFramework
             InstanceOptionalReference focusedInstance = prefabFocusInterface->GetFocusedPrefabInstance(s_editorEntityContextId);
             if (!focusedInstance.has_value())
             {
-                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateEntityDomFromTemplate - "
+                AZ_Assert(false, "Prefab - InstanceDomGenerator::GetEntityDomFromTemplate - "
                     "Could not get the focused instance. It should not be null.");
                 return;
             }
@@ -158,7 +158,7 @@ namespace AzToolsFramework
             InstanceOptionalReference owningInstance = m_instanceEntityMapperInterface->FindOwningInstance(entityId);
             if (!owningInstance.has_value())
             {
-                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateEntityDomFromTemplate - "
+                AZ_Assert(false, "Prefab - InstanceDomGenerator::GetEntityDomFromTemplate - "
                     "Could not get the owning instance for the given entity id.");
                 return;
             }
@@ -169,7 +169,7 @@ namespace AzToolsFramework
             const Instance* focusedOrRootInstance = climbUpResult.m_reachedInstance;
             if (!focusedOrRootInstance)
             {
-                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateEntityDomFromTemplate - "
+                AZ_Assert(false, "Prefab - InstanceDomGenerator::GetEntityDomFromTemplate - "
                     "Could not get the focused or root instance from climb-up. It should not be null.");
                 return;
             }
@@ -195,7 +195,7 @@ namespace AzToolsFramework
                     AZ_Warning(
                         "Prefab",
                         false,
-                        "InstanceDomGenerator::GenerateEntityDomFromTemplate - "
+                        "InstanceDomGenerator::GetEntityDomFromTemplate - "
                         "The entity DOM cannot be found in the template DOM. Output DOM will be null.");
                     return;
                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.cpp
@@ -54,15 +54,15 @@ namespace AzToolsFramework
             AZ::Interface<InstanceDomGeneratorInterface>::Unregister(this);
         }
 
-        void InstanceDomGenerator::GenerateInstanceDom(PrefabDom& instanceDom, const Instance& instance) const
+        void InstanceDomGenerator::GenerateInstanceDomFromTemplate(PrefabDom& instanceDom, const Instance& instance) const
         {
-            AZ_Assert(instanceDom.IsNull(), "GenerateInstanceDom must be called with an empty instance to generate into.");
+            AZ_Assert(instanceDom.IsNull(), "GenerateInstanceDomFromTemplate must be called with an empty instance to generate into.");
 
             // Retrieves the focused instance.
             auto prefabFocusInterface = AZ::Interface<PrefabFocusInterface>::Get();
             if (!prefabFocusInterface)
             {
-                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateInstanceDom - "
+                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateInstanceDomFromTemplate - "
                     "PrefabFocusInterface could not be found.");
                 return;
             }
@@ -70,7 +70,7 @@ namespace AzToolsFramework
             InstanceOptionalReference focusedInstance = prefabFocusInterface->GetFocusedPrefabInstance(s_editorEntityContextId);
             if (!focusedInstance.has_value())
             {
-                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateInstanceDom - "
+                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateInstanceDomFromTemplate - "
                     "Could not get the focused instance. It should not be null.");
                 return;
             }
@@ -80,7 +80,7 @@ namespace AzToolsFramework
             const Instance* focusedOrRootInstance = climbUpResult.m_reachedInstance;
             if (!focusedOrRootInstance)
             {
-                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateInstanceDom - "
+                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateInstanceDomFromTemplate - "
                     "Could not get the focused or root instance. It should not be null.");
                 return;
             }
@@ -94,7 +94,7 @@ namespace AzToolsFramework
             {
                 AZ_Assert(
                     false,
-                    "Prefab - InstanceDomGenerator::GenerateInstanceDom - "
+                    "Prefab - InstanceDomGenerator::GenerateInstanceDomFromTemplate - "
                     "Could not get the instance DOM stored in the focused or root template DOM.");
                 return;
             }
@@ -134,14 +134,14 @@ namespace AzToolsFramework
             // the focused instance has no hierarchy relation with the given instance.
         }
 
-        void InstanceDomGenerator::GenerateEntityDom(PrefabDom& entityDom, const AZ::Entity& entity) const
+        void InstanceDomGenerator::GenerateEntityDomFromTemplate(PrefabDom& entityDom, const AZ::Entity& entity) const
         {
-            AZ_Assert(entityDom.IsNull(), "GenerateEntityDom must be called with an empty entityDom to fill.");
+            AZ_Assert(entityDom.IsNull(), "GenerateEntityDomFromTemplate must be called with an empty entityDom to fill.");
             // Retrieves the focused instance.
             auto prefabFocusInterface = AZ::Interface<PrefabFocusInterface>::Get();
             if (!prefabFocusInterface)
             {
-                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateEntityDom - "
+                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateEntityDomFromTemplate - "
                     "PrefabFocusInterface could not be found.");
                 return;
             }
@@ -149,7 +149,7 @@ namespace AzToolsFramework
             InstanceOptionalReference focusedInstance = prefabFocusInterface->GetFocusedPrefabInstance(s_editorEntityContextId);
             if (!focusedInstance.has_value())
             {
-                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateEntityDom - "
+                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateEntityDomFromTemplate - "
                     "Could not get the focused instance. It should not be null.");
                 return;
             }
@@ -158,7 +158,7 @@ namespace AzToolsFramework
             InstanceOptionalReference owningInstance = m_instanceEntityMapperInterface->FindOwningInstance(entityId);
             if (!owningInstance.has_value())
             {
-                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateEntityDom - "
+                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateEntityDomFromTemplate - "
                     "Could not get the owning instance for the given entity id.");
                 return;
             }
@@ -169,7 +169,7 @@ namespace AzToolsFramework
             const Instance* focusedOrRootInstance = climbUpResult.m_reachedInstance;
             if (!focusedOrRootInstance)
             {
-                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateEntityDom - "
+                AZ_Assert(false, "Prefab - InstanceDomGenerator::GenerateEntityDomFromTemplate - "
                     "Could not get the focused or root instance from climb-up. It should not be null.");
                 return;
             }
@@ -195,7 +195,7 @@ namespace AzToolsFramework
                     AZ_Warning(
                         "Prefab",
                         false,
-                        "InstanceDomGenerator::GenerateEntityDom - "
+                        "InstanceDomGenerator::GenerateEntityDomFromTemplate - "
                         "The entity DOM cannot be found in the template DOM. Output DOM will be null.");
                     return;
                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.h
@@ -33,22 +33,21 @@ namespace AzToolsFramework
             void RegisterInstanceDomGeneratorInterface();
             void UnregisterInstanceDomGeneratorInterface();
 
-            //! Generates an instance DOM for a given instance object based on the currently focused instance.
+            //! Generates an instance DOM for a given instance object from template based on the currently focused instance.
             //! If the given instance is descendant of the focused instance, instance DOM stored in focused
             //! template DOM is used; otherwise, the instance DOM stored in the root template DOM is used.
-            //! In addition, container entity is updated depending on the above relationship with the focused instance.
             //! Note: Link id would be valid in the generated DOM only if the given instance is a proper descendant
             //! of the focused or root instance.
             //! @param[out] instanceDom The output instance DOM that will be modified. It must be empty so that it can be filled.
             //! @param instance The given instance object.
-            void GenerateInstanceDom(PrefabDom& instanceDom, const Instance& instance) const override;
+            void GenerateInstanceDomFromTemplate(PrefabDom& instanceDom, const Instance& instance) const override;
 
-            //! Generates an entity DOM for a given entity object based on the currently focused instance.
+            //! Generates an entity DOM for a given entity object from template based on the currently focused instance.
             //! If the owning instance of the given entity is descendant of the focused instance, entity DOM stored in focused
             //! template DOM is used; otherwise, the entity DOM stored in the root template DOM is used.
             //! @param[out] entityDom The output entity DOM that will be modified. It must be empty so that it can be filled.
             //! @param entity The given entity object.
-            void GenerateEntityDom(PrefabDom& entityDom, const AZ::Entity& entity) const override;
+            void GenerateEntityDomFromTemplate(PrefabDom& entityDom, const AZ::Entity& entity) const override;
 
         private:
             //! Given an instance and its DOM, updates the container entity in the DOM with the one seen

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.h
@@ -33,21 +33,21 @@ namespace AzToolsFramework
             void RegisterInstanceDomGeneratorInterface();
             void UnregisterInstanceDomGeneratorInterface();
 
-            //! Generates an instance DOM for a given instance object from template based on the currently focused instance.
+            //! Gets a copy of instance DOM for a given instance object from template based on the currently focused instance.
             //! If the given instance is descendant of the focused instance, instance DOM stored in focused
             //! template DOM is used; otherwise, the instance DOM stored in the root template DOM is used.
             //! Note: Link id would be valid in the generated DOM only if the given instance is a proper descendant
             //! of the focused or root instance.
             //! @param[out] instanceDom The output instance DOM that will be modified. It must be empty so that it can be filled.
             //! @param instance The given instance object.
-            void GenerateInstanceDomFromTemplate(PrefabDom& instanceDom, const Instance& instance) const override;
+            void GetInstanceDomFromTemplate(PrefabDom& instanceDom, const Instance& instance) const override;
 
-            //! Generates an entity DOM for a given entity object from template based on the currently focused instance.
+            //! Gets a copy of entity DOM for a given entity object from template based on the currently focused instance.
             //! If the owning instance of the given entity is descendant of the focused instance, entity DOM stored in focused
             //! template DOM is used; otherwise, the entity DOM stored in the root template DOM is used.
             //! @param[out] entityDom The output entity DOM that will be modified. It must be empty so that it can be filled.
             //! @param entity The given entity object.
-            void GenerateEntityDomFromTemplate(PrefabDom& entityDom, const AZ::Entity& entity) const override;
+            void GetEntityDomFromTemplate(PrefabDom& entityDom, const AZ::Entity& entity) const override;
 
         private:
             //! Given an instance and its DOM, updates the container entity in the DOM with the one seen

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGeneratorInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGeneratorInterface.h
@@ -21,17 +21,17 @@ namespace AzToolsFramework
             AZ_RTTI(InstanceDomGeneratorInterface, "{269DE807-64B2-4157-93B0-BEDA4133C9A0}");
             virtual ~InstanceDomGeneratorInterface() = default;
 
-            //! Generates an instance DOM that represents a given instance object from template.
+            //! Gets a copy of instance DOM that represents a given instance object from template.
             //! Caller should check if the generated DOM is a valid JSON object.
             //! @param[out] instanceDom The output instance DOM that will be modified.
             //! @param instance The given instance object.
-            virtual void GenerateInstanceDomFromTemplate(PrefabDom& instanceDom, const Instance& instance) const = 0;
+            virtual void GetInstanceDomFromTemplate(PrefabDom& instanceDom, const Instance& instance) const = 0;
 
-            //! Generates an entity DOM that represents a given entity object from template.
+            //! Gets a copy of entity DOM that represents a given entity object from template.
             //! Caller should check if the generated DOM is a valid JSON object.
             //! @param[out] entityDom The output entity DOM that will be modified.
             //! @param entity The given entity object.
-            virtual void GenerateEntityDomFromTemplate(PrefabDom& entityDom, const AZ::Entity& entity) const = 0;
+            virtual void GetEntityDomFromTemplate(PrefabDom& entityDom, const AZ::Entity& entity) const = 0;
         };
     } // namespace Prefab
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGeneratorInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGeneratorInterface.h
@@ -21,17 +21,17 @@ namespace AzToolsFramework
             AZ_RTTI(InstanceDomGeneratorInterface, "{269DE807-64B2-4157-93B0-BEDA4133C9A0}");
             virtual ~InstanceDomGeneratorInterface() = default;
 
-            //! Generates an instance DOM that represents a given instance object.
+            //! Generates an instance DOM that represents a given instance object from template.
             //! Caller should check if the generated DOM is a valid JSON object.
             //! @param[out] instanceDom The output instance DOM that will be modified.
             //! @param instance The given instance object.
-            virtual void GenerateInstanceDom(PrefabDom& instanceDom, const Instance& instance) const = 0;
+            virtual void GenerateInstanceDomFromTemplate(PrefabDom& instanceDom, const Instance& instance) const = 0;
 
-            //! Generates an entity DOM that represents a given entity object.
+            //! Generates an entity DOM that represents a given entity object from template.
             //! Caller should check if the generated DOM is a valid JSON object.
             //! @param[out] entityDom The output entity DOM that will be modified.
             //! @param entity The given entity object.
-            virtual void GenerateEntityDom(PrefabDom& entityDom, const AZ::Entity& entity) const = 0;
+            virtual void GenerateEntityDomFromTemplate(PrefabDom& entityDom, const AZ::Entity& entity) const = 0;
         };
     } // namespace Prefab
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplateInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplateInterface.h
@@ -25,11 +25,17 @@ namespace AzToolsFramework
             AZ_RTTI(InstanceToTemplateInterface, "{9EF54D0F-0951-40B6-91AB-2EB55A322692}");
             virtual ~InstanceToTemplateInterface() = default;
 
-            //! Generates a prefab dom for the entity in its current state and places the result in generatedDom
-            virtual bool GenerateDomForEntity(PrefabDom& generatedEntityDom, const AZ::Entity& entity) = 0;
+            //! Generates an entity DOM for the entity in its current state by serializing the entity object.
+            //! @param[out] entityDom The output entity DOM that will be modified.
+            //! @param entity The given entity object.
+            //! @return True if the entity DOM is generated successfully and false otherwise.
+            virtual bool GenerateEntityDomBySerializing(PrefabDom& entityDom, const AZ::Entity& entity) = 0;
 
-            //! Generates a prefab dom for the instance in its current state and places the result in generatedDom
-            virtual bool GenerateDomForInstance(PrefabDom& generatedInstanceDom, const Instance& instance) = 0;
+            //! Generates an instance DOM for the instance in its current state by serializing the instance object.
+            //! @param[out] instanceDom The output instance DOM that will be modified.
+            //! @param instance The given instance object.
+            //! @return True if the instance DOM is generated successfully and false otherwise.
+            virtual bool GenerateInstanceDomBySerializing(PrefabDom& instanceDom, const Instance& instance) = 0;
 
             //! Generates a patch using serialization system and places the result in generatedPatch
             virtual bool GeneratePatch(PrefabDom& generatedPatch, const PrefabDomValue& initialState, const PrefabDomValue& modifiedState) = 0;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplatePropagator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplatePropagator.cpp
@@ -54,7 +54,7 @@ namespace AzToolsFramework
             AZ::Interface<InstanceToTemplateInterface>::Unregister(this);
         }
 
-        bool InstanceToTemplatePropagator::GenerateDomForEntity(PrefabDom& generatedEntityDom, const AZ::Entity& entity)
+        bool InstanceToTemplatePropagator::GenerateEntityDomBySerializing(PrefabDom& entityDom, const AZ::Entity& entity)
         {
             InstanceOptionalReference owningInstance = m_instanceEntityMapperInterface->FindOwningInstance(entity.GetId());
 
@@ -64,12 +64,12 @@ namespace AzToolsFramework
                 return false;
             }
 
-            return PrefabDomUtils::StoreEntityInPrefabDomFormat(entity, owningInstance->get(), generatedEntityDom);
+            return PrefabDomUtils::StoreEntityInPrefabDomFormat(entity, owningInstance->get(), entityDom);
         }
 
-        bool InstanceToTemplatePropagator::GenerateDomForInstance(PrefabDom& generatedInstanceDom, const Prefab::Instance& instance)
+        bool InstanceToTemplatePropagator::GenerateInstanceDomBySerializing(PrefabDom& instanceDom, const Instance& instance)
         {
-            return PrefabDomUtils::StoreInstanceInPrefabDom(instance, generatedInstanceDom);
+            return PrefabDomUtils::StoreInstanceInPrefabDom(instance, instanceDom);
         }
 
         bool InstanceToTemplatePropagator::GeneratePatch(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplatePropagator.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplatePropagator.h
@@ -28,8 +28,8 @@ namespace AzToolsFramework
             void RegisterInstanceToTemplateInterface();
             void UnregisterInstanceToTemplateInterface();
 
-            bool GenerateDomForEntity(PrefabDom& generatedEntityDom, const AZ::Entity& entity) override;
-            bool GenerateDomForInstance(PrefabDom& generatedInstanceDom, const Prefab::Instance& instance) override;
+            bool GenerateEntityDomBySerializing(PrefabDom& entityDom, const AZ::Entity& entity) override;
+            bool GenerateInstanceDomBySerializing(PrefabDom& instanceDom, const Instance& instance) override;
             bool GeneratePatch(PrefabDom& generatedPatch, const PrefabDomValue& initialState, const PrefabDomValue& modifiedState) override;
             bool GeneratePatchForLink(PrefabDom& generatedPatch, const PrefabDom& initialState,
                 const PrefabDom& modifiedState, LinkId linkId) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -222,7 +222,7 @@ namespace AzToolsFramework
 
                         // Generates instance DOM for a given instance object from focused or root prefab template.
                         PrefabDom instanceDom;
-                        m_instanceDomGeneratorInterface->GenerateInstanceDom(instanceDom, *instanceToUpdate);
+                        m_instanceDomGeneratorInterface->GenerateInstanceDomFromTemplate(instanceDom, *instanceToUpdate);
 
                         if (!instanceDom.IsObject())
                         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -220,9 +220,9 @@ namespace AzToolsFramework
                             continue;
                         }
 
-                        // Generates instance DOM for a given instance object from focused or root prefab template.
+                        // Gets a copy of instance DOM from focused or root prefab template.
                         PrefabDom instanceDom;
-                        m_instanceDomGeneratorInterface->GenerateInstanceDomFromTemplate(instanceDom, *instanceToUpdate);
+                        m_instanceDomGeneratorInterface->GetInstanceDomFromTemplate(instanceDom, *instanceToUpdate);
 
                         if (!instanceDom.IsObject())
                         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -152,7 +152,8 @@ namespace AzToolsFramework
                 PrefabDom commonRootEntityDomBeforeDetaching;
                 if (commonRootEntityId.IsValid())
                 {
-                    m_instanceToTemplateInterface->GenerateDomForEntity(commonRootEntityDomBeforeDetaching,
+                    m_instanceToTemplateInterface->GenerateEntityDomBySerializing(
+                        commonRootEntityDomBeforeDetaching,
                         *GetEntityById(commonRootEntityId));
                 }
 
@@ -244,7 +245,7 @@ namespace AzToolsFramework
 
                 // Update and patch the container entity DOM in template with new components.
                 PrefabDom newContainerEntityDomWithComponents(&(newInstanceTemplateDom.GetAllocator()));
-                m_instanceToTemplateInterface->GenerateDomForEntity(newContainerEntityDomWithComponents, *newContainerEntity);
+                m_instanceToTemplateInterface->GenerateEntityDomBySerializing(newContainerEntityDomWithComponents, *newContainerEntity);
                 PrefabDomPath newContainerEntityAliasDomPath(m_instanceToTemplateInterface->GenerateEntityAliasPath(newContainerEntityId).c_str());
                 newContainerEntityAliasDomPath.Set(newInstanceTemplateDom, newContainerEntityDomWithComponents.Move());
 
@@ -255,7 +256,8 @@ namespace AzToolsFramework
                 // Capture the container entity DOM with parent data in transform.
                 // This DOM will be used later to generate patches for child sort update and they should not contain transform data differences.
                 PrefabDom newContainerEntityDomInitialStateWithTransform;
-                m_instanceToTemplateInterface->GenerateDomForEntity(newContainerEntityDomInitialStateWithTransform, *newContainerEntity);
+                m_instanceToTemplateInterface->GenerateEntityDomBySerializing(
+                    newContainerEntityDomInitialStateWithTransform, *newContainerEntity);
 
                 // Parent the non-container top level entities to the new container entity.
                 // It also patches the entity DOMs to the new template without undo/redo support.
@@ -271,7 +273,7 @@ namespace AzToolsFramework
 
                         // Update the entity DOM with the latest transform data.
                         PrefabDom topLevelContainerEntityDomWithParentInTransform(&(newInstanceTemplateDom.GetAllocator()));
-                        m_instanceToTemplateInterface->GenerateDomForEntity(
+                        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(
                             topLevelContainerEntityDomWithParentInTransform, *topLevelEntity);
 
                         PrefabDomPath entityAliasDomPath(m_instanceToTemplateInterface->GenerateEntityAliasPath(topLevelEntityId).c_str());
@@ -306,12 +308,14 @@ namespace AzToolsFramework
                     if (AZStd::find(topLevelEntities.begin(), topLevelEntities.end(), &nestedInstanceContainerEntity->get()) != topLevelEntities.end())
                     {
                         PrefabDom nestedContainerEntityDomBefore;
-                        m_instanceToTemplateInterface->GenerateDomForEntity(nestedContainerEntityDomBefore, *nestedInstanceContainerEntity);
+                        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(
+                            nestedContainerEntityDomBefore, *nestedInstanceContainerEntity);
 
                         AZ::TransformBus::Event(nestedInstanceContainerEntityId, &AZ::TransformBus::Events::SetParent, newContainerEntityId);
 
                         PrefabDom nestedContainerEntityDomAfter;
-                        m_instanceToTemplateInterface->GenerateDomForEntity(nestedContainerEntityDomAfter, *nestedInstanceContainerEntity);
+                        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(
+                            nestedContainerEntityDomAfter, *nestedInstanceContainerEntity);
 
                         PrefabDom reparentPatch;
                         m_instanceToTemplateInterface->GeneratePatch(reparentPatch, nestedContainerEntityDomBefore, nestedContainerEntityDomAfter);
@@ -327,7 +331,8 @@ namespace AzToolsFramework
 
                 // Patch the new template with child sort array update without undo/redo support.
                 PrefabDom newContainerEntityDomWithTransformAndChildSortOrder;
-                m_instanceToTemplateInterface->GenerateDomForEntity(newContainerEntityDomWithTransformAndChildSortOrder, *newContainerEntity);
+                m_instanceToTemplateInterface->GenerateEntityDomBySerializing(
+                    newContainerEntityDomWithTransformAndChildSortOrder, *newContainerEntity);
 
                 PrefabDom childSortOrderUpdatePatches;
                 m_instanceToTemplateInterface->GeneratePatch(childSortOrderUpdatePatches,
@@ -342,7 +347,8 @@ namespace AzToolsFramework
                 if (commonRootEntityId.IsValid())
                 {
                     PrefabDom commonRootEntityDomAfterAddingNewPrefab;
-                    m_instanceToTemplateInterface->GenerateDomForEntity(commonRootEntityDomAfterAddingNewPrefab,
+                    m_instanceToTemplateInterface->GenerateEntityDomBySerializing(
+                        commonRootEntityDomAfterAddingNewPrefab,
                         *GetEntityById(commonRootEntityId));
 
                     PrefabUndoHelpers::UpdateEntity(
@@ -413,7 +419,7 @@ namespace AzToolsFramework
             // Generate the transform for the container entity out of the top level entities, and set it
             // This step needs to be done before anything is parented to the container, else children position will be wrong
             Prefab::PrefabDom containerEntityDomBefore;
-            m_instanceToTemplateInterface->GenerateDomForEntity(containerEntityDomBefore, *containerEntity);
+            m_instanceToTemplateInterface->GenerateEntityDomBySerializing(containerEntityDomBefore, *containerEntity);
 
             // Set container entity to be child of common root
             AZ::TransformBus::Event(containerEntityId, &AZ::TransformBus::Events::SetParent, parentEntityId);
@@ -423,7 +429,7 @@ namespace AzToolsFramework
             AZ::TransformBus::Event(containerEntityId, &AZ::TransformBus::Events::SetLocalRotationQuaternion, rotation);
 
             PrefabDom containerEntityDomAfter;
-            m_instanceToTemplateInterface->GenerateDomForEntity(containerEntityDomAfter, *containerEntity);
+            m_instanceToTemplateInterface->GenerateEntityDomBySerializing(containerEntityDomAfter, *containerEntity);
 
             PrefabDom patch;
             m_instanceToTemplateInterface->GeneratePatch(patch, containerEntityDomBefore, containerEntityDomAfter);
@@ -498,7 +504,7 @@ namespace AzToolsFramework
 
                 // Instantiate the Prefab
                 PrefabDom instanceToParentUnderDomBeforeCreate;
-                m_instanceToTemplateInterface->GenerateDomForInstance(instanceToParentUnderDomBeforeCreate, instanceToParentUnder->get());
+                m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(instanceToParentUnderDomBeforeCreate, instanceToParentUnder->get());
 
                 auto instanceToCreate = prefabEditorEntityOwnershipInterface->InstantiatePrefab(relativePath, instanceToParentUnder);
 
@@ -514,7 +520,7 @@ namespace AzToolsFramework
                 AZ_Assert(containerEntity, "Invalid container entity detected in InstantiatePrefab.");
 
                 Prefab::PrefabDom containerEntityDomBefore;
-                m_instanceToTemplateInterface->GenerateDomForEntity(containerEntityDomBefore, *containerEntity);
+                m_instanceToTemplateInterface->GenerateEntityDomBySerializing(containerEntityDomBefore, *containerEntity);
 
                 // Capture parent entity DOM before adding the nested prefab instance
                 AZ::Entity* parentEntity = GetEntityById(parentId);
@@ -525,7 +531,7 @@ namespace AzToolsFramework
                 }
 
                 PrefabDom parentEntityDomBeforeAdding;
-                m_instanceToTemplateInterface->GenerateDomForEntity(parentEntityDomBeforeAdding, *parentEntity);
+                m_instanceToTemplateInterface->GenerateEntityDomBySerializing(parentEntityDomBeforeAdding, *parentEntity);
 
                 // Set container entity's parent
                 AZ::TransformBus::Event(containerEntityId, &AZ::TransformBus::Events::SetParent, parentId);
@@ -534,7 +540,7 @@ namespace AzToolsFramework
                 AZ::TransformBus::Event(containerEntityId, &AZ::TransformBus::Events::SetWorldTranslation, position);
 
                 PrefabDom containerEntityDomAfter;
-                m_instanceToTemplateInterface->GenerateDomForEntity(containerEntityDomAfter, *containerEntity);
+                m_instanceToTemplateInterface->GenerateEntityDomBySerializing(containerEntityDomAfter, *containerEntity);
 
                 // Generate patch to be stored in the link
                 PrefabDom patch;
@@ -545,7 +551,7 @@ namespace AzToolsFramework
 
                 // Update parent entity DOM
                 PrefabDom parentEntityDomAfterAdding;
-                m_instanceToTemplateInterface->GenerateDomForEntity(parentEntityDomAfterAdding, *parentEntity);
+                m_instanceToTemplateInterface->GenerateEntityDomBySerializing(parentEntityDomAfterAdding, *parentEntity);
                 PrefabUndoHelpers::UpdateEntity(parentEntityDomBeforeAdding, parentEntityDomAfterAdding, parentId, undoBatch.GetUndoBatch());
 
                 m_prefabUndoCache.UpdateCache(containerEntityId);
@@ -809,12 +815,12 @@ namespace AzToolsFramework
             }
 
             PrefabDom beforeState;
-            m_instanceDomGeneratorInterface->GenerateEntityDom(beforeState, *entity);
+            m_instanceDomGeneratorInterface->GenerateEntityDomFromTemplate(beforeState, *entity);
             AZ::EntityId beforeParentId;
             m_prefabUndoCache.Retrieve(entityId, beforeParentId);
 
             PrefabDom afterState;
-            m_instanceToTemplateInterface->GenerateDomForEntity(afterState, *entity);
+            m_instanceToTemplateInterface->GenerateEntityDomBySerializing(afterState, *entity);
             AZ::EntityId afterParentId;
             AZ::TransformBus::EventResult(afterParentId, entityId, &AZ::TransformBus::Events::GetParentId);
 
@@ -900,7 +906,7 @@ namespace AzToolsFramework
                         Internal_HandleInstanceChange(parentUndoBatch, entity, beforeParentId, afterParentId);
 
                         PrefabDom afterStateafterReparenting;
-                        m_instanceToTemplateInterface->GenerateDomForEntity(afterStateafterReparenting, *entity);
+                        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(afterStateafterReparenting, *entity);
 
                         PrefabDom newPatch;
                         m_instanceToTemplateInterface->GeneratePatch(newPatch, afterState, afterStateafterReparenting);
@@ -1002,7 +1008,7 @@ namespace AzToolsFramework
 
                 // Get the previous state of the prior instance for undo/redo purposes
                 PrefabDom beforeInstanceDomBeforeRemoval;
-                m_instanceToTemplateInterface->GenerateDomForInstance(beforeInstanceDomBeforeRemoval, beforeOwningInstance->get());
+                m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(beforeInstanceDomBeforeRemoval, beforeOwningInstance->get());
 
                 // Remove Entities
                 for (AZ::Entity* nestedEntity : entities)
@@ -1035,7 +1041,7 @@ namespace AzToolsFramework
 
                 // Get the previous state of the new instance for undo/redo purposes
                 PrefabDom afterInstanceDomBeforeAdd;
-                m_instanceToTemplateInterface->GenerateDomForInstance(afterInstanceDomBeforeAdd, afterOwningInstance->get());
+                m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(afterInstanceDomBeforeAdd, afterOwningInstance->get());
 
                 // Add Entities
                 for (AZ::Entity* nestedEntity : entities)
@@ -1221,7 +1227,7 @@ namespace AzToolsFramework
 
                 // Take a snapshot of the instance DOM before we manipulate it
                 PrefabDom instanceDomBefore;
-                m_instanceToTemplateInterface->GenerateDomForInstance(instanceDomBefore, commonOwningInstance->get());
+                m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(instanceDomBefore, commonOwningInstance->get());
 
                 // Make a copy of our before instance DOM where we will add our duplicated entities and/or instances
                 PrefabDom instanceDomAfter;
@@ -1525,7 +1531,7 @@ namespace AzToolsFramework
                     RemoveLink(instancePtr, parentTemplateId, undoBatch.GetUndoBatch());
 
                     Prefab::PrefabDom instanceDomBefore;
-                    m_instanceToTemplateInterface->GenerateDomForInstance(instanceDomBefore, parentInstance);
+                    m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(instanceDomBefore, parentInstance);
 
                     AZStd::unordered_map<AZ::EntityId, AZStd::string> oldEntityAliases;
                     oldEntityAliases.emplace(containerEntityId, instancePtr->GetEntityAlias(containerEntityId)->get());
@@ -1563,7 +1569,7 @@ namespace AzToolsFramework
                     });
 
                     Prefab::PrefabDom instanceDomAfter;
-                    m_instanceToTemplateInterface->GenerateDomForInstance(instanceDomAfter, parentInstance);
+                    m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(instanceDomAfter, parentInstance);
 
                     PrefabUndoInstance* command = aznew PrefabUndoInstance("Instance detachment");
                     command->Capture(instanceDomBefore, instanceDomAfter, parentTemplateId);
@@ -1582,7 +1588,7 @@ namespace AzToolsFramework
                         Instance& nestedInstanceUnderNewParent = parentInstance.AddInstance(AZStd::move(detachedNestedInstance));
                         
                         PrefabDom nestedInstanceDomUnderNewParent;
-                        m_instanceToTemplateInterface->GenerateDomForInstance(
+                        m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(
                             nestedInstanceDomUnderNewParent, nestedInstanceUnderNewParent);
                         PrefabDom reparentPatch;
                         m_instanceToTemplateInterface->GeneratePatch(
@@ -2054,7 +2060,7 @@ namespace AzToolsFramework
                 // Give this the outer allocator so that the memory reference will be valid when
                 // it gets used for AddMember
                 PrefabDom entityDomBefore(&domToAddDuplicatedEntitiesUnder.GetAllocator());
-                m_instanceToTemplateInterface->GenerateDomForEntity(entityDomBefore, *entity);
+                m_instanceToTemplateInterface->GenerateEntityDomBySerializing(entityDomBefore, *entity);
 
                 // Keep track of the old alias <-> new alias mapping for this duplicated entity
                 // so we can fixup references later
@@ -2190,7 +2196,7 @@ namespace AzToolsFramework
             for (auto instance : instances)
             {
                 PrefabDom nestedInstanceDomBefore;
-                m_instanceToTemplateInterface->GenerateDomForInstance(nestedInstanceDomBefore, *instance);
+                m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(nestedInstanceDomBefore, *instance);
 
                 // Keep track of the old alias <-> new alias mapping for this duplicated instance
                 // so we can fixup references later

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -815,7 +815,7 @@ namespace AzToolsFramework
             }
 
             PrefabDom beforeState;
-            m_instanceDomGeneratorInterface->GenerateEntityDomFromTemplate(beforeState, *entity);
+            m_instanceDomGeneratorInterface->GetEntityDomFromTemplate(beforeState, *entity);
             AZ::EntityId beforeParentId;
             m_prefabUndoCache.Retrieve(entityId, beforeParentId);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntity.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntity.cpp
@@ -54,7 +54,7 @@ namespace AzToolsFramework
             if (parentEntityId == focusedInstance.GetContainerEntityId())
             {
                 PrefabDom parentEntityDomBeforeAddingEntity;
-                m_instanceDomGeneratorInterface->GenerateEntityDomFromTemplate(parentEntityDomBeforeAddingEntity, parentEntity);
+                m_instanceDomGeneratorInterface->GetEntityDomFromTemplate(parentEntityDomBeforeAddingEntity, parentEntity);
 
                 if (parentEntityDomBeforeAddingEntity.IsNull())
                 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntity.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntity.cpp
@@ -45,7 +45,7 @@ namespace AzToolsFramework
                 static_cast<AZ::u64>(newEntityId));
 
             PrefabDom parentEntityDomAfterAddingEntity;
-            m_instanceToTemplateInterface->GenerateDomForEntity(parentEntityDomAfterAddingEntity, parentEntity);
+            m_instanceToTemplateInterface->GenerateEntityDomBySerializing(parentEntityDomAfterAddingEntity, parentEntity);
 
             // If the parent is the focused container entity, we need to fetch from root template rather than
             // retrieving from the focused template. The focused containter entity DOM in focused template does
@@ -54,7 +54,7 @@ namespace AzToolsFramework
             if (parentEntityId == focusedInstance.GetContainerEntityId())
             {
                 PrefabDom parentEntityDomBeforeAddingEntity;
-                m_instanceDomGeneratorInterface->GenerateEntityDom(parentEntityDomBeforeAddingEntity, parentEntity);
+                m_instanceDomGeneratorInterface->GenerateEntityDomFromTemplate(parentEntityDomBeforeAddingEntity, parentEntity);
 
                 if (parentEntityDomBeforeAddingEntity.IsNull())
                 {
@@ -94,7 +94,7 @@ namespace AzToolsFramework
             }
 
             PrefabDom newEntityDom;
-            m_instanceToTemplateInterface->GenerateDomForEntity(newEntityDom, newEntity);
+            m_instanceToTemplateInterface->GenerateEntityDomBySerializing(newEntityDom, newEntity);
             PrefabUndoUtils::AppendAddEntityPatch(m_redoPatch, newEntityDom, newEntityAliasPath);
             PrefabUndoUtils::AppendRemovePatch(m_undoPatch, newEntityAliasPath);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntityAsOverride.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntityAsOverride.cpp
@@ -60,7 +60,7 @@ namespace AzToolsFramework
                 parentEntityAliasPathForPatch;
 
             PrefabDom parentEntityDomAfterAddingEntity;
-            m_instanceToTemplateInterface->GenerateDomForEntity(parentEntityDomAfterAddingEntity, parentEntity);
+            m_instanceToTemplateInterface->GenerateEntityDomBySerializing(parentEntityDomAfterAddingEntity, parentEntity);
 
             TemplateId focusedTemplateId = focusedInstance.GetTemplateId();
             PrefabDom& focusedTemplateDom =
@@ -82,7 +82,7 @@ namespace AzToolsFramework
                 entityAliasPathPrefixForPatch + newEntityAliasPath;
 
             PrefabDom newEntityDom;
-            m_instanceToTemplateInterface->GenerateDomForEntity(newEntityDom, newEntity);
+            m_instanceToTemplateInterface->GenerateEntityDomBySerializing(newEntityDom, newEntity);
             PrefabUndoUtils::AppendAddEntityPatch(m_redoPatch, newEntityDom, newEntityAliasPathForPatch);
 
             const LinkId linkId = climbUpResult.m_climbedInstances.back()->GetLinkId();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDelete.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDelete.cpp
@@ -73,7 +73,7 @@ namespace AzToolsFramework
                 const AZStd::string parentEntityAliasPath = m_instanceToTemplateInterface->GenerateEntityAliasPath(parentEntity->GetId());
 
                 PrefabDom parentEntityDomAfterRemovingChildren;
-                m_instanceToTemplateInterface->GenerateDomForEntity(parentEntityDomAfterRemovingChildren, *parentEntity);
+                m_instanceToTemplateInterface->GenerateEntityDomBySerializing(parentEntityDomAfterRemovingChildren, *parentEntity);
 
                 // If the parent is the focused container entity, we need to fetch from root template rather than
                 // retrieving from the focused template. The focused containter entity DOM in focused template does
@@ -82,7 +82,7 @@ namespace AzToolsFramework
                 if (parentEntity->GetId() == focusedInstance.GetContainerEntityId())
                 {
                     PrefabDom parentEntityDomBeforeRemoving;
-                    m_instanceDomGeneratorInterface->GenerateEntityDom(parentEntityDomBeforeRemoving, *parentEntity);
+                    m_instanceDomGeneratorInterface->GenerateEntityDomFromTemplate(parentEntityDomBeforeRemoving, *parentEntity);
 
                     if (parentEntityDomBeforeRemoving.IsNull())
                     {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDelete.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDelete.cpp
@@ -82,7 +82,7 @@ namespace AzToolsFramework
                 if (parentEntity->GetId() == focusedInstance.GetContainerEntityId())
                 {
                     PrefabDom parentEntityDomBeforeRemoving;
-                    m_instanceDomGeneratorInterface->GenerateEntityDomFromTemplate(parentEntityDomBeforeRemoving, *parentEntity);
+                    m_instanceDomGeneratorInterface->GetEntityDomFromTemplate(parentEntityDomBeforeRemoving, *parentEntity);
 
                     if (parentEntityDomBeforeRemoving.IsNull())
                     {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDeleteAsOverride.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDeleteAsOverride.cpp
@@ -116,7 +116,7 @@ namespace AzToolsFramework
                     }
 
                     PrefabDom parentEntityDomAfterRemovingChildren;
-                    m_instanceToTemplateInterface->GenerateDomForEntity(parentEntityDomAfterRemovingChildren, *parentEntity);
+                    m_instanceToTemplateInterface->GenerateEntityDomBySerializing(parentEntityDomAfterRemovingChildren, *parentEntity);
 
                     PrefabUndoUtils::AppendUpdateEntityPatch(
                         m_redoPatch,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.cpp
@@ -78,7 +78,7 @@ namespace AzToolsFramework
                 const AZStd::string entityPathFromTopInstance = overridePatchPathToOwningInstance + entityAliasPath;
 
                 PrefabDom entityDomAfterUpdate;
-                m_instanceToTemplateInterface->GenerateDomForEntity(entityDomAfterUpdate, *entity);
+                m_instanceToTemplateInterface->GenerateEntityDomBySerializing(entityDomAfterUpdate, *entity);
 
                 // Get the before-state entity DOM inside the source template DOM of the top instance.
                 const TemplateId topTemplateId = link->get().GetSourceTemplateId();

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Link/SingleInstanceMultiplePatchesBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Link/SingleInstanceMultiplePatchesBenchmarks.cpp
@@ -56,11 +56,11 @@ namespace Benchmark
                         PrefabDom entityDomBefore;
                         InstanceToTemplateInterface* instanceToTemplateInterface = AZ::Interface<InstanceToTemplateInterface>::Get();
                         AZ_Assert(instanceToTemplateInterface, "Could not retrieve instance of InstanceToTemplateInterface");
-                        instanceToTemplateInterface->GenerateDomForEntity(entityDomBefore, *(entity.get()));
+                        instanceToTemplateInterface->GenerateEntityDomBySerializing(entityDomBefore, *(entity.get()));
 
                         AZ::TransformBus::Event(entity->GetId(), &AZ::TransformBus::Events::SetWorldX, 10.0f);
                         PrefabDom entityDomAfter;
-                        instanceToTemplateInterface->GenerateDomForEntity(entityDomAfter, *(entity.get()));
+                        instanceToTemplateInterface->GenerateEntityDomBySerializing(entityDomAfter, *(entity.get()));
 
                         PrefabDom patch;
                         instanceToTemplateInterface->GeneratePatch(patch, entityDomBefore, entityDomAfter);

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabEntityAliasTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabEntityAliasTests.cpp
@@ -223,12 +223,12 @@ namespace UnitTest
 
         // Capture the before and after for setting the reference property
         PrefabDom entityDomBeforeUpdate;
-        m_instanceToTemplateInterface->GenerateDomForEntity(entityDomBeforeUpdate, *newEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(entityDomBeforeUpdate, *newEntity);
 
         newComponent->m_entityIdProperty = referencedEntity->GetId();
 
         PrefabDom entityDomAfterUpdate;
-        m_instanceToTemplateInterface->GenerateDomForEntity(entityDomAfterUpdate, *newEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(entityDomAfterUpdate, *newEntity);
 
         PrefabDom patch;
         m_instanceToTemplateInterface->GeneratePatch(patch, entityDomBeforeUpdate, entityDomAfterUpdate);

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTestFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTestFixture.cpp
@@ -185,14 +185,14 @@ namespace UnitTest
     void PrefabInstanceDomGeneratorTestFixture::GenerateAndValidateInstanceDom(
         const Instance& instance, EntityAlias entityAlias, float expectedValue)
     {
-        // Generate a prefab DOM for the provided instance
-        PrefabDom generatedInstanceDom;
-        m_instanceDomGeneratorInterface->GenerateInstanceDomFromTemplate(generatedInstanceDom, instance);
+        // Gets a copy of an instance DOM for the provided instance
+        PrefabDom instanceDomFromTemplate;
+        m_instanceDomGeneratorInterface->GetInstanceDomFromTemplate(instanceDomFromTemplate, instance);
 
         // Create an instance from the generated prefab DOM for validation
         Instance instanceFromDom;
         ASSERT_TRUE(PrefabDomUtils::LoadInstanceFromPrefabDom(
-            instanceFromDom, generatedInstanceDom, PrefabDomUtils::LoadFlags::UseSelectiveDeserialization));
+            instanceFromDom, instanceDomFromTemplate, PrefabDomUtils::LoadFlags::UseSelectiveDeserialization));
 
         // Verify that the worldX value of the provided child entity is coming from the correct template
         EntityOptionalReference childEntity = FindEntityInInstanceHierarchy(instanceFromDom, entityAlias);
@@ -248,7 +248,7 @@ namespace UnitTest
     {
         // Generate an entity DOM for the provided entity
         PrefabDom generatedEntityDom;
-        m_instanceDomGeneratorInterface->GenerateEntityDomFromTemplate(generatedEntityDom, entity);
+        m_instanceDomGeneratorInterface->GetEntityDomFromTemplate(generatedEntityDom, entity);
         EXPECT_TRUE(generatedEntityDom.IsObject());
 
         // Create an entity from the generated entity DOM for validation

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTestFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceDomGeneratorTestFixture.cpp
@@ -107,7 +107,7 @@ namespace UnitTest
 
         // Create document with before change snapshot
         PrefabDom entityDomBeforeUpdate;
-        m_instanceToTemplateInterface->GenerateDomForEntity(entityDomBeforeUpdate, *childEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(entityDomBeforeUpdate, *childEntity);
 
         // Change the entity
         float prevXValue = 0.0f;
@@ -119,7 +119,7 @@ namespace UnitTest
 
         // Create document with after change snapshot
         PrefabDom entityDomAfterUpdate;
-        m_instanceToTemplateInterface->GenerateDomForEntity(entityDomAfterUpdate, *childEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(entityDomAfterUpdate, *childEntity);
 
         // Generate patch
         m_instanceToTemplateInterface->GeneratePatch(patchOut, entityDomBeforeUpdate, entityDomAfterUpdate);
@@ -187,7 +187,7 @@ namespace UnitTest
     {
         // Generate a prefab DOM for the provided instance
         PrefabDom generatedInstanceDom;
-        m_instanceDomGeneratorInterface->GenerateInstanceDom(generatedInstanceDom, instance);
+        m_instanceDomGeneratorInterface->GenerateInstanceDomFromTemplate(generatedInstanceDom, instance);
 
         // Create an instance from the generated prefab DOM for validation
         Instance instanceFromDom;
@@ -248,7 +248,7 @@ namespace UnitTest
     {
         // Generate an entity DOM for the provided entity
         PrefabDom generatedEntityDom;
-        m_instanceDomGeneratorInterface->GenerateEntityDom(generatedEntityDom, entity);
+        m_instanceDomGeneratorInterface->GenerateEntityDomFromTemplate(generatedEntityDom, entity);
         EXPECT_TRUE(generatedEntityDom.IsObject());
 
         // Create an entity from the generated entity DOM for validation

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceToTemplatePropagatorTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceToTemplatePropagatorTests.cpp
@@ -36,7 +36,7 @@ namespace UnitTest
         ASSERT_TRUE(prefabInstance);
 
         PrefabDom entityDom;
-        m_instanceToTemplateInterface->GenerateDomForEntity(entityDom, *newEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(entityDom, *newEntity);
 
         auto componentListDom = entityDom.FindMember("Components");
 
@@ -79,7 +79,7 @@ namespace UnitTest
         ASSERT_TRUE(prefabInstance);
 
         PrefabDom instanceDom;
-        m_instanceToTemplateInterface->GenerateDomForInstance(instanceDom, *prefabInstance);
+        m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(instanceDom, *prefabInstance);
 
         // Acquire the entity out of the instanceDom
         auto entitiesDom = instanceDom.FindMember(PrefabDomUtils::EntitiesName);
@@ -141,7 +141,7 @@ namespace UnitTest
 
         //create document with before change snapshot
         PrefabDom entityDomBeforeUpdate;
-        m_instanceToTemplateInterface->GenerateDomForEntity(entityDomBeforeUpdate, *newEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(entityDomBeforeUpdate, *newEntity);
 
         //update values on entity
         const float updatedXValue = 5.0f;
@@ -149,7 +149,7 @@ namespace UnitTest
 
         //create document with after change snapshot
         PrefabDom entityDomAfterUpdate;
-        m_instanceToTemplateInterface->GenerateDomForEntity(entityDomAfterUpdate, *newEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(entityDomAfterUpdate, *newEntity);
 
         //generate patch
         PrefabDom patch;
@@ -192,14 +192,14 @@ namespace UnitTest
 
         //create document with before change snapshot
         PrefabDom instanceDomBeforeUpdate;
-        m_instanceToTemplateInterface->GenerateDomForInstance(instanceDomBeforeUpdate, *firstInstance);
+        m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(instanceDomBeforeUpdate, *firstInstance);
 
         //add entity to instance
         firstInstance->AddEntity(*newEntity);
 
         //create document with after change snapshot
         PrefabDom instanceDomAfterUpdate;
-        m_instanceToTemplateInterface->GenerateDomForInstance(instanceDomAfterUpdate, *firstInstance);
+        m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(instanceDomAfterUpdate, *firstInstance);
 
         //generate patch
         PrefabDom patch;
@@ -243,14 +243,14 @@ namespace UnitTest
 
         //create document with before change snapshot
         PrefabDom instanceDomBeforeUpdate;
-        m_instanceToTemplateInterface->GenerateDomForInstance(instanceDomBeforeUpdate, *firstInstance);
+        m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(instanceDomBeforeUpdate, *firstInstance);
 
         //remove entity from instance
         firstInstance->DetachEntity(entityId);
 
         //create document with after change snapshot
         PrefabDom instanceDomAfterUpdate;
-        m_instanceToTemplateInterface->GenerateDomForInstance(instanceDomAfterUpdate, *firstInstance);
+        m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(instanceDomAfterUpdate, *firstInstance);
 
         //generate patch
         PrefabDom patch;
@@ -288,7 +288,7 @@ namespace UnitTest
 
         //create document with before change snapshot
         PrefabDom instanceDomBeforeUpdate;
-        m_instanceToTemplateInterface->GenerateDomForInstance(instanceDomBeforeUpdate, *firstInstance);
+        m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(instanceDomBeforeUpdate, *firstInstance);
 
         //create new instance and get alias
         AZStd::unique_ptr<Instance> addedInstance = m_prefabSystemComponent->CreatePrefab({}, {}, "test/pathtest");
@@ -299,7 +299,7 @@ namespace UnitTest
 
         //create document with after change snapshot
         PrefabDom instanceDomAfterUpdate;
-        m_instanceToTemplateInterface->GenerateDomForInstance(instanceDomAfterUpdate, *firstInstance);
+        m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(instanceDomAfterUpdate, *firstInstance);
 
         //generate patch
         PrefabDom patch;
@@ -333,7 +333,7 @@ namespace UnitTest
 
         //create document with before change snapshot
         PrefabDom instanceDomBeforeUpdate;
-        m_instanceToTemplateInterface->GenerateDomForInstance(instanceDomBeforeUpdate, *firstInstance);
+        m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(instanceDomBeforeUpdate, *firstInstance);
 
         //remove instance from instance
         AZStd::unique_ptr<Instance> detachedInstance = firstInstance->DetachNestedInstance(addedAlias);
@@ -342,7 +342,7 @@ namespace UnitTest
 
         //create document with after change snapshot
         PrefabDom instanceDomAfterUpdate;
-        m_instanceToTemplateInterface->GenerateDomForInstance(instanceDomAfterUpdate, *firstInstance);
+        m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(instanceDomAfterUpdate, *firstInstance);
 
         //generate patch
         PrefabDom patch;

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUndoEditEntityTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUndoEditEntityTests.cpp
@@ -39,7 +39,7 @@ namespace UnitTest
         wheelEntity = AzToolsFramework::GetEntityById(wheelEntityId);
         EXPECT_TRUE(wheelEntity) << "Could not get entity object.";
         PrefabDom entityDomAfterEdit;
-        m_instanceToTemplateInterface->GenerateDomForEntity(entityDomAfterEdit, *wheelEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(entityDomAfterEdit, *wheelEntity);
         EXPECT_TRUE(entityDomAfterEdit.IsObject()) << "Could not create after-state entity DOM.";
 
         // Get before-state DOM value

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUndoLinkTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUndoLinkTests.cpp
@@ -80,7 +80,7 @@ namespace UnitTest
 
         //generate a patch to add a component to the nested instance
         PrefabDom initialEntityDom;
-        m_instanceToTemplateInterface->GenerateDomForEntity(initialEntityDom, *nestedContainerEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(initialEntityDom, *nestedContainerEntity);
 
         nestedContainerEntity->Deactivate();
         PrefabTestComponent* nestedTestComponent = nestedContainerEntity->CreateComponent<PrefabTestComponent>();
@@ -88,7 +88,7 @@ namespace UnitTest
         nestedContainerEntity->Activate();
 
         PrefabDom modifiedEntityDom;
-        m_instanceToTemplateInterface->GenerateDomForEntity(modifiedEntityDom, *nestedContainerEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(modifiedEntityDom, *nestedContainerEntity);
 
         PrefabDom patch;
         m_instanceToTemplateInterface->GeneratePatch(patch, initialEntityDom, modifiedEntityDom);
@@ -107,9 +107,9 @@ namespace UnitTest
         AZStd::vector<InstanceAlias> aliases = rootInstance->GetNestedInstanceAliases(nestedTemplateId);
 
         //create patch for nesting
-        m_instanceToTemplateInterface->GenerateDomForEntity(initialEntityDom, *nestedContainerEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(initialEntityDom, *nestedContainerEntity);
         nestedTestComponent->m_entityIdProperty = rootContainerEntityId;
-        m_instanceToTemplateInterface->GenerateDomForEntity(modifiedEntityDom, *nestedContainerEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(modifiedEntityDom, *nestedContainerEntity);
         m_instanceToTemplateInterface->GeneratePatch(patch, initialEntityDom, modifiedEntityDom);
         m_instanceToTemplateInterface->AppendEntityAliasToPatchPaths(patch, nestedContainerEntityId);
 
@@ -150,7 +150,7 @@ namespace UnitTest
 
         //add a component for testing to the instance that will be nested
         PrefabDom initialEntityDom;
-        m_instanceToTemplateInterface->GenerateDomForEntity(initialEntityDom, *nestedContainerEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(initialEntityDom, *nestedContainerEntity);
 
         nestedContainerEntity->Deactivate();
         PrefabTestComponent* nestedTestComponent = nestedContainerEntity->CreateComponent<PrefabTestComponent>();
@@ -158,7 +158,7 @@ namespace UnitTest
         nestedContainerEntity->Activate();
 
         PrefabDom modifiedEntityDom;
-        m_instanceToTemplateInterface->GenerateDomForEntity(modifiedEntityDom, *nestedContainerEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(modifiedEntityDom, *nestedContainerEntity);
 
         //create patch
         PrefabDom patch;
@@ -181,11 +181,11 @@ namespace UnitTest
         ASSERT_TRUE(nestedContainerEntity);
 
         //nest the second instance under the first instance
-        m_instanceToTemplateInterface->GenerateDomForEntity(initialEntityDom, *nestedContainerEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(initialEntityDom, *nestedContainerEntity);
 
         rootInstance->AddInstance(AZStd::move(nestedInstance));
 
-        m_instanceToTemplateInterface->GenerateDomForEntity(modifiedEntityDom, *nestedContainerEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(modifiedEntityDom, *nestedContainerEntity);
 
         //create patch
         PrefabDom linkPatch;
@@ -219,12 +219,12 @@ namespace UnitTest
         ASSERT_TRUE(nestedContainerEntity);
 
         //update the property on the nested component
-        m_instanceToTemplateInterface->GenerateDomForEntity(initialEntityDom, *nestedContainerEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(initialEntityDom, *nestedContainerEntity);
 
         nestedTestComponent = nestedContainerEntity->FindComponent<PrefabTestComponent>();
         nestedTestComponent->m_boolProperty = true;
 
-        m_instanceToTemplateInterface->GenerateDomForEntity(modifiedEntityDom, *nestedContainerEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(modifiedEntityDom, *nestedContainerEntity);
 
         //create patch
         PrefabDom updatePatch;
@@ -296,12 +296,12 @@ namespace UnitTest
         ASSERT_TRUE(nestedContainerEntity);
 
         //update the property on the nested component
-        m_instanceToTemplateInterface->GenerateDomForEntity(initialEntityDom, *nestedContainerEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(initialEntityDom, *nestedContainerEntity);
 
         nestedTestComponent = nestedContainerEntity->FindComponent<PrefabTestComponent>();
         nestedTestComponent->m_intProperty = 1;
 
-        m_instanceToTemplateInterface->GenerateDomForEntity(modifiedEntityDom, *nestedContainerEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(modifiedEntityDom, *nestedContainerEntity);
 
         //create patch
         PrefabDom updatePatchIntField;

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUndoTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUndoTests.cpp
@@ -38,7 +38,7 @@ namespace UnitTest
 
         //create document with before change snapshot
         PrefabDom entityDomBeforeUpdate;
-        m_instanceToTemplateInterface->GenerateDomForEntity(entityDomBeforeUpdate, *newEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(entityDomBeforeUpdate, *newEntity);
 
         float checkXValue = 0.0f;
         AZ::TransformBus::EventResult(checkXValue, entityId, &AZ::TransformInterface::GetWorldX);
@@ -53,7 +53,7 @@ namespace UnitTest
 
         //create document with after change snapshot
         PrefabDom entityDomAfterUpdate;
-        m_instanceToTemplateInterface->GenerateDomForEntity(entityDomAfterUpdate, *newEntity);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(entityDomAfterUpdate, *newEntity);
 
         //generate patch
         PrefabDom patch;
@@ -114,14 +114,14 @@ namespace UnitTest
 
         //create document with before change snapshot
         PrefabDom instanceDomBeforeUpdate;
-        m_instanceToTemplateInterface->GenerateDomForInstance(instanceDomBeforeUpdate, *testInstance);
+        m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(instanceDomBeforeUpdate, *testInstance);
 
         //add entity to instance
         testInstance->AddEntity(*newEntity);
 
         //create document with after change snapshot
         PrefabDom instanceDomAfterUpdate;
-        m_instanceToTemplateInterface->GenerateDomForInstance(instanceDomAfterUpdate, *testInstance);
+        m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(instanceDomAfterUpdate, *testInstance);
 
         //generate patch
         PrefabDom patch;
@@ -167,14 +167,14 @@ namespace UnitTest
 
         //create document with before change snapshot
         PrefabDom instanceDomBeforeUpdate;
-        m_instanceToTemplateInterface->GenerateDomForInstance(instanceDomBeforeUpdate, *testInstance);
+        m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(instanceDomBeforeUpdate, *testInstance);
 
         //detach entity from instance
         testInstance->DetachEntity(entityId);
 
         //create document with after change snapshot
         PrefabDom instanceDomAfterUpdate;
-        m_instanceToTemplateInterface->GenerateDomForInstance(instanceDomAfterUpdate, *testInstance);
+        m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(instanceDomAfterUpdate, *testInstance);
 
         //generate patch
         PrefabDom patch;

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUpdateWithPatchesTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUpdateWithPatchesTests.cpp
@@ -107,7 +107,7 @@ namespace UnitTest
 
         //create document with before change snapshot
         PrefabDom entityDomBefore;
-        m_instanceToTemplateInterface->GenerateDomForEntity(entityDomBefore, *wheelEntityUnderAxle);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(entityDomBefore, *wheelEntityUnderAxle);
 
         PrefabTestComponent* axlewheelComponent = wheelEntityUnderAxle->FindComponent<PrefabTestComponent>();
         // Change the bool property of the component from Wheel instance and use it to update the wheel template.
@@ -115,7 +115,7 @@ namespace UnitTest
 
         //create document with after change snapshot
         PrefabDom entityDomAfter;
-        m_instanceToTemplateInterface->GenerateDomForEntity(entityDomAfter, *wheelEntityUnderAxle);
+        m_instanceToTemplateInterface->GenerateEntityDomBySerializing(entityDomAfter, *wheelEntityUnderAxle);
 
         InstanceOptionalReference topMostInstanceInHierarchy = m_instanceToTemplateInterface->GetTopMostInstanceInHierarchy(wheelEntityIdUnderAxle);
         ASSERT_TRUE(topMostInstanceInHierarchy);

--- a/Code/Tools/SerializeContextTools/SliceConverter.cpp
+++ b/Code/Tools/SerializeContextTools/SliceConverter.cpp
@@ -570,7 +570,7 @@ namespace AZ
             // Get the DOM for the unmodified nested instance.  This will be used later below for generating the correct patch
             // to the top-level template DOM.
             AzToolsFramework::Prefab::PrefabDom unmodifiedNestedInstanceDom;
-            instanceToTemplateInterface->GenerateDomForInstance(unmodifiedNestedInstanceDom, *(nestedInstance.get()));
+            instanceToTemplateInterface->GenerateInstanceDomBySerializing(unmodifiedNestedInstanceDom, *(nestedInstance.get()));
 
             // Instantiate a new instance of the nested slice
             SliceComponent* dependentSlice = sliceAsset.Get()->GetComponent();
@@ -733,13 +733,13 @@ namespace AZ
             // create a patch out of it, and patch the top-level prefab template.
 
             AzToolsFramework::Prefab::PrefabDom topLevelInstanceDomBefore;
-            instanceToTemplateInterface->GenerateDomForInstance(topLevelInstanceDomBefore, *topLevelInstance);
+            instanceToTemplateInterface->GenerateInstanceDomBySerializing(topLevelInstanceDomBefore, *topLevelInstance);
 
             // Use the deterministic instance alias for this new instance
             AzToolsFramework::Prefab::Instance& addedInstance = topLevelInstance->AddInstance(AZStd::move(nestedInstance));
 
             AzToolsFramework::Prefab::PrefabDom topLevelInstanceDomAfter;
-            instanceToTemplateInterface->GenerateDomForInstance(topLevelInstanceDomAfter, *topLevelInstance);
+            instanceToTemplateInterface->GenerateInstanceDomBySerializing(topLevelInstanceDomAfter, *topLevelInstance);
 
             AzToolsFramework::Prefab::PrefabDom addedInstancePatch;
             instanceToTemplateInterface->GeneratePatch(addedInstancePatch, topLevelInstanceDomBefore, topLevelInstanceDomAfter);
@@ -749,7 +749,7 @@ namespace AZ
             // to the top-level instance, we've got all the changes we need to generate the correct patch.
 
             AzToolsFramework::Prefab::PrefabDom modifiedNestedInstanceDom;
-            instanceToTemplateInterface->GenerateDomForInstance(modifiedNestedInstanceDom, addedInstance);
+            instanceToTemplateInterface->GenerateInstanceDomBySerializing(modifiedNestedInstanceDom, addedInstance);
 
             AzToolsFramework::Prefab::PrefabDom linkPatch;
             instanceToTemplateInterface->GeneratePatch(linkPatch, unmodifiedNestedInstanceDom, modifiedNestedInstanceDom);


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

This PR renames the prefab entity/instance DOM generator functions to reduce confusion.

Before:

```cpp
InstanceToTemplatePropagator::GenerateDomForInstance();
InstanceToTemplatePropagator::GenerateDomForEntity();
InstanceDomGenerator::GenerateInstanceDom();
InstanceDomGenerator::GenerateEntityDom();
```

After:

```cpp
InstanceToTemplatePropagator::GenerateInstanceDomBySerializing();
InstanceToTemplatePropagator::GenerateEntityDomBySerializing();
InstanceDomGenerator::GetInstanceDomFromTemplate();
InstanceDomGenerator::GetEntityDomFromTemplate();
```

## How was this PR tested?

Passed tests. The PR does not alter implementation logic.