### PR TITLE
Fix an issue where non-PBR materials with valid RoughnessFactor property are not processed properly

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Material/MaterialConverterSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/MaterialConverterSystemComponent.cpp
@@ -175,8 +175,13 @@ namespace AZ
             applyOptionalPropertiesFunc("metallic", "useTexture", materialData.GetUseMetallicMap());
 
             handleTexture("roughness", "textureMap", SceneAPI::DataTypes::IMaterialData::TextureMapType::Roughness);
-            applyOptionalPropertiesFunc("roughness", "factor", materialData.GetRoughnessFactor());
             applyOptionalPropertiesFunc("roughness", "useTexture", materialData.GetUseRoughnessMap());
+            // Both PBR material and non-PBR material can have the RoughnessFactor property
+            AZStd::optional<float> roughness = materialData.GetRoughnessFactor();
+            if (roughness.has_value())
+            {
+                sourceData.SetPropertyValue(Name{"roughness.factor"}, roughness.value());
+            }
 
             handleTexture("emissive", "textureMap", SceneAPI::DataTypes::IMaterialData::TextureMapType::Emissive);
             sourceData.SetPropertyValue(Name{"emissive.color"}, toColor(materialData.GetEmissiveColor()));


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?
After the latest AssImp library upgrade (https://github.com/o3de/o3de/commit/fda9d48d3163006cf137fda4c514ae816006a734), roughness factor of a non-PBR material is detected/exported when users create content via Blender and export it as FBX. This is introduced by the latest AssImp change: https://github.com/assimp/assimp/pull/4466. 

However, this change breaks our existing logic in the material converter: The converter treats roughness factor as one of the PBR material properties and uses it to decide the material type. This causes that non-PBR materials are not processed properly. The screenshots below shows how the testing material look like before/after the recent AssImp upgrade.
![image](https://user-images.githubusercontent.com/68558268/212217048-d0b4abc2-fa20-40e0-82d3-9c6b8fab5d9e.png)
![image](https://user-images.githubusercontent.com/68558268/212217075-9f1c8ea0-0b46-4dab-a430-2fe1187be8a2.png)

This PR updated the material converter to make sure that roughness factor can be handled for non-PBR materials.

## How was this PR tested?
- Verified that the non-PBR material with different roughness factor values could be processed and displayed properly in the Editor.
![image](https://user-images.githubusercontent.com/68558268/212217705-8b1d0a96-98bb-476a-8120-34dbc957b990.png)
- Exiting Atom_Feature_Common.Tests passed
- Python automation test StingRayPBRAsset_PBRMaterialConvertion_AutoAssignOnProcessing passed
