### PR TITLE
Adding AzAutoGen input files as CMake Configure dependencies

### DIFF
--- a/cmake/LyAutoGen.cmake
+++ b/cmake/LyAutoGen.cmake
@@ -39,6 +39,7 @@ function(ly_add_autogen)
         string(STRIP "${AUTOGEN_OUTPUTS}" AUTOGEN_OUTPUTS)
         set(AZCG_DEPENDENCIES ${AZCG_INPUTFILES})
         list(APPEND AZCG_DEPENDENCIES "${LY_ROOT_FOLDER}/cmake/AzAutoGen.py")
+        set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${AZCG_DEPENDENCIES})
         add_custom_command(
             OUTPUT ${AUTOGEN_OUTPUTS}
             DEPENDS ${AZCG_DEPENDENCIES}


### PR DESCRIPTION
This fixes the issue with CMake not re-configuring when an `*.AutoComponent.xml`, `*.AutoComponent.json` or `*.AutoComponent*.jinja` file is modified or removed.

fixes #12973

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>