### PR TITLE
Monolithic Asset Bundle Runtime fixes

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplicationLifecycle.h
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplicationLifecycle.h
@@ -13,9 +13,15 @@
 
 namespace AZ::ComponentApplicationLifecycle
 {
-    //! Root Key where lifecycle events should be registered under
+    //! Root Key used to determine where lifecycle events are registered underneath
     inline constexpr AZStd::string_view ApplicationLifecycleEventRegistrationKey = "/O3DE/Application/LifecycleEvents";
 
+    //! Root Key to use for signaling lifecycle events
+    //! This key section is runtime only and will not be merged into the aggregated setreg file
+    //! produced by the SettingsRegistryBuilder
+    //! It is used to separately from the registration key section, to avoid the scenario
+    //! where registering a lifecycle event would result in signaling the event.
+    inline constexpr AZStd::string_view ApplicationLifecycleEventSignalKey = "/O3DE/Runtime/Application/LifecycleEvents";
 
     //! Validates that the event @eventName is stored in the array at ApplicationLifecycleEventRegistrationKey
     //! @param settingsRegistry registry where @eventName will be searched

--- a/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
@@ -2183,13 +2183,13 @@ namespace AZ::IO
 
     void Archive::OnSystemEntityActivated()
     {
-        for (const auto& archiveInfo : m_archivesWithCatalogsToLoad)
+        auto LoadArchives = [this](const AZ::IO::Archive::ArchivesWithCatalogsToLoad& archiveInfo)
         {
             AZStd::intrusive_ptr<INestedArchive> archive =
                 OpenArchive(archiveInfo.m_fullPath, archiveInfo.m_bindRoot, archiveInfo.m_flags, nullptr);
             if (!archive)
             {
-                continue;
+                return false;
             }
 
             ZipDir::CachePtr pZip = static_cast<NestedArchive*>(archive.get())->GetCache();
@@ -2209,7 +2209,9 @@ namespace AZ::IO
                     archiveNotifications->BundleOpened(bundleName, bundleManifest, nextBundle.c_str(), bundleCatalog);
                 },
                 archiveInfo.m_strFileName.c_str(), bundleManifest, archiveInfo.m_nextBundle, bundleCatalog);
-        }
-        m_archivesWithCatalogsToLoad.clear();
+
+            return true;
+        };
+        AZStd::erase_if(m_archivesWithCatalogsToLoad, LoadArchives);
     }
 }


### PR DESCRIPTION
Updated the Archive system handling of OnSystemActivated lifecycle event to ONLY prune the list of archive files with asset bundle catalogs to load, if the files were opened as an archive successfully.

Updated the Component Application Lifecycle event to signal, using a different section of the Settings Registry which is never loaded from a file and is transient in memory.

See the [setregbuilder](https://github.com/o3de/o3de/blob/development/Registry/setregbuilder.assetprocessor.setreg#L17-L30) settings registry file.

fixes #13473

## How was this PR tested?

Built and Launched the Windows GameLauncher Monolithic build.

