### PR TITLE
Set the Dispatch args in the constructor instead of LoadShader.

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ComputePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ComputePass.cpp
@@ -44,6 +44,20 @@ namespace AZ
             : RenderPass(descriptor)
             , m_passDescriptor(descriptor)
         {
+            const ComputePassData* passData = PassUtils::GetPassData<ComputePassData>(m_passDescriptor);
+            if (passData == nullptr)
+            {
+                AZ_Error(
+                    "PassSystem", false, "[ComputePass '%s']: Trying to construct without valid ComputePassData!", GetPathName().GetCStr());
+                return;
+            }
+
+            RHI::DispatchDirect dispatchArgs;
+            dispatchArgs.m_totalNumberOfThreadsX = passData->m_totalNumberOfThreadsX;
+            dispatchArgs.m_totalNumberOfThreadsY = passData->m_totalNumberOfThreadsY;
+            dispatchArgs.m_totalNumberOfThreadsZ = passData->m_totalNumberOfThreadsZ;
+            m_dispatchItem.m_arguments = dispatchArgs;
+
             LoadShader();
         }
 
@@ -105,19 +119,21 @@ namespace AZ
             const bool compileDrawSrg = false; // The SRG will be compiled in CompileResources()
             m_drawSrg = m_shader->CreateDefaultDrawSrg(compileDrawSrg);
 
-            RHI::DispatchDirect dispatchArgs;
-            dispatchArgs.m_totalNumberOfThreadsX = passData->m_totalNumberOfThreadsX;
-            dispatchArgs.m_totalNumberOfThreadsY = passData->m_totalNumberOfThreadsY;
-            dispatchArgs.m_totalNumberOfThreadsZ = passData->m_totalNumberOfThreadsZ;
-
-            const auto outcome = RPI::GetComputeShaderNumThreads(m_shader->GetAsset(), dispatchArgs);
-            if (!outcome.IsSuccess())
+            if (m_dispatchItem.m_arguments.m_type == RHI::DispatchType::Direct)
             {
-                AZ_Error("PassSystem", false, "[ComputePass '%s']: Shader '%.*s' contains invalid numthreads arguments:\n%s",
-                        GetPathName().GetCStr(), passData->m_shaderReference.m_filePath.size(), passData->m_shaderReference.m_filePath.data(), outcome.GetError().c_str());
+                const auto outcome = RPI::GetComputeShaderNumThreads(m_shader->GetAsset(), m_dispatchItem.m_arguments.m_direct);
+                if (!outcome.IsSuccess())
+                {
+                    AZ_Error(
+                        "PassSystem",
+                        false,
+                        "[ComputePass '%s']: Shader '%.*s' contains invalid numthreads arguments:\n%s",
+                        GetPathName().GetCStr(),
+                        passData->m_shaderReference.m_filePath.size(),
+                        passData->m_shaderReference.m_filePath.data(),
+                        outcome.GetError().c_str());
+                }
             }
-
-            m_dispatchItem.m_arguments = dispatchArgs;
 
             m_isFullscreenPass = passData->m_makeFullscreenPass;
 
@@ -164,7 +180,7 @@ namespace AZ
         void ComputePass::MatchDimensionsToOutput()
         {
             PassAttachment* outputAttachment = nullptr;
-            
+
             if (GetOutputCount() > 0)
             {
                 outputAttachment = GetOutputBinding(0).GetAttachment().get();


### PR DESCRIPTION
Signed-off-by: Martin Sattlecker <martin.sattlecker@huawei.com>

## What does this PR do?

The Dispatch Arguments in the Compute Shader were overwritten when the Shader was reloaded. This was unexpected, as we use Indirect Dispatch, and only set the Dispatch Arguments in the `BuildInternal` function. Not every frame.

We now load the `PassData` Dispatch Arguments in the constructor. Only the data from the Shader is updated in the LoadShader function.

## How was this PR tested?

Windows & Vulkan. Tested with direct and indirect dispatch and hot reloading.
