### PR TITLE
Prevent crash when creating assets with DPE enabled.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.cpp
@@ -192,8 +192,8 @@ namespace AzToolsFramework
             mainLayout->addWidget(m_header);
             m_header->show();
 
-            m_propertyEditor->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-            mainLayout->addWidget(m_propertyEditor);
+            propertyEditor->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+            mainLayout->addWidget(propertyEditor);
 
             setLayout(mainLayout);
 


### PR DESCRIPTION
Signed-off-by: sphrose <82213493+sphrose@users.noreply.github.com>

## What does this PR do?

This PR fixes a crash issue caused by creating an asset withing the asset editor whilst in DPE mode.

## How was this PR tested?

Created multiple assets in DPE and non DPE mode without any issues.
