### PR TITLE
linux now uses system libunwind instead of a o3de package

### DIFF
--- a/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux.cmake
+++ b/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux.cmake
@@ -29,7 +29,6 @@ ly_associate_package(PACKAGE_NAME mcpp-2.7.2_az.2-rev1-linux                    
 ly_associate_package(PACKAGE_NAME mikkelsen-1.0.0.4-linux                           TARGETS mikkelsen                   PACKAGE_HASH 5973b1e71a64633588eecdb5b5c06ca0081f7be97230f6ef64365cbda315b9c8)
 ly_associate_package(PACKAGE_NAME googletest-1.8.1-rev4-linux                       TARGETS googletest                  PACKAGE_HASH 7b7ad330f369450c316a4c4592d17fbb4c14c731c95bd8f37757203e8c2bbc1b)
 ly_associate_package(PACKAGE_NAME googlebenchmark-1.7.0-rev1-linux                  TARGETS GoogleBenchmark             PACKAGE_HASH 230e1881e31490820f0bd2059df4741455b52809ac73367e278e1e821ac89c9b)
-ly_associate_package(PACKAGE_NAME unwind-1.2.1-linux                                TARGETS unwind                      PACKAGE_HASH 3453265fb056e25432f611a61546a25f60388e315515ad39007b5925dd054a77)
 ly_associate_package(PACKAGE_NAME qt-5.15.2-rev8-linux                              TARGETS Qt                          PACKAGE_HASH 613d6a404b305ce0e715c57c936dc00318fb9f0d2d3f6609f8454c198f993095)
 ly_associate_package(PACKAGE_NAME png-1.6.37-rev2-linux                             TARGETS PNG                         PACKAGE_HASH 5c82945a1648905a5c4c5cee30dfb53a01618da1bf58d489610636c7ade5adf5)
 ly_associate_package(PACKAGE_NAME libsamplerate-0.2.1-rev2-linux                    TARGETS libsamplerate               PACKAGE_HASH 41643c31bc6b7d037f895f89d8d8d6369e906b92eff42b0fe05ee6a100f06261)

--- a/cmake/Platform/Linux/PAL_linux.cmake
+++ b/cmake/Platform/Linux/PAL_linux.cmake
@@ -52,6 +52,9 @@ set_property(CACHE PAL_TRAIT_LINUX_WINDOW_MANAGER PROPERTY STRINGS xcb wayland)
 # Use system default OpenSSL library instead of maintaining an O3DE version for Linux
 include(${CMAKE_CURRENT_LIST_DIR}/OpenSSL_linux.cmake)
 
+# Use system default libunwind  instead of maintaining an O3DE version for Linux
+include(${CMAKE_CURRENT_LIST_DIR}/libunwind_linux.cmake)
+
 if ("${OPENSSL_VERSION}" STREQUAL "")
     message(FATAL_ERROR "OpenSSL not detected. The OpenSSL dev package is required for O3DE")
 endif()

--- a/cmake/Platform/Linux/Packaging_linux.cmake
+++ b/cmake/Platform/Linux/Packaging_linux.cmake
@@ -33,6 +33,8 @@ set(package_dependencies
     libxcb-xinput-dev                       # For mouse input
     zlib1g-dev
     mesa-common-dev
+    libunwind-dev
+    pkg-config
 )
 list(JOIN package_dependencies "," CPACK_DEBIAN_PACKAGE_DEPENDS)
 

--- a/cmake/Platform/Linux/libunwind_linux.cmake
+++ b/cmake/Platform/Linux/libunwind_linux.cmake
@@ -1,0 +1,32 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Use system default unwind library instead of maintaining an O3DE version for Linux
+
+find_package(PkgConfig REQUIRED)
+# ask pkg-config to find the libunwind library and prepare an imported target
+pkg_check_modules(libunwind IMPORTED_TARGET libunwind)
+if (NOT TARGET PkgConfig::libunwind)
+    message(FATAL_ERROR "Compiling on linux requires the unwind development libraries and headers as well as pkg-config.  Try using your package manager to install the libunwind-dev libraries.")
+else()
+    add_library(3rdParty::unwind ALIAS PkgConfig::libunwind)
+    set_target_properties(PkgConfig::libunwind 
+        PROPERTIES 
+            LY_SYSTEM_LIBRARY TRUE)
+
+    # include Install.cmake to get access to the ly_install function
+    include(cmake/Install.cmake)
+
+    # Copies over the libunwind_linux.cmake to the same location in the SDK layout.
+    cmake_path(RELATIVE_PATH CMAKE_CURRENT_LIST_DIR BASE_DIRECTORY ${LY_ROOT_FOLDER} OUTPUT_VARIABLE libunwind_linux_cmake_rel_directory)
+    ly_install(FILES "${CMAKE_CURRENT_LIST_FILE}"
+        DESTINATION "${libunwind_linux_cmake_rel_directory}"
+        COMPONENT ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME}
+    )
+
+endif()

--- a/scripts/build/build_node/Platform/Linux/package-list.ubuntu-bionic.txt
+++ b/scripts/build/build_node/Platform/Linux/package-list.ubuntu-bionic.txt
@@ -21,3 +21,5 @@ libxcb-xfixes0-dev                      # For mouse input
 libxcb-xinput-dev                       # For mouse input
 zlib1g-dev
 mesa-common-dev
+libunwind-dev
+pkg-config

--- a/scripts/build/build_node/Platform/Linux/package-list.ubuntu-focal.txt
+++ b/scripts/build/build_node/Platform/Linux/package-list.ubuntu-focal.txt
@@ -26,3 +26,5 @@ ros-humble-gazebo-msgs
 ros-humble-tf2-ros
 ros-humble-urdfdom
 ros-humble-vision-msgs
+libunwind-dev
+

--- a/scripts/build/build_node/Platform/Linux/package-list.ubuntu-jammy.txt
+++ b/scripts/build/build_node/Platform/Linux/package-list.ubuntu-jammy.txt
@@ -26,3 +26,4 @@ ros-humble-gazebo-msgs                  # ROS2 development tools
 ros-humble-tf2-ros                      # ROS2 development tools
 ros-humble-urdfdom                      # ROS2 development tools
 ros-humble-vision-msgs                  # ROS2 development tools
+libunwind-dev


### PR DESCRIPTION
## What does this PR do?

Previously, linux was using a mystery meat package for libunwind with unknown pedigree.
This changes it to use the official libunwind provided by your system.

## How was this PR tested?
Building and running AP on linux and android (android is unaffected by this change, but wanted to be sure).  Also ran all the AzCore tests on linux, to pass.

Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>

