### PR TITLE
Multiplayer: Fix cl_connect_onstartup

### DIFF
--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
@@ -192,6 +192,7 @@ namespace Multiplayer
         VersionMismatchEvent m_versionMismatchEvent;
 
         AZ::Event<NetEntityId>::Handler m_autonomousEntityReplicatorCreatedHandler;
+        AZ::SettingsRegistryInterface::NotifyEventHandler m_componentApplicationLifecycleHandler;
 
         AZStd::queue<AZStd::string> m_pendingConnectionTickets;
         AZStd::unordered_map<uint64_t, NetEntityId> m_playerRejoinData;


### PR DESCRIPTION
If the client wants to connect on startup, wait for all the system components to activate, and then call connect. Connecting too soon causes a 'version mismatch' because all of the system components haven't registered their multiplayer components.
Fixes #13868

## How was this PR tested?
1. Open server launcher
2. Open console: host > loadlevel SampleBase > sv_launch_local_client
3. Notice game opens and connects