### PR TITLE
Update Jenkinsfile to checkout bootstrap scripts from current branch

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -1152,14 +1152,13 @@ try {
 
                         echo "Running repository: \"${repositoryName}\", pipeline: \"${pipelineName}\", branch: \"${branchName}\", CHANGE_ID: \"${env.CHANGE_ID}\", GIT_COMMMIT: \"${scm.GIT_COMMIT}\"..."
 
+                        CheckoutEngineBootstrapScripts(branchName)
                         // Project or external repos may not have the bootstrapping scripts. For these cases, pull the bootstrap scripts from the engine repo at the default branch
                         if (!fileExists(SCRIPTS_PATH) || !fileExists(PIPELINE_CONFIG_FILE) || !(COMMIT_REPOSITORY_NAME == ENGINE_REPOSITORY_NAME)) {
                             echo "No bootstrap scripts found in ${SCRIPTS_PATH} or working repo is not the engine repo, downloading it from the engine repo at ${ENGINE_DEVELOPMENT_BRANCH}"
                             CheckoutEngineBootstrapScripts(ENGINE_DEVELOPMENT_BRANCH)
                         }
-                        else {
-                            CheckoutEngineBootstrapScripts(branchName)
-                        }
+                        
                         // Load configs
                         pipelineConfig = LoadPipelineConfig(pipelineName, branchName)
 

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -1152,7 +1152,7 @@ try {
 
                         echo "Running repository: \"${repositoryName}\", pipeline: \"${pipelineName}\", branch: \"${branchName}\", CHANGE_ID: \"${env.CHANGE_ID}\", GIT_COMMMIT: \"${scm.GIT_COMMIT}\"..."
 
-                        CheckoutEngineBootstrapScripts(branchName)
+                        CheckoutEngineBootstrapScripts(branchName, scm.userRemoteConfigs)
                         // Project or external repos may not have the bootstrapping scripts. For these cases, pull the bootstrap scripts from the engine repo at the default branch
                         if (!fileExists(SCRIPTS_PATH) || !fileExists(PIPELINE_CONFIG_FILE) || !(COMMIT_REPOSITORY_NAME == ENGINE_REPOSITORY_NAME)) {
                             echo "No bootstrap scripts found in ${SCRIPTS_PATH} or working repo is not the engine repo, downloading it from the engine repo at ${ENGINE_DEVELOPMENT_BRANCH}"


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/14052

This change fixes an issue introduced in the Jenkisfile that prevents users from testing build config changes in a branch. The bootstrap files are always loaded from the development branch since the check will fail on new branches. 

This change moves the checkout step to the original location. The bootstrap scripts will still be pulled from the O3DE development branch if they are missing. 

## How was this PR tested?

Performed the following tests in a branch:
- Updated one of the build config files (e.g. scripts/build/Platform/Windows/pipeline.json). Jenkins successfully picked up the change from the branch. 
- Ran a build with the scripts/build folder missing. Bootstrap files successfully loaded from the development branch. 
