### PR TITLE
Fix heap-use-after-free errors in the EditorPythonBindings tests

### DIFF
--- a/Gems/EditorPythonBindings/Code/Tests/CustomTypeBindingBusTests.cpp
+++ b/Gems/EditorPythonBindings/Code/Tests/CustomTypeBindingBusTests.cpp
@@ -333,8 +333,6 @@ namespace UnitTest
             auto handleEntry = m_allocationMap.find(reinterpret_cast<void*>(handle));
             if (handleEntry != m_allocationMap.end())
             {
-                m_allocationMap.erase(handleEntry);
-
                 const AZ::TypeId& typeId = handleEntry->second;
                 if (typeId == azrtti_typeid<AZ::CustomType<int>>())
                 {
@@ -352,6 +350,7 @@ namespace UnitTest
                 {
                     azfree(reinterpret_cast<void*>(handle));
                 }
+                m_allocationMap.erase(handleEntry);
             }
         }
     };

--- a/Gems/EditorPythonBindings/Code/Tests/PythonLogSymbolsComponentTests.cpp
+++ b/Gems/EditorPythonBindings/Code/Tests/PythonLogSymbolsComponentTests.cpp
@@ -185,7 +185,7 @@ namespace UnitTest
         intParam.m_typeId = AZ::AzTypeInfo<AZ::s8>::Uuid(); // Uuid for a supported type
         intParam.m_traits = AZ::BehaviorParameter::TR_NONE;
 
-        AZStd::string_view result = pythonLogSymbolsComponent.FetchPythonTypeWrapper(intParam);
+        AZStd::string result = pythonLogSymbolsComponent.FetchPythonTypeWrapper(intParam);
         EXPECT_EQ(result, "int");
     }
 
@@ -197,7 +197,7 @@ namespace UnitTest
         voidParam.m_typeId = AZ::Uuid("{9B3E8886-B749-418E-A696-6D7E9EB4D691}"); // A random Uuid
         voidParam.m_traits = AZ::BehaviorParameter::TR_NONE;
         
-        AZStd::string_view result = m_pythonLogSymbolsComponent.FetchPythonTypeWrapper(voidParam);
+        AZStd::string result = m_pythonLogSymbolsComponent.FetchPythonTypeWrapper(voidParam);
         EXPECT_EQ(result, "None");
     }
 }


### PR DESCRIPTION
Signed-off-by: Chris Burel <burelc@amazon.com>

## What does this PR do?

There are a few instances where freed variables are read from in the EditorPythonBindings tests. This fixes them.

## How was this PR tested?

Ran the tests with the address sanitizer enabled in Linux
