### PR TITLE
Add optional fileExtension param to PerformanceCollector

### DIFF
--- a/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.cpp
+++ b/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.cpp
@@ -18,8 +18,14 @@
 
 namespace AZ::Debug
 {
-    PerformanceCollector::PerformanceCollector(const AZStd::string_view logCategory, AZStd::span<const AZStd::string_view> m_metricNames, OnBatchCompleteCallback onBatchCompleteCallback)
-        : m_logCategory(logCategory), m_onBatchCompleteCallback(onBatchCompleteCallback)
+    PerformanceCollector::PerformanceCollector(
+        const AZStd::string_view logCategory,
+        AZStd::span<const AZStd::string_view> m_metricNames,
+        OnBatchCompleteCallback onBatchCompleteCallback,
+        const AZStd::string_view fileExtension)
+        : m_logCategory(logCategory)
+        , m_onBatchCompleteCallback(onBatchCompleteCallback)
+        , m_fileExtension(fileExtension)
     {
         for (const auto& metricName : m_metricNames)
         {
@@ -244,7 +250,7 @@ namespace AZ::Debug
             settingsRegistry->Get(m_outputFilePath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectUserPath);
             AZ::Date::Iso8601TimestampString utcTimestamp;
             AZ::Date::GetFilenameCompatibleFormatNowWithMicroseconds(utcTimestamp);
-            m_outputFilePath /= AZStd::string::format("Performance_%s_%s.json", m_logCategory.c_str(), utcTimestamp.c_str());
+            m_outputFilePath /= AZStd::string::format("Performance_%s_%s.%s", m_logCategory.c_str(), utcTimestamp.c_str(), m_fileExtension.c_str());
 
             constexpr AZ::IO::OpenMode openMode = AZ::IO::OpenMode::ModeWrite;
             auto stream = AZStd::make_unique<AZ::IO::SystemFileStream>(m_outputFilePath.c_str(), openMode);

--- a/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.h
+++ b/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.h
@@ -99,11 +99,11 @@ namespace AZ::Debug
         //! and performance capture for as many batches.
         void UpdateNumberOfCaptureBatches(AZ::u32 newValue);
 
-        const AZ::IO::Path& GetOutputFilePath() { return m_outputFilePath;  }
+        const AZ::IO::Path& GetOutputFilePath() const { return m_outputFilePath;  }
 
-        const AZStd::string& GetOutputDataBuffer() { return m_outputDataBuffer; }
+        const AZStd::string& GetOutputDataBuffer() const { return m_outputDataBuffer; }
 
-        const AZStd::string& GetFileExtension() { return m_fileExtension; }
+        const AZStd::string& GetFileExtension() const { return m_fileExtension; }
 
     private:
         //! A helper function that loops across all statistics in @m_statisticsManager

--- a/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.h
+++ b/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.h
@@ -44,7 +44,12 @@ namespace AZ::Debug
         //!                    Each output file will be named Performance_<Category>_<CreationTime>.json
         //! @param m_metricNames List of all the metrics that will be recorded. All metrics will be measured in Microseconds.
         //! @param onBatchCompleteCallback See comments above in OnBatchCompleteCallback declaration.
-        PerformanceCollector(const AZStd::string_view logCategory, AZStd::span<const AZStd::string_view> m_metricNames, OnBatchCompleteCallback onBatchCompleteCallback);
+        //! @param m_fileExtension The extension of the output file, to appear after "." Defaults to "json".
+        PerformanceCollector(
+            const AZStd::string_view logCategory,
+            AZStd::span<const AZStd::string_view> m_metricNames,
+            OnBatchCompleteCallback onBatchCompleteCallback,
+            const AZStd::string_view fileExtension = "json");
         ~PerformanceCollector() = default;
 
         static constexpr char LogName[] = "PerformanceCollector";
@@ -98,6 +103,8 @@ namespace AZ::Debug
 
         const AZStd::string& GetOutputDataBuffer() { return m_outputDataBuffer; }
 
+        const AZStd::string& GetFileExtension() { return m_fileExtension; }
+
     private:
         //! A helper function that loops across all statistics in @m_statisticsManager
         //! and reports each result into @m_eventLogger.
@@ -118,6 +125,7 @@ namespace AZ::Debug
         AZStd::chrono::steady_clock::time_point m_startWaitTime;
         bool m_isWaitingBeforeNextBatch = true;
         OnBatchCompleteCallback m_onBatchCompleteCallback; // A notification will be sent each time a batch of frames is performance collected.
+        AZStd::string m_fileExtension = "json";
 
         //! Only used when @m_captureType == CaptureType::LogStatistics.
         AZ::Statistics::StatisticsManager<AZStd::string> m_statisticsManager;

--- a/Code/Framework/AzCore/Tests/Debug/PerformanceCollectorTests.cpp
+++ b/Code/Framework/AzCore/Tests/Debug/PerformanceCollectorTests.cpp
@@ -187,4 +187,31 @@ namespace UnitTest
         }
     }
 
+    TEST_F(PerformanceCollectorTest, CreatePerformnaceCollector_WithDefaultFileExtension_ValidateFileExtension)
+    {
+        auto paramList = AZStd::to_array<AZStd::string_view>({ "param1" });
+        auto onCompleteCallback = [](AZ::u32)
+        {
+        };
+
+        AZ::Debug::PerformanceCollector performanceCollector("PerformanceCollectorTest", paramList, onCompleteCallback);
+
+        const AZStd::string& actualExtension = performanceCollector.GetFileExtension();
+        ASSERT_EQ("json", actualExtension);
+    }
+
+    TEST_F(PerformanceCollectorTest, CreatePerformanceCollector_WithCustomFileExtension_ValidateFileExtension)
+    {
+        auto paramList = AZStd::to_array<AZStd::string_view>({ "param1" });
+        auto onCompleteCallback = [](AZ::u32)
+        {
+        };
+        const AZStd::string testFileExtention("test.json");
+
+        AZ::Debug::PerformanceCollector performanceCollector("PerformanceCollectorTest", paramList, onCompleteCallback, testFileExtention);
+
+        const AZStd::string& actualExtension = performanceCollector.GetFileExtension();
+        ASSERT_EQ(testFileExtention, actualExtension);
+    }
+
 }//namespace UnitTest

--- a/Gems/PhysX/Code/Source/System/PhysXSystem.cpp
+++ b/Gems/PhysX/Code/Source/System/PhysXSystem.cpp
@@ -122,7 +122,7 @@ namespace PhysX
             AZStd::string::format("%.*s.json", AZ_STRING_ARG(PerformanceLogCategory));
         AZStd::to_lower(fileExtension.begin(), fileExtension.end());
         m_performanceCollector = AZStd::make_unique<AZ::Debug::PerformanceCollector>(
-            logCategory, 
+            logCategory,
             performanceMetrics,
             [](AZ::u32)
             {

--- a/Gems/PhysX/Code/Source/System/PhysXSystem.cpp
+++ b/Gems/PhysX/Code/Source/System/PhysXSystem.cpp
@@ -118,12 +118,16 @@ namespace PhysX
         AZStd::string platformName = AZ::GetPlatformName(AZ::g_currentPlatform);
         auto logCategory =
             AZStd::string::format("%.*s-%s", AZ_STRING_ARG(PerformanceLogCategory), platformName.c_str());
+        auto fileExtension =
+            AZStd::string::format("%.*s.json", AZ_STRING_ARG(PerformanceLogCategory));
+        AZStd::to_lower(fileExtension.begin(), fileExtension.end());
         m_performanceCollector = AZStd::make_unique<AZ::Debug::PerformanceCollector>(
-            logCategory,
+            logCategory, 
             performanceMetrics,
             [](AZ::u32)
             {
-            });
+            },
+            fileExtension);
 
         m_performanceCollector->UpdateDataLogType(GetDataLogTypeFromCVar(physx_metricsDataLogType));
         m_performanceCollector->UpdateFrameCountPerCaptureBatch(physx_metricsFrameCountPerCaptureBatch);


### PR DESCRIPTION
## What does this PR do?

Adds an optional `fileExtension` parameter to _PerformanceCollector_ so logging systems can optionally set a custom extension (such as "physx.json") on the created log file. A custom file extension makes post-processing discovery of the created logs easier, e.g., upload the file to Amazon S3 and trigger a Lambda based on file suffix. 
Defaults to **"json"** if no value is provided.

Also updates the **PhysX** gem to use the extension **"physx.json"** when initializing _PerformanceCollector_.

## How was this PR tested?

* `AzCore.Tests` pass
* `PhysX.Tests` pass
* `Atom_RPI.Tests` pass (not modified, but another user of _PerformanceCollector_)
* Building & running [o3de-multiplayersample](https://github.com/o3de/o3de-multiplayersample) with this change and PhysX metrics turned on produces a log file named "Performance_PhysX-PLATFORM_DATE_TIMESTAMP.**physx.json**":

![image](https://user-images.githubusercontent.com/34254888/212424745-1d263245-4e33-4908-b65b-f16a985c6cd7.png)

NOTE: in light of [this warning](https://github.com/o3de/o3de/blob/development/Code/Framework/AzCore/AzCore/Debug/PerformanceCollector.cpp#L236), I didn't add a unit test which actually created & validated a file name, but I'm open to suggestions on how testing may be improved.
