### PR TITLE
Errors in python packages will now be a build failure

### DIFF
--- a/cmake/LYPython.cmake
+++ b/cmake/LYPython.cmake
@@ -92,8 +92,8 @@ function(update_pip_requirements requirements_file_path unique_name)
     message(VERBOSE "pip output: ${PIP_OUT}")
 
     if (NOT ${PIP_RESULT} EQUAL 0)
-        message(CHECK_FAIL "Failed to fetch / update python dependencies: ${PIP_OUT} - use CMAKE_MESSAGE_LOG_LEVEL to VERBOSE for more information")
-        message(FATAL_ERROR "some python dependencies failed to install/download.  This will likely cause errors further down the line, stopping.")
+        message(CHECK_FAIL "Failed to fetch / update python dependencies from ${requirements_file_path}\nPip install log:\n${PIP_OUT}")
+        message(FATAL_ERROR "The above failure will cause errors later - stopping now.  Check the output log (above) for details.")
     else()
         string(FIND "${PIP_OUT}" "Installing collected packages" NEW_PACKAGES_INSTALLED)
 

--- a/cmake/LYPython.cmake
+++ b/cmake/LYPython.cmake
@@ -93,6 +93,7 @@ function(update_pip_requirements requirements_file_path unique_name)
 
     if (NOT ${PIP_RESULT} EQUAL 0)
         message(CHECK_FAIL "Failed to fetch / update python dependencies: ${PIP_OUT} - use CMAKE_MESSAGE_LOG_LEVEL to VERBOSE for more information")
+        message(FATAL_ERROR "some python dependencies failed to install/download.  This will likely cause errors further down the line, stopping.")
     else()
         string(FIND "${PIP_OUT}" "Installing collected packages" NEW_PACKAGES_INSTALLED)
 
@@ -193,6 +194,7 @@ function(ly_pip_install_local_package_editable package_folder_path pip_package_n
 
     if (NOT ${PIP_RESULT} EQUAL 0)
         message(CHECK_FAIL "Failed to install ${package_folder_path}: ${PIP_OUT} - use CMAKE_MESSAGE_LOG_LEVEL to VERBOSE for more information")
+        message(FATAL_ERROR "Failure to install a python package will likely cause errors further down the line, stopping!")
     else()
         file(TOUCH ${stamp_file})
     endif()

--- a/python/get_python.bat
+++ b/python/get_python.bat
@@ -22,9 +22,7 @@ call python.cmd --version > NUL
 IF !ERRORLEVEL!==0 (
     echo get_python.bat: Python is already installed:
     call python.cmd --version
-    call "%CMD_DIR%\pip.cmd" install -r "%CMD_DIR%/requirements.txt" --quiet --disable-pip-version-check --no-warn-script-location
-    call "%CMD_DIR%\pip.cmd" install -e "%CMD_DIR%/../scripts/o3de" --quiet --disable-pip-version-check --no-warn-script-location --no-deps
-    exit /B 0
+    goto install_packages
 )
 
 cd /D %CMD_DIR%\..
@@ -59,8 +57,19 @@ if ERRORLEVEL 1 (
     EXIT /b 1
 )
 
+:install_packages
 echo calling PIP to install requirements...
 call "%CMD_DIR%\pip.cmd" install -r "%CMD_DIR%/requirements.txt" --disable-pip-version-check --no-warn-script-location
+if ERRORLEVEL 1 (
+    echo Pip install on the requirements.txt returned a non-zero exit code.  Check the log!
+    EXIT /b 1
+)
+
 call "%CMD_DIR%\pip.cmd" install -e "%CMD_DIR%/../scripts/o3de" --disable-pip-version-check --no-warn-script-location --no-deps
-exit /B %ERRORLEVEL%
+if ERRORLEVEL 1 (
+    echo pip install on the o3de package returned a non-zero exit code.  Check the log!
+    EXIT /b 1
+)
+
+exit /b 0
 

--- a/python/get_python.bat
+++ b/python/get_python.bat
@@ -61,13 +61,13 @@ if ERRORLEVEL 1 (
 echo calling PIP to install requirements...
 call "%CMD_DIR%\pip.cmd" install -r "%CMD_DIR%/requirements.txt" --disable-pip-version-check --no-warn-script-location
 if ERRORLEVEL 1 (
-    echo Pip install on the requirements.txt returned a non-zero exit code.  Check the log!
+    echo Failed to install the packages listed in %CMD_DIR%\requirements.txt.  Check the log above!
     EXIT /b 1
 )
 
 call "%CMD_DIR%\pip.cmd" install -e "%CMD_DIR%/../scripts/o3de" --disable-pip-version-check --no-warn-script-location --no-deps
 if ERRORLEVEL 1 (
-    echo pip install on the o3de package returned a non-zero exit code.  Check the log!
+    echo Failed to install %CMD_DIR%\..\scripts\o3de into python.  Check the log above!
     EXIT /b 1
 )
 

--- a/python/get_python.sh
+++ b/python/get_python.sh
@@ -23,14 +23,14 @@ install_dependencies () {
     $DIR/pip.sh install -r $DIR/requirements.txt --disable-pip-version-check --no-warn-script-location
     retVal=$?
     if [ $retVal -ne 0 ]; then
-        echo Pip install on the requirements.txt returned a non-zero exit code.  Check the log!
+        echo "Failed to install the packages listed in $DIR/requirements.txt.  Check the log above!"
         return $retVal
     fi
 
     $DIR/pip.sh install -e $DIR/../scripts/o3de --no-deps --disable-pip-version-check  --no-warn-script-location
     retVal=$?
     if [ $retVal -ne 0 ]; then
-        echo pip install on the o3de package returned a non-zero exit code.  Check the log!
+        echo "Failed to install $DIR/../scripts/o3de into python.  Check the log above!"
         return $retVal
     fi
 }

--- a/python/get_python.sh
+++ b/python/get_python.sh
@@ -18,6 +18,23 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 cd $DIR
 
+install_dependencies () {
+    echo installing via pip...
+    $DIR/pip.sh install -r $DIR/requirements.txt --disable-pip-version-check --no-warn-script-location
+    retVal=$?
+    if [ $retVal -ne 0 ]; then
+        echo Pip install on the requirements.txt returned a non-zero exit code.  Check the log!
+        return $retVal
+    fi
+
+    $DIR/pip.sh install -e $DIR/../scripts/o3de --no-deps --disable-pip-version-check  --no-warn-script-location
+    retVal=$?
+    if [ $retVal -ne 0 ]; then
+        echo pip install on the o3de package returned a non-zero exit code.  Check the log!
+        return $retVal
+    fi
+}
+
 # Overall strategy: Run python with --version to see if its already there
 # otherwise, use cmake and the new package system to download it.
 # To find cmake, search the path for cmake.  If not found, try a fixed known location.
@@ -30,9 +47,8 @@ cd $DIR
 python_exitcode=$?
 if [ $python_exitcode == 0 ]; then
     echo get_python.sh: Python is already downloaded: $(./python.sh --version)
-    $DIR/pip.sh install -r $DIR/requirements.txt --disable-pip-version-check --no-warn-script-location
-    $DIR/pip.sh install -e $DIR/../scripts/o3de --no-deps --disable-pip-version-check  --no-warn-script-location
-    exit 0
+    install_dependencies
+    exit $?
 fi
 if [[ "$OSTYPE" = *"darwin"* ]];
 then
@@ -73,7 +89,5 @@ if [ $retVal -ne 0 ]; then
     exit $retVal
 fi
 
-echo installing via pip...
-$DIR/pip.sh install -r $DIR/requirements.txt --disable-pip-version-check --no-warn-script-location
-$DIR/pip.sh install -e $DIR/../scripts/o3de --no-deps --disable-pip-version-check  --no-warn-script-location
+install_dependencies
 exit $?


### PR DESCRIPTION
## What does this PR do?

This adds checks to the get_python and lypython.cmake files which will cause cmake or the command prompt to fail immediately and return a non zero exit code.

Continuing while the python package configuration is bad causes hard-to-attribute failures.

Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>

## How was this PR tested?

Windows and linux testing.

Tested the following cases on each
* No python installed
* Python installed but no packages
* Python and packages installed

Tested the above 3 against the matrix of
* Via CMake
* Via get_python
* Via CMake + an invaild package -> error
* Via get_python + an invalid package -> error
