### PR TITLE
Removed temporary workaround on Linux that limited the PhysX simulation to one thread

### DIFF
--- a/Gems/PhysX/Code/Source/System/PhysXSystem.cpp
+++ b/Gems/PhysX/Code/Source/System/PhysXSystem.cpp
@@ -455,13 +455,7 @@ namespace PhysX
         m_physXSdk.m_cooking = PxCreateCooking(PX_PHYSICS_VERSION, *m_physXSdk.m_foundation, cookingParams);
 
         // Set up CPU dispatcher
-#if defined(AZ_PLATFORM_LINUX)
-        // Temporary workaround for linux. At the moment using AzPhysXCpuDispatcher results in an assert at
-        // PhysX mutex indicating it must be unlocked only by the thread that has already acquired lock.
-        m_cpuDispatcher = physx::PxDefaultCpuDispatcherCreate(0);
-#else
         m_cpuDispatcher = PhysXCpuDispatcherCreate();
-#endif
 
         PxSetProfilerCallback(&m_pxAzProfilerCallback);
     }


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

Previously using a PhysXCpuDispatcher that allowed more threads resulted in internal PhysX mutex asserting and the app crashing.

This assert happened back in Lumberyard days when Linux platform was still in very early stages and only supported the dedicated server. Now that Linux platform is much more mature this thread limitation can be removed.

## How was this PR tested?

Using a Linux machine I run a level with physics components using the Editor, GameLauncher and ServerLauncher with AutomatedTesting project. Testing with both debug and profile and PhysX 4 and PhysX 5. They all run successfully without PhysX asserts.
