### PR TITLE
Show search results in Asset Browser Thumbnail View (#14003)

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -24,6 +24,7 @@
 
 // AzQtComponents
 #include <AzQtComponents/Utilities/QtWindowUtilities.h>
+#include <AzQtComponents/Components/Widgets/AssetFolderThumbnailView.h>
 
 // Editor
 #include "AzAssetBrowser/AzAssetBrowserRequestHandler.h"
@@ -40,6 +41,8 @@ AZ_CVAR(bool, ed_useWIPAssetBrowserDesign, false, nullptr, AZ::ConsoleFunctorFla
 //! When the Asset Browser window is resized to be less than this many pixels in width
 //! the layout changes to accomodate its narrow state better. See AzAssetBrowserWindow::SetNarrowMode
 static constexpr int s_narrowModeThreshold = 700;
+
+using namespace AzToolsFramework::AssetBrowser;
 
 namespace AzToolsFramework
 {
@@ -154,9 +157,104 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
             m_ui->m_searchWidget, &AzAssetBrowser::SearchWidget::ClearTypeFilter);
 
         m_ui->m_assetBrowserTableViewWidget->SetName("AssetBrowserTableView_main");
-    }
 
-    m_ui->m_thumbnailView->SetPreviewerFrame(m_ui->m_previewerFrame);
+        connect(
+            m_ui->m_thumbnailView,
+            &AssetBrowserThumbnailView::entryClicked,
+            this,
+            [this](const AssetBrowserEntry* entry)
+            {
+                if (entry && entry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Source)
+                {
+                    m_ui->m_previewerFrame->Display(entry);
+                }
+            });
+        connect(
+            m_ui->m_thumbnailView,
+            &AssetBrowserThumbnailView::entryDoubleClicked,
+            this,
+            [this](const AssetBrowserEntry* entry)
+            {
+                if (!m_ui->m_assetBrowserTreeViewWidget)
+                {
+                    return;
+                }
+
+                if (!entry)
+                {
+                    return;
+                }
+
+                if (entry->GetEntryType() != AssetBrowserEntry::AssetEntryType::Folder)
+                {
+                    return;
+                }
+
+                if (!m_assetBrowserModel)
+                {
+                    return;
+                }
+
+                if (!m_filterModel.data())
+                {
+                    return;
+                }
+
+                QModelIndex indexForEntry;
+                m_assetBrowserModel->GetEntryIndex(const_cast<AssetBrowserEntry*>(entry), indexForEntry);
+
+                if (!indexForEntry.isValid())
+                {
+                    return;
+                }
+
+                auto selectionModel = m_ui->m_assetBrowserTreeViewWidget->selectionModel();
+                auto targetIndex = m_filterModel.data()->mapFromSource(indexForEntry);
+
+                selectionModel->select(targetIndex, QItemSelectionModel::ClearAndSelect);
+
+                auto targetIndexAncestor = targetIndex.parent();
+                while (targetIndexAncestor.isValid())
+                {
+                    m_ui->m_assetBrowserTreeViewWidget->expand(targetIndexAncestor);
+                    targetIndexAncestor = targetIndexAncestor.parent();
+                }
+
+                m_ui->m_assetBrowserTreeViewWidget->scrollTo(targetIndex);
+            });
+
+        connect(
+            m_ui->m_thumbnailView,
+            &AssetBrowserThumbnailView::showInFolderTriggered,
+            this,
+            [this](const AssetBrowserEntry* entry)
+            {
+                if (!entry)
+                {
+                    return;
+                }
+
+                if (!entry->GetParent())
+                {
+                    return;
+                }
+
+                m_ui->m_searchWidget->ClearStringFilter();
+
+                QModelIndex indexForEntry;
+                m_assetBrowserModel->GetEntryIndex(const_cast<AssetBrowserEntry*>(entry->GetParent()), indexForEntry);
+
+                if (!indexForEntry.isValid())
+                {
+                    return;
+                }
+
+                auto selectionModel = m_ui->m_assetBrowserTreeViewWidget->selectionModel();
+                auto targetIndex = m_filterModel.data()->mapFromSource(indexForEntry);
+
+                selectionModel->select(targetIndex, QItemSelectionModel::ClearAndSelect);
+            });
+    }
 
     if (!ed_useWIPAssetBrowserDesign)
     {
@@ -226,6 +324,15 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
             {
                 CurrentIndexChangedSlot(selected.indexes()[0]);
             }
+        });
+
+    connect(
+        m_ui->m_assetBrowserTreeViewWidget,
+        &QAbstractItemView::clicked,
+        this,
+        [this](const QModelIndex&)
+        {
+            m_ui->m_searchWidget->ClearStringFilter();
         });
 
     connect(m_ui->m_assetBrowserTreeViewWidget, &QAbstractItemView::doubleClicked, this, &AzAssetBrowserWindow::DoubleClickedItem);
@@ -488,6 +595,24 @@ void AzAssetBrowserWindow::UpdateWidgetAfterFilter()
     {
         m_ui->m_assetBrowserTableViewWidget->setVisible(hasFilter);
         m_ui->m_assetBrowserTreeViewWidget->setVisible(!hasFilter);
+    }
+
+    if (hasFilter)
+    {
+        m_ui->m_assetBrowserTreeViewWidget->selectionModel()->select(
+            m_ui->m_assetBrowserTreeViewWidget->model()->index(0, 0, {}), QItemSelectionModel::ClearAndSelect);
+    }
+
+    if (ed_useNewAssetBrowserTableView)
+    {
+        if (hasFilter)
+        {
+            auto thumbnailWidget = m_ui->m_thumbnailView->GetThumbnailViewWidget();
+            if (thumbnailWidget)
+            {
+                thumbnailWidget->setRootIndex(thumbnailWidget->model()->index(0, 0, {}));
+            }
+        }
     }
 }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
@@ -17,6 +17,7 @@ AZ_PUSH_DISABLE_WARNING(4244 4251 4800, "-Wunknown-warning-option") // 4244: 'in
 #include <QPainter>
 #include <QScrollBar>
 #include <QSettings>
+#include <QMenu>
 AZ_POP_DISABLE_WARNING
 
 namespace
@@ -93,7 +94,7 @@ namespace AzQtComponents
 
     void AssetFolderThumbnailViewDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
     {
-        const auto isTopLevel = index.parent().isValid() == false;
+        const auto isTopLevel = index.data(static_cast<int>(AssetFolderThumbnailView::Role::IsTopLevel)).value<bool>();
 
         painter->save();
 
@@ -448,6 +449,16 @@ namespace AzQtComponents
         return rect.translated(-horizontalOffset(), -verticalOffset());
     }
 
+    void AssetFolderThumbnailView::setRootIndex(const QModelIndex& index)
+    {
+        if (index != rootIndex())
+        {
+            QAbstractItemView::setRootIndex(index);
+            m_expandedIndexes.clear();
+            emit rootIndexChanged(index);
+        }
+    }
+
     QModelIndex AssetFolderThumbnailView::moveCursor(QAbstractItemView::CursorAction cursorAction, Qt::KeyboardModifiers modifiers)
     {
         Q_UNUSED(modifiers);
@@ -521,20 +532,8 @@ namespace AzQtComponents
 
     void AssetFolderThumbnailView::setSelection(const QRect& rect, QItemSelectionModel::SelectionFlags flags)
     {
-        if (!model())
-        {
-            return;
-        }
-
-        const auto translatedRect = rect.translated(horizontalOffset(), verticalOffset());
-
-        for (auto it = m_itemGeometry.constBegin(); it != m_itemGeometry.constEnd(); ++it)
-        {
-            if (it.value().intersects(translatedRect))
-            {
-                selectionModel()->select(it.key(), flags);
-            }
-        }
+        Q_UNUSED(rect);
+        Q_UNUSED(flags);
     }
 
     QRegion AssetFolderThumbnailView::visualRegionForSelection(const QItemSelection& selection) const
@@ -549,7 +548,7 @@ namespace AzQtComponents
 
     bool AssetFolderThumbnailView::isExpandable(const QModelIndex& index) const
     {
-        return !index.parent().isValid() && model()->rowCount(index) > 0;
+        return index.data(static_cast<int>(AssetFolderThumbnailView::Role::IsExpandable)).value<bool>();
     }
 
     void AssetFolderThumbnailView::paintEvent(QPaintEvent* event)
@@ -631,7 +630,7 @@ namespace AzQtComponents
             }
             if (isExpandable(index))
             {
-                if (m_expandedRows.contains(index.row()))
+                if (m_expandedIndexes.contains(index))
                 {
                     option.state |= QStyle::State_UpArrow;
                 }
@@ -643,6 +642,23 @@ namespace AzQtComponents
 
             itemDelegate(index)->paint(painter, option, index);
         }
+    }
+
+    QModelIndex AssetFolderThumbnailView::indexAtPos(const QPoint& pos) const
+    {
+        auto it = std::find_if(
+            m_itemGeometry.keyBegin(),
+            m_itemGeometry.keyEnd(),
+            [this, &pos](const QModelIndex& index)
+            {
+                return m_itemGeometry.value(index).contains(pos);
+            });
+
+        if (it != m_itemGeometry.keyEnd())
+        {
+            return *it;
+        }
+        return {};
     }
 
     void AssetFolderThumbnailView::mousePressEvent(QMouseEvent* event)
@@ -657,7 +673,7 @@ namespace AzQtComponents
                 m_itemGeometry.keyEnd(),
                 [this, &p](const QModelIndex& index)
                 {
-                    if (isExpandable(index) && !m_expandedRows.contains(index.row()))
+                    if (isExpandable(index) && !m_expandedIndexes.contains(index))
                     {
                         const auto& rect = m_itemGeometry.value(index);
                         const auto width = m_config.expandButton.width;
@@ -668,14 +684,13 @@ namespace AzQtComponents
                 });
             if (it != m_itemGeometry.keyEnd())
             {
-                const auto row = it->row();
-                if (m_expandedRows.contains(row))
+                if (m_expandedIndexes.contains(*it))
                 {
-                    m_expandedRows.remove(row);
+                    m_expandedIndexes.remove(*it);
                 }
                 else
                 {
-                    m_expandedRows.insert(row);
+                    m_expandedIndexes.insert(*it);
                 }
                 scheduleDelayedItemsLayout();
                 return;
@@ -685,18 +700,12 @@ namespace AzQtComponents
         // check that the preview on one of the top level items was clicked
         // No need to do computations on m_itemGeometry entries since we handled the expand/collapse button with the case above
         {
-            auto it = std::find_if(
-                m_itemGeometry.keyBegin(),
-                m_itemGeometry.keyEnd(),
-                [this, &p](const QModelIndex& index)
-                {
-                    return m_itemGeometry.value(index).contains(p);
-                });
+            auto idx = indexAtPos(p);
 
-            if (it != m_itemGeometry.keyEnd())
+            if (idx.isValid())
             {
-                selectionModel()->select(*it, QItemSelectionModel::SelectionFlag::ClearAndSelect);
-                emit IndexClicked(*it);
+                selectionModel()->select(idx, QItemSelectionModel::SelectionFlag::ClearAndSelect);
+                emit clicked(idx);
                 return;
             }
         }
@@ -712,10 +721,9 @@ namespace AzQtComponents
             });
             if (it != m_childFrames.end())
             {
-                const auto row = it->index.row();
-                if (m_expandedRows.contains(row))
+                if (m_expandedIndexes.contains(it->index))
                 {
-                    m_expandedRows.remove(row);
+                    m_expandedIndexes.remove(it->index);
                     scheduleDelayedItemsLayout();
                     return;
                 }
@@ -730,24 +738,45 @@ namespace AzQtComponents
         const auto p = event->pos() + QPoint{ horizontalOffset(), verticalOffset() };
 
         // check the expand/collapse buttons on one of the top level items was clicked
+        auto idx = indexAtPos(p);
 
+        if (idx.isValid())
         {
-            auto it = std::find_if(
-                m_itemGeometry.keyBegin(),
-                m_itemGeometry.keyEnd(),
-                [this, &p](const QModelIndex& index)
-                {
-                    return m_itemGeometry.value(index).contains(p);
-                });
-
-            if (it != m_itemGeometry.keyEnd())
-            {
-                emit IndexDoubleClicked(*it);
-                return;
-            }
+            selectionModel()->select(idx, QItemSelectionModel::SelectionFlag::ClearAndSelect);
+            emit doubleClicked(idx);
+            return;
         }
 
         QAbstractItemView::mouseDoubleClickEvent(event);
+    }
+
+    void AssetFolderThumbnailView::contextMenuEvent(QContextMenuEvent* event)
+    {
+        // For now we only have a context menu in search mode for the "show in folder" option
+        if (!m_showSearchResultsMode)
+        {
+            return;
+        }
+
+        const auto p = event->pos() + QPoint{ horizontalOffset(), verticalOffset() };
+        auto idx = indexAtPos(p);
+
+        if (idx.isValid())
+        {
+            m_contextMenu = new QMenu(this);
+            auto action = m_contextMenu->addAction("Show In Folder");
+            connect(
+                action,
+                &QAction::triggered,
+                this,
+                [this, idx]()
+                {
+                    emit showInFolderTriggered(idx);
+                });
+            m_contextMenu->exec(event->globalPos());
+            delete m_contextMenu;
+            m_contextMenu = nullptr;
+        }
     }
 
     int AssetFolderThumbnailView::rootThumbnailSizeInPixels() const
@@ -770,7 +799,28 @@ namespace AzQtComponents
             return;
         }
 
-        const auto rowCount = model()->rowCount();
+        int x = m_config.viewportPadding;
+        int y = m_config.viewportPadding;
+
+        const QSize itemSize{ m_config.rootThumbnail.width, m_config.rootThumbnail.height + 4 + fontMetrics().height() };
+        const int rowHeight = itemSize.height() + m_config.topItemsVerticalSpacing;
+
+        if (m_showSearchResultsMode || !rootIndex().isValid())
+        {
+            updateGeometriesInternal(model()->index(0, 0, {}), x, y);
+        }
+        else
+        {
+            updateGeometriesInternal(rootIndex(), x, y);
+        }
+
+        verticalScrollBar()->setPageStep(viewport()->height());
+        verticalScrollBar()->setRange(0, y + rowHeight - viewport()->height());
+    }
+
+    void AssetFolderThumbnailView::updateGeometriesInternal(const QModelIndex& idx, int& x, int& y)
+    {
+        const auto rowCount = model()->rowCount(idx);
         if (rowCount == 0)
         {
             return;
@@ -785,11 +835,18 @@ namespace AzQtComponents
 
         const int childItemYOffset = (m_config.rootThumbnail.height - m_config.childThumbnail.height) / 2;
 
-        int x = m_config.viewportPadding;
-        int y = m_config.viewportPadding;
-
         for (int row = 0; row < rowCount; ++row)
         {
+            const auto index = model()->index(row, 0, idx);
+
+            // When in search results mode, we visit the whole asset tree, but only display entries that are
+            // exact matches for the search filter. This is reflected in the IsVisible role on the associated
+            // AssetBrowserFilterModel model.
+            if (m_showSearchResultsMode && !index.data(static_cast<int>(Role::IsVisible)).value<bool>())
+            {
+                continue;
+            }
+
             if (row > 0 && x + itemSize.width() > viewportWidth)
             {
                 x = m_config.viewportPadding;
@@ -797,7 +854,6 @@ namespace AzQtComponents
             }
 
             // add item geometry
-            const auto index = model()->index(row, 0, rootIndex());
             m_itemGeometry[index] = { QPoint{ x, y }, itemSize };
             x += itemSize.width();
 
@@ -812,7 +868,7 @@ namespace AzQtComponents
                 continue;
             }
 
-            if (childRowCount && m_expandedRows.contains(row))
+            if (childRowCount && m_expandedIndexes.contains(index))
             {
                 ChildFrame childFrame{index};
 
@@ -876,9 +932,22 @@ namespace AzQtComponents
             x += m_config.topItemsHorizontalSpacing;
         }
 
-        verticalScrollBar()->setPageStep(viewport()->height());
-        verticalScrollBar()->setRange(0, y + rowHeight - viewport()->height());
+        // Generate geometries recursively for all children if in search results mode
+        if (m_showSearchResultsMode)
+        {
+            for (int row = 0; row < rowCount; ++row)
+            {
+                const auto index = model()->index(row, 0, idx);
+                updateGeometriesInternal(index, x, y);
+            }
+        }
     }
+
+    void AssetFolderThumbnailView::SetShowSearchResultsMode(bool searchMode)
+    {
+        m_showSearchResultsMode = searchMode;
+    }
+
 } // namespace AzQtComponents
 
 #include "Components/Widgets/moc_AssetFolderThumbnailView.cpp"

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.h
@@ -89,6 +89,14 @@ namespace AzQtComponents
         };
         Q_ENUM(ThumbnailSize)
 
+        enum class Role
+        {
+            IsExpandable = Qt::UserRole + 1000,
+            IsTopLevel,
+            IsExactMatch,
+            IsVisible,
+        };
+
         void setThumbnailSize(ThumbnailSize size);
         ThumbnailSize thumbnailSize() const;
 
@@ -97,8 +105,13 @@ namespace AzQtComponents
         void scrollTo(const QModelIndex& index, QAbstractItemView::ScrollHint hint) override;
         QRect visualRect(const QModelIndex& index) const override;
 
-        Q_SIGNAL void IndexClicked(const QModelIndex& idx);
-        Q_SIGNAL void IndexDoubleClicked(const QModelIndex& idx);
+        void setRootIndex(const QModelIndex &index) override;
+
+        void SetShowSearchResultsMode(bool searchMode);
+
+    signals:
+        void rootIndexChanged(const QModelIndex& idx);
+        void showInFolderTriggered(const QModelIndex& idx);
 
     protected:
         friend class Style;
@@ -116,6 +129,7 @@ namespace AzQtComponents
         void paintEvent(QPaintEvent* event) override;
         void mousePressEvent(QMouseEvent* event) override;
         void mouseDoubleClickEvent(QMouseEvent* event) override;
+        void contextMenuEvent(QContextMenuEvent* event) override;
 
     private:
         void paintChildFrames(QPainter* painter) const;
@@ -126,6 +140,10 @@ namespace AzQtComponents
         int rootThumbnailSizeInPixels() const;
         int childThumbnailSizeInPixels() const;
 
+        void updateGeometriesInternal(const QModelIndex& index, int& x, int& y);
+
+        QModelIndex indexAtPos(const QPoint& pos) const;
+
         AssetFolderThumbnailViewDelegate* m_delegate;   
         AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 'AzQtComponents::AssetFolderThumbnailView::m_itemGeometry': class 'QHash<QPersistentModelIndex,QRect>' needs to have dll-interface to be used by clients of class 'AzQtComponents::AssetFolderThumbnailView'
         QHash<QPersistentModelIndex, QRect> m_itemGeometry;
@@ -135,9 +153,11 @@ namespace AzQtComponents
             QVector<QRect> rects;
         };
         QVector<ChildFrame> m_childFrames;
-        QSet<int> m_expandedRows;
+        QSet<QPersistentModelIndex> m_expandedIndexes;
         AZ_POP_DISABLE_WARNING
         ThumbnailSize m_thumbnailSize;
         Config m_config;
+        bool m_showSearchResultsMode = false;
+        QMenu* m_contextMenu = nullptr;
     };
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.cpp
@@ -8,6 +8,9 @@
 #include <AzToolsFramework/AssetBrowser/Search/Filter.h>
 #include <AzToolsFramework/AssetBrowser/Entries/FolderAssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/Entries/SourceAssetBrowserEntry.h>
+
+#include <AzQtComponents/Components/Widgets/AssetFolderThumbnailView.h>
+
 #include <AzCore/Console/IConsole.h>
 
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option")
@@ -75,6 +78,21 @@ namespace AzToolsFramework
         QSharedPointer<const StringFilter> AssetBrowserFilterModel::GetStringFilter() const
         {
             return m_stringFilter;
+        }
+
+        QVariant AssetBrowserFilterModel::data(const QModelIndex& index, int role) const
+        {
+            if (role == static_cast<int>(AzQtComponents::AssetFolderThumbnailView::Role::IsExactMatch))
+            {
+                auto entry = static_cast<AssetBrowserEntry*>(mapToSource(index).internalPointer());
+                if (!m_filter)
+                {
+                    return true;
+                }
+                return m_filter->MatchWithoutPropagation(entry);
+            }
+
+            return QSortFilterProxyModel::data(index, role);
         }
 
         bool AssetBrowserFilterModel::filterAcceptsRow(int source_row, const QModelIndex& source_parent) const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.h
@@ -40,6 +40,9 @@ namespace AzToolsFramework
             explicit AssetBrowserFilterModel(QObject* parent = nullptr);
             ~AssetBrowserFilterModel() override;
 
+            // QSortFilterProxyModel
+            QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+
             //asset type filtering
             void SetFilter(FilterConstType filter);
             void FilterUpdatedSlotImmediate();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.h
@@ -101,6 +101,8 @@ namespace AzToolsFramework
 
             void HandleAssetCreatedInEditor(const AZStd::string& assetPath, const AZ::Crc32& creatorBusId = AZ::Crc32());
 
+            bool GetEntryIndex(AssetBrowserEntry* entry, QModelIndex& index) const;
+
         Q_SIGNALS:
             void RequestOpenItemForEditing(const QModelIndex& index);
 
@@ -115,7 +117,6 @@ namespace AzToolsFramework
             AZStd::unordered_map<AssetBrowserEntry*, AZ::Crc32> m_assetEntriesToCreatorBusIds;
             AZStd::unordered_map<AZStd::string, AZ::Crc32> m_newlyCreatedAssetPathsToCreatorBusIds;
 
-            bool GetEntryIndex(AssetBrowserEntry* entry, QModelIndex& index) const;
             void WatchForExpectedAssets(AssetBrowserEntry* entry);
         };
     } // namespace AssetBrowser

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.cpp
@@ -5,9 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#include <AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserModel.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.h>
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.h>
+
+#include <AzQtComponents/Components/Widgets/AssetFolderThumbnailView.h>
 
 #include <AzToolsFramework/Thumbnails/ThumbnailerBus.h>
 
@@ -16,264 +19,97 @@ namespace AzToolsFramework
     namespace AssetBrowser
     {
         AssetBrowserThumbnailViewProxyModel::AssetBrowserThumbnailViewProxyModel(QObject* parent)
-            : QAbstractProxyModel(parent)
+            : QIdentityProxyModel(parent)
         {
         }
 
         AssetBrowserThumbnailViewProxyModel::~AssetBrowserThumbnailViewProxyModel() = default;
 
-        void AssetBrowserThumbnailViewProxyModel::SetSourceModelCurrentSelection(const QModelIndex& sourceIndex)
-        {
-            m_sourceSelectionIndex = sourceIndex;
-
-            beginResetModel();
-            RecomputeValidEntries();
-            endResetModel();
-        }
-
         QVariant AssetBrowserThumbnailViewProxyModel::data(const QModelIndex& index, int role) const
         {
-            if (role == Qt::DecorationRole)
+            auto assetBrowserEntry = mapToSource(index).data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
+            AZ_Assert(assetBrowserEntry, "Couldn't fetch asset entry for the given index.");
+            if (!assetBrowserEntry)
             {
-                auto assetBrowserEntry = mapToSource(index).data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
+                return {};
+            }
 
-                SharedThumbnail thumbnail;
-                QPersistentModelIndex persistentIndex;
-
-                ThumbnailerRequestBus::BroadcastResult(thumbnail, &ThumbnailerRequests::GetThumbnail, assetBrowserEntry->GetThumbnailKey());
-                AZ_Assert(thumbnail, "The shared thumbnail was not available from the ThumbnailerRequestBus.");
-                if (!thumbnail || thumbnail->GetState() == Thumbnail::State::Failed)
+            switch (role)
+            {
+            case Qt::DecorationRole:
                 {
-                    return QIcon{};
+                    SharedThumbnail thumbnail;
+                    QPersistentModelIndex persistentIndex;
+
+                    ThumbnailerRequestBus::BroadcastResult(
+                        thumbnail, &ThumbnailerRequests::GetThumbnail, assetBrowserEntry->GetThumbnailKey());
+                    AZ_Assert(thumbnail, "The shared thumbnail was not available from the ThumbnailerRequestBus.");
+                    if (!thumbnail || thumbnail->GetState() == Thumbnail::State::Failed)
+                    {
+                        return QIcon{};
+                    }
+
+                    return QIcon(thumbnail->GetPixmap());
                 }
 
-                return QIcon(thumbnail->GetPixmap());
+            case static_cast<int>(AzQtComponents::AssetFolderThumbnailView::Role::IsExpandable):
+                {
+                    // We don't want to see children on folders in the thumbnail view
+                    if (assetBrowserEntry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Folder)
+                    {
+                        return false;
+                    }
+
+                    return rowCount(index) > 0;
+                }
+            case static_cast<int>(AzQtComponents::AssetFolderThumbnailView::Role::IsTopLevel):
+                {
+                    if (m_searchResultsMode)
+                    {
+                        auto isExactMatch =
+                            index.data(static_cast<int>(AzQtComponents::AssetFolderThumbnailView::Role::IsExactMatch)).value<bool>();
+                        return isExactMatch;
+                    }
+                    else
+                    {
+                        if (m_rootIndex.isValid())
+                        {
+                            return index.parent() == m_rootIndex;
+                        }
+                        else
+                        {
+                            return index.parent().isValid() && !index.parent().parent().isValid();
+                        }
+                    }
+                }
+            case static_cast<int>(AzQtComponents::AssetFolderThumbnailView::Role::IsVisible):
+                {
+                    auto isExactMatch =
+                        index.data(static_cast<int>(AzQtComponents::AssetFolderThumbnailView::Role::IsExactMatch)).value<bool>();
+                    return !m_searchResultsMode || (m_searchResultsMode && isExactMatch);
+                }
             }
 
             return QAbstractProxyModel::data(index, role);
         }
 
-        QModelIndex AssetBrowserThumbnailViewProxyModel::index(int row, int column, const QModelIndex& parent) const
+        void AssetBrowserThumbnailViewProxyModel::SetRootIndex(const QModelIndex& index)
         {
-            if (!sourceModel())
-            {
-                return {};
-            }
-
-            if (column > 0)
-            {
-                return {};
-            }
-
-            if (parent.isValid())
-            {
-                // Anything with a grandparent is not valid in this model, we only accept
-                // - Children of the selected item on the asset tree view of type "Source" or "Folder"
-                // - All their children without filtering
-                if (parent.parent().isValid())
-                {
-                    return {};
-                }
-
-                // We are dealing with a level 2 (child) item here, fetching the inner pointer from the source model directly
-                // as we're not currently doing any filtering on children
-                else
-                {
-                    auto sourceParentIdx = mapToSource(parent);
-                    if (row >= sourceModel()->rowCount(sourceParentIdx))
-                    {
-                        return {};
-                    }
-
-                    auto sourceData = sourceModel()
-                                          ->data(sourceModel()->index(row, 0, sourceParentIdx), AssetBrowserModel::Roles::EntryRole)
-                                          .value<const AssetBrowserEntry*>();
-
-                    if (sourceData)
-                    {
-                        return createIndex(row, column, const_cast<AssetBrowserEntry*>(sourceData));
-                    }
-
-                    return {};
-                }
-            }
-
-            // Here we deal with a level 1 (parent) item. Get the inner pointer from the local cache, which contains some filtered
-            // children of the currently selected item on the asset tree view.
-            if (row >= m_sourceValidChildren.size())
-            {
-                return {};
-            }
-
-            auto sourceData =
-                sourceModel()
-                    ->data(sourceModel()->index(m_sourceValidChildren[row], 0, m_sourceSelectionIndex), AssetBrowserModel::Roles::EntryRole)
-                    .value<const AssetBrowserEntry*>();
-
-            return createIndex(row, column, const_cast<AssetBrowserEntry*>(sourceData));
+            m_rootIndex = index;
         }
 
-        QModelIndex AssetBrowserThumbnailViewProxyModel::parent(const QModelIndex& child) const
+        bool AssetBrowserThumbnailViewProxyModel::GetShowSearchResultsMode() const
         {
-            auto childData = static_cast<AssetBrowserEntry*>(child.internalPointer());
-            if (!childData)
-            {
-                return {};
-            }
-
-            auto childDataParent = childData->GetParent();
-
-            if (!childDataParent)
-            {
-                return {};
-            }
-
-            // If the parent of the source entry is the currently selected item on the asset tree view, we have a level 1 item,
-            // which has no parent in this model
-            if (childDataParent == m_sourceSelectionIndex.internalPointer())
-            {
-                return {};
-            }
-            else
-            {
-                auto childDataGrandParent = childDataParent->GetParent();
-
-                // Rule out anything that is not a grandchildren of the selected item on the asset tree view
-                if (childDataGrandParent != m_sourceSelectionIndex.internalPointer() || !childDataGrandParent)
-                {
-                    return {};
-                }
-
-                for (int i = 0; i < childDataGrandParent->GetChildCount(); i++)
-                {
-                    if (childDataGrandParent->GetChild(i) == childDataParent)
-                    {
-                        return createIndex(i, 0, childDataGrandParent);
-                    }
-                }
-                return {};
-            }
+            return m_searchResultsMode;
         }
 
-        QModelIndex AssetBrowserThumbnailViewProxyModel::mapToSource(const QModelIndex& proxyIndex) const
+        void AssetBrowserThumbnailViewProxyModel::SetShowSearchResultsMode(bool searchMode)
         {
-            if (!sourceModel())
+            if (m_searchResultsMode != searchMode)
             {
-                return {};
-            }
-
-            auto indexRow = proxyIndex.row();
-
-            // We're mapping a level 1 (parent) item, using the local cache to map to the proxy row properly
-            if (!proxyIndex.parent().isValid())
-            {
-                if (indexRow >= m_sourceValidChildren.size())
-                {
-                    return {};
-                }
-
-                return sourceModel()->index(m_sourceValidChildren[indexRow], 0, m_sourceSelectionIndex);
-            }
-            // We're mapping a level 2 (child) item, passing through the row number
-            else
-            {
-                return sourceModel()->index(indexRow, 0, mapToSource(proxyIndex.parent()));
-            }
-        }
-
-        QModelIndex AssetBrowserThumbnailViewProxyModel::mapFromSource(const QModelIndex& sourceIndex) const
-        {
-            if (!sourceModel())
-            {
-                return {};
-            }
-
-            if (!sourceIndex.isValid())
-            {
-                return {};
-            }
-
-            auto indexRow = sourceIndex.row();
-
-            // We're mapping a level 1 (parent) item, using the local cache to map the source row
-            if (sourceIndex.parent() == m_sourceSelectionIndex)
-            {
-                auto findRowInValidRowsArray = AZStd::equal_range(m_sourceValidChildren.begin(), m_sourceValidChildren.end(), indexRow);
-                if (findRowInValidRowsArray.first == m_sourceValidChildren.end())
-                {
-                    return {};
-                }
-
-                return index(static_cast<int>(AZStd::distance(m_sourceValidChildren.begin(), findRowInValidRowsArray.first)), 0, {});
-            }
-            // We're mapping a level 2 (child) item, passing through the row number
-            else
-            {
-                return index(indexRow, 0, mapFromSource(sourceIndex.parent()));
-            }
-        }
-
-        int AssetBrowserThumbnailViewProxyModel::rowCount(const QModelIndex& parent) const
-        {
-            Q_UNUSED(parent);
-
-            if (!sourceModel())
-            {
-                return 0;
-            }
-
-            // We're counting level 2 (child) items, return 0 if the parent is a folder, otherwise forward row count from the source model
-            if (parent.isValid())
-            {
-                auto parentData = mapToSource(parent).data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
-                if (parentData->GetEntryType() == AssetBrowserEntry::AssetEntryType::Folder)
-                {
-                    return 0;
-                }
-                return sourceModel()->rowCount(mapToSource(parent));
-            }
-
-            // We're counting level 1 (parent) items, use the local cache to determine the row count
-            return static_cast<int>(m_sourceValidChildren.size());
-        }
-
-        int AssetBrowserThumbnailViewProxyModel::columnCount(const QModelIndex& parent) const
-        {
-            Q_UNUSED(parent);
-
-            return 1;
-        }
-
-        void AssetBrowserThumbnailViewProxyModel::RecomputeValidEntries()
-        {
-            m_sourceValidChildren.clear();
-
-            if (!m_sourceSelectionIndex.isValid())
-            {
-                return;
-            }
-
-            if (!sourceModel())
-            {
-                return;
-            }
-
-            // Using AssetBrowserEntry::GetEntryType to determine which children of the selected item on the asset tree
-            // should be shown on the thumbnail view.
-            // Storing the valid indexes in a local cache that gets reused throughout the model.
-            int selectionChildren = sourceModel()->rowCount(m_sourceSelectionIndex);
-            for (int i = 0; i < selectionChildren; i++)
-            {
-                auto childData = sourceModel()
-                                     ->index(i, 0, m_sourceSelectionIndex)
-                                     .data(AssetBrowserModel::Roles::EntryRole)
-                                     .value<const AssetBrowserEntry*>();
-                AZ_Assert(childData, "Source model doesn't have a valid entry for item %d.", i);
-                if (childData->GetEntryType() == AssetBrowserEntry::AssetEntryType::Source ||
-                    childData->GetEntryType() == AssetBrowserEntry::AssetEntryType::Folder)
-                {
-                    m_sourceValidChildren.push_back(i);
-                }
+                m_searchResultsMode = searchMode;
+                beginResetModel();
+                endResetModel();
             }
         }
     } // namespace AssetBrowser

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.h
@@ -8,14 +8,14 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
-#include <QAbstractProxyModel>
+#include <QIdentityProxyModel>
 #endif
 
 namespace AzToolsFramework
 {
     namespace AssetBrowser
     {
-        class AssetBrowserThumbnailViewProxyModel : public QAbstractProxyModel
+        class AssetBrowserThumbnailViewProxyModel : public QIdentityProxyModel
         {
             Q_OBJECT
 
@@ -23,24 +23,18 @@ namespace AzToolsFramework
             explicit AssetBrowserThumbnailViewProxyModel(QObject* parent = nullptr);
             ~AssetBrowserThumbnailViewProxyModel() override;
 
-            void SetSourceModelCurrentSelection(const QModelIndex& sourceIndex);
-
             QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
 
-            QModelIndex index(int row, int column, const QModelIndex& parent = QModelIndex()) const override;
-            QModelIndex parent(const QModelIndex& child) const override;
+            // Used to keep track of the root index on the view consuming this model, so that the model
+            // can generate extra data such as whether an entry is on the top level.
+            void SetRootIndex(const QModelIndex& index);
 
-            QModelIndex mapToSource(const QModelIndex& proxyIndex) const override;
-            QModelIndex mapFromSource(const QModelIndex& sourceIndex) const override;
-
-            int rowCount(const QModelIndex& parent = QModelIndex()) const override;
-            int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+            bool GetShowSearchResultsMode() const;
+            void SetShowSearchResultsMode(bool searchMode);
 
         private:
-            QPersistentModelIndex m_sourceSelectionIndex;
-            AZStd::vector<int> m_sourceValidChildren;
-
-            void RecomputeValidEntries();
+            QPersistentModelIndex m_rootIndex;
+            bool m_searchResultsMode;
         };
     } // namespace AssetBrowser
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.cpp
@@ -128,6 +128,11 @@ namespace AzToolsFramework
             return false;
         }
 
+        bool AssetBrowserEntryFilter::MatchWithoutPropagation(const AssetBrowserEntry* entry) const
+        {
+            return MatchInternal(entry);
+        }
+
         void AssetBrowserEntryFilter::Filter(AZStd::vector<const AssetBrowserEntry*>& result, const AssetBrowserEntry* entry) const
         {
             FilterInternal(result, entry);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.h
@@ -58,6 +58,10 @@ namespace AzToolsFramework
             //! Check if entry matches filter
             bool Match(const AssetBrowserEntry* entry) const;
 
+            //! Check if the entry matches filter without propagation (i.e. it's an exact match and it doesn't match only
+            //  beause a descendant or an ancestor matches)
+            bool MatchWithoutPropagation(const AssetBrowserEntry* entry) const;
+
             //! Retrieve all matching entries that are either entry itself or its parents or children
             void Filter(AZStd::vector<const AssetBrowserEntry*>& result, const AssetBrowserEntry* entry) const;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
@@ -12,7 +12,6 @@
 #include <AzToolsFramework/AssetBrowser/AssetBrowserModel.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.h>
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.h>
-#include <AzToolsFramework/AssetBrowser/Previewer/PreviewerFrame.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h>
 
 #include <AzQtComponents/Components/Widgets/AssetFolderThumbnailView.h>
@@ -40,61 +39,40 @@ namespace AzToolsFramework
 
             connect(
                 m_thumbnailViewWidget,
-                &AzQtComponents::AssetFolderThumbnailView::IndexClicked,
+                &AzQtComponents::AssetFolderThumbnailView::clicked,
                 this,
                 [this](const QModelIndex& index)
                 {
-                    if (!m_previewerFrame)
-                    {
-                        return;
-                    }
-
                     auto indexData = index.data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
-                    if (indexData->GetEntryType() == AssetBrowserEntry::AssetEntryType::Source)
-                    {
-                        m_previewerFrame->Display(indexData);
-                    }
+                    emit entryClicked(indexData);
                 });
 
             connect(
                 m_thumbnailViewWidget,
-                &AzQtComponents::AssetFolderThumbnailView::IndexDoubleClicked,
+                &AzQtComponents::AssetFolderThumbnailView::doubleClicked,
                 this,
                 [this](const QModelIndex& index)
                 {
-                    if (!m_assetTreeView)
-                    {
-                        return;
-                    }
-
                     auto indexData = index.data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
-                    if (indexData->GetEntryType() != AssetBrowserEntry::AssetEntryType::Folder)
-                    {
-                        return;
-                    }
-
-                    auto treeViewFilterModel = qobject_cast<AssetBrowserFilterModel*>(m_assetTreeView->model());
-                    if (!treeViewFilterModel)
-                    {
-                        return;
-                    }
-
-                    auto selectionModel = m_assetTreeView->selectionModel();
-
-                    auto targetIndex =
-                        treeViewFilterModel->mapFromSource(m_assetFilterModel->mapToSource(m_thumbnailViewProxyModel->mapToSource(index)));
-
-                    selectionModel->select(targetIndex, QItemSelectionModel::ClearAndSelect);
-
-                    auto targetIndexAncestor = targetIndex.parent();
-                    while (targetIndexAncestor.isValid())
-                    {
-                        m_assetTreeView->expand(targetIndexAncestor);
-                        targetIndexAncestor = targetIndexAncestor.parent();
-                    }
-
-                    m_assetTreeView->scrollTo(targetIndex);
+                    emit entryDoubleClicked(indexData);
                 });
+
+            connect(
+                m_thumbnailViewWidget,
+                &AzQtComponents::AssetFolderThumbnailView::showInFolderTriggered,
+                this,
+                [this](const QModelIndex& index)
+                {
+                    auto indexData = index.data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
+                    emit showInFolderTriggered(indexData);
+                });
+
+            // Track the root index on the proxy model as well so it can provide info such as whether an entry is first level or not
+            connect(
+                m_thumbnailViewWidget,
+                &AzQtComponents::AssetFolderThumbnailView::rootIndexChanged,
+                m_thumbnailViewProxyModel,
+                &AssetBrowserThumbnailViewProxyModel::SetRootIndex);
 
             auto layout = new QVBoxLayout();
             layout->addWidget(m_thumbnailViewWidget);
@@ -103,9 +81,9 @@ namespace AzToolsFramework
 
         AssetBrowserThumbnailView::~AssetBrowserThumbnailView() = default;
 
-        void AssetBrowserThumbnailView::SetPreviewerFrame(PreviewerFrame* previewerFrame)
+        AzQtComponents::AssetFolderThumbnailView* AssetBrowserThumbnailView::GetThumbnailViewWidget() const
         {
-            m_previewerFrame = previewerFrame;
+            return m_thumbnailViewWidget;
         }
 
         void AssetBrowserThumbnailView::SetAssetTreeView(AssetBrowserTreeView* treeView)
@@ -159,6 +137,16 @@ namespace AzToolsFramework
                 &AssetBrowserThumbnailView::HandleTreeViewSelectionChanged);
         }
 
+        void AssetBrowserThumbnailView::setSelectionMode(QAbstractItemView::SelectionMode mode)
+        {
+            m_thumbnailViewWidget->setSelectionMode(mode);
+        }
+
+        QAbstractItemView::SelectionMode AssetBrowserThumbnailView::selectionMode() const
+        {
+            return m_thumbnailViewWidget->selectionMode();
+        }
+
         void AssetBrowserThumbnailView::HandleTreeViewSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected)
         {
             Q_UNUSED(deselected);
@@ -172,12 +160,13 @@ namespace AzToolsFramework
             auto selectedIndexes = selected.indexes();
             if (selectedIndexes.count() > 0)
             {
-                m_thumbnailViewProxyModel->SetSourceModelCurrentSelection(
+                auto newRootIndex = m_thumbnailViewProxyModel->mapFromSource(
                     m_assetFilterModel->mapFromSource(treeViewFilterModel->mapToSource(selectedIndexes[0])));
+                m_thumbnailViewWidget->setRootIndex(newRootIndex);
             }
             else
             {
-                m_thumbnailViewProxyModel->SetSourceModelCurrentSelection({});
+                m_thumbnailViewWidget->setRootIndex({});
             }
         }
 
@@ -203,11 +192,30 @@ namespace AzToolsFramework
             auto filterCopy = new CompositeFilter(CompositeFilter::LogicOperatorType::AND);
             for (const auto& subFilter : filter->GetSubFilters())
             {
-                if (subFilter->GetName() != "Folder")
+                // Switch between "search mode" where all results in the asset folder tree are shown,
+                // and "normal mode", where only contents for a single folder are shown, depending on
+                // whether there is an active string search ongoing.
+                if (subFilter->GetTag() == "String")
+                {
+                    auto stringCompFilter = qobject_cast<const CompositeFilter*>(subFilter.get());
+                    if (!stringCompFilter)
+                    {
+                        continue;
+                    }
+
+                    auto stringSubFilters = stringCompFilter->GetSubFilters();
+
+                    m_thumbnailViewProxyModel->SetShowSearchResultsMode(stringSubFilters.count() != 0);
+                    m_thumbnailViewWidget->SetShowSearchResultsMode(stringSubFilters.count() != 0);
+                }
+
+                // Skip the folder filter on the thumbnail view so that we can see files
+                if (subFilter->GetTag() != "Folder")
                 {
                     filterCopy->AddFilter(subFilter);
                 }
             }
+            filterCopy->SetFilterPropagation(AssetBrowserEntryFilter::Up | AssetBrowserEntryFilter::Down);
             m_assetFilterModel->SetFilter(FilterConstType(filterCopy));
         }
     } // namespace AssetBrowser

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h
@@ -12,6 +12,7 @@
 
 #include <QItemSelection>
 #include <QWidget>
+#include <QAbstractItemView>
 
 #endif
 
@@ -27,7 +28,7 @@ namespace AzToolsFramework
         class AssetBrowserFilterModel;
         class AssetBrowserTreeView;
         class AssetBrowserThumbnailViewProxyModel;
-        class PreviewerFrame;
+        class AssetBrowserEntry;
 
         class AssetBrowserThumbnailView : public QWidget
         {
@@ -38,12 +39,20 @@ namespace AzToolsFramework
             explicit AssetBrowserThumbnailView(QWidget* parent = nullptr);
             ~AssetBrowserThumbnailView() override;
 
-            void SetPreviewerFrame(PreviewerFrame* previewerFrame);
             void SetAssetTreeView(AssetBrowserTreeView* treeView);
+
+            AzQtComponents::AssetFolderThumbnailView* GetThumbnailViewWidget() const;
+
+            void setSelectionMode(QAbstractItemView::SelectionMode mode);
+            QAbstractItemView::SelectionMode selectionMode() const;
+
+        signals:
+            void entryClicked(const AssetBrowserEntry* entry);
+            void entryDoubleClicked(const AssetBrowserEntry* entry);
+            void showInFolderTriggered(const AssetBrowserEntry* entry);
 
         private:
             AssetBrowserTreeView* m_assetTreeView = nullptr;
-            PreviewerFrame* m_previewerFrame = nullptr;
             AzQtComponents::AssetFolderThumbnailView* m_thumbnailViewWidget = nullptr;
             AssetBrowserThumbnailViewProxyModel* m_thumbnailViewProxyModel = nullptr;
             AssetBrowserFilterModel* m_assetFilterModel = nullptr;


### PR DESCRIPTION
Refactor a bit the underlying model to derive from QIdentityProxyModel and using roles for special functions such as visibility of single  items when filtering with a search string.

After the refactoring also #14002 is fixed.

Add a context menu when showing search results, to allow navigating to the parent folder of a result item.

Signed-off-by: Alessandro Ambrosano <1006222+aambrosano@users.noreply.github.com>

## What does this PR do?

Implements showing search results on the thumbnail view, and adds a context menu for navigating to the parent folder of a search result.

It also refactors the model behind the thumbnail view to make it more robust and appropriate for the search results use case.

Also fixes a crash sometimes happening when expanding source assets (#14002).

Fixes #14002 #14003.

## How was this PR tested?

Manual testing

https://user-images.githubusercontent.com/1006222/212896105-900c752f-624c-49b8-bba2-8dde76e558d7.mp4
