### PR TITLE
Removed unused legacy DeleteSelectedEntities API

### DIFF
--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -2540,17 +2540,6 @@ void CCryEditApp::OnFileExportToGameNoSurfaceTexture()
     UserExportToGame(false);
 }
 
-//////////////////////////////////////////////////////////////////////////
-void CCryEditApp::DeleteSelectedEntities([[maybe_unused]] bool includeDescendants)
-{
-    GetIEditor()->BeginUndo();
-    CUndo undo("Delete Selected Object");
-    GetIEditor()->GetObjectManager()->DeleteSelection();
-    GetIEditor()->AcceptUndo("Delete Selection");
-    GetIEditor()->SetModifiedFlag();
-    GetIEditor()->SetModifiedModule(eModifiedBrushes);
-}
-
 void CCryEditApp::OnMoveObject()
 {
     ////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/CryEdit.h
+++ b/Code/Editor/CryEdit.h
@@ -203,7 +203,6 @@ public:
     void OnViewSwitchToGame();
     void OnViewSwitchToGameFullScreen();
     void OnViewDeploy();
-    void DeleteSelectedEntities(bool includeDescendants);
     void OnMoveObject();
     void OnRenameObj();
     void OnUndo();


### PR DESCRIPTION
## What does this PR do?

Removed unused legacy `DeleteSelectedEntities` API from `CryEdit` that was discovered while working on tangential code.

## How was this PR tested?

Build/ran Editor + ad-hoc tests.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>