### PR TITLE
Fixed Python Scripts show in explorer

### DIFF
--- a/Code/Editor/Controls/FolderTreeCtrl.cpp
+++ b/Code/Editor/Controls/FolderTreeCtrl.cpp
@@ -374,15 +374,22 @@ void CFolderTreeCtrl::Edit(const QString& path)
 
 void CFolderTreeCtrl::ShowInExplorer(const QString& path)
 {
-    QString absolutePath = QDir::currentPath();
-
-    CTreeItem* item = GetItem(path);
-    if (item != m_rootTreeItem)
+    if (QFileInfo(path).isAbsolute())
     {
-        absolutePath += QStringLiteral("/%1").arg(path);
+        AzQtComponents::ShowFileOnDesktop(path);
     }
+    else
+    {
+        QString absolutePath = QDir::currentPath();
 
-    AzQtComponents::ShowFileOnDesktop(absolutePath);
+        CTreeItem* item = GetItem(path);
+        if (item != m_rootTreeItem)
+        {
+            absolutePath += QStringLiteral("/%1").arg(path);
+        }
+
+        AzQtComponents::ShowFileOnDesktop(absolutePath);
+    }
 }
 
 QIcon CFolderTreeCtrl::GetItemIcon(IconType image) const


### PR DESCRIPTION
## What does this PR do?

Fixes #7876 

Fixed issue with the `Show in Explorer` option not working in the Python Scripts tool. The original logic wasn't meant to handle absolute paths being passed in, so updated it to handle an absolute path properly while keeping the relative path logic in place as well.

## How was this PR tested?

Tested the menu option on both files and folders in the Python Scripts tool.

![PythonScriptsShowInExplorer](https://user-images.githubusercontent.com/7519264/213025491-6f807ff7-0ef2-438d-ad2d-4d50ae675858.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>