### PR TITLE
Bump up the scene builder version to reprocess FBX files after the non-PBR material fix (#14036)

### DIFF
--- a/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderComponent.cpp
+++ b/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderComponent.cpp
@@ -44,7 +44,7 @@ namespace SceneBuilder
         builderDescriptor.m_createJobFunction = AZStd::bind(&SceneBuilderWorker::CreateJobs, &m_sceneBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
         builderDescriptor.m_processJobFunction = AZStd::bind(&SceneBuilderWorker::ProcessJob, &m_sceneBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
 
-        builderDescriptor.m_version = 8; // bump this to rebuild everything.
+        builderDescriptor.m_version = 9; // bump this to rebuild everything.
         builderDescriptor.m_analysisFingerprint = m_sceneBuilder.GetFingerprint(); // bump this to at least re-analyze everything.
 
         m_sceneBuilder.BusConnect(builderDescriptor.m_busId);


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?

We had a recent fix for non-PBR material processing due to the latest assimp library upgrade (https://github.com/o3de/o3de/pull/14036). Even though the change is not in SceneAPI or Scene Builder, we should still bump up the builder version to make sure that FBX files can be reprocessed after the fix. 

## How was this PR tested?

Verified that all the FBX files were reprocessed 
