### PR TITLE
Fixing ImageView and BufferView to have consistent bindless IDs after invalidation.

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferView.h
@@ -25,6 +25,8 @@ namespace AZ
             AZ_RTTI(BufferView, "{3012F770-1DD7-4CEC-A5D0-E2FC807548C1}", ResourceView);
             virtual ~BufferView() = default;
 
+            static constexpr uint32_t InvalidBindlessIndex = 0xFFFFFFFF;
+
             //! Initializes the buffer view with the provided buffer and view descriptor.
             ResultCode Init(const Buffer& buffer, const BufferViewDescriptor& viewDescriptor);
 
@@ -46,12 +48,12 @@ namespace AZ
 
             virtual uint32_t GetBindlessReadIndex() const
             {
-                return 0xffffffff;
+                return InvalidBindlessIndex;
             }
 
             virtual uint32_t GetBindlessReadWriteIndex() const
             {
-                return 0xffffffff;
+                return InvalidBindlessIndex;
             }
 
         protected:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageView.h
@@ -26,6 +26,8 @@ namespace AZ
             AZ_RTTI(ImageView, "{F2BDEE1F-DEFD-4443-9012-A28AED028D7B}", ResourceView);
             virtual ~ImageView() = default;
 
+            static constexpr uint32_t InvalidBindlessIndex = 0xFFFFFFFF;
+
             //! Initializes the image view.
             ResultCode Init(const Image& image, const ImageViewDescriptor& viewDescriptor);
 
@@ -43,12 +45,12 @@ namespace AZ
 
             virtual uint32_t GetBindlessReadIndex() const
             {
-                return 0xffffffff;
+                return InvalidBindlessIndex;
             }
 
             virtual uint32_t GetBindlessReadWriteIndex() const
             {
-                return 0xffffffff;
+                return InvalidBindlessIndex;
             }
 
         protected:

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/DescriptorContext.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/DescriptorContext.cpp
@@ -267,7 +267,16 @@ namespace AZ
             D3D12_SHADER_RESOURCE_VIEW_DESC viewDesc;
             ConvertImageView(image, imageViewDescriptor, viewDesc);
             m_device->CreateShaderResourceView(image.GetMemoryView().GetMemory(), &viewDesc, descriptorHandle);
-            staticView = AllocateStaticDescriptor(descriptorHandle);
+
+            if (staticView.m_index == DescriptorHandle::NullIndex)
+            {
+                staticView = AllocateStaticDescriptor(descriptorHandle);
+            }
+            else
+            {
+                m_device->CopyDescriptorsSimple(
+                    1, m_staticPool.GetCpuPlatformHandle(staticView), descriptorHandle, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+            }
         }
 
         void DescriptorContext::CreateUnorderedAccessView(
@@ -310,7 +319,16 @@ namespace AZ
                 }
             }
             CopyDescriptor(unorderedAccessViewClear, unorderedAccessView);
-            staticView = AllocateStaticDescriptor(unorderedAccessDescriptor);
+
+            if (staticView.m_index == DescriptorHandle::NullIndex)
+            {
+                staticView = AllocateStaticDescriptor(unorderedAccessDescriptor);
+            }
+            else
+            {
+                m_device->CopyDescriptorsSimple(
+                    1, m_staticPool.GetCpuPlatformHandle(staticView), unorderedAccessDescriptor, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+            }
         }
 
         void DescriptorContext::CreateRenderTargetView(

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/DescriptorContext.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/DescriptorContext.cpp
@@ -268,6 +268,7 @@ namespace AZ
             ConvertImageView(image, imageViewDescriptor, viewDesc);
             m_device->CreateShaderResourceView(image.GetMemoryView().GetMemory(), &viewDesc, descriptorHandle);
 
+            // Only allocate if the index is already null, otherwise just copy the descriptor onto the old index.
             if (staticView.m_index == DescriptorHandle::NullIndex)
             {
                 staticView = AllocateStaticDescriptor(descriptorHandle);

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/BindlessArgumentBuffer.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/BindlessArgumentBuffer.cpp
@@ -8,40 +8,42 @@
 
 #include <RHI/ArgumentBuffer.h>
 #include <RHI/BindlessArgumentBuffer.h>
+#include <RHI/BufferView.h>
 #include <RHI/Device.h>
+#include <RHI/ImageView.h>
 #include <Metal/Metal.h>
 
 
 namespace AZ::Metal
 {
-     // TODO(BINDLESS): Data drive this number
-     // It's hardcoded here to match the unbounded array size (UNBOUNDED_SIZE) specified in AzslcHeader.azsli
-     constexpr static uint32_t UnboundedArraySize = 100000;
+    // TODO(BINDLESS): Data drive this number
+    // It's hardcoded here to match the unbounded array size (UNBOUNDED_SIZE) specified in AzslcHeader.azsli
+    constexpr static uint32_t UnboundedArraySize = 100000;
 
     RHI::ResultCode BindlessArgumentBuffer::Init(Device* device)
     {
         m_device = device;
         m_unboundedArraySupported = device->GetFeatures().m_unboundedArrays;
         m_unboundedArraySupported = false; //Remove this when unbounded array support is added to spirv-cross
-        
+
         AZStd::vector<id<MTLBuffer>> mtlArgBuffers;
         AZStd::vector<NSUInteger> mtlArgBufferOffsets;
         AZStd::vector<MTLArgumentDescriptor*> argBufferDescriptors;
-        
-        if(m_unboundedArraySupported)
+
+        if (m_unboundedArraySupported)
         {
             //Create a root Argument buffer that will work as a container for ABs related unbouned arrays
             m_rootArgBuffer = ArgumentBuffer::Create();
-            
+
             //Create an Argument buffer per resource type that has an unbounded array
             m_bindlessTextureArgBuffer = ArgumentBuffer::Create();
             m_bindlessRWTextureArgBuffer = ArgumentBuffer::Create();
             m_bindlessBufferArgBuffer = ArgumentBuffer::Create();
             m_bindlessRWBufferArgBuffer = ArgumentBuffer::Create();
-            
+
             AZStd::vector<RHI::Ptr<ArgumentBuffer>> argBuffers;
             //Unbounded read only textures
-            MTLArgumentDescriptor* argDescriptor = [[MTLArgumentDescriptor alloc] init];
+            MTLArgumentDescriptor* argDescriptor = [[MTLArgumentDescriptor alloc]init];
             argDescriptor.dataType = MTLDataTypeTexture;
             argDescriptor.index = 0;
             argDescriptor.access = MTLArgumentAccessReadOnly;
@@ -51,14 +53,14 @@ namespace AZ::Metal
             m_bindlessTextureArgBuffer->Init(device, argBufferDescriptors, "ArgumentBuffer_BindlessROTextures");
             mtlArgBuffers.push_back(m_bindlessTextureArgBuffer->GetArgEncoderBuffer());
             mtlArgBufferOffsets.push_back(m_bindlessTextureArgBuffer->GetOffset());
-                                        
+
             //Unbounded read write textures
             argDescriptor.access = MTLArgumentAccessReadWrite;
             argBufferDescriptors[0] = argDescriptor;
             m_bindlessRWTextureArgBuffer->Init(device, argBufferDescriptors, "ArgumentBuffer_BindlessRWTextures");
             mtlArgBuffers.push_back(m_bindlessRWTextureArgBuffer->GetArgEncoderBuffer());
             mtlArgBufferOffsets.push_back(m_bindlessRWTextureArgBuffer->GetOffset());
-            
+
             //Unbounded read only buffers
             argDescriptor.dataType = MTLDataTypePointer;
             argDescriptor.access = MTLArgumentAccessReadOnly;
@@ -66,14 +68,14 @@ namespace AZ::Metal
             m_bindlessBufferArgBuffer->Init(device, argBufferDescriptors, "ArgumentBuffer_BindlessROBuffers");
             mtlArgBuffers.push_back(m_bindlessBufferArgBuffer->GetArgEncoderBuffer());
             mtlArgBufferOffsets.push_back(m_bindlessBufferArgBuffer->GetOffset());
-              
+
             //Unbounded read write buffers
             argDescriptor.access = MTLArgumentAccessReadWrite;
             argBufferDescriptors[0] = argDescriptor;
             m_bindlessRWBufferArgBuffer->Init(device, argBufferDescriptors, "ArgumentBuffer_BindlessRWTextures");
             mtlArgBuffers.push_back(m_bindlessRWBufferArgBuffer->GetArgEncoderBuffer());
             mtlArgBufferOffsets.push_back(m_bindlessRWBufferArgBuffer->GetOffset());
-            
+
             //Container Argument buffer for all the unbounded arrays
             argDescriptor.dataType = MTLDataTypePointer;
             argDescriptor.index = 0;
@@ -81,13 +83,13 @@ namespace AZ::Metal
             argDescriptor.arrayLength = static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::Count) - 1;
             argBufferDescriptors[0] = argDescriptor;
             m_rootArgBuffer->Init(device, argBufferDescriptors, "ArgumentBuffer_BindlessRoot");
-            [argDescriptor release];
+            [argDescriptor release] ;
             argDescriptor = nil;
-            
-            NSRange range = {0, mtlArgBuffers.size()};
+
+            NSRange range = { 0, mtlArgBuffers.size() };
             [m_rootArgBuffer->GetArgEncoder()     setBuffers: mtlArgBuffers.data()
-                                                     offsets: mtlArgBufferOffsets.data()
-                                                   withRange: range];
+                                                  offsets:    mtlArgBufferOffsets.data()
+                                                  withRange:  range];
         }
         else
         {
@@ -96,33 +98,33 @@ namespace AZ::Metal
             for (uint32_t i = 0; i < static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::Count); ++i)
             {
                 MTLArgumentDescriptor* textureArgDescriptor = [[MTLArgumentDescriptor alloc] init];
-                textureArgDescriptor.index = UnboundedArraySize*i;
+                textureArgDescriptor.index = UnboundedArraySize * i;
                 textureArgDescriptor.arrayLength = UnboundedArraySize;
                 textureArgDescriptor.dataType = MTLDataTypePointer;
-                if(i == static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadTexture) ||
-                   i == static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadWriteTexture))
+                if (i == static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadTexture) ||
+                    i == static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadWriteTexture))
                 {
                     textureArgDescriptor.dataType = MTLDataTypeTexture;
                     textureArgDescriptor.textureType = MTLTextureType2D;
                 }
                 textureArgDescriptor.access = MTLArgumentAccessReadOnly;
-                if(i == static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadWriteTexture) ||
-                   i == static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadWriteBuffer))
+                if (i == static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadWriteTexture) ||
+                    i == static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadWriteBuffer))
                 {
                     textureArgDescriptor.access = MTLArgumentAccessReadWrite;
                 }
                 argBufferDescriptors.push_back(textureArgDescriptor);
             }
-            
+
             m_boundedArgBuffer->Init(device, argBufferDescriptors, "ArgumentBuffer_BindlessSrg");
-            
-            for(MTLArgumentDescriptor* desc : argBufferDescriptors)
+
+            for (MTLArgumentDescriptor* desc : argBufferDescriptors)
             {
                 [desc release];
                 desc = nil;
             }
         }
-        
+
         //Init the free list allocator related to the unbounded arrays for each resource type
         for (uint32_t i = 0; i < static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::Count); ++i)
         {
@@ -142,10 +144,11 @@ namespace AZ::Metal
         AZStd::lock_guard<AZStd::mutex> lock(m_mutex);
 
         uint32_t heapIndex = imageView.GetBindlessReadIndex();
+        uint32_t allocatorIndex = static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadTexture);
+
+        // Only allocate a new index if the view doesn't already have one. This allows views to update in-place.
         if (heapIndex == ImageView::InvalidBindlessIndex)
         {
-            // Only allocate a new index if the view doesn't already have one. This allows views to update in-place.
-            uint32_t allocatorIndex = static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadTexture);
             RHI::VirtualAddress address = m_allocators[allocatorIndex].Allocate(1, 1);
             AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");
             heapIndex = static_cast<uint32_t>(address.m_ptr);
@@ -164,16 +167,17 @@ namespace AZ::Metal
         }
         return heapIndex;
     }
-    
+
     uint32_t BindlessArgumentBuffer::AttachReadWriteImage(ImageView& imageView)
     {
         AZStd::lock_guard<AZStd::mutex> lock(m_mutex);
 
         uint32_t heapIndex = imageView.GetBindlessReadWriteIndex();
+        uint32_t allocatorIndex = static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadWriteTexture);
+
+        // Only allocate a new index if the view doesn't already have one. This allows views to update in-place.
         if (heapIndex == ImageView::InvalidBindlessIndex)
         {
-            // Only allocate a new index if the view doesn't already have one. This allows views to update in-place.
-            uint32_t allocatorIndex = static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadWriteTexture);
             RHI::VirtualAddress address = m_allocators[allocatorIndex].Allocate(1, 1);
             AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");
             heapIndex = static_cast<uint32_t>(address.m_ptr);
@@ -192,16 +196,17 @@ namespace AZ::Metal
         }
         return heapIndex;
     }
-    
+
     uint32_t BindlessArgumentBuffer::AttachReadBuffer(BufferView& bufferView)
     {
         AZStd::lock_guard<AZStd::mutex> lock(m_mutex);
 
         uint32_t heapIndex = bufferView.GetBindlessReadIndex();
+        uint32_t allocatorIndex = static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadBuffer);
+
+        // Only allocate a new index if the view doesn't already have one. This allows views to update in-place.
         if (heapIndex == BufferView::InvalidBindlessIndex)
         {
-            // Only allocate a new index if the view doesn't already have one. This allows views to update in-place.
-            uint32_t allocatorIndex = static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadBuffer);
             RHI::VirtualAddress address = m_allocators[allocatorIndex].Allocate(1, 1);
             AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");
             heapIndex = static_cast<uint32_t>(address.m_ptr);
@@ -222,15 +227,16 @@ namespace AZ::Metal
         return heapIndex;
     }
 
-    uint32_t BindlessArgumentBuffer::AttachReadWriteBuffer(BufferView& bufferView, uint32_t offset)
+    uint32_t BindlessArgumentBuffer::AttachReadWriteBuffer(BufferView& bufferView)
     {
         AZStd::lock_guard<AZStd::mutex> lock(m_mutex);
 
         uint32_t heapIndex = bufferView.GetBindlessReadWriteIndex();
+        uint32_t allocatorIndex = static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadWriteBuffer);
+
+        // Only allocate a new index if the view doesn't already have one. This allows views to update in-place.
         if (heapIndex == BufferView::InvalidBindlessIndex)
         {
-            // Only allocate a new index if the view doesn't already have one. This allows views to update in-place.
-            uint32_t allocatorIndex = static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadWriteBuffer);
             RHI::VirtualAddress address = m_allocators[allocatorIndex].Allocate(1, 1);
             AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");
             heapIndex = static_cast<uint32_t>(address.m_ptr);
@@ -281,7 +287,7 @@ namespace AZ::Metal
 
     RHI::Ptr<ArgumentBuffer> BindlessArgumentBuffer::GetBindlessArgbuffer() const
     {
-        if(m_unboundedArraySupported)
+        if (m_unboundedArraySupported)
         {
             return m_rootArgBuffer;
         }
@@ -291,18 +297,19 @@ namespace AZ::Metal
         }
     }
 
-    void BindlessArgumentBuffer::BindBindlessArgumentBuffer(uint32_t slotIndex,
-                                                    CommandEncoderType commandEncoderType,
-                                                    CommandList::MetalArgumentBufferArray& mtlVertexArgBuffers,
-                                                    CommandList::MetalArgumentBufferArrayOffsets& mtlVertexArgBufferOffsets,
-                                                    CommandList::MetalArgumentBufferArray& mtlFragmentOrComputeArgBuffers,
-                                                    CommandList::MetalArgumentBufferArrayOffsets& mtlFragmentOrComputeArgBufferOffsets,
-                                                    uint32_t& bufferVertexRegisterIdMin,
-                                                    uint32_t& bufferVertexRegisterIdMax,
-                                                    uint32_t& bufferFragmentOrComputeRegisterIdMin,
-                                                    uint32_t& bufferFragmentOrComputeRegisterIdMax)
+    void BindlessArgumentBuffer::BindBindlessArgumentBuffer(
+        uint32_t slotIndex,
+        CommandEncoderType commandEncoderType,
+        CommandList::MetalArgumentBufferArray& mtlVertexArgBuffers,
+        CommandList::MetalArgumentBufferArrayOffsets& mtlVertexArgBufferOffsets,
+        CommandList::MetalArgumentBufferArray& mtlFragmentOrComputeArgBuffers,
+        CommandList::MetalArgumentBufferArrayOffsets& mtlFragmentOrComputeArgBufferOffsets,
+        uint32_t& bufferVertexRegisterIdMin,
+        uint32_t& bufferVertexRegisterIdMax,
+        uint32_t& bufferFragmentOrComputeRegisterIdMin,
+        uint32_t& bufferFragmentOrComputeRegisterIdMax)
     {
-        if(commandEncoderType == CommandEncoderType::Render)
+        if (commandEncoderType == CommandEncoderType::Render)
         {
             mtlVertexArgBuffers[slotIndex] = GetBindlessArgbuffer()->GetArgEncoderBuffer();
             mtlVertexArgBufferOffsets[slotIndex] = GetBindlessArgbuffer()->GetOffset();
@@ -311,7 +318,7 @@ namespace AZ::Metal
             bufferVertexRegisterIdMin = AZStd::min(slotIndex, bufferVertexRegisterIdMin);
             bufferVertexRegisterIdMax = AZStd::max(slotIndex, bufferVertexRegisterIdMax);
         }
-        else if(commandEncoderType == CommandEncoderType::Compute)
+        else if (commandEncoderType == CommandEncoderType::Compute)
         {
             mtlFragmentOrComputeArgBuffers[slotIndex] = GetBindlessArgbuffer()->GetArgEncoderBuffer();
             mtlFragmentOrComputeArgBufferOffsets[slotIndex] = GetBindlessArgbuffer()->GetOffset();
@@ -320,26 +327,27 @@ namespace AZ::Metal
         bufferFragmentOrComputeRegisterIdMax = AZStd::max(slotIndex, bufferFragmentOrComputeRegisterIdMax);
     }
 
-    void BindlessArgumentBuffer::MakeBindlessArgumentBuffersResident(CommandEncoderType commandEncoderType,
-                                                                     ArgumentBuffer::ResourcesPerStageForGraphics& untrackedResourcesGfxRead,
-                                                                     ArgumentBuffer::ResourcesForCompute& untrackedResourceComputeRead)
+    void BindlessArgumentBuffer::MakeBindlessArgumentBuffersResident(
+        CommandEncoderType commandEncoderType,
+        ArgumentBuffer::ResourcesPerStageForGraphics& untrackedResourcesGfxRead,
+        ArgumentBuffer::ResourcesForCompute& untrackedResourceComputeRead)
     {
         //If unbounded arrays are supported (i.e we are using rootAB approach) make all the children ABs resident
-        if(m_unboundedArraySupported)
+        if (m_unboundedArraySupported)
         {
-            if(commandEncoderType == CommandEncoderType::Render)
+            if (commandEncoderType == CommandEncoderType::Render)
             {
                 untrackedResourcesGfxRead[RHI::ShaderStageVertex].insert(m_bindlessTextureArgBuffer->GetArgEncoderBuffer());
                 untrackedResourcesGfxRead[RHI::ShaderStageVertex].insert(m_bindlessRWTextureArgBuffer->GetArgEncoderBuffer());
                 untrackedResourcesGfxRead[RHI::ShaderStageVertex].insert(m_bindlessBufferArgBuffer->GetArgEncoderBuffer());
                 untrackedResourcesGfxRead[RHI::ShaderStageVertex].insert(m_bindlessRWBufferArgBuffer->GetArgEncoderBuffer());
-                
+
                 untrackedResourcesGfxRead[RHI::ShaderStageFragment].insert(m_bindlessTextureArgBuffer->GetArgEncoderBuffer());
                 untrackedResourcesGfxRead[RHI::ShaderStageFragment].insert(m_bindlessRWTextureArgBuffer->GetArgEncoderBuffer());
                 untrackedResourcesGfxRead[RHI::ShaderStageFragment].insert(m_bindlessBufferArgBuffer->GetArgEncoderBuffer());
                 untrackedResourcesGfxRead[RHI::ShaderStageFragment].insert(m_bindlessRWBufferArgBuffer->GetArgEncoderBuffer());
             }
-            else if(commandEncoderType == CommandEncoderType::Compute)
+            else if (commandEncoderType == CommandEncoderType::Compute)
             {
                 untrackedResourceComputeRead.insert(m_bindlessTextureArgBuffer->GetArgEncoderBuffer());
                 untrackedResourceComputeRead.insert(m_bindlessRWTextureArgBuffer->GetArgEncoderBuffer());

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/BindlessArgumentBuffer.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/BindlessArgumentBuffer.cpp
@@ -144,6 +144,7 @@ namespace AZ::Metal
         uint32_t heapIndex = imageView.GetBindlessReadIndex();
         if (heapIndex == ImageView::InvalidBindlessIndex)
         {
+            // Only allocate a new index if the view doesn't already have one. This allows views to update in-place.
             uint32_t allocatorIndex = static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadTexture);
             RHI::VirtualAddress address = m_allocators[allocatorIndex].Allocate(1, 1);
             AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");
@@ -171,6 +172,7 @@ namespace AZ::Metal
         uint32_t heapIndex = imageView.GetBindlessReadWriteIndex();
         if (heapIndex == ImageView::InvalidBindlessIndex)
         {
+            // Only allocate a new index if the view doesn't already have one. This allows views to update in-place.
             uint32_t allocatorIndex = static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadWriteTexture);
             RHI::VirtualAddress address = m_allocators[allocatorIndex].Allocate(1, 1);
             AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");
@@ -198,6 +200,7 @@ namespace AZ::Metal
         uint32_t heapIndex = bufferView.GetBindlessReadIndex();
         if (heapIndex == BufferView::InvalidBindlessIndex)
         {
+            // Only allocate a new index if the view doesn't already have one. This allows views to update in-place.
             uint32_t allocatorIndex = static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadBuffer);
             RHI::VirtualAddress address = m_allocators[allocatorIndex].Allocate(1, 1);
             AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");
@@ -226,6 +229,7 @@ namespace AZ::Metal
         uint32_t heapIndex = bufferView.GetBindlessReadWriteIndex();
         if (heapIndex == BufferView::InvalidBindlessIndex)
         {
+            // Only allocate a new index if the view doesn't already have one. This allows views to update in-place.
             uint32_t allocatorIndex = static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadWriteBuffer);
             RHI::VirtualAddress address = m_allocators[allocatorIndex].Allocate(1, 1);
             AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/BindlessArgumentBuffer.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/BindlessArgumentBuffer.h
@@ -16,7 +16,9 @@ namespace AZ
     {
         class Device;
         class ArgumentBuffer;
-        
+        class BufferView;
+        class ImageView;
+
         //! This class is responsible for managing the global bindless heap. It provides
         //! support for this heap via both unbounded array as well as bounded arrays.
         class BindlessArgumentBuffer
@@ -57,21 +59,23 @@ namespace AZ
 
             //! Add all the argument buffers related to the global bindless heap to the maps passed in
             //! so that it can be bound to the encoder efficiently
-            void BindBindlessArgumentBuffer(uint32_t slotIndex,
-                                            CommandEncoderType commandEncoderType,
-                                            CommandList::MetalArgumentBufferArray& mtlVertexArgBuffers,
-                                            CommandList::MetalArgumentBufferArrayOffsets& mtlVertexArgBufferOffsets,
-                                            CommandList::MetalArgumentBufferArray& mtlFragmentOrComputeArgBuffers,
-                                            CommandList::MetalArgumentBufferArrayOffsets& mtlFragmentOrComputeArgBufferOffsets,
-                                            uint32_t& bufferVertexRegisterIdMin,
-                                            uint32_t& bufferVertexRegisterIdMax,
-                                            uint32_t& bufferFragmentOrComputeRegisterIdMin,
-                                            uint32_t& bufferFragmentOrComputeRegisterIdMax);
+            void BindBindlessArgumentBuffer(
+                uint32_t slotIndex,
+                CommandEncoderType commandEncoderType,
+                CommandList::MetalArgumentBufferArray& mtlVertexArgBuffers,
+                CommandList::MetalArgumentBufferArrayOffsets& mtlVertexArgBufferOffsets,
+                CommandList::MetalArgumentBufferArray& mtlFragmentOrComputeArgBuffers,
+                CommandList::MetalArgumentBufferArrayOffsets& mtlFragmentOrComputeArgBufferOffsets,
+                uint32_t& bufferVertexRegisterIdMin,
+                uint32_t& bufferVertexRegisterIdMax,
+                uint32_t& bufferFragmentOrComputeRegisterIdMin,
+                uint32_t& bufferFragmentOrComputeRegisterIdMax);
 
-            //! Add all all the bindless resource views indirectly bound to the maps passed in so that they can be made resident
-            void MakeBindlessArgumentBuffersResident(CommandEncoderType commandEncoderType,
-                                                     ArgumentBuffer::ResourcesPerStageForGraphics& untrackedResourcesGfxRead,
-                                                     ArgumentBuffer::ResourcesForCompute& untrackedResourceComputeRead);
+            //! Add all the bindless resource views indirectly bound to the maps passed in so that they can be made resident
+            void MakeBindlessArgumentBuffersResident(
+                CommandEncoderType commandEncoderType,
+                ArgumentBuffer::ResourcesPerStageForGraphics& untrackedResourcesGfxRead,
+                ArgumentBuffer::ResourcesForCompute& untrackedResourceComputeRead);
         private:
 
             //Bindless ABs + the rootAB which will act as a container. This is used for unbounded arrays.
@@ -80,10 +84,10 @@ namespace AZ
             RHI::Ptr<ArgumentBuffer> m_bindlessRWTextureArgBuffer;
             RHI::Ptr<ArgumentBuffer> m_bindlessBufferArgBuffer;
             RHI::Ptr<ArgumentBuffer> m_bindlessRWBufferArgBuffer;
-             
-            //Bounded AB in order to simulate bindless behaviour for plats that do not support unbounded arrays.
+
+            //Bounded AB in order to simulate bindless behavior for plats that do not support unbounded arrays.
             RHI::Ptr<ArgumentBuffer> m_boundedArgBuffer;
-            
+
             // Free list allocator per bindless resource type
             RHI::FreeListAllocator m_allocators[static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::Count)];
             Device* m_device = nullptr;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/BindlessArgumentBuffer.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/BindlessArgumentBuffer.h
@@ -29,16 +29,16 @@ namespace AZ
             RHI::Ptr<ArgumentBuffer> GetBindlessArgbuffer() const;
 
             //! Add/Update a read only image pointer to the global bindless heap 
-            uint32_t AttachReadImage(id <MTLTexture> mtlTexture);
+            uint32_t AttachReadImage(ImageView& imageView);
 
             //! Add/Update a read write image pointer to the global bindless heap 
-            uint32_t AttachReadWriteImage(id <MTLTexture> mtlTexture);
+            uint32_t AttachReadWriteImage(ImageView& imageView);
 
             //! Add/Update a read only buffer pointer to the global bindless heap 
-            uint32_t AttachReadBuffer(id <MTLBuffer> mtlTexture, uint32_t offfset);
+            uint32_t AttachReadBuffer(BufferView& bufferView);
 
             //! Add/Update a read write buffer pointer to the global bindless heap 
-            uint32_t AttachReadWriteBuffer(id <MTLBuffer> mtlTexture, uint32_t offfset);
+            uint32_t AttachReadWriteBuffer(BufferView& bufferView);
 
             //! Remove the index associated with a read only image descriptor from the free list allocator
             void DetachReadImage(uint32_t index);

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/BufferView.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/BufferView.cpp
@@ -27,45 +27,45 @@ namespace AZ
             const RHI::BufferViewDescriptor& viewDescriptor = GetDescriptor();
             const RHI::BufferDescriptor& bufferDescriptor = buffer.GetDescriptor();
             auto& device = static_cast<Device&>(deviceBase);
-            
+
             MemoryView buffMemView = buffer.GetMemoryView();
             size_t buffMemOffset = buffMemView.GetOffset() + viewDescriptor.m_elementOffset * viewDescriptor.m_elementSize;
             m_memoryView = MemoryView(buffMemView.GetMemory(), buffMemOffset, viewDescriptor.m_elementSize * viewDescriptor.m_elementCount, buffMemView.GetAlignment());
-            
+
             bool isRGB32Float = viewDescriptor.m_elementFormat == RHI::Format::R32G32B32_FLOAT;
-            
+
             //Create a texture view needed by typed buffers. In hlsl these variables are declared as Buffer/RWBuffer
             //Unfortunately metal does not support R32G32B32_FLOAT. We will need to ensure we dont have a use case
             //where a texture view is needed for a buffer with this format. Details in ATOM-13279
-            if(viewDescriptor.m_elementFormat != RHI::Format::Unknown && !isRGB32Float)
+            if (viewDescriptor.m_elementFormat != RHI::Format::Unknown && !isRGB32Float)
             {
                 id<MTLBuffer> mtlBuffer = buffMemView.GetMemory()->GetGpuAddress<id<MTLBuffer>>();
                 MTLTextureUsage textureUsage = MTLTextureUsageShaderRead;
-                
+
                 if (RHI::CheckBitsAll(bufferDescriptor.m_bindFlags, RHI::BufferBindFlags::ShaderWrite))
                 {
                     textureUsage |= MTLTextureUsageShaderWrite;
                 }
-                
-                const uint32_t bytesPerPixel = RHI::GetFormatSize(viewDescriptor.m_elementFormat);                
+
+                const uint32_t bytesPerPixel = RHI::GetFormatSize(viewDescriptor.m_elementFormat);
                 MTLTextureDescriptor* mtlTextureDesc =
-                      [MTLTextureDescriptor textureBufferDescriptorWithPixelFormat : ConvertPixelFormat(viewDescriptor.m_elementFormat)
-                                                                             width : viewDescriptor.m_elementCount
-                                                                   resourceOptions : mtlBuffer.resourceOptions
-                                                                             usage : textureUsage];
+                    [MTLTextureDescriptor textureBufferDescriptorWithPixelFormat : ConvertPixelFormat(viewDescriptor.m_elementFormat)
+                                                                           width : viewDescriptor.m_elementCount
+                                                                 resourceOptions : mtlBuffer.resourceOptions
+                                                                           usage : textureUsage];
                 mtlTextureDesc.textureType = MTLTextureTypeTextureBuffer;
-                
-                [[maybe_unused]] uint32_t bytesPerRow  = viewDescriptor.m_elementCount * bytesPerPixel;
+
+                [[maybe_unused]] uint32_t bytesPerRow = viewDescriptor.m_elementCount * bytesPerPixel;
                 AZ_Assert(bytesPerRow == (viewDescriptor.m_elementCount * viewDescriptor.m_elementSize), "Mismatch for bytesPerRow");
                 id<MTLTexture> mtlTexture = [mtlBuffer newTextureWithDescriptor : mtlTextureDesc
                                                                          offset : m_memoryView.GetOffset()
                                                                     bytesPerRow : (viewDescriptor.m_elementCount * bytesPerPixel)];
                 AZ_Assert(mtlTexture, "Failed to create texture");
-                
-                RHI::Ptr<MetalResource> textureViewResource = MetalResource::Create(MetalResourceDescriptor{mtlTexture, ResourceType::MtlTextureType});
+
+                RHI::Ptr<MetalResource> textureViewResource = MetalResource::Create(MetalResourceDescriptor{ mtlTexture, ResourceType::MtlTextureType });
                 m_imageBufferMemoryView = MemoryView(textureViewResource, 0, (viewDescriptor.m_elementCount * bytesPerPixel), 0);
             }
-            
+
             bool hasOverrideFlags = viewDescriptor.m_overrideBindFlags != RHI::BufferBindFlags::None;
             const RHI::BufferBindFlags bindFlags = hasOverrideFlags ? viewDescriptor.m_overrideBindFlags : buffer.GetDescriptor().m_bindFlags;
             bool shaderRead = RHI::CheckBitsAny(bindFlags, RHI::BufferBindFlags::ShaderRead);
@@ -86,7 +86,7 @@ namespace AZ
             return RHI::ResultCode::Success;
         }
 
-        RHI::ResultCode ImageView::InvalidateInternal()
+        RHI::ResultCode BufferView::InvalidateInternal()
         {
             ReleaseViews();
             RHI::ResultCode initResult = InitInternal(GetDevice(), GetResource());
@@ -128,30 +128,30 @@ namespace AZ
 
         void BufferView::ShutdownInternal()
         {
-            ReleaseView();
+            ReleaseViews();
             ReleaseBindlessIndices();
         }
-    
+
         const MemoryView& BufferView::GetMemoryView() const
         {
             return m_memoryView;
         }
-        
+
         MemoryView& BufferView::GetMemoryView()
         {
             return m_memoryView;
         }
-    
+
         const MemoryView& BufferView::GetTextureBufferView() const
         {
             return m_imageBufferMemoryView;
         }
-    
+
         MemoryView& BufferView::GetTextureBufferView()
         {
             return m_imageBufferMemoryView;
         }
-    
+
         uint32_t BufferView::GetBindlessReadIndex() const
         {
             return m_readIndex;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/BufferView.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/BufferView.h
@@ -51,7 +51,10 @@ namespace AZ
             RHI::ResultCode InvalidateInternal() override;
             void ShutdownInternal() override;
             //////////////////////////////////////////////////////////////////////////
-                   
+
+            void ReleaseViews();
+            void ReleaseBindlessIndices();
+
             //Buffer view
             MemoryView m_memoryView;
             
@@ -59,8 +62,8 @@ namespace AZ
             MemoryView m_imageBufferMemoryView;
             
             //! Index related to the position of the read and readwrite view within the global Bindless Argument Buffer
-            uint32_t m_readIndex = ~0u;
-            uint32_t m_readWriteIndex = ~0u;
+            uint32_t m_readIndex = InvalidBindlessIndex;
+            uint32_t m_readWriteIndex = InvalidBindlessIndex;
         };
     }
 }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/ImageView.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/ImageView.h
@@ -54,7 +54,10 @@ namespace AZ
             void ShutdownInternal() override;
             //////////////////////////////////////////////////////////////////////////
 
-            //Create a separate own copy of memoryview to be used for rendering.
+            void ReleaseView();
+            void ReleaseBindlessIndices();
+
+            //Create a separate own copy of MemoryView to be used for rendering.
             //Internally it may create a new MTLTexture object that reinterprets the original MTLTexture object from Image
             MemoryView m_memoryView;
             
@@ -62,8 +65,8 @@ namespace AZ
             RHI::ImageSubresourceRange m_imageSubresourceRange;
             
             //! Index related to the position of the read and readwrite view within the global Bindless Argument Buffer
-            uint32_t m_readIndex = ~0u;
-            uint32_t m_readWriteIndex = ~0u;
+            uint32_t m_readIndex = InvalidBindlessIndex;
+            uint32_t m_readWriteIndex = InvalidBindlessIndex;
         };
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BindlessDescriptorPool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BindlessDescriptorPool.cpp
@@ -137,9 +137,14 @@ namespace AZ::Vulkan
         const uint32_t roTextureIndex = static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadTexture);
         
         AZStd::lock_guard<AZStd::mutex> lock(m_mutex);
-        RHI::VirtualAddress address = m_allocators[roTextureIndex].Allocate(1, 1);
-        AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");
-        uint32_t heapIndex = static_cast<uint32_t>(address.m_ptr);
+
+        uint32_t heapIndex = view->GetBindlessReadIndex();
+        if (heapIndex == ImageView::InvalidBindlessIndex)
+        {
+            RHI::VirtualAddress address = m_allocators[roTextureIndex].Allocate(1, 1);
+            AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");
+            heapIndex = static_cast<uint32_t>(address.m_ptr);
+        }
 
         VkWriteDescriptorSet write = PrepareWrite(heapIndex, roTextureIndex, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
         VkDescriptorImageInfo imageInfo{};
@@ -158,9 +163,14 @@ namespace AZ::Vulkan
         const uint32_t rwTextureIndex = static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadWriteTexture);
 
         AZStd::lock_guard<AZStd::mutex> lock(m_mutex);
-        RHI::VirtualAddress address = m_allocators[rwTextureIndex].Allocate(1, 1);
-        AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");
-        uint32_t heapIndex = static_cast<uint32_t>(address.m_ptr);
+
+        uint32_t heapIndex = view->GetBindlessReadWriteIndex();
+        if (heapIndex == ImageView::InvalidBindlessIndex)
+        {
+            RHI::VirtualAddress address = m_allocators[rwTextureIndex].Allocate(1, 1);
+            AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");
+            heapIndex = static_cast<uint32_t>(address.m_ptr);
+        }
 
         VkWriteDescriptorSet write = PrepareWrite(heapIndex, rwTextureIndex, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE);
         VkDescriptorImageInfo imageInfo{};
@@ -180,9 +190,14 @@ namespace AZ::Vulkan
         const uint32_t roBufferIndex = static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadBuffer);
 
         AZStd::lock_guard<AZStd::mutex> lock(m_mutex);
-        RHI::VirtualAddress address = m_allocators[roBufferIndex].Allocate(1, 1);
-        AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");
-        uint32_t heapIndex = static_cast<uint32_t>(address.m_ptr);
+
+        uint32_t heapIndex = view->GetBindlessReadIndex();
+        if (heapIndex == ImageView::InvalidBindlessIndex)
+        {
+            RHI::VirtualAddress address = m_allocators[roBufferIndex].Allocate(1, 1);
+            AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");
+            heapIndex = static_cast<uint32_t>(address.m_ptr);
+        }
 
         const auto& viewDesc = view->GetDescriptor();
         const Vulkan::BufferMemoryView& bufferMemoryView = *static_cast<const Vulkan::Buffer&>(view->GetBuffer()).GetBufferMemoryView();
@@ -202,9 +217,14 @@ namespace AZ::Vulkan
         const uint32_t rwBufferIndex = static_cast<uint32_t>(RHI::ShaderResourceGroupData::BindlessResourceType::ReadWriteBuffer);
 
         AZStd::lock_guard<AZStd::mutex> lock(m_mutex);
-        RHI::VirtualAddress address = m_allocators[rwBufferIndex].Allocate(1, 1);
-        AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");
-        uint32_t heapIndex = static_cast<uint32_t>(address.m_ptr);
+
+        uint32_t heapIndex = view->GetBindlessReadWriteIndex();
+        if (heapIndex == ImageView::InvalidBindlessIndex)
+        {
+            RHI::VirtualAddress address = m_allocators[rwBufferIndex].Allocate(1, 1);
+            AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");
+            heapIndex = static_cast<uint32_t>(address.m_ptr);
+        }
 
         const auto& viewDesc = view->GetDescriptor();
         const Vulkan::BufferMemoryView& bufferMemoryView = *static_cast<const Vulkan::Buffer&>(view->GetBuffer()).GetBufferMemoryView();

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BindlessDescriptorPool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BindlessDescriptorPool.cpp
@@ -141,6 +141,7 @@ namespace AZ::Vulkan
         uint32_t heapIndex = view->GetBindlessReadIndex();
         if (heapIndex == ImageView::InvalidBindlessIndex)
         {
+            // Only allocate a new index if the view doesn't already have one. This allows views to update in-place.
             RHI::VirtualAddress address = m_allocators[roTextureIndex].Allocate(1, 1);
             AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");
             heapIndex = static_cast<uint32_t>(address.m_ptr);
@@ -167,6 +168,7 @@ namespace AZ::Vulkan
         uint32_t heapIndex = view->GetBindlessReadWriteIndex();
         if (heapIndex == ImageView::InvalidBindlessIndex)
         {
+            // Only allocate a new index if the view doesn't already have one. This allows views to update in-place.
             RHI::VirtualAddress address = m_allocators[rwTextureIndex].Allocate(1, 1);
             AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");
             heapIndex = static_cast<uint32_t>(address.m_ptr);
@@ -194,6 +196,7 @@ namespace AZ::Vulkan
         uint32_t heapIndex = view->GetBindlessReadIndex();
         if (heapIndex == ImageView::InvalidBindlessIndex)
         {
+            // Only allocate a new index if the view doesn't already have one. This allows views to update in-place.
             RHI::VirtualAddress address = m_allocators[roBufferIndex].Allocate(1, 1);
             AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");
             heapIndex = static_cast<uint32_t>(address.m_ptr);
@@ -221,6 +224,7 @@ namespace AZ::Vulkan
         uint32_t heapIndex = view->GetBindlessReadWriteIndex();
         if (heapIndex == ImageView::InvalidBindlessIndex)
         {
+            // Only allocate a new index if the view doesn't already have one. This allows views to update in-place.
             RHI::VirtualAddress address = m_allocators[rwBufferIndex].Allocate(1, 1);
             AZ_Assert(address.IsValid(), "Bindless allocator ran out of space.");
             heapIndex = static_cast<uint32_t>(address.m_ptr);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BufferView.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BufferView.cpp
@@ -81,29 +81,46 @@ namespace AZ
 
         RHI::ResultCode BufferView::InvalidateInternal()
         {
+            ReleaseView();
+            RHI::ResultCode initResult = InitInternal(GetDevice(), GetResource());
+            if (initResult != RHI::ResultCode::Success)
+            {
+                ReleaseBindlessIndices();
+            }
+            return initResult;
+        }
+
+        void BufferView::ReleaseView()
+        {
             if (m_nativeBufferView != VK_NULL_HANDLE)
             {
                 auto& device = static_cast<Device&>(GetDevice());
                 device.QueueForRelease(new ReleaseContainer<VkBufferView>(
                     device.GetNativeDevice(), m_nativeBufferView, device.GetContext().DestroyBufferView));
                 m_nativeBufferView = VK_NULL_HANDLE;
-
-                if (m_readIndex != ~0u)
-                {
-                    device.GetBindlessDescriptorPool().DetachReadBuffer(m_readIndex);
-                }
-
-                if (m_readWriteIndex != ~0u)
-                {
-                    device.GetBindlessDescriptorPool().DetachReadWriteBuffer(m_readWriteIndex);
-                }
             }
-            return RHI::ResultCode::Success;
+        }
+
+        void BufferView::ReleaseBindlessIndices()
+        {
+            auto& device = static_cast<Device&>(GetDevice());
+            if (m_readIndex != InvalidBindlessIndex)
+            {
+                device.GetBindlessDescriptorPool().DetachReadBuffer(m_readIndex);
+                m_readIndex = InvalidBindlessIndex;
+            }
+
+            if (m_readWriteIndex != InvalidBindlessIndex)
+            {
+                device.GetBindlessDescriptorPool().DetachReadWriteBuffer(m_readWriteIndex);
+                m_readWriteIndex = InvalidBindlessIndex;
+            }
         }
 
         void BufferView::ShutdownInternal()
         {
-            InvalidateInternal();
+            ReleaseView();
+            ReleaseBindlessIndices();
         }
 
         RHI::ResultCode BufferView::BuildNativeBufferView(Device& device, const Buffer& buffer, const RHI::BufferViewDescriptor& descriptor)

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BufferView.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BufferView.h
@@ -60,12 +60,14 @@ namespace AZ
             //////////////////////////////////////////////////////////////////////////
 
             RHI::ResultCode BuildNativeBufferView(Device& device, const Buffer& buffer, const RHI::BufferViewDescriptor& descriptor);
+            void ReleaseView();
+            void ReleaseBindlessIndices();
 
             VkBufferView m_nativeBufferView = VK_NULL_HANDLE;
             VkAccelerationStructureKHR m_nativeAccelerationStructure = VK_NULL_HANDLE;
 
-            uint32_t m_readIndex = ~0u;
-            uint32_t m_readWriteIndex = ~0u;
+            uint32_t m_readIndex = InvalidBindlessIndex;
+            uint32_t m_readWriteIndex = InvalidBindlessIndex;
         };
 
     }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImageView.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImageView.cpp
@@ -135,29 +135,46 @@ namespace AZ
 
         RHI::ResultCode ImageView::InvalidateInternal()
         {
-            ShutdownInternal();
-            return InitInternal(GetDevice(), GetResource());
+            ReleaseView();
+            RHI::ResultCode initResult = InitInternal(GetDevice(), GetResource());
+            if (initResult != RHI::ResultCode::Success)
+            {
+                ReleaseBindlessIndices();
+            }
+            return initResult;
         }
 
-        void ImageView::ShutdownInternal()
-        {            
+        void ImageView::ReleaseView()
+        {
             if (m_vkImageView != VK_NULL_HANDLE)
             {
                 auto& device = static_cast<Device&>(GetDevice());
                 device.QueueForRelease(
                     new ReleaseContainer<VkImageView>(device.GetNativeDevice(), m_vkImageView, device.GetContext().DestroyImageView));
                 m_vkImageView = VK_NULL_HANDLE;
-
-                if (m_readIndex != ~0u)
-                {
-                    device.GetBindlessDescriptorPool().DetachReadImage(m_readIndex);
-                }
-
-                if (m_readWriteIndex != ~0u)
-                {
-                    device.GetBindlessDescriptorPool().DetachReadWriteImage(m_readWriteIndex);
-                }
             }
+        }
+
+        void ImageView::ReleaseBindlessIndices()
+        {
+            auto& device = static_cast<Device&>(GetDevice());
+            if (m_readIndex != InvalidBindlessIndex)
+            {
+                device.GetBindlessDescriptorPool().DetachReadImage(m_readIndex);
+                m_readIndex = InvalidBindlessIndex;
+            }
+
+            if (m_readWriteIndex != InvalidBindlessIndex)
+            {
+                device.GetBindlessDescriptorPool().DetachReadWriteImage(m_readWriteIndex);
+                m_readWriteIndex = InvalidBindlessIndex;
+            }
+        }
+
+        void ImageView::ShutdownInternal()
+        {
+            ReleaseView();
+            ReleaseBindlessIndices();
         }
 
         VkImageViewType ImageView::GetImageViewType(const Image& image) const

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImageView.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImageView.h
@@ -56,14 +56,16 @@ namespace AZ
 
             VkImageViewType GetImageViewType(const Image& image) const;
             void BuildImageSubresourceRange(VkImageViewType imageViewType, VkImageAspectFlags aspectFlags);
+            void ReleaseView();
+            void ReleaseBindlessIndices();
 
             VkImageView m_vkImageView = VK_NULL_HANDLE;
             RHI::Format m_format = RHI::Format::Unknown;
             RHI::ImageSubresourceRange m_imageSubresourceRange;
             VkImageSubresourceRange m_vkImageSubResourceRange;
 
-            uint32_t m_readIndex = ~0u;
-            uint32_t m_readWriteIndex = ~0u;
+            uint32_t m_readIndex = InvalidBindlessIndex;
+            uint32_t m_readWriteIndex = InvalidBindlessIndex;
         };
     }
 }


### PR DESCRIPTION
## What does this PR do?

Previously, when an ImageView or BufferView was invalidated, the old location on the bindless array was deallocated and a new one was created. This meant that it was possible for the bindless ID of the view to change under the hood, which could cause crashes in anything using that view in a bindless way. This updates DirectX, Vulkan, and Metal to replace the old location instead of allocating a new location when a view is being invalidated and reinitialized.

This also fixes BufferView invalidation in Vulkan which was previously just shutting down the BufferView instead of reinitializing it. Making it reinitialize keeps the behavior consistent with the way both ImageView on Vulkan and BufferView on Dx12 work.

The root issue this PR is attempting to address is from #13660 where as mips streamed in for terrain detail materials (which use bindless), the image would not update (dx12) or it would lead to a crash (vulkan).

Fixes: #13660

Tested the full ASV test suite. Also tested with bindless terrain locally where the mip issue was originally occurring.
