### PR TITLE
pass editor args for log timestamps

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/launchers/platforms/linux/launcher.py
+++ b/Tools/LyTestTools/ly_test_tools/launchers/platforms/linux/launcher.py
@@ -172,6 +172,7 @@ class LinuxLauncher(Launcher):
         self.args.append(f'--regset="/Amazon/AzCore/Bootstrap/remote_ip={host_ip}"')
         self.args.append(f'--regset="/Amazon/AzCore/Bootstrap/allowed_list={host_ip}"')
         self.args.append(f'--log_RemoteConsoleAllowedAddresses={host_ip}')
+        self.args.append("--log_IncludeTime=1")
 
 
 class DedicatedLinuxLauncher(LinuxLauncher):

--- a/Tools/LyTestTools/ly_test_tools/launchers/platforms/win/launcher.py
+++ b/Tools/LyTestTools/ly_test_tools/launchers/platforms/win/launcher.py
@@ -172,6 +172,7 @@ class WinLauncher(Launcher):
         self.args.append(f'--regset="/Amazon/AzCore/Bootstrap/remote_ip={host_ip}"')
         self.args.append(f'--regset="/Amazon/AzCore/Bootstrap/allowed_list={host_ip}"')
         self.args.append(f'--log_RemoteConsoleAllowedAddresses={host_ip}')
+        self.args.append("--log_IncludeTime=1")
 
 
 class DedicatedWinLauncher(WinLauncher):

--- a/Tools/LyTestTools/ly_test_tools/o3de/multi_test_framework.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/multi_test_framework.py
@@ -793,7 +793,9 @@ class MultiTestSuite(object):
         if type(executable) in [WinEditor, LinuxEditor]:  # Handle Editor CLI args since we need workspace context to populate them.
             test_cmdline_args += [
                 "--regset=/Amazon/Preferences/EnablePrefabSystem=true",
-                f"--regset-file={os.path.join(workspace.paths.engine_root(), 'Registry', 'prefab.test.setreg')}"]
+                f"--regset-file={os.path.join(workspace.paths.engine_root(), 'Registry', 'prefab.test.setreg')}",
+                "--log_IncludeTime=1"
+            ]
         if self.use_null_renderer:
             test_cmdline_args += ["-rhi=null"]
         if any([t.attach_debugger for t in test_spec_list]):


### PR DESCRIPTION
Signed-off-by: sweeneys <sweeneys@amazon.com>

## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/13913 by passing the editor log timestamps by default

## How was this PR tested?

Forced an assert in a local test targeting the Editor.
