### PR TITLE
Added an explicit binary directory to the mono-default configure CMake

### DIFF
--- a/cmake/Platform/Android/CMakePresets.json
+++ b/cmake/Platform/Android/CMakePresets.json
@@ -25,6 +25,7 @@
       "displayName": "Android Monolithic with Unity and Ninja",
       "description": "Configures Android to build the Monolithic permutation using Ninja with Unity builds",
       "toolchainFile": "${sourceDir}/cmake/Platform/Android/Toolchain_android.cmake",
+      "binaryDir": "${sourceDir}/build/android_mono",
       "inherits": [
         "android-ninja",
         "android-unity",

--- a/cmake/Platform/Linux/CMakePresets.json
+++ b/cmake/Platform/Linux/CMakePresets.json
@@ -23,6 +23,7 @@
             "name": "linux-mono-default",
             "displayName": "Linux Monolithic with Unity and Ninja",
             "description": "Configures Mac to build the Monolithic permutation using Ninja with Unity builds",
+            "binaryDir": "${sourceDir}/build/linux_mono",
             "inherits": [
                 "linux-ninja",
                 "linux-unity",

--- a/cmake/Platform/Mac/CMakePresets.json
+++ b/cmake/Platform/Mac/CMakePresets.json
@@ -12,7 +12,7 @@
     {
       "name": "mac-default",
       "displayName": "Mac",
-      "description": "Mac default configuratoin",
+      "description": "Mac default configuration",
       "inherits": [
         "mac-xcode",
         "mac-unity",
@@ -23,8 +23,9 @@
       "name": "mac-mono-default",
       "displayName": "Mac Monolithic with Unity and Xcode",
       "description": "Configures Mac to build the Monolithic permutation using Xcode with Unity builds",
+      "binaryDir": "${sourceDir}/build/mac_mono",
       "inherits": [
-        "mac-ninja",
+        "mac-xcode",
         "mac-unity",
         "mac-monolithic"
       ]

--- a/cmake/Platform/Windows/CMakePresets.json
+++ b/cmake/Platform/Windows/CMakePresets.json
@@ -21,6 +21,7 @@
             "name": "windows-mono-default",
             "displayName": "Windows Monolithic with Unity and Visual Studio",
             "description": "Configures Windows to build the Monolithic permutation using Visual Studio with Unity builds",
+            "binaryDir": "${sourceDir}/build/windows_mono",
             "inherits": [
                 "windows-unity",
                 "windows-monolithic"

--- a/cmake/Platform/iOS/CMakePresets.json
+++ b/cmake/Platform/iOS/CMakePresets.json
@@ -25,8 +25,9 @@
       "displayName": "iOS Monolithic with Unity and Xcode",
       "description": "Configures iOS to build the Monolithic permutation using Xcode with Unity builds",
       "toolchainFile": "${sourceDir}/cmake/Platform/iOS/Toolchain_ios.cmake",
+      "binaryDir": "${sourceDir}/build/ios_mono",
       "inherits": [
-        "ios-ninja",
+        "ios-xcode",
         "ios-unity",
         "ios-monolithic"
       ]


### PR DESCRIPTION
Presets.

Previously these presets did not specify a binary directory, therefore using these presets would default to using the binary directory of the first inherited preset.

For example windows this would result in the monolithic build being placed in the same folder as non-monolithic builds(`build/windows`), because the windows_unity target has a binary directory set to `build/windows`. his makes it so that by default the monolithic binary directory is a different directory than the non-monolithic binary directory. This can overridden via the `-B <binary-dir>` option when cmake configuring.

For more information see the
[configure_preset](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html?highlight=presets#configure-preset) inherits entry documentation for inheritance of presets work.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Configure using the Engine using following command and verified that the binary directory was `<engine-root>/build/windows_mono`
```cmake
cmake --preset windows-mono-default -DLY_PROJECTS=AutomatedTesting
```
