### PR TITLE
Fixes two bugs from FrameCaptureSystemComponent:

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
@@ -556,7 +556,7 @@ namespace AZ
                 return CaptureHandle::Null();
             }
 
-            CaptureHandle captureHandle = ScreenshotPreparation(outputFilePath, nullptr);
+            CaptureHandle captureHandle = ScreenshotPreparation(outputFilePath, callbackFunction);
 
             if (captureHandle.IsNull())
             {


### PR DESCRIPTION
1- Avoid constant spam message:
"No callback or image path is set. No result will be generated."  
2- Allows the MaterialEditor render thumbnails.

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>

## What does this PR do?

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_

_Please add links to any issues, RFCs or other items that are relevant to this PR._

## How was this PR tested?

_Please describe any testing performed._
