### PR TITLE
Ensure update code is called when entity layout changes.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
@@ -1180,6 +1180,7 @@ namespace AzToolsFramework
                 {
                     const QModelIndex endIndex = createIndex(beginIndex.row(), VisibleColumnCount - 1, beginIndex.internalId());
                     emit dataChanged(beginIndex, endIndex);
+                    m_entityLayoutQueued = true;
                 }
             }
         


### PR DESCRIPTION
Signed-off-by: sphrose <82213493+sphrose@users.noreply.github.com>

## What does this PR do?

This PR resolves #11956 and resolves #13130. It does this by ensuring the existing layout update code within the EntityOutlinerListModel::ProcessEntityUpdates function is called when necessary, whereas it was previously inaccessible.

## How was this PR tested?

Prefabs were opened and closed multiple times, both through double clicking and the context menus.
