### PR TITLE
Sanitize name of the stubBoneAnimForMorph node to replace invalid character

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/MorphTargetOneMaterial/SceneDebug/morphtargetonematerial.dbgsg
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/MorphTargetOneMaterial/SceneDebug/morphtargetonematerial.dbgsg
@@ -10,8 +10,8 @@ Node Type: RootBoneData
 		BasisZ: < 0.000000,  0.000000,  1.000000>
 		Transl: < 0.000000,  0.000000,  0.000000>
 
-Node Name: animationMball.001*0
-Node Path: RootNode.animationMball.001*0
+Node Name: animationMball_001*0
+Node Path: RootNode.animationMball_001*0
 Node Type: AnimationData
 	KeyFrames: Count 31. Hash: 16594569657313590262
 	TimeStepBetweenFrames: 0.041667
@@ -46,8 +46,8 @@ Node Path: RootNode.Mball_001.SkinWeight_
 Node Type: SkinWeightData
 	VertexLinks: Count 696. Hash: 10428453650987264418
 
-Node Name: animationMball.001*0
-Node Path: RootNode.Mball_001.animationMball.001*0
+Node Name: animationMball_001*0
+Node Path: RootNode.Mball_001.animationMball_001*0
 Node Type: AnimationData
 	KeyFrames: Count 31. Hash: 16444376794354522612
 	TimeStepBetweenFrames: 0.041667
@@ -78,9 +78,9 @@ Node Type: BlendShapeData
 Node Name: custom_properties
 Node Path: RootNode.Mball_001.custom_properties
 Node Type: CustomPropertyData
-	UserProperties: 
 	IsNull: false
 	DefaultAttributeIndex: 0
+	UserProperties: 
 	InheritType: 1
 
 Node Name: UVMap
@@ -105,7 +105,7 @@ Node Type: MaterialData
 	UseMetallicMap: Not set
 	MetallicFactor: Not set
 	UseRoughnessMap: Not set
-	RoughnessFactor: Not set
+	RoughnessFactor: 0.500000
 	UseEmissiveMap: Not set
 	EmissiveIntensity: Not set
 	UseAOMap: Not set
@@ -132,8 +132,8 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 696. Hash: 5593568244043778543
 	GenerationMethod: 1
 
-Node Name: animationMball.001*0
-Node Path: RootNode.Armature.animationMball.001*0
+Node Name: animationMball_001*0
+Node Path: RootNode.Armature.animationMball_001*0
 Node Type: AnimationData
 	KeyFrames: Count 31. Hash: 16444376794354522612
 	TimeStepBetweenFrames: 0.041667
@@ -163,6 +163,14 @@ Node Type: BoneData
 		BasisY: <-0.000000,  0.000016,  100.000000>
 		BasisZ: <-0.000009,  100.000000, -0.000016>
 		Transl: < 0.000000,  0.000000,  0.000000>
+
+Node Name: custom_properties
+Node Path: RootNode.Mball_001_MorphTargetOneMaterial_optimized.custom_properties
+Node Type: CustomPropertyData
+	IsNull: false
+	DefaultAttributeIndex: 0
+	UserProperties: 
+	InheritType: 1
 
 Node Name: UVMap
 Node Path: RootNode.Mball_001_MorphTargetOneMaterial_optimized.UVMap
@@ -202,8 +210,8 @@ Node Type: BlendShapeData
 	Normals: Count 1044. Hash: 4838429295025120454
 	Faces: Count 348. Hash: 10303589656939351813
 
-Node Name: animationMball.001*0
-Node Path: RootNode.Mball_001_MorphTargetOneMaterial_optimized.animationMball.001*0
+Node Name: animationMball_001*0
+Node Path: RootNode.Mball_001_MorphTargetOneMaterial_optimized.animationMball_001*0
 Node Type: AnimationData
 	KeyFrames: Count 31. Hash: 16444376794354522612
 	TimeStepBetweenFrames: 0.041667
@@ -216,14 +224,6 @@ Node Type: TransformData
 		BasisY: < 0.000009, -100.000000,  0.000000>
 		BasisZ: < 0.000000,  0.000000,  100.000000>
 		Transl: < 0.000000,  0.000000,  0.000000>
-
-Node Name: custom_properties
-Node Path: RootNode.Mball_001_MorphTargetOneMaterial_optimized.custom_properties
-Node Type: CustomPropertyData
-	UserProperties: 
-	IsNull: false
-	DefaultAttributeIndex: 0
-	InheritType: 1
 
 Node Name: Material_001
 Node Path: RootNode.Mball_001_MorphTargetOneMaterial_optimized.Material_001
@@ -241,7 +241,7 @@ Node Type: MaterialData
 	UseMetallicMap: Not set
 	MetallicFactor: Not set
 	UseRoughnessMap: Not set
-	RoughnessFactor: Not set
+	RoughnessFactor: 0.500000
 	UseEmissiveMap: Not set
 	EmissiveIntensity: Not set
 	UseAOMap: Not set
@@ -255,8 +255,8 @@ Node Type: MaterialData
 	EmissiveTexture: 
 	BaseColorTexture: 
 
-Node Name: animationMball.001*0
-Node Path: RootNode.Armature.Bone.animationMball.001*0
+Node Name: animationMball_001*0
+Node Path: RootNode.Armature.Bone.animationMball_001*0
 Node Type: AnimationData
 	KeyFrames: Count 31. Hash: 12571026262766850303
 	TimeStepBetweenFrames: 0.041667
@@ -287,8 +287,8 @@ Node Type: BoneData
 		BasisZ: <-0.000009,  100.000000, -0.000016>
 		Transl: <-0.000000,  0.000000,  1.000000>
 
-Node Name: animationMball.001*0
-Node Path: RootNode.Armature.Bone.Bone_001.animationMball.001*0
+Node Name: animationMball_001*0
+Node Path: RootNode.Armature.Bone.Bone_001.animationMball_001*0
 Node Type: AnimationData
 	KeyFrames: Count 31. Hash: 11054744277397627493
 	TimeStepBetweenFrames: 0.041667
@@ -319,8 +319,8 @@ Node Type: BoneData
 		BasisZ: <-0.000009,  100.000000, -0.000016>
 		Transl: <-0.000000,  0.000000,  2.000000>
 
-Node Name: animationMball.001*0
-Node Path: RootNode.Armature.Bone.Bone_001.Bone_002.animationMball.001*0
+Node Name: animationMball_001*0
+Node Path: RootNode.Armature.Bone.Bone_001.Bone_002.animationMball_001*0
 Node Type: AnimationData
 	KeyFrames: Count 31. Hash: 11054744277397627493
 	TimeStepBetweenFrames: 0.041667
@@ -351,8 +351,8 @@ Node Type: BoneData
 		BasisZ: <-0.000009,  100.000000, -0.000016>
 		Transl: <-0.000000,  0.000000,  3.050803>
 
-Node Name: animationMball.001*0
-Node Path: RootNode.Armature.Bone.Bone_001.Bone_002.Bone_003.animationMball.001*0
+Node Name: animationMball_001*0
+Node Path: RootNode.Armature.Bone.Bone_001.Bone_002.Bone_003.animationMball_001*0
 Node Type: AnimationData
 	KeyFrames: Count 31. Hash: 5380291732685406748
 	TimeStepBetweenFrames: 0.041667
@@ -383,8 +383,8 @@ Node Type: TransformData
 		BasisZ: < 0.000000,  0.000000,  1.000000>
 		Transl: < 0.000000,  0.009451,  0.000000>
 
-Node Name: animationMball.001*0
-Node Path: RootNode.Armature.Bone.Bone_001.Bone_002.Bone_003.Bone_003_end.animationMball.001*0
+Node Name: animationMball_001*0
+Node Path: RootNode.Armature.Bone.Bone_001.Bone_002.Bone_003.Bone_003_end.animationMball_001*0
 Node Type: AnimationData
 	KeyFrames: Count 31. Hash: 14966422776310279327
 	TimeStepBetweenFrames: 0.041667

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/MorphTargetOneMaterial/SceneDebug/morphtargetonematerial.dbgsg.xml
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/MorphTargetOneMaterial/SceneDebug/morphtargetonematerial.dbgsg.xml
@@ -18,8 +18,8 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Name" value="animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="AnimationData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
@@ -185,8 +185,8 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.Mball_001.animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Name" value="animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Mball_001.animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="AnimationData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
@@ -405,6 +405,12 @@
 							<Class name="double" field="m_data" value="25.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
 						</Class>
 					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="RoughnessFactor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="0.5000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
@@ -464,8 +470,8 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.Armature.animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Name" value="animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Armature.animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="AnimationData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
@@ -535,6 +541,31 @@
 						<Class name="AZStd::string" field="value1" value="WorldTransform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="Matrix3x4" field="m_data" value="-100.0000000 -0.0000087 0.0000000 -0.0000000 0.0000163 100.0000000 -0.0000087 100.0000000 -0.0000163 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Mball_001_MorphTargetOneMaterial_optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="IsNull" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="bool" field="m_data" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="DefaultAttributeIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="0" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="InheritType" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -720,8 +751,8 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.Mball_001_MorphTargetOneMaterial_optimized.animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Name" value="animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Mball_001_MorphTargetOneMaterial_optimized.animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="AnimationData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
@@ -753,31 +784,6 @@
 						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="Matrix3x4" field="m_data" value="-100.0000000 -0.0000087 0.0000000 0.0000087 -100.0000000 0.0000000 0.0000000 0.0000000 100.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
-						</Class>
-					</Class>
-				</Class>
-			</Class>
-			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.Mball_001_MorphTargetOneMaterial_optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
-					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
-						<Class name="AZStd::string" field="value1" value="IsNull" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
-							<Class name="bool" field="m_data" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
-						<Class name="AZStd::string" field="value1" value="DefaultAttributeIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
-							<Class name="AZ::s64" field="m_data" value="0" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
-						<Class name="AZStd::string" field="value1" value="InheritType" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
-							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -835,11 +841,17 @@
 							<Class name="double" field="m_data" value="25.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
 						</Class>
 					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="RoughnessFactor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="0.5000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Name" value="animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="AnimationData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
@@ -914,8 +926,8 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.Bone_001.animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Name" value="animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.Bone_001.animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="AnimationData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
@@ -990,8 +1002,8 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.Bone_001.Bone_002.animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Name" value="animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.Bone_001.Bone_002.animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="AnimationData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
@@ -1066,8 +1078,8 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.Bone_001.Bone_002.Bone_003.animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Name" value="animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.Bone_001.Bone_002.Bone_003.animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="AnimationData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
@@ -1142,8 +1154,8 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.Bone_001.Bone_002.Bone_003.Bone_003_end.animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Name" value="animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.Bone_001.Bone_002.Bone_003.Bone_003_end.animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="AnimationData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/MorphTargetTwoMaterials/SceneDebug/morphtargettwomaterials.dbgsg
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/MorphTargetTwoMaterials/SceneDebug/morphtargettwomaterials.dbgsg
@@ -10,8 +10,8 @@ Node Type: RootBoneData
 		BasisZ: < 0.000000,  0.000000,  1.000000>
 		Transl: < 0.000000,  0.000000,  0.000000>
 
-Node Name: animationMball.001*0
-Node Path: RootNode.animationMball.001*0
+Node Name: animationMball_001*0
+Node Path: RootNode.animationMball_001*0
 Node Type: AnimationData
 	KeyFrames: Count 31. Hash: 16594569657313590262
 	TimeStepBetweenFrames: 0.041667
@@ -46,8 +46,8 @@ Node Path: RootNode.Mball_001.SkinWeight_
 Node Type: SkinWeightData
 	VertexLinks: Count 696. Hash: 3679794148289697009
 
-Node Name: animationMball.001*0
-Node Path: RootNode.Mball_001.animationMball.001*0
+Node Name: animationMball_001*0
+Node Path: RootNode.Mball_001.animationMball_001*0
 Node Type: AnimationData
 	KeyFrames: Count 31. Hash: 16444376794354522612
 	TimeStepBetweenFrames: 0.041667
@@ -78,9 +78,9 @@ Node Type: BlendShapeData
 Node Name: custom_properties
 Node Path: RootNode.Mball_001.custom_properties
 Node Type: CustomPropertyData
-	UserProperties: 
 	IsNull: false
 	DefaultAttributeIndex: 0
+	UserProperties: 
 	InheritType: 1
 
 Node Name: UV0
@@ -105,7 +105,7 @@ Node Type: MaterialData
 	UseMetallicMap: Not set
 	MetallicFactor: Not set
 	UseRoughnessMap: Not set
-	RoughnessFactor: Not set
+	RoughnessFactor: 0.500000
 	UseEmissiveMap: Not set
 	EmissiveIntensity: Not set
 	UseAOMap: Not set
@@ -135,7 +135,7 @@ Node Type: MaterialData
 	UseMetallicMap: Not set
 	MetallicFactor: Not set
 	UseRoughnessMap: Not set
-	RoughnessFactor: Not set
+	RoughnessFactor: 0.500000
 	UseEmissiveMap: Not set
 	EmissiveIntensity: Not set
 	UseAOMap: Not set
@@ -162,8 +162,8 @@ Node Type: MeshVertexBitangentData
 	Bitangents: Count 696. Hash: 3823093349406338410
 	GenerationMethod: 1
 
-Node Name: animationMball.001*0
-Node Path: RootNode.Armature.animationMball.001*0
+Node Name: animationMball_001*0
+Node Path: RootNode.Armature.animationMball_001*0
 Node Type: AnimationData
 	KeyFrames: Count 31. Hash: 16444376794354522612
 	TimeStepBetweenFrames: 0.041667
@@ -193,6 +193,14 @@ Node Type: BoneData
 		BasisY: <-0.000000,  0.000016,  100.000000>
 		BasisZ: <-0.000009,  100.000000, -0.000016>
 		Transl: < 0.000000,  0.000000,  0.000000>
+
+Node Name: custom_properties
+Node Path: RootNode.Mball_001_MorphTargetTwoMaterials_optimized.custom_properties
+Node Type: CustomPropertyData
+	IsNull: false
+	DefaultAttributeIndex: 0
+	UserProperties: 
+	InheritType: 1
 
 Node Name: UV0
 Node Path: RootNode.Mball_001_MorphTargetTwoMaterials_optimized.UV0
@@ -232,8 +240,8 @@ Node Type: BlendShapeData
 	Normals: Count 1044. Hash: 6177248697915669024
 	Faces: Count 348. Hash: 10303589656939351813
 
-Node Name: animationMball.001*0
-Node Path: RootNode.Mball_001_MorphTargetTwoMaterials_optimized.animationMball.001*0
+Node Name: animationMball_001*0
+Node Path: RootNode.Mball_001_MorphTargetTwoMaterials_optimized.animationMball_001*0
 Node Type: AnimationData
 	KeyFrames: Count 31. Hash: 16444376794354522612
 	TimeStepBetweenFrames: 0.041667
@@ -246,14 +254,6 @@ Node Type: TransformData
 		BasisY: < 0.000009, -100.000000,  0.000000>
 		BasisZ: < 0.000000,  0.000000,  100.000000>
 		Transl: < 0.000000,  0.000000,  0.000000>
-
-Node Name: custom_properties
-Node Path: RootNode.Mball_001_MorphTargetTwoMaterials_optimized.custom_properties
-Node Type: CustomPropertyData
-	UserProperties: 
-	IsNull: false
-	DefaultAttributeIndex: 0
-	InheritType: 1
 
 Node Name: Material_002
 Node Path: RootNode.Mball_001_MorphTargetTwoMaterials_optimized.Material_002
@@ -271,7 +271,7 @@ Node Type: MaterialData
 	UseMetallicMap: Not set
 	MetallicFactor: Not set
 	UseRoughnessMap: Not set
-	RoughnessFactor: Not set
+	RoughnessFactor: 0.500000
 	UseEmissiveMap: Not set
 	EmissiveIntensity: Not set
 	UseAOMap: Not set
@@ -301,7 +301,7 @@ Node Type: MaterialData
 	UseMetallicMap: Not set
 	MetallicFactor: Not set
 	UseRoughnessMap: Not set
-	RoughnessFactor: Not set
+	RoughnessFactor: 0.500000
 	UseEmissiveMap: Not set
 	EmissiveIntensity: Not set
 	UseAOMap: Not set
@@ -315,8 +315,8 @@ Node Type: MaterialData
 	EmissiveTexture: 
 	BaseColorTexture: 
 
-Node Name: animationMball.001*0
-Node Path: RootNode.Armature.Bone.animationMball.001*0
+Node Name: animationMball_001*0
+Node Path: RootNode.Armature.Bone.animationMball_001*0
 Node Type: AnimationData
 	KeyFrames: Count 31. Hash: 12571026262766850303
 	TimeStepBetweenFrames: 0.041667
@@ -347,8 +347,8 @@ Node Type: BoneData
 		BasisZ: <-0.000009,  100.000000, -0.000016>
 		Transl: <-0.000000,  0.000000,  1.000000>
 
-Node Name: animationMball.001*0
-Node Path: RootNode.Armature.Bone.Bone_001.animationMball.001*0
+Node Name: animationMball_001*0
+Node Path: RootNode.Armature.Bone.Bone_001.animationMball_001*0
 Node Type: AnimationData
 	KeyFrames: Count 31. Hash: 11054744277397627493
 	TimeStepBetweenFrames: 0.041667
@@ -379,8 +379,8 @@ Node Type: BoneData
 		BasisZ: <-0.000009,  100.000000, -0.000016>
 		Transl: <-0.000000,  0.000000,  2.000000>
 
-Node Name: animationMball.001*0
-Node Path: RootNode.Armature.Bone.Bone_001.Bone_002.animationMball.001*0
+Node Name: animationMball_001*0
+Node Path: RootNode.Armature.Bone.Bone_001.Bone_002.animationMball_001*0
 Node Type: AnimationData
 	KeyFrames: Count 31. Hash: 11054744277397627493
 	TimeStepBetweenFrames: 0.041667
@@ -411,8 +411,8 @@ Node Type: BoneData
 		BasisZ: <-0.000009,  100.000000, -0.000016>
 		Transl: <-0.000000,  0.000000,  3.050803>
 
-Node Name: animationMball.001*0
-Node Path: RootNode.Armature.Bone.Bone_001.Bone_002.Bone_003.animationMball.001*0
+Node Name: animationMball_001*0
+Node Path: RootNode.Armature.Bone.Bone_001.Bone_002.Bone_003.animationMball_001*0
 Node Type: AnimationData
 	KeyFrames: Count 31. Hash: 5380291732685406748
 	TimeStepBetweenFrames: 0.041667
@@ -443,8 +443,8 @@ Node Type: TransformData
 		BasisZ: < 0.000000,  0.000000,  1.000000>
 		Transl: < 0.000000,  0.009451,  0.000000>
 
-Node Name: animationMball.001*0
-Node Path: RootNode.Armature.Bone.Bone_001.Bone_002.Bone_003.Bone_003_end.animationMball.001*0
+Node Name: animationMball_001*0
+Node Path: RootNode.Armature.Bone.Bone_001.Bone_002.Bone_003.Bone_003_end.animationMball_001*0
 Node Type: AnimationData
 	KeyFrames: Count 31. Hash: 14966422776310279327
 	TimeStepBetweenFrames: 0.041667

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/MorphTargetTwoMaterials/SceneDebug/morphtargettwomaterials.dbgsg.xml
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/assets/MorphTargetTwoMaterials/SceneDebug/morphtargettwomaterials.dbgsg.xml
@@ -18,8 +18,8 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Name" value="animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="AnimationData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
@@ -185,8 +185,8 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.Mball_001.animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Name" value="animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Mball_001.animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="AnimationData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
@@ -405,6 +405,12 @@
 							<Class name="double" field="m_data" value="25.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
 						</Class>
 					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="RoughnessFactor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="0.5000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
@@ -458,6 +464,12 @@
 						<Class name="AZStd::string" field="value1" value="Shininess" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="double" field="m_data" value="25.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="RoughnessFactor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="0.5000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -519,8 +531,8 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.Armature.animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Name" value="animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Armature.animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="AnimationData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
@@ -590,6 +602,31 @@
 						<Class name="AZStd::string" field="value1" value="WorldTransform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="Matrix3x4" field="m_data" value="-100.0000000 -0.0000087 0.0000000 -0.0000000 0.0000163 100.0000000 -0.0000087 100.0000000 -0.0000163 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
+				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Mball_001_MorphTargetTwoMaterials_optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="IsNull" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="bool" field="m_data" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="DefaultAttributeIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="0" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
+						</Class>
+					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="InheritType" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -775,8 +812,8 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.Mball_001_MorphTargetTwoMaterials_optimized.animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Name" value="animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Mball_001_MorphTargetTwoMaterials_optimized.animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="AnimationData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
@@ -808,31 +845,6 @@
 						<Class name="AZStd::string" field="value1" value="Matrix" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
 							<Class name="Matrix3x4" field="m_data" value="-100.0000000 -0.0000087 0.0000000 0.0000087 -100.0000000 0.0000000 0.0000000 0.0000000 100.0000000 0.0000000 0.0000000 0.0000000" type="{1906D8A5-7DEC-4DE3-A606-9E53BB3459E7}"/>
-						</Class>
-					</Class>
-				</Class>
-			</Class>
-			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.Mball_001_MorphTargetTwoMaterials_optimized.custom_properties" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Type" value="CustomPropertyData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
-					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
-						<Class name="AZStd::string" field="value1" value="IsNull" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
-							<Class name="bool" field="m_data" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
-						<Class name="AZStd::string" field="value1" value="DefaultAttributeIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
-							<Class name="AZ::s64" field="m_data" value="0" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
-						<Class name="AZStd::string" field="value1" value="InheritType" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
-							<Class name="AZ::s64" field="m_data" value="1" type="{70D8A282-A1EA-462D-9D04-51EDE81FAC2F}"/>
 						</Class>
 					</Class>
 				</Class>
@@ -890,6 +902,12 @@
 							<Class name="double" field="m_data" value="25.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
 						</Class>
 					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="RoughnessFactor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="0.5000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
@@ -945,11 +963,17 @@
 							<Class name="double" field="m_data" value="25.0000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
 						</Class>
 					</Class>
+					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
+						<Class name="AZStd::string" field="value1" value="RoughnessFactor" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+						<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+							<Class name="double" field="m_data" value="0.5000000" type="{110C4B14-11A8-4E9D-8638-5051013A56AC}"/>
+						</Class>
+					</Class>
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Name" value="animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="AnimationData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
@@ -1024,8 +1048,8 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.Bone_001.animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Name" value="animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.Bone_001.animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="AnimationData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
@@ -1100,8 +1124,8 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.Bone_001.Bone_002.animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Name" value="animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.Bone_001.Bone_002.animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="AnimationData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
@@ -1176,8 +1200,8 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.Bone_001.Bone_002.Bone_003.animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Name" value="animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.Bone_001.Bone_002.Bone_003.animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="AnimationData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">
@@ -1252,8 +1276,8 @@
 				</Class>
 			</Class>
 			<Class name="DebugNode" field="element" type="{490B9D4C-1847-46EB-BEBC-49812E104626}">
-				<Class name="AZStd::string" field="Name" value="animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.Bone_001.Bone_002.Bone_003.Bone_003_end.animationMball.001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Name" value="animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="AZStd::string" field="Path" value="RootNode.Armature.Bone.Bone_001.Bone_002.Bone_003.Bone_003_end.animationMball_001*0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="Type" value="AnimationData" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::vector&lt;AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;, allocator&gt;" field="Data" type="{AB34420F-52EB-5851-B700-14041D779DBC}">
 					<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::any&gt;" field="element" type="{48BF1FCF-92A6-52E1-A543-F0B96702B0E2}">

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/fbx_tests.py
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/fbx_tests/fbx_tests.py
@@ -571,7 +571,7 @@ blackbox_fbx_tests = [
                             job_key='Scene compilation',
                             builder_guid=b'bd8bf65894854fe3830e8ec3a23c35f3',
                             status=4,
-                            error_count=9,
+                            error_count=0,
                             products=[
                                 asset_db_utils.DBProduct(
                                     product_name='morphtargetonematerial/morphtargetonematerial.actor',
@@ -627,7 +627,7 @@ blackbox_fbx_tests = [
                             job_key='Scene compilation',
                             builder_guid=b'bd8bf65894854fe3830e8ec3a23c35f3',
                             status=4,
-                            error_count=9,
+                            error_count=0,
                             products=[
                                 asset_db_utils.DBProduct(
                                     product_name='morphtargettwomaterials/morphtargettwomaterials.actor',

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpAnimationImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpAnimationImporter.cpp
@@ -436,7 +436,9 @@ namespace AZ
                             createdAnimationData->AddKeyFrame(localTransform);
                         }
 
-                        const AZStd::string stubBoneAnimForMorphName(AZStd::string::format("%s%s", nodeName.c_str(), nodeAnim->mName.C_Str()));
+                        AZStd::string stubBoneAnimForMorphName(AZStd::string::format("%s%s", nodeName.c_str(), nodeAnim->mName.C_Str()));
+                        RenamedNodesMap::SanitizeNodeName(stubBoneAnimForMorphName, context.m_scene.GetGraph(), context.m_currentGraphPosition);
+
                         Containers::SceneGraph::NodeIndex addNode = context.m_scene.GetGraph().AddChild(
                             context.m_currentGraphPosition, stubBoneAnimForMorphName.c_str(), AZStd::move(createdAnimationData));
                         context.m_scene.GetGraph().MakeEndPoint(addNode);

--- a/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderComponent.cpp
+++ b/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderComponent.cpp
@@ -44,7 +44,7 @@ namespace SceneBuilder
         builderDescriptor.m_createJobFunction = AZStd::bind(&SceneBuilderWorker::CreateJobs, &m_sceneBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
         builderDescriptor.m_processJobFunction = AZStd::bind(&SceneBuilderWorker::ProcessJob, &m_sceneBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
 
-        builderDescriptor.m_version = 9; // bump this to rebuild everything.
+        builderDescriptor.m_version = 10; // bump this to rebuild everything.
         builderDescriptor.m_analysisFingerprint = m_sceneBuilder.GetFingerprint(); // bump this to at least re-analyze everything.
 
         m_sceneBuilder.BusConnect(builderDescriptor.m_busId);


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

## What does this PR do?

Sanitize name of the stubBoneAnimForMorph node to replace invalid character "." with "_". This helps to resolve the FBX processing errors caused by the invalid node name and fixed the existing FBX tests.

Also bumped up the scene processing builder version to reprocess existing FBX files. Note that the version is bumped from "8" to "10" since there's another pending PR to bump up the version for a separate bug fix (https://github.com/o3de/o3de/pull/14094).

## How was this PR tested?

Ran the FBX tests locally and the following two tests passed:
- MorphTargetOneMaterial_RunAP_SuccessWithMatchingProducts
- MorphTargetTwoMaterials_RunAP_SuccessWithMatchingProducts
