### PR TITLE
Fix incorrect triggering of an assert for Bindless SRG.

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
@@ -415,14 +415,13 @@ namespace AZ
                 RootParameterBinding binding = pipelineLayout->GetRootParameterBindingByIndex(srgIndex);
 
                 //Check if we are iterating over the bindless srg slot
-                if (srgSlot != RHI::Limits::Pipeline::ShaderResourceGroupCountMax && shaderResourceGroup == nullptr)
+                if (srgSlot == RHI::ShaderResourceGroupData::BindlessSRGFrequencyId && shaderResourceGroup == nullptr)
                 {
                     // Skip in case the global static heap is already bound
                     if (m_state.m_bindBindlessHeap)
                     {
                         continue;
                     }
-                    AZ_Assert(srgSlot == RHI::ShaderResourceGroupData::BindlessSRGFrequencyId,"Bindless SRG slot needs to match the one described in the shader.");
                     AZ_Assert(binding.m_bindlessTable.IsValid(), "BindlessSRG handles is not valid.");
 
                     switch (pipelineType)

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
@@ -272,16 +272,13 @@ namespace AZ
                 uint32_t slotIndex = static_cast<uint32_t>(pipelineLayout.GetIndexBySlot(slot));
  
                 //Check explicitly for Bindless SRG. This needs to be data driven (todo)
-                if (slotIndex != RHI::Limits::Pipeline::ShaderResourceGroupCountMax && shaderResourceGroup == nullptr)
+                if (srgSlot == RHI::ShaderResourceGroupData::BindlessSRGFrequencyId && shaderResourceGroup == nullptr)
                 {
                     //Skip if the global static bindless heap is already bound
                     if (m_state.m_bindBindlessHeap)
                     {
                         continue;
                     }
-                    AZ_Assert(
-                        slot == RHI::ShaderResourceGroupData::BindlessSRGFrequencyId,
-                        "Bindless SRG slot needs to match the one described in the shader.");
                     
                     //Add the bindless AB info to the arrays in order to bind it to the appropriate encoder
                     m_device->GetBindlessArgumentBuffer().BindBindlessArgumentBuffer(slotIndex, m_commandEncoderType,


### PR DESCRIPTION

Signed-off-by: moudgils <47460854+moudgils@users.noreply.github.com>

## What does this PR do?

If an srg was not provided by RPI we would trigger a bindless srg assert which is incorrect. Now it only goes into the bindless srg section when the slot is for that srg. 

## How was this PR tested?

Tested ASV 
