### PR TITLE
Fix out-of-bounds reference that occurs when the command line ends with an argument containing a single digit.

### DIFF
--- a/Code/Legacy/CrySystem/CmdLine.cpp
+++ b/Code/Legacy/CrySystem/CmdLine.cpp
@@ -68,7 +68,7 @@ CCmdLine::CCmdLine(const char* commandLine)
         {
             bool bSecondCharIsNumber = false;
 
-            if (arg[0] && arg[1] >= '0' && arg[1] <= '9')
+            if ((arg.length() > 1) && arg[1] >= '0' && arg[1] <= '9')
             {
                 bSecondCharIsNumber = true;
             }


### PR DESCRIPTION
## What does this PR do?

This fixes an assert that can occur with command lines that end in a single digit, such as "enableProfiling 1".

## How was this PR tested?

Verified that the command line ending in a single digit no longer asserts.
