### PR TITLE
WIP: Ambiguous shortcut handling for new action manager

### DIFF
--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/QComponentEntityEditorMainWindow.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/QComponentEntityEditorMainWindow.cpp
@@ -40,7 +40,7 @@ void QComponentEntityEditorInspectorWindow::Init()
 {
     QVBoxLayout* layout = new QVBoxLayout();
 
-    m_propertyEditor = new AzToolsFramework::EntityPropertyEditor(nullptr);
+    m_propertyEditor = new AzToolsFramework::EntityPropertyEditor(this);
     layout->addWidget(m_propertyEditor);
 
     QWidget* window = new QWidget();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorAction.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorAction.cpp
@@ -40,6 +40,10 @@ namespace AzToolsFramework
         UpdateIconFromPath();
         m_action = new QAction(m_icon, m_name.c_str(), parentWidget);
 
+        // The action needs to be explicitly added, not just parented on creation, or it won't
+        // show up in widget->actions(), and won't handle some events properly
+        parentWidget->addAction(m_action);
+
         QObject::connect(
             m_action, &QAction::triggered, parentWidget,
             [h = AZStd::move(handler)]()
@@ -136,6 +140,7 @@ namespace AzToolsFramework
     void EditorAction::SetHotKey(const AZStd::string& hotKey)
     {
         m_action->setShortcut(QKeySequence(hotKey.c_str()));
+        m_action->setShortcutContext(Qt::WidgetWithChildrenShortcut);
         UpdateTooltipText();
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
@@ -23,6 +23,7 @@
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/Commands/SelectionCommand.h>
 #include <AzToolsFramework/ComponentMode/EditorComponentModeBus.h>
+#include <AzToolsFramework/Editor/ActionManagerUtils.h>
 #include <AzToolsFramework/Editor/EditorContextMenuBus.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
@@ -878,11 +879,14 @@ namespace AzToolsFramework
         connect(m_actionToDeleteSelection, &QAction::triggered, this, &EntityOutlinerWidget::DoDeleteSelection);
         addAction(m_actionToDeleteSelection);
 
-        m_actionToDeleteSelectionAndDescendants = new QAction(tr("Delete Selection And Descendants"), this);
-        m_actionToDeleteSelectionAndDescendants->setShortcut(QKeySequence::Delete);
-        m_actionToDeleteSelectionAndDescendants->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-        connect(m_actionToDeleteSelectionAndDescendants, &QAction::triggered, this, &EntityOutlinerWidget::DoDeleteSelectionAndDescendants);
-        addAction(m_actionToDeleteSelectionAndDescendants);
+        if (!IsNewActionManagerEnabled())
+        {
+            m_actionToDeleteSelectionAndDescendants = new QAction(tr("Delete Selection And Descendants"), this);
+            m_actionToDeleteSelectionAndDescendants->setShortcut(QKeySequence::Delete);
+            m_actionToDeleteSelectionAndDescendants->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+            connect(m_actionToDeleteSelectionAndDescendants, &QAction::triggered, this, &EntityOutlinerWidget::DoDeleteSelectionAndDescendants);
+            addAction(m_actionToDeleteSelectionAndDescendants);
+        }
 
         m_actionToRenameSelection = new QAction(tr("Rename"), this);
     #if defined(Q_OS_MAC)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
@@ -61,9 +61,11 @@ namespace AZ
 
 namespace AzToolsFramework
 {
+    class ActionManagerInterface;
     class ComponentEditor;
     class ComponentPaletteWidget;
     class ComponentModeCollectionInterface;
+    class HotKeyManagerInterface;
     struct SourceControlFileInfo;
     class ReadOnlyEntityPublicInterface;
     class FocusModeInterface;
@@ -401,6 +403,9 @@ namespace AzToolsFramework
         QAction* m_actionToMoveComponentsTop = nullptr;
         QAction* m_actionToMoveComponentsBottom = nullptr;
         QAction* m_resetToSliceAction = nullptr;
+
+        AzToolsFramework::ActionManagerInterface* m_actionManagerInterface = nullptr;
+        AzToolsFramework::HotKeyManagerInterface* m_hotKeyManagerInterface = nullptr;
 
         void CreateActions();
         void UpdateActions();


### PR DESCRIPTION
## What does this PR do?

WIP: Handling ambiguous shortcuts with the new action manager. Specifically, when a parent and child (or N-child) have an action with the same shortcut, Qt hits an ambiguous shortcut error and doesn't know which action to trigger so it does nothing.

## How was this PR tested?

_Please describe any testing performed._

Signed-off-by: Chris Galvan <chgalvan@amazon.com>