### PR TITLE
EMotionFX: Allow changing the actor instance update enable or disable through ebus

### DIFF
--- a/Gems/EMotionFX/Code/Include/Integration/ActorComponentBus.h
+++ b/Gems/EMotionFX/Code/Include/Integration/ActorComponentBus.h
@@ -96,6 +96,10 @@ namespace EMotionFX
             // Use this to alter the actor asset.
             virtual void SetActorAsset(AZ::Data::Asset<EMotionFX::Integration::ActorAsset> actorAsset) = 0;
 
+            // Use this bus to enable or disable the actor instance update in the job scheduler system.
+            // This could be useful if you want to manuelly update the actor instance.
+            virtual void EnableInstanceUpdate(bool enableInstanceUpdate) = 0;
+
             static const size_t s_invalidJointIndex = std::numeric_limits<size_t>::max();
         };
 

--- a/Gems/EMotionFX/Code/Include/Integration/ActorComponentBus.h
+++ b/Gems/EMotionFX/Code/Include/Integration/ActorComponentBus.h
@@ -97,7 +97,7 @@ namespace EMotionFX
             virtual void SetActorAsset(AZ::Data::Asset<EMotionFX::Integration::ActorAsset> actorAsset) = 0;
 
             // Use this bus to enable or disable the actor instance update in the job scheduler system.
-            // This could be useful if you want to manuelly update the actor instance.
+            // This could be useful if you want to manually update the actor instance.
             virtual void EnableInstanceUpdate(bool enableInstanceUpdate) = 0;
 
             static const size_t s_invalidJointIndex = std::numeric_limits<size_t>::max();

--- a/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.cpp
@@ -216,6 +216,7 @@ namespace EMotionFX
                     ->Event("GetRenderCharacter", &ActorComponentRequestBus::Events::GetRenderCharacter)
                     ->Event("SetRenderCharacter", &ActorComponentRequestBus::Events::SetRenderCharacter)
                     ->Event("GetRenderActorVisible", &ActorComponentRequestBus::Events::GetRenderActorVisible)
+                    ->Event("EnableInstanceUpdate", &ActorComponentRequestBus::Events::EnableInstanceUpdate)
                     ->VirtualProperty("RenderCharacter", "GetRenderCharacter", "SetRenderCharacter")
                 ;
 
@@ -232,6 +233,18 @@ namespace EMotionFX
         {
             m_configuration.m_actorAsset = actorAsset;
             CheckActorCreation();
+        }
+
+        void ActorComponent::EnableInstanceUpdate(bool enable)
+        {
+            if (m_actorInstance)
+            {
+                m_actorInstance->SetIsEnabled(enable);
+            }
+            else
+            {
+                AZ_ErrorOnce("EMotionFX", false, "Cannot enable the actor instance update because actor instance haven't been created.");
+            }
         }
 
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.h
@@ -121,6 +121,7 @@ namespace EMotionFX
             bool GetRenderActorVisible() const override;
             SkinningMethod GetSkinningMethod() const override;
             void SetActorAsset(AZ::Data::Asset<ActorAsset> actorAsset) override;
+            void EnableInstanceUpdate(bool enable) override;
 
             //////////////////////////////////////////////////////////////////////////
             // ActorComponentNotificationBus::Handler

--- a/Gems/EMotionFX/Code/Source/Integration/Components/AnimGraphComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/AnimGraphComponent.cpp
@@ -356,7 +356,7 @@ namespace EMotionFX
             }
             else
             {
-                AZ_Error("EMotionFX", false, "Cannot create snapshot as anim graph instance has not been created yet. "
+                AZ_ErrorOnce("EMotionFX", false, "Cannot create snapshot as anim graph instance has not been created yet. "
                     "Please make sure you selected an anim graph in the anim graph component.");
             }
         }

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
@@ -603,6 +603,18 @@ namespace EMotionFX
             CheckActorCreation();
         }
 
+        void EditorActorComponent::EnableInstanceUpdate(bool enable)
+        {
+            if (m_actorInstance)
+            {
+                m_actorInstance->SetIsEnabled(enable);
+            }
+            else
+            {
+                AZ_ErrorOnce("EMotionFX", false, "Cannot enable the actor instance update because actor instance haven't been created.");
+            }
+        }
+
         void EditorActorComponent::InitializeMaterial(ActorAsset& actorAsset)
         {
             if (!m_materialPerLOD.empty())

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.h
@@ -65,6 +65,7 @@ namespace EMotionFX
             size_t GetNumJoints() const override;
             SkinningMethod GetSkinningMethod() const override;
             void SetActorAsset(AZ::Data::Asset<ActorAsset> actorAsset) override;
+            void EnableInstanceUpdate(bool enable) override;
 
             // EditorActorComponentRequestBus overrides ...
             const AZ::Data::AssetId& GetActorAssetId() override;


### PR DESCRIPTION
Signed-off-by: Roman Hong <rhhong@amazon.com>

## What does this PR do?

Add an ebus to actor request bus to allow enable/disable actor instance update.
This is done so the end user can directly control that without having to go through create a snapshot.
