### PR TITLE
AttributeInvocable non-void instance call wrapper

### DIFF
--- a/Code/Framework/AzCore/AzCore/RTTI/AttributeReader.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/AttributeReader.h
@@ -165,27 +165,34 @@ namespace AZ
         template <class T, class U, typename... Args>
         bool Read(U& value, Args&&... args)
         {
-            return Internal::AttributeReader<T, U, Args...>::Read(value, m_attribute, m_instancePointer, AZStd::forward<Args>(args)...);
+            return Internal::AttributeReader<T, U, Args...>::Read(value, m_attribute, m_instance, AZStd::forward<Args>(args)...);
         }
 
         template <typename RetType, typename... Args>
         bool Invoke(Args&&... args)
         {
-            return Internal::AttributeInvoke<RetType>(m_attribute, m_instancePointer, AZStd::forward<Args>(args)...);
+            return Internal::AttributeInvoke<RetType>(m_attribute, m_instance, AZStd::forward<Args>(args)...);
         }
 
         // ------------ private implementation ---------------------------------
-        AttributeInvoker(InstType* instancePointer, Attribute* attrib)
-            : m_instancePointer(instancePointer)
+        AttributeInvoker(const InstType& instance, Attribute* attrib)
+            : m_instance(instance)
+            , m_attribute(attrib)
+        {
+        }
+
+        AttributeInvoker(InstType&& instance, Attribute* attrib)
+            : m_instance(AZStd::move(instance))
             , m_attribute(attrib)
         {
         }
 
         Attribute* GetAttribute() const { return m_attribute; }
-        InstType* GetInstancePointer() const { return m_instancePointer; }
+        InstType& GetInstance() { return m_instance; }
+        const InstType& GetInstance() const { return m_instance; }
 
     private:
-        InstType* m_instancePointer;
+        InstType m_instance;
         Attribute* m_attribute;
     };
 
@@ -194,13 +201,13 @@ namespace AZ
     // For Attributes that stores raw or free function such as AZ::AttributeData and AZ::AttributeFunction
     // this class works fine as the void pointer instance isn't used, but for Attributes that works
     class AttributeReader
-        : public AttributeInvoker<void>
+        : public AttributeInvoker<void*>
     {
     public:
         AZ_CLASS_ALLOCATOR(AttributeReader, AZ::SystemAllocator, 0);
 
-        // Bring in AttributeInvoker<void> constructors into scope
-        using AttributeInvoker<void>::AttributeInvoker;
+        // Bring in AttributeInvoker<void*> constructors into scope
+        using AttributeInvoker<void*>::AttributeInvoker;
     };
 
     using AZ::Internal::AttributeRead;

--- a/Code/Framework/AzCore/AzCore/RTTI/AttributeReader.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/AttributeReader.h
@@ -5,8 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#ifndef AZCORE_ATTRIBUTE_READER_H
-#define AZCORE_ATTRIBUTE_READER_H
+#pragma once
 
 #include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/std/string/string.h>
@@ -36,7 +35,7 @@ namespace AZ
                 value = static_cast<DestType>(invocable->operator()(AZStd::forward<InstType>(instance), AZStd::forward<Args>(args)...));
                 return true;
             }
-            // try a type with an invocable function that takes no arguments
+            // try a type with an invocable function that takes no "this" instance
             if (auto invocable = azrtti_cast<AttributeInvocable<AttrType(Args...)>*>(attr); invocable != nullptr)
             {
                 value = static_cast<DestType>(invocable->operator()(AZStd::forward<Args>(args)...));
@@ -61,7 +60,7 @@ namespace AZ
                 invocable->operator()(AZStd::forward<InstType>(instance), AZStd::forward<Args>(args)...);
                 return true;
             }
-            // try a type with an invocable function that takes no arguments
+            // try a type with an invocable function that takes no "this" instance
             if (auto invocable = azrtti_cast<AttributeInvocable<RetType(Args...)>*>(attr); invocable != nullptr)
             {
                 invocable->operator()(AZStd::forward<Args>(args)...);
@@ -242,115 +241,5 @@ namespace AZ
     };
 
     using AZ::Internal::AttributeRead;
-
-    struct UnsafeAttributeInvoker
-    {
-        AttributeReader GetAttributeReader()
-        {
-            return m_reader;
-        }
-    private:
-        UnsafeAttributeInvoker(AZStd::unique_ptr<AZ::Attribute> attribute, AZ::AttributeReader reader)
-            : m_callableAttribute(AZStd::move(attribute))
-            , m_reader(AZStd::move(reader))
-        {}
-
-        AZStd::unique_ptr<AZ::Attribute> m_callableAttribute;
-        AttributeReader m_reader;
-
-        friend class ::AZ::Attribute;
-
-        template<class Invocable>
-        friend class ::AZ::AttributeInvocable;
-    };
-
-    namespace Internal
-    {
-        template<class RetType, class... Args>
-        struct ClassToVoidInvoker;
-
-        // Specialization for function object with no parameters
-        template<class RetType>
-        struct ClassToVoidInvoker<RetType>
-        {
-            explicit ClassToVoidInvoker(AZStd::function<RetType()> callable)
-                : m_callable(AZStd::move(callable))
-            {}
-
-            // In the case of the function object not accepting at least one argument, then the class type is assumed to be non-existent
-            RetType operator()() const
-            {
-                return m_callable();
-            }
-
-        private:
-            AZStd::function<RetType()> m_callable;
-        };
-
-        // Specialization for function object with at least one parameter
-        // The first parameter is assumed to be the class type
-        // The void pointer instance will be cast to that type
-        template<class RetType, class ClassType, class... Args>
-        struct ClassToVoidInvoker<RetType, ClassType, Args...>
-        {
-            explicit ClassToVoidInvoker(AZStd::function<RetType(ClassType, Args...)> callable)
-                : m_callable(AZStd::move(callable))
-            {}
-            RetType operator()(void* instancePtr, Args... args) const
-            {
-                if constexpr (AZStd::is_pointer_v<ClassType>)
-                {
-                    // ClassType is a pointer so cast directly from the void pointer
-                    return m_callable(static_cast<ClassType>(instancePtr), static_cast<Args&&>(args)...);
-                }
-                else
-                {
-                    // If the ClassType parameter accepts a value type, then cast the void pointer to a class type pointer
-                    // and deference
-                    return m_callable(*static_cast<AZStd::remove_cvref_t<ClassType>*>(instancePtr), static_cast<Args&&>(args)...);
-                }
-            }
-
-        private:
-            AZStd::function<RetType(ClassType, Args...)> m_callable;
-        };
-
-        template<class RetType>
-        struct FunctionObjectInvoker
-        {
-            template<class... Args>
-            using ClassToVoidArgsInvoker = ClassToVoidInvoker<RetType, Args...>;
-        };
-    } // namespace Internal
-
-    inline UnsafeAttributeInvoker Attribute::GetUnsafeAttributeReader(void* instance)
-    {
-        return UnsafeAttributeInvoker{ nullptr, AttributeReader(instance, this) };
-    }
-
-    template<class Invocable>
-    inline UnsafeAttributeInvoker AttributeInvocable<Invocable>::GetUnsafeAttributeReader(void* instance)
-    {
-        // Make a temporary AttributeInvocable attribute that can cast from a void pointer
-        // to the class type needed by this AttributeInvocable
-
-        if constexpr (AZStd::function_traits<Callable>::value)
-        {
-            using CallableReturnType = typename AZStd::function_traits<Callable>::return_type;
-            using VoidInstanceCallWrapper = typename AZStd::function_traits<Callable>::template expand_args<
-                Internal::FunctionObjectInvoker<CallableReturnType>::template ClassToVoidArgsInvoker>;
-            VoidInstanceCallWrapper voidWrapper{ m_callable };
-            auto wrappedAttributeInvocable = new AttributeInvocable<typename AZStd::function_traits<VoidInstanceCallWrapper>::function_type>(voidWrapper);
-            return UnsafeAttributeInvoker{ AZStd::unique_ptr<AZ::Attribute>(wrappedAttributeInvocable),
-                AttributeReader(instance, wrappedAttributeInvocable) };
-        }
-        else
-        {
-            // Otherwise if the type being wrapped is not callable then assume it is a regular value type and use
-            // Invoke base Attribute class GetUnsafeAttributeReader function to get an AttributeInvoker
-            return Attribute::GetUnsafeAttributeReader(instance);
-        }
-    }
 } // namespace AZ
 
-#endif // AZCORE_ATTRIBUTE_READER_H

--- a/Code/Framework/AzCore/AzCore/RTTI/AttributeReader.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/AttributeReader.h
@@ -197,11 +197,11 @@ namespace AZ
             if constexpr (AZStd::is_pointer_v<DecayInstType> && AZStd::is_void_v<AZStd::remove_pointer_t<DecayInstType>>)
             {
                 // Forward the void* as an rvalue so it is not a void*&
-                return Internal::AttributeInvoke<RetType>(m_attribute, static_cast<DecayInstType>(m_instance), AZStd::forward<Args>(args...));
+                return Internal::AttributeInvoke<RetType>(m_attribute, static_cast<DecayInstType>(m_instance), AZStd::forward<Args>(args)...);
             }
             else
             {
-                return Internal::AttributeInvoke<RetType>(m_attribute, m_instance, AZStd::forward<Args>(args...));
+                return Internal::AttributeInvoke<RetType>(m_attribute, m_instance, AZStd::forward<Args>(args)...);
             }
         }
 

--- a/Code/Framework/AzCore/AzCore/RTTI/ReflectContext.cpp
+++ b/Code/Framework/AzCore/AzCore/RTTI/ReflectContext.cpp
@@ -12,6 +12,22 @@
 #include <AzCore/std/functional.h>
 #include <AzCore/std/string/string.h>
 
+namespace AZ::Internal
+{
+    AttributeDeleter::AttributeDeleter() = default;
+    AttributeDeleter::AttributeDeleter(bool deletePtr)
+        : m_deletePtr(deletePtr)
+    {}
+
+    void AttributeDeleter::operator()(AZ::Attribute* attribute)
+    {
+        if (m_deletePtr)
+        {
+            delete attribute;
+        }
+    }
+}
+
 namespace AZ
 {
     const AZ::Name Attribute::s_typeField = AZ::Name::FromStringLiteral("$type", AZ::Interface<AZ::NameDictionary>::Get());

--- a/Code/Framework/AzCore/AzCore/RTTI/ReflectContext.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/ReflectContext.h
@@ -29,6 +29,8 @@ namespace AZ
 {
     class ReflectContext;
 
+    class Attribute;
+
     /// Function type to called for on demand reflection within methods, properties, etc.
     /// OnDemandReflection functions must be static, so we can optimize by just using function pointer instead of object
     using StaticReflectionFunctionPtr = void(*)(ReflectContext* context);
@@ -83,7 +85,7 @@ namespace AZ
         void NoSpecializationFunction();
     };
 
-    AZ_HAS_MEMBER(NoOnDemandReflection, NoSpecializationFunction, void, ())
+    AZ_HAS_MEMBER(NoOnDemandReflection, NoSpecializationFunction, void, ());
 
     /**
      * Base class for all reflection contexts.
@@ -101,7 +103,7 @@ namespace AZ
     class ReflectContext
     {
     public:
-        AZ_RTTI(ReflectContext, "{B18D903B-7FAD-4A53-918A-3967B3198224}")
+        AZ_RTTI(ReflectContext, "{B18D903B-7FAD-4A53-918A-3967B3198224}");
 
         ReflectContext();
         virtual ~ReflectContext() = default;
@@ -132,12 +134,84 @@ namespace AZ
 
         friend OnDemandReflectionOwner;
     };
+}
 
+namespace AZ::Internal
+{
+    template<class RetType, class... Args>
+    struct ClassToVoidInvoker;
+
+    // Specialization for function object with no parameters
+    template<class RetType>
+    struct ClassToVoidInvoker<RetType>
+    {
+        explicit ClassToVoidInvoker(AZStd::function<RetType()> callable)
+            : m_callable(AZStd::move(callable))
+        {}
+
+        // In the case of the function object not accepting at least one argument, then the class type is assumed to be non-existent
+        RetType operator()() const
+        {
+            return m_callable();
+        }
+
+    private:
+        AZStd::function<RetType()> m_callable;
+    };
+
+    // Specialization for function object with at least one parameter
+    // The first parameter is assumed to be the class type
+    // The void pointer instance will be cast to that type
+    template<class RetType, class ClassType, class... Args>
+    struct ClassToVoidInvoker<RetType, ClassType, Args...>
+    {
+        explicit ClassToVoidInvoker(AZStd::function<RetType(ClassType, Args...)> callable)
+            : m_callable(AZStd::move(callable))
+        {}
+        RetType operator()(void* instancePtr, Args... args) const
+        {
+            if constexpr (AZStd::is_pointer_v<ClassType>)
+            {
+                // ClassType is a pointer so cast directly from the void pointer
+                return m_callable(static_cast<ClassType>(instancePtr), static_cast<Args&&>(args)...);
+            }
+            else
+            {
+                // If the ClassType parameter accepts a value type, then cast the void pointer to a class type pointer
+                // and deference
+                return m_callable(*static_cast<AZStd::remove_cvref_t<ClassType>*>(instancePtr), static_cast<Args&&>(args)...);
+            }
+        }
+
+    private:
+        AZStd::function<RetType(ClassType, Args...)> m_callable;
+    };
+
+    template<class RetType>
+    struct FunctionObjectInvoker
+    {
+        template<class... Args>
+        using ClassToVoidArgsInvoker = ClassToVoidInvoker<RetType, Args...>;
+    };
+
+    // Custom struct to use as a unique_ptr deleter which can selectively deletes an attribute if
+    // the caller should the pointer
+    struct AttributeDeleter
+    {
+        AttributeDeleter();
+        AttributeDeleter(bool deletePtr);
+
+        void operator()(AZ::Attribute* attribute);
+
+    private:
+        bool m_deletePtr{ true };
+    };
+} // namespace AZ::Internal
+
+namespace AZ
+{
+    using AttributeUniquePtr = AZStd::unique_ptr<AZ::Attribute, Internal::AttributeDeleter>;
     // Attributes to be used by reflection contexts
-    // Forward declare UnsafeAttributeInvoker here so that it can be used as return value for
-    // GetUnsafeAttributeInvoker function below, but it is implemented in AttributeReader.h to avoid
-    // a circular include
-    struct UnsafeAttributeInvoker;
 
     /**
     * Base abstract class for all attributes. Use azrtti to get the
@@ -175,7 +249,11 @@ namespace AZ
             return false;
         }
 
-        virtual UnsafeAttributeInvoker GetUnsafeAttributeReader(void* instance);
+        virtual AttributeUniquePtr GetVoidInstanceAttributeInvocable()
+        {
+            constexpr bool deleteAttribute = false;
+            return AttributeUniquePtr(this, Internal::AttributeDeleter{ deleteAttribute });
+        }
 
         /// Returns true if this attribute is invokable, given a set of arguments.
         /// @param arguments A Dom::Value that must contain an Array of arguments for this invokable attribute.
@@ -450,7 +528,9 @@ namespace AZ
     class AttributeInvocable
         : public Attribute
     {
-        using Callable = AZStd::conditional_t<AZStd::function_traits<Invocable>::value, AZStd::function<typename AZStd::function_traits<Invocable>::function_type>, Invocable>;
+        using Callable = AZStd::conditional_t<AZStd::function_traits<Invocable>::value,
+            AZStd::function<typename AZStd::function_traits<Invocable>::function_type>,
+            AZStd::remove_cvref_t<Invocable>>;
     public:
         AZ_RTTI((AttributeInvocable<Invocable>, "{60D5804F-9AF4-4EB1-8F5A-62AFB4883F9D}", Invocable), AZ::Attribute);
         AZ_CLASS_ALLOCATOR(AttributeInvocable<Invocable>, SystemAllocator, 0);
@@ -460,7 +540,26 @@ namespace AZ
         {
         }
 
-        UnsafeAttributeInvoker GetUnsafeAttributeReader(void* instance) override;
+        AttributeUniquePtr GetVoidInstanceAttributeInvocable() override
+        {
+            // Make a temporary AttributeInvocable attribute that can cast from a void pointer
+            // to the class type needed by this AttributeInvocable
+
+            if constexpr (AZStd::function_traits<Callable>::value)
+            {
+                using CallableReturnType = typename AZStd::function_traits<Callable>::return_type;
+                using VoidInstanceCallWrapper = typename AZStd::function_traits<Callable>::template expand_args<
+                    Internal::FunctionObjectInvoker<CallableReturnType>::template ClassToVoidArgsInvoker>;
+                return AttributeUniquePtr(new AttributeInvocable<typename AZStd::function_traits<VoidInstanceCallWrapper>::function_type>(
+                    VoidInstanceCallWrapper{ m_callable }));
+            }
+            else
+            {
+                // Otherwise if the type being wrapped is not callable then assume it is a regular value type and
+                // invoke base class version of this function
+                return Attribute::GetVoidInstanceAttributeInvocable();
+            }
+        }
 
         template<typename... FuncArgs>
         decltype(auto) operator()(FuncArgs&&... args)
@@ -498,7 +597,9 @@ namespace AZ
     // If the type has valid function traits(i.e it fits the callable concept, then the function_type is retrieved from the function type),
     // otherwise the type is used without modification
     template<typename Invocable>
-    AttributeInvocable(Invocable&&) -> AttributeInvocable<AZStd::conditional_t<AZStd::function_traits<Invocable>::value, typename AZStd::function_traits<Invocable>::function_type, Invocable>>;
+    AttributeInvocable(Invocable&&) -> AttributeInvocable<AZStd::conditional_t<AZStd::function_traits<Invocable>::value,
+        typename AZStd::function_traits<Invocable>::function_type,
+        AZStd::remove_cvref_t<Invocable>>>;
 
     /**
     * Generic attribute member function pointer container. All function must return non void result (we can implement this)

--- a/Code/Framework/AzCore/Tests/Serialization.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization.cpp
@@ -5738,9 +5738,9 @@ namespace UnitTest
         AZ::Attribute* attribute = AZ::FindAttribute(invokableCrc, classData->m_attributes);
         ASSERT_NE(nullptr, attribute);
         void* instance = &baseNoRttiInstance;
-        AZ::UnsafeAttributeInvoker unsafeAttributeInvoker = attribute->GetUnsafeAttributeReader(instance);
+        auto voidAttributeInvocable = attribute->GetVoidInstanceAttributeInvocable();
 
-        AZ::AttributeReader reader = unsafeAttributeInvoker.GetAttributeReader();
+        AZ::AttributeReader reader(instance, voidAttributeInvocable.get());
         float value = 0;
         EXPECT_TRUE(reader.Read<float>(value));
         EXPECT_FLOAT_EQ(2.0f, value);

--- a/Code/Framework/AzCore/Tests/Serialization.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization.cpp
@@ -5712,6 +5712,39 @@ namespace UnitTest
         EXPECT_FLOAT_EQ(4.0f, value);
     }
 
+    TEST_F(Serialization, AttributeInvocable_UsingVoidPointerInstance_Succeeds)
+    {
+        constexpr AZ::Crc32 invokableCrc = AZ_CRC_CE("Invokable");
+        auto ReadFloat = [](SerializeTestClasses::BaseNoRtti* instance) -> float
+        {
+            auto noRttiInstance = instance;
+            if (!noRttiInstance)
+            {
+                ADD_FAILURE() << "BaseNoRtti instance object should not be nullptr";
+                return 0.0f;
+            }
+            EXPECT_FALSE(noRttiInstance->m_data);
+            return 2.0f;
+        };
+
+        m_serializeContext->Class<SerializeTestClasses::BaseNoRtti>()
+            ->Attribute(invokableCrc, ReadFloat)
+            ;
+
+        SerializeTestClasses::BaseNoRtti baseNoRttiInstance;
+        baseNoRttiInstance.Set();
+        auto classData = m_serializeContext->FindClassData(azrtti_typeid<SerializeTestClasses::BaseNoRtti>());
+        ASSERT_NE(nullptr, classData);
+        AZ::Attribute* attribute = AZ::FindAttribute(invokableCrc, classData->m_attributes);
+        ASSERT_NE(nullptr, attribute);
+        void* instance = &baseNoRttiInstance;
+        AZ::UnsafeAttributeInvoker unsafeAttributeInvoker = attribute->GetUnsafeAttributeReader(instance);
+
+        AZ::AttributeReader reader = unsafeAttributeInvoker.GetAttributeReader();
+        float value = 0;
+        EXPECT_TRUE(reader.Read<float>(value));
+        EXPECT_FLOAT_EQ(2.0f, value);
+    }
 
     class ObjectStreamSerialization
         : public LeakDetectionFixture

--- a/Code/Framework/AzCore/Tests/Serialization.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization.cpp
@@ -5674,8 +5674,8 @@ namespace UnitTest
 
     TEST_F(Serialization, AttributeData_WithCallableType_Succeeds)
     {
-        constexpr AZ::Crc32 invokableCrc = AZ_CRC_CE("Invokable");
-        constexpr AZ::Crc32 nonInvokableCrc = AZ_CRC_CE("NonInvokable");
+        static constexpr AZ::Crc32 invokableCrc = AZ_CRC_CE("Invokable");
+        static constexpr AZ::Crc32 nonInvokableCrc = AZ_CRC_CE("NonInvokable");
         auto ReadFloat = [](SerializeTestClasses::BaseNoRtti* instance) -> float
         {
             auto noRttiInstance = instance;
@@ -5714,7 +5714,7 @@ namespace UnitTest
 
     TEST_F(Serialization, AttributeInvocable_UsingVoidPointerInstance_Succeeds)
     {
-        constexpr AZ::Crc32 invokableCrc = AZ_CRC_CE("Invokable");
+        static constexpr AZ::Crc32 invokableCrc = AZ_CRC_CE("Invokable");
         auto ReadFloat = [](SerializeTestClasses::BaseNoRtti* instance) -> float
         {
             auto noRttiInstance = instance;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEnumComboBoxCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEnumComboBoxCtrl.hxx
@@ -96,7 +96,7 @@ namespace AzToolsFramework
                             {
                                 for (const AZ::AttributePair& attributePair : data->m_attributes)
                                 {
-                                    PropertyAttributeReader reader(attrValue->GetInstancePointer(), attributePair.second);
+                                    PropertyAttributeReader reader(attrValue->GetInstance(), attributePair.second);
                                     ConsumeAttribute(GUI, attributePair.first, &reader, debugName);
                                 }
                             }

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/AnimGraphNodeNameHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/AnimGraphNodeNameHandler.cpp
@@ -76,7 +76,7 @@ namespace EMotionFX
     {
         if (attrValue)
         {
-            m_node = static_cast<AnimGraphNode*>(attrValue->GetInstancePointer());
+            m_node = static_cast<AnimGraphNode*>(attrValue->GetInstance());
             GUI->SetNode(m_node);
         }
 

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/AnimGraphParameterMaskHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/AnimGraphParameterMaskHandler.cpp
@@ -45,7 +45,7 @@ namespace EMotionFX
     {
         if (attrValue)
         {
-            AnimGraphNode* node = static_cast<AnimGraphNode*>(attrValue->GetInstancePointer());
+            AnimGraphNode* node = static_cast<AnimGraphNode*>(attrValue->GetInstance());
             m_object = azdynamic_cast<ObjectAffectedByParameterChanges*>(node);
             GUI->SetObjectAffectedByParameterChanges(m_object);
         }

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/AnimGraphTransitionHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/AnimGraphTransitionHandler.cpp
@@ -372,7 +372,7 @@ namespace EMotionFX
     {
         if (attrValue)
         {
-            AnimGraphStateTransition* transition = static_cast<AnimGraphStateTransition*>(attrValue->GetInstancePointer());
+            AnimGraphStateTransition* transition = static_cast<AnimGraphStateTransition*>(attrValue->GetInstance());
             m_transition = transition;
             GUI->SetTransition(m_transition);
         }

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/BlendNParamWeightsHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/BlendNParamWeightsHandler.cpp
@@ -451,7 +451,7 @@ namespace EMotionFX
     {
         if (attrib == AZ_CRC("BlendTreeBlendNNodeParamWeightsElement", 0x7eae1990) && attrValue)
         {
-            m_node = static_cast<AnimGraphNode*>(attrValue->GetInstancePointer());
+            m_node = static_cast<AnimGraphNode*>(attrValue->GetInstance());
         }
     }
 

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/BlendSpaceMotionContainerHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/BlendSpaceMotionContainerHandler.cpp
@@ -557,7 +557,7 @@ namespace EMotionFX
     {
         if (attrValue)
         {
-            m_blendSpaceNode = static_cast<BlendSpaceNode*>(attrValue->GetInstancePointer());
+            m_blendSpaceNode = static_cast<BlendSpaceNode*>(attrValue->GetInstance());
             GUI->SetBlendSpaceNode(m_blendSpaceNode);
         }
 

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/BlendSpaceMotionHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/BlendSpaceMotionHandler.cpp
@@ -100,7 +100,7 @@ namespace EMotionFX
     {
         if (attrValue)
         {
-            m_blendSpaceNode = static_cast<BlendSpaceNode*>(attrValue->GetInstancePointer());
+            m_blendSpaceNode = static_cast<BlendSpaceNode*>(attrValue->GetInstance());
             GUI->SetBlendSpaceNode(m_blendSpaceNode);
         }
 


### PR DESCRIPTION
## What does this PR do?

Added the GetVoidInstanceAttributeInvocable function which returns a smart pointer that either wraps the existing attribute instance in a deleter that is a no-op or if the Attribute is of type `AttributeInvocable` wrap that wraps a functor stored inside of it with another function that can call the original with the first argument replaced with a void*.

It is the responsibility of the caller to verify that correct instance type is passed supplied when using the wrapped attribute with an AttributeReader. This is due to needing to perform static_cast from a `void*` instance to the original first argument type in order to make the function call.

fixes #13830

Fixed the creation of the GenericValueList attribute in the EditContext whenever an EnumValues attribute is reflected.
It now properly replicates an `EnumValues` attribute that stores data in an `AZStd::vector<Edit::EnumConstant<EnumType>` to a GenericValueList attribute that stores the data in an `AZStd::vector<AZStd::pair<EnumType, AZStd::string>>`

This allow all querying of the value, description pairs for a combobox to be serviced through a Unified API.
This is done by just using the `GenericValueList` attribute.
The Legacy ReflectedPropertyEditor still uses `EnumValues` attribute for querying the list of (enum value -> enum description) entries.

## How was this PR tested?

Added a UnitTest to validate that the GetUnsafeAttributeReader was able to call a lambda function that accepted a class type as the first parameter.