### PR TITLE
Execute the RayTracingAccelerationStructurePass in only one pipeline per scene

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -65,6 +65,8 @@ namespace AZ
 
             // FeatureProcessor overrides ...
             void Activate() override;
+            void Deactivate() override;
+            void OnRenderPipelineChanged(RPI::RenderPipeline* renderPipeline, RPI::SceneNotification::RenderPipelineChangeType changeType) override;
 
             struct Mesh;
 


### PR DESCRIPTION
The RayTracingFeatureProcessor will now set one RayTracingAccelerationStructurePass active and disable any others when there are multiple pipelines rendering on the scene.  This avoids redundant updates of the acceleration structure which reduce performance and cause a failure on Linux when there are 3+ pipelines.

Tested AtomSampleViewer DX12/Vulkan
Tested Editor DX12/Vulkan

Signed-off-by: dmcdiarmid-ly <63674186+dmcdiarmid-ly@users.noreply.github.com>


