### PR TITLE
Enable gems with found implicit gem dependencies

### DIFF
--- a/scripts/o3de/o3de/compatibility.py
+++ b/scripts/o3de/o3de/compatibility.py
@@ -70,7 +70,7 @@ def get_incompatible_gem_dependencies(gem_json_data:dict, all_gems_json_data:dic
     if not gem_dependencies:
         return set()
 
-    return get_incompatible_gem_version_specifiers(gem_dependencies, all_gems_json_data, set())
+    return get_incompatible_gem_version_specifiers(gem_dependencies, all_gems_json_data, checked_specifiers=set())
 
 
 def get_gem_project_incompatible_objects(gem_json_data:dict, project_path:pathlib.Path, all_gems_json_data:dict = None) -> set:
@@ -170,7 +170,7 @@ def get_incompatible_objects_for_engine(object_json_data:dict, engine_json_data:
     return incompatible_objects
 
 
-def get_incompatible_gem_version_specifiers(gem_version_specifier_list:list, all_gems_json_data:dict, checked_specifiers:set() = None) -> set:
+def get_incompatible_gem_version_specifiers(gem_version_specifier_list:list, all_gems_json_data:dict, checked_specifiers:set) -> set:
     """
     Returns a set of gem version specifiers that are not compatible with the gem's provided
     If a gem_version_specifier_list entry only has a gem name, it is assumed compatible with every gem version with that name.

--- a/scripts/o3de/o3de/compatibility.py
+++ b/scripts/o3de/o3de/compatibility.py
@@ -70,7 +70,7 @@ def get_incompatible_gem_dependencies(gem_json_data:dict, all_gems_json_data:dic
     if not gem_dependencies:
         return set()
 
-    return get_incompatible_gem_version_specifiers(gem_dependencies, all_gems_json_data)
+    return get_incompatible_gem_version_specifiers(gem_dependencies, all_gems_json_data, set())
 
 
 def get_gem_project_incompatible_objects(gem_json_data:dict, project_path:pathlib.Path, all_gems_json_data:dict = None) -> set:
@@ -100,7 +100,7 @@ def get_gem_project_incompatible_objects(gem_json_data:dict, project_path:pathli
         logger.error(f'Failed to load engine.json data based on the engine field in project.json or detect the engine from the current folder')
         return set(f'engine.json (missing)') 
 
-    if not all_gems_json_data:
+    if not isinstance(all_gems_json_data, dict):
         all_gems_json_data = manifest.get_gems_json_data_by_name(engine_path, project_path, include_manifest_gems=True)
 
     # compatibility will be based on the engine the project uses and the gems visible to
@@ -170,7 +170,7 @@ def get_incompatible_objects_for_engine(object_json_data:dict, engine_json_data:
     return incompatible_objects
 
 
-def get_incompatible_gem_version_specifiers(gem_version_specifier_list:list, all_gems_json_data:dict) -> set:
+def get_incompatible_gem_version_specifiers(gem_version_specifier_list:list, all_gems_json_data:dict, checked_specifiers:set() = None) -> set:
     """
     Returns a set of gem version specifiers that are not compatible with the gem's provided
     If a gem_version_specifier_list entry only has a gem name, it is assumed compatible with every gem version with that name.
@@ -185,7 +185,21 @@ def get_incompatible_gem_version_specifiers(gem_version_specifier_list:list, all
         return set(gem_version_specifier_list)
 
     incompatible_gem_version_specifiers = set()
+
+    # helper function to check dependency tree for incompatible gem dependencies
+    def get_gem_dependency_version_specifiers(gem_name):
+        gem_dependencies = all_gems_json_data[gem_name].get('dependencies')
+        if gem_dependencies:
+            incompatible_dependency_specifiers = get_incompatible_gem_version_specifiers(gem_dependencies, all_gems_json_data, checked_specifiers)
+            if incompatible_dependency_specifiers:
+                incompatible_gem_version_specifiers.update(incompatible_dependency_specifiers)
+
     for gem_version_specifier in gem_version_specifier_list:
+        if gem_version_specifier in checked_specifiers:
+            continue
+
+        checked_specifiers.add(gem_version_specifier)
+
         gem_name, version_specifier = utils.get_object_name_and_optional_version_specifier(gem_version_specifier)
         if not gem_name in all_gems_json_data:
             incompatible_gem_version_specifiers.add(f"{gem_version_specifier} (missing dependency)")
@@ -193,12 +207,15 @@ def get_incompatible_gem_version_specifiers(gem_version_specifier_list:list, all
 
         if not version_specifier:
             # when no version specifier is provided we assume compatibility with any version
+            get_gem_dependency_version_specifiers(gem_name)
             continue
         
         gem_version = all_gems_json_data[gem_name].get('version')
         if gem_version and not has_compatible_version([gem_version_specifier], gem_name, gem_version):
             incompatible_gem_version_specifiers.add(f"{gem_version_specifier} (different version found ${gem_version})")
             continue
+
+        get_gem_dependency_version_specifiers(gem_name)
 
     return incompatible_gem_version_specifiers
 

--- a/scripts/o3de/o3de/compatibility.py
+++ b/scripts/o3de/o3de/compatibility.py
@@ -70,7 +70,7 @@ def get_incompatible_gem_dependencies(gem_json_data:dict, all_gems_json_data:dic
     if not gem_dependencies:
         return set()
 
-    return get_incompatible_gem_version_specifiers(gem_dependencies, all_gems_json_data, checked_specifiers=set())
+    return get_incompatible_gem_version_specifiers(gem_json_data, all_gems_json_data, checked_specifiers=set())
 
 
 def get_gem_project_incompatible_objects(gem_json_data:dict, project_path:pathlib.Path, all_gems_json_data:dict = None) -> set:
@@ -170,13 +170,14 @@ def get_incompatible_objects_for_engine(object_json_data:dict, engine_json_data:
     return incompatible_objects
 
 
-def get_incompatible_gem_version_specifiers(gem_version_specifier_list:list, all_gems_json_data:dict, checked_specifiers:set) -> set:
+def get_incompatible_gem_version_specifiers(gem_json_data:dict, all_gems_json_data:dict, checked_specifiers:set) -> set:
     """
     Returns a set of gem version specifiers that are not compatible with the gem's provided
     If a gem_version_specifier_list entry only has a gem name, it is assumed compatible with every gem version with that name.
     :param gem_version_specifier_list: a list of gem names and (optional)version specifiers
     :param all_gems_json_data: json data of all gems to use for compatibility checks
     """
+    gem_version_specifier_list = gem_json_data.get('dependencies')
     if not gem_version_specifier_list:
         return set()
 
@@ -190,7 +191,7 @@ def get_incompatible_gem_version_specifiers(gem_version_specifier_list:list, all
     def get_gem_dependency_version_specifiers(gem_name):
         gem_dependencies = all_gems_json_data[gem_name].get('dependencies')
         if gem_dependencies:
-            incompatible_dependency_specifiers = get_incompatible_gem_version_specifiers(gem_dependencies, all_gems_json_data, checked_specifiers)
+            incompatible_dependency_specifiers = get_incompatible_gem_version_specifiers(all_gems_json_data[gem_name], all_gems_json_data, checked_specifiers)
             if incompatible_dependency_specifiers:
                 incompatible_gem_version_specifiers.update(incompatible_dependency_specifiers)
 
@@ -202,7 +203,7 @@ def get_incompatible_gem_version_specifiers(gem_version_specifier_list:list, all
 
         gem_name, version_specifier = utils.get_object_name_and_optional_version_specifier(gem_version_specifier)
         if not gem_name in all_gems_json_data:
-            incompatible_gem_version_specifiers.add(f"{gem_version_specifier} (missing dependency)")
+            incompatible_gem_version_specifiers.add(f"{gem_json_data['gem_name']} is missing the dependency {gem_version_specifier}")
             continue
 
         if not version_specifier:
@@ -212,7 +213,7 @@ def get_incompatible_gem_version_specifiers(gem_version_specifier_list:list, all
         
         gem_version = all_gems_json_data[gem_name].get('version')
         if gem_version and not has_compatible_version([gem_version_specifier], gem_name, gem_version):
-            incompatible_gem_version_specifiers.add(f"{gem_version_specifier} (different version found ${gem_version})")
+            incompatible_gem_version_specifiers.add(f"{gem_json_data['gem_name']} depends on {gem_version_specifier} but {gem_name} version {gem_version} was found")
             continue
 
         get_gem_dependency_version_specifiers(gem_name)

--- a/scripts/o3de/o3de/enable_gem.py
+++ b/scripts/o3de/o3de/enable_gem.py
@@ -120,8 +120,8 @@ def enable_gem_in_project(gem_name: str = None,
             # it takes about 150ms to populate this structure with 137 gems, 4696 bytes in total
             all_gems_json_data = manifest.get_gems_json_data_by_name(project_path=project_path, include_manifest_gems=True, include_engine_gems=True)
 
-            # remove any gems that are not active or dependencies
-            manifest.remove_non_dependency_gem_json_data(enabled_gem_names, all_gems_json_data)
+            # we don't remove gems that are not active or dependencies
+            # because they will be implicitely found and activated via cmake 
 
             incompatible_objects = compatibility.get_gem_project_incompatible_objects(gem_json_data, project_path, all_gems_json_data)
             if incompatible_objects:

--- a/scripts/o3de/o3de/enable_gem.py
+++ b/scripts/o3de/o3de/enable_gem.py
@@ -120,7 +120,7 @@ def enable_gem_in_project(gem_name: str = None,
             # it takes about 150ms to populate this structure with 137 gems, 4696 bytes in total
             all_gems_json_data = manifest.get_gems_json_data_by_name(project_path=project_path, include_manifest_gems=True, include_engine_gems=True)
 
-            # we don't remove gems that are not active or dependencies
+            # Note: we don't remove gems that are not active or dependencies
             # because they will be implicitely found and activated via cmake 
 
             incompatible_objects = compatibility.get_gem_project_incompatible_objects(gem_json_data, project_path, all_gems_json_data)


### PR DESCRIPTION
Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>

## What does this PR do?

1. Fixes #14154 (enable-gem functionality does not automatically add dependencies and fails)
2. Fixes bad logic in `get_gem_project_incompatible_objects` that was causing unit tests to pass when they shouldn't
3. Adds 2 unit tests that check implicit dependencies
4. Adds infinite recursion protection to `get_incompatible_gem_version_specifiers` and makes it check dependencies recursively


## How was this PR tested?

- Updated unit tests, new unit tests
- Tested adding implicit dependencies (existing, missing and recursive) to misc gem.json files and used --dry-run to see if enable_gem returned correct output.
