### PR TITLE
Up the connection check time for the EBus Connection Policy test

### DIFF
--- a/Code/Framework/AzCore/Tests/EBus.cpp
+++ b/Code/Framework/AzCore/Tests/EBus.cpp
@@ -3646,7 +3646,10 @@ namespace UnitTest
             DelayUnlockHandler connectHandler;
             waitHandler.m_connectMethod = [&connectHandler]()
             {
-                constexpr int waitMsMax = 100;
+                // Check that a connection for the connectHandler has occured
+                // within a 1 second, which should be more than enough
+                // time for a connection to occur even when the system is under load
+                constexpr int waitMsMax = 1000;
                 auto startTime = AZStd::chrono::steady_clock::now();
                 auto endTime = startTime + AZStd::chrono::milliseconds(waitMsMax);
 
@@ -3660,10 +3663,8 @@ namespace UnitTest
             };
             AZStd::thread connectThread([&connectHandler]()
             {
-
                 connectHandler.BusConnect();
-            }
-            );
+            });
             waitHandler.BusConnect();
             connectThread.join();
             EXPECT_EQ(connectHandler.m_didConnect, true);


### PR DESCRIPTION
The `EBus.ConnectionPolicy_WaitOnSecondHandlerWhileStillLocked_CantComplete` test checked that a connection to the `BusWithConnectionPolicyUnlocksBus` EBus occured within 100 milliseconds which is a bit to low on the Jenkins Windows server machine running CI/CD.

The test failed previously due to it taking 100.133100 milliseconds for the `connectHandler` to connect to the `BusWithConnectionPolicyUnlocksBus` EBus.

Therefore the connection check time has been updated to 1 second.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Made sure the code compiled.
