### PR TITLE
Fix folder creation in WIP Asset Browser

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -469,13 +469,17 @@ void AzAssetBrowserWindow::CreateToolsMenu()
         m_toolsMenu->addAction(collapseAllAction);
 
         m_toolsMenu->addSeparator();
-        auto* projectSourceAssets = new QAction(tr("Filter Project and Source Assets"), this);
+        auto* projectSourceAssets = new QAction(tr("Hide Product Assets"), this);
         projectSourceAssets->setCheckable(true);
         projectSourceAssets->setChecked(true);
-        connect(projectSourceAssets, &QAction::triggered, this, [this] { m_ui->m_searchWidget->ToggleProjectSourceAssetFilter(); });
+        connect(projectSourceAssets, &QAction::triggered, this,
+            [this, projectSourceAssets]
+            {
+                m_ui->m_searchWidget->ToggleProjectSourceAssetFilter(projectSourceAssets->isChecked());
+            });
         m_toolsMenu->addAction(projectSourceAssets);
 
-        m_ui->m_searchWidget->GetFilter()->AddFilter(m_ui->m_searchWidget->GetProjectSourceFilter());
+        m_ui->m_searchWidget->ToggleProjectSourceAssetFilter(projectSourceAssets->isChecked());
         m_ui->m_searchWidget->AddFolderFilter();
 
         m_assetBrowserDisplayState = AzToolsFramework::AssetBrowser::AssetBrowserDisplayState::TreeViewMode;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.cpp
@@ -170,7 +170,7 @@ namespace AzToolsFramework
             }
 
             auto productFilter = new EntryTypeFilter();
-            productFilter->SetName("Source");
+            productFilter->SetName("Product");
             productFilter->SetEntryType(AssetBrowserEntry::AssetEntryType::Product);
             auto inverseProductFilter = new InverseFilter();
             inverseProductFilter->SetFilter(FilterConstType(productFilter));

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.cpp
@@ -169,10 +169,12 @@ namespace AzToolsFramework
                 SetTypeFilters(buildTypesFilterList());
             }
 
-            auto sourceFilter = new EntryTypeFilter();
-            sourceFilter->SetName("Source");
-            sourceFilter->SetEntryType(AssetBrowserEntry::AssetEntryType::Source);
-            m_projectSourceFilter->AddFilter(FilterConstType(sourceFilter));
+            auto productFilter = new EntryTypeFilter();
+            productFilter->SetName("Source");
+            productFilter->SetEntryType(AssetBrowserEntry::AssetEntryType::Product);
+            auto inverseProductFilter = new InverseFilter();
+            inverseProductFilter->SetFilter(FilterConstType(productFilter));
+            m_projectSourceFilter->AddFilter(FilterConstType(inverseProductFilter));
 
             auto pathFilter = new AssetPathFilter();
             pathFilter->SetAssetPath(AZStd::string_view{ AZ::Utils::GetProjectPath() });
@@ -184,9 +186,9 @@ namespace AzToolsFramework
             m_folderFilter->AddFilter(FilterConstType(directoryFilter));
         }
 
-        void SearchWidget::ToggleProjectSourceAssetFilter()
+        void SearchWidget::ToggleProjectSourceAssetFilter(bool checked)
         {
-            if (m_filter->GetSubFilters().contains(m_projectSourceFilter))
+            if (!checked)
             {
                 m_filter->RemoveFilter(FilterConstType(m_projectSourceFilter));
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.h
@@ -33,7 +33,7 @@ namespace AzToolsFramework
 
             void Setup(bool stringFilter, bool assetTypeFilter);
 
-            void ToggleProjectSourceAssetFilter();
+            void ToggleProjectSourceAssetFilter(bool checked);
 
             void AddFolderFilter();
 


### PR DESCRIPTION
Signed-off-by: Daniel Tamkin <jotamkin@amazon.com>

## What does this PR do?

Resolves #14136.
The filter in place was only allowing source assets to be displayed,
fixes folder creation by changing the filter to an inverse product filter, allowing empty folders to be displayed.

## How was this PR tested?

Locally, tested that folders can now be created