### PR TITLE
Material Canvas: Fixing base and standard PBR material templates

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_Common.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_Common.azsli
@@ -8,42 +8,63 @@
  
 #pragma once
 
-// ------- Options -------
+#ifndef ENABLE_CLEAR_COAT
+#define ENABLE_CLEAR_COAT 0
+#endif
 
-#define ENABLE_CLEAR_COAT               0
-#define ENABLE_TRANSMISSION             0
-#define ENABLE_AREA_LIGHT_VALIDATION    0
-#define ENABLE_SHADER_DEBUGGING         0
-#define OUTPUT_SUBSURFACE               0
-#define OUTPUT_DEPTH                    1
-#define FORCE_OPAQUE                    1
-#define ENABLE_PARALLAX                 0 // Disabled until parallax depth functions can be rewritten to not pass in the heightmap or sampler from the material SRG
-#define UvSetCount                      2
+#ifndef ENABLE_TRANSMISSION
+#define ENABLE_TRANSMISSION 0
+#endif
+
+#ifndef ENABLE_AREA_LIGHT_VALIDATION
+#define ENABLE_AREA_LIGHT_VALIDATION 0
+#endif
+
+#ifndef ENABLE_SHADER_DEBUGGING
+#define ENABLE_SHADER_DEBUGGING 1
+#endif
+
+#ifndef OUTPUT_SUBSURFACE
+#define OUTPUT_SUBSURFACE 0
+#endif
+
+#ifndef OUTPUT_DEPTH
+#define OUTPUT_DEPTH 0
+#endif
+
+#ifndef FORCE_OPAQUE
+#define FORCE_OPAQUE 1
+#endif
+
+#ifndef ENABLE_PARALLAX
+// Disabled until parallax depth functions can be rewritten to not pass in the heightmap or sampler from the material SRG
+#define ENABLE_PARALLAX 0
+#endif
+
+#ifndef UvSetCount
+#define UvSetCount 2
+#endif
 
 #include <Atom/Features/ShaderQualityOptions.azsli>
 #include <Atom/Features/PBR/LightingOptions.azsli>
-
-option bool o_normal_override_enabled = false;
-
-// ------- Shader Resource Groups -------
+#include <Atom/Features/PBR/AlphaUtils.azsli>
 
 #include <scenesrg.srgi>
 #include <viewsrg.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
-#include <Atom/RPI/TangentSpace.azsli>
-#include "Atom/Feature/Common/Assets/Shaders/Materials/MaterialFunctions/EvaluateTangentFrame.azsli"
-#include <Atom/Features/PBR/LightingOptions.azsli>
-#include <Atom/Features/PBR/AlphaUtils.azsli>
+
 #include <Atom/Features/SrgSemantics.azsli>
+#include <Atom/RPI/TangentSpace.azsli>
+#include <../Shaders/Materials/MaterialFunctions/EvaluateTangentFrame.azsli>
+
+option bool o_normal_override_enabled = false;
 
 ShaderResourceGroup MaterialSrg : SRG_PerMaterial
 {
     // O3DE_GENERATED_MATERIAL_SRG_BEGIN
     // O3DE_GENERATED_MATERIAL_SRG_END
 }
-
-// ------- Shader Stitching -------
  
 // O3DE_GENERATED_INCLUDES_BEGIN
 // O3DE_GENERATED_INCLUDES_END
@@ -59,15 +80,12 @@ bool NeedsTangentFrame()
     return true;
 }
 
-#include <Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_VertexData.azsli>
+#include <../Shaders/Materials/BasePBR/BasePBR_VertexData.azsli>
 #include "MaterialGraphName_VertexEval.azsli"
 
-#include <Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_PixelGeometryData.azsli>
-#include <Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_PixelGeometryEval.azsli>
+#include <../Shaders/Materials/BasePBR/BasePBR_PixelGeometryData.azsli>
+#include <../Shaders/Materials/BasePBR/BasePBR_PixelGeometryEval.azsli>
 
-#include <Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceData.azsli>
+#include <../Shaders/Materials/BasePBR/BasePBR_SurfaceData.azsli>
 #include "MaterialGraphName_SurfaceEval.azsli"
 
-#include <Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_LightingData.azsli>
-#include <Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_LightingBrdf.azsli>
-#include <Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_LightingEval.azsli>

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_Depth.azsl
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_Depth.azsl
@@ -6,15 +6,6 @@
  *
  */
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
-#include <Atom/Features/PBR/DefaultObjectSrg.azsli>
-#include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
-#include <Atom/Features/Pipeline/Forward/ForwardPassOutput.azsli>
-#include <Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli>
-#include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
-#include <Atom/Features/SrgSemantics.azsli>
-
 #include "MaterialGraphName_Common.azsli"
 
 VsOutput MainVS(VsInput IN)
@@ -29,18 +20,14 @@ struct PsDepthOutput
 
 PsDepthOutput MainPS(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
 {
-    PsDepthOutput OUT;
-    OUT.depth = IN.position.z;
-
-#if DEPTH_WITH_PS
     PixelGeometryData geoData = EvaluatePixelGeometry(IN, isFrontFace);
-
     Surface surface = EvaluateSurface(geoData);
 
-    CheckClipping(surface.alpha, 0.0);
-
-    OUT.depth = surface.position.z;
+#if !FORCE_OPAQUE
+    CheckClipping(surface.alpha, 0.5);
 #endif
 
+    PsDepthOutput OUT;
+    OUT.depth = surface.position.z;
     return OUT;
 }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_DepthPass.shader
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_DepthPass.shader
@@ -12,10 +12,6 @@
         {
           "name": "MainVS",
           "type": "Vertex"
-        },
-        {
-          "name": "MainPS",
-          "type": "Fragment"
         }
       ]
     },

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_Forward.azsl
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_Forward.azsl
@@ -6,11 +6,13 @@
  *
  */
 
-// --- Pass SRG ---
 #include <Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli>
-
-// --- Material ---
 #include "MaterialGraphName_Common.azsli"
+
+// These cannot be included in the common file because the lighting data accesses the pass SRG which is not available on the depth pass
+#include <../Shaders/Materials/BasePBR/BasePBR_LightingData.azsli>
+#include <../Shaders/Materials/BasePBR/BasePBR_LightingBrdf.azsli>
+#include <../Shaders/Materials/BasePBR/BasePBR_LightingEval.azsli>
 
 // --- Vertex + Pixel Shader ---
 #if MULTI_VIEW_FORWARD

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_ForwardPass.shader
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_ForwardPass.shader
@@ -1,8 +1,6 @@
 {
     "Source": "./MaterialGraphName_Forward.azsl",
 
-    "Definitions": ["OUTPUT_DEPTH=1"],
-
     "DepthStencilState" :
     {
         "Depth" :

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_LowEndForward.shader
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_LowEndForward.shader
@@ -1,10 +1,4 @@
 {
-    // Note: "LowEnd" shaders are for supporting the low end pipeline
-    // These shaders can be safely added to materials without incurring additional runtime draw
-    // items as draw items for shaders are only created if the scene has a pass with a matching
-    // DrawListTag. If your pipeline doesn't have a "lowEndForward" DrawListTag, no draw items
-    // for this shader will be created.
-
     "Source" : "./MaterialGraphName_Forward.azsl",
 
     "Definitions": ["QUALITY_LOW_END_TIER1=1", "LOW_END_FORWARD=1"],

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_MeshMotionVector.azsl
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_MeshMotionVector.azsl
@@ -6,11 +6,7 @@
  *
  */
 
-#include <Atom/Features/PBR/DefaultObjectSrg.azsli>
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
-
-#include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
+#include "MaterialGraphName_Common.azsli"
 
 struct VSInput
 {
@@ -80,3 +76,4 @@ PSOutput MainPS(VSOutput IN)
     
     return OUT;
 }
+

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_MultiViewForward.shader
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_MultiViewForward.shader
@@ -1,10 +1,4 @@
 {
-    // Note: "LowEnd" shaders are for supporting the low end pipeline
-    // These shaders can be safely added to materials without incurring additional runtime draw
-    // items as draw items for shaders are only created if the scene has a pass with a matching
-    // DrawListTag. If your pipeline doesn't have a "multiViewForward" DrawListTag, no draw items
-    // for this shader will be created.
-
     "Source" : "./MaterialGraphName_Forward.azsl",
 
     "Definitions": ["QUALITY_LOW_END_TIER1=1", "QUALITY_LOW_END_TIER2=1", "MULTI_VIEW_FORWARD=1" ],
@@ -52,7 +46,6 @@
             }
         ]
     },
-
 
     "DrawList" : "multiViewForward"
 }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_Shadowmap.shader
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_Shadowmap.shader
@@ -3,15 +3,12 @@
 
     "Definitions" : ["SHADOWMAP=1"] ,
 
-    
     "DepthStencilState" : {
         "Depth" : { "Enable" : true, "CompareFunc" : "LessEqual" }
     },
 
     "DrawList" : "shadow",
     
-    // Note that lights now expose their own bias controls.
-    // It may be worth increasing their default values in the future and reducing the depthBias values encoded here.
     "RasterState" :
     {
         "depthBias" : "10",
@@ -25,10 +22,6 @@
         {
           "name": "MainVS",
           "type": "Vertex"
-        },
-        {
-          "name": "MainPS",
-          "type": "Fragment"
         }
       ]
     }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_VertexEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_VertexEval.azsli
@@ -26,7 +26,7 @@ VsOutput EvaluateVertexGeometry_MaterialGraphName(
 {
     float4x4 objectToWorld = ObjectSrg::GetWorldMatrix();
     float4 worldPosition = mul(objectToWorld, float4(position, 1.0));
-    float bitangent = cross(normal, (float3)tangent);
+    float3 bitangent = cross(normal, (float3)tangent);
 
     #define O3DE_MC_POSITION position
     #define O3DE_MC_UV(index) (index == 0 ? uv0 : uv1);

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Common.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Common.azsli
@@ -5,54 +5,75 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-
+ 
 #pragma once
 
-// ------- Options -------
+#ifndef ENABLE_CLEAR_COAT
+#define ENABLE_CLEAR_COAT 1
+#endif
 
-#define ENABLE_CLEAR_COAT               1
-#define ENABLE_TRANSMISSION             0
-#define ENABLE_AREA_LIGHT_VALIDATION    0
-#define ENABLE_SHADER_DEBUGGING         0
-#define OUTPUT_SUBSURFACE               0
-#define OUTPUT_DEPTH                    1
-#define FORCE_OPAQUE                    0
-#define ENABLE_PARALLAX                 0 // Disabled until parallax depth functions can be rewritten to not pass in the heightmap or sampler from the material SRG
-#define UvSetCount                      2
+#ifndef ENABLE_TRANSMISSION
+#define ENABLE_TRANSMISSION 0
+#endif
+
+#ifndef ENABLE_AREA_LIGHT_VALIDATION
+#define ENABLE_AREA_LIGHT_VALIDATION 0
+#endif
+
+#ifndef ENABLE_SHADER_DEBUGGING
+#define ENABLE_SHADER_DEBUGGING 1
+#endif
+
+#ifndef OUTPUT_SUBSURFACE
+#define OUTPUT_SUBSURFACE 0
+#endif
+
+#ifndef OUTPUT_DEPTH
+#define OUTPUT_DEPTH 0
+#endif
+
+#ifndef FORCE_OPAQUE
+#define FORCE_OPAQUE 0
+#endif
+
+#ifndef ENABLE_PARALLAX
+// Disabled until parallax depth functions can be rewritten to not pass in the heightmap or sampler from the material SRG
+#define ENABLE_PARALLAX 0
+#endif
+
+#ifndef UvSetCount
+#define UvSetCount 2
+#endif
 
 #include <Atom/Features/ShaderQualityOptions.azsli>
 #include <Atom/Features/PBR/LightingOptions.azsli>
+#include <Atom/Features/PBR/AlphaUtils.azsli>
+
+#include <scenesrg.srgi>
+#include <viewsrg.srgi>
+#include <Atom/Features/PBR/DefaultObjectSrg.azsli>
+#include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
+
+#include <Atom/Features/SrgSemantics.azsli>
+#include <Atom/RPI/TangentSpace.azsli>
+#include <../Shaders/Materials/MaterialFunctions/EvaluateTangentFrame.azsli>
+
+#if ENABLE_PARALLAX
+#include <../Shaders/Materials/MaterialFunctions/StandardGetAlphaAndClip.azsli>
+#include <../Shaders/Materials/MaterialFunctions/ParallaxDepth.azsli>
+COMMON_OPTIONS_PARALLAX()
+#endif
 
 option bool o_normal_override_enabled = false;
 option bool o_opacity_affects_specular_factor = true;
 option bool o_clearCoat_enabled = false;
 option bool o_clearCoat_normal_override_enabled = false;
 
-// ------- Shader Resource Groups -------
-
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
-#include <Atom/Features/PBR/DefaultObjectSrg.azsli>
-#include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
-#include <Atom/RPI/TangentSpace.azsli>
-#include "Atom/Feature/Common/Assets/Shaders/Materials/MaterialFunctions/EvaluateTangentFrame.azsli"
-#include <Atom/Features/PBR/LightingOptions.azsli>
-#include <Atom/Features/PBR/AlphaUtils.azsli>
-#include <Atom/Features/SrgSemantics.azsli>
-
-#if ENABLE_PARALLAX
-#include "Atom/Feature/Common/Assets/Shaders/Materials/MaterialFunctions/StandardGetAlphaAndClip.azsli"
-#include "Atom/Feature/Common/Assets/Shaders/Materials/MaterialFunctions/ParallaxDepth.azsli"
-COMMON_OPTIONS_PARALLAX()
-#endif
-
 ShaderResourceGroup MaterialSrg : SRG_PerMaterial
 {
     // O3DE_GENERATED_MATERIAL_SRG_BEGIN
     // O3DE_GENERATED_MATERIAL_SRG_END
 }
-
-// ------- Shader Stitching -------
  
 // O3DE_GENERATED_INCLUDES_BEGIN
 // O3DE_GENERATED_INCLUDES_END
@@ -95,15 +116,12 @@ bool NeedsTangentFrame()
 }
 
 // Use same vertex logic as BasePBR
-#include <Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_VertexData.azsli>
+#include <../Shaders/Materials/BasePBR/BasePBR_VertexData.azsli>
 #include "MaterialGraphName_VertexEval.azsli"
 
-#include <Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_PixelGeometryData.azsli>
+#include <../Shaders/Materials/StandardPBR/StandardPBR_PixelGeometryData.azsli>
 #include "MaterialGraphName_PixelGeometryEval.azsli"
 
-#include <Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_SurfaceData.azsli>
+#include <../Shaders/Materials/StandardPBR/StandardPBR_SurfaceData.azsli>
 #include "MaterialGraphName_SurfaceEval.azsli"
 
-#include <Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_LightingData.azsli>
-#include <Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_LightingBrdf.azsli>
-#include <Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_LightingEval.azsli>

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Depth.azsl
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Depth.azsl
@@ -6,15 +6,6 @@
  *
  */
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
-#include <Atom/Features/PBR/DefaultObjectSrg.azsli>
-#include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
-#include <Atom/Features/Pipeline/Forward/ForwardPassOutput.azsli>
-#include <Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli>
-#include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
-#include <Atom/Features/SrgSemantics.azsli>
-
 #include "MaterialGraphName_Common.azsli"
 
 VsOutput MainVS(VsInput IN)
@@ -29,18 +20,14 @@ struct PsDepthOutput
 
 PsDepthOutput MainPS(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
 {
-    PsDepthOutput OUT;
-    OUT.depth = IN.position.z;
-
-#if DEPTH_WITH_PS
     PixelGeometryData geoData = EvaluatePixelGeometry(IN, isFrontFace);
-
     Surface surface = EvaluateSurface(geoData);
 
-    CheckClipping(surface.alpha, 0.0);
-
-    OUT.depth = surface.position.z;
+#if !FORCE_OPAQUE
+    CheckClipping(surface.alpha, 0.5);
 #endif
 
+    PsDepthOutput OUT;
+    OUT.depth = surface.position.z;
     return OUT;
 }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_DepthPass.shader
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_DepthPass.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "./MaterialGraphName_Depth.azsl",
+    "Source" : "./MaterialGraphName_Depth.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "GreaterEqual" }
@@ -12,10 +12,6 @@
         {
           "name": "MainVS",
           "type": "Vertex"
-        },
-        {
-          "name": "MainPS",
-          "type": "Fragment"
         }
       ]
     },

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_DepthPass_WithPS.shader
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_DepthPass_WithPS.shader
@@ -1,8 +1,6 @@
 {
     "Source" : "./MaterialGraphName_Depth.azsl",
 
-    "Definitions" : ["DEPTH_WITH_PS=1"],
-
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "GreaterEqual" }
     },

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Forward.azsl
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Forward.azsl
@@ -6,11 +6,13 @@
  *
  */
 
-// --- Pass SRG ---
 #include <Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli>
-
-// --- Material ---
 #include "MaterialGraphName_Common.azsli"
+
+// These cannot be included in the common file because the lighting data accesses the pass SRG which is not available on the depth pass
+#include <../Shaders/Materials/BasePBR/BasePBR_LightingData.azsli>
+#include <../Shaders/Materials/StandardPBR/StandardPBR_LightingBrdf.azsli>
+#include <../Shaders/Materials/StandardPBR/StandardPBR_LightingEval.azsli>
 
 // --- Vertex + Pixel Shader ---
 #if MULTI_VIEW_FORWARD

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_LowEndForward.shader
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_LowEndForward.shader
@@ -1,13 +1,7 @@
 {
-    // Note: "LowEnd" shaders are for supporting the low end pipeline
-    // These shaders can be safely added to materials without incurring additional runtime draw
-    // items as draw items for shaders are only created if the scene has a pass with a matching
-    // DrawListTag. If your pipeline doesn't have a "lowEndForward" DrawListTag, no draw items
-    // for this shader will be created.
-
     "Source" : "./MaterialGraphName_Forward.azsl",
 
-    "Definitions": ["QUALITY_LOW_END_TIER1=1", "OUTPUT_DEPTH=1", "LOW_END_FORWARD=1"],
+    "Definitions": ["QUALITY_LOW_END_TIER1=1", "LOW_END_FORWARD=1", "OUTPUT_DEPTH=1"],
 
     "DepthStencilState" :
     {

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_LowEndForward_EDS.shader
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_LowEndForward_EDS.shader
@@ -1,10 +1,4 @@
 {
-    // Note: "LowEnd" shaders are for supporting the low end pipeline
-    // These shaders can be safely added to materials without incurring additional runtime draw
-    // items as draw items for shaders are only created if the scene has a pass with a matching
-    // DrawListTag. If your pipeline doesn't have a "lowEndForward" DrawListTag, no draw items
-    // for this shader will be created.
-
     "Source" : "./MaterialGraphName_Forward.azsl",
 
     "Definitions" : ["QUALITY_LOW_END_TIER1=1", "LOW_END_FORWARD=1"],

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_MeshMotionVector.azsl
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_MeshMotionVector.azsl
@@ -6,11 +6,7 @@
  *
  */
 
-#include <Atom/Features/PBR/DefaultObjectSrg.azsli>
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
-
-#include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
+#include "MaterialGraphName_Common.azsli"
 
 struct VSInput
 {
@@ -80,3 +76,4 @@ PSOutput MainPS(VSOutput IN)
     
     return OUT;
 }
+

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_MultiViewForward.shader
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_MultiViewForward.shader
@@ -1,13 +1,7 @@
 {
-    // Note: "LowEnd" shaders are for supporting the low end pipeline
-    // These shaders can be safely added to materials without incurring additional runtime draw
-    // items as draw items for shaders are only created if the scene has a pass with a matching
-    // DrawListTag. If your pipeline doesn't have a "multiViewForward" DrawListTag, no draw items
-    // for this shader will be created.
-
     "Source" : "./MaterialGraphName_Forward.azsl",
 
-    "Definitions" : [ "QUALITY_LOW_END_TIER1=1", "QUALITY_LOW_END_TIER2=1", "OUTPUT_DEPTH=1", "MULTI_VIEW_FORWARD=1" ],
+    "Definitions": ["QUALITY_LOW_END_TIER1=1", "QUALITY_LOW_END_TIER2=1", "MULTI_VIEW_FORWARD=1", "OUTPUT_DEPTH=1"],
 
     "DepthStencilState" :
     {

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_MultiViewForward_EDS.shader
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_MultiViewForward_EDS.shader
@@ -1,10 +1,4 @@
 {
-    // Note: "LowEnd" shaders are for supporting the low end pipeline
-    // These shaders can be safely added to materials without incurring additional runtime draw
-    // items as draw items for shaders are only created if the scene has a pass with a matching
-    // DrawListTag. If your pipeline doesn't have a "multiViewForward" DrawListTag, no draw items
-    // for this shader will be created.
-
     "Source" : "./MaterialGraphName_Forward.azsl",
 
     "Definitions" : ["QUALITY_LOW_END_TIER1=1", "QUALITY_LOW_END_TIER2=1", "MULTI_VIEW_FORWARD=1"],

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_MultiViewTransparentForward_EDS.shader
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_MultiViewTransparentForward_EDS.shader
@@ -1,10 +1,4 @@
 {
-    // Note: "LowEnd" shaders are for supporting the low end pipeline
-    // These shaders can be safely added to materials without incurring additional runtime draw
-    // items as draw items for shaders are only created if the scene has a pass with a matching
-    // DrawListTag. If your pipeline doesn't have a "multiviewTransparent" DrawListTag, no draw items
-    // for this shader will be created.
-
     "Source" : "./MaterialGraphName_Forward.azsl",
 
     "Definitions" : ["QUALITY_LOW_END_TIER1=1", "QUALITY_LOW_END_TIER2=1", "MULTI_VIEW_FORWARD=1"],

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Shadowmap.shader
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Shadowmap.shader
@@ -3,15 +3,12 @@
 
     "Definitions" : ["SHADOWMAP=1"] ,
 
-    
     "DepthStencilState" : {
         "Depth" : { "Enable" : true, "CompareFunc" : "LessEqual" }
     },
 
     "DrawList" : "shadow",
     
-    // Note that lights now expose their own bias controls.
-    // It may be worth increasing their default values in the future and reducing the depthBias values encoded here.
     "RasterState" :
     {
         "depthBias" : "10",
@@ -25,10 +22,6 @@
         {
           "name": "MainVS",
           "type": "Vertex"
-        },
-        {
-          "name": "MainPS",
-          "type": "Fragment"
         }
       ]
     }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Shadowmap_WithPS.shader
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Shadowmap_WithPS.shader
@@ -1,15 +1,14 @@
 {
     "Source" : "./MaterialGraphName_Depth.azsl",
 
-    "Definitions" : ["SHADOWMAP=1", "DEPTH_WITH_PS=1"],
+    "Definitions" : ["SHADOWMAP=1"],
+
     "DepthStencilState" : {
         "Depth" : { "Enable" : true, "CompareFunc" : "LessEqual" }
     },
 
     "DrawList" : "shadow",
     
-    // Note that lights now expose their own bias controls.
-    // It may be worth increasing their default values in the future and reducing the depthBias values encoded here.
     "RasterState" :
     {
         "depthBias" : "10",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
@@ -79,7 +79,7 @@ Surface EvaluateSurface_MaterialGraphName(
     surface.specularOcclusion = inSpecularOcclusion;
     surface.opacityAffectsSpecularFactor = o_opacity_affects_specular_factor;
 
-    CheckClipping(surface.alpha, 0.0);
+    CheckClipping(surface.alpha, 0.5);
 
     // ------- Clearcoat -------
 


### PR DESCRIPTION
## What does this PR do?

This change fixes and cleans up all of the shaders provided with the current material canvas templates. When they were last submitted with support for transparency, everything appeared to work correctly on the tested pipelines but the depth shader was spamming warnings and asserts about requiring an SRG that was not bound. This turned out to be the pass SRG, which is not used in the depth shader code but was referenced in the included, common lighting code. The resulting log spam eventually caused a significant frame rate drop and potential crash.

Signed-off-by: gadams3 <guthadam@amazon.com>

Resolves https://github.com/o3de/o3de/issues/14121 and similar issues

Created material graphs using both templates.
Configured inputs upon created graphs to test transparency options and alpha.
Tested generated materials on all available pipelines through material canvas and material editor.
Confirmed that there were no errors reported by the AP for the templates or the generated assets.
Confirmed that spam no longer appeared or caused the drop in frame rate in material canvas and material edito.