### PR TITLE
Fixing potential crash that can happen with cached shadows

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/ProjectedShadowmapsPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/ProjectedShadowmapsPass.cpp
@@ -164,6 +164,12 @@ namespace AZ
                 }
             }
 
+            if (!m_clearShadowDrawPacket)
+            {
+                CreateClearShadowDrawPacket();
+            }
+            RHI::Handle<uint32_t> casterMovedBit = GetScene()->GetViewTagBitRegistry().FindTag(MeshCommon::MeshMovedName);
+
             for (const auto& it : sliceInfo)
             {
                 if (!it.m_hasStaticShadows)
@@ -180,7 +186,7 @@ namespace AZ
                     for (auto* pass : it.m_shadowPasses)
                     {
                         pass->SetClearShadowDrawPacket(m_clearShadowDrawPacket);
-                        pass->SetCasterMovedBit(m_casterMovedBit);
+                        pass->SetCasterMovedBit(casterMovedBit);
                     }
                 }
             }
@@ -196,13 +202,14 @@ namespace AZ
             return m_atlas.GetOrigin(index);
         }
 
-        ShadowmapAtlas& ProjectedShadowmapsPass::GetShadowmapAtlas()
+        const ShadowmapAtlas& ProjectedShadowmapsPass::GetShadowmapAtlas() const
         {
             return m_atlas;
         }
 
         void ProjectedShadowmapsPass::BuildInternal()
         {
+            m_updateChildren = true;
             UpdateChildren();
 
             // [GFX TODO][ATOM-2470] stop caring about attachment
@@ -223,17 +230,6 @@ namespace AZ
             imageDescriptor.m_arraySize = m_atlas.GetArraySliceCount();
 
             Base::BuildInternal();
-        }
-
-        void ProjectedShadowmapsPass::FrameBeginInternal(FramePrepareParams params)
-        {
-            if (!m_clearShadowDrawPacket)
-            {
-                CreateClearShadowDrawPacket();
-                m_updateChildren = true;
-            }
-            m_casterMovedBit = GetScene()->GetViewTagBitRegistry().FindTag(MeshCommon::MeshMovedName);
-            Base::FrameBeginInternal(params);
         }
 
         void ProjectedShadowmapsPass::GetPipelineViewTags(RPI::SortedPipelineViewTags& outTags) const

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/ProjectedShadowmapsPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/ProjectedShadowmapsPass.h
@@ -65,7 +65,7 @@ namespace AZ
             ShadowmapAtlas::Origin GetOriginInAtlas(uint16_t index) const;
 
             //! This exposes the shadowmap atlas.
-            ShadowmapAtlas& GetShadowmapAtlas();
+            const ShadowmapAtlas& GetShadowmapAtlas() const;
 
         private:
             ProjectedShadowmapsPass() = delete;
@@ -75,7 +75,6 @@ namespace AZ
             void BuildInternal() override;
             void GetPipelineViewTags(RPI::SortedPipelineViewTags& outTags) const override;
             void GetViewDrawListInfo(RHI::DrawListMask& outDrawListMask, RPI::PassesByDrawList& outPassesByDrawList, const RPI::PipelineViewTag& viewTag) const override;
-            void FrameBeginInternal(FramePrepareParams params) override;
 
             RHI::Ptr<ShadowmapPass> CreateChild(size_t childIndex);
 
@@ -92,7 +91,6 @@ namespace AZ
             AZStd::unordered_map<uint16_t, ShadowmapPass*> m_shadowIndicesToPass;
             Data::Instance<AZ::RPI::Shader> m_clearShadowShader;
             RHI::ConstPtr<AZ::RHI::DrawPacket> m_clearShadowDrawPacket;
-            RHI::Handle<uint32_t> m_casterMovedBit = RHI::Handle<uint32_t>(0);
 
             ShadowmapAtlas m_atlas;
             bool m_updateChildren = true;


### PR DESCRIPTION
## What does this PR do?

Previously, `ProjectedShadowmapsPass` expected that `FrameBeginInternal()` will always be called before `BuildInternal()` however this is not always true. That caused `m_clearShadowDrawPacket` to sometimes not be initialized when it was needed. This PR changes it so that we no longer rely on `FrameBeginInternal()` and simply make sure the draw packet is built if needed right before its used.

In addition, there seem to be circumstances where `BuildInternal()` can be called and the children should update even if `m_updateChildren` isn't set to true. This PR changes it so the children always rebuild if `BuildInternal()` is called, which forces cached shadows to re-draw.

There is still a bug where it's possible for cached shadows to become corrupted, at least in editor mode. It seems to be related to the Editor Mode selection overlay injecting draw packets into the pipeline. I'm still investigating that, but reasoned it was best to get a fix for the crash bug in immediately while I search for the rarer and less fatal shadow corruption bug.

## How was this PR tested?

Tested using the multi camera project from ROSCon
