### PR TITLE
Preserve entity order in newly created prefab

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -260,7 +260,7 @@ namespace AzToolsFramework
                     newContainerEntityDomInitialStateWithTransform, *newContainerEntity);
 
                 // Helper function to create a link between a nested instance and the newly created instance
-                auto createLinkForNestedInstanceFunc = [&](Instance& nestedInstance)
+                auto createLinkForNestedInstance = [&](Instance& nestedInstance)
                 {
                     EntityOptionalReference nestedInstanceContainerEntity = nestedInstance.GetContainerEntity();
                     AZ_Assert(
@@ -294,7 +294,7 @@ namespace AzToolsFramework
                         AZ_Assert(topLevelInstance.has_value(), "Invalid nested instance found in the new prefab created.");
 
                         // Create a link for the nested instance
-                        createLinkForNestedInstanceFunc(topLevelInstance->get());
+                        createLinkForNestedInstance(topLevelInstance->get());
 
                         // Update the instance link with the new parent transform data
                         PrefabDom nestedContainerEntityDomBefore;
@@ -333,7 +333,7 @@ namespace AzToolsFramework
                 EditorEntityContextNotificationBus::Broadcast(&EditorEntityContextNotification::SetForceAddEntitiesToBackFlag, false);
 
                 // Set up remaining links for the nested instances that are not at the top level. This is done without undo/redo support.
-                instanceToCreate->get().GetNestedInstances([topLevelEntities, createLinkForNestedInstanceFunc](AZStd::unique_ptr<Instance>& nestedInstance) {
+                instanceToCreate->get().GetNestedInstances([topLevelEntities, createLinkForNestedInstance](AZStd::unique_ptr<Instance>& nestedInstance) {
                     AZ_Assert(nestedInstance, "Invalid nested instance found in the new prefab created.");
 
                     EntityOptionalReference nestedInstanceContainerEntity = nestedInstance->GetContainerEntity();
@@ -343,7 +343,7 @@ namespace AzToolsFramework
                     // Create a link if this container entity is not a top-level entity. Otherwise, the link has already been created
                     if (AZStd::find(topLevelEntities.begin(), topLevelEntities.end(), &nestedInstanceContainerEntity->get()) == topLevelEntities.end())
                     {
-                        createLinkForNestedInstanceFunc(*nestedInstance);
+                        createLinkForNestedInstance(*nestedInstance);
                     }
                 });
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -266,7 +266,6 @@ namespace AzToolsFramework
                     AZ_Assert(
                         nestedInstanceContainerEntity, "Invalid container entity found for the nested instance used in prefab creation.");
 
-                    AZ::EntityId nestedInstanceContainerEntityId = nestedInstanceContainerEntity->get().GetId();
                     PrefabDom previousPatch;
 
                     // Retrieve the previous patch if it exists

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabCreateInMemoryTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabCreateInMemoryTests.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+
+#include <Prefab/PrefabTestFixture.h>
+
+namespace UnitTest
+{
+    using PrefabCreateInMemoryTest = PrefabTestFixture;
+
+    TEST_F(PrefabCreateInMemoryTest, CreatePrefabFromEntitiesAndValidateChildEntityOrder)
+    {
+        // Level
+        // | Car
+        //   | Engine   (entity)
+        //   | Wheel    (instance)
+        //     | Tire
+        //   | Battery  (entity)
+
+        const AZStd::string carPrefabName = "CarPrefab";
+        const AZStd::string wheelPrefabName = "WheelPrefab";
+        const AZStd::string tireEntityName = "Tire";
+        const AZStd::string engineEntityName = "Engine";
+        const AZStd::string batteryEntityName = "Battery";
+
+        AZ::IO::Path engineRootPath;
+        m_settingsRegistryInterface->Get(engineRootPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
+        AZ::IO::Path carPrefabFilepath = engineRootPath / carPrefabName;
+        AZ::IO::Path wheelPrefabFilepath = engineRootPath / wheelPrefabName;
+
+        // Create an Engine entity first
+        AZ::EntityId engineEntityId = CreateEditorEntityUnderRoot(engineEntityName);
+        // Create the Wheel instance after the Engine entity
+        AZ::EntityId tireEntityId = CreateEditorEntityUnderRoot(tireEntityName);
+        AZ::EntityId wheelContainerId = CreateEditorPrefab(wheelPrefabFilepath, { tireEntityId });
+        // Create the Battery entity after the Wheel instance
+        AZ::EntityId batteryEntityId = CreateEditorEntityUnderRoot(batteryEntityName);
+        // Create a Car prefab from the entities and isntance
+        AZ::EntityId carContainerId = CreateEditorPrefab(carPrefabFilepath, { engineEntityId, batteryEntityId, wheelContainerId });
+        auto carInstance = m_instanceEntityMapperInterface->FindOwningInstance(carContainerId);
+        ASSERT_TRUE(carInstance.has_value());
+        ASSERT_TRUE(carInstance->get().GetContainerEntityId() == carContainerId);
+
+        // Validate the child entity order of the car instance
+        AzToolsFramework::EntityOrderArray entityOrderArray = AzToolsFramework::GetEntityChildOrder(carContainerId);
+        EXPECT_TRUE(entityOrderArray.size() == 3);
+        AZStd::string entityName;
+        AZ::ComponentApplicationBus::BroadcastResult(entityName, &AZ::ComponentApplicationRequests::GetEntityName, entityOrderArray[0]);
+        EXPECT_TRUE(entityName == engineEntityName);
+        AZ::ComponentApplicationBus::BroadcastResult(entityName, &AZ::ComponentApplicationRequests::GetEntityName, entityOrderArray[1]);
+        EXPECT_TRUE(entityName == wheelPrefabName);
+        AZ::ComponentApplicationBus::BroadcastResult(entityName, &AZ::ComponentApplicationRequests::GetEntityName, entityOrderArray[2]);
+        EXPECT_TRUE(entityName == batteryEntityName);
+    }
+}

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabCreateTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabCreateTests.cpp
@@ -7,14 +7,13 @@
  */
 
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
-
 #include <Prefab/PrefabTestFixture.h>
 
 namespace UnitTest
 {
-    using PrefabCreateInMemoryTest = PrefabTestFixture;
+    using PrefabCreateTests = PrefabTestFixture;
 
-    TEST_F(PrefabCreateInMemoryTest, CreatePrefabFromEntitiesAndValidateChildEntityOrder)
+    TEST_F(PrefabCreateTests, CreatePrefabFromEntitiesAndValidateChildEntityOrder)
     {
         // Level
         // | Car
@@ -45,17 +44,17 @@ namespace UnitTest
         AZ::EntityId carContainerId = CreateEditorPrefab(carPrefabFilepath, { engineEntityId, batteryEntityId, wheelContainerId });
         auto carInstance = m_instanceEntityMapperInterface->FindOwningInstance(carContainerId);
         ASSERT_TRUE(carInstance.has_value());
-        ASSERT_TRUE(carInstance->get().GetContainerEntityId() == carContainerId);
+        ASSERT_EQ(carInstance->get().GetContainerEntityId(), carContainerId);
 
         // Validate the child entity order of the car instance
         AzToolsFramework::EntityOrderArray entityOrderArray = AzToolsFramework::GetEntityChildOrder(carContainerId);
-        EXPECT_TRUE(entityOrderArray.size() == 3);
+        EXPECT_EQ(entityOrderArray.size(), 3);
         AZStd::string entityName;
         AZ::ComponentApplicationBus::BroadcastResult(entityName, &AZ::ComponentApplicationRequests::GetEntityName, entityOrderArray[0]);
-        EXPECT_TRUE(entityName == engineEntityName);
+        EXPECT_EQ(entityName, engineEntityName);
         AZ::ComponentApplicationBus::BroadcastResult(entityName, &AZ::ComponentApplicationRequests::GetEntityName, entityOrderArray[1]);
-        EXPECT_TRUE(entityName == wheelPrefabName);
+        EXPECT_EQ(entityName, wheelPrefabName);
         AZ::ComponentApplicationBus::BroadcastResult(entityName, &AZ::ComponentApplicationRequests::GetEntityName, entityOrderArray[2]);
-        EXPECT_TRUE(entityName == batteryEntityName);
+        EXPECT_EQ(entityName, batteryEntityName);
     }
-}
+} // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
+++ b/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
@@ -98,7 +98,7 @@ set(FILES
     Prefab/Overrides/PrefabOverridePublicInterfaceTests.cpp
     Prefab/Overrides/PrefabOverrideTestFixture.cpp
     Prefab/Overrides/PrefabOverrideTestFixture.h
-    Prefab/PrefabCreateInMemoryTests.cpp
+    Prefab/PrefabCreateTests.cpp
     Prefab/PrefabDeleteTests.cpp
     Prefab/PrefabDeleteAsOverrideTests.cpp
     Prefab/PrefabDuplicateTests.cpp

--- a/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
+++ b/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
@@ -98,6 +98,7 @@ set(FILES
     Prefab/Overrides/PrefabOverridePublicInterfaceTests.cpp
     Prefab/Overrides/PrefabOverrideTestFixture.cpp
     Prefab/Overrides/PrefabOverrideTestFixture.h
+    Prefab/PrefabCreateInMemoryTests.cpp
     Prefab/PrefabDeleteTests.cpp
     Prefab/PrefabDeleteAsOverrideTests.cpp
     Prefab/PrefabDuplicateTests.cpp


### PR DESCRIPTION
Signed-off-by: michabr <82236305+michabr@users.noreply.github.com>

## What does this PR do?

Rearrange the "Create prefab" logic a bit so the original entity order remains intact when a prefab is created out of those entities. Before this PR, top-level container entities always appeared before regular entities.

Fixes #12603
 
## How was this PR tested?

Tested different hierarchies with a mix of entities and nested instances in Editor.
