### PR TITLE
Remove loaded template if the last prefab instance is deleted from the level

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/prefab_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/prefab_utils.py
@@ -226,7 +226,6 @@ class Prefab:
         :param prefab_instance_name: A name for the very first instance generated while prefab creation. The default instance name is the same as the file name in file_path.
         :return: Created Prefab object and the very first PrefabInstance object owned by the prefab.
         """
-        assert not Prefab.is_prefab_loaded(file_path), f"Can't create Prefab '{file_path}' since the prefab already exists"
 
         new_prefab = Prefab(file_path)
         entity_ids = [entity.id for entity in entities]

--- a/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Periodic.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Periodic.py
@@ -50,6 +50,9 @@ class TestAutomationNoOverrides(EditorTestSuite):
     class test_Lua_Spawnables_SimpleSpawnAndDespawn(EditorBatchedTest):
         from .tests.spawnables import Lua_Spawnables_SimpleSpawnAndDespawn as test_module
 
+    class test_DeletePrefab_AndCreateWithSameName(EditorBatchedTest):
+        from .tests.delete_prefab import DeletePrefab_AndCreateWithSameName as test_module
+
 
 @pytest.mark.SUITE_periodic
 @pytest.mark.parametrize("launcher_platform", ['windows_editor'])

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/delete_prefab/DeletePrefab_AndCreateWithSameName.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/delete_prefab/DeletePrefab_AndCreateWithSameName.py
@@ -1,0 +1,53 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+def DeletePrefab_AndCreateWithSameName():
+
+    from pathlib import Path
+
+    import azlmbr.legacy.general as general
+
+    from editor_python_test_tools.editor_entity_utils import EditorEntity
+    from editor_python_test_tools.prefab_utils import Prefab
+    from editor_python_test_tools.wait_utils import PrefabWaiter
+    import Prefab.tests.PrefabTestUtils as prefab_test_utils
+
+    CAR_PREFAB_FILE_NAME = Path(__file__).stem + 'car_prefab'
+
+    prefab_test_utils.open_base_tests_level()
+
+    # Creates a new entity at the root level
+    car_entity = EditorEntity.create_editor_entity()
+    car_prefab_entities = [car_entity]
+
+    # Creates a prefab from the new entity
+    _, car = Prefab.create_prefab(
+        car_prefab_entities, CAR_PREFAB_FILE_NAME)
+
+    # Get parent entity and container id for verifying successful Undo/Redo operations
+    instance_parent_id = EditorEntity(car.container_entity.get_parent_id())
+    instance_id = car.container_entity.id
+
+    # Deletes the prefab instance. This will remove the template too since this is the last instance.
+    Prefab.remove_prefabs([car])
+
+    # Creates another new car entity
+    new_car_entity = EditorEntity.create_editor_entity()
+    new_car_entity_parent = new_car_entity.get_parent_id()
+    new_car_prefab_entities = [new_car_entity]
+
+    # Creates a prefab from the new entity
+    _, new_car = Prefab.create_prefab(
+        new_car_prefab_entities, CAR_PREFAB_FILE_NAME)
+
+    # Test undo/redo on prefab creation
+    prefab_test_utils.validate_undo_redo_on_prefab_creation(new_car, new_car_entity_parent)
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(DeletePrefab_AndCreateWithSameName)

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/delete_prefab/DeletePrefab_ContainingASingleEntity.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/delete_prefab/DeletePrefab_ContainingASingleEntity.py
@@ -10,6 +10,7 @@ def DeletePrefab_ContainingASingleEntity():
     from pathlib import Path
 
     import azlmbr.legacy.general as general
+    from azlmbr.math import Vector3
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity
     from editor_python_test_tools.prefab_utils import Prefab
@@ -25,15 +26,21 @@ def DeletePrefab_ContainingASingleEntity():
     car_prefab_entities = [car_entity]
 
     # Creates a prefab from the new entity
-    _, car = Prefab.create_prefab(
+    carPrefab, carInstance = Prefab.create_prefab(
         car_prefab_entities, CAR_PREFAB_FILE_NAME)
 
+    # Template will get removed if the only instance is deleted. So, instantiate a second instance so that the
+    # template will stay around in-memory. This is only needed for testing the undo behavior because in the real-world,
+    # we will load the template again from file when undo is pressed.
+    carPrefab.instantiate(
+        prefab_position=Vector3(10.00, 20.0, 30.0))
+
     # Get parent entity and container id for verifying successful Undo/Redo operations
-    instance_parent_id = EditorEntity(car.container_entity.get_parent_id())
-    instance_id = car.container_entity.id
+    instance_parent_id = EditorEntity(carInstance.container_entity.get_parent_id())
+    instance_id = carInstance.container_entity.id
 
     # Deletes the prefab instance
-    Prefab.remove_prefabs([car])
+    Prefab.remove_prefabs([carInstance])
 
     # Undo the prefab delete
     general.undo()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.h
@@ -52,7 +52,7 @@ namespace AzToolsFramework
              * @param filePath A Prefab Template file path.
              * @return A unique id of Template on filePath loaded. Return invalid template id if loading Template on filePath failed.
              */
-            TemplateId LoadTemplateFromFile(AZ::IO::PathView filePath) override;
+            TemplateId LoadTemplateFromFile(AZ::IO::PathView filePath, TemplateId templateId = InvalidTemplateId) override;
 
              /**
              * Reloads Prefab Template from given file path and updates values that are changed
@@ -161,7 +161,8 @@ namespace AzToolsFramework
              */
             TemplateId LoadTemplateFromFile(
                 AZ::IO::PathView filePath,
-                AZStd::unordered_set<AZ::IO::Path>& progressedFilePathsSet);
+                AZStd::unordered_set<AZ::IO::Path>& progressedFilePathsSet,
+                TemplateId templateId = InvalidTemplateId);
 
             /**
              * Load Prefab Template from given string to memory and return the id of loaded Template.
@@ -173,7 +174,8 @@ namespace AzToolsFramework
             TemplateId LoadTemplateFromString(
                 AZStd::string_view fileContent,
                 AZ::IO::PathView filePath,
-                AZStd::unordered_set<AZ::IO::Path>& progressedFilePathsSet);
+                AZStd::unordered_set<AZ::IO::Path>& progressedFilePathsSet,
+                TemplateId templateId = InvalidTemplateId);
 
             /**
              * Load nested instance given a nested instance value iterator and target Template with its id.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoaderInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoaderInterface.h
@@ -40,7 +40,7 @@ namespace AzToolsFramework
              * @param filePath A Prefab Template file path.
              * @return A unique id of Template on filePath loaded. Return invalid template id if loading Template on filePath failed.
              */
-            virtual TemplateId LoadTemplateFromFile(AZ::IO::PathView filePath) = 0;
+            virtual TemplateId LoadTemplateFromFile(AZ::IO::PathView filePath, TemplateId templateId = InvalidTemplateId) = 0;
 
             /**
              * Load Prefab Template from given content string to memory and return the id of loaded Template.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -640,7 +640,10 @@ namespace AzToolsFramework
         }
 
         void PrefabPublicHandler::RemoveLink(
-            AZStd::unique_ptr<Instance>& sourceInstance, TemplateId targetTemplateId, UndoSystem::URSequencePoint* undoBatch)
+            AZStd::unique_ptr<Instance>& sourceInstance,
+            TemplateId targetTemplateId,
+            UndoSystem::URSequencePoint* undoBatch,
+            bool removeTemplateIfLastInstance)
         {
             LinkReference nestedInstanceLink = m_prefabSystemComponentInterface->FindLink(sourceInstance->GetLinkId());
             AZ_Assert(
@@ -659,7 +662,7 @@ namespace AzToolsFramework
 
             PrefabUndoHelpers::RemoveLink(
                 sourceInstance->GetTemplateId(), targetTemplateId, sourceInstance->GetInstanceAlias(), sourceInstance->GetLinkId(),
-                AZStd::move(patchesCopyForUndoSupport), undoBatch);
+                AZStd::move(patchesCopyForUndoSupport), undoBatch, removeTemplateIfLastInstance);
         }
 
         PrefabOperationResult PrefabPublicHandler::SavePrefab(AZ::IO::Path filePath)
@@ -1418,7 +1421,7 @@ namespace AzToolsFramework
                 else
                 {
                     // Removes the link if it is source template editing.
-                    RemoveLink(detachedInstance, commonOwningInstance->get().GetTemplateId(), undoBatch.GetUndoBatch());
+                    RemoveLink(detachedInstance, commonOwningInstance->get().GetTemplateId(), undoBatch.GetUndoBatch(), true);
                 }
 
                 detachedInstance.reset();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
@@ -145,7 +145,7 @@ namespace AzToolsFramework
              * \param undoBatch The undo batch to set as parent for this remove link action.
              */
             void RemoveLink(
-                AZStd::unique_ptr<Instance>& sourceInstance, TemplateId targetTemplateId, UndoSystem::URSequencePoint* undoBatch);
+                AZStd::unique_ptr<Instance>& sourceInstance, TemplateId targetTemplateId, UndoSystem::URSequencePoint* undoBatch, bool removeTemplateIfLastInstance = false);
 
             /**
              * Given a list of entityIds, finds the prefab instance that owns the common root entity of the entityIds.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
@@ -523,11 +523,16 @@ namespace AzToolsFramework
             }
         }
 
-        TemplateId PrefabSystemComponent::AddTemplate(const AZ::IO::Path& filePath, PrefabDom prefabDom)
+        TemplateId PrefabSystemComponent::AddTemplate(const AZ::IO::Path& filePath, PrefabDom prefabDom, TemplateId templateId)
         {
-            TemplateId newTemplateId = CreateUniqueTemplateId();
-            Template& newTemplate = m_templateIdMap.emplace(
-                AZStd::make_pair(newTemplateId, AZStd::move(Template(filePath, AZStd::move(prefabDom))))).first->second;
+            if (templateId == InvalidTemplateId)
+            {
+                templateId = CreateUniqueTemplateId();
+            }
+            
+            Template& newTemplate =
+                m_templateIdMap.emplace(AZStd::make_pair(templateId, AZStd::move(Template(filePath, AZStd::move(prefabDom)))))
+                    .first->second;
 
             if (!newTemplate.IsValid())
             {
@@ -536,19 +541,19 @@ namespace AzToolsFramework
                     "Can't add this new Template on file path '%s' since it is invalid.",
                     filePath.c_str());
 
-                m_templateIdMap.erase(newTemplateId);
+                m_templateIdMap.erase(templateId);
                 return InvalidTemplateId;
             }
 
-            if (!m_templateInstanceMapper.RegisterTemplate(newTemplateId))
+            if (!m_templateInstanceMapper.RegisterTemplate(templateId))
             {
-                m_templateIdMap.erase(newTemplateId);
+                m_templateIdMap.erase(templateId);
                 return InvalidTemplateId;
             }
 
-            m_templateFilePathToIdMap.emplace(AZStd::make_pair(filePath, newTemplateId));
+            m_templateFilePathToIdMap.emplace(AZStd::make_pair(filePath, templateId));
 
-            return newTemplateId;
+            return templateId;
         }
 
         void PrefabSystemComponent::UpdateTemplateFilePath(TemplateId templateId, const AZ::IO::PathView& filePath)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.h
@@ -103,7 +103,7 @@ namespace AzToolsFramework
             * @param prefabDom A Prefab DOM presenting this Template.
             * @return A unique id for the new Template.
             */
-            TemplateId AddTemplate(const AZ::IO::Path& filePath, PrefabDom prefabDom) override;
+            TemplateId AddTemplate(const AZ::IO::Path& filePath, PrefabDom prefabDom, TemplateId templateId = InvalidTemplateId) override;
 
             /**
              * Updates relative filepath location of a prefab (in case of SaveAs operation).

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponentInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponentInterface.h
@@ -35,7 +35,8 @@ namespace AzToolsFramework
             virtual TemplateReference FindTemplate(TemplateId id) = 0;
             virtual LinkReference FindLink(const LinkId& id) = 0;
 
-            virtual TemplateId AddTemplate(const AZ::IO::Path& filePath, PrefabDom prefabDom) = 0;
+            virtual TemplateId AddTemplate(
+                const AZ::IO::Path& filePath, PrefabDom prefabDom, TemplateId templateId = InvalidTemplateId) = 0;
             virtual void UpdateTemplateFilePath(TemplateId templateId, const AZ::IO::PathView& filePath) = 0;
             virtual void RemoveTemplate(TemplateId templateId) = 0;
             virtual void RemoveAllTemplates() = 0;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.cpp
@@ -47,10 +47,13 @@ namespace AzToolsFramework
 
             void RemoveLink(
                 TemplateId sourceTemplateId, TemplateId targetTemplateId, const InstanceAlias& instanceAlias, LinkId linkId,
-                PrefabDom linkPatches, UndoSystem::URSequencePoint* undoBatch)
+                PrefabDom linkPatches,
+                UndoSystem::URSequencePoint* undoBatch,
+                bool removeTemplateIfLastInstance)
             {
                 auto linkRemoveUndo = aznew PrefabUndoInstanceLink("Remove Link");
-                linkRemoveUndo->Capture(targetTemplateId, sourceTemplateId, instanceAlias, AZStd::move(linkPatches), linkId);
+                linkRemoveUndo->Capture(
+                    targetTemplateId, sourceTemplateId, instanceAlias, AZStd::move(linkPatches), linkId, removeTemplateIfLastInstance);
                 linkRemoveUndo->SetParent(undoBatch);
                 linkRemoveUndo->Redo();
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.h
@@ -24,7 +24,9 @@ namespace AzToolsFramework
                 const InstanceAlias& instanceAlias, UndoSystem::URSequencePoint* undoBatch);
             void RemoveLink(
                 TemplateId sourceTemplateId, TemplateId targetTemplateId, const InstanceAlias& instanceAlias, LinkId linkId,
-                PrefabDom linkPatches, UndoSystem::URSequencePoint* undoBatch);
+                PrefabDom linkPatches,
+                UndoSystem::URSequencePoint* undoBatch,
+                bool removeTemplateIfLastInstance = false);
 
             //! Helper function for adding an entity to a prefab template with undo-redo support.
             //! @param parentEntity The target parent entity of the newly added entity.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndo.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndo.h
@@ -17,6 +17,9 @@ namespace AzToolsFramework
 {
     namespace Prefab
     {
+        class PrefabLoaderInterface;
+        class TemplateInstanceMapperInterface;
+
         //! handles the addition and removal of entities from instances
         class PrefabUndoInstance
             : public PrefabUndoBase
@@ -82,7 +85,8 @@ namespace AzToolsFramework
                 TemplateId sourceId,
                 const InstanceAlias& instanceAlias,
                 PrefabDom linkPatches = PrefabDom(),
-                const LinkId linkId = InvalidLinkId);
+                const LinkId linkId = InvalidLinkId,
+                bool removeTemplateIfLastInstance = false);
 
             void Undo() override;
             void Redo() override;
@@ -96,13 +100,16 @@ namespace AzToolsFramework
 
             void RemoveLink();
 
+            PrefabDom m_linkPatches; // data for delete/update
+            InstanceAlias m_instanceAlias;
+            AZ::IO::Path m_sourceTemplatePath;
+            PrefabLoaderInterface* m_prefabLoaderInterface = nullptr;
+            TemplateInstanceMapperInterface* m_templateInstanceMapperInterface = nullptr;
             TemplateId m_targetId;
             TemplateId m_sourceId;
-            InstanceAlias m_instanceAlias;
-
             LinkId m_linkId;
-            PrefabDom m_linkPatches;  //data for delete/update
             LinkStatus m_linkStatus;
+            bool m_removeTemplateIfLastInstance = false;
         };
     }
 }


### PR DESCRIPTION
## What does this PR do?

This draft PR provides an alternative way to fix https://github.com/o3de/o3de/issues/13832

## Why is this not a good solution?

- Too much branching logic in multiple classes and functions
- Solves only this 1 very particular use case of deleting a template when the last known instance is deleted
- Works for small prefabs but will have performance impact for large prefabs. Reloading of large and deeply nested prefab can be costly
  - User deletes and hits undo ---this solution would need to load file from disk again
  - User deletes and instantiates the same prefab again — this solution would need to load file from disk again

## What is a better alternative
https://github.com/o3de/o3de/pull/14197
