### PR TITLE
Update prefab undo nodes to use utility functions

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.cpp
@@ -87,10 +87,10 @@ namespace AzToolsFramework
                 TemplateId templateId,
                 UndoSystem::URSequencePoint* undoBatch)
             {
-                PrefabUndoRemoveEntities* removeEntitiesUndoState = aznew PrefabUndoRemoveEntities("Undo Removing Entities");
-                removeEntitiesUndoState->SetParent(undoBatch);
-                removeEntitiesUndoState->Capture(entityDomAndPathList, templateId);
-                removeEntitiesUndoState->Redo();
+                PrefabUndoRemoveEntityDoms* state = aznew PrefabUndoRemoveEntityDoms("Undo Removing Entity DOMs");
+                state->SetParent(undoBatch);
+                state->Capture(entityDomAndPathList, templateId);
+                state->Redo();
             }
 
             void UpdateEntity(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndo.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndo.cpp
@@ -10,6 +10,7 @@
 #include <AzToolsFramework/Prefab/PrefabDomUtils.h>
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
 #include <AzToolsFramework/Prefab/Undo/PrefabUndo.h>
+#include <AzToolsFramework/Prefab/Undo/PrefabUndoUtils.h>
 
 namespace AzToolsFramework
 {
@@ -33,14 +34,14 @@ namespace AzToolsFramework
             m_instanceToTemplateInterface->GeneratePatch(m_undoPatch, endState, initialState);
         }
 
-        // PrefabUndoRemoveEntities
+        // PrefabUndoRemoveEntityDoms
 
-        PrefabUndoRemoveEntities::PrefabUndoRemoveEntities(const AZStd::string& undoOperationName)
+        PrefabUndoRemoveEntityDoms::PrefabUndoRemoveEntityDoms(const AZStd::string& undoOperationName)
             : PrefabUndoBase(undoOperationName)
         {
         }
 
-        void PrefabUndoRemoveEntities::Capture(
+        void PrefabUndoRemoveEntityDoms::Capture(
             const AZStd::vector<AZStd::pair<const PrefabDomValue*, AZStd::string>>& entityDomAndPathList, TemplateId templateId)
         {
             m_templateId = templateId;
@@ -50,28 +51,11 @@ namespace AzToolsFramework
 
             for (const auto& entityDomAndPath : entityDomAndPathList)
             {
-                if (entityDomAndPath.first)
+                const PrefabDomValue* entityDomValue = entityDomAndPath.first;
+                if (entityDomValue)
                 {
-                    const AZStd::string& entityAliasPath = entityDomAndPath.second;
-
-                    // Create redo patch.
-                    PrefabDomValue redoPatch(rapidjson::kObjectType);
-                    PrefabDomValue path(entityAliasPath.data(), aznumeric_caster(entityAliasPath.length()), m_redoPatch.GetAllocator());
-
-                    redoPatch.AddMember(rapidjson::StringRef("op"), rapidjson::StringRef("remove"), m_redoPatch.GetAllocator())
-                        .AddMember(rapidjson::StringRef("path"), AZStd::move(path), m_redoPatch.GetAllocator());
-                    m_redoPatch.PushBack(redoPatch.Move(), m_redoPatch.GetAllocator());
-
-                    // Create undo patch.
-                    PrefabDomValue undoPatch(rapidjson::kObjectType);
-                    path = PrefabDomValue(entityAliasPath.data(), aznumeric_caster(entityAliasPath.length()), m_undoPatch.GetAllocator());
-
-                    PrefabDomValue patchValue;
-                    patchValue.CopyFrom(*(entityDomAndPath.first), m_undoPatch.GetAllocator(), true);
-                    undoPatch.AddMember(rapidjson::StringRef("op"), rapidjson::StringRef("add"), m_undoPatch.GetAllocator())
-                        .AddMember(rapidjson::StringRef("path"), AZStd::move(path), m_undoPatch.GetAllocator())
-                        .AddMember(rapidjson::StringRef("value"), AZStd::move(patchValue), m_undoPatch.GetAllocator());
-                    m_undoPatch.PushBack(undoPatch.Move(), m_undoPatch.GetAllocator());
+                    PrefabUndoUtils::AppendRemovePatch(m_redoPatch, entityDomAndPath.second);
+                    PrefabUndoUtils::AppendAddEntityPatch(m_undoPatch, *entityDomValue, entityDomAndPath.second);
                 }
             }
         }
@@ -104,23 +88,15 @@ namespace AzToolsFramework
             m_entityAlias = aliasReference.value();
 
             //generate undo/redo patches
-            m_instanceToTemplateInterface->GeneratePatch(m_redoPatch, initialState, endState);
-            m_instanceToTemplateInterface->AppendEntityAliasToPatchPaths(m_redoPatch, entityId);
-            
-            m_instanceToTemplateInterface->GeneratePatch(m_undoPatch, endState, initialState);
-            m_instanceToTemplateInterface->AppendEntityAliasToPatchPaths(m_undoPatch, entityId);
+            const AZStd::string& entityAliasPath = m_instanceToTemplateInterface->GenerateEntityAliasPath(entityId);
+            PrefabUndoUtils::GenerateUpdateEntityPatch(m_redoPatch, initialState, endState, entityAliasPath);
+            PrefabUndoUtils::GenerateUpdateEntityPatch(m_redoPatch, endState, initialState, entityAliasPath);
 
             // Preemptively updates the cached DOM to prevent reloading instance DOM.
-            AZStd::string entityAliasPath = m_instanceToTemplateInterface->GenerateEntityAliasPath(entityId);
-            if (!entityAliasPath.empty())
+            PrefabDomReference cachedOwningInstanceDom = instance.GetCachedInstanceDom();
+            if (cachedOwningInstanceDom.has_value())
             {
-                PrefabDomReference cachedDom = instance.GetCachedInstanceDom();
-
-                if (cachedDom.has_value())
-                {
-                    Prefab::PrefabDomPath entityPathInDom(entityAliasPath.c_str());
-                    entityPathInDom.Set(cachedDom->get(), endState);
-                }
+                PrefabUndoUtils::UpdateEntityInInstanceDom(cachedOwningInstanceDom, endState, entityAliasPath);
             }
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndo.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndo.cpp
@@ -54,8 +54,9 @@ namespace AzToolsFramework
                 const PrefabDomValue* entityDomValue = entityDomAndPath.first;
                 if (entityDomValue)
                 {
-                    PrefabUndoUtils::AppendRemovePatch(m_redoPatch, entityDomAndPath.second);
-                    PrefabUndoUtils::AppendAddEntityPatch(m_undoPatch, *entityDomValue, entityDomAndPath.second);
+                    const AZStd::string& entityAliasPath = entityDomAndPath.second;
+                    PrefabUndoUtils::AppendRemovePatch(m_redoPatch, entityAliasPath);
+                    PrefabUndoUtils::AppendAddEntityPatch(m_undoPatch, *entityDomValue, entityAliasPath);
                 }
             }
         }
@@ -90,7 +91,7 @@ namespace AzToolsFramework
             //generate undo/redo patches
             const AZStd::string& entityAliasPath = m_instanceToTemplateInterface->GenerateEntityAliasPath(entityId);
             PrefabUndoUtils::GenerateUpdateEntityPatch(m_redoPatch, initialState, endState, entityAliasPath);
-            PrefabUndoUtils::GenerateUpdateEntityPatch(m_redoPatch, endState, initialState, entityAliasPath);
+            PrefabUndoUtils::GenerateUpdateEntityPatch(m_undoPatch, endState, initialState, entityAliasPath);
 
             // Preemptively updates the cached DOM to prevent reloading instance DOM.
             PrefabDomReference cachedOwningInstanceDom = instance.GetCachedInstanceDom();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndo.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndo.h
@@ -30,12 +30,12 @@ namespace AzToolsFramework
                 TemplateId templateId);
         };
         
-        //! Undo class for handling deletion of entities to a prefab template.
-        class PrefabUndoRemoveEntities
+        //! Undo class for handling removal of entity DOMs to a prefab template.
+        class PrefabUndoRemoveEntityDoms
             : public PrefabUndoBase
         {
         public:
-            explicit PrefabUndoRemoveEntities(const AZStd::string& undoOperationName);
+            explicit PrefabUndoRemoveEntityDoms(const AZStd::string& undoOperationName);
 
             void Capture(const AZStd::vector<AZStd::pair<const PrefabDomValue*, AZStd::string>>& entityDomAndPathList,
                 TemplateId templateId);


### PR DESCRIPTION
Signed-off-by: Junhao Wang <wjunhao@amazon.com>

## What does this PR do?

This PR updates some prefab nodes to use undo utility functions that we introduced earlier.

- PrefabUndoEntityUpdate
- PrefabUndoRemoveEntities (renamed to PrefabUndoRemoveEntityDoms)

## How was this PR tested?

Passed tests.
