### PR TITLE
Material Canvas: Restoring graph model caching and minor graph canvas optimizations

### DIFF
--- a/Gems/GraphCanvas/Code/Source/Components/StylingComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/StylingComponent.cpp
@@ -137,13 +137,14 @@ namespace GraphCanvas
     {
         Styling::SelectorVector selectors = m_coreSelectors;
 
-        QGraphicsItem* root = nullptr;
-        SceneMemberUIRequestBus::EventResult(root, GetEntityId(), &SceneMemberUIRequests::GetRootGraphicsItem);
-
+        selectors.reserve(selectors.size() + m_dynamicSelectors.size());
         for (auto& mapPair : m_dynamicSelectors)
         {
             selectors.emplace_back(mapPair.second);
         }
+
+        QGraphicsItem* root = nullptr;
+        SceneMemberUIRequestBus::EventResult(root, GetEntityId(), &SceneMemberUIRequests::GetRootGraphicsItem);
 
         if (!root)
         {
@@ -170,10 +171,11 @@ namespace GraphCanvas
 
         // TODO collapsed and highlighted
 
-        for (auto& mapPair : m_dynamicSelectors)
-        {
-            selectors.emplace_back(mapPair.second);
-        }
+        // Why is this repeated?
+        //for (auto& mapPair : m_dynamicSelectors)
+        //{
+        //    selectors.emplace_back(mapPair.second);
+        //}
 
         return selectors;
     }

--- a/Gems/GraphCanvas/Code/Source/Components/StylingComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/StylingComponent.cpp
@@ -137,7 +137,9 @@ namespace GraphCanvas
     {
         Styling::SelectorVector selectors = m_coreSelectors;
 
-        selectors.reserve(selectors.size() + m_dynamicSelectors.size());
+        // Reserve space for all of these selectors added in this function
+        selectors.reserve(selectors.size() + m_dynamicSelectors.size() + 3);
+
         for (auto& mapPair : m_dynamicSelectors)
         {
             selectors.emplace_back(mapPair.second);
@@ -170,12 +172,6 @@ namespace GraphCanvas
         }
 
         // TODO collapsed and highlighted
-
-        // Why is this repeated?
-        //for (auto& mapPair : m_dynamicSelectors)
-        //{
-        //    selectors.emplace_back(mapPair.second);
-        //}
 
         return selectors;
     }

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Styling/PseudoElement.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Styling/PseudoElement.cpp
@@ -66,7 +66,9 @@ namespace GraphCanvas
             StyledEntityRequestBus::EventResult(selectors, m_real, &StyledEntityRequests::GetStyleSelectors);
             AZStd::replace(selectors.begin(), selectors.end(), m_parentSelector, m_virtualChildSelector);
 
+            // Reserve space for all of these selectors added in this function
             selectors.reserve(selectors.size() + m_dynamicSelectors.size());
+
             for (const auto& mapPair : m_dynamicSelectors)
             {
                 selectors.emplace_back(mapPair.second);

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Styling/PseudoElement.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Styling/PseudoElement.cpp
@@ -66,9 +66,10 @@ namespace GraphCanvas
             StyledEntityRequestBus::EventResult(selectors, m_real, &StyledEntityRequests::GetStyleSelectors);
             AZStd::replace(selectors.begin(), selectors.end(), m_parentSelector, m_virtualChildSelector);
 
+            selectors.reserve(selectors.size() + m_dynamicSelectors.size());
             for (const auto& mapPair : m_dynamicSelectors)
             {
-                selectors.push_back(mapPair.second);
+                selectors.emplace_back(mapPair.second);
             }
 
             return selectors;

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Styling/SelectorImplementations.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Styling/SelectorImplementations.cpp
@@ -139,7 +139,7 @@ namespace GraphCanvas
             SelectorVector selectors;
             StyledEntityRequestBus::EventResult(selectors, object, &StyledEntityRequests::GetStyleSelectors);
 
-            return std::all_of(m_parts.cbegin(), m_parts.cend(), [=](const Selector& s) {
+            return std::all_of(m_parts.cbegin(), m_parts.cend(), [&](const Selector& s) {
                 return std::find(selectors.cbegin(), selectors.cend(), s) != selectors.cend();
             });
         }

--- a/Gems/GraphModel/Code/Include/GraphModel/Model/Graph.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Model/Graph.h
@@ -119,9 +119,17 @@ namespace GraphModel
         //! Return our full map of node wrappings
         const NodeWrappingMap& GetNodeWrappings();
 
+        //! Search for a note with the corresponding ID
         NodePtr GetNode(NodeId nodeId);
+
+        //! Return a map of all nodes in the graph
         const NodeMap& GetNodes();
+
+        //! Return a map of all nodes in the graph
         ConstNodeMap GetNodes() const;
+
+        //! Return the number of nodes in the graph
+        size_t GetNodeCount() const;
 
         //! Adds a new connection between sourceSlot and targetSlot and returns the
         //! new Connection, or returns the existing Connection if one already exists.
@@ -130,7 +138,11 @@ namespace GraphModel
         //! Removes a connection from the Graph, and returns whether it was found and removed
         bool RemoveConnection(ConstConnectionPtr connection);
 
+        //! Return a container of all connections in the graph
         const ConnectionList& GetConnections();
+
+        //! Return the number of connections for all nodes and slots in the graph
+        size_t GetConnectionCount() const;
 
         //! Set/gets a bundle of generic metadata that is provided by the node graph UI
         //! system. This may include node positions, comment blocks, node groupings, and 
@@ -140,6 +152,9 @@ namespace GraphModel
         GraphModelIntegration::GraphCanvasMetadata& GetUiMetadata();
 
         AZStd::shared_ptr<Slot> FindSlot(const Endpoint& endpoint);
+
+        //! Reset any data that was cached for this graph
+        void ClearCachedData();
 
     protected:
         bool Contains(SlotPtr slot) const;

--- a/Gems/GraphModel/Code/Include/GraphModel/Model/Node.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Model/Node.h
@@ -113,6 +113,7 @@ namespace GraphModel
         //! other types, such as wrapper nodes
         virtual NodeType GetNodeType() const;
 
+        //! Return the unique ID for this node in the containing graph
         NodeId GetId() const;
 
         //! Return the greatest distance, number of connected nodes, between this node and other root nodes.
@@ -219,6 +220,9 @@ namespace GraphModel
         //! will be handled automatically by PostLoadSetup()).
         void CreateSlotData();
 
+        //! Clear any data that was cached for this node
+        void ClearCachedData();
+
     private:
 
         //! Common implementation for RegisterSlot() to a specific SlotDefinitionList
@@ -268,6 +272,13 @@ namespace GraphModel
         SlotDefinitionList m_outputEventSlotDefinitions; //!< For slots with configuration = SlotDirection::Output SlotType::Event
         SlotDefinitionList m_extendableSlotDefinitions;  //!< For all extendable slot configurations
         SlotDefinitionList m_allSlotDefinitions; //!< Provies a single list of all of the above SlotDefinitionLists for convenient looping over them all
+
+        // Storing the minimum and maximum input depth for this node so that it does not have to be calculated every time
+        mutable AZStd::mutex m_maxInputDepthMutex;
+        mutable uint32_t m_maxInputDepth = AZStd::numeric_limits<uint32_t>::max();
+
+        mutable AZStd::mutex m_maxOutputDepthMutex;
+        mutable uint32_t m_maxOutputDepth = AZStd::numeric_limits<uint32_t>::max();
     };
 
 } // namespace GraphModel

--- a/Gems/GraphModel/Code/Include/GraphModel/Model/Slot.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Model/Slot.h
@@ -238,15 +238,12 @@ namespace GraphModel
     //! class hierarchy).
     class Slot : public GraphElement, public AZStd::enable_shared_from_this<Slot>
     {
-        friend class Graph; // So the Graph can update the Slot's cache of Connection pointers
-
     public:
         AZ_CLASS_ALLOCATOR(Slot, AZ::SystemAllocator, 0);
         AZ_RTTI(Slot, "{50494867-04F1-4785-BB9C-9D6C96DCBFC9}", GraphElement);
         static void Reflect(AZ::ReflectContext* context);
 
-        using ConnectionList = AZStd::set<AZStd::shared_ptr<Connection>>; // AZStd::unordered_set doesn't work with shared_ptr so use set
-        using WeakConnectionList = AZStd::list<AZStd::weak_ptr<Connection>>; // AZStd::set doesn't work with weak_ptr so use list
+        using ConnectionList = AZStd::vector<AZStd::shared_ptr<Connection>>;
 
         Slot() = default; // Needed by SerializeContext
         ~Slot() override = default;
@@ -324,19 +321,36 @@ namespace GraphModel
 
         //! Returns the list of connections to this Slot.
         //! (Property slots will never have connections)
-        ConnectionList GetConnections() const;
+        const ConnectionList& GetConnections() const;
+
+        //! Reset any data that was cached for this slot
+        void ClearCachedData();
 
     private:
-
 #if defined(AZ_ENABLE_TRACING)
         void AssertWithTypeInfo(bool expression, DataTypePtr dataTypeRequested, const char* message) const;
 #endif
         DataTypePtr GetDataTypeForTypeId(const AZ::Uuid& typeId) const;
         DataTypePtr GetDataTypeForValue(const AZStd::any& value) const;
 
-        SlotDefinitionPtr m_slotDefinition;         //!< Pointer to the SlotDefinition in the parent Node, that defines this slot.
-        AZStd::any m_value;                         //!< This is the value that gets used for a Property slot or an Input Data slot that doesn't have any connection.
-        SlotSubId m_subId = 0;                      //!< SubId to uniquely identify extendable slots of the same name (regular slots will always have a SubId of 0)
+        // Pointer to the SlotDefinition in the parent Node, that defines this slot.
+        SlotDefinitionPtr m_slotDefinition;
+
+        // This is the value that gets used for a Property slot or an Input Data slot that doesn't have any connection.
+        AZStd::any m_value;
+
+        // SubId to uniquely identify extendable slots of the same name (regular slots will always have a SubId of 0)
+        SlotSubId m_subId = 0;
+
+        // Storing the parent node so that it only needs to be looked up once unless the graph state and cached data is clear
+        mutable AZStd::mutex m_parentNodeMutex;
+        mutable bool m_parentNodeDirty = true;
+        mutable NodePtr m_parentNode;
+
+        // Storing a list of connections for this slot, copied From the owner graph object.
+        mutable AZStd::mutex m_connectionsMutex;
+        mutable bool m_connectionsDirty = true;
+        mutable ConnectionList m_connections;
     };
 
     template<typename T>
@@ -361,9 +375,8 @@ namespace GraphModel
 
 namespace AZStd
 {
-    // This must be defined so that our custom data type SlotId can be used as a key
-    // in AZStd::unordered_map
-    template <>
+    // This must be defined so that our custom data type SlotId can be used as a key in AZStd::unordered_map
+    template<>
     struct hash<GraphModel::SlotId>
     {
         typedef GraphModel::SlotId argument_type;
@@ -373,4 +386,4 @@ namespace AZStd
             return id.GetHash();
         }
     };
-}
+} // namespace AZStd

--- a/Gems/GraphModel/Code/Source/Model/Node.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Node.cpp
@@ -52,7 +52,6 @@ namespace GraphModel
 
         m_graph = graph;
         m_id = id;
-
         PostLoadSetup();
     }
 
@@ -105,6 +104,8 @@ namespace GraphModel
 
         AZ_Assert(m_allSlots.size() == m_propertySlots.size() + m_inputDataSlots.size() + m_outputDataSlots.size() + m_inputEventSlots.size() + m_outputEventSlots.size() + numExtendableSlots, "Slot counts don't match");
         AZ_Assert(m_allSlotDefinitions.size() == m_propertySlotDefinitions.size() + m_inputDataSlotDefinitions.size() + m_outputDataSlotDefinitions.size() + m_inputEventSlotDefinitions.size() + m_outputEventSlotDefinitions.size() + m_extendableSlotDefinitions.size(), "SlotDefinition counts don't match");
+
+        ClearCachedData();
     }
 
     //! Returns the name that will be displayed as the sub-title of the Node in the UI
@@ -125,6 +126,24 @@ namespace GraphModel
         CreateSlotData(m_outputEventSlots, m_outputEventSlotDefinitions);
 
         CreateExtendableSlotData();
+    }
+
+    void Node::ClearCachedData()
+    {
+        {
+            AZStd::scoped_lock lock(m_maxInputDepthMutex);
+            m_maxInputDepth = AZStd::numeric_limits<uint32_t>::max();
+        }
+
+        {
+            AZStd::scoped_lock lock(m_maxOutputDepthMutex);
+            m_maxOutputDepth = AZStd::numeric_limits<uint32_t>::max();
+        }
+
+        for (auto& slotPair : m_allSlots)
+        {
+            slotPair.second->ClearCachedData();
+        }
     }
 
     void Node::CreateSlotData(SlotMap& slotMap, const SlotDefinitionList& slotDefinitionList)
@@ -274,38 +293,44 @@ namespace GraphModel
 
     uint32_t Node::GetMaxInputDepth() const
     {
-        uint32_t maxInputDepth = 0;
-        AZStd::for_each(m_allSlots.begin(), m_allSlots.end(), [&](const auto& slotPair) {
-            const auto& slot = slotPair.second;
-            if (slot->GetSlotDirection() == GraphModel::SlotDirection::Input)
+        AZStd::scoped_lock lock(m_maxInputDepthMutex);
+        if (m_maxInputDepth == AZStd::numeric_limits<uint32_t>::max())
+        {
+            m_maxInputDepth = 0;
+            for (const auto& slotPair : m_inputDataSlots)
             {
-                const auto& connections = slot->GetConnections();
-                AZStd::for_each(connections.begin(), connections.end(), [&](const auto& connection) {
+                const auto& slot = slotPair.second;
+                AZ_Assert(slot->GetSlotDirection() == GraphModel::SlotDirection::Input, "Slots in this container must be input slots.");
+                for (const auto& connection : slot->GetConnections())
+                {
                     AZ_Assert(connection->GetSourceNode().get() != this, "This should never be the source node on an input connection.");
                     AZ_Assert(connection->GetTargetNode().get() == this, "This should always be the target node on an input connection.");
-                    maxInputDepth = AZStd::max(maxInputDepth, connection->GetSourceNode()->GetMaxInputDepth() + 1);
-                });
+                    m_maxInputDepth = AZStd::max(m_maxInputDepth, connection->GetSourceNode()->GetMaxInputDepth() + 1);
+                }
             }
-        });
-        return maxInputDepth;
+        }
+        return m_maxInputDepth;
     }
 
     uint32_t Node::GetMaxOutputDepth() const
     {
-        uint32_t maxOutputDepth = 0;
-        AZStd::for_each(m_allSlots.begin(), m_allSlots.end(), [&](const auto& slotPair) {
-            const auto& slot = slotPair.second;
-            if (slot->GetSlotDirection() == GraphModel::SlotDirection::Output)
+        AZStd::scoped_lock lock(m_maxOutputDepthMutex);
+        if (m_maxOutputDepth == AZStd::numeric_limits<uint32_t>::max())
+        {
+            m_maxOutputDepth = 0;
+            for (const auto& slotPair : m_outputDataSlots)
             {
-                const auto& connections = slot->GetConnections();
-                AZStd::for_each(connections.begin(), connections.end(), [&](const auto& connection) {
+                const auto& slot = slotPair.second;
+                AZ_Assert(slot->GetSlotDirection() == GraphModel::SlotDirection::Output, "Slots in this container must be output slots.");
+                for (const auto& connection : slot->GetConnections())
+                {
                     AZ_Assert(connection->GetSourceNode().get() == this, "This should always be the source node on an output connection.");
                     AZ_Assert(connection->GetTargetNode().get() != this, "This should never be the target node on an output connection.");
-                    maxOutputDepth = AZStd::max(maxOutputDepth, connection->GetTargetNode()->GetMaxOutputDepth() + 1);
-                });
+                    m_maxOutputDepth = AZStd::max(m_maxOutputDepth, connection->GetTargetNode()->GetMaxOutputDepth() + 1);
+                }
             }
-        });
-        return maxOutputDepth;
+        }
+        return m_maxOutputDepth;
     }
 
     bool Node::HasSlots() const
@@ -315,18 +340,12 @@ namespace GraphModel
 
     bool Node::HasInputSlots() const
     {
-        return AZStd::any_of(m_allSlots.begin(), m_allSlots.end(), [](const auto& slotPair) {
-            const auto& slot = slotPair.second;
-            return slot->GetSlotDirection() == GraphModel::SlotDirection::Input;
-        });
+        return !m_inputDataSlots.empty() || !m_inputEventSlots.empty();
     }
 
     bool Node::HasOutputSlots() const
     {
-        return AZStd::any_of(m_allSlots.begin(), m_allSlots.end(), [](const auto& slotPair) {
-            const auto& slot = slotPair.second;
-            return slot->GetSlotDirection() == GraphModel::SlotDirection::Output;
-        });
+        return !m_outputDataSlots.empty() || !m_outputEventSlots.empty();
     }
 
     bool Node::HasConnections() const
@@ -339,45 +358,47 @@ namespace GraphModel
 
     bool Node::HasInputConnections() const
     {
-        return AZStd::any_of(m_allSlots.begin(), m_allSlots.end(), [](const auto& slotPair) {
+        return AZStd::any_of(m_inputDataSlots.begin(), m_inputDataSlots.end(), [](const auto& slotPair) {
             const auto& slot = slotPair.second;
-            return slot->GetSlotDirection() == GraphModel::SlotDirection::Input && !slot->GetConnections().empty();
+            AZ_Assert(slot->GetSlotDirection() == GraphModel::SlotDirection::Input, "Slots in this container must be input slots.");
+            return !slot->GetConnections().empty();
         });
     }
 
     bool Node::HasOutputConnections() const
     {
-        return AZStd::any_of(m_allSlots.begin(), m_allSlots.end(), [](const auto& slotPair) {
+        return AZStd::any_of(m_outputDataSlots.begin(), m_outputDataSlots.end(), [](const auto& slotPair) {
             const auto& slot = slotPair.second;
-            return slot->GetSlotDirection() == GraphModel::SlotDirection::Output && !slot->GetConnections().empty();
+            AZ_Assert(slot->GetSlotDirection() == GraphModel::SlotDirection::Output, "Slots in this container must be output slots.");
+            return !slot->GetConnections().empty();
         });
     }
 
     bool Node::HasInputConnectionFromNode(ConstNodePtr node) const
     {
-        return AZStd::any_of(m_allSlots.begin(), m_allSlots.end(), [&](const auto& slotPair) {
+         return AZStd::any_of(m_inputDataSlots.begin(), m_inputDataSlots.end(), [&](const auto& slotPair) {
             const auto& slot = slotPair.second;
+            AZ_Assert(slot->GetSlotDirection() == GraphModel::SlotDirection::Input, "Slots in this container must be input slots.");
             const auto& connections = slot->GetConnections();
-            return slot->GetSlotDirection() == GraphModel::SlotDirection::Input &&
-                AZStd::any_of(connections.begin(), connections.end(), [&](const auto& connection) {
-                    AZ_Assert(connection->GetSourceNode().get() != this, "This should never be the source node on an input connection.");
-                    AZ_Assert(connection->GetTargetNode().get() == this, "This should always be the target node on an input connection.");
-                    return connection->GetSourceNode() == node || connection->GetSourceNode()->HasInputConnectionFromNode(node);
-                });
+            return AZStd::any_of(connections.begin(), connections.end(), [&](const auto& connection) {
+                AZ_Assert(connection->GetSourceNode().get() != this, "This should never be the source node on an input connection.");
+                AZ_Assert(connection->GetTargetNode().get() == this, "This should always be the target node on an input connection.");
+                return connection->GetSourceNode() == node || connection->GetSourceNode()->HasInputConnectionFromNode(node);
+            });
         });
     }
 
     bool Node::HasOutputConnectionToNode(ConstNodePtr node) const
     {
-        return AZStd::any_of(m_allSlots.begin(), m_allSlots.end(), [&](const auto& slotPair) {
+        return AZStd::any_of(m_outputDataSlots.begin(), m_outputDataSlots.end(), [&](const auto& slotPair) {
             const auto& slot = slotPair.second;
+            AZ_Assert(slot->GetSlotDirection() == GraphModel::SlotDirection::Output, "Slots in this container must be output slots.");
             const auto& connections = slot->GetConnections();
-            return slot->GetSlotDirection() == GraphModel::SlotDirection::Output &&
-                AZStd::any_of(connections.begin(), connections.end(), [&](const auto& connection) {
-                    AZ_Assert(connection->GetSourceNode().get() == this, "This should always be the source node on an output connection.");
-                    AZ_Assert(connection->GetTargetNode().get() != this, "This should never be the target node on an output connection.");
-                    return connection->GetTargetNode() == node || connection->GetTargetNode()->HasOutputConnectionToNode(node);
-                });
+            return AZStd::any_of(connections.begin(), connections.end(), [&](const auto& connection) {
+                AZ_Assert(connection->GetSourceNode().get() == this, "This should always be the source node on an output connection.");
+                AZ_Assert(connection->GetTargetNode().get() != this, "This should never be the target node on an output connection.");
+                return connection->GetTargetNode() == node || connection->GetTargetNode()->HasOutputConnectionToNode(node);
+            });
         });
     }
 
@@ -450,6 +471,7 @@ namespace GraphModel
             {
                 extendableSlotsIt->second.erase(slot);
             }
+            ClearCachedData();
         }
     }
 
@@ -518,6 +540,7 @@ namespace GraphModel
         m_allSlots.insert(AZStd::make_pair(slot->GetSlotId(), slot));
         currentSlots.insert(slot);
 
+        ClearCachedData();
         return slot;
     }
 

--- a/Gems/GraphModel/Code/Source/Model/Node.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Node.cpp
@@ -376,7 +376,7 @@ namespace GraphModel
 
     bool Node::HasInputConnectionFromNode(ConstNodePtr node) const
     {
-         return AZStd::any_of(m_inputDataSlots.begin(), m_inputDataSlots.end(), [&](const auto& slotPair) {
+        return AZStd::any_of(m_inputDataSlots.begin(), m_inputDataSlots.end(), [&](const auto& slotPair) {
             const auto& slot = slotPair.second;
             AZ_Assert(slot->GetSlotDirection() == GraphModel::SlotDirection::Input, "Slots in this container must be input slots.");
             const auto& connections = slot->GetConnections();


### PR DESCRIPTION
## What does this PR do?

Material canvas does extensive traversing and sorting of nodes for populating the inspector and ordering instructions to generate code. Most accessor functions require looking up data on the graph object, which contains all of the node and connection data, which can be expensive.

This PR reimplements caching that saves parent nodes, connections, and data for some other recursive functions needed during sorting. The data is also protected using mutexes because a subsequent change makes material canvas sort and generate data asynchronously.

There are also minor changes to graph canvas to reserve space and avoid copying data in some places. During a stress test that loads a large graph of hundreds of nodes, it looks like most of the time is going to looking up and applying styles to graph canvas objects. Looking up matching styles is expensive because it copies containers of selector objects that are cloned and reallocated every time the search is done per object. This could be optimized by creating a set of functions that pass in the entity ID to be compared instead of copying the containers.

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Tested loading and editing large graph with hundreds of nodes