### PR TITLE
Scene settings help button

### DIFF
--- a/Code/Tools/SceneAPI/SceneData/Groups/AnimationGroup.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Groups/AnimationGroup.cpp
@@ -159,6 +159,7 @@ namespace AZ
                             ->Attribute("AutoExpand", true)
                             ->Attribute(Edit::Attributes::NameLabelOverride, "")
                             ->Attribute(AZ::Edit::Attributes::CategoryStyle, "display divider")
+                            ->Attribute(AZ::Edit::Attributes::HelpPageURL, "https://www.o3de.org/docs/user-guide/assets/scene-settings/motions-tab/")
                         ->DataElement(AZ_CRC("ManifestName", 0x5215b349), &AnimationGroup::m_name, "Group name",
                             "Name for the group. This name will also be used as the name for the generated file.")
                             ->Attribute("FilterType", DataTypes::IAnimationGroup::TYPEINFO_Uuid())

--- a/Code/Tools/SceneAPI/SceneData/Groups/MeshGroup.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Groups/MeshGroup.cpp
@@ -94,6 +94,7 @@ namespace AZ
                             ->Attribute("AutoExpand", true)
                             ->Attribute(Edit::Attributes::NameLabelOverride, "")
                             ->Attribute(AZ::Edit::Attributes::CategoryStyle, "display divider")
+                            ->Attribute(AZ::Edit::Attributes::HelpPageURL, "https://www.o3de.org/docs/user-guide/assets/scene-settings/meshes-tab/")
                         ->DataElement(AZ_CRC("ManifestName", 0x5215b349), &MeshGroup::m_name, "Name mesh",
                             "Name the mesh as you want it to appear in the Open 3D Engine Asset Browser.")
                             ->Attribute("FilterType", DataTypes::IMeshGroup::TYPEINFO_Uuid())

--- a/Code/Tools/SceneAPI/SceneUI/SceneWidgets/ManifestWidgetPage.h
+++ b/Code/Tools/SceneAPI/SceneUI/SceneWidgets/ManifestWidgetPage.h
@@ -68,8 +68,10 @@ namespace AZ
             protected:
                 //! Callback that's triggered when the add button has multiple entries.
                 virtual void OnMultiGroupAdd(const Uuid& id);
+                virtual void OnHelpButtonClicked();
 
                 virtual void BuildAndConnectAddButton();
+                virtual void BuildHelpButton();
                 
                 virtual AZStd::string ClassIdToName(const Uuid& id) const;
                 virtual void AddNewObject(const Uuid& id);
@@ -99,6 +101,7 @@ namespace AZ
                 AzToolsFramework::ReflectedPropertyEditor* m_propertyEditor;
                 SerializeContext* m_context;
                 size_t m_capSize;
+                QString m_helpUrl;
             };
         } // namespace UI
     } // namespace SceneAPI

--- a/Code/Tools/SceneAPI/SceneUI/SceneWidgets/ManifestWidgetPage.ui
+++ b/Code/Tools/SceneAPI/SceneUI/SceneWidgets/ManifestWidgetPage.ui
@@ -45,6 +45,19 @@
        <number>0</number>
       </property>
       <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
        <widget class="QPushButton" name="m_addButton">
         <property name="maximumSize">
          <size>
@@ -52,10 +65,82 @@
           <height>16777215</height>
          </size>
         </property>
+        <property name="styleSheet">
+         <string notr="true">padding-left: 12px; padding-right: 12px;</string>
+        </property>
+         <property name="minimumSize">
+           <size>
+             <width>10</width>
+             <height>24</height>
+           </size>
+         </property>
         <property name="text">
          <string>Add another</string>
         </property>
        </widget>
+      </item>
+      <item>
+       <spacer name="ButtonSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>8</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="m_supportButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>10</width>
+          <height>10</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>10</width>
+          <height>10</height>
+         </size>
+        </property>
+        <property name="baseSize">
+         <size>
+          <width>10</width>
+          <height>10</height>
+         </size>
+        </property>
+        <property name="icon">
+         <iconset theme=":/Cards/img/UI20/Cards/help.svg"></iconset>
+        </property>
+        <property name="flat">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>

--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Groups/ActorGroup.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Groups/ActorGroup.cpp
@@ -122,6 +122,7 @@ namespace EMotionFX
                             ->Attribute("AutoExpand", true)
                             ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
                             ->Attribute(AZ::Edit::Attributes::CategoryStyle, "display divider")
+                            ->Attribute(AZ::Edit::Attributes::HelpPageURL, "https://www.o3de.org/docs/user-guide/assets/scene-settings/actors-tab/")
                         ->DataElement(AZ_CRC("ManifestName", 0x5215b349), &ActorGroup::m_name, "Name actor",
                             "Name for the group. This name will also be used as the name for the generated file.")
                             ->Attribute("FilterType", IActorGroup::TYPEINFO_Uuid())

--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Groups/MotionGroup.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Groups/MotionGroup.cpp
@@ -105,6 +105,7 @@ namespace EMotionFX
                             ->Attribute("AutoExpand", true)
                             ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
                             ->Attribute(AZ::Edit::Attributes::CategoryStyle, "display divider")
+                            ->Attribute(AZ::Edit::Attributes::HelpPageURL, "https://www.o3de.org/docs/user-guide/assets/scene-settings/motions-tab/")
                         ->DataElement(AZ_CRC("ManifestName", 0x5215b349), &MotionGroup::m_name, "Name motion",
                             "Name for the group. This name will also be used as the name for the generated file.")
                             ->Attribute("FilterType", IMotionGroup::TYPEINFO_Uuid())

--- a/Gems/PhysX/Code/Source/Pipeline/MeshGroup.cpp
+++ b/Gems/PhysX/Code/Source/Pipeline/MeshGroup.cpp
@@ -618,6 +618,7 @@ namespace PhysX
                             ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
                             ->Attribute(AZ::Edit::Attributes::Icon, "Editor/Icons/MeshCollider.svg")
                             ->Attribute(AZ::Edit::Attributes::CategoryStyle, "display divider")
+                            ->Attribute(AZ::Edit::Attributes::HelpPageURL, "https://www.o3de.org/docs/user-guide/assets/scene-settings/physx-tab/")
 
                         ->DataElement(AZ_CRC_CE("ManifestName"), &MeshGroup::m_name, "Name PhysX Mesh",
                             "<span>Name for the group. This name will also be used as a part of the name for the "

--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroup.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroup.cpp
@@ -138,6 +138,8 @@ namespace AZ::SceneAPI::SceneData
                         ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
                         ->Attribute(AZ::Edit::Attributes::Max, 1)
                         ->Attribute(AZ::Edit::Attributes::CategoryStyle, "display divider")
+                        // There isn't a documentation page for default prefabs under the scene settings documentation category, yet.
+                        ->Attribute(AZ::Edit::Attributes::HelpPageURL, "https://www.o3de.org/docs/user-guide/assets/scene-settings/")
                     ->UIElement(AZ::Edit::UIHandlers::MultiLineEdit, "", prefabTooltip)
                         ->Attribute(AZ::Edit::Attributes::ValueText, "The prefab group controls the generation of default procedural prefabs.")
                         ->Attribute(AZ::Edit::Attributes::ReadOnly, true);


### PR DESCRIPTION
## What does this PR do?

Adds a help button to the scene manifest widget page, that links to documentation about the group associated with that page.

![image](https://user-images.githubusercontent.com/4838196/214436854-346f8df8-8bf9-46f0-b59f-7e55895881ad.png)

## How was this PR tested?

Manually tested so far. I'm investigating what our options are for capturing the URL open command in an automated test. That automated test will be a separate PR.
