### PR TITLE
Add an option to upload build artifacts after the build is done

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -824,32 +824,34 @@ def UploadCrashArtifacts(String platform) {
 }
 
 def UploadBuildArtifacts(String workspace, String s3sisUploadParams = "") {
-    dir(workspace) {
-        checkout scm: [
-            $class: 'GitSCM',
-            branches: [[name: '*/configure']],
-            extensions: [
-                [$class: 'AuthorInChangelog'],
-                [$class: 'RelativeTargetDirectory', relativeTargetDir: 's3sis']
-            ],
-            userRemoteConfigs: [[url: "https://github.com/aws-lumberyard/s3sis.git", credentialsId: "${env.GITHUB_USER}"]]
-        ]
-    }
-    dir("${workspace}/s3sis") {
-        if (env.IS_UNIX) {
-            PlatformSh("sudo python3 -m pip install PyGithub", "Installing PyGithub")
-            PlatformSh("sudo python3 setup.py install", "Installing S3SIS")
-        } else {
-            PlatformSh("python3 -m pip install PyGithub", "Installing PyGithub")
-            PlatformSh("python3 setup.py install", "Installing S3SIS")
+    catchError(message: "Error uploading build artifacts (this won't fail the build)", buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
+        dir(workspace) {
+            checkout scm: [
+                $class: 'GitSCM',
+                branches: [[name: '*/configure']],
+                extensions: [
+                    [$class: 'AuthorInChangelog'],
+                    [$class: 'RelativeTargetDirectory', relativeTargetDir: 's3sis']
+                ],
+                userRemoteConfigs: [[url: "https://github.com/aws-lumberyard/s3sis.git", credentialsId: "${env.GITHUB_USER}"]]
+            ]
         }
-        PlatformSh("s3siscli configure", "Configuring S3SIS")
-    }
-    dir("${workspace}/${ENGINE_REPOSITORY_NAME}") {
-        try {
-            PlatformSh("s3siscli upload ${s3sisUploadParams}")
-        } catch (Exception e) {
-            echo "WARN: Failed to upload build artifacts. \n${e}"
+        dir("${workspace}/s3sis") {
+            if (env.IS_UNIX) {
+                PlatformSh("sudo python3 -m pip install PyGithub", "Installing PyGithub")
+                PlatformSh("sudo python3 setup.py install", "Installing S3SIS")
+            } else {
+                PlatformSh("python3 -m pip install PyGithub", "Installing PyGithub")
+                PlatformSh("python3 setup.py install", "Installing S3SIS")
+            }
+            PlatformSh("s3siscli configure", "Configuring S3SIS")
+        }
+        dir("${workspace}/${ENGINE_REPOSITORY_NAME}") {
+            try {
+                PlatformSh("s3siscli upload ${s3sisUploadParams}")
+            } catch (Exception e) {
+                echo "WARN: Failed to upload build artifacts. \n${e}"
+            }
         }
     }
 }

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -823,6 +823,37 @@ def UploadCrashArtifacts(String platform) {
     }
 }
 
+def UploadBuildArtifacts(String workspace, String s3sisUploadParams = "") {
+    dir(workspace) {
+        checkout scm: [
+            $class: 'GitSCM',
+            branches: [[name: '*/configure']],
+            extensions: [
+                [$class: 'AuthorInChangelog'],
+                [$class: 'RelativeTargetDirectory', relativeTargetDir: 's3sis']
+            ],
+            userRemoteConfigs: [[url: "https://github.com/aws-lumberyard/s3sis.git", credentialsId: "${env.GITHUB_USER}"]]
+        ]
+    }
+    dir("${workspace}/s3sis") {
+        if (env.IS_UNIX) {
+            PlatformSh("sudo python3 -m pip install PyGithub", "Installing PyGithub")
+            PlatformSh("sudo python3 setup.py install", "Installing S3SIS")
+        } else {
+            PlatformSh("python3 -m pip install PyGithub", "Installing PyGithub")
+            PlatformSh("python3 setup.py install", "Installing S3SIS")
+        }
+        PlatformSh("s3siscli configure", "Configuring S3SIS")
+    }
+    dir("${workspace}/${ENGINE_REPOSITORY_NAME}") {
+        try {
+            PlatformSh("s3siscli upload ${s3sisUploadParams}")
+        } catch (Exception e) {
+            echo "WARN: Failed to upload build artifacts. \n${e}"
+        }
+    }
+}
+
 def PostBuildCommonSteps(String workspace, Map params, String projectName, String pipelineName, String branchName, String platform, String buildType, boolean mount = true) {
     echo 'Starting post-build common steps...'
     if (params && params.containsKey('OUTPUT_DIRECTORY')){
@@ -940,6 +971,19 @@ def CreateUploadCrashArtifactStage(String jobName, String platform) {
     }
 }
 
+def CreateUploadBuildArtifactStage(String workspace, String jobName, String s3sisUploadParams="") {
+    if(env.S3SIS_UPLOAD_PARAMS?.trim()) {
+        s3sisUploadParams = env.S3SIS_UPLOAD_PARAMS
+    }
+    if(s3sisUploadParams?.trim()) {
+        return {
+            stage("${jobName}_upload_build_artifacts") {
+                UploadBuildArtifacts(workspace, s3sisUploadParams)
+            }
+        }
+    }
+}
+
 def CreateTeardownStage(Map environmentVars, Map params, String projectName, String pipelineName, String branchName, String platformName, String buildType) {
     return {
         stage('Teardown') {
@@ -1025,6 +1069,8 @@ def CreateSingleNode(Map pipelineConfig, def platform, def build_job, Map envVar
                         if (params && params.containsKey('TEST_SCREENSHOTS') && params.TEST_SCREENSHOTS == 'True' && currentResult == 'FAILURE') {
                             CreateExportTestScreenshotsStage(pipelineConfig, branchName, platform.key, build_job_name, envVars, params).call()
                         }
+                        uploadBuildArtifactsStage = CreateUploadBuildArtifactStage(envVars['WORKSPACE'], build_job_name, envVars['S3SIS_UPLOAD_PARAMS'])
+                        if (uploadBuildArtifactsStage) uploadBuildArtifactsStage.call()
                         CreateTeardownStage(envVars, params, projectName, pipelineName, branchName, platform.key, build_job.key).call()
                         if (envVars['CREATE_SNAPSHOT']?.toBoolean()) {
                             CreateSnapshotStage(repositoryName, projectName, pipelineName, branchName, platform.key, build_job.key, build_job_name).call()
@@ -1182,6 +1228,7 @@ try {
                         if (!IsPullRequest(branchName) || IsPeriodicPipeline(pipelineName)) {
                             pipelineParameters.add(stringParam(defaultValue: '', description: 'Filters and overrides the list of jobs to run for each of the below platforms (comma-separated). Can\'t be used during a pull request.', name: 'JOB_LIST_OVERRIDE'))
                             pipelineParameters.add(stringParam(defaultValue: '', description: 'Name of the project to build. Overrides default project', name: 'PROJECT_OVERRIDE'))
+                            pipelineParameters.add(stringParam(defaultValue: '', description: 'S3SIS upload parameters, upload won\'t be performed if this is empty', name: 'S3SIS_UPLOAD_PARAMS'))
                             pipelineConfig.platforms.each { platform ->
                                 pipelineParameters.add(booleanParam(defaultValue: true, description: '', name: platform.key))
                             }

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -825,18 +825,8 @@ def UploadCrashArtifacts(String platform) {
 
 def UploadBuildArtifacts(String workspace, String s3sisUploadParams = "") {
     catchError(message: "Error uploading build artifacts (this won't fail the build)", buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
-        dir(workspace) {
-            checkout scm: [
-                $class: 'GitSCM',
-                branches: [[name: '*/configure']],
-                extensions: [
-                    [$class: 'AuthorInChangelog'],
-                    [$class: 'RelativeTargetDirectory', relativeTargetDir: 's3sis']
-                ],
-                userRemoteConfigs: [[url: "https://github.com/aws-lumberyard/s3sis.git", credentialsId: "${env.GITHUB_USER}"]]
-            ]
-        }
         dir("${workspace}/s3sis") {
+            PlatformSh("aws s3 cp ${env.S3SIS_SOURCE} . --recursive")
             if (env.IS_UNIX) {
                 PlatformSh("sudo python3 setup.py install", "Installing S3SIS")
             } else {

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -823,10 +823,10 @@ def UploadCrashArtifacts(String platform) {
     }
 }
 
-def UploadBuildArtifacts(String workspace, String s3sisUploadParams = "") {
+def UploadBuildArtifacts(String workspace, String platform, String jobName, String s3sisUploadParams = "") {
     catchError(message: "Error uploading build artifacts (this won't fail the build)", buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
         dir("${workspace}/s3sis") {
-            PlatformSh("aws s3 cp ${env.S3SIS_SOURCE} . --recursive")
+            PlatformSh("aws s3 cp ${env.S3SIS_SOURCE} . --recursive", "Downloading s3sis", winSlashReplacement=false)
             if (env.IS_UNIX) {
                 PlatformSh("sudo python3 setup.py install", "Installing S3SIS")
             } else {
@@ -836,7 +836,11 @@ def UploadBuildArtifacts(String workspace, String s3sisUploadParams = "") {
         }
         dir("${workspace}/${ENGINE_REPOSITORY_NAME}") {
             try {
-                PlatformSh("s3siscli upload ${s3sisUploadParams}")
+                def cmd = "s3siscli upload --label ${env.JENKINS_JOB_NAME}/${platform}/${jobName}"
+                if (s3sisUploadParams?.trim()) {
+                    cmd += " ${s3sisUploadParams}"
+                }
+                PlatformSh(cmd, "Uploading build artifacts", winSlashReplacement=false)
             } catch (Exception e) {
                 echo "WARN: Failed to upload build artifacts. \n${e}"
             }
@@ -961,15 +965,13 @@ def CreateUploadCrashArtifactStage(String jobName, String platform) {
     }
 }
 
-def CreateUploadBuildArtifactStage(String workspace, String jobName, String s3sisUploadParams="") {
+def CreateUploadBuildArtifactStage(String workspace, String platform, String jobName, String s3sisUploadParams="") {
     if(env.S3SIS_UPLOAD_PARAMS?.trim()) {
         s3sisUploadParams = env.S3SIS_UPLOAD_PARAMS
     }
-    if(s3sisUploadParams?.trim()) {
-        return {
-            stage("${jobName}_upload_build_artifacts") {
-                UploadBuildArtifacts(workspace, s3sisUploadParams)
-            }
+    return {
+        stage("${jobName}_upload_build_artifacts") {
+            UploadBuildArtifacts(workspace, platform, jobName, s3sisUploadParams)
         }
     }
 }
@@ -1059,8 +1061,9 @@ def CreateSingleNode(Map pipelineConfig, def platform, def build_job, Map envVar
                         if (params && params.containsKey('TEST_SCREENSHOTS') && params.TEST_SCREENSHOTS == 'True' && currentResult == 'FAILURE') {
                             CreateExportTestScreenshotsStage(pipelineConfig, branchName, platform.key, build_job_name, envVars, params).call()
                         }
-                        uploadBuildArtifactsStage = CreateUploadBuildArtifactStage(envVars['WORKSPACE'], build_job_name, envVars['S3SIS_UPLOAD_PARAMS'])
-                        if (uploadBuildArtifactsStage) uploadBuildArtifactsStage.call()
+                        if (env.UPLOAD_BUILD_ARTIFACTS?.toBoolean()) {
+                            CreateUploadBuildArtifactStage(envVars['WORKSPACE'], platform.key, build_job_name, envVars['S3SIS_UPLOAD_PARAMS']).call()
+                        }
                         CreateTeardownStage(envVars, params, projectName, pipelineName, branchName, platform.key, build_job.key).call()
                         if (envVars['CREATE_SNAPSHOT']?.toBoolean()) {
                             CreateSnapshotStage(repositoryName, projectName, pipelineName, branchName, platform.key, build_job.key, build_job_name).call()
@@ -1218,7 +1221,8 @@ try {
                         if (!IsPullRequest(branchName) || IsPeriodicPipeline(pipelineName)) {
                             pipelineParameters.add(stringParam(defaultValue: '', description: 'Filters and overrides the list of jobs to run for each of the below platforms (comma-separated). Can\'t be used during a pull request.', name: 'JOB_LIST_OVERRIDE'))
                             pipelineParameters.add(stringParam(defaultValue: '', description: 'Name of the project to build. Overrides default project', name: 'PROJECT_OVERRIDE'))
-                            pipelineParameters.add(stringParam(defaultValue: '', description: 'S3SIS upload parameters, upload won\'t be performed if this is empty', name: 'S3SIS_UPLOAD_PARAMS'))
+                            pipelineParameters.add(booleanParam(defaultValue: false, description: 'Upload build artifacts to S3.', name: 'UPLOAD_BUILD_ARTIFACTS'),)
+                            pipelineParameters.add(stringParam(defaultValue: '', description: 'Additional S3SIS upload parameters, for example, use --include or --exclude to specify the files to be uploaded.', name: 'S3SIS_UPLOAD_PARAMS'))
                             pipelineConfig.platforms.each { platform ->
                                 pipelineParameters.add(booleanParam(defaultValue: true, description: '', name: platform.key))
                             }

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -836,11 +836,14 @@ def UploadBuildArtifacts(String workspace, String platform, String jobName, Stri
         }
         dir("${workspace}/${ENGINE_REPOSITORY_NAME}") {
             try {
-                def cmd = "s3siscli upload --label ${env.JENKINS_JOB_NAME}/${platform}/${jobName}"
+                def cmd = "s3siscli upload"
                 if (s3sisUploadParams?.trim()) {
                     cmd += " ${s3sisUploadParams}"
                 }
-                PlatformSh(cmd, "Uploading build artifacts", winSlashReplacement=false)
+                current_cmd = cmd + " --label ${env.JENKINS_JOB_NAME}/${platform}/${jobName}/${env.BUILD_NUMBER}"
+                PlatformSh(current_cmd, "Uploading build artifacts", winSlashReplacement=false)
+                latest_cmd = cmd + " --label ${env.JENKINS_JOB_NAME}/${platform}/${jobName}/latest"
+                PlatformSh(latest_cmd, "Uploading build artifacts", winSlashReplacement=false)
             } catch (Exception e) {
                 echo "WARN: Failed to upload build artifacts. \n${e}"
             }

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -838,10 +838,8 @@ def UploadBuildArtifacts(String workspace, String s3sisUploadParams = "") {
         }
         dir("${workspace}/s3sis") {
             if (env.IS_UNIX) {
-                PlatformSh("sudo python3 -m pip install PyGithub", "Installing PyGithub")
                 PlatformSh("sudo python3 setup.py install", "Installing S3SIS")
             } else {
-                PlatformSh("python3 -m pip install PyGithub", "Installing PyGithub")
                 PlatformSh("python3 setup.py install", "Installing S3SIS")
             }
             PlatformSh("s3siscli configure", "Configuring S3SIS")


### PR DESCRIPTION
Signed-off-by: Shirang Jia <shiranj@amazon.com>

## What does this PR do?

Add an option to use S3SIS to upload build artifacts after the build is done.

Use Jenkins build parameter "S3SIS_UPLOAD_PARAMS" or add "S3SIS_UPLOAD_PARAMS" in pipeline environment override in build_config.json to specify s3sis upload parameters. No upload if S3SIS_UPLOAD_PARAMS is not specified.

This allows people to upload build artifacts to S3 from branch builds and periodic builds.

## How was this PR tested?

Tested by uploading MultipleSample build artifacts.
