### PR TITLE
Switch to using a persistent resource for the projected shadow map atlas

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/ProjectedShadowmaps.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ProjectedShadowmaps.pass
@@ -21,7 +21,7 @@
             "ImageAttachments": [
                 {
                     "Name": "ShadowmapImage",
-                    "Lifetime":  "Imported",
+                    "Lifetime":  "Imported"
                 }
             ],
             "Connections": [

--- a/Gems/Atom/Feature/Common/Assets/Passes/ProjectedShadowmaps.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ProjectedShadowmaps.pass
@@ -21,9 +21,7 @@
             "ImageAttachments": [
                 {
                     "Name": "ShadowmapImage",
-                    "ImageDescriptor": {
-                        "Format": "D32_FLOAT"
-                    }
+                    "Lifetime":  "Imported",
                 }
             ],
             "Connections": [


### PR DESCRIPTION
## What does this PR do?

Cached shadows were implemented with the expectation that the shadow maps were persistent resources, however they were not. The fact that they've mostly worked thus far is surprising, but it _is_ possible for the cached shadows to be overwritten by other passes since they're transient resources. This PR updates the resource to be persistent so that the memory won't be stomped on by some other pass.

## How was this PR tested?

Tested using a test level with multiple cameras. Also tested in loft which uses many cached shadows.
