### PR TITLE
Replace EBUS_EVENT style macros in sig-content code

### DIFF
--- a/Code/Editor/Controls/ReflectedPropertyControl/PropertyCtrl.cpp
+++ b/Code/Editor/Controls/ReflectedPropertyControl/PropertyCtrl.cpp
@@ -20,13 +20,20 @@ void RegisterReflectedVarHandlers()
     if (!registered)
     {
         registered = true;
-        EBUS_EVENT(AzToolsFramework::PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew SequencePropertyHandler());
-        EBUS_EVENT(AzToolsFramework::PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew SequenceIdPropertyHandler());
-        EBUS_EVENT(AzToolsFramework::PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew LocalStringPropertyHandler());
-        EBUS_EVENT(AzToolsFramework::PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew LightAnimationPropertyHandler());
-        EBUS_EVENT(AzToolsFramework::PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew UserPopupWidgetHandler());
-        EBUS_EVENT(AzToolsFramework::PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew FloatCurveHandler());
-        EBUS_EVENT(AzToolsFramework::PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew MotionPropertyWidgetHandler());
+        AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew SequencePropertyHandler());
+        AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew SequenceIdPropertyHandler());
+        AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew LocalStringPropertyHandler());
+        AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew LightAnimationPropertyHandler());
+        AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew UserPopupWidgetHandler());
+        AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew FloatCurveHandler());
+        AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew MotionPropertyWidgetHandler());
     }
 }
 

--- a/Code/Editor/Controls/ReflectedPropertyControl/PropertyGenericCtrl.h
+++ b/Code/Editor/Controls/ReflectedPropertyControl/PropertyGenericCtrl.h
@@ -192,10 +192,10 @@ public:
     {
         ListEditWidget* newCtrl = aznew T(pParent);
         connect(newCtrl, &ListEditWidget::ValueChanged, newCtrl, [newCtrl]()
-        {
+            {
                 AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
                     &AzToolsFramework::PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
-        });
+            });
         return newCtrl;
     }
     virtual void ConsumeAttribute(ListEditWidget* GUI, AZ::u32 attrib, AzToolsFramework::PropertyAttributeReader* attrValue, const char* debugName) override {

--- a/Code/Editor/Controls/ReflectedPropertyControl/PropertyGenericCtrl.h
+++ b/Code/Editor/Controls/ReflectedPropertyControl/PropertyGenericCtrl.h
@@ -65,7 +65,8 @@ public:
         GenericPopupPropertyEditor* newCtrl = aznew T(pParent);
         connect(newCtrl, &GenericPopupPropertyEditor::ValueChanged, newCtrl, [newCtrl]()
             {
-                EBUS_EVENT(AzToolsFramework::PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                    &AzToolsFramework::PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
             });
         return newCtrl;
     }
@@ -192,7 +193,8 @@ public:
         ListEditWidget* newCtrl = aznew T(pParent);
         connect(newCtrl, &ListEditWidget::ValueChanged, newCtrl, [newCtrl]()
         {
-            EBUS_EVENT(AzToolsFramework::PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                    &AzToolsFramework::PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
         });
         return newCtrl;
     }

--- a/Code/Editor/Controls/ReflectedPropertyControl/PropertyMiscCtrl.cpp
+++ b/Code/Editor/Controls/ReflectedPropertyControl/PropertyMiscCtrl.cpp
@@ -99,10 +99,10 @@ QWidget* UserPopupWidgetHandler::CreateGUI(QWidget *pParent)
 {
     UserPropertyEditor* newCtrl = aznew UserPropertyEditor(pParent);
     connect(newCtrl, &UserPropertyEditor::ValueChanged, newCtrl, [newCtrl]()
-    {
+        {
             AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
                 &AzToolsFramework::PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
-    });
+        });
 
     return newCtrl;
 }

--- a/Code/Editor/Controls/ReflectedPropertyControl/PropertyMiscCtrl.cpp
+++ b/Code/Editor/Controls/ReflectedPropertyControl/PropertyMiscCtrl.cpp
@@ -100,7 +100,8 @@ QWidget* UserPopupWidgetHandler::CreateGUI(QWidget *pParent)
     UserPropertyEditor* newCtrl = aznew UserPropertyEditor(pParent);
     connect(newCtrl, &UserPropertyEditor::ValueChanged, newCtrl, [newCtrl]()
     {
-        EBUS_EVENT(AzToolsFramework::PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
+            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                &AzToolsFramework::PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
     });
 
     return newCtrl;
@@ -154,7 +155,8 @@ QWidget* FloatCurveHandler::CreateGUI(QWidget *pParent)
 }
 void FloatCurveHandler::OnSplineChange(CSplineCtrl*)
 {
-//    EBUS_EVENT(AzToolsFramework::PropertyEditorGUIMessages::Bus, RequestWrite, splineWidget);
+    //AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+    //    &AzToolsFramework::PropertyEditorGUIMessages::Bus::Events::RequestWrite, splineWidget);
 }
 
 void FloatCurveHandler::ConsumeAttribute(CSplineCtrl *, AZ::u32, AzToolsFramework::PropertyAttributeReader*, const char*)

--- a/Code/Editor/Controls/ReflectedPropertyControl/PropertyMotionCtrl.cpp
+++ b/Code/Editor/Controls/ReflectedPropertyControl/PropertyMotionCtrl.cpp
@@ -19,7 +19,8 @@ QWidget* MotionPropertyWidgetHandler::CreateGUI(QWidget* pParent)
     AzToolsFramework::PropertyAssetCtrl* newCtrl = aznew AzToolsFramework::PropertyAssetCtrl(pParent);
     connect(
         newCtrl, &AzToolsFramework::PropertyAssetCtrl::OnAssetIDChanged, this, [newCtrl]([[maybe_unused]] AZ::Data::AssetId newAssetId) {
-            EBUS_EVENT(AzToolsFramework::PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
+            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                &AzToolsFramework::PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
             AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
                 &AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
         });

--- a/Code/Editor/Controls/ReflectedPropertyControl/ReflectedPropertyCtrl.cpp
+++ b/Code/Editor/Controls/ReflectedPropertyControl/ReflectedPropertyCtrl.cpp
@@ -52,7 +52,7 @@ ReflectedPropertyControl::ReflectedPropertyControl(QWidget *parent /*= nullptr*/
     , m_initialized(false)
     , m_isTwoColumnSection(false)
 {
-    EBUS_EVENT_RESULT(m_serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+    AZ::ComponentApplicationBus::BroadcastResult(m_serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
     AZ_Assert(m_serializeContext, "Serialization context not available");
     qRegisterMetaType<IVariable*>("IVariablePtr");
 

--- a/Code/Editor/Controls/ReflectedPropertyControl/ReflectedVarWrapper.cpp
+++ b/Code/Editor/Controls/ReflectedPropertyControl/ReflectedVarWrapper.cpp
@@ -473,7 +473,8 @@ void ReflectedVarMotionAdapter::SetVariable(IVariable *pVariable)
     m_reflectedVar->m_assetId = AZ::Data::AssetId(guid, subId);
 
     // Lookup Filename by assetId and get the filename part of the description
-    EBUS_EVENT_RESULT(m_reflectedVar->m_motion, AZ::Data::AssetCatalogRequestBus, GetAssetPathById, m_reflectedVar->m_assetId);
+    AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+        m_reflectedVar->m_motion, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, m_reflectedVar->m_assetId);
 }
 
 void ReflectedVarMotionAdapter::SyncReflectedVarToIVar(IVariable *pVariable)
@@ -484,7 +485,8 @@ void ReflectedVarMotionAdapter::SyncReflectedVarToIVar(IVariable *pVariable)
     m_reflectedVar->m_assetId = AZ::Data::AssetId(guid, subId);
 
     // Lookup Filename by assetId and get the filename part of the description
-    EBUS_EVENT_RESULT(m_reflectedVar->m_motion, AZ::Data::AssetCatalogRequestBus, GetAssetPathById, m_reflectedVar->m_assetId);
+    AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+        m_reflectedVar->m_motion, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, m_reflectedVar->m_assetId);
 }
 
 void ReflectedVarMotionAdapter::SyncIVarToReflectedVar(IVariable *pVariable)

--- a/Code/Editor/Core/QtEditorApplication.cpp
+++ b/Code/Editor/Core/QtEditorApplication.cpp
@@ -265,7 +265,7 @@ namespace Editor
     void EditorQtApplication::LoadSettings()
     {
         AZ::SerializeContext* context;
-        EBUS_EVENT_RESULT(context, AZ::ComponentApplicationBus, GetSerializeContext);
+        AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         AZ_Assert(context, "No serialize context");
         char resolvedPath[AZ_MAX_PATH_LEN];
         AZ::IO::FileIOBase::GetInstance()->ResolvePath("@user@/EditorUserSettings.xml", resolvedPath, AZ_MAX_PATH_LEN);
@@ -291,7 +291,7 @@ namespace Editor
         if (m_activatedLocalUserSettings)
         {
             AZ::SerializeContext* context;
-            EBUS_EVENT_RESULT(context, AZ::ComponentApplicationBus, GetSerializeContext);
+            AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
             AZ_Assert(context, "No serialize context");
 
             char resolvedPath[AZ_MAX_PATH_LEN];

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -2194,7 +2194,8 @@ int CCryEditApp::ExitInstance(int exitCode)
     {
         // Ensure component entities are wiped prior to unloading plugins,
         // since components may be implemented in those plugins.
-        EBUS_EVENT(AzToolsFramework::EditorEntityContextRequestBus, ResetEditorContext);
+        AzToolsFramework::EditorEntityContextRequestBus::Broadcast(
+            &AzToolsFramework::EditorEntityContextRequestBus::Events::ResetEditorContext);
 
         // vital, so that the Qt integration can unhook itself!
         m_pEditor->UnloadPlugins();
@@ -2318,11 +2319,11 @@ int CCryEditApp::IdleProcessing(bool bBackgroundUpdate)
         // launcher so this is only needed on windows.
         if (bActive)
         {
-            EBUS_EVENT(AzFramework::WindowsLifecycleEvents::Bus, OnSetFocus);
+            AzFramework::WindowsLifecycleEvents::Bus::Broadcast(&AzFramework::WindowsLifecycleEvents::Bus::Events::OnSetFocus);
         }
         else
         {
-            EBUS_EVENT(AzFramework::WindowsLifecycleEvents::Bus, OnKillFocus);
+            AzFramework::WindowsLifecycleEvents::Bus::Broadcast(&AzFramework::WindowsLifecycleEvents::Bus::Events::OnKillFocus);
         }
     #endif
     }

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -1168,7 +1168,8 @@ void CCryEditApp::InitLevel(const CEditCommandLineInfo& cmdInfo)
         const bool runningPythonScript = cmdInfo.m_bRunPythonScript || cmdInfo.m_bRunPythonTestScript;
 
         AZ::EBusLogicalResult<bool, AZStd::logical_or<bool> > skipStartupUIProcess(false);
-        EBUS_EVENT_RESULT(skipStartupUIProcess, AzToolsFramework::EditorEvents::Bus, SkipEditorStartupUI);
+        AzToolsFramework::EditorEvents::Bus::BroadcastResult(
+            skipStartupUIProcess, &AzToolsFramework::EditorEvents::Bus::Events::SkipEditorStartupUI);
 
         if (!skipStartupUIProcess.value)
         {

--- a/Code/Editor/CryEditDoc.cpp
+++ b/Code/Editor/CryEditDoc.cpp
@@ -881,7 +881,7 @@ bool CCryEditDoc::OnSaveDocument(const QString& lpszPathName)
         // Don't allow saving in AI/Physics mode.
         // Prompt the user to exit Simulation Mode (aka AI/Phyics mode) before saving.
         QWidget* mainWindow = nullptr;
-        EBUS_EVENT_RESULT(mainWindow, AzToolsFramework::EditorRequests::Bus, GetMainWindow);
+        AzToolsFramework::EditorRequests::Bus::BroadcastResult(mainWindow, &AzToolsFramework::EditorRequests::Bus::Events::GetMainWindow);
 
         QMessageBox msgBox(mainWindow);
         msgBox.setText(tr("You must exit AI/Physics mode before saving."));

--- a/Code/Editor/CryEditDoc.cpp
+++ b/Code/Editor/CryEditDoc.cpp
@@ -244,7 +244,8 @@ void CCryEditDoc::DeleteContents()
     GetIEditor()->Notify(eNotify_OnCloseScene);
     CrySystemEventBus::Broadcast(&CrySystemEventBus::Events::OnCryEditorCloseScene);
 
-    EBUS_EVENT(AzToolsFramework::EditorEntityContextRequestBus, ResetEditorContext);
+    AzToolsFramework::EditorEntityContextRequestBus::Broadcast(
+        &AzToolsFramework::EditorEntityContextRequestBus::Events::ResetEditorContext);
 
     //////////////////////////////////////////////////////////////////////////
     // Clear all undo info.

--- a/Code/Editor/CryEditDoc.cpp
+++ b/Code/Editor/CryEditDoc.cpp
@@ -1225,8 +1225,11 @@ bool CCryEditDoc::SaveLevel(const QString& filename)
         AZ::IO::ByteContainerStream<AZStd::vector<char>> entitySaveStream(&entitySaveBuffer);
         {
             AZ_PROFILE_SCOPE(Editor, "CCryEditDoc::SaveLevel Save Entities To Stream");
-            EBUS_EVENT_RESULT(
-                savedEntities, AzToolsFramework::EditorEntityContextRequestBus, SaveToStreamForEditor, entitySaveStream, layerEntities,
+            AzToolsFramework::EditorEntityContextRequestBus::BroadcastResult(
+                savedEntities,
+                &AzToolsFramework::EditorEntityContextRequestBus::Events::SaveToStreamForEditor,
+                entitySaveStream,
+                layerEntities,
                 instancesInLayers);
         }
 
@@ -1480,8 +1483,10 @@ bool CCryEditDoc::LoadEntitiesFromLevel(const QString& levelPakFile)
                     {
                         AZ::IO::ByteContainerStream<AZStd::vector<char>> fileStream(&fileBuffer);
 
-                        EBUS_EVENT_RESULT(
-                            loadedSuccessfully, AzToolsFramework::EditorEntityContextRequestBus, LoadFromStreamWithLayers, fileStream,
+                        AzToolsFramework::EditorEntityContextRequestBus::BroadcastResult(
+                            loadedSuccessfully,
+                            &AzToolsFramework::EditorEntityContextRequestBus::Events::LoadFromStreamWithLayers,
+                            fileStream,
                             levelPakFile);
                     }
                     else

--- a/Code/Editor/EditorPreferencesDialog.cpp
+++ b/Code/Editor/EditorPreferencesDialog.cpp
@@ -51,7 +51,7 @@ EditorPreferencesDialog::EditorPreferencesDialog(QWidget* pParent)
     connect(ui->filter, &FilteredSearchWidget::TextFilterChanged, this, &EditorPreferencesDialog::SetFilter);
 
     AZ::SerializeContext* serializeContext = nullptr;
-    EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+    AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
     AZ_Assert(serializeContext, "Serialization context not available");
 
     static bool bAlreadyRegistered = false;

--- a/Code/Editor/EditorPreferencesTreeWidgetItem.cpp
+++ b/Code/Editor/EditorPreferencesTreeWidgetItem.cpp
@@ -46,7 +46,7 @@ void EditorPreferencesTreeWidgetItem::Setup(IPreferencesPage* page)
     setData(0, Qt::DisplayRole, m_preferencesPage->GetTitle());
 
     AZ::SerializeContext* serializeContext = nullptr;
-    EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+    AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
     AZ_Assert(serializeContext, "Serialization context not available");
 
     // Grab all property names on the page so we can filter by property text by recursing through the hierarchy

--- a/Code/Editor/GameEngine.cpp
+++ b/Code/Editor/GameEngine.cpp
@@ -787,7 +787,7 @@ void CGameEngine::Update()
     }
 
     AZ::ComponentApplication* componentApplication = nullptr;
-    EBUS_EVENT_RESULT(componentApplication, AZ::ComponentApplicationBus, GetApplication);
+    AZ::ComponentApplicationBus::BroadcastResult(componentApplication, &AZ::ComponentApplicationBus::Events::GetApplication);
 
     if (m_bInGameMode)
     {

--- a/Code/Editor/GameEngine.cpp
+++ b/Code/Editor/GameEngine.cpp
@@ -437,7 +437,7 @@ AZ::Outcome<void, AZStd::string> CGameEngine::Init(
     gEnv->pConsole->RemoveCommand("quit");
     REGISTER_COMMAND("quit", CGameEngine::HandleQuitRequest, VF_RESTRICTEDMODE, "Quit/Shutdown the engine");
 
-    EBUS_EVENT(CrySystemEventBus, OnCryEditorInitialized);
+    CrySystemEventBus::Broadcast(&CrySystemEventBus::Events::OnCryEditorInitialized);
 
     return AZ::Success();
 }
@@ -542,7 +542,7 @@ void CGameEngine::SwitchToInGame()
     m_pISystem->GetIMovieSystem()->Reset(true, false);
 
     // Transition to runtime entity context.
-    EBUS_EVENT(AzToolsFramework::EditorEntityContextRequestBus, StartPlayInEditor);
+    AzToolsFramework::EditorEntityContextRequestBus::Broadcast(&AzToolsFramework::EditorEntityContextRequestBus::Events::StartPlayInEditor);
 
     if (!CCryEditApp::instance()->IsInAutotestMode())
     {
@@ -558,7 +558,7 @@ void CGameEngine::SwitchToInGame()
 void CGameEngine::SwitchToInEditor()
 {
     // Transition to editor entity context.
-    EBUS_EVENT(AzToolsFramework::EditorEntityContextRequestBus, StopPlayInEditor);
+    AzToolsFramework::EditorEntityContextRequestBus::Broadcast(&AzToolsFramework::EditorEntityContextRequestBus::Events::StopPlayInEditor);
 
     // Reset movie system
     for (int i = m_pISystem->GetIMovieSystem()->GetNumPlayingSequences(); --i >= 0;)

--- a/Code/Editor/GameExporter.cpp
+++ b/Code/Editor/GameExporter.cpp
@@ -291,7 +291,11 @@ void CGameExporter::ExportLevelData(const QString& path, bool /*bExportMission*/
     AZStd::vector<char> entitySaveBuffer;
     AZ::IO::ByteContainerStream<AZStd::vector<char> > entitySaveStream(&entitySaveBuffer);
     bool savedEntities = false;
-    EBUS_EVENT_RESULT(savedEntities, AzToolsFramework::EditorEntityContextRequestBus, SaveToStreamForGame, entitySaveStream, AZ::DataStream::ST_BINARY);
+    AzToolsFramework::EditorEntityContextRequestBus::BroadcastResult(
+        savedEntities,
+        &AzToolsFramework::EditorEntityContextRequestBus::Events::SaveToStreamForGame,
+        entitySaveStream,
+        AZ::DataStream::ST_BINARY);
     if (savedEntities)
     {
         QString entitiesFile;

--- a/Code/Editor/MainWindow.cpp
+++ b/Code/Editor/MainWindow.cpp
@@ -452,7 +452,7 @@ void MainWindow::InitCentralWidget()
     // make sure the layout wnd knows to reset it's layout and settings
     connect(m_viewPaneManager, &QtViewPaneManager::layoutReset, m_pLayoutWnd, &CLayoutWnd::ResetLayout);
 
-    EBUS_EVENT(AzToolsFramework::EditorEvents::Bus, NotifyCentralWidgetInitialized);
+    AzToolsFramework::EditorEvents::Bus::Broadcast(&AzToolsFramework::EditorEvents::Bus::Events::NotifyCentralWidgetInitialized);
 }
 
 void MainWindow::Initialize()

--- a/Code/Editor/MainWindow.cpp
+++ b/Code/Editor/MainWindow.cpp
@@ -359,7 +359,7 @@ MainWindow::MainWindow(QWidget* parent)
 void MainWindow::SystemTick()
 {
     AZ::ComponentApplication* componentApplication = nullptr;
-    EBUS_EVENT_RESULT(componentApplication, AZ::ComponentApplicationBus, GetApplication);
+    AZ::ComponentApplicationBus::BroadcastResult(componentApplication, &AZ::ComponentApplicationBus::Events::GetApplication);
     if (componentApplication)
     {
         componentApplication->TickSystem();

--- a/Code/Editor/Objects/ObjectManager.cpp
+++ b/Code/Editor/Objects/ObjectManager.cpp
@@ -380,7 +380,8 @@ void CObjectManager::DeleteSelection(CSelectionGroup* pSelection)
         else
         {
             AZ::EntityId id;
-            EBUS_EVENT_ID_RESULT(id, object, AzToolsFramework::ComponentEntityObjectRequestBus, GetAssociatedEntityId);
+            AzToolsFramework::ComponentEntityObjectRequestBus::EventResult(
+                id, object, &AzToolsFramework::ComponentEntityObjectRequestBus::Events::GetAssociatedEntityId);
             if (id.IsValid())
             {
                 selectedComponentEntities.push_back(id);

--- a/Code/Editor/Objects/ObjectManager.cpp
+++ b/Code/Editor/Objects/ObjectManager.cpp
@@ -392,11 +392,13 @@ void CObjectManager::DeleteSelection(CSelectionGroup* pSelection)
     // Delete AZ (component) entities.
     if (QApplication::keyboardModifiers() & Qt::ShiftModifier)
     {
-        EBUS_EVENT(AzToolsFramework::ToolsApplicationRequests::Bus, DeleteEntities, selectedComponentEntities);
+        AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+            &AzToolsFramework::ToolsApplicationRequests::Bus::Events::DeleteEntities, selectedComponentEntities);
     }
     else
     {
-        EBUS_EVENT(AzToolsFramework::ToolsApplicationRequests::Bus, DeleteEntitiesAndAllDescendants, selectedComponentEntities);
+        AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+            &AzToolsFramework::ToolsApplicationRequests::Bus::Events::DeleteEntitiesAndAllDescendants, selectedComponentEntities);
     }
 }
 
@@ -767,7 +769,8 @@ void CObjectManager::UnselectCurrent()
 
     // Unselect all component entities as one bulk operation instead of individually
     AzToolsFramework::EntityIdList selectedEntities;
-    EBUS_EVENT(AzToolsFramework::ToolsApplicationRequests::Bus, SetSelectedEntities, selectedEntities);
+    AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+        &AzToolsFramework::ToolsApplicationRequests::Bus::Events::SetSelectedEntities, selectedEntities);
 
     for (int i = 0; i < m_currSelection->GetCount(); i++)
     {

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/ComponentEntityEditorPlugin.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/ComponentEntityEditorPlugin.cpp
@@ -36,7 +36,7 @@ namespace ComponentEntityEditorPluginInternal
         GetIEditor()->GetClassFactory()->RegisterClass(new CTemplateObjectClassDesc<CComponentEntityObject>("ComponentEntity", "", "", OBJTYPE_AZENTITY, 201, "*.entity"));
 
         AZ::SerializeContext* serializeContext = nullptr;
-        EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         AZ_Assert(serializeContext, "Serialization context not available");
 
         if (serializeContext)

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/Objects/ComponentEntityObject.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/Objects/ComponentEntityObject.cpp
@@ -103,7 +103,8 @@ void CComponentEntityObject::AssignEntity(AZ::Entity* entity, bool destroyOld)
 
         if (destroyOld && m_entityId != newEntityId)
         {
-            EBUS_EVENT(AzToolsFramework::EditorEntityContextRequestBus, DestroyEditorEntity, m_entityId);
+            AzToolsFramework::EditorEntityContextRequestBus::Broadcast(
+                &AzToolsFramework::EditorEntityContextRequestBus::Events::DestroyEditorEntity, m_entityId);
         }
 
         m_entityId.SetInvalid();
@@ -135,7 +136,8 @@ void CComponentEntityObject::AssignEntity(AZ::Entity* entity, bool destroyOld)
             }
         }
 
-        EBUS_EVENT(AzToolsFramework::EditorEntityContextRequestBus, AddRequiredComponents, *entity);
+        AzToolsFramework::EditorEntityContextRequestBus::Broadcast(
+            &AzToolsFramework::EditorEntityContextRequestBus::Events::AddRequiredComponents, *entity);
 
         AZ::TransformNotificationBus::Handler::BusConnect(m_entityId);
         LmbrCentral::RenderBoundsNotificationBus::Handler::BusConnect(m_entityId);
@@ -258,7 +260,8 @@ void CComponentEntityObject::SetHighlight(bool bHighlight)
 
     if (m_entityId.IsValid())
     {
-        EBUS_EVENT(AzToolsFramework::ToolsApplicationRequests::Bus, SetEntityHighlighted, m_entityId, bHighlight);
+        AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+            &AzToolsFramework::ToolsApplicationRequests::Bus::Events::SetEntityHighlighted, m_entityId, bHighlight);
     }
 }
 
@@ -289,7 +292,8 @@ void CComponentEntityObject::AttachChild(CBaseObject* child, bool /*bKeepPos*/)
                 undoBatch.MarkEntityDirty(childEntityId);
             }
 
-            EBUS_EVENT(AzToolsFramework::ToolsApplicationEvents::Bus, InvalidatePropertyDisplay, AzToolsFramework::Refresh_Values);
+            AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
+                &AzToolsFramework::ToolsApplicationEvents::Bus::Events::InvalidatePropertyDisplay, AzToolsFramework::Refresh_Values);
         }
     }
 }
@@ -311,7 +315,8 @@ void CComponentEntityObject::DetachThis(bool /*bKeepPos*/)
             undoBatch.MarkEntityDirty(m_entityId);
         }
 
-        EBUS_EVENT(AzToolsFramework::ToolsApplicationEvents::Bus, InvalidatePropertyDisplay, AzToolsFramework::Refresh_Values);
+        AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
+            &AzToolsFramework::ToolsApplicationEvents::Bus::Events::InvalidatePropertyDisplay, AzToolsFramework::Refresh_Values);
     }
 }
 

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/Objects/ComponentEntityObject.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/Objects/ComponentEntityObject.cpp
@@ -194,7 +194,7 @@ void CComponentEntityObject::SetName(const QString& name)
         EditorActionScope nameChange(m_nameReentryGuard);
 
         AZ::Entity* entity = nullptr;
-        EBUS_EVENT_RESULT(entity, AZ::ComponentApplicationBus, FindEntity, m_entityId);
+        AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, m_entityId);
 
         if (entity)
         {

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/Objects/ComponentEntityObject.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/Objects/ComponentEntityObject.cpp
@@ -712,7 +712,8 @@ XmlNodeRef CComponentEntityObject::Export([[maybe_unused]] const QString& levelP
 CComponentEntityObject* CComponentEntityObject::FindObjectForEntity(AZ::EntityId id)
 {
     CEntityObject* object = nullptr;
-    EBUS_EVENT_ID_RESULT(object, id, AzToolsFramework::ComponentEntityEditorRequestBus, GetSandboxObject);
+    AzToolsFramework::ComponentEntityEditorRequestBus::EventResult(
+        object, id, &AzToolsFramework::ComponentEntityEditorRequestBus::Events::GetSandboxObject);
 
     if (object && (object->GetType() == OBJTYPE_AZENTITY))
     {

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/Objects/ComponentEntityObject.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/Objects/ComponentEntityObject.cpp
@@ -285,7 +285,7 @@ void CComponentEntityObject::AttachChild(CBaseObject* child, bool /*bKeepPos*/)
 
             {
                 AzToolsFramework::ScopedUndoBatch undoBatch("Editor Parent");
-                EBUS_EVENT_ID(childEntityId, AZ::TransformBus, SetParent, m_entityId);
+                AZ::TransformBus::Event(childEntityId, &AZ::TransformBus::Events::SetParent, m_entityId);
                 undoBatch.MarkEntityDirty(childEntityId);
             }
 
@@ -307,7 +307,7 @@ void CComponentEntityObject::DetachThis(bool /*bKeepPos*/)
         if (m_entityId.IsValid())
         {
             AzToolsFramework::ScopedUndoBatch undoBatch("Editor Unparent");
-            EBUS_EVENT_ID(m_entityId, AZ::TransformBus, SetParent, AZ::EntityId());
+            AZ::TransformBus::Event(m_entityId, &AZ::TransformBus::Events::SetParent, AZ::EntityId());
             undoBatch.MarkEntityDirty(m_entityId);
         }
 
@@ -563,7 +563,7 @@ void CComponentEntityObject::InvalidateTM(int nWhyFlags)
         if (m_entityId.IsValid())
         {
             Matrix34 worldTransform = GetWorldTM();
-            EBUS_EVENT_ID(m_entityId, AZ::TransformBus, SetWorldTM, LYTransformToAZTransform(worldTransform));
+            AZ::TransformBus::Event(m_entityId, &AZ::TransformBus::Events::SetWorldTM, LYTransformToAZTransform(worldTransform));
         }
     }
 }

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -1305,7 +1305,8 @@ AZ::EntityId SandboxIntegrationManager::CreateNewEntityAtPosition(const AZ::Vect
             selectionCommand->SetParent(undo.GetUndoBatch());
             selectionCommand.release();
 
-            EBUS_EVENT(AzToolsFramework::ToolsApplicationRequests::Bus, SetSelectedEntities, selection);
+            AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+                &AzToolsFramework::ToolsApplicationRequests::Bus::Events::SetSelectedEntities, selection);
         }
     }
     else
@@ -1375,7 +1376,8 @@ AZStd::string SandboxIntegrationManager::GetLevelName()
 void SandboxIntegrationManager::OnContextReset()
 {
     // Deselect everything.
-    EBUS_EVENT(AzToolsFramework::ToolsApplicationRequests::Bus, SetSelectedEntities, AzToolsFramework::EntityIdList());
+    AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+        &AzToolsFramework::ToolsApplicationRequests::Bus::Events::SetSelectedEntities, AzToolsFramework::EntityIdList());
 
     std::vector<CBaseObject*> objects;
     objects.reserve(128);

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -1754,8 +1754,8 @@ void SandboxIntegrationManager::ContextMenu_SelectSlice()
         }
     }
 
-    EBUS_EVENT(AzToolsFramework::ToolsApplicationRequests::Bus,
-        SetSelectedEntities, newSelectedEntities);
+    AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+        &AzToolsFramework::ToolsApplicationRequests::Bus::Events::SetSelectedEntities, newSelectedEntities);
 }
 
 void SandboxIntegrationManager::ContextMenu_PushEntitiesToSlice(AzToolsFramework::EntityIdList entities,
@@ -1793,9 +1793,8 @@ void SandboxIntegrationManager::ContextMenu_ResetToSliceDefaults(AzToolsFramewor
 
 void SandboxIntegrationManager::GetSelectedEntities(AzToolsFramework::EntityIdList& entities)
 {
-    EBUS_EVENT_RESULT(entities,
-        AzToolsFramework::ToolsApplicationRequests::Bus,
-        GetSelectedEntities);
+    AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
+        entities, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::GetSelectedEntities);
 }
 
 void SandboxIntegrationManager::GetSelectedOrHighlightedEntities(AzToolsFramework::EntityIdList& entities)
@@ -1803,13 +1802,11 @@ void SandboxIntegrationManager::GetSelectedOrHighlightedEntities(AzToolsFramewor
     AzToolsFramework::EntityIdList selectedEntities;
     AzToolsFramework::EntityIdList highlightedEntities;
 
-    EBUS_EVENT_RESULT(selectedEntities,
-        AzToolsFramework::ToolsApplicationRequests::Bus,
-        GetSelectedEntities);
+    AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
+        selectedEntities, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::GetSelectedEntities);
 
-    EBUS_EVENT_RESULT(highlightedEntities,
-        AzToolsFramework::ToolsApplicationRequests::Bus,
-        GetHighlightedEntities);
+    AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
+        highlightedEntities, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::GetHighlightedEntities);
 
     entities = AZStd::move(selectedEntities);
 

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -430,7 +430,8 @@ DisplayContext* SandboxIntegrationManager::GetDC()
 void SandboxIntegrationManager::OnBeginUndo([[maybe_unused]] const char* label)
 {
     AzToolsFramework::UndoSystem::URSequencePoint* currentBatch = nullptr;
-    EBUS_EVENT_RESULT(currentBatch, AzToolsFramework::ToolsApplicationRequests::Bus, GetCurrentUndoBatch);
+    AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
+        currentBatch, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::GetCurrentUndoBatch);
 
     AZ_Assert(currentBatch, "No undo batch is active.");
 
@@ -993,7 +994,8 @@ void SandboxIntegrationManager::SetupSliceContextMenu_Modify(QMenu* menu, const 
 
     // Gather the set of relevant entities from the selected entities and all descendants
     AzToolsFramework::EntityIdSet relevantEntitiesSet;
-    EBUS_EVENT_RESULT(relevantEntitiesSet, AzToolsFramework::ToolsApplicationRequests::Bus, GatherEntitiesAndAllDescendents, selectedEntities);
+    AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
+        relevantEntitiesSet, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::GatherEntitiesAndAllDescendents, selectedEntities);
     AzToolsFramework::EntityIdList relevantEntities;
     relevantEntities.reserve(relevantEntitiesSet.size());
     for (AZ::EntityId& id : relevantEntitiesSet)
@@ -1763,7 +1765,7 @@ void SandboxIntegrationManager::ContextMenu_PushEntitiesToSlice(AzToolsFramework
     (void)affectEntireHierarchy;
 
     AZ::SerializeContext* serializeContext = nullptr;
-    EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+    AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
     AZ_Assert(serializeContext, "No serialize context");
 
     AzToolsFramework::SliceUtilities::PushEntitiesModal(GetMainWindow(), entities, serializeContext);
@@ -1843,7 +1845,7 @@ AZStd::string SandboxIntegrationManager::GetComponentIconPath(const AZ::Uuid& co
     AZStd::string iconPath;
 
     AZ::SerializeContext* serializeContext = nullptr;
-    EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+    AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
     AZ_Assert(serializeContext, "No serialize context");
 
     auto classData = serializeContext->FindClassData(componentType);

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -1063,7 +1063,8 @@ bool SandboxIntegrationManager::DestroyEditorRepresentation(AZ::EntityId entityI
     if (editor->GetObjectManager())
     {
         CEntityObject* object = nullptr;
-        EBUS_EVENT_ID_RESULT(object, entityId, AzToolsFramework::ComponentEntityEditorRequestBus, GetSandboxObject);
+        AzToolsFramework::ComponentEntityEditorRequestBus::EventResult(
+            object, entityId, &AzToolsFramework::ComponentEntityEditorRequestBus::Events::GetSandboxObject);
 
         if (object && (object->GetType() == OBJTYPE_AZENTITY))
         {

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.cpp
@@ -105,7 +105,7 @@ AssetCatalogModel::AssetCatalogModel(QObject* parent)
     AZStd::vector<AZ::Data::AssetType> assetTypes;
     //  Discover all types that the Asset system recognizes.
     //  Create a one-to-many map that associates extensions with AssetTypes.
-    EBUS_EVENT(AZ::Data::AssetCatalogRequestBus, GetHandledAssetTypes, assetTypes);
+    AZ::Data::AssetCatalogRequestBus::Broadcast(&AZ::Data::AssetCatalogRequestBus::Events::GetHandledAssetTypes, assetTypes);
     for (auto type : assetTypes)
     {
         AZStd::vector<AZStd::string> extensions;
@@ -212,7 +212,8 @@ AZ::Data::AssetType AssetCatalogModel::GetAssetType(const QString &filename) con
 
         //  There are multiple types with this extension. Search for a handler that can handle this data type.
         AZStd::string azFilename = filename.toStdString().c_str();
-        EBUS_EVENT(AzFramework::ApplicationRequests::Bus, MakePathAssetRootRelative, azFilename);
+        AzFramework::ApplicationRequests::Bus::Broadcast(
+            &AzFramework::ApplicationRequests::Bus::Events::MakePathAssetRootRelative, azFilename);
         AZ::Data::AssetId assetId;
         AZ::Data::AssetCatalogRequestBus::BroadcastResult(
             assetId, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetIdByPath, azFilename.c_str(), AZ::Data::s_invalidAssetType, false);
@@ -464,7 +465,7 @@ void AssetCatalogModel::LoadDatabase()
             Q_EMIT SetTotalProgress(static_cast<int>(m_fileCache.size()));
         };
 
-    EBUS_EVENT(AZ::Data::AssetCatalogRequestBus, EnumerateAssets, startCB, enumerateCB, endCB);
+    AZ::Data::AssetCatalogRequestBus::Broadcast(&AZ::Data::AssetCatalogRequestBus::Events::EnumerateAssets, startCB, enumerateCB, endCB);
 
     AzFramework::AssetCatalogEventBus::Handler::BusConnect();
 

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.cpp
@@ -135,7 +135,7 @@ AssetCatalogModel::AssetCatalogModel(QObject* parent)
     }
 
     AZ::SerializeContext* serializeContext = nullptr;
-    EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+    AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
     AZ_Assert(serializeContext, "Failed to acquire application serialize context.");
 
     serializeContext->EnumerateDerived<AZ::Component>([this](const AZ::SerializeContext::ClassData* classData, const AZ::Uuid&) -> bool
@@ -214,7 +214,8 @@ AZ::Data::AssetType AssetCatalogModel::GetAssetType(const QString &filename) con
         AZStd::string azFilename = filename.toStdString().c_str();
         EBUS_EVENT(AzFramework::ApplicationRequests::Bus, MakePathAssetRootRelative, azFilename);
         AZ::Data::AssetId assetId;
-        EBUS_EVENT_RESULT(assetId, AZ::Data::AssetCatalogRequestBus, GetAssetIdByPath, azFilename.c_str(), AZ::Data::s_invalidAssetType, false);
+        AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+            assetId, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetIdByPath, azFilename.c_str(), AZ::Data::s_invalidAssetType, false);
 
         for (const AZ::Uuid& type : pair.second)
         {
@@ -507,7 +508,7 @@ void AssetCatalogModel::StopProcessingAssets()
 void AssetCatalogModel::OnCatalogAssetAdded(const AZ::Data::AssetId& assetId)
 {
     AZ::Data::AssetInfo assetInfo;
-    EBUS_EVENT_RESULT(assetInfo, AZ::Data::AssetCatalogRequestBus, GetAssetInfoById, assetId);
+    AZ::Data::AssetCatalogRequestBus::BroadcastResult(assetInfo, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetInfoById, assetId);
 
     // note that this will get called twice, once with the real assetId and once with legacy assetId.
     // we only want to add the real asset to the list, in which the assetId passed in is equal to the final assetId returned

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.cpp
@@ -110,7 +110,7 @@ AssetCatalogModel::AssetCatalogModel(QObject* parent)
     {
         AZStd::vector<AZStd::string> extensions;
         allExtensions.clear();
-        EBUS_EVENT_ID(type, AZ::AssetTypeInfoBus, GetAssetTypeExtensions, extensions);
+        AZ::AssetTypeInfoBus::Event(type, &AZ::AssetTypeInfoBus::Events::GetAssetTypeExtensions, extensions);
         for (int i = 0; i < extensions.size(); i++)
         {
             if (i > 0)

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerListModel.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerListModel.cpp
@@ -601,7 +601,9 @@ bool OutlinerListModel::setData(const QModelIndex& index, const QVariant& value,
                         entity->SetName(newName);
                         undo.MarkEntityDirty(entity->GetId());
 
-                        EBUS_EVENT(AzToolsFramework::ToolsApplicationEvents::Bus, InvalidatePropertyDisplay, AzToolsFramework::Refresh_EntireTree);
+                        AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
+                            &AzToolsFramework::ToolsApplicationEvents::Bus::Events::InvalidatePropertyDisplay,
+                            AzToolsFramework::Refresh_EntireTree);
                     }
                 }
                 else
@@ -1225,7 +1227,8 @@ bool OutlinerListModel::ReparentEntities(const AZ::EntityId& newParentId, const 
     // reselect the entities to ensure they're visible if appropriate
     AzToolsFramework::ToolsApplicationRequestBus::Broadcast(&AzToolsFramework::ToolsApplicationRequests::SetSelectedEntities, processedEntityIds);
 
-    EBUS_EVENT(AzToolsFramework::ToolsApplicationEvents::Bus, InvalidatePropertyDisplay, AzToolsFramework::Refresh_Values);
+    AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
+        &AzToolsFramework::ToolsApplicationEvents::Bus::Events::InvalidatePropertyDisplay, AzToolsFramework::Refresh_Values);
     return true;
 }
 

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerListModel.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerListModel.cpp
@@ -1173,7 +1173,7 @@ bool OutlinerListModel::ReparentEntities(const AZ::EntityId& newParentId, const 
             else
             {
                 //  Guarding this to prevent the entity from being marked dirty when the parent doesn't change.
-                EBUS_EVENT_ID(entityId, AZ::TransformBus, SetParent, newParentId);
+                AZ::TransformBus::Event(entityId, &AZ::TransformBus::Events::SetParent, newParentId);
             }
 
             // The old parent is dirty due to sort change

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerListModel.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerListModel.cpp
@@ -988,7 +988,8 @@ bool OutlinerListModel::DropMimeDataAssets(const QMimeData* data, [[maybe_unused
         if (createdNewEntity && &pair == &componentAssetPairs.front())
         {
             AZStd::string assetPath;
-            EBUS_EVENT_RESULT(assetPath, AZ::Data::AssetCatalogRequestBus, GetAssetPathById, assetId);
+            AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+                assetPath, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, assetId);
             if (!assetPath.empty())
             {
                 AZStd::string entityName;
@@ -1068,7 +1069,8 @@ bool OutlinerListModel::CanReparentEntities(const AZ::EntityId& newParentId, con
         }
 
         bool isEntityEditable = true;
-        EBUS_EVENT_RESULT(isEntityEditable, AzToolsFramework::ToolsApplicationRequests::Bus, IsEntityEditable, entityId);
+        AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
+            isEntityEditable, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::IsEntityEditable, entityId);
         if (!isEntityEditable)
         {
             return false;

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerListModel.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerListModel.cpp
@@ -1163,7 +1163,7 @@ bool OutlinerListModel::ReparentEntities(const AZ::EntityId& newParentId, const 
         for (AZ::EntityId entityId : selectedEntityIds)
         {
             AZ::EntityId oldParentId;
-            EBUS_EVENT_ID_RESULT(oldParentId, entityId, AZ::TransformBus, GetParentId);
+            AZ::TransformBus::EventResult(oldParentId, entityId, &AZ::TransformBus::Events::GetParentId);
 
             if (oldParentId != newParentId
                 && AzToolsFramework::SliceUtilities::IsReparentNonTrivial(entityId, newParentId))

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerWidget.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerWidget.cpp
@@ -721,7 +721,8 @@ void OutlinerWidget::DoShowSlice()
         QString commonSliceName = FindCommonSliceAssetName(m_selectedEntityIds);
         if (!commonSliceName.isEmpty())
         {
-            EBUS_EVENT(AzToolsFramework::ToolsApplicationEvents::Bus, ShowAssetInBrowser, commonSliceName.toStdString().c_str());
+            AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
+                &AzToolsFramework::ToolsApplicationEvents::Bus::Events::ShowAssetInBrowser, commonSliceName.toStdString().c_str());
         }
     }
 }
@@ -735,7 +736,7 @@ void OutlinerWidget::DoDuplicateSelection()
         AzToolsFramework::ScopedUndoBatch undo("Duplicate Entity(s)");
 
         bool handled = false;
-        EBUS_EVENT(AzToolsFramework::EditorRequests::Bus, CloneSelection, handled);
+        AzToolsFramework::EditorRequests::Bus::Broadcast(&AzToolsFramework::EditorRequests::Bus::Events::CloneSelection, handled);
     }
 }
 
@@ -743,7 +744,7 @@ void OutlinerWidget::DoDeleteSelection()
 {
     PrepareSelection();
 
-    EBUS_EVENT(AzToolsFramework::EditorRequests::Bus, DeleteSelectedEntities, false);
+    AzToolsFramework::EditorRequests::Bus::Broadcast(&AzToolsFramework::EditorRequests::Bus::Events::DeleteSelectedEntities, false);
 
     PrepareSelection();
 }
@@ -752,7 +753,7 @@ void OutlinerWidget::DoDeleteSelectionAndDescendants()
 {
     PrepareSelection();
 
-    EBUS_EVENT(AzToolsFramework::EditorRequests::Bus, DeleteSelectedEntities, true);
+    AzToolsFramework::EditorRequests::Bus::Broadcast(&AzToolsFramework::EditorRequests::Bus::Events::DeleteSelectedEntities, true);
 
     PrepareSelection();
 }

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerWidget.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerWidget.cpp
@@ -248,7 +248,7 @@ OutlinerWidget::OutlinerWidget(QWidget* pParent, Qt::WindowFlags flags)
     connect(m_gui->m_searchWidget, &AzQtComponents::FilteredSearchWidget::TypeFilterChanged, this, &OutlinerWidget::OnFilterChanged);
 
     AZ::SerializeContext* serializeContext = nullptr;
-    EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+    AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
     if (serializeContext)
     {
@@ -533,7 +533,8 @@ void OutlinerWidget::contextMenuEvent(QContextMenuEvent* event)
     AZ_PROFILE_FUNCTION(Editor);
 
     bool isDocumentOpen = false;
-    EBUS_EVENT_RESULT(isDocumentOpen, AzToolsFramework::EditorRequests::Bus, IsLevelDocumentOpen);
+    AzToolsFramework::EditorRequests::Bus::BroadcastResult(
+        isDocumentOpen, &AzToolsFramework::EditorRequests::Bus::Events::IsLevelDocumentOpen);
     if (!isDocumentOpen)
     {
         return;
@@ -672,7 +673,8 @@ QString OutlinerWidget::FindCommonSliceAssetName(const AZStd::vector<AZ::EntityI
 AzFramework::EntityContextId OutlinerWidget::GetPickModeEntityContextId()
 {
     AzFramework::EntityContextId editorEntityContextId = AzFramework::EntityContextId::CreateNull();
-    EBUS_EVENT_RESULT(editorEntityContextId, AzToolsFramework::EditorRequests::Bus, GetEntityContextId);
+    AzToolsFramework::EditorRequests::Bus::BroadcastResult(
+        editorEntityContextId, &AzToolsFramework::EditorRequests::Bus::Events::GetEntityContextId);
 
     return editorEntityContextId;
 }
@@ -680,7 +682,8 @@ AzFramework::EntityContextId OutlinerWidget::GetPickModeEntityContextId()
 void OutlinerWidget::PrepareSelection()
 {
     m_selectedEntityIds.clear();
-    EBUS_EVENT_RESULT(m_selectedEntityIds, AzToolsFramework::ToolsApplicationRequests::Bus, GetSelectedEntities);
+    AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
+        m_selectedEntityIds, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::GetSelectedEntities);
 }
 
 void OutlinerWidget::DoCreateEntity()
@@ -705,7 +708,8 @@ void OutlinerWidget::DoCreateEntityWithParent(const AZ::EntityId& parentId)
     PrepareSelection();
 
     AZ::EntityId entityId;
-    EBUS_EVENT_RESULT(entityId, AzToolsFramework::EditorRequests::Bus, CreateNewEntity, parentId);
+    AzToolsFramework::EditorRequests::Bus::BroadcastResult(
+        entityId, &AzToolsFramework::EditorRequests::Bus::Events::CreateNewEntity, parentId);
 }
 
 void OutlinerWidget::DoShowSlice()

--- a/Code/Editor/Plugins/EditorAssetImporter/AssetBrowserContextProvider.cpp
+++ b/Code/Editor/Plugins/EditorAssetImporter/AssetBrowserContextProvider.cpp
@@ -32,7 +32,8 @@ namespace AZ
     bool AssetBrowserContextProvider::HandlesSource(const AzToolsFramework::AssetBrowser::SourceAssetBrowserEntry* entry) const
     {
         AZStd::unordered_set<AZStd::string> extensions;
-        EBUS_EVENT(AZ::SceneAPI::Events::AssetImportRequestBus, GetSupportedFileExtensions, extensions);
+        AZ::SceneAPI::Events::AssetImportRequestBus::Broadcast(
+            &AZ::SceneAPI::Events::AssetImportRequestBus::Events::GetSupportedFileExtensions, extensions);
         if (extensions.empty())
         {
             return false;
@@ -84,7 +85,8 @@ namespace AZ
         {
             // this does include the "." in the extension.
             AZStd::unordered_set<AZStd::string> extensions;
-            EBUS_EVENT(AZ::SceneAPI::Events::AssetImportRequestBus, GetSupportedFileExtensions, extensions);
+            AZ::SceneAPI::Events::AssetImportRequestBus::Broadcast(
+                &AZ::SceneAPI::Events::AssetImportRequestBus::Events::GetSupportedFileExtensions, extensions);
             for (AZStd::string potentialExtension : extensions)
             {
                 if (AzFramework::StringFunc::Equal(extensionString.c_str(), potentialExtension.c_str()))

--- a/Code/Editor/Plugins/EditorAssetImporter/AssetImporterWindow.cpp
+++ b/Code/Editor/Plugins/EditorAssetImporter/AssetImporterWindow.cpp
@@ -180,7 +180,8 @@ void AssetImporterWindow::Init()
 
     // Filling the initial browse prompt text to be programmatically set from available extensions
     AZStd::unordered_set<AZStd::string> extensions;
-    EBUS_EVENT(AZ::SceneAPI::Events::AssetImportRequestBus, GetSupportedFileExtensions, extensions);
+    AZ::SceneAPI::Events::AssetImportRequestBus::Broadcast(
+        &AZ::SceneAPI::Events::AssetImportRequestBus::Events::GetSupportedFileExtensions, extensions);
     AZ_Error(AZ::SceneAPI::Utilities::ErrorWindow, !extensions.empty(), "No file extensions defined for assets.");
     if (!extensions.empty())
     {

--- a/Code/Editor/Plugins/EditorAssetImporter/AssetImporterWindow.cpp
+++ b/Code/Editor/Plugins/EditorAssetImporter/AssetImporterWindow.cpp
@@ -142,7 +142,7 @@ void AssetImporterWindow::closeEvent(QCloseEvent* ev)
 void AssetImporterWindow::Init()
 {
     // Serialization and reflection framework setup
-    EBUS_EVENT_RESULT(m_serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+    AZ::ComponentApplicationBus::BroadcastResult(m_serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
     AZ_Assert(m_serializeContext, "Serialization context not available");
 
     // Load the style sheets
@@ -433,8 +433,12 @@ void AssetImporterWindow::OnSceneResetRequested()
             m_assetImporterDocument->GetScene()->GetManifest().Clear();
 
             AZ::SceneAPI::Events::ProcessingResultCombiner result;
-            EBUS_EVENT_RESULT(result, AssetImportRequestBus, UpdateManifest, *m_assetImporterDocument->GetScene(),
-                AssetImportRequest::ManifestAction::ConstructDefault, AssetImportRequest::RequestingApplication::Editor);
+            AssetImportRequestBus::BroadcastResult(
+                result,
+                &AssetImportRequestBus::Events::UpdateManifest,
+                *m_assetImporterDocument->GetScene(),
+                AssetImportRequest::ManifestAction::ConstructDefault,
+                AssetImportRequest::RequestingApplication::Editor);
 
             // Specifically using success, because ignore would be an invalid case.
             // Whenever we do construct default, it should always be done

--- a/Code/Editor/Plugins/ProjectSettingsTool/PropertyFuncValBrowseEdit.cpp
+++ b/Code/Editor/Plugins/ProjectSettingsTool/PropertyFuncValBrowseEdit.cpp
@@ -44,7 +44,8 @@ namespace ProjectSettingsTool
         connect(m_browseEdit, &AzQtComponents::BrowseEdit::textChanged, this, &PropertyFuncValBrowseEditCtrl::ValidateAndShowErrors);
         connect(m_browseEdit, &AzQtComponents::BrowseEdit::textChanged, this, [this]([[maybe_unused]] const QString& text)
             {
-                EBUS_EVENT(AzToolsFramework::PropertyEditorGUIMessages::Bus, RequestWrite, this);
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                    &AzToolsFramework::PropertyEditorGUIMessages::Bus::Events::RequestWrite, this);
             });
     }
 

--- a/Code/Editor/Plugins/ProjectSettingsTool/PropertyFuncValLineEdit.cpp
+++ b/Code/Editor/Plugins/ProjectSettingsTool/PropertyFuncValLineEdit.cpp
@@ -24,7 +24,8 @@ namespace ProjectSettingsTool
         connect(m_pLineEdit, &QLineEdit::textChanged, this, &PropertyFuncValLineEditCtrl::ValidateAndShowErrors);
         connect(m_pLineEdit, &QLineEdit::textChanged, this, [this]([[maybe_unused]] const QString& text)
             {
-                EBUS_EVENT(AzToolsFramework::PropertyEditorGUIMessages::Bus, RequestWrite, this);
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                    &AzToolsFramework::PropertyEditorGUIMessages::Bus::Events::RequestWrite, this);
             });
     }
 

--- a/Code/Editor/TrackView/AssetBlendKeyUIControls.cpp
+++ b/Code/Editor/TrackView/AssetBlendKeyUIControls.cpp
@@ -111,7 +111,8 @@ void CAssetBlendKeyUIControls::OnUIChange(IVariable* pVar, CTrackViewKeyBundle& 
 
                     // Lookup Filename by assetId and get the filename part of the description
                     AZStd::string assetPath;
-                    EBUS_EVENT_RESULT(assetPath, AZ::Data::AssetCatalogRequestBus, GetAssetPathById, assetBlendKey.m_assetId);
+                    AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+                        assetPath, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, assetBlendKey.m_assetId);
 
                     assetBlendKey.m_description = "";
                     if (!assetPath.empty())

--- a/Code/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Editor/TrackView/TrackViewNodes.cpp
@@ -402,7 +402,7 @@ CTrackViewNodesCtrl::CTrackViewNodesCtrl(QWidget* hParentWnd, CTrackViewDialog* 
     ///////////////////////////////////////////////////////////////
     // Populate m_componentTypeToIconMap with all component icons
     AZ::SerializeContext* serializeContext = nullptr;
-    EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+    AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
     AZ_Assert(serializeContext, "Failed to acquire serialize context.");
 
     serializeContext->EnumerateDerived<AZ::Component>([this](const AZ::SerializeContext::ClassData* classData, const AZ::Uuid&) -> bool

--- a/Code/Editor/TrackView/TrackViewSequence.cpp
+++ b/Code/Editor/TrackView/TrackViewSequence.cpp
@@ -1569,7 +1569,7 @@ CTrackViewSequence* CTrackViewSequence::LookUpSequenceByEntityId(const AZ::Entit
     CTrackViewSequence* sequence = nullptr;
 
     IEditor* editor = nullptr;
-    EBUS_EVENT_RESULT(editor, AzToolsFramework::EditorRequests::Bus, GetEditor);
+    AzToolsFramework::EditorRequests::Bus::BroadcastResult(editor, &AzToolsFramework::EditorRequests::Bus::Events::GetEditor);
     if (editor)
     {
         ITrackViewSequenceManager* sequenceManager = editor->GetSequenceManager();

--- a/Code/Editor/TrackView/TrackViewSequenceManager.cpp
+++ b/Code/Editor/TrackView/TrackViewSequenceManager.cpp
@@ -151,12 +151,13 @@ void CTrackViewSequenceManager::CreateSequence(QString name, [[maybe_unused]] Se
     AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(selectedEntities, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::GetSelectedEntities);
 
     AZ::EntityId newEntityId;   // initialized with InvalidEntityId
-    EBUS_EVENT_RESULT(newEntityId, AzToolsFramework::EditorRequests::Bus, CreateNewEntity, AZ::EntityId());
+    AzToolsFramework::EditorRequests::Bus::BroadcastResult(
+        newEntityId, &AzToolsFramework::EditorRequests::Bus::Events::CreateNewEntity, AZ::EntityId());
     if (newEntityId.IsValid())
     {
         // set the entity name
         AZ::Entity* entity = nullptr;
-        EBUS_EVENT_RESULT(entity, AZ::ComponentApplicationBus, FindEntity, newEntityId);
+        AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, newEntityId);
         if (entity)
         {
             entity->SetName(static_cast<const char*>(name.toUtf8().data()));

--- a/Code/Editor/Util/PathUtil.cpp
+++ b/Code/Editor/Util/PathUtil.cpp
@@ -307,7 +307,11 @@ namespace Path
         bool relPathFound = false;
         AZStd::string relativePath;
         AZStd::string fullAssetPath(fullPath.toUtf8().data());
-        EBUS_EVENT_RESULT(relPathFound, AzToolsFramework::AssetSystemRequestBus, GetRelativeProductPathFromFullSourceOrProductPath, fullAssetPath, relativePath);
+        AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+            relPathFound,
+            &AzToolsFramework::AssetSystemRequestBus::Events::GetRelativeProductPathFromFullSourceOrProductPath,
+            fullAssetPath,
+            relativePath);
 
         if (relPathFound)
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
@@ -629,7 +629,9 @@ namespace AzToolsFramework
             {
                 AZ::EBusConnectionPolicy<Bus>::Connect(busPtr, context, handler, connectLock, id);
                 EntityIdList selectedEntities;
-                EBUS_EVENT_RESULT(selectedEntities, ToolsApplicationRequests::Bus, GetSelectedEntities);
+                ToolsApplicationRequests::Bus::BroadcastResult(
+                    selectedEntities,
+                    &ToolsApplicationRequests::Bus::Events::GetSelectedEntities);
                 if (AZStd::find(selectedEntities.begin(), selectedEntities.end(), id) != selectedEntities.end())
                 {
                     handler->OnSelected();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -810,7 +810,7 @@ namespace AzToolsFramework
             output.insert(id);
 
             tempList.clear();
-            EBUS_EVENT_ID_RESULT(tempList, id, AZ::TransformBus, GetAllDescendants);
+            AZ::TransformBus::EventResult(tempList, id, &AZ::TransformBus::Events::GetAllDescendants);
             output.insert(tempList.begin(), tempList.end());
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -177,7 +177,7 @@ namespace AzToolsFramework
 
             if (createdUndo)
             {
-                EBUS_EVENT(ToolsApplicationRequests::Bus, EndUndoBatch);
+                ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::Bus::Events::EndUndoBatch);
             }
         }
 
@@ -488,7 +488,7 @@ namespace AzToolsFramework
 
         if (result)
         {
-            EBUS_EVENT(ToolsApplicationEvents::Bus, EntityRegistered, entity->GetId());
+            ToolsApplicationEvents::Bus::Broadcast(&ToolsApplicationEvents::Bus::Events::EntityRegistered, entity->GetId());
         }
 
         return result;
@@ -507,7 +507,7 @@ namespace AzToolsFramework
         MarkEntityDeselected(entity->GetId());
         SetEntityHighlighted(entity->GetId(), false);
 
-        EBUS_EVENT(ToolsApplicationEvents::Bus, EntityDeregistered, entity->GetId());
+        ToolsApplicationEvents::Bus::Broadcast(&ToolsApplicationEvents::Bus::Events::EntityDeregistered, entity->GetId());
 
         {
             AZ_PROFILE_SCOPE(AzToolsFramework, "ToolsApplication::RemoveEntity:CallApplicationRemoveEntity");
@@ -1451,9 +1451,9 @@ namespace AzToolsFramework
             if (m_undoStack->CanUndo())
             {
                 m_isDuringUndoRedo = true;
-                EBUS_EVENT(ToolsApplicationEvents::Bus, BeforeUndoRedo);
+                ToolsApplicationEvents::Bus::Broadcast(&ToolsApplicationEvents::Bus::Events::BeforeUndoRedo);
                 m_undoStack->Undo();
-                EBUS_EVENT(ToolsApplicationEvents::Bus, AfterUndoRedo);
+                ToolsApplicationEvents::Bus::Broadcast(&ToolsApplicationEvents::Bus::Events::AfterUndoRedo);
                 m_isDuringUndoRedo = false;
 
 #if defined(ENABLE_UNDOCACHE_CONSISTENCY_CHECKS)
@@ -1470,9 +1470,9 @@ namespace AzToolsFramework
             if (m_undoStack->CanRedo())
             {
                 m_isDuringUndoRedo = true;
-                EBUS_EVENT(ToolsApplicationEvents::Bus, BeforeUndoRedo);
+                ToolsApplicationEvents::Bus::Broadcast(&ToolsApplicationEvents::Bus::Events::BeforeUndoRedo);
                 m_undoStack->Redo();
-                EBUS_EVENT(ToolsApplicationEvents::Bus, AfterUndoRedo);
+                ToolsApplicationEvents::Bus::Broadcast(&ToolsApplicationEvents::Bus::Events::AfterUndoRedo);
                 m_isDuringUndoRedo = false;
 
 #if defined(ENABLE_UNDOCACHE_CONSISTENCY_CHECKS)
@@ -1518,7 +1518,7 @@ namespace AzToolsFramework
             // notify Cry undo has started (SandboxIntegrationManager)
             // Only do this at the root level. OnEndUndo will be called at the root
             // level when EndUndoBatch is called.
-            EBUS_EVENT(ToolsApplicationEvents::Bus, OnBeginUndo, label);
+            ToolsApplicationEvents::Bus::Broadcast(&ToolsApplicationEvents::Bus::Events::OnBeginUndo, label);
         }
         else
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -127,8 +127,8 @@ namespace AzToolsFramework
 
             UndoSystem::UndoStack* undoStack = nullptr;
             PreemptiveUndoCache* preemptiveUndoCache = nullptr;
-            EBUS_EVENT_RESULT(undoStack, ToolsApplicationRequests::Bus, GetUndoStack);
-            EBUS_EVENT_RESULT(preemptiveUndoCache, ToolsApplicationRequests::Bus, GetUndoCache);
+            ToolsApplicationRequests::Bus::BroadcastResult(undoStack, &ToolsApplicationRequests::Bus::Events::GetUndoStack);
+            ToolsApplicationRequests::Bus::BroadcastResult(preemptiveUndoCache, &ToolsApplicationRequests::Bus::Events::GetUndoCache);
             AZ_Assert(undoStack, "Failed to retrieve undo stack.");
             AZ_Assert(preemptiveUndoCache, "Failed to retrieve preemptive undo cache.");
             if (undoStack && preemptiveUndoCache)
@@ -138,7 +138,7 @@ namespace AzToolsFramework
                 // Commands always execute themselves first and then their children (when going forwards)
                 // and do the opposite when going backwards.
                 AzToolsFramework::EntityIdList selection;
-                EBUS_EVENT_RESULT(selection, ToolsApplicationRequests::Bus, GetSelectedEntities);
+                ToolsApplicationRequests::Bus::BroadcastResult(selection, &ToolsApplicationRequests::Bus::Events::GetSelectedEntities);
                 AzToolsFramework::SelectionCommand* selCommand = aznew AzToolsFramework::SelectionCommand(selection, "Delete Entities");
 
                 // We insert a "deselect all" command before we delete the entities. This ensures the delete operations aren't changing
@@ -155,7 +155,7 @@ namespace AzToolsFramework
                     for (const auto& entityId : entityIds)
                     {
                         AZ::Entity* entity = nullptr;
-                        EBUS_EVENT_RESULT(entity, AZ::ComponentApplicationBus, FindEntity, entityId);
+                        AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, entityId);
 
                         if (entity)
                         {
@@ -523,7 +523,7 @@ namespace AzToolsFramework
     void ToolsApplication::PreExportEntity(AZ::Entity& source, AZ::Entity& target)
     {
         AZ::SerializeContext* serializeContext = nullptr;
-        EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         AZ_Assert(serializeContext, "No serialization context found");
 
         const AZ::Entity::ComponentArrayType& editorComponents = source.GetComponents();
@@ -1651,7 +1651,7 @@ namespace AzToolsFramework
             for (AZ::EntityId entityId : m_dirtyEntities)
             {
                 AZ::Entity* entity = nullptr;
-                EBUS_EVENT_RESULT(entity, AZ::ComponentApplicationBus, FindEntity, entityId);
+                AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, entityId);
 
                 if (entity)
                 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBundle/AssetBundleComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBundle/AssetBundleComponent.cpp
@@ -711,7 +711,7 @@ namespace AzToolsFramework
 
         // deserialize the manifest
         AZ::SerializeContext* serializeContext = nullptr;
-        EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         AZ_Assert(serializeContext, "Unable to retrieve serialize context.");
         if (nullptr == serializeContext->FindClassData(AZ::AzTypeInfo<AzFramework::AssetBundleManifest>::Uuid()))
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.cpp
@@ -1757,7 +1757,7 @@ namespace AzToolsFramework
         AZStd::string AssetDatabaseConnection::GetAssetDatabaseFilePath()
         {
             AZStd::string databaseLocation;
-            EBUS_EVENT(AssetDatabaseRequests::Bus, GetAssetDatabaseLocation, databaseLocation);
+            AssetDatabaseRequests::Bus::Broadcast(&AssetDatabaseRequests::Bus::Events::GetAssetDatabaseLocation, databaseLocation);
             if (databaseLocation.empty())
             {
                 databaseLocation = "assetdb.sqlite";

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/EntityStateCommand.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/EntityStateCommand.cpp
@@ -163,7 +163,7 @@ namespace AzToolsFramework
         else
         {
             // Normal entities will be deleted and loaded anew
-            //EBUS_EVENT(AZ::ComponentApplicationBus, DeleteEntity, m_entityID);
+            //AZ::ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::DeleteEntity, m_entityID);
             AZ::ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::DeleteEntity, m_entityID);
         }
 
@@ -231,7 +231,7 @@ namespace AzToolsFramework
             EntityStateCommandNotificationBus::Event(m_entityID, &EntityStateCommandNotificationBus::Events::PostRestore, entity);
         }
 
-        EBUS_EVENT(ToolsApplicationRequests::Bus, SetSelectedEntities, selectedEntities);
+        ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::Bus::Events::SetSelectedEntities, selectedEntities);
     }
 
     void EntityStateCommand::Undo()
@@ -263,7 +263,7 @@ namespace AzToolsFramework
     void EntityDeleteCommand::Redo()
     {
         AZ_PROFILE_FUNCTION(AzToolsFramework);
-        EBUS_EVENT(AZ::ComponentApplicationBus, DeleteEntity, m_entityID);
+        AZ::ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::DeleteEntity, m_entityID);
         PreemptiveUndoCache::Get()->PurgeCache(m_entityID);
     }
 
@@ -281,7 +281,7 @@ namespace AzToolsFramework
     void EntityCreateCommand::Undo()
     {
         AZ_PROFILE_FUNCTION(AzToolsFramework);
-        EBUS_EVENT(AZ::ComponentApplicationBus, DeleteEntity, m_entityID);
+        AZ::ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::DeleteEntity, m_entityID);
         PreemptiveUndoCache::Get()->PurgeCache(m_entityID);
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/EntityStateCommand.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/EntityStateCommand.cpp
@@ -187,7 +187,8 @@ namespace AzToolsFramework
             {
                 if (!m_entityContextId.IsNull() && !isSliceMetadataEntity)
                 {
-                    EBUS_EVENT_ID(m_entityContextId, AzFramework::EntityContextRequestBus, AddEntity, entity);
+                    AzFramework::EntityContextRequestBus::Event(
+                        m_entityContextId, &AzFramework::EntityContextRequestBus::Events::AddEntity, entity);
                 }
 
                 if (m_entityState == AZ::Entity::State::Init || m_entityState == AZ::Entity::State::Active)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/EntityStateCommand.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/EntityStateCommand.cpp
@@ -58,7 +58,8 @@ namespace AzToolsFramework
 
         m_entityID = pSourceEntity->GetId();
         EBUS_EVENT_ID_RESULT(m_entityContextId, m_entityID, AzFramework::EntityIdContextQueryBus, GetOwningContextId);
-        EBUS_EVENT_RESULT(m_isSelected, AzToolsFramework::ToolsApplicationRequests::Bus, IsSelected, m_entityID);
+        AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(m_isSelected,
+            &AzToolsFramework::ToolsApplicationRequests::Bus::Events::IsSelected, m_entityID);
 
         AZ::SliceComponent::EntityRestoreInfo& sliceRestoreInfo = captureUndo ? m_undoSliceRestoreInfo : m_redoSliceRestoreInfo;
         sliceRestoreInfo = AZ::SliceComponent::EntityRestoreInfo();
@@ -67,7 +68,7 @@ namespace AzToolsFramework
         AZ_Assert(PreemptiveUndoCache::Get(), "You need a pre-emptive undo cache instance to exist for this to work.");
         AZ_Assert((!captureUndo) || (m_undoState.empty()), "You can't capture undo more than once");
         AZ::SerializeContext* sc = nullptr;
-        EBUS_EVENT_RESULT(sc, AZ::ComponentApplicationBus, GetSerializeContext);
+        AZ::ComponentApplicationBus::BroadcastResult(sc, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         AZ_Assert(sc, "Serialization context not found!");
 
         m_entityState = pSourceEntity->GetState();
@@ -120,7 +121,7 @@ namespace AzToolsFramework
         AZ_Assert(bufferSizeBytes, "Undo data is empty.");
 
         AZ::SerializeContext* serializeContext = nullptr;
-        EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         AZ_Assert(serializeContext, "Serialization context not found!");
         AZ::IO::MemoryStream memoryStream(reinterpret_cast<const char*>(buffer), bufferSizeBytes);
 
@@ -134,11 +135,11 @@ namespace AzToolsFramework
 
         // We have to delete the entity. If it's currently selected, make sure we re-select after re-creating.
         AzToolsFramework::EntityIdList selectedEntities;
-        EBUS_EVENT_RESULT(selectedEntities, ToolsApplicationRequests::Bus, GetSelectedEntities);
+        ToolsApplicationRequests::Bus::BroadcastResult(selectedEntities, &ToolsApplicationRequests::Bus::Events::GetSelectedEntities);
 
         AZ::Entity* entity = nullptr;
 
-        EBUS_EVENT_RESULT(entity, AZ::ComponentApplicationBus, FindEntity, m_entityID);
+        AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, m_entityID);
         EntityStateCommandNotificationBus::Event(m_entityID, &EntityStateCommandNotificationBus::Events::PreRestore);
 
         bool isSliceMetadataEntity = false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/EntityStateCommand.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/EntityStateCommand.cpp
@@ -57,7 +57,8 @@ namespace AzToolsFramework
         AZ_PROFILE_FUNCTION(AzToolsFramework);
 
         m_entityID = pSourceEntity->GetId();
-        EBUS_EVENT_ID_RESULT(m_entityContextId, m_entityID, AzFramework::EntityIdContextQueryBus, GetOwningContextId);
+        AzFramework::EntityIdContextQueryBus::EventResult(
+            m_entityContextId, m_entityID, &AzFramework::EntityIdContextQueryBus::Events::GetOwningContextId);
         AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(m_isSelected,
             &AzToolsFramework::ToolsApplicationRequests::Bus::Events::IsSelected, m_entityID);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/PreemptiveUndoCache.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/PreemptiveUndoCache.cpp
@@ -91,7 +91,7 @@ namespace AzToolsFramework
         // capture it
 
         AZ::Entity* pEnt = nullptr;
-        EBUS_EVENT_RESULT(pEnt, AZ::ComponentApplicationBus, FindEntity, entityId);
+        AZ::ComponentApplicationBus::BroadcastResult(pEnt, &AZ::ComponentApplicationBus::Events::FindEntity, entityId);
         if (!pEnt)
         {
             AZ_Warning("Undo", false, "Preemptive Undo Cache was told to update the cache for a particular entity, but that entity is not available in FindEntity");
@@ -104,7 +104,7 @@ namespace AzToolsFramework
         AZ::IO::ByteContainerStream<CacheLineType> ms(&newData);
 
         AZ::SerializeContext* sc = nullptr;
-        EBUS_EVENT_RESULT(sc, AZ::ComponentApplicationBus, GetSerializeContext);
+        AZ::ComponentApplicationBus::BroadcastResult(sc, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         AZ_Assert(sc, "Serialization context not found!");
 
         // capture state.
@@ -147,7 +147,7 @@ namespace AzToolsFramework
         {
             // display a useful message
             AZ::Entity* pEnt = nullptr;
-            EBUS_EVENT_RESULT(pEnt, AZ::ComponentApplicationBus, FindEntity, entityId);
+            AZ::ComponentApplicationBus::BroadcastResult(pEnt, &AZ::ComponentApplicationBus::Events::FindEntity, entityId);
             if (!pEnt)
             {
                 AZ_Warning("Undo", false, "Undo system wasn't informed about the deletion of entity %p - make sure you call DeleteEntity, instead of directly deleting it.\n", entityId);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/SelectionCommand.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/SelectionCommand.cpp
@@ -14,7 +14,8 @@ namespace AzToolsFramework
     SelectionCommand::SelectionCommand(const AZStd::vector<AZ::EntityId>& proposedSelection, const AZStd::string& friendlyName)
         : UndoSystem::URSequencePoint(friendlyName)
     {
-        EBUS_EVENT_RESULT(m_previousSelectionList, AzToolsFramework::ToolsApplicationRequests::Bus, GetSelectedEntities);
+        AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(m_previousSelectionList,
+            &AzToolsFramework::ToolsApplicationRequests::Bus::Events::GetSelectedEntities);
 
         m_proposedSelectionList = proposedSelection;
     }
@@ -35,7 +36,8 @@ namespace AzToolsFramework
     void SelectionCommand::Post()
     {
         UndoSystem::UndoStack* undoStack = nullptr;
-        EBUS_EVENT_RESULT(undoStack, AzToolsFramework::ToolsApplicationRequests::Bus, GetUndoStack);
+        AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(undoStack,
+            &AzToolsFramework::ToolsApplicationRequests::Bus::Events::GetUndoStack);
 
         if (undoStack)
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/SelectionCommand.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/SelectionCommand.cpp
@@ -47,11 +47,13 @@ namespace AzToolsFramework
 
     void SelectionCommand::Undo()
     {
-        EBUS_EVENT(AzToolsFramework::ToolsApplicationRequests::Bus, SetSelectedEntities, m_previousSelectionList);
+        AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+            &AzToolsFramework::ToolsApplicationRequests::Bus::Events::SetSelectedEntities, m_previousSelectionList);
     }
 
     void SelectionCommand::Redo()
     {
-        EBUS_EVENT(AzToolsFramework::ToolsApplicationRequests::Bus, SetSelectedEntities, m_proposedSelectionList);
+        AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+            &AzToolsFramework::ToolsApplicationRequests::Bus::Events::SetSelectedEntities, m_proposedSelectionList);
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Debug/TraceContext.inl
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Debug/TraceContext.inl
@@ -14,167 +14,167 @@ namespace AzToolsFramework
     {
         TraceContextScope::TraceContextScope(const char* key, const char* value)
         {
-            EBUS_EVENT(TraceContextBus, PushStringEntry, AZStd::this_thread::get_id(), key , value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushStringEntry, AZStd::this_thread::get_id(), key , value);
         }
 
         TraceContextScope::TraceContextScope(const char* key, const AZStd::string& value)
         {
-            EBUS_EVENT(TraceContextBus, PushStringEntry, AZStd::this_thread::get_id(), key , value.c_str());
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushStringEntry, AZStd::this_thread::get_id(), key , value.c_str());
         }
 
         TraceContextScope::TraceContextScope(const char* key, const AZ::OSString& value)
         {
-            EBUS_EVENT(TraceContextBus, PushStringEntry, AZStd::this_thread::get_id(), key, value.c_str());
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushStringEntry, AZStd::this_thread::get_id(), key, value.c_str());
         }
 
         TraceContextScope::TraceContextScope(const char* key, bool value)
         {
-            EBUS_EVENT(TraceContextBus, PushBoolEntry, AZStd::this_thread::get_id(), key, value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushBoolEntry, AZStd::this_thread::get_id(), key, value);
         }
 
         TraceContextScope::TraceContextScope(const char* key, int8_t value)
         {
-            EBUS_EVENT(TraceContextBus, PushIntEntry, AZStd::this_thread::get_id(), key, value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushIntEntry, AZStd::this_thread::get_id(), key, value);
         }
 
         TraceContextScope::TraceContextScope(const char* key, int16_t value)
         {
-            EBUS_EVENT(TraceContextBus, PushIntEntry, AZStd::this_thread::get_id(), key, value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushIntEntry, AZStd::this_thread::get_id(), key, value);
         }
 
         TraceContextScope::TraceContextScope(const char* key, int32_t value)
         {
-            EBUS_EVENT(TraceContextBus, PushIntEntry, AZStd::this_thread::get_id(), key, value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushIntEntry, AZStd::this_thread::get_id(), key, value);
         }
 
         TraceContextScope::TraceContextScope(const char* key, int64_t value)
         {
-            EBUS_EVENT(TraceContextBus, PushIntEntry, AZStd::this_thread::get_id(), key, value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushIntEntry, AZStd::this_thread::get_id(), key, value);
         }
 
         TraceContextScope::TraceContextScope(const char* key, uint8_t value)
         {
-            EBUS_EVENT(TraceContextBus, PushUintEntry, AZStd::this_thread::get_id(), key, value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushUintEntry, AZStd::this_thread::get_id(), key, value);
         }
 
         TraceContextScope::TraceContextScope(const char* key, uint16_t value)
         {
-            EBUS_EVENT(TraceContextBus, PushUintEntry, AZStd::this_thread::get_id(), key, value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushUintEntry, AZStd::this_thread::get_id(), key, value);
         }
 
         TraceContextScope::TraceContextScope(const char* key, uint32_t value)
         {
-            EBUS_EVENT(TraceContextBus, PushUintEntry, AZStd::this_thread::get_id(), key, value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushUintEntry, AZStd::this_thread::get_id(), key, value);
         }
 
         TraceContextScope::TraceContextScope(const char* key, uint64_t value)
         {
-            EBUS_EVENT(TraceContextBus, PushUintEntry, AZStd::this_thread::get_id(), key, value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushUintEntry, AZStd::this_thread::get_id(), key, value);
         }
 
         TraceContextScope::TraceContextScope(const char* key, float value)
         {
-            EBUS_EVENT(TraceContextBus, PushFloatEntry, AZStd::this_thread::get_id(), key, value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushFloatEntry, AZStd::this_thread::get_id(), key, value);
         }
 
         TraceContextScope::TraceContextScope(const char* key, double value)
         {
-            EBUS_EVENT(TraceContextBus, PushDoubleEntry, AZStd::this_thread::get_id(), key, value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushDoubleEntry, AZStd::this_thread::get_id(), key, value);
         }
 
         TraceContextScope::TraceContextScope(const char* key, const AZ::Uuid& value)
         {
-            EBUS_EVENT(TraceContextBus, PushUuidEntry, AZStd::this_thread::get_id(), key, &value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushUuidEntry, AZStd::this_thread::get_id(), key, &value);
         }
 
         TraceContextScope::TraceContextScope(const char* key, const AZ::Uuid* value)
         {
-            EBUS_EVENT(TraceContextBus, PushUuidEntry, AZStd::this_thread::get_id(), key, value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushUuidEntry, AZStd::this_thread::get_id(), key, value);
         }
 
         TraceContextScope::TraceContextScope(const AZStd::string& key, const char* value)
         {
-            EBUS_EVENT(TraceContextBus, PushStringEntry, AZStd::this_thread::get_id(), key.c_str(), value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushStringEntry, AZStd::this_thread::get_id(), key.c_str(), value);
         }
 
         TraceContextScope::TraceContextScope(const AZStd::string& key, const AZStd::string& value)
         {
-            EBUS_EVENT(TraceContextBus, PushStringEntry, AZStd::this_thread::get_id(), key.c_str(), value.c_str());
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushStringEntry, AZStd::this_thread::get_id(), key.c_str(), value.c_str());
         }
 
         TraceContextScope::TraceContextScope(const AZStd::string& key, const AZ::OSString& value)
         {
-            EBUS_EVENT(TraceContextBus, PushStringEntry, AZStd::this_thread::get_id(), key.c_str(), value.c_str());
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushStringEntry, AZStd::this_thread::get_id(), key.c_str(), value.c_str());
         }
 
         TraceContextScope::TraceContextScope(const AZStd::string& key, bool value)
         {
-            EBUS_EVENT(TraceContextBus, PushBoolEntry, AZStd::this_thread::get_id(), key.c_str(), value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushBoolEntry, AZStd::this_thread::get_id(), key.c_str(), value);
         }
 
         TraceContextScope::TraceContextScope(const AZStd::string& key, int8_t value)
         {
-            EBUS_EVENT(TraceContextBus, PushIntEntry, AZStd::this_thread::get_id(), key.c_str(), value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushIntEntry, AZStd::this_thread::get_id(), key.c_str(), value);
         }
 
         TraceContextScope::TraceContextScope(const AZStd::string& key, int16_t value)
         {
-            EBUS_EVENT(TraceContextBus, PushIntEntry, AZStd::this_thread::get_id(), key.c_str(), value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushIntEntry, AZStd::this_thread::get_id(), key.c_str(), value);
         }
 
         TraceContextScope::TraceContextScope(const AZStd::string& key, int32_t value)
         {
-            EBUS_EVENT(TraceContextBus, PushIntEntry, AZStd::this_thread::get_id(), key.c_str(), value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushIntEntry, AZStd::this_thread::get_id(), key.c_str(), value);
         }
 
         TraceContextScope::TraceContextScope(const AZStd::string& key, int64_t value)
         {
-            EBUS_EVENT(TraceContextBus, PushIntEntry, AZStd::this_thread::get_id(), key.c_str(), value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushIntEntry, AZStd::this_thread::get_id(), key.c_str(), value);
         }
 
         TraceContextScope::TraceContextScope(const AZStd::string& key, uint8_t value)
         {
-            EBUS_EVENT(TraceContextBus, PushUintEntry, AZStd::this_thread::get_id(), key.c_str(), value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushUintEntry, AZStd::this_thread::get_id(), key.c_str(), value);
         }
 
         TraceContextScope::TraceContextScope(const AZStd::string& key, uint16_t value)
         {
-            EBUS_EVENT(TraceContextBus, PushUintEntry, AZStd::this_thread::get_id(), key.c_str(), value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushUintEntry, AZStd::this_thread::get_id(), key.c_str(), value);
         }
 
         TraceContextScope::TraceContextScope(const AZStd::string& key, uint32_t value)
         {
-            EBUS_EVENT(TraceContextBus, PushUintEntry, AZStd::this_thread::get_id(), key.c_str(), value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushUintEntry, AZStd::this_thread::get_id(), key.c_str(), value);
         }
 
         TraceContextScope::TraceContextScope(const AZStd::string& key, uint64_t value)
         {
-            EBUS_EVENT(TraceContextBus, PushUintEntry, AZStd::this_thread::get_id(), key.c_str(), value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushUintEntry, AZStd::this_thread::get_id(), key.c_str(), value);
         }
 
         TraceContextScope::TraceContextScope(const AZStd::string& key, float value)
         {
-            EBUS_EVENT(TraceContextBus, PushFloatEntry, AZStd::this_thread::get_id(), key.c_str(), value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushFloatEntry, AZStd::this_thread::get_id(), key.c_str(), value);
         }
         
         TraceContextScope::TraceContextScope(const AZStd::string& key, double value)
         {
-            EBUS_EVENT(TraceContextBus, PushDoubleEntry, AZStd::this_thread::get_id(), key.c_str(), value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushDoubleEntry, AZStd::this_thread::get_id(), key.c_str(), value);
         }
         
         TraceContextScope::TraceContextScope(const AZStd::string& key, const AZ::Uuid& value)
         {
-            EBUS_EVENT(TraceContextBus, PushUuidEntry, AZStd::this_thread::get_id(), key.c_str(), &value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushUuidEntry, AZStd::this_thread::get_id(), key.c_str(), &value);
         }
 
         TraceContextScope::TraceContextScope(const AZStd::string& key, const AZ::Uuid* value)
         {
-            EBUS_EVENT(TraceContextBus, PushUuidEntry, AZStd::this_thread::get_id(), key.c_str(), value);
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PushUuidEntry, AZStd::this_thread::get_id(), key.c_str(), value);
         }
 
         TraceContextScope::~TraceContextScope()
         {
-            EBUS_EVENT(TraceContextBus, PopEntry, AZStd::this_thread::get_id());
+            TraceContextBus::Broadcast(&TraceContextBus::Events::PopEntry, AZStd::this_thread::get_id());
         }
     } // Debug
 } // AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityActionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityActionComponent.cpp
@@ -608,7 +608,8 @@ namespace AzToolsFramework
                         bool isEditorComponent = componentClassData->m_azRtti && componentClassData->m_azRtti->IsTypeOf(Components::EditorComponentBase::RTTI_Type());
                         if (isEditorComponent)
                         {
-                            EBUS_EVENT_ID_RESULT(component, componentClassData->m_typeId, AZ::ComponentDescriptorBus, CreateComponent);
+                            AZ::ComponentDescriptorBus::EventResult(
+                                component, componentClassData->m_typeId, &AZ::ComponentDescriptorBus::Events::CreateComponent);
                         }
                         else
                         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityActionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityActionComponent.cpp
@@ -334,7 +334,8 @@ namespace AzToolsFramework
                 AZ::Entity* entity = component->GetEntity();
 
                 bool isEntityEditable = false;
-                EBUS_EVENT_RESULT(isEntityEditable, AzToolsFramework::ToolsApplicationRequests::Bus, IsEntityEditable, entity->GetId());
+                AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(isEntityEditable,
+                    &AzToolsFramework::ToolsApplicationRequests::Bus::Events::IsEntityEditable, entity->GetId());
                 if (!isEntityEditable)
                 {
                     continue;
@@ -390,7 +391,8 @@ namespace AzToolsFramework
                 AZ::Entity* entity = component->GetEntity();
 
                 bool isEntityEditable = false;
-                EBUS_EVENT_RESULT(isEntityEditable, AzToolsFramework::ToolsApplicationRequests::Bus, IsEntityEditable, entity->GetId());
+                AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(isEntityEditable,
+                    &AzToolsFramework::ToolsApplicationRequests::Bus::Events::IsEntityEditable, entity->GetId());
                 if (!isEntityEditable)
                 {
                     continue;
@@ -461,7 +463,8 @@ namespace AzToolsFramework
                     AZ::Entity* entity = componentToRemove->GetEntity();
 
                     bool isEntityEditable = false;
-                    EBUS_EVENT_RESULT(isEntityEditable, AzToolsFramework::ToolsApplicationRequests::Bus, IsEntityEditable, entity->GetId());
+                    AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(isEntityEditable,
+                        &AzToolsFramework::ToolsApplicationRequests::Bus::Events::IsEntityEditable, entity->GetId());
                     if (!isEntityEditable)
                     {
                         continue;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityHelpers.cpp
@@ -619,7 +619,8 @@ namespace AzToolsFramework
                 (void)knownType;
 
                 AZ::ComponentDescriptor* componentDescriptor = nullptr;
-                EBUS_EVENT_ID_RESULT(componentDescriptor, componentClass->m_typeId, AZ::ComponentDescriptorBus, GetDescriptor);
+                AZ::ComponentDescriptorBus::EventResult(
+                    componentDescriptor, componentClass->m_typeId, &AZ::ComponentDescriptorBus::Events::GetDescriptor);
                 if (componentDescriptor)
                 {
                     AZ::ComponentDescriptor::DependencyArrayType providedServices;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.cpp
@@ -583,7 +583,7 @@ namespace AzToolsFramework
         //when an editor entity is created and registered, add it to a pending list.
         //once all entities in the pending list are activated, add them to model.
         bool isEditorEntity = false;
-        EBUS_EVENT_RESULT(isEditorEntity, EditorEntityContextRequestBus, IsEditorEntity, entityId);
+        EditorEntityContextRequestBus::BroadcastResult(isEditorEntity, &EditorEntityContextRequestBus::Events::IsEditorEntity, entityId);
         if (isEditorEntity)
         {
             // As an optimization, new entities are queued.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceMetadataEntityContextComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceMetadataEntityContextComponent.cpp
@@ -100,7 +100,7 @@ namespace AzToolsFramework
         m_metadataEntityByIdMap.clear();
         m_sliceAddressToRootMetadataMap.clear();
 
-        EBUS_EVENT(SliceMetadataEntityContextNotificationBus, OnContextReset);
+        SliceMetadataEntityContextNotificationBus::Broadcast(&SliceMetadataEntityContextNotificationBus::Events::OnContextReset);
     }
 
     /*!  Called to reset the current context.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceTransaction.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceTransaction.cpp
@@ -1023,9 +1023,10 @@ namespace AzToolsFramework
                 AZStd::string devAssetPath = fileIO->GetAlias("@projectroot@");
                 AZStd::string userPath = fileIO->GetAlias("@user@");
                 AZStd::string tempPath = fullPath;
-                EBUS_EVENT(AzFramework::ApplicationRequests::Bus, NormalizePath, devAssetPath);
-                EBUS_EVENT(AzFramework::ApplicationRequests::Bus, NormalizePath, userPath);
-                EBUS_EVENT(AzFramework::ApplicationRequests::Bus, NormalizePath, tempPath);
+                AzFramework::ApplicationRequests::Bus::Broadcast(
+                    &AzFramework::ApplicationRequests::Bus::Events::NormalizePath, devAssetPath);
+                AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::Bus::Events::NormalizePath, userPath);
+                AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::Bus::Events::NormalizePath, tempPath);
                 AzFramework::StringFunc::Replace(tempPath, "@projectroot@", devAssetPath.c_str());
                 AzFramework::StringFunc::Replace(tempPath, devAssetPath.c_str(), userPath.c_str());
                 tempPath.append(".slicetemp");
@@ -1094,7 +1095,8 @@ namespace AzToolsFramework
                         // Bump the slice asset up in the asset processor's queue.
                         {
                             AZ_PROFILE_SCOPE(AzToolsFramework, "SliceUtilities::Internal::SaveSliceToDisk:TempToTargetFileReplacement:GetAssetStatus");
-                            EBUS_EVENT(AzFramework::AssetSystemRequestBus, EscalateAssetBySearchTerm, targetPath);
+                            AzFramework::AssetSystemRequestBus::Broadcast(
+                                &AzFramework::AssetSystemRequestBus::Events::EscalateAssetBySearchTerm, targetPath);
                         }
                         return AZ::Success();
                     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceUtilities.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceUtilities.cpp
@@ -414,7 +414,7 @@ namespace AzToolsFramework
             for (const AZ::EntityId& id : selectedAndReferencedEntities)
             {
                 AZ::Entity* entity = nullptr;
-                EBUS_EVENT_RESULT(entity, AZ::ComponentApplicationBus, FindEntity, id);
+                AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, id);
                 if (entity)
                 {
                     if (entities.find(id) != entities.end())
@@ -617,7 +617,7 @@ namespace AzToolsFramework
 
             if (!serializeContext)
             {
-                EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+                AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
                 AZ_Assert(serializeContext, "Failed to retrieve application serialize context.");
             }
 
@@ -940,7 +940,7 @@ namespace AzToolsFramework
                 floodQueue.pop_back();
 
                 AZ::Entity* entity = nullptr;
-                EBUS_EVENT_RESULT(entity, AZ::ComponentApplicationBus, FindEntity, id);
+                AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, id);
 
                 if (entity)
                 {
@@ -2911,7 +2911,7 @@ namespace AzToolsFramework
                     if (usedNameEntities.find(id) == usedNameEntities.end())
                     {
                         AZ::Entity* entity = nullptr;
-                        EBUS_EVENT_RESULT(entity, AZ::ComponentApplicationBus, FindEntity, id);
+                        AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, id);
                         if (entity)
                         {
                             AZStd::string entityNameFiltered = entity->GetName();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceUtilities.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceUtilities.cpp
@@ -784,7 +784,11 @@ namespace AzToolsFramework
                     newParentWorldTM.SetTranslation(sliceRootEntityPosition);
 
                     //signal entities that parent is about to move
-                    EBUS_EVENT_ID(entity->GetId(), AZ::TransformNotificationBus, OnParentTransformWillChange, oldParentWorldTM, newParentWorldTM);
+                    AZ::TransformNotificationBus::Event(
+                        entity->GetId(),
+                        &AZ::TransformNotificationBus::Events::OnParentTransformWillChange,
+                        oldParentWorldTM,
+                        newParentWorldTM);
 
                     ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entity->GetId());
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/SourceControl/PerforceComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/SourceControl/PerforceComponent.cpp
@@ -902,7 +902,7 @@ namespace AzToolsFramework
     {
         AZStd::lock_guard<AZStd::mutex> locker(m_SettingsQueueMutex);
         m_settingsQueue.push(AZStd::move(result));
-        EBUS_QUEUE_FUNCTION(AZ::TickBus, &PerforceComponent::ProcessResultQueue, this);
+        AZ::TickBus::QueueFunction(&PerforceComponent::ProcessResultQueue, this);
     }
 
     bool PerforceComponent::CheckConnectivityForAction(const char* actionDesc, const char* filePath) const
@@ -1458,7 +1458,7 @@ namespace AzToolsFramework
             {
                 AZStd::lock_guard<AZStd::mutex> locker(m_ResultQueueMutex);
                 m_resultQueue.push(AZStd::move(resp));
-                EBUS_QUEUE_FUNCTION(AZ::TickBus, &PerforceComponent::ProcessResultQueue, this);// narrow events to the main thread.
+                AZ::TickBus::QueueFunction(&PerforceComponent::ProcessResultQueue, this); // narrow events to the main thread.
             }
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ComponentMimeData.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ComponentMimeData.cpp
@@ -101,7 +101,7 @@ namespace AzToolsFramework
     AZStd::unique_ptr<QMimeData> ComponentMimeData::Create(const ComponentDataContainer& components)
     {
         AZ::SerializeContext* context;
-        EBUS_EVENT_RESULT(context, AZ::ComponentApplicationBus, GetSerializeContext);
+        AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         if (!context)
         {
             AZ_Assert(context, "No serialize context");

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.cpp
@@ -51,7 +51,8 @@ namespace AzToolsFramework
         {
             if (GetEntity())
             {
-                EBUS_EVENT(AzToolsFramework::ToolsApplicationRequests::Bus, AddDirtyEntity, GetEntity()->GetId());
+                AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+                    &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, GetEntity()->GetId());
             }
             else
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorEntityIconComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorEntityIconComponent.cpp
@@ -259,7 +259,7 @@ namespace AzToolsFramework
                 bool preferNoViewportIcon = false;
 
                 AZ::SerializeContext* serializeContext = nullptr;
-                EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+                AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
                 AZ_Assert(serializeContext, "No serialize context");
 
                 for (AZ::ComponentId componentId : componentOrderArray)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/GenericComponentWrapper.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/GenericComponentWrapper.cpp
@@ -308,9 +308,8 @@ namespace AzToolsFramework
                 const GenericComponentWrapper* wrapper = azrtti_cast<const GenericComponentWrapper*>(instance);
                 if (wrapper && wrapper->GetTemplate())
                 {
-                    EBUS_EVENT_ID_RESULT(
-                        templateDescriptor, wrapper->GetTemplate()->RTTI_GetType(),
-                        AZ::ComponentDescriptorBus, GetDescriptor);
+                    AZ::ComponentDescriptorBus::EventResult(
+                        templateDescriptor, wrapper->GetTemplate()->RTTI_GetType(), &AZ::ComponentDescriptorBus::Events::GetDescriptor);
                 }
 
                 return templateDescriptor;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/GenericComponentWrapper.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/GenericComponentWrapper.cpp
@@ -63,7 +63,8 @@ namespace AzToolsFramework
 
         GenericComponentWrapper::GenericComponentWrapper(const AZ::SerializeContext::ClassData* templateClassData)
         {
-            EBUS_EVENT_ID_RESULT(m_template, templateClassData->m_typeId, AZ::ComponentDescriptorBus, CreateComponent);
+            AZ::ComponentDescriptorBus::EventResult(
+                m_template, templateClassData->m_typeId, &AZ::ComponentDescriptorBus::Events::CreateComponent);
         }
 
         GenericComponentWrapper::GenericComponentWrapper(AZ::Component* templateClassInstance)
@@ -360,7 +361,8 @@ namespace AzToolsFramework
         AZ::ComponentDescriptor* GenericComponentWrapper::CreateDescriptor()
         {
             AZ::ComponentDescriptor* descriptor = nullptr;
-            EBUS_EVENT_ID_RESULT(descriptor, GenericComponentWrapper::RTTI_Type(), AZ::ComponentDescriptorBus, GetDescriptor);
+            AZ::ComponentDescriptorBus::EventResult(
+                descriptor, GenericComponentWrapper::RTTI_Type(), &AZ::ComponentDescriptorBus::Events::GetDescriptor);
 
             return descriptor ? descriptor : aznew GenericComponentWrapperDescriptor();
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.cpp
@@ -233,7 +233,7 @@ namespace AzToolsFramework
 
                     // Create an EntityId instance
                     const AZ::SerializeContext* context = nullptr;
-                    EBUS_EVENT_RESULT(context, AZ::ComponentApplicationBus, GetSerializeContext);
+                    AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
                     const AZ::SerializeContext::ClassData* entityIdClassData = context->FindClassData(azrtti_typeid<AZ::EntityId>());
                     AZ_Assert(entityIdClassData && entityIdClassData->m_factory, "AZ::EntityId is missing ClassData or factory in the SerializeContext");
                     AZ::EntityId* entityId = static_cast<AZ::EntityId*>(entityIdClassData->m_factory->Create(name));
@@ -940,7 +940,8 @@ namespace AzToolsFramework
             AZStd::string scriptFilename;
             if (assetId.IsValid())
             {
-                EBUS_EVENT_RESULT(scriptFilename, AZ::Data::AssetCatalogRequestBus, GetAssetPathById, assetId);
+                AZ::Data::AssetCatalogRequestBus::BroadcastResult(scriptFilename,
+                    &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, assetId);
             }
             EBUS_EVENT(AzToolsFramework::EditorRequests::Bus, LaunchLuaEditor, scriptFilename.c_str());
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.cpp
@@ -782,7 +782,7 @@ namespace AzToolsFramework
                 m_scriptComponent.m_context->GetDebugContext()->ConnectHook();
             }
 
-            EBUS_EVENT(ToolsApplicationEvents::Bus, InvalidatePropertyDisplay, Refresh_EntireTree);
+            ToolsApplicationEvents::Bus::Broadcast(&ToolsApplicationEvents::Bus::Events::InvalidatePropertyDisplay, Refresh_EntireTree);
             ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::Bus::Events::AddDirtyEntity, GetEntityId());
         }
 
@@ -842,7 +842,7 @@ namespace AzToolsFramework
 
             SortProperties(m_scriptComponent.m_properties);
 
-            EBUS_EVENT(ToolsApplicationEvents::Bus, InvalidatePropertyDisplay, Refresh_EntireTree);
+            ToolsApplicationEvents::Bus::Broadcast(&ToolsApplicationEvents::Bus::Events::InvalidatePropertyDisplay, Refresh_EntireTree);
         }
 
         void ScriptEditorComponent::ClearDataElements()
@@ -904,7 +904,8 @@ namespace AzToolsFramework
             {
                 SetScript(asset);
                 ScriptHasChanged();
-                EBUS_EVENT(AzToolsFramework::ToolsApplicationRequests::Bus, AddDirtyEntity, GetEntityId());
+                AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+                    &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, GetEntityId());
             }
         }
 
@@ -943,7 +944,8 @@ namespace AzToolsFramework
                 AZ::Data::AssetCatalogRequestBus::BroadcastResult(scriptFilename,
                     &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, assetId);
             }
-            EBUS_EVENT(AzToolsFramework::EditorRequests::Bus, LaunchLuaEditor, scriptFilename.c_str());
+            AzToolsFramework::EditorRequests::Bus::Broadcast(
+                &AzToolsFramework::EditorRequests::Bus::Events::LaunchLuaEditor, scriptFilename.c_str());
         }
 
         void ScriptEditorComponent::OnAssetReady(AZ::Data::Asset<AZ::Data::AssetData> asset)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -742,7 +742,8 @@ namespace AzToolsFramework
 
             // This is for Create Entity as child / Drag+drop parent update / add component
             EBUS_EVENT(AzToolsFramework::ToolsApplicationEvents::Bus, EntityParentChanged, GetEntityId(), parentId, oldParentId);
-            EBUS_EVENT_ID(GetEntityId(), AZ::TransformNotificationBus, OnParentChanged, oldParentId, parentId);
+            AZ::TransformNotificationBus::Event(
+                GetEntityId(), &AZ::TransformNotificationBus::Events::OnParentChanged, oldParentId, parentId);
             m_parentChangedEvent.Signal(oldParentId, parentId);
 
             TransformChanged();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -741,7 +741,8 @@ namespace AzToolsFramework
             m_suppressTransformChangedEvent = false;
 
             // This is for Create Entity as child / Drag+drop parent update / add component
-            EBUS_EVENT(AzToolsFramework::ToolsApplicationEvents::Bus, EntityParentChanged, GetEntityId(), parentId, oldParentId);
+            AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
+                &AzToolsFramework::ToolsApplicationEvents::Bus::Events::EntityParentChanged, GetEntityId(), parentId, oldParentId);
             AZ::TransformNotificationBus::Event(
                 GetEntityId(), &AZ::TransformNotificationBus::Events::OnParentChanged, oldParentId, parentId);
             m_parentChangedEvent.Signal(oldParentId, parentId);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkAPI.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkAPI.cpp
@@ -18,56 +18,56 @@ namespace LegacyFramework
     const char* appName()
     {
         const char* result = nullptr;
-        EBUS_EVENT_RESULT(result, FrameworkApplicationMessages::Bus, GetApplicationName);
+        FrameworkApplicationMessages::Bus::BroadcastResult(result, &FrameworkApplicationMessages::Bus::Events::GetApplicationName);
         return result;
     }
 
     const char* appModule()
     {
         const char* result = nullptr;
-        EBUS_EVENT_RESULT(result, FrameworkApplicationMessages::Bus, GetApplicationModule);
+        FrameworkApplicationMessages::Bus::BroadcastResult(result, &FrameworkApplicationMessages::Bus::Events::GetApplicationModule);
         return result;
     }
 
     const char* appDir()
     {
         const char* result = nullptr;
-        EBUS_EVENT_RESULT(result, FrameworkApplicationMessages::Bus, GetApplicationDirectory);
+        FrameworkApplicationMessages::Bus::BroadcastResult(result, &FrameworkApplicationMessages::Bus::Events::GetApplicationDirectory);
         return result;
     }
 
     bool RequiresGameProject()
     {
         bool result = false;
-        EBUS_EVENT_RESULT(result, FrameworkApplicationMessages::Bus, RequiresGameProject);
+        FrameworkApplicationMessages::Bus::BroadcastResult(result, &FrameworkApplicationMessages::Bus::Events::RequiresGameProject);
         return result;
     }
 
     bool IsGUIMode()
     {
         bool result = false;
-        EBUS_EVENT_RESULT(result, FrameworkApplicationMessages::Bus, IsRunningInGUIMode);
+        FrameworkApplicationMessages::Bus::BroadcastResult(result, &FrameworkApplicationMessages::Bus::Events::IsRunningInGUIMode);
         return result;
     }
 
     bool appAbortRequested()
     {
         bool result = false;
-        EBUS_EVENT_RESULT(result, FrameworkApplicationMessages::Bus, GetAbortRequested);
+        FrameworkApplicationMessages::Bus::BroadcastResult(result, &FrameworkApplicationMessages::Bus::Events::GetAbortRequested);
         return result;
     }
 
     bool isPrimary()
     {
         bool result = false;
-        EBUS_EVENT_RESULT(result, FrameworkApplicationMessages::Bus, IsPrimary);
+        FrameworkApplicationMessages::Bus::BroadcastResult(result, &FrameworkApplicationMessages::Bus::Events::IsPrimary);
         return result;
     }
 
     bool IsAppConfigWritable()
     {
         bool result = false;
-        EBUS_EVENT_RESULT(result, FrameworkApplicationMessages::Bus, IsAppConfigWritable);
+        FrameworkApplicationMessages::Bus::BroadcastResult(result, &FrameworkApplicationMessages::Bus::Events::IsAppConfigWritable);
         return result;
     }
 
@@ -75,7 +75,7 @@ namespace LegacyFramework
     AZ::SerializeContext* GetSerializeContext()
     {
         AZ::SerializeContext* serializeContext = nullptr;
-        EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         AZ_Assert(serializeContext, "No serialize context");
         return serializeContext;
     }
@@ -91,7 +91,7 @@ namespace LegacyFramework
     bool ShouldRunAssetProcessor()
     {
         bool result = false;
-        EBUS_EVENT_RESULT(result, FrameworkApplicationMessages::Bus, ShouldRunAssetProcessor);
+        FrameworkApplicationMessages::Bus::BroadcastResult(result, &FrameworkApplicationMessages::Bus::Events::ShouldRunAssetProcessor);
         return result;
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkApplication.cpp
@@ -131,7 +131,7 @@ namespace LegacyFramework
 #ifdef AZ_PLATFORM_WINDOWS
     BOOL CTRL_BREAK_HandlerRoutine(DWORD /*dwCtrlType*/)
     {
-        EBUS_EVENT(FrameworkApplicationMessages::Bus, SetAbortRequested);
+        FrameworkApplicationMessages::Bus::Broadcast(&FrameworkApplicationMessages::Bus::Events::SetAbortRequested);
         return TRUE;
     }
 #endif
@@ -205,7 +205,7 @@ namespace LegacyFramework
 
             // if we're not the primary instance, what exactly do we do?  This is a generic framework - not a specific app
             // and what we do might depend on implementation specifics for each app.
-            EBUS_EVENT(LegacyFramework::CoreMessageBus, RunAsAnotherInstance);
+            LegacyFramework::CoreMessageBus::Broadcast(&LegacyFramework::CoreMessageBus::Events::RunAsAnotherInstance);
         }
         else
         {
@@ -215,7 +215,7 @@ namespace LegacyFramework
                 CreateApplicationComponent();
             }
 
-            EBUS_EVENT(LegacyFramework::CoreMessageBus, Run);
+            LegacyFramework::CoreMessageBus::Broadcast(&LegacyFramework::CoreMessageBus::Events::Run);
 
             // as a precaution here, we save our app and system entities BEFORE we destroy anything
             // so that we have the highest chance of storing the user's precious application state and preferences

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/IPCComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/IPCComponent.cpp
@@ -227,7 +227,7 @@ namespace LegacyFramework
                 m_CommandsWaitingToExecute.push_back(WaitingIPCCommand(command.c_str(), contents.c_str()));
             }
 
-            EBUS_QUEUE_FUNCTION(AZ::SystemTickBus, &IPCComponent::ExecuteIPCHandlers, this);
+            AZ::SystemTickBus::QueueFunction(&IPCComponent::ExecuteIPCHandlers, this);
         }
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/CustomMenus/CustomMenusComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/CustomMenus/CustomMenusComponent.cpp
@@ -73,7 +73,8 @@ namespace LegacyFramework
     {
         CustomMenusMessages::Bus::Handler::BusConnect();
 
-        EBUS_EVENT(LegacyFramework::CustomMenusRegistration::Bus, RegisterMenuEntries);
+        LegacyFramework::CustomMenusRegistration::Bus::Broadcast(
+            &LegacyFramework::CustomMenusRegistration::Bus::Events::RegisterMenuEntries);
     }
 
     void CustomMenusComponent::Deactivate()
@@ -92,7 +93,8 @@ namespace LegacyFramework
 
         if (hotkeyId != AZ::Crc32())
         {
-            EBUS_EVENT(AzToolsFramework::FrameworkMessages::Bus, RegisterActionToHotkey, hotkeyId, action);
+            AzToolsFramework::FrameworkMessages::Bus::Broadcast(
+                &AzToolsFramework::FrameworkMessages::Bus::Events::RegisterActionToHotkey, hotkeyId, action);
         }
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/UIFramework.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/UIFramework.cpp
@@ -186,7 +186,8 @@ namespace AzToolsFramework
         pApplication->setApplicationName("O3DE Editor");
 
         bool GUIMode = true;
-        EBUS_EVENT_RESULT(GUIMode, LegacyFramework::FrameworkApplicationMessages::Bus, IsRunningInGUIMode);
+        LegacyFramework::FrameworkApplicationMessages::Bus::BroadcastResult(GUIMode,
+            &LegacyFramework::FrameworkApplicationMessages::Bus::Events::IsRunningInGUIMode);
 
         // if we're not in GUI Mode why bother reigstering fonts and style sheets?
         if (GUIMode)
@@ -278,7 +279,7 @@ namespace AzToolsFramework
             m_ptrTicker->cancel();
             QApplication::processEvents();
             AZ::ComponentApplication* pApp = nullptr;
-            EBUS_EVENT_RESULT(pApp, AZ::ComponentApplicationBus, GetApplication);
+            AZ::ComponentApplicationBus::BroadcastResult(pApp, &AZ::ComponentApplicationBus::Events::GetApplication);
             if (pApp)
             {
                 pApp->Tick();
@@ -363,7 +364,7 @@ namespace AzToolsFramework
         m_bTicking = true;
         // Tick the component app.
         AZ::ComponentApplication* pApp = nullptr;
-        EBUS_EVENT_RESULT(pApp, AZ::ComponentApplicationBus, GetApplication);
+        AZ::ComponentApplicationBus::BroadcastResult(pApp, &AZ::ComponentApplicationBus::Events::GetApplication);
         if (pApp && m_ptrTicker)
         {
             AZ::SystemTickBus::ExecuteQueuedEvents();
@@ -447,7 +448,7 @@ namespace AzToolsFramework
         // start the shutdown sequence:
         Ebus_Event_AllOkay check;
 
-        EBUS_EVENT_RESULT(check, LegacyFramework::CoreMessageBus, OnGetPermissionToShutDown);
+        LegacyFramework::CoreMessageBus::BroadcastResult(check, &LegacyFramework::CoreMessageBus::Events::OnGetPermissionToShutDown);
         if (!check.Accepted())
         {
             return;
@@ -466,7 +467,7 @@ namespace AzToolsFramework
 
         Ebus_Event_AllOkay check;
 
-        EBUS_EVENT_RESULT(check, LegacyFramework::CoreMessageBus, CheckOkayToShutDown);
+        LegacyFramework::CoreMessageBus::BroadcastResult(check, &LegacyFramework::CoreMessageBus::Events::CheckOkayToShutDown);
         if (!check.Accepted())
         {
             // the above could cause contexts to generate threaded requests that are outstanding (like a long data save).
@@ -482,7 +483,7 @@ namespace AzToolsFramework
         // pump the tickbus one last time!
        // QApplication::processEvents();
         AZ::ComponentApplication* pApp = nullptr;
-        EBUS_EVENT_RESULT(pApp, AZ::ComponentApplicationBus, GetApplication);
+        AZ::ComponentApplicationBus::BroadcastResult(pApp, &AZ::ComponentApplicationBus::Events::GetApplication);
         if (pApp)
         {
             pApp->Tick();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/NewLogTabDialog.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/NewLogTabDialog.cpp
@@ -31,7 +31,7 @@ namespace AzToolsFramework
             uiManager->windowNameBox->addItem("All");
 
             AZStd::vector<AZStd::string> knownWindows;
-            EBUS_EVENT(LegacyFramework::LogComponentAPI::Bus, EnumWindowTypes, knownWindows);
+            LegacyFramework::LogComponentAPI::Bus::Broadcast(&LegacyFramework::LogComponentAPI::Bus::Events::EnumWindowTypes, knownWindows);
 
             if (knownWindows.size() > 0)
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
@@ -1003,7 +1003,7 @@ namespace AzToolsFramework
                 AZ::TransformBus::EventResult(oldParentId, entityId, &AZ::TransformBus::Events::GetParentId);
 
                 //  Guarding this to prevent the entity from being marked dirty when the parent doesn't change.
-                EBUS_EVENT_ID(entityId, AZ::TransformBus, SetParent, newParentId);
+                AZ::TransformBus::Event(entityId, &AZ::TransformBus::Events::SetParent, newParentId);
 
                 // The old parent is dirty due to sort change
                 undo2.MarkEntityDirty(GetEntityIdForSortInfo(oldParentId));

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
@@ -1000,7 +1000,7 @@ namespace AzToolsFramework
             for (AZ::EntityId entityId : selectedEntityIds)
             {
                 AZ::EntityId oldParentId;
-                EBUS_EVENT_ID_RESULT(oldParentId, entityId, AZ::TransformBus, GetParentId);
+                AZ::TransformBus::EventResult(oldParentId, entityId, &AZ::TransformBus::Events::GetParentId);
 
                 //  Guarding this to prevent the entity from being marked dirty when the parent doesn't change.
                 EBUS_EVENT_ID(entityId, AZ::TransformBus, SetParent, newParentId);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
@@ -496,7 +496,8 @@ namespace AzToolsFramework
                             entity->SetName(newName);
                             undo.MarkEntityDirty(entity->GetId());
 
-                            EBUS_EVENT(ToolsApplicationEvents::Bus, InvalidatePropertyDisplay, Refresh_EntireTree);
+                            ToolsApplicationEvents::Bus::Broadcast(
+                                &ToolsApplicationEvents::Bus::Events::InvalidatePropertyDisplay, Refresh_EntireTree);
                         }
                     }
                     else
@@ -1058,7 +1059,7 @@ namespace AzToolsFramework
         // reselect the entities to ensure they're visible if appropriate
         ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequests::SetSelectedEntities, processedEntityIds);
 
-        EBUS_EVENT(ToolsApplicationEvents::Bus, InvalidatePropertyDisplay, Refresh_Values);
+        ToolsApplicationEvents::Bus::Broadcast(&ToolsApplicationEvents::Bus::Events::InvalidatePropertyDisplay, Refresh_Values);
         return true;
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
@@ -904,7 +904,8 @@ namespace AzToolsFramework
             }
 
             bool isEntityEditable = true;
-            EBUS_EVENT_RESULT(isEntityEditable, ToolsApplicationRequests::Bus, IsEntityEditable, entityId);
+            ToolsApplicationRequests::Bus::BroadcastResult(
+                isEntityEditable, &ToolsApplicationRequests::Bus::Events::IsEntityEditable, entityId);
             if (!isEntityEditable)
             {
                 return false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
@@ -728,7 +728,7 @@ namespace AzToolsFramework
             ScopedUndoBatch undo("Duplicate Entity(s)");
 
             bool handled = false;
-            EBUS_EVENT(EditorRequests::Bus, CloneSelection, handled);
+            EditorRequests::Bus::Broadcast(&EditorRequests::Bus::Events::CloneSelection, handled);
         }
     }
 
@@ -736,7 +736,7 @@ namespace AzToolsFramework
     {
         PrepareSelection();
 
-        EBUS_EVENT(EditorRequests::Bus, DeleteSelectedEntities, false);
+        EditorRequests::Bus::Broadcast(&EditorRequests::Bus::Events::DeleteSelectedEntities, false);
 
         PrepareSelection();
     }
@@ -745,7 +745,7 @@ namespace AzToolsFramework
     {
         PrepareSelection();
 
-        EBUS_EVENT(EditorRequests::Bus, DeleteSelectedEntities, true);
+        EditorRequests::Bus::Broadcast(&EditorRequests::Bus::Events::DeleteSelectedEntities, true);
 
         PrepareSelection();
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
@@ -273,7 +273,7 @@ namespace AzToolsFramework
         connect(m_gui->m_searchWidget, &AzQtComponents::FilteredSearchWidget::TypeFilterChanged, this, &EntityOutlinerWidget::OnFilterChanged);
 
         AZ::SerializeContext* serializeContext = nullptr;
-        EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
         if (serializeContext)
         {
@@ -573,7 +573,7 @@ namespace AzToolsFramework
         AZ_PROFILE_FUNCTION(Editor);
 
         bool isDocumentOpen = false;
-        EBUS_EVENT_RESULT(isDocumentOpen, EditorRequests::Bus, IsLevelDocumentOpen);
+        EditorRequests::Bus::BroadcastResult(isDocumentOpen, &EditorRequests::Bus::Events::IsLevelDocumentOpen);
         if (!isDocumentOpen)
         {
             return;
@@ -683,7 +683,7 @@ namespace AzToolsFramework
     AzFramework::EntityContextId EntityOutlinerWidget::GetPickModeEntityContextId()
     {
         AzFramework::EntityContextId editorEntityContextId = AzFramework::EntityContextId::CreateNull();
-        EBUS_EVENT_RESULT(editorEntityContextId, EditorRequests::Bus, GetEntityContextId);
+        EditorRequests::Bus::BroadcastResult(editorEntityContextId, &EditorRequests::Bus::Events::GetEntityContextId);
 
         return editorEntityContextId;
     }
@@ -691,7 +691,7 @@ namespace AzToolsFramework
     void EntityOutlinerWidget::PrepareSelection()
     {
         m_selectedEntityIds.clear();
-        EBUS_EVENT_RESULT(m_selectedEntityIds, ToolsApplicationRequests::Bus, GetSelectedEntities);
+        ToolsApplicationRequests::Bus::BroadcastResult(m_selectedEntityIds, &ToolsApplicationRequests::Bus::Events::GetSelectedEntities);
     }
 
     void EntityOutlinerWidget::DoCreateEntity()
@@ -716,7 +716,7 @@ namespace AzToolsFramework
         PrepareSelection();
 
         AZ::EntityId entityId;
-        EBUS_EVENT_RESULT(entityId, EditorRequests::Bus, CreateNewEntity, parentId);
+        EditorRequests::Bus::BroadcastResult(entityId, &EditorRequests::Bus::Events::CreateNewEntity, parentId);
     }
 
     void EntityOutlinerWidget::DoDuplicateSelection()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
@@ -646,7 +646,8 @@ namespace AzToolsFramework
         GetHeader()->SetTitle(ComponentEditorConstants::kUnknownComponentTitle);
 
         AZStd::string iconPath;
-        EBUS_EVENT_RESULT(iconPath, AzToolsFramework::EditorRequests::Bus, GetDefaultComponentEditorIcon);
+        AzToolsFramework::EditorRequests::Bus::BroadcastResult(
+            iconPath, &AzToolsFramework::EditorRequests::Bus::Events::GetDefaultComponentEditorIcon);
         GetHeader()->SetIcon(QIcon(iconPath.c_str()));
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
@@ -670,7 +670,8 @@ namespace AzToolsFramework
         }
 
         AZ::ComponentDescriptor* componentDescriptor = nullptr;
-        EBUS_EVENT_ID_RESULT(componentDescriptor, thisComponent->RTTI_GetType(), AZ::ComponentDescriptorBus, GetDescriptor);
+        AZ::ComponentDescriptorBus::EventResult(
+            componentDescriptor, thisComponent->RTTI_GetType(), &AZ::ComponentDescriptorBus::Events::GetDescriptor);
 
         if (!componentDescriptor)
         {
@@ -705,7 +706,8 @@ namespace AzToolsFramework
                 }
 
                 AZ::ComponentDescriptor* otherDescriptor = nullptr;
-                EBUS_EVENT_ID_RESULT(otherDescriptor, otherComponent->RTTI_GetType(), AZ::ComponentDescriptorBus, GetDescriptor);
+                AZ::ComponentDescriptorBus::EventResult(
+                    otherDescriptor, otherComponent->RTTI_GetType(), &AZ::ComponentDescriptorBus::Events::GetDescriptor);
 
                 if (otherDescriptor)
                 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -5708,7 +5708,7 @@ namespace AzToolsFramework
         {
             DisconnectFromEntityBuses(entityId);
         }
-        EBUS_EVENT(AzToolsFramework::EditorRequests::Bus, ClosePinnedInspector, this);
+        AzToolsFramework::EditorRequests::Bus::Broadcast(&AzToolsFramework::EditorRequests::Bus::Events::ClosePinnedInspector, this);
     }
 
     void EntityPropertyEditor::SetSystemEntityEditor(bool isSystemEntityEditor)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/MultiLineTextEditHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/MultiLineTextEditHandler.cpp
@@ -16,7 +16,8 @@ namespace AzToolsFramework
         GrowTextEdit* textEdit = aznew GrowTextEdit(parent);
         connect(textEdit, &GrowTextEdit::textChanged, this, [textEdit]()
         {
-            EBUS_EVENT(AzToolsFramework::PropertyEditorGUIMessages::Bus, RequestWrite, textEdit);
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                    &AzToolsFramework::PropertyEditorGUIMessages::Bus::Events::RequestWrite, textEdit);
         });
         connect(textEdit, &GrowTextEdit::EditCompleted, this, [textEdit]()
         {
@@ -83,7 +84,8 @@ namespace AzToolsFramework
 
     void RegisterMultiLineEditHandler()
     {
-        EBUS_EVENT(AzToolsFramework::PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew MultiLineTextEditHandler());
+        AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew MultiLineTextEditHandler());
     }
 }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -782,7 +782,7 @@ namespace AzToolsFramework
         {
             // Show default asset editor (property grid dialog) if this asset type has edit reflection.
             AZ::SerializeContext* serializeContext = nullptr;
-            EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+            AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
             if (serializeContext)
             {
                 const AZ::SerializeContext::ClassData* classData = serializeContext->FindClassData(GetCurrentAssetType());
@@ -1738,7 +1738,8 @@ namespace AzToolsFramework
         (void)node;
 
         AZStd::string assetPath;
-        EBUS_EVENT_RESULT(assetPath, AZ::Data::AssetCatalogRequestBus, GetAssetPathById, GUI->GetSelectedAssetID());
+        AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+            assetPath, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, GUI->GetSelectedAssetID());
 
         instance.SetAssetPath(assetPath.c_str());
     }
@@ -1753,7 +1754,8 @@ namespace AzToolsFramework
         AZ::Data::AssetId assetId;
         if (!instance.GetAssetPath().empty())
         {
-            EBUS_EVENT_RESULT(assetId, AZ::Data::AssetCatalogRequestBus, GetAssetIdByPath, instance.GetAssetPath().c_str(), instance.GetAssetType(), true);
+            AZ::Data::AssetCatalogRequestBus::BroadcastResult(assetId, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetIdByPath,
+                instance.GetAssetPath().c_str(), instance.GetAssetType(), true);
         }
 
         // Set the hint in case the asset is not able to be found by assetId

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -623,7 +623,7 @@ namespace AzToolsFramework
         SetCurrentAssetHint(AZStd::string());
         SetSelectedAssetID(AZ::Data::AssetId());
         // To clear the asset we only need to refresh the values.
-        EBUS_EVENT(ToolsApplicationEvents::Bus, InvalidatePropertyDisplay, Refresh_Values);
+        ToolsApplicationEvents::Bus::Broadcast(&ToolsApplicationEvents::Bus::Events::InvalidatePropertyDisplay, Refresh_Values);
     }
 
     void PropertyAssetCtrl::SourceFileChanged(AZStd::string /*relativePath*/, AZStd::string /*scanFolder*/, AZ::Uuid sourceUUID)
@@ -1401,7 +1401,7 @@ namespace AzToolsFramework
         connect(newCtrl, &PropertyAssetCtrl::OnAssetIDChanged, this, [newCtrl](AZ::Data::AssetId newAssetID)
         {
             (void)newAssetID;
-            EBUS_EVENT(PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
+            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
             AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
         });
         return newCtrl;
@@ -1685,7 +1685,7 @@ namespace AzToolsFramework
         connect(newCtrl, &PropertyAssetCtrl::OnAssetIDChanged, this, [newCtrl](AZ::Data::AssetId newAssetID)
         {
             (void)newAssetID;
-            EBUS_EVENT(PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
+            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
             AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
         });
         return newCtrl;
@@ -1721,7 +1721,7 @@ namespace AzToolsFramework
         connect(newCtrl, &PropertyAssetCtrl::OnAssetIDChanged, this, [newCtrl](AZ::Data::AssetId newAssetID)
         {
             (void)newAssetID;
-            EBUS_EVENT(PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
+            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
             AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
         });
         return newCtrl;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAudioCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAudioCtrl.cpp
@@ -194,7 +194,8 @@ namespace AzToolsFramework
         connect(newCtrl, &AudioControlSelectorWidget::ControlNameChanged, this,
             [newCtrl] ()
             {
-                EBUS_EVENT(AzToolsFramework::PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                    &AzToolsFramework::PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
                 AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
             }
         );

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyBoolComboBoxCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyBoolComboBoxCtrl.cpp
@@ -85,7 +85,7 @@ namespace AzToolsFramework
         PropertyBoolComboBoxCtrl* newCtrl = aznew PropertyBoolComboBoxCtrl(pParent);
         connect(newCtrl, &PropertyBoolComboBoxCtrl::valueChanged, this, [newCtrl]()
             {
-                EBUS_EVENT(PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
+                PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
                 AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
             });
         return newCtrl;
@@ -118,7 +118,8 @@ namespace AzToolsFramework
 
     void RegisterBoolComboBoxHandler()
     {
-        EBUS_EVENT(PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew BoolPropertyComboBoxHandler());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew BoolPropertyComboBoxHandler());
     }
 }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyButtonCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyButtonCtrl.cpp
@@ -202,9 +202,12 @@ namespace AzToolsFramework
 
     void RegisterButtonPropertyHandlers()
     {
-        EBUS_EVENT(PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew ButtonGenericHandler());
-        EBUS_EVENT(PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew ButtonBoolHandler());
-        EBUS_EVENT(PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew ButtonStringHandler());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew ButtonGenericHandler());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew ButtonBoolHandler());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew ButtonStringHandler());
     }
 
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
@@ -408,7 +408,7 @@ namespace AzToolsFramework
         PropertyColorCtrl* newCtrl = aznew PropertyColorCtrl(pParent);
         connect(newCtrl, &PropertyColorCtrl::valueChanged, this, [newCtrl]()
             {
-                EBUS_EVENT(PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
+                PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
             });
         connect(newCtrl, &PropertyColorCtrl::editingFinished, this, [newCtrl]()
             {
@@ -447,8 +447,10 @@ namespace AzToolsFramework
     ////////////////////////////////////////////////////////////////
     void RegisterColorPropertyHandlers()
     {
-        EBUS_EVENT(PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew Vector3ColorPropertyHandler());
-        EBUS_EVENT(PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew AZColorPropertyHandler());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew Vector3ColorPropertyHandler());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew AZColorPropertyHandler());
     }
 
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSliderCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSliderCtrl.cpp
@@ -272,7 +272,7 @@ namespace AzToolsFramework
         PropertyDoubleSliderCtrl* newCtrl = aznew PropertyDoubleSliderCtrl(pParent);
         connect(newCtrl, &PropertyDoubleSliderCtrl::valueChanged, this, [newCtrl]()
             {
-                EBUS_EVENT(PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
+                PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
             });
         connect(newCtrl, &PropertyDoubleSliderCtrl::editingFinished, this, [newCtrl]()
         {
@@ -291,7 +291,7 @@ namespace AzToolsFramework
         PropertyDoubleSliderCtrl* newCtrl = aznew PropertyDoubleSliderCtrl(pParent);
         connect(newCtrl, &PropertyDoubleSliderCtrl::valueChanged, this, [newCtrl]()
             {
-                EBUS_EVENT(PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
+                PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
             });
         connect(newCtrl, &PropertyDoubleSliderCtrl::editingFinished, this, [newCtrl]()
         {
@@ -421,8 +421,10 @@ namespace AzToolsFramework
 
     void RegisterDoubleSliderHandlers()
     {
-        EBUS_EVENT(PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew doublePropertySliderHandler());
-        EBUS_EVENT(PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew floatPropertySliderHandler());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew doublePropertySliderHandler());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew floatPropertySliderHandler());
     }
 
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSpinCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSpinCtrl.cpp
@@ -306,7 +306,7 @@ namespace AzToolsFramework
         PropertyDoubleSpinCtrl* newCtrl = aznew PropertyDoubleSpinCtrl(pParent);
         connect(newCtrl, &PropertyDoubleSpinCtrl::valueChanged, this, [newCtrl]()
             {
-                EBUS_EVENT(PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
+                PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
             });
         connect(newCtrl, &PropertyDoubleSpinCtrl::editingFinished, this, [newCtrl]()
         {
@@ -326,7 +326,7 @@ namespace AzToolsFramework
         PropertyDoubleSpinCtrl* newCtrl = aznew PropertyDoubleSpinCtrl(pParent);
         connect(newCtrl, &PropertyDoubleSpinCtrl::valueChanged, this, [newCtrl]()
             {
-                EBUS_EVENT(PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
+                PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
             });
         connect(newCtrl, &PropertyDoubleSpinCtrl::editingFinished, this, [newCtrl]()
         {
@@ -463,8 +463,10 @@ namespace AzToolsFramework
 
     void RegisterDoubleSpinBoxHandlers()
     {
-        EBUS_EVENT(PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew doublePropertySpinboxHandler());
-        EBUS_EVENT(PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew floatPropertySpinboxHandler());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew doublePropertySpinboxHandler());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew floatPropertySpinboxHandler());
     }
 
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.cpp
@@ -492,7 +492,7 @@ namespace AzToolsFramework
         PropertyEntityIdCtrl* newCtrl = aznew PropertyEntityIdCtrl(pParent);
         connect(newCtrl, &PropertyEntityIdCtrl::OnEntityIdChanged, this, [newCtrl](AZ::EntityId)
             {
-                EBUS_EVENT(PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
+                PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
                 AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
             });
         return newCtrl;
@@ -589,7 +589,8 @@ namespace AzToolsFramework
 
     void RegisterEntityIdPropertyHandler()
     {
-        EBUS_EVENT(PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew EntityIdPropertyHandler());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew EntityIdPropertyHandler());
     }
 
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.cpp
@@ -360,7 +360,8 @@ namespace AzToolsFramework
                 for (const AZ::Component* component : components)
                 {
                     AZ::ComponentDescriptor* componentDescriptor = nullptr;
-                    EBUS_EVENT_ID_RESULT(componentDescriptor, component->RTTI_GetType(), AZ::ComponentDescriptorBus, GetDescriptor);
+                    AZ::ComponentDescriptorBus::EventResult(
+                        componentDescriptor, component->RTTI_GetType(), &AZ::ComponentDescriptorBus::Events::GetDescriptor);
                     AZ::ComponentDescriptor::DependencyArrayType providedServices;
                     componentDescriptor->GetProvidedServices(providedServices, component);
                     for (int serviceIdx = azlossy_cast<int>(unmatchedServices.size() - 1); serviceIdx >= 0; --serviceIdx)
@@ -478,7 +479,10 @@ namespace AzToolsFramework
         bool supportsViewportEntityIdPicking = true;
         if (!m_acceptedEntityContextId.IsNull())
         {
-            EBUS_EVENT_ID_RESULT(supportsViewportEntityIdPicking, m_acceptedEntityContextId, AzToolsFramework::EditorEntityContextPickingRequestBus, SupportsViewportEntityIdPicking);
+            AzToolsFramework::EditorEntityContextPickingRequestBus::EventResult(
+                supportsViewportEntityIdPicking,
+                m_acceptedEntityContextId,
+                &AzToolsFramework::EditorEntityContextPickingRequestBus::Events::SupportsViewportEntityIdPicking);
         }
         m_pickButton->setVisible(supportsViewportEntityIdPicking);
     }
@@ -574,7 +578,8 @@ namespace AzToolsFramework
         AzFramework::EntityContextId contextId = AzFramework::EntityContextId::CreateNull();
         if (entityId.IsValid())
         {
-            EBUS_EVENT_ID_RESULT(contextId, entityId, AzFramework::EntityIdContextQueryBus, GetOwningContextId);
+            AzFramework::EntityIdContextQueryBus::EventResult(
+                contextId, entityId, &AzFramework::EntityIdContextQueryBus::Events::GetOwningContextId);
         }
         GUI->SetAcceptedEntityContext(contextId);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.cpp
@@ -350,7 +350,7 @@ namespace AzToolsFramework
             bool servicesMismatch = false;
 
             AZ::Entity* entity = nullptr;
-            EBUS_EVENT_RESULT(entity, AZ::ComponentApplicationBus, FindEntity, newEntityId);
+            AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, newEntityId);
 
             if (entity)
             {
@@ -414,7 +414,8 @@ namespace AzToolsFramework
     QString PropertyEntityIdCtrl::BuildTooltip()
     {
         AZ::Entity* entity = nullptr;
-        EBUS_EVENT_RESULT(entity, AZ::ComponentApplicationBus, FindEntity, m_entityIdLineEdit->GetEntityId());
+        AZ::ComponentApplicationBus::BroadcastResult(
+            entity, &AZ::ComponentApplicationBus::Events::FindEntity, m_entityIdLineEdit->GetEntityId());
 
         if (!entity)
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
@@ -263,7 +263,7 @@ namespace AzToolsFramework
             {
                 // does a base class have a handler?
                 AZ::SerializeContext* sc = nullptr;
-                EBUS_EVENT_RESULT(sc, AZ::ComponentApplicationBus, GetSerializeContext);
+                AZ::ComponentApplicationBus::BroadcastResult(sc, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
                 AZStd::vector<const AZ::SerializeContext::ClassData*> classes;
 
                 sc->EnumerateBase(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
@@ -326,7 +326,8 @@ namespace AzToolsFramework
 
             // --------------------- HANDLER discovery:
             // in order to discover this, we need the property type and handler type.
-            EBUS_EVENT_RESULT(m_handler, PropertyTypeRegistrationMessages::Bus, ResolvePropertyHandler, m_handlerName, typeUuid);
+            PropertyTypeRegistrationMessages::Bus::BroadcastResult(
+                m_handler, &PropertyTypeRegistrationMessages::Bus::Events::ResolvePropertyHandler, m_handlerName, typeUuid);
 
             
             if (m_handler)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.cpp
@@ -198,7 +198,7 @@ namespace AzToolsFramework
         PropertyStringComboBoxCtrl* newCtrl = aznew PropertyStringComboBoxCtrl(pParent);
         connect(newCtrl, &PropertyStringComboBoxCtrl::valueChanged, this, [newCtrl]()
             {
-                EBUS_EVENT(PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
+                PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
                 AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
             });
         return newCtrl;
@@ -221,7 +221,8 @@ namespace AzToolsFramework
 
     void RegisterStringComboBoxHandler()
     {
-        EBUS_EVENT(PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew StringEnumPropertyComboBoxHandler());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew StringEnumPropertyComboBoxHandler());
     }
 
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.cpp
@@ -115,7 +115,7 @@ namespace AzToolsFramework
         PropertyStringLineEditCtrl* newCtrl = aznew PropertyStringLineEditCtrl(pParent);
         connect(newCtrl, &PropertyStringLineEditCtrl::valueChanged, this, [newCtrl]()
             {
-                EBUS_EVENT(PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
+                PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
             });
         return newCtrl;
     }
@@ -159,7 +159,8 @@ namespace AzToolsFramework
 
     void RegisterStringLineEditHandler()
     {
-        EBUS_EVENT(PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew StringPropertyLineEditHandler());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew StringPropertyLineEditHandler());
     }
 
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyVectorCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyVectorCtrl.cpp
@@ -22,7 +22,7 @@ namespace AzToolsFramework
         AzQtComponents::VectorInput* newCtrl = new AzQtComponents::VectorInput(parent, m_elementCount, m_elementsPerRow, m_customLabels.c_str());
         QObject::connect(newCtrl, &AzQtComponents::VectorInput::valueChanged, newCtrl, [newCtrl]()
             {
-                EBUS_EVENT(PropertyEditorGUIMessages::Bus, RequestWrite, newCtrl);
+                PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
             });
         newCtrl->connect(newCtrl, &AzQtComponents::VectorInput::editingFinished, [newCtrl]()
         {
@@ -208,10 +208,14 @@ namespace AzToolsFramework
 
     void RegisterVectorHandlers()
     {
-        EBUS_EVENT(PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, new Vector2PropertyHandler());
-        EBUS_EVENT(PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, new Vector3PropertyHandler());
-        EBUS_EVENT(PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, new Vector4PropertyHandler());
-        EBUS_EVENT(PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, new QuaternionPropertyHandler());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, new Vector2PropertyHandler());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, new Vector3PropertyHandler());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, new Vector4PropertyHandler());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, new QuaternionPropertyHandler());
     }
 
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Slice/SlicePushWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Slice/SlicePushWidget.cpp
@@ -2811,7 +2811,10 @@ namespace AzToolsFramework
                     assets[asset.GetId()] = asset;
 
                     AZStd::string assetFullPath;
-                    EBUS_EVENT(AzToolsFramework::AssetSystemRequestBus, GetFullSourcePathFromRelativeProductPath, sliceAssetPath, assetFullPath);
+                    AzToolsFramework::AssetSystemRequestBus::Broadcast(
+                        &AzToolsFramework::AssetSystemRequestBus::Events::GetFullSourcePathFromRelativeProductPath,
+                        sliceAssetPath,
+                        assetFullPath);
                     if (fileIO->IsReadOnly(assetFullPath.c_str()))
                     {
                         // Issue checkout order for each affected slice.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Slice/SlicePushWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Slice/SlicePushWidget.cpp
@@ -909,7 +909,8 @@ namespace AzToolsFramework
     {
         // Slice has changed underneath us, transaction invalidated
         AZStd::string sliceAssetPath;
-        EBUS_EVENT_RESULT(sliceAssetPath, AZ::Data::AssetCatalogRequestBus, GetAssetPathById, asset.GetId());
+        AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+            sliceAssetPath, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, asset.GetId());
 
         QMessageBox::warning(this, QStringLiteral("Push to Slice Aborting"), 
             QString("Slice asset changed on disk during push configuration, transaction canceled.\r\n\r\nAsset:\r\n%1").arg(sliceAssetPath.c_str()), 
@@ -1033,7 +1034,7 @@ namespace AzToolsFramework
 
         if (!m_serializeContext)
         {
-            EBUS_EVENT_RESULT(m_serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+            AZ::ComponentApplicationBus::BroadcastResult(m_serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         }
 
         PopulateFieldTree(entities);
@@ -1053,7 +1054,8 @@ namespace AzToolsFramework
                     item->m_selectedAsset = validSliceAssets.back().GetId();
 
                     AZStd::string sliceAssetPath;
-                    EBUS_EVENT_RESULT(sliceAssetPath, AZ::Data::AssetCatalogRequestBus, GetAssetPathById, item->m_selectedAsset);
+                    AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+                        sliceAssetPath, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, item->m_selectedAsset);
 
                     SetFieldIcon(item);
 
@@ -1211,7 +1213,8 @@ namespace AzToolsFramework
 
                 AZStd::string assetPath;
                 AZStd::string itemText;
-                EBUS_EVENT_RESULT(assetPath, AZ::Data::AssetCatalogRequestBus, GetAssetPathById, sliceAssetId);
+                AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+                    assetPath, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, sliceAssetId);
                 AzFramework::StringFunc::Path::GetFullFileName(assetPath.c_str(), itemText);
                 if (itemText.empty())
                 {
@@ -1602,7 +1605,8 @@ namespace AzToolsFramework
                     item->m_selectedAsset = assetId;
 
                     AZStd::string assetPath;
-                    EBUS_EVENT_RESULT(assetPath, AZ::Data::AssetCatalogRequestBus, GetAssetPathById, assetId);
+                    AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+                        assetPath, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, assetId);
 
                     item->setText(1, assetPath.c_str());
 
@@ -1864,7 +1868,7 @@ namespace AzToolsFramework
         for (const AZ::EntityId& entityId : processEntityIds)
         {
             AZ::Entity* entity = nullptr;
-            EBUS_EVENT_RESULT(entity, AZ::ComponentApplicationBus, FindEntity, entityId);
+            AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, entityId);
 
             if (entity)
             {
@@ -2724,7 +2728,8 @@ namespace AzToolsFramework
             {
                 // Unsuccessful commit
                 AZStd::string sliceAssetPath;
-                EBUS_EVENT_RESULT(sliceAssetPath, AZ::Data::AssetCatalogRequestBus, GetAssetPathById, transactionPair.first);
+                AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+                    sliceAssetPath, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, transactionPair.first);
                 if (sliceAssetPath.empty())
                 {
                     sliceAssetPath = transactionPair.first.ToString<AZStd::string>();
@@ -2791,7 +2796,8 @@ namespace AzToolsFramework
                     }
 
                     AZStd::string sliceAssetPath;
-                    EBUS_EVENT_RESULT(sliceAssetPath, AZ::Data::AssetCatalogRequestBus, GetAssetPathById, asset.GetId());
+                    AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+                        sliceAssetPath, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, asset.GetId());
 
                     if (sliceAssetPath.empty())
                     {

--- a/Code/Framework/AzToolsFramework/Tests/EntityTestbed.h
+++ b/Code/Framework/AzToolsFramework/Tests/EntityTestbed.h
@@ -96,7 +96,7 @@ namespace UnitTest
                 []()
                 {
                     AZ::TickBus::ExecuteQueuedEvents();
-                    EBUS_EVENT(AZ::TickBus, OnTick, 0.3f, AZ::ScriptTimePoint());
+                    AZ::TickBus::Broadcast(&AZ::TickBus::Events::OnTick, 0.3f, AZ::ScriptTimePoint());
                 }
                 );
 
@@ -218,7 +218,8 @@ namespace UnitTest
 
         void DeleteSelected()
         {
-            EBUS_EVENT(AzToolsFramework::ToolsApplicationRequests::Bus, DeleteSelected);
+            AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+                &AzToolsFramework::ToolsApplicationRequests::Bus::Events::DeleteSelected);
         }
 
         void SaveRoot()
@@ -236,7 +237,8 @@ namespace UnitTest
 
         void ResetRoot()
         {
-            EBUS_EVENT(AzToolsFramework::EditorEntityContextRequestBus, ResetEditorContext);
+            AzToolsFramework::EditorEntityContextRequestBus::Broadcast(
+                &AzToolsFramework::EditorEntityContextRequestBus::Events::ResetEditorContext);
         }
     };
 } // namespace UnitTest;

--- a/Code/Framework/AzToolsFramework/Tests/EntityTestbed.h
+++ b/Code/Framework/AzToolsFramework/Tests/EntityTestbed.h
@@ -117,7 +117,7 @@ namespace UnitTest
             m_propertyEditor = aznew AzToolsFramework::EntityPropertyEditor(nullptr);
 
             AZ::SerializeContext* serializeContext = nullptr;
-            EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+            AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
             m_window->setMinimumHeight(600);
             m_propertyEditor->setMinimumWidth(600);

--- a/Code/Framework/AzToolsFramework/Tests/Script/ScriptComponentTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Script/ScriptComponentTests.cpp
@@ -53,9 +53,9 @@ namespace UnitTest
             systemEntity->Init();
             systemEntity->Activate();
 
-            EBUS_EVENT_RESULT(m_scriptContext, ScriptSystemRequestBus, GetContext, DefaultScriptContextId);
-            EBUS_EVENT_RESULT(m_behaviorContext, AZ::ComponentApplicationBus, GetBehaviorContext);
-            EBUS_EVENT_RESULT(m_serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+            ScriptSystemRequestBus::BroadcastResult(m_scriptContext, &ScriptSystemRequestBus::Events::GetContext, DefaultScriptContextId);
+            AZ::ComponentApplicationBus::BroadcastResult(m_behaviorContext, &AZ::ComponentApplicationBus::Events::GetBehaviorContext);
+            AZ::ComponentApplicationBus::BroadcastResult(m_serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
             AzToolsFramework::Components::ScriptEditorComponent::CreateDescriptor(); // descriptor is deleted by app
             AzToolsFramework::Components::ScriptEditorComponent::Reflect(m_serializeContext);

--- a/Code/Framework/AzToolsFramework/Tests/Script/ScriptComponentTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Script/ScriptComponentTests.cpp
@@ -81,7 +81,7 @@ namespace UnitTest
                 Data::Asset<ScriptAsset> scriptAsset = Data::AssetManager::Instance().CreateAsset<ScriptAsset>(Data::AssetId(id));
                 scriptAsset.SetAutoLoadBehavior(AZ::Data::AssetLoadBehavior::PreLoad);
                 scriptAsset.Get()->m_data = compileRequest.m_luaScriptDataOut;
-                EBUS_EVENT(Data::AssetManagerBus, OnAssetReady, scriptAsset);
+                Data::AssetManagerBus::Broadcast(&Data::AssetManagerBus::Events::OnAssetReady, scriptAsset);
                 m_app.Tick();
                 m_app.TickSystem(); // flush assets etc.
 

--- a/Code/Framework/AzToolsFramework/Tests/Slices.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Slices.cpp
@@ -403,7 +403,7 @@ namespace UnitTest
                 while (m_stressLoadPending > 0)
                 {
                     AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(10));
-                    EBUS_EVENT(AZ::TickBus, OnTick, 0.3f, AZ::ScriptTimePoint());
+                    AZ::TickBus::Broadcast(&AZ::TickBus::Events::OnTick, 0.3f, AZ::ScriptTimePoint());
                 }
 
                 const AZStd::chrono::steady_clock::time_point assetLoadFinishTime = AZStd::chrono::steady_clock::now();

--- a/Code/Framework/AzToolsFramework/Tests/Slices.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Slices.cpp
@@ -240,7 +240,8 @@ namespace UnitTest
                 azsnprintf(assetFile, AZ_ARRAY_SIZE(assetFile), "GeneratedSlices/Gen%zu_Descendent%zu_%zu.xml", generation, i, nextSliceIndex++);
 
                 AZ::Data::AssetId assetId;
-                EBUS_EVENT_RESULT(assetId, AZ::Data::AssetCatalogRequestBus, GetAssetIdByPath, assetFile, azrtti_typeid<AZ::SliceAsset>(), true);
+                AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+                    assetId, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetIdByPath, assetFile, azrtti_typeid<AZ::SliceAsset>(), true);
 
                 AZ::Utils::SaveObjectToFile(assetFile, AZ::DataStream::ST_XML, entity);
 
@@ -286,7 +287,8 @@ namespace UnitTest
             // override from the parent.
 
             AZ::Data::AssetId assetId;
-            EBUS_EVENT_RESULT(assetId, AZ::Data::AssetCatalogRequestBus, GetAssetIdByPath, "GeneratedSlices/Gen0.xml", azrtti_typeid<AZ::SliceAsset>(), true);
+            AZ::Data::AssetCatalogRequestBus::BroadcastResult(assetId, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetIdByPath,
+                "GeneratedSlices/Gen0.xml", azrtti_typeid<AZ::SliceAsset>(), true);
 
             AZ::Data::Asset<AZ::SliceAsset> baseSliceAsset;
             baseSliceAsset.Create(assetId, false);
@@ -310,7 +312,8 @@ namespace UnitTest
                 azsnprintf(assetFile, AZ_ARRAY_SIZE(assetFile), "GeneratedSlices/Gen%zu_Descendent%zu_%zu.xml", generation, i, nextSliceIndex++);
 
                 AZ::Data::AssetId assetId;
-                EBUS_EVENT_RESULT(assetId, AZ::Data::AssetCatalogRequestBus, GetAssetIdByPath, assetFile, azrtti_typeid<AZ::SliceAsset>(), true);
+                AZ::Data::AssetCatalogRequestBus::BroadcastResult(assetId, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetIdByPath,
+                    assetFile, azrtti_typeid<AZ::SliceAsset>(), true);
 
                 if (assetId.IsValid())
                 {
@@ -377,7 +380,8 @@ namespace UnitTest
 
             // Preload all slice assets.
             AZ::Data::AssetId rootAssetId;
-            EBUS_EVENT_RESULT(rootAssetId, AZ::Data::AssetCatalogRequestBus, GetAssetIdByPath, "GeneratedSlices/Gen0.xml", azrtti_typeid<AZ::SliceAsset>(), true);
+            AZ::Data::AssetCatalogRequestBus::BroadcastResult(rootAssetId, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetIdByPath,
+                "GeneratedSlices/Gen0.xml", azrtti_typeid<AZ::SliceAsset>(), true);
             if (rootAssetId.IsValid())
             {
                 AZ::Data::AssetBus::MultiHandler::BusConnect(rootAssetId);
@@ -420,7 +424,8 @@ namespace UnitTest
             // Instantiate from the bottom generation up.
             {
                 AZ::Data::AssetId assetId;
-                EBUS_EVENT_RESULT(assetId, AZ::Data::AssetCatalogRequestBus, GetAssetIdByPath, "GeneratedSlices/Gen0.xml", azrtti_typeid<AZ::SliceAsset>(), true);
+                AZ::Data::AssetCatalogRequestBus::BroadcastResult(assetId, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetIdByPath,
+                    "GeneratedSlices/Gen0.xml", azrtti_typeid<AZ::SliceAsset>(), true);
 
                 AZ::Data::Asset<AZ::SliceAsset> baseSliceAsset;
                 baseSliceAsset.Create(assetId, false);
@@ -481,7 +486,8 @@ namespace UnitTest
             static AZ::u32 sliceCounter = 1;
 
             AzToolsFramework::EntityIdList selected;
-            EBUS_EVENT_RESULT(selected, AzToolsFramework::ToolsApplicationRequests::Bus, GetSelectedEntities);
+            AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
+                selected, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::GetSelectedEntities);
 
             AZ::SliceComponent* rootSlice = nullptr;
             AzToolsFramework::SliceEditorEntityOwnershipServiceRequestBus::BroadcastResult(
@@ -500,7 +506,7 @@ namespace UnitTest
                 for (AZ::EntityId id : selected)
                 {
                     AZ::Entity* entity = nullptr;
-                    EBUS_EVENT_RESULT(entity, AZ::ComponentApplicationBus, FindEntity, id);
+                    AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, id);
                     if (entity)
                     {
                         AZ::SliceComponent::SliceInstanceAddress sliceAddress = rootSlice->FindSlice(entity);
@@ -557,7 +563,8 @@ namespace UnitTest
             if (!loadFrom.isEmpty())
             {
                 AZ::Data::AssetId assetId;
-                EBUS_EVENT_RESULT(assetId, AZ::Data::AssetCatalogRequestBus, GetAssetIdByPath, loadFrom.toUtf8().constData(), azrtti_typeid<AZ::SliceAsset>(), true);
+                AZ::Data::AssetCatalogRequestBus::BroadcastResult(assetId, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetIdByPath,
+                    loadFrom.toUtf8().constData(), azrtti_typeid<AZ::SliceAsset>(), true);
 
                 AZ::Data::Asset<AZ::SliceAsset> baseSliceAsset;
                 baseSliceAsset.Create(assetId, true);

--- a/Code/Tools/AssetBundler/source/utils/applicationManager.cpp
+++ b/Code/Tools/AssetBundler/source/utils/applicationManager.cpp
@@ -60,7 +60,7 @@ namespace AssetBundler
         Start(AzFramework::Application::Descriptor(), startupParameters);
 
         AZ::SerializeContext* context;
-        EBUS_EVENT_RESULT(context, AZ::ComponentApplicationBus, GetSerializeContext);
+        AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         AZ_Assert(context, "No serialize context");
         AzToolsFramework::AssetSeedManager::Reflect(context);
         AzToolsFramework::AssetFileInfoListComparison::Reflect(context);

--- a/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/AssetBuilderSDK.cpp
+++ b/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/AssetBuilderSDK.cpp
@@ -1213,7 +1213,7 @@ namespace AssetBuilderSDK
     {
         AZ::SerializeContext* serializeContext = nullptr;
 
-        EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         AZ_Assert(serializeContext, "Unable to retrieve serialize context.");
 
         InitializeReflectContext(serializeContext);
@@ -1223,7 +1223,7 @@ namespace AssetBuilderSDK
     {
         AZ::BehaviorContext* behaviorContext = nullptr;
 
-        EBUS_EVENT_RESULT(behaviorContext, AZ::ComponentApplicationBus, GetBehaviorContext);
+        AZ::ComponentApplicationBus::BroadcastResult(behaviorContext, &AZ::ComponentApplicationBus::Events::GetBehaviorContext);
         AZ_Error("asset", behaviorContext, "Unable to retrieve behavior context.");
         if (behaviorContext)
         {

--- a/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/AssetBuilderSDK.cpp
+++ b/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/AssetBuilderSDK.cpp
@@ -141,7 +141,7 @@ namespace AssetBuilderSDK
     {
         va_list args;
         va_start(args, message);
-        EBUS_EVENT(AssetBuilderSDK::AssetBuilderBus, BuilderLog, builderId, message, args);
+        AssetBuilderSDK::AssetBuilderBus::Broadcast(&AssetBuilderSDK::AssetBuilderBus::Events::BuilderLog, builderId, message, args);
         va_end(args);
     }
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
@@ -291,7 +291,7 @@ namespace AssetProcessor
             m_catalogIsDirty = false;
             // Reflect registry for serialization.
             AZ::SerializeContext* serializeContext = nullptr;
-            EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+            AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
             AZ_Assert(serializeContext, "Unable to retrieve serialize context.");
             if (nullptr == serializeContext->FindClassData(AZ::AzTypeInfo<AzFramework::AssetRegistry>::Uuid()))
             {

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetRequestHandler.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetRequestHandler.cpp
@@ -480,7 +480,7 @@ void AssetRequestHandler::SendAssetStatus(NetworkRequestID groupID, unsigned int
 {
     ResponseAssetStatus resp;
     resp.m_assetStatus = status;
-    EBUS_EVENT_ID(groupID.first, AssetProcessor::ConnectionBus, SendResponse, groupID.second, resp);
+    AssetProcessor::ConnectionBus::Event(groupID.first, &AssetProcessor::ConnectionBus::Events::SendResponse, groupID.second, resp);
 }
 
 AssetRequestHandler::AssetRequestHandler()

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetRequestHandler.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetRequestHandler.cpp
@@ -581,7 +581,7 @@ void AssetRequestHandler::DeleteFenceFile_Retry(unsigned int fenceId, QString fe
 void AssetRequestHandler::OnNewIncomingRequest(unsigned int connId, unsigned int serial, QByteArray payload, QString platform)
 {
     AZ::SerializeContext* serializeContext = nullptr;
-    EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
+    AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
     AZ_Assert(serializeContext, "Unable to retrieve serialize context.");
     AZStd::shared_ptr<BaseAssetProcessorMessage> message{ AZ::Utils::LoadObjectFromBuffer<BaseAssetProcessorMessage>(payload.constData(), payload.size(), serializeContext) };
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -837,7 +837,7 @@ namespace AssetProcessor
             // send a network message when not in batch mode.
             const ScanFolderInfo* scanFolder = m_platformConfig->GetScanFolderByPath(jobEntry.m_sourceAssetReference.ScanFolderPath().c_str());
             AzToolsFramework::AssetSystem::SourceFileNotificationMessage message(AZ::OSString(source.m_sourceName.c_str()), AZ::OSString(scanFolder->ScanPath().toUtf8().constData()), AzToolsFramework::AssetSystem::SourceFileNotificationMessage::FileFailed, source.m_sourceGuid);
-            EBUS_EVENT(AssetProcessor::ConnectionBus, Send, 0, message);
+            AssetProcessor::ConnectionBus::Broadcast(&AssetProcessor::ConnectionBus::Events::Send, 0, message);
             MessageInfoBus::Broadcast(&MessageInfoBusTraits::OnAssetFailed, source.m_sourceName);
         }
 
@@ -2281,7 +2281,8 @@ namespace AssetProcessor
         ++m_numTotalSourcesFound;
 
         AssetProcessor::BuilderInfoList builderInfoList;
-        EBUS_EVENT(AssetProcessor::AssetBuilderInfoBus, GetMatchingBuildersInfo, sourceAsset.AbsolutePath().c_str(), builderInfoList);
+        AssetProcessor::AssetBuilderInfoBus::Broadcast(
+            &AssetProcessor::AssetBuilderInfoBus::Events::GetMatchingBuildersInfo, sourceAsset.AbsolutePath().c_str(), builderInfoList);
 
         if (builderInfoList.size())
         {

--- a/Code/Tools/AssetProcessor/native/FileServer/fileServer.cpp
+++ b/Code/Tools/AssetProcessor/native/FileServer/fileServer.cpp
@@ -274,7 +274,7 @@ template <class R>
 inline void FileServer::Send(unsigned int connId, unsigned int serial, const R& response)
 {
     size_t bytesSent;
-    EBUS_EVENT_ID_RESULT(bytesSent, connId, AssetProcessor::ConnectionBus, SendResponse, serial, response);
+    AssetProcessor::ConnectionBus::EventResult(bytesSent, connId, &AssetProcessor::ConnectionBus::Events::SendResponse, serial, response);
     m_bytesSent += bytesSent;
     AddBytesSent(connId, bytesSent, m_realtimeMetrics);
 }

--- a/Code/Tools/AssetProcessor/native/connection/connectionManager.cpp
+++ b/Code/Tools/AssetProcessor/native/connection/connectionManager.cpp
@@ -185,7 +185,8 @@ void ConnectionManager::OnStatusChanged(unsigned int connId)
 
             if (priorCount == 0)
             {
-                EBUS_EVENT(AssetProcessorPlatformBus, AssetProcessorPlatformConnected, thisPlatform.toUtf8().data());
+                AssetProcessorPlatformBus::Broadcast(
+                    &AssetProcessorPlatformBus::Events::AssetProcessorPlatformConnected, thisPlatform.toUtf8().data());
             }
         }
     }
@@ -198,7 +199,8 @@ void ConnectionManager::OnStatusChanged(unsigned int connId)
             m_platformsConnected[thisPlatform] = priorCount - 1;
             if (priorCount == 1)
             {
-                EBUS_EVENT(AssetProcessorPlatformBus, AssetProcessorPlatformDisconnected, thisPlatform.toUtf8().data());
+                AssetProcessorPlatformBus::Broadcast(
+                    &AssetProcessorPlatformBus::Events::AssetProcessorPlatformDisconnected, thisPlatform.toUtf8().data());
             }
         }
     }

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/RCBuilder.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/RCBuilder.cpp
@@ -441,7 +441,7 @@ namespace AssetProcessor
             // Register the builder desc if its registrable
             if ((builder.GetType() == BuilderIdAndName::Type::REGISTERED_BUILDER) && (builder.GetUuid(builderUuid)))
             {
-                EBUS_EVENT(AssetBuilderRegistrationBus, UnRegisterBuilderDescriptor, builderUuid);
+                AssetBuilderRegistrationBus::Broadcast(&AssetBuilderRegistrationBus::Events::UnRegisterBuilderDescriptor, builderUuid);
             }
         }
     }

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -3016,7 +3016,8 @@ TEST_F(AssetProcessorManagerTest, AssessDeletedFile_OnJobInFlight_IsIgnored)
         ASSERT_FALSE(gotUnexpectedAssetToProcess);
 
         // now tell it to stop ignoring the cache delete and let it do the next one.
-        EBUS_EVENT(AssetProcessor::ProcessingJobInfoBus, EndCacheFileUpdate, filePathToGenerate.toUtf8().data(), false);
+        AssetProcessor::ProcessingJobInfoBus::Broadcast(
+            &AssetProcessor::ProcessingJobInfoBus::Events::EndCacheFileUpdate, filePathToGenerate.toUtf8().data(), false);
 
         // simulate a "late" deletion notify coming from the file monitor that it outside the "ignore delete" section.  This should STILL not generate additional
         // deletion notifies as it should ignore these if the file in fact actually there when it gets around to checking it

--- a/Code/Tools/AssetProcessor/native/unittests/MockApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/MockApplicationManager.cpp
@@ -129,7 +129,7 @@ namespace AssetProcessor
             // After the first initialization, the builder with id BUILDER_ID_COPY will have already been registered to the builder bus.  
             // After the initial registration, make sure to unregister based on the fixed internal uuid so we can register it again
             AZ::Uuid uuid = AZ::Uuid::CreateString(newBuilderId.toUtf8().data());
-            EBUS_EVENT(AssetBuilderRegistrationBus, UnRegisterBuilderDescriptor, uuid);
+            AssetBuilderRegistrationBus::Broadcast(&AssetBuilderRegistrationBus::Events::UnRegisterBuilderDescriptor, uuid);
         }
 
         if (!builder->InitializeMockBuilder(rec))

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.cpp
@@ -326,10 +326,11 @@ void ApplicationManager::QuitRequested()
     m_duringShutdown = true;
 
     //Inform all the builders to shutdown
-    EBUS_EVENT(AssetBuilderSDK::AssetBuilderCommandBus, ShutDown);
+    AssetBuilderSDK::AssetBuilderCommandBus::Broadcast(&AssetBuilderSDK::AssetBuilderCommandBus::Events::ShutDown);
 
     // the following call will invoke on the main thread of the application, since its a direct bus call.
-    EBUS_EVENT(AssetProcessor::ApplicationManagerNotifications::Bus, ApplicationShutdownRequested);
+    AssetProcessor::ApplicationManagerNotifications::Bus::Broadcast(
+        &AssetProcessor::ApplicationManagerNotifications::Bus::Events::ApplicationShutdownRequested);
 
     // while it may be tempting to just collapse all of this to a bus call,  Qt Objects have the advantage of being
     // able to automatically queue calls onto their own thread, and a lot of these involved objects are in fact

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.cpp
@@ -225,7 +225,7 @@ ApplicationManager::~ApplicationManager()
     }
 
     //Unregistering and deleting all the components
-    EBUS_EVENT_ID(azrtti_typeid<AzFramework::LogComponent>(), AZ::ComponentDescriptorBus, ReleaseDescriptor);
+    AZ::ComponentDescriptorBus::Event(azrtti_typeid<AzFramework::LogComponent>(), &AZ::ComponentDescriptorBus::Events::ReleaseDescriptor);
 
     //Stop AZFramework
     m_frameworkApp.Stop();

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -602,7 +602,7 @@ void ApplicationManagerBase::InitConnectionManager()
                 QString msg = QCoreApplication::translate("O3DE Asset Processor", "Processing %1 (%2)...\n", "%1 is the name of the file, and %2 is the platform to process it for").arg(inputFile, platform);
                 AZ_Printf(AssetProcessor::ConsoleChannel, "%s", msg.toUtf8().constData());
                 AssetNotificationMessage message(inputFile.toUtf8().constData(), AssetNotificationMessage::JobStarted, AZ::Data::s_invalidAssetType, platform.toUtf8().constData());
-                EBUS_EVENT(AssetProcessor::ConnectionBus, SendPerPlatform, 0, message, platform);
+                AssetProcessor::ConnectionBus::Broadcast(&AssetProcessor::ConnectionBus::Events::SendPerPlatform, 0, message, platform);
             }
             );
     AZ_Assert(result, "Failed to connect to RCController signal");
@@ -611,7 +611,11 @@ void ApplicationManagerBase::InitConnectionManager()
             [](AssetProcessor::JobEntry entry, AssetBuilderSDK::ProcessJobResponse /*response*/)
             {
                 AssetNotificationMessage message(entry.m_sourceAssetReference.RelativePath().c_str(), AssetNotificationMessage::JobCompleted, AZ::Data::s_invalidAssetType, entry.m_platformInfo.m_identifier.c_str());
-                EBUS_EVENT(AssetProcessor::ConnectionBus, SendPerPlatform, 0, message, QString::fromUtf8(entry.m_platformInfo.m_identifier.c_str()));
+            AssetProcessor::ConnectionBus::Broadcast(
+                &AssetProcessor::ConnectionBus::Events::SendPerPlatform,
+                0,
+                message,
+                QString::fromUtf8(entry.m_platformInfo.m_identifier.c_str()));
             }
             );
     AZ_Assert(result, "Failed to connect to RCController signal");
@@ -620,7 +624,11 @@ void ApplicationManagerBase::InitConnectionManager()
             [](AssetProcessor::JobEntry entry)
             {
                 AssetNotificationMessage message(entry.m_sourceAssetReference.RelativePath().c_str(), AssetNotificationMessage::JobFailed, AZ::Data::s_invalidAssetType, entry.m_platformInfo.m_identifier.c_str());
-                EBUS_EVENT(AssetProcessor::ConnectionBus, SendPerPlatform, 0, message, QString::fromUtf8(entry.m_platformInfo.m_identifier.c_str()));
+            AssetProcessor::ConnectionBus::Broadcast(
+                &AssetProcessor::ConnectionBus::Events::SendPerPlatform,
+                0,
+                message,
+                QString::fromUtf8(entry.m_platformInfo.m_identifier.c_str()));
             }
             );
     AZ_Assert(result, "Failed to connect to RCController signal");
@@ -629,7 +637,7 @@ void ApplicationManagerBase::InitConnectionManager()
             [](QString platform, int count)
             {
                 AssetNotificationMessage message(QByteArray::number(count).constData(), AssetNotificationMessage::JobCount, AZ::Data::s_invalidAssetType, platform.toUtf8().constData());
-                EBUS_EVENT(AssetProcessor::ConnectionBus, SendPerPlatform, 0, message, platform);
+                AssetProcessor::ConnectionBus::Broadcast(&AssetProcessor::ConnectionBus::Events::SendPerPlatform, 0, message, platform);
             }
             );
     AZ_Assert(result, "Failed to connect to RCController signal");

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -638,7 +638,7 @@ void ApplicationManagerBase::InitConnectionManager()
         AZStd::bind([](unsigned int connId, unsigned int /*type*/, unsigned int serial, QByteArray /*payload*/)
             {
                 ResponsePing responsePing;
-                EBUS_EVENT_ID(connId, AssetProcessor::ConnectionBus, SendResponse, serial, responsePing);
+                AssetProcessor::ConnectionBus::Event(connId, &AssetProcessor::ConnectionBus::Events::SendResponse, serial, responsePing);
             }, AZStd::placeholders::_1, AZStd::placeholders::_2, AZStd::placeholders::_3, AZStd::placeholders::_4)
         );
 
@@ -713,7 +713,8 @@ void ApplicationManagerBase::InitConnectionManager()
                     Q_EMIT ConnectionStatusMsg(QString(" Critical assets need to be processed for %1 platform. Editor/Game will launch once they are processed.").arg(requestAssetProcessorMessage.m_platform.c_str()));
                     m_highestConnId = connId;
                 }
-                EBUS_EVENT_ID(connId, AssetProcessor::ConnectionBus, SendResponse, serial, responseAssetProcessorMessage);
+                AssetProcessor::ConnectionBus::Event(
+                    connId, &AssetProcessor::ConnectionBus::Events::SendResponse, serial, responseAssetProcessorMessage);
             }
         };
     // connect the network messages to the Request handler:

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -607,30 +607,42 @@ void ApplicationManagerBase::InitConnectionManager()
             );
     AZ_Assert(result, "Failed to connect to RCController signal");
 
-    result = QObject::connect(GetRCController(), &AssetProcessor::RCController::FileCompiled, this,
-            [](AssetProcessor::JobEntry entry, AssetBuilderSDK::ProcessJobResponse /*response*/)
-            {
-                AssetNotificationMessage message(entry.m_sourceAssetReference.RelativePath().c_str(), AssetNotificationMessage::JobCompleted, AZ::Data::s_invalidAssetType, entry.m_platformInfo.m_identifier.c_str());
+    result = QObject::connect(
+        GetRCController(),
+        &AssetProcessor::RCController::FileCompiled,
+        this,
+        [](AssetProcessor::JobEntry entry, AssetBuilderSDK::ProcessJobResponse /*response*/)
+        {
+            AssetNotificationMessage message(
+                entry.m_sourceAssetReference.RelativePath().c_str(),
+                AssetNotificationMessage::JobCompleted,
+                AZ::Data::s_invalidAssetType,
+                entry.m_platformInfo.m_identifier.c_str());
             AssetProcessor::ConnectionBus::Broadcast(
                 &AssetProcessor::ConnectionBus::Events::SendPerPlatform,
                 0,
                 message,
                 QString::fromUtf8(entry.m_platformInfo.m_identifier.c_str()));
-            }
-            );
+        });
     AZ_Assert(result, "Failed to connect to RCController signal");
 
-    result = QObject::connect(GetRCController(), &AssetProcessor::RCController::FileFailed, this,
-            [](AssetProcessor::JobEntry entry)
-            {
-                AssetNotificationMessage message(entry.m_sourceAssetReference.RelativePath().c_str(), AssetNotificationMessage::JobFailed, AZ::Data::s_invalidAssetType, entry.m_platformInfo.m_identifier.c_str());
+    result = QObject::connect(
+        GetRCController(),
+        &AssetProcessor::RCController::FileFailed,
+        this,
+        [](AssetProcessor::JobEntry entry)
+        {
+            AssetNotificationMessage message(
+                entry.m_sourceAssetReference.RelativePath().c_str(),
+                AssetNotificationMessage::JobFailed,
+                AZ::Data::s_invalidAssetType,
+                entry.m_platformInfo.m_identifier.c_str());
             AssetProcessor::ConnectionBus::Broadcast(
                 &AssetProcessor::ConnectionBus::Events::SendPerPlatform,
                 0,
                 message,
                 QString::fromUtf8(entry.m_platformInfo.m_identifier.c_str()));
-            }
-            );
+        });
     AZ_Assert(result, "Failed to connect to RCController signal");
 
     result = QObject::connect(GetRCController(), &AssetProcessor::RCController::JobsInQueuePerPlatform, this,

--- a/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
@@ -367,7 +367,7 @@ bool GUIApplicationManager::Run()
     m_mainWindow = nullptr;
 
     AZ::SerializeContext* context;
-    EBUS_EVENT_RESULT(context, AZ::ComponentApplicationBus, GetSerializeContext);
+    AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
     AZ_Assert(context, "No serialize context");
     QDir projectCacheRoot;
     AssetUtilities::ComputeProjectCacheRoot(projectCacheRoot);
@@ -490,7 +490,7 @@ bool GUIApplicationManager::Activate()
     m_startupErrorCollector = AZStd::make_unique<ErrorCollector>(m_mainWindow);
 
     AZ::SerializeContext* context;
-    EBUS_EVENT_RESULT(context, AZ::ComponentApplicationBus, GetSerializeContext);
+    AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
     AZ_Assert(context, "No serialize context");
     QDir projectCacheRoot;
     AssetUtilities::ComputeProjectCacheRoot(projectCacheRoot);

--- a/Code/Tools/LuaIDE/Source/Editor/LuaEditor.cpp
+++ b/Code/Tools/LuaIDE/Source/Editor/LuaEditor.cpp
@@ -66,8 +66,9 @@ int main(int argc, char* argv[])
         // so ideally to make a file processor or something, simply call app.Initialize(.... but with false as the gui mode ... )
         // and make at least one component which starts processing in response to CoreMessages::RestoreState(), and then sends UserWantsToQuit() once it has done its processing.
         // calling UserWantsToQuit will simply queue the quit, so its safe to call from any thread.
-        // your components can query EBUS_EVENT_RESULT(res, LegacyFramework::FrameworkApplicationMessages::IsRunningInGUIMode) to determine
-        // if its in GUI mode or not.
+        // your components can query
+        // FrameworkApplicationMessages::Bus::BroadcastResult(result, &FrameworkApplicationMessages::Bus::Events::IsRunningInGUIMode) to
+        // determine if its in GUI mode or not.
     }
 
     return exitCode;

--- a/Code/Tools/LuaIDE/Source/Editor/LuaEditor.cpp
+++ b/Code/Tools/LuaIDE/Source/Editor/LuaEditor.cpp
@@ -62,7 +62,7 @@ int main(int argc, char* argv[])
         // but make a component which does your processing, in response to RestoreState(). in the  CoreMessages bus.
         // RestoreState will always be called right before the main message pump activates.
         // and will then block until someone calls:
-        /*EBUS_EVENT(UIFramework::FrameworkMessages::Bus, UserWantsToQuit); */
+        /*UIFramework::FrameworkMessages::Bus::Broadcast(&UIFramework::FrameworkMessages::Bus::Events::UserWantsToQuit); */
         // so ideally to make a file processor or something, simply call app.Initialize(.... but with false as the gui mode ... )
         // and make at least one component which starts processing in response to CoreMessages::RestoreState(), and then sends UserWantsToQuit() once it has done its processing.
         // calling UserWantsToQuit will simply queue the quit, so its safe to call from any thread.

--- a/Code/Tools/LuaIDE/Source/LUA/BreakpointPanel.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/BreakpointPanel.cpp
@@ -30,7 +30,8 @@ DHBreakpointsWidget::~DHBreakpointsWidget()
 void DHBreakpointsWidget::PullFromContext()
 {
     const LUAEditor::BreakpointMap* myData = NULL;
-    EBUS_EVENT_RESULT(myData, LUAEditor::LUABreakpointRequestMessages::Bus, RequestBreakpoints);
+    LUAEditor::LUABreakpointRequestMessages::Bus::BroadcastResult(
+        myData, &LUAEditor::LUABreakpointRequestMessages::Bus::Events::RequestBreakpoints);
     AZ_Assert(myData, "Nobody responded to the request breakpoints message.");
     BreakpointsUpdate(*myData);
 }

--- a/Code/Tools/LuaIDE/Source/LUA/BreakpointPanel.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/BreakpointPanel.cpp
@@ -174,7 +174,10 @@ void DHBreakpointsWidget::OnDoubleClicked(const QModelIndex& modelIdx)
     QTableWidgetItem* line = item(modelIdx.row(), 0);
     QTableWidgetItem* file = item(modelIdx.row(), 1);
 
-    EBUS_EVENT(LUAEditor::LUABreakpointRequestMessages::Bus, RequestEditorFocus, AZStd::string(file->data(Qt::DisplayRole).toString().toUtf8().data()), line->data(Qt::DisplayRole).toInt());
+    LUAEditor::LUABreakpointRequestMessages::Bus::Broadcast(
+        &LUAEditor::LUABreakpointRequestMessages::Bus::Events::RequestEditorFocus,
+        AZStd::string(file->data(Qt::DisplayRole).toString().toUtf8().data()),
+        line->data(Qt::DisplayRole).toInt());
 }
 
 void DHBreakpointsWidget::RemoveRow(int which)
@@ -186,5 +189,6 @@ void DHBreakpointsWidget::RemoveRow(int which)
     QByteArray fileName = file->data(Qt::DisplayRole).toString().toUtf8().data();
     int lineNumber = line->data(Qt::DisplayRole).toInt();
 
-    EBUS_EVENT(LUAEditor::LUABreakpointRequestMessages::Bus, RequestDeleteBreakpoint, AZStd::string(fileName.constData()), lineNumber);
+    LUAEditor::LUABreakpointRequestMessages::Bus::Broadcast(
+        &LUAEditor::LUABreakpointRequestMessages::Bus::Events::RequestDeleteBreakpoint, AZStd::string(fileName.constData()), lineNumber);
 }

--- a/Code/Tools/LuaIDE/Source/LUA/CodeCompletion/LUACompletionModel.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/CodeCompletion/LUACompletionModel.cpp
@@ -64,9 +64,9 @@ namespace LUAEditor
     void CompletionModel::UpdateKeywords()
     {
         const HighlightedWords::LUAKeywordsType* keywords = nullptr;
-        EBUS_EVENT_RESULT(keywords, HighlightedWords::Bus, GetLUAKeywords);
+        HighlightedWords::Bus::BroadcastResult(keywords, &HighlightedWords::Bus::Events::GetLUAKeywords);
         const HighlightedWords::LUAKeywordsType* libraryFuncs = nullptr;
-        EBUS_EVENT_RESULT(libraryFuncs, HighlightedWords::Bus, GetLUALibraryFunctions);
+        HighlightedWords::Bus::BroadcastResult(libraryFuncs, &HighlightedWords::Bus::Events::GetLUALibraryFunctions);
 
         m_keywords.clear();
         m_builtIns.Reset();

--- a/Code/Tools/LuaIDE/Source/LUA/DebugAttachmentButton.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/DebugAttachmentButton.cpp
@@ -58,12 +58,12 @@ namespace LUAEditor
         switch (m_State)
         {
         case DAS_ATTACHED:
-            EBUS_EVENT(Context_DebuggerManagement::Bus, RequestDetachDebugger);
+            Context_DebuggerManagement::Bus::Broadcast(&Context_DebuggerManagement::Bus::Events::RequestDetachDebugger);
             break;
         case DAS_UNATTACHED:
         case DAS_REFUSED:
         {
-            EBUS_EVENT(Context_DebuggerManagement::Bus, RequestAttachDebugger);
+            Context_DebuggerManagement::Bus::Broadcast(&Context_DebuggerManagement::Bus::Events::RequestAttachDebugger);
         }
         break;
         }

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorContext.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorContext.cpp
@@ -408,7 +408,7 @@ namespace LUAEditor
                             if (!m_bReloadCheckQueued)
                             {
                                 m_bReloadCheckQueued = true;
-                                EBUS_QUEUE_FUNCTION(AZ::SystemTickBus, &Context::ProcessReloadCheck, this);
+                                AZ::SystemTickBus::QueueFunction(&Context::ProcessReloadCheck, this);
                             }
                         }
                     }
@@ -491,7 +491,7 @@ namespace LUAEditor
                 {
                     AZ_TracePrintf(LUAEditorDebugName, "ProcessReloadCheck user queueing reload for assetId '%s' '%s'\n", info.m_assetId.c_str(), info.m_assetName.c_str());
                 }
-                EBUS_QUEUE_FUNCTION(AZ::SystemTickBus, &Context::OnReloadDocument, this, info.m_assetId);
+                AZ::SystemTickBus::QueueFunction(&Context::OnReloadDocument, this, info.m_assetId);
             }
             else
             {
@@ -1476,7 +1476,7 @@ namespace LUAEditor
                 return;
             }
 
-            EBUS_QUEUE_FUNCTION(AZ::SystemTickBus, &Context::OpenMostRecentDocumentView, this);
+            AZ::SystemTickBus::QueueFunction(&Context::OpenMostRecentDocumentView, this);
             return;
         }
 
@@ -1567,7 +1567,7 @@ namespace LUAEditor
         }
 
         mostRecentlyOpenedDocumentView = normalizedAssetId;
-        EBUS_QUEUE_FUNCTION(AZ::SystemTickBus, &Context::OpenMostRecentDocumentView, this);
+        AZ::SystemTickBus::QueueFunction(&Context::OpenMostRecentDocumentView, this);
     }
 
     void Context::RunAsAnotherInstance()
@@ -2424,7 +2424,7 @@ namespace LUAEditor
             AZStd::lock_guard<AZStd::mutex> lock(m_failedAssetMessagesMutex);
             m_failedAssets.push(assetPath);
 
-            EBUS_QUEUE_FUNCTION(AZ::SystemTickBus, &Context::ProcessFailedAssetMessages, this);
+            AZ::SystemTickBus::QueueFunction(&Context::ProcessFailedAssetMessages, this);
         }
     }
 

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorContext.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorContext.cpp
@@ -173,7 +173,7 @@ namespace LUAEditor
         desc.name = "LUA Editor";
         desc.ContextID = ContextID;
         desc.hotkeyDesc = AzToolsFramework::HotkeyDescription(AZ_CRC("LUAOpenEditor", 0x5870cf6d), "Ctrl+Shift+L", "Open LUA Editor", "General", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW);
-        EBUS_EVENT(AzToolsFramework::FrameworkMessages::Bus, AddComponentInfo, desc);
+        AzToolsFramework::FrameworkMessages::Bus::Broadcast(&AzToolsFramework::FrameworkMessages::Bus::Events::AddComponentInfo, desc);
 
         LegacyFramework::IPCCommandBus::BroadcastResult(
             m_ipcOpenFilesHandle,
@@ -203,7 +203,7 @@ namespace LUAEditor
 
     void Context::Deactivate()
     {
-        EBUS_EVENT(LegacyFramework::IPCCommandBus, UnregisterIPCHandler, m_ipcOpenFilesHandle);
+        LegacyFramework::IPCCommandBus::Broadcast(&LegacyFramework::IPCCommandBus::Events::UnregisterIPCHandler, m_ipcOpenFilesHandle);
 
         //AzToolsFramework::UnRegisterAssetType(AZ::ScriptAsset::StaticAssetType());
         LUATargetContextRequestMessages::Handler::BusDisconnect();
@@ -291,7 +291,8 @@ namespace LUAEditor
                 m_pLUAEditorMainWindow->setFocus();
 
 
-                EBUS_EVENT(LUABreakpointTrackerMessages::Bus, BreakpointsUpdate, m_pBreakpointSavedState->m_Breakpoints);
+                LUABreakpointTrackerMessages::Bus::Broadcast(
+                    &LUABreakpointTrackerMessages::Bus::Events::BreakpointsUpdate, m_pBreakpointSavedState->m_Breakpoints);
             }
 
             return true;
@@ -324,7 +325,8 @@ namespace LUAEditor
     void Context::ApplicationCensus()
     {
         auto newState = AZ::UserSettings::CreateFind<LUAEditorContextSavedState>(AZ_CRC("LUA EDITOR CONTEXT STATE", 0xc20c7427), AZ::UserSettings::CT_LOCAL);
-        EBUS_EVENT(AzToolsFramework::FrameworkMessages::Bus, ApplicationCensusReply, newState->m_MainEditorWindowIsVisible);
+        AzToolsFramework::FrameworkMessages::Bus::Broadcast(
+            &AzToolsFramework::FrameworkMessages::Bus::Events::ApplicationCensusReply, newState->m_MainEditorWindowIsVisible);
     }
 
     void Context::AddDefaultLUAKeywords()
@@ -516,17 +518,17 @@ namespace LUAEditor
 
         if (connected)
         {
-            EBUS_EVENT(LUAEditorDebuggerMessages::Bus, EnumerateContexts);
-            EBUS_EVENT(LUAEditorMainWindowMessages::Bus, OnConnectedToTarget);
-            EBUS_EVENT(LUAEditor::Context_ControlManagement::Bus, OnTargetConnected);
+            LUAEditorDebuggerMessages::Bus::Broadcast(&LUAEditorDebuggerMessages::Bus::Events::EnumerateContexts);
+            LUAEditorMainWindowMessages::Bus::Broadcast(&LUAEditorMainWindowMessages::Bus::Events::OnConnectedToTarget);
+            LUAEditor::Context_ControlManagement::Bus::Broadcast(&LUAEditor::Context_ControlManagement::Bus::Events::OnTargetConnected);
             m_connectedState = true;
 
         }
         else
         {
-            EBUS_EVENT(LUAEditorMainWindowMessages::Bus, OnDisconnectedFromTarget);
-            EBUS_EVENT(LUAEditor::Context_ControlManagement::Bus, OnTargetDisconnected);
-            EBUS_EVENT(LUAEditor::Context_DebuggerManagement::Bus, OnDebuggerDetached);
+            LUAEditorMainWindowMessages::Bus::Broadcast(&LUAEditorMainWindowMessages::Bus::Events::OnDisconnectedFromTarget);
+            LUAEditor::Context_ControlManagement::Bus::Broadcast(&LUAEditor::Context_ControlManagement::Bus::Events::OnTargetDisconnected);
+            LUAEditor::Context_DebuggerManagement::Bus::Broadcast(&LUAEditor::Context_DebuggerManagement::Bus::Events::OnDebuggerDetached);
             m_connectedState = false;
 
         }
@@ -646,7 +648,8 @@ namespace LUAEditor
                 if (bp.m_documentLine == lineNumber - 1) // -1 offset is counter to the +1 line numbering scheme used by the LUA editor
                 {
                     DeleteBreakpoint(bp.m_breakpointId);
-                    EBUS_EVENT(LUABreakpointTrackerMessages::Bus, BreakpointsUpdate, m_pBreakpointSavedState->m_Breakpoints);
+                    LUABreakpointTrackerMessages::Bus::Broadcast(
+                        &LUABreakpointTrackerMessages::Bus::Events::BreakpointsUpdate, m_pBreakpointSavedState->m_Breakpoints);
                     break;
                 }
             }
@@ -666,24 +669,24 @@ namespace LUAEditor
         typedef AzToolsFramework::FrameworkMessages::Bus HotkeyBus;
         // register our hotkeys so that they exist in the preferences panel even if we're not open:
 
-        EBUS_EVENT(HotkeyBus, RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAFind", 0xc62d8078),                    "Ctrl+F",           "Find",                                 "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
-        EBUS_EVENT(HotkeyBus, RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAQuickFindLocal", 0x115cbcda),          "Ctrl+F3",          "Quick Find Local",                     "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
-        EBUS_EVENT(HotkeyBus, RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAQuickFindLocalReverse", 0xdd8a0c22),   "Ctrl+Shift+F3",    "Quick Find Local (Reverse)",           "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
-        EBUS_EVENT(HotkeyBus, RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAFindInFiles", 0xdaebdfdd),             "Ctrl+Shift+F",     "Find In Files",                        "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
-        EBUS_EVENT(HotkeyBus, RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAReplace", 0x1fd5510c),                 "Ctrl+R",           "Replace",                              "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
-        EBUS_EVENT(HotkeyBus, RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAReplaceInFiles", 0x38b609e0),          "Ctrl+Shift+R",     "Replace In Files",                     "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
-        EBUS_EVENT(HotkeyBus, RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAGoToLine", 0xb6603f27),                "Ctrl+G",           "Go to line number...",                 "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
-        EBUS_EVENT(HotkeyBus, RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAFold", 0xf0969e48),                    "Alt+0",            "Fold Source Functions",                "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
-        EBUS_EVENT(HotkeyBus, RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAUnfold", 0x36934ecd),                  "Alt+Shift+0",      "Unfold Source Functions",              "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
-        EBUS_EVENT(HotkeyBus, RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUACloseAllExceptCurrent", 0x0076409a),   "Ctrl+Alt+F4",      "Close All Windows Except Current",     "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
-        EBUS_EVENT(HotkeyBus, RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUACloseAll", 0xf732678f),                "Ctrl+Shift+F4",    "Close All Windows",                    "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
-        EBUS_EVENT(HotkeyBus, RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAComment", 0x873c2725),                 "Ctrl+K",           "Comment Selected Block",               "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
-        EBUS_EVENT(HotkeyBus, RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAUncomment", 0x9190cf18),               "Ctrl+Shift+K",     "Uncomment Selected Block",             "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
+        HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAFind", 0xc62d8078),                    "Ctrl+F",           "Find",                                 "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
+        HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAQuickFindLocal", 0x115cbcda),          "Ctrl+F3",          "Quick Find Local",                     "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
+        HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAQuickFindLocalReverse", 0xdd8a0c22),   "Ctrl+Shift+F3",    "Quick Find Local (Reverse)",           "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
+        HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAFindInFiles", 0xdaebdfdd),             "Ctrl+Shift+F",     "Find In Files",                        "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
+        HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAReplace", 0x1fd5510c),                 "Ctrl+R",           "Replace",                              "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
+        HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAReplaceInFiles", 0x38b609e0),          "Ctrl+Shift+R",     "Replace In Files",                     "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
+        HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAGoToLine", 0xb6603f27),                "Ctrl+G",           "Go to line number...",                 "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
+        HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAFold", 0xf0969e48),                    "Alt+0",            "Fold Source Functions",                "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
+        HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAUnfold", 0x36934ecd),                  "Alt+Shift+0",      "Unfold Source Functions",              "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
+        HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUACloseAllExceptCurrent", 0x0076409a),   "Ctrl+Alt+F4",      "Close All Windows Except Current",     "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
+        HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUACloseAll", 0xf732678f),                "Ctrl+Shift+F4",    "Close All Windows",                    "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
+        HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAComment", 0x873c2725),                 "Ctrl+K",           "Comment Selected Block",               "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
+        HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAUncomment", 0x9190cf18),               "Ctrl+Shift+K",     "Uncomment Selected Block",             "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
 
-        EBUS_EVENT(HotkeyBus, RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUALinesUpTranspose", 0xafc899ef),        "Ctrl+Shift+Up",    "Transpose Lines Up",                   "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
-        EBUS_EVENT(HotkeyBus, RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUALinesDnTranspose", 0xf9d733bf),        "Ctrl+Shift+Down",  "Transpose Lines Down",                 "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
+        HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUALinesUpTranspose", 0xafc899ef),        "Ctrl+Shift+Up",    "Transpose Lines Up",                   "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
+        HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUALinesDnTranspose", 0xf9d733bf),        "Ctrl+Shift+Down",  "Transpose Lines Down",                 "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
 
-        EBUS_EVENT(HotkeyBus, RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAResetZoom", 0xbe0787ad),               "Ctrl+0",           "Reset Default Zoom",                   "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
+        HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAResetZoom", 0xbe0787ad),               "Ctrl+0",           "Reset Default Zoom",                   "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
 
         bool GUIMode = true;
         LegacyFramework::FrameworkApplicationMessages::Bus::BroadcastResult(
@@ -856,7 +859,8 @@ namespace LUAEditor
                 }
             }
 
-            EBUS_EVENT(LUABreakpointTrackerMessages::Bus, BreakpointsUpdate, m_pBreakpointSavedState->m_Breakpoints);
+            LUABreakpointTrackerMessages::Bus::Broadcast(
+                &LUABreakpointTrackerMessages::Bus::Events::BreakpointsUpdate, m_pBreakpointSavedState->m_Breakpoints);
         }
     }
 
@@ -1027,7 +1031,8 @@ namespace LUAEditor
                 AZStd::string normalizedAssetId = newAssetName;
                 AZStd::to_lower(normalizedAssetId.begin(), normalizedAssetId.end());
 
-                EBUS_EVENT(Context_DocumentManagement::Bus, OnLoadDocument, normalizedAssetId, true);
+                Context_DocumentManagement::Bus::Broadcast(
+                    &Context_DocumentManagement::Bus::Events::OnLoadDocument, normalizedAssetId, true);
                 DocumentCheckOutRequested(normalizedAssetId);
             }
         }
@@ -1178,7 +1183,7 @@ namespace LUAEditor
 
             if (documentInfo.m_bCloseAfterSave)
             {
-                EBUS_EVENT(Context_DocumentManagement::Bus, OnCloseDocument, assetId);
+                Context_DocumentManagement::Bus::Broadcast(&Context_DocumentManagement::Bus::Events::OnCloseDocument, assetId);
             }
         }
     }
@@ -1591,7 +1596,8 @@ namespace LUAEditor
         }
 
         // Send the list of files to open to the running instance.
-        EBUS_EVENT(LegacyFramework::IPCCommandBus, SendIPCCommand, "open_files", parameters.c_str());
+        LegacyFramework::IPCCommandBus::Broadcast(
+            &LegacyFramework::IPCCommandBus::Events::SendIPCCommand, "open_files", parameters.c_str());
     }
 
     void Context::ShowLUAEditorView()
@@ -1620,7 +1626,7 @@ namespace LUAEditor
         // if its unnamed, it's synthesized
         AZStd::string debugName = documentInfo.m_assetName;
 
-        EBUS_EVENT(LUAEditor::LUAStackTrackerMessages::Bus, StackClear);
+        LUAEditor::LUAStackTrackerMessages::Bus::Broadcast(&LUAEditor::LUAStackTrackerMessages::Bus::Events::StackClear);
 
         SynchronizeBreakpoints();
 
@@ -1651,10 +1657,12 @@ namespace LUAEditor
         for (BreakpointMap::iterator it = m_pBreakpointSavedState->m_Breakpoints.begin(); it != m_pBreakpointSavedState->m_Breakpoints.end(); ++it)
         {
             Breakpoint& bp = it->second;
-            EBUS_EVENT(LUAEditorDebuggerMessages::Bus, CreateBreakpoint, bp.m_assetName, bp.m_documentLine);
+            LUAEditorDebuggerMessages::Bus::Broadcast(
+                &LUAEditorDebuggerMessages::Bus::Events::CreateBreakpoint, bp.m_assetName, bp.m_documentLine);
         }
 
-        EBUS_EVENT(LUABreakpointTrackerMessages::Bus, BreakpointsUpdate, m_pBreakpointSavedState->m_Breakpoints);
+        LUABreakpointTrackerMessages::Bus::Broadcast(
+            &LUABreakpointTrackerMessages::Bus::Events::BreakpointsUpdate, m_pBreakpointSavedState->m_Breakpoints);
     }
 
     void Context::CreateBreakpoint(const AZStd::string& fromAssetId, int lineNumber)
@@ -1684,11 +1692,12 @@ namespace LUAEditor
         // we now know the 'debug name' (a string) that was submitted to the piece of code that this breakpoint is for, and we know the line number
         // inside that blob that the breakpoint wants to be set on.
 
-        EBUS_EVENT(LUAEditorDebuggerMessages::Bus, CreateBreakpoint, debugName, lineNumber);
+        LUAEditorDebuggerMessages::Bus::Broadcast(&LUAEditorDebuggerMessages::Bus::Events::CreateBreakpoint, debugName, lineNumber);
 
         //AZ_TracePrintf(LUAEditorDebugName, "Setting breakpoint in '%s' on line %i (In document %s line %i)\n", debugName.c_str(), lineNumber, doc.m_displayName.c_str(), lineNumber);
 
-        EBUS_EVENT(LUABreakpointTrackerMessages::Bus, BreakpointsUpdate, m_pBreakpointSavedState->m_Breakpoints);
+        LUABreakpointTrackerMessages::Bus::Broadcast(
+            &LUABreakpointTrackerMessages::Bus::Events::BreakpointsUpdate, m_pBreakpointSavedState->m_Breakpoints);
     }
 
     void Context::DeleteBreakpoint(const AZ::Uuid& breakpointUID)
@@ -1705,11 +1714,13 @@ namespace LUAEditor
 
             AZ_TracePrintf(LUAEditorDebugName, "  -  Removed breakpoint in '%s' on line '%i'\n", bp.m_assetName.c_str(), bp.m_documentLine);
 
-            EBUS_EVENT(LUAEditorDebuggerMessages::Bus, RemoveBreakpoint, bp.m_assetName, bp.m_documentLine);
+            LUAEditorDebuggerMessages::Bus::Broadcast(
+                &LUAEditorDebuggerMessages::Bus::Events::RemoveBreakpoint, bp.m_assetName, bp.m_documentLine);
 
             m_pBreakpointSavedState->m_Breakpoints.erase(finder);
 
-            EBUS_EVENT(LUABreakpointTrackerMessages::Bus, BreakpointsUpdate, m_pBreakpointSavedState->m_Breakpoints);
+            LUABreakpointTrackerMessages::Bus::Broadcast(
+                &LUABreakpointTrackerMessages::Bus::Events::BreakpointsUpdate, m_pBreakpointSavedState->m_Breakpoints);
         }
     }
 
@@ -1732,7 +1743,8 @@ namespace LUAEditor
         }
 
         // submit the updated list
-        EBUS_EVENT(LUABreakpointTrackerMessages::Bus, BreakpointsUpdate, m_pBreakpointSavedState->m_Breakpoints);
+        LUABreakpointTrackerMessages::Bus::Broadcast(
+            &LUABreakpointTrackerMessages::Bus::Events::BreakpointsUpdate, m_pBreakpointSavedState->m_Breakpoints);
     }
 
     //TODO: add a valid-invalid state to local breakpoints
@@ -1766,7 +1778,8 @@ namespace LUAEditor
             }
 
             // send out the update
-            EBUS_EVENT(LUABreakpointTrackerMessages::Bus, BreakpointsUpdate, m_pBreakpointSavedState->m_Breakpoints);
+            LUABreakpointTrackerMessages::Bus::Broadcast(
+                &LUABreakpointTrackerMessages::Bus::Events::BreakpointsUpdate, m_pBreakpointSavedState->m_Breakpoints);
         }
     }
 
@@ -1774,12 +1787,15 @@ namespace LUAEditor
     {
         //AZ_TracePrintf(LUAEditorDebugName, "Context::OnDebuggerAttached()\n");
 
-        EBUS_EVENT(Context_ControlManagement::Bus, OnDebuggerAttached);
-        EBUS_EVENT(LUAEditorDebuggerMessages::Bus, EnumRegisteredClasses, m_currentTargetContext.c_str());
-        EBUS_EVENT(LUAEditorDebuggerMessages::Bus, EnumRegisteredEBuses, m_currentTargetContext.c_str());
-        EBUS_EVENT(LUAEditorDebuggerMessages::Bus, EnumRegisteredGlobals, m_currentTargetContext.c_str());
-        EBUS_EVENT(LUAEditorMainWindowMessages::Bus, OnConnectedToDebugger);
-        EBUS_EVENT(LUAWatchesDebuggerMessages::Bus, OnDebuggerAttached);
+        Context_ControlManagement::Bus::Broadcast(&Context_ControlManagement::Bus::Events::OnDebuggerAttached);
+        LUAEditorDebuggerMessages::Bus::Broadcast(
+            &LUAEditorDebuggerMessages::Bus::Events::EnumRegisteredClasses, m_currentTargetContext.c_str());
+        LUAEditorDebuggerMessages::Bus::Broadcast(
+            &LUAEditorDebuggerMessages::Bus::Events::EnumRegisteredEBuses, m_currentTargetContext.c_str());
+        LUAEditorDebuggerMessages::Bus::Broadcast(
+            &LUAEditorDebuggerMessages::Bus::Events::EnumRegisteredGlobals, m_currentTargetContext.c_str());
+        LUAEditorMainWindowMessages::Bus::Broadcast(&LUAEditorMainWindowMessages::Bus::Events::OnConnectedToDebugger);
+        LUAWatchesDebuggerMessages::Bus::Broadcast(&LUAWatchesDebuggerMessages::Bus::Events::OnDebuggerAttached);
 
         SynchronizeBreakpoints();
     }
@@ -1788,18 +1804,18 @@ namespace LUAEditor
     {
         //AZ_TracePrintf(LUAEditorDebugName, "Context::OnDebuggerRefused()\n");
 
-        EBUS_EVENT(LUAEditorMainWindowMessages::Bus, OnDisconnectedFromDebugger);
-        EBUS_EVENT(Context_ControlManagement::Bus, OnDebuggerDetached);
-        EBUS_EVENT(LUAWatchesDebuggerMessages::Bus, OnDebuggerDetached);
+        LUAEditorMainWindowMessages::Bus::Broadcast(&LUAEditorMainWindowMessages::Bus::Events::OnDisconnectedFromDebugger);
+        Context_ControlManagement::Bus::Broadcast(&Context_ControlManagement::Bus::Events::OnDebuggerDetached);
+        LUAWatchesDebuggerMessages::Bus::Broadcast(&LUAWatchesDebuggerMessages::Bus::Events::OnDebuggerDetached);
     }
 
     void Context::OnDebuggerDetached()
     {
         //AZ_TracePrintf(LUAEditorDebugName, "Context::OnDebuggerDetached()\n");
 
-        EBUS_EVENT(LUAEditorMainWindowMessages::Bus, OnDisconnectedFromDebugger);
-        EBUS_EVENT(Context_ControlManagement::Bus, OnDebuggerDetached);
-        EBUS_EVENT(LUAWatchesDebuggerMessages::Bus, OnDebuggerDetached);
+        LUAEditorMainWindowMessages::Bus::Broadcast(&LUAEditorMainWindowMessages::Bus::Events::OnDisconnectedFromDebugger);
+        Context_ControlManagement::Bus::Broadcast(&Context_ControlManagement::Bus::Events::OnDebuggerDetached);
+        LUAWatchesDebuggerMessages::Bus::Broadcast(&LUAWatchesDebuggerMessages::Bus::Events::OnDebuggerDetached);
     }
 
     // this happens when a breakpoint is hit:
@@ -1808,18 +1824,25 @@ namespace LUAEditor
         // Convert from debug path (relative) to absolute path (how the Lua IDE stores files)
         AZStd::string absolutePath;
         AZStd::string formattedRelativePath = relativePath.substr(1);
-        EBUS_EVENT(AzToolsFramework::AssetSystemRequestBus, GetFullSourcePathFromRelativeProductPath, formattedRelativePath, absolutePath);
+        AzToolsFramework::AssetSystemRequestBus::Broadcast(
+            &AzToolsFramework::AssetSystemRequestBus::Events::GetFullSourcePathFromRelativeProductPath,
+            formattedRelativePath,
+            absolutePath);
 
         // If finding a .lua fails, attempt the equivalent .luac
         if (absolutePath.empty() && relativePath.ends_with(".lua"))
         {
             formattedRelativePath = relativePath.substr(1) + "c";
-            EBUS_EVENT(AzToolsFramework::AssetSystemRequestBus, GetFullSourcePathFromRelativeProductPath, formattedRelativePath, absolutePath); 
+            AzToolsFramework::AssetSystemRequestBus::Broadcast(
+                &AzToolsFramework::AssetSystemRequestBus::Events::GetFullSourcePathFromRelativeProductPath,
+                formattedRelativePath,
+                absolutePath); 
         }
 
         //AZ_TracePrintf(LUAEditorDebugName, "Breakpoint '%s' was hit on line %i\n", assetIdString.c_str(), lineNumber);
-        EBUS_EVENT(LUAEditorDebuggerMessages::Bus, GetCallstack);
-        EBUS_EVENT(LUAEditor::LUABreakpointRequestMessages::Bus, RequestEditorFocus, absolutePath, lineNumber);
+        LUAEditorDebuggerMessages::Bus::Broadcast(&LUAEditorDebuggerMessages::Bus::Events::GetCallstack);
+        LUAEditor::LUABreakpointRequestMessages::Bus::Broadcast(
+            &LUAEditor::LUABreakpointRequestMessages::Bus::Events::RequestEditorFocus, absolutePath, lineNumber);
 
         AZStd::string assetId = absolutePath;
 
@@ -1857,7 +1880,7 @@ namespace LUAEditor
                     {
                         // this is that breakpoint!
                         actualDocumentLineNumber = bp.m_documentLine; // bump it if its shifted:
-                        EBUS_EVENT(LUABreakpointTrackerMessages::Bus, BreakpointHit, bp);
+                        LUABreakpointTrackerMessages::Bus::Broadcast(&LUABreakpointTrackerMessages::Bus::Events::BreakpointHit, bp);
                         break;
                     }
                 }
@@ -1872,7 +1895,7 @@ namespace LUAEditor
                 dbp.m_assetId = "";
                 dbp.m_documentLine = lineNumber;
 
-                EBUS_EVENT(LUABreakpointTrackerMessages::Bus, BreakpointHit, dbp);
+                LUABreakpointTrackerMessages::Bus::Broadcast(&LUABreakpointTrackerMessages::Bus::Events::BreakpointHit, dbp);
             }
         }
 
@@ -1915,7 +1938,8 @@ namespace LUAEditor
             m_currentTargetContext = "Default";
         }
 
-        EBUS_EVENT(LUAEditor::Context_ControlManagement::Bus, OnTargetContextPrepared, m_currentTargetContext);
+        LUAEditor::Context_ControlManagement::Bus::Broadcast(
+            &LUAEditor::Context_ControlManagement::Bus::Events::OnTargetContextPrepared, m_currentTargetContext);
 
         RequestAttachDebugger();
     }
@@ -2118,19 +2142,19 @@ namespace LUAEditor
             Q_EMIT m_pLUAEditorMainWindow->OnReferenceDataChanged();
         }
 
-        EBUS_EVENT(HighlightedWordNotifications::Bus, LUALibraryFunctionsUpdated);
+        HighlightedWordNotifications::Bus::Broadcast(&HighlightedWordNotifications::Bus::Events::LUALibraryFunctionsUpdated);
     }
 
     void Context::OnReceivedLocalVariables(const AZStd::vector<AZStd::string>& vars)
     {
         //AZ_TracePrintf(LUAEditorDebugName, "Context::OnReceivedLocalVariables()\n");
 
-        EBUS_EVENT(LUALocalsTrackerMessages::Bus, LocalsUpdate, vars);
+        LUALocalsTrackerMessages::Bus::Broadcast(&LUALocalsTrackerMessages::Bus::Events::LocalsUpdate, vars);
 
         for (size_t i = 0; i < vars.size(); ++i)
         {
             //AZ_TracePrintf(LUAEditorDebugName, "\t%s\n", vars[i].c_str());
-            EBUS_EVENT(LUAEditorDebuggerMessages::Bus, GetValue, vars[i]);
+            LUAEditorDebuggerMessages::Bus::Broadcast(&LUAEditorDebuggerMessages::Bus::Events::GetValue, vars[i]);
         }
     }
 
@@ -2236,21 +2260,21 @@ namespace LUAEditor
             }
         }
 
-        EBUS_EVENT(LUAEditor::LUAStackTrackerMessages::Bus, StackUpdate, sl);
+        LUAEditor::LUAStackTrackerMessages::Bus::Broadcast(&LUAEditor::LUAStackTrackerMessages::Bus::Events::StackUpdate, sl);
     }
 
     void Context::RequestWatchedVariable(const AZStd::string& varName)
     {
         //AZ_TracePrintf(LUAEditorDebugName, "RequestWatchedVariable: name=%s\n", varName.c_str());
 
-        EBUS_EVENT(LUAEditorDebuggerMessages::Bus, GetValue, varName);
+        LUAEditorDebuggerMessages::Bus::Broadcast(&LUAEditorDebuggerMessages::Bus::Events::GetValue, varName);
     }
 
     void Context::OnReceivedValueState(const AZ::ScriptContextDebug::DebugValue& value)
     {
         //AZ_TracePrintf(LUAEditorDebugName, "Received LUA var: name=%s, val=%s, type=0x%x, flags=0x%x\n", value.m_name.c_str(), value.m_value.c_str(), (int)value.m_assetType, (int)value.m_flags);
 
-        EBUS_EVENT(LUAEditor::LUAWatchesDebuggerMessages::Bus, WatchesUpdate, value);
+        LUAEditor::LUAWatchesDebuggerMessages::Bus::Broadcast(&LUAEditor::LUAWatchesDebuggerMessages::Bus::Events::WatchesUpdate, value);
     }
 
     void Context::OnSetValueResult(const AZStd::string& /*name*/, bool /*success*/)
@@ -2267,15 +2291,15 @@ namespace LUAEditor
             m_pLUAEditorMainWindow->MoveProgramCursor("", -1);
         }
 
-        EBUS_EVENT(LUAEditor::LUAStackTrackerMessages::Bus, StackClear);
-        EBUS_EVENT(LUABreakpointTrackerMessages::Bus, BreakpointResume);
+        LUAEditor::LUAStackTrackerMessages::Bus::Broadcast(&LUAEditor::LUAStackTrackerMessages::Bus::Events::StackClear);
+        LUABreakpointTrackerMessages::Bus::Broadcast(&LUABreakpointTrackerMessages::Bus::Events::BreakpointResume);
     }
 
     void Context::OnExecuteScriptResult(bool success)
     {
         //AZ_TracePrintf(LUAEditorDebugName, "Context::OnExecutionScriptResult( %d )\n", success);
 
-        EBUS_EVENT(LUAEditorMainWindowMessages::Bus, OnExecuteScriptResult, success);
+        LUAEditorMainWindowMessages::Bus::Broadcast(&LUAEditorMainWindowMessages::Bus::Events::OnExecuteScriptResult, success);
     }
 
     void Context::ResetTargetContexts()
@@ -2283,7 +2307,8 @@ namespace LUAEditor
         m_targetContexts.clear();
         m_currentTargetContext = "Default";
 
-        EBUS_EVENT(LUAEditor::Context_ControlManagement::Bus, OnTargetContextPrepared, m_currentTargetContext);
+        LUAEditor::Context_ControlManagement::Bus::Broadcast(
+            &LUAEditor::Context_ControlManagement::Bus::Events::OnTargetContextPrepared, m_currentTargetContext);
     }
 
     void Context::SetCurrentTargetContext(AZStd::string& contextName)
@@ -2307,7 +2332,8 @@ namespace LUAEditor
             ResetTargetContexts();
         }
 
-        EBUS_EVENT(LUAEditor::Context_ControlManagement::Bus, OnTargetContextPrepared, m_currentTargetContext);
+        LUAEditor::Context_ControlManagement::Bus::Broadcast(
+            &LUAEditor::Context_ControlManagement::Bus::Events::OnTargetContextPrepared, m_currentTargetContext);
 
         UpdateReferenceWindow();
         RequestAttachDebugger();
@@ -2318,11 +2344,11 @@ namespace LUAEditor
     //////////////////////////////////////////////////////////////////////////
     void Context::RequestDetachDebugger()
     {
-        EBUS_EVENT(LUAEditorDebuggerMessages::Bus, DetachDebugger);
+        LUAEditorDebuggerMessages::Bus::Broadcast(&LUAEditorDebuggerMessages::Bus::Events::DetachDebugger);
     }
     void Context::RequestAttachDebugger()
     {
-        EBUS_EVENT(LUAEditorDebuggerMessages::Bus, AttachDebugger, m_currentTargetContext.c_str());
+        LUAEditorDebuggerMessages::Bus::Broadcast(&LUAEditorDebuggerMessages::Bus::Events::AttachDebugger, m_currentTargetContext.c_str());
     }
 
     ReferenceItem::ReferenceItem(const QIcon& icon, const QString& text, size_t id)

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorContext.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorContext.cpp
@@ -175,7 +175,11 @@ namespace LUAEditor
         desc.hotkeyDesc = AzToolsFramework::HotkeyDescription(AZ_CRC("LUAOpenEditor", 0x5870cf6d), "Ctrl+Shift+L", "Open LUA Editor", "General", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW);
         EBUS_EVENT(AzToolsFramework::FrameworkMessages::Bus, AddComponentInfo, desc);
 
-        EBUS_EVENT_RESULT(m_ipcOpenFilesHandle, LegacyFramework::IPCCommandBus, RegisterIPCHandler, "open_files", AZStd::bind(&Context::OnIPCOpenFiles, this, AZStd::placeholders::_1));
+        LegacyFramework::IPCCommandBus::BroadcastResult(
+            m_ipcOpenFilesHandle,
+            &LegacyFramework::IPCCommandBus::Events::RegisterIPCHandler,
+            "open_files",
+            AZStd::bind(&Context::OnIPCOpenFiles, this, AZStd::placeholders::_1));
 
         bool connectedToAssetProcessor = false;
 
@@ -682,7 +686,8 @@ namespace LUAEditor
         EBUS_EVENT(HotkeyBus, RegisterHotkey, AzToolsFramework::HotkeyDescription(AZ_CRC("LUAResetZoom", 0xbe0787ad),               "Ctrl+0",           "Reset Default Zoom",                   "LUA Editor", 1, AzToolsFramework::HotkeyDescription::SCOPE_WINDOW));
 
         bool GUIMode = true;
-        EBUS_EVENT_RESULT(GUIMode, LegacyFramework::FrameworkApplicationMessages::Bus, IsRunningInGUIMode);
+        LegacyFramework::FrameworkApplicationMessages::Bus::BroadcastResult(
+            GUIMode, &LegacyFramework::FrameworkApplicationMessages::Bus::Events::IsRunningInGUIMode);
         if (!GUIMode)
         {
             // do not auto create lua editor main window in batch mode.
@@ -963,7 +968,12 @@ namespace LUAEditor
             }
 
             AZ::Data::AssetId catalogAssetId;
-            EBUS_EVENT_RESULT(catalogAssetId, AZ::Data::AssetCatalogRequestBus, GetAssetIdByPath, newAssetName.c_str(), AZ::AzTypeInfo<AZ::ScriptAsset>::Uuid(), false);
+            AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+                catalogAssetId,
+                &AZ::Data::AssetCatalogRequestBus::Events::GetAssetIdByPath,
+                newAssetName.c_str(),
+                AZ::AzTypeInfo<AZ::ScriptAsset>::Uuid(),
+                false);
 
             if (catalogAssetId.IsValid() || m_fileIO->Exists(newAssetName.c_str()))
             {
@@ -1487,7 +1497,8 @@ namespace LUAEditor
         // Register the script into the asset catalog
         AZ::Data::AssetType assetType = AZ::AzTypeInfo<AZ::ScriptAsset>::Uuid();
         AZ::Data::AssetId catalogAssetId;
-        EBUS_EVENT_RESULT(catalogAssetId, AZ::Data::AssetCatalogRequestBus, GetAssetIdByPath, normalizedAssetId.c_str(), assetType, true);
+        AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+            catalogAssetId, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetIdByPath, normalizedAssetId.c_str(), assetType, true);
 
         uint64_t modTime = m_fileIO->ModificationTime(assetId.c_str());
 
@@ -1619,7 +1630,8 @@ namespace LUAEditor
         if (executeLocally)
         {
             AZ::ScriptContext* sc = nullptr;
-            EBUS_EVENT_RESULT(sc, AZ::ScriptSystemRequestBus, GetContext, AZ::ScriptContextIds::DefaultScriptContextId);
+            AZ::ScriptSystemRequestBus::BroadcastResult(
+                sc, &AZ::ScriptSystemRequestBus::Events::GetContext, AZ::ScriptContextIds::DefaultScriptContextId);
             if (sc)
             {
                 // we might want to bracket this with some sort of error or warning protection, to collect

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindDialog.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindDialog.cpp
@@ -514,7 +514,8 @@ namespace LUAEditor
         {
             AZ_Assert(false, "Fix assets!");
             //AZ::u32 platformFeatureFlags = PLATFORM_FEATURE_FLAGS_ALL;
-            //EBUS_EVENT_RESULT(platformFeatureFlags, EditorFramework::EditorAssetCatalogMessages::Bus, GetCurrentPlatformFeatureFlags);
+            //EditorFramework::EditorAssetCatalogMessages::Bus::BroadcastResult(
+            //    platformFeatureFlags, &EditorFramework::EditorAssetCatalogMessages::Bus::Events::GetCurrentPlatformFeatureFlags);
             //EBUS_EVENT(EditorFramework::EditorAssetCatalogMessages::Bus, FindEditorAssetsByType, m_dFindAllLUAAssetsInfo, AZ::ScriptAsset::StaticAssetType(), platformFeatureFlags);
         }
 
@@ -984,7 +985,8 @@ namespace LUAEditor
         AZ_Assert(false, "Fix assets!");
 
         //AZ::u32 platformFeatureFlags = PLATFORM_FEATURE_FLAGS_ALL;
-        //EBUS_EVENT_RESULT(platformFeatureFlags, EditorFramework::EditorAssetCatalogMessages::Bus, GetCurrentPlatformFeatureFlags);
+        //EditorFramework::EditorAssetCatalogMessages::Bus::BroadcastResult(
+        //    platformFeatureFlags, &EditorFramework::EditorAssetCatalogMessages::Bus::Events::GetCurrentPlatformFeatureFlags);
         //EBUS_EVENT(EditorFramework::EditorAssetCatalogMessages::Bus, FindEditorAssetsByType, m_RIFData.m_dReplaceAllLUAAssetsInfo, AZ::ScriptAsset::StaticAssetType(), platformFeatureFlags);
 
         m_RIFData.m_OpenView = pLUAEditorMainWindow->GetAllViews();

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindDialog.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindDialog.cpp
@@ -516,7 +516,11 @@ namespace LUAEditor
             //AZ::u32 platformFeatureFlags = PLATFORM_FEATURE_FLAGS_ALL;
             //EditorFramework::EditorAssetCatalogMessages::Bus::BroadcastResult(
             //    platformFeatureFlags, &EditorFramework::EditorAssetCatalogMessages::Bus::Events::GetCurrentPlatformFeatureFlags);
-            //EBUS_EVENT(EditorFramework::EditorAssetCatalogMessages::Bus, FindEditorAssetsByType, m_dFindAllLUAAssetsInfo, AZ::ScriptAsset::StaticAssetType(), platformFeatureFlags);
+            //EditorFramework::EditorAssetCatalogMessages::Bus::Broadcast(
+            //    &EditorFramework::EditorAssetCatalogMessages::Bus::Events::FindEditorAssetsByType,
+            //    m_dFindAllLUAAssetsInfo,
+            //    AZ::ScriptAsset::StaticAssetType(),
+            //    platformFeatureFlags);
         }
 
 
@@ -558,7 +562,11 @@ namespace LUAEditor
                 // successful sync between the QScintilla document and the raw buffer version that we need
                 const char* buffer = nullptr;
                 AZStd::size_t actualSize = 0;
-                EBUS_EVENT(Context_DocumentManagement::Bus, GetDocumentData, (*m_FIFData.m_openViewIter)->m_Info.m_assetId, &buffer, actualSize);
+                Context_DocumentManagement::Bus::Broadcast(
+                    &Context_DocumentManagement::Bus::Events::GetDocumentData,
+                    (*m_FIFData.m_openViewIter)->m_Info.m_assetId,
+                    &buffer,
+                    actualSize);
 
                 /************************************************************************/
                 /* Open files are similar but not identical to closed file processing   */
@@ -987,7 +995,11 @@ namespace LUAEditor
         //AZ::u32 platformFeatureFlags = PLATFORM_FEATURE_FLAGS_ALL;
         //EditorFramework::EditorAssetCatalogMessages::Bus::BroadcastResult(
         //    platformFeatureFlags, &EditorFramework::EditorAssetCatalogMessages::Bus::Events::GetCurrentPlatformFeatureFlags);
-        //EBUS_EVENT(EditorFramework::EditorAssetCatalogMessages::Bus, FindEditorAssetsByType, m_RIFData.m_dReplaceAllLUAAssetsInfo, AZ::ScriptAsset::StaticAssetType(), platformFeatureFlags);
+        //EditorFramework::EditorAssetCatalogMessages::Bus::Broadcast(
+        //    &EditorFramework::EditorAssetCatalogMessages::Bus::Events::FindEditorAssetsByType,
+        //    m_RIFData.m_dReplaceAllLUAAssetsInfo,
+        //    AZ::ScriptAsset::StaticAssetType(),
+        //    platformFeatureFlags);
 
         m_RIFData.m_OpenView = pLUAEditorMainWindow->GetAllViews();
 
@@ -1157,7 +1169,13 @@ namespace LUAEditor
 
             //find it in the database
             //AZStd::vector<EditorFramework::EditorAsset> dAssetInfo;
-            //EBUS_EVENT(EditorFramework::EditorAssetCatalogMessages::Bus, FindEditorAssetsByName, dAssetInfo, databaseRoot.c_str(), databasePath.c_str(), databaseFile.c_str(), fileExtension.c_str());
+            //EditorFramework::EditorAssetCatalogMessages::Bus::Broadcast(
+            //    &EditorFramework::EditorAssetCatalogMessages::Bus::Events::FindEditorAssetsByName,
+            //    dAssetInfo,
+            //    databaseRoot.c_str(),
+            //    databasePath.c_str(),
+            //    databaseFile.c_str(),
+            //    fileExtension.c_str());
             //if (dAssetInfo.empty())
             //  return;
 

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindDialog.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindDialog.cpp
@@ -952,9 +952,8 @@ namespace LUAEditor
                      pLUAViewWidget->m_Info.m_bSourceControl_CanCheckOut)
             {
                 // check it out for edit
-                EBUS_EVENT(Context_DocumentManagement::Bus,
-                    DocumentCheckOutRequested,
-                    pLUAViewWidget->m_Info.m_assetId);
+                Context_DocumentManagement::Bus::Broadcast(
+                    &Context_DocumentManagement::Bus::Events::DocumentCheckOutRequested, pLUAViewWidget->m_Info.m_assetId);
                 AZ::SystemTickBus::QueueFunction(&LUAEditorFindDialog::OnReplace, this);
             }
             else if (!pLUAViewWidget->m_Info.m_bSourceControl_CanWrite)
@@ -1180,11 +1179,11 @@ namespace LUAEditor
             //  return;
 
             //request it be opened
-            //EBUS_EVENT_ID(    LUAEditor::ContextID,
-            //EditorFramework::AssetManagementMessages::Bus,
-            // AssetOpenRequested,
-            // dAssetInfo[0].m_databaseAsset.m_assetId,
-            // AZ::ScriptAsset::StaticAssetType());
+            //EditorFramework::AssetManagementMessages::Bus::Event(
+            //    LUAEditor::ContextID,
+            //    &EditorFramework::AssetManagementMessages::Bus::Events::AssetOpenRequested,
+            //    dAssetInfo[0].m_databaseAsset.m_assetId,
+            //    AZ::ScriptAsset::StaticAssetType());
 
             QTimer::singleShot(0, this, &LUAEditorFindDialog::ProcessReplaceItems);
         }
@@ -1279,9 +1278,8 @@ namespace LUAEditor
                  pLUAViewWidget->m_Info.m_bSourceControl_CanCheckOut)
         {
             // check it out for edit
-            EBUS_EVENT(Context_DocumentManagement::Bus,
-                DocumentCheckOutRequested,
-                pLUAViewWidget->m_Info.m_assetId);
+            Context_DocumentManagement::Bus::Broadcast(
+                &Context_DocumentManagement::Bus::Events::DocumentCheckOutRequested, pLUAViewWidget->m_Info.m_assetId);
             return -2;
         }
         else if (!pLUAViewWidget->m_Info.m_bSourceControl_CanWrite)

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindDialog.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindDialog.cpp
@@ -790,7 +790,7 @@ namespace LUAEditor
             if (!m_bCancelFindSignal)
             {
                 PostProcessOn();
-                EBUS_QUEUE_FUNCTION(AZ::SystemTickBus, &LUAEditorFindDialog::ProcessFindItems, this);
+                AZ::SystemTickBus::QueueFunction(&LUAEditorFindDialog::ProcessFindItems, this);
             }
             else
             {
@@ -946,7 +946,7 @@ namespace LUAEditor
                 pLUAViewWidget->m_Info.m_bSourceControl_BusyGettingStats ||
                 pLUAViewWidget->m_Info.m_bSourceControl_Ready == false)
             {
-                EBUS_QUEUE_FUNCTION(AZ::SystemTickBus, &LUAEditorFindDialog::OnReplace, this);
+                AZ::SystemTickBus::QueueFunction(&LUAEditorFindDialog::OnReplace, this);
             }
             else if (!pLUAViewWidget->m_Info.m_bSourceControl_CanWrite &&
                      pLUAViewWidget->m_Info.m_bSourceControl_CanCheckOut)
@@ -955,7 +955,7 @@ namespace LUAEditor
                 EBUS_EVENT(Context_DocumentManagement::Bus,
                     DocumentCheckOutRequested,
                     pLUAViewWidget->m_Info.m_assetId);
-                EBUS_QUEUE_FUNCTION(AZ::SystemTickBus, &LUAEditorFindDialog::OnReplace, this);
+                AZ::SystemTickBus::QueueFunction(&LUAEditorFindDialog::OnReplace, this);
             }
             else if (!pLUAViewWidget->m_Info.m_bSourceControl_CanWrite)
             {

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
@@ -102,7 +102,8 @@ namespace LUAEditor
             QKeySequence("Alt+F4")
             );
 
-        EBUS_EVENT(AzToolsFramework::FrameworkMessages::Bus, PopulateApplicationMenu, theMenu);
+        AzToolsFramework::FrameworkMessages::Bus::Broadcast(
+            &AzToolsFramework::FrameworkMessages::Bus::Events::PopulateApplicationMenu, theMenu);
         menuBar()->insertMenu(m_gui->menuFile->menuAction(), theMenu);
 
         m_ptrFindDialog = aznew LUAEditorFindDialog(this);
@@ -194,7 +195,7 @@ namespace LUAEditor
 
         LUABreakpointTrackerMessages::Handler::BusConnect();
 
-        EBUS_EVENT(Context_DebuggerManagement::Bus, CleanUpBreakpoints);
+        Context_DebuggerManagement::Bus::Broadcast(&Context_DebuggerManagement::Bus::Events::CleanUpBreakpoints);
 
         SetDebugControlsToInitial();
         SetEditContolsToNoFilesOpen();
@@ -237,35 +238,35 @@ namespace LUAEditor
             using namespace AzToolsFramework;
             typedef FrameworkMessages::Bus HotkeyBus;
 
-            EBUS_EVENT(HotkeyBus, RegisterActionToHotkey, AZ_CRC("LUALinesUpTranspose", 0xafc899ef), m_gui->actionLinesUpTranspose);
-            EBUS_EVENT(HotkeyBus, RegisterActionToHotkey, AZ_CRC("LUALinesDnTranspose", 0xf9d733bf), m_gui->actionLinesDnTranspose);
-            EBUS_EVENT(HotkeyBus, RegisterActionToHotkey, AZ_CRC("GeneralOpenAssetBrowser", 0xa15ceb44), m_gui->actionAssetBrowser);
-            EBUS_EVENT(HotkeyBus, RegisterActionToHotkey, AZ_CRC("LUAFind", 0xc62d8078), m_gui->actionFind);
-            EBUS_EVENT(HotkeyBus, RegisterActionToHotkey, AZ_CRC("LUAQuickFindLocal", 0x115cbcda), m_gui->actionFindLocal);
-            EBUS_EVENT(HotkeyBus, RegisterActionToHotkey, AZ_CRC("LUAQuickFindLocalReverse", 0xdd8a0c22), m_gui->actionFindLocalReverse);
-            EBUS_EVENT(HotkeyBus, RegisterActionToHotkey, AZ_CRC("LUAFindInFiles", 0xdaebdfdd), m_gui->actionFindInAllOpen);
-            EBUS_EVENT(HotkeyBus, RegisterActionToHotkey, AZ_CRC("LUAReplace", 0x1fd5510c), m_gui->actionReplace);
-            EBUS_EVENT(HotkeyBus, RegisterActionToHotkey, AZ_CRC("LUAReplaceInFiles", 0x38b609e0), m_gui->actionReplaceInAllOpen);
-            EBUS_EVENT(HotkeyBus, RegisterActionToHotkey, AZ_CRC("LUAGoToLine", 0xb6603f27), m_gui->actionGoToLine);
-            EBUS_EVENT(HotkeyBus, RegisterActionToHotkey, AZ_CRC("LUAFold", 0xf0969e48), m_gui->actionFoldAll);
-            EBUS_EVENT(HotkeyBus, RegisterActionToHotkey, AZ_CRC("LUAUnfold", 0x36934ecd), m_gui->actionUnfoldAll);
-            EBUS_EVENT(HotkeyBus, RegisterActionToHotkey, AZ_CRC("LUACloseAllExceptCurrent", 0x0076409a), m_gui->actionCloseAllExcept);
-            EBUS_EVENT(HotkeyBus, RegisterActionToHotkey, AZ_CRC("LUACloseAll", 0xf732678f), m_gui->actionCloseAll);
-            EBUS_EVENT(HotkeyBus, RegisterActionToHotkey, AZ_CRC("LUAComment", 0x873c2725), m_gui->actionComment_Selected_Block);
-            EBUS_EVENT(HotkeyBus, RegisterActionToHotkey, AZ_CRC("LUAUncomment", 0x9190cf18), m_gui->actionUnComment_Selected_Block);
-            EBUS_EVENT(HotkeyBus, RegisterActionToHotkey, AZ_CRC("LUAResetZoom", 0xbe0787ad), m_gui->actionResetZoom);
+            HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUALinesUpTranspose", 0xafc899ef), m_gui->actionLinesUpTranspose);
+            HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUALinesDnTranspose", 0xf9d733bf), m_gui->actionLinesDnTranspose);
+            HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("GeneralOpenAssetBrowser", 0xa15ceb44), m_gui->actionAssetBrowser);
+            HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUAFind", 0xc62d8078), m_gui->actionFind);
+            HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUAQuickFindLocal", 0x115cbcda), m_gui->actionFindLocal);
+            HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUAQuickFindLocalReverse", 0xdd8a0c22), m_gui->actionFindLocalReverse);
+            HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUAFindInFiles", 0xdaebdfdd), m_gui->actionFindInAllOpen);
+            HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUAReplace", 0x1fd5510c), m_gui->actionReplace);
+            HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUAReplaceInFiles", 0x38b609e0), m_gui->actionReplaceInAllOpen);
+            HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUAGoToLine", 0xb6603f27), m_gui->actionGoToLine);
+            HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUAFold", 0xf0969e48), m_gui->actionFoldAll);
+            HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUAUnfold", 0x36934ecd), m_gui->actionUnfoldAll);
+            HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUACloseAllExceptCurrent", 0x0076409a), m_gui->actionCloseAllExcept);
+            HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUACloseAll", 0xf732678f), m_gui->actionCloseAll);
+            HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUAComment", 0x873c2725), m_gui->actionComment_Selected_Block);
+            HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUAUncomment", 0x9190cf18), m_gui->actionUnComment_Selected_Block);
+            HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUAResetZoom", 0xbe0787ad), m_gui->actionResetZoom);
         }
 
         //m_StoredTabAssetId = AZ::Uuid::CreateNull();
         installEventFilter(this);
 
-        EBUS_EVENT(LegacyFramework::CustomMenusMessages::Bus, RegisterMenu, LegacyFramework::CustomMenusCommon::LUAEditor::Application, theMenu);
-        EBUS_EVENT(LegacyFramework::CustomMenusMessages::Bus, RegisterMenu, LegacyFramework::CustomMenusCommon::LUAEditor::File, m_gui->menuFile);
-        EBUS_EVENT(LegacyFramework::CustomMenusMessages::Bus, RegisterMenu, LegacyFramework::CustomMenusCommon::LUAEditor::Edit, m_gui->menuEdit);
-        EBUS_EVENT(LegacyFramework::CustomMenusMessages::Bus, RegisterMenu, LegacyFramework::CustomMenusCommon::LUAEditor::View, m_gui->menuView);
-        EBUS_EVENT(LegacyFramework::CustomMenusMessages::Bus, RegisterMenu, LegacyFramework::CustomMenusCommon::LUAEditor::Debug, m_gui->menuDebug);
-        EBUS_EVENT(LegacyFramework::CustomMenusMessages::Bus, RegisterMenu, LegacyFramework::CustomMenusCommon::LUAEditor::SourceControl, m_gui->menuSource_Control);
-        EBUS_EVENT(LegacyFramework::CustomMenusMessages::Bus, RegisterMenu, LegacyFramework::CustomMenusCommon::LUAEditor::Options, m_gui->menu_Options);
+        LegacyFramework::CustomMenusMessages::Bus::Broadcast(&LegacyFramework::CustomMenusMessages::Bus::Events::RegisterMenu, LegacyFramework::CustomMenusCommon::LUAEditor::Application, theMenu);
+        LegacyFramework::CustomMenusMessages::Bus::Broadcast(&LegacyFramework::CustomMenusMessages::Bus::Events::RegisterMenu, LegacyFramework::CustomMenusCommon::LUAEditor::File, m_gui->menuFile);
+        LegacyFramework::CustomMenusMessages::Bus::Broadcast(&LegacyFramework::CustomMenusMessages::Bus::Events::RegisterMenu, LegacyFramework::CustomMenusCommon::LUAEditor::Edit, m_gui->menuEdit);
+        LegacyFramework::CustomMenusMessages::Bus::Broadcast(&LegacyFramework::CustomMenusMessages::Bus::Events::RegisterMenu, LegacyFramework::CustomMenusCommon::LUAEditor::View, m_gui->menuView);
+        LegacyFramework::CustomMenusMessages::Bus::Broadcast(&LegacyFramework::CustomMenusMessages::Bus::Events::RegisterMenu, LegacyFramework::CustomMenusCommon::LUAEditor::Debug, m_gui->menuDebug);
+        LegacyFramework::CustomMenusMessages::Bus::Broadcast(&LegacyFramework::CustomMenusMessages::Bus::Events::RegisterMenu, LegacyFramework::CustomMenusCommon::LUAEditor::SourceControl, m_gui->menuSource_Control);
+        LegacyFramework::CustomMenusMessages::Bus::Broadcast(&LegacyFramework::CustomMenusMessages::Bus::Events::RegisterMenu, LegacyFramework::CustomMenusCommon::LUAEditor::Options, m_gui->menu_Options);
 
         QObject::connect(m_gui->menu_Options, &QMenu::aboutToShow, this, &LUAEditorMainWindow::OnOptionsMenuRequested);
 
@@ -350,7 +351,7 @@ namespace LUAEditor
                 auto entryType = selectedAsset->GetEntryType();
                 if (entryType == AzToolsFramework::AssetBrowser::AssetBrowserEntry::AssetEntryType::Source)
                 {
-                    EBUS_EVENT(Context_DocumentManagement::Bus, OnLoadDocument, filePath, true);
+                    Context_DocumentManagement::Bus::Broadcast(&Context_DocumentManagement::Bus::Events::OnLoadDocument, filePath, true);
                 }                    
             }
         });
@@ -413,7 +414,8 @@ namespace LUAEditor
 
     void LUAEditorMainWindow::OnMenuCloseCurrentWindow()
     {
-        EBUS_EVENT(AzToolsFramework::FrameworkMessages::Bus, RequestMainWindowClose, ContextID);
+        AzToolsFramework::FrameworkMessages::Bus::Broadcast(
+            &AzToolsFramework::FrameworkMessages::Bus::Events::RequestMainWindowClose, ContextID);
     }
 
     void LUAEditorMainWindow::OnAutocompleteChanged(bool change)
@@ -730,7 +732,8 @@ namespace LUAEditor
         }
         if (SyncDocumentToContext(m_lastFocusedAssetId))
         {
-            EBUS_EVENT(Context_DebuggerManagement::Bus, ExecuteScriptBlob, m_lastFocusedAssetId, executeLocally);
+            Context_DebuggerManagement::Bus::Broadcast(
+                &Context_DebuggerManagement::Bus::Events::ExecuteScriptBlob, m_lastFocusedAssetId, executeLocally);
         }
     }
 
@@ -786,22 +789,22 @@ namespace LUAEditor
 
     void LUAEditorMainWindow::OnDebugContinueRunning()
     {
-        EBUS_EVENT(LUAEditorDebuggerMessages::Bus, DebugRunContinue);
+        LUAEditorDebuggerMessages::Bus::Broadcast(&LUAEditorDebuggerMessages::Bus::Events::DebugRunContinue);
     }
 
     void LUAEditorMainWindow::OnDebugStepOver()
     {
-        EBUS_EVENT(LUAEditorDebuggerMessages::Bus, DebugRunStepOver);
+        LUAEditorDebuggerMessages::Bus::Broadcast(&LUAEditorDebuggerMessages::Bus::Events::DebugRunStepOver);
     }
 
     void LUAEditorMainWindow::OnDebugStepIn()
     {
-        EBUS_EVENT(LUAEditorDebuggerMessages::Bus, DebugRunStepIn);
+        LUAEditorDebuggerMessages::Bus::Broadcast(&LUAEditorDebuggerMessages::Bus::Events::DebugRunStepIn);
     }
 
     void LUAEditorMainWindow::OnDebugStepOut()
     {
-        EBUS_EVENT(LUAEditorDebuggerMessages::Bus, DebugRunStepOut);
+        LUAEditorDebuggerMessages::Bus::Broadcast(&LUAEditorDebuggerMessages::Bus::Events::DebugRunStepOut);
     }
 
     //file menu
@@ -825,7 +828,7 @@ namespace LUAEditor
         }
 
         AZStd::string assetId(name.toUtf8().data());
-        EBUS_EVENT(Context_DocumentManagement::Bus, OnLoadDocument, assetId, true);
+        Context_DocumentManagement::Bus::Broadcast(&Context_DocumentManagement::Bus::Events::OnLoadDocument, assetId, true);
 
         AzFramework::StringFunc::Path::Split(assetId.c_str(), nullptr, &m_lastOpenFilePath);
     }
@@ -843,7 +846,7 @@ namespace LUAEditor
             assetId += ".lua";
         }
 
-        EBUS_EVENT(Context_DocumentManagement::Bus, OnNewDocument, assetId);
+        Context_DocumentManagement::Bus::Broadcast(&Context_DocumentManagement::Bus::Events::OnNewDocument, assetId);
         SetEditContolsToAtLeastOneFileOpen();
     }
 
@@ -860,7 +863,8 @@ namespace LUAEditor
         QByteArray viewBuffer = viewInfo.luaViewWidget()->GetText().toUtf8();
         AZStd::size_t viewSize = viewBuffer.size();
 
-        EBUS_EVENT(Context_DocumentManagement::Bus, UpdateDocumentData, assetId, viewBuffer.data(), viewSize);
+        Context_DocumentManagement::Bus::Broadcast(
+            &Context_DocumentManagement::Bus::Events::UpdateDocumentData, assetId, viewBuffer.data(), viewSize);
         return true;
     }
 
@@ -884,7 +888,8 @@ namespace LUAEditor
 
         if (SyncDocumentToContext(m_lastFocusedAssetId))
         {
-            EBUS_EVENT(Context_DocumentManagement::Bus, OnSaveDocument, m_lastFocusedAssetId, false, false);
+            Context_DocumentManagement::Bus::Broadcast(
+                &Context_DocumentManagement::Bus::Events::OnSaveDocument, m_lastFocusedAssetId, false, false);
         }
     }
 
@@ -917,7 +922,8 @@ namespace LUAEditor
 
             if (SyncDocumentToContext(viewInfo.luaViewWidget()->m_Info.m_assetId))
             {
-                EBUS_EVENT(Context_DocumentManagement::Bus, OnSaveDocument, viewInfo.luaViewWidget()->m_Info.m_assetId, false, false);
+                Context_DocumentManagement::Bus::Broadcast(
+                    &Context_DocumentManagement::Bus::Events::OnSaveDocument, viewInfo.luaViewWidget()->m_Info.m_assetId, false, false);
             }
         }
     }
@@ -963,8 +969,8 @@ namespace LUAEditor
         // Need to store this off for use on the reload since it will be cleared out/changed as part of the OnCloseDocument call
         AZStd::string asset = m_lastFocusedAssetId;
 
-        EBUS_EVENT(Context_DocumentManagement::Bus, OnCloseDocument, m_lastFocusedAssetId);
-        EBUS_EVENT(Context_DocumentManagement::Bus, OnLoadDocument, asset, true);
+        Context_DocumentManagement::Bus::Broadcast(&Context_DocumentManagement::Bus::Events::OnCloseDocument, m_lastFocusedAssetId);
+        Context_DocumentManagement::Bus::Broadcast(&Context_DocumentManagement::Bus::Events::OnLoadDocument, asset, true);
 
         //not sure about this... looks like legacy, may need to be removed?
         // instate the topmost tab as the current asset ID
@@ -1032,13 +1038,13 @@ namespace LUAEditor
                     return false;
                 }
 
-                EBUS_EVENT(Context_DocumentManagement::Bus, OnSaveDocument, assetId, true, false);
+                Context_DocumentManagement::Bus::Broadcast(&Context_DocumentManagement::Bus::Events::OnSaveDocument, assetId, true, false);
                 return true;
             }
             else if (dr == AzToolsFramework::SCDR_DiscardAndContinue)
             {
                 //the user has chosen to continue to close the document and lose changes
-                EBUS_EVENT(Context_DocumentManagement::Bus, OnCloseDocument, assetId);
+                Context_DocumentManagement::Bus::Broadcast(&Context_DocumentManagement::Bus::Events::OnCloseDocument, assetId);
                 return true;
             }
             else
@@ -1050,7 +1056,7 @@ namespace LUAEditor
         else
         {
             //no changes, just close the document
-            EBUS_EVENT(Context_DocumentManagement::Bus, OnCloseDocument, assetId);
+            Context_DocumentManagement::Bus::Broadcast(&Context_DocumentManagement::Bus::Events::OnCloseDocument, assetId);
             return true;
         }
     }
@@ -1478,7 +1484,7 @@ namespace LUAEditor
             return;
         }
 
-        EBUS_EVENT(Context_DocumentManagement::Bus, RefreshAllDocumentPerforceStat);
+        Context_DocumentManagement::Bus::Broadcast(&Context_DocumentManagement::Bus::Events::RefreshAllDocumentPerforceStat);
 
         if (!SyncDocumentToContext(m_lastFocusedAssetId))
         {
@@ -1487,7 +1493,8 @@ namespace LUAEditor
             return;
         }
 
-        EBUS_EVENT(Context_DocumentManagement::Bus, DocumentCheckOutRequested, m_lastFocusedAssetId);
+        Context_DocumentManagement::Bus::Broadcast(
+            &Context_DocumentManagement::Bus::Events::DocumentCheckOutRequested, m_lastFocusedAssetId);
     }
 
     //tools menu
@@ -1536,7 +1543,8 @@ namespace LUAEditor
 
                     AZ_TracePrintf(LUAEditorDebugName, "LUAEditorMainWindow::OnGetPermissionToShutDown() SAVING %s\n", viewInfo.luaViewWidget()->m_Info.m_assetName.c_str());
 
-                    EBUS_EVENT(Context_DocumentManagement::Bus, OnSaveDocument, viewInfo.luaViewWidget()->m_Info.m_assetId, false, false);
+                    Context_DocumentManagement::Bus::Broadcast(
+                        &Context_DocumentManagement::Bus::Events::OnSaveDocument, viewInfo.luaViewWidget()->m_Info.m_assetId, false, false);
                 }
                 else if (dr == AzToolsFramework::SCDR_DiscardAndContinue)
                 {
@@ -1546,14 +1554,16 @@ namespace LUAEditor
                         AZ_TracePrintf(LUAEditorDebugName, "                            Forced close\n");
 
                         // all untitled documents are force closed to clear any tracked states that will be serialized by their trackers
-                        EBUS_EVENT(Context_DocumentManagement::Bus, OnCloseDocument, viewInfo.luaViewWidget()->m_Info.m_assetId);
+                        Context_DocumentManagement::Bus::Broadcast(
+                            &Context_DocumentManagement::Bus::Events::OnCloseDocument, viewInfo.luaViewWidget()->m_Info.m_assetId);
                         viewInfoIter = m_dOpenLUAView.begin();
                     }
                     else // all titled (i.e. preexisting or saved files, simply reload
                     {
                         AZ_TracePrintf(LUAEditorDebugName, "                            Forced reload\n");
 
-                        EBUS_EVENT(Context_DocumentManagement::Bus, OnReloadDocument, viewInfo.luaViewWidget()->m_Info.m_assetId);
+                        Context_DocumentManagement::Bus::Broadcast(
+                            &Context_DocumentManagement::Bus::Events::OnReloadDocument, viewInfo.luaViewWidget()->m_Info.m_assetId);
                         viewInfoIter = m_dOpenLUAView.begin();
                     }
                 }
@@ -1633,7 +1643,7 @@ namespace LUAEditor
 
             for (const auto& assetId : pEditorMainSavedState->m_openAssetIds)
             {
-                EBUS_EVENT(Context_DocumentManagement::Bus, OnLoadDocument, assetId, false);
+                Context_DocumentManagement::Bus::Broadcast(&Context_DocumentManagement::Bus::Events::OnLoadDocument, assetId, false);
             }
 
             restoreGeometry(editorGeomData);
@@ -1899,7 +1909,7 @@ namespace LUAEditor
             viewInfo.luaViewWidget()->UpdateCurrentExecutingLine(-1);
         }
 
-        EBUS_EVENT(LUAEditor::LUAStackTrackerMessages::Bus, StackClear);
+        LUAEditor::LUAStackTrackerMessages::Bus::Broadcast(&LUAEditor::LUAStackTrackerMessages::Bus::Events::StackClear);
     }
     void LUAEditorMainWindow::SetDebugControlsToAtBreak()
     {
@@ -2265,7 +2275,7 @@ namespace LUAEditor
             AZ_TracePrintf("Debug", "URL: %s\n", path.toUtf8().data());
 
             AZStd::string assetId(path.toUtf8().data());
-            EBUS_EVENT(Context_DocumentManagement::Bus, OnLoadDocument, assetId, true);
+            Context_DocumentManagement::Bus::Broadcast(&Context_DocumentManagement::Bus::Events::OnLoadDocument, assetId, true);
         }
     }
 

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
@@ -898,7 +898,8 @@ namespace LUAEditor
         if (SyncDocumentToContext(m_lastFocusedAssetId))
         {
             bool saveSuccess = false;
-            EBUS_EVENT_RESULT(saveSuccess, Context_DocumentManagement::Bus, OnSaveDocumentAs, m_lastFocusedAssetId, false);
+            Context_DocumentManagement::Bus::BroadcastResult(
+                saveSuccess, &Context_DocumentManagement::Bus::Events::OnSaveDocumentAs, m_lastFocusedAssetId, false);
         }
     }
 

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
@@ -1736,11 +1736,9 @@ namespace LUAEditor
         {
             // the document was probably closed, request it be reopened
             m_dProcessFindListClicked.push_back(result);
-            /*EBUS_EVENT_ID(    LUAEditor::ContextID,
-                            EditorFramework::AssetManagementMessages::Bus,
-                            AssetOpenRequested,
-                            result.m_assetId,
-                            AZ::ScriptAsset::StaticAssetType());*/
+            //EditorFramework::AssetManagementMessages::Bus::Event(LUAEditor::ContextID, &EditorFramework::AssetManagementMessages::Bus::Events::AssetOpenRequested,
+            //    result.m_assetId,
+            //    AZ::ScriptAsset::StaticAssetType());
             AZ_Assert(false, "Fix assets!");
         }
     }

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
@@ -516,7 +516,7 @@ namespace LUAEditor
             QApplication::processEvents();
         }
 
-        EBUS_QUEUE_FUNCTION(AZ::SystemTickBus, &LUAEditorMainWindow::OnDockWidgetLocationChanged, this, docInfo.m_assetId);
+        AZ::SystemTickBus::QueueFunction(&LUAEditorMainWindow::OnDockWidgetLocationChanged, this, docInfo.m_assetId);
 
         luaDockWidget->show();
         luaDockWidget->raise();
@@ -559,7 +559,7 @@ namespace LUAEditor
             connect(pBar, &QTabBar::tabCloseRequested, this,
                 [assetId, this]()
                 {
-                    EBUS_QUEUE_FUNCTION(AZ::SystemTickBus, &LUAEditorMainWindow::RequestCloseDocument, this, assetId);
+                    AZ::SystemTickBus::QueueFunction(&LUAEditorMainWindow::RequestCloseDocument, this, assetId);
                 });
 
             pBar->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -611,7 +611,7 @@ namespace LUAEditor
         {
             if (it->first != m_currentTabContextMenuUUID)
             {
-                EBUS_QUEUE_FUNCTION(AZ::SystemTickBus, &LUAEditorMainWindow::RequestCloseDocument, this, it->first);
+                AZ::SystemTickBus::QueueFunction(&LUAEditorMainWindow::RequestCloseDocument, this, it->first);
             }
         }
         m_currentTabContextMenuUUID = "";
@@ -996,7 +996,7 @@ namespace LUAEditor
     {
         for (TrackedLUAViewMap::iterator it = m_dOpenLUAView.begin(); it != m_dOpenLUAView.end(); ++it)
         {
-            EBUS_QUEUE_FUNCTION(AZ::SystemTickBus, &LUAEditorMainWindow::RequestCloseDocument, this, it->first);
+            AZ::SystemTickBus::QueueFunction(&LUAEditorMainWindow::RequestCloseDocument, this, it->first);
         }
     }
 
@@ -1006,7 +1006,7 @@ namespace LUAEditor
         {
             if (it->first != m_lastFocusedAssetId)
             {
-                EBUS_QUEUE_FUNCTION(AZ::SystemTickBus, &LUAEditorMainWindow::RequestCloseDocument, this, it->first);
+                AZ::SystemTickBus::QueueFunction(&LUAEditorMainWindow::RequestCloseDocument, this, it->first);
             }
         }
     }
@@ -1755,7 +1755,7 @@ namespace LUAEditor
                 iter->m_assetId = pLUAViewWidget->m_Info.m_assetId;
                 iter->m_assignAssetId(info.m_assetName, pLUAViewWidget->m_Info.m_assetId);
 
-                EBUS_QUEUE_FUNCTION(AZ::SystemTickBus, &LUAEditorMainWindow::OnFindResultClicked, this, *iter);
+                AZ::SystemTickBus::QueueFunction(&LUAEditorMainWindow::OnFindResultClicked, this, *iter);
                 m_dProcessFindListClicked.erase(iter);
                 return;
             }

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorPlainTextEdit.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorPlainTextEdit.cpp
@@ -628,7 +628,7 @@ namespace LUAEditor
                 AZ_TracePrintf("Debug", "URL: %s\n", path.toUtf8().data());
 
                 AZStd::string assetId(path.toUtf8().data());
-                EBUS_EVENT(Context_DocumentManagement::Bus, OnLoadDocument, assetId, true);
+                Context_DocumentManagement::Bus::Broadcast(&Context_DocumentManagement::Bus::Events::OnLoadDocument, assetId, true);
             }
         }
         else

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorSettingsDialog.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorSettingsDialog.cpp
@@ -78,9 +78,9 @@ namespace LUAEditor
 
     void LUAEditorSettingsDialog::OnSave()
     {
-        EBUS_EVENT(AZ::UserSettingsComponentRequestBus, Save);
+        AZ::UserSettingsComponentRequestBus::Broadcast(&AZ::UserSettingsComponentRequestBus::Events::Save);
 
-        EBUS_EVENT(LUAEditorMainWindowMessages::Bus, Repaint);
+        LUAEditorMainWindowMessages::Bus::Broadcast(&LUAEditorMainWindowMessages::Bus::Events::Repaint);
     }
 
     void LUAEditorSettingsDialog::OnSaveClose()
@@ -96,7 +96,7 @@ namespace LUAEditor
         // Revert the stored copy, no changes will be stored.
         *syntaxStyleSettings = m_originalSettings;
 
-        EBUS_EVENT(LUAEditorMainWindowMessages::Bus, Repaint);
+        LUAEditorMainWindowMessages::Bus::Broadcast(&LUAEditorMainWindowMessages::Bus::Events::Repaint);
 
         close();
     }

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorSettingsDialog.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorSettingsDialog.cpp
@@ -39,7 +39,7 @@ namespace LUAEditor
 
         AZ::SerializeContext* context = nullptr;
         {
-            EBUS_EVENT_RESULT(context, AZ::ComponentApplicationBus, GetSerializeContext);
+            AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
             AZ_Assert(context, "We should have a valid context!");
         }
 

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorStyleMessages.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorStyleMessages.cpp
@@ -174,11 +174,11 @@ namespace LUAEditor
 
     void SyntaxStyleSettings::OnColorChange()
     {
-        EBUS_EVENT(LUAEditorMainWindowMessages::Bus, Repaint);
+        LUAEditorMainWindowMessages::Bus::Broadcast(&LUAEditorMainWindowMessages::Bus::Events::Repaint);
     }
 
     void SyntaxStyleSettings::OnFontChange()
     {
-        EBUS_EVENT(LUAEditorMainWindowMessages::Bus, Repaint);
+        LUAEditorMainWindowMessages::Bus::Broadcast(&LUAEditorMainWindowMessages::Bus::Events::Repaint);
     }
 }

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorSyntaxHighlighter.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorSyntaxHighlighter.cpp
@@ -576,9 +576,9 @@ namespace LUAEditor
         auto colors = AZ::UserSettings::CreateFind<SyntaxStyleSettings>(AZ_CRC("LUA Editor Text Settings", 0xb6e15565), AZ::UserSettings::CT_GLOBAL);
 
         const HighlightedWords::LUAKeywordsType* keywords = nullptr;
-        EBUS_EVENT_RESULT(keywords, HighlightedWords::Bus, GetLUAKeywords);
+        HighlightedWords::Bus::BroadcastResult(keywords, &HighlightedWords::Bus::Events::GetLUAKeywords);
         const HighlightedWords::LUAKeywordsType* libraryFuncs = nullptr;
-        EBUS_EVENT_RESULT(libraryFuncs, HighlightedWords::Bus, GetLUALibraryFunctions);
+        HighlightedWords::Bus::BroadcastResult(libraryFuncs, &HighlightedWords::Bus::Events::GetLUALibraryFunctions);
 
         auto cBlock = currentBlock();
 
@@ -747,9 +747,9 @@ namespace LUAEditor
         m_machine->SetOnDecFoldLevel([](int) {});
 
         const HighlightedWords::LUAKeywordsType* keywords = nullptr;
-        EBUS_EVENT_RESULT(keywords, HighlightedWords::Bus, GetLUAKeywords);
+        HighlightedWords::Bus::BroadcastResult(keywords, &HighlightedWords::Bus::Events::GetLUAKeywords);
         const HighlightedWords::LUAKeywordsType* libraryFuncs = nullptr;
-        EBUS_EVENT_RESULT(libraryFuncs, HighlightedWords::Bus, GetLUALibraryFunctions);
+        HighlightedWords::Bus::BroadcastResult(libraryFuncs, &HighlightedWords::Bus::Events::GetLUALibraryFunctions);
 
         auto syntaxSettings = AZ::UserSettings::CreateFind<SyntaxStyleSettings>(AZ_CRC("LUA Editor Text Settings", 0xb6e15565), AZ::UserSettings::CT_GLOBAL);
         auto font = syntaxSettings->GetFont();

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.cpp
@@ -277,10 +277,11 @@ namespace LUAEditor
             {
                 const char* buffer = NULL;
                 AZStd::size_t actualSize = 0;
-                EBUS_EVENT(Context_DocumentManagement::Bus, GetDocumentData, newInfo.m_assetId, &buffer, actualSize);
+                Context_DocumentManagement::Bus::Broadcast(
+                    &Context_DocumentManagement::Bus::Events::GetDocumentData, newInfo.m_assetId, &buffer, actualSize);
                 m_gui->m_luaTextEdit->setPlainText(buffer);
 
-                EBUS_EVENT(LUAViewMessages::Bus, OnDataLoadedAndSet, newInfo, this);
+                LUAViewMessages::Bus::Broadcast(&LUAViewMessages::Bus::Events::OnDataLoadedAndSet, newInfo, this);
             }
 
             //remove the loading shield
@@ -478,13 +479,13 @@ namespace LUAEditor
         {
             m_gui->m_breakpoints->setEnabled(true);
             m_gui->m_folding->setEnabled(true);
-            EBUS_EVENT(LUAEditorMainWindowMessages::Bus, OnFocusInEvent, m_Info.m_assetId);
+            LUAEditorMainWindowMessages::Bus::Broadcast(&LUAEditorMainWindowMessages::Bus::Events::OnFocusInEvent, m_Info.m_assetId);
         }
         else
         {
             m_gui->m_breakpoints->setEnabled(false);
             m_gui->m_folding->setEnabled(false);
-            EBUS_EVENT(LUAEditorMainWindowMessages::Bus, OnFocusOutEvent, m_Info.m_assetId);
+            LUAEditorMainWindowMessages::Bus::Broadcast(&LUAEditorMainWindowMessages::Bus::Events::OnFocusOutEvent, m_Info.m_assetId);
         }
     }
 
@@ -513,7 +514,8 @@ namespace LUAEditor
         auto breakpoint = m_Breakpoints.find(fromLineNumber);
         if (breakpoint != m_Breakpoints.end())
         {
-            EBUS_EVENT(Context_DebuggerManagement::Bus, MoveBreakpoint, breakpoint->second.m_editorId, toLineNumber);
+            Context_DebuggerManagement::Bus::Broadcast(
+                &Context_DebuggerManagement::Bus::Events::MoveBreakpoint, breakpoint->second.m_editorId, toLineNumber);
         }
     }
 
@@ -522,13 +524,14 @@ namespace LUAEditor
         auto breakpoint = m_Breakpoints.find(removedLineNumber);
         if (breakpoint != m_Breakpoints.end())
         {
-            EBUS_EVENT(Context_DebuggerManagement::Bus, DeleteBreakpoint, breakpoint->second.m_editorId);
+            Context_DebuggerManagement::Bus::Broadcast(
+                &Context_DebuggerManagement::Bus::Events::DeleteBreakpoint, breakpoint->second.m_editorId);
         }
     }
 
     void LUAViewWidget::modificationChanged(bool m)
     {
-        EBUS_EVENT(Context_DocumentManagement::Bus, NotifyDocumentModified, m_Info.m_assetId, m);
+        Context_DocumentManagement::Bus::Broadcast(&Context_DocumentManagement::Bus::Events::NotifyDocumentModified, m_Info.m_assetId, m);
         UpdateModifyFlag();
     }
 
@@ -632,11 +635,12 @@ namespace LUAEditor
         auto breakpoint = m_Breakpoints.find(line);
         if (breakpoint == m_Breakpoints.end())
         {
-            EBUS_EVENT(Context_DebuggerManagement::Bus, CreateBreakpoint, m_Info.m_assetId, line);
+            Context_DebuggerManagement::Bus::Broadcast(&Context_DebuggerManagement::Bus::Events::CreateBreakpoint, m_Info.m_assetId, line);
         }
         else
         {
-            EBUS_EVENT(Context_DebuggerManagement::Bus, DeleteBreakpoint, breakpoint->second.m_editorId);
+            Context_DebuggerManagement::Bus::Broadcast(
+                &Context_DebuggerManagement::Bus::Events::DeleteBreakpoint, breakpoint->second.m_editorId);
         }
     }
 
@@ -674,7 +678,8 @@ namespace LUAEditor
                 int ret = msgBox.exec();
                 if (ret == QMessageBox::Ok)
                 {
-                    EBUS_EVENT(LUAEditorMainWindowMessages::Bus, OnRequestCheckOut, m_Info.m_assetId);
+                    LUAEditorMainWindowMessages::Bus::Broadcast(
+                        &LUAEditorMainWindowMessages::Bus::Events::OnRequestCheckOut, m_Info.m_assetId);
                 }
             }
         }

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.cpp
@@ -292,7 +292,8 @@ namespace LUAEditor
 
             // scan the breakpoint store from our context and pre-set the markers to get in sync
             const LUAEditor::BreakpointMap* myData = NULL;
-            EBUS_EVENT_RESULT(myData, LUAEditor::LUABreakpointRequestMessages::Bus, RequestBreakpoints);
+            LUAEditor::LUABreakpointRequestMessages::Bus::BroadcastResult(
+                myData, &LUAEditor::LUABreakpointRequestMessages::Bus::Events::RequestBreakpoints);
             AZ_Assert(myData, "LUAEditor::LUABreakpointRequestMessages::Bus, RequestBreakpoints failed to return any data.");
             BreakpointsUpdate(*myData);
             UpdateCurrentEditingLine(newInfo.m_PresetLineAtOpen);
@@ -595,7 +596,8 @@ namespace LUAEditor
         m_gui->m_breakpoints->ClearBreakpoints();
 
         const LUAEditor::BreakpointMap* myData = NULL;
-        EBUS_EVENT_RESULT(myData, LUAEditor::LUABreakpointRequestMessages::Bus, RequestBreakpoints);
+        LUAEditor::LUABreakpointRequestMessages::Bus::BroadcastResult(
+            myData, &LUAEditor::LUABreakpointRequestMessages::Bus::Events::RequestBreakpoints);
         AZ_Assert(myData, "Nobody responded to the request breakpoints message.");
 
         // and slam down a new set

--- a/Code/Tools/LuaIDE/Source/LUA/StackPanel.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/StackPanel.cpp
@@ -66,5 +66,8 @@ void DHStackWidget::OnDoubleClicked(const QModelIndex& modelIdx)
     QTableWidgetItem* line = item(modelIdx.row(), 0);
     QTableWidgetItem* file = item(modelIdx.row(), 1);
 
-    EBUS_EVENT(LUAEditor::LUAStackRequestMessages::Bus, RequestStackClicked, AZStd::string(file->data(Qt::DisplayRole).toString().toUtf8().data()), line->data(Qt::DisplayRole).toInt());
+    LUAEditor::LUAStackRequestMessages::Bus::Broadcast(
+        &LUAEditor::LUAStackRequestMessages::Bus::Events::RequestStackClicked,
+        AZStd::string(file->data(Qt::DisplayRole).toString().toUtf8().data()),
+        line->data(Qt::DisplayRole).toInt());
 }

--- a/Code/Tools/LuaIDE/Source/LUA/TargetContextButton.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/TargetContextButton.cpp
@@ -46,7 +46,8 @@ namespace LUA
         QMenu menu;
 
         AZStd::vector<AZStd::string> contexts;
-        EBUS_EVENT_RESULT(contexts, LUAEditor::LUATargetContextRequestMessages::Bus, RequestTargetContexts);
+        LUAEditor::LUATargetContextRequestMessages::Bus::BroadcastResult(
+            contexts, &LUAEditor::LUATargetContextRequestMessages::Bus::Events::RequestTargetContexts);
 
         for (AZStd::vector<AZStd::string>::const_iterator it = contexts.begin(); it != contexts.end(); ++it)
         {

--- a/Code/Tools/LuaIDE/Source/LUA/TargetContextButton.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/TargetContextButton.cpp
@@ -22,7 +22,8 @@ namespace LUA
         LUAEditor::Context_ControlManagement::Handler::BusConnect();
 
         AZStd::string context("Default");
-        EBUS_EVENT(LUAEditor::LUATargetContextRequestMessages::Bus, SetCurrentTargetContext, context);
+        LUAEditor::LUATargetContextRequestMessages::Bus::Broadcast(
+            &LUAEditor::LUATargetContextRequestMessages::Bus::Events::SetCurrentTargetContext, context);
         this->setText("Context: Default");
 
         QSizePolicy sizePolicy1(QSizePolicy::Preferred, QSizePolicy::Preferred);
@@ -62,7 +63,8 @@ namespace LUA
         {
             AZStd::string context = resultAction->property("context").toString().toUtf8().data();
             this->setText("Context: None"); // prepare for failure
-            EBUS_EVENT(LUAEditor::LUATargetContextRequestMessages::Bus, SetCurrentTargetContext, context);
+            LUAEditor::LUATargetContextRequestMessages::Bus::Broadcast(
+                &LUAEditor::LUATargetContextRequestMessages::Bus::Events::SetCurrentTargetContext, context);
         }
     }
 

--- a/Code/Tools/PythonBindingsExample/source/Application.cpp
+++ b/Code/Tools/PythonBindingsExample/source/Application.cpp
@@ -42,7 +42,7 @@ namespace PythonBindingsExample
         Start(Descriptor());
 
         AZ::SerializeContext* context;
-        EBUS_EVENT_RESULT(context, AZ::ComponentApplicationBus, GetSerializeContext);
+        AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         AZ_Assert(context, "Application did not start; detected no serialize context");
 
         AZ_TracePrintf("Python Bindings", "Init() \n");

--- a/Code/Tools/SceneAPI/SceneCore/Containers/Utilities/SceneGraphUtilities.inl
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/Utilities/SceneGraphUtilities.inl
@@ -33,7 +33,11 @@ namespace AZ
                     for (auto it = view.begin(); it != view.end(); ++it)
                     {
                         AZStd::set<Crc32> types;
-                        EBUS_EVENT(Events::GraphMetaInfoBus, GetVirtualTypes, types, scene, graph.ConvertToNodeIndex(it.GetBaseIterator()));
+                        Events::GraphMetaInfoBus::Broadcast(
+                            &Events::GraphMetaInfoBus::Events::GetVirtualTypes,
+                            types,
+                            scene,
+                            graph.ConvertToNodeIndex(it.GetBaseIterator()));
                         // Check if the type is not a virtual type. If it is, this isn't a valid type for T.
                         if (types.empty())
                         {

--- a/Gems/LyShineExamples/Code/Source/LyShineExamplesCppExample.cpp
+++ b/Gems/LyShineExamples/Code/Source/LyShineExamplesCppExample.cpp
@@ -247,11 +247,11 @@ namespace LyShineExamples
         AZ::Entity* button = nullptr;
         if (atRoot)
         {
-            EBUS_EVENT_ID_RESULT(button, parent, UiCanvasBus, CreateChildElement, name);
+            UiCanvasBus::EventResult(button, parent, &UiCanvasBus::Events::CreateChildElement, name);
         }
         else
         {
-            EBUS_EVENT_ID_RESULT(button, parent, UiElementBus, CreateChildElement, name);
+            UiElementBus::EventResult(button, parent, &UiElementBus::Events::CreateChildElement, name);
         }
 
         AZ::EntityId buttonId = button->GetId();
@@ -281,7 +281,7 @@ namespace LyShineExamples
         }
 
         AZ::Entity* textElem = nullptr;
-        EBUS_EVENT_ID_RESULT(textElem, buttonId, UiElementBus, CreateChildElement, "ButtonText");
+        UiElementBus::EventResult(textElem, buttonId, &UiElementBus::Events::CreateChildElement, "ButtonText");
         AZ::EntityId textId = textElem->GetId();
 
         // Create and set up the text element (text displayed on the button)
@@ -317,11 +317,11 @@ namespace LyShineExamples
         AZ::Entity* checkbox = nullptr;
         if (atRoot)
         {
-            EBUS_EVENT_ID_RESULT(checkbox, parent, UiCanvasBus, CreateChildElement, name);
+            UiCanvasBus::EventResult(checkbox, parent, &UiCanvasBus::Events::CreateChildElement, name);
         }
         else
         {
-            EBUS_EVENT_ID_RESULT(checkbox, parent, UiElementBus, CreateChildElement, name);
+            UiElementBus::EventResult(checkbox, parent, &UiElementBus::Events::CreateChildElement, name);
         }
 
         AZ::EntityId checkboxId = checkbox->GetId();
@@ -350,7 +350,7 @@ namespace LyShineExamples
 
         // Create the On element (the checkmark that will be displayed when the checkbox is "on")
         AZ::Entity* onElement;
-        EBUS_EVENT_ID_RESULT(onElement, checkboxId, UiElementBus, CreateChildElement, "onElem");
+        UiElementBus::EventResult(onElement, checkboxId, &UiElementBus::Events::CreateChildElement, "onElem");
 
         AZ::EntityId onId = onElement->GetId();
 
@@ -386,11 +386,11 @@ namespace LyShineExamples
         AZ::Entity* textElem = nullptr;
         if (atRoot)
         {
-            EBUS_EVENT_ID_RESULT(textElem, parent, UiCanvasBus, CreateChildElement, name);
+            UiCanvasBus::EventResult(textElem, parent, &UiCanvasBus::Events::CreateChildElement, name);
         }
         else
         {
-            EBUS_EVENT_ID_RESULT(textElem, parent, UiElementBus, CreateChildElement, name);
+            UiElementBus::EventResult(textElem, parent, &UiElementBus::Events::CreateChildElement, name);
         }
 
         AZ::EntityId textId = textElem->GetId();
@@ -429,11 +429,11 @@ namespace LyShineExamples
         AZ::Entity* textInputElem = nullptr;
         if (atRoot)
         {
-            EBUS_EVENT_ID_RESULT(textInputElem, parent, UiCanvasBus, CreateChildElement, name);
+            UiCanvasBus::EventResult(textInputElem, parent, &UiCanvasBus::Events::CreateChildElement, name);
         }
         else
         {
-            EBUS_EVENT_ID_RESULT(textInputElem, parent, UiElementBus, CreateChildElement, name);
+            UiElementBus::EventResult(textInputElem, parent, &UiElementBus::Events::CreateChildElement, name);
         }
 
         AZ::EntityId textInputId = textInputElem->GetId();
@@ -507,11 +507,11 @@ namespace LyShineExamples
         AZ::Entity* image = nullptr;
         if (atRoot)
         {
-            EBUS_EVENT_ID_RESULT(image, parent, UiCanvasBus, CreateChildElement, name);
+            UiCanvasBus::EventResult(image, parent, &UiCanvasBus::Events::CreateChildElement, name);
         }
         else
         {
-            EBUS_EVENT_ID_RESULT(image, parent, UiElementBus, CreateChildElement, name);
+            UiElementBus::EventResult(image, parent, &UiElementBus::Events::CreateChildElement, name);
         }
 
         AZ::EntityId imageId = image->GetId();

--- a/Gems/LyShineExamples/Code/Source/LyShineExamplesCppExample.cpp
+++ b/Gems/LyShineExamples/Code/Source/LyShineExamplesCppExample.cpp
@@ -152,13 +152,14 @@ namespace LyShineExamples
         // We want the background to stretch to the corners of the canvas
         // So we set the anchors to go all the way to the right and to the bottom
         AZ::EntityId backgroundId = background->GetId();
-        EBUS_EVENT_ID(backgroundId, UiTransform2dBus, SetAnchors, UiTransform2dInterface::Anchors(0.0f, 0.0f, 1.0f, 1.0f), false, false);
+        UiTransform2dBus::Event(
+            backgroundId, &UiTransform2dBus::Events::SetAnchors, UiTransform2dInterface::Anchors(0.0f, 0.0f, 1.0f, 1.0f), false, false);
 
         // Set the color of the background image to black
-        EBUS_EVENT_ID(backgroundId, UiImageBus, SetColor, AZ::Color(0.f, 0.f, 0.f, 1.f));
+        UiImageBus::Event(backgroundId, &UiImageBus::Events::SetColor, AZ::Color(0.f, 0.f, 0.f, 1.f));
 
         // Set the background button's navigation to none
-        EBUS_EVENT_ID(backgroundId, UiNavigationBus, SetNavigationMode, UiNavigationInterface::NavigationMode::None);
+        UiNavigationBus::Event(backgroundId, &UiNavigationBus::Events::SetNavigationMode, UiNavigationInterface::NavigationMode::None);
 
         // Now let's create a child of the background
         AZ::Entity* foreground = canvas->CreateChildElement("Foreground");
@@ -169,7 +170,8 @@ namespace LyShineExamples
 
         // Stretch it to the corners of the background with the anchors, stretch it 90% of background to still a background outline
         AZ::EntityId foregroundId = foreground->GetId();
-        EBUS_EVENT_ID(foregroundId, UiTransform2dBus, SetAnchors, UiTransform2dInterface::Anchors(0.1f, 0.1f, 0.9f, 0.9f), false, false);
+        UiTransform2dBus::Event(
+            foregroundId, &UiTransform2dBus::Events::SetAnchors, UiTransform2dInterface::Anchors(0.1f, 0.1f, 0.9f, 0.9f), false, false);
 
         return foregroundId;
     }
@@ -264,20 +266,45 @@ namespace LyShineExamples
 
             AZ_Assert(UiTransform2dBus::FindFirstHandler(buttonId), "Transform2d component missing");
 
-            EBUS_EVENT_ID(buttonId, UiTransformBus, SetScaleToDeviceMode, scaleToDeviceMode);
-            EBUS_EVENT_ID(buttonId, UiTransform2dBus, SetAnchors, anchors, false, false);
-            EBUS_EVENT_ID(buttonId, UiTransform2dBus, SetOffsets, offsets);
-            EBUS_EVENT_ID(buttonId, UiImageBus, SetColor, baseColor);
+            UiTransformBus::Event(buttonId, &UiTransformBus::Events::SetScaleToDeviceMode, scaleToDeviceMode);
+            UiTransform2dBus::Event(buttonId, &UiTransform2dBus::Events::SetAnchors, anchors, false, false);
+            UiTransform2dBus::Event(buttonId, &UiTransform2dBus::Events::SetOffsets, offsets);
+            UiImageBus::Event(buttonId, &UiImageBus::Events::SetColor, baseColor);
 
-            EBUS_EVENT_ID(buttonId, UiInteractableStatesBus, SetStateColor, UiInteractableStatesInterface::StateHover, buttonId, selectedColor);
-            EBUS_EVENT_ID(buttonId, UiInteractableStatesBus, SetStateAlpha, UiInteractableStatesInterface::StateHover, buttonId, selectedColor.GetA());
-            EBUS_EVENT_ID(buttonId, UiInteractableStatesBus, SetStateColor, UiInteractableStatesInterface::StatePressed, buttonId, pressedColor);
-            EBUS_EVENT_ID(buttonId, UiInteractableStatesBus, SetStateAlpha, UiInteractableStatesInterface::StatePressed, buttonId, pressedColor.GetA());
+            UiInteractableStatesBus::Event(
+                buttonId,
+                &UiInteractableStatesBus::Events::SetStateColor,
+                UiInteractableStatesInterface::StateHover,
+                buttonId,
+                selectedColor);
+            UiInteractableStatesBus::Event(
+                buttonId,
+                &UiInteractableStatesBus::Events::SetStateAlpha,
+                UiInteractableStatesInterface::StateHover,
+                buttonId,
+                selectedColor.GetA());
+            UiInteractableStatesBus::Event(
+                buttonId,
+                &UiInteractableStatesBus::Events::SetStateColor,
+                UiInteractableStatesInterface::StatePressed,
+                buttonId,
+                pressedColor);
+            UiInteractableStatesBus::Event(
+                buttonId,
+                &UiInteractableStatesBus::Events::SetStateAlpha,
+                UiInteractableStatesInterface::StatePressed,
+                buttonId,
+                pressedColor.GetA());
 
-            EBUS_EVENT_ID(buttonId, UiImageBus, SetSpritePathname, "UI/Textures/Prefab/button_normal.sprite");
-            EBUS_EVENT_ID(buttonId, UiImageBus, SetImageType, UiImageInterface::ImageType::Sliced);
+            UiImageBus::Event(buttonId, &UiImageBus::Events::SetSpritePathname, "UI/Textures/Prefab/button_normal.sprite");
+            UiImageBus::Event(buttonId, &UiImageBus::Events::SetImageType, UiImageInterface::ImageType::Sliced);
 
-            EBUS_EVENT_ID(buttonId, UiInteractableStatesBus, SetStateSpritePathname, UiInteractableStatesInterface::StateDisabled, buttonId, "UI/Textures/Prefab/button_disabled.sprite");
+            UiInteractableStatesBus::Event(
+                buttonId,
+                &UiInteractableStatesBus::Events::SetStateSpritePathname,
+                UiInteractableStatesInterface::StateDisabled,
+                buttonId,
+                "UI/Textures/Prefab/button_disabled.sprite");
         }
 
         AZ::Entity* textElem = nullptr;
@@ -291,18 +318,19 @@ namespace LyShineExamples
 
             AZ_Assert(UiTransform2dBus::FindFirstHandler(textId), "Transform component missing");
 
-            EBUS_EVENT_ID(textId, UiTransform2dBus, SetAnchors, UiTransform2dInterface::Anchors(0.5, 0.5, 0.5, 0.5), false, false);
-            EBUS_EVENT_ID(textId, UiTransform2dBus, SetOffsets, UiTransform2dInterface::Offsets(0, 0, 0, 0));
+            UiTransform2dBus::Event(
+                textId, &UiTransform2dBus::Events::SetAnchors, UiTransform2dInterface::Anchors(0.5, 0.5, 0.5, 0.5), false, false);
+            UiTransform2dBus::Event(textId, &UiTransform2dBus::Events::SetOffsets, UiTransform2dInterface::Offsets(0, 0, 0, 0));
 
-            EBUS_EVENT_ID(textId, UiTextBus, SetText, text);
-            EBUS_EVENT_ID(textId, UiTextBus, SetTextAlignment, IDraw2d::HAlign::Center, IDraw2d::VAlign::Center);
-            EBUS_EVENT_ID(textId, UiTextBus, SetColor, textColor);
-            EBUS_EVENT_ID(textId, UiTextBus, SetFontSize, 24.0f);
+            UiTextBus::Event(textId, &UiTextBus::Events::SetText, text);
+            UiTextBus::Event(textId, &UiTextBus::Events::SetTextAlignment, IDraw2d::HAlign::Center, IDraw2d::VAlign::Center);
+            UiTextBus::Event(textId, &UiTextBus::Events::SetColor, textColor);
+            UiTextBus::Event(textId, &UiTextBus::Events::SetFontSize, 24.0f);
         }
 
         // Trigger all InGamePostActivate
-        EBUS_EVENT_ID(buttonId, UiInitializationBus, InGamePostActivate);
-        EBUS_EVENT_ID(textId, UiInitializationBus, InGamePostActivate);
+        UiInitializationBus::Event(buttonId, &UiInitializationBus::Events::InGamePostActivate);
+        UiInitializationBus::Event(textId, &UiInitializationBus::Events::InGamePostActivate);
 
         return buttonId;
     }
@@ -334,18 +362,38 @@ namespace LyShineExamples
 
             AZ_Assert(UiTransform2dBus::FindFirstHandler(checkboxId), "Transform2d component missing");
 
-            EBUS_EVENT_ID(checkboxId, UiTransformBus, SetScaleToDeviceMode, scaleToDeviceMode);
-            EBUS_EVENT_ID(checkboxId, UiTransform2dBus, SetAnchors, anchors, false, false);
-            EBUS_EVENT_ID(checkboxId, UiTransform2dBus, SetOffsets, offsets);
-            EBUS_EVENT_ID(checkboxId, UiImageBus, SetColor, baseColor);
+            UiTransformBus::Event(checkboxId, &UiTransformBus::Events::SetScaleToDeviceMode, scaleToDeviceMode);
+            UiTransform2dBus::Event(checkboxId, &UiTransform2dBus::Events::SetAnchors, anchors, false, false);
+            UiTransform2dBus::Event(checkboxId, &UiTransform2dBus::Events::SetOffsets, offsets);
+            UiImageBus::Event(checkboxId, &UiImageBus::Events::SetColor, baseColor);
 
-            EBUS_EVENT_ID(checkboxId, UiImageBus, SetSpritePathname, "UI/Textures/Prefab/checkbox_box_normal.sprite");
+            UiImageBus::Event(checkboxId, &UiImageBus::Events::SetSpritePathname, "UI/Textures/Prefab/checkbox_box_normal.sprite");
 
-            EBUS_EVENT_ID(checkboxId, UiInteractableStatesBus, SetStateColor, UiInteractableStatesInterface::StateHover, checkboxId, selectedColor);
-            EBUS_EVENT_ID(checkboxId, UiInteractableStatesBus, SetStateAlpha, UiInteractableStatesInterface::StateHover, checkboxId, selectedColor.GetA());
-            EBUS_EVENT_ID(checkboxId, UiInteractableStatesBus, SetStateSpritePathname, UiInteractableStatesInterface::StateHover, checkboxId, "UI/Textures/Prefab/checkbox_box_hover.sprite");
+            UiInteractableStatesBus::Event(
+                checkboxId,
+                &UiInteractableStatesBus::Events::SetStateColor,
+                UiInteractableStatesInterface::StateHover,
+                checkboxId,
+                selectedColor);
+            UiInteractableStatesBus::Event(
+                checkboxId,
+                &UiInteractableStatesBus::Events::SetStateAlpha,
+                UiInteractableStatesInterface::StateHover,
+                checkboxId,
+                selectedColor.GetA());
+            UiInteractableStatesBus::Event(
+                checkboxId,
+                &UiInteractableStatesBus::Events::SetStateSpritePathname,
+                UiInteractableStatesInterface::StateHover,
+                checkboxId,
+                "UI/Textures/Prefab/checkbox_box_hover.sprite");
 
-            EBUS_EVENT_ID(checkboxId, UiInteractableStatesBus, SetStateSpritePathname, UiInteractableStatesInterface::StateDisabled, checkboxId, "UI/Textures/Prefab/checkbox_box_disabled.sprite");
+            UiInteractableStatesBus::Event(
+                checkboxId,
+                &UiInteractableStatesBus::Events::SetStateSpritePathname,
+                UiInteractableStatesInterface::StateDisabled,
+                checkboxId,
+                "UI/Textures/Prefab/checkbox_box_disabled.sprite");
         }
 
         // Create the On element (the checkmark that will be displayed when the checkbox is "on")
@@ -359,19 +407,20 @@ namespace LyShineExamples
             CreateComponent(onElement, LyShine::UiTransform2dComponentUuid);
             CreateComponent(onElement, LyShine::UiImageComponentUuid);
 
-            EBUS_EVENT_ID(onId, UiTransform2dBus, SetAnchors, UiTransform2dInterface::Anchors(0.5f, 0.5f, 0.5f, 0.5f), false, false);
-            EBUS_EVENT_ID(onId, UiTransform2dBus, SetOffsets, offsets);
+            UiTransform2dBus::Event(
+                onId, &UiTransform2dBus::Events::SetAnchors, UiTransform2dInterface::Anchors(0.5f, 0.5f, 0.5f, 0.5f), false, false);
+            UiTransform2dBus::Event(onId, &UiTransform2dBus::Events::SetOffsets, offsets);
 
-            EBUS_EVENT_ID(onId, UiImageBus, SetSpritePathname, "UI/Textures/Prefab/checkbox_check.sprite");
-            EBUS_EVENT_ID(onId, UiImageBus, SetColor, checkColor);
+            UiImageBus::Event(onId, &UiImageBus::Events::SetSpritePathname, "UI/Textures/Prefab/checkbox_check.sprite");
+            UiImageBus::Event(onId, &UiImageBus::Events::SetColor, checkColor);
         }
 
         // Link the on and off child entities to the parent checkbox entity.
-        EBUS_EVENT_ID(checkboxId, UiCheckboxBus, SetCheckedEntity, onId);
+        UiCheckboxBus::Event(checkboxId, &UiCheckboxBus::Events::SetCheckedEntity, onId);
 
         // Trigger all InGamePostActivate
-        EBUS_EVENT_ID(onId, UiInitializationBus, InGamePostActivate);
-        EBUS_EVENT_ID(checkboxId, UiInitializationBus, InGamePostActivate);
+        UiInitializationBus::Event(onId, &UiInitializationBus::Events::InGamePostActivate);
+        UiInitializationBus::Event(checkboxId, &UiInitializationBus::Events::InGamePostActivate);
 
         return checkboxId;
     }
@@ -402,17 +451,17 @@ namespace LyShineExamples
 
             AZ_Assert(UiTransform2dBus::FindFirstHandler(textId), "Transform component missing");
 
-            EBUS_EVENT_ID(textId, UiTransformBus, SetScaleToDeviceMode, scaleToDeviceMode);
-            EBUS_EVENT_ID(textId, UiTransform2dBus, SetAnchors, anchors, false, false);
-            EBUS_EVENT_ID(textId, UiTransform2dBus, SetOffsets, offsets);
+            UiTransformBus::Event(textId, &UiTransformBus::Events::SetScaleToDeviceMode, scaleToDeviceMode);
+            UiTransform2dBus::Event(textId, &UiTransform2dBus::Events::SetAnchors, anchors, false, false);
+            UiTransform2dBus::Event(textId, &UiTransform2dBus::Events::SetOffsets, offsets);
 
-            EBUS_EVENT_ID(textId, UiTextBus, SetText, text);
-            EBUS_EVENT_ID(textId, UiTextBus, SetTextAlignment, hAlign, vAlign);
-            EBUS_EVENT_ID(textId, UiTextBus, SetColor, textColor);
+            UiTextBus::Event(textId, &UiTextBus::Events::SetText, text);
+            UiTextBus::Event(textId, &UiTextBus::Events::SetTextAlignment, hAlign, vAlign);
+            UiTextBus::Event(textId, &UiTextBus::Events::SetColor, textColor);
         }
 
         // Trigger all InGamePostActivate
-        EBUS_EVENT_ID(textId, UiInitializationBus, InGamePostActivate);
+        UiInitializationBus::Event(textId, &UiInitializationBus::Events::InGamePostActivate);
 
         return textId;
     }
@@ -446,23 +495,53 @@ namespace LyShineExamples
 
             AZ_Assert(UiTransform2dBus::FindFirstHandler(textInputId), "Transform2d component missing");
 
-            EBUS_EVENT_ID(textInputId, UiTransformBus, SetScaleToDeviceMode, scaleToDeviceMode);
-            EBUS_EVENT_ID(textInputId, UiTransform2dBus, SetAnchors, anchors, false, false);
-            EBUS_EVENT_ID(textInputId, UiTransform2dBus, SetOffsets, offsets);
-            EBUS_EVENT_ID(textInputId, UiImageBus, SetColor, baseColor);
+            UiTransformBus::Event(textInputId, &UiTransformBus::Events::SetScaleToDeviceMode, scaleToDeviceMode);
+            UiTransform2dBus::Event(textInputId, &UiTransform2dBus::Events::SetAnchors, anchors, false, false);
+            UiTransform2dBus::Event(textInputId, &UiTransform2dBus::Events::SetOffsets, offsets);
+            UiImageBus::Event(textInputId, &UiImageBus::Events::SetColor, baseColor);
 
-            EBUS_EVENT_ID(textInputId, UiInteractableStatesBus, SetStateColor, UiInteractableStatesInterface::StateHover, textInputId, selectedColor);
-            EBUS_EVENT_ID(textInputId, UiInteractableStatesBus, SetStateAlpha, UiInteractableStatesInterface::StateHover, textInputId, selectedColor.GetA());
+            UiInteractableStatesBus::Event(
+                textInputId,
+                &UiInteractableStatesBus::Events::SetStateColor,
+                UiInteractableStatesInterface::StateHover,
+                textInputId,
+                selectedColor);
+            UiInteractableStatesBus::Event(
+                textInputId,
+                &UiInteractableStatesBus::Events::SetStateAlpha,
+                UiInteractableStatesInterface::StateHover,
+                textInputId,
+                selectedColor.GetA());
 
-            EBUS_EVENT_ID(textInputId, UiInteractableStatesBus, SetStateColor, UiInteractableStatesInterface::StatePressed, textInputId, pressedColor);
-            EBUS_EVENT_ID(textInputId, UiInteractableStatesBus, SetStateAlpha, UiInteractableStatesInterface::StatePressed, textInputId, pressedColor.GetA());
+            UiInteractableStatesBus::Event(
+                textInputId,
+                &UiInteractableStatesBus::Events::SetStateColor,
+                UiInteractableStatesInterface::StatePressed,
+                textInputId,
+                pressedColor);
+            UiInteractableStatesBus::Event(
+                textInputId,
+                &UiInteractableStatesBus::Events::SetStateAlpha,
+                UiInteractableStatesInterface::StatePressed,
+                textInputId,
+                pressedColor.GetA());
 
-            EBUS_EVENT_ID(textInputId, UiImageBus, SetSpritePathname, "UI/Textures/Prefab/textinput_normal.sprite");
-            EBUS_EVENT_ID(textInputId, UiImageBus, SetImageType, UiImageInterface::ImageType::Sliced);
+            UiImageBus::Event(textInputId, &UiImageBus::Events::SetSpritePathname, "UI/Textures/Prefab/textinput_normal.sprite");
+            UiImageBus::Event(textInputId, &UiImageBus::Events::SetImageType, UiImageInterface::ImageType::Sliced);
 
-            EBUS_EVENT_ID(textInputId, UiInteractableStatesBus, SetStateSpritePathname, UiInteractableStatesInterface::StateHover, textInputId, "UI/Textures/Prefab/textinput_hover.sprite");
+            UiInteractableStatesBus::Event(
+                textInputId,
+                &UiInteractableStatesBus::Events::SetStateSpritePathname,
+                UiInteractableStatesInterface::StateHover,
+                textInputId,
+                "UI/Textures/Prefab/textinput_hover.sprite");
 
-            EBUS_EVENT_ID(textInputId, UiInteractableStatesBus, SetStateSpritePathname, UiInteractableStatesInterface::StateDisabled, textInputId, "UI/Textures/Prefab/textinput_disabled.sprite");
+            UiInteractableStatesBus::Event(
+                textInputId,
+                &UiInteractableStatesBus::Events::SetStateSpritePathname,
+                UiInteractableStatesInterface::StateDisabled,
+                textInputId,
+                "UI/Textures/Prefab/textinput_disabled.sprite");
         }
 
         // Create the text element (what the user will type)
@@ -472,10 +551,10 @@ namespace LyShineExamples
                 text, textColor, IDraw2d::HAlign::Center, IDraw2d::VAlign::Center);
 
         // reduce the font size
-        EBUS_EVENT_ID(textElemId, UiTextBus, SetFontSize, 24.0f);
+        UiTextBus::Event(textElemId, &UiTextBus::Events::SetFontSize, 24.0f);
 
         // now link the textInputComponent to the child text entity
-        EBUS_EVENT_ID(textInputId, UiTextInputBus, SetTextEntity, textElemId);
+        UiTextInputBus::Event(textInputId, &UiTextInputBus::Events::SetTextEntity, textElemId);
 
         // Create the placeholder text element (what appears before any text is typed)
         AZ::EntityId placeHolderElemId = CreateText("PlaceholderText", false, textInputId,
@@ -484,15 +563,15 @@ namespace LyShineExamples
                 placeHolderText, placeHolderColor, IDraw2d::HAlign::Center, IDraw2d::VAlign::Center);
 
         // reduce the font size
-        EBUS_EVENT_ID(placeHolderElemId, UiTextBus, SetFontSize, 24.0f);
+        UiTextBus::Event(placeHolderElemId, &UiTextBus::Events::SetFontSize, 24.0f);
 
         // now link the textInputComponent to the child placeholder text entity
-        EBUS_EVENT_ID(textInputId, UiTextInputBus, SetPlaceHolderTextEntity, placeHolderElemId);
+        UiTextInputBus::Event(textInputId, &UiTextInputBus::Events::SetPlaceHolderTextEntity, placeHolderElemId);
 
         // Trigger all InGamePostActivate
-        EBUS_EVENT_ID(textInputId, UiInitializationBus, InGamePostActivate);
-        EBUS_EVENT_ID(textElemId, UiInitializationBus, InGamePostActivate);
-        EBUS_EVENT_ID(placeHolderElemId, UiInitializationBus, InGamePostActivate);
+        UiInitializationBus::Event(textInputId, &UiInitializationBus::Events::InGamePostActivate);
+        UiInitializationBus::Event(textElemId, &UiInitializationBus::Events::InGamePostActivate);
+        UiInitializationBus::Event(placeHolderElemId, &UiInitializationBus::Events::InGamePostActivate);
 
         return textInputId;
     }
@@ -523,17 +602,17 @@ namespace LyShineExamples
 
             AZ_Assert(UiTransform2dBus::FindFirstHandler(imageId), "Transform2d component missing");
 
-            EBUS_EVENT_ID(imageId, UiTransformBus, SetScaleToDeviceMode, scaleToDeviceMode);
-            EBUS_EVENT_ID(imageId, UiTransform2dBus, SetAnchors, anchors, false, false);
-            EBUS_EVENT_ID(imageId, UiTransform2dBus, SetOffsets, offsets);
+            UiTransformBus::Event(imageId, &UiTransformBus::Events::SetScaleToDeviceMode, scaleToDeviceMode);
+            UiTransform2dBus::Event(imageId, &UiTransform2dBus::Events::SetAnchors, anchors, false, false);
+            UiTransform2dBus::Event(imageId, &UiTransform2dBus::Events::SetOffsets, offsets);
 
-            EBUS_EVENT_ID(imageId, UiImageBus, SetColor, color);
-            EBUS_EVENT_ID(imageId, UiImageBus, SetSpritePathname, spritePath);
-            EBUS_EVENT_ID(imageId, UiImageBus, SetImageType, imageType);
+            UiImageBus::Event(imageId, &UiImageBus::Events::SetColor, color);
+            UiImageBus::Event(imageId, &UiImageBus::Events::SetSpritePathname, spritePath);
+            UiImageBus::Event(imageId, &UiImageBus::Events::SetImageType, imageType);
         }
 
         // Trigger all InGamePostActivate
-        EBUS_EVENT_ID(imageId, UiInitializationBus, InGamePostActivate);
+        UiInitializationBus::Event(imageId, &UiInitializationBus::Events::InGamePostActivate);
 
         return imageId;
     }
@@ -548,6 +627,6 @@ namespace LyShineExamples
         UiTransform2dInterface::Offsets newOffsets = m_maxHealthBarOffsets;
         float healthFraction = m_health / 10.f;
         newOffsets.m_right = m_maxHealthBarOffsets.m_left + (m_maxHealthBarOffsets.m_right - m_maxHealthBarOffsets.m_left) * healthFraction;
-        EBUS_EVENT_ID(m_healthBar, UiTransform2dBus, SetOffsets, newOffsets);
+        UiTransform2dBus::Event(m_healthBar, &UiTransform2dBus::Events::SetOffsets, newOffsets);
     }
 }

--- a/Gems/LyShineExamples/Code/Source/UiCustomImageComponent.cpp
+++ b/Gems/LyShineExamples/Code/Source/UiCustomImageComponent.cpp
@@ -391,9 +391,9 @@ namespace LyShineExamples
     bool UiCustomImageComponent::IsPixelAligned()
     {
         AZ::EntityId canvasEntityId;
-        EBUS_EVENT_ID_RESULT(canvasEntityId, GetEntityId(), UiElementBus, GetCanvasEntityId);
+        UiElementBus::EventResult(canvasEntityId, GetEntityId(), &UiElementBus::Events::GetCanvasEntityId);
         bool isPixelAligned = true;
-        EBUS_EVENT_ID_RESULT(isPixelAligned, canvasEntityId, UiCanvasBus, GetIsPixelAligned);
+        UiCanvasBus::EventResult(isPixelAligned, canvasEntityId, &UiCanvasBus::Events::GetIsPixelAligned);
         return isPixelAligned;
     }
 
@@ -442,7 +442,7 @@ namespace LyShineExamples
     {
         // tell the canvas to invalidate the render graph (never want to do this while rendering)
         AZ::EntityId canvasEntityId;
-        EBUS_EVENT_ID_RESULT(canvasEntityId, GetEntityId(), UiElementBus, GetCanvasEntityId);
+        UiElementBus::EventResult(canvasEntityId, GetEntityId(), &UiElementBus::Events::GetCanvasEntityId);
         EBUS_EVENT_ID(canvasEntityId, UiCanvasComponentImplementationBus, MarkRenderGraphDirty);
     }
 

--- a/Gems/LyShineExamples/Code/Source/UiCustomImageComponent.cpp
+++ b/Gems/LyShineExamples/Code/Source/UiCustomImageComponent.cpp
@@ -335,7 +335,7 @@ namespace LyShineExamples
     void UiCustomImageComponent::RenderToCache(LyShine::IRenderGraph* renderGraph)
     {
         UiTransformInterface::RectPoints points;
-        EBUS_EVENT_ID(GetEntityId(), UiTransformBus, GetViewportSpacePoints, points);
+        UiTransformBus::Event(GetEntityId(), &UiTransformBus::Events::GetViewportSpacePoints, points);
 
         // points are a clockwise quad
         const AZ::Vector2 uvs[4] = {
@@ -443,7 +443,7 @@ namespace LyShineExamples
         // tell the canvas to invalidate the render graph (never want to do this while rendering)
         AZ::EntityId canvasEntityId;
         UiElementBus::EventResult(canvasEntityId, GetEntityId(), &UiElementBus::Events::GetCanvasEntityId);
-        EBUS_EVENT_ID(canvasEntityId, UiCanvasComponentImplementationBus, MarkRenderGraphDirty);
+        UiCanvasComponentImplementationBus::Event(canvasEntityId, &UiCanvasComponentImplementationBus::Events::MarkRenderGraphDirty);
     }
 
 }

--- a/Gems/LyShineExamples/Code/Source/UiTestScrollBoxDataProviderComponent.cpp
+++ b/Gems/LyShineExamples/Code/Source/UiTestScrollBoxDataProviderComponent.cpp
@@ -38,7 +38,7 @@ namespace LyShineExamples
     int UiTestScrollBoxDataProviderComponent::GetNumElements()
     {
         UiDynamicContentDatabase *uiDynamicContentDB = nullptr;
-        EBUS_EVENT_RESULT(uiDynamicContentDB, LyShineExamplesInternalBus, GetUiDynamicContentDatabase);
+        LyShineExamplesInternalBus::BroadcastResult(uiDynamicContentDB, &LyShineExamplesInternalBus::Events::GetUiDynamicContentDatabase);
         if (uiDynamicContentDB)
         {
             return uiDynamicContentDB->GetNumColors(UiDynamicContentDatabaseInterface::ColorType::PaidColors);
@@ -51,7 +51,7 @@ namespace LyShineExamples
     void UiTestScrollBoxDataProviderComponent::OnElementBecomingVisible(AZ::EntityId entityId, int index)
     {
         UiDynamicContentDatabase *uiDynamicContentDB = nullptr;
-        EBUS_EVENT_RESULT(uiDynamicContentDB, LyShineExamplesInternalBus, GetUiDynamicContentDatabase);
+        LyShineExamplesInternalBus::BroadcastResult(uiDynamicContentDB, &LyShineExamplesInternalBus::Events::GetUiDynamicContentDatabase);
         if (uiDynamicContentDB)
         {
             if ((index >= 0) && (index < uiDynamicContentDB->GetNumColors(UiDynamicContentDatabaseInterface::ColorType::PaidColors)))

--- a/Gems/LyShineExamples/Code/Source/UiTestScrollBoxDataProviderComponent.cpp
+++ b/Gems/LyShineExamples/Code/Source/UiTestScrollBoxDataProviderComponent.cpp
@@ -58,7 +58,7 @@ namespace LyShineExamples
             {
                 AZ::Entity* entity = nullptr;
 
-                EBUS_EVENT_ID_RESULT(entity, entityId, UiElementBus, FindChildByName, "Name");
+                UiElementBus::EventResult(entity, entityId, &UiElementBus::Events::FindChildByName, "Name");
                 if (entity)
                 {
                     AZStd::string text = uiDynamicContentDB->GetColorName(UiDynamicContentDatabaseInterface::ColorType::PaidColors, index);
@@ -66,7 +66,7 @@ namespace LyShineExamples
                 }
 
                 entity = nullptr;
-                EBUS_EVENT_ID_RESULT(entity, entityId, UiElementBus, FindChildByName, "Price");
+                UiElementBus::EventResult(entity, entityId, &UiElementBus::Events::FindChildByName, "Price");
                 if (entity)
                 {
                     AZStd::string text = uiDynamicContentDB->GetColorPrice(UiDynamicContentDatabaseInterface::ColorType::PaidColors, index);
@@ -74,7 +74,7 @@ namespace LyShineExamples
                 }
 
                 entity = nullptr;
-                EBUS_EVENT_ID_RESULT(entity, entityId, UiElementBus, FindChildByName, "Icon");
+                UiElementBus::EventResult(entity, entityId, &UiElementBus::Events::FindChildByName, "Icon");
                 if (entity)
                 {
                     AZ::Color color = uiDynamicContentDB->GetColor(UiDynamicContentDatabaseInterface::ColorType::PaidColors, index);

--- a/Gems/LyShineExamples/Code/Source/UiTestScrollBoxDataProviderComponent.cpp
+++ b/Gems/LyShineExamples/Code/Source/UiTestScrollBoxDataProviderComponent.cpp
@@ -62,7 +62,7 @@ namespace LyShineExamples
                 if (entity)
                 {
                     AZStd::string text = uiDynamicContentDB->GetColorName(UiDynamicContentDatabaseInterface::ColorType::PaidColors, index);
-                    EBUS_EVENT_ID(entity->GetId(), UiTextBus, SetText, text.c_str());
+                    UiTextBus::Event(entity->GetId(), &UiTextBus::Events::SetText, text.c_str());
                 }
 
                 entity = nullptr;
@@ -70,7 +70,7 @@ namespace LyShineExamples
                 if (entity)
                 {
                     AZStd::string text = uiDynamicContentDB->GetColorPrice(UiDynamicContentDatabaseInterface::ColorType::PaidColors, index);
-                    EBUS_EVENT_ID(entity->GetId(), UiTextBus, SetText, text.c_str());
+                    UiTextBus::Event(entity->GetId(), &UiTextBus::Events::SetText, text.c_str());
                 }
 
                 entity = nullptr;
@@ -78,7 +78,7 @@ namespace LyShineExamples
                 if (entity)
                 {
                     AZ::Color color = uiDynamicContentDB->GetColor(UiDynamicContentDatabaseInterface::ColorType::PaidColors, index);
-                    EBUS_EVENT_ID(entity->GetId(), UiImageBus, SetColor, color);
+                    UiImageBus::Event(entity->GetId(), &UiImageBus::Events::SetColor, color);
                 }
             }
         }

--- a/Gems/Maestro/Code/Source/Components/EditorSequenceComponent.cpp
+++ b/Gems/Maestro/Code/Source/Components/EditorSequenceComponent.cpp
@@ -303,7 +303,8 @@ namespace Maestro
             AZ::TickBus::Handler::BusConnect();
         }
 
-        EBUS_EVENT_ID_RESULT(changed, ebusId, Maestro::SequenceAgentComponentRequestBus, SetAnimatedPropertyValue, animatableAddress, value);
+        Maestro::SequenceAgentComponentRequestBus::EventResult(
+            changed, ebusId, &Maestro::SequenceAgentComponentRequestBus::Events::SetAnimatedPropertyValue, animatableAddress, value);
 
         return changed;
     }
@@ -341,7 +342,8 @@ namespace Maestro
         {
             CEntityObject* entityObject = nullptr;
 
-            EBUS_EVENT_ID_RESULT(entityObject, GetEntityId(), AzToolsFramework::ComponentEntityEditorRequestBus, GetSandboxObject);
+            AzToolsFramework::ComponentEntityEditorRequestBus::EventResult(
+                entityObject, GetEntityId(), &AzToolsFramework::ComponentEntityEditorRequestBus::Events::GetSandboxObject);
             if (entityObject)
             {
                 entityObject->SetModified(false);

--- a/Gems/Maestro/Code/Source/Components/EditorSequenceComponent.cpp
+++ b/Gems/Maestro/Code/Source/Components/EditorSequenceComponent.cpp
@@ -238,7 +238,7 @@ namespace Maestro
         const Maestro::SequenceAgentEventBusId ebusId(GetEntityId(), removedEntityId);
 
         // Notify the SequenceAgentComponent that we're disconnecting from it
-        EBUS_EVENT_ID(ebusId, Maestro::SequenceAgentComponentRequestBus, DisconnectSequence);
+        Maestro::SequenceAgentComponentRequestBus::Event(ebusId, &Maestro::SequenceAgentComponentRequestBus::Events::DisconnectSequence);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -254,7 +254,8 @@ namespace Maestro
     {
         const Maestro::SequenceAgentEventBusId ebusId(GetEntityId(), animatedEntityId);
 
-        EBUS_EVENT_ID(ebusId, Maestro::EditorSequenceAgentComponentRequestBus, GetAnimatableComponents, componentIds);
+        Maestro::EditorSequenceAgentComponentRequestBus::Event(
+            ebusId, &Maestro::EditorSequenceAgentComponentRequestBus::Events::GetAnimatableComponents, componentIds);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -272,7 +273,8 @@ namespace Maestro
     void EditorSequenceComponent::GetAssetDuration(AnimatedValue& returnValue, const AZ::EntityId& animatedEntityId, AZ::ComponentId componentId, const AZ::Data::AssetId& assetId)
     {
         const Maestro::SequenceAgentEventBusId ebusId(GetEntityId(), animatedEntityId);
-        EBUS_EVENT_ID(ebusId, Maestro::SequenceAgentComponentRequestBus, GetAssetDuration, returnValue, componentId, assetId);
+        Maestro::SequenceAgentComponentRequestBus::Event(
+            ebusId, &Maestro::SequenceAgentComponentRequestBus::Events::GetAssetDuration, returnValue, componentId, assetId);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -328,7 +330,8 @@ namespace Maestro
     void EditorSequenceComponent::GetAnimatedPropertyValue(AnimatedValue& returnValue, const AZ::EntityId& animatedEntityId, const Maestro::SequenceComponentRequests::AnimatablePropertyAddress& animatableAddress)
     {
         const Maestro::SequenceAgentEventBusId ebusId(GetEntityId(), animatedEntityId);
-        EBUS_EVENT_ID(ebusId, Maestro::SequenceAgentComponentRequestBus, GetAnimatedPropertyValue, returnValue, animatableAddress);
+        Maestro::SequenceAgentComponentRequestBus::Event(
+            ebusId, &Maestro::SequenceAgentComponentRequestBus::Events::GetAnimatedPropertyValue, returnValue, animatableAddress);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/Maestro/Code/Source/Components/EditorSequenceComponent.cpp
+++ b/Gems/Maestro/Code/Source/Components/EditorSequenceComponent.cpp
@@ -63,7 +63,7 @@ namespace Maestro
         }
 
         IEditor* editor = nullptr;
-        EBUS_EVENT_RESULT(editor, AzToolsFramework::EditorRequests::Bus, GetEditor);
+        AzToolsFramework::EditorRequests::Bus::BroadcastResult(editor, &AzToolsFramework::EditorRequests::Bus::Events::GetEditor);
         if (editor)
         {
             IAnimSequence* sequence = editor->GetMovieSystem()->FindSequenceById(m_sequenceId);
@@ -127,7 +127,7 @@ namespace Maestro
         EditorComponentBase::Init();
         m_sequenceId = s_invalidSequenceId;
         IEditor* editor = nullptr;
-        EBUS_EVENT_RESULT(editor, AzToolsFramework::EditorRequests::Bus, GetEditor);
+        AzToolsFramework::EditorRequests::Bus::BroadcastResult(editor, &AzToolsFramework::EditorRequests::Bus::Events::GetEditor);
 
         if (editor)
         {
@@ -170,7 +170,7 @@ namespace Maestro
         Maestro::SequenceComponentRequestBus::Handler::BusConnect(GetEntityId());
 
         IEditor* editor = nullptr;
-        EBUS_EVENT_RESULT(editor, AzToolsFramework::EditorRequests::Bus, GetEditor);
+        AzToolsFramework::EditorRequests::Bus::BroadcastResult(editor, &AzToolsFramework::EditorRequests::Bus::Events::GetEditor);
         if (editor)
         {
             editor->GetSequenceManager()->OnSequenceActivated(GetEntityId());
@@ -336,7 +336,7 @@ namespace Maestro
         bool retSuccess = false;
         AZ::Entity* entity = nullptr;
 
-        EBUS_EVENT_RESULT(entity, AZ::ComponentApplicationBus, FindEntity, GetEntityId());
+        AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, GetEntityId());
         if (entity)
         {
             CEntityObject* entityObject = nullptr;

--- a/Gems/Maestro/Code/Source/Components/SequenceAgent.cpp
+++ b/Gems/Maestro/Code/Source/Components/SequenceAgent.cpp
@@ -53,7 +53,7 @@ namespace Maestro
     void SequenceAgent::CacheAllVirtualPropertiesFromBehaviorContext()
     {
         AZ::BehaviorContext* behaviorContext = nullptr;
-        EBUS_EVENT_RESULT(behaviorContext, AZ::ComponentApplicationBus, GetBehaviorContext);
+        AZ::ComponentApplicationBus::BroadcastResult(behaviorContext, &AZ::ComponentApplicationBus::Events::GetBehaviorContext);
         
         AZ::Entity::ComponentArrayType entityComponents;
         GetEntityComponents(entityComponents);

--- a/Gems/Maestro/Code/Source/Components/SequenceComponent.cpp
+++ b/Gems/Maestro/Code/Source/Components/SequenceComponent.cpp
@@ -249,7 +249,8 @@ namespace Maestro
     {
         const Maestro::SequenceAgentEventBusId ebusId(GetEntityId(), animatedEntityId);
 
-        EBUS_EVENT_ID(ebusId, Maestro::SequenceAgentComponentRequestBus, GetAnimatedPropertyValue, returnValue, animatableAddress);
+        Maestro::SequenceAgentComponentRequestBus::Event(
+            ebusId, &Maestro::SequenceAgentComponentRequestBus::Events::GetAnimatedPropertyValue, returnValue, animatableAddress);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -267,7 +268,8 @@ namespace Maestro
     void SequenceComponent::GetAssetDuration(AnimatedValue& returnValue, const AZ::EntityId& animatedEntityId, AZ::ComponentId componentId, const AZ::Data::AssetId& assetId)
     {
         const Maestro::SequenceAgentEventBusId ebusId(GetEntityId(), animatedEntityId);
-        EBUS_EVENT_ID(ebusId, Maestro::SequenceAgentComponentRequestBus, GetAssetDuration, returnValue, componentId, assetId);
+        Maestro::SequenceAgentComponentRequestBus::Event(
+            ebusId, &Maestro::SequenceAgentComponentRequestBus::Events::GetAssetDuration, returnValue, componentId, assetId);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/Maestro/Code/Source/Components/SequenceComponent.cpp
+++ b/Gems/Maestro/Code/Source/Components/SequenceComponent.cpp
@@ -238,7 +238,8 @@ namespace Maestro
         const Maestro::SequenceAgentEventBusId ebusId(GetEntityId(), animatedEntityId);
         bool changed = false;
         
-        EBUS_EVENT_ID_RESULT(changed, ebusId, Maestro::SequenceAgentComponentRequestBus, SetAnimatedPropertyValue, animatableAddress, value);
+        Maestro::SequenceAgentComponentRequestBus::EventResult(
+            changed, ebusId, &Maestro::SequenceAgentComponentRequestBus::Events::SetAnimatedPropertyValue, animatableAddress, value);
         
         return changed;
     }


### PR DESCRIPTION
## What does this PR do?
Replaces EBUS_EVENT style macros used in various places owned by sig-content. Apart from a handful of cases done manually, the replacements were made using the same regexes from #14099 plus one new one which wasn't required before

```
EBUS_QUEUE_FUNCTION\((.*Bus), (.*)\)
$1::QueueFunction($2)
```

## How was this PR tested?
Building and running tests.