### PR TITLE
Adapt components that query simulated bodies

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Audio/AudioAreaEnvironmentComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Audio/AudioAreaEnvironmentComponent.h
@@ -9,6 +9,7 @@
 
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TransformBus.h>
+#include <AzFramework/Physics/RigidBodyBus.h>
 #include <AzFramework/Physics/Common/PhysicsSimulatedBodyEvents.h>
 
 #include <IAudioSystem.h>
@@ -28,6 +29,7 @@ namespace LmbrCentral
      */
     class AudioAreaEnvironmentComponent
         : public AZ::Component
+        , protected Physics::RigidBodyNotificationBus::Handler
         , private AZ::TransformNotificationBus::MultiHandler
     {
         friend class EditorAudioAreaEnvironmentComponent;
@@ -69,6 +71,10 @@ namespace LmbrCentral
         }
 
         static void Reflect(AZ::ReflectContext* context);
+
+        // Physics::RigidBodyNotifications overrides...
+        void OnPhysicsEnabled(const AZ::EntityId& entityId) override;
+        void OnPhysicsDisabled(const AZ::EntityId& entityId) override;
 
     private:
         void OnTriggerEnter(const AzPhysics::TriggerEvent& triggerEvent);

--- a/Gems/LmbrCentral/Code/Source/Audio/AudioAreaEnvironmentComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Audio/AudioAreaEnvironmentComponent.h
@@ -72,7 +72,7 @@ namespace LmbrCentral
 
         static void Reflect(AZ::ReflectContext* context);
 
-        // Physics::RigidBodyNotifications overrides...
+        // Physics::RigidBodyNotifications overrides ...
         void OnPhysicsEnabled(const AZ::EntityId& entityId) override;
         void OnPhysicsDisabled(const AZ::EntityId& entityId) override;
 

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkRigidBodyComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkRigidBodyComponent.h
@@ -47,7 +47,7 @@ namespace Multiplayer
         void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
 
     private:
-        // Physics::RigidBodyNotifications overrides...
+        // Physics::RigidBodyNotifications overrides ...
         void OnPhysicsEnabled(const AZ::EntityId& entityId) override;
 
         void OnTransformUpdate(const AZ::Transform& worldTm);
@@ -76,7 +76,7 @@ namespace Multiplayer
 #endif
 
     private:
-        // Physics::RigidBodyNotifications overrides...
+        // Physics::RigidBodyNotifications overrides ...
         void OnPhysicsEnabled(const AZ::EntityId& entityId) override;
 
         Physics::RigidBodyRequests* m_physicsRigidBodyComponent = nullptr;

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkRigidBodyComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkRigidBodyComponent.h
@@ -10,6 +10,7 @@
 
 #include <Source/AutoGen/NetworkRigidBodyComponent.AutoComponent.h>
 #include <AzCore/Component/TransformBus.h>
+#include <AzFramework/Physics/RigidBodyBus.h>
 #include <Multiplayer/Components/NetBindComponent.h>
 
 namespace Physics
@@ -27,6 +28,7 @@ namespace Multiplayer
 
     class NetworkRigidBodyComponent final
         : public NetworkRigidBodyComponentBase
+        , private Physics::RigidBodyNotificationBus::Handler
         , private NetworkRigidBodyRequestBus::Handler
     {
         friend class NetworkRigidBodyComponentController;
@@ -45,6 +47,9 @@ namespace Multiplayer
         void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
 
     private:
+        // Physics::RigidBodyNotifications overrides...
+        void OnPhysicsEnabled(const AZ::EntityId& entityId) override;
+
         void OnTransformUpdate(const AZ::Transform& worldTm);
         void OnSyncRewind();
 
@@ -56,6 +61,7 @@ namespace Multiplayer
 
     class NetworkRigidBodyComponentController
         : public NetworkRigidBodyComponentControllerBase
+        , private Physics::RigidBodyNotificationBus::Handler
     {
     public:
         NetworkRigidBodyComponentController(NetworkRigidBodyComponent& parent);
@@ -68,5 +74,11 @@ namespace Multiplayer
         void OnTransformUpdate();
         AZ::TransformChangedEvent::Handler m_transformChangedHandler;
 #endif
+
+    private:
+        // Physics::RigidBodyNotifications overrides...
+        void OnPhysicsEnabled(const AZ::EntityId& entityId) override;
+
+        Physics::RigidBodyRequests* m_physicsRigidBodyComponent = nullptr;
     };
 } // namespace Multiplayer

--- a/Gems/Multiplayer/Code/Source/Components/NetworkRigidBodyComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetworkRigidBodyComponent.cpp
@@ -29,7 +29,7 @@ namespace Multiplayer
     void NetworkRigidBodyComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         NetworkRigidBodyComponentBase::GetRequiredServices(required);
-        required.push_back(AZ_CRC_CE("PhysicsRigidBodyService"));
+        required.push_back(AZ_CRC_CE("PhysicsDynamicRigidBodyService"));
     }
 
     NetworkRigidBodyComponent::NetworkRigidBodyComponent()
@@ -44,21 +44,36 @@ namespace Multiplayer
 
     void NetworkRigidBodyComponent::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
+        // During activation the simulated bodies are not created yet.
+        // Connect to RigidBodyNotificationBus to listen when it's enabled after creation.
+        Physics::RigidBodyNotificationBus::Handler::BusConnect(GetEntityId());
+    }
+
+    void NetworkRigidBodyComponent::OnPhysicsEnabled(const AZ::EntityId& entityId)
+    {
+        Physics::RigidBodyNotificationBus::Handler::BusDisconnect();
+
+        m_physicsRigidBodyComponent = Physics::RigidBodyRequestBus::FindFirstHandler(entityId);
+        AZ_Assert(m_physicsRigidBodyComponent, "Physics Rigid Body is required on entity %s", GetEntity()->GetName().c_str());
+
+        // By default we're kinematic unless there is a controller, in which case the controller will handle it.
+        if (!HasController())
+        {
+            m_physicsRigidBodyComponent->SetKinematic(true);
+        }
+
         NetworkRigidBodyRequestBus::Handler::BusConnect(GetEntityId());
 
         GetNetBindComponent()->AddEntitySyncRewindEventHandler(m_syncRewindHandler);
         GetEntity()->GetTransform()->BindTransformChangedEventHandler(m_transformChangedHandler);
-
-        m_physicsRigidBodyComponent =
-            Physics::RigidBodyRequestBus::FindFirstHandler(GetEntity()->GetId());
-        AZ_Assert(m_physicsRigidBodyComponent, "PhysX Rigid Body Component is required on entity %s", GetEntity()->GetName().c_str());
-        // By default we're kinematic, activating a controller will allow us to simulate
-        m_physicsRigidBodyComponent->SetKinematic(true);
     }
 
     void NetworkRigidBodyComponent::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
+        Physics::RigidBodyNotificationBus::Handler::BusDisconnect();
         NetworkRigidBodyRequestBus::Handler::BusDisconnect();
+
+        m_physicsRigidBodyComponent = nullptr;
     }
 
     void NetworkRigidBodyComponent::OnTransformUpdate(const AZ::Transform& worldTm)
@@ -119,11 +134,24 @@ namespace Multiplayer
 
     void NetworkRigidBodyComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
-        GetParent().m_physicsRigidBodyComponent->SetKinematic(false);
+        // During activation the simulated bodies are not created yet.
+        // Connect to RigidBodyNotificationBus to listen when it's enabled after creation.
+        Physics::RigidBodyNotificationBus::Handler::BusConnect(GetEntityId());
+    }
+
+    void NetworkRigidBodyComponentController::OnPhysicsEnabled(const AZ::EntityId& entityId)
+    {
+        Physics::RigidBodyNotificationBus::Handler::BusDisconnect();
+
+        m_physicsRigidBodyComponent = Physics::RigidBodyRequestBus::FindFirstHandler(entityId);
+        AZ_Assert(m_physicsRigidBodyComponent, "Physics Rigid Body is required on entity %s", GetEntity()->GetName().c_str());
+
+        m_physicsRigidBodyComponent->SetKinematic(false);
+
 #if AZ_TRAIT_SERVER
         if (IsNetEntityRoleAuthority())
         {
-            if (AzPhysics::RigidBody* rigidBody = GetParent().m_physicsRigidBodyComponent->GetRigidBody())
+            if (AzPhysics::RigidBody* rigidBody = m_physicsRigidBodyComponent->GetRigidBody())
             {
                 rigidBody->SetLinearVelocity(GetLinearVelocity());
                 rigidBody->SetAngularVelocity(GetAngularVelocity());
@@ -138,7 +166,11 @@ namespace Multiplayer
 #if AZ_TRAIT_SERVER
         m_transformChangedHandler.Disconnect();
 #endif
-        GetParent().m_physicsRigidBodyComponent->SetKinematic(true);
+        if (m_physicsRigidBodyComponent)
+        {
+            m_physicsRigidBodyComponent->SetKinematic(true);
+            m_physicsRigidBodyComponent = nullptr;
+        }
     }
 
 #if AZ_TRAIT_SERVER
@@ -149,7 +181,7 @@ namespace Multiplayer
         const AZ::Vector3& worldPoint
     )
     {
-        if (AzPhysics::RigidBody* rigidBody = GetParent().m_physicsRigidBodyComponent->GetRigidBody())
+        if (AzPhysics::RigidBody* rigidBody = m_physicsRigidBodyComponent->GetRigidBody())
         {
             rigidBody->ApplyLinearImpulseAtWorldPoint(impulse, worldPoint);
         }
@@ -157,7 +189,7 @@ namespace Multiplayer
 
     void NetworkRigidBodyComponentController::OnTransformUpdate()
     {
-        if (AzPhysics::RigidBody* rigidBody = GetParent().m_physicsRigidBodyComponent->GetRigidBody())
+        if (AzPhysics::RigidBody* rigidBody = m_physicsRigidBodyComponent->GetRigidBody())
         {
             SetLinearVelocity(rigidBody->GetLinearVelocity());
             SetAngularVelocity(rigidBody->GetAngularVelocity());

--- a/Gems/PhysX/Code/Source/EditorBallJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorBallJointComponent.cpp
@@ -55,7 +55,7 @@ namespace PhysX
     void EditorBallJointComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         required.push_back(AZ_CRC_CE("TransformService"));
-        required.push_back(AZ_CRC_CE("PhysicsRigidBodyService"));
+        required.push_back(AZ_CRC_CE("PhysicsDynamicRigidBodyService"));
     }
 
     void EditorBallJointComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)

--- a/Gems/PhysX/Code/Source/EditorFixedJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorFixedJointComponent.cpp
@@ -52,7 +52,7 @@ namespace PhysX
     void EditorFixedJointComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         required.push_back(AZ_CRC_CE("TransformService"));
-        required.push_back(AZ_CRC_CE("PhysicsRigidBodyService"));
+        required.push_back(AZ_CRC_CE("PhysicsDynamicRigidBodyService"));
     }
 
     void EditorFixedJointComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)

--- a/Gems/PhysX/Code/Source/EditorHingeJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorHingeJointComponent.cpp
@@ -57,7 +57,7 @@ namespace PhysX
     void EditorHingeJointComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         required.push_back(AZ_CRC_CE("TransformService"));
-        required.push_back(AZ_CRC_CE("PhysicsRigidBodyService"));
+        required.push_back(AZ_CRC_CE("PhysicsDynamicRigidBodyService"));
     }
 
     void EditorHingeJointComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)

--- a/Gems/PhysX/Code/Source/EditorPrismaticJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorPrismaticJointComponent.cpp
@@ -55,7 +55,7 @@ namespace PhysX
     void EditorPrismaticJointComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         required.push_back(AZ_CRC_CE("TransformService"));
-        required.push_back(AZ_CRC_CE("PhysicsRigidBodyService"));
+        required.push_back(AZ_CRC_CE("PhysicsDynamicRigidBodyService"));
     }
 
     void EditorPrismaticJointComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)

--- a/Gems/PhysX/Code/Source/ForceRegionComponent.cpp
+++ b/Gems/PhysX/Code/Source/ForceRegionComponent.cpp
@@ -59,26 +59,21 @@ namespace PhysX
             sceneInterface->RegisterSceneSimulationFinishHandler(sceneHandle, m_sceneFinishSimHandler);
         }
 
-        if (auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get())
-        {
-            AZStd::pair<AzPhysics::SceneHandle, AzPhysics::SimulatedBodyHandle> foundBody = physicsSystem->FindAttachedBodyHandleFromEntityId(m_entity->GetId());
-            if (foundBody.first != AzPhysics::InvalidSceneHandle)
-            {
-                AzPhysics::SimulatedBodyEvents::RegisterOnTriggerEnterHandler(
-                    foundBody.first, foundBody.second, m_onTriggerEnterHandler);
-                AzPhysics::SimulatedBodyEvents::RegisterOnTriggerExitHandler(
-                    foundBody.first, foundBody.second, m_onTriggerExitHandler);
-            }
-        }
+        // During entity activation the simulated bodies are not created yet.
+        // Connect to RigidBodyNotificationBus to listen when they get enabled to register the trigger handlers.
+        Physics::RigidBodyNotificationBus::Handler::BusConnect(GetEntityId());
+
         if (m_debugForces)
         {
-            AzFramework::EntityDebugDisplayEventBus::Handler::BusConnect(m_entity->GetId());
+            AzFramework::EntityDebugDisplayEventBus::Handler::BusConnect(GetEntityId());
         }
         m_forceRegion.Activate(GetEntityId());
     }
 
     void ForceRegionComponent::Deactivate()
     {
+        Physics::RigidBodyNotificationBus::Handler::BusDisconnect();
+
         m_forceRegion.Deactivate();
         if (m_debugForces)
         {
@@ -89,6 +84,28 @@ namespace PhysX
         m_sceneFinishSimHandler.Disconnect();
 
         m_entities.clear(); // On re-activation, each entity in this force region triggers OnTriggerEnter again.
+    }
+
+    void ForceRegionComponent::OnPhysicsEnabled(const AZ::EntityId& entityId)
+    {
+        if (auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get())
+        {
+            AZStd::pair<AzPhysics::SceneHandle, AzPhysics::SimulatedBodyHandle> foundBody =
+                physicsSystem->FindAttachedBodyHandleFromEntityId(entityId);
+            if (foundBody.first != AzPhysics::InvalidSceneHandle)
+            {
+                AzPhysics::SimulatedBodyEvents::RegisterOnTriggerEnterHandler(
+                    foundBody.first, foundBody.second, m_onTriggerEnterHandler);
+                AzPhysics::SimulatedBodyEvents::RegisterOnTriggerExitHandler(
+                    foundBody.first, foundBody.second, m_onTriggerExitHandler);
+            }
+        }
+    }
+
+    void ForceRegionComponent::OnPhysicsDisabled([[maybe_unused]] const AZ::EntityId& entityId)
+    {
+        m_onTriggerEnterHandler.Disconnect();
+        m_onTriggerExitHandler.Disconnect();
     }
 
     void ForceRegionComponent::InitPhysicsTickHandler()

--- a/Gems/PhysX/Code/Source/ForceRegionComponent.h
+++ b/Gems/PhysX/Code/Source/ForceRegionComponent.h
@@ -14,6 +14,7 @@
 
 #include <AzCore/Component/Component.h>
 
+#include <AzFramework/Physics/RigidBodyBus.h>
 #include <AzFramework/Physics/Common/PhysicsEvents.h>
 #include <AzFramework/Physics/Common/PhysicsSimulatedBodyEvents.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
@@ -31,6 +32,7 @@ namespace PhysX
     /// A net force will be calculated per entity by summing all the attached forces on each tick.
     class ForceRegionComponent
         : public AZ::Component
+        , protected Physics::RigidBodyNotificationBus::Handler
         , private AzFramework::EntityDebugDisplayEventBus::Handler
     {
     public:
@@ -52,6 +54,10 @@ namespace PhysX
         // Component
         void Activate() override;
         void Deactivate() override;
+
+        // Physics::RigidBodyNotifications overrides...
+        void OnPhysicsEnabled(const AZ::EntityId& entityId) override;
+        void OnPhysicsDisabled(const AZ::EntityId& entityId) override;
 
         // EntityDebugDisplayEventBus
         void DisplayEntityViewport(const AzFramework::ViewportInfo& viewportInfo


### PR DESCRIPTION
**Note**
This work has been divided into multiple PRs to make it easier to review. Merging each PR into the staging branch `PhysX_StaticRigidBody_Staging_o3de`.

This change is part of the following PR https://github.com/o3de/o3de/pull/14261

Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

This PR adapts Joints, ForceRegion, NetworkRigidBody and AudioAreaEnvironment components to query for simulated bodies after the rigid body (static or dynamic) has created them by listening to `RigidBodyNotificationBus` notifications.

Joints initialization improved to only be enabled when all the rigid bodies involved in the joint are enabled.

**Components initialization order when colliders and rigid bodies are involved:**
1. Entity calls Component::Activate
    1. Rigid Body components connect to `EntityBus` to delay the creation of simulated body until `OnEntityActivated` (since shapes are not created yet)
    1. All the PhysX Collider components will create their shapes during component activation.
    1. Other components that were querying for simulated bodies during activation, they will now instead connect to `RigidBodyNotificationBus` bus (because the simulated bodies are not created yet).
1. Entity calls OnEntityActivated
    1. Rigid Body components will query all the shapes (that colliders produced during activation) and create simulated body with all the shapes
    1. Rigid Body components will enable physics on the simulate body and send a `RigidBodyNotification::OnPhysicsEnabled`.
    1. The components listening to the `RigidBodyNotificationBus` will receive the `OnPhysicsEnabled` notification and they will query the simulated bodies.

## How was this PR tested?

PhysX unit tests pass.
Multiplayer unit tests pass.
Passed AR in local branch `PhysX_StaticRigidBody` which has all the PRs combined.
