### PR TITLE
Update Whitebox and Heightfield components' dependencies

### DIFF
--- a/Gems/PhysX/Code/Source/EditorHeightfieldColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorHeightfieldColliderComponent.cpp
@@ -128,7 +128,8 @@ namespace PhysX
     void EditorHeightfieldColliderComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
     {
         incompatible.push_back(AZ_CRC_CE("PhysicsColliderService"));
-        incompatible.push_back(AZ_CRC_CE("PhysicsStaticRigidBodyService"));
+        // Incompatible with other rigid bodies because it handles its own rigid body
+        // internally and it would conflict if another rigid body is added to the entity.
         incompatible.push_back(AZ_CRC_CE("PhysicsRigidBodyService"));
     }
 

--- a/Gems/PhysX/Code/Source/HeightfieldColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/HeightfieldColliderComponent.cpp
@@ -44,7 +44,6 @@ namespace PhysX
         provided.push_back(AZ_CRC_CE("PhysicsWorldBodyService"));
         provided.push_back(AZ_CRC_CE("PhysicsColliderService"));
         provided.push_back(AZ_CRC_CE("PhysicsHeightfieldColliderService"));
-        provided.push_back(AZ_CRC_CE("PhysicsStaticRigidBodyService"));
     }
 
     void HeightfieldColliderComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
@@ -55,7 +54,8 @@ namespace PhysX
     void HeightfieldColliderComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
     {
         incompatible.push_back(AZ_CRC_CE("PhysicsColliderService"));
-        incompatible.push_back(AZ_CRC_CE("PhysicsStaticRigidBodyService"));
+        // Incompatible with other rigid bodies because it handles its own rigid body
+        // internally and it would conflict if another rigid body is added to the entity.
         incompatible.push_back(AZ_CRC_CE("PhysicsRigidBodyService"));
     }
 

--- a/Gems/PhysX/Code/Source/HeightfieldColliderComponent.h
+++ b/Gems/PhysX/Code/Source/HeightfieldColliderComponent.h
@@ -30,12 +30,13 @@ namespace PhysX
 {
     class StaticRigidBody;
 
-    //! Component that provides a Heightfield Collider and associated Static Rigid Body.
+    //! Component that provides a Heightfield Collider.
+    //! It covers the static rigid body functionality as well, but it can be refactored out
+    //! once EditorStaticRigidBodyComponent handles the creation of the simulated body.
+    //! 
     //! The heightfield collider is a bit different from the other shape colliders in that it gets the heightfield data from a
     //! HeightfieldProvider, which can control position, rotation, size, and even change its data at runtime.
-    //! 
-    //! This component directly implements both the collider and static rigid body instead of
-    //! using BaseColliderComponent and StaticRigidBodyComponent.
+    //! Due to these differences, this component directly implements the collider instead of using BaseColliderComponent.
     class HeightfieldColliderComponent
         : public AZ::Component
         , public ColliderComponentRequestBus::Handler

--- a/Gems/PhysX/Code/Source/HeightfieldColliderComponent.h
+++ b/Gems/PhysX/Code/Source/HeightfieldColliderComponent.h
@@ -34,7 +34,7 @@ namespace PhysX
     //! The heightfield collider is a bit different from the other shape colliders in that it gets the heightfield data from a
     //! HeightfieldProvider, which can control position, rotation, size, and even change its data at runtime.
     //! 
-    //! Due to these differences, this component directly implements both the collider and static rigid body services instead of
+    //! This component directly implements both the collider and static rigid body instead of
     //! using BaseColliderComponent and StaticRigidBodyComponent.
     class HeightfieldColliderComponent
         : public AZ::Component

--- a/Gems/WhiteBox/Code/Source/Components/EditorWhiteBoxColliderComponent.cpp
+++ b/Gems/WhiteBox/Code/Source/Components/EditorWhiteBoxColliderComponent.cpp
@@ -62,7 +62,6 @@ namespace WhiteBox
     void EditorWhiteBoxColliderComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
     {
         provided.push_back(AZ_CRC_CE("WhiteBoxColliderService"));
-        provided.push_back(AZ_CRC_CE("PhysicsStaticRigidBodyService"));
     }
 
     void EditorWhiteBoxColliderComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
@@ -75,6 +74,9 @@ namespace WhiteBox
     {
         incompatible.push_back(AZ_CRC_CE("NonUniformScaleService"));
         incompatible.push_back(AZ_CRC_CE("WhiteBoxColliderService"));
+        // Incompatible with other rigid bodies because it handles its own rigid body
+        // internally and it would conflict if another rigid body is added to the entity.
+        incompatible.push_back(AZ_CRC_CE("PhysicsRigidBodyService"));
     }
 
     void EditorWhiteBoxColliderComponent::Activate()

--- a/Gems/WhiteBox/Code/Source/Components/WhiteBoxColliderComponent.cpp
+++ b/Gems/WhiteBox/Code/Source/Components/WhiteBoxColliderComponent.cpp
@@ -33,9 +33,8 @@ namespace WhiteBox
         }
     }
 
-    void WhiteBoxColliderComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    void WhiteBoxColliderComponent::GetProvidedServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& provided)
     {
-        provided.push_back(AZ_CRC_CE("PhysicsStaticRigidBodyService"));
     }
 
     void WhiteBoxColliderComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
@@ -46,6 +45,9 @@ namespace WhiteBox
     void WhiteBoxColliderComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
     {
         incompatible.push_back(AZ_CRC_CE("NonUniformScaleService"));
+        // Incompatible with other rigid bodies because it handles its own rigid body
+        // internally and it would conflict if another rigid body is added to the entity.
+        incompatible.push_back(AZ_CRC_CE("PhysicsRigidBodyService"));
     }
 
     WhiteBoxColliderComponent::WhiteBoxColliderComponent(

--- a/Gems/WhiteBox/Code/Source/Components/WhiteBoxColliderComponent.h
+++ b/Gems/WhiteBox/Code/Source/Components/WhiteBoxColliderComponent.h
@@ -18,7 +18,10 @@
 
 namespace WhiteBox
 {
-    //! Runtime White Box Collider.
+    //! Component that provides a White box Collider and associated Rigid Body.
+    //! 
+    //! This component directly implements both the collider and rigid body instead of
+    //! using BaseColliderComponent and StaticRigidBodyComponent/RigidBodyComponent.
     class WhiteBoxColliderComponent
         : public AZ::Component
         , private AZ::TransformNotificationBus::Handler

--- a/Gems/WhiteBox/Code/Source/Components/WhiteBoxColliderComponent.h
+++ b/Gems/WhiteBox/Code/Source/Components/WhiteBoxColliderComponent.h
@@ -18,10 +18,9 @@
 
 namespace WhiteBox
 {
-    //! Component that provides a White box Collider and associated Rigid Body.
-    //! 
-    //! This component directly implements both the collider and rigid body instead of
-    //! using BaseColliderComponent and StaticRigidBodyComponent/RigidBodyComponent.
+    //! Component that provides a White box Collider.
+    //! It covers the rigid body functionality as well, but it can be refactored out
+    //! once EditorStaticRigidBodyComponent handles the creation of the simulated body.
     class WhiteBoxColliderComponent
         : public AZ::Component
         , private AZ::TransformNotificationBus::Handler


### PR DESCRIPTION
**Note**
This work has been divided into multiple PRs to make it easier to review. Merging each PR into the staging branch `PhysX_StaticRigidBody_Staging_o3de`.

This change is part of the following PR https://github.com/o3de/o3de/pull/14261

## What does this PR do?

Whitebox and Heightfield colliders handle their own collision and rigid body, so they have been explicitly made incompatible with other rigid bodies.

**Out of Scope**
- Now that there is a Static Rigid Body component, refactor Whitebox and Heightfield code so they don't have to handle their own rigid body, they user could instead add a rigid body component.

## How was this PR tested?

PhysX unit tests pass.
Passed AR in local branch `PhysX_StaticRigidBody` which has all the PRs combined.
