### PR TITLE
Component Mode | Disable prefab focus breadcrumb on component mode

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.cpp
@@ -369,6 +369,7 @@ namespace AzQtComponents
     {
         if (event->type() == QEvent::EnabledChange)
         {
+            // Refresh the contents of the label since they are different based on the enabled state of the widget.
             fillLabel();
         }
         QFrame::changeEvent(event);
@@ -418,7 +419,6 @@ namespace AzQtComponents
             default:;
             }
         }
-
         return QFrame::eventFilter(obj, ev);
     }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.cpp
@@ -483,9 +483,10 @@ namespace AzQtComponents
         const qreal iconSpaceWidth = g_iconWidth + fm.horizontalAdvance(QStringLiteral("\u00a0\u00a0"));
 
         QString plainTextPath;
-
-        auto formatLink = [this](const QString& fullPath, const QString& shortPath) -> QString {
-            return QString("<a href=\"%1\" style=\"color: %2\">%3</a>").arg(fullPath, m_config.linkColor, shortPath);
+        QString linkColor = isEnabled() ? m_config.linkColor : m_config.disabledLinkColor;
+        auto formatLink = [linkColor](const QString& fullPath, const QString& shortPath) -> QString
+        {
+            return QString("<a href=\"%1\" style=\"color: %2\">%3</a>").arg(fullPath, linkColor, shortPath);
         };
 
         const QString nonBreakingSpace = QStringLiteral("&nbsp;");
@@ -583,6 +584,7 @@ namespace AzQtComponents
     {
         Config config = defaultConfig();
 
+        ConfigHelpers::read<QString>(settings, QStringLiteral("DisabledLinkColor"), config.disabledLinkColor);
         ConfigHelpers::read<QString>(settings, QStringLiteral("LinkColor"), config.linkColor);
 
         return config;
@@ -592,6 +594,7 @@ namespace AzQtComponents
     {
         Config config;
 
+        config.disabledLinkColor = QStringLiteral("#999999");
         config.linkColor = QStringLiteral("white");
 
         return config;

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.cpp
@@ -365,6 +365,15 @@ namespace AzQtComponents
         QFrame::resizeEvent(event);
     }
 
+    void BreadCrumbs::changeEvent(QEvent* event)
+    {
+        if (event->type() == QEvent::EnabledChange)
+        {
+            fillLabel();
+        }
+        QFrame::changeEvent(event);
+    }
+
     bool BreadCrumbs::eventFilter(QObject* obj, QEvent* ev)
     {
         if (obj == m_label)
@@ -409,6 +418,7 @@ namespace AzQtComponents
             default:;
             }
         }
+
         return QFrame::eventFilter(obj, ev);
     }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.h
@@ -159,8 +159,8 @@ namespace AzQtComponents
 
     protected:
         void resizeEvent(QResizeEvent* event) override;
+        void changeEvent(QEvent* event) override;
         bool eventFilter(QObject* obj, QEvent* ev) override;
-        void fillLabel();
 
     private Q_SLOTS:
         void onLinkActivated(const QString& link);
@@ -169,6 +169,7 @@ namespace AzQtComponents
 
     private:
         QString generateIconHtml(int index);
+        void fillLabel();
         void changePath(const QString& newPath);
 
         void getButtonStates(BreadCrumbButtonStates buttonStates);

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.h
@@ -63,7 +63,8 @@ namespace AzQtComponents
         //! Style configuration for the Breadcrumbs class.
         struct Config
         {
-            QString linkColor;      //!< Color for links. Must be a string using the hex format #rrggbb.
+            QString disabledLinkColor;  //!< Color for disabled links. Must be a string using the hex format #rrggbb.
+            QString linkColor;          //!< Color for links. Must be a string using the hex format #rrggbb.
         };
 
         explicit BreadCrumbs(QWidget* parent = nullptr);
@@ -159,6 +160,7 @@ namespace AzQtComponents
     protected:
         void resizeEvent(QResizeEvent* event) override;
         bool eventFilter(QObject* obj, QEvent* ev) override;
+        void fillLabel();
 
     private Q_SLOTS:
         void onLinkActivated(const QString& link);
@@ -167,7 +169,6 @@ namespace AzQtComponents
 
     private:
         QString generateIconHtml(int index);
-        void fillLabel();
         void changePath(const QString& newPath);
 
         void getButtonStates(BreadCrumbButtonStates buttonStates);

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbsConfig.ini
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbsConfig.ini
@@ -1,2 +1,3 @@
 LinkColor=white
+DisabledLinkColor=#999999
 OptimalPathWidth=0.8

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/ActionManagerIdentifiers/EditorActionUpdaterIdentifiers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/ActionManagerIdentifiers/EditorActionUpdaterIdentifiers.h
@@ -13,8 +13,8 @@
 namespace EditorIdentifiers
 {
     inline constexpr AZStd::string_view AngleSnappingStateChangedUpdaterIdentifier = "o3de.updater.onAngleSnappingStateChanged";
-    inline constexpr AZStd::string_view DrawHelpersStateChangedUpdaterIdentifier = "o3de.updater.onViewportDrawHelpersStateChanged";
     inline constexpr AZStd::string_view ComponentModeChangedUpdaterIdentifier = "o3de.updater.onComponentModeChanged";
+    inline constexpr AZStd::string_view DrawHelpersStateChangedUpdaterIdentifier = "o3de.updater.onViewportDrawHelpersStateChanged";
     inline constexpr AZStd::string_view EntitySelectionChangedUpdaterIdentifier = "o3de.updater.onEntitySelectionChanged";
     inline constexpr AZStd::string_view GameModeStateChangedUpdaterIdentifier = "o3de.updater.onGameModeStateChanged";
     inline constexpr AZStd::string_view GridShowingChangedUpdaterIdentifier = "o3de.updater.onGridShowingChanged";

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
@@ -18,6 +18,7 @@
 
 #include <AzToolsFramework/ActionManager/Action/ActionManagerInterface.h>
 #include <AzToolsFramework/ActionManager/ToolBar/ToolBarManagerInterface.h>
+#include <AzToolsFramework/ComponentMode/EditorComponentModeBus.h>
 #include <AzToolsFramework/ContainerEntity/ContainerEntityInterface.h>
 #include <AzToolsFramework/Editor/ActionManagerIdentifiers/EditorActionUpdaterIdentifiers.h>
 #include <AzToolsFramework/Editor/ActionManagerIdentifiers/EditorContextIdentifiers.h>
@@ -269,10 +270,12 @@ namespace AzToolsFramework
                     "o3de.action.prefabs.upOneLevel",
                     [prefabFocusPublicInterface = s_prefabFocusPublicInterface, editorEntityContextId = s_editorEntityContextId]() -> bool
                     {
-                        return prefabFocusPublicInterface->GetPrefabFocusPathLength(editorEntityContextId) > 1;
+                        return !ComponentModeFramework::InComponentMode() &&
+                            prefabFocusPublicInterface->GetPrefabFocusPathLength(editorEntityContextId) > 1;
                     }
                 );
 
+                m_actionManagerInterface->AddActionToUpdater(EditorIdentifiers::ComponentModeChangedUpdaterIdentifier, "o3de.action.prefabs.upOneLevel");
                 m_actionManagerInterface->AddActionToUpdater(PrefabFocusChangedUpdaterIdentifier, "o3de.action.prefabs.upOneLevel");
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabViewportFocusPathHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabViewportFocusPathHandler.cpp
@@ -22,10 +22,16 @@ namespace AzToolsFramework::Prefab
 
         // Connect to Prefab Focus Notifications
         PrefabFocusNotificationBus::Handler::BusConnect(m_editorEntityContextId);
+
+        // Connect to Viewport Editor Mode Notifications
+        ViewportEditorModeNotificationsBus::Handler::BusConnect(m_editorEntityContextId);
     }
 
     PrefabViewportFocusPathHandler::~PrefabViewportFocusPathHandler()
     {
+        // Disconnect from Viewport Editor Mode Notifications
+        ViewportEditorModeNotificationsBus::Handler::BusDisconnect();
+
         // Disconnect from Prefab Focus Notifications
         PrefabFocusNotificationBus::Handler::BusDisconnect();
     }
@@ -85,6 +91,30 @@ namespace AzToolsFramework::Prefab
         Refresh();
     }
 
+    void PrefabViewportFocusPathHandler::OnEditorModeActivated(
+        [[maybe_unused]] const ViewportEditorModesInterface& editorModeState, ViewportEditorMode mode)
+    {
+        // This function triggers when the Editor changes from regular editing to a Component Mode.
+        if (mode == ViewportEditorMode::Component)
+        {
+            // Disable the widgets to prevent it from being used to change selection.
+            m_backButton->setEnabled(false);
+            m_breadcrumbsWidget->setEnabled(false);
+        }
+    }
+
+    void PrefabViewportFocusPathHandler::OnEditorModeDeactivated(
+        [[maybe_unused]] const ViewportEditorModesInterface& editorModeState, ViewportEditorMode mode)
+    {
+        // This function triggers when the Editor changes from a Component Mode to regular editing.
+        if (mode == ViewportEditorMode::Component)
+        {
+            // Enable the widgets when leaving component mode.
+            m_backButton->setEnabled(true);
+            m_breadcrumbsWidget->setEnabled(true);
+        }
+    }
+
     void PrefabViewportFocusPathHandler::Refresh()
     {
         if (int prefabFocusPathLength = m_prefabFocusPublicInterface->GetPrefabFocusPathLength(m_editorEntityContextId);
@@ -135,10 +165,12 @@ namespace AzToolsFramework::Prefab
         );
 
         PrefabFocusNotificationBus::Handler::BusConnect(m_editorEntityContextId);
+        ViewportEditorModeNotificationsBus::Handler::BusConnect(m_editorEntityContextId);
     }
 
     PrefabFocusPathWidget::~PrefabFocusPathWidget()
     {
+        ViewportEditorModeNotificationsBus::Handler::BusDisconnect();
         PrefabFocusNotificationBus::Handler::BusDisconnect();
     }
 
@@ -151,6 +183,28 @@ namespace AzToolsFramework::Prefab
     void PrefabFocusPathWidget::OnPrefabFocusRefreshed()
     {
         Refresh();
+    }
+
+    void PrefabFocusPathWidget::OnEditorModeActivated(
+        [[maybe_unused]] const ViewportEditorModesInterface& editorModeState, ViewportEditorMode mode)
+    {
+        // This function triggers when the Editor changes from regular editing to a Component Mode.
+        if (mode == ViewportEditorMode::Component)
+        {
+            // Disable the widgets to prevent it from being used to change selection.
+            setEnabled(false);
+        }
+    }
+
+    void PrefabFocusPathWidget::OnEditorModeDeactivated(
+        [[maybe_unused]] const ViewportEditorModesInterface& editorModeState, ViewportEditorMode mode)
+    {
+        // This function triggers when the Editor changes from a Component Mode to regular editing.
+        if (mode == ViewportEditorMode::Component)
+        {
+            // Enable the widgets when leaving component mode.
+            setEnabled(true);
+        }
     }
 
     void PrefabFocusPathWidget::Refresh()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabViewportFocusPathHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabViewportFocusPathHandler.cpp
@@ -100,7 +100,6 @@ namespace AzToolsFramework::Prefab
             // Disable the widgets to prevent it from being used to change selection.
             m_backButton->setEnabled(false);
             m_breadcrumbsWidget->setEnabled(false);
-            m_breadcrumbsWidget->repaint();
         }
     }
 
@@ -113,7 +112,6 @@ namespace AzToolsFramework::Prefab
             // Enable the widgets when leaving component mode.
             m_backButton->setEnabled(true);
             m_breadcrumbsWidget->setEnabled(true);
-            m_breadcrumbsWidget->repaint();
         }
     }
 
@@ -195,7 +193,6 @@ namespace AzToolsFramework::Prefab
         {
             // Disable the widgets to prevent it from being used to change selection.
             setEnabled(false);
-            fillLabel();
         }
     }
 
@@ -207,7 +204,6 @@ namespace AzToolsFramework::Prefab
         {
             // Enable the widgets when leaving component mode.
             setEnabled(true);
-            fillLabel();
         }
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabViewportFocusPathHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabViewportFocusPathHandler.cpp
@@ -100,6 +100,7 @@ namespace AzToolsFramework::Prefab
             // Disable the widgets to prevent it from being used to change selection.
             m_backButton->setEnabled(false);
             m_breadcrumbsWidget->setEnabled(false);
+            m_breadcrumbsWidget->repaint();
         }
     }
 
@@ -112,6 +113,7 @@ namespace AzToolsFramework::Prefab
             // Enable the widgets when leaving component mode.
             m_backButton->setEnabled(true);
             m_breadcrumbsWidget->setEnabled(true);
+            m_breadcrumbsWidget->repaint();
         }
     }
 
@@ -193,6 +195,7 @@ namespace AzToolsFramework::Prefab
         {
             // Disable the widgets to prevent it from being used to change selection.
             setEnabled(false);
+            fillLabel();
         }
     }
 
@@ -204,6 +207,7 @@ namespace AzToolsFramework::Prefab
         {
             // Enable the widgets when leaving component mode.
             setEnabled(true);
+            fillLabel();
         }
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabViewportFocusPathHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabViewportFocusPathHandler.h
@@ -10,6 +10,7 @@
 
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 
+#include <AzToolsFramework/API/ViewportEditorModeTrackerNotificationBus.h>
 #include <AzToolsFramework/Prefab/PrefabFocusNotificationBus.h>
 
 #include <AzQtComponents/Components/Widgets/BreadCrumbs.h>
@@ -24,6 +25,7 @@ namespace AzToolsFramework::Prefab
     // Handler for the Prefab Focus Path widget used with the legacy Action Manager
     class PrefabViewportFocusPathHandler
         : public PrefabFocusNotificationBus::Handler
+        , private ViewportEditorModeNotificationsBus::Handler
         , private QObject
     {
     public:
@@ -38,6 +40,10 @@ namespace AzToolsFramework::Prefab
         void OnPrefabFocusRefreshed() override;
 
     private:
+        // ViewportEditorModeNotificationsBus overrides ...
+        void OnEditorModeActivated(const ViewportEditorModesInterface& editorModeState, ViewportEditorMode mode) override;
+        void OnEditorModeDeactivated(const ViewportEditorModesInterface& editorModeState, ViewportEditorMode mode) override;
+
         void Refresh();
 
         AzQtComponents::BreadCrumbs* m_breadcrumbsWidget = nullptr;
@@ -53,6 +59,7 @@ namespace AzToolsFramework::Prefab
     class PrefabFocusPathWidget
         : public AzQtComponents::BreadCrumbs
         , private PrefabFocusNotificationBus::Handler
+        , private ViewportEditorModeNotificationsBus::Handler
     {
     public:
         PrefabFocusPathWidget();
@@ -63,6 +70,10 @@ namespace AzToolsFramework::Prefab
         void OnPrefabFocusRefreshed() override;
 
     private:
+        // ViewportEditorModeNotificationsBus overrides ...
+        void OnEditorModeActivated(const ViewportEditorModesInterface& editorModeState, ViewportEditorMode mode) override;
+        void OnEditorModeDeactivated(const ViewportEditorModesInterface& editorModeState, ViewportEditorMode mode) override;
+
         void Refresh();
 
         AzFramework::EntityContextId m_editorEntityContextId = AzFramework::EntityContextId::CreateNull();


### PR DESCRIPTION
## What does this PR do?
Fixes https://github.com/o3de/o3de/issues/8231

Disables the Prefab Focus Breadcrumbs during Component Mode.
This prevents the user from being able to change prefab focus and with it the entity selection while using Component Mode and editing a nested prefab.

Also adds some code to the Breadcrumbs component so that it paints the 

## How was this PR tested?
Manual testing. Verified the behavior is now correct and Breadcrumbs links are not clickable while in Component Mode.
![DisablePrefabFocusBreadcrumbsInComponentMode](https://user-images.githubusercontent.com/82231674/215147442-6b0ead3b-46b6-4a16-b54c-3e33ff0e907d.gif)
