### PR TITLE
Adapt PhysX unit tests using the new static rigid body component

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_PxMeshConvexMeshCollides.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_PxMeshConvexMeshCollides.py
@@ -86,8 +86,8 @@ def Collider_PxMeshConvexMeshCollides():
     collider_component = collider.add_component("PhysX Collider")
     Report.result(Tests.physx_collider_added, collider.has_component("PhysX Collider"))
 
-    collider.add_component("PhysX Rigid Body")
-    Report.result(Tests.physx_rigid_body_added, collider.has_component("PhysX Rigid Body"))
+    collider.add_component("PhysX Dynamic Rigid Body")
+    Report.result(Tests.physx_rigid_body_added, collider.has_component("PhysX Dynamic Rigid Body"))
 
     collider.add_component("Mesh")
     Report.result(Tests.mesh_added, collider.has_component("Mesh"))

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/tick/Tick_InterpolatedRigidBodyMotionIsSmooth.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/tick/Tick_InterpolatedRigidBodyMotionIsSmooth.py
@@ -61,10 +61,10 @@ def Tick_InterpolatedRigidBodyMotionIsSmooth():
         azlmbr.bus.Event, "SetWorldTranslation", test_entity.id, math.Vector3(0.0, 0.0, 0.0))
 
     # 3) Add rigid body component
-    rigid_body_component = test_entity.add_component("PhysX Rigid Body")
+    rigid_body_component = test_entity.add_component("PhysX Dynamic Rigid Body")
     rigid_body_component.set_component_property_value("Configuration|Interpolate motion", True)
     azlmbr.physics.RigidBodyRequestBus(azlmbr.bus.Event, "SetLinearDamping", test_entity.id, 0.0)
-    Report.result(Tests.rigid_body_added, test_entity.has_component("PhysX Rigid Body"))
+    Report.result(Tests.rigid_body_added, test_entity.has_component("PhysX Dynamic Rigid Body"))
 
     # 4) Enter game mode and collect data for the rigid body's z co-ordinate and the time values for a series of frames
     t = []

--- a/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_SupportsPhysics.py
+++ b/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_SupportsPhysics.py
@@ -72,7 +72,7 @@ def Terrain_SupportsPhysics():
     # 2) Create 2 test entities, one parent at 512.0, 512.0, 50.0 and one child at the default position and add the required components
     entity1_components_to_add = ["Axis Aligned Box Shape", "Terrain Layer Spawner", "Terrain Height Gradient List", "Terrain Physics Heightfield Collider", "PhysX Heightfield Collider"]
     entity2_components_to_add = ["Shape Reference", "Gradient Transform Modifier", "FastNoise Gradient"]
-    ball_components_to_add = ["Sphere Shape", "PhysX Collider", "PhysX Rigid Body"]
+    ball_components_to_add = ["Sphere Shape", "PhysX Collider", "PhysX Dynamic Rigid Body"]
     terrain_spawner_entity = hydra.Entity("TestEntity1")
     terrain_spawner_entity.create_entity(azmath.Vector3(512.0, 512.0, 50.0), entity1_components_to_add)
     Report.result(Tests.create_terrain_spawner_entity, terrain_spawner_entity.id.IsValid())

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/PhysXColliderSurfaceTagEmitter_E2E_Editor.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/PhysXColliderSurfaceTagEmitter_E2E_Editor.py
@@ -115,7 +115,7 @@ def PhysXColliderSurfaceTagEmitter_E2E_Editor():
     collider_entity = hydra.Entity("Collider Surface")
     collider_entity.create_entity(
         entity_center_point,
-        ["PhysX Collider", "PhysX Collider Surface Tag Emitter"]
+        ["PhysX Collider", "PhysX Collider Surface Tag Emitter", "PhysX Static Rigid Body"]
         )
     Report.result(collider_entity_created, collider_entity.id.IsValid())
 
@@ -176,12 +176,12 @@ def PhysXColliderSurfaceTagEmitter_E2E_Editor():
     collider_entity.add_component("PhysX Collider")
     helper.wait_for_condition(lambda: editor.EditorComponentAPIBus(bus.Broadcast, 'IsComponentEnabled',
                                                                    collider_entity.components[1]), 5.0)
-    hydra.get_set_test(collider_entity, 1, "Shape Configuration|Shape", 7)
-    hydra.get_set_test(collider_entity, 1, "Shape Configuration|Asset|PhysX Mesh", test_physx_mesh_asset_id)
+    hydra.get_set_test(collider_entity, 2, "Shape Configuration|Shape", 7)
+    hydra.get_set_test(collider_entity, 2, "Shape Configuration|Asset|PhysX Mesh", test_physx_mesh_asset_id)
 
     # Set the asset scale to match the test heights of the shapes tested
     asset_scale = math.Vector3(1.0, 1.0, 9.0)
-    collider_entity.get_set_test(1, "Shape Configuration|Asset|Configuration|Asset Scale", asset_scale)
+    collider_entity.get_set_test(2, "Shape Configuration|Asset|Configuration|Asset Scale", asset_scale)
 
     # Test:  Generate a new surface on the collider.
     # There should be one instance at the very top of the collider mesh, and none on the baseline surface

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/PhysXColliderSurfaceTagEmitter_E2E_Editor.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/PhysXColliderSurfaceTagEmitter_E2E_Editor.py
@@ -120,17 +120,17 @@ def PhysXColliderSurfaceTagEmitter_E2E_Editor():
     Report.result(collider_entity_created, collider_entity.id.IsValid())
 
     # Set up the PhysX Collider so that each shape type (sphere, box, capsule) has the same test height.
-    hydra.get_set_test(collider_entity, 0, "Shape Configuration|Sphere|Radius", collider_radius)
-    hydra.get_set_test(collider_entity, 0, "Shape Configuration|Box|Dimensions", math.Vector3(collider_diameter,
+    hydra.get_set_test(collider_entity, component_index=0, path="Shape Configuration|Sphere|Radius", value=collider_radius)
+    hydra.get_set_test(collider_entity, component_index=0, path="Shape Configuration|Box|Dimensions", value=math.Vector3(collider_diameter,
                                                                                               collider_diameter,
                                                                                               collider_diameter))
-    hydra.get_set_test(collider_entity, 0, "Shape Configuration|Capsule|Height", collider_diameter)
+    hydra.get_set_test(collider_entity, component_index=0, path="Shape Configuration|Capsule|Height", value=collider_diameter)
 
     # Run through each collider shape type (sphere, box, capsule) and verify the surface generation
     # and surface modification of the PhysX Collision Surface Tag Emitter Component.
     for collider_shape in range(0, 3):
         collider_shapes = {0: "Sphere", 1: "Box", 2: "Capsule"}
-        hydra.get_set_test(collider_entity, 0, "Shape Configuration|Shape", collider_shape)
+        hydra.get_set_test(collider_entity, component_index=0, path="Shape Configuration|Shape", value=collider_shape)
 
         # Test:  Generate a new surface on the collider.
         # There should be one instance at the very top of the collider sphere, and none on the baseline surface
@@ -143,8 +143,8 @@ def PhysXColliderSurfaceTagEmitter_E2E_Editor():
             f"Expected number of instances found on the baseline point for {collider_shapes[collider_shape]} shape",
             f"Found an unexpected number of instances on the baseline point for {collider_shapes[collider_shape]} shape"
         )
-        hydra.get_set_test(collider_entity, 1, "Configuration|Generated Tags", [surface_tag])
-        hydra.get_set_test(collider_entity, 1, "Configuration|Extended Tags", [invalid_tag])
+        hydra.get_set_test(collider_entity, component_index=1, path="Configuration|Generated Tags", value=[surface_tag])
+        hydra.get_set_test(collider_entity, component_index=1, path="Configuration|Extended Tags", value=[invalid_tag])
         top_point = math.Vector3(entity_center_point.x, entity_center_point.y, entity_center_point.z +
                                  collider_radius)
         baseline_surface_point = math.Vector3(entity_center_point.x, entity_center_point.y, entity_center_point.z +
@@ -159,8 +159,8 @@ def PhysXColliderSurfaceTagEmitter_E2E_Editor():
         # There should be no instances at the very top of the collider sphere, and one on the baseline surface
         # within our query box.
         # (We use a small query box to only check for one placed instance point)
-        hydra.get_set_test(collider_entity, 1, "Configuration|Generated Tags", [invalid_tag])
-        hydra.get_set_test(collider_entity, 1, "Configuration|Extended Tags", [surface_tag])
+        hydra.get_set_test(collider_entity, component_index=1, path="Configuration|Generated Tags", value=[invalid_tag])
+        hydra.get_set_test(collider_entity, component_index=1, path="Configuration|Extended Tags", value=[surface_tag])
         top_point_success = helper.wait_for_condition(lambda: dynveg.validate_instance_count(top_point, 0.25, 0), 5.0)
         Report.result(on_collider_top_point_count, top_point_success)
         baseline_success = helper.wait_for_condition(lambda: dynveg.validate_instance_count(baseline_surface_point,
@@ -176,8 +176,8 @@ def PhysXColliderSurfaceTagEmitter_E2E_Editor():
     collider_entity.add_component("PhysX Collider")
     helper.wait_for_condition(lambda: editor.EditorComponentAPIBus(bus.Broadcast, 'IsComponentEnabled',
                                                                    collider_entity.components[1]), 5.0)
-    hydra.get_set_test(collider_entity, 2, "Shape Configuration|Shape", 7)
-    hydra.get_set_test(collider_entity, 2, "Shape Configuration|Asset|PhysX Mesh", test_physx_mesh_asset_id)
+    hydra.get_set_test(collider_entity, component_index=2, path="Shape Configuration|Shape", value=7)
+    hydra.get_set_test(collider_entity, component_index=2, path="Shape Configuration|Asset|PhysX Mesh", value=test_physx_mesh_asset_id)
 
     # Set the asset scale to match the test heights of the shapes tested
     asset_scale = math.Vector3(1.0, 1.0, 9.0)
@@ -195,8 +195,8 @@ def PhysXColliderSurfaceTagEmitter_E2E_Editor():
         f"Expected number of instances found on the baseline point for a PhysX Mesh",
         f"Found an unexpected number of instances on the baseline point for a PhysX Mesh"
     )
-    hydra.get_set_test(collider_entity, 0, "Configuration|Generated Tags", [surface_tag])
-    hydra.get_set_test(collider_entity, 0, "Configuration|Extended Tags", [invalid_tag])
+    hydra.get_set_test(collider_entity, component_index=0, path="Configuration|Generated Tags", value=[surface_tag])
+    hydra.get_set_test(collider_entity, component_index=0, path="Configuration|Extended Tags", value=[invalid_tag])
     top_point_success = helper.wait_for_condition(lambda: dynveg.validate_instance_count(top_point, 0.25, 1), 5.0)
     Report.result(on_collider_top_point_count, top_point_success)
     baseline_success = helper.wait_for_condition(lambda: dynveg.validate_instance_count(baseline_surface_point,
@@ -207,8 +207,8 @@ def PhysXColliderSurfaceTagEmitter_E2E_Editor():
     # There should be no instances at the very top of the collider mesh, and none on the baseline surface within
     # our query box as PhysX meshes are treated as hollow shells, not solid volumes.
     # (We use a small query box to only check for one placed instance point)
-    hydra.get_set_test(collider_entity, 0, "Configuration|Generated Tags", [invalid_tag])
-    hydra.get_set_test(collider_entity, 0, "Configuration|Extended Tags", [surface_tag])
+    hydra.get_set_test(collider_entity, component_index=0, path="Configuration|Generated Tags", value=[invalid_tag])
+    hydra.get_set_test(collider_entity, component_index=0, path="Configuration|Extended Tags", value=[surface_tag])
     top_point_success = helper.wait_for_condition(lambda: dynveg.validate_instance_count(top_point, 0.25, 0), 5.0)
     Report.result(on_collider_top_point_count, top_point_success)
     baseline_success = helper.wait_for_condition(lambda: dynveg.validate_instance_count(baseline_surface_point,

--- a/Gems/PhysX/Code/Tests/ColliderScalingTests.cpp
+++ b/Gems/PhysX/Code/Tests/ColliderScalingTests.cpp
@@ -13,6 +13,7 @@
 #include <CapsuleColliderComponent.h>
 #include <EditorColliderComponent.h>
 #include <EditorRigidBodyComponent.h>
+#include <EditorStaticRigidBodyComponent.h>
 #include <EditorTestUtilities.h>
 #include <RigidBodyComponent.h>
 #include <RigidBodyStatic.h>
@@ -39,6 +40,7 @@ namespace PhysXEditorTests
     {
         EntityPtr editorEntity = CreateInactiveEditorEntity("Box");
         editorEntity->CreateComponent<PhysX::EditorColliderComponent>(Physics::ColliderConfiguration(), Physics::BoxShapeConfiguration());
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         editorEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
         editorEntity->Activate();
 
@@ -60,6 +62,7 @@ namespace PhysXEditorTests
         Physics::BoxShapeConfiguration boxShapeConfig(AZ::Vector3(0.5f, 0.7f, 0.9f));
         editorEntity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, boxShapeConfig);
         editorEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         editorEntity->Activate();
 
         AZ::EntityId editorId = editorEntity->GetId();
@@ -116,6 +119,7 @@ namespace PhysXEditorTests
         EntityPtr editorEntity = CreateInactiveEditorEntity("Capsule");
         editorEntity->CreateComponent<PhysX::EditorColliderComponent>(Physics::ColliderConfiguration(), Physics::CapsuleShapeConfiguration());
         editorEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         editorEntity->Activate();
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
@@ -136,6 +140,7 @@ namespace PhysXEditorTests
         Physics::CapsuleShapeConfiguration capsuleShapeConfig(1.4f, 0.3f);
         editorEntity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, capsuleShapeConfig);
         editorEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         editorEntity->Activate();
 
         AZ::EntityId capsuleId = editorEntity->GetId();
@@ -194,6 +199,7 @@ namespace PhysXEditorTests
         EntityPtr editorEntity = CreateInactiveEditorEntity("Sphere");
         editorEntity->CreateComponent<PhysX::EditorColliderComponent>(Physics::ColliderConfiguration(), Physics::SphereShapeConfiguration());
         editorEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         editorEntity->Activate();
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
@@ -214,6 +220,7 @@ namespace PhysXEditorTests
         Physics::SphereShapeConfiguration sphereShapeConfig(0.7f);
         editorEntity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, sphereShapeConfig);
         editorEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         editorEntity->Activate();
 
         AZ::EntityId sphereId = editorEntity->GetId();

--- a/Gems/PhysX/Code/Tests/DebugDrawTests.cpp
+++ b/Gems/PhysX/Code/Tests/DebugDrawTests.cpp
@@ -10,6 +10,7 @@
 #include <EditorTestUtilities.h>
 #include <EditorColliderComponent.h>
 #include <EditorShapeColliderComponent.h>
+#include <EditorStaticRigidBodyComponent.h>
 #include <AzToolsFramework/ToolsComponents/EditorNonUniformScaleComponent.h>
 #include <AZTestShared/Math/MathTestHelpers.h>
 #include <AZTestShared/Utils/Utils.h>
@@ -27,6 +28,7 @@ namespace PhysXEditorTests
         colliderConfig.m_position = AZ::Vector3(1.0f, 2.0f, 3.0f);
         Physics::BoxShapeConfiguration boxShapeConfig(AZ::Vector3(0.5f, 0.7f, 0.9f));
         boxEntity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, boxShapeConfig);
+        boxEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         boxEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
         boxEntity->Activate();
 
@@ -53,6 +55,7 @@ namespace PhysXEditorTests
         colliderConfig.m_position = AZ::Vector3(3.0f, -1.0f, 2.0f);
         Physics::BoxShapeConfiguration boxShapeConfig(AZ::Vector3(1.2f, 0.4f, 1.3f));
         boxEntity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, boxShapeConfig);
+        boxEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         boxEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
         boxEntity->Activate();
 
@@ -81,6 +84,7 @@ namespace PhysXEditorTests
         colliderConfig.m_position = AZ::Vector3(1.0f, -2.0f, 1.0f);
         Physics::BoxShapeConfiguration boxShapeConfig(AZ::Vector3(0.8f, 0.7f, 1.6f));
         boxEntity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, boxShapeConfig);
+        boxEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         boxEntity->Activate();
 
         AZ::EntityId boxId = boxEntity->GetId();
@@ -112,6 +116,7 @@ namespace PhysXEditorTests
         colliderConfig.m_position = AZ::Vector3(2.0f, 5.0f, 3.0f);
         Physics::CapsuleShapeConfiguration capsuleShapeConfig(1.4f, 0.3f);
         capsuleEntity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, capsuleShapeConfig);
+        capsuleEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         capsuleEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
         capsuleEntity->Activate();
 
@@ -138,6 +143,7 @@ namespace PhysXEditorTests
         colliderConfig.m_position = AZ::Vector3(2.0f, -2.0f, 3.0f);
         Physics::CapsuleShapeConfiguration capsuleShapeConfig(1.2f, 0.2f);
         capsuleEntity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, capsuleShapeConfig);
+        capsuleEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         capsuleEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
         capsuleEntity->Activate();
 
@@ -166,6 +172,7 @@ namespace PhysXEditorTests
         colliderConfig.m_position = AZ::Vector3(3.0f, -2.0f, 2.0f);
         Physics::SphereShapeConfiguration sphereShapeConfig(0.7f);
         sphereEntity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, sphereShapeConfig);
+        sphereEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         sphereEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
         sphereEntity->Activate();
 
@@ -192,6 +199,7 @@ namespace PhysXEditorTests
         colliderConfig.m_position = AZ::Vector3(-1.0f, -2.0f, 1.0f);
         Physics::SphereShapeConfiguration sphereShapeConfig(0.4f);
         sphereEntity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, sphereShapeConfig);
+        sphereEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         sphereEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
         sphereEntity->Activate();
 

--- a/Gems/PhysX/Code/Tests/EditorTestUtilities.cpp
+++ b/Gems/PhysX/Code/Tests/EditorTestUtilities.cpp
@@ -12,6 +12,7 @@
 #include <AzToolsFramework/ToolsComponents/EditorNonUniformScaleComponent.h>
 #include <EditorColliderComponent.h>
 #include <EditorRigidBodyComponent.h>
+#include <EditorStaticRigidBodyComponent.h>
 #include <EditorShapeColliderComponent.h>
 #include <LmbrCentral/Shape/BoxShapeComponentBus.h>
 #include <LmbrCentral/Shape/CapsuleShapeComponentBus.h>
@@ -62,6 +63,10 @@ namespace PhysXEditorTests
         {
             editorEntity->CreateComponent<PhysX::EditorRigidBodyComponent>();
         }
+        else
+        {
+            editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
+        }
         editorEntity->Activate();
         AZ::EntityId editorEntityId = editorEntity->GetId();
 
@@ -84,6 +89,10 @@ namespace PhysXEditorTests
         if (rigidBodyType == RigidBodyType::Dynamic)
         {
             editorEntity->CreateComponent<PhysX::EditorRigidBodyComponent>();
+        }
+        else
+        {
+            editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         }
         editorEntity->Activate();
         AZ::EntityId editorEntityId = editorEntity->GetId();
@@ -109,6 +118,10 @@ namespace PhysXEditorTests
         {
             editorEntity->CreateComponent<PhysX::EditorRigidBodyComponent>();
         }
+        else
+        {
+            editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
+        }
         editorEntity->Activate();
         AZ::EntityId editorEntityId = editorEntity->GetId();
 
@@ -133,6 +146,10 @@ namespace PhysXEditorTests
         if (rigidBodyType == RigidBodyType::Dynamic)
         {
             editorEntity->CreateComponent<PhysX::EditorRigidBodyComponent>();
+        }
+        else
+        {
+            editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         }
         editorEntity->Activate();
 
@@ -263,6 +280,7 @@ namespace PhysXEditorTests
         // create an editor entity with a shape collider component and a cylinder shape component
         EntityPtr editorEntity = CreateInactiveEditorEntity("ShapeColliderComponentEditorEntity");
         editorEntity->CreateComponent<PhysX::EditorShapeColliderComponent>();
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         editorEntity->CreateComponent(LmbrCentral::EditorCylinderShapeComponentTypeId);
         editorEntity->Activate();
 

--- a/Gems/PhysX/Code/Tests/PhysXColliderComponentModeTests.cpp
+++ b/Gems/PhysX/Code/Tests/PhysXColliderComponentModeTests.cpp
@@ -21,6 +21,7 @@
 #include <AzToolsFramework/ToolsComponents/EditorNonUniformScaleComponent.h>
 #include <Tests/Viewport/ViewportUiManagerTests.cpp>
 #include <EditorColliderComponent.h>
+#include <EditorStaticRigidBodyComponent.h>
 
 namespace UnitTest
 {
@@ -487,6 +488,7 @@ namespace UnitTest
         m_entity->Deactivate();
         auto* colliderComponent =
             m_entity->CreateComponent<PhysX::EditorColliderComponent>(Physics::ColliderConfiguration(), shapeConfiguration);
+        m_entity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         m_entity->Activate();
         m_idPair = AZ::EntityComponentIdPair(m_entity->GetId(), colliderComponent->GetId());
         PhysX::EditorColliderComponentRequestBus::Event(

--- a/Gems/PhysX/Code/Tests/ShapeColliderComponentTests.cpp
+++ b/Gems/PhysX/Code/Tests/ShapeColliderComponentTests.cpp
@@ -12,6 +12,7 @@
 #include <EditorColliderComponent.h>
 #include <EditorForceRegionComponent.h>
 #include <EditorRigidBodyComponent.h>
+#include <EditorStaticRigidBodyComponent.h>
 #include <EditorShapeColliderComponent.h>
 #include <LmbrCentral/Shape/BoxShapeComponentBus.h>
 #include <LmbrCentral/Shape/CompoundShapeComponentBus.h>
@@ -57,6 +58,7 @@ namespace PhysXEditorTests
     {
         EntityPtr entity = CreateInactiveEditorEntity("ShapeColliderComponentEditorEntity");
         entity->CreateComponent<PhysX::EditorShapeColliderComponent>();
+        entity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         entity->CreateComponent(LmbrCentral::EditorBoxShapeComponentTypeId);
 
         // the entity should be in a valid state because the shape component requirement is satisfied
@@ -68,8 +70,21 @@ namespace PhysXEditorTests
     {
         EntityPtr entity = CreateInactiveEditorEntity("ShapeColliderComponentEditorEntity");
         entity->CreateComponent<PhysX::EditorShapeColliderComponent>();
+        entity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
 
         // the entity should not be in a valid state because the shape collider component requires a shape component
+        AZ::Entity::DependencySortOutcome sortOutcome = entity->EvaluateDependenciesGetDetails();
+        EXPECT_FALSE(sortOutcome.IsSuccess());
+        EXPECT_TRUE(sortOutcome.GetError().m_code == AZ::Entity::DependencySortResult::MissingRequiredService);
+    }
+
+    TEST_F(PhysXEditorFixture, EditorShapeColliderComponent_RigidBodyDependencyMissing_EntityIsInvalid)
+    {
+        EntityPtr entity = CreateInactiveEditorEntity("ShapeColliderComponentEditorEntity");
+        entity->CreateComponent<PhysX::EditorShapeColliderComponent>();
+        entity->CreateComponent(LmbrCentral::EditorBoxShapeComponentTypeId);
+
+        // the entity should not be in a valid state because the shape collider component requires a rigid body component
         AZ::Entity::DependencySortOutcome sortOutcome = entity->EvaluateDependenciesGetDetails();
         EXPECT_FALSE(sortOutcome.IsSuccess());
         EXPECT_TRUE(sortOutcome.GetError().m_code == AZ::Entity::DependencySortResult::MissingRequiredService);
@@ -79,6 +94,7 @@ namespace PhysXEditorTests
     {
         EntityPtr entity = CreateInactiveEditorEntity("ShapeColliderComponentEditorEntity");
         entity->CreateComponent<PhysX::EditorShapeColliderComponent>();
+        entity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         entity->CreateComponent(LmbrCentral::EditorBoxShapeComponentTypeId);
 
         // adding a second shape collider component should make the entity invalid
@@ -94,6 +110,7 @@ namespace PhysXEditorTests
     {
         EntityPtr entity = CreateInactiveEditorEntity("ShapeColliderComponentEditorEntity");
         entity->CreateComponent<PhysX::EditorShapeColliderComponent>();
+        entity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         entity->CreateComponent(LmbrCentral::EditorBoxShapeComponentTypeId);
 
         // the shape collider component should be compatible with multiple collider components
@@ -110,6 +127,7 @@ namespace PhysXEditorTests
         // create an editor entity with a shape collider component and a box shape component
         EntityPtr editorEntity = CreateInactiveEditorEntity("ShapeColliderComponentEditorEntity");
         editorEntity->CreateComponent<PhysX::EditorShapeColliderComponent>();
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         editorEntity->CreateComponent(LmbrCentral::EditorBoxShapeComponentTypeId);
         editorEntity->Activate();
 
@@ -125,6 +143,7 @@ namespace PhysXEditorTests
         // create an editor entity with a shape collider component and a box shape component
         EntityPtr editorEntity = CreateInactiveEditorEntity("ShapeColliderComponentEditorEntity");
         editorEntity->CreateComponent<PhysX::EditorShapeColliderComponent>();
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         editorEntity->CreateComponent(LmbrCentral::EditorBoxShapeComponentTypeId);
         editorEntity->Activate();
 
@@ -360,6 +379,7 @@ namespace PhysXEditorTests
         // create an editor entity with a shape collider component and a polygon prism shape component
         EntityPtr editorEntity = CreateInactiveEditorEntity("ShapeColliderComponentEditorEntity");
         editorEntity->CreateComponent<PhysX::EditorShapeColliderComponent>();
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         editorEntity->CreateComponent(LmbrCentral::EditorPolygonPrismShapeComponentTypeId);
 
         // suppress the shape collider error that will be raised because the polygon prism vertices have not been set yet
@@ -403,6 +423,7 @@ namespace PhysXEditorTests
         // create an editor entity with a shape collider component and a polygon prism shape component
         EntityPtr editorEntity = CreateInactiveEditorEntity("ShapeColliderComponentEditorEntity");
         editorEntity->CreateComponent<PhysX::EditorShapeColliderComponent>();
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         editorEntity->CreateComponent(LmbrCentral::EditorPolygonPrismShapeComponentTypeId);
 
         // add a non-uniform scale component
@@ -439,6 +460,7 @@ namespace PhysXEditorTests
         // create an editor entity with a shape collider component and a cylinder shape component
         EntityPtr editorEntity = CreateInactiveEditorEntity("ShapeColliderComponentEditorEntity");
         editorEntity->CreateComponent<PhysX::EditorShapeColliderComponent>();
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         editorEntity->CreateComponent(LmbrCentral::EditorCylinderShapeComponentTypeId);
         editorEntity->Activate();
 
@@ -454,6 +476,7 @@ namespace PhysXEditorTests
         // create an editor entity with a shape collider component and a cylinder shape component
         EntityPtr editorEntity = CreateInactiveEditorEntity("ShapeColliderComponentEditorEntity");
         editorEntity->CreateComponent<PhysX::EditorShapeColliderComponent>();
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         editorEntity->CreateComponent(LmbrCentral::EditorCylinderShapeComponentTypeId);
         editorEntity->Activate();
         
@@ -526,6 +549,7 @@ namespace PhysXEditorTests
         // create an editor entity with a shape collider component and a cylinder shape component
         EntityPtr editorEntity = CreateInactiveEditorEntity("ShapeColliderComponentEditorEntity");
         editorEntity->CreateComponent<PhysX::EditorShapeColliderComponent>();
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         editorEntity->CreateComponent(LmbrCentral::EditorCylinderShapeComponentTypeId);
         editorEntity->Activate();
 
@@ -614,6 +638,7 @@ namespace PhysXEditorTests
         // create an editor entity with a shape collider component and a box shape component
         EntityPtr editorEntity = CreateInactiveEditorEntity("ShapeColliderComponentEditorEntity");
         editorEntity->CreateComponent<PhysX::EditorShapeColliderComponent>();
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         editorEntity->CreateComponent(LmbrCentral::EditorBoxShapeComponentTypeId);
         editorEntity->Activate();
         AZ::EntityId editorEntityId = editorEntity->GetId();
@@ -708,6 +733,7 @@ namespace PhysXEditorTests
         SetTrigger(shapeColliderComponent, true);
         forceRegionEditorEntity->CreateComponent(LmbrCentral::EditorPolygonPrismShapeComponentTypeId);
         forceRegionEditorEntity->CreateComponent<PhysX::EditorForceRegionComponent>();
+        forceRegionEditorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
 
         // suppress the shape collider error that will be raised because the polygon prism vertices have not been set yet
         UnitTest::ErrorHandler polygonPrismErrorHandler("Invalid polygon prism");
@@ -798,6 +824,7 @@ namespace PhysXEditorTests
         auto* shapeColliderComponent = editorEntity->CreateComponent<PhysX::EditorShapeColliderComponent>();
         SetSingleSided(shapeColliderComponent, singleSided);
         editorEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         const auto entityId = editorEntity->GetId();
 
         editorEntity->Activate();
@@ -828,6 +855,7 @@ namespace PhysXEditorTests
         auto* boxShapeComponent = editorEntity->CreateComponent(LmbrCentral::EditorBoxShapeComponentTypeId);
         auto* shapeColliderComponent = editorEntity->CreateComponent<PhysX::EditorShapeColliderComponent>();
         SetTrigger(shapeColliderComponent, initialTriggerSetting);
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         editorEntity->Activate();
 
         // the trigger setting should be what it was set to
@@ -859,31 +887,34 @@ namespace PhysXEditorTests
     {
         bool initialSingleSidedSetting = GetParam();
 
-        // create an editor entity without a rigid body (that means both single-sided and double-sided quads are valid)
+        // create an editor entity with a static rigid body (that means both single-sided and double-sided quads are valid)
         EntityPtr editorEntity = CreateInactiveEditorEntity("QuadEntity");
         editorEntity->CreateComponent(LmbrCentral::EditorQuadShapeComponentTypeId);
         auto* shapeColliderComponent = editorEntity->CreateComponent<PhysX::EditorShapeColliderComponent>();
         SetSingleSided(shapeColliderComponent, initialSingleSidedSetting);
+        auto* staticRigidBodyComponent = editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         editorEntity->Activate();
 
         // verify that the single sided setting matches the initial value
         EXPECT_EQ(IsSingleSided(shapeColliderComponent), initialSingleSidedSetting);
 
-        // add an editor rigid body component (this should mean single-sided quads are not supported)
+        // add a dynamic rigid body component (this should mean single-sided quads are not supported)
         editorEntity->Deactivate();
-        auto rigidBodyComponent = editorEntity->CreateComponent<PhysX::EditorRigidBodyComponent>();
+        editorEntity->RemoveComponent(staticRigidBodyComponent);
+        auto* rigidBodyComponent = editorEntity->CreateComponent<PhysX::EditorRigidBodyComponent>();
         editorEntity->Activate();
 
         EXPECT_FALSE(IsSingleSided(shapeColliderComponent));
 
-        // remove the editor rigid body component (the previous single-sided setting should be restored)
+        // add back the the static rigid body (the previous single-sided setting should be restored)
         editorEntity->Deactivate();
         editorEntity->RemoveComponent(rigidBodyComponent);
+        editorEntity->AddComponent(staticRigidBodyComponent);
         editorEntity->Activate();
 
         EXPECT_EQ(IsSingleSided(shapeColliderComponent), initialSingleSidedSetting);
 
-        // the rigid body component is no longer attached to the entity so won't be automatically cleared up
+        // the dynamic rigid body component is no longer attached to the entity so won't be automatically cleared up
         delete rigidBodyComponent;
     }
 
@@ -896,6 +927,7 @@ namespace PhysXEditorTests
         editorQuadEntity->CreateComponent(LmbrCentral::EditorQuadShapeComponentTypeId);
         auto* shapeColliderComponent = editorQuadEntity->CreateComponent<PhysX::EditorShapeColliderComponent>();
         SetSingleSided(shapeColliderComponent, true);
+        editorQuadEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
         editorQuadEntity->Activate();
         LmbrCentral::QuadShapeComponentRequestBus::Event(editorQuadEntity->GetId(), &LmbrCentral::QuadShapeComponentRequests::SetQuadHeight, 10.0f);
         LmbrCentral::QuadShapeComponentRequestBus::Event(editorQuadEntity->GetId(), &LmbrCentral::QuadShapeComponentRequests::SetQuadWidth, 10.0f);

--- a/Gems/PhysX/Code/Tests/StaticRigidBodyComponentTests.cpp
+++ b/Gems/PhysX/Code/Tests/StaticRigidBodyComponentTests.cpp
@@ -12,7 +12,7 @@
 #include <Source/EditorColliderComponent.h>
 #include <Source/EditorShapeColliderComponent.h>
 #include <Source/EditorRigidBodyComponent.h>
-#include <Source/EditorColliderComponent.h>
+#include <Source/EditorStaticRigidBodyComponent.h>
 #include <Source/StaticRigidBodyComponent.h>
 
 #include <Tests/EditorTestUtilities.h>
@@ -51,12 +51,29 @@ namespace PhysXEditorTests
             boxDimensions);
     }
 
-    TEST_F(PhysXEditorFixture, StaticRigidBodyComponent_NoRigidBody_RuntimeStaticRigidBodyComponentCreated)
+    TEST_F(PhysXEditorFixture, StaticRigidBodyComponent_NoRigidBody_NoRuntimeStaticRigidBodyComponent)
     {
         // Create editor entity
         EntityPtr editorEntity = CreateInactiveEditorEntity("Entity");
         editorEntity->CreateComponent<PhysX::EditorShapeColliderComponent>();
         AddEditorBoxShapeComponent(editorEntity);
+
+        // Create game entity and verify StaticRigidBodyComponent was NOTcreated
+        EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
+        const auto* staticRigidBody = gameEntity->FindComponent<PhysX::StaticRigidBodyComponent>();
+
+        EXPECT_TRUE(staticRigidBody == nullptr);
+    }
+
+    TEST_F(PhysXEditorFixture, StaticRigidBodyComponent_StaticRigidBody_RuntimeStaticRigidBodyComponentCreated)
+    {
+        // Create editor entity
+        EntityPtr editorEntity = CreateInactiveEditorEntity("Entity");
+        editorEntity->CreateComponent<PhysX::EditorShapeColliderComponent>();
+        AddEditorBoxShapeComponent(editorEntity);
+
+        // Add static rigid body component
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
 
         // Create game entity and verify StaticRigidBodyComponent was created
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
@@ -65,15 +82,14 @@ namespace PhysXEditorTests
         EXPECT_TRUE(staticRigidBody != nullptr);
     }
 
-    TEST_F(PhysXEditorFixture, StaticRigidBodyComponent_RigidBody_NoRuntimeStaticRigidBodyComponent)
+    TEST_F(PhysXEditorFixture, StaticRigidBodyComponent_DynamicRigidBody_NoRuntimeStaticRigidBodyComponent)
     {
         // Create editor entity
         EntityPtr editorEntity = CreateInactiveEditorEntity("Entity");
         editorEntity->CreateComponent<PhysX::EditorShapeColliderComponent>();
         AddEditorBoxShapeComponent(editorEntity);
 
-        // Add EditorRigidBodyComponent (depends on PhysXColliderService and
-        // should prevent runtime StaticRigidBodyComponent creation)
+        // Add dynamic rigid body component
         editorEntity->CreateComponent<PhysX::EditorRigidBodyComponent>();
 
         // Create game entity and verify StaticRigidBodyComponent was NOT created
@@ -81,6 +97,11 @@ namespace PhysXEditorTests
         const auto* staticRigidBody = gameEntity->FindComponent<PhysX::StaticRigidBodyComponent>();
 
         EXPECT_TRUE(staticRigidBody == nullptr);
+
+        // Verify RigidBodyComponent was created
+        const auto* rigidBody = gameEntity->FindComponent<PhysX::RigidBodyComponent>();
+
+        EXPECT_TRUE(rigidBody != nullptr);
     }
 
     TEST_F(PhysXEditorFixture, StaticRigidBodyComponent_MultipleColliderComponents_SingleRuntimeStaticRigidBodyComponent)
@@ -93,6 +114,9 @@ namespace PhysXEditorTests
         editorEntity->CreateComponent<PhysX::EditorColliderComponent>();
         editorEntity->CreateComponent<PhysX::EditorColliderComponent>();
 
+        // Add static rigid body component
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
+
         // Create game entity and verify only one StaticRigidBodyComponent was created
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
         AZ::Entity::ComponentArrayType staticRigidBodyComponents =
@@ -101,7 +125,20 @@ namespace PhysXEditorTests
         EXPECT_EQ(staticRigidBodyComponents.size(), 1);
     }
 
-    TEST_F(PhysXEditorFixture, StaticRigidBodyComponent_EditorColliderAndNoRigidBodyComponent_EditorStaticRigidBodyCreated)
+    TEST_F(PhysXEditorFixture, StaticRigidBodyComponent_EditorColliderAndNoRigidBodyComponent_EntityIsInvalid)
+    {
+        // Create editor entity
+        EntityPtr editorEntity = CreateInactiveEditorEntity("Entity");
+        editorEntity->CreateComponent<PhysX::EditorColliderComponent>();
+        AddEditorBoxShapeComponent(editorEntity);
+
+        // the entity should not be in a valid state because the shape collider component requires a rigid body component
+        AZ::Entity::DependencySortOutcome sortOutcome = editorEntity->EvaluateDependenciesGetDetails();
+        EXPECT_FALSE(sortOutcome.IsSuccess());
+        EXPECT_TRUE(sortOutcome.GetError().m_code == AZ::Entity::DependencySortResult::MissingRequiredService);
+    }
+
+    TEST_F(PhysXEditorFixture, StaticRigidBodyComponent_EditorColliderAndStaticRigidBodyComponent_EditorStaticRigidBodyCreated)
     {
         // Get current number of static rigid body actors in editor world
         const int originalStaticRigidBodyCount = GetEditorStaticRigidBodyCount();
@@ -110,14 +147,17 @@ namespace PhysXEditorTests
         EntityPtr editorEntity = CreateInactiveEditorEntity("Entity");
         editorEntity->CreateComponent<PhysX::EditorShapeColliderComponent>();
         AddEditorBoxShapeComponent(editorEntity);
+
+        // Add static rigid body component
+        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
 
         editorEntity->Activate();
 
-        // Verify number of static rigid body actors increased by 1 
+        // Verify number of static rigid body actors increased by 1
         EXPECT_EQ(GetEditorStaticRigidBodyCount(), originalStaticRigidBodyCount + 1);
     }
 
-    TEST_F(PhysXEditorFixture, StaticRigidBodyComponent_EditorColliderAndRigidBodyComponent_NoEditorStaticRigidBodyCreated)
+    TEST_F(PhysXEditorFixture, StaticRigidBodyComponent_EditorColliderAndDynamicRigidBodyComponent_NoEditorStaticRigidBodyCreated)
     {
         // Get current number of static rigid body actors in editor world
         const int originalStaticRigidBodyCount = GetEditorStaticRigidBodyCount();
@@ -127,6 +167,7 @@ namespace PhysXEditorTests
         editorEntity->CreateComponent<PhysX::EditorShapeColliderComponent>();
         AddEditorBoxShapeComponent(editorEntity);
 
+        // Add dynamic rigid body component
         editorEntity->CreateComponent<PhysX::EditorRigidBodyComponent>();
 
         editorEntity->Activate();

--- a/Gems/PhysX/Code/Tests/StaticRigidBodyComponentTests.cpp
+++ b/Gems/PhysX/Code/Tests/StaticRigidBodyComponentTests.cpp
@@ -58,7 +58,7 @@ namespace PhysXEditorTests
         editorEntity->CreateComponent<PhysX::EditorShapeColliderComponent>();
         AddEditorBoxShapeComponent(editorEntity);
 
-        // Create game entity and verify StaticRigidBodyComponent was NOTcreated
+        // Create game entity and verify StaticRigidBodyComponent was NOT created
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
         const auto* staticRigidBody = gameEntity->FindComponent<PhysX::StaticRigidBodyComponent>();
 


### PR DESCRIPTION
**Note**
This work has been divided into multiple PRs to make it easier to review. Merging each PR into the staging branch `PhysX_StaticRigidBody_Staging_o3de`.

This change is part of the following PR https://github.com/o3de/o3de/pull/14261

Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

- Adapt PhysX unit tests to count for the colliders requiring a rigid body (static or dynamic).
- Fixed dyn_veg PhysXColliderSurfaceTagEmitter python test.

## How was this PR tested?

PhysX unit tests pass.
Passed AR in local branch `PhysX_StaticRigidBody` which has all the PRs combined.
