### PR TITLE
Added console command that updates prefabs containing colliders with no rigid bodies

### DIFF
--- a/Gems/PhysX/Code/Editor/Source/Components/Conversion/CollidersPrefabConversion.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Components/Conversion/CollidersPrefabConversion.cpp
@@ -20,13 +20,13 @@
 
 namespace PhysX
 {
-    void FixPrefabsWithColliderComponents(const AZ::ConsoleCommandContainer& commandArgs);
+    void UpdatePrefabsWithColliderComponents(const AZ::ConsoleCommandContainer& commandArgs);
 
     AZ_CONSOLEFREEFUNC(
-        "ed_physxFixPrefabsWithColliderComponents",
-        FixPrefabsWithColliderComponents,
+        "ed_physxUpdatePrefabsWithColliderComponents",
+        UpdatePrefabsWithColliderComponents,
         AZ::ConsoleFunctorFlags::Null,
-        "Finds entities with collider components and no rigid bodies and fixes them by adding a static rigid body component.");
+        "Finds entities with collider components and no rigid bodies and updates them to the new pattern which requires a static rigid body component.");
 
     bool AddStaticRigidBodyToPrefabEntity(
         Utils::PrefabInfo& prefabInfo,
@@ -71,7 +71,7 @@ namespace PhysX
         return true;
     }
 
-    void FixPrefabPhysXColliders(Utils::PrefabInfo& prefabInfo)
+    void UpdatePrefabPhysXColliders(Utils::PrefabInfo& prefabInfo)
     {
         bool prefabModified = false;
         for (auto* entity : Utils::GetPrefabEntities(prefabInfo.m_template->GetPrefabDom()))
@@ -115,7 +115,7 @@ namespace PhysX
         }
     }
 
-    void FixPrefabsWithColliderComponents([[maybe_unused]] const AZ::ConsoleCommandContainer& commandArgs)
+    void UpdatePrefabsWithColliderComponents([[maybe_unused]] const AZ::ConsoleCommandContainer& commandArgs)
     {
         bool prefabSystemEnabled = false;
         AzFramework::ApplicationRequests::Bus::BroadcastResult(
@@ -142,7 +142,7 @@ namespace PhysX
 
         for (auto& prefab : prefabs)
         {
-            FixPrefabPhysXColliders(prefab);
+            UpdatePrefabPhysXColliders(prefab);
         }
 
         AZ_TracePrintf("PhysXColliderConversion", "Prefab conversion finished.\n");

--- a/Gems/PhysX/Code/Editor/Source/Components/Conversion/CollidersPrefabConversion.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Components/Conversion/CollidersPrefabConversion.cpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Asset/AssetManager.h>
+#include <AzCore/Console/IConsole.h>
+
+#include <AzFramework/API/ApplicationAPI.h>
+
+#include <EditorColliderComponent.h>
+#include <EditorShapeColliderComponent.h>
+#include <EditorRigidBodyComponent.h>
+#include <EditorStaticRigidBodyComponent.h>
+
+#include <Editor/Source/Components/Conversion/PrefabConversionUtils.h>
+
+namespace PhysX
+{
+    void FixPrefabsWithColliderComponents(const AZ::ConsoleCommandContainer& commandArgs);
+
+    AZ_CONSOLEFREEFUNC(
+        "ed_physxFixPrefabsWithColliderComponents",
+        FixPrefabsWithColliderComponents,
+        AZ::ConsoleFunctorFlags::Null,
+        "Finds entities with collider components and no rigid bodies and fixes them by adding a static rigid body component.");
+
+    bool AddStaticRigidBodyToPrefabEntity(
+        Utils::PrefabInfo& prefabInfo,
+        AzToolsFramework::Prefab::PrefabDomValue& entityPrefab)
+    {
+        AZ::Entity entity;
+        Utils::PrefabEntityIdMapper prefabEntityIdMapper;
+
+        if (!Utils::LoadPrefabEntity(prefabEntityIdMapper, entityPrefab, entity))
+        {
+            AZ_Warning(
+                "PhysXColliderConversion",
+                false,
+                "Unable to load entity '%s' from prefab '%s'.",
+                entity.GetName().c_str(),
+                prefabInfo.m_prefabFullPath.c_str());
+            return false;
+        }
+
+        if (!entity.CreateComponent<EditorStaticRigidBodyComponent>())
+        {
+            AZ_Warning(
+                "PhysXColliderConversion",
+                false,
+                "Failed to create static rigid body component for entity '%s' in prefab '%s'.",
+                entity.GetName().c_str(),
+                prefabInfo.m_prefabFullPath.c_str());
+            return false;
+        }
+
+        if (!Utils::StorePrefabEntity(prefabEntityIdMapper, prefabInfo.m_template->GetPrefabDom(), entityPrefab, entity))
+        {
+            AZ_Warning(
+                "PhysXColliderConversion",
+                false,
+                "Unable to store entity '%s' into prefab '%s'.",
+                entity.GetName().c_str(),
+                prefabInfo.m_prefabFullPath.c_str());
+            return false;
+        }
+
+        return true;
+    }
+
+    void FixPrefabPhysXColliders(Utils::PrefabInfo& prefabInfo)
+    {
+        bool prefabModified = false;
+        for (auto* entity : Utils::GetPrefabEntities(prefabInfo.m_template->GetPrefabDom()))
+        {
+            const auto entityComponents = Utils::GetEntityComponents(*entity);
+
+            const bool rigidBodyMissing = AZStd::none_of(
+                entityComponents.begin(),
+                entityComponents.end(),
+                [](const auto* component)
+                {
+                    const auto typeId = Utils::GetComponentTypeId(*component);
+                    return typeId == azrtti_typeid<EditorRigidBodyComponent>() || typeId == azrtti_typeid<EditorStaticRigidBodyComponent>();
+                });
+
+            const bool colliderPresent = AZStd::any_of(
+                entityComponents.begin(),
+                entityComponents.end(),
+                [](const auto* component)
+                {
+                    const auto typeId = Utils::GetComponentTypeId(*component);
+                    return typeId == azrtti_typeid<EditorColliderComponent>() || typeId == azrtti_typeid<EditorShapeColliderComponent>();
+                });
+
+            if (rigidBodyMissing && colliderPresent)
+            {
+                if (AddStaticRigidBodyToPrefabEntity(prefabInfo, *entity))
+                {
+                    prefabModified = true;
+                }
+            }
+        }
+
+        if (prefabModified)
+        {
+            AZ_TracePrintf("PhysXColliderConversion", "Saving modified prefab '%s'.\n", prefabInfo.m_prefabFullPath.c_str());
+
+            Utils::SavePrefab(prefabInfo);
+
+            AZ_TracePrintf("PhysXColliderConversion", "\n");
+        }
+    }
+
+    void FixPrefabsWithColliderComponents([[maybe_unused]] const AZ::ConsoleCommandContainer& commandArgs)
+    {
+        bool prefabSystemEnabled = false;
+        AzFramework::ApplicationRequests::Bus::BroadcastResult(
+            prefabSystemEnabled, &AzFramework::ApplicationRequests::IsPrefabSystemEnabled);
+        if (!prefabSystemEnabled)
+        {
+            AZ_TracePrintf("PhysXColliderConversion", "Prefabs system is not enabled. Prefabs won't be converted.\n");
+            AZ_TracePrintf("PhysXColliderConversion", "\n");
+            return;
+        }
+
+        AZ_TracePrintf("PhysXColliderConversion", "Searching for prefabs to convert...\n");
+        AZ_TracePrintf("PhysXColliderConversion", "\n");
+
+        AZStd::vector<Utils::PrefabInfo> prefabs = Utils::CollectPrefabs();
+        if (prefabs.empty())
+        {
+            AZ_TracePrintf("PhysXColliderConversion", "No prefabs found.\n");
+            AZ_TracePrintf("PhysXColliderConversion", "\n");
+            return;
+        }
+        AZ_TracePrintf("PhysXColliderConversion", "Found %zu prefabs to check.\n", prefabs.size());
+        AZ_TracePrintf("PhysXColliderConversion", "\n");
+
+        for (auto& prefab : prefabs)
+        {
+            FixPrefabPhysXColliders(prefab);
+        }
+
+        AZ_TracePrintf("PhysXColliderConversion", "Prefab conversion finished.\n");
+        AZ_TracePrintf("PhysXColliderConversion", "\n");
+    }
+} // namespace PhysX

--- a/Gems/PhysX/Code/Editor/Source/Components/Conversion/PrefabConversionUtils.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Components/Conversion/PrefabConversionUtils.cpp
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Asset/AssetManager.h>
+#include <AzFramework/Spawnable/Spawnable.h>
+#include <AzToolsFramework/API/EditorAssetSystemAPI.h>
+#include <AzToolsFramework/SourceControl/SourceControlAPI.h>
+
+#include <Editor/Source/Components/Conversion/PrefabConversionUtils.h>
+
+namespace PhysX::Utils
+{
+    static AZStd::optional<AZStd::string> GetFullSourceAssetPathById(AZ::Data::AssetId assetId)
+    {
+        AZStd::string assetPath;
+        AZ::Data::AssetCatalogRequestBus::BroadcastResult(assetPath, &AZ::Data::AssetCatalogRequests::GetAssetPathById, assetId);
+        AZ_Assert(!assetPath.empty(), "Asset Catalog returned an invalid path from an enumerated asset.");
+        if (assetPath.empty())
+        {
+            AZ_Warning(
+                "PhysXPrefabUtils",
+                false,
+                "Not able to get asset path for asset with id %s.",
+                assetId.ToString<AZStd::string>().c_str());
+            return AZStd::nullopt;
+        }
+
+        AZStd::string assetFullPath;
+        bool assetFullPathFound = false;
+        AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+            assetFullPathFound,
+            &AzToolsFramework::AssetSystem::AssetSystemRequest::GetFullSourcePathFromRelativeProductPath,
+            assetPath,
+            assetFullPath);
+        if (!assetFullPathFound)
+        {
+            AZ_Warning("PhysXPrefabUtils", false, "Source file of asset '%s' could not be found.", assetPath.c_str());
+            return AZStd::nullopt;
+        }
+
+        return { AZStd::move(assetFullPath) };
+    }
+
+    AZStd::vector<PrefabInfo> CollectPrefabs()
+    {
+        AZStd::vector<PrefabInfo> prefabs;
+
+        auto* prefabLoader = AZ::Interface<AzToolsFramework::Prefab::PrefabLoaderInterface>::Get();
+        auto* prefabSystemComponent = AZ::Interface<AzToolsFramework::Prefab::PrefabSystemComponentInterface>::Get();
+
+        AZ::Data::AssetCatalogRequests::AssetEnumerationCB assetEnumerationCB =
+            [&prefabs, prefabLoader, prefabSystemComponent](
+                const AZ::Data::AssetId assetId, const AZ::Data::AssetInfo& assetInfo)
+        {
+            if (assetInfo.m_assetType != AzFramework::Spawnable::RTTI_Type())
+            {
+                return;
+            }
+
+            AZStd::optional<AZStd::string> assetFullPath = GetFullSourceAssetPathById(assetId);
+            if (!assetFullPath.has_value())
+            {
+                return;
+            }
+
+            if (auto templateId = prefabLoader->LoadTemplateFromFile(assetFullPath->c_str());
+                templateId != AzToolsFramework::Prefab::InvalidTemplateId)
+            {
+                if (auto templateResult = prefabSystemComponent->FindTemplate(templateId); templateResult.has_value())
+                {
+                    AzToolsFramework::Prefab::Template& templateRef = templateResult->get();
+                    prefabs.push_back({ templateId, &templateRef, AZStd::move(*assetFullPath) });
+                }
+            }
+        };
+
+        AZ::Data::AssetCatalogRequestBus::Broadcast(
+            &AZ::Data::AssetCatalogRequestBus::Events::EnumerateAssets, nullptr, assetEnumerationCB, nullptr);
+
+        return prefabs;
+    }
+
+    void SavePrefab(PrefabInfo& prefabInfo)
+    {
+        auto* prefabSystemComponent = AZ::Interface<AzToolsFramework::Prefab::PrefabSystemComponentInterface>::Get();
+
+        prefabInfo.m_template->MarkAsDirty(true);
+        prefabSystemComponent->PropagateTemplateChanges(prefabInfo.m_templateId);
+
+        // Request source control to edit prefab file
+        AzToolsFramework::SourceControlCommandBus::Broadcast(
+            &AzToolsFramework::SourceControlCommandBus::Events::RequestEdit,
+            prefabInfo.m_prefabFullPath.c_str(),
+            true,
+            [prefabInfo]([[maybe_unused]] bool success, const AzToolsFramework::SourceControlFileInfo& info)
+            {
+                // This is called from the main thread on the next frame from TickBus,
+                // that is why 'prefabInfo' is captured as a copy.
+                if (!info.IsReadOnly())
+                {
+                    auto* prefabLoader = AZ::Interface<AzToolsFramework::Prefab::PrefabLoaderInterface>::Get();
+                    if (!prefabLoader->SaveTemplate(prefabInfo.m_templateId))
+                    {
+                        AZ_Warning("PhysXPrefabUtils", false, "Unable to save prefab '%s'", prefabInfo.m_prefabFullPath.c_str());
+                    }
+                }
+                else
+                {
+                    AZ_Warning(
+                        "PhysXPrefabUtils",
+                        false,
+                        "Unable to check out asset '%s' in source control.",
+                        prefabInfo.m_prefabFullPath.c_str());
+                }
+            });
+    }
+
+    AZStd::vector<AzToolsFramework::Prefab::PrefabDomValue*> GetPrefabEntities(AzToolsFramework::Prefab::PrefabDom& prefab)
+    {
+        if (!prefab.IsObject())
+        {
+            return {};
+        }
+
+        AZStd::vector<AzToolsFramework::Prefab::PrefabDomValue*> entities;
+
+        if (auto entitiesIter = prefab.FindMember(AzToolsFramework::Prefab::PrefabDomUtils::EntitiesName);
+            entitiesIter != prefab.MemberEnd() && entitiesIter->value.IsObject())
+        {
+            entities.reserve(entitiesIter->value.MemberCount());
+
+            for (auto entityIter = entitiesIter->value.MemberBegin(); entityIter != entitiesIter->value.MemberEnd(); ++entityIter)
+            {
+                if (entityIter->value.IsObject())
+                {
+                    entities.push_back(&entityIter->value);
+                }
+            }
+        }
+
+        return entities;
+    }
+
+    AZStd::vector<AzToolsFramework::Prefab::PrefabDomValue*> GetEntityComponents(AzToolsFramework::Prefab::PrefabDomValue& entity)
+    {
+        AZStd::vector<AzToolsFramework::Prefab::PrefabDomValue*> components;
+
+        if (auto componentsIter = entity.FindMember(AzToolsFramework::Prefab::PrefabDomUtils::ComponentsName);
+            componentsIter != entity.MemberEnd() && componentsIter->value.IsObject())
+        {
+            components.reserve(componentsIter->value.MemberCount());
+
+            for (auto componentIter = componentsIter->value.MemberBegin(); componentIter != componentsIter->value.MemberEnd();
+                 ++componentIter)
+            {
+                if (!componentIter->value.IsObject())
+                {
+                    continue;
+                }
+
+                components.push_back(&componentIter->value);
+            }
+        }
+
+        return components;
+    }
+
+    AZ::TypeId GetComponentTypeId(const AzToolsFramework::Prefab::PrefabDomValue& component)
+    {
+        const auto typeFieldIter = component.FindMember(AzToolsFramework::Prefab::PrefabDomUtils::TypeName);
+        if (typeFieldIter == component.MemberEnd())
+        {
+            return AZ::TypeId::CreateNull();
+        }
+
+        AZ::TypeId typeId = AZ::TypeId::CreateNull();
+        AZ::JsonSerialization::LoadTypeId(typeId, typeFieldIter->value);
+
+        return typeId;
+    }
+
+    AZ::JsonSerializationResult::Result PrefabEntityIdMapper::MapJsonToId(
+        AZ::EntityId& outputValue, const rapidjson::Value& inputValue, AZ::JsonDeserializerContext& context)
+    {
+        if (!inputValue.IsString())
+        {
+            return context.Report(
+                AZ::JsonSerializationResult::Tasks::ReadField,
+                AZ::JsonSerializationResult::Outcomes::TypeMismatch,
+                "Unexpected type for prefab id.");
+        }
+
+        const size_t entityIdHash = AZStd::hash<AZStd::string_view>()(inputValue.GetString());
+        outputValue = AZ::EntityId(entityIdHash);
+        m_entityIdMap[outputValue] = inputValue.GetString();
+
+        return context.Report(
+            AZ::JsonSerializationResult::Tasks::ReadField,
+            AZ::JsonSerializationResult::Outcomes::Success,
+            "Successfully mapped string id to Entity Id For Prefab Entity load");
+    }
+
+    AZ::JsonSerializationResult::Result PrefabEntityIdMapper::MapIdToJson(
+        rapidjson::Value& outputValue, const AZ::EntityId& inputValue, AZ::JsonSerializerContext& context)
+    {
+        auto it = m_entityIdMap.find(inputValue);
+        if (it == m_entityIdMap.end())
+        {
+            return context.Report(
+                AZ::JsonSerializationResult::Tasks::WriteValue,
+                AZ::JsonSerializationResult::Outcomes::Missing,
+                "Missing entity id in the map.");
+        }
+
+        outputValue.SetString(it->second.c_str(), it->second.size(), context.GetJsonAllocator());
+
+        return context.Report(
+            AZ::JsonSerializationResult::Tasks::WriteValue,
+            AZ::JsonSerializationResult::Outcomes::Success,
+            "Successfully mapped Entity Id to string id for Prefab Entity store");
+    }
+
+    bool LoadPrefabEntity(
+        PrefabEntityIdMapper& prefabEntityIdMapper, const AzToolsFramework::Prefab::PrefabDomValue& prefabEntity, AZ::Entity& entity)
+    {
+        AZ::JsonDeserializerSettings settings;
+        settings.m_metadata.Add(static_cast<AZ::JsonEntityIdSerializer::JsonEntityIdMapper*>(&prefabEntityIdMapper));
+
+        auto result = AZ::JsonSerialization::Load(&entity, azrtti_typeid<AZ::Entity>(), prefabEntity, settings);
+
+        return result.GetProcessing() == AZ::JsonSerializationResult::Processing::Completed;
+    }
+
+    bool StorePrefabEntity(
+        const PrefabEntityIdMapper& prefabEntityIdMapper,
+        AzToolsFramework::Prefab::PrefabDom& prefabDom,
+        AzToolsFramework::Prefab::PrefabDomValue& prefabEntity,
+        const AZ::Entity& entity)
+    {
+        AZ::JsonSerializerSettings settings;
+        settings.m_metadata.Add(static_cast<const AZ::JsonEntityIdSerializer::JsonEntityIdMapper*>(&prefabEntityIdMapper));
+
+        auto result = AZ::JsonSerialization::Store(
+            prefabEntity, prefabDom.GetAllocator(), &entity, nullptr, azrtti_typeid<AZ::Entity>(), settings);
+
+        return result.GetProcessing() == AZ::JsonSerializationResult::Processing::Completed;
+    }
+} // namespace PhysX::Utils

--- a/Gems/PhysX/Code/Editor/Source/Components/Conversion/PrefabConversionUtils.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Components/Conversion/PrefabConversionUtils.cpp
@@ -80,7 +80,7 @@ namespace PhysX::Utils
         };
 
         AZ::Data::AssetCatalogRequestBus::Broadcast(
-            &AZ::Data::AssetCatalogRequestBus::Events::EnumerateAssets, nullptr, assetEnumerationCB, nullptr);
+            &AZ::Data::AssetCatalogRequestBus::Events::EnumerateAssets, /*beginCB*/nullptr, assetEnumerationCB, /*endCB*/nullptr);
 
         return prefabs;
     }
@@ -96,7 +96,7 @@ namespace PhysX::Utils
         AzToolsFramework::SourceControlCommandBus::Broadcast(
             &AzToolsFramework::SourceControlCommandBus::Events::RequestEdit,
             prefabInfo.m_prefabFullPath.c_str(),
-            true,
+            /*allowMultiCheckout*/true,
             [prefabInfo]([[maybe_unused]] bool success, const AzToolsFramework::SourceControlFileInfo& info)
             {
                 // This is called from the main thread on the next frame from TickBus,
@@ -192,7 +192,7 @@ namespace PhysX::Utils
             return context.Report(
                 AZ::JsonSerializationResult::Tasks::ReadField,
                 AZ::JsonSerializationResult::Outcomes::TypeMismatch,
-                "Unexpected type for prefab id.");
+                "Unexpected json type for prefab id, expected a String type.");
         }
 
         const size_t entityIdHash = AZStd::hash<AZStd::string_view>()(inputValue.GetString());
@@ -202,7 +202,7 @@ namespace PhysX::Utils
         return context.Report(
             AZ::JsonSerializationResult::Tasks::ReadField,
             AZ::JsonSerializationResult::Outcomes::Success,
-            "Successfully mapped string id to Entity Id For Prefab Entity load");
+            "Successfully mapped string id to entity id.");
     }
 
     AZ::JsonSerializationResult::Result PrefabEntityIdMapper::MapIdToJson(
@@ -222,7 +222,7 @@ namespace PhysX::Utils
         return context.Report(
             AZ::JsonSerializationResult::Tasks::WriteValue,
             AZ::JsonSerializationResult::Outcomes::Success,
-            "Successfully mapped Entity Id to string id for Prefab Entity store");
+            "Successfully mapped entity id to string id.");
     }
 
     bool LoadPrefabEntity(
@@ -246,7 +246,7 @@ namespace PhysX::Utils
         settings.m_metadata.Add(static_cast<const AZ::JsonEntityIdSerializer::JsonEntityIdMapper*>(&prefabEntityIdMapper));
 
         auto result = AZ::JsonSerialization::Store(
-            prefabEntity, prefabDom.GetAllocator(), &entity, nullptr, azrtti_typeid<AZ::Entity>(), settings);
+            prefabEntity, prefabDom.GetAllocator(), &entity, /*defaultObject*/nullptr, azrtti_typeid<AZ::Entity>(), settings);
 
         return result.GetProcessing() == AZ::JsonSerializationResult::Processing::Completed;
     }

--- a/Gems/PhysX/Code/Editor/Source/Components/Conversion/PrefabConversionUtils.h
+++ b/Gems/PhysX/Code/Editor/Source/Components/Conversion/PrefabConversionUtils.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/Component/EntityIdSerializer.h>
+#include <AzToolsFramework/Prefab/PrefabDomUtils.h>
+#include <AzToolsFramework/Prefab/PrefabLoaderInterface.h>
+#include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
+
+namespace PhysX::Utils
+{
+    struct PrefabInfo
+    {
+        AzToolsFramework::Prefab::TemplateId m_templateId;
+        AzToolsFramework::Prefab::Template* m_template = nullptr;
+        AZStd::string m_prefabFullPath;
+    };
+
+    AZStd::vector<PrefabInfo> CollectPrefabs();
+
+    void SavePrefab(PrefabInfo& prefabInfo);
+
+    AZStd::vector<AzToolsFramework::Prefab::PrefabDomValue*> GetPrefabEntities(AzToolsFramework::Prefab::PrefabDom& prefab);
+
+    AZStd::vector<AzToolsFramework::Prefab::PrefabDomValue*> GetEntityComponents(AzToolsFramework::Prefab::PrefabDomValue& entity);
+
+    AZ::TypeId GetComponentTypeId(const AzToolsFramework::Prefab::PrefabDomValue& component);
+
+    // Mapper to ensure the entity ids remain the same when loading and storing entities from a prefab.
+    class PrefabEntityIdMapper final
+        : public AZ::JsonEntityIdSerializer::JsonEntityIdMapper
+    {
+    public:
+        AZ_RTTI(PrefabEntityIdMapper, "{CAA0D7E0-00B0-4B84-8480-A3475CE25043}", AZ::JsonEntityIdSerializer::JsonEntityIdMapper);
+
+        PrefabEntityIdMapper() = default;
+
+        AZ::JsonSerializationResult::Result MapJsonToId(
+            AZ::EntityId& outputValue, const rapidjson::Value& inputValue, AZ::JsonDeserializerContext& context) override;
+
+        AZ::JsonSerializationResult::Result MapIdToJson(
+            rapidjson::Value& outputValue, [[maybe_unused]] const AZ::EntityId& inputValue, AZ::JsonSerializerContext& context) override;
+
+    private:
+        AZStd::unordered_map<AZ::EntityId, AZStd::string> m_entityIdMap;
+    };
+
+    bool LoadPrefabEntity(
+        PrefabEntityIdMapper& prefabEntityIdMapper, const AzToolsFramework::Prefab::PrefabDomValue& prefabEntity, AZ::Entity& entity);
+
+    bool StorePrefabEntity(
+        const PrefabEntityIdMapper& prefabEntityIdMapper,
+        AzToolsFramework::Prefab::PrefabDom& prefabDom,
+        AzToolsFramework::Prefab::PrefabDomValue& prefabEntity,
+        const AZ::Entity& entity);
+
+} // namespace PhysX::Utils

--- a/Gems/PhysX/Code/physx_editor_files.cmake
+++ b/Gems/PhysX/Code/physx_editor_files.cmake
@@ -112,6 +112,9 @@ set(FILES
 
     Editor/Source/Components/EditorSystemComponent.h
     Editor/Source/Components/EditorSystemComponent.cpp
+    Editor/Source/Components/Conversion/CollidersPrefabConversion.cpp
+    Editor/Source/Components/Conversion/PrefabConversionUtils.h
+    Editor/Source/Components/Conversion/PrefabConversionUtils.cpp
     Editor/Source/ComponentModes/Joints/JointsComponentMode.h
     Editor/Source/ComponentModes/Joints/JointsComponentMode.cpp
     Editor/Source/ComponentModes/Joints/JointsComponentModeBus.h


### PR DESCRIPTION
**Note**
This work has been divided into multiple PRs to make it easier to review. Merging each PR into the staging branch `PhysX_StaticRigidBody_Staging_o3de`.

This change is part of the following PR https://github.com/o3de/o3de/pull/14261

Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

Added console command `ed_physxUpdatePrefabsWithColliderComponents` that finds prefabs containing entities with collider components and no rigid bodies and fixes them by adding a static rigid body component.

## How was this PR tested?

Run `ed_physxUpdatePrefabsWithColliderComponents` console command and checked the prefabs were modified correctly and processed successfully by Asset Processor.

PR with o3de prefabs updated: https://github.com/o3de/o3de/pull/14295