### PR TITLE
Update TAA to make a copy of its output for next frame's history.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.cpp
@@ -69,10 +69,29 @@ namespace AZ::Render
 
         m_shaderResourceGroup->SetConstant(m_constantDataIndex, cb);
 
-
         Base::CompileResources(context);
     }
-    
+
+    void TaaPass::BuildCommandListInternal(const RHI::FrameGraphExecuteContext& context)
+    {
+        Base::BuildCommandListInternal(context);
+        if (ShouldCopyHistoryBuffer)
+        {
+            context.GetCommandList()->Submit(m_copyItem);
+        }
+    }
+
+    void TaaPass::SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph)
+    {
+        if (ShouldCopyHistoryBuffer)
+        {
+            // Override the estimated item count to include the copy item.
+            frameGraph.SetEstimatedItemCount(2);
+        }
+
+        Base::SetupFrameGraphDependencies(frameGraph);
+    }
+
     void TaaPass::FrameBeginInternal(FramePrepareParams params)
     {
         RHI::Size inputSize = m_inputColorBinding->GetAttachment()->m_descriptor.m_image.m_size;
@@ -83,11 +102,13 @@ namespace AZ::Render
         Offset offset = m_subPixelOffsets.at(m_offsetIndex);
         view->SetClipSpaceOffset(offset.m_xOffset * rcpInputSize.GetX(), offset.m_yOffset * rcpInputSize.GetY());
 
-        m_lastFrameAccumulationBinding->SetAttachment(m_accumulationAttachments[m_accumulationOuptutIndex]);
-        m_accumulationOuptutIndex ^= 1; // swap which attachment is the output and last frame
-
-        UpdateAttachmentImage(m_accumulationAttachments[m_accumulationOuptutIndex]);
-        m_outputColorBinding->SetAttachment(m_accumulationAttachments[m_accumulationOuptutIndex]);
+        if (!ShouldCopyHistoryBuffer)
+        {
+            m_lastFrameAccumulationBinding->SetAttachment(m_accumulationAttachments[m_accumulationOuptutIndex]);
+            m_accumulationOuptutIndex ^= 1; // swap which attachment is the output and last frame
+            UpdateAttachmentImage(m_accumulationOuptutIndex);
+            m_outputColorBinding->SetAttachment(m_accumulationAttachments[m_accumulationOuptutIndex]);
+        }
         
         Base::FrameBeginInternal(params);
     }
@@ -119,7 +140,7 @@ namespace AZ::Render
             {
                 if (!m_accumulationAttachments[i]->m_importedResource)
                 {
-                    UpdateAttachmentImage(m_accumulationAttachments[i]);
+                    UpdateAttachmentImage(i);
                 }
             }
         }
@@ -130,6 +151,13 @@ namespace AZ::Render
         AZ_Error("TaaPass", m_lastFrameAccumulationBinding, "TaaPass requires a slot for LastFrameAccumulation.");
         m_outputColorBinding = FindAttachmentBinding(Name("OutputColor"));
         AZ_Error("TaaPass", m_outputColorBinding, "TaaPass requires a slot for OutputColor.");
+
+        RHI::CopyImageDescriptor desc;
+        desc.m_sourceImage = m_attachmentImages[1]->GetRHIImage();
+        desc.m_destinationImage = m_attachmentImages[0]->GetRHIImage();
+        desc.m_sourceSize = desc.m_sourceImage->GetDescriptor().m_size;
+
+        m_copyItem = RHI::CopyItem(desc);
 
         // Set up the attachment for last frame accumulation and output color if it's never been done to
         // ensure SRG indices are set up correctly by the pass system.
@@ -142,8 +170,9 @@ namespace AZ::Render
         Base::BuildInternal();
     }
 
-    void TaaPass::UpdateAttachmentImage(RPI::Ptr<RPI::PassAttachment>& attachment)
+    void TaaPass::UpdateAttachmentImage(uint32_t attachmentIndex)
     {
+        RPI::Ptr<RPI::PassAttachment>& attachment = m_accumulationAttachments[attachmentIndex];
         if (!attachment)
         {
             return;
@@ -177,6 +206,7 @@ namespace AZ::Render
         {
             attachment->m_path = attachmentImage->GetAttachmentId();
             attachment->m_importedResource = attachmentImage;
+            m_attachmentImages[attachmentIndex] = attachmentImage;
         }
         else
         {

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.cpp
@@ -83,13 +83,12 @@ namespace AZ::Render
 
     void TaaPass::SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph)
     {
+        Base::SetupFrameGraphDependencies(frameGraph);
         if (ShouldCopyHistoryBuffer)
         {
             // Override the estimated item count to include the copy item.
             frameGraph.SetEstimatedItemCount(2);
         }
-
-        Base::SetupFrameGraphDependencies(frameGraph);
     }
 
     void TaaPass::FrameBeginInternal(FramePrepareParams params)

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ComputePass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ComputePass.h
@@ -53,7 +53,6 @@ namespace AZ
             void FrameBeginInternal(FramePrepareParams params) override;
 
             // Scope producer functions...
-            void SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph) override;
             void CompileResources(const RHI::FrameGraphCompileContext& context) override;
             void BuildCommandListInternal(const RHI::FrameGraphExecuteContext& context) override;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ComputePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ComputePass.cpp
@@ -149,11 +149,6 @@ namespace AZ
 
         // Scope producer functions
 
-        void ComputePass::SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph)
-        {
-            RenderPass::SetupFrameGraphDependencies(frameGraph);
-        }
-
         void ComputePass::CompileResources(const RHI::FrameGraphCompileContext& context)
         {
             if (m_shaderResourceGroup != nullptr)


### PR DESCRIPTION
## What does this PR do?

Previously, the TAA pass would swap between two images to manage its history buffer. The current frame's output would become the next frame's history, and the current frame's history would be overwritten on the next frame. This avoids needing to copy the image to the history buffer every frame. However, this method had a problem due to the way the pass system currently works.

The pass system has no way to mark textures as read-only, which means when a pass's output is used as the input for another pass, that pass may overwrite the same image with its own modifications. This was causing TAA's output buffer to be overwritten by all the postfx passes that came after it - bloom, dof, etc. So unfortunately, a copy needs to be added for now to avoid this problem.

I implemented this change in a way that keeps the old method around, so we should be able to easily revert back when the pass system is improved.

## How was this PR tested?

Tested primary on the loft scene which has a lot of post fx to ensure there was no longer a feedback loop on the post fx output being used as the history buffer.
