### PR TITLE
MaterialEditor starting periodic suite test for saving materials.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/Atom/CMakeLists.txt
@@ -149,7 +149,18 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED)
             AssetProcessor
             AutomatedTesting.Assets
             Editor
-            MaterialCanvas
+        COMPONENT
+            Atom
+    )
+    ly_add_pytest(
+        NAME AutomatedTesting::Atom_Periodic_Null_Render_MaterialEditor
+        TEST_SUITE periodic
+        TEST_SERIAL
+        TIMEOUT 1200
+        PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite_Periodic_Null_Render_MaterialEditor_01.py
+        RUNTIME_DEPENDENCIES
+            AssetProcessor
+            AutomatedTesting.Assets
             MaterialEditor
         COMPONENT
             Atom

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Periodic_Null_Render_MaterialEditor_01.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Periodic_Null_Render_MaterialEditor_01.py
@@ -1,0 +1,20 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+import pytest
+
+from ly_test_tools.o3de.atom_tools_test import AtomToolsBatchedTest, AtomToolsTestSuite
+
+
+@pytest.mark.parametrize("project", ["AutomatedTesting"])
+@pytest.mark.parametrize("launcher_platform", ['windows_atom_tools'])
+class TestMaterialEditorAtomPeriodic(AtomToolsTestSuite):
+
+    log_name = "material_editor_test.log"
+    atom_tools_executable_name = "MaterialEditor"
+
+    class MaterialEditor_Atom_PeriodicTests(AtomToolsBatchedTest):
+        from Atom.tests import MaterialEditor_Atom_PeriodicTests as test_module

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_PeriodicTests.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_PeriodicTests.py
@@ -1,0 +1,328 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+
+class Tests:
+    open_existing_material_document = (
+        "Existing material document opened successfully.",
+        "P0: Failed to open existing material document.")
+    close_opened_material_document = (
+        "Closed existing material document.",
+        "P0: Failed to close existing material document.")
+    close_all_opened_material_documents = (
+        "Closed all currently opened material documents.",
+        "P0: Failed to close all currently opened material documents.")
+    changed_material_document_color = (
+        "Material document color property value changed successfully.",
+        "P0: Failed to change the color property values of the material document.")
+    changed_material_document_metallic_factor = (
+        "Material document metallic factor property value changed successfully.",
+        "P0: Failed to change the metallic factor property of the material document.")
+    saved_material_document = (
+        "Material document was saved successfully.",
+        "P0: Material document could not be saved.")
+    verify_all_material_documents_are_opened = (
+        "Expected material documents are opened.",
+        "P0: Failed to verify the expected material documents are opened.")
+    verify_file_changes_saved = (
+        "Material document has expected changes saved.",
+        "P0: Failed to find expected changes saved for material document.")
+    reverted_original_material_document_color = (
+        "Material document color reverted to original value before saving.",
+        "P0: Failed to revert 'original_material_document material' document color to original value.")
+
+
+def MaterialEditor_FileSaveChecks_AllChecksPass():
+    """
+    Summary:
+    Tests basic MaterialEditor functionality that deals with file I/O writes (i.e. saving materials).
+
+    Expected Behavior:
+    All MaterialEditor tests dealing with file saving all pass without issues.
+
+    Test Steps:
+    1) Open an existing material document referred to as "original_material_document".
+    2) Change the baseColor.color property value of original_material_document to 0.25, 0.25, 0.25, 1.0.
+    3) Save over original_material_document.
+    4) Change the baseColor.color property value of original_material_document to 0.5, 0.5, 0.5, 1.0.
+    5) Save a new material document from original_material_document referred to as "new_material_document".
+    6) Change the baseColor.color property value of original_material_document to 0.75, 0.75, 0.75, 1.0.
+    7) Save a new child material document referred to as "child_material_document".
+    8) Close & open previously saved original_material_document, new_material_document, & child_material_document.
+    9) Verify the changes are saved in original_material_document.
+    10) Verify the changes are saved in new_material_document.
+    11) Verify the changes are saved in child_material_document.
+    12) Revert changes to original_material_document and save them.
+    13) Close all currently opened documents.
+    14) Open a material document referred to as "first_material_document".
+    15) Change the metallic.factor property value of first_material_document to 0.444.
+    16) Save the first_material_document as a new material document file.
+    17) Open a second material document referred to as "second_material_document".
+    18) Change the baseColor.color property value of the second_material_document to 0.4156, 0.0196, 0.6862, 1.0.
+    19) Save the second_material_document as a new material document file.
+    20) Close the first_material_document and second_material_document.
+    21) Open the first_material_document & verify the changes are saved.
+    22) Open the second_material_document & verify the changes are saved.
+    23) Revert changes to first_material_document and second_material_document then save.
+    24) Close all currently opened documents.
+    25) Look for errors and asserts.
+
+    :return: None
+    """
+    import os
+
+    import azlmbr.math
+    import azlmbr.paths
+
+    import Atom.atom_utils.atom_tools_utils as atom_tools_utils
+    import Atom.atom_utils.material_editor_utils as material_editor_utils
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+
+    with Tracer() as error_tracer:
+
+        # Set constants before starting test steps.
+        base_color_property_name = "baseColor.color"
+        metallic_factor_property_name = "metallic.factor"
+        original_material_document = os.path.join(
+            atom_tools_utils.TEST_DATA_MATERIALS_PATH, "StandardPbrTestCases", "001_DefaultWhite.material")
+        new_material_document = os.path.join(
+            atom_tools_utils.TEST_DATA_MATERIALS_PATH, "new_material_document.material")
+        child_material_document = os.path.join(
+            atom_tools_utils.TEST_DATA_MATERIALS_PATH, "child_material_document.material")
+        first_material_document = os.path.join(
+            atom_tools_utils.TEST_DATA_MATERIALS_PATH, "StandardPbrTestCases", "003_MetalMatte.material")
+        second_material_document = os.path.join(
+            atom_tools_utils.TEST_DATA_MATERIALS_PATH, "StandardPbrTestCases", "004_MetalMap.material")
+
+        # 1. Open an existing material document referred to as "original_material_document".
+        original_material_document_id = atom_tools_utils.open_document(original_material_document)
+        starting_material_document_color = material_editor_utils.get_property(
+            original_material_document_id, base_color_property_name)
+        Report.result(
+            Tests.open_existing_material_document,
+            atom_tools_utils.is_document_open(original_material_document_id) is True)
+
+        # 2. Change the baseColor.color property value of original_material_document to 0.25, 0.25, 0.25, 1.0.
+        original_material_document_color = azlmbr.math.Color(0.25, 0.25, 0.25, 1.0)
+        material_editor_utils.set_property(
+            original_material_document_id, base_color_property_name, original_material_document_color)
+        Report.result(
+            Tests.changed_material_document_color,
+            material_editor_utils.get_property(
+                original_material_document_id, base_color_property_name) == original_material_document_color)
+
+        # 3. Save over original_material_document.
+        original_material_document_saved = atom_tools_utils.save_document(original_material_document_id)
+        Report.result(
+            Tests.saved_material_document,
+            original_material_document_saved is True)
+
+        # 4. Change the baseColor.color property value of original_material_document to 0.5, 0.5, 0.5, 1.0.
+        new_material_document_color = azlmbr.math.Color(0.5, 0.5, 0.5, 1.0)
+        material_editor_utils.set_property(
+            original_material_document_id, base_color_property_name, new_material_document_color)
+        Report.result(
+            Tests.changed_material_document_color,
+            material_editor_utils.get_property(
+                original_material_document_id, base_color_property_name) == new_material_document_color)
+
+        # 5. Save a new material document from original_material_document referred to as "new_material_document".
+        new_material_document_saved = atom_tools_utils.save_document_as_copy(
+            original_material_document_id, new_material_document)
+        Report.result(
+            Tests.saved_material_document,
+            new_material_document_saved is True)
+
+        # 6. Change the baseColor.color property value of original_material_document to 0.75, 0.75, 0.75, 1.0.
+        child_material_document_color = azlmbr.math.Color(0.75, 0.75, 0.75, 1.0)
+        material_editor_utils.set_property(
+            original_material_document_id, base_color_property_name, child_material_document_color)
+        Report.result(
+            Tests.changed_material_document_color,
+            material_editor_utils.get_property(
+                original_material_document_id, base_color_property_name) == child_material_document_color)
+
+        # 7. Save a new child material document referred to as "child_material_document".
+        child_material_document_saved = atom_tools_utils.save_document_as_child(
+            original_material_document_id, child_material_document)
+        Report.result(
+            Tests.saved_material_document,
+            child_material_document_saved is True)
+
+        # 8. Close & open previously saved original_material_document, new_material_document, & child_material_document.
+        closed_all_material_documents = atom_tools_utils.close_all_documents()
+        Report.result(
+            Tests.close_all_opened_material_documents,
+            closed_all_material_documents is True)
+
+        original_material_document_id = atom_tools_utils.open_document(original_material_document)
+        new_material_document_id = atom_tools_utils.open_document(new_material_document)
+        child_material_document_id = atom_tools_utils.open_document(child_material_document)
+        material_document_ids = [original_material_document_id, new_material_document_id, child_material_document_id]
+        for material_document_id in material_document_ids:
+            Report.result(
+                Tests.verify_all_material_documents_are_opened,
+                atom_tools_utils.is_document_open(material_document_id) is True)
+
+        # 9. Verify the changes are saved in original_material_document.
+        Report.result(
+            Tests.verify_file_changes_saved,
+            material_editor_utils.get_property(
+                original_material_document_id, base_color_property_name) == original_material_document_color)
+
+        # 10. Verify the changes are saved in new_material_document.
+        Report.result(
+            Tests.verify_file_changes_saved,
+            material_editor_utils.get_property(
+                new_material_document_id, base_color_property_name) == new_material_document_color)
+
+        # 11. Verify the changes are saved in child_material_document.
+        Report.result(
+            Tests.verify_file_changes_saved,
+            material_editor_utils.get_property(
+                child_material_document_id, base_color_property_name) == child_material_document_color)
+
+        # 12. Revert original_material_document color to starting_material_document_color and save it.
+        material_editor_utils.set_property(
+            original_material_document_id, base_color_property_name, starting_material_document_color)
+        Report.result(
+            Tests.reverted_original_material_document_color,
+            material_editor_utils.get_property(
+                original_material_document_id, base_color_property_name) == starting_material_document_color)
+        original_document_saved = atom_tools_utils.save_document(original_material_document_id)
+        Report.result(
+            Tests.saved_material_document,
+            original_document_saved is True)
+
+        # 13. Close all currently opened documents.
+        closed_all_material_documents = atom_tools_utils.close_all_documents()
+        Report.result(
+            Tests.close_all_opened_material_documents,
+            closed_all_material_documents is True)
+        for material_document_id in material_document_ids:
+            Report.result(
+                Tests.verify_all_material_documents_are_opened,
+                atom_tools_utils.is_document_open(material_document_id) is False)
+
+        # 14. Open a material document referred to as "first_material_document".
+        first_material_document_id = atom_tools_utils.open_document(first_material_document)
+        Report.result(
+            Tests.open_existing_material_document,
+            atom_tools_utils.is_document_open(first_material_document_id) is True)
+
+        # 15. Change the metallic.factor property value of first_material_document to 0.444.
+        starting_first_material_document_metallic_factor = material_editor_utils.get_property(
+            first_material_document_id, metallic_factor_property_name)
+        first_material_document_metallic_factor = 0.444
+        material_editor_utils.set_property(
+            first_material_document_id, metallic_factor_property_name, first_material_document_metallic_factor)
+        Report.result(
+            Tests.changed_material_document_metallic_factor,
+            material_editor_utils.get_property(
+                first_material_document_id, metallic_factor_property_name) == first_material_document_metallic_factor)
+
+        # 16. Save the first_material_document as a new material document file.
+        first_material_document_saved = atom_tools_utils.save_document(first_material_document_id)
+        Report.result(
+            Tests.saved_material_document,
+            first_material_document_saved is True)
+
+        # 17. Open a second material document referred to as "second_material_document".
+        second_material_document_id = atom_tools_utils.open_document(second_material_document)
+        Report.result(
+            Tests.open_existing_material_document,
+            atom_tools_utils.is_document_open(second_material_document_id) is True)
+
+        # 18. Change the baseColor.color property value of the second_material_document to 0.4156, 0.0196, 0.6862, 1.0.
+        starting_second_material_document_color = material_editor_utils.get_property(
+            second_material_document_id, base_color_property_name)
+        second_material_document_color = azlmbr.math.Color(0.4156, 0.0196, 0.6862, 1.0)
+        material_editor_utils.set_property(
+            second_material_document_id, base_color_property_name, second_material_document_color)
+        Report.result(
+            Tests.changed_material_document_color,
+            material_editor_utils.get_property(
+                second_material_document_id, base_color_property_name) == second_material_document_color)
+
+        # 19. Save the second_material_document as a new material document file.
+        second_material_document_saved = atom_tools_utils.save_document(second_material_document_id)
+        Report.result(
+            Tests.saved_material_document,
+            second_material_document_saved is True)
+
+        # 20. Close the first_material_document and second_material_document.
+        first_material_document_closed = atom_tools_utils.close_document(first_material_document_id)
+        Report.result(
+            Tests.close_opened_material_document,
+            first_material_document_closed is True)
+        second_material_document_closed = atom_tools_utils.close_document(second_material_document_id)
+        Report.result(
+            Tests.close_opened_material_document,
+            second_material_document_closed is True)
+
+        # 21. Open the first_material_document & verify the changes are saved.
+        first_material_document_id = atom_tools_utils.open_document(first_material_document)
+        Report.result(
+            Tests.changed_material_document_metallic_factor,
+            material_editor_utils.get_property(
+                first_material_document_id, metallic_factor_property_name) == first_material_document_metallic_factor)
+
+        # 22. Open the second_material_document & verify the changes are saved.
+        second_material_document_id = atom_tools_utils.open_document(second_material_document)
+        Report.result(
+            Tests.changed_material_document_color,
+            material_editor_utils.get_property(
+                second_material_document_id, base_color_property_name) == second_material_document_color)
+
+        # 23. Revert changes to first_material_document and second_material_document then save.
+        material_editor_utils.set_property(
+            first_material_document_id, metallic_factor_property_name, starting_first_material_document_metallic_factor)
+        Report.result(
+            Tests.changed_material_document_metallic_factor,
+            material_editor_utils.get_property(
+                first_material_document_id,
+                metallic_factor_property_name) == starting_first_material_document_metallic_factor)
+        material_editor_utils.set_property(
+            second_material_document_id, base_color_property_name, starting_second_material_document_color)
+        Report.result(
+            Tests.changed_material_document_color,
+            material_editor_utils.get_property(
+                second_material_document_id,
+                metallic_factor_property_name) == starting_second_material_document_color)
+
+        first_material_document_resaved = atom_tools_utils.save_document(first_material_document_id)
+        Report.result(
+            Tests.saved_material_document,
+            first_material_document_resaved is True)
+        second_material_document_resaved = atom_tools_utils.save_document(second_material_document_id)
+        Report.result(
+            Tests.saved_material_document,
+            second_material_document_resaved is True)
+
+        # 24. Close all currently opened documents.
+        closed_all_material_documents = atom_tools_utils.close_all_documents()
+        Report.result(
+            Tests.close_all_opened_material_documents,
+            closed_all_material_documents is True)
+        Report.result(
+            Tests.close_opened_material_document,
+            atom_tools_utils.is_document_open(first_material_document_id) is False)
+        Report.result(
+            Tests.close_opened_material_document,
+            atom_tools_utils.is_document_open(second_material_document_id) is False)
+
+        # 25. Look for errors and asserts.
+        TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+        for error_info in error_tracer.errors:
+            Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+        for assert_info in error_tracer.asserts:
+            Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(MaterialEditor_FileSaveChecks_AllChecksPass)

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_PeriodicTests.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_PeriodicTests.py
@@ -8,20 +8,20 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 
 class Tests:
     changed_original_material_document_color = (
-        "original_material_document_color baseColor property value was changed successfully.",
-        "P0: original_material_document_color failed to change baseColor property value.")
+        "original_material_document_color baseColor.color property value was changed successfully.",
+        "P0: original_material_document_color failed to change baseColor.color property value.")
     changed_new_material_document_color = (
-        "new_material_document_color baseColor property value was changed successfully.",
-        "P0: new_material_document_color failed to change baseColor property value.")
+        "new_material_document_color baseColor.color property value was changed successfully.",
+        "P0: new_material_document_color failed to change baseColor.color property value.")
     changed_child_material_document_color = (
-        "child_material_document baseColor property value was changed successfully.",
-        "P0: child_material_document failed to change baseColor property value.")
-    changed_first_material_document_metallic_factor = (
-        "first_material_document metallic factor property value changed successfully.",
-        "P0: Failed to change the first_material_document metallic factor property.")
+        "child_material_document baseColor.color property value was changed successfully.",
+        "P0: child_material_document failed to change baseColor.color property value.")
+    changed_first_material_document_color = (
+        "first_material_document color factor property value changed successfully.",
+        "P0: Failed to change the first_material_document color factor property.")
     changed_second_material_document_color = (
-        "second_material_document baseColor property value was changed successfully.",
-        "P0: second_material_document failed to change baseColor property value.")
+        "second_material_document baseColor.color property value was changed successfully.",
+        "P0: second_material_document failed to change baseColor.color property value.")
     closed_original_new_and_child_material_documents = (
         "Closed original_material_document, new_material_document, & child_material_document successfully.",
         "P0: Failed to close original_material_document, new_material_document, & child_material_document.")
@@ -71,14 +71,14 @@ class Tests:
         "second_material_document was re-saved successfully.",
         "P0: second_material_document could not be re-saved.")
     reverted_original_material_document_color = (
-        "original_material_document baseColor property value reverted to original value before changing it.",
-        "P0: Failed to revert original_material_document baseColor property value to original value.")
-    reverted_first_material_document_metallic_factor = (
-        "first_material_document metallic.factor property value reverted to original value before changing it.",
-        "P0: Failed to revert first_material_document metallic.factor property value to original value.")
+        "original_material_document baseColor.color property value reverted to original value before changing it.",
+        "P0: Failed to revert original_material_document baseColor.color property value to original value.")
+    reverted_first_material_document_color = (
+        "first_material_document baseColor.color property value reverted to original value before changing it.",
+        "P0: Failed to revert first_material_document baseColor.color property value to original value.")
     reverted_second_material_document_color = (
-        "second_material_document baseColor property value reverted to original value before changing it.",
-        "P0: Failed to revert second_material_document baseColor property value to original value.")
+        "second_material_document baseColor.color property value reverted to original value before changing it.",
+        "P0: Failed to revert second_material_document baseColor.color property value to original value.")
     saved_original_material_document = (
         "original_material_document was saved successfully.",
         "P0: original_material_document could not be saved.")
@@ -103,12 +103,12 @@ class Tests:
     saved_second_material_document = (
         "Changes saved successfully for second_material_document",
         "P0: second_material_document changes could not be saved.")
-    verified_first_material_document_metallic_factor = (
-        "Verified first_material_document property value for metallic.factor is accurate",
-        "P0: Unexpected first_material_document property value for metallic.factor returned.")
+    verified_first_material_document_color = (
+        "Verified first_material_document property value for baseColor.color is accurate",
+        "P0: Unexpected first_material_document property value for baseColor.color returned.")
     verified_second_material_document_color = (
-        "Verified second_material_document property value for baseColor is accurate",
-        "P0: Unexpected second_material_document property value for baseColor returned.")
+        "Verified second_material_document property value for baseColor.color is accurate",
+        "P0: Unexpected second_material_document property value for baseColor.color returned.")
 
 
 def MaterialEditor_FileSaveChecks_AllChecksPass():
@@ -134,7 +134,7 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
     12) Revert changes to original_material_document and save them.
     13) Close all currently opened documents.
     14) Open a material document referred to as "first_material_document".
-    15) Change the metallic.factor property value of first_material_document to 0.444.
+    15) Change the baseColor.color property value of first_material_document to 0.4156, 0.0196, 0.6862, 1.0.
     16) Save the first_material_document as a new material document file.
     17) Open a second material document referred to as "second_material_document".
     18) Change the baseColor.color property value of the second_material_document to 0.4156, 0.0196, 0.6862, 1.0.
@@ -162,7 +162,6 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
 
         # Set constants before starting test steps.
         base_color_property_name = "baseColor.color"
-        metallic_factor_property_name = "metallic.factor"
         original_material_document = os.path.join(
             atom_tools_utils.TEST_DATA_MATERIALS_PATH, "StandardPbrTestCases", "001_DefaultWhite.material")
         new_material_document = os.path.join(
@@ -289,16 +288,16 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
             Tests.opened_first_material_document,
             atom_tools_utils.is_document_open(first_material_document_id) is True)
 
-        # 15. Change the metallic.factor property value of first_material_document to 0.444.
-        starting_first_material_document_metallic_factor = material_editor_utils.get_property(
-            first_material_document_id, metallic_factor_property_name)
-        first_material_document_metallic_factor = 0.444
+        # 15. Change the baseColor.color property value of first_material_document to 0.0156, 0.0196, 0.0862, 1.0.
+        starting_first_material_document_color = material_editor_utils.get_property(
+            first_material_document_id, base_color_property_name)
+        first_material_document_color = azlmbr.math.Color(0.0156, 0.0196, 0.0862, 1.0)
         material_editor_utils.set_property(
-            first_material_document_id, metallic_factor_property_name, first_material_document_metallic_factor)
+            first_material_document_id, base_color_property_name, first_material_document_color)
         Report.result(
-            Tests.changed_first_material_document_metallic_factor,
+            Tests.changed_first_material_document_color,
             material_editor_utils.get_property(
-                first_material_document_id, metallic_factor_property_name) == first_material_document_metallic_factor)
+                first_material_document_id, base_color_property_name) == first_material_document_color)
 
         # 16. Save the first_material_document as a new material document file.
         first_material_document_saved = atom_tools_utils.save_document(first_material_document_id)
@@ -345,9 +344,9 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
             Tests.reopened_first_material_document,
             atom_tools_utils.is_document_open(first_material_document_id))
         Report.result(
-            Tests.verified_first_material_document_metallic_factor,
+            Tests.verified_first_material_document_color,
             material_editor_utils.get_property(
-                first_material_document_id, metallic_factor_property_name) == first_material_document_metallic_factor)
+                first_material_document_id, base_color_property_name) == first_material_document_color)
 
         # 22. Open the second_material_document & verify the changes are saved.
         second_material_document_id = atom_tools_utils.open_document(second_material_document)
@@ -361,19 +360,19 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
 
         # 23. Revert changes to first_material_document and second_material_document.
         material_editor_utils.set_property(
-            first_material_document_id, metallic_factor_property_name, starting_first_material_document_metallic_factor)
+            first_material_document_id, base_color_property_name, starting_first_material_document_color)
         Report.result(
-            Tests.reverted_first_material_document_metallic_factor,
+            Tests.reverted_first_material_document_color,
             material_editor_utils.get_property(
                 first_material_document_id,
-                metallic_factor_property_name) == starting_first_material_document_metallic_factor)
+                base_color_property_name) == starting_first_material_document_color)
         material_editor_utils.set_property(
             second_material_document_id, base_color_property_name, starting_second_material_document_color)
         Report.result(
             Tests.reverted_second_material_document_color,
             material_editor_utils.get_property(
                 second_material_document_id,
-                metallic_factor_property_name) == starting_second_material_document_color)
+                base_color_property_name) == starting_second_material_document_color)
 
         # 24. Re-save first_material_document and second_material_document to restore their original values.
         first_material_document_resaved = atom_tools_utils.save_document(first_material_document_id)

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_PeriodicTests.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_PeriodicTests.py
@@ -17,7 +17,7 @@ class Tests:
         "child_material_document baseColor.color property value was changed successfully.",
         "P0: child_material_document failed to change baseColor.color property value.")
     changed_first_material_document_color = (
-        "first_material_document color factor property value changed successfully.",
+        "first_material_document baseColor.color property value changed successfully.",
         "P0: Failed to change the first_material_document color factor property.")
     changed_second_material_document_color = (
         "second_material_document baseColor.color property value was changed successfully.",
@@ -34,18 +34,30 @@ class Tests:
     closed_first_and_second_material_documents = (
         "Closed first_material_document & second_material_document successfully.",
         "P0: Failed to close first_material_document & second_material_document.")
+    first_material_document_has_expected_starting_color = (
+        "first_material_document has expected baseColor.color property value",
+        "P0: first_material_document did not have expected baseColor.color property value.")
+    first_material_document_is_not_open = (
+        "first_material_document is not currently open.",
+        "P0: first_material_document was unexpectedly open.")
     opened_original_material_document = (
         "original_material_document opened successfully",
         "P0: Failed to open original_material_document.")
-    opened_original_new_child_material_documents = (
-        "Opened original_material_document, new_material_document, & child_material_document.",
-        "P0: Failed to open original_material_document, new_material_document, & child_material_document.")
     opened_first_material_document = (
         "Opened first_material_document.",
         "P0: Failed to open first_material_document.")
     opened_second_material_document = (
         "Opened second_material_document.",
         "P0: Failed to open second_material_document.")
+    opened_first_material_document_copy = (
+        "Opened first_material_document_copy successfully",
+        "P0: Failed to open first_material_document_copy.")
+    opened_second_material_document_copy = (
+        "Opened second_material_document_copy successfully",
+        "P0: Failed to open second_material_document_copy.")
+    original_material_document_has_expected_starting_color = (
+        "original_material_document has expected baseColor.color property value",
+        "P0: original_material_document did not have expected baseColor.color property value.")
     reclosed_original_new_child_material_documents = (
         "Re-closed original_material_document, new_material_document, & child_material_document.",
         "P0: Failed to re-close original_material_document, new_material_document, & child_material_document.")
@@ -55,12 +67,6 @@ class Tests:
     reclosed_second_material_document = (
         "Re-closed second material document.",
         "P0: Failed to re-cloe second material document.")
-    reopened_first_material_document = (
-        "Re-opened first_material_document successfully",
-        "P0: Failed to re-open first_material_document.")
-    reopened_second_material_document = (
-        "Re-opened second_material_document successfully",
-        "P0: Failed to re-open second_material_document.")
     resaved_original_material_document = (
         "original_material_document was re-saved successfully.",
         "P0: original_material_document could not be re-saved.")
@@ -103,11 +109,17 @@ class Tests:
     saved_second_material_document = (
         "Changes saved successfully for second_material_document",
         "P0: second_material_document changes could not be saved.")
+    second_material_document_has_expected_starting_color = (
+        "second_material_document has expected baseColor.color property value",
+        "P0: second_material_document did not have expected baseColor.color property value.")
+    second_material_document_is_not_open = (
+        "second_material_document is not currently open.",
+        "P0: second_material_document was unexpectedly open.")
     verified_first_material_document_color = (
-        "Verified first_material_document property value for baseColor.color is accurate",
+        "Verified first_material_document_copy property value for baseColor.color is accurate",
         "P0: Unexpected first_material_document property value for baseColor.color returned.")
     verified_second_material_document_color = (
-        "Verified second_material_document property value for baseColor.color is accurate",
+        "Verified second_material_document_copy property value for baseColor.color is accurate",
         "P0: Unexpected second_material_document property value for baseColor.color returned.")
 
 
@@ -121,38 +133,41 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
 
     Test Steps:
     1) Open an existing material document referred to as "original_material_document".
-    2) Change the baseColor.color property value of original_material_document to 0.25, 0.25, 0.25, 1.0.
-    3) Save over original_material_document.
-    4) Change the baseColor.color property value of original_material_document to 0.5, 0.5, 0.5, 1.0.
-    5) Save a new material document from original_material_document referred to as "new_material_document".
-    6) Change the baseColor.color property value of original_material_document to 0.75, 0.75, 0.75, 1.0.
-    7) Save a new child material document referred to as "child_material_document".
-    8) Close & open previously saved original_material_document, new_material_document, & child_material_document.
-    9) Verify the changes are saved in original_material_document.
-    10) Verify the changes are saved in new_material_document.
-    11) Verify the changes are saved in child_material_document.
-    12) Revert changes to original_material_document and save them.
-    13) Close all currently opened documents.
-    14) Open a material document referred to as "first_material_document".
-    15) Change the baseColor.color property value of first_material_document to 0.4156, 0.0196, 0.6862, 1.0.
-    16) Save the first_material_document as a new material document file.
-    17) Open a second material document referred to as "second_material_document".
-    18) Change the baseColor.color property value of the second_material_document to 0.4156, 0.0196, 0.6862, 1.0.
-    19) Save the second_material_document as a new material document file.
-    20) Close the first_material_document and second_material_document.
-    21) Open the first_material_document & verify the changes are saved.
-    22) Open the second_material_document & verify the changes are saved.
-    23) Revert changes to first_material_document and second_material_document.
-    24) Re-save first_material_document and second_material_document to restore their original values.
-    25) Close all currently opened documents.
-    26) Look for errors and asserts.
+    2) Verify original_material_document baseColor.color property value is 255.0, 255.0, 255.0, 1.0.
+    3) Change the baseColor.color property value of original_material_document to 0.25, 0.25, 0.25, 1.0.
+    4) Save over original_material_document.
+    5) Change the baseColor.color property value of original_material_document to 0.5, 0.5, 0.5, 1.0.
+    6) Save a new material document from original_material_document referred to as "new_material_document".
+    7) Change the baseColor.color property value of original_material_document to 0.75, 0.75, 0.75, 1.0.
+    8) Save a new child material document referred to as "child_material_document".
+    9) Close & open previously saved original_material_document, new_material_document, & child_material_document.
+    10) Verify the changes are saved in original_material_document.
+    11) Verify the changes are saved in new_material_document.
+    12) Verify the changes are saved in child_material_document.
+    13) Revert changes to original_material_document and save them.
+    14) Close all currently opened documents.
+    15) Open a material document referred to as "first_material_document".
+    16) Verify first_material_document baseColor.color property value is 128.0, 128.0, 128.0, 1.0.
+    17) Change the baseColor.color property value of first_material_document to 0.4156, 0.0196, 0.6862, 1.0.
+    18) Save the first_material_document as a new material document file.
+    19) Open a second material document referred to as "second_material_document".
+    20) Verify second_material_document baseColor.color property value is 130.0, 130.0, 130.0, 1.0.
+    21) Change the baseColor.color property value of the second_material_document to 0.4156, 0.0196, 0.6862, 1.0.
+    22) Save the second_material_document as a new material document file.
+    23) Close the first_material_document and second_material_document.
+    24) Open the first_material_document & verify the changes are saved.
+    25) Open the second_material_document & verify the changes are saved.
+    26) Revert changes to first_material_document and second_material_document.
+    27) Re-save first_material_document and second_material_document to restore their original values.
+    28) Close all currently opened documents.
+    29) Look for errors and asserts.
 
     :return: None
     """
     import os
 
-    import azlmbr.math
     import azlmbr.paths
+    from azlmbr.math import Color
 
     import Atom.atom_utils.atom_tools_utils as atom_tools_utils
     import Atom.atom_utils.material_editor_utils as material_editor_utils
@@ -170,19 +185,28 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
             atom_tools_utils.TEST_DATA_MATERIALS_PATH, "child_material_document.material")
         first_material_document = os.path.join(
             atom_tools_utils.TEST_DATA_MATERIALS_PATH, "StandardPbrTestCases", "003_MetalMatte.material")
+        first_material_document_copy = os.path.join(
+            atom_tools_utils.TEST_DATA_MATERIALS_PATH, "first_material_document.material")
         second_material_document = os.path.join(
             atom_tools_utils.TEST_DATA_MATERIALS_PATH, "StandardPbrTestCases", "004_MetalMap.material")
+        second_material_document_copy = os.path.join(
+            atom_tools_utils.TEST_DATA_MATERIALS_PATH, "second_material_document.material")
 
         # 1. Open an existing material document referred to as "original_material_document".
         original_material_document_id = atom_tools_utils.open_document(original_material_document)
-        starting_material_document_color = material_editor_utils.get_property(
-            original_material_document_id, base_color_property_name)
         Report.result(
             Tests.opened_original_material_document,
             atom_tools_utils.is_document_open(original_material_document_id) is True)
 
-        # 2. Change the baseColor.color property value of original_material_document to 0.25, 0.25, 0.25, 1.0.
-        original_material_document_color = azlmbr.math.Color(0.25, 0.25, 0.25, 1.0)
+        # 2. Verify original_material_document baseColor.color property value is 255.0, 255.0, 255.0, 1.0.
+        expected_original_material_starting_color = Color(255.0, 255.0, 255.0, 1.0)
+        Report.result(
+            Tests.original_material_document_has_expected_starting_color,
+            material_editor_utils.get_property(
+                original_material_document_id, base_color_property_name) == expected_original_material_starting_color)
+
+        # 3. Change the baseColor.color property value of original_material_document to 0.25, 0.25, 0.25, 1.0.
+        original_material_document_color = Color(0.25, 0.25, 0.25, 1.0)
         material_editor_utils.set_property(
             original_material_document_id, base_color_property_name, original_material_document_color)
         Report.result(
@@ -190,14 +214,14 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
             material_editor_utils.get_property(
                 original_material_document_id, base_color_property_name) == original_material_document_color)
 
-        # 3. Save over original_material_document.
+        # 4. Save over original_material_document.
         original_material_document_saved = atom_tools_utils.save_document(original_material_document_id)
         Report.result(
             Tests.saved_original_material_document,
             original_material_document_saved is True)
 
-        # 4. Change the baseColor.color property value of original_material_document to 0.5, 0.5, 0.5, 1.0.
-        new_material_document_color = azlmbr.math.Color(0.5, 0.5, 0.5, 1.0)
+        # 5. Change the baseColor.color property value of original_material_document to 0.5, 0.5, 0.5, 1.0.
+        new_material_document_color = Color(0.5, 0.5, 0.5, 1.0)
         material_editor_utils.set_property(
             original_material_document_id, base_color_property_name, new_material_document_color)
         Report.result(
@@ -205,15 +229,15 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
             material_editor_utils.get_property(
                 original_material_document_id, base_color_property_name) == new_material_document_color)
 
-        # 5. Save a new material document from original_material_document referred to as "new_material_document".
+        # 6. Save a new material document from original_material_document referred to as "new_material_document".
         new_material_document_saved = atom_tools_utils.save_document_as_copy(
             original_material_document_id, new_material_document)
         Report.result(
             Tests.saved_new_material_document,
             new_material_document_saved is True)
 
-        # 6. Change the baseColor.color property value of original_material_document to 0.75, 0.75, 0.75, 1.0.
-        child_material_document_color = azlmbr.math.Color(0.75, 0.75, 0.75, 1.0)
+        # 7. Change the baseColor.color property value of original_material_document to 0.75, 0.75, 0.75, 1.0.
+        child_material_document_color = Color(0.75, 0.75, 0.75, 1.0)
         material_editor_utils.set_property(
             original_material_document_id, base_color_property_name, child_material_document_color)
         Report.result(
@@ -221,14 +245,14 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
             material_editor_utils.get_property(
                 original_material_document_id, base_color_property_name) == child_material_document_color)
 
-        # 7. Save a new child material document referred to as "child_material_document".
+        # 8. Save a new child material document referred to as "child_material_document".
         child_material_document_saved = atom_tools_utils.save_document_as_child(
             original_material_document_id, child_material_document)
         Report.result(
             Tests.saved_child_material_document,
             child_material_document_saved is True)
 
-        # 8. Close & open previously saved original_material_document, new_material_document, & child_material_document.
+        # 9. Close & open previously saved original_material_document, new_material_document, & child_material_document.
         closed_all_material_documents = atom_tools_utils.close_all_documents()
         Report.result(
             Tests.closed_original_new_and_child_material_documents,
@@ -236,62 +260,72 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
         original_material_document_id = atom_tools_utils.open_document(original_material_document)
         new_material_document_id = atom_tools_utils.open_document(new_material_document)
         child_material_document_id = atom_tools_utils.open_document(child_material_document)
-        material_document_ids = [original_material_document_id, new_material_document_id, child_material_document_id]
-        for material_document_id in material_document_ids:
+        material_document_ids = {
+            "original_material_document": original_material_document_id,
+            "new_material_document": new_material_document_id,
+            "child_material_document": child_material_document_id}
+        for material_document_key, material_document_id in material_document_ids.items():
             Report.result(
-                Tests.opened_original_new_child_material_documents,
+                (f"Opened {material_document_key} with document_id value of {material_document_id}",
+                 f"Failed to open {material_document_key} with document_id value of {material_document_id}"),
                 atom_tools_utils.is_document_open(material_document_id) is True)
 
-        # 9. Verify the changes are saved in original_material_document.
+        # 10. Verify the changes are saved in original_material_document.
         Report.result(
             Tests.saved_changes_to_original_material_document,
             material_editor_utils.get_property(
                 original_material_document_id, base_color_property_name) == original_material_document_color)
 
-        # 10. Verify the changes are saved in new_material_document.
+        # 11. Verify the changes are saved in new_material_document.
         Report.result(
             Tests.saved_changes_to_new_material_document,
             material_editor_utils.get_property(
                 new_material_document_id, base_color_property_name) == new_material_document_color)
 
-        # 11. Verify the changes are saved in child_material_document.
+        # 12. Verify the changes are saved in child_material_document.
         Report.result(
             Tests.saved_changes_to_child_material_document,
             material_editor_utils.get_property(
                 child_material_document_id, base_color_property_name) == child_material_document_color)
 
-        # 12. Revert original_material_document color to starting_material_document_color and save it.
+        # 13. Revert original_material_document color to expected_original_material_starting_color and save it.
         material_editor_utils.set_property(
-            original_material_document_id, base_color_property_name, starting_material_document_color)
-        Report.result(
-            Tests.reverted_original_material_document_color,
-            material_editor_utils.get_property(
-                original_material_document_id, base_color_property_name) == starting_material_document_color)
+            original_material_document_id, base_color_property_name, expected_original_material_starting_color)
         original_document_saved = atom_tools_utils.save_document(original_material_document_id)
         Report.result(
             Tests.resaved_original_material_document,
             original_document_saved is True)
+        Report.result(
+            Tests.reverted_original_material_document_color,
+            material_editor_utils.get_property(
+                original_material_document_id, base_color_property_name) == expected_original_material_starting_color)
 
-        # 13. Close all currently opened documents.
+        # 14. Close all currently opened documents.
         closed_all_material_documents = atom_tools_utils.close_all_documents()
         Report.result(
             Tests.reclosed_original_new_child_material_documents,
             closed_all_material_documents is True)
-        for material_document_id in material_document_ids:
+        for material_document_key, material_document_id in material_document_ids.items():
             Report.result(
-                Tests.reclosed_original_new_child_material_documents,
+                (f"Closed {material_document_key} with document_id value of {material_document_id}",
+                 f"Failed to close {material_document_key} with document_id value of {material_document_id}"),
                 atom_tools_utils.is_document_open(material_document_id) is False)
 
-        # 14. Open a material document referred to as "first_material_document".
+        # 15. Open a material document referred to as "first_material_document".
         first_material_document_id = atom_tools_utils.open_document(first_material_document)
         Report.result(
             Tests.opened_first_material_document,
             atom_tools_utils.is_document_open(first_material_document_id) is True)
 
-        # 15. Change the baseColor.color property value of first_material_document to 0.0156, 0.0196, 0.0862, 1.0.
-        starting_first_material_document_color = material_editor_utils.get_property(
-            first_material_document_id, base_color_property_name)
-        first_material_document_color = azlmbr.math.Color(0.0156, 0.0196, 0.0862, 1.0)
+        # 16. Verify first_material_document baseColor.color property value is 128.0, 128.0, 128.0, 1.0.
+        expected_first_material_starting_color = Color(128.0, 128.0, 128.0, 1.0)
+        Report.result(
+            Tests.first_material_document_has_expected_starting_color,
+            material_editor_utils.get_property(
+                first_material_document_id, base_color_property_name) == expected_first_material_starting_color)
+
+        # 17. Change the baseColor.color property value of first_material_document to 0.0156, 0.0196, 0.0862, 1.0.
+        first_material_document_color = Color(0.0156, 0.0196, 0.0862, 1.0)
         material_editor_utils.set_property(
             first_material_document_id, base_color_property_name, first_material_document_color)
         Report.result(
@@ -299,22 +333,28 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
             material_editor_utils.get_property(
                 first_material_document_id, base_color_property_name) == first_material_document_color)
 
-        # 16. Save the first_material_document as a new material document file.
-        first_material_document_saved = atom_tools_utils.save_document(first_material_document_id)
+        # 18. Save the first_material_document as a new material document file.
+        first_material_document_saved = atom_tools_utils.save_document_as_copy(
+            first_material_document_id, first_material_document_copy)
         Report.result(
             Tests.saved_first_material_document,
             first_material_document_saved is True)
 
-        # 17. Open a second material document referred to as "second_material_document".
+        # 19. Open a second material document referred to as "second_material_document".
         second_material_document_id = atom_tools_utils.open_document(second_material_document)
         Report.result(
             Tests.opened_second_material_document,
             atom_tools_utils.is_document_open(second_material_document_id) is True)
 
-        # 18. Change the baseColor.color property value of the second_material_document to 0.4156, 0.0196, 0.6862, 1.0.
-        starting_second_material_document_color = material_editor_utils.get_property(
-            second_material_document_id, base_color_property_name)
-        second_material_document_color = azlmbr.math.Color(0.4156, 0.0196, 0.6862, 1.0)
+        # 20. Verify second_material_document baseColor.color property value is 130.0, 130.0, 130.0, 1.0.
+        expected_second_material_starting_color = Color(130.0, 130.0, 130.0, 1.0)
+        Report.result(
+            Tests.second_material_document_has_expected_starting_color,
+            material_editor_utils.get_property(
+                second_material_document_id, base_color_property_name) == expected_second_material_starting_color)
+
+        # 21. Change the baseColor.color property value of the second_material_document to 0.4156, 0.0196, 0.6862, 1.0.
+        second_material_document_color = Color(0.4156, 0.0196, 0.6862, 1.0)
         material_editor_utils.set_property(
             second_material_document_id, base_color_property_name, second_material_document_color)
         Report.result(
@@ -322,59 +362,66 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
             material_editor_utils.get_property(
                 second_material_document_id, base_color_property_name) == second_material_document_color)
 
-        # 19. Save the second_material_document as a new material document file.
-        second_material_document_saved = atom_tools_utils.save_document(second_material_document_id)
+        # 22. Save the second_material_document as a new material document file.
+        second_material_document_saved = atom_tools_utils.save_document_as_copy(
+            second_material_document_id, second_material_document_copy)
         Report.result(
             Tests.saved_second_material_document,
             second_material_document_saved is True)
 
-        # 20. Close the first_material_document and second_material_document.
+        # 23. Close the first_material_document and second_material_document.
         first_material_document_closed = atom_tools_utils.close_document(first_material_document_id)
         Report.result(
             Tests.closed_first_material_document,
             first_material_document_closed is True)
+        Report.result(
+            Tests.first_material_document_is_not_open,
+            atom_tools_utils.is_document_open(first_material_document_id) is False)
         second_material_document_closed = atom_tools_utils.close_document(second_material_document_id)
         Report.result(
             Tests.closed_second_material_document,
             second_material_document_closed is True)
-
-        # 21. Open the first_material_document & verify the changes are saved.
-        first_material_document_id = atom_tools_utils.open_document(first_material_document)
         Report.result(
-            Tests.reopened_first_material_document,
-            atom_tools_utils.is_document_open(first_material_document_id))
+            Tests.second_material_document_is_not_open,
+            atom_tools_utils.is_document_open(second_material_document_id) is False)
+
+        # 24. Open the first_material_document & verify the changes are saved.
+        first_material_document_id = atom_tools_utils.open_document(first_material_document_copy)
+        Report.result(
+            Tests.opened_first_material_document_copy,
+            atom_tools_utils.is_document_open(first_material_document_id) is True)
         Report.result(
             Tests.verified_first_material_document_color,
             material_editor_utils.get_property(
                 first_material_document_id, base_color_property_name) == first_material_document_color)
 
-        # 22. Open the second_material_document & verify the changes are saved.
-        second_material_document_id = atom_tools_utils.open_document(second_material_document)
+        # 25. Open the second_material_document & verify the changes are saved.
+        second_material_document_id = atom_tools_utils.open_document(second_material_document_copy)
         Report.result(
-            Tests.reopened_second_material_document,
-            atom_tools_utils.is_document_open(first_material_document_id))
+            Tests.opened_second_material_document_copy,
+            atom_tools_utils.is_document_open(first_material_document_id) is True)
         Report.result(
             Tests.verified_second_material_document_color,
             material_editor_utils.get_property(
                 second_material_document_id, base_color_property_name) == second_material_document_color)
 
-        # 23. Revert changes to first_material_document and second_material_document.
+        # 26. Revert changes to first_material_document and second_material_document.
         material_editor_utils.set_property(
-            first_material_document_id, base_color_property_name, starting_first_material_document_color)
+            first_material_document_id, base_color_property_name, expected_first_material_starting_color)
         Report.result(
             Tests.reverted_first_material_document_color,
             material_editor_utils.get_property(
                 first_material_document_id,
-                base_color_property_name) == starting_first_material_document_color)
+                base_color_property_name) == expected_first_material_starting_color)
         material_editor_utils.set_property(
-            second_material_document_id, base_color_property_name, starting_second_material_document_color)
+            second_material_document_id, base_color_property_name, expected_second_material_starting_color)
         Report.result(
             Tests.reverted_second_material_document_color,
             material_editor_utils.get_property(
                 second_material_document_id,
-                base_color_property_name) == starting_second_material_document_color)
+                base_color_property_name) == expected_second_material_starting_color)
 
-        # 24. Re-save first_material_document and second_material_document to restore their original values.
+        # 27. Re-save first_material_document and second_material_document to restore their original values.
         first_material_document_resaved = atom_tools_utils.save_document(first_material_document_id)
         Report.result(
             Tests.resaved_first_material_document,
@@ -384,7 +431,7 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
             Tests.resaved_second_material_document,
             second_material_document_resaved is True)
 
-        # 25. Close all currently opened documents.
+        # 28. Close all currently opened documents.
         closed_all_material_documents = atom_tools_utils.close_all_documents()
         Report.result(
             Tests.closed_first_and_second_material_documents,
@@ -396,7 +443,7 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
             Tests.reclosed_second_material_document,
             atom_tools_utils.is_document_open(second_material_document_id) is False)
 
-        # 26. Look for errors and asserts.
+        # 28. Look for errors and asserts.
         TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
         for error_info in error_tracer.errors:
             Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_PeriodicTests.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_PeriodicTests.py
@@ -7,33 +7,108 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 
 
 class Tests:
-    open_existing_material_document = (
-        "Existing material document opened successfully.",
-        "P0: Failed to open existing material document.")
-    close_opened_material_document = (
-        "Closed existing material document.",
-        "P0: Failed to close existing material document.")
-    close_all_opened_material_documents = (
-        "Closed all currently opened material documents.",
-        "P0: Failed to close all currently opened material documents.")
-    changed_material_document_color = (
-        "Material document color property value changed successfully.",
-        "P0: Failed to change the color property values of the material document.")
-    changed_material_document_metallic_factor = (
-        "Material document metallic factor property value changed successfully.",
-        "P0: Failed to change the metallic factor property of the material document.")
-    saved_material_document = (
-        "Material document was saved successfully.",
-        "P0: Material document could not be saved.")
-    verify_all_material_documents_are_opened = (
-        "Expected material documents are opened.",
-        "P0: Failed to verify the expected material documents are opened.")
-    verify_file_changes_saved = (
-        "Material document has expected changes saved.",
-        "P0: Failed to find expected changes saved for material document.")
+    changed_original_material_document_color = (
+        "original_material_document_color baseColor property value was changed successfully.",
+        "P0: original_material_document_color failed to change baseColor property value.")
+    changed_new_material_document_color = (
+        "new_material_document_color baseColor property value was changed successfully.",
+        "P0: new_material_document_color failed to change baseColor property value.")
+    changed_child_material_document_color = (
+        "child_material_document baseColor property value was changed successfully.",
+        "P0: child_material_document failed to change baseColor property value.")
+    changed_first_material_document_metallic_factor = (
+        "first_material_document metallic factor property value changed successfully.",
+        "P0: Failed to change the first_material_document metallic factor property.")
+    changed_second_material_document_color = (
+        "second_material_document baseColor property value was changed successfully.",
+        "P0: second_material_document failed to change baseColor property value.")
+    closed_original_new_and_child_material_documents = (
+        "Closed original_material_document, new_material_document, & child_material_document successfully.",
+        "P0: Failed to close original_material_document, new_material_document, & child_material_document.")
+    closed_first_material_document = (
+        "Closed first_material_document successfully.",
+        "P0: Failed to close first_material_document.")
+    closed_second_material_document = (
+        "Closed second_material_document successfully.",
+        "P0: Failed to close second_material_document.")
+    closed_first_and_second_material_documents = (
+        "Closed first_material_document & second_material_document successfully.",
+        "P0: Failed to close first_material_document & second_material_document.")
+    opened_original_material_document = (
+        "original_material_document opened successfully",
+        "P0: Failed to open original_material_document.")
+    opened_original_new_child_material_documents = (
+        "Opened original_material_document, new_material_document, & child_material_document.",
+        "P0: Failed to open original_material_document, new_material_document, & child_material_document.")
+    opened_first_material_document = (
+        "Opened first_material_document.",
+        "P0: Failed to open first_material_document.")
+    opened_second_material_document = (
+        "Opened second_material_document.",
+        "P0: Failed to open second_material_document.")
+    reclosed_original_new_child_material_documents = (
+        "Re-closed original_material_document, new_material_document, & child_material_document.",
+        "P0: Failed to re-close original_material_document, new_material_document, & child_material_document.")
+    reclosed_first_material_document = (
+        "Re-closed first_material_document.",
+        "P0: Failed to re-close first_material_document.")
+    reclosed_second_material_document = (
+        "Re-closed second material document.",
+        "P0: Failed to re-cloe second material document.")
+    reopened_first_material_document = (
+        "Re-opened first_material_document successfully",
+        "P0: Failed to re-open first_material_document.")
+    reopened_second_material_document = (
+        "Re-opened second_material_document successfully",
+        "P0: Failed to re-open second_material_document.")
+    resaved_original_material_document = (
+        "original_material_document was re-saved successfully.",
+        "P0: original_material_document could not be re-saved.")
+    resaved_first_material_document = (
+        "first_material_document was re-saved successfully.",
+        "P0: first_material_document could not be re-saved.")
+    resaved_second_material_document = (
+        "second_material_document was re-saved successfully.",
+        "P0: second_material_document could not be re-saved.")
     reverted_original_material_document_color = (
-        "Material document color reverted to original value before saving.",
-        "P0: Failed to revert 'original_material_document material' document color to original value.")
+        "original_material_document baseColor property value reverted to original value before changing it.",
+        "P0: Failed to revert original_material_document baseColor property value to original value.")
+    reverted_first_material_document_metallic_factor = (
+        "first_material_document metallic.factor property value reverted to original value before changing it.",
+        "P0: Failed to revert first_material_document metallic.factor property value to original value.")
+    reverted_second_material_document_color = (
+        "second_material_document baseColor property value reverted to original value before changing it.",
+        "P0: Failed to revert second_material_document baseColor property value to original value.")
+    saved_original_material_document = (
+        "original_material_document was saved successfully.",
+        "P0: original_material_document could not be saved.")
+    saved_new_material_document = (
+        "new_material_document was saved successfully.",
+        "P0: new_material_document could not be saved.")
+    saved_child_material_document = (
+        "child_material_document was saved successfully.",
+        "P0: child_material_document could not be saved.")
+    saved_changes_to_original_material_document = (
+        "Changes saved successfully for original_material_document",
+        "P0: original_material_document changes could not be saved.")
+    saved_changes_to_new_material_document = (
+        "Changes saved successfully for new_material_document",
+        "P0: new_material_document changes could not be saved.")
+    saved_first_material_document = (
+        "Changes saved successfully for first_material_document",
+        "P0: first_material_document changes could not be saved.")
+    saved_changes_to_child_material_document = (
+        "Changes saved successfully for child_material_document",
+        "P0: child_material_document changes could not be saved.")
+    saved_second_material_document = (
+        "Changes saved successfully for second_material_document",
+        "P0: second_material_document changes could not be saved.")
+    verified_first_material_document_metallic_factor = (
+        "Verified first_material_document property value for metallic.factor is accurate",
+        "P0: Unexpected first_material_document property value for metallic.factor returned.")
+    verified_second_material_document_color = (
+        "Verified second_material_document property value for baseColor is accurate",
+        "P0: Unexpected second_material_document property value for baseColor returned.")
 
 
 def MaterialEditor_FileSaveChecks_AllChecksPass():
@@ -67,9 +142,10 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
     20) Close the first_material_document and second_material_document.
     21) Open the first_material_document & verify the changes are saved.
     22) Open the second_material_document & verify the changes are saved.
-    23) Revert changes to first_material_document and second_material_document then save.
-    24) Close all currently opened documents.
-    25) Look for errors and asserts.
+    23) Revert changes to first_material_document and second_material_document.
+    24) Re-save first_material_document and second_material_document to restore their original values.
+    25) Close all currently opened documents.
+    26) Look for errors and asserts.
 
     :return: None
     """
@@ -103,7 +179,7 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
         starting_material_document_color = material_editor_utils.get_property(
             original_material_document_id, base_color_property_name)
         Report.result(
-            Tests.open_existing_material_document,
+            Tests.opened_original_material_document,
             atom_tools_utils.is_document_open(original_material_document_id) is True)
 
         # 2. Change the baseColor.color property value of original_material_document to 0.25, 0.25, 0.25, 1.0.
@@ -111,14 +187,14 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
         material_editor_utils.set_property(
             original_material_document_id, base_color_property_name, original_material_document_color)
         Report.result(
-            Tests.changed_material_document_color,
+            Tests.changed_original_material_document_color,
             material_editor_utils.get_property(
                 original_material_document_id, base_color_property_name) == original_material_document_color)
 
         # 3. Save over original_material_document.
         original_material_document_saved = atom_tools_utils.save_document(original_material_document_id)
         Report.result(
-            Tests.saved_material_document,
+            Tests.saved_original_material_document,
             original_material_document_saved is True)
 
         # 4. Change the baseColor.color property value of original_material_document to 0.5, 0.5, 0.5, 1.0.
@@ -126,7 +202,7 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
         material_editor_utils.set_property(
             original_material_document_id, base_color_property_name, new_material_document_color)
         Report.result(
-            Tests.changed_material_document_color,
+            Tests.changed_new_material_document_color,
             material_editor_utils.get_property(
                 original_material_document_id, base_color_property_name) == new_material_document_color)
 
@@ -134,7 +210,7 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
         new_material_document_saved = atom_tools_utils.save_document_as_copy(
             original_material_document_id, new_material_document)
         Report.result(
-            Tests.saved_material_document,
+            Tests.saved_new_material_document,
             new_material_document_saved is True)
 
         # 6. Change the baseColor.color property value of original_material_document to 0.75, 0.75, 0.75, 1.0.
@@ -142,7 +218,7 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
         material_editor_utils.set_property(
             original_material_document_id, base_color_property_name, child_material_document_color)
         Report.result(
-            Tests.changed_material_document_color,
+            Tests.changed_child_material_document_color,
             material_editor_utils.get_property(
                 original_material_document_id, base_color_property_name) == child_material_document_color)
 
@@ -150,39 +226,38 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
         child_material_document_saved = atom_tools_utils.save_document_as_child(
             original_material_document_id, child_material_document)
         Report.result(
-            Tests.saved_material_document,
+            Tests.saved_child_material_document,
             child_material_document_saved is True)
 
         # 8. Close & open previously saved original_material_document, new_material_document, & child_material_document.
         closed_all_material_documents = atom_tools_utils.close_all_documents()
         Report.result(
-            Tests.close_all_opened_material_documents,
+            Tests.closed_original_new_and_child_material_documents,
             closed_all_material_documents is True)
-
         original_material_document_id = atom_tools_utils.open_document(original_material_document)
         new_material_document_id = atom_tools_utils.open_document(new_material_document)
         child_material_document_id = atom_tools_utils.open_document(child_material_document)
         material_document_ids = [original_material_document_id, new_material_document_id, child_material_document_id]
         for material_document_id in material_document_ids:
             Report.result(
-                Tests.verify_all_material_documents_are_opened,
+                Tests.opened_original_new_child_material_documents,
                 atom_tools_utils.is_document_open(material_document_id) is True)
 
         # 9. Verify the changes are saved in original_material_document.
         Report.result(
-            Tests.verify_file_changes_saved,
+            Tests.saved_changes_to_original_material_document,
             material_editor_utils.get_property(
                 original_material_document_id, base_color_property_name) == original_material_document_color)
 
         # 10. Verify the changes are saved in new_material_document.
         Report.result(
-            Tests.verify_file_changes_saved,
+            Tests.saved_changes_to_new_material_document,
             material_editor_utils.get_property(
                 new_material_document_id, base_color_property_name) == new_material_document_color)
 
         # 11. Verify the changes are saved in child_material_document.
         Report.result(
-            Tests.verify_file_changes_saved,
+            Tests.saved_changes_to_child_material_document,
             material_editor_utils.get_property(
                 child_material_document_id, base_color_property_name) == child_material_document_color)
 
@@ -195,23 +270,23 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
                 original_material_document_id, base_color_property_name) == starting_material_document_color)
         original_document_saved = atom_tools_utils.save_document(original_material_document_id)
         Report.result(
-            Tests.saved_material_document,
+            Tests.resaved_original_material_document,
             original_document_saved is True)
 
         # 13. Close all currently opened documents.
         closed_all_material_documents = atom_tools_utils.close_all_documents()
         Report.result(
-            Tests.close_all_opened_material_documents,
+            Tests.reclosed_original_new_child_material_documents,
             closed_all_material_documents is True)
         for material_document_id in material_document_ids:
             Report.result(
-                Tests.verify_all_material_documents_are_opened,
+                Tests.reclosed_original_new_child_material_documents,
                 atom_tools_utils.is_document_open(material_document_id) is False)
 
         # 14. Open a material document referred to as "first_material_document".
         first_material_document_id = atom_tools_utils.open_document(first_material_document)
         Report.result(
-            Tests.open_existing_material_document,
+            Tests.opened_first_material_document,
             atom_tools_utils.is_document_open(first_material_document_id) is True)
 
         # 15. Change the metallic.factor property value of first_material_document to 0.444.
@@ -221,20 +296,20 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
         material_editor_utils.set_property(
             first_material_document_id, metallic_factor_property_name, first_material_document_metallic_factor)
         Report.result(
-            Tests.changed_material_document_metallic_factor,
+            Tests.changed_first_material_document_metallic_factor,
             material_editor_utils.get_property(
                 first_material_document_id, metallic_factor_property_name) == first_material_document_metallic_factor)
 
         # 16. Save the first_material_document as a new material document file.
         first_material_document_saved = atom_tools_utils.save_document(first_material_document_id)
         Report.result(
-            Tests.saved_material_document,
+            Tests.saved_first_material_document,
             first_material_document_saved is True)
 
         # 17. Open a second material document referred to as "second_material_document".
         second_material_document_id = atom_tools_utils.open_document(second_material_document)
         Report.result(
-            Tests.open_existing_material_document,
+            Tests.opened_second_material_document,
             atom_tools_utils.is_document_open(second_material_document_id) is True)
 
         # 18. Change the baseColor.color property value of the second_material_document to 0.4156, 0.0196, 0.6862, 1.0.
@@ -244,78 +319,85 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
         material_editor_utils.set_property(
             second_material_document_id, base_color_property_name, second_material_document_color)
         Report.result(
-            Tests.changed_material_document_color,
+            Tests.changed_second_material_document_color,
             material_editor_utils.get_property(
                 second_material_document_id, base_color_property_name) == second_material_document_color)
 
         # 19. Save the second_material_document as a new material document file.
         second_material_document_saved = atom_tools_utils.save_document(second_material_document_id)
         Report.result(
-            Tests.saved_material_document,
+            Tests.saved_second_material_document,
             second_material_document_saved is True)
 
         # 20. Close the first_material_document and second_material_document.
         first_material_document_closed = atom_tools_utils.close_document(first_material_document_id)
         Report.result(
-            Tests.close_opened_material_document,
+            Tests.closed_first_material_document,
             first_material_document_closed is True)
         second_material_document_closed = atom_tools_utils.close_document(second_material_document_id)
         Report.result(
-            Tests.close_opened_material_document,
+            Tests.closed_second_material_document,
             second_material_document_closed is True)
 
         # 21. Open the first_material_document & verify the changes are saved.
         first_material_document_id = atom_tools_utils.open_document(first_material_document)
         Report.result(
-            Tests.changed_material_document_metallic_factor,
+            Tests.reopened_first_material_document,
+            atom_tools_utils.is_document_open(first_material_document_id))
+        Report.result(
+            Tests.verified_first_material_document_metallic_factor,
             material_editor_utils.get_property(
                 first_material_document_id, metallic_factor_property_name) == first_material_document_metallic_factor)
 
         # 22. Open the second_material_document & verify the changes are saved.
         second_material_document_id = atom_tools_utils.open_document(second_material_document)
         Report.result(
-            Tests.changed_material_document_color,
+            Tests.reopened_second_material_document,
+            atom_tools_utils.is_document_open(first_material_document_id))
+        Report.result(
+            Tests.verified_second_material_document_color,
             material_editor_utils.get_property(
                 second_material_document_id, base_color_property_name) == second_material_document_color)
 
-        # 23. Revert changes to first_material_document and second_material_document then save.
+        # 23. Revert changes to first_material_document and second_material_document.
         material_editor_utils.set_property(
             first_material_document_id, metallic_factor_property_name, starting_first_material_document_metallic_factor)
         Report.result(
-            Tests.changed_material_document_metallic_factor,
+            Tests.reverted_first_material_document_metallic_factor,
             material_editor_utils.get_property(
                 first_material_document_id,
                 metallic_factor_property_name) == starting_first_material_document_metallic_factor)
         material_editor_utils.set_property(
             second_material_document_id, base_color_property_name, starting_second_material_document_color)
         Report.result(
-            Tests.changed_material_document_color,
+            Tests.reverted_second_material_document_color,
             material_editor_utils.get_property(
                 second_material_document_id,
                 metallic_factor_property_name) == starting_second_material_document_color)
 
+        # 24. Re-save first_material_document and second_material_document to restore their original values.
         first_material_document_resaved = atom_tools_utils.save_document(first_material_document_id)
         Report.result(
-            Tests.saved_material_document,
+            Tests.resaved_first_material_document,
             first_material_document_resaved is True)
         second_material_document_resaved = atom_tools_utils.save_document(second_material_document_id)
         Report.result(
-            Tests.saved_material_document,
+            Tests.resaved_second_material_document,
             second_material_document_resaved is True)
 
-        # 24. Close all currently opened documents.
+        # 25. Close all currently opened documents.
         closed_all_material_documents = atom_tools_utils.close_all_documents()
         Report.result(
-            Tests.close_all_opened_material_documents,
+            Tests.closed_first_and_second_material_documents,
             closed_all_material_documents is True)
         Report.result(
-            Tests.close_opened_material_document,
+            Tests.reclosed_first_material_document,
             atom_tools_utils.is_document_open(first_material_document_id) is False)
         Report.result(
-            Tests.close_opened_material_document,
+            Tests.reclosed_second_material_document,
             atom_tools_utils.is_document_open(second_material_document_id) is False)
 
-        # 25. Look for errors and asserts.
+        # 26. Look for errors and asserts.
         TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
         for error_info in error_tracer.errors:
             Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")


### PR DESCRIPTION
## What does this PR do?
Re-adds the deleted tests from https://github.com/o3de/o3de/pull/12583/files that deal with saving materials after updating them. These tests had to be moved to the periodic suite because they deal with saving files to disk and we try to avoid that as much as possible in the main suite (causes intermittent failures).

## How was this PR tested?
1. Test command used: `C:\git\o3de\python\runtime\python-3.10.5-rev1-windows\python\python.exe -m pytest -vv -s --build-directory="C:\git\o3de\build\bin\profile" C:\git\o3de\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Periodic_Null_Render_MaterialEditor_01.py`
2. Test output:
```py
Starting test MaterialEditor_FileSaveChecks_AllChecksPass...
Test MaterialEditor_FileSaveChecks_AllChecksPass finished.
Report:
[SUCCESS] Success: original_material_document opened successfully
[SUCCESS] Success: original_material_document_color baseColor.color property value was changed successfully.
[SUCCESS] Success: original_material_document was saved successfully.
[SUCCESS] Success: new_material_document_color baseColor.color property value was changed successfully.
[SUCCESS] Success: new_material_document was saved successfully.
[SUCCESS] Success: child_material_document baseColor.color property value was changed successfully.
[SUCCESS] Success: child_material_document was saved successfully.
[SUCCESS] Success: Closed original_material_document, new_material_document, & child_material_document successfully.
[SUCCESS] Success: Opened original_material_document, new_material_document, & child_material_document.
[SUCCESS] Success: Opened original_material_document, new_material_document, & child_material_document.
[SUCCESS] Success: Opened original_material_document, new_material_document, & child_material_document.
[SUCCESS] Success: Changes saved successfully for original_material_document
[SUCCESS] Success: Changes saved successfully for new_material_document
[SUCCESS] Success: Changes saved successfully for child_material_document
[SUCCESS] Success: original_material_document baseColor.color property value reverted to original value before changing it.
[SUCCESS] Success: original_material_document was re-saved successfully.
[SUCCESS] Success: Re-closed original_material_document, new_material_document, & child_material_document.
[SUCCESS] Success: Re-closed original_material_document, new_material_document, & child_material_document.
[SUCCESS] Success: Re-closed original_material_document, new_material_document, & child_material_document.
[SUCCESS] Success: Re-closed original_material_document, new_material_document, & child_material_document.
[SUCCESS] Success: Opened first_material_document.
[SUCCESS] Success: first_material_document color factor property value changed successfully.
[SUCCESS] Success: Changes saved successfully for first_material_document
[SUCCESS] Success: Opened second_material_document.
[SUCCESS] Success: second_material_document baseColor.color property value was changed successfully.
[SUCCESS] Success: Changes saved successfully for second_material_document
[SUCCESS] Success: Closed first_material_document successfully.
[SUCCESS] Success: Closed second_material_document successfully.
[SUCCESS] Success: Re-opened first_material_document successfully
[SUCCESS] Success: Verified first_material_document property value for baseColor.color is accurate
[SUCCESS] Success: Re-opened second_material_document successfully
[SUCCESS] Success: Verified second_material_document property value for baseColor.color is accurate
[SUCCESS] Success: first_material_document baseColor.color property value reverted to original value before changing it.
[SUCCESS] Success: second_material_document baseColor.color property value reverted to original value before changing it.
[SUCCESS] Success: first_material_document was re-saved successfully.
[SUCCESS] Success: second_material_document was re-saved successfully.
[SUCCESS] Success: Closed first_material_document & second_material_document successfully.
[SUCCESS] Success: Re-closed first_material_document.
[SUCCESS] Success: Re-closed second material document.
Test result:  SUCCESS
```