### PR TITLE
Remove warning on irradiance color blend mode

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -1434,15 +1434,6 @@ namespace AZ
 
                         // We do a simple 'multiply' blend with the base color
                         // Note: other blend modes are currently not supported
-                        propertyIndex = material->FindPropertyIndex(s_baseColor_textureBlendMode_Name);
-                        if (propertyIndex.IsValid())
-                        {
-                            AZ::Name textureBlendMode = material->GetMaterialPropertiesLayout()
-                                     ->GetPropertyDescriptor(propertyIndex)
-                                     ->GetEnumName(material->GetPropertyValue<uint32_t>(propertyIndex));
-                        }
-
-                        // 'Multiply' blend mode:
                         subMesh.m_irradianceColor = avgColor * subMesh.m_baseColor;
                     }
                     else

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -1432,22 +1432,16 @@ namespace AZ
                         // characterisation of the full material.
                         Color avgColor = baseColorStreamingImg->GetAverageColor();
 
-                        // We do a simple 'multiply' blend with the base color for now. Warn
-                        // the user if something else was intended.
+                        // We do a simple 'multiply' blend with the base color
+                        // Note: other blend modes are currently not supported
                         propertyIndex = material->FindPropertyIndex(s_baseColor_textureBlendMode_Name);
                         if (propertyIndex.IsValid())
                         {
                             AZ::Name textureBlendMode = material->GetMaterialPropertiesLayout()
                                      ->GetPropertyDescriptor(propertyIndex)
                                      ->GetEnumName(material->GetPropertyValue<uint32_t>(propertyIndex));
-                            if (textureBlendMode != s_Multiply_Name)
-                            {
-                                AZ_Warning("MeshFeatureProcessor", false, "textureBlendMode '%s' is not "
-                                        "yet supported when requesting BaseColor irradiance source, "
-                                        "using 'Multiply' for deriving the irradiance color.",
-                                        textureBlendMode.GetCStr());
-                            }
                         }
+
                         // 'Multiply' blend mode:
                         subMesh.m_irradianceColor = avgColor * subMesh.m_baseColor;
                     }


### PR DESCRIPTION
Removed the AZ_Warning on unsupported irradiance color blend mode, which causes excessive output in the Editor.

Tested Editor and AtomSampleViewer.

Signed-off-by: dmcdiarmid-ly <63674186+dmcdiarmid-ly@users.noreply.github.com>