### PR TITLE
Materials: Fixing problems with material hot reloading after shader and material type changes (WIP)

### DIFF
--- a/Code/Framework/AtomCore/AtomCore/Instance/InstanceDatabase.h
+++ b/Code/Framework/AtomCore/AtomCore/Instance/InstanceDatabase.h
@@ -345,11 +345,11 @@ namespace AZ
             if (!assetLocal.IsReady())
             {
                 return nullptr;
-            }         
-            
+            }
+
             // Take a lock to guard the insertion.  Note that this will not guard against recursive insertions on the same thread.
             AZStd::scoped_lock<AZStd::recursive_mutex> lock(m_databaseMutex);
-            return EmplaceInstance(id, assetLocal, param);            
+            return EmplaceInstance(id, assetLocal, param);
         }
 
         template<typename Type>

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialSourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialSourceData.h
@@ -34,12 +34,6 @@ namespace AZ
         class MaterialAsset;
         class MaterialAssetCreator;
 
-        enum class MaterialAssetProcessingMode
-        {
-            PreBake,      //!< all material asset processing is done in the Asset Processor, producing a finalized material asset
-            DeferredBake  //!< some material asset processing is deferred, and the material asset is finalized at runtime after loading
-        };
-
         //! This is a simple data structure for serializing in/out material source files.
         class MaterialSourceData final
         {
@@ -92,7 +86,6 @@ namespace AZ
             Outcome<Data::Asset<MaterialAsset>> CreateMaterialAsset(
                 Data::AssetId assetId,
                 const AZStd::string& materialSourceFilePath,
-                MaterialAssetProcessingMode processingMode,
                 bool elevateWarnings = true) const;
 
             //! Creates a MaterialAsset from the MaterialSourceData content.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
@@ -213,7 +213,7 @@ namespace AZ
             ChangeId m_compiledChangeId = DEFAULT_CHANGE_ID;
 
             bool m_isInitializing = false;
-                
+
             MaterialPropertyPsoHandling m_psoHandling = MaterialPropertyPsoHandling::Warning;
         };
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialAsset.h
@@ -114,18 +114,15 @@ namespace AZ
             //!
             //! Calling GetPropertyValues() will automatically finalize the material asset if it isn't finalized already. The
             //! MaterialTypeAsset must be loaded and ready.
-            const AZStd::vector<MaterialPropertyValue>& GetPropertyValues();
+            const AZStd::vector<MaterialPropertyValue>& GetPropertyValues() const;
             
-            //! Returns true if material was created in a finalize state, as opposed to being finalized after loading from disk.
-            bool WasPreFinalized() const;
-            
-            //! Returns the list of raw values for all properties in this material, as listed in the source .material file(s), before the material asset was Finalized.
-            //! 
-            //! The MaterialAsset can be created in a "half-baked" state (see MaterialUtils::BuildersShouldFinalizeMaterialAssets) where
-            //! minimal processing has been done because it did not yet have access to the MaterialTypeAsset. In that case, the list will
-            //! be populated with values copied from the source .material file with little or no validation or other processing. It includes
-            //! all parent .material files, with properties listed in low-to-high priority order. 
-            //! This list will be empty however if the asset was finalized at build-time (i.e. WasPreFinalized() returns true).
+            //! Returns the list of raw values for all properties in this material, as listed in the source .material file(s), before the
+            //! material asset was Finalized.
+            //!
+            //! The MaterialAsset can be created in a "half-baked" state where minimal processing has been done because it did not yet have
+            //! access to the MaterialTypeAsset. In that case, the list will be populated with values copied from the source .material file
+            //! with little or no validation or other processing. It includes all parent .material files, with properties listed in
+            //! low-to-high priority order. This list will be empty however if the asset was finalized at build-time.
             const AZStd::vector<AZStd::pair<Name, MaterialPropertyValue>>& GetRawPropertyValues() const;
 
         private:
@@ -162,13 +159,6 @@ namespace AZ
             //! can't be applied until the MaterialTypeAsset is available, so we have to keep the properties in the same order they
             //! were originally encountered.
             AZStd::vector<AZStd::pair<Name, MaterialPropertyValue>> m_rawPropertyValues;
-            
-            //! Tracks whether Finalize() has been called, meaning m_propertyValues is populated with data matching the material type's property layout.
-            //! (This value is intentionally not serialized, it is set by the Finalize() function)
-            mutable bool m_isFinalized = false;
-
-            //! Tracks whether the MaterialAsset was already in a finalized state when it was loaded.
-            bool m_wasPreFinalized = false;
             
             //! The materialTypeVersion this materialAsset was based off. If the versions do not match at runtime when a
             //! materialTypeAsset is loaded, automatic updates will be attempted.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialAssetCreator.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialAssetCreator.h
@@ -18,17 +18,14 @@ namespace AZ
     {
         //! Use a MaterialAssetCreator to create and configure a new MaterialAsset.
         //!
-        //! There are two options for how to create the MaterialAsset, whether it should be finalized now or deferred.
-        //!  - Finalized now: This requires the MaterialTypeAsset to be fully populated so it can read the property layout.
-        //!  - Deferred finalize: This only requires the MaterialTypeAsset to have a valid AssetId; the data inside will not be used. MaterialAsset::Finalize()
-        //!                       will need to be called later when the final MaterialTypeAsset is available, presumably after loading the MaterialAsset at runtime.
+        //! This requires the MaterialTypeAsset to be fully populated so it can read the property layout.
         class MaterialAssetCreator  
             : public AssetCreator<MaterialAsset>
         {
         public:
             friend class MaterialSourceData;
 
-            void Begin(const Data::AssetId& assetId, const Data::Asset<MaterialTypeAsset>& materialType, bool shouldFinalize);
+            void Begin(const Data::AssetId& assetId, const Data::Asset<MaterialTypeAsset>& materialType);
             bool End(Data::Asset<MaterialAsset>& result);
 
             void SetMaterialTypeVersion(uint32_t version);
@@ -38,9 +35,6 @@ namespace AZ
             void SetPropertyValue(const Name& name, const Data::Asset<ImageAsset>& imageAsset);
             void SetPropertyValue(const Name& name, const Data::Asset<StreamingImageAsset>& imageAsset);
             void SetPropertyValue(const Name& name, const Data::Asset<AttachmentImageAsset>& imageAsset);
-
-        private:
-            bool m_shouldFinalize = false;
         };
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -29,7 +29,7 @@ namespace AZ
 
         AZStd::string MaterialBuilder::GetBuilderSettingsFingerprint() const
         {
-            return AZStd::string::format("[BuildersShouldFinalizeMaterialAssets=%d]", MaterialBuilderUtils::BuildersShouldFinalizeMaterialAssets());
+            return "";
         }
 
         void MaterialBuilder::RegisterBuilder()
@@ -113,9 +113,10 @@ namespace AZ
 
             if (!parentMaterialPath.empty())
             {
-                // Register dependency on the parent material source file so we can load it and use it's data to build this variant material.
-                // Note, we don't need a direct dependency on the material type because the parent material will depend on it.
-                MaterialBuilderUtils::AddPossibleDependencies(request.m_sourceFile,
+                // Register dependency on the parent material source file so we can load it and use it's data to build this variant
+                // material. Note, we don't need a direct dependency on the material type because the parent material will depend on it.
+                MaterialBuilderUtils::AddPossibleDependencies(
+                    request.m_sourceFile,
                     parentMaterialPath,
                     JobKey,
                     outputJobDescriptor.m_jobDependencyList,
@@ -136,7 +137,8 @@ namespace AZ
                 // At this point the builder does not know which is the case, without loading the .materialtype file and inspecting its data. The builder
                 // avoids that because it could slow things down, and instead just registers both dependencies.
 
-                MaterialBuilderUtils::AddPossibleDependencies(request.m_sourceFile,
+                MaterialBuilderUtils::AddPossibleDependencies(
+                    request.m_sourceFile,
                     materialTypePath,
                     MaterialTypeBuilder::FinalStageJobKey,
                     outputJobDescriptor.m_jobDependencyList,
@@ -144,10 +146,12 @@ namespace AZ
                     false,
                     0);
 
-                AZStd::string intermediateMaterialTypePath = MaterialUtils::PredictIntermediateMaterialTypeSourcePath(request.m_sourceFile, materialTypePath);
+                const AZStd::string intermediateMaterialTypePath =
+                    MaterialUtils::PredictIntermediateMaterialTypeSourcePath(request.m_sourceFile, materialTypePath);
                 if (!intermediateMaterialTypePath.empty())
                 {
-                    MaterialBuilderUtils::AddPossibleDependencies(request.m_sourceFile,
+                    MaterialBuilderUtils::AddPossibleDependencies(
+                        request.m_sourceFile,
                         intermediateMaterialTypePath,
                         MaterialTypeBuilder::FinalStageJobKey,
                         outputJobDescriptor.m_jobDependencyList,
@@ -211,9 +215,7 @@ namespace AZ
                 return {};
             }
 
-            MaterialAssetProcessingMode processingMode = MaterialBuilderUtils::BuildersShouldFinalizeMaterialAssets() ? MaterialAssetProcessingMode::PreBake : MaterialAssetProcessingMode::DeferredBake;
-
-            auto materialAssetOutcome = material.GetValue().CreateMaterialAsset(Uuid::CreateRandom(), materialSourceFilePath, processingMode, ShouldReportMaterialAssetWarningsAsErrors());
+            auto materialAssetOutcome = material.GetValue().CreateMaterialAsset(Uuid::CreateRandom(), materialSourceFilePath, ShouldReportMaterialAssetWarningsAsErrors());
             if (!materialAssetOutcome.IsSuccess())
             {
                 return {};

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.cpp
@@ -24,12 +24,9 @@ namespace AZ::RPI::MaterialBuilderUtils
         AZStd::optional<AZ::u32> productSubId)
     {
         bool dependencyFileFound = false;
-            
-        const bool currentFileIsMaterial = AzFramework::StringFunc::Path::IsExtension(currentFilePath.c_str(), MaterialSourceData::Extension);
-        const bool referencedFileIsMaterialType = AzFramework::StringFunc::Path::IsExtension(referencedParentPath.c_str(), MaterialTypeSourceData::Extension);
-        const bool shouldFinalizeMaterialAssets = MaterialBuilderUtils::BuildersShouldFinalizeMaterialAssets();
 
-        AZStd::vector<AZStd::string> possibleDependencies = RPI::AssetUtils::GetPossibleDepenencyPaths(currentFilePath, referencedParentPath);
+        AZStd::vector<AZStd::string> possibleDependencies =
+            RPI::AssetUtils::GetPossibleDepenencyPaths(currentFilePath, referencedParentPath);
         for (auto& file : possibleDependencies)
         {
             // The first path found is the highest priority, and will have a job dependency, as this is the one
@@ -38,7 +35,12 @@ namespace AZ::RPI::MaterialBuilderUtils
             {
                 AZ::Data::AssetInfo sourceInfo;
                 AZStd::string watchFolder;
-                AzToolsFramework::AssetSystemRequestBus::BroadcastResult(dependencyFileFound, &AzToolsFramework::AssetSystem::AssetSystemRequest::GetSourceInfoBySourcePath, file.c_str(), sourceInfo, watchFolder);
+                AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+                    dependencyFileFound,
+                    &AzToolsFramework::AssetSystem::AssetSystemRequest::GetSourceInfoBySourcePath,
+                    file.c_str(),
+                    sourceInfo,
+                    watchFolder);
 
                 if (dependencyFileFound)
                 {
@@ -46,16 +48,13 @@ namespace AZ::RPI::MaterialBuilderUtils
                     jobDependency.m_jobKey = jobKey;
                     jobDependency.m_sourceFile.m_sourceFileDependencyPath = file;
                     jobDependency.m_type = AssetBuilderSDK::JobDependencyType::Order;
-                        
-                    if(productSubId)
+
+                    if (productSubId)
                     {
                         jobDependency.m_productSubIds.push_back(productSubId.value());
                     }
-                        
-                    // If we aren't finalizing material assets, then a normal job dependency isn't needed because the MaterialTypeAsset data won't be used.
-                    // However, we do still need at least an OrderOnce dependency to ensure the Asset Processor knows about the material type asset so the builder can get it's AssetId.
-                    // This can significantly reduce AP processing time when a material type or its shaders are edited.
-                    if (forceOrderOnce || (currentFileIsMaterial && referencedFileIsMaterialType && !shouldFinalizeMaterialAssets))
+
+                    if (forceOrderOnce)
                     {
                         jobDependency.m_type = AssetBuilderSDK::JobDependencyType::OrderOnce;
                     }
@@ -103,25 +102,5 @@ namespace AZ::RPI::MaterialBuilderUtils
             jobDependencies,
             sourceDependencies,
             forceOrderOnce);
-    }
-
-    bool BuildersShouldFinalizeMaterialAssets()
-    {
-        // Disable this registry setting to improve iteration times when making changes to widely used shaders and material types,
-        // like standard PBR, that require a large number of model assets to be reprocessed by the AP. Disabling finalization will
-        // also disable build dependencies between materials and material types. Without those dependencies in place, loading and
-        // reloading material assets will require special handling because typical asset notifications will not be sent when
-        // dependencies are changed. Before, this option was disabled by default because of the long iteration times, but caused hot
-        // reload problems so we enabled it again. We should explore options for handling dependencies on standard PBR differently
-        // at the model builder level, and hopefully improve the iteration times that way. In that case, we should come back and
-        // remove the deferred-finalize option entirely.
-        bool shouldFinalize = true;
-
-        if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
-        {
-            settingsRegistry->Get(shouldFinalize, "/O3DE/Atom/RPI/MaterialBuilder/FinalizeMaterialAssets");
-        }
-
-        return shouldFinalize;
     }
 }

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.h
@@ -43,12 +43,6 @@ namespace AZ
                 const AZStd::string& imageFilePath,
                 AZStd::vector<AssetBuilderSDK::JobDependency>& jobDependencies,
                 AZStd::vector<AssetBuilderSDK::SourceFileDependency>& sourceDependencies);
-
-            //! Materials assets can either be finalized during asset-processing time or when materials are loaded at runtime.
-            //! Finalizing during asset processing reduces load times and obfuscates the material data.
-            //! Waiting to finalize at load time reduces dependencies on the material type data, resulting in fewer asset rebuilds and less time spent processing assets.
-            //! Removing the dependency on the material type data will require special handling of material type asset dependencies when loading and reloading materials.
-            bool BuildersShouldFinalizeMaterialAssets();
         }
 
     } // namespace RPI

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -197,7 +197,8 @@ namespace AZ
 
             for (auto& shader : materialTypeSourceData.m_shaderCollection)
             {
-                MaterialBuilderUtils::AddPossibleDependencies(request.m_sourceFile,
+                MaterialBuilderUtils::AddPossibleDependencies(
+                    request.m_sourceFile,
                     shader.m_shaderFilePath,
                     "Shader Asset",
                     outputJobDescriptor.m_jobDependencyList,
@@ -214,7 +215,8 @@ namespace AZ
 
                     for (const MaterialFunctorSourceData::AssetDependency& dependency : dependencies)
                     {
-                        MaterialBuilderUtils::AddPossibleDependencies(request.m_sourceFile,
+                        MaterialBuilderUtils::AddPossibleDependencies(
+                            request.m_sourceFile,
                             dependency.m_sourceFilePath,
                             dependency.m_jobKey.c_str(),
                             outputJobDescriptor.m_jobDependencyList,
@@ -249,7 +251,8 @@ namespace AZ
             {
                 for (auto& shader : pipelinePair.second.m_shaderCollection)
                 {
-                    MaterialBuilderUtils::AddPossibleDependencies(request.m_sourceFile,
+                    MaterialBuilderUtils::AddPossibleDependencies(
+                        request.m_sourceFile,
                         shader.m_shaderFilePath,
                         "Shader Asset",
                         outputJobDescriptor.m_jobDependencyList,
@@ -283,13 +286,13 @@ namespace AZ
 
             if (!materialType.IsSuccess())
             {
-                return  {};
+                return {};
             }
 
             auto materialTypeAssetOutcome = materialType.GetValue().CreateMaterialTypeAsset(Uuid::CreateRandom(), materialTypeSourceFilePath, true);
             if (!materialTypeAssetOutcome.IsSuccess())
             {
-                return  {};
+                return {};
             }
 
             return materialTypeAssetOutcome.GetValue();

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialUtils.cpp
@@ -308,8 +308,7 @@ namespace AZ
 
             AZStd::string GetIntermediateMaterialTypeSourcePath(const AZStd::string& forOriginalMaterialTypeSourcePath)
             {
-                AZStd::string intermediatePathString = PredictIntermediateMaterialTypeSourcePath(forOriginalMaterialTypeSourcePath);
-
+                const AZStd::string intermediatePathString = PredictIntermediateMaterialTypeSourcePath(forOriginalMaterialTypeSourcePath);
                 if (IO::LocalFileIO::GetInstance()->Exists(intermediatePathString.c_str()))
                 {
                     return intermediatePathString;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
@@ -59,6 +59,12 @@ namespace AZ
 
             ScopedValue isInitializing(&m_isInitializing, true, false);
 
+            // All of these members must be reset if the material can be reinitialized because of the shader reload notification bus
+            m_shaderResourceGroup = {};
+            m_rhiShaderResourceGroup = {};
+            m_materialProperties = {};
+            m_generalShaderCollection = {};
+            m_materialPipelineData = {};
             m_materialAsset = { &materialAsset, AZ::Data::AssetLoadBehavior::PreLoad };
 
             // Cache off pointers to some key data structures from the material type...
@@ -79,16 +85,16 @@ namespace AZ
                 }
             }
 
-            m_generalShaderCollection = materialAsset.GetGeneralShaderCollection();
+            m_generalShaderCollection = m_materialAsset->GetGeneralShaderCollection();
 
-            if (!m_materialProperties.Init(m_materialAsset->GetMaterialPropertiesLayout(), materialAsset.GetPropertyValues()))
+            if (!m_materialProperties.Init(m_materialAsset->GetMaterialPropertiesLayout(), m_materialAsset->GetPropertyValues()))
             {
                 return RHI::ResultCode::Fail;
             }
 
             m_materialProperties.SetAllPropertyDirtyFlags();
 
-            for (auto& [materialPipelineName, materialPipeline] : materialAsset.GetMaterialPipelinePayloads())
+            for (auto& [materialPipelineName, materialPipeline] : m_materialAsset->GetMaterialPipelinePayloads())
             {
                 MaterialPipelineState& pipelineData = m_materialPipelineData[materialPipelineName];
 
@@ -286,7 +292,7 @@ namespace AZ
             // Note that it might not be strictly necessary to reinitialize the entire material, we might be able to get away with
             // just bumping the m_currentChangeId or some other minor updates. But it's pretty hard to know what exactly needs to be
             // updated to correctly handle the reload, so it's safer to just reinitialize the whole material.
-            Init(*m_materialAsset);
+            //Init(*m_materialAsset);
         }
 
         void Material::OnShaderAssetReinitialized(const Data::Asset<ShaderAsset>& shaderAsset)
@@ -295,7 +301,7 @@ namespace AZ
             // Note that it might not be strictly necessary to reinitialize the entire material, we might be able to get away with
             // just bumping the m_currentChangeId or some other minor updates. But it's pretty hard to know what exactly needs to be
             // updated to correctly handle the reload, so it's safer to just reinitialize the whole material.
-            Init(*m_materialAsset);
+            //Init(*m_materialAsset);
         }
 
         void Material::OnShaderVariantReinitialized(const ShaderVariant& shaderVariant)
@@ -311,7 +317,7 @@ namespace AZ
             // and mask out the parts of the ShaderVariantId that aren't owned by the material, but that would be premature optimization at this point, adding
             // potentially unnecessary complexity. There may also be more edge cases I haven't thought of. In short, it's much safer to just reinitialize every time
             // this callback happens.
-            Init(*m_materialAsset);
+            //Init(*m_materialAsset);
         }
         ///////////////////////////////////////////////////////////////////
 

--- a/Gems/Atom/RPI/Code/Tests/Material/LuaMaterialFunctorTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/LuaMaterialFunctorTests.cpp
@@ -107,7 +107,7 @@ namespace UnitTest
 
             Data::Asset<MaterialAsset> materialAsset;
             MaterialAssetCreator materialCreator;
-            materialCreator.Begin(Uuid::CreateRandom(), m_materialTypeAsset, true);
+            materialCreator.Begin(Uuid::CreateRandom(), m_materialTypeAsset);
             EXPECT_TRUE(materialCreator.End(materialAsset));
 
             m_material = Material::Create(materialAsset);
@@ -133,7 +133,7 @@ namespace UnitTest
 
             Data::Asset<MaterialAsset> materialAsset;
             MaterialAssetCreator materialCreator;
-            materialCreator.Begin(Uuid::CreateRandom(),m_materialTypeAsset, true);
+            materialCreator.Begin(Uuid::CreateRandom(),m_materialTypeAsset);
             EXPECT_TRUE(materialCreator.End(materialAsset));
 
             m_material = Material::Create(materialAsset);
@@ -160,7 +160,7 @@ namespace UnitTest
 
             Data::Asset<MaterialAsset> materialAsset;
             MaterialAssetCreator materialCreator;
-            materialCreator.Begin(Uuid::CreateRandom(), m_materialTypeAsset, true);
+            materialCreator.Begin(Uuid::CreateRandom(), m_materialTypeAsset);
             EXPECT_TRUE(materialCreator.End(materialAsset));
 
             m_material = Material::Create(materialAsset);
@@ -189,7 +189,7 @@ namespace UnitTest
 
             Data::Asset<MaterialAsset> materialAsset;
             MaterialAssetCreator materialCreator;
-            materialCreator.Begin(Uuid::CreateRandom(), m_materialTypeAsset, true);
+            materialCreator.Begin(Uuid::CreateRandom(), m_materialTypeAsset);
             EXPECT_TRUE(materialCreator.End(materialAsset));
 
             m_material = Material::Create(materialAsset);
@@ -220,7 +220,7 @@ namespace UnitTest
 
             Data::Asset<MaterialAsset> materialAsset;
             MaterialAssetCreator materialCreator;
-            materialCreator.Begin(Uuid::CreateRandom(), m_materialTypeAsset, true);
+            materialCreator.Begin(Uuid::CreateRandom(), m_materialTypeAsset);
             EXPECT_TRUE(materialCreator.End(materialAsset));
 
             m_material = Material::Create(materialAsset);
@@ -252,7 +252,7 @@ namespace UnitTest
 
             Data::Asset<MaterialAsset> materialAsset;
             MaterialAssetCreator materialCreator;
-            materialCreator.Begin(Uuid::CreateRandom(), m_materialTypeAsset, true);
+            materialCreator.Begin(Uuid::CreateRandom(), m_materialTypeAsset);
             EXPECT_TRUE(materialCreator.End(materialAsset));
 
             m_material = Material::Create(materialAsset);
@@ -286,7 +286,7 @@ namespace UnitTest
 
             Data::Asset<MaterialAsset> materialAsset;
             MaterialAssetCreator materialCreator;
-            materialCreator.Begin(Uuid::CreateRandom(), m_materialTypeAsset, true);
+            materialCreator.Begin(Uuid::CreateRandom(), m_materialTypeAsset);
             EXPECT_TRUE(materialCreator.End(materialAsset));
 
             m_material = Material::Create(materialAsset);

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialAssetTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialAssetTests.cpp
@@ -67,11 +67,6 @@ namespace UnitTest
 
             RPITestFixture::TearDown();
         }
-
-        void ReplaceMaterialType(Data::Asset<MaterialAsset> materialAsset, Data::Asset<MaterialTypeAsset> upgradedMaterialTypeAsset)
-        {
-            materialAsset->m_materialTypeAsset = upgradedMaterialTypeAsset;
-        }
     };
 
     TEST_F(MaterialAssetTests, Basic)
@@ -98,7 +93,7 @@ namespace UnitTest
         Data::AssetId assetId(Uuid::CreateRandom());
 
         MaterialAssetCreator creator;
-        creator.Begin(assetId, m_testMaterialTypeAsset, true);
+        creator.Begin(assetId, m_testMaterialTypeAsset);
         creator.SetPropertyValue(Name{ "MyFloat2" }, Vector2{ 0.1f, 0.2f });
         creator.SetPropertyValue(Name{ "MyFloat3" }, Vector3{ 1.1f, 1.2f, 1.3f });
         creator.SetPropertyValue(Name{ "MyFloat4" }, Vector4{ 2.1f, 2.2f, 2.3f, 2.4f });
@@ -117,7 +112,6 @@ namespace UnitTest
         EXPECT_EQ(assetId, materialAsset->GetId());
         EXPECT_EQ(Data::AssetData::AssetStatus::Ready, materialAsset->GetStatus());
 
-        EXPECT_TRUE(materialAsset->WasPreFinalized());
         EXPECT_EQ(0, materialAsset->GetRawPropertyValues().size());
 
         validate(materialAsset);
@@ -132,66 +126,13 @@ namespace UnitTest
         Data::Asset<RPI::MaterialAsset> serializedAsset = tester.SerializeIn(Data::AssetId(Uuid::CreateRandom()), noAssets);
         validate(serializedAsset);
     }
-    
-    TEST_F(MaterialAssetTests, DeferredFinalize)
-    {
-        Data::AssetId assetId(Uuid::CreateRandom());
-
-        MaterialAssetCreator creator;
-        bool shouldFinalize = false;
-        creator.Begin(assetId, m_testMaterialTypeAsset, shouldFinalize);
-
-        creator.SetPropertyValue(Name{ "MyFloat2" }, Vector2{ 0.1f, 0.2f });
-        creator.SetPropertyValue(Name{ "MyFloat3" }, Vector3{ 1.1f, 1.2f, 1.3f });
-        creator.SetPropertyValue(Name{ "MyFloat4" }, Vector4{ 2.1f, 2.2f, 2.3f, 2.4f });
-        creator.SetPropertyValue(Name{ "MyColor"  }, Color{ 1.0f, 1.0f, 1.0f, 1.0f });
-        creator.SetPropertyValue(Name{ "MyInt"    }, -2);
-        creator.SetPropertyValue(Name{ "MyUInt"   }, 12u);
-        creator.SetPropertyValue(Name{ "MyFloat"  }, 1.5f);
-        creator.SetPropertyValue(Name{ "MyBool"   }, true);
-        creator.SetPropertyValue(Name{ "MyImage"  }, m_testImageAsset);
-        creator.SetPropertyValue(Name{ "MyEnum"   }, 1u);
-        creator.SetPropertyValue(Name{ "MyAttachmentImage"  }, m_testAttachmentImageAsset);
-
-        Data::Asset<MaterialAsset> materialAsset;
-        EXPECT_TRUE(creator.End(materialAsset));
-
-        EXPECT_FALSE(materialAsset->WasPreFinalized());
-        EXPECT_EQ(11, materialAsset->GetRawPropertyValues().size());
-
-        // Also test serialization...
-
-        SerializeTester<RPI::MaterialAsset> tester(GetSerializeContext());
-        tester.SerializeOut(materialAsset.Get());
-
-        // Using a filter that skips loading assets because we are using a dummy image asset
-        ObjectStream::FilterDescriptor noAssets{ AZ::Data::AssetFilterNoAssetLoading };
-        Data::Asset<RPI::MaterialAsset> serializedAsset = tester.SerializeIn(Data::AssetId(Uuid::CreateRandom()), noAssets);
-        
-        EXPECT_FALSE(materialAsset->WasPreFinalized());
-        EXPECT_EQ(11, materialAsset->GetRawPropertyValues().size());
-
-        // GetPropertyValues() will automatically finalize the material asset, so we can go ahead and check the property values.
-        EXPECT_EQ(materialAsset->GetPropertyValues().size(), 11);
-        EXPECT_EQ(materialAsset->GetPropertyValues()[0].GetValue<bool>(), true);
-        EXPECT_EQ(materialAsset->GetPropertyValues()[1].GetValue<int32_t>(), -2);
-        EXPECT_EQ(materialAsset->GetPropertyValues()[2].GetValue<uint32_t>(), 12);
-        EXPECT_EQ(materialAsset->GetPropertyValues()[3].GetValue<float>(), 1.5f);
-        EXPECT_EQ(materialAsset->GetPropertyValues()[4].GetValue<Vector2>(), Vector2(0.1f, 0.2f));
-        EXPECT_EQ(materialAsset->GetPropertyValues()[5].GetValue<Vector3>(), Vector3(1.1f, 1.2f, 1.3f));
-        EXPECT_EQ(materialAsset->GetPropertyValues()[6].GetValue<Vector4>(), Vector4(2.1f, 2.2f, 2.3f, 2.4f));
-        EXPECT_EQ(materialAsset->GetPropertyValues()[7].GetValue<Color>(), Color(1.0f, 1.0f, 1.0f, 1.0f));
-        EXPECT_EQ(materialAsset->GetPropertyValues()[8].GetValue<Data::Asset<ImageAsset>>(), m_testImageAsset);
-        EXPECT_EQ(materialAsset->GetPropertyValues()[9].GetValue<uint32_t>(), 1u);
-        EXPECT_EQ(materialAsset->GetPropertyValues()[10].GetValue<Data::Asset<ImageAsset>>(), m_testAttachmentImageAsset);
-    }
 
     TEST_F(MaterialAssetTests, PropertyDefaultValuesComeFromParentMaterial)
     {
         Data::AssetId assetId(Uuid::CreateRandom());
 
         MaterialAssetCreator creator;
-        creator.Begin(assetId, m_testMaterialTypeAsset, true);
+        creator.Begin(assetId, m_testMaterialTypeAsset);
         creator.SetPropertyValue(Name{ "MyFloat" }, 3.14f);
 
         Data::Asset<MaterialAsset> materialAsset;
@@ -234,7 +175,7 @@ namespace UnitTest
 
         Data::Asset<MaterialAsset> materialAsset;
         MaterialAssetCreator materialCreator;
-        materialCreator.Begin(Uuid::CreateRandom(), emptyMaterialTypeAsset, true);
+        materialCreator.Begin(Uuid::CreateRandom(), emptyMaterialTypeAsset);
         EXPECT_TRUE(materialCreator.End(materialAsset));
         EXPECT_EQ(emptyMaterialTypeAsset, materialAsset->GetMaterialTypeAsset());
         EXPECT_EQ(materialAsset->GetPropertyValues().size(), 0);
@@ -252,7 +193,7 @@ namespace UnitTest
         Data::AssetId assetId(Uuid::CreateRandom());
 
         MaterialAssetCreator creator;
-        creator.Begin(assetId, m_testMaterialTypeAsset, true);
+        creator.Begin(assetId, m_testMaterialTypeAsset);
         creator.SetPropertyValue(Name{ "MyImage" }, streamingImageAsset);
 
         Data::Asset<MaterialAsset> materialAsset;
@@ -281,35 +222,10 @@ namespace UnitTest
 
         auto shaderAsset = CreateTestShaderAsset(Uuid::CreateRandom(), materialSrgLayout);
 
-        Data::Asset<MaterialTypeAsset> testMaterialTypeAssetV1;
-        MaterialTypeAssetCreator materialTypeCreator;
-        materialTypeCreator.Begin(Uuid::CreateRandom());
-        materialTypeCreator.AddShader(shaderAsset);
-        // Set default values
-        AddMaterialPropertyForSrg(materialTypeCreator, Name{ "MyInt" }, MaterialPropertyDataType::Int, Name{ "m_int" });
-        AddMaterialPropertyForSrg(materialTypeCreator, Name{ "MyUInt" }, MaterialPropertyDataType::UInt, Name{ "m_uint" });
-        AddMaterialPropertyForSrg(materialTypeCreator, Name{ "MyFloat" }, MaterialPropertyDataType::Float, Name{ "m_float" });
-        AddMaterialPropertyForSrg(materialTypeCreator, Name{ "MyFloat2" }, MaterialPropertyDataType::Int, Name{ "m_float2" });
-        AddMaterialPropertyForSrg(materialTypeCreator, Name{ "MyFloat3" }, MaterialPropertyDataType::Int, Name{ "m_float3" });
-        EXPECT_TRUE(materialTypeCreator.End(testMaterialTypeAssetV1));
-
         // Construct the material asset with materialTypeAsset version 1
         Data::AssetId assetId(Uuid::CreateRandom());
 
-        MaterialAssetCreator creator;
-        const bool shouldFinalize = false;
-        creator.Begin(assetId, testMaterialTypeAssetV1, shouldFinalize);
-        creator.SetMaterialTypeVersion(1);
-        // Set some properties to non-default values
-        creator.SetPropertyValue(Name{ "MyInt" }, 7);
-        creator.SetPropertyValue(Name{ "MyUInt" }, 8u);
-        creator.SetPropertyValue(Name{ "MyFloat" }, 9.0f);
-        creator.SetPropertyValue(Name{ "MyFloat2" }, 10.0f);
-        Data::Asset<MaterialAsset> materialAsset;
-        EXPECT_TRUE(creator.End(materialAsset));
-
-
-        Data::Asset<MaterialTypeAsset> testMaterialTypeAssetV3;
+        MaterialTypeAssetCreator materialTypeCreator;
         materialTypeCreator.Begin(Uuid::CreateRandom());
         // Prepare material type asset version 3 with update actions
         materialTypeCreator.SetVersion(3);
@@ -376,11 +292,9 @@ namespace UnitTest
         AddMaterialPropertyForSrg(materialTypeCreator, Name{ "MyIntFinalRename" }, MaterialPropertyDataType::Int, Name{ "m_int" });
         AddMaterialPropertyForSrg(materialTypeCreator, Name{ "MyFloat2" }, MaterialPropertyDataType::Float, Name{ "m_float2" });
         AddMaterialPropertyForSrg(materialTypeCreator, Name{ "MyFloat3" }, MaterialPropertyDataType::Float, Name{ "m_float3" });
-        EXPECT_TRUE(materialTypeCreator.End(testMaterialTypeAssetV3));
 
-        // This is our way of faking the idea that an old version of the MaterialAsset could be
-        // loaded with a new version of the MaterialTypeAsset.
-        ReplaceMaterialType(materialAsset, testMaterialTypeAssetV3);
+        Data::Asset<MaterialTypeAsset> testMaterialTypeAssetV3;
+        EXPECT_TRUE(materialTypeCreator.End(testMaterialTypeAssetV3));
 
         // Expected warning messages
         ErrorMessageFinder warningFinder; 
@@ -407,8 +321,18 @@ namespace UnitTest
         ExpectOverwriteMessage(2, "MyFloat2", nullptr);
         ExpectOverwriteMessage(2, "MyUInt", "MyUIntRenamed");
 
-        // Trigger the version updates of the material asset and check the warnings
-        materialAsset->GetPropertyValues(); // triggers version updates
+        MaterialAssetCreator creator;
+        creator.Begin(assetId, testMaterialTypeAssetV3);
+        creator.SetMaterialTypeVersion(1);
+        // Set some properties to non-default values
+        creator.SetPropertyValue(Name{ "MyInt" }, 7);
+        creator.SetPropertyValue(Name{ "MyUInt" }, 8u);
+        creator.SetPropertyValue(Name{ "MyFloat" }, 9.0f);
+        creator.SetPropertyValue(Name{ "MyFloat2" }, 10.0f);
+
+        Data::Asset<MaterialAsset> materialAsset;
+        EXPECT_TRUE(creator.End(materialAsset));
+
         warningFinder.CheckExpectedErrorsFound();
 
         // Since the MaterialAsset has already been updated, and the warnings reported once, we
@@ -471,66 +395,34 @@ namespace UnitTest
 
         auto expectCreatorError = [this](const char* expectedErrorMessage, AZStd::function<void(MaterialAssetCreator& creator)> passBadInput)
         {
-            // Test with finalizing enabled
-            {
-                MaterialAssetCreator creator;
-                creator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset, true);
+            MaterialAssetCreator creator;
+            creator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset);
 
-                ErrorMessageFinder errorMessageFinder;
-                errorMessageFinder.AddExpectedErrorMessage(expectedErrorMessage);
-                errorMessageFinder.AddIgnoredErrorMessage("Failed to build", true);
+            ErrorMessageFinder errorMessageFinder;
+            errorMessageFinder.AddExpectedErrorMessage(expectedErrorMessage);
+            errorMessageFinder.AddIgnoredErrorMessage("Failed to build", true);
 
-                passBadInput(creator);
+            passBadInput(creator);
 
-                Data::Asset<MaterialAsset> materialAsset;
-                EXPECT_FALSE(creator.End(materialAsset));
+            Data::Asset<MaterialAsset> materialAsset;
+            EXPECT_FALSE(creator.End(materialAsset));
 
-                errorMessageFinder.CheckExpectedErrorsFound();
+            errorMessageFinder.CheckExpectedErrorsFound();
 
-                EXPECT_TRUE(creator.GetErrorCount() > 0);
-            }
-            
-            // Test with finalizing disabled, so no validation occurs because the MaterialTypeAsset data is not used.
-            {
-                MaterialAssetCreator creator;
-                creator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset, false);
-
-                passBadInput(creator);
-
-                Data::Asset<MaterialAsset> materialAsset;
-                EXPECT_TRUE(creator.End(materialAsset));
-
-                EXPECT_EQ(creator.GetErrorCount(), 0);
-            }
+            EXPECT_TRUE(creator.GetErrorCount() > 0);
         };
 
         auto expectCreatorWarning = [this](AZStd::function<void(MaterialAssetCreator& creator)> passBadInput)
         {
-            // Test with finalizing enabled
-            {
-                MaterialAssetCreator creator;
-                creator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset, true);
+            MaterialAssetCreator creator;
+            creator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset);
 
-                passBadInput(creator);
+            passBadInput(creator);
 
-                Data::Asset<MaterialAsset> material;
-                creator.End(material);
+            Data::Asset<MaterialAsset> material;
+            creator.End(material);
 
-                EXPECT_EQ(1, creator.GetWarningCount());
-            }
-            
-            // Test with finalizing disabled, so no validation occurs because the MaterialTypeAsset data is not used.
-            {
-                MaterialAssetCreator creator;
-                creator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset, false);
-
-                passBadInput(creator);
-
-                Data::Asset<MaterialAsset> material;
-                creator.End(material);
-
-                EXPECT_EQ(0, creator.GetWarningCount());
-            }
+            EXPECT_EQ(1, creator.GetWarningCount());
         };
 
         // Invalid input ID

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialFunctorTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialFunctorTests.cpp
@@ -282,7 +282,7 @@ namespace UnitTest
         materialTypeCreator.End(m_testMaterialTypeAsset);
 
         MaterialAssetCreator materialCreator;
-        materialCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset, true);
+        materialCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset);
         materialCreator.SetPropertyValue(registedPropertyName, 42);
         materialCreator.SetPropertyValue(unregistedPropertyName, 42);
         materialCreator.SetPropertyValue(unrelatedPropertyName, 42);

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialSourceDataTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialSourceDataTests.cpp
@@ -202,12 +202,11 @@ namespace UnitTest
         AddProperty(sourceData, "general", "MyImage", AZStd::string("@exefolder@/Temp/test.streamingimage"));
         AddProperty(sourceData, "general", "MyEnum", AZStd::string("Enum1"));
 
-        auto materialAssetOutcome = sourceData.CreateMaterialAsset(Uuid::CreateRandom(), "", MaterialAssetProcessingMode::PreBake, true);
+        auto materialAssetOutcome = sourceData.CreateMaterialAsset(Uuid::CreateRandom(), "", true);
         EXPECT_TRUE(materialAssetOutcome.IsSuccess());
 
         Data::Asset<MaterialAsset> materialAsset = materialAssetOutcome.GetValue();
 
-        EXPECT_TRUE(materialAsset->WasPreFinalized());
         EXPECT_EQ(0, materialAsset->GetRawPropertyValues().size()); // A pre-baked material has no need for the original raw property names and values
 
         // The order here is based on the order in the MaterialTypeSourceData, as added to the MaterialTypeAssetCreator.
@@ -221,105 +220,6 @@ namespace UnitTest
         EXPECT_EQ(materialAsset->GetPropertyValues()[7].GetValue<Color>(), Color(0.1f, 0.2f, 0.3f, 0.4f));
         EXPECT_EQ(materialAsset->GetPropertyValues()[8].GetValue<Data::Asset<ImageAsset>>(), m_testImageAsset);
         EXPECT_EQ(materialAsset->GetPropertyValues()[9].GetValue<uint32_t>(), 1u);
-    }
-    
-    TEST_F(MaterialSourceDataTests, CreateMaterialAsset_DeferredBake)
-    {
-        // This test is similar to CreateMaterialAsset_BasicProperties but uses MaterialAssetProcessingMode::DeferredBake instead of PreBake.
-
-        Data::AssetId materialTypeAssetId = Uuid::CreateRandom();
-
-        // This material type asset will be known by the asset system (stub) but doesn't exist in the AssetManager.
-        // This demonstrates that the CreateMaterialAsset does not attempt to access the MaterialTypeAsset data in MaterialAssetProcessingMode::DeferredBake.
-        m_assetSystemStub.RegisterSourceInfo("testDeferredBake.materialtype", materialTypeAssetId);
-
-        MaterialSourceData sourceData;
-
-        sourceData.m_materialType = "testDeferredBake.materialtype";
-        AddPropertyGroup(sourceData, "general");
-        AddProperty(sourceData, "general", "MyBool"  , true);
-        AddProperty(sourceData, "general", "MyInt"   , -10);
-        AddProperty(sourceData, "general", "MyUInt"  , 25u);
-        AddProperty(sourceData, "general", "MyFloat" , 1.5f);
-        AddProperty(sourceData, "general", "MyColor" , AZ::Color{0.1f, 0.2f, 0.3f, 0.4f});
-        AddProperty(sourceData, "general", "MyFloat2", AZ::Vector2(2.1f, 2.2f));
-        AddProperty(sourceData, "general", "MyFloat3", AZ::Vector3(3.1f, 3.2f, 3.3f));
-        AddProperty(sourceData, "general", "MyFloat4", AZ::Vector4(4.1f, 4.2f, 4.3f, 4.4f));
-        AddProperty(sourceData, "general", "MyImage" , AZStd::string("@exefolder@/Temp/test.streamingimage"));
-        AddProperty(sourceData, "general", "MyEnum"  , AZStd::string("Enum1"));
-
-        auto materialAssetOutcome = sourceData.CreateMaterialAsset(Uuid::CreateRandom(), "", MaterialAssetProcessingMode::DeferredBake, true);
-        EXPECT_TRUE(materialAssetOutcome.IsSuccess());
-
-        Data::Asset<MaterialAsset> materialAsset = materialAssetOutcome.GetValue();
-
-        EXPECT_FALSE(materialAsset->WasPreFinalized());
-
-        // Note we avoid calling  GetPropertyValues() because that will auto-finalize the material. We want to check its raw property values first.
-
-        auto findRawPropertyValue = [materialAsset](const char* propertyId)
-        {
-            auto iter = AZStd::find_if(materialAsset->GetRawPropertyValues().begin(), materialAsset->GetRawPropertyValues().end(), [propertyId](const AZStd::pair<Name, MaterialPropertyValue>& pair)
-                {
-                    return pair.first == AZ::Name{propertyId};
-                });
-
-            if (iter == materialAsset->GetRawPropertyValues().end())
-            {
-                return MaterialPropertyValue{};
-            }
-            else
-            {
-                return iter->second;
-            }
-        };
-
-        auto checkRawPropertyValues = [findRawPropertyValue, this]()
-        {
-            EXPECT_EQ(findRawPropertyValue("general.MyBool"  ).GetValue<bool>(), true);
-            EXPECT_EQ(findRawPropertyValue("general.MyInt"   ).GetValue<int32_t>(), -10);
-            EXPECT_EQ(findRawPropertyValue("general.MyUInt"  ).GetValue<uint32_t>(), 25u);
-            EXPECT_EQ(findRawPropertyValue("general.MyFloat" ).GetValue<float>(), 1.5f);
-            EXPECT_EQ(findRawPropertyValue("general.MyFloat2").GetValue<Vector2>(), Vector2(2.1f, 2.2f));
-            EXPECT_EQ(findRawPropertyValue("general.MyFloat3").GetValue<Vector3>(), Vector3(3.1f, 3.2f, 3.3f));
-            EXPECT_EQ(findRawPropertyValue("general.MyFloat4").GetValue<Vector4>(), Vector4(4.1f, 4.2f, 4.3f, 4.4f));
-            EXPECT_EQ(findRawPropertyValue("general.MyColor" ).GetValue<Color>(), Color(0.1f, 0.2f, 0.3f, 0.4f));
-            EXPECT_EQ(findRawPropertyValue("general.MyImage" ).GetValue<Data::Asset<ImageAsset>>(), m_testImageAsset);
-            // The raw value for an enum is the original string, not the numerical value, because the material type holds the necessary metadata to match the name to the value.
-            EXPECT_EQ(findRawPropertyValue("general.MyEnum"  ).GetValue<AZStd::string>(), AZStd::string("Enum1")); 
-        };
-
-        // We check the raw property values before the material type asset is even available
-        checkRawPropertyValues();
-
-        // Now we'll create the material type asset in memory so the material will have what it needs to finalize itself.
-        Data::Asset<MaterialTypeAsset> testMaterialTypeAsset = CreateTestMaterialTypeAsset(materialTypeAssetId);
-
-        // The MaterialAsset is still holding an reference to an unloaded asset, so we run it through the serializer which causes the loaded MaterialAsset
-        // to have access to the testMaterialTypeAsset. This is similar to how the AP would save the MaterialAsset to the cache and the runtime would load it.
-        SerializeTester<RPI::MaterialAsset> tester(GetSerializeContext());
-        tester.SerializeOut(materialAsset.Get());
-        materialAsset = tester.SerializeIn(Uuid::CreateRandom(), ObjectStream::FilterDescriptor{AZ::Data::AssetFilterNoAssetLoading});
-
-        // We check that the asset is still in the original un-finalized state after going through the serialization process.
-        EXPECT_FALSE(materialAsset->WasPreFinalized());
-        checkRawPropertyValues();
-
-        // Now all the property values should be available through the main GetPropertyValues() API.
-        EXPECT_EQ(materialAsset->GetPropertyValues()[0].GetValue<bool>(), true);
-        EXPECT_EQ(materialAsset->GetPropertyValues()[1].GetValue<int32_t>(), -10);
-        EXPECT_EQ(materialAsset->GetPropertyValues()[2].GetValue<uint32_t>(), 25u);
-        EXPECT_EQ(materialAsset->GetPropertyValues()[3].GetValue<float>(), 1.5f);
-        EXPECT_EQ(materialAsset->GetPropertyValues()[4].GetValue<Vector2>(), Vector2(2.1f, 2.2f));
-        EXPECT_EQ(materialAsset->GetPropertyValues()[5].GetValue<Vector3>(), Vector3(3.1f, 3.2f, 3.3f));
-        EXPECT_EQ(materialAsset->GetPropertyValues()[6].GetValue<Vector4>(), Vector4(4.1f, 4.2f, 4.3f, 4.4f));
-        EXPECT_EQ(materialAsset->GetPropertyValues()[7].GetValue<Color>(), Color(0.1f, 0.2f, 0.3f, 0.4f));
-        EXPECT_EQ(materialAsset->GetPropertyValues()[8].GetValue<Data::Asset<ImageAsset>>(), m_testImageAsset);
-        EXPECT_EQ(materialAsset->GetPropertyValues()[9].GetValue<uint32_t>(), 1u);
-        
-        // The raw property values are still available (because they are needed if a hot-reload of the MaterialTypeAsset occurs)
-        EXPECT_FALSE(materialAsset->WasPreFinalized());
-        checkRawPropertyValues();
     }
     
     TEST_F(MaterialSourceDataTests, CreateMaterialAsset_VersionUpdate_ReportTheSpecifiedMaterialTypeVersion)
@@ -342,7 +242,7 @@ namespace UnitTest
         findVersionWarning.AddExpectedErrorMessage("Consider updating the .material source file");
 
         findVersionWarning.ResetCounts();
-        sourceData.CreateMaterialAsset(Uuid::CreateRandom(), "", MaterialAssetProcessingMode::PreBake);
+        sourceData.CreateMaterialAsset(Uuid::CreateRandom(), "");
         findVersionWarning.CheckExpectedErrorsFound();
         
         findVersionWarning.ResetCounts();
@@ -372,7 +272,7 @@ namespace UnitTest
         findVersionWarning.AddExpectedErrorMessage("Consider updating the .material source file");
 
         findVersionWarning.ResetCounts();
-        sourceData.CreateMaterialAsset(Uuid::CreateRandom(), "", MaterialAssetProcessingMode::PreBake);
+        sourceData.CreateMaterialAsset(Uuid::CreateRandom(), "");
         findVersionWarning.CheckExpectedErrorsFound();
         
         findVersionWarning.ResetCounts();
@@ -671,14 +571,9 @@ namespace UnitTest
 
         ErrorMessageFinder errorMessageFinder;
 
-        errorMessageFinder.AddExpectedErrorMessage("materialType was not specified");
-        auto result = material.CreateMaterialAsset(AZ::Uuid::CreateRandom(), "test.material", AZ::RPI::MaterialAssetProcessingMode::DeferredBake, elevateWarnings);
-        EXPECT_FALSE(result.IsSuccess());
-        errorMessageFinder.CheckExpectedErrorsFound();
-
         errorMessageFinder.Reset();
         errorMessageFinder.AddExpectedErrorMessage("materialType was not specified");
-        result = material.CreateMaterialAsset(AZ::Uuid::CreateRandom(), "test.material", AZ::RPI::MaterialAssetProcessingMode::PreBake, elevateWarnings);
+        auto result = material.CreateMaterialAsset(AZ::Uuid::CreateRandom(), "test.material", elevateWarnings);
         EXPECT_FALSE(result.IsSuccess());
         errorMessageFinder.CheckExpectedErrorsFound();
         
@@ -708,14 +603,9 @@ namespace UnitTest
 
         ErrorMessageFinder errorMessageFinder;
 
-        errorMessageFinder.AddExpectedErrorMessage("Could not find asset for source file [DoesNotExist.materialtype]");
-        auto result = material.CreateMaterialAsset(AZ::Uuid::CreateRandom(), "test.material", AZ::RPI::MaterialAssetProcessingMode::DeferredBake, elevateWarnings);
-        EXPECT_FALSE(result.IsSuccess());
-        errorMessageFinder.CheckExpectedErrorsFound();
-
         errorMessageFinder.Reset();
         errorMessageFinder.AddExpectedErrorMessage("Could not find asset for source file [DoesNotExist.materialtype]");
-        result = material.CreateMaterialAsset(AZ::Uuid::CreateRandom(), "test.material", AZ::RPI::MaterialAssetProcessingMode::PreBake, elevateWarnings);
+        auto result = material.CreateMaterialAsset(AZ::Uuid::CreateRandom(), "test.material", elevateWarnings);
         EXPECT_FALSE(result.IsSuccess());
         errorMessageFinder.CheckExpectedErrorsFound();
         
@@ -739,7 +629,7 @@ namespace UnitTest
 
         ErrorMessageFinder errorMessageFinder("\"general.FieldDoesNotExist\" is not found");
         errorMessageFinder.AddIgnoredErrorMessage("Failed to build MaterialAsset", true);
-        auto result = material.CreateMaterialAsset(AZ::Uuid::CreateRandom(), "test.material", AZ::RPI::MaterialAssetProcessingMode::PreBake, elevateWarnings);
+        auto result = material.CreateMaterialAsset(AZ::Uuid::CreateRandom(), "test.material", elevateWarnings);
         EXPECT_FALSE(result.IsSuccess());
         errorMessageFinder.CheckExpectedErrorsFound();
     }
@@ -765,21 +655,18 @@ namespace UnitTest
         AddPropertyGroup(sourceDataLevel3, "general");
         AddProperty(sourceDataLevel3, "general", "MyFloat", 3.5f);
 
-        auto materialAssetLevel1 = sourceDataLevel1.CreateMaterialAsset(Uuid::CreateRandom(), "", MaterialAssetProcessingMode::PreBake, true);
+        auto materialAssetLevel1 = sourceDataLevel1.CreateMaterialAsset(Uuid::CreateRandom(), "", true);
         EXPECT_TRUE(materialAssetLevel1.IsSuccess());
-        EXPECT_TRUE(materialAssetLevel1.GetValue()->WasPreFinalized());
 
         m_assetSystemStub.RegisterSourceInfo("level1.material", materialAssetLevel1.GetValue().GetId());
 
-        auto materialAssetLevel2 = sourceDataLevel2.CreateMaterialAsset(Uuid::CreateRandom(), "", MaterialAssetProcessingMode::PreBake, true);
+        auto materialAssetLevel2 = sourceDataLevel2.CreateMaterialAsset(Uuid::CreateRandom(), "", true);
         EXPECT_TRUE(materialAssetLevel2.IsSuccess());
-        EXPECT_TRUE(materialAssetLevel2.GetValue()->WasPreFinalized());
 
         m_assetSystemStub.RegisterSourceInfo("level2.material", materialAssetLevel2.GetValue().GetId());
 
-        auto materialAssetLevel3 = sourceDataLevel3.CreateMaterialAsset(Uuid::CreateRandom(), "", MaterialAssetProcessingMode::PreBake, true);
+        auto materialAssetLevel3 = sourceDataLevel3.CreateMaterialAsset(Uuid::CreateRandom(), "", true);
         EXPECT_TRUE(materialAssetLevel3.IsSuccess());
-        EXPECT_TRUE(materialAssetLevel3.GetValue()->WasPreFinalized());
 
         auto layout = m_testMaterialTypeAsset->GetMaterialPropertiesLayout();
         MaterialPropertyIndex myFloat = layout->FindPropertyIndex(Name("general.MyFloat"));
@@ -807,96 +694,6 @@ namespace UnitTest
         EXPECT_EQ(properties[myColor.GetIndex()].GetValue<Color>(), Color(0.15f, 0.25f, 0.35f, 0.45f));
     }
     
-    TEST_F(MaterialSourceDataTests, CreateMaterialAsset_MultiLevelDataInheritance_DeferredBake)
-    {
-        // This test is similar to CreateMaterialAsset_MultiLevelDataInheritance but uses MaterialAssetProcessingMode::DeferredBake instead of PreBake.
-
-        Data::AssetId materialTypeAssetId = Uuid::CreateRandom();
-
-        // This material type asset will be known by the asset system (stub) but doesn't exist in the AssetManager.
-        // This demonstrates that the CreateMaterialAsset does not attempt to access the MaterialTypeAsset data in MaterialAssetProcessingMode::DeferredBake.
-        m_assetSystemStub.RegisterSourceInfo("testDeferredBake.materialtype", materialTypeAssetId);
-
-        MaterialSourceData sourceDataLevel1;
-        sourceDataLevel1.m_materialType = "testDeferredBake.materialtype";
-        AddPropertyGroup(sourceDataLevel1, "general");
-        AddProperty(sourceDataLevel1, "general", "MyFloat", 1.5f);
-        AddProperty(sourceDataLevel1, "general", "MyColor", AZ::Color{0.1f, 0.2f, 0.3f, 0.4f});
-
-        MaterialSourceData sourceDataLevel2;
-        sourceDataLevel2.m_materialType = "testDeferredBake.materialtype";
-        sourceDataLevel2.m_parentMaterial = "level1.material";
-        AddPropertyGroup(sourceDataLevel2, "general");
-        AddProperty(sourceDataLevel2, "general", "MyColor", AZ::Color{0.15f, 0.25f, 0.35f, 0.45f});
-        AddProperty(sourceDataLevel2, "general", "MyFloat2", AZ::Vector2{4.1f, 4.2f});
-
-        MaterialSourceData sourceDataLevel3;
-        sourceDataLevel3.m_materialType = "testDeferredBake.materialtype";
-        sourceDataLevel3.m_parentMaterial = "level2.material";
-        AddPropertyGroup(sourceDataLevel3, "general");
-        AddProperty(sourceDataLevel3, "general", "MyFloat", 3.5f);
-
-        auto materialAssetLevel1Result = sourceDataLevel1.CreateMaterialAsset(Uuid::CreateRandom(), "", MaterialAssetProcessingMode::DeferredBake, true);
-        EXPECT_TRUE(materialAssetLevel1Result.IsSuccess());
-        Data::Asset<MaterialAsset> materialAssetLevel1 = materialAssetLevel1Result.TakeValue();
-        EXPECT_FALSE(materialAssetLevel1->WasPreFinalized());
-
-        m_assetSystemStub.RegisterSourceInfo("level1.material", materialAssetLevel1.GetId());
-
-        auto materialAssetLevel2Result = sourceDataLevel2.CreateMaterialAsset(Uuid::CreateRandom(), "", MaterialAssetProcessingMode::DeferredBake, true);
-        EXPECT_TRUE(materialAssetLevel2Result.IsSuccess());
-        Data::Asset<MaterialAsset> materialAssetLevel2 = materialAssetLevel2Result.TakeValue();
-        EXPECT_FALSE(materialAssetLevel2->WasPreFinalized());
-
-        m_assetSystemStub.RegisterSourceInfo("level2.material", materialAssetLevel2.GetId());
-
-        auto materialAssetLevel3Result = sourceDataLevel3.CreateMaterialAsset(Uuid::CreateRandom(), "", MaterialAssetProcessingMode::DeferredBake, true);
-        EXPECT_TRUE(materialAssetLevel3Result.IsSuccess());
-        Data::Asset<MaterialAsset> materialAssetLevel3 = materialAssetLevel3Result.TakeValue();
-        EXPECT_FALSE(materialAssetLevel3->WasPreFinalized());
-
-        // Now we'll create the material type asset in memory so the materials will have what they need to finalize.
-        Data::Asset<MaterialTypeAsset> testMaterialTypeAsset = CreateTestMaterialTypeAsset(materialTypeAssetId);
-
-        auto layout = testMaterialTypeAsset->GetMaterialPropertiesLayout();
-        MaterialPropertyIndex myFloat = layout->FindPropertyIndex(Name("general.MyFloat"));
-        MaterialPropertyIndex myFloat2 = layout->FindPropertyIndex(Name("general.MyFloat2"));
-        MaterialPropertyIndex myColor = layout->FindPropertyIndex(Name("general.MyColor"));
-
-        
-        // The MaterialAsset is still holding an reference to an unloaded asset, so we run it through the serializer which causes the loaded MaterialAsset
-        // to have access to the testMaterialTypeAsset. This is similar to how the AP would save the MaterialAsset to the cache and the runtime would load it.
-        SerializeTester<RPI::MaterialAsset> tester(GetSerializeContext());
-        tester.SerializeOut(materialAssetLevel1.Get());
-        materialAssetLevel1 = tester.SerializeIn(Uuid::CreateRandom(), ObjectStream::FilterDescriptor{AZ::Data::AssetFilterNoAssetLoading});
-        tester.SerializeOut(materialAssetLevel2.Get());
-        materialAssetLevel2 = tester.SerializeIn(Uuid::CreateRandom(), ObjectStream::FilterDescriptor{AZ::Data::AssetFilterNoAssetLoading});
-        tester.SerializeOut(materialAssetLevel3.Get());
-        materialAssetLevel3 = tester.SerializeIn(Uuid::CreateRandom(), ObjectStream::FilterDescriptor{AZ::Data::AssetFilterNoAssetLoading});
-
-        // The properties will finalize automatically when we call GetPropertyValues()...
-
-        AZStd::span<const MaterialPropertyValue> properties;
-
-        // Check level 1 properties
-        properties = materialAssetLevel1->GetPropertyValues();
-        EXPECT_EQ(properties[myFloat.GetIndex()].GetValue<float>(), 1.5f);
-        EXPECT_EQ(properties[myFloat2.GetIndex()].GetValue<Vector2>(), Vector2(0.0f, 0.0f));
-        EXPECT_EQ(properties[myColor.GetIndex()].GetValue<Color>(), Color(0.1f, 0.2f, 0.3f, 0.4f));
-
-        // Check level 2 properties
-        properties = materialAssetLevel2->GetPropertyValues();
-        EXPECT_EQ(properties[myFloat.GetIndex()].GetValue<float>(), 1.5f);
-        EXPECT_EQ(properties[myFloat2.GetIndex()].GetValue<Vector2>(), Vector2(4.1f, 4.2f));
-        EXPECT_EQ(properties[myColor.GetIndex()].GetValue<Color>(), Color(0.15f, 0.25f, 0.35f, 0.45f));
-
-        // Check level 3 properties
-        properties = materialAssetLevel3->GetPropertyValues();
-        EXPECT_EQ(properties[myFloat.GetIndex()].GetValue<float>(), 3.5f);
-        EXPECT_EQ(properties[myFloat2.GetIndex()].GetValue<Vector2>(), Vector2(4.1f, 4.2f));
-        EXPECT_EQ(properties[myColor.GetIndex()].GetValue<Color>(), Color(0.15f, 0.25f, 0.35f, 0.45f));
-    }
-
     TEST_F(MaterialSourceDataTests, CreateMaterialAsset_MultiLevelDataInheritance_Error_MaterialTypesDontMatch)
     {
         Data::Asset<MaterialTypeAsset> otherMaterialType;
@@ -918,18 +715,18 @@ namespace UnitTest
         sourceDataLevel3.m_materialType = "@exefolder@/Temp/otherBase.materialtype";
         sourceDataLevel3.m_parentMaterial = "level2.material";
 
-        auto materialAssetLevel1 = sourceDataLevel1.CreateMaterialAsset(Uuid::CreateRandom(), "", MaterialAssetProcessingMode::PreBake, true);
+        auto materialAssetLevel1 = sourceDataLevel1.CreateMaterialAsset(Uuid::CreateRandom(), "", true);
         EXPECT_TRUE(materialAssetLevel1.IsSuccess());
 
         m_assetSystemStub.RegisterSourceInfo("level1.material", materialAssetLevel1.GetValue().GetId());
 
-        auto materialAssetLevel2 = sourceDataLevel2.CreateMaterialAsset(Uuid::CreateRandom(), "", MaterialAssetProcessingMode::PreBake, true);
+        auto materialAssetLevel2 = sourceDataLevel2.CreateMaterialAsset(Uuid::CreateRandom(), "", true);
         EXPECT_TRUE(materialAssetLevel2.IsSuccess());
 
         m_assetSystemStub.RegisterSourceInfo("level2.material", materialAssetLevel2.GetValue().GetId());
 
         AZ_TEST_START_ASSERTTEST;
-        auto materialAssetLevel3 = sourceDataLevel3.CreateMaterialAsset(Uuid::CreateRandom(), "", MaterialAssetProcessingMode::PreBake, true);
+        auto materialAssetLevel3 = sourceDataLevel3.CreateMaterialAsset(Uuid::CreateRandom(), "", true);
         AZ_TEST_STOP_ASSERTTEST(1);
         EXPECT_FALSE(materialAssetLevel3.IsSuccess());
     }
@@ -939,7 +736,7 @@ namespace UnitTest
         // We use local functions to easily start a new MaterialAssetCreator for each test case because
         // the AssetCreator would just skip subsequent operations after the first failure is detected.
 
-        auto expectWarning = [](const char* expectedErrorMessage, AZStd::function<void(MaterialSourceData& materialSourceData)> setOneBadInput, bool warningOccursBeforeFinalize = false)
+        auto expectWarning = [](const char* expectedErrorMessage, AZStd::function<void(MaterialSourceData& materialSourceData)> setOneBadInput)
         {
             MaterialSourceData sourceData;
 
@@ -949,23 +746,13 @@ namespace UnitTest
 
             setOneBadInput(sourceData);
 
-            // Check with MaterialAssetProcessingMode::PreBake
-            {
-                ErrorMessageFinder errorFinder;
-                errorFinder.AddExpectedErrorMessage(expectedErrorMessage);
-                errorFinder.AddIgnoredErrorMessage("Failed to build", true);
-                auto materialAssetOutcome = sourceData.CreateMaterialAsset(Uuid::CreateRandom(), "", MaterialAssetProcessingMode::PreBake, true);
-                errorFinder.CheckExpectedErrorsFound();
+            ErrorMessageFinder errorFinder;
+            errorFinder.AddExpectedErrorMessage(expectedErrorMessage);
+            errorFinder.AddIgnoredErrorMessage("Failed to build", true);
+            auto materialAssetOutcome = sourceData.CreateMaterialAsset(Uuid::CreateRandom(), "", true);
+            errorFinder.CheckExpectedErrorsFound();
 
-                EXPECT_FALSE(materialAssetOutcome.IsSuccess());
-            }
-            
-            // Check with MaterialAssetProcessingMode::DeferredBake, no validation occurs because the MaterialTypeAsset cannot be used and so the MaterialAsset is not finalized
-            if(!warningOccursBeforeFinalize)
-            {
-                auto materialAssetOutcome = sourceData.CreateMaterialAsset(Uuid::CreateRandom(), "", MaterialAssetProcessingMode::DeferredBake, true);
-                EXPECT_TRUE(materialAssetOutcome.IsSuccess());
-            }
+            EXPECT_FALSE(materialAssetOutcome.IsSuccess());
         };
 
         // Test property does not exist...
@@ -1005,13 +792,6 @@ namespace UnitTest
             {
                 AddProperty(materialSourceData, "general", "DoesNotExist", AZStd::string("@exefolder@/Temp/test.streamingimage"));
             });
-
-        // Missing image reference
-        expectWarning("Could not find the image 'doesNotExist.streamingimage'",
-            [](MaterialSourceData& materialSourceData)
-            {
-                AddProperty(materialSourceData, "general", "MyImage", AZStd::string("doesNotExist.streamingimage"));
-            }, true); // In this case, the warning does happen even when the asset is not finalized, because the image path is checked earlier than that
     }
     
     template<typename PropertyTypeT>
@@ -1041,7 +821,7 @@ namespace UnitTest
 
         MaterialSourceData material;
         JsonTestResult loadResult = LoadTestDataFromJson(material, inputJson);
-        auto materialAssetResult = material.CreateMaterialAsset(Uuid::CreateRandom(), "test.material", AZ::RPI::MaterialAssetProcessingMode::PreBake);
+        auto materialAssetResult = material.CreateMaterialAsset(Uuid::CreateRandom(), "test.material");
         EXPECT_TRUE(materialAssetResult);
         MaterialPropertyIndex propertyIndex = materialAssetResult.GetValue()->GetMaterialPropertiesLayout()->FindPropertyIndex(MaterialPropertyId{groupName, propertyName});
         CheckSimilar(expectedFinalValue, materialAssetResult.GetValue()->GetPropertyValues()[propertyIndex.GetIndex()].GetValue<PropertyTypeT>());
@@ -1178,15 +958,12 @@ namespace UnitTest
         
         auto materialAssetLevel1 = sourceDataLevel1.CreateMaterialAssetFromSourceData(Uuid::CreateRandom());
         ASSERT_TRUE(materialAssetLevel1.IsSuccess());
-        EXPECT_TRUE(materialAssetLevel1.GetValue()->WasPreFinalized());
 
         auto materialAssetLevel2 = sourceDataLevel2.CreateMaterialAssetFromSourceData(Uuid::CreateRandom());
         ASSERT_TRUE(materialAssetLevel2.IsSuccess());
-        EXPECT_TRUE(materialAssetLevel2.GetValue()->WasPreFinalized());
 
         auto materialAssetLevel3 = sourceDataLevel3.CreateMaterialAssetFromSourceData(Uuid::CreateRandom());
         ASSERT_TRUE(materialAssetLevel3.IsSuccess());
-        EXPECT_TRUE(materialAssetLevel3.GetValue()->WasPreFinalized());
 
         auto layout = materialAssetLevel1.GetValue()->GetMaterialPropertiesLayout();
         MaterialPropertyIndex myFloat = layout->FindPropertyIndex(Name("general.MyFloat"));
@@ -1304,15 +1081,12 @@ namespace UnitTest
         
         auto materialAssetLevel1 = sourceDataLevel1.CreateMaterialAssetFromSourceData(Uuid::CreateRandom());
         EXPECT_TRUE(materialAssetLevel1.IsSuccess());
-        EXPECT_TRUE(materialAssetLevel1.GetValue()->WasPreFinalized());
 
         auto materialAssetLevel2 = sourceDataLevel2.CreateMaterialAssetFromSourceData(Uuid::CreateRandom());
         EXPECT_TRUE(materialAssetLevel2.IsSuccess());
-        EXPECT_TRUE(materialAssetLevel2.GetValue()->WasPreFinalized());
 
         auto materialAssetLevel3 = sourceDataLevel3.CreateMaterialAssetFromSourceData(Uuid::CreateRandom());
         EXPECT_TRUE(materialAssetLevel3.IsSuccess());
-        EXPECT_TRUE(materialAssetLevel3.GetValue()->WasPreFinalized());
 
         auto layout = materialAssetLevel1.GetValue()->GetMaterialPropertiesLayout();
         MaterialPropertyIndex myFloat = layout->FindPropertyIndex(Name("general.MyFloat"));

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialTests.cpp
@@ -105,7 +105,7 @@ namespace UnitTest
             m_testAttachmentImage = AttachmentImage::FindOrCreate(m_testAttachmentImageAsset);
 
             MaterialAssetCreator materialCreator;
-            materialCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset, true);
+            materialCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset);
             materialCreator.SetPropertyValue(Name{ "MyFloat2" }, Vector2{ 0.1f, 0.2f });
             materialCreator.SetPropertyValue(Name{ "MyFloat3" }, Vector3{ 1.1f, 1.2f, 1.3f });
             materialCreator.SetPropertyValue(Name{ "MyFloat4" }, Vector4{ 2.1f, 2.2f, 2.3f, 2.4f });
@@ -395,7 +395,7 @@ namespace UnitTest
         materialTypeCreator.End(materialTypeAsset);
 
         MaterialAssetCreator materialAssetCreator;
-        materialAssetCreator.Begin(Uuid::CreateRandom(), materialTypeAsset, true);
+        materialAssetCreator.Begin(Uuid::CreateRandom(), materialTypeAsset);
         materialAssetCreator.End(materialAsset);
 
         Data::Instance<Material> material = Material::FindOrCreate(materialAsset);
@@ -447,7 +447,7 @@ namespace UnitTest
         Data::Asset<MaterialAsset> materialAssetWithEmptyImage;
 
         MaterialAssetCreator materialCreator;
-        materialCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset, true);
+        materialCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset);
         materialCreator.SetPropertyValue(Name{"MyFloat2"}, Vector2{0.1f, 0.2f});
         materialCreator.SetPropertyValue(Name{"MyFloat3"}, Vector3{1.1f, 1.2f, 1.3f});
         materialCreator.SetPropertyValue(Name{"MyFloat4"}, Vector4{2.1f, 2.2f, 2.3f, 2.4f});
@@ -485,7 +485,7 @@ namespace UnitTest
 
         Data::Asset<MaterialAsset> emptyMaterialAsset;
         MaterialAssetCreator materialCreator;
-        materialCreator.Begin(Uuid::CreateRandom(), emptyMaterialTypeAsset, true);
+        materialCreator.Begin(Uuid::CreateRandom(), emptyMaterialTypeAsset);
         EXPECT_TRUE(materialCreator.End(emptyMaterialAsset));
 
         Data::Instance<Material> material = Material::FindOrCreate(emptyMaterialAsset);
@@ -547,7 +547,7 @@ namespace UnitTest
         materialTypeCreator.End(m_testMaterialTypeAsset);
 
         MaterialAssetCreator materialAssetCreator;
-        materialAssetCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset, true);
+        materialAssetCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset);
         materialAssetCreator.End(m_testMaterialAsset);
 
         Data::Instance<Material> material = Material::FindOrCreate(m_testMaterialAsset);
@@ -619,7 +619,7 @@ namespace UnitTest
         materialTypeCreator.End(m_testMaterialTypeAsset);
 
         MaterialAssetCreator materialAssetCreator;
-        materialAssetCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset, true);
+        materialAssetCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset);
         materialAssetCreator.End(m_testMaterialAsset);
 
         Data::Instance<Material> material = Material::FindOrCreate(m_testMaterialAsset);
@@ -668,7 +668,7 @@ namespace UnitTest
         materialTypeCreator.End(m_testMaterialTypeAsset);
 
         MaterialAssetCreator materialAssetCreator;
-        materialAssetCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset, true);
+        materialAssetCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset);
         materialAssetCreator.End(m_testMaterialAsset);
 
         Data::Instance<Material> material = Material::FindOrCreate(m_testMaterialAsset);
@@ -750,7 +750,7 @@ namespace UnitTest
         materialTypeCreator.End(m_testMaterialTypeAsset);
 
         MaterialAssetCreator materialAssetCreator;
-        materialAssetCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset, true);
+        materialAssetCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset);
         materialAssetCreator.End(m_testMaterialAsset);
 
         Data::Instance<Material> material = Material::FindOrCreate(m_testMaterialAsset);
@@ -858,7 +858,7 @@ namespace UnitTest
         materialTypeCreator.End(m_testMaterialTypeAsset);
 
         MaterialAssetCreator materialAssetCreator;
-        materialAssetCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset, true);
+        materialAssetCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset);
         materialAssetCreator.End(m_testMaterialAsset);
 
         Data::Instance<Material> material = Material::FindOrCreate(m_testMaterialAsset);
@@ -975,7 +975,7 @@ namespace UnitTest
         materialTypeCreator.End(m_testMaterialTypeAsset);
 
         MaterialAssetCreator materialAssetCreator;
-        materialAssetCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset, true);
+        materialAssetCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset);
         materialAssetCreator.End(m_testMaterialAsset);
 
         Data::Instance<Material> material = Material::FindOrCreate(m_testMaterialAsset);
@@ -1104,7 +1104,7 @@ namespace UnitTest
         materialTypeCreator.End(m_testMaterialTypeAsset);
 
         MaterialAssetCreator materialAssetCreator;
-        materialAssetCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset, true);
+        materialAssetCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset);
         materialAssetCreator.End(m_testMaterialAsset);
 
         Data::Instance<Material> material = Material::FindOrCreate(m_testMaterialAsset);
@@ -1165,7 +1165,7 @@ namespace UnitTest
         materialTypeCreator.End(m_testMaterialTypeAsset);
 
         MaterialAssetCreator materialAssetCreator;
-        materialAssetCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset, true);
+        materialAssetCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset);
         materialAssetCreator.End(m_testMaterialAsset);
 
         Data::Instance<Material> material = Material::FindOrCreate(m_testMaterialAsset);
@@ -1229,7 +1229,7 @@ namespace UnitTest
         materialTypeCreator.End(m_testMaterialTypeAsset);
 
         MaterialAssetCreator materialAssetCreator;
-        materialAssetCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset, true);
+        materialAssetCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset);
         materialAssetCreator.End(m_testMaterialAsset);
 
         Data::Instance<Material> material = Material::FindOrCreate(m_testMaterialAsset);
@@ -1254,7 +1254,7 @@ namespace UnitTest
     {
         Data::Asset<MaterialAsset> materialAsset;
         MaterialAssetCreator materialCreator;
-        materialCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset, true);
+        materialCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset);
         materialCreator.SetPropertyValue(Name{ "MyFloat2" }, Vector2{ 0.1f, 0.2f });
         materialCreator.SetPropertyValue(Name{ "MyFloat3" }, Vector3{ 1.1f, 1.2f, 1.3f });
         materialCreator.SetPropertyValue(Name{ "MyFloat4" }, Vector4{ 2.1f, 2.2f, 2.3f, 2.4f });
@@ -1363,7 +1363,7 @@ namespace UnitTest
         materialTypeCreator.End(materialTypeAsset);
 
         MaterialAssetCreator materialAssetCreator;
-        materialAssetCreator.Begin(Uuid::CreateRandom(), materialTypeAsset, true);
+        materialAssetCreator.Begin(Uuid::CreateRandom(), materialTypeAsset);
         materialAssetCreator.End(materialAsset);
 
         Data::Instance<Material> material = Material::FindOrCreate(materialAsset);
@@ -1408,7 +1408,7 @@ namespace UnitTest
         materialTypeCreator.End(m_testMaterialTypeAsset);
 
         MaterialAssetCreator materialCreator;
-        materialCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset, true);
+        materialCreator.Begin(Uuid::CreateRandom(), m_testMaterialTypeAsset);
         materialCreator.End(m_testMaterialAsset);
 
         Data::Instance<Material> material = Material::FindOrCreate(m_testMaterialAsset);

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialTypeAssetTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialTypeAssetTests.cpp
@@ -606,22 +606,22 @@ namespace UnitTest
         MaterialAssetCreator materialCreator;
 
         Data::Asset<MaterialAsset> materialAssetV1;
-        materialCreator.Begin(Uuid::CreateRandom(), materialTypeAsset, true);
+        materialCreator.Begin(Uuid::CreateRandom(), materialTypeAsset);
         materialCreator.SetMaterialTypeVersion(1);
         EXPECT_TRUE(materialCreator.End(materialAssetV1));
 
         Data::Asset<MaterialAsset> materialAssetV3;
-        materialCreator.Begin(Uuid::CreateRandom(), materialTypeAsset, true);
+        materialCreator.Begin(Uuid::CreateRandom(), materialTypeAsset);
         materialCreator.SetMaterialTypeVersion(3);
         EXPECT_TRUE(materialCreator.End(materialAssetV3));
 
         Data::Asset<MaterialAsset> materialAssetV6;
-        materialCreator.Begin(Uuid::CreateRandom(), materialTypeAsset, true);
+        materialCreator.Begin(Uuid::CreateRandom(), materialTypeAsset);
         materialCreator.SetMaterialTypeVersion(6);
         EXPECT_TRUE(materialCreator.End(materialAssetV6));
 
         Data::Asset<MaterialAsset> materialAssetV9;
-        materialCreator.Begin(Uuid::CreateRandom(), materialTypeAsset, true);
+        materialCreator.Begin(Uuid::CreateRandom(), materialTypeAsset);
         materialCreator.SetMaterialTypeVersion(9);
         EXPECT_TRUE(materialCreator.End(materialAssetV9));
 
@@ -711,7 +711,7 @@ namespace UnitTest
         // Add the MaterialTypeAsset to a MaterialAsset to trigger the value updates
         Data::Asset<MaterialAsset> materialAsset;
         MaterialAssetCreator materialCreator;
-        materialCreator.Begin(Uuid::CreateRandom(), materialTypeAsset, true);
+        materialCreator.Begin(Uuid::CreateRandom(), materialTypeAsset);
         materialCreator.SetMaterialTypeVersion(1);
         EXPECT_TRUE(materialCreator.End(materialAsset));
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnailRenderer.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnailRenderer.cpp
@@ -108,8 +108,7 @@ namespace AZ
                 ThumbnailConfig thumbnailConfig;
                 AZ::RPI::MaterialSourceData materialSourceData;
                 materialSourceData.m_materialType = AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetInfo.m_assetId);
-                auto outcome = materialSourceData.CreateMaterialAsset(
-                    AZ::Uuid::CreateRandom(), "", AZ::RPI::MaterialAssetProcessingMode::PreBake, false);
+                auto outcome = materialSourceData.CreateMaterialAsset(AZ::Uuid::CreateRandom(), "", false);
 
                 if (outcome)
                 {


### PR DESCRIPTION
## What does this PR do?

This PR will address multiple problems with material asset dependencies, hot reloading, and stability. Without these changes, materials, material types, and shaders will not be synchronized when reloading, leading to performance loss, spam related to mismatching material property layouts, spam and rendering anomalies because of missing or mismatching material SRGs, materials not refreshing after changes in material canvas or manual edits to shaders and material types.

Changes include:

Code and options have been removed that allowed opting out of fully baking materials at build time. This prevented asset dependencies and notifications from being propagated correctly and the correct version of assets from being referenced consistently. The material finalization settings were intended to prevent changes made to low level, common shader code utilized by the standard PBR material type from triggering model assets dependent on standard PBR from rebuilding. Instead, the intention is to remove the dependency on standard PBR from the model builder.

Material initialization resets member variables pointing to property layouts in shader resource groups. Without this, reinitialized materials would retain pointers to the previous version of those objects. In the case of material canvas, a generated material may not initially have a material SRG. Once material inputs are added, the material SRG is generated but the reinitialized material ignored it. The same situation would arise if material inputs were moved or the layout changed in any way. The result was log spam, objects rendering incorrectly, if at all, and Instability.

Exploring removing shader reload notification support from the material and asset classes. Handling these notifications attempts to reinitialize the material by passing in its own outdated version of the asset. By doing this, it’s also passing in an outdated version of the material type, shaders, and other assets unless those embedded assets are also handling the shader reload notifications and updating themselves internally. Either way, it’s not the fully baked version of the material being passed in. Instead, high level systems like the material component and other material providers can create a new material instance or reinitialize after they receive material ready and reload notifications from the asset bus.

Signed-off-by: gadams3 <guthadam@amazon.com>

Resolves https://github.com/o3de/o3de/issues/13667

## How was this PR tested?

Updated and ran unit tests. All tests passed.
Testing and verified hot reloading of iterative changes in material canvas and material editor.
Preparing to test ASV.

Continuing to test these changes but so far material component and material canvas reloading is consistent and no longer reporting any errors or asserts. Materials refresh and reflect changes as expected.