### PR TITLE
Updated prefabs in o3de to follow new pattern that colliders require a rigid body

### DIFF
--- a/Assets/Editor/Prefabs/Default_Level.prefab
+++ b/Assets/Editor/Prefabs/Default_Level.prefab
@@ -141,6 +141,10 @@
                     "$type": "EditorInspectorComponent",
                     "Id": 16919232076966545697
                 },
+                "Component_[4228479570410194639]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4228479570410194639
+                },
                 "Component_[5182430712893438093]": {
                     "$type": "EditorMaterialComponent",
                     "Id": 5182430712893438093

--- a/AutomatedTesting/Levels/DefaultLevel/DefaultLevel.prefab
+++ b/AutomatedTesting/Levels/DefaultLevel/DefaultLevel.prefab
@@ -208,6 +208,10 @@
                     "$type": "EditorLockComponent",
                     "Id": 7090012899106946164
                 },
+                "Component_[773790315487116393]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 773790315487116393
+                },
                 "Component_[9410832619875640998]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 9410832619875640998

--- a/AutomatedTesting/Levels/Multiplayer/ReactivatingNetEntity/ReactivatingNetEntity.prefab
+++ b/AutomatedTesting/Levels/Multiplayer/ReactivatingNetEntity/ReactivatingNetEntity.prefab
@@ -136,6 +136,10 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 13711420870643673468
                 },
+                "Component_[13722683864759125153]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13722683864759125153
+                },
                 "Component_[138002849734991713]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 138002849734991713
@@ -742,20 +746,6 @@
                 "Component_[460678799589944781]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 460678799589944781
-                },
-                "Component_[6338428544016584613]": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 6338428544016584613,
-                    "m_template": {
-                        "$type": "NetworkPlayerSpawnerComponent",
-                        "SpawnableAsset": {
-                            "assetId": {
-                                "guid": "{129F7D66-108C-5549-92C6-5C909B95DA62}",
-                                "subId": 738868766
-                            },
-                            "assetHint": "levels/multiplayer/reactivatingnetentity/player.network.spawnable"
-                        }
-                    }
                 },
                 "Component_[7753493077417004814]": {
                     "$type": "EditorEntitySortComponent",

--- a/AutomatedTesting/Levels/Navigation/NavigationSample/CityPortion.prefab
+++ b/AutomatedTesting/Levels/Navigation/NavigationSample/CityPortion.prefab
@@ -7,10 +7,6 @@
                 "$type": "EditorEntityIconComponent",
                 "Id": 11043277518452554776
             },
-            "Component_[1224239024537701137]": {
-                "$type": "SelectionComponent",
-                "Id": 1224239024537701137
-            },
             "Component_[12825388930915858146]": {
                 "$type": "EditorDisabledCompositionComponent",
                 "Id": 12825388930915858146
@@ -165,11 +161,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -187,9 +178,9 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 8231836430223196434
                 },
-                "Component_[9076658479587913644]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9076658479587913644
+                "Component_[9129779652031523105]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9129779652031523105
                 }
             }
         },
@@ -204,10 +195,6 @@
                 "Component_[11940241940314955283]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 11940241940314955283
-                },
-                "Component_[12094608478409290456]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12094608478409290456
                 },
                 "Component_[15065514314034488866]": {
                     "$type": "EditorInspectorComponent",
@@ -270,6 +257,10 @@
             "Id": "Entity_[11299011348621]",
             "Name": "Ground",
             "Components": {
+                "Component_[10444376930591328744]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 10444376930591328744
+                },
                 "Component_[10946777360722158921]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 10946777360722158921,
@@ -370,11 +361,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -391,10 +377,6 @@
                 "Component_[8231836430223196434]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 8231836430223196434
-                },
-                "Component_[9076658479587913644]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9076658479587913644
                 }
             }
         },
@@ -502,11 +484,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -524,9 +501,9 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 8231836430223196434
                 },
-                "Component_[9076658479587913644]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9076658479587913644
+                "Component_[8260769176303463586]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8260769176303463586
                 }
             }
         },
@@ -624,6 +601,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 4191213037974650114
                 },
+                "Component_[5523114719137612391]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5523114719137612391
+                },
                 "Component_[561144275819577369]": {
                     "$type": "EditorColliderComponent",
                     "Id": 561144275819577369,
@@ -633,11 +614,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -655,10 +631,6 @@
                 "Component_[8231836430223196434]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 8231836430223196434
-                },
-                "Component_[9076658479587913644]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9076658479587913644
                 }
             }
         },
@@ -686,6 +658,10 @@
                             "SortIndex": 3
                         }
                     ]
+                },
+                "Component_[1143529838174529455]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1143529838174529455
                 },
                 "Component_[11786689926888634210]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -766,11 +742,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -787,10 +758,6 @@
                 "Component_[8231836430223196434]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 8231836430223196434
-                },
-                "Component_[9076658479587913644]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9076658479587913644
                 }
             }
         },
@@ -818,6 +785,10 @@
                             "SortIndex": 3
                         }
                     ]
+                },
+                "Component_[11626066835780709791]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 11626066835780709791
                 },
                 "Component_[11786689926888634210]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -898,11 +869,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -919,10 +885,6 @@
                 "Component_[8231836430223196434]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 8231836430223196434
-                },
-                "Component_[9076658479587913644]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9076658479587913644
                 }
             }
         },
@@ -1030,11 +992,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -1048,13 +1005,13 @@
                         }
                     }
                 },
+                "Component_[5617458393138790682]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5617458393138790682
+                },
                 "Component_[8231836430223196434]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 8231836430223196434
-                },
-                "Component_[9076658479587913644]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9076658479587913644
                 }
             }
         },
@@ -1086,6 +1043,10 @@
                 "Component_[11786689926888634210]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 11786689926888634210
+                },
+                "Component_[12721781019698885872]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 12721781019698885872
                 },
                 "Component_[13316023297093478237]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -1167,11 +1128,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -1188,10 +1144,6 @@
                 "Component_[8231836430223196434]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 8231836430223196434
-                },
-                "Component_[9076658479587913644]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9076658479587913644
                 }
             }
         },
@@ -1281,6 +1233,10 @@
                     "$type": "EditorLockComponent",
                     "Id": 17193921221555106955
                 },
+                "Component_[18148311216392106435]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 18148311216392106435
+                },
                 "Component_[18333533576999955869]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 18333533576999955869
@@ -1299,11 +1255,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -1320,10 +1271,6 @@
                 "Component_[8231836430223196434]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 8231836430223196434
-                },
-                "Component_[9076658479587913644]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9076658479587913644
                 }
             }
         },
@@ -1417,6 +1364,10 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 18333533576999955869
                 },
+                "Component_[3659461388081519064]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 3659461388081519064
+                },
                 "Component_[4191213037974650114]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 4191213037974650114
@@ -1430,11 +1381,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -1452,10 +1398,6 @@
                 "Component_[8231836430223196434]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 8231836430223196434
-                },
-                "Component_[9076658479587913644]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9076658479587913644
                 }
             }
         },
@@ -1563,11 +1505,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -1581,13 +1518,13 @@
                         }
                     }
                 },
+                "Component_[8130325540891911590]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8130325540891911590
+                },
                 "Component_[8231836430223196434]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 8231836430223196434
-                },
-                "Component_[9076658479587913644]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9076658479587913644
                 }
             }
         },
@@ -1595,6 +1532,10 @@
             "Id": "Entity_[11569594288269]",
             "Name": "Ground",
             "Components": {
+                "Component_[10466589213229408165]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 10466589213229408165
+                },
                 "Component_[10946777360722158921]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 10946777360722158921,
@@ -1695,11 +1636,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -1716,10 +1652,6 @@
                 "Component_[8231836430223196434]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 8231836430223196434
-                },
-                "Component_[9076658479587913644]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9076658479587913644
                 }
             }
         },
@@ -1793,6 +1725,10 @@
                         }
                     }
                 },
+                "Component_[16562318651126349772]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 16562318651126349772
+                },
                 "Component_[16756187867691340653]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 16756187867691340653,
@@ -1827,11 +1763,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -1848,10 +1779,6 @@
                 "Component_[8231836430223196434]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 8231836430223196434
-                },
-                "Component_[9076658479587913644]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9076658479587913644
                 }
             }
         },
@@ -1945,6 +1872,10 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 18333533576999955869
                 },
+                "Component_[2019623542322377295]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 2019623542322377295
+                },
                 "Component_[4191213037974650114]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 4191213037974650114
@@ -1958,11 +1889,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -1980,10 +1906,6 @@
                 "Component_[8231836430223196434]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 8231836430223196434
-                },
-                "Component_[9076658479587913644]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9076658479587913644
                 }
             }
         },
@@ -2023,6 +1945,10 @@
                 "Component_[13633009520175731636]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 13633009520175731636
+                },
+                "Component_[1422295178687924955]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1422295178687924955
                 },
                 "Component_[14594453775970915486]": {
                     "$type": "AZ::Render::EditorMeshComponent",
@@ -2091,11 +2017,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -2112,10 +2033,6 @@
                 "Component_[8231836430223196434]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 8231836430223196434
-                },
-                "Component_[9076658479587913644]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9076658479587913644
                 }
             }
         },
@@ -2223,11 +2140,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -2245,9 +2157,9 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 8231836430223196434
                 },
-                "Component_[9076658479587913644]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9076658479587913644
+                "Component_[8986611733273153699]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8986611733273153699
                 }
             }
         },
@@ -2274,6 +2186,10 @@
                     "$type": "EditorInspectorComponent",
                     "Id": 12731562982192231049
                 },
+                "Component_[15404821413892525429]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 15404821413892525429
+                },
                 "Component_[15662589502982568121]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 15662589502982568121,
@@ -2299,10 +2215,6 @@
                 "Component_[1989157093308533954]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 1989157093308533954
-                },
-                "Component_[3336260609790664760]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3336260609790664760
                 },
                 "Component_[3703844470882397551]": {
                     "$type": "EditorMaterialComponent",
@@ -2339,11 +2251,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -2417,13 +2324,13 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 15918579274461744191
                 },
+                "Component_[17017182064968299551]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17017182064968299551
+                },
                 "Component_[1989157093308533954]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 1989157093308533954
-                },
-                "Component_[3336260609790664760]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3336260609790664760
                 },
                 "Component_[3703844470882397551]": {
                     "$type": "EditorMaterialComponent",
@@ -2460,11 +2367,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -2542,10 +2444,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 1989157093308533954
                 },
-                "Component_[3336260609790664760]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3336260609790664760
-                },
                 "Component_[3703844470882397551]": {
                     "$type": "EditorMaterialComponent",
                     "Id": 3703844470882397551,
@@ -2582,11 +2480,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -2611,6 +2504,10 @@
                 "Component_[8659510516882020099]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 8659510516882020099
+                },
+                "Component_[9104334404173946520]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9104334404173946520
                 }
             }
         },
@@ -2676,10 +2573,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 1989157093308533954
                 },
-                "Component_[3336260609790664760]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3336260609790664760
-                },
                 "Component_[3874326360471912205]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 3874326360471912205
@@ -2697,11 +2590,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -2727,6 +2615,10 @@
                 "Component_[8659510516882020099]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 8659510516882020099
+                },
+                "Component_[8946763346869141532]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8946763346869141532
                 }
             }
         }

--- a/AutomatedTesting/Levels/Physics/Collider_AddingNewGroupWorks/Collider_AddingNewGroupWorks.prefab
+++ b/AutomatedTesting/Levels/Physics/Collider_AddingNewGroupWorks/Collider_AddingNewGroupWorks.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -55,6 +51,10 @@
             "Id": "Entity_[263565336022]",
             "Name": "Sphere",
             "Components": {
+                "Component_[10270843354917552198]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 10270843354917552198
+                },
                 "Component_[1077035889980990778]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 1077035889980990778
@@ -87,10 +87,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 16774751424420453062
                 },
-                "Component_[2076554166090224023]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2076554166090224023
-                },
                 "Component_[3796327233831302715]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 3796327233831302715,
@@ -115,9 +111,11 @@
                         "CollisionGroupId": {
                             "GroupId": "{C6156E97-7789-4EFA-AA8B-F987FF1C829F}"
                         },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -175,10 +173,6 @@
                 "Component_[3047355939801335922]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
-                },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
                 },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",

--- a/AutomatedTesting/Levels/Physics/Collider_CollisionGroupsWorkflow/Collider_CollisionGroupsWorkflow.prefab
+++ b/AutomatedTesting/Levels/Physics/Collider_CollisionGroupsWorkflow/Collider_CollisionGroupsWorkflow.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -96,9 +92,11 @@
                         "CollisionGroupId": {
                             "GroupId": "{2C698BDF-B2CC-47FC-8356-6BAB160AFFE9}"
                         },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -139,10 +137,6 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 2810034955465504327
                 },
-                "Component_[3274864013943777794]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3274864013943777794
-                },
                 "Component_[3519576227402671568]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 3519576227402671568
@@ -165,12 +159,17 @@
                     "Configuration": {
                         "entityId": "",
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 6.0
-                        }
+                        "Inertia tensor": [
+                            6.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            6.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            6.0
+                        ]
                     }
                 }
             }
@@ -185,12 +184,17 @@
                     "Configuration": {
                         "entityId": "",
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 6.0
-                        }
+                        "Inertia tensor": [
+                            6.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            6.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            6.0
+                        ]
                     }
                 },
                 "Component_[15577190100407053290]": {
@@ -269,10 +273,6 @@
                         }
                     }
                 },
-                "Component_[6609021482930126566]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6609021482930126566
-                },
                 "Component_[7888321721748456023]": {
                     "$type": "EditorColliderComponent",
                     "Id": 7888321721748456023,
@@ -283,9 +283,11 @@
                         "CollisionGroupId": {
                             "GroupId": "{802547AF-5A11-4FEE-B30F-D12BFA2624C6}"
                         },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -309,12 +311,17 @@
                     "Configuration": {
                         "entityId": "",
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 6.0
-                        }
+                        "Inertia tensor": [
+                            6.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            6.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            6.0
+                        ]
                     }
                 },
                 "Component_[15577190100407053290]": {
@@ -393,10 +400,6 @@
                         }
                     }
                 },
-                "Component_[6609021482930126566]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6609021482930126566
-                },
                 "Component_[7888321721748456023]": {
                     "$type": "EditorColliderComponent",
                     "Id": 7888321721748456023,
@@ -407,9 +410,11 @@
                         "CollisionGroupId": {
                             "GroupId": "{802547AF-5A11-4FEE-B30F-D12BFA2624C6}"
                         },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -469,10 +474,6 @@
                         }
                     ]
                 },
-                "Component_[16052791866579738900]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16052791866579738900
-                },
                 "Component_[16429863672749850210]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 16429863672749850210
@@ -491,9 +492,11 @@
                         "CollisionGroupId": {
                             "GroupId": "{802547AF-5A11-4FEE-B30F-D12BFA2624C6}"
                         },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -507,6 +510,10 @@
                             ]
                         }
                     ]
+                },
+                "Component_[1927410549490098029]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1927410549490098029
                 },
                 "Component_[2455764014686394094]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -575,10 +582,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -609,6 +612,10 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 13699442376833814569
                 },
+                "Component_[13839339887306521722]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13839339887306521722
+                },
                 "Component_[15635759330685702346]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 15635759330685702346,
@@ -625,10 +632,6 @@
                             "SortIndex": 2
                         }
                     ]
-                },
-                "Component_[16052791866579738900]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16052791866579738900
                 },
                 "Component_[16429863672749850210]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -673,9 +676,11 @@
                         "CollisionGroupId": {
                             "GroupId": "{2C698BDF-B2CC-47FC-8356-6BAB160AFFE9}"
                         },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -745,9 +750,11 @@
                         "CollisionGroupId": {
                             "GroupId": "{2C698BDF-B2CC-47FC-8356-6BAB160AFFE9}"
                         },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -788,10 +795,6 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 2810034955465504327
                 },
-                "Component_[3274864013943777794]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3274864013943777794
-                },
                 "Component_[3519576227402671568]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 3519576227402671568
@@ -814,12 +817,17 @@
                     "Configuration": {
                         "entityId": "",
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 6.0
-                        }
+                        "Inertia tensor": [
+                            6.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            6.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            6.0
+                        ]
                     }
                 }
             }

--- a/AutomatedTesting/Levels/Physics/Collider_PxMeshErrorIfNoMesh/Collider_PxMeshErrorIfNoMesh.prefab
+++ b/AutomatedTesting/Levels/Physics/Collider_PxMeshErrorIfNoMesh/Collider_PxMeshErrorIfNoMesh.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -96,10 +92,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -130,13 +122,19 @@
                         ]
                     }
                 },
+                "Component_[14059406946656899002]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 14059406946656899002
+                },
                 "Component_[14197962870538087335]": {
                     "$type": "EditorColliderComponent",
                     "Id": 14197962870538087335,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     }
@@ -160,10 +158,6 @@
                 "Component_[4534782371004434129]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 4534782371004434129
-                },
-                "Component_[657568858670829150]": {
-                    "$type": "SelectionComponent",
-                    "Id": 657568858670829150
                 },
                 "Component_[6962773877616982646]": {
                     "$type": "EditorVisibilityComponent",

--- a/AutomatedTesting/Levels/Physics/Collider_TriggerPassThrough/Collider_TriggerPassThrough.prefab
+++ b/AutomatedTesting/Levels/Physics/Collider_TriggerPassThrough/Collider_TriggerPassThrough.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -91,10 +87,6 @@
                 "Component_[3047355939801335922]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
-                },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
                 },
                 "Component_[4677020082511410627]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -150,9 +142,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 2500413517137346426,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -186,10 +180,6 @@
                             "SortIndex": 3
                         }
                     ]
-                },
-                "Component_[4513570945482921177]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4513570945482921177
                 },
                 "Component_[5181032452959651218]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -268,10 +258,6 @@
                         }
                     ]
                 },
-                "Component_[14360604399974600422]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14360604399974600422
-                },
                 "Component_[1638976515288798682]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 1638976515288798682
@@ -284,6 +270,10 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 17778751519274450365
                 },
+                "Component_[18384675688115197126]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 18384675688115197126
+                },
                 "Component_[18424302950171014166]": {
                     "$type": "EditorColliderComponent",
                     "Id": 18424302950171014166,
@@ -293,9 +283,11 @@
                             0.0,
                             1.0
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -379,10 +371,6 @@
                         }
                     ]
                 },
-                "Component_[14360604399974600422]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14360604399974600422
-                },
                 "Component_[1638976515288798682]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 1638976515288798682
@@ -406,9 +394,11 @@
                             0.0,
                             1.0
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -440,6 +430,10 @@
                             }
                         }
                     }
+                },
+                "Component_[4190697708283374601]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4190697708283374601
                 }
             }
         }

--- a/AutomatedTesting/Levels/Physics/EnablingGravityWorks/EnablingGravityWorks.prefab
+++ b/AutomatedTesting/Levels/Physics/EnablingGravityWorks/EnablingGravityWorks.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -55,13 +51,13 @@
             "Id": "Entity_[258695561562]",
             "Name": "Terrain",
             "Components": {
+                "Component_[103605035329056672]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 103605035329056672
+                },
                 "Component_[11134362586460591061]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 11134362586460591061
-                },
-                "Component_[12079850593699113824]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12079850593699113824
                 },
                 "Component_[12876908415630047209]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -129,9 +125,11 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 8251430000110142445,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -193,10 +191,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9042477178449779636]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 9042477178449779636
@@ -230,10 +224,6 @@
                 "Component_[12002902910001242503]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 12002902910001242503
-                },
-                "Component_[12062958768063128753]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12062958768063128753
                 },
                 "Component_[16573499138393956547]": {
                     "$type": "EditorEntityIconComponent",
@@ -271,12 +261,17 @@
                         "entityId": "",
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 2.5
-                        }
+                        "Inertia tensor": [
+                            2.5,
+                            0.0,
+                            0.0,
+                            0.0,
+                            2.5,
+                            0.0,
+                            0.0,
+                            0.0,
+                            2.5
+                        ]
                     }
                 },
                 "Component_[7842182096652302722]": {
@@ -287,9 +282,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 8567733134384127375,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },

--- a/AutomatedTesting/Levels/Physics/ForceRegion_CapsuleShapedForce/ForceRegion_CapsuleShapedForce.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_CapsuleShapedForce/ForceRegion_CapsuleShapedForce.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -91,10 +87,6 @@
                 "Component_[3047355939801335922]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
-                },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
                 },
                 "Component_[3959118778101598946]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -150,6 +142,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 16382725053857185045
                 },
+                "Component_[179746941743246621]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 179746941743246621
+                },
                 "Component_[2008515508908179722]": {
                     "$type": "EditorLockComponent",
                     "Id": 2008515508908179722
@@ -157,10 +153,6 @@
                 "Component_[3347528728285583652]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 3347528728285583652
-                },
-                "Component_[3667189370747951032]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3667189370747951032
                 },
                 "Component_[5374281256218458327]": {
                     "$type": "EditorForceRegionComponent",
@@ -197,9 +189,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -270,9 +264,11 @@
                             0.0,
                             0.5
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -299,10 +295,6 @@
                             45.0
                         ]
                     }
-                },
-                "Component_[3531552003066974404]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3531552003066974404
                 },
                 "Component_[4472989986428660453]": {
                     "$type": "EditorInspectorComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_DirectionHasNoAffectOnTotalForce/ForceRegion_DirectionHasNoAffectOnTotalForce.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_DirectionHasNoAffectOnTotalForce/ForceRegion_DirectionHasNoAffectOnTotalForce.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -55,10 +51,6 @@
             "Id": "Entity_[262856422196]",
             "Name": "force_region_2",
             "Components": {
-                "Component_[11076685892229420454]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11076685892229420454
-                },
                 "Component_[1825012846916095498]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 1825012846916095498
@@ -89,9 +81,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -105,6 +99,10 @@
                             ]
                         }
                     }
+                },
+                "Component_[5943479712153949608]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5943479712153949608
                 },
                 "Component_[7217128968425074271]": {
                     "$type": "EditorForceRegionComponent",
@@ -177,6 +175,10 @@
                     "$type": "EditorLockComponent",
                     "Id": 13018077446556189592
                 },
+                "Component_[14378741359094190334]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 14378741359094190334
+                },
                 "Component_[14740728446475380331]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 14740728446475380331
@@ -236,9 +238,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -252,10 +256,6 @@
                             ]
                         }
                     }
-                },
-                "Component_[564253058341979437]": {
-                    "$type": "SelectionComponent",
-                    "Id": 564253058341979437
                 },
                 "Component_[6330270960515826312]": {
                     "$type": "EditorEntitySortComponent",
@@ -284,10 +284,6 @@
             "Id": "Entity_[271446356788]",
             "Name": "sphere_2",
             "Components": {
-                "Component_[12982173553597989381]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12982173553597989381
-                },
                 "Component_[13533479963545119787]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 13533479963545119787
@@ -309,9 +305,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 18258932247456487838,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -429,10 +427,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -493,9 +487,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 18366716326380447553,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -516,10 +512,6 @@
                         "Gravity Enabled": false,
                         "Compute Mass": false
                     }
-                },
-                "Component_[3091026005228595364]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3091026005228595364
                 },
                 "Component_[3709960250008472987]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -555,9 +547,9 @@
             "Id": "Entity_[280036291380]",
             "Name": "force_region_4",
             "Components": {
-                "Component_[11076685892229420454]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11076685892229420454
+                "Component_[18063023949559998466]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 18063023949559998466
                 },
                 "Component_[1825012846916095498]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -589,9 +581,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -669,10 +663,6 @@
             "Id": "Entity_[281526095057]",
             "Name": "force_region_0",
             "Components": {
-                "Component_[11076685892229420454]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11076685892229420454
-                },
                 "Component_[1825012846916095498]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 1825012846916095498
@@ -684,6 +674,10 @@
                 "Component_[2253717676126693144]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 2253717676126693144
+                },
+                "Component_[3498345613419071648]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 3498345613419071648
                 },
                 "Component_[3668557058367528113]": {
                     "$type": "EditorEntityIconComponent",
@@ -703,9 +697,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -791,6 +787,10 @@
                     "$type": "EditorLockComponent",
                     "Id": 13018077446556189592
                 },
+                "Component_[1402974762762366163]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1402974762762366163
+                },
                 "Component_[14740728446475380331]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 14740728446475380331
@@ -850,9 +850,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -866,10 +868,6 @@
                             ]
                         }
                     }
-                },
-                "Component_[564253058341979437]": {
-                    "$type": "SelectionComponent",
-                    "Id": 564253058341979437
                 },
                 "Component_[6330270960515826312]": {
                     "$type": "EditorEntitySortComponent",
@@ -898,6 +896,10 @@
             "Id": "Entity_[285821062353]",
             "Name": "force_region_1",
             "Components": {
+                "Component_[10152414761927665425]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 10152414761927665425
+                },
                 "Component_[1281723178393925641]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 1281723178393925641
@@ -965,9 +967,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -981,10 +985,6 @@
                             ]
                         }
                     }
-                },
-                "Component_[564253058341979437]": {
-                    "$type": "SelectionComponent",
-                    "Id": 564253058341979437
                 },
                 "Component_[6330270960515826312]": {
                     "$type": "EditorEntitySortComponent",
@@ -1013,10 +1013,6 @@
             "Id": "Entity_[288626225972]",
             "Name": "sphere_4",
             "Components": {
-                "Component_[12982173553597989381]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12982173553597989381
-                },
                 "Component_[13533479963545119787]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 13533479963545119787
@@ -1038,9 +1034,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 18258932247456487838,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1117,10 +1115,6 @@
             "Id": "Entity_[290116029649]",
             "Name": "sphere_0",
             "Components": {
-                "Component_[12982173553597989381]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12982173553597989381
-                },
                 "Component_[13533479963545119787]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 13533479963545119787
@@ -1142,9 +1136,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 18258932247456487838,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1263,9 +1259,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 18366716326380447553,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1286,10 +1284,6 @@
                         "Gravity Enabled": false,
                         "Compute Mass": false
                     }
-                },
-                "Component_[3091026005228595364]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3091026005228595364
                 },
                 "Component_[3709960250008472987]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -1367,9 +1361,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 18366716326380447553,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1390,10 +1386,6 @@
                         "Gravity Enabled": false,
                         "Compute Mass": false
                     }
-                },
-                "Component_[3091026005228595364]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3091026005228595364
                 },
                 "Component_[3709960250008472987]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_HighValuesDirectionAxesWorkWithNoError/ForceRegion_HighValuesDirectionAxesWorkWithNoError.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_HighValuesDirectionAxesWorkWithNoError/ForceRegion_HighValuesDirectionAxesWorkWithNoError.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -88,10 +84,6 @@
                         ]
                     }
                 },
-                "Component_[1217101245303897300]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1217101245303897300
-                },
                 "Component_[12291252161569845485]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12291252161569845485
@@ -104,9 +96,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14337613086038282335,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -198,9 +192,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -222,6 +218,10 @@
                 "Component_[5180749011316010468]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 5180749011316010468
+                },
+                "Component_[6126897910407196487]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6126897910407196487
                 },
                 "Component_[7533425702745957756]": {
                     "$type": "EditorForceRegionComponent",
@@ -251,10 +251,6 @@
                             }
                         }
                     ]
-                },
-                "Component_[7673319437897703826]": {
-                    "$type": "SelectionComponent",
-                    "Id": 7673319437897703826
                 },
                 "Component_[8974245314304170844]": {
                     "$type": "EditorLockComponent",
@@ -303,10 +299,6 @@
                         ]
                     }
                 },
-                "Component_[1217101245303897300]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1217101245303897300
-                },
                 "Component_[12291252161569845485]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12291252161569845485
@@ -319,9 +311,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14337613086038282335,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -403,6 +397,10 @@
                         ]
                     }
                 },
+                "Component_[1576838936660125820]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1576838936660125820
+                },
                 "Component_[17444672391153729398]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 17444672391153729398
@@ -413,9 +411,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -470,10 +470,6 @@
                         }
                     ]
                 },
-                "Component_[7673319437897703826]": {
-                    "$type": "SelectionComponent",
-                    "Id": 7673319437897703826
-                },
                 "Component_[8974245314304170844]": {
                     "$type": "EditorLockComponent",
                     "Id": 8974245314304170844
@@ -521,10 +517,6 @@
                         ]
                     }
                 },
-                "Component_[1217101245303897300]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1217101245303897300
-                },
                 "Component_[12291252161569845485]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12291252161569845485
@@ -537,9 +529,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14337613086038282335,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -595,10 +589,6 @@
                 "Component_[15255763170409911822]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 15255763170409911822
-                },
-                "Component_[16487716786068262334]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16487716786068262334
                 },
                 "Component_[3657230180793708178]": {
                     "$type": "EditorEntitySortComponent",
@@ -707,9 +697,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -732,9 +724,9 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 5180749011316010468
                 },
-                "Component_[7673319437897703826]": {
-                    "$type": "SelectionComponent",
-                    "Id": 7673319437897703826
+                "Component_[8149900326387931357]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8149900326387931357
                 },
                 "Component_[8974245314304170844]": {
                     "$type": "EditorLockComponent",
@@ -797,9 +789,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -813,6 +807,10 @@
                             ]
                         }
                     }
+                },
+                "Component_[4356469818833126992]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4356469818833126992
                 },
                 "Component_[4680012562900031353]": {
                     "$type": "EditorVisibilityComponent",
@@ -849,10 +847,6 @@
                             }
                         }
                     ]
-                },
-                "Component_[7673319437897703826]": {
-                    "$type": "SelectionComponent",
-                    "Id": 7673319437897703826
                 },
                 "Component_[8974245314304170844]": {
                     "$type": "EditorLockComponent",
@@ -901,10 +895,6 @@
                         ]
                     }
                 },
-                "Component_[1217101245303897300]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1217101245303897300
-                },
                 "Component_[12291252161569845485]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12291252161569845485
@@ -917,9 +907,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14337613086038282335,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -997,10 +989,6 @@
                         ]
                     }
                 },
-                "Component_[1217101245303897300]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1217101245303897300
-                },
                 "Component_[12291252161569845485]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12291252161569845485
@@ -1013,9 +1001,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14337613086038282335,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1085,6 +1075,10 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 1184472558140852547
                 },
+                "Component_[12382375580271959391]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 12382375580271959391
+                },
                 "Component_[15529417857362096874]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 15529417857362096874,
@@ -1107,9 +1101,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1160,10 +1156,6 @@
                             }
                         }
                     ]
-                },
-                "Component_[7673319437897703826]": {
-                    "$type": "SelectionComponent",
-                    "Id": 7673319437897703826
                 },
                 "Component_[8974245314304170844]": {
                     "$type": "EditorLockComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_ImpulsesBoxShapedRigidBody/ForceRegion_ImpulsesBoxShapedRigidBody.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_ImpulsesBoxShapedRigidBody/ForceRegion_ImpulsesBoxShapedRigidBody.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -96,10 +92,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -118,10 +110,6 @@
             "Id": "Entity_[355506484304]",
             "Name": "Force Region",
             "Components": {
-                "Component_[11280909321423981689]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11280909321423981689
-                },
                 "Component_[16854315530707009745]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 16854315530707009745
@@ -136,9 +124,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -180,6 +170,10 @@
                 "Component_[5888163144028789147]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 5888163144028789147
+                },
+                "Component_[6209861274415601701]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6209861274415601701
                 },
                 "Component_[6424236228697592522]": {
                     "$type": "EditorForceRegionComponent",
@@ -250,9 +244,11 @@
                             0.0,
                             1.0
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -278,10 +274,6 @@
                         "entityId": "",
                         "Compute Mass": false
                     }
-                },
-                "Component_[16753379648037728845]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16753379648037728845
                 },
                 "Component_[1702798579844760976]": {
                     "$type": "EditorLockComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_ImpulsesCapsuleShapedRigidBody/ForceRegion_ImpulsesCapsuleShapedRigidBody.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_ImpulsesCapsuleShapedRigidBody/ForceRegion_ImpulsesCapsuleShapedRigidBody.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -96,10 +92,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -118,9 +110,9 @@
             "Id": "Entity_[355506484304]",
             "Name": "Force Region",
             "Components": {
-                "Component_[11280909321423981689]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11280909321423981689
+                "Component_[13990796929987269592]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13990796929987269592
                 },
                 "Component_[16854315530707009745]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -136,9 +128,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -250,9 +244,11 @@
                             0.0,
                             1.0
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -278,10 +274,6 @@
                         "entityId": "",
                         "Compute Mass": false
                     }
-                },
-                "Component_[16753379648037728845]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16753379648037728845
                 },
                 "Component_[1702798579844760976]": {
                     "$type": "EditorLockComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_ImpulsesPxMeshShapedRigidBody/ForceRegion_ImpulsesPxMeshShapedRigidBody.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_ImpulsesPxMeshShapedRigidBody/ForceRegion_ImpulsesPxMeshShapedRigidBody.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -83,9 +79,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 17072051774364123210,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -115,10 +113,6 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 18276539780150073839
                 },
-                "Component_[2066690476385973349]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2066690476385973349
-                },
                 "Component_[4921143390685436960]": {
                     "$type": "EditorRigidBodyComponent",
                     "Id": 4921143390685436960,
@@ -130,12 +124,17 @@
                             -0.07926200330257416,
                             0.434479296207428
                         ],
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 0.88129061460495
-                        }
+                        "Inertia tensor": [
+                            0.88129061460495,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.88129061460495,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.88129061460495
+                        ]
                     }
                 },
                 "Component_[5346221168058002519]": {
@@ -214,10 +213,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -278,9 +273,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -312,13 +309,13 @@
                         }
                     ]
                 },
-                "Component_[3872163302901841777]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3872163302901841777
-                },
                 "Component_[6396247764760116092]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 6396247764760116092
+                },
+                "Component_[7725802731985081045]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 7725802731985081045
                 },
                 "Component_[7728919727375645335]": {
                     "$type": "EditorVisibilityComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_LinearDampingForceOnRigidBodies/ForceRegion_LinearDampingForceOnRigidBodies.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_LinearDampingForceOnRigidBodies/ForceRegion_LinearDampingForceOnRigidBodies.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -95,10 +91,6 @@
                 "Component_[3047355939801335922]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
-                },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
                 },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -169,6 +161,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 15124982576423132697
                 },
+                "Component_[15264324071228283130]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 15264324071228283130
+                },
                 "Component_[15404147350950921063]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 15404147350950921063
@@ -183,9 +179,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -211,10 +209,6 @@
                             }
                         }
                     ]
-                },
-                "Component_[8746009087687308085]": {
-                    "$type": "SelectionComponent",
-                    "Id": 8746009087687308085
                 },
                 "Component_[9050210137740138695]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -287,9 +281,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 284487610596488543,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -304,10 +300,6 @@
                 "Component_[6567853573351593579]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 6567853573351593579
-                },
-                "Component_[6657555488150791773]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6657555488150791773
                 },
                 "Component_[7363342380577489355]": {
                     "$type": "EditorEntityIconComponent",
@@ -360,19 +352,17 @@
                         }
                     ]
                 },
-                "Component_[4429422174533779014]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4429422174533779014
-                },
                 "Component_[4851027798256990127]": {
                     "$type": "EditorColliderComponent",
                     "Id": 4851027798256990127,
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -420,6 +410,10 @@
                 "Component_[7182682966725935291]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 7182682966725935291
+                },
+                "Component_[7472058718412293425]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 7472058718412293425
                 },
                 "Component_[7735698619234889834]": {
                     "$type": "EditorPendingCompositionComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_LocalSpaceForceOnRigidBodies/ForceRegion_LocalSpaceForceOnRigidBodies.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_LocalSpaceForceOnRigidBodies/ForceRegion_LocalSpaceForceOnRigidBodies.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -96,10 +92,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -124,9 +116,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -172,10 +166,6 @@
                         }
                     ]
                 },
-                "Component_[3228372766822292280]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3228372766822292280
-                },
                 "Component_[3953010346260389577]": {
                     "$type": "EditorLockComponent",
                     "Id": 3953010346260389577
@@ -195,6 +185,10 @@
                 "Component_[4777009146570219810]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 4777009146570219810
+                },
+                "Component_[5912585905272923206]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5912585905272923206
                 },
                 "Component_[5933256255355945925]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -282,10 +276,6 @@
                         ]
                     }
                 },
-                "Component_[13374137142518600136]": {
-                    "$type": "SelectionComponent",
-                    "Id": 13374137142518600136
-                },
                 "Component_[14261030316739436718]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 14261030316739436718
@@ -320,9 +310,11 @@
                             0.0,
                             0.5
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },

--- a/AutomatedTesting/Levels/Physics/ForceRegion_MovingForceRegionChangesNetForce/ForceRegion_MovingForceRegionChangesNetForce.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_MovingForceRegionChangesNetForce/ForceRegion_MovingForceRegionChangesNetForce.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -58,10 +54,6 @@
                 "Component_[11715519062967203564]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 11715519062967203564
-                },
-                "Component_[12116605035306086849]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12116605035306086849
                 },
                 "Component_[12527068633650846978]": {
                     "$type": "EditorEntityIconComponent",
@@ -79,6 +71,10 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 17968486723623259793
                 },
+                "Component_[18319946024592317322]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 18319946024592317322
+                },
                 "Component_[3582638891871769105]": {
                     "$type": "EditorColliderComponent",
                     "Id": 3582638891871769105,
@@ -90,9 +86,11 @@
                             0.0,
                             0.5
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -159,10 +157,6 @@
             "Id": "Entity_[287124693539]",
             "Name": "SphereRigidBody",
             "Components": {
-                "Component_[11933716127308513926]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11933716127308513926
-                },
                 "Component_[14778399419284274541]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 14778399419284274541
@@ -237,9 +231,11 @@
                             0.0,
                             0.5
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },

--- a/AutomatedTesting/Levels/Physics/ForceRegion_MultipleComponentsCombineForces/ForceRegion_MultipleComponentsCombineForces.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_MultipleComponentsCombineForces/ForceRegion_MultipleComponentsCombineForces.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -96,10 +92,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -124,9 +116,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -140,6 +134,10 @@
                             ]
                         }
                     }
+                },
+                "Component_[10539467539571757957]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 10539467539571757957
                 },
                 "Component_[12838489135272223497]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -206,10 +204,6 @@
                 "Component_[4746672286683920775]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 4746672286683920775
-                },
-                "Component_[6112275728051139122]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6112275728051139122
                 }
             }
         },
@@ -223,9 +217,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -251,6 +247,10 @@
                 "Component_[14369151857466231221]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 14369151857466231221
+                },
+                "Component_[14980866372571301058]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 14980866372571301058
                 },
                 "Component_[16154030206307636514]": {
                     "$type": "EditorEntityIconComponent",
@@ -308,10 +308,6 @@
                 "Component_[4746672286683920775]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 4746672286683920775
-                },
-                "Component_[6112275728051139122]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6112275728051139122
                 }
             }
         },
@@ -328,9 +324,11 @@
                             0.0,
                             0.5
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -341,10 +339,6 @@
                 "Component_[16279388574077995590]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 16279388574077995590
-                },
-                "Component_[17660057469603617926]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17660057469603617926
                 },
                 "Component_[18407444214271538352]": {
                     "$type": "EditorEntityIconComponent",
@@ -426,9 +420,11 @@
                             0.0,
                             0.5
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -439,10 +435,6 @@
                 "Component_[16279388574077995590]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 16279388574077995590
-                },
-                "Component_[17660057469603617926]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17660057469603617926
                 },
                 "Component_[18407444214271538352]": {
                     "$type": "EditorEntityIconComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_MultipleForcesInSameComponentCombineForces/ForceRegion_MultipleForcesInSameComponentCombineForces.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_MultipleForcesInSameComponentCombineForces/ForceRegion_MultipleForcesInSameComponentCombineForces.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -91,10 +87,6 @@
                 "Component_[3047355939801335922]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
-                },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
                 },
                 "Component_[761453111961316947]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -167,9 +159,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -212,9 +206,9 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 475116335422037420
                 },
-                "Component_[5799844388461702133]": {
-                    "$type": "SelectionComponent",
-                    "Id": 5799844388461702133
+                "Component_[6629906396685401764]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6629906396685401764
                 },
                 "Component_[8675597473547646053]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -302,10 +296,6 @@
                         ]
                     }
                 },
-                "Component_[4508540238885657540]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4508540238885657540
-                },
                 "Component_[5400193701816852996]": {
                     "$type": "EditorColliderComponent",
                     "Id": 5400193701816852996,
@@ -315,9 +305,11 @@
                             0.0,
                             0.5
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },

--- a/AutomatedTesting/Levels/Physics/ForceRegion_NoQuiverOnHighLinearDampingForce/ForceRegion_NoQuiverOnHighLinearDampingForce.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_NoQuiverOnHighLinearDampingForce/ForceRegion_NoQuiverOnHighLinearDampingForce.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -71,10 +67,6 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10512175486999420826
                 },
-                "Component_[10729728356565917095]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10729728356565917095
-                },
                 "Component_[11783523334734810042]": {
                     "$type": "EditorForceRegionComponent",
                     "Id": 11783523334734810042,
@@ -90,6 +82,10 @@
                 "Component_[13500036476732578341]": {
                     "$type": "EditorLockComponent",
                     "Id": 13500036476732578341
+                },
+                "Component_[13601221085707996595]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13601221085707996595
                 },
                 "Component_[17475484965829344677]": {
                     "$type": "EditorEntitySortComponent",
@@ -139,11 +135,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -206,10 +197,6 @@
                 "Component_[1933240123730478370]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 1933240123730478370
-                },
-                "Component_[2433946146395572651]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2433946146395572651
                 },
                 "Component_[3068220161200459190]": {
                     "$type": "EditorOnlyEntityComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_ParentChildForcesCombineForces/ForceRegion_ParentChildForcesCombineForces.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_ParentChildForcesCombineForces/ForceRegion_ParentChildForcesCombineForces.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -82,9 +78,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -130,6 +128,10 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 14716066842794086837
                 },
+                "Component_[16416031669382050634]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 16416031669382050634
+                },
                 "Component_[17519113110653241937]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 17519113110653241937
@@ -155,10 +157,6 @@
                             ]
                         }
                     }
-                },
-                "Component_[2457515126342722840]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2457515126342722840
                 },
                 "Component_[596343620181960911]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -208,9 +206,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -254,9 +254,9 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 2631293066231955056
                 },
-                "Component_[655080765307091941]": {
-                    "$type": "SelectionComponent",
-                    "Id": 655080765307091941
+                "Component_[7620459147782584658]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 7620459147782584658
                 },
                 "Component_[9473616213752171715]": {
                     "$type": "EditorBoxShapeComponent",
@@ -328,10 +328,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -377,9 +373,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -439,6 +437,10 @@
                         "Entity_[1612948785617]"
                     ]
                 },
+                "Component_[1674414876533995895]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1674414876533995895
+                },
                 "Component_[17519113110653241937]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 17519113110653241937
@@ -450,10 +452,6 @@
                 "Component_[185260310632811827]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 185260310632811827
-                },
-                "Component_[2457515126342722840]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2457515126342722840
                 },
                 "Component_[596343620181960911]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -501,9 +499,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 13125029424343233715,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -553,10 +553,6 @@
                 "Component_[2631293066231955056]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 2631293066231955056
-                },
-                "Component_[655080765307091941]": {
-                    "$type": "SelectionComponent",
-                    "Id": 655080765307091941
                 },
                 "Component_[9301036236118645777]": {
                     "$type": "EditorRigidBodyComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_PointForceOnRigidBodies/ForceRegion_PointForceOnRigidBodies.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_PointForceOnRigidBodies/ForceRegion_PointForceOnRigidBodies.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -95,10 +91,6 @@
                 "Component_[3047355939801335922]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
-                },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
                 },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -160,9 +152,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -214,14 +208,14 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 8666893775284351835
                 },
-                "Component_[8942463751737332902]": {
-                    "$type": "SelectionComponent",
-                    "Id": 8942463751737332902
-                },
                 "Component_[9707418614808762591]": {
                     "$type": "EditorBoxShapeComponent",
                     "Id": 9707418614808762591,
                     "GameView": true
+                },
+                "Component_[9963847657929568140]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9963847657929568140
                 }
             }
         },
@@ -277,10 +271,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 6771629689623098442
                 },
-                "Component_[7685618063763946451]": {
-                    "$type": "SelectionComponent",
-                    "Id": 7685618063763946451
-                },
                 "Component_[8701595253904669652]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 8701595253904669652,
@@ -311,9 +301,11 @@
                             0.0,
                             0.5
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },

--- a/AutomatedTesting/Levels/Physics/ForceRegion_PositionOffset/ForceRegion_PositionOffset.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_PositionOffset/ForceRegion_PositionOffset.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -96,10 +92,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -129,9 +121,11 @@
                             0.0,
                             0.0
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -153,6 +147,10 @@
                 "Component_[11422707812942686882]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 11422707812942686882
+                },
+                "Component_[13243203667155267594]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13243203667155267594
                 },
                 "Component_[14237237900281326814]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -242,10 +240,6 @@
                             "SortIndex": 3
                         }
                     ]
-                },
-                "Component_[6122974305635603954]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6122974305635603954
                 }
             }
         },
@@ -257,9 +251,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -301,10 +297,6 @@
                 "Component_[2849452631059171820]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
-                },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
                 },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -339,6 +331,10 @@
                         }
                     ]
                 },
+                "Component_[8130835354367386354]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8130835354367386354
+                },
                 "Component_[9136380755680336740]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 9136380755680336740
@@ -357,9 +353,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -394,6 +392,10 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15891766986063042570
                 },
+                "Component_[16933657985301043635]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 16933657985301043635
+                },
                 "Component_[2450079780500558114]": {
                     "$type": "EditorLockComponent",
                     "Id": 2450079780500558114
@@ -401,10 +403,6 @@
                 "Component_[2849452631059171820]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
-                },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
                 },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -457,9 +455,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -502,9 +502,9 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
                 },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
+                "Component_[483315658493947521]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 483315658493947521
                 },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -557,9 +557,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -601,10 +603,6 @@
                 "Component_[2849452631059171820]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
-                },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
                 },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -639,6 +637,10 @@
                         }
                     ]
                 },
+                "Component_[8729558420291307478]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8729558420291307478
+                },
                 "Component_[9136380755680336740]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 9136380755680336740
@@ -657,9 +659,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -694,6 +698,10 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15891766986063042570
                 },
+                "Component_[17653625690180643194]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17653625690180643194
+                },
                 "Component_[2450079780500558114]": {
                     "$type": "EditorLockComponent",
                     "Id": 2450079780500558114
@@ -701,10 +709,6 @@
                 "Component_[2849452631059171820]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
-                },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
                 },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -790,9 +794,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14224898404594011297,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -822,10 +828,6 @@
                 "Component_[3196271264232348143]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 3196271264232348143
-                },
-                "Component_[4322068942380886068]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4322068942380886068
                 },
                 "Component_[4464572295159651560]": {
                     "$type": "EditorVisibilityComponent",
@@ -874,9 +876,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -919,10 +923,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
                 },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
-                },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 5177784304866978075,
@@ -934,6 +934,10 @@
                             37.25
                         ]
                     }
+                },
+                "Component_[5484806693434552740]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5484806693434552740
                 },
                 "Component_[5911269087661464643]": {
                     "$type": "EditorEntityIconComponent",
@@ -974,9 +978,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1019,10 +1025,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
                 },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
-                },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 5177784304866978075,
@@ -1055,6 +1057,10 @@
                             "SortIndex": 2
                         }
                     ]
+                },
+                "Component_[8505571863125799077]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8505571863125799077
                 },
                 "Component_[9136380755680336740]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -1107,9 +1113,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14224898404594011297,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1139,10 +1147,6 @@
                 "Component_[3196271264232348143]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 3196271264232348143
-                },
-                "Component_[4322068942380886068]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4322068942380886068
                 },
                 "Component_[4464572295159651560]": {
                     "$type": "EditorVisibilityComponent",
@@ -1191,9 +1195,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1224,6 +1230,10 @@
                         }
                     }
                 },
+                "Component_[15776575069262296152]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 15776575069262296152
+                },
                 "Component_[15891766986063042570]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15891766986063042570
@@ -1235,10 +1245,6 @@
                 "Component_[2849452631059171820]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
-                },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
                 },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -1298,9 +1304,11 @@
                             3.0,
                             0.0
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1412,9 +1420,9 @@
                         }
                     ]
                 },
-                "Component_[6122974305635603954]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6122974305635603954
+                "Component_[5893257077180569446]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5893257077180569446
                 }
             }
         },
@@ -1459,9 +1467,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14224898404594011297,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1491,10 +1501,6 @@
                 "Component_[3196271264232348143]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 3196271264232348143
-                },
-                "Component_[4322068942380886068]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4322068942380886068
                 },
                 "Component_[4464572295159651560]": {
                     "$type": "EditorVisibilityComponent",
@@ -1576,9 +1582,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14224898404594011297,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1608,10 +1616,6 @@
                 "Component_[3196271264232348143]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 3196271264232348143
-                },
-                "Component_[4322068942380886068]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4322068942380886068
                 },
                 "Component_[4464572295159651560]": {
                     "$type": "EditorVisibilityComponent",
@@ -1667,9 +1671,11 @@
                             0.0,
                             3.0
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1781,9 +1787,9 @@
                         }
                     ]
                 },
-                "Component_[6122974305635603954]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6122974305635603954
+                "Component_[8917810987558000894]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8917810987558000894
                 }
             }
         },
@@ -1795,9 +1801,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1808,6 +1816,10 @@
                 "Component_[11773955025499748960]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 11773955025499748960
+                },
+                "Component_[12088240635022253573]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 12088240635022253573
                 },
                 "Component_[12379720822775260097]": {
                     "$type": "EditorBoxShapeComponent",
@@ -1839,10 +1851,6 @@
                 "Component_[2849452631059171820]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
-                },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
                 },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -1928,9 +1936,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14224898404594011297,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1960,10 +1970,6 @@
                 "Component_[3196271264232348143]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 3196271264232348143
-                },
-                "Component_[4322068942380886068]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4322068942380886068
                 },
                 "Component_[4464572295159651560]": {
                     "$type": "EditorVisibilityComponent",
@@ -2012,9 +2018,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -2056,10 +2064,6 @@
                 "Component_[2849452631059171820]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
-                },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
                 },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -2094,6 +2098,10 @@
                         }
                     ]
                 },
+                "Component_[786376167476127993]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 786376167476127993
+                },
                 "Component_[9136380755680336740]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 9136380755680336740
@@ -2112,9 +2120,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -2157,9 +2167,9 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
                 },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
+                "Component_[3609716012330359002]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 3609716012330359002
                 },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -2245,9 +2255,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14224898404594011297,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -2277,10 +2289,6 @@
                 "Component_[3196271264232348143]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 3196271264232348143
-                },
-                "Component_[4322068942380886068]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4322068942380886068
                 },
                 "Component_[4464572295159651560]": {
                     "$type": "EditorVisibilityComponent",
@@ -2329,9 +2337,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -2362,6 +2372,10 @@
                         }
                     }
                 },
+                "Component_[1398753364733312760]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1398753364733312760
+                },
                 "Component_[15891766986063042570]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15891766986063042570
@@ -2373,10 +2387,6 @@
                 "Component_[2849452631059171820]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
-                },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
                 },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_PrefabInstantiates/ForceRegionEntity.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_PrefabInstantiates/ForceRegionEntity.prefab
@@ -39,10 +39,6 @@
                 "$type": "EditorLockComponent",
                 "Id": 2052804302889291078
             },
-            "Component_[2863922822500093657]": {
-                "$type": "SelectionComponent",
-                "Id": 2863922822500093657
-            },
             "Component_[5519696087052953252]": {
                 "$type": "EditorPrefabComponent",
                 "Id": 5519696087052953252
@@ -69,10 +65,6 @@
                         }
                     ]
                 },
-                "Component_[11972970532048219080]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11972970532048219080
-                },
                 "Component_[12192522742539893057]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 12192522742539893057
@@ -93,6 +85,10 @@
                             "SortIndex": 2
                         }
                     ]
+                },
+                "Component_[13801150941276366001]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13801150941276366001
                 },
                 "Component_[17342015521141665263]": {
                     "$type": "EditorEntitySortComponent",
@@ -129,9 +125,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },

--- a/AutomatedTesting/Levels/Physics/ForceRegion_PxMeshShapedForce/ForceRegion_PxMeshShapedForce.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_PxMeshShapedForce/ForceRegion_PxMeshShapedForce.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -61,9 +57,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -139,9 +137,9 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 18244240723284900447
                 },
-                "Component_[2384529240485117149]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2384529240485117149
+                "Component_[587394366223174429]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 587394366223174429
                 },
                 "Component_[607250426053999174]": {
                     "$type": "EditorEntityIconComponent",
@@ -219,12 +217,17 @@
                     "Configuration": {
                         "entityId": "",
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 },
                 "Component_[18301470101490524797]": {
@@ -270,19 +273,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 6742936953893799137,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
                     "ShapeConfiguration": {
                         "ShapeType": 0
                     }
-                },
-                "Component_[7354819447050428862]": {
-                    "$type": "SelectionComponent",
-                    "Id": 7354819447050428862
                 }
             }
         }

--- a/AutomatedTesting/Levels/Physics/ForceRegion_RotationalOffset/ForceRegion_RotationalOffset.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_RotationalOffset/ForceRegion_RotationalOffset.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -96,10 +92,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -130,9 +122,11 @@
                             0.0,
                             0.708984375
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -244,9 +238,9 @@
                         }
                     ]
                 },
-                "Component_[6122974305635603954]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6122974305635603954
+                "Component_[6387915907247308328]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6387915907247308328
                 }
             }
         },
@@ -258,9 +252,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -303,9 +299,9 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
                 },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
+                "Component_[5093658278033215283]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5093658278033215283
                 },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -363,9 +359,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -420,10 +418,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
                 },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
-                },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 5177784304866978075,
@@ -462,6 +456,10 @@
                         }
                     ]
                 },
+                "Component_[9122163073077435100]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9122163073077435100
+                },
                 "Component_[9136380755680336740]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 9136380755680336740
@@ -480,9 +478,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -525,9 +525,9 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
                 },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
+                "Component_[4387924250392629883]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4387924250392629883
                 },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -580,9 +580,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -617,6 +619,10 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15891766986063042570
                 },
+                "Component_[16682476456632150710]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 16682476456632150710
+                },
                 "Component_[2450079780500558114]": {
                     "$type": "EditorLockComponent",
                     "Id": 2450079780500558114
@@ -624,10 +630,6 @@
                 "Component_[2849452631059171820]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
-                },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
                 },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -685,9 +687,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -718,6 +722,10 @@
                         }
                     }
                 },
+                "Component_[15070763185710998413]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 15070763185710998413
+                },
                 "Component_[15891766986063042570]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15891766986063042570
@@ -729,10 +737,6 @@
                 "Component_[2849452631059171820]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
-                },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
                 },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -818,9 +822,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14224898404594011297,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -850,10 +856,6 @@
                 "Component_[3196271264232348143]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 3196271264232348143
-                },
-                "Component_[4322068942380886068]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4322068942380886068
                 },
                 "Component_[4464572295159651560]": {
                     "$type": "EditorVisibilityComponent",
@@ -902,9 +904,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -959,10 +963,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
                 },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
-                },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 5177784304866978075,
@@ -1001,6 +1001,10 @@
                         }
                     ]
                 },
+                "Component_[8850631706297673266]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8850631706297673266
+                },
                 "Component_[9136380755680336740]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 9136380755680336740
@@ -1019,9 +1023,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1052,6 +1058,10 @@
                         }
                     }
                 },
+                "Component_[13154483884331833601]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13154483884331833601
+                },
                 "Component_[15891766986063042570]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15891766986063042570
@@ -1063,10 +1073,6 @@
                 "Component_[2849452631059171820]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
-                },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
                 },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -1152,9 +1158,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14224898404594011297,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1184,10 +1192,6 @@
                 "Component_[3196271264232348143]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 3196271264232348143
-                },
-                "Component_[4322068942380886068]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4322068942380886068
                 },
                 "Component_[4464572295159651560]": {
                     "$type": "EditorVisibilityComponent",
@@ -1236,9 +1240,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1273,6 +1279,10 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15891766986063042570
                 },
+                "Component_[18141216088001977333]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 18141216088001977333
+                },
                 "Component_[2450079780500558114]": {
                     "$type": "EditorLockComponent",
                     "Id": 2450079780500558114
@@ -1280,10 +1290,6 @@
                 "Component_[2849452631059171820]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
-                },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
                 },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -1344,9 +1350,11 @@
                             0.0,
                             0.708984375
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1437,6 +1445,10 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 3202926484013115517
                 },
+                "Component_[4126118587115496841]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4126118587115496841
+                },
                 "Component_[5003642034301844595]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 5003642034301844595,
@@ -1457,10 +1469,6 @@
                             "SortIndex": 3
                         }
                     ]
-                },
-                "Component_[6122974305635603954]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6122974305635603954
                 }
             }
         },
@@ -1505,9 +1513,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14224898404594011297,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1537,10 +1547,6 @@
                 "Component_[3196271264232348143]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 3196271264232348143
-                },
-                "Component_[4322068942380886068]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4322068942380886068
                 },
                 "Component_[4464572295159651560]": {
                     "$type": "EditorVisibilityComponent",
@@ -1622,9 +1628,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14224898404594011297,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1654,10 +1662,6 @@
                 "Component_[3196271264232348143]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 3196271264232348143
-                },
-                "Component_[4322068942380886068]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4322068942380886068
                 },
                 "Component_[4464572295159651560]": {
                     "$type": "EditorVisibilityComponent",
@@ -1714,9 +1718,11 @@
                             0.7071437239646912,
                             0.708984375
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1775,6 +1781,10 @@
                     "$type": "EditorLockComponent",
                     "Id": 17255931630896525843
                 },
+                "Component_[2084606549780077974]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 2084606549780077974
+                },
                 "Component_[2101484393736205036]": {
                     "$type": "EditorBoxShapeComponent",
                     "Id": 2101484393736205036,
@@ -1827,10 +1837,6 @@
                             "SortIndex": 3
                         }
                     ]
-                },
-                "Component_[6122974305635603954]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6122974305635603954
                 }
             }
         },
@@ -1842,9 +1848,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1879,6 +1887,10 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15891766986063042570
                 },
+                "Component_[17655716505527630519]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17655716505527630519
+                },
                 "Component_[2450079780500558114]": {
                     "$type": "EditorLockComponent",
                     "Id": 2450079780500558114
@@ -1886,10 +1898,6 @@
                 "Component_[2849452631059171820]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
-                },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
                 },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -1975,9 +1983,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14224898404594011297,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -2007,10 +2017,6 @@
                 "Component_[3196271264232348143]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 3196271264232348143
-                },
-                "Component_[4322068942380886068]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4322068942380886068
                 },
                 "Component_[4464572295159651560]": {
                     "$type": "EditorVisibilityComponent",
@@ -2059,9 +2065,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -2104,10 +2112,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
                 },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
-                },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 5177784304866978075,
@@ -2123,6 +2127,10 @@
                 "Component_[5911269087661464643]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 5911269087661464643
+                },
+                "Component_[5983003562163138967]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5983003562163138967
                 },
                 "Component_[7806598650913923730]": {
                     "$type": "EditorInspectorComponent",
@@ -2159,9 +2167,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -2175,6 +2185,10 @@
                             ]
                         }
                     }
+                },
+                "Component_[10914572999228522307]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 10914572999228522307
                 },
                 "Component_[11773955025499748960]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -2215,10 +2229,6 @@
                 "Component_[2849452631059171820]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
-                },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
                 },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -2309,9 +2319,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14224898404594011297,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -2341,10 +2353,6 @@
                 "Component_[3196271264232348143]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 3196271264232348143
-                },
-                "Component_[4322068942380886068]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4322068942380886068
                 },
                 "Component_[4464572295159651560]": {
                     "$type": "EditorVisibilityComponent",
@@ -2393,9 +2401,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10641714068494953363,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -2430,6 +2440,10 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15891766986063042570
                 },
+                "Component_[2304322499782661365]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 2304322499782661365
+                },
                 "Component_[2450079780500558114]": {
                     "$type": "EditorLockComponent",
                     "Id": 2450079780500558114
@@ -2437,10 +2451,6 @@
                 "Component_[2849452631059171820]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 2849452631059171820
-                },
-                "Component_[4373559361383615054]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4373559361383615054
                 },
                 "Component_[5177784304866978075]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_SimpleDragForceOnRigidBodies/ForceRegion_SimpleDragForceOnRigidBodies.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_SimpleDragForceOnRigidBodies/ForceRegion_SimpleDragForceOnRigidBodies.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -96,10 +92,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -138,15 +130,21 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 2666651999496282559
                 },
+                "Component_[3602094712739312751]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 3602094712739312751
+                },
                 "Component_[4190351693097703533]": {
                     "$type": "EditorColliderComponent",
                     "Id": 4190351693097703533,
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -193,10 +191,6 @@
                         ]
                     }
                 },
-                "Component_[7131239797354804502]": {
-                    "$type": "SelectionComponent",
-                    "Id": 7131239797354804502
-                },
                 "Component_[9253882679972673809]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 9253882679972673809,
@@ -237,9 +231,11 @@
                             0.0,
                             0.5
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -299,10 +295,6 @@
                             "SortIndex": 3
                         }
                     ]
-                },
-                "Component_[3588192566961159594]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3588192566961159594
                 },
                 "Component_[6926982803772662053]": {
                     "$type": "EditorOnlyEntityComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_SmallMagnitudeDeviationOnLargeForces/ForceRegion_SmallMagnitudeDeviationOnLargeForces.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_SmallMagnitudeDeviationOnLargeForces/ForceRegion_SmallMagnitudeDeviationOnLargeForces.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -94,9 +90,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -138,6 +136,10 @@
                         ]
                     }
                 },
+                "Component_[4078031199745025593]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4078031199745025593
+                },
                 "Component_[5763927342520629215]": {
                     "$type": "EditorLockComponent",
                     "Id": 5763927342520629215
@@ -145,10 +147,6 @@
                 "Component_[7531376322926995655]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 7531376322926995655
-                },
-                "Component_[8264507417233530976]": {
-                    "$type": "SelectionComponent",
-                    "Id": 8264507417233530976
                 },
                 "Component_[8358337765875207462]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -182,10 +180,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 1115113803276103220
                 },
-                "Component_[11924195204198903977]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11924195204198903977
-                },
                 "Component_[1276345366428075735]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 1276345366428075735
@@ -198,9 +192,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16172305626787000438,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },

--- a/AutomatedTesting/Levels/Physics/ForceRegion_SphereShapedForce/ForceRegion_SphereShapedForce.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_SphereShapedForce/ForceRegion_SphereShapedForce.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -91,10 +87,6 @@
                 "Component_[3047355939801335922]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
-                },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
                 },
                 "Component_[4502579211853420197]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -156,9 +148,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -168,6 +162,10 @@
                             "Radius": 3.0
                         }
                     }
+                },
+                "Component_[13699730929521034254]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13699730929521034254
                 },
                 "Component_[16742559604579969148]": {
                     "$type": "EditorEntitySortComponent",
@@ -180,10 +178,6 @@
                 "Component_[4394422991431442012]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 4394422991431442012
-                },
-                "Component_[6273568731103770037]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6273568731103770037
                 },
                 "Component_[6689678886724215129]": {
                     "$type": "EditorLockComponent",
@@ -235,9 +229,11 @@
                             0.0,
                             0.5
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -264,10 +260,6 @@
                 "Component_[15509001367106311440]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 15509001367106311440
-                },
-                "Component_[16442108914364885784]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16442108914364885784
                 },
                 "Component_[1941132031561600273]": {
                     "$type": "EditorVisibilityComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_SplineForceOnRigidBodies/ForceRegion_SplineForceOnRigidBodies.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_SplineForceOnRigidBodies/ForceRegion_SplineForceOnRigidBodies.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -98,9 +94,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -147,9 +145,9 @@
                     "$type": "EditorLockComponent",
                     "Id": 6996958029592442366
                 },
-                "Component_[7234536879080653142]": {
-                    "$type": "SelectionComponent",
-                    "Id": 7234536879080653142
+                "Component_[7885430517313815047]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 7885430517313815047
                 },
                 "Component_[8379145965981853801]": {
                     "$type": "EditorEntitySortComponent",
@@ -242,9 +240,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4457568364146036575,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -280,10 +280,6 @@
                             56.0
                         ]
                     }
-                },
-                "Component_[9881234323561781444]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9881234323561781444
                 }
             }
         },
@@ -302,6 +298,10 @@
                             51.0
                         ]
                     }
+                },
+                "Component_[10824731405786987184]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 10824731405786987184
                 },
                 "Component_[11958516455748178589]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -334,9 +334,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -347,10 +349,6 @@
                 "Component_[18312154701274824579]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 18312154701274824579
-                },
-                "Component_[5503056011896155663]": {
-                    "$type": "SelectionComponent",
-                    "Id": 5503056011896155663
                 },
                 "Component_[5503383422952588599]": {
                     "$type": "EditorSphereShapeComponent",
@@ -436,9 +434,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -449,10 +449,6 @@
                 "Component_[18312154701274824579]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 18312154701274824579
-                },
-                "Component_[5503056011896155663]": {
-                    "$type": "SelectionComponent",
-                    "Id": 5503056011896155663
                 },
                 "Component_[5503383422952588599]": {
                     "$type": "EditorSphereShapeComponent",
@@ -488,6 +484,10 @@
                 "Component_[9622679977791551339]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 9622679977791551339
+                },
+                "Component_[9808826355636870171]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9808826355636870171
                 }
             }
         },
@@ -515,6 +515,10 @@
                     "$type": "EditorLockComponent",
                     "Id": 12905621489618495352
                 },
+                "Component_[13630277075092398255]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13630277075092398255
+                },
                 "Component_[14910199652269985177]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 14910199652269985177,
@@ -538,9 +542,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -551,10 +557,6 @@
                 "Component_[18312154701274824579]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 18312154701274824579
-                },
-                "Component_[5503056011896155663]": {
-                    "$type": "SelectionComponent",
-                    "Id": 5503056011896155663
                 },
                 "Component_[5503383422952588599]": {
                     "$type": "EditorSphereShapeComponent",
@@ -640,9 +642,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -653,10 +657,6 @@
                 "Component_[18312154701274824579]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 18312154701274824579
-                },
-                "Component_[5503056011896155663]": {
-                    "$type": "SelectionComponent",
-                    "Id": 5503056011896155663
                 },
                 "Component_[5503383422952588599]": {
                     "$type": "EditorSphereShapeComponent",
@@ -676,6 +676,10 @@
                             ]
                         }
                     }
+                },
+                "Component_[570979903557905559]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 570979903557905559
                 },
                 "Component_[6960222251430158177]": {
                     "$type": "EditorEntityIconComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_SplineRegionWithModifiedTransform/ForceRegion_SplineRegionWithModifiedTransform.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_SplineRegionWithModifiedTransform/ForceRegion_SplineRegionWithModifiedTransform.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -75,9 +71,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14852461319282422545,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -163,10 +161,6 @@
                             "SortIndex": 3
                         }
                     ]
-                },
-                "Component_[9781300856110304578]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9781300856110304578
                 }
             }
         },
@@ -196,9 +190,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -253,6 +249,10 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 8572430005774015373
                 },
+                "Component_[8904415192085086079]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8904415192085086079
+                },
                 "Component_[9188864009972696870]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 9188864009972696870,
@@ -269,10 +269,6 @@
                             "SortIndex": 2
                         }
                     ]
-                },
-                "Component_[9781300856110304578]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9781300856110304578
                 }
             }
         },
@@ -283,6 +279,10 @@
                 "Component_[10405021042248159955]": {
                     "$type": "EditorLockComponent",
                     "Id": 10405021042248159955
+                },
+                "Component_[12089750689633134015]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 12089750689633134015
                 },
                 "Component_[13459286072711980262]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -302,9 +302,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -375,10 +377,6 @@
                             "SortIndex": 2
                         }
                     ]
-                },
-                "Component_[9781300856110304578]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9781300856110304578
                 }
             }
         },
@@ -408,9 +406,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -453,6 +453,10 @@
                         }
                     }
                 },
+                "Component_[3067654867744298937]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 3067654867744298937
+                },
                 "Component_[6220057123735521038]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 6220057123735521038
@@ -481,10 +485,6 @@
                             "SortIndex": 2
                         }
                     ]
-                },
-                "Component_[9781300856110304578]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9781300856110304578
                 }
             }
         },
@@ -514,9 +514,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -538,6 +540,10 @@
                 "Component_[17211297289344545407]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 17211297289344545407
+                },
+                "Component_[17884481120891166287]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17884481120891166287
                 },
                 "Component_[2235796114524801607]": {
                     "$type": "EditorSphereShapeComponent",
@@ -587,10 +593,6 @@
                             "SortIndex": 2
                         }
                     ]
-                },
-                "Component_[9781300856110304578]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9781300856110304578
                 }
             }
         },
@@ -707,9 +709,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -829,13 +833,13 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 165699220815603099
                 },
+                "Component_[17658317937142073417]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17658317937142073417
+                },
                 "Component_[2460290057035236623]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 2460290057035236623
-                },
-                "Component_[7928301240147624334]": {
-                    "$type": "SelectionComponent",
-                    "Id": 7928301240147624334
                 }
             }
         }

--- a/AutomatedTesting/Levels/Physics/ForceRegion_WorldSpaceForceOnRigidBodies/ForceRegion_WorldSpaceForceOnRigidBodies.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_WorldSpaceForceOnRigidBodies/ForceRegion_WorldSpaceForceOnRigidBodies.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -73,10 +69,6 @@
                             }
                         }
                     ]
-                },
-                "Component_[16552379245302227119]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16552379245302227119
                 },
                 "Component_[3221035514528112017]": {
                     "$type": "EditorInspectorComponent",
@@ -121,9 +113,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -141,6 +135,10 @@
                 "Component_[6679033685309347475]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 6679033685309347475
+                },
+                "Component_[672703097116189883]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 672703097116189883
                 },
                 "Component_[6834749143646896747]": {
                     "$type": "EditorVisibilityComponent",
@@ -184,10 +182,6 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 14184826875203987683
                 },
-                "Component_[15166068009966661228]": {
-                    "$type": "SelectionComponent",
-                    "Id": 15166068009966661228
-                },
                 "Component_[16162525862031058734]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 16162525862031058734
@@ -213,9 +207,11 @@
                             0.0,
                             0.5
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -294,10 +290,6 @@
                 "Component_[3047355939801335922]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
-                },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
                 },
                 "Component_[8826722283956091153]": {
                     "$type": "EditorOnlyEntityComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_ZeroLinearDampingDoesNothing/ForceRegion_ZeroLinearDampingDoesNothing.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_ZeroLinearDampingDoesNothing/ForceRegion_ZeroLinearDampingDoesNothing.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -91,10 +87,6 @@
                 "Component_[3047355939801335922]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
-                },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
                 },
                 "Component_[735314560482743923]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -159,9 +151,11 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 15207509147789878003,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -197,6 +191,10 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 4063930810265535511
                 },
+                "Component_[4938441519899494402]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4938441519899494402
+                },
                 "Component_[6305042967059717778]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 6305042967059717778
@@ -204,10 +202,6 @@
                 "Component_[6579162722167290272]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 6579162722167290272
-                },
-                "Component_[7505241169297468186]": {
-                    "$type": "SelectionComponent",
-                    "Id": 7505241169297468186
                 },
                 "Component_[9901087016055414497]": {
                     "$type": "EditorLockComponent",
@@ -272,10 +266,6 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 14814439440515955733
                 },
-                "Component_[15163432692112924310]": {
-                    "$type": "SelectionComponent",
-                    "Id": 15163432692112924310
-                },
                 "Component_[256177509800666852]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 256177509800666852
@@ -310,15 +300,21 @@
                         }
                     ]
                 },
+                "Component_[8924198280690702493]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8924198280690702493
+                },
                 "Component_[9615281521574313681]": {
                     "$type": "EditorColliderComponent",
                     "Id": 9615281521574313681,
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -352,9 +348,11 @@
                             0.0,
                             0.5
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -377,10 +375,6 @@
                 "Component_[12642490403915699899]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 12642490403915699899
-                },
-                "Component_[15610374916332332393]": {
-                    "$type": "SelectionComponent",
-                    "Id": 15610374916332332393
                 },
                 "Component_[17438165335713050007]": {
                     "$type": "EditorInspectorComponent",
@@ -422,12 +416,17 @@
                             0.0,
                             0.5
                         ],
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.000000953674316
-                        }
+                        "Inertia tensor": [
+                            10.000000953674316,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.000000953674316,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.000000953674316
+                        ]
                     }
                 },
                 "Component_[6180223862466446734]": {

--- a/AutomatedTesting/Levels/Physics/ForceRegion_ZeroLocalSpaceForceDoesNothing/ForceRegion_ZeroLocalSpaceForceDoesNothing.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_ZeroLocalSpaceForceDoesNothing/ForceRegion_ZeroLocalSpaceForceDoesNothing.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -95,10 +91,6 @@
                 "Component_[3047355939801335922]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
-                },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
                 },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -190,9 +182,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -207,6 +201,10 @@
                         }
                     }
                 },
+                "Component_[3526603432953702275]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 3526603432953702275
+                },
                 "Component_[3642268784022034771]": {
                     "$type": "EditorBoxShapeComponent",
                     "Id": 3642268784022034771,
@@ -220,10 +218,6 @@
                             ]
                         }
                     }
-                },
-                "Component_[3958314576452149141]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3958314576452149141
                 },
                 "Component_[5079483651742217799]": {
                     "$type": "EditorVisibilityComponent",
@@ -252,9 +246,11 @@
                             0.0,
                             0.5
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -307,10 +303,6 @@
                     "$type": "EditorLockComponent",
                     "Id": 4049958820765177422
                 },
-                "Component_[6457248176216218598]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6457248176216218598
-                },
                 "Component_[7105892263773553905]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 7105892263773553905,
@@ -338,12 +330,17 @@
                             0.0,
                             0.5
                         ],
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.000000953674316
-                        }
+                        "Inertia tensor": [
+                            10.000000953674316,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.000000953674316,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.000000953674316
+                        ]
                     }
                 }
             }
@@ -389,9 +386,11 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 4232158654100578738,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -414,10 +413,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 592510569866213886
                 },
-                "Component_[6207391197758784171]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6207391197758784171
-                },
                 "Component_[6829315767193964115]": {
                     "$type": "EditorBoxShapeComponent",
                     "Id": 6829315767193964115,
@@ -430,6 +425,10 @@
                             ]
                         }
                     }
+                },
+                "Component_[8589431087825935532]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8589431087825935532
                 },
                 "Component_[8949240157660157638]": {
                     "$type": "EditorOnlyEntityComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_ZeroPointForceDoesNothing/ForceRegion_ZeroPointForceDoesNothing.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_ZeroPointForceDoesNothing/ForceRegion_ZeroPointForceDoesNothing.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -95,10 +91,6 @@
                 "Component_[3047355939801335922]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
-                },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
                 },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -179,6 +171,10 @@
                         }
                     ]
                 },
+                "Component_[2172970840575710674]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 2172970840575710674
+                },
                 "Component_[2894675157918644101]": {
                     "$type": "EditorBoxShapeComponent",
                     "Id": 2894675157918644101,
@@ -199,9 +195,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -215,10 +213,6 @@
                             ]
                         }
                     }
-                },
-                "Component_[3958314576452149141]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3958314576452149141
                 },
                 "Component_[5079483651742217799]": {
                     "$type": "EditorVisibilityComponent",
@@ -247,9 +241,11 @@
                             0.0,
                             0.5
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -302,10 +298,6 @@
                     "$type": "EditorLockComponent",
                     "Id": 4049958820765177422
                 },
-                "Component_[6457248176216218598]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6457248176216218598
-                },
                 "Component_[7105892263773553905]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 7105892263773553905,
@@ -333,12 +325,17 @@
                             0.0,
                             0.5
                         ],
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.000000953674316
-                        }
+                        "Inertia tensor": [
+                            10.000000953674316,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.000000953674316,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.000000953674316
+                        ]
                     }
                 }
             }
@@ -351,9 +348,11 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 12542751962260553639,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -422,9 +421,9 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 592510569866213886
                 },
-                "Component_[6207391197758784171]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6207391197758784171
+                "Component_[7104193989178785876]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 7104193989178785876
                 },
                 "Component_[8949240157660157638]": {
                     "$type": "EditorOnlyEntityComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_ZeroSimpleDragForceDoesNothing/ForceRegion_ZeroSimpleDragForceDoesNothing.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_ZeroSimpleDragForceDoesNothing/ForceRegion_ZeroSimpleDragForceDoesNothing.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -58,6 +54,10 @@
                 "Component_[1058672161870704752]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 1058672161870704752
+                },
+                "Component_[12042550642434868091]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 12042550642434868091
                 },
                 "Component_[12116468728378293251]": {
                     "$type": "EditorInspectorComponent",
@@ -96,10 +96,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 16390152007823170626
                 },
-                "Component_[4231458678471163444]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4231458678471163444
-                },
                 "Component_[5226966346162381737]": {
                     "$type": "EditorForceRegionComponent",
                     "Id": 5226966346162381737,
@@ -130,9 +126,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -157,10 +155,6 @@
             "Id": "Entity_[285613356524]",
             "Name": "Sphere",
             "Components": {
-                "Component_[10572912425605638221]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10572912425605638221
-                },
                 "Component_[15461500731098694891]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 15461500731098694891,
@@ -207,9 +201,11 @@
                             0.0,
                             0.5
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },

--- a/AutomatedTesting/Levels/Physics/ForceRegion_ZeroSplineForceDoesNothing/ForceRegion_ZeroSplineForceDoesNothing.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_ZeroSplineForceDoesNothing/ForceRegion_ZeroSplineForceDoesNothing.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -98,9 +94,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -145,13 +143,13 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 3946436068336355998
                 },
+                "Component_[5436314495931969430]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5436314495931969430
+                },
                 "Component_[6996958029592442366]": {
                     "$type": "EditorLockComponent",
                     "Id": 6996958029592442366
-                },
-                "Component_[7234536879080653142]": {
-                    "$type": "SelectionComponent",
-                    "Id": 7234536879080653142
                 },
                 "Component_[8379145965981853801]": {
                     "$type": "EditorEntitySortComponent",
@@ -244,9 +242,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4457568364146036575,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -282,10 +282,6 @@
                             56.0
                         ]
                     }
-                },
-                "Component_[9881234323561781444]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9881234323561781444
                 }
             }
         },
@@ -336,9 +332,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -349,10 +347,6 @@
                 "Component_[18312154701274824579]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 18312154701274824579
-                },
-                "Component_[5503056011896155663]": {
-                    "$type": "SelectionComponent",
-                    "Id": 5503056011896155663
                 },
                 "Component_[5503383422952588599]": {
                     "$type": "EditorSphereShapeComponent",
@@ -372,6 +366,10 @@
                             ]
                         }
                     }
+                },
+                "Component_[5586086115611890411]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5586086115611890411
                 },
                 "Component_[6960222251430158177]": {
                     "$type": "EditorEntityIconComponent",
@@ -438,9 +436,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -452,9 +452,9 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 18312154701274824579
                 },
-                "Component_[5503056011896155663]": {
-                    "$type": "SelectionComponent",
-                    "Id": 5503056011896155663
+                "Component_[3593384816103627024]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 3593384816103627024
                 },
                 "Component_[5503383422952588599]": {
                     "$type": "EditorSphereShapeComponent",
@@ -540,9 +540,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -550,13 +552,13 @@
                         "ShapeType": 0
                     }
                 },
+                "Component_[17624463191548141287]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17624463191548141287
+                },
                 "Component_[18312154701274824579]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 18312154701274824579
-                },
-                "Component_[5503056011896155663]": {
-                    "$type": "SelectionComponent",
-                    "Id": 5503056011896155663
                 },
                 "Component_[5503383422952588599]": {
                     "$type": "EditorSphereShapeComponent",
@@ -611,6 +613,10 @@
                         ]
                     }
                 },
+                "Component_[10853864583250132273]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 10853864583250132273
+                },
                 "Component_[11958516455748178589]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 11958516455748178589
@@ -642,9 +648,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -655,10 +663,6 @@
                 "Component_[18312154701274824579]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 18312154701274824579
-                },
-                "Component_[5503056011896155663]": {
-                    "$type": "SelectionComponent",
-                    "Id": 5503056011896155663
                 },
                 "Component_[5503383422952588599]": {
                     "$type": "EditorSphereShapeComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_ZeroWorldSpaceForceDoesNothing/ForceRegion_ZeroWorldSpaceForceDoesNothing.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_ZeroWorldSpaceForceDoesNothing/ForceRegion_ZeroWorldSpaceForceDoesNothing.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -95,10 +91,6 @@
                 "Component_[3047355939801335922]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
-                },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
                 },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -203,9 +195,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -220,9 +214,9 @@
                         }
                     }
                 },
-                "Component_[3958314576452149141]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3958314576452149141
+                "Component_[3792005848495104629]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 3792005848495104629
                 },
                 "Component_[5079483651742217799]": {
                     "$type": "EditorVisibilityComponent",
@@ -251,9 +245,11 @@
                             0.0,
                             0.5
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -302,10 +298,6 @@
                     "$type": "EditorLockComponent",
                     "Id": 4049958820765177422
                 },
-                "Component_[6457248176216218598]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6457248176216218598
-                },
                 "Component_[7105892263773553905]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 7105892263773553905,
@@ -333,12 +325,17 @@
                             0.0,
                             0.5
                         ],
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.000000953674316
-                        }
+                        "Inertia tensor": [
+                            10.000000953674316,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.000000953674316,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.000000953674316
+                        ]
                     }
                 }
             }
@@ -351,9 +348,11 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 14156005219870653977,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -367,6 +366,10 @@
                             ]
                         }
                     ]
+                },
+                "Component_[14286913393959357259]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 14286913393959357259
                 },
                 "Component_[16077279250477418332]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -408,10 +411,6 @@
                 "Component_[592510569866213886]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 592510569866213886
-                },
-                "Component_[6207391197758784171]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6207391197758784171
                 },
                 "Component_[7563372064540743544]": {
                     "$type": "EditorBoxShapeComponent",

--- a/AutomatedTesting/Levels/Physics/Joints_BallNoLimitsConstrained/Joints_BallNoLimitsConstrained.prefab
+++ b/AutomatedTesting/Levels/Physics/Joints_BallNoLimitsConstrained/Joints_BallNoLimitsConstrained.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -55,10 +51,6 @@
             "Id": "Entity_[286081428076]",
             "Name": "lead",
             "Components": {
-                "Component_[10023033763705225227]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10023033763705225227
-                },
                 "Component_[13011255769289009335]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 13011255769289009335
@@ -99,11 +91,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -119,12 +106,17 @@
                         "Gravity Enabled": false,
                         "Compute Mass": false,
                         "Mass": 999.0,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 0.010010000318288803
-                        }
+                        "Inertia tensor": [
+                            0.010010000318288803,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.010010000318288803,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.010010000318288803
+                        ]
                     }
                 },
                 "Component_[2634845782760090713]": {
@@ -230,10 +222,6 @@
                         }
                     ]
                 },
-                "Component_[3317660974688951744]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3317660974688951744
-                },
                 "Component_[6861005041189176147]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 6861005041189176147
@@ -248,11 +236,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -269,6 +252,10 @@
                 "Component_[8497797771983319252]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 8497797771983319252
+                },
+                "Component_[8697887525241204415]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8697887525241204415
                 },
                 "Component_[9487204736869257485]": {
                     "$type": "EditorBoxShapeComponent",
@@ -369,12 +356,17 @@
                         ],
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 },
                 "Component_[2304545190715981019]": {
@@ -385,10 +377,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 281621200381688046
                 },
-                "Component_[3788104328409405778]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3788104328409405778
-                },
                 "Component_[5053986797366085195]": {
                     "$type": "EditorColliderComponent",
                     "Id": 5053986797366085195,
@@ -398,11 +386,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     }

--- a/AutomatedTesting/Levels/Physics/Material_CharacterController/Material_CharacterController.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_CharacterController/Material_CharacterController.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -104,13 +100,13 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 16230689882780910812
                 },
-                "Component_[17914199320544874011]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17914199320544874011
-                },
                 "Component_[18377528337686856462]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 18377528337686856462
+                },
+                "Component_[2273851137384159771]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 2273851137384159771
                 },
                 "Component_[2372725671404085774]": {
                     "$type": "EditorColliderComponent",
@@ -123,11 +119,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -201,10 +192,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -242,10 +229,6 @@
                 "Component_[1191036568178048800]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 1191036568178048800
-                },
-                "Component_[1312913198288358182]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1312913198288358182
                 },
                 "Component_[17767073666136164898]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -357,10 +340,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 1191036568178048800
                 },
-                "Component_[1312913198288358182]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1312913198288358182
-                },
                 "Component_[17767073666136164898]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 17767073666136164898
@@ -471,10 +450,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 1191036568178048800
                 },
-                "Component_[1312913198288358182]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1312913198288358182
-                },
                 "Component_[17767073666136164898]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 17767073666136164898
@@ -579,11 +554,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -605,10 +575,6 @@
                 "Component_[212116149561142254]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 212116149561142254
-                },
-                "Component_[3469442090661448878]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3469442090661448878
                 },
                 "Component_[4124763457304427835]": {
                     "$type": "EditorVisibilityComponent",
@@ -745,9 +711,9 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 16230689882780910812
                 },
-                "Component_[17914199320544874011]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17914199320544874011
+                "Component_[1804743484822373134]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1804743484822373134
                 },
                 "Component_[18377528337686856462]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -764,11 +730,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -854,10 +815,6 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 16230689882780910812
                 },
-                "Component_[17914199320544874011]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17914199320544874011
-                },
                 "Component_[18377528337686856462]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 18377528337686856462
@@ -874,11 +831,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -888,6 +840,10 @@
                 "Component_[8407016953149050130]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 8407016953149050130
+                },
+                "Component_[8643832216909363747]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8643832216909363747
                 },
                 "Component_[8715876380695213524]": {
                     "$type": "EditorBoxShapeComponent",
@@ -924,11 +880,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -950,10 +901,6 @@
                 "Component_[212116149561142254]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 212116149561142254
-                },
-                "Component_[3469442090661448878]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3469442090661448878
                 },
                 "Component_[4124763457304427835]": {
                     "$type": "EditorVisibilityComponent",
@@ -1051,11 +998,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -1077,10 +1019,6 @@
                 "Component_[212116149561142254]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 212116149561142254
-                },
-                "Component_[3469442090661448878]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3469442090661448878
                 },
                 "Component_[4124763457304427835]": {
                     "$type": "EditorVisibilityComponent",

--- a/AutomatedTesting/Levels/Physics/Material_DefaultLibraryConsistentOnAllFeatures/Material_DefaultLibraryConsistentOnAllFeatures.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_DefaultLibraryConsistentOnAllFeatures/Material_DefaultLibraryConsistentOnAllFeatures.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -58,10 +54,6 @@
                 "Component_[10840566128898283059]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10840566128898283059
-                },
-                "Component_[10983094587467278454]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10983094587467278454
                 },
                 "Component_[11383036399300899746]": {
                     "$type": "EditorInspectorComponent",
@@ -103,11 +95,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -158,6 +145,10 @@
                     "$type": "EditorLockComponent",
                     "Id": 5110395982372092581
                 },
+                "Component_[5802532315539827478]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5802532315539827478
+                },
                 "Component_[6266147445640237600]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 6266147445640237600,
@@ -179,10 +170,6 @@
                 "Component_[10840566128898283059]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10840566128898283059
-                },
-                "Component_[10983094587467278454]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10983094587467278454
                 },
                 "Component_[11383036399300899746]": {
                     "$type": "EditorInspectorComponent",
@@ -209,6 +196,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 156509540013497987
                 },
+                "Component_[17166791731025807082]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17166791731025807082
+                },
                 "Component_[1721990367369414539]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 1721990367369414539
@@ -224,11 +215,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -376,10 +362,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 15970275978245520354
                 },
-                "Component_[202435863520473857]": {
-                    "$type": "SelectionComponent",
-                    "Id": 202435863520473857
-                },
                 "Component_[2546823006136226180]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 2546823006136226180
@@ -435,8 +417,8 @@
                     "Id": 14358908923983911426,
                     "Configuration": {
                         "entityId": "",
-                        "Gravity Enabled": false,
                         "Kinematic": true,
+                        "Gravity Enabled": false,
                         "Compute Mass": false
                     }
                 },
@@ -458,11 +440,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -475,10 +452,6 @@
                             ]
                         }
                     }
-                },
-                "Component_[4791314600057497309]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4791314600057497309
                 },
                 "Component_[7946554280901980058]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -568,8 +541,8 @@
                     "Id": 14358908923983911426,
                     "Configuration": {
                         "entityId": "",
-                        "Gravity Enabled": false,
                         "Kinematic": true,
+                        "Gravity Enabled": false,
                         "Compute Mass": false
                     }
                 },
@@ -591,11 +564,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -608,10 +576,6 @@
                             ]
                         }
                     }
-                },
-                "Component_[4791314600057497309]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4791314600057497309
                 },
                 "Component_[7946554280901980058]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -708,10 +672,6 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 2251383250964041996
                 },
-                "Component_[3557869430458031692]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3557869430458031692
-                },
                 "Component_[4920652687285202617]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 4920652687285202617
@@ -789,10 +749,6 @@
                 "Component_[17823417752576404336]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 17823417752576404336
-                },
-                "Component_[2401496945657124059]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2401496945657124059
                 },
                 "Component_[4104197490219530434]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -877,10 +833,6 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10840566128898283059
                 },
-                "Component_[10983094587467278454]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10983094587467278454
-                },
                 "Component_[11383036399300899746]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 11383036399300899746,
@@ -922,11 +874,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -939,6 +886,10 @@
                             ]
                         }
                     }
+                },
+                "Component_[18032270469084513644]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 18032270469084513644
                 },
                 "Component_[2005399217246976371]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -1035,10 +986,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -1095,10 +1042,6 @@
                 "Component_[17823417752576404336]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 17823417752576404336
-                },
-                "Component_[2401496945657124059]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2401496945657124059
                 },
                 "Component_[4104197490219530434]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -1183,10 +1126,6 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10840566128898283059
                 },
-                "Component_[10983094587467278454]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10983094587467278454
-                },
                 "Component_[11383036399300899746]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 11383036399300899746,
@@ -1208,6 +1147,10 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 13530932529430511545
                 },
+                "Component_[147038757022866361]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 147038757022866361
+                },
                 "Component_[156509540013497987]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 156509540013497987
@@ -1227,11 +1170,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -1304,10 +1242,6 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10840566128898283059
                 },
-                "Component_[10983094587467278454]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10983094587467278454
-                },
                 "Component_[11383036399300899746]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 11383036399300899746,
@@ -1349,11 +1283,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -1370,6 +1299,10 @@
                 "Component_[2005399217246976371]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 2005399217246976371
+                },
+                "Component_[2361213470063869563]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 2361213470063869563
                 },
                 "Component_[3428108517473506]": {
                     "$type": "EditorBoxShapeComponent",
@@ -1425,10 +1358,6 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10840566128898283059
                 },
-                "Component_[10983094587467278454]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10983094587467278454
-                },
                 "Component_[11383036399300899746]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 11383036399300899746,
@@ -1454,6 +1383,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 156509540013497987
                 },
+                "Component_[17119093722250109879]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17119093722250109879
+                },
                 "Component_[1721990367369414539]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 1721990367369414539
@@ -1469,11 +1402,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -1585,10 +1513,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 17823417752576404336
                 },
-                "Component_[2401496945657124059]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2401496945657124059
-                },
                 "Component_[4104197490219530434]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 4104197490219530434
@@ -1634,11 +1558,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -1705,10 +1624,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 17823417752576404336
                 },
-                "Component_[2401496945657124059]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2401496945657124059
-                },
                 "Component_[4104197490219530434]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 4104197490219530434
@@ -1754,11 +1669,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -1865,10 +1775,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 15970275978245520354
                 },
-                "Component_[202435863520473857]": {
-                    "$type": "SelectionComponent",
-                    "Id": 202435863520473857
-                },
                 "Component_[2546823006136226180]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 2546823006136226180
@@ -1915,10 +1821,6 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10840566128898283059
                 },
-                "Component_[10983094587467278454]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10983094587467278454
-                },
                 "Component_[11383036399300899746]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 11383036399300899746,
@@ -1944,6 +1846,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 156509540013497987
                 },
+                "Component_[17136072271366858184]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17136072271366858184
+                },
                 "Component_[1721990367369414539]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 1721990367369414539
@@ -1959,11 +1865,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -2071,10 +1972,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 17823417752576404336
                 },
-                "Component_[2401496945657124059]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2401496945657124059
-                },
                 "Component_[4104197490219530434]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 4104197490219530434
@@ -2120,11 +2017,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -2176,10 +2068,6 @@
                 "Component_[10961108575362702323]": {
                     "$type": "EditorLockComponent",
                     "Id": 10961108575362702323
-                },
-                "Component_[11690509593126538189]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11690509593126538189
                 },
                 "Component_[13783802219168995402]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -2276,10 +2164,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 1580182453287462118
                 },
-                "Component_[3146614964891511007]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3146614964891511007
-                },
                 "Component_[4187386723339130447]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 4187386723339130447
@@ -2347,10 +2231,6 @@
                 "Component_[10961108575362702323]": {
                     "$type": "EditorLockComponent",
                     "Id": 10961108575362702323
-                },
-                "Component_[11690509593126538189]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11690509593126538189
                 },
                 "Component_[13783802219168995402]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -2447,10 +2327,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 1580182453287462118
                 },
-                "Component_[3146614964891511007]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3146614964891511007
-                },
                 "Component_[4187386723339130447]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 4187386723339130447
@@ -2498,10 +2374,6 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10840566128898283059
                 },
-                "Component_[10983094587467278454]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10983094587467278454
-                },
                 "Component_[11383036399300899746]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 11383036399300899746,
@@ -2542,11 +2414,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -2608,6 +2475,10 @@
                             36.875
                         ]
                     }
+                },
+                "Component_[8573838388405794989]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8573838388405794989
                 }
             }
         },
@@ -2618,10 +2489,6 @@
                 "Component_[10840566128898283059]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10840566128898283059
-                },
-                "Component_[10983094587467278454]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10983094587467278454
                 },
                 "Component_[11383036399300899746]": {
                     "$type": "EditorInspectorComponent",
@@ -2663,11 +2530,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -2710,6 +2572,10 @@
                         }
                     }
                 },
+                "Component_[4020601037831651611]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4020601037831651611
+                },
                 "Component_[5040620082781400644]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 5040620082781400644
@@ -2739,10 +2605,6 @@
                 "Component_[10840566128898283059]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10840566128898283059
-                },
-                "Component_[10983094587467278454]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10983094587467278454
                 },
                 "Component_[11383036399300899746]": {
                     "$type": "EditorInspectorComponent",
@@ -2784,11 +2646,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -2850,6 +2707,10 @@
                             34.0
                         ]
                     }
+                },
+                "Component_[7340993600096537651]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 7340993600096537651
                 }
             }
         },
@@ -2860,10 +2721,6 @@
                 "Component_[10840566128898283059]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10840566128898283059
-                },
-                "Component_[10983094587467278454]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10983094587467278454
                 },
                 "Component_[11383036399300899746]": {
                     "$type": "EditorInspectorComponent",
@@ -2905,11 +2762,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -2971,6 +2823,10 @@
                             34.25
                         ]
                     }
+                },
+                "Component_[7244603542322900077]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 7244603542322900077
                 }
             }
         },
@@ -3021,10 +2877,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 17823417752576404336
                 },
-                "Component_[2401496945657124059]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2401496945657124059
-                },
                 "Component_[4104197490219530434]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 4104197490219530434
@@ -3071,11 +2923,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -3105,10 +2952,6 @@
                 "Component_[10840566128898283059]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10840566128898283059
-                },
-                "Component_[10983094587467278454]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10983094587467278454
                 },
                 "Component_[11383036399300899746]": {
                     "$type": "EditorInspectorComponent",
@@ -3150,11 +2993,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -3216,6 +3054,10 @@
                             33.25
                         ]
                     }
+                },
+                "Component_[9180160843010240171]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9180160843010240171
                 }
             }
         },
@@ -3226,10 +3068,6 @@
                 "Component_[10840566128898283059]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10840566128898283059
-                },
-                "Component_[10983094587467278454]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10983094587467278454
                 },
                 "Component_[11383036399300899746]": {
                     "$type": "EditorInspectorComponent",
@@ -3271,11 +3109,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -3337,6 +3170,10 @@
                             37.0
                         ]
                     }
+                },
+                "Component_[6801176898729589264]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6801176898729589264
                 }
             }
         },
@@ -3347,10 +3184,6 @@
                 "Component_[10840566128898283059]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10840566128898283059
-                },
-                "Component_[10983094587467278454]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10983094587467278454
                 },
                 "Component_[11383036399300899746]": {
                     "$type": "EditorInspectorComponent",
@@ -3393,11 +3226,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -3414,6 +3242,10 @@
                 "Component_[2005399217246976371]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 2005399217246976371
+                },
+                "Component_[3157657273367205879]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 3157657273367205879
                 },
                 "Component_[3428108517473506]": {
                     "$type": "EditorBoxShapeComponent",
@@ -3469,10 +3301,6 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10840566128898283059
                 },
-                "Component_[10983094587467278454]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10983094587467278454
-                },
                 "Component_[11383036399300899746]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 11383036399300899746,
@@ -3494,6 +3322,10 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 13530932529430511545
                 },
+                "Component_[15106594784498510757]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 15106594784498510757
+                },
                 "Component_[156509540013497987]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 156509540013497987
@@ -3513,11 +3345,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -3625,10 +3452,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 17823417752576404336
                 },
-                "Component_[2401496945657124059]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2401496945657124059
-                },
                 "Component_[4104197490219530434]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 4104197490219530434
@@ -3675,11 +3498,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -3709,10 +3527,6 @@
                 "Component_[10840566128898283059]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10840566128898283059
-                },
-                "Component_[10983094587467278454]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10983094587467278454
                 },
                 "Component_[11383036399300899746]": {
                     "$type": "EditorInspectorComponent",
@@ -3755,11 +3569,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -3800,6 +3609,10 @@
                             ]
                         }
                     }
+                },
+                "Component_[4672818955097144643]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4672818955097144643
                 },
                 "Component_[5040620082781400644]": {
                     "$type": "EditorEntitySortComponent",
@@ -3866,10 +3679,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 17823417752576404336
                 },
-                "Component_[2401496945657124059]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2401496945657124059
-                },
                 "Component_[4104197490219530434]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 4104197490219530434
@@ -3915,11 +3724,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },

--- a/AutomatedTesting/Levels/Physics/Material_DefaultLibraryUpdatedAcrossLevels/0/0.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_DefaultLibraryUpdatedAcrossLevels/0/0.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -87,10 +83,6 @@
                 "Component_[3047355939801335922]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
-                },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
                 },
                 "Component_[4712694840150876798]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -134,10 +126,6 @@
                             "SortIndex": 3
                         }
                     ]
-                },
-                "Component_[11346323631807681262]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11346323631807681262
                 },
                 "Component_[1153076453892596685]": {
                     "$type": "EditorEntityIconComponent",
@@ -214,12 +202,17 @@
                         ],
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 },
                 "Component_[7385062050909259476]": {
@@ -233,10 +226,6 @@
             "Id": "Entity_[285015917770]",
             "Name": "terrain",
             "Components": {
-                "Component_[12368241148684771968]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12368241148684771968
-                },
                 "Component_[14478545718944713607]": {
                     "$type": "EditorLockComponent",
                     "Id": 14478545718944713607
@@ -254,11 +243,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -317,6 +301,10 @@
                 "Component_[7071637913266534486]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 7071637913266534486
+                },
+                "Component_[7476780700387468022]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 7476780700387468022
                 }
             }
         },
@@ -341,9 +329,9 @@
                         }
                     ]
                 },
-                "Component_[16014778893970138866]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16014778893970138866
+                "Component_[15909051135029218004]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 15909051135029218004
                 },
                 "Component_[17048341836974969891]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -368,11 +356,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },

--- a/AutomatedTesting/Levels/Physics/Material_DefaultLibraryUpdatedAcrossLevels/1/1.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_DefaultLibraryUpdatedAcrossLevels/1/1.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -55,10 +51,6 @@
             "Id": "Entity_[261705524673]",
             "Name": "sphere",
             "Components": {
-                "Component_[11646493884547176136]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11646493884547176136
-                },
                 "Component_[11906722936407481270]": {
                     "$type": "EditorColliderComponent",
                     "Id": 11906722936407481270,
@@ -94,12 +86,17 @@
                         ],
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 },
                 "Component_[14780167336961960724]": {
@@ -211,10 +208,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[4712694840150876798]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 4712694840150876798
@@ -237,10 +230,6 @@
             "Id": "Entity_[285015917770]",
             "Name": "terrain",
             "Components": {
-                "Component_[12368241148684771968]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12368241148684771968
-                },
                 "Component_[14478545718944713607]": {
                     "$type": "EditorLockComponent",
                     "Id": 14478545718944713607
@@ -270,11 +259,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -314,6 +298,10 @@
                         }
                     ]
                 },
+                "Component_[4881643477244228967]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4881643477244228967
+                },
                 "Component_[5741926347424366246]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 5741926347424366246
@@ -345,10 +333,6 @@
                         }
                     ]
                 },
-                "Component_[16014778893970138866]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16014778893970138866
-                },
                 "Component_[17048341836974969891]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 17048341836974969891
@@ -372,11 +356,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -428,6 +407,10 @@
                 "Component_[6873431808813245234]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 6873431808813245234
+                },
+                "Component_[9082731732445471258]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9082731732445471258
                 },
                 "Component_[9461177873056538692]": {
                     "$type": "EditorOnlyEntityComponent",

--- a/AutomatedTesting/Levels/Physics/Material_EmptyLibraryUsesDefault/Material_EmptyLibraryUsesDefault.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_EmptyLibraryUsesDefault/Material_EmptyLibraryUsesDefault.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -59,9 +55,11 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 10131916318786260150,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -126,10 +124,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15308818810773485994
                 },
-                "Component_[15840538373800101541]": {
-                    "$type": "SelectionComponent",
-                    "Id": 15840538373800101541
-                },
                 "Component_[17755930108359081035]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 17755930108359081035
@@ -149,6 +143,10 @@
                 "Component_[6534162403380073417]": {
                     "$type": "EditorLockComponent",
                     "Id": 6534162403380073417
+                },
+                "Component_[938689551918509263]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 938689551918509263
                 }
             }
         },
@@ -167,10 +165,6 @@
                 "Component_[13724541256316894675]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 13724541256316894675
-                },
-                "Component_[14278953062209923807]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14278953062209923807
                 },
                 "Component_[16046379088641642538]": {
                     "$type": "EditorInspectorComponent",
@@ -197,9 +191,11 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 17099031793310612741,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -219,12 +215,17 @@
                     "Configuration": {
                         "entityId": "",
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 },
                 "Component_[3607123429290193540]": {
@@ -274,10 +275,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 13724541256316894675
                 },
-                "Component_[14278953062209923807]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14278953062209923807
-                },
                 "Component_[16046379088641642538]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 16046379088641642538,
@@ -303,9 +300,11 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 17099031793310612741,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -325,12 +324,17 @@
                     "Configuration": {
                         "entityId": "",
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 },
                 "Component_[3607123429290193540]": {
@@ -380,10 +384,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 13724541256316894675
                 },
-                "Component_[14278953062209923807]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14278953062209923807
-                },
                 "Component_[16046379088641642538]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 16046379088641642538,
@@ -414,9 +414,11 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 17099031793310612741,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -442,12 +444,17 @@
                             0.0,
                             -0.5
                         ],
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 2.3999998569488525
-                        },
+                        "Inertia tensor": [
+                            2.3999998569488525,
+                            0.0,
+                            0.0,
+                            0.0,
+                            2.3999998569488525,
+                            0.0,
+                            0.0,
+                            0.0,
+                            2.3999998569488525
+                        ],
                         "Debug Draw Center of Mass": true
                     }
                 },
@@ -493,10 +500,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 13724541256316894675
                 },
-                "Component_[14278953062209923807]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14278953062209923807
-                },
                 "Component_[14564167809659215569]": {
                     "$type": "EditorBoxShapeComponent",
                     "Id": 14564167809659215569,
@@ -527,9 +530,11 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 17099031793310612741,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -555,12 +560,17 @@
                             0.0,
                             -0.5
                         ],
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 2.3999998569488525
-                        },
+                        "Inertia tensor": [
+                            2.3999998569488525,
+                            0.0,
+                            0.0,
+                            0.0,
+                            2.3999998569488525,
+                            0.0,
+                            0.0,
+                            0.0,
+                            2.3999998569488525
+                        ],
                         "Debug Draw Center of Mass": true
                     }
                 },

--- a/AutomatedTesting/Levels/Physics/Material_LibraryChangesReflectInstantly/Material_LibraryChangesReflectInstantly.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_LibraryChangesReflectInstantly/Material_LibraryChangesReflectInstantly.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -55,10 +51,6 @@
             "Id": "Entity_[1011301294950]",
             "Name": "trigger",
             "Components": {
-                "Component_[10177271249943941360]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10177271249943941360
-                },
                 "Component_[15134750255872632480]": {
                     "$type": "EditorBoxShapeComponent",
                     "Id": 15134750255872632480,
@@ -102,6 +94,10 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 17044248283146127093
                 },
+                "Component_[17612961656424497006]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17612961656424497006
+                },
                 "Component_[17656225355810724488]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 17656225355810724488
@@ -135,11 +131,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -213,10 +204,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[8964779992189042072]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 8964779992189042072
@@ -239,10 +226,6 @@
             "Id": "Entity_[281156854630]",
             "Name": "sphere_0",
             "Components": {
-                "Component_[10422448568969909101]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10422448568969909101
-                },
                 "Component_[10608077766366924597]": {
                     "$type": "EditorSphereShapeComponent",
                     "Id": 10608077766366924597,
@@ -369,10 +352,6 @@
                         ]
                     }
                 },
-                "Component_[12287644288883736884]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12287644288883736884
-                },
                 "Component_[13363420471903321484]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 13363420471903321484
@@ -470,10 +449,6 @@
                 "Component_[10880848152918698630]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10880848152918698630
-                },
-                "Component_[10993747078839261711]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10993747078839261711
                 },
                 "Component_[11962089952362907403]": {
                     "$type": "EditorEntitySortComponent",
@@ -675,10 +650,6 @@
                         }
                     ]
                 },
-                "Component_[6408021591593091139]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6408021591593091139
-                },
                 "Component_[969119709860529359]": {
                     "$type": "EditorRigidBodyComponent",
                     "Id": 969119709860529359,
@@ -726,10 +697,6 @@
                             35.0
                         ]
                     }
-                },
-                "Component_[13558624633219310097]": {
-                    "$type": "SelectionComponent",
-                    "Id": 13558624633219310097
                 },
                 "Component_[17851857614423757842]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -906,10 +873,6 @@
                     "Id": 17998392348447200702,
                     "GameView": true
                 },
-                "Component_[1964072586603507375]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1964072586603507375
-                },
                 "Component_[3796980743963885327]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 3796980743963885327
@@ -928,6 +891,10 @@
             "Id": "Entity_[306926658406]",
             "Name": "block",
             "Components": {
+                "Component_[11967684837246765052]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 11967684837246765052
+                },
                 "Component_[12382634988339210856]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 12382634988339210856,
@@ -994,10 +961,6 @@
                             ]
                         }
                     }
-                },
-                "Component_[5493593570289811910]": {
-                    "$type": "SelectionComponent",
-                    "Id": 5493593570289811910
                 },
                 "Component_[8410997340656467467]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -1091,10 +1054,6 @@
                 "Component_[7027064350878945104]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 7027064350878945104
-                },
-                "Component_[789490538071906007]": {
-                    "$type": "SelectionComponent",
-                    "Id": 789490538071906007
                 }
             }
         }

--- a/AutomatedTesting/Levels/Physics/Material_LibraryUpdatedAcrossLevels/0/0.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_LibraryUpdatedAcrossLevels/0/0.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -101,17 +97,18 @@
                         ],
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
-                },
-                "Component_[15836496613906916845]": {
-                    "$type": "SelectionComponent",
-                    "Id": 15836496613906916845
                 },
                 "Component_[16597972522349022176]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -129,9 +126,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4355996461495376905,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -206,10 +205,6 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 3552038377029839116
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -274,17 +269,18 @@
                         ],
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
-                },
-                "Component_[15836496613906916845]": {
-                    "$type": "SelectionComponent",
-                    "Id": 15836496613906916845
                 },
                 "Component_[16597972522349022176]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -302,9 +298,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4355996461495376905,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -359,6 +357,10 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 10871399259191966069
                 },
+                "Component_[11531003981497427439]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 11531003981497427439
+                },
                 "Component_[12515684864447251759]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 12515684864447251759
@@ -393,10 +395,6 @@
                     "$type": "EditorLockComponent",
                     "Id": 3078346116579265539
                 },
-                "Component_[4904090692018630100]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4904090692018630100
-                },
                 "Component_[7960354929538954982]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 7960354929538954982
@@ -407,9 +405,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -503,10 +503,6 @@
                 "Component_[2029679326492259668]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 2029679326492259668
-                },
-                "Component_[6843859049760163738]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6843859049760163738
                 }
             }
         }

--- a/AutomatedTesting/Levels/Physics/Material_LibraryUpdatedAcrossLevels/1/1.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_LibraryUpdatedAcrossLevels/1/1.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -61,9 +57,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -125,13 +123,13 @@
                         }
                     ]
                 },
-                "Component_[17871090743916940997]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17871090743916940997
-                },
                 "Component_[18263618414370492472]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 18263618414370492472
+                },
+                "Component_[450055663958573819]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 450055663958573819
                 },
                 "Component_[4769459002306564121]": {
                     "$type": "EditorEntitySortComponent",
@@ -200,10 +198,6 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 3552038377029839116
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -268,17 +262,18 @@
                         ],
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
-                },
-                "Component_[15836496613906916845]": {
-                    "$type": "SelectionComponent",
-                    "Id": 15836496613906916845
                 },
                 "Component_[16597972522349022176]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -296,9 +291,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4355996461495376905,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -384,10 +381,6 @@
                 "Component_[2029679326492259668]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 2029679326492259668
-                },
-                "Component_[6843859049760163738]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6843859049760163738
                 }
             }
         },
@@ -441,17 +434,18 @@
                         ],
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
-                },
-                "Component_[15836496613906916845]": {
-                    "$type": "SelectionComponent",
-                    "Id": 15836496613906916845
                 },
                 "Component_[16597972522349022176]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -469,9 +463,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4355996461495376905,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },

--- a/AutomatedTesting/Levels/Physics/Material_NoEffectIfNoColliderShape/Material_NoEffectIfNoColliderShape.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_NoEffectIfNoColliderShape/Material_NoEffectIfNoColliderShape.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -92,10 +88,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[7164043216881357760]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 7164043216881357760
@@ -122,17 +114,15 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 10233737701874797018
                 },
-                "Component_[11193065989988835644]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11193065989988835644
-                },
                 "Component_[11885287454855755410]": {
                     "$type": "EditorColliderComponent",
                     "Id": 11885287454855755410,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     }
@@ -205,6 +195,10 @@
                         }
                     ]
                 },
+                "Component_[955724289592309383]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 955724289592309383
+                },
                 "Component_[9806670091592883612]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 9806670091592883612
@@ -238,17 +232,15 @@
                         }
                     }
                 },
-                "Component_[11193065989988835644]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11193065989988835644
-                },
                 "Component_[11885287454855755410]": {
                     "$type": "EditorColliderComponent",
                     "Id": 11885287454855755410,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -267,6 +259,10 @@
                 "Component_[17462258511890366623]": {
                     "$type": "EditorLockComponent",
                     "Id": 17462258511890366623
+                },
+                "Component_[2933959899102505394]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 2933959899102505394
                 },
                 "Component_[5437855560987636045]": {
                     "$type": "EditorEntitySortComponent",
@@ -348,9 +344,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -373,10 +371,6 @@
                             }
                         }
                     }
-                },
-                "Component_[14158587883552441503]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14158587883552441503
                 },
                 "Component_[15218441006761085606]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -410,6 +404,10 @@
                 "Component_[3321317640247600009]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 3321317640247600009
+                },
+                "Component_[7595437039523567506]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 7595437039523567506
                 },
                 "Component_[7911748468698987442]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -472,9 +470,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -498,13 +498,13 @@
                         }
                     }
                 },
-                "Component_[14158587883552441503]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14158587883552441503
-                },
                 "Component_[15218441006761085606]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 15218441006761085606
+                },
+                "Component_[17436374398764502348]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17436374398764502348
                 },
                 "Component_[17921237041097851030]": {
                     "$type": "EditorInspectorComponent",
@@ -627,17 +627,15 @@
                         }
                     }
                 },
-                "Component_[3624335115656130395]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3624335115656130395
-                },
                 "Component_[5389333556473580041]": {
                     "$type": "EditorColliderComponent",
                     "Id": 5389333556473580041,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -745,17 +743,15 @@
                         }
                     }
                 },
-                "Component_[3624335115656130395]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3624335115656130395
-                },
                 "Component_[5389333556473580041]": {
                     "$type": "EditorColliderComponent",
                     "Id": 5389333556473580041,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },

--- a/AutomatedTesting/Levels/Physics/Material_PerFaceMaterialGetsCorrectMaterial/Material_PerFaceMaterialGetsCorrectMaterial.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_PerFaceMaterialGetsCorrectMaterial/Material_PerFaceMaterialGetsCorrectMaterial.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -55,6 +51,10 @@
             "Id": "Entity_[263299149192]",
             "Name": "Perface_Entity",
             "Components": {
+                "Component_[11696143035287514767]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 11696143035287514767
+                },
                 "Component_[12895135369190770831]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 12895135369190770831,
@@ -71,10 +71,6 @@
                             "SortIndex": 2
                         }
                     ]
-                },
-                "Component_[12933367835807479524]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12933367835807479524
                 },
                 "Component_[14094829544062915163]": {
                     "$type": "EditorColliderComponent",
@@ -219,10 +215,6 @@
                         }
                     ]
                 },
-                "Component_[1341105588245574408]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1341105588245574408
-                },
                 "Component_[14079522067308699507]": {
                     "$type": "EditorLockComponent",
                     "Id": 14079522067308699507
@@ -244,12 +236,17 @@
                         "Linear damping": 0.0,
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 },
                 "Component_[17367340743922879512]": {
@@ -342,10 +339,6 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10435545141396253755
                 },
-                "Component_[10589025713121715221]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10589025713121715221
-                },
                 "Component_[1360399676717184302]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 1360399676717184302
@@ -421,12 +414,17 @@
                         "Linear damping": 0.0,
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 }
             },
@@ -462,10 +460,6 @@
                 "Component_[10435545141396253755]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10435545141396253755
-                },
-                "Component_[10589025713121715221]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10589025713121715221
                 },
                 "Component_[1360399676717184302]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -542,12 +536,17 @@
                         "Linear damping": 0.0,
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 }
             },
@@ -593,10 +592,6 @@
                 "Component_[3047355939801335922]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
-                },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
                 },
                 "Component_[722204632874297368]": {
                     "$type": "EditorOnlyEntityComponent",

--- a/AutomatedTesting/Levels/Physics/Material_RestitutionCombinePriorityOrder/Material_RestitutionCombinePriorityOrder.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_RestitutionCombinePriorityOrder/Material_RestitutionCombinePriorityOrder.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -77,9 +73,9 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 13396737954818371455
                 },
-                "Component_[14094079953882345085]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14094079953882345085
+                "Component_[13430278792265392683]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13430278792265392683
                 },
                 "Component_[15151923958895865240]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -220,10 +216,6 @@
                         }
                     ]
                 },
-                "Component_[10516303889368809827]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10516303889368809827
-                },
                 "Component_[11252974442733513437]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 11252974442733513437
@@ -315,6 +307,10 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 10327124523666310780
                 },
+                "Component_[11172438983929971957]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 11172438983929971957
+                },
                 "Component_[11959116158231937437]": {
                     "$type": "EditorBoxShapeComponent",
                     "Id": 11959116158231937437,
@@ -342,10 +338,6 @@
                 "Component_[13396737954818371455]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 13396737954818371455
-                },
-                "Component_[14094079953882345085]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14094079953882345085
                 },
                 "Component_[15151923958895865240]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -492,13 +484,13 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 13396737954818371455
                 },
-                "Component_[14094079953882345085]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14094079953882345085
-                },
                 "Component_[15151923958895865240]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 15151923958895865240
+                },
+                "Component_[16060773451043724036]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 16060773451043724036
                 },
                 "Component_[2374380279612689881]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -641,10 +633,6 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 13396737954818371455
                 },
-                "Component_[14094079953882345085]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14094079953882345085
-                },
                 "Component_[15151923958895865240]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 15151923958895865240
@@ -744,6 +732,10 @@
                         }
                     }
                 },
+                "Component_[4987343837484879472]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4987343837484879472
+                },
                 "Component_[6437575279376969517]": {
                     "$type": "EditorLockComponent",
                     "Id": 6437575279376969517
@@ -783,10 +775,6 @@
                             "SortIndex": 3
                         }
                     ]
-                },
-                "Component_[10516303889368809827]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10516303889368809827
                 },
                 "Component_[11252974442733513437]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -901,10 +889,6 @@
                         }
                     ]
                 },
-                "Component_[10516303889368809827]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10516303889368809827
-                },
                 "Component_[11252974442733513437]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 11252974442733513437
@@ -1017,10 +1001,6 @@
                             "SortIndex": 3
                         }
                     ]
-                },
-                "Component_[10516303889368809827]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10516303889368809827
                 },
                 "Component_[11252974442733513437]": {
                     "$type": "EditorPendingCompositionComponent",

--- a/AutomatedTesting/Levels/Physics/NameNode_Prints/NameNode_Prints.prefab
+++ b/AutomatedTesting/Levels/Physics/NameNode_Prints/NameNode_Prints.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -92,10 +88,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -126,10 +118,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 10668615725757120918
                 },
-                "Component_[11499318648734982432]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11499318648734982432
-                },
                 "Component_[11809244746758920254]": {
                     "$type": "EditorColliderComponent",
                     "Id": 11809244746758920254,
@@ -146,11 +134,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -160,6 +143,10 @@
                 "Component_[12668293490291972571]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 12668293490291972571
+                },
+                "Component_[12902745641494942852]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 12902745641494942852
                 },
                 "Component_[13829008864828557117]": {
                     "$type": "EditorLockComponent",
@@ -236,10 +223,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 10668615725757120918
                 },
-                "Component_[11499318648734982432]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11499318648734982432
-                },
                 "Component_[11809244746758920254]": {
                     "$type": "EditorColliderComponent",
                     "Id": 11809244746758920254,
@@ -255,11 +238,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -315,6 +293,10 @@
                         }
                     ]
                 },
+                "Component_[3028105337823205546]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 3028105337823205546
+                },
                 "Component_[485296799080181542]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 485296799080181542,
@@ -358,11 +340,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -372,6 +349,10 @@
                 "Component_[12612842838095137446]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 12612842838095137446
+                },
+                "Component_[13898773828324844644]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13898773828324844644
                 },
                 "Component_[14768773875483735434]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -436,10 +417,6 @@
                 "Component_[7296510245297829595]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 7296510245297829595
-                },
-                "Component_[8046044211277469545]": {
-                    "$type": "SelectionComponent",
-                    "Id": 8046044211277469545
                 }
             },
             "IsRuntimeActive": false
@@ -448,6 +425,10 @@
             "Id": "Entity_[461816450099]",
             "Name": "C19536275_0",
             "Components": {
+                "Component_[10630509762856920685]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 10630509762856920685
+                },
                 "Component_[10824038651895419042]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 10824038651895419042
@@ -548,10 +529,6 @@
                 "Component_[7296510245297829595]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 7296510245297829595
-                },
-                "Component_[8046044211277469545]": {
-                    "$type": "SelectionComponent",
-                    "Id": 8046044211277469545
                 }
             },
             "IsRuntimeActive": false
@@ -657,13 +634,13 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 414394093141836853
                 },
+                "Component_[6325028548166347714]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6325028548166347714
+                },
                 "Component_[7296510245297829595]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 7296510245297829595
-                },
-                "Component_[8046044211277469545]": {
-                    "$type": "SelectionComponent",
-                    "Id": 8046044211277469545
                 }
             },
             "IsRuntimeActive": false
@@ -708,6 +685,10 @@
                 "Component_[12612842838095137446]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 12612842838095137446
+                },
+                "Component_[14126978007795755949]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 14126978007795755949
                 },
                 "Component_[14768773875483735434]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -772,10 +753,6 @@
                 "Component_[7296510245297829595]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 7296510245297829595
-                },
-                "Component_[8046044211277469545]": {
-                    "$type": "SelectionComponent",
-                    "Id": 8046044211277469545
                 }
             },
             "IsRuntimeActive": false

--- a/AutomatedTesting/Levels/Physics/Physics_WorldBodyBusWorksOnEditorComponents/Physics_WorldBodyBusWorksOnEditorComponents.prefab
+++ b/AutomatedTesting/Levels/Physics/Physics_WorldBodyBusWorksOnEditorComponents/Physics_WorldBodyBusWorksOnEditorComponents.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -59,9 +55,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16300212154464470531,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -76,10 +74,6 @@
                 "Component_[2355668156940730228]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 2355668156940730228
-                },
-                "Component_[2801111889414931848]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2801111889414931848
                 },
                 "Component_[4403703683034890123]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -149,9 +143,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10271136976310200923,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -167,9 +163,9 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 2355668156940730228
                 },
-                "Component_[2801111889414931848]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2801111889414931848
+                "Component_[280625196657739250]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 280625196657739250
                 },
                 "Component_[4403703683034890123]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -226,9 +222,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10271136976310200923,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -243,10 +241,6 @@
                 "Component_[2355668156940730228]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 2355668156940730228
-                },
-                "Component_[2801111889414931848]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2801111889414931848
                 },
                 "Component_[4403703683034890123]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -263,6 +257,10 @@
                             33.314109802246094
                         ]
                     }
+                },
+                "Component_[5449671723874720078]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5449671723874720078
                 },
                 "Component_[5743451229161796048]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -303,9 +301,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16300212154464470531,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -320,10 +320,6 @@
                 "Component_[2355668156940730228]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 2355668156940730228
-                },
-                "Component_[2801111889414931848]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2801111889414931848
                 },
                 "Component_[4403703683034890123]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -393,9 +389,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10271136976310200923,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -410,10 +408,6 @@
                 "Component_[2355668156940730228]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 2355668156940730228
-                },
-                "Component_[2801111889414931848]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2801111889414931848
                 },
                 "Component_[4403703683034890123]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -434,6 +428,10 @@
                 "Component_[5743451229161796048]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 5743451229161796048
+                },
+                "Component_[6575495009457126236]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6575495009457126236
                 },
                 "Component_[6813315874512071748]": {
                     "$type": "EditorEntitySortComponent",
@@ -470,9 +468,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16300212154464470531,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -487,10 +487,6 @@
                 "Component_[2355668156940730228]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 2355668156940730228
-                },
-                "Component_[2801111889414931848]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2801111889414931848
                 },
                 "Component_[4403703683034890123]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -560,9 +556,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10271136976310200923,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -587,6 +585,10 @@
                         }
                     }
                 },
+                "Component_[12545020046919826868]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 12545020046919826868
+                },
                 "Component_[17486590914851669702]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 17486590914851669702
@@ -594,10 +596,6 @@
                 "Component_[2355668156940730228]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 2355668156940730228
-                },
-                "Component_[2801111889414931848]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2801111889414931848
                 },
                 "Component_[4403703683034890123]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -654,9 +652,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16300212154464470531,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -688,10 +688,6 @@
                 "Component_[2355668156940730228]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 2355668156940730228
-                },
-                "Component_[2801111889414931848]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2801111889414931848
                 },
                 "Component_[4403703683034890123]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -769,10 +765,6 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 2355668156940730228
                 },
-                "Component_[2801111889414931848]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2801111889414931848
-                },
                 "Component_[4403703683034890123]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 4403703683034890123
@@ -839,9 +831,11 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 9011838012457954872,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -865,9 +859,11 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 17487900436023939565,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -880,10 +876,6 @@
                 "Component_[2355668156940730228]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 2355668156940730228
-                },
-                "Component_[2801111889414931848]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2801111889414931848
                 },
                 "Component_[4403703683034890123]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -904,6 +896,10 @@
                             33.314109802246094
                         ]
                     }
+                },
+                "Component_[5278210653403985606]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5278210653403985606
                 },
                 "Component_[5743451229161796048]": {
                     "$type": "EditorPendingCompositionComponent",

--- a/AutomatedTesting/Levels/Physics/RigidBody_AngularDampingAffectsRotation/RigidBody_AngularDampingAffectsRotation.prefab
+++ b/AutomatedTesting/Levels/Physics/RigidBody_AngularDampingAffectsRotation/RigidBody_AngularDampingAffectsRotation.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -96,10 +92,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -147,10 +139,6 @@
                             "SortIndex": 2
                         }
                     ]
-                },
-                "Component_[14532080444774604174]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14532080444774604174
                 },
                 "Component_[15460193905310649551]": {
                     "$type": "EditorEntitySortComponent",
@@ -219,10 +207,6 @@
                         ]
                     }
                 },
-                "Component_[10591944275956345455]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10591944275956345455
-                },
                 "Component_[1149538037597439289]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 1149538037597439289
@@ -237,9 +221,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -262,6 +248,10 @@
                 "Component_[18007512079132112583]": {
                     "$type": "EditorLockComponent",
                     "Id": 18007512079132112583
+                },
+                "Component_[2408464323461693031]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 2408464323461693031
                 },
                 "Component_[3013370522614808895]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -324,10 +314,6 @@
                         ]
                     }
                 },
-                "Component_[10591944275956345455]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10591944275956345455
-                },
                 "Component_[1149538037597439289]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 1149538037597439289
@@ -342,9 +328,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -400,6 +388,10 @@
                             "SortIndex": 2
                         }
                     ]
+                },
+                "Component_[9753463628623177388]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9753463628623177388
                 }
             }
         },
@@ -418,10 +410,6 @@
                 "Component_[13208852873506236611]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 13208852873506236611
-                },
-                "Component_[13222097061619369926]": {
-                    "$type": "SelectionComponent",
-                    "Id": 13222097061619369926
                 },
                 "Component_[14812140231390143898]": {
                     "$type": "EditorEntitySortComponent",
@@ -449,9 +437,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16066027089711095181,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -558,10 +548,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 13208852873506236611
                 },
-                "Component_[13222097061619369926]": {
-                    "$type": "SelectionComponent",
-                    "Id": 13222097061619369926
-                },
                 "Component_[14812140231390143898]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 14812140231390143898
@@ -588,9 +574,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16066027089711095181,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -697,10 +685,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 13208852873506236611
                 },
-                "Component_[13222097061619369926]": {
-                    "$type": "SelectionComponent",
-                    "Id": 13222097061619369926
-                },
                 "Component_[14812140231390143898]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 14812140231390143898
@@ -727,9 +711,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16066027089711095181,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -846,10 +832,6 @@
                         ]
                     }
                 },
-                "Component_[10591944275956345455]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10591944275956345455
-                },
                 "Component_[1149538037597439289]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 1149538037597439289
@@ -858,15 +840,21 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 15964844323015613661
                 },
+                "Component_[16686658831696409071]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 16686658831696409071
+                },
                 "Component_[17282705340948180667]": {
                     "$type": "EditorColliderComponent",
                     "Id": 17282705340948180667,
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -946,10 +934,6 @@
                         ]
                     }
                 },
-                "Component_[10591944275956345455]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10591944275956345455
-                },
                 "Component_[1149538037597439289]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 1149538037597439289
@@ -964,9 +948,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -993,6 +979,10 @@
                 "Component_[3013370522614808895]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 3013370522614808895
+                },
+                "Component_[3932881930085784751]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 3932881930085784751
                 },
                 "Component_[5534018830273953734]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -1046,10 +1036,6 @@
                         ]
                     }
                 },
-                "Component_[10591944275956345455]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10591944275956345455
-                },
                 "Component_[1149538037597439289]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 1149538037597439289
@@ -1064,9 +1050,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1101,6 +1089,10 @@
                 "Component_[6131237205847493259]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 6131237205847493259
+                },
+                "Component_[865997925272758608]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 865997925272758608
                 },
                 "Component_[9434410003036206430]": {
                     "$type": "EditorEntityIconComponent",
@@ -1151,10 +1143,6 @@
                         ]
                     }
                 },
-                "Component_[10591944275956345455]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10591944275956345455
-                },
                 "Component_[1149538037597439289]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 1149538037597439289
@@ -1169,9 +1157,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1198,6 +1188,10 @@
                 "Component_[3013370522614808895]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 3013370522614808895
+                },
+                "Component_[3227657461315542851]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 3227657461315542851
                 },
                 "Component_[5534018830273953734]": {
                     "$type": "EditorOnlyEntityComponent",

--- a/AutomatedTesting/Levels/Physics/RigidBody_InitialAngularVelocity/RigidBody_InitialAngularVelocity.prefab
+++ b/AutomatedTesting/Levels/Physics/RigidBody_InitialAngularVelocity/RigidBody_InitialAngularVelocity.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -95,10 +91,6 @@
                 "Component_[3047355939801335922]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
-                },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
                 },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -162,9 +154,11 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 12951355599267579564,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -219,10 +213,6 @@
                     "$type": "EditorLockComponent",
                     "Id": 2831691161233173832
                 },
-                "Component_[4665167481611369785]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4665167481611369785
-                },
                 "Component_[4970361985768575813]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 4970361985768575813,
@@ -266,10 +256,6 @@
                         }
                     ]
                 },
-                "Component_[10331925645927272359]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10331925645927272359
-                },
                 "Component_[10596250505207393570]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 10596250505207393570
@@ -281,6 +267,10 @@
                 "Component_[408871196476742770]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 408871196476742770
+                },
+                "Component_[4240380267615554668]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4240380267615554668
                 },
                 "Component_[4725557049047311832]": {
                     "$type": "EditorEntityIconComponent",
@@ -301,9 +291,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },

--- a/AutomatedTesting/Levels/Physics/RigidBody_InitialLinearVelocity/RigidBody_InitialLinearVelocity.prefab
+++ b/AutomatedTesting/Levels/Physics/RigidBody_InitialLinearVelocity/RigidBody_InitialLinearVelocity.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -66,10 +62,6 @@
                             38.0
                         ]
                     }
-                },
-                "Component_[11276642112795332830]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11276642112795332830
                 },
                 "Component_[11716281764184623533]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -106,9 +98,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -117,6 +111,10 @@
                             "$type": "BoxShapeConfiguration"
                         }
                     ]
+                },
+                "Component_[216819592811779490]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 216819592811779490
                 },
                 "Component_[3302118507919839154]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -200,10 +198,6 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 3582225014418902287
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -233,10 +227,6 @@
                 "Component_[2280595334114802403]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 2280595334114802403
-                },
-                "Component_[3002168776546645566]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3002168776546645566
                 },
                 "Component_[3030257996947907887]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -306,9 +296,11 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 9159776008985726394,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },

--- a/AutomatedTesting/Levels/Physics/RigidBody_LinearDampingAffectsMotion/RigidBody_LinearDampingAffectsMotion.prefab
+++ b/AutomatedTesting/Levels/Physics/RigidBody_LinearDampingAffectsMotion/RigidBody_LinearDampingAffectsMotion.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -90,9 +86,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -125,6 +123,10 @@
                 "Component_[17106484645172612912]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 17106484645172612912
+                },
+                "Component_[17543558456555778346]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17543558456555778346
                 },
                 "Component_[17708193097712213074]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -160,10 +162,6 @@
                 "Component_[7566595799749134094]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 7566595799749134094
-                },
-                "Component_[8818011697750170772]": {
-                    "$type": "SelectionComponent",
-                    "Id": 8818011697750170772
                 }
             }
         },
@@ -212,10 +210,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -258,10 +252,6 @@
                             "SortIndex": 2
                         }
                     ]
-                },
-                "Component_[14532080444774604174]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14532080444774604174
                 },
                 "Component_[15460193905310649551]": {
                     "$type": "EditorEntitySortComponent",
@@ -333,6 +323,10 @@
                         }
                     ]
                 },
+                "Component_[14125570464837926705]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 14125570464837926705
+                },
                 "Component_[15251041960189410484]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 15251041960189410484
@@ -343,9 +337,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -413,10 +409,6 @@
                 "Component_[7566595799749134094]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 7566595799749134094
-                },
-                "Component_[8818011697750170772]": {
-                    "$type": "SelectionComponent",
-                    "Id": 8818011697750170772
                 }
             }
         },
@@ -459,9 +451,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -518,6 +512,10 @@
                         "UniformScale": 3.0
                     }
                 },
+                "Component_[17840053283255387968]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17840053283255387968
+                },
                 "Component_[4252376017882677834]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 4252376017882677834
@@ -529,10 +527,6 @@
                 "Component_[7566595799749134094]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 7566595799749134094
-                },
-                "Component_[8818011697750170772]": {
-                    "$type": "SelectionComponent",
-                    "Id": 8818011697750170772
                 }
             }
         },
@@ -551,10 +545,6 @@
                 "Component_[13208852873506236611]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 13208852873506236611
-                },
-                "Component_[13222097061619369926]": {
-                    "$type": "SelectionComponent",
-                    "Id": 13222097061619369926
                 },
                 "Component_[14812140231390143898]": {
                     "$type": "EditorEntitySortComponent",
@@ -581,9 +571,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16066027089711095181,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },

--- a/AutomatedTesting/Levels/Physics/RigidBody_MassDifferentValuesWorks/RigidBody_MassDifferentValuesWorks.prefab
+++ b/AutomatedTesting/Levels/Physics/RigidBody_MassDifferentValuesWorks/RigidBody_MassDifferentValuesWorks.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -59,9 +55,9 @@
                     "$type": "EditorLockComponent",
                     "Id": 10185161546517584499
                 },
-                "Component_[10536030598467430649]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10536030598467430649
+                "Component_[1032130510390196713]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1032130510390196713
                 },
                 "Component_[12335834086104166461]": {
                     "$type": "EditorInspectorComponent",
@@ -103,9 +99,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -159,19 +157,17 @@
                     "$type": "EditorLockComponent",
                     "Id": 10185161546517584499
                 },
-                "Component_[10536030598467430649]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10536030598467430649
-                },
                 "Component_[11676612620968322981]": {
                     "$type": "EditorColliderComponent",
                     "Id": 11676612620968322981,
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -237,6 +233,10 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 5816541080168941300
                 },
+                "Component_[6418352395209967460]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6418352395209967460
+                },
                 "Component_[7151267576376688961]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 7151267576376688961
@@ -296,10 +296,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -346,10 +342,6 @@
                             32.0
                         ]
                     }
-                },
-                "Component_[14750018756059242159]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14750018756059242159
                 },
                 "Component_[15504055482504256662]": {
                     "$type": "EditorLockComponent",
@@ -405,9 +397,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 17085632993552713258,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -422,10 +416,6 @@
                 "Component_[2646422733150336382]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 2646422733150336382
-                },
-                "Component_[3080683692678717260]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3080683692678717260
                 },
                 "Component_[3099655263685875895]": {
                     "$type": "EditorInspectorComponent",
@@ -551,19 +541,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4585016080616893121,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
                     "ShapeConfiguration": {
                         "ShapeType": 0
                     }
-                },
-                "Component_[7786508561410024741]": {
-                    "$type": "SelectionComponent",
-                    "Id": 7786508561410024741
                 },
                 "Component_[9676896356615942129]": {
                     "$type": "EditorVisibilityComponent",
@@ -579,19 +567,17 @@
                     "$type": "EditorLockComponent",
                     "Id": 10185161546517584499
                 },
-                "Component_[10536030598467430649]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10536030598467430649
-                },
                 "Component_[12113475241723976949]": {
                     "$type": "EditorColliderComponent",
                     "Id": 12113475241723976949,
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -664,6 +650,10 @@
                 "Component_[809396532358010893]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 809396532358010893
+                },
+                "Component_[8916876439994997474]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8916876439994997474
                 },
                 "Component_[9090651604957931210]": {
                     "$type": "EditorPendingCompositionComponent",

--- a/AutomatedTesting/Levels/Physics/RigidBody_MomentOfInertiaManualSetting/RigidBody_MomentOfInertiaManualSetting.prefab
+++ b/AutomatedTesting/Levels/Physics/RigidBody_MomentOfInertiaManualSetting/RigidBody_MomentOfInertiaManualSetting.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -91,10 +87,6 @@
                 "Component_[3047355939801335922]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
-                },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
                 },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -155,12 +147,17 @@
                             0.25
                         ],
                         "Compute inertia": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10000.0
-                        }
+                        "Inertia tensor": [
+                            10000.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10000.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10000.0
+                        ]
                     }
                 },
                 "Component_[2967603762597971538]": {
@@ -180,10 +177,6 @@
                         ],
                         "UniformScale": 2.0
                     }
-                },
-                "Component_[4206850997686106107]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4206850997686106107
                 },
                 "Component_[5392686469694720113]": {
                     "$type": "EditorEntitySortComponent",
@@ -210,9 +203,11 @@
                             0.0,
                             0.125
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -258,13 +253,19 @@
                         }
                     }
                 },
+                "Component_[18051671306501498215]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 18051671306501498215
+                },
                 "Component_[2757154626874696767]": {
                     "$type": "EditorShapeColliderComponent",
                     "Id": 2757154626874696767,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -315,10 +316,6 @@
                 "Component_[7778583323115120252]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7778583323115120252
-                },
-                "Component_[7845429639411639216]": {
-                    "$type": "SelectionComponent",
-                    "Id": 7845429639411639216
                 },
                 "Component_[8828005644065248266]": {
                     "$type": "EditorEntityIconComponent",
@@ -374,12 +371,17 @@
                             0.0,
                             0.25
                         ],
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 1.5
-                        }
+                        "Inertia tensor": [
+                            1.5,
+                            0.0,
+                            0.0,
+                            0.0,
+                            1.5,
+                            0.0,
+                            0.0,
+                            0.0,
+                            1.5
+                        ]
                     }
                 },
                 "Component_[2967603762597971538]": {
@@ -399,10 +401,6 @@
                         ],
                         "UniformScale": 2.0
                     }
-                },
-                "Component_[4206850997686106107]": {
-                    "$type": "SelectionComponent",
-                    "Id": 4206850997686106107
                 },
                 "Component_[5392686469694720113]": {
                     "$type": "EditorEntitySortComponent",
@@ -429,9 +427,11 @@
                             0.0,
                             0.125
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },

--- a/AutomatedTesting/Levels/Physics/RigidBody_SetGravityWorks/RigidBody_SetGravityWorks.prefab
+++ b/AutomatedTesting/Levels/Physics/RigidBody_SetGravityWorks/RigidBody_SetGravityWorks.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -91,10 +87,6 @@
                 "Component_[3047355939801335922]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
-                },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
                 },
                 "Component_[8765166714670902929]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -159,10 +151,6 @@
                         }
                     ]
                 },
-                "Component_[18150567164506774936]": {
-                    "$type": "SelectionComponent",
-                    "Id": 18150567164506774936
-                },
                 "Component_[2159294230913654042]": {
                     "$type": "EditorBoxShapeComponent",
                     "Id": 2159294230913654042,
@@ -176,6 +164,10 @@
                         }
                     }
                 },
+                "Component_[4066838027017049128]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4066838027017049128
+                },
                 "Component_[4764495813565133776]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 4764495813565133776
@@ -188,9 +180,11 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 5289109873564300682,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -234,12 +228,17 @@
                         "entityId": "",
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 },
                 "Component_[14736140193451661185]": {
@@ -267,9 +266,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14778207592594232488,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -300,10 +301,6 @@
                 "Component_[17875611294493709075]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 17875611294493709075
-                },
-                "Component_[18125885518139477388]": {
-                    "$type": "SelectionComponent",
-                    "Id": 18125885518139477388
                 },
                 "Component_[9048247752809714523]": {
                     "$type": "EditorLockComponent",

--- a/AutomatedTesting/Levels/Physics/RigidBody_SleepWhenBelowKineticThreshold/RigidBody_SleepWhenBelowKineticThreshold.prefab
+++ b/AutomatedTesting/Levels/Physics/RigidBody_SleepWhenBelowKineticThreshold/RigidBody_SleepWhenBelowKineticThreshold.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -106,9 +102,9 @@
                         }
                     }
                 },
-                "Component_[17440085855360858421]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17440085855360858421
+                "Component_[1684788451027628478]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1684788451027628478
                 },
                 "Component_[17710225643410447498]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -128,9 +124,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -171,6 +169,10 @@
                         ]
                     }
                 },
+                "Component_[1216961199732943312]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1216961199732943312
+                },
                 "Component_[13705595800936724303]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 13705595800936724303
@@ -210,10 +212,6 @@
                         }
                     }
                 },
-                "Component_[17440085855360858421]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17440085855360858421
-                },
                 "Component_[17710225643410447498]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 17710225643410447498
@@ -232,9 +230,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -300,10 +300,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[8632259647013426420]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 8632259647013426420
@@ -341,10 +337,6 @@
                             32.0
                         ]
                     }
-                },
-                "Component_[14578073896948839034]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14578073896948839034
                 },
                 "Component_[15267743821294241076]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -393,9 +385,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 11064482613129484744,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -465,10 +459,6 @@
                 "Component_[8067047277662259991]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 8067047277662259991
-                },
-                "Component_[8204947769676427228]": {
-                    "$type": "SelectionComponent",
-                    "Id": 8204947769676427228
                 },
                 "Component_[9669700246250139094]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -550,17 +540,15 @@
                         }
                     ]
                 },
-                "Component_[15265885789909818889]": {
-                    "$type": "SelectionComponent",
-                    "Id": 15265885789909818889
-                },
                 "Component_[15549955898409156745]": {
                     "$type": "EditorColliderComponent",
                     "Id": 15549955898409156745,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -637,9 +625,9 @@
                         }
                     }
                 },
-                "Component_[17440085855360858421]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17440085855360858421
+                "Component_[17392513660787212856]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17392513660787212856
                 },
                 "Component_[17710225643410447498]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -659,9 +647,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },

--- a/AutomatedTesting/Levels/Physics/RigidBody_StartGravityEnabledWorks/RigidBody_StartGravityEnabledWorks.prefab
+++ b/AutomatedTesting/Levels/Physics/RigidBody_StartGravityEnabledWorks/RigidBody_StartGravityEnabledWorks.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -96,10 +92,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -118,10 +110,6 @@
             "Id": "Entity_[300968265444]",
             "Name": "RigidBody",
             "Components": {
-                "Component_[10467546351044882674]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10467546351044882674
-                },
                 "Component_[11751036250091821183]": {
                     "$type": "EditorLockComponent",
                     "Id": 11751036250091821183
@@ -175,9 +163,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 2171887721398116180,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -200,12 +190,17 @@
                         "entityId": "",
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 },
                 "Component_[8147019729551544296]": {
@@ -263,9 +258,11 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 16833171179654804716,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -301,13 +298,13 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 3901897916366081391
                 },
+                "Component_[4695027413274280856]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4695027413274280856
+                },
                 "Component_[8021136952219404015]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 8021136952219404015
-                },
-                "Component_[9206125947585620166]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9206125947585620166
                 },
                 "Component_[9523680483955538265]": {
                     "$type": "EditorOnlyEntityComponent",

--- a/AutomatedTesting/Levels/Physics/ScriptCanvas_CollisionEvents/ScriptCanvas_CollisionEvents.prefab
+++ b/AutomatedTesting/Levels/Physics/ScriptCanvas_CollisionEvents/ScriptCanvas_CollisionEvents.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -92,10 +88,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
                 },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
-                },
                 "Component_[9432950532896492451]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9432950532896492451,
@@ -114,10 +106,6 @@
             "Id": "Entity_[334020569918]",
             "Name": "Begin Signal",
             "Components": {
-                "Component_[10086183393590052783]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10086183393590052783
-                },
                 "Component_[11212898224298393352]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 11212898224298393352
@@ -176,10 +164,6 @@
                 "Component_[12405124462018761521]": {
                     "$type": "EditorLockComponent",
                     "Id": 12405124462018761521
-                },
-                "Component_[17303801290637898798]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17303801290637898798
                 },
                 "Component_[17471919493216976961]": {
                     "$type": "EditorVisibilityComponent",
@@ -251,10 +235,6 @@
                 "Component_[17945696094944770262]": {
                     "$type": "EditorLockComponent",
                     "Id": 17945696094944770262
-                },
-                "Component_[18325697466939096425]": {
-                    "$type": "SelectionComponent",
-                    "Id": 18325697466939096425
                 },
                 "Component_[3493262362913959097]": {
                     "$type": "EditorEntitySortComponent",
@@ -333,9 +313,11 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 14110900608286705866,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -349,6 +331,10 @@
                             ]
                         }
                     ]
+                },
+                "Component_[283934156241595823]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 283934156241595823
                 },
                 "Component_[3148068961413705897]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -373,10 +359,6 @@
                             31.0
                         ]
                     }
-                },
-                "Component_[6089046069377098239]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6089046069377098239
                 },
                 "Component_[714241131360278670]": {
                     "$type": "EditorEntitySortComponent",
@@ -447,12 +429,17 @@
                     "Configuration": {
                         "entityId": "",
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 2.5
-                        }
+                        "Inertia tensor": [
+                            2.5,
+                            0.0,
+                            0.0,
+                            0.0,
+                            2.5,
+                            0.0,
+                            0.0,
+                            0.0,
+                            2.5
+                        ]
                     }
                 },
                 "Component_[17736810712679913703]": {
@@ -463,112 +450,113 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 2499566050349593055
                 },
-                "Component_[2556187931131992823]": {
-                    "$type": "SelectionComponent",
-                    "Id": 2556187931131992823
-                },
                 "Component_[584441947048980638]": {
                     "$type": "EditorScriptCanvasComponent",
                     "Id": 584441947048980638,
-                    "m_name": "collision_events_script.scriptcanvas",
-                    "runtimeDataIsValid": true,
-                    "runtimeDataOverrides": {
-                        "source": {
+                    "configuration": {
+                        "sourceHandle": {
                             "id": "{80C6B26A-79AA-5734-B254-388DB32E2407}",
                             "path": "D:/Projects/o3de-dev/o3de/AutomatedTesting/Levels/Physics/ScriptCanvas_CollisionEvents/collision_events_script.scriptcanvas"
                         },
-                        "entityId": [
-                            [
-                                {
-                                    "m_id": "{79C630E7-2ED7-40E9-929D-6D88FC32ADD9}"
-                                },
-                                ""
+                        "propertyOverrides": {
+                            "source": {
+                                "id": "{80C6B26A-79AA-5734-B254-388DB32E2407}",
+                                "path": "D:/Projects/o3de-dev/o3de/AutomatedTesting/Levels/Physics/ScriptCanvas_CollisionEvents/collision_events_script.scriptcanvas"
+                            },
+                            "entityId": [
+                                [
+                                    {
+                                        "m_id": "{79C630E7-2ED7-40E9-929D-6D88FC32ADD9}"
+                                    },
+                                    ""
+                                ],
+                                [
+                                    {
+                                        "m_id": "{C802DF6D-82C4-4648-81AD-99DB01A03B3B}"
+                                    },
+                                    ""
+                                ],
+                                [
+                                    {
+                                        "m_id": "{F1E1AFD6-DCE6-4A1F-AF22-59F2B7B943CC}"
+                                    },
+                                    ""
+                                ]
                             ],
-                            [
+                            "overrides": [
                                 {
-                                    "m_id": "{C802DF6D-82C4-4648-81AD-99DB01A03B3B}"
+                                    "Datum": {
+                                        "isOverloadedStorage": false,
+                                        "scriptCanvasType": {
+                                            "m_type": 1
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "EntityId",
+                                        "value": "Entity_[338315537214]",
+                                        "label": "Persist Signal ID"
+                                    },
+                                    "InputControlVisibility": {
+                                        "Value": 850104567
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{79C630E7-2ED7-40E9-929D-6D88FC32ADD9}"
+                                    },
+                                    "VariableName": "Persist Signal ID",
+                                    "InitialValueSource": 1
                                 },
-                                ""
-                            ],
-                            [
                                 {
-                                    "m_id": "{F1E1AFD6-DCE6-4A1F-AF22-59F2B7B943CC}"
+                                    "Datum": {
+                                        "isOverloadedStorage": false,
+                                        "scriptCanvasType": {
+                                            "m_type": 1
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "EntityId",
+                                        "value": "Entity_[342610504510]",
+                                        "label": "End Signal ID"
+                                    },
+                                    "InputControlVisibility": {
+                                        "Value": 850104567
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{C802DF6D-82C4-4648-81AD-99DB01A03B3B}"
+                                    },
+                                    "VariableName": "End Signal ID",
+                                    "InitialValueSource": 1
                                 },
-                                ""
+                                {
+                                    "Datum": {
+                                        "isOverloadedStorage": false,
+                                        "scriptCanvasType": {
+                                            "m_type": 1
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "EntityId",
+                                        "value": "Entity_[334020569918]",
+                                        "label": "Begin Signal ID"
+                                    },
+                                    "InputControlVisibility": {
+                                        "Value": 850104567
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{F1E1AFD6-DCE6-4A1F-AF22-59F2B7B943CC}"
+                                    },
+                                    "VariableName": "Begin Signal ID",
+                                    "InitialValueSource": 1
+                                }
                             ]
-                        ],
-                        "overrides": [
-                            {
-                                "Datum": {
-                                    "scriptCanvasType": {
-                                        "m_type": 1
-                                    },
-                                    "isNullPointer": false,
-                                    "$type": "EntityId",
-                                    "value": "Entity_[338315537214]",
-                                    "label": "Persist Signal ID"
-                                },
-                                "InputControlVisibility": {
-                                    "Value": 850104567
-                                },
-                                "VariableId": {
-                                    "m_id": "{79C630E7-2ED7-40E9-929D-6D88FC32ADD9}"
-                                },
-                                "VariableName": "Persist Signal ID",
-                                "InitialValueSource": 1
-                            },
-                            {
-                                "Datum": {
-                                    "scriptCanvasType": {
-                                        "m_type": 1
-                                    },
-                                    "isNullPointer": false,
-                                    "$type": "EntityId",
-                                    "value": "Entity_[342610504510]",
-                                    "label": "End Signal ID"
-                                },
-                                "InputControlVisibility": {
-                                    "Value": 850104567
-                                },
-                                "VariableId": {
-                                    "m_id": "{C802DF6D-82C4-4648-81AD-99DB01A03B3B}"
-                                },
-                                "VariableName": "End Signal ID",
-                                "InitialValueSource": 1
-                            },
-                            {
-                                "Datum": {
-                                    "scriptCanvasType": {
-                                        "m_type": 1
-                                    },
-                                    "isNullPointer": false,
-                                    "$type": "EntityId",
-                                    "value": "Entity_[334020569918]",
-                                    "label": "Begin Signal ID"
-                                },
-                                "InputControlVisibility": {
-                                    "Value": 850104567
-                                },
-                                "VariableId": {
-                                    "m_id": "{F1E1AFD6-DCE6-4A1F-AF22-59F2B7B943CC}"
-                                },
-                                "VariableName": "Begin Signal ID",
-                                "InitialValueSource": 1
-                            }
-                        ]
-                    },
-                    "sourceHandle": {
-                        "id": "{80C6B26A-79AA-5734-B254-388DB32E2407}",
-                        "path": "D:/Projects/o3de-dev/o3de/AutomatedTesting/Levels/Physics/ScriptCanvas_CollisionEvents/collision_events_script.scriptcanvas"
+                        }
                     }
                 },
                 "Component_[6003927233414867950]": {
                     "$type": "EditorColliderComponent",
                     "Id": 6003927233414867950,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },

--- a/AutomatedTesting/Levels/Physics/ScriptCanvas_PostPhysicsUpdate/ScriptCanvas_PostPhysicsUpdate.prefab
+++ b/AutomatedTesting/Levels/Physics/ScriptCanvas_PostPhysicsUpdate/ScriptCanvas_PostPhysicsUpdate.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -55,13 +51,13 @@
             "Id": "Entity_[281305126238]",
             "Name": "ForceRegion",
             "Components": {
+                "Component_[10005778345231242227]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 10005778345231242227
+                },
                 "Component_[11067593639950420183]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 11067593639950420183
-                },
-                "Component_[11296977532458138796]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11296977532458138796
                 },
                 "Component_[13263255503400547953]": {
                     "$type": "EditorInspectorComponent",
@@ -137,9 +133,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -175,21 +173,17 @@
                 "Component_[11388627947025080736]": {
                     "$type": "EditorScriptCanvasComponent",
                     "Id": 11388627947025080736,
-                    "m_name": "ontick",
-                    "runtimeDataIsValid": true,
-                    "runtimeDataOverrides": {
-                        "source": {
-                            "id": "{129013F1-8514-5A07-AD83-EC85BD0DA57C}"
+                    "configuration": {
+                        "sourceHandle": {
+                            "id": "{129013F1-8514-5A07-AD83-EC85BD0DA57C}",
+                            "path": "levels/physics/scriptcanvas_postphysicsupdate/ontick.scriptcanvas"
+                        },
+                        "propertyOverrides": {
+                            "source": {
+                                "id": "{129013F1-8514-5A07-AD83-EC85BD0DA57C}"
+                            }
                         }
-                    },
-                    "sourceHandle": {
-                        "id": "{129013F1-8514-5A07-AD83-EC85BD0DA57C}",
-                        "path": "levels/physics/scriptcanvas_postphysicsupdate/ontick.scriptcanvas"
                     }
-                },
-                "Component_[12926460860226400954]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12926460860226400954
                 },
                 "Component_[13099430927808761140]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -210,27 +204,32 @@
                         "entityId": "",
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 },
                 "Component_[16662689546275335159]": {
                     "$type": "EditorScriptCanvasComponent",
                     "Id": 16662689546275335159,
-                    "m_name": "onpostphysicsupdate",
-                    "runtimeDataIsValid": true,
-                    "runtimeDataOverrides": {
-                        "source": {
-                            "id": "{36AE9162-BCBE-59B3-9A43-ABFCCA150B78}"
+                    "configuration": {
+                        "sourceHandle": {
+                            "id": "{36AE9162-BCBE-59B3-9A43-ABFCCA150B78}",
+                            "path": "levels/physics/scriptcanvas_postphysicsupdate/onpostphysicsupdate.scriptcanvas"
+                        },
+                        "propertyOverrides": {
+                            "source": {
+                                "id": "{36AE9162-BCBE-59B3-9A43-ABFCCA150B78}"
+                            }
                         }
-                    },
-                    "sourceHandle": {
-                        "id": "{36AE9162-BCBE-59B3-9A43-ABFCCA150B78}",
-                        "path": "levels/physics/scriptcanvas_postphysicsupdate/onpostphysicsupdate.scriptcanvas"
                     }
                 },
                 "Component_[2476622826402871625]": {
@@ -274,9 +273,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 5790409583652412480,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },

--- a/AutomatedTesting/Levels/Physics/ScriptCanvas_SpawnEntityWithPhysComponents/ScriptCanvas_SpawnEntityWithPhysComponents.prefab
+++ b/AutomatedTesting/Levels/Physics/ScriptCanvas_SpawnEntityWithPhysComponents/ScriptCanvas_SpawnEntityWithPhysComponents.prefab
@@ -37,10 +37,6 @@
                 "$type": "EditorEntityIconComponent",
                 "Id": 5688118765544765547
             },
-            "Component_[6545738857812235305]": {
-                "$type": "SelectionComponent",
-                "Id": 6545738857812235305
-            },
             "Component_[7247035804068349658]": {
                 "$type": "EditorPrefabComponent",
                 "Id": 7247035804068349658
@@ -73,10 +69,6 @@
                         }
                     }
                 },
-                "Component_[11701138785793981042]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11701138785793981042
-                },
                 "Component_[12260880513256986252]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 12260880513256986252
@@ -90,11 +82,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -147,6 +134,10 @@
                         }
                     }
                 },
+                "Component_[3741021495640157955]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 3741021495640157955
+                },
                 "Component_[5681893399601237518]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 5681893399601237518
@@ -169,10 +160,6 @@
             "Id": "Entity_[3721848391988]",
             "Name": "Spawn_Point",
             "Components": {
-                "Component_[10012298246375265627]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10012298246375265627
-                },
                 "Component_[10841247711583713947]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 10841247711583713947

--- a/AutomatedTesting/Levels/Physics/ScriptCanvas_TriggerEvents/ScriptCanvas_TriggerEvents.prefab
+++ b/AutomatedTesting/Levels/Physics/ScriptCanvas_TriggerEvents/ScriptCanvas_TriggerEvents.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -55,10 +51,6 @@
             "Id": "Entity_[279454450788]",
             "Name": "Box",
             "Components": {
-                "Component_[10349274502019720655]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10349274502019720655
-                },
                 "Component_[10909557756965435232]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 10909557756965435232
@@ -88,6 +80,10 @@
                         }
                     ]
                 },
+                "Component_[15669826384274097496]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 15669826384274097496
+                },
                 "Component_[18213634137398041457]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 18213634137398041457,
@@ -106,9 +102,11 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -135,16 +133,16 @@
                 "Component_[814892852661066937]": {
                     "$type": "EditorScriptCanvasComponent",
                     "Id": 814892852661066937,
-                    "m_name": "ScriptCanvasBox",
-                    "runtimeDataIsValid": true,
-                    "runtimeDataOverrides": {
-                        "source": {
-                            "id": "{374FA4D5-6167-56A8-BC77-04D5F71C3ED2}"
+                    "configuration": {
+                        "sourceHandle": {
+                            "id": "{374FA4D5-6167-56A8-BC77-04D5F71C3ED2}",
+                            "path": "scriptcanvas/scriptcanvasbox.scriptcanvas"
+                        },
+                        "propertyOverrides": {
+                            "source": {
+                                "id": "{374FA4D5-6167-56A8-BC77-04D5F71C3ED2}"
+                            }
                         }
-                    },
-                    "sourceHandle": {
-                        "id": "{374FA4D5-6167-56A8-BC77-04D5F71C3ED2}",
-                        "path": "scriptcanvas/scriptcanvasbox.scriptcanvas"
                     }
                 }
             }
@@ -173,19 +171,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16210676658230708095,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
                     "ShapeConfiguration": {
                         "ShapeType": 0
                     }
-                },
-                "Component_[16690187173417031376]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16690187173417031376
                 },
                 "Component_[17183713697901649461]": {
                     "$type": "EditorLockComponent",

--- a/AutomatedTesting/Levels/Prefab/PrefabLevel_OpensLevelWithEntities/PrefabLevel_OpensLevelWithEntities.prefab
+++ b/AutomatedTesting/Levels/Prefab/PrefabLevel_OpensLevelWithEntities/PrefabLevel_OpensLevelWithEntities.prefab
@@ -64,6 +64,10 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 11161653124805884473
                 },
+                "Component_[11880342253837797716]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 11880342253837797716
+                },
                 "Component_[13116773315299882093]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 13116773315299882093

--- a/AutomatedTesting/Levels/Prefab/QuitOnSuccessfulSpawn/QuitOnSuccessfulSpawn.prefab
+++ b/AutomatedTesting/Levels/Prefab/QuitOnSuccessfulSpawn/QuitOnSuccessfulSpawn.prefab
@@ -209,6 +209,10 @@
                     "$type": "EditorLockComponent",
                     "Id": 7090012899106946164
                 },
+                "Component_[9063502120995369413]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9063502120995369413
+                },
                 "Component_[9410832619875640998]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 9410832619875640998

--- a/AutomatedTesting/Levels/TestLevel/TestLevel.prefab
+++ b/AutomatedTesting/Levels/TestLevel/TestLevel.prefab
@@ -146,6 +146,10 @@
                     "$type": "EditorInspectorComponent",
                     "Id": 16919232076966545697
                 },
+                "Component_[17323933878488717651]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17323933878488717651
+                },
                 "Component_[5182430712893438093]": {
                     "$type": "EditorMaterialComponent",
                     "Id": 5182430712893438093

--- a/AutomatedTesting/Levels/Utils/Tracer_ErrorEntity/Tracer_ErrorEntity.prefab
+++ b/AutomatedTesting/Levels/Utils/Tracer_ErrorEntity/Tracer_ErrorEntity.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -88,10 +84,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 17982257912988768282
                 },
-                "Component_[5540118842216992104]": {
-                    "$type": "SelectionComponent",
-                    "Id": 5540118842216992104
-                },
                 "Component_[6131282612213913817]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 6131282612213913817
@@ -100,9 +92,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 7666850511170058566,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -132,6 +126,10 @@
                 "Component_[9055996217752214834]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 9055996217752214834
+                },
+                "Component_[9469942922917322012]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9469942922917322012
                 }
             }
         },
@@ -175,10 +173,6 @@
                 "Component_[3047355939801335922]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 3047355939801335922
-                },
-                "Component_[3687396159953003426]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3687396159953003426
                 },
                 "Component_[7505662882395796332]": {
                     "$type": "EditorOnlyEntityComponent",


### PR DESCRIPTION
**Note**
This work has been divided into multiple PRs to make it easier to review. Merging each PR into the staging branch `PhysX_StaticRigidBody_Staging_o3de`.

This change is part of the following PR https://github.com/o3de/o3de/pull/14261

- Built and open editor
- Run command `ed_physxUpdatePrefabsWithColliderComponents` in the console
- Confirmed all the updated prefabs are successfully processed by Asset Processor.
- Verified that the default level template has been updated correctly.

Resaving the prefabs caused to get rid of some old components that don't exist anymore and also save others with newer serialization content.

Signed-off-by: moraaar <moraaar@amazon.com>