### PR TITLE
Improve how Hinge/Prismatic joints handle the connection to JointRequest bus

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/RigidBodyBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/RigidBodyBus.h
@@ -110,7 +110,7 @@ namespace Physics
                         // Only immediately dispatch if the entity is a RigidBodyRequestBus' handler.
                         RigidBodyRequestBus::EnumerateHandlersId(
                             id,
-                            [handler, id](const RigidBodyRequests* rigidBodyhandler)
+                            [&handler, id](const RigidBodyRequests* rigidBodyhandler)
                             {
                                 if (rigidBodyhandler->IsPhysicsEnabled())
                                 {

--- a/Gems/PhysX/Code/Source/EditorStaticRigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorStaticRigidBodyComponent.cpp
@@ -15,8 +15,7 @@ namespace PhysX
 {
     void EditorStaticRigidBodyComponent::Reflect(AZ::ReflectContext* context)
     {
-        auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
-        if (serializeContext)
+        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<EditorStaticRigidBodyComponent, AzToolsFramework::Components::EditorComponentBase>()
                 ->Version(1);

--- a/Gems/PhysX/Code/Source/EditorStaticRigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorStaticRigidBodyComponent.cpp
@@ -21,8 +21,7 @@ namespace PhysX
             serializeContext->Class<EditorStaticRigidBodyComponent, AzToolsFramework::Components::EditorComponentBase>()
                 ->Version(1);
 
-            AZ::EditContext* editContext = serializeContext->GetEditContext();
-            if (editContext)
+            if (auto* editContext = serializeContext->GetEditContext())
             {
                 editContext
                     ->Class<EditorStaticRigidBodyComponent>(

--- a/Gems/PhysX/Code/Source/HingeJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/HingeJointComponent.cpp
@@ -88,19 +88,18 @@ namespace PhysX
             m_jointSceneOwner = leadFollowerInfo.m_followerBody->m_sceneOwner;
         }
         m_nativeJoint = GetPhysXNativeRevoluteJoint();
+
+        if (m_nativeJoint)
+        {
+            const AZ::EntityComponentIdPair id(GetEntityId(), GetId());
+            PhysX::JointRequestBus::Handler::BusConnect(id);
+        }
     }
 
-    void HingeJointComponent::Activate()
+    void HingeJointComponent::DeinitNativeJoint()
     {
-        JointComponent::Activate();
-        const AZ::EntityComponentIdPair id(GetEntityId(), GetId());
-        PhysX::JointRequestBus::Handler::BusConnect(id);
-    }
-
-    void HingeJointComponent::Deactivate()
-    {
-        PhysX::JointRequestBus::Handler::BusDisconnect();
-        JointComponent::Deactivate();
+        JointRequestBus::Handler::BusDisconnect();
+        m_nativeJoint = nullptr;
     }
 
     physx::PxRevoluteJoint* HingeJointComponent::GetPhysXNativeRevoluteJoint()

--- a/Gems/PhysX/Code/Source/HingeJointComponent.h
+++ b/Gems/PhysX/Code/Source/HingeJointComponent.h
@@ -30,7 +30,7 @@ namespace PhysX
             const JointMotorProperties& motorProperties = JointMotorProperties());
         ~HingeJointComponent() = default;
 
-        // JointRequestBus::Handler overrides
+        // JointRequestBus::Handler overrides ...
         float GetPosition() const override;
         float GetVelocity() const override;
         AZ::Transform GetTransform() const override;
@@ -38,13 +38,10 @@ namespace PhysX
         void SetMaximumForce(float force) override;
         AZStd::pair<float, float> GetLimits() const override;
 
-        // AZ::Component overrides
-        void Activate() override;
-        void Deactivate() override;
-
     protected:
-        // JointComponent
+        // JointComponent overrides ...
         void InitNativeJoint() override;
+        void DeinitNativeJoint() override;
 
     private:
        physx::PxRevoluteJoint* GetPhysXNativeRevoluteJoint();

--- a/Gems/PhysX/Code/Source/JointComponent.cpp
+++ b/Gems/PhysX/Code/Source/JointComponent.cpp
@@ -187,6 +187,8 @@ namespace PhysX
             return;
         }
 
+        DeinitNativeJoint();
+
         if (auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get())
         {
             if (auto* scene = physicsSystem->GetScene(m_jointSceneOwner))

--- a/Gems/PhysX/Code/Source/JointComponent.h
+++ b/Gems/PhysX/Code/Source/JointComponent.h
@@ -92,8 +92,9 @@ namespace PhysX
         // Invoked when one of the involved rigid bodies is disabled.
         void DestroyNativeJoint();
 
-        /// Specific joint types will instantiate native joint pointer.
-        virtual void InitNativeJoint() {};
+        // Specific joint types will instantiate native joint pointer.
+        virtual void InitNativeJoint(){};
+        virtual void DeinitNativeJoint(){};
 
         AZ::Transform GetJointLocalPose(const physx::PxRigidActor* actor, const AZ::Transform& jointPose);
 

--- a/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
@@ -88,7 +88,7 @@ namespace PhysX
         {
             // Early out if there's no relevant physics world present.
             // It may be a valid case when we have game-time components assigned to editor entities via a script
-            // So no need to print a warning here.
+            // so no need to print a warning here.
             return;
         }
 

--- a/Gems/PhysX/Code/Source/PrismaticJointComponent.h
+++ b/Gems/PhysX/Code/Source/PrismaticJointComponent.h
@@ -33,7 +33,7 @@ namespace PhysX
             const JointMotorProperties& motorProperties);
         ~PrismaticJointComponent() = default;
 
-        // JointRequestBus::Handler overrides
+        // JointRequestBus::Handler overrides ...
         float GetPosition() const override;
         float GetVelocity() const override;
         AZ::Transform GetTransform() const override;
@@ -41,13 +41,10 @@ namespace PhysX
         void SetMaximumForce(float force) override;
         AZStd::pair<float, float> GetLimits() const override;
 
-        // AZ::Component overrides
-        void Activate() override;
-        void Deactivate() override;
-
     protected:
-        // JointComponent
+        // JointComponent overrides ...
         void InitNativeJoint() override;
+        void DeinitNativeJoint() override;
 
     private:
         physx::PxD6Joint* GetPhysXD6Joint();

--- a/Gems/PhysX/Code/Source/RigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/RigidBodyComponent.cpp
@@ -142,7 +142,7 @@ namespace PhysX
         {
             // Early out if there's no relevant physics world present.
             // It may be a valid case when we have game-time components assigned to editor entities via a script
-            // So no need to print a warning here.
+            // so no need to print a warning here.
             return;
         }
 

--- a/Gems/PhysX/Code/Source/StaticRigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/StaticRigidBodyComponent.cpp
@@ -102,7 +102,7 @@ namespace PhysX
         {
             // Early out if there's no relevant physics world present.
             // It may be a valid case when we have game-time components assigned to editor entities via a script
-            // So no need to print a warning here.
+            // so no need to print a warning here.
             return;
         }
 


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

Before this change the Hinge & Prismatic joints were connecting to the JointRequest bus too early, when their native joint wasn't created yet, so potentially JointRequest calls could arrive before the native joint is created.

## How was this PR tested?

PhysX unit tests passed.
