### PR TITLE
Adds sig-graphics-audio reviewers to Audio Gems

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -130,3 +130,5 @@
 # SIG-Graphics-Audio ownership areas
 /Gems/Atom*/ @o3de/sig-graphics-audio-maintainers @o3de/sig-graphics-audio-reviewers
 /Gems/Terrain/ @o3de/sig-graphics-audio-maintainers @o3de/sig-graphics-audio-reviewers
+/Gems/Audio*/ @o3de/sig-graphics-audio-maintainers @o3de/sig-graphics-audio-reviewers
+/Gems/Microphone/ @o3de/sig-graphics-audio-maintainers @o3de/sig-graphics-audio-reviewers


### PR DESCRIPTION
Signed-off-by: amzn-phist <52085794+amzn-phist@users.noreply.github.com>

## What does this PR do?

Add sig graphics audio to audio-related paths in the CODEOWNERS file.

## How was this PR tested?

None
