### PR TITLE
Connect product filter to Asset Browser thumbnail view

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -475,6 +475,7 @@ void AzAssetBrowserWindow::CreateToolsMenu()
         connect(projectSourceAssets, &QAction::triggered, this,
             [this, projectSourceAssets]
             {
+                m_ui->m_thumbnailView->HideProductAssets(projectSourceAssets->isChecked());
                 m_ui->m_searchWidget->ToggleProjectSourceAssetFilter(projectSourceAssets->isChecked());
             });
         m_toolsMenu->addAction(projectSourceAssets);

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
@@ -548,7 +548,7 @@ namespace AzQtComponents
 
     bool AssetFolderThumbnailView::isExpandable(const QModelIndex& index) const
     {
-        return index.data(static_cast<int>(AssetFolderThumbnailView::Role::IsExpandable)).value<bool>();
+        return (m_hideProductAssets ? false : index.data(static_cast<int>(AssetFolderThumbnailView::Role::IsExpandable)).value<bool>());
     }
 
     void AssetFolderThumbnailView::paintEvent(QPaintEvent* event)
@@ -946,6 +946,11 @@ namespace AzQtComponents
     void AssetFolderThumbnailView::SetShowSearchResultsMode(bool searchMode)
     {
         m_showSearchResultsMode = searchMode;
+    }
+
+    void AssetFolderThumbnailView::HideProductAssets(bool checked)
+    {
+        m_hideProductAssets = checked;
     }
 
 } // namespace AzQtComponents

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.h
@@ -109,6 +109,8 @@ namespace AzQtComponents
 
         void SetShowSearchResultsMode(bool searchMode);
 
+        void HideProductAssets(bool checked);
+
     signals:
         void rootIndexChanged(const QModelIndex& idx);
         void showInFolderTriggered(const QModelIndex& idx);
@@ -158,6 +160,7 @@ namespace AzQtComponents
         ThumbnailSize m_thumbnailSize;
         Config m_config;
         bool m_showSearchResultsMode = false;
+        bool m_hideProductAssets = true;
         QMenu* m_contextMenu = nullptr;
     };
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
@@ -141,6 +141,11 @@ namespace AzToolsFramework
                 &AssetBrowserThumbnailView::HandleTreeViewSelectionChanged);
         }
 
+        void AssetBrowserThumbnailView::HideProductAssets(bool checked)
+        {
+            m_thumbnailViewWidget->HideProductAssets(checked);
+        }
+
         void AssetBrowserThumbnailView::setSelectionMode(QAbstractItemView::SelectionMode mode)
         {
             m_thumbnailViewWidget->setSelectionMode(mode);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h
@@ -41,6 +41,8 @@ namespace AzToolsFramework
 
             void SetAssetTreeView(AssetBrowserTreeView* treeView);
 
+            void HideProductAssets(bool checked);
+
             AzQtComponents::AssetFolderThumbnailView* GetThumbnailViewWidget() const;
 
             void setSelectionMode(QAbstractItemView::SelectionMode mode);


### PR DESCRIPTION
Signed-off-by: Daniel Tamkin <jotamkin@amazon.com>

## What does this PR do?

Connects the functionality of the product asset filter to the new asset browser thumbnail view

![Editor_qMsQJmujJ5](https://user-images.githubusercontent.com/84731577/215605308-ea345a70-27ea-4904-83b7-fcf5c3e016a6.gif)

## How was this PR tested?

Locally
