### PR TITLE
Alexmont/dpe fixes

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/FilterAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/FilterAdapter.cpp
@@ -259,14 +259,6 @@ namespace AZ::DocumentPropertyEditor
 
                     // replace operations can change child values from or into rows. Handle all cases
                     auto existingRowNode = GetMatchNodeAtPath(patchPath);
-
-                    /* <apm> replace is hard. The possibilities are:
-                    * row->row - generate the remove (if mapping exists), Incremental patch generates Add if necessary
-                    * row->column - if the row was filtered out, this is an Add. If not, this is a Replace
-                    * column->row - treat this as a remove (if mapping exists), Incremental patch generates Add if necessary
-                    * column->column - always a Replace, if the mapping exists
-                    * */
-
                     const bool replacementIsRow = (patchPath == rowPath);
                     if (!replacementIsRow && !existingRowNode)
                     {
@@ -435,7 +427,6 @@ namespace AZ::DocumentPropertyEditor
                         return (currNode == testNode);
                     });
                 size_t index = AZStd::distance(parentNode->m_childMatchState.begin(), foundIter);
-
                 path.Push(index);
             }
         };

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/FilterAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/FilterAdapter.h
@@ -79,6 +79,7 @@ namespace AZ::DocumentPropertyEditor
         void HandleDomChange(const Dom::Patch& patch) override;
 
         MatchInfoNode* GetMatchNodeAtPath(const Dom::Path& sourcePath);
+        Dom::Path GetSourcePathForNode(const MatchInfoNode* matchNode);
 
         /*! populates the MatchInfoNode nodes for the given path and any descendant row children created.
          *  All new nodes have their m_matchesSelf, m_matchingDescendants, and  m_matchableDomTerms set */
@@ -93,7 +94,7 @@ namespace AZ::DocumentPropertyEditor
             RemovalsFromSource, // patch all removals to get from the source adapter's state to the current filter state
             PatchToSource // patch all additions required to get from the current filter state to the source adapter's state
         };
-        void GeneratePatch(PatchType patchType);
+        void GeneratePatch(PatchType patchType, AZ::Dom::Patch& patchToFill);
 
         /*! updates the match states (m_matchesSelf, m_matchingDescendants) for the given row node,
             and updates the m_matchingDescendants state for all its ancestors

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/FilterAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/FilterAdapter.h
@@ -42,6 +42,12 @@ namespace AZ::DocumentPropertyEditor
                 return (m_matchesSelf || m_hasMatchingAncestor || !m_matchingDescendants.empty());
             };
 
+            void RemoveChildAtIndex(size_t index)
+            {
+                AZ_Assert(m_childMatchState.size() > index, "MatchInfoNode child out of bounds!");
+                m_childMatchState.erase(m_childMatchState.begin() + index);
+            }
+
             bool m_matchesSelf = false;
 
             //! this will only be set and checked if the FilterAdapter has m_includeAllMatchDescendants set

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -803,28 +803,31 @@ namespace AzToolsFramework
                 auto dpe = GetDPE();
                 const auto childIterator = m_domOrderedChildren.begin() + childIndex;
                 auto childWidget = *childIterator;
-                DPERowWidget* rowToRemove = qobject_cast<DPERowWidget*>(childWidget);
-                if (rowToRemove)
+                if (childWidget)
                 {
-                    // we're removing a row, remove any associated saved expander state
-                    dpe->RemoveExpanderStateForRow(rowToRemove->GetPath());
-                    DocumentPropertyEditor::GetRowPool()->RecycleInstance(rowToRemove);
-                }
-                else if (auto foundEntry = m_widgetToPropertyHandlerInfo.find(childWidget);
-                         foundEntry != m_widgetToPropertyHandlerInfo.end())
-                {
-                    ReleaseHandler(foundEntry->second);
-                    m_widgetToPropertyHandlerInfo.erase(foundEntry);
-                    RemoveAttributes(childIndex);
-                    DetachAndHide(childWidget);
-                }
-                else // not a row, not a PropertyHandler, must be a label
-                {
-                    auto label = qobject_cast<AzQtComponents::ElidingLabel*>(childWidget);
-                    AZ_Assert(label, "not a label, unknown widget discovered!");
-                    if (label)
+                    DPERowWidget* rowToRemove = qobject_cast<DPERowWidget*>(childWidget);
+                    if (rowToRemove)
                     {
-                        DocumentPropertyEditor::GetLabelPool()->RecycleInstance(label);
+                        // we're removing a row, remove any associated saved expander state
+                        dpe->RemoveExpanderStateForRow(rowToRemove->GetPath());
+                        DocumentPropertyEditor::GetRowPool()->RecycleInstance(rowToRemove);
+                    }
+                    else if (auto foundEntry = m_widgetToPropertyHandlerInfo.find(childWidget);
+                             foundEntry != m_widgetToPropertyHandlerInfo.end())
+                    {
+                        ReleaseHandler(foundEntry->second);
+                        m_widgetToPropertyHandlerInfo.erase(foundEntry);
+                        RemoveAttributes(childIndex);
+                        DetachAndHide(childWidget);
+                    }
+                    else // not a row, not a PropertyHandler, must be a label
+                    {
+                        auto label = qobject_cast<AzQtComponents::ElidingLabel*>(childWidget);
+                        AZ_Assert(label, "not a label, unknown widget discovered!");
+                        if (label)
+                        {
+                            DocumentPropertyEditor::GetLabelPool()->RecycleInstance(label);
+                        }
                     }
                 }
                 m_domOrderedChildren.erase(childIterator);


### PR DESCRIPTION
## What does this PR do?
- fix FilterAdapter only passing through row-level patches
- optimize patch operations to only update affected nodes once per patch
- fix for collapsed (null) nodes being removed in a patch

## How was this PR tested?
locally, in both the CVar Editor and the DPE standalone
