### PR TITLE
Fix ASV screenshot

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Surfaces/StandardSurface.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Surfaces/StandardSurface.azsli
@@ -89,6 +89,9 @@ void Surface::ApplySpecularAA()
     float kernelRoughnessA2 = min(2.0 * variance , varianceThresh );
     float filteredRoughnessA2 = saturate ( roughnessA2 + kernelRoughnessA2 );
     roughnessA2 = filteredRoughnessA2;
+
+    roughnessA = sqrt(roughnessA2);
+    roughnessLinear = sqrt(roughnessA);
 }
 
 void Surface::CalculateRoughnessA()

--- a/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
@@ -582,7 +582,7 @@ namespace AZ
             const AZStd::string& outputFilePath,
             RPI::PassAttachmentReadbackOption option)
         {
-            CaptureHandle captureHandle = InternalCapturePassAttachment(passHierarchy, slot, outputFilePath, option, AZStd::bind(&FrameCaptureSystemComponent::CaptureAttachmentCallback, this, AZStd::placeholders::_1));
+            CaptureHandle captureHandle = InternalCapturePassAttachment(passHierarchy, slot, outputFilePath, option, nullptr);
             if (captureHandle.IsNull())
             {
                 return InvalidFrameCaptureId;


### PR DESCRIPTION
Signed-off-by: jiaweig <51759646+jiaweig-amzn@users.noreply.github.com>

## What does this PR do?

1. Fix screenshot capture for secondary windows.
2. Fix issue that was exposed by multiscene sample

The multiscene sample started to fail from this commit:
https://github.com/o3de/o3de/pull/11016/commits/b0d199ad67aa50b798f23504dd77d9e4d6838341
It didn't introduce bug, but in fact exposed an older bug where there were different behavior after calculating specularAA, which is whether to set back linear roughness after calculating specular AA.

Check
[Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceData.azsli](https://github.com/o3de/o3de/pull/11016/files#diff-d7a09bf799d2de8986dda7232c78614abe97385120b888c75c0535df8780f78e) line 49 - 82
[Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Surfaces/StandardSurface.azsli](https://github.com/o3de/o3de/pull/11016/files#diff-717ad64bab26699482e10183d3983f833f87771397d1c9c2c0fc8d66e6bae81b) line 70 - 100

The screenshot of multiscene used to not apply roughness back after calculating specular AA. Now it does after the PBR shader refactor. So the fix is updating the screenshot and fix other places that don't apply roughness back.
Screenshot is updated here: https://github.com/o3de/o3de-atom-sampleviewer/pull/577

## How was this PR tested?
2 errors are:
Multiscene screenshot, which is updated as mentioned above.
The other is in the backlog to clear. [Error] (PassSystem) - Do not remove child passes outside of the removal, reset, or build phases.
Automation: Running script 'scripts/RenderTargetTexture.bv.luac'...

![ASV 1 31](https://user-images.githubusercontent.com/51759646/215832488-b8b8fddf-20eb-400e-abe4-8fb605c2496c.JPG)

