### PR TITLE
Fixed InputHandler node allocator

### DIFF
--- a/Gems/StartingPointInput/Code/Source/InputHandlerNodeable.h
+++ b/Gems/StartingPointInput/Code/Source/InputHandlerNodeable.h
@@ -26,6 +26,8 @@ namespace StartingPointInput
         SCRIPTCANVAS_NODE(InputHandlerNodeable)
 
     public:
+        AZ_CLASS_ALLOCATOR(InputHandlerNodeable, AZ::SystemAllocator, 0);
+
         ~InputHandlerNodeable() override;
 
     protected:


### PR DESCRIPTION
## What does this PR do?

Fixes #14165 

This fixes an issue where any Script Canvas script with an `InputHandler` node fails to compile in the Asset Processor.

## How was this PR tested?

Verified scripts that use `InputHandler` now compile in the Asset Processor and handle user inputs as expected.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>