### PR TITLE
Move Linux workaround for UI Editor

### DIFF
--- a/Gems/LyShine/Code/Editor/EditorWindow.cpp
+++ b/Gems/LyShine/Code/Editor/EditorWindow.cpp
@@ -2211,16 +2211,7 @@ void EditorWindow::closeEvent(QCloseEvent* closeEvent)
 
     m_animationWidget->EditorAboutToClose();
 
-#if defined(AZ_PLATFORM_LINUX)
-    // Work-around for issue on Linux where closing (and destroying) the window an re-opening causes the Editor
-    // to hang or crash. So instead of closing this window, replicate the action of unchecking UI Editor from the
-    //  Editor toolbar by hiding the parent view pane instead
-    nativeParentWidget()->hide();
-    closeEvent->ignore();
-#else
     QMainWindow::closeEvent(closeEvent);
-#endif
-
 }
 
 void EditorWindow::dragEnterEvent(QDragEnterEvent* event)

--- a/Gems/LyShine/Code/Editor/LyShineEditorSystemComponent.cpp
+++ b/Gems/LyShine/Code/Editor/LyShineEditorSystemComponent.cpp
@@ -150,7 +150,14 @@ namespace LyShineEditor
             AzToolsFramework::ViewPaneOptions opt;
             opt.isPreview = true;
             opt.paneRect = QRect(x, y, (int)editorWidth, (int)editorHeight);
-            opt.isDeletable = true; // we're in a plugin; make sure we can be deleted
+#if defined(AZ_PLATFORM_LINUX)
+            // Work-around for issue on Linux where closing (and destroying) the window and re-opening causes the Editor
+            // to hang or crash. So instead of closing this window, replicate the action of unchecking UI Editor from the
+            // Editor toolbar by hiding the parent view pane instead
+            opt.isDeletable = false;
+#else
+            opt.isDeletable = true;
+#endif
             opt.showOnToolsToolbar = true;
             opt.toolbarIcon = ":/Menu/ui_editor.svg";
             // opt.canHaveMultipleInstances = true; // uncomment this when CUiAnimViewSequenceManager::CanvasUnloading supports multiple canvases


### PR DESCRIPTION
Signed-off-by: michabr <82236305+michabr@users.noreply.github.com>

Fix Editor closing issues due to a Linux workaround for UI Editor. The workaround was added because the UI Editor hangs if it's destroyed and recreated on Linux (which appears to be a graphics related issue). The workaround was to have the UI Editor ignore the close event and just hide its window when asked to close, but that prevented the Editor from closing.

Now instead of special casing the UI Editor's close event, the UI Editor's view pane sets its "isDeletable" flag to false on Linux which hides/shows the UI Editor window instead of destroying/recreating it.

The root issue that warranted this workaround will be addressed in a separate ticket.

Fixes #12739.

## How was this PR tested?

Manual testing on Linux.