### PR TITLE
Sandboxing flaky test again

### DIFF
--- a/Code/Tools/AssetProcessor/native/tests/ApplicationManagerTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/ApplicationManagerTests.cpp
@@ -81,7 +81,7 @@ namespace UnitTests
 
     using BatchApplicationManagerTest = UnitTest::LeakDetectionFixture;
 
-    TEST_F(ApplicationManagerTest, FileWatcherEventsTriggered_ProperlySignalledOnCorrectThread)
+    TEST_F(ApplicationManagerTest, FileWatcherEventsTriggered_ProperlySignalledOnCorrectThread_SUITE_sandbox)
     {
         AZ::IO::Path assetRootDir(m_databaseLocationListener.GetAssetRootDir());
 


### PR DESCRIPTION
Signed-off-by: AMZN-stankowi <4838196+AMZN-stankowi@users.noreply.github.com>

## What does this PR do?

Sandboxing a flaky test again. It's been sandboxed before: https://github.com/o3de/o3de/pull/13866/files and it looks like it's still flaky https://jenkins.build.o3de.org/blue/rest/organizations/jenkins/pipelines/O3DE/branches/development/runs/3864/nodes/88/steps/792/log/?start=0

https://github.com/o3de/o3de/issues/12638

## How was this PR tested?

It's a sandbox so nothing direct. This is moving a test out of the main suite to the sandbox suite to avoid disrupting others.
