### PR TITLE
Add `needs-*` labels to Deprecation Notice Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/deprecation_template.md
+++ b/.github/ISSUE_TEMPLATE/deprecation_template.md
@@ -2,7 +2,7 @@
 name: Deprecation Notice
 about: A notice for one or more feature or API deprecations
 title: 'Deprecation Notice'
-labels: 'kind/deprecation'
+labels: 'needs-triage,needs-sig,kind/deprecation'
 
 ---
 


### PR DESCRIPTION
The Deprecation Notice now adds the `needs-triage` and `needs-sig` labels by default

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>
