### PR TITLE
Change the order of module initialization to stay the same in monolithic builds

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -1214,12 +1214,15 @@ namespace AZ
     //=========================================================================
     void ComponentApplication::CreateStaticModules(AZStd::vector<AZ::Module*>& outModules)
     {
+        // Add this to the front of the list. In monolithic builds, dynamic modules become static modules,
+        // so we want this to load before the dynamic modules load regardless of the build type.
+        outModules.insert(outModules.begin(), aznew AzCoreModule());
+
         if (m_startupParameters.m_createStaticModulesCallback)
         {
             m_startupParameters.m_createStaticModulesCallback(outModules);
         }
 
-        outModules.emplace_back(aznew AzCoreModule());
     }
 
     void ComponentApplication::LoadModules()

--- a/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
@@ -404,10 +404,14 @@ namespace AzFramework
 
     void Application::CreateStaticModules(AZStd::vector<AZ::Module*>& outModules)
     {
+        // Add this to the front of the list. In monolithic builds, dynamic modules become static modules,
+        // so we want this to load before the dynamic modules load regardless of the build type.
+        // Note that because of the order we add these in, AzNetworkingModule will appear before AzFrameworkModule in the list.
+        outModules.insert(outModules.begin(), aznew AzFrameworkModule());
+        outModules.insert(outModules.begin(), aznew AzNetworking::AzNetworkingModule());
+
         AZ::ComponentApplication::CreateStaticModules(outModules);
 
-        outModules.emplace_back(aznew AzNetworking::AzNetworkingModule());
-        outModules.emplace_back(aznew AzFrameworkModule());
     }
 
     const char* Application::GetCurrentConfigurationName() const

--- a/Code/Framework/AzGameFramework/AzGameFramework/Application/GameApplication.cpp
+++ b/Code/Framework/AzGameFramework/AzGameFramework/Application/GameApplication.cpp
@@ -111,9 +111,11 @@ namespace AzGameFramework
 
     void GameApplication::CreateStaticModules(AZStd::vector<AZ::Module*>& outModules)
     {
-        AzFramework::Application::CreateStaticModules(outModules);
+        // Add this to the front of the list. In monolithic builds, dynamic modules become static modules,
+        // so we want this to load before the dynamic modules load regardless of the build type.
+        outModules.insert(outModules.begin(), aznew AzGameFrameworkModule());
 
-        outModules.emplace_back(aznew AzGameFrameworkModule());
+        AzFramework::Application::CreateStaticModules(outModules);
     }
 
     void GameApplication::QueryApplicationType(AZ::ApplicationTypeQuery& appType) const


### PR DESCRIPTION
## What does this PR do?

In monolithic builds, the static engine modules (AzCore, AzFramework, AzNetworking, AzGameFramework) were getting initialized *after* the "dynamic" modules that become static, where in non-monolithic builds, they get initialized first.

This was causing a crash in the Multiplayer Gem in monolithic builds because it relied on AzNetworking being initialized first.

The reason for the order change is because the modules were getting added to the list in this order:
* ComponentApplication::CreateStaticModules()
** startupParameters.m_createStaticModulesCallback()
** AzCoreModule
* Application::CreateStaticModules()
** AzNetworkingModule
** AzFrameworkModule
* GameApplication::CreateStaticModules()
** AzGameFrameworkModule
* CreateDynamicModules()

In monolithic builds, the createStaticModulesCallback() contains all the modules that appear in CreateDynamicModules() in non-monolithic builds.

The fix is to change the various CreateStaticModules() calls to push their modules to the front instead of the end, so that they appear before both the createStaticModulesCallback() and the CreateDynamicModules() list.

## How was this PR tested?

Ran a monolithic and non-monolithic build and verified the module order appears correct in both, and Multiplayer no longer crashes in either scenario.
