### PR TITLE
Fix an issue updating the Gem Cart in Project Manager

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectGemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectGemCatalogScreen.cpp
@@ -83,6 +83,10 @@ namespace O3DE::ProjectManager
 
                 return ConfiguredGemsResult::Failed;
             }
+            else
+            {
+                GemModel::SetWasPreviouslyAdded(*m_gemModel, modelIndex, true);
+            }
 
             // register external gems that were added with relative paths
             if (m_gemsToRegisterWithProject.contains(gemPath))
@@ -101,6 +105,10 @@ namespace O3DE::ProjectManager
                     tr("Cannot remove gem %1 from project.<br><br>Error:<br>%2").arg(GemModel::GetDisplayName(modelIndex), result.GetError().c_str()));
 
                 return ConfiguredGemsResult::Failed;
+            }
+            else
+            {
+                GemModel::SetWasPreviouslyAdded(*m_gemModel, modelIndex, false);
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

- When saving, need to refresh and update the cart so that Project Manager knows it's got a clean slate for the next operation.
- Without this, you can't seem to toggle gem activations back and forth.

fixes #12328 
fixes #14222 

## How was this PR tested?

Run Project Manager, enable some Gems, and Save.  Check `enabled_gems.cmake` that the changes are reflected there.  The Gem Cart now shows `0`.  Reverse the operations and Save again.  The changes are correct and the Gem Cart also goes to `0`.
