### PR TITLE
Fix flaky test - increase timeout

### DIFF
--- a/Code/Tools/AssetProcessor/native/tests/ApplicationManagerTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/ApplicationManagerTests.cpp
@@ -72,8 +72,10 @@ namespace UnitTests
     {
         m_applicationManager->DestroyFileMonitor();
 
-        m_apmThread->exit();
-        m_fileProcessorThread->exit();
+        m_apmThread->quit();
+        m_fileProcessorThread->quit();
+        m_apmThread->wait();
+        m_fileProcessorThread->wait();
         m_mockAPM = nullptr;
 
         LeakDetectionFixture::TearDown();

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/TestEventSignal.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/TestEventSignal.cpp
@@ -25,7 +25,13 @@ namespace UnitTests
 
     bool TestEventPair::WaitAndCheck()
     {
-        constexpr int MaxWaitTimeMilliseconds = 100;
+        // usually this completes under a millisecond or two, but a slow machine or busy machine
+        // can cause hiccups of anywhere between a few milliseconds to a few seconds.
+        // Since this test will exit the instant it gets its signal, prefer to set a very long timeout
+        // beyond what is even remotely necessary, so that if the test hits it, we know with a high degree of confidence
+        // that the message is not forthcoming, not that we just didn't wait long enough for it due to environmental
+        // issues.
+        constexpr int MaxWaitTimeMilliseconds = 30000;
 
         auto thisThreadId = AZStd::this_thread::get_id();
         bool acquireSuccess = m_event.try_acquire_for(AZStd::chrono::milliseconds(MaxWaitTimeMilliseconds));


### PR DESCRIPTION
Fixes #12638

## What does this PR do?

Increases the timeout a test is waiting for a cross-thread signal so that it if it doesn't get it we are very confident that its never going to get it.

When I measured this locally on a machine that was idle, it was something near 100ms to perform this test (total) and ~1ms to check the condition.

However, when I added a stress load to the machine, the time it takes was anywhere between 100ms and 8 seconds, which easily explains the flakyness on our test boxes.  

Also fixes a rare crash in Qt if the thread is deleted before it stops, this occurs very rarely as I tested this on repeat 10000.

## How was this PR tested?

 I tested this on repeat 10000 with and without a load.
 
 
Signed-off-by: Nicholas Lawson <70027408+lawsonamzn@users.noreply.github.com>
