### PR TITLE
Material Component: Error handling for missing assets

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Material/MaterialAssignment.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/MaterialAssignment.cpp
@@ -104,7 +104,7 @@ namespace AZ
                 return;
             }
 
-            if (m_materialAsset.GetId().IsValid() || m_materialAsset.IsReady())
+            if (m_materialAsset.GetId().IsValid() && m_materialAsset.IsReady())
             {
                 m_materialInstance = m_propertyOverrides.empty() ? RPI::Material::FindOrCreate(m_materialAsset) : RPI::Material::Create(m_materialAsset);
                 AZ_Error("MaterialAssignment", m_materialInstance, "Material instance not initialized");
@@ -117,7 +117,7 @@ namespace AZ
                 return;
             }
 
-            if (m_defaultMaterialAsset.GetId().IsValid() || m_defaultMaterialAsset.IsReady())
+            if (m_defaultMaterialAsset.GetId().IsValid() && m_defaultMaterialAsset.IsReady())
             {
                 m_materialInstance = m_propertyOverrides.empty() ? RPI::Material::FindOrCreate(m_defaultMaterialAsset) : RPI::Material::Create(m_defaultMaterialAsset);
                 AZ_Error("MaterialAssignment", m_materialInstance, "Material instance not initialized");

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -908,14 +908,7 @@ namespace AZ
         {
             m_scene->GetCullingScene()->UnregisterCullable(m_cullable);
 
-            for (const auto& materialAssignment : m_materialAssignments)
-            {
-                const AZ::Data::Instance<RPI::Material>& materialInstance = materialAssignment.second.m_materialInstance;
-                if (materialInstance.get())
-                {
-                    MaterialAssignmentNotificationBus::MultiHandler::BusDisconnect(materialInstance->GetAssetId());
-                }
-            }
+            MaterialAssignmentNotificationBus::MultiHandler::BusDisconnect();
 
             RemoveRayTracingData(rayTracingFeatureProcessor);
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
@@ -88,6 +88,8 @@ namespace AZ
             //! Data::AssetBus overrides...
             void OnAssetReady(Data::Asset<Data::AssetData> asset) override;
             void OnAssetReloaded(Data::Asset<Data::AssetData> asset) override;
+            void OnAssetError(Data::Asset<Data::AssetData> asset) override;
+            void OnAssetReloadError(Data::Asset<Data::AssetData> asset) override;
 
             // AZ::SystemTickBus overrides...
             void OnSystemTick() override;
@@ -108,6 +110,8 @@ namespace AZ
             void ConvertAssetsForSerialization();
             void ConvertAssetsForSerialization(MaterialPropertyOverrideMap& propertyMap);
             AZStd::any ConvertAssetsForSerialization(const AZStd::any& value) const;
+
+            void DisplayMissingAssetWarning(Data::Asset<Data::AssetData> asset) const;
 
             EntityId m_entityId;
             MaterialComponentConfig m_configuration;


### PR DESCRIPTION
## What does this PR do?

This PR updates the material component to handle missing assets and asset failures. If materials in the component configuration are missing or have errors, warnings will be reported and those materials will be ignored while waiting for all materials to load and setting up material instances.

Signed-off-by: gadams3 <guthadam@amazon.com>

## How was this PR tested?

Tested by loading a level with entities referencing materials to confirm that it looked correct. Then closed the level, deleted the referenced material assets, and reopen the level. Warnings were printed in the console window with information about which materials were missing and which entities were affected.

Tested restoring the missing materials. The restored materials are hot loaded and appear on the model because the asset bus is connected and listens for reloads.

Deleting the source materials does not caused them to disappear on the model because there is no notification for files being deleted.

Tested by deleting half of the material source files for the sponza level. Warnings were printed for the deleted materials. The remaining default and overridden materials were still applied correctly. Restoring the missing materials caused them to reload and be applied.