### PR TITLE
Fix LyShine Entity Reference Crash

### DIFF
--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -1123,14 +1123,14 @@ bool SandboxIntegrationManager::CanGoToEntityOrChildren(const AZ::EntityId& enti
         return false;
     }
 
-    // Skip if this is a ui component; ui components use UiCanvas and are not visible in the Editor viewport
+    // Skip if this is a UI component; UI components use LyShine's "UI Canvas" and are not visible in the Editor viewport
     const AZ::Component* uiElementComponent = entity->FindComponent(AZ::Uuid("{4A97D63E-CE7A-45B6-AAE4-102DB4334688}"));
     if (uiElementComponent != nullptr)
     {
         return false;
     }
 
-    // If this is a layer entity, if it has any children that are visible in viewport
+    // If this is a layer entity, check if the layer has any children that are visible in the viewport
     bool isLayerEntity = false;
     AzToolsFramework::Layers::EditorLayerComponentRequestBus::EventResult(
         isLayerEntity,

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -1123,14 +1123,6 @@ bool SandboxIntegrationManager::CanGoToEntityOrChildren(const AZ::EntityId& enti
         return false;
     }
 
-    // Skip if this is a UI component; UI components use LyShine's "UI Canvas" and are not visible in the Editor viewport
-    constexpr AZ::Uuid uiElementComponentUuid{ "{4A97D63E-CE7A-45B6-AAE4-102DB4334688}" };
-    const AZ::Component* uiElementComponent = entity->FindComponent(uiElementComponentUuid);
-    if (uiElementComponent != nullptr)
-    {
-        return false;
-    }
-
     // If this is a layer entity, check if the layer has any children that are visible in the viewport
     bool isLayerEntity = false;
     AzToolsFramework::Layers::EditorLayerComponentRequestBus::EventResult(
@@ -1139,7 +1131,9 @@ bool SandboxIntegrationManager::CanGoToEntityOrChildren(const AZ::EntityId& enti
         &AzToolsFramework::Layers::EditorLayerComponentRequestBus::Events::HasLayer);
     if (!isLayerEntity)
     {
-        return true;
+        // Skip if this entity doesn't have a transform;
+        // UI entities and system components don't have transforms and thus aren't visible in the Editor viewport
+        return entity->GetTransform() != nullptr;
     }
 
     AZStd::vector<AZ::EntityId> layerChildren;

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -1124,7 +1124,8 @@ bool SandboxIntegrationManager::CanGoToEntityOrChildren(const AZ::EntityId& enti
     }
 
     // Skip if this is a UI component; UI components use LyShine's "UI Canvas" and are not visible in the Editor viewport
-    const AZ::Component* uiElementComponent = entity->FindComponent(AZ::Uuid("{4A97D63E-CE7A-45B6-AAE4-102DB4334688}"));
+    constexpr AZ::Uuid uiElementComponentUuid{ "{4A97D63E-CE7A-45B6-AAE4-102DB4334688}" };
+    const AZ::Component* uiElementComponent = entity->FindComponent(uiElementComponentUuid);
     if (uiElementComponent != nullptr)
     {
         return false;

--- a/Code/Framework/AzFramework/AzFramework/Visibility/BoundsBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/BoundsBus.h
@@ -78,6 +78,11 @@ namespace AzFramework
         }
 
         AZ::TransformInterface* transformInterface = entity->GetTransform();
+        if (!transformInterface)
+        {
+            return AZ::Aabb::CreateNull();
+        }
+
         const AZ::Vector3 worldTranslation = transformInterface->GetWorldTranslation();
         return AZ::Aabb::CreateCenterHalfExtents(worldTranslation, AZ::Vector3(0.5f));
     }


### PR DESCRIPTION
Stop LyShine editor crash which was caused by the editor attempting to access a null transform component.
Adding null checks, but also stopping the editor before it even gets to that point by stopping the Editor from trying to view ui entities in the viewport
Fixes #14344 
![image](https://user-images.githubusercontent.com/32776221/216200775-1a7dc177-af3f-4143-b3f7-64fdcab36915.png)

## How was this PR tested?
Selected entity references in Ui Canvas as well as the normal Editor and made sure everything still worked. Ui entities were selected without crashing, and normal editor would still point to look at the entity