### PR TITLE
Optimized scene queries by replacing RTTI with request type

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/Common/PhysicsSceneQueries.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Common/PhysicsSceneQueries.h
@@ -151,7 +151,7 @@ namespace AzPhysics
         static void Reflect(AZ::ReflectContext* context);
         virtual ~SceneQueryRequest() = default;
 
-        RequestType m_requestType = Undefined;
+        RequestType m_requestType = RequestType::Undefined;
         AZ::u32 m_maxResults = 32; //!< The Maximum results for this request to return, this is limited by the value set in the SceneConfiguration
         CollisionGroup m_collisionGroup = CollisionGroup::All; //!< Collision filter for the query.
         SceneQuery::QueryType m_queryType = SceneQuery::QueryType::StaticAndDynamic; //!< Object types to include in the query

--- a/Code/Framework/AzFramework/AzFramework/Physics/Common/PhysicsSceneQueries.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Common/PhysicsSceneQueries.h
@@ -132,12 +132,27 @@ namespace AzPhysics
     //! Not valid to be used with Scene::QueryScene functions
     struct SceneQueryRequest
     {
+        enum RequestType : AZ::u8
+        {
+            Undefined = 0,
+            Raycast,
+            Shapecast,
+            Overlap
+        };
+
         AZ_CLASS_ALLOCATOR_DECL;
         AZ_RTTI(SceneQueryRequest, "{76ECAB7D-42BA-461F-82E6-DCED8E1BDCB9}");
+
+        explicit SceneQueryRequest(RequestType requestType)
+            : m_requestType(requestType)
+        {
+        }
+        SceneQueryRequest() = default;
         static void Reflect(AZ::ReflectContext* context);
         virtual ~SceneQueryRequest() = default;
 
-        AZ::u64 m_maxResults = 32; //!< The Maximum results for this request to return, this is limited by the value set in the SceneConfiguration
+        RequestType m_requestType = Undefined;
+        AZ::u32 m_maxResults = 32; //!< The Maximum results for this request to return, this is limited by the value set in the SceneConfiguration
         CollisionGroup m_collisionGroup = CollisionGroup::All; //!< Collision filter for the query.
         SceneQuery::QueryType m_queryType = SceneQuery::QueryType::StaticAndDynamic; //!< Object types to include in the query
     };
@@ -149,6 +164,12 @@ namespace AzPhysics
     {
         AZ_CLASS_ALLOCATOR_DECL;
         AZ_RTTI(RayCastRequest, "{53EAD088-A391-48F1-8370-2A1DBA31512F}", SceneQueryRequest);
+
+        RayCastRequest()
+            : SceneQueryRequest(RequestType::Raycast)
+        {
+        }
+
         static void Reflect(AZ::ReflectContext* context);
 
         float m_distance = 500.0f; //!< The distance to cast along the direction.
@@ -165,6 +186,11 @@ namespace AzPhysics
     {
         AZ_CLASS_ALLOCATOR_DECL;
         AZ_RTTI(ShapeCastRequest, "{52F6C536-92F6-4C05-983D-0A74800AE56D}", SceneQueryRequest);
+
+        ShapeCastRequest()
+            : SceneQueryRequest(RequestType::Shapecast)
+        {
+        }
         static void Reflect(AZ::ReflectContext* context);
 
         float m_distance = 500.0f; //! The distance to cast along the direction.
@@ -207,6 +233,12 @@ namespace AzPhysics
     {
         AZ_CLASS_ALLOCATOR_DECL;
         AZ_RTTI(OverlapRequest, "{3DC986C2-316B-4C54-A0A6-8ABBB8ABCC4A}", SceneQueryRequest);
+
+        OverlapRequest()
+            : SceneQueryRequest(RequestType::Overlap)
+        {
+        }
+
         static void Reflect(AZ::ReflectContext* context);
 
         AZ::Transform m_pose = AZ::Transform::CreateIdentity(); //!< Initial shape pose

--- a/Code/Framework/AzFramework/AzFramework/Physics/Common/PhysicsSceneQueries.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Common/PhysicsSceneQueries.h
@@ -132,7 +132,7 @@ namespace AzPhysics
     //! Not valid to be used with Scene::QueryScene functions
     struct SceneQueryRequest
     {
-        enum RequestType : AZ::u8
+        enum class RequestType : AZ::u8
         {
             Undefined = 0,
             Raycast,

--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SystemConfiguration.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SystemConfiguration.h
@@ -33,9 +33,9 @@ namespace AzPhysics
         float m_maxTimestep = 0.1f; //!< Maximum fixed timestep in seconds to run the physics update (10FPS).
         float m_fixedTimestep = DefaultFixedTimestep; //!< Timestep in seconds to run the physics update. See DefaultFixedTimestep.
 
-        AZ::u64 m_raycastBufferSize = 32; //!< Maximum number of hits that will be returned from a raycast.
-        AZ::u64 m_shapecastBufferSize = 32; //!< Maximum number of hits that can be returned from a shapecast.
-        AZ::u64 m_overlapBufferSize = 32; //!< Maximum number of overlaps that can be returned from an overlap query.
+        AZ::u32 m_raycastBufferSize = 32; //!< Maximum number of hits that will be returned from a raycast.
+        AZ::u32 m_shapecastBufferSize = 32; //!< Maximum number of hits that can be returned from a shapecast.
+        AZ::u32 m_overlapBufferSize = 32; //!< Maximum number of overlaps that can be returned from an overlap query.
 
         //! Contains the default global collision layers and groups.
         //! Each Physics Scene uses this as a base and will override as needed.

--- a/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
+++ b/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
@@ -974,19 +974,20 @@ namespace PhysX
         // Query flags.
         const physx::PxQueryFlags queryFlags = SceneQueryHelpers::GetPxQueryFlags(request->m_queryType);
         const physx::PxQueryFilterData queryData(queryFlags);
+
         switch (request->m_requestType)
         {
-        case AzPhysics::SceneQueryRequest::Raycast:
+        case AzPhysics::SceneQueryRequest::RequestType::Raycast:
             {
                 return Internal::RayCast(
                     static_cast<const AzPhysics::RayCastRequest*>(request), s_rayCastBuffer, m_pxScene, queryData, m_raycastBufferSize);
             }
-        case AzPhysics::SceneQueryRequest::Shapecast:
+        case AzPhysics::SceneQueryRequest::RequestType::Shapecast:
             {
                 return Internal::ShapeCast(
                     static_cast<const AzPhysics::ShapeCastRequest*>(request), s_sweepBuffer, m_pxScene, queryData, m_shapecastBufferSize);
             }
-        case AzPhysics::SceneQueryRequest::Overlap:
+        case AzPhysics::SceneQueryRequest::RequestType::Overlap:
             {
                 return Internal::OverlapQuery(
                     static_cast<const AzPhysics::OverlapRequest*>(request), s_overlapBuffer, m_pxScene, queryData, m_overlapBufferSize);

--- a/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
+++ b/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
@@ -271,7 +271,7 @@ namespace PhysX
             AZStd::vector<physx::PxRaycastHit>& raycastBuffer,
             physx::PxScene* physxScene,
             const physx::PxQueryFilterData queryData,
-            const AZ::u64 sceneMaxResults)
+            const AZ::u32 sceneMaxResults)
         {
             // if this query need to report multiple hits, we need to prepare a buffer to hold up to the max allowed.
             // The filter should also use the eTOUCH flag to find all contacts with the ray.
@@ -280,12 +280,12 @@ namespace PhysX
             SceneQueryHelpers::PhysXQueryFilterCallback queryFilterCallback;
             if (raycastRequest->m_reportMultipleHits)
             {
-                const AZ::u64 maxSize = AZStd::min(raycastRequest->m_maxResults, sceneMaxResults);
+                const AZ::u32 maxSize = AZStd::min(raycastRequest->m_maxResults, sceneMaxResults);
                 if (raycastBuffer.size() < maxSize) //todo this needs to be limited by the config setting
                 {
                     raycastBuffer.resize(maxSize);
                 }
-                castResult = physx::PxRaycastBuffer(raycastBuffer.begin(), aznumeric_cast<physx::PxU32>(maxSize));
+                castResult = physx::PxRaycastBuffer(raycastBuffer.begin(), maxSize);
                 queryFilterCallback = SceneQueryHelpers::PhysXQueryFilterCallback(
                     raycastRequest->m_collisionGroup,
                     raycastRequest->m_filterCallback,
@@ -334,7 +334,7 @@ namespace PhysX
             AZStd::vector<physx::PxSweepHit>& shapecastBuffer,
             physx::PxScene* physxScene,
             const physx::PxQueryFilterData queryData,
-            const AZ::u64 sceneMaxResults)
+            const AZ::u32 sceneMaxResults)
         {
             // if this query need to report multiple hits, we need to prepare a buffer to hold up to the max allowed.
             // The filter should also use the eTOUCH flag to find all contacts with the shape.
@@ -343,12 +343,12 @@ namespace PhysX
             SceneQueryHelpers::PhysXQueryFilterCallback queryFilterCallback;
             if (shapecastRequest->m_reportMultipleHits)
             {
-                const AZ::u64 maxSize = AZStd::min(shapecastRequest->m_maxResults, sceneMaxResults);
+                const AZ::u32 maxSize = AZStd::min(shapecastRequest->m_maxResults, sceneMaxResults);
                 if (shapecastBuffer.size() < maxSize) //todo this needs to be limited by the config setting
                 {
                     shapecastBuffer.resize(maxSize);
                 }
-                castResult = physx::PxSweepBuffer(shapecastBuffer.begin(), aznumeric_cast<physx::PxU32>(maxSize));
+                castResult = physx::PxSweepBuffer(shapecastBuffer.begin(), maxSize);
                 queryFilterCallback = SceneQueryHelpers::PhysXQueryFilterCallback(
                     shapecastRequest->m_collisionGroup,
                     shapecastRequest->m_filterCallback,
@@ -434,9 +434,9 @@ namespace PhysX
             AZStd::vector<physx::PxOverlapHit>& overlapBuffer,
             physx::PxScene* physxScene,
             const physx::PxQueryFilterData queryData,
-            const AZ::u64 sceneMaxResults)
+            const AZ::u32 sceneMaxResults)
         {
-            const AZ::u64 maxSize = AZStd::min(overlapRequest->m_maxResults, sceneMaxResults);
+            const AZ::u32 maxSize = AZStd::min(overlapRequest->m_maxResults, sceneMaxResults);
             if (overlapBuffer.size() < maxSize)
             {
                 overlapBuffer.resize(maxSize);
@@ -453,7 +453,7 @@ namespace PhysX
                 return {};
             }
 
-            physx::PxOverlapBuffer queryHits(overlapBuffer.begin(), aznumeric_cast<physx::PxU32>(maxSize));
+            physx::PxOverlapBuffer queryHits(overlapBuffer.begin(), maxSize);
             bool status = OverlapGeneric(physxScene, overlapRequest, queryHits, queryData);
 
             AzPhysics::SceneQueryHits results;
@@ -974,27 +974,29 @@ namespace PhysX
         // Query flags.
         const physx::PxQueryFlags queryFlags = SceneQueryHelpers::GetPxQueryFlags(request->m_queryType);
         const physx::PxQueryFilterData queryData(queryFlags);
-
-        if (azrtti_istypeof<AzPhysics::RayCastRequest>(request))
+        switch (request->m_requestType)
         {
-            return Internal::RayCast(azdynamic_cast<const AzPhysics::RayCastRequest*>(request),
-                s_rayCastBuffer, m_pxScene, queryData, m_raycastBufferSize);
-        }
-        else if (azrtti_istypeof<AzPhysics::ShapeCastRequest>(request))
-        {
-            return Internal::ShapeCast(azdynamic_cast<const AzPhysics::ShapeCastRequest*>(request),
-                s_sweepBuffer, m_pxScene, queryData, m_shapecastBufferSize);
-        }
-        else if (azrtti_istypeof<AzPhysics::OverlapRequest>(request))
-        {
-            return Internal::OverlapQuery(azdynamic_cast<const AzPhysics::OverlapRequest*>(request),
-                s_overlapBuffer, m_pxScene, queryData, m_overlapBufferSize);
-        }
-        else
-        {
-            AZ_Warning("Physx", false, "Unknown Scene Query request type.");
-        }
-        return AzPhysics::SceneQueryHits();
+        case AzPhysics::SceneQueryRequest::Raycast:
+            {
+                return Internal::RayCast(
+                    static_cast<const AzPhysics::RayCastRequest*>(request), s_rayCastBuffer, m_pxScene, queryData, m_raycastBufferSize);
+            }
+        case AzPhysics::SceneQueryRequest::Shapecast:
+            {
+                return Internal::ShapeCast(
+                    static_cast<const AzPhysics::ShapeCastRequest*>(request), s_sweepBuffer, m_pxScene, queryData, m_shapecastBufferSize);
+            }
+        case AzPhysics::SceneQueryRequest::Overlap:
+            {
+                return Internal::OverlapQuery(
+                    static_cast<const AzPhysics::OverlapRequest*>(request), s_overlapBuffer, m_pxScene, queryData, m_overlapBufferSize);
+            }
+        default:
+            {
+                AZ_Warning("Physx", false, "Unknown Scene Query request type.");
+                return {};
+            }
+        };
     }
 
     AzPhysics::SceneQueryHitsList PhysXScene::QuerySceneBatch(const AzPhysics::SceneQueryRequests& requests)

--- a/Gems/PhysX/Code/Source/Scene/PhysXScene.h
+++ b/Gems/PhysX/Code/Source/Scene/PhysXScene.h
@@ -144,9 +144,9 @@ namespace PhysX
         static thread_local AZStd::vector<physx::PxRaycastHit> s_rayCastBuffer; //!< thread local structure to hold hits for a single raycast or shapecast.
         static thread_local AZStd::vector<physx::PxSweepHit> s_sweepBuffer; //!< thread local structure to hold hits for a single shapecast.
         static thread_local AZStd::vector<physx::PxOverlapHit> s_overlapBuffer; //!< thread local structure to hold hits for a single overlap query.
-        AZ::u64 m_raycastBufferSize = 32; //!< Maximum number of hits that will be returned from a raycast.
-        AZ::u64 m_shapecastBufferSize = 32; //!< Maximum number of hits that can be returned from a shapecast.
-        AZ::u64 m_overlapBufferSize = 32; //!< Maximum number of overlaps that can be returned from an overlap query.
+        AZ::u32 m_raycastBufferSize = 32; //!< Maximum number of hits that will be returned from a raycast.
+        AZ::u32 m_shapecastBufferSize = 32; //!< Maximum number of hits that can be returned from a shapecast.
+        AZ::u32 m_overlapBufferSize = 32; //!< Maximum number of overlaps that can be returned from an overlap query.
 
         SceneSimulationFilterCallback m_collisionFilterCallback; //!< Handles the filtering of collision pairs reported from PhysX.
         SceneSimulationEventCallback m_simulationEventCallback; //!< Handles the collision and trigger events reported from PhysX.

--- a/Gems/PhysX/Code/Tests/Benchmarks/PhysXJointBenchmarks.cpp
+++ b/Gems/PhysX/Code/Tests/Benchmarks/PhysXJointBenchmarks.cpp
@@ -453,7 +453,8 @@ namespace PhysX::Benchmarks
 
        BENCHMARK_REGISTER_F(PhysXJointBenchmarkFixture, BM_Joints_Snake)
          ->RangeMultiplier(JointConstants::BenchmarkSettings::RangeMultipler)
-         ->Range(JointConstants::BenchmarkSettings::StartRange, JointConstants::BenchmarkSettings::EndRange)
+         ->Ranges({ { JointConstants::BenchmarkSettings::StartRange, JointConstants::BenchmarkSettings::EndRange },
+                   { RigidBodyApiObject, RigidBodyEntity } })
          ->Unit(benchmark::kMillisecond)
          ->Iterations(JointConstants::BenchmarkSettings::NumIterations)
          ;


### PR DESCRIPTION
Signed-off-by: Sergey Pereslavtsev <pereslav@amazon.com>

## What does this PR do?

Improves performance of scene queries in PhysX gem by replacing expensive AZ_RTTI mechanism with storing request type in the base class. 

## How was this PR tested?

Unit tests

![image](https://user-images.githubusercontent.com/60428010/216300968-06ff9696-2908-42b6-8293-911743a8d469.png)

