### PR TITLE
Action Manager | Allow multiple Enabled State Callbacks, refactor Action Visibility properties

### DIFF
--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -210,7 +210,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "New Level";
         actionProperties.m_description = "Create a new level";
         actionProperties.m_category = "Level";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -235,7 +235,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Open Level...";
         actionProperties.m_description = "Open an existing level";
         actionProperties.m_category = "Level";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -270,7 +270,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
                 actionProperties.m_name = AZStd::string::format("Recent File #%i", index + 1);
             }
             actionProperties.m_category = "Level";
-            actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+            actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
             AZStd::string actionIdentifier = AZStd::string::format("o3de.action.file.recent.file%i", index + 1);
 
@@ -306,7 +306,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Clear All";
         actionProperties.m_description = "Clear the recent files list.";
         actionProperties.m_category = "Level";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -340,7 +340,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Save";
         actionProperties.m_description = "Save the current level";
         actionProperties.m_category = "Level";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
         
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier, "o3de.action.file.save", actionProperties,
@@ -362,7 +362,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Save As...";
         actionProperties.m_description = "Save the current level";
         actionProperties.m_category = "Level";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier, "o3de.action.file.saveAs", actionProperties,
@@ -384,7 +384,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Save Level Statistics";
         actionProperties.m_description = "Logs Editor memory usage.";
         actionProperties.m_category = "Level";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -416,7 +416,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Edit Project Settings...";
         actionProperties.m_description = "Open the Project Settings panel.";
         actionProperties.m_category = "Project";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -458,7 +458,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "New Project...";
         actionProperties.m_description = "Create a new project in the Project Manager.";
         actionProperties.m_category = "Project";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -481,7 +481,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Open Project...";
         actionProperties.m_description = "Open a different project in the Project Manager.";
         actionProperties.m_category = "Project";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -503,7 +503,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         AzToolsFramework::ActionProperties actionProperties;
         actionProperties.m_name = "Show Log File";
         actionProperties.m_category = "Project";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -545,7 +545,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "&Undo";
         actionProperties.m_description = "Undo last operation";
         actionProperties.m_category = "Edit";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -577,7 +577,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "&Redo";
         actionProperties.m_description = "Redo last undo operation";
         actionProperties.m_category = "Edit";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -611,7 +611,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_description = "Toggle angle snapping";
         actionProperties.m_category = "Edit";
         actionProperties.m_iconPath = ":/stylesheet/img/UI20/toolbar/Angle.svg";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterCheckableAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -642,7 +642,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_description = "Toggle grid snapping";
         actionProperties.m_category = "Edit";
         actionProperties.m_iconPath = ":/stylesheet/img/UI20/toolbar/Grid.svg";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterCheckableAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -672,7 +672,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Show Grid";
         actionProperties.m_description = "Show Grid for entity snapping.";
         actionProperties.m_category = "Edit";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterCheckableAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -747,7 +747,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_description = "Activate the game input mode.";
         actionProperties.m_category = "Game";
         actionProperties.m_iconPath = ":/stylesheet/img/UI20/toolbar/Play.svg";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterCheckableAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -780,7 +780,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Play Game (Maximized)";
         actionProperties.m_description = "Activate the game input mode (maximized).";
         actionProperties.m_category = "Game";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterCheckableAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -812,7 +812,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_description = "Enable processing of Physics and AI.";
         actionProperties.m_category = "Game";
         actionProperties.m_iconPath = ":/stylesheet/img/UI20/toolbar/Simulate_Physics.svg";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterCheckableAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -843,7 +843,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Export Selected Objects";
         actionProperties.m_description = "Export Selected Objects.";
         actionProperties.m_category = "Game";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -869,7 +869,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Export Occlusion Mesh";
         actionProperties.m_description = "Export Occlusion Mesh.";
         actionProperties.m_category = "Game";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -892,7 +892,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Move Player and Camera Separately";
         actionProperties.m_description = "Move Player and Camera Separately.";
         actionProperties.m_category = "Game";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterCheckableAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -919,7 +919,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Stop All Sounds";
         actionProperties.m_description = "Stop All Sounds.";
         actionProperties.m_category = "Game";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -943,7 +943,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Refresh";
         actionProperties.m_description = "Refresh Audio System.";
         actionProperties.m_category = "Game";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -976,7 +976,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Error Report";
         actionProperties.m_description = "Open the Error Report dialog.";
         actionProperties.m_category = "Debugging";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -999,7 +999,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Configure Toolbox Macros...";
         actionProperties.m_description = "Open the Toolbox Macros dialog.";
         actionProperties.m_category = "Debugging";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -1027,7 +1027,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         AzToolsFramework::ActionProperties actionProperties;
         actionProperties.m_name = "Component Entity Layout (Default)";
         actionProperties.m_category = "Layout";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -1050,7 +1050,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Save Layout...";
         actionProperties.m_description = "Save the current layout.";
         actionProperties.m_category = "Layout";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -1073,7 +1073,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Restore Default Layout";
         actionProperties.m_description = "Restored the default layout for the Editor.";
         actionProperties.m_category = "Layout";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -1097,7 +1097,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_description = "Move the editor camera to the position and rotation provided.";
         actionProperties.m_category = "View";
         actionProperties.m_iconPath = ":/Menu/camera.svg";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -1120,7 +1120,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Center on Selection";
         actionProperties.m_description = "Center the viewport to show selected entities.";
         actionProperties.m_category = "View";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -1376,7 +1376,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         AzToolsFramework::ActionProperties actionProperties;
         actionProperties.m_name = "&Welcome";
         actionProperties.m_category = "Help";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -2188,7 +2188,7 @@ void EditorActionsHandler::RefreshLayoutActions()
                 actionProperties.m_name = "Load";
                 actionProperties.m_description = AZStd::string::format("Load the \"%s\" layout.", layoutName.toUtf8().data());
                 actionProperties.m_category = "Layout";
-                actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+                actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
                 m_actionManagerInterface->RegisterAction(
                     EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -2212,7 +2212,7 @@ void EditorActionsHandler::RefreshLayoutActions()
                 actionProperties.m_name = "Save";
                 actionProperties.m_description = AZStd::string::format("Save the \"%s\" layout.", layoutName.toUtf8().data());
                 actionProperties.m_category = "Layout";
-                actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+                actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
                 m_actionManagerInterface->RegisterAction(
                     EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -2236,7 +2236,7 @@ void EditorActionsHandler::RefreshLayoutActions()
                 actionProperties.m_name = "Rename...";
                 actionProperties.m_description = AZStd::string::format("Rename the \"%s\" layout.", layoutName.toUtf8().data());
                 actionProperties.m_category = "Layout";
-                actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+                actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
                 m_actionManagerInterface->RegisterAction(
                     EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -2260,7 +2260,7 @@ void EditorActionsHandler::RefreshLayoutActions()
                 actionProperties.m_name = "Delete";
                 actionProperties.m_description = AZStd::string::format("Delete the \"%s\" layout.", layoutName.toUtf8().data());
                 actionProperties.m_category = "Layout";
-                actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+                actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
                 m_actionManagerInterface->RegisterAction(
                     EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -2312,7 +2312,7 @@ void EditorActionsHandler::RefreshToolboxMacroActions()
                 actionProperties.m_name = macro->GetTitle().toStdString().c_str();
                 actionProperties.m_category = "Toolbox Macro";
                 actionProperties.m_iconPath = macro->GetIconPath().toStdString().c_str();
-                actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+                actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
                 m_actionManagerInterface->RegisterAction(
                     EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -2368,8 +2368,8 @@ void EditorActionsHandler::RefreshToolActions()
                                                                                        : viewpane.m_name.toUtf8().data();
             actionProperties.m_category = "Tool";
             actionProperties.m_iconPath = viewpane.m_options.toolbarIcon;
-            actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
-            actionProperties.m_toolBarVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+            actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
+            actionProperties.m_toolBarVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
             m_actionManagerInterface->RegisterCheckableAction(
                 EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -2417,7 +2417,7 @@ void EditorActionsHandler::InitializeViewBookmarkActions()
         actionProperties.m_name = AZStd::string::format("Go to Location %i", index+1);
         actionProperties.m_description = AZStd::string::format("Go to Location %i.", index+1);
         actionProperties.m_category = "View Bookmark";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         auto outcome = m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -2475,7 +2475,7 @@ void EditorActionsHandler::InitializeViewBookmarkActions()
         actionProperties.m_name = AZStd::string::format("Save Location %i", index+1);
         actionProperties.m_description = AZStd::string::format("Save Location %i.", index+1);
         actionProperties.m_category = "View Bookmark";
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,

--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -210,7 +210,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "New Level";
         actionProperties.m_description = "Create a new level";
         actionProperties.m_category = "Level";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -235,7 +235,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Open Level...";
         actionProperties.m_description = "Open an existing level";
         actionProperties.m_category = "Level";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -270,7 +270,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
                 actionProperties.m_name = AZStd::string::format("Recent File #%i", index + 1);
             }
             actionProperties.m_category = "Level";
-            actionProperties.m_hideFromMenusWhenDisabled = false;
+            actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
             AZStd::string actionIdentifier = AZStd::string::format("o3de.action.file.recent.file%i", index + 1);
 
@@ -306,7 +306,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Clear All";
         actionProperties.m_description = "Clear the recent files list.";
         actionProperties.m_category = "Level";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -340,8 +340,8 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Save";
         actionProperties.m_description = "Save the current level";
         actionProperties.m_category = "Level";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
-
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier, "o3de.action.file.save", actionProperties,
             [cryEdit = m_cryEditApp]
@@ -362,7 +362,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Save As...";
         actionProperties.m_description = "Save the current level";
         actionProperties.m_category = "Level";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier, "o3de.action.file.saveAs", actionProperties,
@@ -384,7 +384,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Save Level Statistics";
         actionProperties.m_description = "Logs Editor memory usage.";
         actionProperties.m_category = "Level";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -416,7 +416,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Edit Project Settings...";
         actionProperties.m_description = "Open the Project Settings panel.";
         actionProperties.m_category = "Project";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -458,7 +458,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "New Project...";
         actionProperties.m_description = "Create a new project in the Project Manager.";
         actionProperties.m_category = "Project";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -481,7 +481,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Open Project...";
         actionProperties.m_description = "Open a different project in the Project Manager.";
         actionProperties.m_category = "Project";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -503,7 +503,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         AzToolsFramework::ActionProperties actionProperties;
         actionProperties.m_name = "Show Log File";
         actionProperties.m_category = "Project";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -545,7 +545,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "&Undo";
         actionProperties.m_description = "Undo last operation";
         actionProperties.m_category = "Edit";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -577,7 +577,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "&Redo";
         actionProperties.m_description = "Redo last undo operation";
         actionProperties.m_category = "Edit";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -611,7 +611,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_description = "Toggle angle snapping";
         actionProperties.m_category = "Edit";
         actionProperties.m_iconPath = ":/stylesheet/img/UI20/toolbar/Angle.svg";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterCheckableAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -642,7 +642,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_description = "Toggle grid snapping";
         actionProperties.m_category = "Edit";
         actionProperties.m_iconPath = ":/stylesheet/img/UI20/toolbar/Grid.svg";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterCheckableAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -672,7 +672,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Show Grid";
         actionProperties.m_description = "Show Grid for entity snapping.";
         actionProperties.m_category = "Edit";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterCheckableAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -747,7 +747,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_description = "Activate the game input mode.";
         actionProperties.m_category = "Game";
         actionProperties.m_iconPath = ":/stylesheet/img/UI20/toolbar/Play.svg";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterCheckableAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -780,7 +780,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Play Game (Maximized)";
         actionProperties.m_description = "Activate the game input mode (maximized).";
         actionProperties.m_category = "Game";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterCheckableAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -812,7 +812,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_description = "Enable processing of Physics and AI.";
         actionProperties.m_category = "Game";
         actionProperties.m_iconPath = ":/stylesheet/img/UI20/toolbar/Simulate_Physics.svg";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterCheckableAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -843,7 +843,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Export Selected Objects";
         actionProperties.m_description = "Export Selected Objects.";
         actionProperties.m_category = "Game";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -869,7 +869,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Export Occlusion Mesh";
         actionProperties.m_description = "Export Occlusion Mesh.";
         actionProperties.m_category = "Game";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -892,7 +892,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Move Player and Camera Separately";
         actionProperties.m_description = "Move Player and Camera Separately.";
         actionProperties.m_category = "Game";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterCheckableAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -919,7 +919,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Stop All Sounds";
         actionProperties.m_description = "Stop All Sounds.";
         actionProperties.m_category = "Game";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -943,7 +943,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Refresh";
         actionProperties.m_description = "Refresh Audio System.";
         actionProperties.m_category = "Game";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -976,7 +976,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Error Report";
         actionProperties.m_description = "Open the Error Report dialog.";
         actionProperties.m_category = "Debugging";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -999,7 +999,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Configure Toolbox Macros...";
         actionProperties.m_description = "Open the Toolbox Macros dialog.";
         actionProperties.m_category = "Debugging";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -1027,7 +1027,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         AzToolsFramework::ActionProperties actionProperties;
         actionProperties.m_name = "Component Entity Layout (Default)";
         actionProperties.m_category = "Layout";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -1050,7 +1050,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Save Layout...";
         actionProperties.m_description = "Save the current layout.";
         actionProperties.m_category = "Layout";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -1073,7 +1073,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Restore Default Layout";
         actionProperties.m_description = "Restored the default layout for the Editor.";
         actionProperties.m_category = "Layout";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -1097,7 +1097,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_description = "Move the editor camera to the position and rotation provided.";
         actionProperties.m_category = "View";
         actionProperties.m_iconPath = ":/Menu/camera.svg";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -1120,7 +1120,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         actionProperties.m_name = "Center on Selection";
         actionProperties.m_description = "Center the viewport to show selected entities.";
         actionProperties.m_category = "View";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -1376,7 +1376,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
         AzToolsFramework::ActionProperties actionProperties;
         actionProperties.m_name = "&Welcome";
         actionProperties.m_category = "Help";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -2188,7 +2188,7 @@ void EditorActionsHandler::RefreshLayoutActions()
                 actionProperties.m_name = "Load";
                 actionProperties.m_description = AZStd::string::format("Load the \"%s\" layout.", layoutName.toUtf8().data());
                 actionProperties.m_category = "Layout";
-                actionProperties.m_hideFromMenusWhenDisabled = false;
+                actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
                 m_actionManagerInterface->RegisterAction(
                     EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -2212,7 +2212,7 @@ void EditorActionsHandler::RefreshLayoutActions()
                 actionProperties.m_name = "Save";
                 actionProperties.m_description = AZStd::string::format("Save the \"%s\" layout.", layoutName.toUtf8().data());
                 actionProperties.m_category = "Layout";
-                actionProperties.m_hideFromMenusWhenDisabled = false;
+                actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
                 m_actionManagerInterface->RegisterAction(
                     EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -2236,7 +2236,7 @@ void EditorActionsHandler::RefreshLayoutActions()
                 actionProperties.m_name = "Rename...";
                 actionProperties.m_description = AZStd::string::format("Rename the \"%s\" layout.", layoutName.toUtf8().data());
                 actionProperties.m_category = "Layout";
-                actionProperties.m_hideFromMenusWhenDisabled = false;
+                actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
                 m_actionManagerInterface->RegisterAction(
                     EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -2260,7 +2260,7 @@ void EditorActionsHandler::RefreshLayoutActions()
                 actionProperties.m_name = "Delete";
                 actionProperties.m_description = AZStd::string::format("Delete the \"%s\" layout.", layoutName.toUtf8().data());
                 actionProperties.m_category = "Layout";
-                actionProperties.m_hideFromMenusWhenDisabled = false;
+                actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
                 m_actionManagerInterface->RegisterAction(
                     EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -2312,7 +2312,7 @@ void EditorActionsHandler::RefreshToolboxMacroActions()
                 actionProperties.m_name = macro->GetTitle().toStdString().c_str();
                 actionProperties.m_category = "Toolbox Macro";
                 actionProperties.m_iconPath = macro->GetIconPath().toStdString().c_str();
-                actionProperties.m_hideFromMenusWhenDisabled = false;
+                actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
                 m_actionManagerInterface->RegisterAction(
                     EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -2368,7 +2368,8 @@ void EditorActionsHandler::RefreshToolActions()
                                                                                        : viewpane.m_name.toUtf8().data();
             actionProperties.m_category = "Tool";
             actionProperties.m_iconPath = viewpane.m_options.toolbarIcon;
-            actionProperties.m_hideFromMenusWhenDisabled = false;
+            actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+            actionProperties.m_toolBarVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
             m_actionManagerInterface->RegisterCheckableAction(
                 EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -2416,7 +2417,7 @@ void EditorActionsHandler::InitializeViewBookmarkActions()
         actionProperties.m_name = AZStd::string::format("Go to Location %i", index+1);
         actionProperties.m_description = AZStd::string::format("Go to Location %i.", index+1);
         actionProperties.m_category = "View Bookmark";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         auto outcome = m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -2474,7 +2475,7 @@ void EditorActionsHandler::InitializeViewBookmarkActions()
         actionProperties.m_name = AZStd::string::format("Save Location %i", index+1);
         actionProperties.m_description = AZStd::string::format("Save Location %i.", index+1);
         actionProperties.m_category = "View Bookmark";
-        actionProperties.m_hideFromMenusWhenDisabled = false;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.cpp
@@ -404,14 +404,7 @@ namespace AzToolsFramework
                 actionIdentifier.c_str()));
         }
 
-        if (actionIterator->second.HasEnabledStateCallback())
-        {
-            return AZ::Failure(AZStd::string::format(
-                "Action Manager - Could not install enabled state callback on action \"%s\" - action already has an enabled state callback installed.",
-                actionIdentifier.c_str()));
-        }
-
-        actionIterator->second.SetEnabledStateCallback(AZStd::move(enabledStateCallback));
+        actionIterator->second.AddEnabledStateCallback(AZStd::move(enabledStateCallback));
         return AZ::Success();
     }
     

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.cpp
@@ -774,7 +774,7 @@ namespace AzToolsFramework
         if (actionIterator == m_actions.end())
         {
             // Return the default value.
-            return ActionVisibility::HIDE_WHEN_DISABLED;
+            return ActionVisibility::HideWhenDisabled;
         }
 
         return actionIterator->second.GetMenuVisibility();
@@ -786,7 +786,7 @@ namespace AzToolsFramework
         if (actionIterator == m_actions.end())
         {
             // Return the default value.
-            return ActionVisibility::ONLY_IN_ACTIVE_MODE;
+            return ActionVisibility::OnlyInActiveMode;
         }
 
         return actionIterator->second.GetToolBarVisibility();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.cpp
@@ -194,8 +194,8 @@ namespace AzToolsFramework
                     properties.m_description,
                     properties.m_category,
                     properties.m_iconPath,
-                    properties.m_hideFromMenusWhenDisabled,
-                    properties.m_hideFromToolBarsWhenDisabled,
+                    properties.m_menuVisibility,
+                    properties.m_toolBarVisibility,
                     handler
                 )
             }
@@ -241,8 +241,8 @@ namespace AzToolsFramework
                     properties.m_description,
                     properties.m_category,
                     properties.m_iconPath,
-                    properties.m_hideFromMenusWhenDisabled,
-                    properties.m_hideFromToolBarsWhenDisabled,
+                    properties.m_menuVisibility,
+                    properties.m_toolBarVisibility,
                     handler,
                     checkStateCallback
                 )
@@ -645,6 +645,22 @@ namespace AzToolsFramework
         return AZ::Success();
     }
 
+    ActionManagerBooleanResult ActionManager::IsActionActiveInCurrentMode(const AZStd::string& actionIdentifier)
+    {
+        auto actionIterator = m_actions.find(actionIdentifier);
+        if (actionIterator == m_actions.end())
+        {
+            return AZ::Failure(
+                AZStd::string::format(
+                    "Action Manager - Could not retrieve whether action \"%s\" is active in current mode as no action with that identifier was registered.",
+                    actionIdentifier.c_str()
+                )
+            );
+        }
+
+        return AZ::Success(actionIterator->second.IsActiveInCurrentMode());
+    }
+
     ActionManagerOperationResult ActionManager::SetActiveActionContextMode(
         const AZStd::string& actionContextIdentifier, const AZStd::string& modeIdentifier)
     {
@@ -736,28 +752,28 @@ namespace AzToolsFramework
         return &actionIterator->second;
     }
 
-    bool ActionManager::GetHideFromMenusWhenDisabled(const AZStd::string& actionIdentifier) const
+    ActionVisibility ActionManager::GetActionMenuVisibility(const AZStd::string& actionIdentifier) const
     {
         auto actionIterator = m_actions.find(actionIdentifier);
         if (actionIterator == m_actions.end())
         {
             // Return the default value.
-            return true;
+            return ActionVisibility::HIDE_WHEN_DISABLED;
         }
 
-        return actionIterator->second.GetHideFromMenusWhenDisabled();
+        return actionIterator->second.GetMenuVisibility();
     }
 
-    bool ActionManager::GetHideFromToolBarsWhenDisabled(const AZStd::string& actionIdentifier) const
+    ActionVisibility ActionManager::GetActionToolBarVisibility(const AZStd::string& actionIdentifier) const
     {
         auto actionIterator = m_actions.find(actionIdentifier);
         if (actionIterator == m_actions.end())
         {
             // Return the default value.
-            return false;
+            return ActionVisibility::ONLY_IN_ACTIVE_MODE;
         }
 
-        return actionIterator->second.GetHideFromToolBarsWhenDisabled();
+        return actionIterator->second.GetToolBarVisibility();
     }
 
     QWidget* ActionManager::GenerateWidgetFromWidgetAction(const AZStd::string& widgetActionIdentifier)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.cpp
@@ -661,7 +661,7 @@ namespace AzToolsFramework
         return AZ::Success();
     }
 
-    ActionManagerBooleanResult ActionManager::IsActionActiveInCurrentMode(const AZStd::string& actionIdentifier)
+    ActionManagerBooleanResult ActionManager::IsActionActiveInCurrentMode(const AZStd::string& actionIdentifier) const
     {
         auto actionIterator = m_actions.find(actionIdentifier);
         if (actionIterator == m_actions.end())

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.h
@@ -81,7 +81,7 @@ namespace AzToolsFramework
             const AZStd::string& actionContextIdentifier, const AZStd::string& modeIdentifier) override;
         ActionManagerOperationResult AssignModeToAction(
             const AZStd::string& modeIdentifier, const AZStd::string& actionIdentifier) override;
-        ActionManagerBooleanResult IsActionActiveInCurrentMode(const AZStd::string& actionIdentifier) override;
+        ActionManagerBooleanResult IsActionActiveInCurrentMode(const AZStd::string& actionIdentifier) const override;
         ActionManagerOperationResult SetActiveActionContextMode(
             const AZStd::string& actionContextIdentifier, const AZStd::string& modeIdentifier) override;
         ActionManagerGetterResult GetActiveActionContextMode(const AZStd::string& actionContextIdentifier) const override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.h
@@ -81,6 +81,7 @@ namespace AzToolsFramework
             const AZStd::string& actionContextIdentifier, const AZStd::string& modeIdentifier) override;
         ActionManagerOperationResult AssignModeToAction(
             const AZStd::string& modeIdentifier, const AZStd::string& actionIdentifier) override;
+        ActionManagerBooleanResult IsActionActiveInCurrentMode(const AZStd::string& actionIdentifier) override;
         ActionManagerOperationResult SetActiveActionContextMode(
             const AZStd::string& actionContextIdentifier, const AZStd::string& modeIdentifier) override;
         ActionManagerGetterResult GetActiveActionContextMode(const AZStd::string& actionContextIdentifier) const override;
@@ -90,8 +91,8 @@ namespace AzToolsFramework
         const QAction* GetActionConst(const AZStd::string& actionIdentifier) const override;
         EditorAction* GetEditorAction(const AZStd::string& actionIdentifier) override;
         const EditorAction* GetEditorActionConst(const AZStd::string& actionIdentifier) const override;
-        bool GetHideFromMenusWhenDisabled(const AZStd::string& actionIdentifier) const override;
-        bool GetHideFromToolBarsWhenDisabled(const AZStd::string& actionIdentifier) const override;
+        ActionVisibility GetActionMenuVisibility(const AZStd::string& actionIdentifier) const override;
+        ActionVisibility GetActionToolBarVisibility(const AZStd::string& actionIdentifier) const override;
         QWidget* GenerateWidgetFromWidgetAction(const AZStd::string& widgetActionIdentifier) override;
         void UpdateAllActionsInActionContext(const AZStd::string& actionContextIdentifier) override;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManagerInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManagerInterface.h
@@ -49,7 +49,7 @@ namespace AzToolsFramework
         AZStd::string m_iconPath; //!< The qrc path to the icon to be used in UI.
         //! Determines in which mode this action should be accessible.
         //! Empty means action will always appear regardless of the mode.
-        AZStd::vector<AZStd::string> m_modes = {};
+        AZStd::vector<AZStd::string> m_modes;
 
         //! Determines visibility for this action in Menus.
         ActionVisibility m_menuVisibility = ActionVisibility::HideWhenDisabled;
@@ -271,7 +271,7 @@ namespace AzToolsFramework
         //! Returns whether the Action is active in the Mode its Action Context is currently in.
         //! @param actionIdentifier The action to query.
         //! @return A successful outcome object with the result, or a string with a message detailing the error in case of failure.
-        virtual ActionManagerBooleanResult IsActionActiveInCurrentMode(const AZStd::string& actionIdentifier) = 0;
+        virtual ActionManagerBooleanResult IsActionActiveInCurrentMode(const AZStd::string& actionIdentifier) const = 0;
 
         //! Sets the active mode for an action context via its identifier.
         //! @param actionContextIdentifier The action context to set the active mode to.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManagerInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManagerInterface.h
@@ -52,9 +52,9 @@ namespace AzToolsFramework
         AZStd::vector<AZStd::string> m_modes = {};
 
         //! Determines visibility for this action in Menus.
-        ActionVisibility m_menuVisibility = ActionVisibility::HIDE_WHEN_DISABLED;
+        ActionVisibility m_menuVisibility = ActionVisibility::HideWhenDisabled;
         //! Determines visibility for this action in ToolBars.
-        ActionVisibility m_toolBarVisibility = ActionVisibility::ONLY_IN_ACTIVE_MODE;
+        ActionVisibility m_toolBarVisibility = ActionVisibility::OnlyInActiveMode;
     };
 
     //! Widget Action Properties object.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManagerInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManagerInterface.h
@@ -12,12 +12,12 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/function/function_base.h>
 
+#include <AzToolsFramework/ActionManager/Action/EditorActionUtils.h>
+
 class QWidget;
 
 namespace AzToolsFramework
 {
-    constexpr const char* DefaultActionContextModeIdentifier = "default";
-
     using ActionManagerOperationResult = AZ::Outcome<void, AZStd::string>;
     using ActionManagerBooleanResult = AZ::Outcome<bool, AZStd::string>;
     using ActionManagerGetterResult = AZ::Outcome<AZStd::string, AZStd::string>;
@@ -49,9 +49,12 @@ namespace AzToolsFramework
         AZStd::string m_iconPath; //!< The qrc path to the icon to be used in UI.
         //! Determines in which mode this action should be accessible.
         //! Empty means action will always appear regardless of the mode.
-        AZStd::vector<AZStd::string> m_modes = {}; 
-        bool m_hideFromMenusWhenDisabled = true; //!< Determines whether this actions should be hidden in menus when disabled.
-        bool m_hideFromToolBarsWhenDisabled = false; //!< Determines whether this actions should be hidden in toolbars when disabled.
+        AZStd::vector<AZStd::string> m_modes = {};
+
+        //! Determines visibility for this action in Menus.
+        ActionVisibility m_menuVisibility = ActionVisibility::HIDE_WHEN_DISABLED;
+        //! Determines visibility for this action in ToolBars.
+        ActionVisibility m_toolBarVisibility = ActionVisibility::ONLY_IN_ACTIVE_MODE;
     };
 
     //! Widget Action Properties object.
@@ -264,6 +267,11 @@ namespace AzToolsFramework
         //! @return A successful outcome object, or a string with a message detailing the error in case of failure.
         virtual ActionManagerOperationResult AssignModeToAction(
             const AZStd::string& modeIdentifier, const AZStd::string& actionIdentifier) = 0;
+
+        //! Returns whether the Action is active in the Mode its Action Context is currently in.
+        //! @param actionIdentifier The action to query.
+        //! @return A successful outcome object with the result, or a string with a message detailing the error in case of failure.
+        virtual ActionManagerBooleanResult IsActionActiveInCurrentMode(const AZStd::string& actionIdentifier) = 0;
 
         //! Sets the active mode for an action context via its identifier.
         //! @param actionContextIdentifier The action context to set the active mode to.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManagerInternalInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManagerInternalInterface.h
@@ -48,15 +48,15 @@ namespace AzToolsFramework
         //! @return A raw const pointer to the EditorAction, or nullptr if the action could not be found.
         virtual const EditorAction* GetEditorActionConst(const AZStd::string& actionIdentifier) const = 0;
 
-        //! Retrieve whether an Action should be hidden from Menus when disabled.
+        //! Retrieve the Action's visibility property for Menus.
         //! @param actionIdentifier The identifier for the action to query.
         //! @return True if the actions should be hidden, false otherwise.
-        virtual bool GetHideFromMenusWhenDisabled(const AZStd::string& actionIdentifier) const = 0;
+        virtual ActionVisibility GetActionMenuVisibility(const AZStd::string& actionIdentifier) const = 0;
 
-        //! Retrieve whether an Action should be hidden from ToolBars when disabled.
+        //! Retrieve the Action's visibility property for ToolBars.
         //! @param actionIdentifier The identifier for the action to query.
         //! @return True if the actions should be hidden, false otherwise.
-        virtual bool GetHideFromToolBarsWhenDisabled(const AZStd::string& actionIdentifier) const = 0;
+        virtual ActionVisibility GetActionToolBarVisibility(const AZStd::string& actionIdentifier) const = 0;
 
         //! Generate a QWidget from a Widget Action identifier.
         //! The WidgetAction will generate a new instance of the Widget and parent it to the widget provided.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorAction.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorAction.cpp
@@ -8,7 +8,6 @@
 
 #include <AzToolsFramework/ActionManager/Action/EditorAction.h>
 
-#include <AzToolsFramework/ActionManager/Action/ActionManagerInterface.h>
 #include <AzToolsFramework/ActionManager/Action/ActionManagerNotificationBus.h>
 
 #include <QAction>
@@ -24,8 +23,8 @@ namespace AzToolsFramework
         AZStd::string description,
         AZStd::string category,
         AZStd::string iconPath,
-        bool hideFromMenusWhenDisabled,
-        bool hideFromToolBarsWhenDisabled,
+        ActionVisibility menuVisibility,
+        ActionVisibility toolBarVisibility,
         AZStd::function<void()> handler,
         AZStd::function<bool()> checkStateCallback)
         : m_contextIdentifier(AZStd::move(contextIdentifier))
@@ -34,8 +33,8 @@ namespace AzToolsFramework
         , m_description(AZStd::move(description))
         , m_category(AZStd::move(category))
         , m_iconPath(AZStd::move(iconPath))
-        , m_hideFromMenusWhenDisabled(hideFromMenusWhenDisabled)
-        , m_hideFromToolBarsWhenDisabled(hideFromToolBarsWhenDisabled)
+        , m_menuVisibility(menuVisibility)
+        , m_toolBarVisibility(toolBarVisibility)
     {
         UpdateIconFromPath();
         m_action = new QAction(m_icon, m_name.c_str(), parentWidget);
@@ -146,14 +145,14 @@ namespace AzToolsFramework
         UpdateTooltipText();
     }
 
-    bool EditorAction::GetHideFromMenusWhenDisabled() const
+    ActionVisibility EditorAction::GetMenuVisibility() const
     {
-        return m_hideFromMenusWhenDisabled;
+        return m_menuVisibility;
     }
 
-    bool EditorAction::GetHideFromToolBarsWhenDisabled() const
+    ActionVisibility EditorAction::GetToolBarVisibility() const
     {
-        return m_hideFromToolBarsWhenDisabled;
+        return m_toolBarVisibility;
     }
 
     QAction* EditorAction::GetAction()
@@ -203,7 +202,7 @@ namespace AzToolsFramework
         }
 
         // Refresh enabled state.
-        bool enabled = IsEnabledInCurrentMode();
+        bool enabled = IsActiveInCurrentMode();
 
         if (enabled  && !m_enabledStateCallbacks.empty())
         {
@@ -255,7 +254,7 @@ namespace AzToolsFramework
         m_action->setToolTip(toolTipText.c_str());
     }
 
-    bool EditorAction::IsEnabledInCurrentMode() const
+    bool EditorAction::IsActiveInCurrentMode() const
     {
         auto outcome = s_actionManagerInterface->GetActiveActionContextMode(m_contextIdentifier);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorAction.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorAction.h
@@ -67,7 +67,7 @@ namespace AzToolsFramework
         //! Adds a mode to the list of modes this action is enabled in.
         void AssignToMode(AZStd::string modeIdentifier);
 
-        //! Returns true if the EditorAction has one ore more enabled state callbacks set, false otherwise.
+        //! Returns true if the EditorAction has one or more enabled state callbacks set, false otherwise.
         bool HasEnabledStateCallbacks() const;
 
         //! Returns true if the EditorAction is enabled, false otherwise.
@@ -79,7 +79,7 @@ namespace AzToolsFramework
         //! Updates the action's checked and enabled state via the appropriate callbacks, if any.
         void Update();
 
-        //! Returns whether the Action is active 
+        //! Returns whether the Action is active.
         bool IsActiveInCurrentMode() const;
 
     private:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorAction.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorAction.h
@@ -12,14 +12,14 @@
 #include <AzCore/std/function/function_template.h>
 #include <AzCore/std/string/string.h>
 
+#include <AzToolsFramework/ActionManager/Action/ActionManagerInterface.h>
+
 #include <QIcon>
 
 class QAction;
 
 namespace AzToolsFramework
 {
-    class ActionManagerInterface;
-
     //! Editor Action class definitions.
     //! Wraps a QAction and provides additional metadata.
     class EditorAction
@@ -34,8 +34,8 @@ namespace AzToolsFramework
             AZStd::string description,
             AZStd::string category,
             AZStd::string iconPath,
-            bool hideFromMenusWhenDisabled,
-            bool hideFromToolBarsWhenDisabled,
+            ActionVisibility menuVisibility,
+            ActionVisibility toolBarVisibility,
             AZStd::function<void()> handler,
             AZStd::function<bool()> checkStateCallback = nullptr
         );
@@ -54,8 +54,8 @@ namespace AzToolsFramework
         void SetIconPath(AZStd::string iconPath);
         AZStd::string GetHotKey() const;
         void SetHotKey(const AZStd::string& hotKey);
-        bool GetHideFromMenusWhenDisabled() const;
-        bool GetHideFromToolBarsWhenDisabled() const;
+        ActionVisibility GetMenuVisibility() const;
+        ActionVisibility GetToolBarVisibility() const;
 
         //! Returns the pointer to the action.
         QAction* GetAction();
@@ -79,11 +79,13 @@ namespace AzToolsFramework
         //! Updates the action's checked and enabled state via the appropriate callbacks, if any.
         void Update();
 
+        //! Returns whether the Action is active 
+        bool IsActiveInCurrentMode() const;
+
     private:
         void UpdateIconFromPath();
         void UpdateTooltipText();
 
-        bool IsEnabledInCurrentMode() const;
 
         QAction* m_action = nullptr;
         QIcon m_icon;
@@ -98,8 +100,8 @@ namespace AzToolsFramework
         AZStd::function<bool()> m_checkStateCallback = nullptr;
         AZStd::vector<AZStd::function<bool()>> m_enabledStateCallbacks;
 
-        bool m_hideFromMenusWhenDisabled;
-        bool m_hideFromToolBarsWhenDisabled;
+        ActionVisibility m_menuVisibility;
+        ActionVisibility m_toolBarVisibility;
 
         // If the modes vector is empty, the action will be enabled in all modes.
         AZStd::unordered_set<AZStd::string> m_modes;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorAction.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorAction.h
@@ -61,14 +61,14 @@ namespace AzToolsFramework
         QAction* GetAction();
         const QAction* GetAction() const;
 
-        //! Sets the enabled state callback for the action.
-        void SetEnabledStateCallback(AZStd::function<bool()> enabledStateCallback);
+        //! Adds an enabled state callback to the action.
+        void AddEnabledStateCallback(AZStd::function<bool()> enabledStateCallback);
 
         //! Adds a mode to the list of modes this action is enabled in.
         void AssignToMode(AZStd::string modeIdentifier);
 
-        //! Returns true if the EditorAction has an enabled state callback set, false otherwise.
-        bool HasEnabledStateCallback() const;
+        //! Returns true if the EditorAction has one ore more enabled state callbacks set, false otherwise.
+        bool HasEnabledStateCallbacks() const;
 
         //! Returns true if the EditorAction is enabled, false otherwise.
         bool IsEnabled() const;
@@ -96,7 +96,7 @@ namespace AzToolsFramework
         AZStd::string m_iconPath;
 
         AZStd::function<bool()> m_checkStateCallback = nullptr;
-        AZStd::function<bool()> m_enabledStateCallback = nullptr;
+        AZStd::vector<AZStd::function<bool()>> m_enabledStateCallbacks;
 
         bool m_hideFromMenusWhenDisabled;
         bool m_hideFromToolBarsWhenDisabled;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorActionContext.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorActionContext.h
@@ -21,7 +21,7 @@ namespace AzToolsFramework
     constexpr const char* DefaultModeIdentifier = "default";
 
     //! Editor Action Context class definition.
-    //! Identifies a collection of Actions in the context of 
+    //! Identifies a collection of Actions and their accessibility in the context of the whole O3DE Editor.
     class EditorActionContext
         : public QObject
     {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorActionUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorActionUtils.h
@@ -17,16 +17,16 @@ namespace AzToolsFramework
     //! The action will be greyed out if shown while disabled by an enabled state callback.
     enum class ActionVisibility
     {
-        ALWAYS_SHOW = 0, //!< Action is always shown even in Action Context Modes where it is not available.
-        ONLY_IN_ACTIVE_MODE, //!< Action is only shown in Action Context Modes it was added to.
-        HIDE_WHEN_DISABLED //!< Action is only shown when enabled, and hidden in all other cases.
+        AlwaysShow = 0,     //!< Action is always shown even in Action Context Modes where it is not available.
+        OnlyInActiveMode,   //!< Action is only shown in Action Context Modes it was added to.
+        HideWhenDisabled    //!< Action is only shown when enabled, and hidden in all other cases.
     };
 
     inline static bool IsActionVisible(ActionVisibility actionVisibility, bool actionIsActiveInCurrentMode, bool actionIsEnabled)
     {
-        return  (actionVisibility == ActionVisibility::ALWAYS_SHOW) ||
-                (actionVisibility == ActionVisibility::ONLY_IN_ACTIVE_MODE && actionIsActiveInCurrentMode) ||
-                (actionVisibility == ActionVisibility::HIDE_WHEN_DISABLED && actionIsEnabled);
+        return  (actionVisibility == ActionVisibility::AlwaysShow) ||
+                (actionVisibility == ActionVisibility::OnlyInActiveMode && actionIsActiveInCurrentMode) ||
+                (actionVisibility == ActionVisibility::HideWhenDisabled && actionIsEnabled);
     }
 
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorActionUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorActionUtils.h
@@ -10,7 +10,7 @@
 
 namespace AzToolsFramework
 {
-    constexpr const char* DefaultActionContextModeIdentifier = "default";
+    inline constexpr const char* DefaultActionContextModeIdentifier = "default";
 
     //! Action Visibility enum.
     //! Determines whether an action should be displayed in a Menu or ToolBar.
@@ -22,7 +22,7 @@ namespace AzToolsFramework
         HideWhenDisabled    //!< Action is only shown when enabled, and hidden in all other cases.
     };
 
-    inline static bool IsActionVisible(ActionVisibility actionVisibility, bool actionIsActiveInCurrentMode, bool actionIsEnabled)
+    inline bool IsActionVisible(ActionVisibility actionVisibility, bool actionIsActiveInCurrentMode, bool actionIsEnabled)
     {
         return  (actionVisibility == ActionVisibility::AlwaysShow) ||
                 (actionVisibility == ActionVisibility::OnlyInActiveMode && actionIsActiveInCurrentMode) ||

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorActionUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorActionUtils.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+namespace AzToolsFramework
+{
+    constexpr const char* DefaultActionContextModeIdentifier = "default";
+
+    //! Action Visibility enum.
+    //! Determines whether an action should be displayed in a Menu or ToolBar.
+    //! The action will be greyed out if shown while disabled by an enabled state callback.
+    enum class ActionVisibility
+    {
+        ALWAYS_SHOW = 0, //!< Action is always shown even in Action Context Modes where it is not available.
+        ONLY_IN_ACTIVE_MODE, //!< Action is only shown in Action Context Modes it was added to.
+        HIDE_WHEN_DISABLED //!< Action is only shown when enabled, and hidden in all other cases.
+    };
+
+    inline static bool IsActionVisible(ActionVisibility actionVisibility, bool actionIsActiveInCurrentMode, bool actionIsEnabled)
+    {
+        return  (actionVisibility == ActionVisibility::ALWAYS_SHOW) ||
+                (actionVisibility == ActionVisibility::ONLY_IN_ACTIVE_MODE && actionIsActiveInCurrentMode) ||
+                (actionVisibility == ActionVisibility::HIDE_WHEN_DISABLED && actionIsEnabled);
+    }
+
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/EditorMenu.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/EditorMenu.cpp
@@ -187,8 +187,16 @@ namespace AzToolsFramework
                     {
                         if (QAction* action = s_actionManagerInternalInterface->GetAction(menuItem.m_identifier))
                         {
-                            if (!action->isEnabled() &&
-                                s_actionManagerInternalInterface->GetHideFromMenusWhenDisabled(menuItem.m_identifier))
+                            auto outcome = s_actionManagerInterface->IsActionActiveInCurrentMode(menuItem.m_identifier);
+                            bool isActiveInCurrentMode = outcome.IsSuccess() && outcome.GetValue();
+
+                            if (
+                                !IsActionVisible(
+                                    s_actionManagerInternalInterface->GetActionMenuVisibility(menuItem.m_identifier),
+                                    isActiveInCurrentMode,
+                                    action->isEnabled()
+                                )
+                            )
                             {
                                 continue;
                             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/MenuManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/MenuManager.cpp
@@ -731,7 +731,7 @@ namespace AzToolsFramework
     void MenuManager::OnActionStateChanged(AZStd::string actionIdentifier)
     {
         // Only refresh the menu if the action state changing could result in the action being shown/hidden.
-        if (m_actionManagerInternalInterface->GetActionMenuVisibility(actionIdentifier) != ActionVisibility::ALWAYS_SHOW)
+        if (m_actionManagerInternalInterface->GetActionMenuVisibility(actionIdentifier) != ActionVisibility::AlwaysShow)
         {
             QueueRefreshForMenusContainingAction(actionIdentifier);
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/MenuManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/MenuManager.cpp
@@ -731,7 +731,7 @@ namespace AzToolsFramework
     void MenuManager::OnActionStateChanged(AZStd::string actionIdentifier)
     {
         // Only refresh the menu if the action state changing could result in the action being shown/hidden.
-        if (m_actionManagerInternalInterface->GetHideFromMenusWhenDisabled(actionIdentifier))
+        if (m_actionManagerInternalInterface->GetActionMenuVisibility(actionIdentifier) != ActionVisibility::ALWAYS_SHOW)
         {
             QueueRefreshForMenusContainingAction(actionIdentifier);
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ToolBar/EditorToolBar.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ToolBar/EditorToolBar.cpp
@@ -142,8 +142,13 @@ namespace AzToolsFramework
                         {
                             if (QAction* action = s_actionManagerInternalInterface->GetAction(toolBarItem.m_identifier))
                             {
-                                if (!action->isEnabled() &&
-                                    s_actionManagerInternalInterface->GetHideFromToolBarsWhenDisabled(toolBarItem.m_identifier))
+                                auto outcome = s_actionManagerInterface->IsActionActiveInCurrentMode(toolBarItem.m_identifier);
+                                bool isActiveInCurrentMode = outcome.IsSuccess() && outcome.GetValue();
+
+                                if (!IsActionVisible(
+                                        s_actionManagerInternalInterface->GetActionToolBarVisibility(toolBarItem.m_identifier),
+                                        isActiveInCurrentMode,
+                                        action->isEnabled()))
                                 {
                                     continue;
                                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ToolBar/ToolBarManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ToolBar/ToolBarManager.cpp
@@ -493,7 +493,7 @@ namespace AzToolsFramework
     void ToolBarManager::OnActionStateChanged(AZStd::string actionIdentifier)
     {
         // Only refresh the toolbar if the action state changing could result in the action being shown/hidden.
-        if (m_actionManagerInternalInterface->GetActionToolBarVisibility(actionIdentifier) != ActionVisibility::ALWAYS_SHOW)
+        if (m_actionManagerInternalInterface->GetActionToolBarVisibility(actionIdentifier) != ActionVisibility::AlwaysShow)
         {
             QueueRefreshForToolBarsContainingAction(actionIdentifier);
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ToolBar/ToolBarManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ToolBar/ToolBarManager.cpp
@@ -493,7 +493,7 @@ namespace AzToolsFramework
     void ToolBarManager::OnActionStateChanged(AZStd::string actionIdentifier)
     {
         // Only refresh the toolbar if the action state changing could result in the action being shown/hidden.
-        if (m_actionManagerInternalInterface->GetHideFromToolBarsWhenDisabled(actionIdentifier))
+        if (m_actionManagerInternalInterface->GetActionToolBarVisibility(actionIdentifier) != ActionVisibility::ALWAYS_SHOW)
         {
             QueueRefreshForToolBarsContainingAction(actionIdentifier);
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeActionHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeActionHandler.cpp
@@ -87,6 +87,7 @@ namespace AzToolsFramework
             actionProperties.m_name = "Done";
             actionProperties.m_description = "Return to normal viewport editing";
             actionProperties.m_category = "Component Modes";
+            actionProperties.m_menuVisibility = ActionVisibility::ONLY_IN_ACTIVE_MODE;
 
             m_actionManagerInterface->RegisterAction(
                 EditorIdentifiers::MainWindowActionContextIdentifier,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeActionHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeActionHandler.cpp
@@ -87,7 +87,7 @@ namespace AzToolsFramework
             actionProperties.m_name = "Done";
             actionProperties.m_description = "Return to normal viewport editing";
             actionProperties.m_category = "Component Modes";
-            actionProperties.m_menuVisibility = ActionVisibility::ONLY_IN_ACTIVE_MODE;
+            actionProperties.m_menuVisibility = ActionVisibility::OnlyInActiveMode;
 
             m_actionManagerInterface->RegisterAction(
                 EditorIdentifiers::MainWindowActionContextIdentifier,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/ActionManagerIdentifiers/EditorActionUpdaterIdentifiers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/ActionManagerIdentifiers/EditorActionUpdaterIdentifiers.h
@@ -20,9 +20,10 @@ namespace EditorIdentifiers
     inline constexpr AZStd::string_view GridShowingChangedUpdaterIdentifier = "o3de.updater.onGridShowingChanged";
     inline constexpr AZStd::string_view GridSnappingStateChangedUpdaterIdentifier = "o3de.updater.onGridSnappingStateChanged";
     inline constexpr AZStd::string_view IconsStateChangedUpdaterIdentifier = "o3de.updater.onViewportIconsStateChanged";
-    inline constexpr AZStd::string_view OnlyShowHelpersForSelectedEntitiesUpdaterIdentifier ="o3de.updater.onOnlyShowHelpersForSelectedEntitiesChanged";
     inline constexpr AZStd::string_view LevelLoadedUpdaterIdentifier = "o3de.updater.onLevelLoaded";
+    inline constexpr AZStd::string_view OnlyShowHelpersForSelectedEntitiesUpdaterIdentifier ="o3de.updater.onOnlyShowHelpersForSelectedEntitiesChanged";
     inline constexpr AZStd::string_view RecentFilesChangedUpdaterIdentifier = "o3de.updater.onRecentFilesChanged";
+    inline constexpr AZStd::string_view VertexSelectionChangedUpdaterIdentifier = "o3de.updater.onVertexSelectionChanged";
     inline constexpr AZStd::string_view UndoRedoUpdaterIdentifier = "o3de.updater.onUndoRedo";
     inline constexpr AZStd::string_view ViewportDisplayInfoStateChangedUpdaterIdentifier = "o3de.updater.onViewportDisplayInfoStateChanged";
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
@@ -121,7 +121,7 @@ namespace AzToolsFramework
             actionProperties.m_name = s_duplicateVerticesTitle;
             actionProperties.m_description = s_duplicateVerticesDesc;
             actionProperties.m_category = "Vertex Selection";
-            actionProperties.m_menuVisibility = ActionVisibility::ONLY_IN_ACTIVE_MODE;
+            actionProperties.m_menuVisibility = ActionVisibility::OnlyInActiveMode;
 
             actionManagerInterface->RegisterAction(
                 EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -162,7 +162,7 @@ namespace AzToolsFramework
             actionProperties.m_name = s_deleteVerticesTitle;
             actionProperties.m_description = s_deleteVerticesDesc;
             actionProperties.m_category = "Vertex Selection";
-            actionProperties.m_menuVisibility = ActionVisibility::ONLY_IN_ACTIVE_MODE;
+            actionProperties.m_menuVisibility = ActionVisibility::OnlyInActiveMode;
 
             actionManagerInterface->RegisterAction(
                 EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -203,7 +203,7 @@ namespace AzToolsFramework
             actionProperties.m_name = s_deselectVerticesTitle;
             actionProperties.m_description = s_deselectVerticesDesc;
             actionProperties.m_category = "Vertex Selection";
-            actionProperties.m_menuVisibility = ActionVisibility::ONLY_IN_ACTIVE_MODE;
+            actionProperties.m_menuVisibility = ActionVisibility::OnlyInActiveMode;
 
             actionManagerInterface->RegisterAction(
                 EditorIdentifiers::MainWindowActionContextIdentifier,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
@@ -121,6 +121,7 @@ namespace AzToolsFramework
             actionProperties.m_name = s_duplicateVerticesTitle;
             actionProperties.m_description = s_duplicateVerticesDesc;
             actionProperties.m_category = "Vertex Selection";
+            actionProperties.m_menuVisibility = ActionVisibility::ONLY_IN_ACTIVE_MODE;
 
             actionManagerInterface->RegisterAction(
                 EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -161,6 +162,7 @@ namespace AzToolsFramework
             actionProperties.m_name = s_deleteVerticesTitle;
             actionProperties.m_description = s_deleteVerticesDesc;
             actionProperties.m_category = "Vertex Selection";
+            actionProperties.m_menuVisibility = ActionVisibility::ONLY_IN_ACTIVE_MODE;
 
             actionManagerInterface->RegisterAction(
                 EditorIdentifiers::MainWindowActionContextIdentifier,
@@ -201,6 +203,7 @@ namespace AzToolsFramework
             actionProperties.m_name = s_deselectVerticesTitle;
             actionProperties.m_description = s_deselectVerticesDesc;
             actionProperties.m_category = "Vertex Selection";
+            actionProperties.m_menuVisibility = ActionVisibility::ONLY_IN_ACTIVE_MODE;
 
             actionManagerInterface->RegisterAction(
                 EditorIdentifiers::MainWindowActionContextIdentifier,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
@@ -250,6 +250,23 @@ namespace AzToolsFramework
         menuManagerInterface->AddActionToMenu(EditorIdentifiers::EditMenuIdentifier, "o3de.action.vertexSelection.clearSelection", 6002);
     }
 
+    void EditorVertexSelectionActionManagement::DisableComponentModeEndOnVertexSelection()
+    {
+        auto actionManagerInterface = AZ::Interface<AzToolsFramework::ActionManagerInterface>::Get();
+        AZ_Assert(actionManagerInterface, "EditorVertexSelection - could not get ActionManagerInterface on DisableComponentModeEndOnVertexSelection.");
+
+        // Install an Enabled State Callback to the End Component Mode action to disable it when Vertex Selection is non-empty.
+        actionManagerInterface->InstallEnabledStateCallback(
+            "o3de.action.componentMode.end",
+            []() -> bool
+            {
+                return IsVertexSelectionEmpty();
+            }
+        );
+        actionManagerInterface->AddActionToUpdater(
+            EditorIdentifiers::VertexSelectionChangedUpdaterIdentifier, "o3de.action.componentMode.end");
+    }
+
     static void RefreshUiAfterAddRemove(const AZ::EntityComponentIdPair& entityComponentIdPair)
     {
         // ensure editor entity model (entity inspector) is refreshed

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
@@ -20,6 +20,7 @@
 #include <AzToolsFramework/Editor/ActionManagerIdentifiers/EditorActionUpdaterIdentifiers.h>
 #include <AzToolsFramework/Editor/ActionManagerIdentifiers/EditorContextIdentifiers.h>
 #include <AzToolsFramework/Editor/ActionManagerIdentifiers/EditorMenuIdentifiers.h>
+#include <AzToolsFramework/Editor/ActionManagerUtils.h>
 #include <AzToolsFramework/Manipulators/LinearManipulator.h>
 #include <AzToolsFramework/Manipulators/ManipulatorSnapping.h>
 #include <AzToolsFramework/Manipulators/ManipulatorView.h>
@@ -86,7 +87,7 @@ namespace AzToolsFramework
                 EditorVertexSelectionVariableRequestBus::EventResult(
                     count, entityComponentIdPair, &EditorVertexSelectionVariableRequests::GetSelectedVerticesCount);
 
-                emptySelection = emptySelection && (count == 0);
+                emptySelection = emptySelection && count == 0;
             }
         );
 
@@ -95,9 +96,12 @@ namespace AzToolsFramework
 
     void OnVertexSelectionCountChanged()
     {
-        auto actionManagerInterface = AZ::Interface<AzToolsFramework::ActionManagerInterface>::Get();
-        AZ_Assert(actionManagerInterface, "EditorVertexSelection - could not get ActionManagerInterface.");
-        actionManagerInterface->TriggerActionUpdater(EditorIdentifiers::VertexSelectionChangedUpdaterIdentifier);
+        if (AzToolsFramework::IsNewActionManagerEnabled())
+        {
+            auto actionManagerInterface = AZ::Interface<AzToolsFramework::ActionManagerInterface>::Get();
+            AZ_Assert(actionManagerInterface, "EditorVertexSelection - could not get ActionManagerInterface.");
+            actionManagerInterface->TriggerActionUpdater(EditorIdentifiers::VertexSelectionChangedUpdaterIdentifier);
+        }
     }
 
     void EditorVertexSelectionActionManagement::RegisterEditorVertexSelectionActions()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.h
@@ -338,10 +338,11 @@ namespace AzToolsFramework
         void DuplicateSelected();
         void DestroySelected();
 
-        // EditorVertexSelectionVariableRequests overrides ...
+        // EditorVertexSelectionVariableRequestBus overrides ...
         void DuplicateSelectedVertices() override;
         void DeleteSelectedVertices() override;
         void ClearVertexSelection() override;
+        int GetSelectedVerticesCount() override;
 
     protected:
         // EditorVertexSelectionBase

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.h
@@ -27,6 +27,7 @@ namespace AzToolsFramework
     {
         static void RegisterEditorVertexSelectionActions();
         static void BindEditorVertexSelectionActionsToMenus();
+        static void DisableComponentModeEndOnVertexSelection();
     };
 
     //! Concrete implementation of AZ::VariableVertices backed by an AZ::VertexContainer.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelectionBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelectionBus.h
@@ -19,6 +19,7 @@ namespace AzToolsFramework
         virtual void DuplicateSelectedVertices() = 0;
         virtual void DeleteSelectedVertices() = 0;
         virtual void ClearVertexSelection() = 0;
+        virtual int GetSelectedVerticesCount() = 0;
 
     protected:
         ~EditorVertexSelectionVariableRequests() = default;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -17,6 +17,7 @@ set(FILES
     ActionManager/Action/ActionManagerNotificationBus.h
     ActionManager/Action/EditorAction.cpp
     ActionManager/Action/EditorAction.h
+    ActionManager/Action/EditorActionUtils.h
     ActionManager/Action/EditorActionContext.cpp
     ActionManager/Action/EditorActionContext.h
     ActionManager/Action/EditorWidgetAction.cpp

--- a/Code/Framework/AzToolsFramework/Tests/ActionManager/MenuManagerTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/ActionManager/MenuManagerTests.cpp
@@ -747,7 +747,7 @@ namespace UnitTest
         QMenu* menu = m_menuManagerInternalInterface->GetMenu("o3de.menu.test");
         EXPECT_EQ(menu->actions().size(), 0);
 
-        // Register a new action and add it to the menu. HideFromMenusWhenDisabled is set to true by default.
+        // Register a new action and add it to the menu. MenuVisibility is set to HideWhenDisabled by default.
         m_actionManagerInterface->RegisterActionContext("", "o3de.context.test", {}, m_widget);
         m_actionManagerInterface->RegisterAction("o3de.context.test", "o3de.action.test", {}, []{});
         m_menuManagerInterface->AddActionToMenu("o3de.menu.test", "o3de.action.test", 42);
@@ -786,9 +786,9 @@ namespace UnitTest
         QMenu* menu = m_menuManagerInternalInterface->GetMenu("o3de.menu.test");
         EXPECT_EQ(menu->actions().size(), 0);
 
-        // Register a new action and add it to the menu. Have MenuVisibility set to ALWAYS_SHOW.
+        // Register a new action and add it to the menu. Have MenuVisibility set to AlwaysShow.
         AzToolsFramework::ActionProperties actionProperties;
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterActionContext("", "o3de.context.test", {}, m_widget);
         m_actionManagerInterface->RegisterAction("o3de.context.test", "o3de.action.test", actionProperties, []{});
@@ -860,9 +860,9 @@ namespace UnitTest
         QMenu* menu = m_menuManagerInternalInterface->GetMenu("o3de.menu.test");
         EXPECT_EQ(menu->actions().size(), 0);
 
-        // Register a new action and add it to the default mode. Have MenuVisibility set to ALWAYS_SHOW.
+        // Register a new action and add it to the default mode. Have MenuVisibility set to AlwaysShow.
         AzToolsFramework::ActionProperties actionProperties;
-        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterActionContext("", "o3de.context.test", {}, m_widget);
         m_actionManagerInterface->RegisterAction("o3de.context.test", "o3de.action.test", actionProperties, []{});

--- a/Code/Framework/AzToolsFramework/Tests/ActionManager/ToolBarManagerTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/ActionManager/ToolBarManagerTests.cpp
@@ -153,12 +153,12 @@ namespace UnitTest
 
     TEST_F(ActionManagerFixture, VerifyActionInToolBar)
     {
-        // Register toolbar, get it and verify it's empty.
+        // Register ToolBar, get it and verify it's empty.
         m_toolBarManagerInterface->RegisterToolBar("o3de.toolbar.test", {});
         QToolBar* toolBar = m_toolBarManagerInterface->GetToolBar("o3de.toolbar.test");
         EXPECT_EQ(toolBar->actions().size(), 0);
 
-        // Register a new action and add it to the toolbar.
+        // Register a new action and add it to the ToolBar.
         m_actionManagerInterface->RegisterActionContext("", "o3de.context.test", {}, m_widget);
         m_actionManagerInterface->RegisterAction("o3de.context.test", "o3de.action.test", {}, []{});
         auto outcome = m_toolBarManagerInterface->AddActionToToolBar("o3de.toolbar.test", "o3de.action.test", 42);
@@ -166,18 +166,18 @@ namespace UnitTest
         // Manually trigger ToolBar refresh - Editor will call this once per tick.
         m_toolBarManagerInternalInterface->RefreshToolBars();
 
-        // Verify the action is now in the toolbar.
+        // Verify the action is now in the ToolBar.
         EXPECT_EQ(toolBar->actions().size(), 1);
     }
 
     TEST_F(ActionManagerFixture, VerifyActionOrderInToolBar)
     {
-        // Register toolbar, get it and verify it's empty.
+        // Register ToolBar, get it and verify it's empty.
         m_toolBarManagerInterface->RegisterToolBar("o3de.toolbar.test", {});
         QToolBar* toolBar = m_toolBarManagerInterface->GetToolBar("o3de.toolbar.test");
         EXPECT_EQ(toolBar->actions().size(), 0);
 
-        // Register a new action and add it to the toolbar.
+        // Register a new action and add it to the ToolBar.
         m_actionManagerInterface->RegisterActionContext("", "o3de.context.test", {}, m_widget);
         m_actionManagerInterface->RegisterAction("o3de.context.test", "o3de.action.test1", {}, []{});
         m_actionManagerInterface->RegisterAction("o3de.context.test", "o3de.action.test2", {}, []{});
@@ -187,7 +187,7 @@ namespace UnitTest
         // Manually trigger ToolBar refresh - Editor will call this once per tick.
         m_toolBarManagerInternalInterface->RefreshToolBars();
 
-        // Verify the actions are now in the toolbar.
+        // Verify the actions are now in the ToolBar.
         EXPECT_EQ(toolBar->actions().size(), 2);
 
         // Verify the order is correct.
@@ -201,12 +201,12 @@ namespace UnitTest
 
     TEST_F(ActionManagerFixture, VerifyActionOrderInToolBarWithCollision)
     {
-        // Register toolbar, get it and verify it's empty.
+        // Register ToolBar, get it and verify it's empty.
         m_toolBarManagerInterface->RegisterToolBar("o3de.toolbar.test", {});
         QToolBar* toolBar = m_toolBarManagerInterface->GetToolBar("o3de.toolbar.test");
         EXPECT_EQ(toolBar->actions().size(), 0);
         
-        // Register a new action and add it to the toolbar.
+        // Register a new action and add it to the ToolBar.
         m_actionManagerInterface->RegisterActionContext("", "o3de.context.test", {}, m_widget);
         m_actionManagerInterface->RegisterAction("o3de.context.test", "o3de.action.test1", {}, []{});
         m_actionManagerInterface->RegisterAction("o3de.context.test", "o3de.action.test2", {}, []{});
@@ -216,7 +216,7 @@ namespace UnitTest
         // Manually trigger ToolBar refresh - Editor will call this once per tick.
         m_toolBarManagerInternalInterface->RefreshToolBars();
 
-        // Verify the actions are now in the toolbar.
+        // Verify the actions are now in the ToolBar.
         EXPECT_EQ(toolBar->actions().size(), 2);
 
         // Verify the order is correct (when a collision happens, items should be in order of addition).
@@ -230,18 +230,18 @@ namespace UnitTest
 
     TEST_F(ActionManagerFixture, VerifySeparatorInToolBar)
     {
-        // Register toolbar, get it and verify it's empty.
+        // Register ToolBar, get it and verify it's empty.
         m_toolBarManagerInterface->RegisterToolBar("o3de.toolbar.test", {});
         QToolBar* toolBar = m_toolBarManagerInterface->GetToolBar("o3de.toolbar.test");
         EXPECT_EQ(toolBar->actions().size(), 0);
 
-        // Add a separator to the toolbar.
+        // Add a separator to the ToolBar.
         m_toolBarManagerInterface->AddSeparatorToToolBar("o3de.toolbar.test", 42);
 
         // Manually trigger ToolBar refresh - Editor will call this once per tick.
         m_toolBarManagerInternalInterface->RefreshToolBars();
 
-        // Verify the separator is now in the toolbar.
+        // Verify the separator is now in the ToolBar.
         const auto& actions = toolBar->actions();
 
         EXPECT_EQ(actions.size(), 1);
@@ -250,7 +250,7 @@ namespace UnitTest
 
     TEST_F(ActionManagerFixture, AddUnregisteredWidgetInToolBar)
     {
-        // Register toolbar.
+        // Register ToolBar.
         m_toolBarManagerInterface->RegisterToolBar("o3de.toolbar.test", {});
 
         // Try to add a nullptr widget.
@@ -260,7 +260,7 @@ namespace UnitTest
 
     TEST_F(ActionManagerFixture, VerifyWidgetInToolBar)
     {
-        // Register toolbar and widget action.
+        // Register ToolBar and widget action.
         m_toolBarManagerInterface->RegisterToolBar("o3de.toolbar.test", {});
 
         QWidget* widget = new QWidget();
@@ -275,13 +275,13 @@ namespace UnitTest
             }
         );
 
-        // Add the widget to the toolbar.
+        // Add the widget to the ToolBar.
         m_toolBarManagerInterface->AddWidgetToToolBar("o3de.toolbar.test", "o3de.widgetAction.test", 42);
 
         // Manually trigger ToolBar refresh - Editor will call this once per tick.
         m_toolBarManagerInternalInterface->RefreshToolBars();
 
-        // Verify the separator is now in the menu.
+        // Verify the separator is now in the ToolBar.
         QToolBar* toolBar = m_toolBarManagerInterface->GetToolBar("o3de.toolbar.test");
         const auto& actions = toolBar->actions();
 
@@ -301,7 +301,7 @@ namespace UnitTest
         m_actionManagerInterface->RegisterAction("o3de.context.test", "o3de.action.test1", {}, []{});
         m_actionManagerInterface->RegisterAction("o3de.context.test", "o3de.action.test2", {}, []{});
 
-        // Create a toolbar with this setup. Order of addition is intentionally scrambled to verify sortKeys.
+        // Create a ToolBar with this setup. Order of addition is intentionally scrambled to verify sortKeys.
         // - Test 1 Action
         // - Separator
         // - Test 2 Action
@@ -309,7 +309,7 @@ namespace UnitTest
         m_toolBarManagerInterface->AddActionToToolBar("o3de.toolbar.test", "o3de.action.test1", 1);
         m_toolBarManagerInterface->AddSeparatorToToolBar("o3de.toolbar.test", 10);
 
-        // Verify the actions are now in the toolbar in the expected order.
+        // Verify the actions are now in the ToolBar in the expected order.
         QToolBar* toolBar = m_toolBarManagerInterface->GetToolBar("o3de.toolbar.test");
         QAction* test1 = m_actionManagerInternalInterface->GetAction("o3de.action.test1");
         QAction* test2 = m_actionManagerInternalInterface->GetAction("o3de.action.test2");
@@ -317,7 +317,7 @@ namespace UnitTest
         // Manually trigger ToolBar refresh - Editor will call this once per tick.
         m_toolBarManagerInternalInterface->RefreshToolBars();
 
-        // Note: separators and sub-menus are still QActions in the context of the toolbar.
+        // Note: separators are still QActions in the context of the ToolBar.
         const auto& actions = toolBar->actions();
         EXPECT_EQ(actions.size(), 3);
 
@@ -359,13 +359,13 @@ namespace UnitTest
         m_toolBarManagerInterface->RegisterToolBarArea("o3de.toolbararea.test", m_mainWindow, Qt::ToolBarArea::TopToolBarArea);
         m_toolBarManagerInterface->RegisterToolBar("o3de.toolbar.test", {});
 
-        // Add the toolbar to the toolbar area.
+        // Add the ToolBar to the toolbar area.
         m_toolBarManagerInterface->AddToolBarToToolBarArea("o3de.toolbararea.test", "o3de.toolbar.test", 42);
 
-        // Manually trigger toolbar refresh - Editor will call this once per tick.
+        // Manually trigger ToolBar refresh - Editor will call this once per tick.
         m_toolBarManagerInternalInterface->RefreshToolBarAreas();
 
-        // Verify the toolbar is now in the toolbar area.
+        // Verify the ToolBar is now in the ToolBar Area.
         QToolBar* toolBar = m_toolBarManagerInterface->GetToolBar("o3de.toolbar.test");
         EXPECT_EQ(m_mainWindow->toolBarArea(toolBar), Qt::ToolBarArea::TopToolBarArea);
     }
@@ -376,7 +376,7 @@ namespace UnitTest
         m_actionManagerInterface->RegisterActionContext("", "o3de.context.test", {}, m_widget);
         m_actionManagerInterface->RegisterAction("o3de.context.test", "o3de.action.test", {}, []{});
 
-        // Add the action to the toolbar.
+        // Add the action to the ToolBar.
         m_toolBarManagerInterface->AddActionToToolBar("o3de.toolbar.test", "o3de.action.test", 42);
 
         // Verify the API returns the correct sort key.
@@ -400,7 +400,7 @@ namespace UnitTest
         m_actionManagerInterface->RegisterActionContext("", "o3de.context.test", {}, m_widget);
         m_actionManagerInterface->RegisterAction("o3de.context.test", "o3de.action.test", {}, []{});
 
-        // Verify the API fails as the action is registered but was not added to the toolbar.
+        // Verify the API fails as the action is registered but was not added to the ToolBar.
         auto outcome = m_toolBarManagerInterface->GetSortKeyOfActionInToolBar("o3de.toolbar.test", "o3de.action.test");
         EXPECT_FALSE(outcome.IsSuccess());
     }
@@ -417,7 +417,7 @@ namespace UnitTest
             }
         );
 
-        // Add the widget to the toolBar.
+        // Add the widget to the ToolBar.
         m_toolBarManagerInterface->AddWidgetToToolBar("o3de.toolbar.test", "o3de.widgetAction.test", 42);
 
         // Verify the API returns the correct sort key.
@@ -447,21 +447,21 @@ namespace UnitTest
             }
         );
 
-        // Verify the API fails as the widget is registered but was not added to the toolBar.
+        // Verify the API fails as the widget is registered but was not added to the ToolBar.
         auto outcome = m_toolBarManagerInterface->GetSortKeyOfWidgetInToolBar("o3de.toolbar.test", "o3de.widgetAction.test");
         EXPECT_FALSE(outcome.IsSuccess());
     }
 
-    TEST_F(ActionManagerFixture, VerifyHideFromToolBarsWhenDisabledTrue)
+    TEST_F(ActionManagerFixture, VerifyToolBarVisibilityHideWhenDisabled)
     {
         // Register toolbar, get it and verify it's empty.
         m_toolBarManagerInterface->RegisterToolBar("o3de.toolbar.test", {});
         QToolBar* toolBar = m_toolBarManagerInterface->GetToolBar("o3de.toolbar.test");
         EXPECT_EQ(toolBar->actions().size(), 0);
 
-        // Register a new action and add it to the menu. Have HideFromToolBarsWhenDisabled set to true.
+        // Register a new action and add it to the ToolBar. Have ToolBarVisibility set to HIDE_WHEN_DISABLED.
         AzToolsFramework::ActionProperties actionProperties;
-        actionProperties.m_hideFromToolBarsWhenDisabled = true;
+        actionProperties.m_toolBarVisibility = AzToolsFramework::ActionVisibility::HIDE_WHEN_DISABLED;
 
         m_actionManagerInterface->RegisterActionContext("", "o3de.context.test", {}, m_widget);
         m_actionManagerInterface->RegisterAction("o3de.context.test", "o3de.action.test", actionProperties, []{});
@@ -480,7 +480,7 @@ namespace UnitTest
         // Manually trigger ToolBar refresh - Editor will call this once per tick.
         m_toolBarManagerInternalInterface->RefreshToolBars();
 
-        // Verify the action is now in the menu.
+        // Verify the action is now in the ToolBar.
         EXPECT_EQ(toolBar->actions().size(), 1);
 
         // Set the action as disabled.
@@ -490,18 +490,18 @@ namespace UnitTest
         // Manually trigger ToolBar refresh - Editor will call this once per tick.
         m_toolBarManagerInternalInterface->RefreshToolBars();
 
-        // Verify the action is no longer in the toolbar.
+        // Verify the action is no longer in the ToolBar.
         EXPECT_EQ(toolBar->actions().size(), 0);
     }
 
-    TEST_F(ActionManagerFixture, VerifyHideFromToolBarsWhenDisabledFalse)
+    TEST_F(ActionManagerFixture, VerifyDefaultToolBarVisibility)
     {
-        // Register toolbar, get it and verify it's empty.
+        // Register ToolBar, get it and verify it's empty.
         m_toolBarManagerInterface->RegisterToolBar("o3de.toolbar.test", {});
         QToolBar* toolBar = m_toolBarManagerInterface->GetToolBar("o3de.toolbar.test");
         EXPECT_EQ(toolBar->actions().size(), 0);
 
-        // Register a new action and add it to the menu. HideFromToolBarsWhenDisabled is set to false by default.
+        // Register a new action and add it to the menu. ToolBarVisibility is set to ONLY_IN_ACTIVE_MODE by default.
         m_actionManagerInterface->RegisterActionContext("", "o3de.context.test", {}, m_widget);
         m_actionManagerInterface->RegisterAction("o3de.context.test", "o3de.action.test", {}, []{});
         m_toolBarManagerInterface->AddActionToToolBar("o3de.toolbar.test", "o3de.action.test", 42);
@@ -519,7 +519,7 @@ namespace UnitTest
         // Manually trigger ToolBar refresh - Editor will call this once per tick.
         m_toolBarManagerInternalInterface->RefreshToolBars();
 
-        // Verify the action is now in the menu.
+        // Verify the action is now in the ToolBar.
         EXPECT_EQ(toolBar->actions().size(), 1);
 
         // Set the action as disabled.
@@ -529,7 +529,42 @@ namespace UnitTest
         // Manually trigger ToolBar refresh - Editor will call this once per tick.
         m_toolBarManagerInternalInterface->RefreshToolBars();
 
-        // Verify the action is still in the toolbar.
+        // Verify the action is still in the ToolBar.
+        EXPECT_EQ(toolBar->actions().size(), 1);
+    }
+
+    TEST_F(ActionManagerFixture, VerifyToolBarVisibilityAlwaysShowWhenChangingMode)
+    {
+        // Register ToolBar, get it and verify it's empty.
+        m_toolBarManagerInterface->RegisterToolBar("o3de.toolbar.test", {});
+        QToolBar* toolBar = m_toolBarManagerInterface->GetToolBar("o3de.toolbar.test");
+        EXPECT_EQ(toolBar->actions().size(), 0);
+
+        // Register a new action and add it to the default mode. Set ToolBarVisibility to ALWAYS_SHOW.
+        AzToolsFramework::ActionProperties actionProperties;
+        actionProperties.m_toolBarVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+
+        m_actionManagerInterface->RegisterActionContext("", "o3de.context.test", {}, m_widget);
+        m_actionManagerInterface->RegisterAction("o3de.context.test", "o3de.action.test", actionProperties, []{});
+        m_actionManagerInterface->AssignModeToAction(AzToolsFramework::DefaultActionContextModeIdentifier, "o3de.action.test");
+
+        // Add the action to the ToolBar.
+        m_toolBarManagerInterface->AddActionToToolBar("o3de.toolbar.test", "o3de.action.test", 42);
+
+        // Manually trigger ToolBar refresh - Editor will call this once per tick.
+        m_toolBarManagerInternalInterface->RefreshToolBars();
+
+        // Verify the action is now in the ToolBar.
+        EXPECT_EQ(toolBar->actions().size(), 1);
+
+        // Register a new mode and switch to it.
+        m_actionManagerInterface->RegisterActionContextMode("o3de.context.test", "testMode");
+        m_actionManagerInterface->SetActiveActionContextMode("o3de.context.test", "testMode");
+
+        // Manually trigger ToolBar refresh - Editor will call this once per tick.
+        m_toolBarManagerInternalInterface->RefreshToolBars();
+
+        // Verify the action is still in the ToolBar.
         EXPECT_EQ(toolBar->actions().size(), 1);
     }
 

--- a/Code/Framework/AzToolsFramework/Tests/ActionManager/ToolBarManagerTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/ActionManager/ToolBarManagerTests.cpp
@@ -459,9 +459,9 @@ namespace UnitTest
         QToolBar* toolBar = m_toolBarManagerInterface->GetToolBar("o3de.toolbar.test");
         EXPECT_EQ(toolBar->actions().size(), 0);
 
-        // Register a new action and add it to the ToolBar. Have ToolBarVisibility set to HIDE_WHEN_DISABLED.
+        // Register a new action and add it to the ToolBar. Have ToolBarVisibility set to HideWhenDisabled.
         AzToolsFramework::ActionProperties actionProperties;
-        actionProperties.m_toolBarVisibility = AzToolsFramework::ActionVisibility::HIDE_WHEN_DISABLED;
+        actionProperties.m_toolBarVisibility = AzToolsFramework::ActionVisibility::HideWhenDisabled;
 
         m_actionManagerInterface->RegisterActionContext("", "o3de.context.test", {}, m_widget);
         m_actionManagerInterface->RegisterAction("o3de.context.test", "o3de.action.test", actionProperties, []{});
@@ -501,7 +501,7 @@ namespace UnitTest
         QToolBar* toolBar = m_toolBarManagerInterface->GetToolBar("o3de.toolbar.test");
         EXPECT_EQ(toolBar->actions().size(), 0);
 
-        // Register a new action and add it to the menu. ToolBarVisibility is set to ONLY_IN_ACTIVE_MODE by default.
+        // Register a new action and add it to the menu. ToolBarVisibility is set to OnlyInActiveMode by default.
         m_actionManagerInterface->RegisterActionContext("", "o3de.context.test", {}, m_widget);
         m_actionManagerInterface->RegisterAction("o3de.context.test", "o3de.action.test", {}, []{});
         m_toolBarManagerInterface->AddActionToToolBar("o3de.toolbar.test", "o3de.action.test", 42);
@@ -540,9 +540,9 @@ namespace UnitTest
         QToolBar* toolBar = m_toolBarManagerInterface->GetToolBar("o3de.toolbar.test");
         EXPECT_EQ(toolBar->actions().size(), 0);
 
-        // Register a new action and add it to the default mode. Set ToolBarVisibility to ALWAYS_SHOW.
+        // Register a new action and add it to the default mode. Set ToolBarVisibility to AlwaysShow.
         AzToolsFramework::ActionProperties actionProperties;
-        actionProperties.m_toolBarVisibility = AzToolsFramework::ActionVisibility::ALWAYS_SHOW;
+        actionProperties.m_toolBarVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
         m_actionManagerInterface->RegisterActionContext("", "o3de.context.test", {}, m_widget);
         m_actionManagerInterface->RegisterAction("o3de.context.test", "o3de.action.test", actionProperties, []{});

--- a/Gems/LmbrCentral/Code/Source/LmbrCentralEditor.cpp
+++ b/Gems/LmbrCentral/Code/Source/LmbrCentralEditor.cpp
@@ -147,6 +147,12 @@ namespace LmbrCentral
             AzToolsFramework::BoxComponentMode::BindActionsToMenus();
         }
     }
+
+    void LmbrCentralEditorModule::OnPostActionManagerRegistrationHook()
+    {
+        EditorSplineComponentMode::PostActionManagerRegistration();
+    }
+
 } // namespace LmbrCentral
 
 AZ_DECLARE_MODULE_CLASS(Gem_LmbrCentralEditor, LmbrCentral::LmbrCentralEditorModule)

--- a/Gems/LmbrCentral/Code/Source/LmbrCentralEditor.cpp
+++ b/Gems/LmbrCentral/Code/Source/LmbrCentralEditor.cpp
@@ -150,7 +150,7 @@ namespace LmbrCentral
 
     void LmbrCentralEditorModule::OnPostActionManagerRegistrationHook()
     {
-        EditorSplineComponentMode::PostActionManagerRegistration();
+        AzToolsFramework::EditorVertexSelectionActionManagement::DisableComponentModeEndOnVertexSelection();
     }
 
 } // namespace LmbrCentral

--- a/Gems/LmbrCentral/Code/Source/LmbrCentralEditor.h
+++ b/Gems/LmbrCentral/Code/Source/LmbrCentralEditor.h
@@ -36,5 +36,6 @@ namespace LmbrCentral
         void OnActionRegistrationHook() override;
         void OnActionContextModeBindingHook() override;
         void OnMenuBindingHook() override;
+        void OnPostActionManagerRegistrationHook() override;
     };
 } // namespace LmbrCentral

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorSplineComponentMode.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorSplineComponentMode.cpp
@@ -68,6 +68,11 @@ namespace LmbrCentral
         AzToolsFramework::EditorVertexSelectionActionManagement::BindEditorVertexSelectionActionsToMenus();
     }
 
+    void EditorSplineComponentMode::PostActionManagerRegistration()
+    {
+        AzToolsFramework::EditorVertexSelectionActionManagement::DisableComponentModeEndOnVertexSelection();
+    }
+
     void EditorSplineComponentMode::Refresh()
     {
         ContainerChanged();

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorSplineComponentMode.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorSplineComponentMode.cpp
@@ -50,7 +50,7 @@ namespace LmbrCentral
     void EditorSplineComponentMode::BindActionsToModes()
     {
         auto actionManagerInterface = AZ::Interface<AzToolsFramework::ActionManagerInterface>::Get();
-        AZ_Assert(actionManagerInterface, "EditorVertexSelection - could not get ActionManagerInterface on RegisterActions.");
+        AZ_Assert(actionManagerInterface, "EditorSplineComponentMode - could not get ActionManagerInterface on RegisterActions.");
 
         AZ::SerializeContext* serializeContext = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorSplineComponentMode.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorSplineComponentMode.cpp
@@ -68,11 +68,6 @@ namespace LmbrCentral
         AzToolsFramework::EditorVertexSelectionActionManagement::BindEditorVertexSelectionActionsToMenus();
     }
 
-    void EditorSplineComponentMode::PostActionManagerRegistration()
-    {
-        AzToolsFramework::EditorVertexSelectionActionManagement::DisableComponentModeEndOnVertexSelection();
-    }
-
     void EditorSplineComponentMode::Refresh()
     {
         ContainerChanged();

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorSplineComponentMode.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorSplineComponentMode.h
@@ -36,6 +36,7 @@ namespace LmbrCentral
         static void RegisterActions();
         static void BindActionsToModes();
         static void BindActionsToMenus();
+        static void PostActionManagerRegistration();
 
     private:
         // EditorBaseComponentMode

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorSplineComponentMode.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorSplineComponentMode.h
@@ -36,7 +36,6 @@ namespace LmbrCentral
         static void RegisterActions();
         static void BindActionsToModes();
         static void BindActionsToMenus();
-        static void PostActionManagerRegistration();
 
     private:
         // EditorBaseComponentMode


### PR DESCRIPTION
## What does this PR do?
Refactors a couple Action Manager systems to give clients more versatility and allow for better UX.

- Allow multiple Enabled State Callbacks to be installed on an Action. The enabled state of the Action will be determined by chaining the results with an AND (so if any of the callbacks returns false, the Action will be disabled).
- Refactor the Action Visibility properties to allow for actions to be shown as greyed out when disabled while in an Action Context Mode where they are active, but be hidden otherwise. The bool values have been replaced with an enum so that more granularity can be provided.

This allowed to refactor the Spline Component Mode so that the End Component Mode (`Done`) action can be disabled when any of the Spline Vertices is selected. This way, pressing `Esc` when a selection is present will just empty the selection without leaving Component Mode, and another `Esc` button press is needed to actually go back to regular editing.

![NestedEsc](https://user-images.githubusercontent.com/82231674/216338814-fb204995-ea96-4a57-ba05-43b112dd3928.gif)
_(Whenever something happens with no mouse movement, I'm pressing `Esc`)._

## How was this PR tested?

Added Unit Tests for new functionality. Manual testing for the UX changes.

```
Note: Google Test filter = *ActionManagerFixture*
[==========] Running 143 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 143 tests from ActionManagerFixture
[ RUN      ] ActionManagerFixture.RegisterActionContextWithoutWidget
[       OK ] ActionManagerFixture.RegisterActionContextWithoutWidget (25 ms)
[ RUN      ] ActionManagerFixture.RegisterActionContext
[       OK ] ActionManagerFixture.RegisterActionContext (2 ms)
...
[ RUN      ] ActionManagerFixture.VerifyDefaultToolBarVisibility
[       OK ] ActionManagerFixture.VerifyDefaultToolBarVisibility (4 ms)
[ RUN      ] ActionManagerFixture.VerifyToolBarVisibilityAlwaysShowWhenChangingMode
[       OK ] ActionManagerFixture.VerifyToolBarVisibilityAlwaysShowWhenChangingMode (4 ms)
[----------] 143 tests from ActionManagerFixture (493 ms total)

[----------] Global test environment tear-down
[==========] 143 tests from 1 test case ran. (496 ms total)
[  PASSED  ] 143 tests.
```