### PR TITLE
Mbalfour/networking init cleanups

### DIFF
--- a/Gems/AWSCore/Code/Source/AWSCoreSystemComponent.cpp
+++ b/Gems/AWSCore/Code/Source/AWSCoreSystemComponent.cpp
@@ -137,12 +137,21 @@ namespace AWSCore
 
     void AWSCoreSystemComponent::InitAWSApi()
     {
-        AWSNativeSDKInit::InitializationManager::InitAwsApi();
+        // Multiple different Gems might try to use the AWSNativeSDK, so make sure it only gets initialized / shutdown once
+        // by the first Gem to try using it.
+        m_ownsAwsNativeInitialization = !AWSNativeSDKInit::InitializationManager::IsInitialized();
+        if (m_ownsAwsNativeInitialization)
+        {
+            AWSNativeSDKInit::InitializationManager::InitAwsApi();
+        }
     }
 
     void AWSCoreSystemComponent::ShutdownAWSApi()
     {
-        AWSNativeSDKInit::InitializationManager::Shutdown();
+        if (m_ownsAwsNativeInitialization)
+        {
+            AWSNativeSDKInit::InitializationManager::Shutdown();
+        }
     }
 
     AZ::JobContext* AWSCoreSystemComponent::GetDefaultJobContext()

--- a/Gems/AWSCore/Code/Source/AWSCoreSystemComponent.h
+++ b/Gems/AWSCore/Code/Source/AWSCoreSystemComponent.h
@@ -77,6 +77,8 @@ namespace AWSCore
         AZStd::unique_ptr<AWSCoreConfiguration> m_awsCoreConfiguration;
         AZStd::unique_ptr<AWSCredentialManager> m_awsCredentialManager;
         AZStd::unique_ptr<AWSResourceMappingManager> m_awsResourceMappingManager;
+
+        bool m_ownsAwsNativeInitialization; // Track whether or not this module initialized the native layer
     };
 
 } // namespace AWSCore

--- a/Gems/AWSCore/Code/Source/AWSCoreSystemComponent.h
+++ b/Gems/AWSCore/Code/Source/AWSCoreSystemComponent.h
@@ -78,7 +78,7 @@ namespace AWSCore
         AZStd::unique_ptr<AWSCredentialManager> m_awsCredentialManager;
         AZStd::unique_ptr<AWSResourceMappingManager> m_awsResourceMappingManager;
 
-        bool m_ownsAwsNativeInitialization; // Track whether or not this module initialized the native layer
+        bool m_ownsAwsNativeInitialization = false; // Track whether or not this module initialized the native layer
     };
 
 } // namespace AWSCore

--- a/Gems/HttpRequestor/Code/Source/HttpRequestManager.h
+++ b/Gems/HttpRequestor/Code/Source/HttpRequestManager.h
@@ -53,7 +53,7 @@ namespace HttpRequestor
         AZStd::atomic<bool>                     m_runThread;                        // Run flag used to signal the worker thread
         AZStd::thread                           m_thread;                           // This is the thread that will be used for all async operations
         static const char*                      s_loggingName;                      // Name to use for log messages etc...
-        bool                                    m_ownsAwsNativeInitialization;      // Whether or not this module initialized the native layer
+        bool                                    m_ownsAwsNativeInitialization = false; // Whether or not this module initialized the native layer
     };
 
     using ManagerPtr = AZStd::shared_ptr<Manager>;

--- a/Gems/HttpRequestor/Code/Source/HttpRequestManager.h
+++ b/Gems/HttpRequestor/Code/Source/HttpRequestManager.h
@@ -53,6 +53,7 @@ namespace HttpRequestor
         AZStd::atomic<bool>                     m_runThread;                        // Run flag used to signal the worker thread
         AZStd::thread                           m_thread;                           // This is the thread that will be used for all async operations
         static const char*                      s_loggingName;                      // Name to use for log messages etc...
+        bool                                    m_ownsAwsNativeInitialization;      // Whether or not this module initialized the native layer
     };
 
     using ManagerPtr = AZStd::shared_ptr<Manager>;

--- a/Gems/Multiplayer/Code/CMakeLists.txt
+++ b/Gems/Multiplayer/Code/CMakeLists.txt
@@ -47,6 +47,20 @@ ly_add_target(
         *.AutoPackets.xml,AutoPacketDispatcher_Inline.jinja,$path/$fileprefix.AutoPacketDispatcher.inl
 )
 
+# Typically, the Editor Connection Listener is enabled in all regular builds, and disabled in all monolithic builds.
+# This can be overridden by passing -DFORCE_ENABLE_O3DE_EDITOR_CONNECTION_LISTENER=0 or 1 when generating the build files.
+# The override can be removed by passing -UFORCE_ENABLE_O3DE_EDITOR_CONNECTION_LISTENER when generating the build files.
+set(FORCE_ENABLE_O3DE_EDITOR_CONNECTION_LISTENER "" CACHE STRING 
+"Overrides the creation of the Editor Connection Listener.
+  If unset, it is only created in non-monolithic builds.
+  0 always disables the Editor Connection Listener.
+  1 always enables the Editor Connection Listener.")
+
+# If there's a value in FORCE_ENABLE_O3DE_EDITOR_CONNECTION_LISTENER, the compiler flag will get set to it.
+# Otherwise, the variable will be empty and no compiler flag will be set, leaving it to the code to decide
+# whether or not to include the listener.
+set(O3DE_EDITOR_CONNECTION_LISTENER_ENABLE_FLAG $<$<NOT:$<STREQUAL:"${FORCE_ENABLE_O3DE_EDITOR_CONNECTION_LISTENER}","">>:O3DE_EDITOR_CONNECTION_LISTENER_ENABLE=$<BOOL:${FORCE_ENABLE_O3DE_EDITOR_CONNECTION_LISTENER}>>)
+
 ly_add_target(
     NAME Multiplayer.Client.Static STATIC
     NAMESPACE Gem
@@ -63,6 +77,7 @@ ly_add_target(
         PUBLIC
             AZ_TRAIT_CLIENT=1
             AZ_TRAIT_SERVER=0
+            ${O3DE_EDITOR_CONNECTION_LISTENER_ENABLE_FLAG}
     BUILD_DEPENDENCIES
         PUBLIC
             Gem::Multiplayer.Common.Static
@@ -92,6 +107,7 @@ ly_add_target(
         PUBLIC
             AZ_TRAIT_CLIENT=0
             AZ_TRAIT_SERVER=1
+            ${O3DE_EDITOR_CONNECTION_LISTENER_ENABLE_FLAG}
     BUILD_DEPENDENCIES
         PUBLIC
             Gem::Multiplayer.Common.Static
@@ -121,6 +137,7 @@ ly_add_target(
         PUBLIC
             AZ_TRAIT_CLIENT=1
             AZ_TRAIT_SERVER=1
+            ${O3DE_EDITOR_CONNECTION_LISTENER_ENABLE_FLAG}
     BUILD_DEPENDENCIES
         PUBLIC
             Gem::Multiplayer.Common.Static

--- a/Gems/Multiplayer/Code/CMakeLists.txt
+++ b/Gems/Multiplayer/Code/CMakeLists.txt
@@ -105,6 +105,12 @@ ly_add_target(
         *.AutoComponent.xml,AutoComponentTypes_Source.jinja,$path/AutoComponentTypes.cpp
 )
 
+# By default, enable the Editor connection listener in everything but release builds.
+# Override this with -DO3DE_EDITOR_CONNECTION_LISTENER_ENABLE=0 or 1 if you want to use a non-default value.
+# Clear with -UO3DE_EDITOR_CONNECTION_LISTENER_ENABLE to go back to the defaults.
+set(O3DE_EDITOR_CONNECTION_LISTENER_ENABLE $<IF:$<CONFIG:Release>,0,1> CACHE BOOL 
+	"Sets whether or not to enable the Editor connection listener.")
+
 ly_add_target(
     NAME Multiplayer.Unified.Static STATIC
     NAMESPACE Gem
@@ -121,6 +127,7 @@ ly_add_target(
         PUBLIC
             AZ_TRAIT_CLIENT=1
             AZ_TRAIT_SERVER=1
+            O3DE_EDITOR_CONNECTION_LISTENER_ENABLE=${O3DE_EDITOR_CONNECTION_LISTENER_ENABLE}
     BUILD_DEPENDENCIES
         PUBLIC
             Gem::Multiplayer.Common.Static

--- a/Gems/Multiplayer/Code/CMakeLists.txt
+++ b/Gems/Multiplayer/Code/CMakeLists.txt
@@ -109,7 +109,7 @@ ly_add_target(
 # Override this with -DO3DE_EDITOR_CONNECTION_LISTENER_ENABLE=0 or 1 if you want to use a non-default value.
 # Clear with -UO3DE_EDITOR_CONNECTION_LISTENER_ENABLE to go back to the defaults.
 set(O3DE_EDITOR_CONNECTION_LISTENER_ENABLE $<IF:$<CONFIG:Release>,0,1> CACHE BOOL 
-	"Sets whether or not to enable the Editor connection listener.")
+    "Sets whether or not to enable the Editor connection listener.")
 
 ly_add_target(
     NAME Multiplayer.Unified.Static STATIC

--- a/Gems/Multiplayer/Code/CMakeLists.txt
+++ b/Gems/Multiplayer/Code/CMakeLists.txt
@@ -105,12 +105,6 @@ ly_add_target(
         *.AutoComponent.xml,AutoComponentTypes_Source.jinja,$path/AutoComponentTypes.cpp
 )
 
-# By default, enable the Editor connection listener in everything but release builds.
-# Override this with -DO3DE_EDITOR_CONNECTION_LISTENER_ENABLE=0 or 1 if you want to use a non-default value.
-# Clear with -UO3DE_EDITOR_CONNECTION_LISTENER_ENABLE to go back to the defaults.
-set(O3DE_EDITOR_CONNECTION_LISTENER_ENABLE $<IF:$<CONFIG:Release>,0,1> CACHE BOOL 
-    "Sets whether or not to enable the Editor connection listener.")
-
 ly_add_target(
     NAME Multiplayer.Unified.Static STATIC
     NAMESPACE Gem
@@ -127,7 +121,6 @@ ly_add_target(
         PUBLIC
             AZ_TRAIT_CLIENT=1
             AZ_TRAIT_SERVER=1
-            O3DE_EDITOR_CONNECTION_LISTENER_ENABLE=${O3DE_EDITOR_CONNECTION_LISTENER_ENABLE}
     BUILD_DEPENDENCIES
         PUBLIC
             Gem::Multiplayer.Common.Static

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -263,7 +263,7 @@ namespace Multiplayer
 
     void MultiplayerSystemComponent::Activate()
     {
-#if !defined(AZ_RELEASE_BUILD)
+#if (O3DE_EDITOR_CONNECTION_LISTENER_ENABLE)
         m_editorConnectionListener = AZStd::make_unique<MultiplayerEditorConnection>();
 #endif
 
@@ -351,7 +351,7 @@ namespace Multiplayer
 
         m_networkEntityManager.Reset();
 
-#if !defined(AZ_RELEASE_BUILD)
+#if (O3DE_EDITOR_CONNECTION_LISTENER_ENABLE)
         m_editorConnectionListener.reset();
 #endif
     }

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -263,7 +263,7 @@ namespace Multiplayer
 
     void MultiplayerSystemComponent::Activate()
     {
-#if (O3DE_EDITOR_CONNECTION_LISTENER_ENABLE)
+#if !defined(AZ_RELEASE_BUILD)
         m_editorConnectionListener = AZStd::make_unique<MultiplayerEditorConnection>();
 #endif
 
@@ -351,7 +351,7 @@ namespace Multiplayer
 
         m_networkEntityManager.Reset();
 
-#if (O3DE_EDITOR_CONNECTION_LISTENER_ENABLE)
+#if !defined(AZ_RELEASE_BUILD)
         m_editorConnectionListener.reset();
 #endif
     }

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -263,6 +263,10 @@ namespace Multiplayer
 
     void MultiplayerSystemComponent::Activate()
     {
+#if !defined(AZ_RELEASE_BUILD)
+        m_editorConnectionListener = AZStd::make_unique<MultiplayerEditorConnection>();
+#endif
+
         RegisterMetrics();
 
         AzFramework::RootSpawnableNotificationBus::Handler::BusConnect();
@@ -346,6 +350,10 @@ namespace Multiplayer
         AzFramework::RootSpawnableNotificationBus::Handler::BusDisconnect();
 
         m_networkEntityManager.Reset();
+
+#if !defined(AZ_RELEASE_BUILD)
+        m_editorConnectionListener.reset();
+#endif
     }
 
     bool MultiplayerSystemComponent::StartHosting(uint16_t port, bool isDedicated)

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
@@ -245,7 +245,10 @@ namespace Multiplayer
         } };
 
 #if !defined(AZ_RELEASE_BUILD)
-        MultiplayerEditorConnection m_editorConnectionListener;
+        // This is a unique_ptr instead of a raw instance so that we can defer the construction
+        // until the Activate(). If it gets constructed during the MultiplayerSystemComponent constructor,
+        // the AzNetworking systems might not be constructed and activated yet, which would crash.
+        AZStd::unique_ptr<MultiplayerEditorConnection> m_editorConnectionListener;
 #endif
     };
 }

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
@@ -245,7 +245,7 @@ namespace Multiplayer
         } };
 
         // By default, this is enabled in everything but release builds.
-#if (O3DE_EDITOR_CONNECTION_LISTENER_ENABLE)
+#if !defined(AZ_RELEASE_BUILD)
         // This is a unique_ptr instead of a raw instance so that we can defer the construction
         // until the Activate(). If it gets constructed during the MultiplayerSystemComponent constructor,
         // the AzNetworking systems might not be constructed and activated yet, which would crash.

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
@@ -244,7 +244,8 @@ namespace Multiplayer
             OnPhysicsPostSimulate(dt);
         } };
 
-#if !defined(AZ_RELEASE_BUILD)
+        // By default, this is enabled in everything but release builds.
+#if (O3DE_EDITOR_CONNECTION_LISTENER_ENABLE)
         // This is a unique_ptr instead of a raw instance so that we can defer the construction
         // until the Activate(). If it gets constructed during the MultiplayerSystemComponent constructor,
         // the AzNetworking systems might not be constructed and activated yet, which would crash.

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
@@ -25,6 +25,15 @@
 #include <AzFramework/Physics/Common/PhysicsEvents.h>
 #include <AzNetworking/ConnectionLayer/IConnectionListener.h>
 
+// This can be overridden in the build files by defining O3DE_EDITOR_CONNECTION_LISTENER_ENABLE to 0 or 1
+// to force disabling or enabling the listener. But by default, it will be enabled in non-monolithic builds
+// and disabled in monolithic builds.
+#if !defined(O3DE_EDITOR_CONNECTION_LISTENER_ENABLE)
+    #if !defined(AZ_MONOLITHIC_BUILD)
+        #define O3DE_EDITOR_CONNECTION_LISTENER_ENABLE 1
+    #endif
+#endif
+
 namespace AzFramework
 {
     struct SessionConfig;
@@ -244,8 +253,8 @@ namespace Multiplayer
             OnPhysicsPostSimulate(dt);
         } };
 
-        // By default, this is enabled in everything but release builds.
-#if !defined(AZ_RELEASE_BUILD)
+        // By default, this is only enabled in non-monolithic builds, since the Editor doesn't support monolithic builds.
+#if (O3DE_EDITOR_CONNECTION_LISTENER_ENABLE)
         // This is a unique_ptr instead of a raw instance so that we can defer the construction
         // until the Activate(). If it gets constructed during the MultiplayerSystemComponent constructor,
         // the AzNetworking systems might not be constructed and activated yet, which would crash.


### PR DESCRIPTION
## What does this PR do?

Fixes a couple of different init/shutdown errors in the networking code:
1. The MultiplayerEditorConnection was getting constructed as a part of the MultiplayerSystemComponent constructor. However, it relied on AzNetworking being active at that point or else it would crash. AzNetworking is only guaranteed to be active for the Activate() call, not during construction, so this crashed in monolithic builds. The solution is to defer the MEC construction until the Activate() call.
2. Both AWSCore and HttpRequestor were trying to init and shutdown the AwsNativeSDK. This caused a crash on shutdown because some AwsNativeSDK-allocated pointers could no longer get freed after the first shutdown. The solution is to add ownership guards to both gems so that only the first gem to activate owns the init/shutdown sequence, and the other one doesn't. Since neither gem appears to depend on the other currently, I didn't want to introduce any cross-dependencies between the two gems just to solve this issue. However, the implication is that if any future gems get added that also try to own AwsNativeSDK startup/shutdown, they will need to add the same ownership guard too.

## How was this PR tested?

Ran a monolithic build and verified that it no longer crashes on shutdown due to bad AwsNativeSDK shutdown order. (It still crashes on shutdown in ScriptCanvasRegistry::ReleaseDescriptors(), but that's well after the AWS module shutdowns and doesn't appear to be related)
