### PR TITLE
Improve asset dependency discovery for

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.cpp
@@ -81,7 +81,7 @@ namespace AZ
 
             bool found = false;
 
-            AZStd::vector<AZStd::string> possibleDependencies = RPI::AssetUtils::GetPossibleDepenencyPaths(currentFilePath, referencedParentPath);
+            AZStd::vector<AZStd::string> possibleDependencies = RPI::AssetUtils::GetPossibleDependencyPaths(currentFilePath, referencedParentPath);
             for (auto& file : possibleDependencies)
             {
                 AssetBuilderSDK::SourceFileDependency sourceFileDependency;
@@ -102,40 +102,6 @@ namespace AZ
             }
 
             return found;
-        }
-
-
-        //! Returns true if @sourceFileFullPath starts with a valid asset processor scan folder, false otherwise.
-        //! In case of true, it splits @sourceFileFullPath into @scanFolderFullPath and @filePathFromScanFolder.
-        //! @sourceFileFullPath The full path to a source asset file.
-        //! @scanFolderFullPath [out] Gets the full path of the scan folder where the source file is located.
-        //! @filePathFromScanFolder [out] Get the file path relative to  @scanFolderFullPath.
-        static bool SplitSourceAssetPathIntoScanFolderFullPathAndRelativeFilePath(const AZStd::string& sourceFileFullPath, AZStd::string& scanFolderFullPath, AZStd::string& filePathFromScanFolder)
-        {
-            AZStd::vector<AZStd::string> scanFolders;
-            bool success = false;
-            AzToolsFramework::AssetSystemRequestBus::BroadcastResult(success, &AzToolsFramework::AssetSystem::AssetSystemRequest::GetAssetSafeFolders, scanFolders);
-            if (!success)
-            {
-                AZ_Error(ShaderVariantAssetBuilderName, false, "Couldn't get the scan folders");
-                return false;
-            }
-
-            for (AZStd::string scanFolder : scanFolders)
-            {
-                AZ::StringFunc::Path::Normalize(scanFolder);
-                if (!AZ::StringFunc::StartsWith(sourceFileFullPath, scanFolder))
-                {
-                    continue;
-                }
-                const size_t scanFolderSize = scanFolder.size();
-                const size_t sourcePathSize = sourceFileFullPath.size();
-                scanFolderFullPath = scanFolder;
-                filePathFromScanFolder = sourceFileFullPath.substr(scanFolderSize + 1, sourcePathSize - scanFolderSize - 1);
-                return true;
-            }
-
-            return false;
         }
 
         //! Validates if a given .shadervariantlist file is located at the correct path for a given .shader full path.
@@ -161,7 +127,11 @@ namespace AZ
         {
             AZStd::string scanFolderFullPath;
             AZStd::string shaderProductFileRelativePath;
-            if (!SplitSourceAssetPathIntoScanFolderFullPathAndRelativeFilePath(shaderFileFullPath, scanFolderFullPath, shaderProductFileRelativePath))
+            bool success = false;
+            AzToolsFramework::AssetSystemRequestBus::BroadcastResult(success
+                , &AzToolsFramework::AssetSystem::AssetSystemRequest::GenerateRelativeSourcePath
+                , shaderFileFullPath, shaderProductFileRelativePath, scanFolderFullPath);
+            if (!success)
             {
                 AZ_Error(ShaderVariantAssetBuilderName, false, "Couldn't get the scan folder for shader [%s]", shaderFileFullPath.c_str());
                 return false;
@@ -299,7 +269,10 @@ namespace AZ
                 response.m_result = AssetBuilderSDK::CreateJobsResultCode::Failed;
                 return;
             }
-            
+
+            // Even if the shader file doesn't exist yet, when calling LocateReferencedSourceFile() the source
+            // asset dependency list will be populated. This will cause to re-run this builder
+            // when the source *.shader file comes into existence.
             AZStd::string foundShaderFile;
             LocateReferencedSourceFile(variantListFullPath, shaderVariantList.m_shaderFilePath, response.m_sourceFileDependencyList, foundShaderFile);
 
@@ -312,7 +285,11 @@ namespace AZ
 
                     jobDescriptor.m_priority = -5000;
                     jobDescriptor.m_critical = false;
-                    jobDescriptor.m_jobKey = ShaderVariantAssetBuilderJobKey;
+                    // We are going to create a fake job that we know will fail.
+                    // We need to use a job key of a real product (In this case we are using the job key for the ShaderVariantTreeAsset).
+                    // Using a real product job key will guarantee to clear old errors in the future, because a successful product build will
+                    // replace the lingering error thanks to matching job keys.
+                    jobDescriptor.m_jobKey = GetShaderVariantTreeAssetJobKey();
                     jobDescriptor.SetPlatformIdentifier(info.m_identifier.data());
                     
                     if (!foundShaderFile.empty())

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Common/AssetUtils.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Common/AssetUtils.h
@@ -80,7 +80,7 @@ namespace AZ
             //! @param originatingSourceFilePath  Path to a file that references referencedSourceFilePath. May be absolute or relative to asset-root.
             //! @param referencedSourceFilePath   The referenced path as it appears in the originating file. May be relative to the originating file location or relative to asset-root.
             //! @return the list of possible paths, ordered from highest priority to lowest priority
-            AZStd::vector<AZStd::string> GetPossibleDepenencyPaths(const AZStd::string& originatingSourceFilePath, const AZStd::string& referencedSourceFilePath);
+            AZStd::vector<AZStd::string> GetPossibleDependencyPaths(const AZStd::string& originatingSourceFilePath, const AZStd::string& referencedSourceFilePath);
 
             //! Takes an arbitrary string and replaces some characters to make it a valid filename. The result will be compatible with AzQtComponents::FileDialog.
             //! Ex. SanitizeFileName("Left=>Right.txt") == "Left_Right.txt"

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.cpp
@@ -25,8 +25,7 @@ namespace AZ::RPI::MaterialBuilderUtils
     {
         bool dependencyFileFound = false;
 
-        AZStd::vector<AZStd::string> possibleDependencies =
-            RPI::AssetUtils::GetPossibleDepenencyPaths(currentFilePath, referencedParentPath);
+        AZStd::vector<AZStd::string> possibleDependencies = RPI::AssetUtils::GetPossibleDependencyPaths(currentFilePath, referencedParentPath);
         for (auto& file : possibleDependencies)
         {
             // The first path found is the highest priority, and will have a job dependency, as this is the one

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -133,7 +133,7 @@ namespace AZ
 
             auto addPossibleDependencies = [&response](const AZStd::string& originatingSourceFilePath, const AZStd::string& referencedSourceFilePath)
             {
-                AZStd::vector<AZStd::string> possibleDependencies = RPI::AssetUtils::GetPossibleDepenencyPaths(originatingSourceFilePath, referencedSourceFilePath);
+                AZStd::vector<AZStd::string> possibleDependencies = RPI::AssetUtils::GetPossibleDependencyPaths(originatingSourceFilePath, referencedSourceFilePath);
                 for (const AZStd::string& path : possibleDependencies)
                 {
                     response.m_sourceFileDependencyList.push_back({});

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Common/AssetUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Common/AssetUtils.cpp
@@ -124,22 +124,25 @@ namespace AZ
                 return referencedPath.LexicallyNormal().String();
             }
 
-            AZStd::vector<AZStd::string> GetPossibleDepenencyPaths(
+            AZStd::vector<AZStd::string> GetPossibleDependencyPaths(
                 const AZStd::string& originatingSourceFilePath, const AZStd::string& referencedSourceFilePath)
             {
                 AZStd::vector<AZStd::string> results;
 
                 // Convert incoming paths containing aliases into absolute paths
-                AZ::IO::FixedMaxPath originatingPath;
-                AZ::IO::FileIOBase::GetInstance()->ReplaceAlias(originatingPath, AZ::IO::PathView{ originatingSourceFilePath });
                 AZ::IO::FixedMaxPath referencedPath;
                 AZ::IO::FileIOBase::GetInstance()->ReplaceAlias(referencedPath, AZ::IO::PathView{ referencedSourceFilePath });
 
-                // Use the referencedSourceFilePath as a relative path starting at originatingSourceFilePath
-                AZ::IO::FixedMaxPath combinedPath = originatingPath.ParentPath();
-                combinedPath /= referencedPath;
+                if (referencedPath.IsRelative())
+                {
+                    AZ::IO::FixedMaxPath originatingPath;
+                    AZ::IO::FileIOBase::GetInstance()->ReplaceAlias(originatingPath, AZ::IO::PathView{ originatingSourceFilePath });
+                    // Use the referencedSourceFilePath as a relative path starting at originatingSourceFilePath
+                    AZ::IO::FixedMaxPath combinedPath = originatingPath.ParentPath();
+                    combinedPath /= referencedPath;
 
-                results.push_back(combinedPath.LexicallyNormal().String());
+                    results.push_back(combinedPath.LexicallyNormal().String());
+                }
 
                 // Use the referencedSourceFilePath as a standard asset path
                 results.push_back(referencedPath.LexicallyNormal().String());


### PR DESCRIPTION
ShaderVariantAssetBuilder which help for cases
when the .shadervariantlist file references a .shader file that will eventually appear under the "Cache/Intermediate Assets/" folder.

Fixed typo in function name inside AssetUtils.h/.cpp and other files that were referencing the old function name.

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>

## What does this PR do?

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_

_Please add links to any issues, RFCs or other items that are relevant to this PR._

## How was this PR tested?

_Please describe any testing performed._
