### PR TITLE
Fixed automated tests failing with new action manager enabled

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/BasicEditorWorkflows_LevelEntityComponentCRUD.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/BasicEditorWorkflows_LevelEntityComponentCRUD.py
@@ -68,6 +68,7 @@ def BasicEditorWorkflows_LevelEntityComponentCRUD():
         import azlmbr.bus as bus
         import azlmbr.editor as editor
         import azlmbr.entity as entity
+        import azlmbr.legacy.general as general
         import azlmbr.math as math
         import azlmbr.paths as paths
 
@@ -85,6 +86,12 @@ def BasicEditorWorkflows_LevelEntityComponentCRUD():
         # 1) Create a new level
         lvl_name = "tmp_level"
         editor_window = pyside_utils.get_editor_main_window()
+
+        # The action manager doesn't register the menus until the next system tick, so need to wait
+        # until the menu bar has been populated
+        general.idle_enable(True)
+        await pyside_utils.wait_for_condition(lambda: len(editor_window.menuBar().actions()) > 1)
+
         new_level_action = pyside_utils.get_action_for_menu_path(editor_window, "File", "New Level")
         pyside_utils.trigger_action_async(new_level_action)
         active_modal_widget = await pyside_utils.wait_for_modal_widget()

--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/Menus_EditMenuOptions.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/Menus_EditMenuOptions.py
@@ -26,6 +26,7 @@ def Menus_EditMenuOptions_Work():
     :return: None
     """
 
+    import azlmbr.legacy.general as general
     import editor_python_test_tools.hydra_editor_utils as hydra
     import pyside_utils
     from editor_python_test_tools.utils import Report
@@ -51,7 +52,6 @@ def Menus_EditMenuOptions_Work():
         ("Modify", "Transform Mode", "Scale"),
         ("Editor Settings", "Global Preferences"),
         ("Editor Settings", "Editor Settings Manager"),
-        ("Editor Settings", "Keyboard Customization", "Customize Keyboard"),
         # The following menu options are temporarily disabled due to https://github.com/o3de/o3de/issues/6746
         #("Editor Settings", "Keyboard Customization", "Export Keyboard Settings"),
         #("Editor Settings", "Keyboard Customization", "Import Keyboard Settings"),
@@ -59,6 +59,11 @@ def Menus_EditMenuOptions_Work():
 
     # 1) Open an existing simple level
     hydra.open_base_level()
+
+    # The action manager doesn't register the menus until the next system tick, so need to wait
+    # until the menu bar has been populated
+    general.idle_enable(True)
+    general.idle_wait_frames(1)
 
     # 2) Interact with Edit Menu options
     editor_window = pyside_utils.get_editor_main_window()

--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/Menus_ViewMenuOptions.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/Menus_ViewMenuOptions.py
@@ -26,20 +26,15 @@ def Menus_ViewMenuOptions_Work():
     :return: None
     """
 
+    import azlmbr.legacy.general as general
     import editor_python_test_tools.hydra_editor_utils as hydra
     import pyside_utils
     from editor_python_test_tools.utils import Report
 
     view_menu_options = [
-        ("Center on Selection",),
-        ("Show Quick Access Bar",),
-        ("Layouts", "Component Entity Layout",),
-        ("Layouts", "Save Layout",),
         ("Viewport", "Go to Position"),
         ("Viewport", "Center on Selection"),
         ("Viewport", "Go to Location"),
-        ("Viewport", "Remember Location"),
-        ("Viewport", "Switch Camera"),
         ("Viewport", "Show Helpers"),
         ("Viewport", "Show Icons"),
         ("Refresh Style",),
@@ -47,6 +42,11 @@ def Menus_ViewMenuOptions_Work():
 
     # 1) Open an existing simple level
     hydra.open_base_level()
+
+    # The action manager doesn't register the menus until the next system tick, so need to wait
+    # until the menu bar has been populated
+    general.idle_enable(True)
+    general.idle_wait_frames(1)
 
     # 2) Interact with View Menu options
     editor_window = pyside_utils.get_editor_main_window()


### PR DESCRIPTION
## What does this PR do?

Fixes #13349 

This fixes a few automated tests that were executing before the new action manager had fully initialized. This occurred because the new action manager doesn't add the menus until the following system tick. I added logic in the tests to wait until the menus had been added. Also removed some menu checks for items that aren't shared by both the new and old action managers.

## How was this PR tested?

Ran the `editor/TestSuite_Main.py` with both the new action manager enabled and disabled and verified all the automated tests passed.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>