### PR TITLE
Fix linker error in Android builds on Linux 

### DIFF
--- a/cmake/Platform/Android/Configurations_android.cmake
+++ b/cmake/Platform/Android/Configurations_android.cmake
@@ -56,7 +56,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 
             -u ANativeActivity_onCreate
 
-            -L${LY_NDK_ABI_ROOT}/usr/lib
             -L${LY_NDK_SRC_ROOT}/cxx-stl/llvm-libc++/libs/${ANDROID_ABI}
 
         LINK_NON_STATIC_DEBUG

--- a/cmake/Platform/Android/Configurations_android.cmake
+++ b/cmake/Platform/Android/Configurations_android.cmake
@@ -56,8 +56,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 
             -u ANativeActivity_onCreate
 
-            -L${LY_NDK_SRC_ROOT}/cxx-stl/llvm-libc++/libs/${ANDROID_ABI}
-
         LINK_NON_STATIC_DEBUG
             -Wl,--build-id       # Android Studio needs the libraries to have an id in order to match them with what"s running on the device.
             -shared


### PR DESCRIPTION
## What does this PR do?

Fixing linker error  by not linking libraries from ${LY_NDK_ABI_ROOT}/usr/lib since LY_NDK_ABI_ROOT is never set.
`'ld: error: --fix-cortex-a53-843419 is only supported on AArch64 targets' ` 

## How was this PR tested?

Android build on linux ran succesfully.
