### PR TITLE
Action Manager | Disable "End Component Mode" action when Editor is in Entity Pick mode

### DIFF
--- a/Code/Editor/Core/EditorActionsHandler.h
+++ b/Code/Editor/Core/EditorActionsHandler.h
@@ -40,6 +40,7 @@ class EditorActionsHandler
     , private AzToolsFramework::EditorEntityContextNotificationBus::Handler
     , private AzToolsFramework::ToolsApplicationNotificationBus::Handler
     , private AzToolsFramework::ViewportInteraction::ViewportSettingsNotificationBus::Handler
+    , private AzToolsFramework::EditorPickModeNotificationBus::Handler
 {
 public:
     void Initialize(MainWindow* mainWindow);
@@ -85,6 +86,10 @@ private:
     void OnGridSnappingChanged(bool enabled) override;
     void OnIconsVisibilityChanged(bool enabled) override;
     void OnOnlyShowHelpersForSelectedEntitiesChanged(bool enabled) override;
+
+    // EditorPickModeNotificationBus overrides ...
+    void OnEntityPickModeStarted() override;
+    void OnEntityPickModeStopped() override;
 
     // Layouts
     void RefreshLayoutActions();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/ActionManagerIdentifiers/EditorActionUpdaterIdentifiers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/ActionManagerIdentifiers/EditorActionUpdaterIdentifiers.h
@@ -15,6 +15,7 @@ namespace EditorIdentifiers
     inline constexpr AZStd::string_view AngleSnappingStateChangedUpdaterIdentifier = "o3de.updater.onAngleSnappingStateChanged";
     inline constexpr AZStd::string_view ComponentModeChangedUpdaterIdentifier = "o3de.updater.onComponentModeChanged";
     inline constexpr AZStd::string_view DrawHelpersStateChangedUpdaterIdentifier = "o3de.updater.onViewportDrawHelpersStateChanged";
+    inline constexpr AZStd::string_view EntityPickingModeChangedUpdaterIdentifier = "o3de.updater.onEntityPickingModeChanged";
     inline constexpr AZStd::string_view EntitySelectionChangedUpdaterIdentifier = "o3de.updater.onEntitySelectionChanged";
     inline constexpr AZStd::string_view GameModeStateChangedUpdaterIdentifier = "o3de.updater.onGameModeStateChanged";
     inline constexpr AZStd::string_view GridShowingChangedUpdaterIdentifier = "o3de.updater.onGridShowingChanged";

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
@@ -83,7 +83,7 @@ namespace AzToolsFramework
         componentModeCollectionInterface->EnumerateActiveComponents(
             [&emptySelection](const AZ::EntityComponentIdPair& entityComponentIdPair, const AZ::Uuid&)
             {
-                int count;
+                int count = 0;
                 EditorVertexSelectionVariableRequestBus::EventResult(
                     count, entityComponentIdPair, &EditorVertexSelectionVariableRequests::GetSelectedVerticesCount);
 


### PR DESCRIPTION
## What does this PR do?
Adds an Enabled State CallBack to the "End Component Mode" action so that it is disabled when the Editor is in Entity Pick mode.
This allows the usage of the `Esc` shortcut in a nested fashion: when entering Entity Pick mode inside a Component Mode, pressing `Esc` a first time will just end the Entity Pick mode, while pressing it a second time will close the Component Mode.

Took the chance to verify that multiple Enabled State Callbacks on a single action work as intended in a real environment (unit tests already exist).

## How was this PR tested?
Manual testing.

![EntityPickingEscBefore](https://user-images.githubusercontent.com/82231674/216672451-c7910d5b-eec4-42fe-bc93-f3fd46ef7d09.gif)
Before this PR

![EntityPickingEscAfter](https://user-images.githubusercontent.com/82231674/216672496-152dcbd2-d404-470d-99e1-a28292786824.gif)
After this PR
