### PR TITLE
Sandboxing a flaky test

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_batch_tests_2.py
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_batch_tests_2.py
@@ -129,6 +129,7 @@ class TestsAssetProcessorBatch_AllPlatforms(object):
     @pytest.mark.BAT
     @pytest.mark.assetpipeline
     @pytest.mark.parametrize("clear_type", ["rewrite", "delete_asset", "delete_dir"])
+    @pytest.mark.SUITE_sandbox(reason="Disabling flaky test")
     def test_AllSupportedPlatforms_DeleteBadAssets_BatchFailedJobsCleared(
             self, workspace, request, ap_setup_fixture, asset_processor,  clear_type):
         """


### PR DESCRIPTION
Signed-off-by: AMZN-stankowi <4838196+AMZN-stankowi@users.noreply.github.com>

## What does this PR do?

This is a flaky test - it passes most of the time, but it failed on Linux in a recent development branch build https://jenkins.build.o3de.org/job/O3DE/job/development/3881/


> 107/129 Test #143: APTests.Batch_2_Main.main::TEST_RUN .....................................***Failed   39.47 sec
> 
> /data/workspace/o3de/python/python.sh -m pytest -v --tb=short --show-capture=stdout -c /data/workspace/o3de/pytest.ini --build-directory /data/workspace/o3de/build/linux/bin/profile --output-path /data/workspace/o3de/build/linux/Testing/LyTestTools/APTests.Batch_2_Main --junitxml=/data/workspace/o3de/build/linux/Testing/Pytest/APTests.Batch_2_Main.xml -m not SUITE_sandbox /data/workspace/o3de/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_batch_tests_2.py::TestsAssetProcessorBatch_AllPlatforms::test_AllSupportedPlatforms_DeleteBadAssets_BatchFailedJobsCleared[linux-delete_asset-AutomatedTesting]


## How was this PR tested?

Test passes locally for me either way, but it's a flaky test so that's to be expected.
