### PR TITLE
Use a `constexpr` static variable to force evaluation of typeid strings at compile time

### DIFF
--- a/Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h
@@ -1390,7 +1390,10 @@ namespace AZ
     } \
     static constexpr AZ::TypeId TYPEINFO_Uuid() \
     { \
-        return AZ::TypeId(_ClassUuid) + AZ::Internal::AggregateTypes<__VA_ARGS__>::Uuid(); \
+        /* using a local constexpr variable ensures that the TypeId's string is
+         * parsed at compile time */ \
+        constexpr auto typeId = AZ::TypeId(_ClassUuid) + AZ::Internal::AggregateTypes<__VA_ARGS__>::Uuid(); \
+        return typeId; \
     }
 
 // Template class type info

--- a/Code/Framework/AzCore/AzCore/RTTI/TypeInfoSimple.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/TypeInfoSimple.h
@@ -20,7 +20,12 @@ namespace AZ
     struct TYPEINFO_Enable{}; \
     struct TypeNameInternal { constexpr const char* operator()() const { return #_ClassName; } }; \
     static constexpr const char* TYPEINFO_Name() { return TypeNameInternal{}(); } \
-    static constexpr AZ::TypeId TYPEINFO_Uuid() { return AZ::TypeId(_ClassUuid); }
+    static constexpr AZ::TypeId TYPEINFO_Uuid() { \
+        /* using a local constexpr variable ensures that the TypeId's string is
+         * parsed at compile time */ \
+        constexpr AZ::TypeId typeId(_ClassUuid); \
+        return typeId; \
+    }
 
 #define AZ_TYPE_INFO_1 AZ_TYPE_INFO_INTERNAL_1
 #define AZ_TYPE_INFO_2 AZ_TYPE_INFO_INTERNAL_2

--- a/Code/Framework/AzCore/Tests/RTTI/IsTypeofBenchmarks.cpp
+++ b/Code/Framework/AzCore/Tests/RTTI/IsTypeofBenchmarks.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#if defined(HAVE_BENCHMARK)
+
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <benchmark/benchmark.h>
+
+namespace AZ
+{
+    class IsTypeofBenchmarkBaseType
+    {
+    public:
+        virtual ~IsTypeofBenchmarkBaseType() = default;
+        AZ_RTTI(IsTypeofBenchmarkBaseType, "{4699B4B3-2A44-4A02-9F70-CD9889B4B36D}")
+    };
+
+    class IsTypeOfBenchmarkDerivedType : public IsTypeofBenchmarkBaseType
+    {
+    public:
+        AZ_RTTI(IsTypeOfBenchmarkDerivedType, "{C89B7EAC-26A0-4B37-A14E-CEC20FCAD7A8}", IsTypeofBenchmarkBaseType)
+    };
+
+    static void BenchmarkIsTypeof(benchmark::State& state)
+    {
+        auto derived = AZStd::make_unique<IsTypeOfBenchmarkDerivedType>();
+        IsTypeofBenchmarkBaseType* base = derived.get();
+        for (auto _ : state)
+        {
+            azrtti_istypeof<IsTypeOfBenchmarkDerivedType>(base);
+        }
+    }
+
+    BENCHMARK(BenchmarkIsTypeof);
+} // namespace AZ
+
+#endif

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -177,6 +177,7 @@ set(FILES
     OutcomeTests.cpp
     Patching.cpp
     RemappableId.cpp
+    RTTI/IsTypeofBenchmarks.cpp
     RTTI/TypeSafeIntegralTests.cpp
     Rtti.cpp
     Script.cpp

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.h
@@ -38,7 +38,7 @@ namespace AzToolsFramework
         {
         public:
             AZ_CLASS_ALLOCATOR(PrefabLoader, AZ::SystemAllocator, 0);
-            AZ_RTTI(PrefabLoader, "{A302B072-4DC4-4B7E-9188-226F56A3429C8}", PrefabLoaderInterface);
+            AZ_RTTI(PrefabLoader, "{A302B072-4DC4-4B7E-9188-226F56A3429C}", PrefabLoaderInterface);
 
             static void Reflect(AZ::ReflectContext* context);
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/IndirectBufferSignature.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/IndirectBufferSignature.h
@@ -37,7 +37,7 @@ namespace AZ
         {
             using Base = RHI::DeviceObject;
         public:
-            AZ_RTTI(IndirectBufferSignature, "IndirectBufferSignature", Base);
+            AZ_RTTI(IndirectBufferSignature, "{3A2F9DF0-589B-4E05-9205-B688EB896AEA}", Base);
             virtual ~IndirectBufferSignature() {};
 
             //! Initialize an IndirectBufferSignature object.


### PR DESCRIPTION
This yields a 13.5x speed increase to the `TYPEINFO_Uuid()` method for classes, without adding any new symbols. It does this by forcing the calculation of a class's uuid at compile time, avoiding the expensive call to `AZ::Uuid::CreateStringSkipWarnings` at runtime.

Because the class's `TYPEINFO_Uuid_v` static variable is never ODR-used, no symbol is emitted for it into the generated binary.

The speed was measured with this benchmark:

```cpp
class Base
{
public:
    virtual ~Base() = default;
    AZ_RTTI(Base, "{4699b4b3-2a44-4a02-9f70-cd9889b4b36d}")
};

class Derived
    : public Base
{
public:
    AZ_RTTI(Derived, "{c89b7eac-26a0-4b37-a14e-cec20fcad7a8}", Base)
};

static void BenchmarkIsTypeof(benchmark::State& state)
{
    auto derived = std::make_unique<Derived>();
    Base* base = derived.get();
    for (auto _ : state)
    {
        azrtti_istypeof<Derived>(base);
    }
}
BENCHMARK(BenchmarkIsTypeof);
```

```
Benchmark                  Time             CPU   Iterations
------------------------------------------------------------
BenchmarkIsTypeof.old   64.0 ns         64.0 ns     10901595
BenchmarkIsTypeof.new   4.60 ns         4.60 ns    152030119
```

This should fix the issue that #14350 was designed to work around.

Signed-off-by: Chris Burel <burelc@amazon.com>
