### PR TITLE
Fix non-svg component icons not being loaded

### DIFF
--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -60,8 +60,10 @@
 #include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
 #include <MathConversion.h>
 
+#include <Atom/ImageProcessing/ImageProcessingDefines.h>
 #include <Atom/RPI.Public/ViewportContext.h>
 #include <Atom/RPI.Public/ViewportContextBus.h>
+#include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
 #include <AtomToolsFramework/Viewport/ModularViewportCameraControllerRequestBus.h>
 
 #include "Objects/ComponentEntityObject.h"
@@ -1920,12 +1922,45 @@ AZStd::string SandboxIntegrationManager::GetComponentIconPath(const AZ::Uuid& co
                 }
                 else
                 {
-                    AZ_Warning(
-                        "SandboxIntegration",
-                        false,
-                        "Unable to find icon path \"%s\" for component type: %s",
-                        iconPath.c_str(),
-                        classData->m_editData->m_name);
+                    // If we couldn't find the full source path, try appending the product extension if the icon
+                    // source asset is one of the supported image assets. Most component icons are in .svg format,
+                    // which isn't actually consumed by the Asset Processor so the GetFullSourcePathFromRelativeProductPath
+                    // API can find the source asset without needing the product extension as well. So this edge case is
+                    // to cover any component icons that are still using other formats (e.g. png), that haven't been converted
+                    // to .svg yet, or for customers that prefer to use image formats besides .svg.
+                    AZStd::string extension;
+                    AzFramework::StringFunc::Path::GetExtension(iconPath.c_str(), extension);
+                    bool supportedStreamingImage = false;
+                    for (int i = 0; i < ImageProcessingAtom::s_TotalSupportedImageExtensions; ++i)
+                    {
+                        if (AZStd::wildcard_match(ImageProcessingAtom::s_SupportedImageExtensions[i], extension.c_str()))
+                        {
+                            supportedStreamingImage = true;
+                            break;
+                        }
+                    }
+                    if (supportedStreamingImage)
+                    {
+                        iconPath = AZStd::string::format("%s.%s", iconPath.c_str(), AZ::RPI::StreamingImageAsset::Extension);
+
+                        AssetSysReqBus::BroadcastResult(
+                            pathFound, &AssetSysReqBus::Events::GetFullSourcePathFromRelativeProductPath,
+                            iconPath, iconFullPath);
+                    }
+
+                    if (pathFound)
+                    {
+                        iconPath = AZStd::move(iconFullPath);
+                    }
+                    else
+                    {
+                        AZ_Warning(
+                            "SandboxIntegration",
+                            false,
+                            "Unable to find icon path \"%s\" for component type: %s",
+                            iconPath.c_str(),
+                            classData->m_editData->m_name);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What does this PR do?

This fixes an issue where non-svg component icons weren't being loaded. Almost all component icons have been converted to `.svg`, but some are still in the previous default format (`.png`). Because the `.svg` files aren't picked up by the Asset Processor, there is an API being used to query the full source path given a relative path that doesn't work on the `.png` files because that API expects the product extension to be on the path.

## How was this PR tested?

Launched the UI Editor and verified that the component icons show up on the component cards, whereas previously they were empty and warning messages were printed in the Editor log.

![UIEditorComponentIcons](https://user-images.githubusercontent.com/7519264/217077683-06d4a5af-fe7c-4373-a01d-c1834732140b.png)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>