### PR TITLE
updated screen control setup code in ProjectGemCatalogScreen to setup…

### DIFF
--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -68,13 +68,7 @@ namespace O3DE::ProjectManager
         connect(m_gemModel, &GemModel::gemStatusChanged, this, &GemCatalogScreen::OnGemStatusChanged);
         connect(m_gemModel, &GemModel::dependencyGemStatusChanged, this, &GemCatalogScreen::OnDependencyGemStatusChanged);
         connect(
-            m_gemModel->GetSelectionModel(),
-            &QItemSelectionModel::selectionChanged,
-            this,
-            [this]
-            {
-                ShowInspector();
-            });
+            connect(m_gemModel->GetSelectionModel(), &QItemSelectionModel::selectionChanged, this, &GemCatalogScreen::ShowInspector);
         connect(m_headerWidget, &GemCatalogHeaderWidget::RefreshGems, this, &GemCatalogScreen::Refresh);
         connect(m_headerWidget, &GemCatalogHeaderWidget::OpenGemsRepo, this, &GemCatalogScreen::HandleOpenGemRepo);
         connect(m_headerWidget, &GemCatalogHeaderWidget::CreateGem, this, &GemCatalogScreen::HandleCreateGem);

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -67,7 +67,14 @@ namespace O3DE::ProjectManager
 
         connect(m_gemModel, &GemModel::gemStatusChanged, this, &GemCatalogScreen::OnGemStatusChanged);
         connect(m_gemModel, &GemModel::dependencyGemStatusChanged, this, &GemCatalogScreen::OnDependencyGemStatusChanged);
-        connect(m_gemModel->GetSelectionModel(), &QItemSelectionModel::selectionChanged, this, [this]{ ShowInspector(); });
+        connect(
+            m_gemModel->GetSelectionModel(),
+            &QItemSelectionModel::selectionChanged,
+            this,
+            [this]
+            {
+                ShowInspector();
+            });
         connect(m_headerWidget, &GemCatalogHeaderWidget::RefreshGems, this, &GemCatalogScreen::Refresh);
         connect(m_headerWidget, &GemCatalogHeaderWidget::OpenGemsRepo, this, &GemCatalogScreen::HandleOpenGemRepo);
         connect(m_headerWidget, &GemCatalogHeaderWidget::CreateGem, this, &GemCatalogScreen::HandleCreateGem);
@@ -75,23 +82,7 @@ namespace O3DE::ProjectManager
         connect(m_headerWidget, &GemCatalogHeaderWidget::UpdateGemCart, this, &GemCatalogScreen::UpdateAndShowGemCart);
         connect(m_downloadController, &DownloadController::Done, this, &GemCatalogScreen::OnGemDownloadResult);
 
-        m_screensControl = qobject_cast<ScreensCtrl*>(parent);
-        if (m_screensControl)
-        {
-            ScreenWidget* createGemScreen = m_screensControl->FindScreen(ProjectManagerScreen::CreateGem);
-            if (createGemScreen)
-            {
-                CreateGem* createGem = static_cast<CreateGem*>(createGemScreen);
-                connect(createGem, &CreateGem::GemCreated, this, &GemCatalogScreen::HandleGemCreated);
-            }
-
-            ScreenWidget* editGemScreen = m_screensControl->FindScreen(ProjectManagerScreen::EditGem);
-            if (editGemScreen)
-            {
-                EditGem* editGem = static_cast<EditGem*>(editGemScreen);
-                connect(editGem, &EditGem::GemEdited, this, &GemCatalogScreen::HandleGemEdited);
-            }
-        }
+        setupScreensControl(parent);
 
         QHBoxLayout* hLayout = new QHBoxLayout();
         hLayout->setMargin(0);
@@ -102,7 +93,13 @@ namespace O3DE::ProjectManager
 
         m_gemInspector = new GemInspector(m_gemModel, m_rightPanelStack);
 
-        connect(m_gemInspector, &GemInspector::TagClicked, [=](const Tag& tag) { SelectGem(tag.id); });
+        connect(
+            m_gemInspector,
+            &GemInspector::TagClicked,
+            [=](const Tag& tag)
+            {
+                SelectGem(tag.id);
+            });
         connect(m_gemInspector, &GemInspector::UpdateGem, this, &GemCatalogScreen::UpdateGem);
         connect(m_gemInspector, &GemInspector::UninstallGem, this, &GemCatalogScreen::UninstallGem);
         connect(m_gemInspector, &GemInspector::EditGem, this, &GemCatalogScreen::HandleEditGem);
@@ -120,20 +117,16 @@ namespace O3DE::ProjectManager
         constexpr int minHeaderSectionWidth = 100;
         AdjustableHeaderWidget* listHeaderWidget = new AdjustableHeaderWidget(
             QStringList{ tr("Gem Image"), tr("Gem Name"), tr("Gem Summary"), tr("Status") },
-            QVector<int>{
-                GemPreviewImageWidth + AdjustableHeaderWidget::s_headerTextIndent,
-                -GemPreviewImageWidth - AdjustableHeaderWidget::s_headerTextIndent + GemItemDelegate::s_defaultSummaryStartX - 30,
-                0, // Section is set to stretch to fit
-                GemItemDelegate::s_statusIconSize + GemItemDelegate::s_statusButtonSpacing + GemItemDelegate::s_buttonWidth + GemItemDelegate::s_contentMargins.right()
-            },
+            QVector<int>{ GemPreviewImageWidth + AdjustableHeaderWidget::s_headerTextIndent,
+                          -GemPreviewImageWidth - AdjustableHeaderWidget::s_headerTextIndent + GemItemDelegate::s_defaultSummaryStartX - 30,
+                          0, // Section is set to stretch to fit
+                          GemItemDelegate::s_statusIconSize + GemItemDelegate::s_statusButtonSpacing + GemItemDelegate::s_buttonWidth +
+                              GemItemDelegate::s_contentMargins.right() },
             minHeaderSectionWidth,
-            QVector<QHeaderView::ResizeMode>
-            {
-                QHeaderView::ResizeMode::Fixed,
-                QHeaderView::ResizeMode::Interactive,
-                QHeaderView::ResizeMode::Stretch,
-                QHeaderView::ResizeMode::Fixed
-            },
+            QVector<QHeaderView::ResizeMode>{ QHeaderView::ResizeMode::Fixed,
+                                              QHeaderView::ResizeMode::Interactive,
+                                              QHeaderView::ResizeMode::Stretch,
+                                              QHeaderView::ResizeMode::Fixed },
             this);
 
         m_gemListView = new GemListView(m_proxyModel, m_proxyModel->GetSelectionModel(), listHeaderWidget, m_readOnly, this);
@@ -161,6 +154,27 @@ namespace O3DE::ProjectManager
         m_notificationsView = AZStd::make_unique<AzToolsFramework::ToastNotificationsView>(this, AZ_CRC("GemCatalogNotificationsView"));
         m_notificationsView->SetOffset(QPoint(10, 70));
         m_notificationsView->SetMaxQueuedNotifications(1);
+    }
+
+    void GemCatalogScreen::setupScreensControl(QWidget* parent)
+    {
+        m_screensControl = qobject_cast<ScreensCtrl*>(parent);
+        if (m_screensControl)
+        {
+            ScreenWidget* createGemScreen = m_screensControl->FindScreen(ProjectManagerScreen::CreateGem);
+            if (createGemScreen)
+            {
+                CreateGem* createGem = static_cast<CreateGem*>(createGemScreen);
+                connect(createGem, &CreateGem::GemCreated, this, &GemCatalogScreen::HandleGemCreated);
+            }
+
+            ScreenWidget* editGemScreen = m_screensControl->FindScreen(ProjectManagerScreen::EditGem);
+            if (editGemScreen)
+            {
+                EditGem* editGem = static_cast<EditGem*>(editGemScreen);
+                connect(editGem, &EditGem::GemEdited, this, &GemCatalogScreen::HandleGemEdited);
+            }
+        }
     }
 
     void GemCatalogScreen::NotifyCurrentScreen()

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -149,7 +149,7 @@ namespace O3DE::ProjectManager
         m_notificationsView->SetMaxQueuedNotifications(1);
     }
 
-    void GemCatalogScreen::setupScreensControl(QWidget* parent)
+    void GemCatalogScreen::SetUpScreensControl(QWidget* parent)
     {
         m_screensControl = qobject_cast<ScreensCtrl*>(parent);
         if (m_screensControl)

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -67,8 +67,7 @@ namespace O3DE::ProjectManager
 
         connect(m_gemModel, &GemModel::gemStatusChanged, this, &GemCatalogScreen::OnGemStatusChanged);
         connect(m_gemModel, &GemModel::dependencyGemStatusChanged, this, &GemCatalogScreen::OnDependencyGemStatusChanged);
-        connect(
-            connect(m_gemModel->GetSelectionModel(), &QItemSelectionModel::selectionChanged, this, &GemCatalogScreen::ShowInspector);
+        connect(m_gemModel->GetSelectionModel(), &QItemSelectionModel::selectionChanged, this, &GemCatalogScreen::ShowInspector);
         connect(m_headerWidget, &GemCatalogHeaderWidget::RefreshGems, this, &GemCatalogScreen::Refresh);
         connect(m_headerWidget, &GemCatalogHeaderWidget::OpenGemsRepo, this, &GemCatalogScreen::HandleOpenGemRepo);
         connect(m_headerWidget, &GemCatalogHeaderWidget::CreateGem, this, &GemCatalogScreen::HandleCreateGem);
@@ -76,7 +75,7 @@ namespace O3DE::ProjectManager
         connect(m_headerWidget, &GemCatalogHeaderWidget::UpdateGemCart, this, &GemCatalogScreen::UpdateAndShowGemCart);
         connect(m_downloadController, &DownloadController::Done, this, &GemCatalogScreen::OnGemDownloadResult);
 
-        setupScreensControl(parent);
+        SetUpScreensControl(parent);
 
         QHBoxLayout* hLayout = new QHBoxLayout();
         hLayout->setMargin(0);

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
@@ -69,9 +69,13 @@ namespace O3DE::ProjectManager
         void showEvent(QShowEvent* event) override;
         void resizeEvent(QResizeEvent* event) override;
         void moveEvent(QMoveEvent* event) override;
+        virtual void setupScreensControl(QWidget* parent);
 
         GemModel* m_gemModel = nullptr;
         QSet<QString> m_gemsToRegisterWithProject;
+        ScreensCtrl* m_screensControl = nullptr;
+
+
 
     private slots:
         void HandleOpenGemRepo();
@@ -98,7 +102,6 @@ namespace O3DE::ProjectManager
         QVBoxLayout* m_filterWidgetLayout = nullptr;
         GemFilterWidget* m_filterWidget = nullptr;
         DownloadController* m_downloadController = nullptr;
-        ScreensCtrl* m_screensControl = nullptr;
         bool m_notificationsEnabled = true;
         QString m_projectPath;
         bool m_readOnly;

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
@@ -69,7 +69,7 @@ namespace O3DE::ProjectManager
         void showEvent(QShowEvent* event) override;
         void resizeEvent(QResizeEvent* event) override;
         void moveEvent(QMoveEvent* event) override;
-        virtual void setupScreensControl(QWidget* parent);
+        virtual void SetUpScreensControl(QWidget* parent);
 
         GemModel* m_gemModel = nullptr;
         QSet<QString> m_gemsToRegisterWithProject;

--- a/Code/Tools/ProjectManager/Source/ProjectGemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectGemCatalogScreen.cpp
@@ -26,7 +26,7 @@ namespace O3DE::ProjectManager
         // We have to fetch the parent of our parent, because Project Manager Gem Catalog is usually embedded inside another workflow, like
         // CreateProjectScreen or UpdateProjectScreen
         // As such, it does not have direct access to ScreenControls
-        setupScreensControl(parent->parentWidget());
+        SetUpScreensControl(parent->parentWidget());
     }
 
     ProjectManagerScreen ProjectGemCatalogScreen::GetScreenEnum()

--- a/Code/Tools/ProjectManager/Source/ProjectGemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectGemCatalogScreen.cpp
@@ -23,7 +23,10 @@ namespace O3DE::ProjectManager
     ProjectGemCatalogScreen::ProjectGemCatalogScreen(DownloadController* downloadController, QWidget* parent)
         : GemCatalogScreen(downloadController , /*readOnly = */ false, parent)
     {
-
+        // We have to fetch the parent of our parent, because Project Manager Gem Catalog is usually embedded inside another workflow, like
+        // CreateProjectScreen or UpdateProjectScreen
+        // As such, it does not have direct access to ScreenControls
+        setupScreensControl(parent->parentWidget());
     }
 
     ProjectManagerScreen ProjectGemCatalogScreen::GetScreenEnum()

--- a/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
+++ b/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
@@ -42,7 +42,7 @@ namespace O3DE::ProjectManager
         vLayout->addWidget(m_header);
 
         m_updateSettingsScreen = new UpdateProjectSettingsScreen();
-        m_projectGemCatalogScreen = new ProjectGemCatalogScreen(downloadController);
+        m_projectGemCatalogScreen = new ProjectGemCatalogScreen(downloadController, this);
         m_gemRepoScreen = new GemRepoScreen(this);
 
         connect(m_projectGemCatalogScreen, &ScreenWidget::ChangeScreenRequest, this, &UpdateProjectCtrl::OnChangeScreenRequest);


### PR DESCRIPTION
… ScreensCtrl based on parent of parent

Signed-off-by: T.J. Kotha <112996779+tkothadev@users.noreply.github.com>

## What does this PR do?

This PR updates `ProjectGemCatalogScreen` and `GemCatalogScreen` to call a single function `GemCatalogScreen::setupScreensControl(QWidget* parent)` to handle initialization of `m_screensControl`. The reason for this is because `ProjectGemCatalogScreen` fails to initialize that variable, because it is not a direct descendant of the `ScreenCtrls` class, but rather one of `CreateProjectCtrl` or `UpdateProjectCtrl`.

As such, I've moved all initialization of `m_screenControls` to a helper function that can be called independently to pass in the necessary parent chain.

This PR is the fix for the following issue: https://github.com/o3de/o3de/issues/13770

## How was this PR tested?

_Please describe any testing performed._

All testing was performed manually to verify that the behavior observed in the original issue was fixed.

From the Project Screen:
![ProjejctGemCatalogEditButtonFixed](https://user-images.githubusercontent.com/112996779/217099840-4c9c9143-d5d2-4091-9180-3cf5a9e6c16c.gif)

From the Gems Tab:
![GemTabGemCatalogEditButtonFixed](https://user-images.githubusercontent.com/112996779/217100074-6db0d4df-9e3b-434d-82d4-b0dac8c64d04.gif)

When Creating a new Project:
![CreateProjectGemCatalogEditButtonFixed](https://user-images.githubusercontent.com/112996779/217100507-69d40b98-17cc-463b-b945-225e1ac7225f.gif)
