### PR TITLE
Fixed some ambiguous shortcuts with new action manager

### DIFF
--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphCanvasEditor/GraphCanvasAssetEditorMainWindow.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphCanvasEditor/GraphCanvasAssetEditorMainWindow.cpp
@@ -344,6 +344,7 @@ namespace GraphCanvas
         QAction* action = new QAction(QObject::tr("&New Asset"), this);
         action->setShortcut(QKeySequence::New);
         action->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        addAction(action);
         QObject::connect(action, &QAction::triggered, [this] {
             CreateEditorDockWidget();
         });
@@ -417,6 +418,7 @@ namespace GraphCanvas
         m_cutSelectedAction = new QAction(QObject::tr("Cut"), this);
         m_cutSelectedAction->setShortcut(QKeySequence::Cut);
         m_cutSelectedAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        addAction(m_cutSelectedAction);
         QObject::connect(m_cutSelectedAction, &QAction::triggered, [this] {
             SceneRequestBus::Event(GetActiveGraphCanvasGraphId(), &SceneRequests::CutSelection);
         });
@@ -430,6 +432,7 @@ namespace GraphCanvas
         m_copySelectedAction = new QAction(QObject::tr("Copy"), this);
         m_copySelectedAction->setShortcut(QKeySequence::Copy);
         m_copySelectedAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        addAction(m_copySelectedAction);
         QObject::connect(m_copySelectedAction, &QAction::triggered, [this] {
             SceneRequestBus::Event(GetActiveGraphCanvasGraphId(), &SceneRequests::CopySelection);
         });
@@ -443,6 +446,7 @@ namespace GraphCanvas
         m_pasteSelectedAction = new QAction(QObject::tr("Paste"), this);
         m_pasteSelectedAction->setShortcut(QKeySequence::Paste);
         m_pasteSelectedAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        addAction(m_pasteSelectedAction);
         QObject::connect(m_pasteSelectedAction, &QAction::triggered, [this] {
             SceneRequestBus::Event(GetActiveGraphCanvasGraphId(), &SceneRequests::Paste);
         });
@@ -456,6 +460,7 @@ namespace GraphCanvas
         m_duplicateSelectedAction = new QAction(QObject::tr("Duplicate"), this);
         m_duplicateSelectedAction->setShortcut(QKeySequence("Ctrl+D"));
         m_duplicateSelectedAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        addAction(m_duplicateSelectedAction);
         QObject::connect(m_duplicateSelectedAction, &QAction::triggered, [this] {
             SceneRequestBus::Event(GetActiveGraphCanvasGraphId(), &SceneRequests::DuplicateSelection);
         });
@@ -469,6 +474,7 @@ namespace GraphCanvas
         m_deleteSelectedAction = new QAction(QObject::tr("Delete"), this);
         m_deleteSelectedAction->setShortcut(QKeySequence::Delete);
         m_deleteSelectedAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        addAction(m_deleteSelectedAction);
         QObject::connect(m_deleteSelectedAction, &QAction::triggered, [this] {
             SceneRequestBus::Event(GetActiveGraphCanvasGraphId(), &SceneRequests::DeleteSelection);
         });

--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
@@ -16,9 +16,11 @@
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzFramework/Terrain/TerrainDataRequestBus.h>
 #include <AzQtComponents/Buses/ShortcutDispatch.h>
+#include <AzToolsFramework/ActionManager/Action/ActionManagerInterface.h>
 #include <AzToolsFramework/API/ComponentEntityObjectBus.h>
 #include <AzToolsFramework/API/EntityCompositionRequestBus.h>
 #include <AzToolsFramework/Commands/EntityStateCommand.h>
+#include <AzToolsFramework/Editor/ActionManagerUtils.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <AzToolsFramework/Entity/EditorEntityInfoBus.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
@@ -525,6 +527,19 @@ namespace LandscapeCanvasEditor
         m_sceneContextMenu->AddMenuAction(aznew FindSelectedNodesAction(this));
 
         UpdateGraphEnabled();
+
+        if (AzToolsFramework::IsNewActionManagerEnabled())
+        {
+            static constexpr AZStd::string_view LandscapeCanvasActionContextIdentifier = "o3de.context.editor.landscapecanvas";
+
+            auto actionManagerInterface = AZ::Interface<AzToolsFramework::ActionManagerInterface>::Get();
+
+            AzToolsFramework::ActionContextProperties contextProperties;
+            contextProperties.m_name = "O3DE Landscape Canvas";
+
+            // Register a custom action context to allow duplicated shortcut hotkeys to work
+            actionManagerInterface->RegisterActionContext("", LandscapeCanvasActionContextIdentifier, contextProperties, this);
+        }
     }
 
     MainWindow::~MainWindow()

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -82,11 +82,13 @@
 #include <AzFramework/Asset/AssetCatalog.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 
+#include <AzToolsFramework/ActionManager/Action/ActionManagerInterface.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserModel.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <AzToolsFramework/API/EntityCompositionRequestBus.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <AzToolsFramework/Editor/ActionManagerUtils.h>
 #include <AzToolsFramework/ToolsComponents/EditorEntityIdContainer.h>
 #include <AzToolsFramework/ToolsComponents/GenericComponentWrapper.h>
 #include <AzToolsFramework/ToolsComponents/ToolsAssetCatalogBus.h>
@@ -438,6 +440,19 @@ namespace ScriptCanvasEditor
         m_emptyCanvas->RegisterAcceptedMimeType(AzToolsFramework::EditorEntityIdContainer::GetMimeType());
 
         m_editorToolbar = aznew GraphCanvas::AssetEditorToolbar(ScriptCanvasEditor::AssetEditorId);
+
+        if (AzToolsFramework::IsNewActionManagerEnabled())
+        {
+            static constexpr AZStd::string_view ScriptCanvasActionContextIdentifier = "o3de.context.editor.scriptcanvas";
+
+            auto actionManagerInterface = AZ::Interface<AzToolsFramework::ActionManagerInterface>::Get();
+
+            AzToolsFramework::ActionContextProperties contextProperties;
+            contextProperties.m_name = "O3DE Script Canvas";
+
+            // Register a custom action context to allow duplicated shortcut hotkeys to work
+            actionManagerInterface->RegisterActionContext("", ScriptCanvasActionContextIdentifier, contextProperties, this);
+        }
 
         // Custom Actions
         {
@@ -1866,6 +1881,12 @@ namespace ScriptCanvasEditor
         ui->action_Copy->setShortcut(QKeySequence(QKeySequence::Copy));
         ui->action_Paste->setShortcut(QKeySequence(QKeySequence::Paste));
         ui->action_Delete->setShortcut(QKeySequence(QKeySequence::Delete));
+        addAction(ui->action_Undo);
+        addAction(ui->action_Cut);
+        addAction(ui->action_Copy);
+        addAction(ui->action_Paste);
+        addAction(ui->action_Delete);
+        addAction(ui->action_Duplicate);
 
         connect(ui->menuEdit, &QMenu::aboutToShow, this, &MainWindow::OnEditMenuShow);
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/mainwindow.ui
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/mainwindow.ui
@@ -167,7 +167,6 @@
    <addaction name="menuView_2"/>
    <addaction name="menuTools_2"/>
    <addaction name="menuSettings_2"/>
-   <addaction name="menuScript_Events_PREVIEW"/>
   </widget>
   <widget class="QStatusBar" name="statusBar"/>
   <action name="action_New_Script">
@@ -415,6 +414,9 @@
    <property name="shortcut">
     <string>Ctrl+D</string>
    </property>
+   <property name="shortcutContext">
+    <enum>Qt::WidgetWithChildrenShortcut</enum>
+   </property>
    <property name="autoRepeat">
     <bool>false</bool>
    </property>
@@ -425,6 +427,9 @@
    </property>
    <property name="text">
     <string>Delete</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::WidgetWithChildrenShortcut</enum>
    </property>
    <property name="autoRepeat">
     <bool>false</bool>


### PR DESCRIPTION
## What does this PR do?

Fix some additional ambiguous shortcuts in Script Canvas and Landscape Canvas when the new action manager is enabled. These are necessary since we are currently allowing a mix of actions registered with the new action manager + registered explicitly through Qt.

## How was this PR tested?

Tested shortcuts in Script Canvas and Landscape Canvas with the new action manager enabled and disabled and verified they worked as expected.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>