### PR TITLE
Added missing terrain seed files.

### DIFF
--- a/Gems/Terrain/Assets/seedList.seed
+++ b/Gems/Terrain/Assets/seedList.seed
@@ -1,5 +1,5 @@
 <ObjectStream version="3">
-	<Class name="AZStd::vector" type="{82FC5264-88D0-57CD-9307-FC52E4DAD550}">
+	<Class name="AZStd::vector&lt;SeedInfo, allocator&gt;" type="{82FC5264-88D0-57CD-9307-FC52E4DAD550}">
 		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
 			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
 				<Class name="AZ::Uuid" field="guid" value="{D9987129-3063-57BD-8A13-3E0A65BC127E}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
@@ -23,6 +23,22 @@
 			</Class>
 			<Class name="unsigned int" field="platformFlags" value="255" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			<Class name="AZStd::string" field="pathHint" value="passes/terrainpasstemplates.azasset" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{C2ADF3B1-E8B2-5314-898C-767A586ED0B9}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="255" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="materials/terrain/defaultpbrterrain.azmaterial" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{B6798C1D-73B7-5A75-AB9B-1D221498D400}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="255" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="materials/terrain/terraindetailmaterial.azmaterialtype" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 		</Class>
 	</Class>
 </ObjectStream>


### PR DESCRIPTION
## What does this PR do?

Adds more files to the default seed list in the Terrain Gem, so that asset bundles will contain the necessary material and shader files for rendering terrain.

## How was this PR tested?

Ran a release build of MultiplayerSample and verified that the terrain appeared. (Prior to this PR, the terrain did not appear)
