### PR TITLE
Ensure All AZ::Console Commands Eventually Get Called 

### DIFF
--- a/Code/Framework/AzCore/AzCore/Console/Console.cpp
+++ b/Code/Framework/AzCore/AzCore/Console/Console.cpp
@@ -53,7 +53,7 @@ namespace AZ
         MoveFunctorsToDeferredHead(AZ::ConsoleFunctorBase::GetDeferredHead());
     }
 
-    bool Console::PerformCommand
+    PerformCommandResult Console::PerformCommand
     (
         const char* command,
         ConsoleSilentMode silentMode,
@@ -83,7 +83,7 @@ namespace AZ
         return PerformCommand(commandView, commandArgsView, silentMode, invokedFrom, requiredSet, requiredClear);
     }
 
-    bool Console::PerformCommand
+    PerformCommandResult Console::PerformCommand
     (
         const ConsoleCommandContainer& commandAndArgs,
         ConsoleSilentMode silentMode,
@@ -94,13 +94,13 @@ namespace AZ
     {
         if (commandAndArgs.empty())
         {
-            return false;
+            return AZ::Failure("CommandAndArgs is empty.");
         }
 
         return PerformCommand(commandAndArgs.front(), ConsoleCommandContainer(commandAndArgs.begin() + 1, commandAndArgs.end()), silentMode, invokedFrom, requiredSet, requiredClear);
     }
 
-    bool Console::PerformCommand
+    PerformCommandResult Console::PerformCommand
     (
         AZStd::string_view command,
         const ConsoleCommandContainer& commandArgs,
@@ -120,11 +120,14 @@ namespace AZ
                                              requiredSet,
                                              requiredClear };
 
+            CVarFixedString commandLowercase(command);
+            AZStd::to_lower(commandLowercase.begin(), commandLowercase.end());
             m_deferredCommands.emplace_back(AZStd::move(deferredCommand));
-            return false;
+            return AZ::Failure(AZStd::string::format(
+                "Command \"%s\" is not yet registered. Deferring to attempt execution later.", commandLowercase.c_str()));
         }
 
-        return true;
+        return AZ::Success();
     }
 
     void Console::ExecuteConfigFile(AZStd::string_view configFileName)

--- a/Code/Framework/AzCore/AzCore/Console/Console.h
+++ b/Code/Framework/AzCore/AzCore/Console/Console.h
@@ -33,7 +33,7 @@ namespace AZ
 
         //! IConsole interface
         //! @{
-        bool PerformCommand
+        PerformCommandResult PerformCommand
         (
             const char* command,
             ConsoleSilentMode silentMode = ConsoleSilentMode::NotSilent,
@@ -41,7 +41,7 @@ namespace AZ
             ConsoleFunctorFlags requiredSet = ConsoleFunctorFlags::Null,
             ConsoleFunctorFlags requiredClear = ConsoleFunctorFlags::ReadOnly
         ) override;
-        bool PerformCommand
+        PerformCommandResult PerformCommand
         (
             const ConsoleCommandContainer& commandAndArgs,
             ConsoleSilentMode silentMode = ConsoleSilentMode::NotSilent,
@@ -49,7 +49,7 @@ namespace AZ
             ConsoleFunctorFlags requiredSet = ConsoleFunctorFlags::Null,
             ConsoleFunctorFlags requiredClear = ConsoleFunctorFlags::ReadOnly
         ) override;
-        bool PerformCommand
+        PerformCommandResult PerformCommand
         (
             AZStd::string_view command,
             const ConsoleCommandContainer& commandArgs,

--- a/Code/Framework/AzCore/AzCore/Console/IConsole.h
+++ b/Code/Framework/AzCore/AzCore/Console/IConsole.h
@@ -12,6 +12,7 @@
 #include <AzCore/Console/ConsoleDataWrapper.h>
 #include <AzCore/Console/IConsoleTypes.h>
 #include <AzCore/EBus/Event.h>
+#include <AzCore/Outcome/Outcome.h>
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/functional.h>
@@ -20,6 +21,7 @@ namespace AZ
 {
     class SettingsRegistryInterface;
     class CommandLine;
+    using PerformCommandResult = Outcome<void, AZStd::string>;
 
 
     //! @class IConsole
@@ -34,6 +36,7 @@ namespace AZ
         inline static constexpr AZStd::string_view ConsoleRuntimeCommandKey = "/Amazon/AzCore/Runtime/ConsoleCommands";
         inline static constexpr AZStd::string_view ConsoleAutoexecCommandKey = "/O3DE/Autoexec/ConsoleCommands";
 
+
         IConsole() = default;
         virtual ~IConsole() = default;
 
@@ -43,8 +46,9 @@ namespace AZ
         //! @param invokedFrom   the source point that initiated console invocation
         //! @param requiredSet   a set of flags that must be set on the functor for it to execute
         //! @param requiredClear a set of flags that must *NOT* be set on the functor for it to execute
-        //! @return boolean true on success, false otherwise
-        virtual bool PerformCommand
+        //! @return PerformCommandResult Returns "AZ::Success" if the command was executed; otherwise "AZ::Failure". 
+        //! Note: A failure could result in a deferred execution (check error for details).
+        virtual PerformCommandResult PerformCommand
         (
             const char* command,
             ConsoleSilentMode silentMode = ConsoleSilentMode::NotSilent,
@@ -59,8 +63,9 @@ namespace AZ
         //! @param invokedFrom    the source point that initiated console invocation
         //! @param requiredSet    a set of flags that must be set on the functor for it to execute
         //! @param requiredClear  a set of flags that must *NOT* be set on the functor for it to execute
-        //! @return boolean true on success, false otherwise
-        virtual bool PerformCommand
+        //! @return PerformCommandResult Returns "AZ::Success" if the command was executed; otherwise "AZ::Failure".
+        //! Note: A failure could result in a deferred execution (check error for details).
+        virtual PerformCommandResult PerformCommand
         (
             const ConsoleCommandContainer& commandAndArgs,
             ConsoleSilentMode silentMode = ConsoleSilentMode::NotSilent,
@@ -76,8 +81,9 @@ namespace AZ
         //! @param invokedFrom   the source point that initiated console invocation
         //! @param requiredSet   a set of flags that must be set on the functor for it to execute
         //! @param requiredClear a set of flags that must *NOT* be set on the functor for it to execute
-        //! @return boolean true on success, false otherwise
-        virtual bool PerformCommand
+        //! @return PerformCommandResult Returns "AZ::Success" if the command was executed; otherwise "AZ::Failure".
+        //! Note: A failure could result in a deferred execution (check error for details).
+        virtual PerformCommandResult PerformCommand
         (
             AZStd::string_view command,
             const ConsoleCommandContainer& commandArgs,

--- a/Code/Framework/AzCore/Tests/Console/ConsoleTests.cpp
+++ b/Code/Framework/AzCore/Tests/Console/ConsoleTests.cpp
@@ -348,7 +348,7 @@ namespace AZ
         // Verify that we can successfully execute a free-standing console functor.
         // The test functor puts the number of arguments into s_consoleFreeFuncArgs.
         s_consoleFreeFuncArgs = 0;
-        bool result = console->PerformCommand("TestFreeFunc arg1 arg2");
+        bool result = static_cast<bool>(console->PerformCommand("TestFreeFunc arg1 arg2"));
         EXPECT_TRUE(result);
         EXPECT_EQ(2, s_consoleFreeFuncArgs);
     }
@@ -361,7 +361,7 @@ namespace AZ
         // Verify that we can successfully execute a class instance console functor.
         // The test functor puts the number of arguments into m_classFuncArgs.
         m_classFuncArgs = 0;
-        bool result = console->PerformCommand("ConsoleTests.TestClassFunc arg1 arg2");
+        bool result = static_cast<bool>(console->PerformCommand("ConsoleTests.TestClassFunc arg1 arg2"));
         EXPECT_TRUE(result);
         EXPECT_EQ(2, m_classFuncArgs);
     }
@@ -389,7 +389,7 @@ namespace AZ
         AZ::IConsole* console = AZ::Interface<AZ::IConsole>::Get();
         ASSERT_TRUE(console);
 
-        bool result = console->PerformCommand("Example.TestClassFunc arg1 arg2");
+        bool result = static_cast<bool>(console->PerformCommand("Example.TestClassFunc arg1 arg2"));
         EXPECT_TRUE(result);
         for (auto& instance : multiInstances)
         {

--- a/Code/Legacy/CrySystem/SystemCFG.cpp
+++ b/Code/Legacy/CrySystem/SystemCFG.cpp
@@ -444,7 +444,7 @@ void CSystem::OnLoadConfigurationEntry(const char* szKey, const char* szValue, [
     {
         AZStd::string command(AZStd::string::format("%s %s", szKey, szValue));
 
-        azConsoleProcessed = console->PerformCommand(command.c_str());
+        azConsoleProcessed = static_cast<bool>(console->PerformCommand(command.c_str()));
     }
 
     if (!azConsoleProcessed)


### PR DESCRIPTION
Ensure AZ::Console::PerformCommand() will defer commands to be executed at a later time if the command isn't yet registered
Fixes #14449 

## How was this PR tested?
Call PerformCommand on a cvar before the gem module owning that cvar was registered. Later checked the cvar and noticed the cvar is now properly set. 
