### PR TITLE
Fix broken link to EBus docs

### DIFF
--- a/Code/Framework/AzCore/AzCore/EBus/BusImpl.h
+++ b/Code/Framework/AzCore/AzCore/EBus/BusImpl.h
@@ -10,7 +10,7 @@
  * @file
  * Header file for internal EBus classes.
  * For more information about EBuses, see AZ::EBus and AZ::EBusTraits in this guide and
- * [Event Bus documentation](https://www.o3de.org/docs/user-guide/programming/ebus/).
+ * [Event Bus documentation](https://www.o3de.org/docs/user-guide/programming/messaging/ebus/).
  */
 
 #pragma once


### PR DESCRIPTION
## What does this PR do?

It resolves a (soon-to-be) broken documentation link to the EBus docs. 
The PR that changes the link is located here: https://github.com/o3de/o3de.org/pull/2209
