### PR TITLE
Fix the height of the polygon light will be reset to 0 if other parameters are modified

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/PolygonLightDelegate.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/PolygonLightDelegate.cpp
@@ -17,7 +17,6 @@ namespace AZ::Render
         , m_shapeBus(shapeBus)
     {
         InitBase(entityId);
-        shapeBus->SetHeight(0.0f);
     }
 
     void PolygonLightDelegate::SetLightEmitsBothDirections(bool lightEmitsBothDirections)


### PR DESCRIPTION
Signed-off-by: Zhang-Baochong <zhangbaochong@huawei.com>

## What does this PR do?
 The parameter Height for the Polygon light is set to 0 improperly when operating any other parameter.
Fixes : #5541

## How was this PR tested?
Manually tested in editor.
1.Open Editor.
2.Create a new Entity.
3.Add `Light` Component.
4.Select `Polygon` as Light type.
5.Change the Height value.
6.Change any other parameter on the Light panel, the Height value set previously is unchanged.
