### PR TITLE
Forbid to modify shadow parameters if disabled shadow.

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentConfig.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentConfig.cpp
@@ -191,13 +191,14 @@ namespace AZ
 
         bool AreaLightComponentConfig::IsShadowPcfDisabled() const
         {
-            return !(m_shadowFilterMethod == ShadowFilterMethod::Pcf ||
+            return ShadowsDisabled() || !(m_shadowFilterMethod == ShadowFilterMethod::Pcf ||
                 m_shadowFilterMethod == ShadowFilterMethod::EsmPcf);
         }
 
         bool AreaLightComponentConfig::IsEsmDisabled() const
         {
-            return !(m_shadowFilterMethod == ShadowFilterMethod::Esm || m_shadowFilterMethod == ShadowFilterMethod::EsmPcf);
+            return ShadowsDisabled() ||
+                !(m_shadowFilterMethod == ShadowFilterMethod::Esm || m_shadowFilterMethod == ShadowFilterMethod::EsmPcf);
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Zhang-Baochong <zhangbaochong@huawei.com>

## What does this PR do?

Some parameters can be modified even if disabled shadow.

![1](https://user-images.githubusercontent.com/124341515/217483552-dd76e0bc-c657-4b27-af33-54503ff11e2f.png)

## How was this PR tested?

Manually tested in editor.
1.Open Editor.
2.Create a new Entity.
3.Add Light Component.
4.Close `Enable shadow`
5.Test if all parameters of shaodw cannot be modified.
![2](https://user-images.githubusercontent.com/124341515/217484520-9b3c85be-f3cf-48a2-a422-37b450992381.png)

