### PR TITLE
Fixed error while loading PhysX materials.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/Material/PhysicsMaterialManager.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Material/PhysicsMaterialManager.cpp
@@ -62,24 +62,27 @@ namespace Physics
             return materialFound;
         }
 
-        // Take a reference so we can mutate it.
-        AZ::Data::Asset<AZ::Data::AssetData> assetLocal = materialAsset;
-        if (!assetLocal.IsReady())
-        {
-            assetLocal.QueueLoad();
-            assetLocal.BlockUntilLoadComplete();
-
-            // Failed to load the asset
-            if (!assetLocal.IsReady())
-            {
-                return nullptr;
-            }
-        }
-
-        auto newMaterial = CreateMaterialInternal(id, assetLocal);
+        auto newMaterial = CreateMaterialInternal(id, materialAsset);
         if (newMaterial)
         {
             m_materials.emplace(newMaterial->GetId(), newMaterial);
+        }
+
+        // Block until the material asset is loaded.
+        // It's important that the loading of physics material assets is not delayed,
+        // otherwise objects would react differently during simulation for a few
+        // frames until the material is loaded, causing unexpected behaviors.
+        AZ::Data::Asset<AZ::Data::AssetData> assetLocal = materialAsset; // Take a reference so we can mutate it for loading.
+        if (!assetLocal.IsReady())
+        {
+            assetLocal.QueueLoad();
+
+            // The call to BlockUntilLoadComplete must happen after the new material
+            // has been added to m_materials container. This is because BlockUntilLoadComplete
+            // will dispatch events for other assets while waiting, and if other OnAssetRead
+            // code ends up trying find/create the same material it needs to find it in the
+            // container and return it.
+            assetLocal.BlockUntilLoadComplete();
         }
 
         return newMaterial;

--- a/Gems/PhysX/Code/Include/PhysX/Material/PhysXMaterial.h
+++ b/Gems/PhysX/Code/Include/PhysX/Material/PhysXMaterial.h
@@ -116,6 +116,7 @@ namespace PhysX
 
     protected:
         // AssetBus overrides...
+        void OnAssetReady(AZ::Data::Asset<AZ::Data::AssetData> asset) override;
         void OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset) override;
 
     private:

--- a/Gems/PhysX/Code/Source/BaseColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/BaseColliderComponent.cpp
@@ -329,7 +329,7 @@ namespace PhysX
         }
 
         const bool hasNonUniformScale = (AZ::NonUniformScaleRequestBus::FindFirstHandler(GetEntityId()) != nullptr);
-        Utils::GetShapesFromAsset(physicsAssetConfiguration, componentColliderConfiguration, hasNonUniformScale,
+        Utils::CreateShapesFromAsset(physicsAssetConfiguration, componentColliderConfiguration, hasNonUniformScale,
             physicsAssetConfiguration.m_subdivisionLevel, m_shapes);
 
         return true;

--- a/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
@@ -667,7 +667,7 @@ namespace PhysX
         if (m_shapeConfiguration.IsAssetConfig())
         {
             AZStd::vector<AZStd::shared_ptr<Physics::Shape>> shapes;
-            Utils::GetShapesFromAsset(m_shapeConfiguration.m_physicsAsset.m_configuration,
+            Utils::CreateShapesFromAsset(m_shapeConfiguration.m_physicsAsset.m_configuration,
                 m_configuration, m_hasNonUniformScale, m_shapeConfiguration.m_subdivisionLevel, shapes);
             configuration.m_colliderAndShapeData = shapes;
         }
@@ -823,7 +823,7 @@ namespace PhysX
             m_shapeConfiguration.m_physicsAsset.m_pxAsset.IsReady())
         {
             AZStd::vector<AZStd::shared_ptr<Physics::Shape>> shapes;
-            Utils::GetShapesFromAsset(m_shapeConfiguration.m_physicsAsset.m_configuration, m_configuration, m_hasNonUniformScale,
+            Utils::CreateShapesFromAsset(m_shapeConfiguration.m_physicsAsset.m_configuration, m_configuration, m_hasNonUniformScale,
                 m_shapeConfiguration.m_subdivisionLevel, shapes);
 
             if (shapes.empty())

--- a/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
@@ -29,7 +29,7 @@ namespace PhysX
 {
     namespace Internal
     {
-        AZStd::vector<AZStd::shared_ptr<Physics::Shape>> GetCollisionShapes(AZ::Entity* entity)
+        AZStd::vector<AZStd::shared_ptr<Physics::Shape>> CreateCollisionShapes(AZ::Entity* entity)
         {
             AZStd::vector<AZStd::shared_ptr<Physics::Shape>> allShapes;
 
@@ -50,7 +50,8 @@ namespace PhysX
                 if (shapeConfigurationProxy.IsAssetConfig())
                 {
                     AZStd::vector<AZStd::shared_ptr<Physics::Shape>> shapes;
-                    Utils::GetShapesFromAsset(shapeConfigurationProxy.m_physicsAsset.m_configuration,
+                    Utils::CreateShapesFromAsset(
+                        shapeConfigurationProxy.m_physicsAsset.m_configuration,
                         colliderConfigurationUnscaled, hasNonUniformScaleComponent, shapeConfigurationProxy.m_subdivisionLevel, shapes);
 
                     for (const auto& shape : shapes)
@@ -517,7 +518,7 @@ namespace PhysX
         configuration.m_position = colliderTransform.GetTranslation();
         configuration.m_entityId = GetEntityId();
         configuration.m_debugName = GetEntity()->GetName();
-        configuration.m_colliderAndShapeData = Internal::GetCollisionShapes(GetEntity());
+        configuration.m_colliderAndShapeData = Internal::CreateCollisionShapes(GetEntity());
 
         if (auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get())
         {

--- a/Gems/PhysX/Code/Source/Material/PhysXMaterial.cpp
+++ b/Gems/PhysX/Code/Source/Material/PhysXMaterial.cpp
@@ -119,14 +119,6 @@ namespace PhysX
         AZ_Assert(m_pxMaterial, "Failed to create physx material");
         m_pxMaterial->userData = this;
 
-        MaterialConfiguration::ValidateMaterialAsset(m_materialAsset);
-
-        for (const auto& materialProperty : m_materialAsset->GetMaterialProperties())
-        {
-            SetProperty(materialProperty.first, materialProperty.second);
-        }
-
-        // Connect to asset bus to listen to asset reloads notifications
         AZ::Data::AssetBus::Handler::BusConnect(m_materialAsset.GetId());
     }
 
@@ -296,7 +288,7 @@ namespace PhysX
         return m_pxMaterial.get();
     }
 
-    void Material::OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset)
+    void Material::OnAssetReady(AZ::Data::Asset<AZ::Data::AssetData> asset)
     {
         m_materialAsset = asset;
 
@@ -306,5 +298,10 @@ namespace PhysX
         {
             SetProperty(materialProperty.first, materialProperty.second);
         }
+    }
+
+    void Material::OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset)
+    {
+        OnAssetReady(asset);
     }
 } // namespace PhysX

--- a/Gems/PhysX/Code/Source/Utils.cpp
+++ b/Gems/PhysX/Code/Source/Utils.cpp
@@ -1150,7 +1150,7 @@ namespace PhysX
             }
         }
 
-        void GetShapesFromAsset(const Physics::PhysicsAssetShapeConfiguration& assetConfiguration,
+        void CreateShapesFromAsset(const Physics::PhysicsAssetShapeConfiguration& assetConfiguration,
             const Physics::ColliderConfiguration& originalColliderConfiguration, bool hasNonUniformScale,
             AZ::u8 subdivisionLevel, AZStd::vector<AZStd::shared_ptr<Physics::Shape>>& resultingShapes)
         {

--- a/Gems/PhysX/Code/Source/Utils.h
+++ b/Gems/PhysX/Code/Source/Utils.h
@@ -172,7 +172,7 @@ namespace PhysX
 
         bool TriggerColliderExists(AZ::EntityId entityId);
 
-        void GetShapesFromAsset(const Physics::PhysicsAssetShapeConfiguration& assetConfiguration,
+        void CreateShapesFromAsset(const Physics::PhysicsAssetShapeConfiguration& assetConfiguration,
             const Physics::ColliderConfiguration& originalColliderConfiguration, bool hasNonUniformScale,
             AZ::u8 subdivisionLevel, AZStd::vector<AZStd::shared_ptr<Physics::Shape>>& resultingShapes);
 


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

Fixes a bug that causes a crash when while waiting for a physics material asset to load the asset manager dispatches events for other assets. These events can cause `OnAssetReady` of other assets to be called and if those end up trying to create the same physics material then it leads to the crash.

Solved by creating the material first, then block until loaded.

Also renamed the utility function `GetShapesFromAsset` to `CreateShapesFromAsset` since that reflects better what it does.

## How was this PR tested?

Run PhysX unit tests.
Tested using a local level that was crashing while loading due to the issue described above. After this fix the level loads correctly. Also debugged the loading of colliders and rigid bodies to verify it works correctly.
