### PR TITLE
Bug Fix: Empty combo box on Component change

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/GenericComboBoxCtrl.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/GenericComboBoxCtrl.h
@@ -92,6 +92,7 @@ namespace AzToolsFramework
         void addElements(const AZStd::vector<AZStd::pair<T, AZStd::string>>& genericValues);
         void addElement(const AZStd::pair<T, AZStd::string>& genericValue);
         void setElements(const AZStd::vector<AZStd::pair<T, AZStd::string>>& genericValues);
+        void clearElements();
 
         void SetWarning(const AZStd::string& warningText);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/GenericComboBoxCtrl.inl
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/GenericComboBoxCtrl.inl
@@ -18,6 +18,10 @@ AZ_POP_DISABLE_WARNING
 #include <AzToolsFramework/UI/PropertyEditor/PropertyQTConstants.h>
 #include <AzToolsFramework/UI/PropertyEditor/DHQComboBox.hxx>
 
+
+#pragma optimize("", off)
+#pragma inline_depth(0)
+
 namespace
 {
     template<typename T>
@@ -164,6 +168,14 @@ namespace AzToolsFramework
             m_values.push_back(genericValue);
             m_pComboBox->addItem(genericValue.second.data());
         }
+    }
+
+    template<typename T>
+    void GenericComboBoxCtrl<T>::clearElements()
+    {
+        QSignalBlocker signalBlocker(m_pComboBox);
+        m_values.clear();
+        m_pComboBox->clear();
     }
 
     template<typename T>
@@ -433,3 +445,5 @@ namespace AzToolsFramework
         }
     }
 } // namespace AzToolsFramework
+#pragma optimize("", on)
+#pragma inline_depth()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/GenericComboBoxCtrl.inl
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/GenericComboBoxCtrl.inl
@@ -18,10 +18,6 @@ AZ_POP_DISABLE_WARNING
 #include <AzToolsFramework/UI/PropertyEditor/PropertyQTConstants.h>
 #include <AzToolsFramework/UI/PropertyEditor/DHQComboBox.hxx>
 
-
-#pragma optimize("", off)
-#pragma inline_depth(0)
-
 namespace
 {
     template<typename T>
@@ -445,5 +441,3 @@ namespace AzToolsFramework
         }
     }
 } // namespace AzToolsFramework
-#pragma optimize("", on)
-#pragma inline_depth()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.cpp
@@ -46,7 +46,7 @@ namespace AzToolsFramework
 
     void PropertyStringComboBoxCtrl::Add(const AZStd::vector<AZStd::string>& vals)
     {
-        GetComboBox()->clear();
+        ComboBoxBase::clearElements();
         for (size_t valIndex = 0; valIndex < vals.size(); valIndex++)
         {
             auto value = vals[valIndex];

--- a/Gems/NvCloth/Code/Source/Editor/MeshNodeHandler.cpp
+++ b/Gems/NvCloth/Code/Source/Editor/MeshNodeHandler.cpp
@@ -98,8 +98,7 @@ namespace NvCloth
 
         bool MeshNodeHandler::ReadValuesIntoGUI([[maybe_unused]] size_t index, widget_t* GUI, const property_t& instance, [[maybe_unused]] AzToolsFramework::InstanceDataNode* node)
         {
-            QSignalBlocker signalBlocker(GUI->GetComboBox());
-            GUI->GetComboBox()->setCurrentText(instance.c_str());
+            GUI->setValue(instance);
             return true;
         }
 

--- a/Gems/NvCloth/Code/Source/Editor/MeshNodeHandler.cpp
+++ b/Gems/NvCloth/Code/Source/Editor/MeshNodeHandler.cpp
@@ -74,12 +74,11 @@ namespace NvCloth
                 AZStd::vector<AZStd::string> value;
                 if (attrValue->Read<AZStd::vector<AZStd::string>>(value))
                 {
-                    QSignalBlocker signalBlocker(GUI->GetComboBox());
-                    GUI->GetComboBox()->clear();
+                    GUI->clearElements();
 
                     for (const auto& item : value)
                     {
-                        GUI->GetComboBox()->addItem(item.c_str());
+                        GUI->Add(item);
                     }
 
                     bool hasAsset = GetMeshAsset(m_entityId).Get() != nullptr;

--- a/Gems/PhysX/Code/Editor/CollisionGroupWidget.cpp
+++ b/Gems/PhysX/Code/Editor/CollisionGroupWidget.cpp
@@ -70,7 +70,6 @@ namespace PhysX
 
         bool CollisionGroupWidget::ReadValuesIntoGUI([[maybe_unused]] size_t index, widget_t* GUI, const property_t& instance, [[maybe_unused]] AzToolsFramework::InstanceDataNode* node)
         {
-            QSignalBlocker signalBlocker(GUI->GetComboBox());
             GUI->clearElements();
 
             auto groupNames = GetGroupNames();
@@ -79,8 +78,7 @@ namespace PhysX
                 GUI->Add(layerName);
             }
 
-            auto groupName = GetNameFromGroup(instance);
-            GUI->GetComboBox()->setCurrentText(groupName.c_str());
+            GUI->setValue(GetNameFromGroup(instance));
             return false;
         }
 

--- a/Gems/PhysX/Code/Editor/CollisionGroupWidget.cpp
+++ b/Gems/PhysX/Code/Editor/CollisionGroupWidget.cpp
@@ -71,7 +71,7 @@ namespace PhysX
         bool CollisionGroupWidget::ReadValuesIntoGUI([[maybe_unused]] size_t index, widget_t* GUI, const property_t& instance, [[maybe_unused]] AzToolsFramework::InstanceDataNode* node)
         {
             QSignalBlocker signalBlocker(GUI->GetComboBox());
-            GUI->GetComboBox()->clear();
+            GUI->clearElements();
 
             auto groupNames = GetGroupNames();
             for (auto& layerName : groupNames)

--- a/Gems/PhysX/Code/Editor/CollisionLayerWidget.cpp
+++ b/Gems/PhysX/Code/Editor/CollisionLayerWidget.cpp
@@ -74,9 +74,7 @@ namespace PhysX
                 GUI->Add(layerName);
             }
 
-            auto layerName = GetNameFromLayer(instance);
-            GUI->GetComboBox()->setCurrentText(layerName.c_str());
-
+            GUI->setValue(GetNameFromLayer(instance));
             return true;
         }
 

--- a/Gems/PhysX/Code/Editor/CollisionLayerWidget.cpp
+++ b/Gems/PhysX/Code/Editor/CollisionLayerWidget.cpp
@@ -66,8 +66,7 @@ namespace PhysX
 
         bool CollisionLayerWidget::ReadValuesIntoGUI([[maybe_unused]] size_t index, widget_t* GUI, const property_t& instance, [[maybe_unused]] AzToolsFramework::InstanceDataNode* node)
         {
-            QSignalBlocker signalBlocker(GUI->GetComboBox());
-            GUI->GetComboBox()->clear();
+            GUI->clearElements();
 
             auto layerNames = GetLayerNames();
             for (auto& layerName : layerNames)


### PR DESCRIPTION
## What does this PR do?

The custom widgets `CollisionLayerWidget`, `CollisionGroupWidget` and `MeshNodeHandler` were recently changed to indirectly inherit from `GenericComboBoxCtrl`. This created a bug where the widgets were trying to clear and re-add elements to the ComboBox but the values were not being re-added because they weren't being cleared from the values stored in the `GenericComboBoxCtrl`.

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_

When the component changed the fields were cleared and not repopulated, this PR corrects the behavior of the elements being removed so that it can work as intended.

![Editor_HxfCxOfiT9](https://user-images.githubusercontent.com/105638312/217605591-687ea27a-35b2-4a32-a71c-6109c9ab14cd.png)


## How was this PR tested?

Manual testing in editor.