### PR TITLE
Fix for create new asset in thumbnail view

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -333,8 +333,23 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
     connect(m_ui->m_assetBrowserTreeViewWidget, &AzAssetBrowser::AssetBrowserTreeView::ClearTypeFilter,
         m_ui->m_searchWidget, &AzAssetBrowser::SearchWidget::ClearTypeFilter);
 
-    connect(m_assetBrowserModel, &AzAssetBrowser::AssetBrowserModel::RequestOpenItemForEditing,
-        m_ui->m_assetBrowserTreeViewWidget, &AzAssetBrowser::AssetBrowserTreeView::OpenItemForEditing);
+    connect(
+        m_assetBrowserModel,
+        &AzAssetBrowser::AssetBrowserModel::RequestOpenItemForEditing,
+        this,
+        [this](const QModelIndex& index)
+        {
+            m_ui->m_assetBrowserTreeViewWidget->OpenItemForEditing(index);
+        });
+
+    connect(
+        m_assetBrowserModel,
+        &AzAssetBrowser::AssetBrowserModel::RequestThumbnailviewUpdate,
+        this,
+        [this]
+        {
+            m_ui->m_thumbnailView->UpdateThumbnailview();
+        });
 
     connect(this, &AzAssetBrowserWindow::SizeChangedSignal,
         m_ui->m_assetBrowserTableViewWidget, &AzAssetBrowser::AssetBrowserTableView::UpdateSizeSlot);

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -336,20 +336,11 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
     connect(
         m_assetBrowserModel,
         &AzAssetBrowser::AssetBrowserModel::RequestOpenItemForEditing,
-        this,
-        [this](const QModelIndex& index)
-        {
-            m_ui->m_assetBrowserTreeViewWidget->OpenItemForEditing(index);
-        });
+        m_ui->m_assetBrowserTreeViewWidget, &AzAssetBrowser::AssetBrowserTreeView::OpenItemForEditing);
 
     connect(
-        m_assetBrowserModel,
-        &AzAssetBrowser::AssetBrowserModel::RequestThumbnailviewUpdate,
-        this,
-        [this]
-        {
-            m_ui->m_thumbnailView->UpdateThumbnailview();
-        });
+        m_assetBrowserModel, &AzAssetBrowser::AssetBrowserModel::RequestThumbnailviewUpdate,
+            m_ui->m_thumbnailView, &AzAssetBrowser::AssetBrowserThumbnailView::UpdateThumbnailview);
 
     connect(this, &AzAssetBrowserWindow::SizeChangedSignal,
         m_ui->m_assetBrowserTableViewWidget, &AzAssetBrowser::AssetBrowserTableView::UpdateSizeSlot);

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
@@ -462,7 +462,7 @@ namespace AzQtComponents
     void AssetFolderThumbnailView::RefreshThumbnailview()
     {
         updateGeometries();
-        repaint();
+        update();
     }
 
     QModelIndex AssetFolderThumbnailView::moveCursor(QAbstractItemView::CursorAction cursorAction, Qt::KeyboardModifiers modifiers)

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
@@ -459,10 +459,10 @@ namespace AzQtComponents
         }
     }
 
-    void AssetFolderThumbnailView::RefreshRootIndex()
+    void AssetFolderThumbnailView::RefreshThumbnailview()
     {
-        QAbstractItemView::setRootIndex(rootIndex());
-        emit rootIndexChanged(rootIndex());
+        updateGeometries();
+        repaint();
     }
 
     QModelIndex AssetFolderThumbnailView::moveCursor(QAbstractItemView::CursorAction cursorAction, Qt::KeyboardModifiers modifiers)

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
@@ -459,6 +459,12 @@ namespace AzQtComponents
         }
     }
 
+    void AssetFolderThumbnailView::RefreshRootIndex()
+    {
+        QAbstractItemView::setRootIndex(rootIndex());
+        emit rootIndexChanged(rootIndex());
+    }
+
     QModelIndex AssetFolderThumbnailView::moveCursor(QAbstractItemView::CursorAction cursorAction, Qt::KeyboardModifiers modifiers)
     {
         Q_UNUSED(modifiers);

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.h
@@ -107,6 +107,8 @@ namespace AzQtComponents
 
         void setRootIndex(const QModelIndex &index) override;
 
+        void RefreshRootIndex();
+
         void SetShowSearchResultsMode(bool searchMode);
 
         void HideProductAssets(bool checked);

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.h
@@ -107,7 +107,7 @@ namespace AzQtComponents
 
         void setRootIndex(const QModelIndex &index) override;
 
-        void RefreshRootIndex();
+        void RefreshThumbnailview();
 
         void SetShowSearchResultsMode(bool searchMode);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserBus.h
@@ -362,7 +362,8 @@ namespace AzToolsFramework
             //! Notifies the handler that a new asset was created from the editor so they can handle renaming or other behavior as necessary.
             //! @param assetPath The full path to the asset that was created.
             //! @param creatorBusId The file creator's bus handler address. A default constructed Crc32 implies no one is listening.
-            virtual void HandleAssetCreatedInEditor(const AZStd::string_view /*assetPath*/, const AZ::Crc32& /*creatorBusId*/) {}
+            //! @param initialFilenameChange Notifies the handler that this file should give users the option to rename upon creation, set to false if you will use custom naming
+            virtual void HandleAssetCreatedInEditor(const AZStd::string_view /*assetPath*/, const AZ::Crc32& /*creatorBusId*/, const bool /*initialFilenameChange*/) {}
 
             //! Notifies a given handler that an asset which was recently created has been given a non-default name.
             //! @param assetPath The full path to the asset that had its initial name change.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.cpp
@@ -272,14 +272,14 @@ namespace AzToolsFramework
             return SourceFileDetails();
         }
 
-        void AssetBrowserComponent::HandleAssetCreatedInEditor(const AZStd::string_view assetPath, const AZ::Crc32& creatorBusId)
+        void AssetBrowserComponent::HandleAssetCreatedInEditor(const AZStd::string_view assetPath, const AZ::Crc32& creatorBusId, const bool initialFilenameChange)
         {
             if (assetPath.empty())
             {
                 return;
             }
 
-            m_assetBrowserModel->HandleAssetCreatedInEditor(assetPath, creatorBusId);
+            m_assetBrowserModel->HandleAssetCreatedInEditor(assetPath, creatorBusId, initialFilenameChange);
         }
 
         void AssetBrowserComponent::AddFile(const AZ::s64& fileId) 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.h
@@ -139,7 +139,7 @@ namespace AzToolsFramework
 
             //////////////////////////////////////////////////////////////////////////
             // AssetBrowserFileCreationNotificationBus
-            void HandleAssetCreatedInEditor(const AZStd::string_view assetPath, const AZ::Crc32& creatorBusId /*= AZ::Crc32()*/) override;
+            void HandleAssetCreatedInEditor(const AZStd::string_view assetPath, const AZ::Crc32& creatorBusId /*= AZ::Crc32()*/, const bool initialFilenameChange) override;
             //////////////////////////////////////////////////////////////////////////
         };
     } // namespace AssetBrowser

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
@@ -440,7 +440,7 @@ namespace AzToolsFramework
                     }
                 }
 
-                if (!m_newlyCreatedAssetPathsToCreatorBusIds.empty())
+                if (!m_newlyCreatedAssetPathsToCreatorBusIds.empty() || !m_customNewlyCreatedAssetPathsToCreatorBusIds.empty())
                 {
                     // Gets the newest child with the assumption that BeginAddEntry still adds entries at GetChildCount
                     AssetBrowserEntry* newestChildEntry = parent->GetChild(parent->GetChildCount() - 1);
@@ -469,16 +469,24 @@ namespace AzToolsFramework
             }
         }
 
-        void AssetBrowserModel::HandleAssetCreatedInEditor(const AZStd::string& assetPath, const AZ::Crc32& creatorBusId)
+        void AssetBrowserModel::HandleAssetCreatedInEditor(const AZStd::string& assetPath, const AZ::Crc32& creatorBusId, const bool initialFilenameChange)
         {
-            QModelIndex index = findIndex(assetPath.c_str());
-            if (index.isValid())
+            if (initialFilenameChange)
             {
-                emit RequestOpenItemForEditing(index);
+                QModelIndex index = findIndex(assetPath.c_str());
+                if (index.isValid())
+                {
+                    emit RequestOpenItemForEditing(index);
+                    emit RequestThumbnailviewUpdate();
+                }
+                else
+                {
+                    m_newlyCreatedAssetPathsToCreatorBusIds[AZ::IO::Path(assetPath).AsPosix()] = creatorBusId;
+                }
             }
             else
             {
-                m_newlyCreatedAssetPathsToCreatorBusIds[AZ::IO::Path(assetPath).AsPosix()] = creatorBusId;
+                m_customNewlyCreatedAssetPathsToCreatorBusIds[AZ::IO::Path(assetPath).AsPosix()] = creatorBusId;
             }
         }
 
@@ -548,6 +556,28 @@ namespace AzToolsFramework
                         if (GetEntryIndex(entry, index))
                         {
                             emit RequestOpenItemForEditing(index);
+                            emit RequestThumbnailviewUpdate();
+                        }
+                    });
+            }
+            else if (m_customNewlyCreatedAssetPathsToCreatorBusIds.contains(fullpath))
+            {
+                if (m_customNewlyCreatedAssetPathsToCreatorBusIds[fullpath] != AZ::Crc32())
+                {
+                    m_assetEntriesToCreatorBusIds[entry] = m_customNewlyCreatedAssetPathsToCreatorBusIds[fullpath];
+                }
+
+                m_customNewlyCreatedAssetPathsToCreatorBusIds.erase(fullpath);
+
+                QTimer::singleShot(
+                    0,
+                    this,
+                    [this, entry]()
+                    {
+                        QModelIndex index;
+                        if (GetEntryIndex(entry, index))
+                        {
+                            emit RequestThumbnailviewUpdate();
                         }
                     });
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.h
@@ -99,12 +99,14 @@ namespace AzToolsFramework
             static void SourceIndexesToAssetIds(const QModelIndexList& indexes, AZStd::vector<AZ::Data::AssetId>& assetIds);
             static void SourceIndexesToAssetDatabaseEntries(const QModelIndexList& indexes, AZStd::vector<AssetBrowserEntry*>& entries);
 
-            void HandleAssetCreatedInEditor(const AZStd::string& assetPath, const AZ::Crc32& creatorBusId = AZ::Crc32());
+            void HandleAssetCreatedInEditor(const AZStd::string& assetPath, const AZ::Crc32& creatorBusId = AZ::Crc32(), const bool initialFilenameChange = true);
 
             bool GetEntryIndex(AssetBrowserEntry* entry, QModelIndex& index) const;
 
         Q_SIGNALS:
             void RequestOpenItemForEditing(const QModelIndex& index);
+
+            void RequestThumbnailviewUpdate();
 
         private:
             //Non owning pointer
@@ -116,6 +118,7 @@ namespace AzToolsFramework
             bool m_isTickBusEnabled = false;
             AZStd::unordered_map<AssetBrowserEntry*, AZ::Crc32> m_assetEntriesToCreatorBusIds;
             AZStd::unordered_map<AZStd::string, AZ::Crc32> m_newlyCreatedAssetPathsToCreatorBusIds;
+            AZStd::unordered_map<AZStd::string, AZ::Crc32> m_customNewlyCreatedAssetPathsToCreatorBusIds;
 
             void WatchForExpectedAssets(AssetBrowserEntry* entry);
         };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
@@ -78,6 +78,7 @@ namespace AzToolsFramework
                 m_thumbnailViewProxyModel,
                 &AssetBrowserThumbnailViewProxyModel::SetRootIndex);
 
+
             auto layout = new QVBoxLayout();
             layout->addWidget(m_thumbnailViewWidget);
             setLayout(layout);
@@ -177,6 +178,11 @@ namespace AzToolsFramework
             {
                 m_thumbnailViewWidget->setRootIndex({});
             }
+        }
+
+        void AssetBrowserThumbnailView::UpdateThumbnailview()
+        {
+            m_thumbnailViewWidget->RefreshRootIndex();
         }
 
         void AssetBrowserThumbnailView::UpdateFilterInLocalFilterModel()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
@@ -78,7 +78,6 @@ namespace AzToolsFramework
                 m_thumbnailViewProxyModel,
                 &AssetBrowserThumbnailViewProxyModel::SetRootIndex);
 
-
             auto layout = new QVBoxLayout();
             layout->addWidget(m_thumbnailViewWidget);
             setLayout(layout);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
@@ -181,7 +181,7 @@ namespace AzToolsFramework
 
         void AssetBrowserThumbnailView::UpdateThumbnailview()
         {
-            m_thumbnailViewWidget->RefreshRootIndex();
+            m_thumbnailViewWidget->RefreshThumbnailview();
         }
 
         void AssetBrowserThumbnailView::UpdateFilterInLocalFilterModel()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h
@@ -43,6 +43,8 @@ namespace AzToolsFramework
 
             void HideProductAssets(bool checked);
 
+            void UpdateThumbnailview();
+
             AzQtComponents::AssetFolderThumbnailView* GetThumbnailViewWidget() const;
 
             void setSelectionMode(QAbstractItemView::SelectionMode mode);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h
@@ -43,8 +43,6 @@ namespace AzToolsFramework
 
             void HideProductAssets(bool checked);
 
-            void UpdateThumbnailview();
-
             AzQtComponents::AssetFolderThumbnailView* GetThumbnailViewWidget() const;
 
             void setSelectionMode(QAbstractItemView::SelectionMode mode);
@@ -54,6 +52,9 @@ namespace AzToolsFramework
             void entryClicked(const AssetBrowserEntry* entry);
             void entryDoubleClicked(const AssetBrowserEntry* entry);
             void showInFolderTriggered(const AssetBrowserEntry* entry);
+
+        public Q_SLOTS:
+            void UpdateThumbnailview();
 
         private:
             AssetBrowserTreeView* m_assetTreeView = nullptr;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -898,7 +898,8 @@ namespace AzToolsFramework
                         AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::FileCreationNotificationBusId,
                         &AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::HandleAssetCreatedInEditor,
                         path.c_str(),
-                        AZ::Crc32());
+                        AZ::Crc32(),
+                        true);
 
                     if (!AZ::IO::SystemFile::Exists(path.c_str()))
                     {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Script/LuaEditorSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Script/LuaEditorSystemComponent.cpp
@@ -81,7 +81,8 @@ namespace AzToolsFramework
                         AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::FileCreationNotificationBusId,
                         &AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::HandleAssetCreatedInEditor,
                         fullFilepath,
-                        AZ::Crc32());
+                        AZ::Crc32(),
+                        true);
                 }
                 else
                 {
@@ -112,7 +113,8 @@ namespace AzToolsFramework
                         AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::FileCreationNotificationBusId,
                         &AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::HandleAssetCreatedInEditor,
                         fullFilepath,
-                        LuaComponentScriptBusId);
+                        LuaComponentScriptBusId,
+                        true);
                 }
                 else
                 {

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialBrowserInteractions.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialBrowserInteractions.cpp
@@ -121,6 +121,12 @@ namespace AZ
                           dialog.m_sourcePath.toUtf8().constData();
                           materialData.m_parentMaterial = "";
                           AZ::RPI::JsonUtils::SaveObjectToFile(dialog.m_targetPath.toUtf8().constData(), materialData);
+                          AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotificationBus::Event(
+                              AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::FileCreationNotificationBusId,
+                              &AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::HandleAssetCreatedInEditor,
+                              dialog.m_targetPath.toUtf8().constData(),
+                              AZ::Crc32(),
+                              false);
                       }
                   } });
 
@@ -156,6 +162,12 @@ namespace AZ
                       {
                           AZ::IO::FileIOBase::GetInstance()->Copy(
                               dialog.m_sourcePath.toUtf8().constData(), dialog.m_targetPath.toUtf8().constData());
+                          AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotificationBus::Event(
+                              AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::FileCreationNotificationBusId,
+                              &AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::HandleAssetCreatedInEditor,
+                              dialog.m_targetPath.toUtf8().constData(),
+                              AZ::Crc32(),
+                              false);
                       }
                   } });
         }

--- a/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
@@ -939,12 +939,6 @@ namespace EMotionFX
                       AZ::IO::FixedMaxPath outFilePath = AzFramework::StringFunc::Path::MakeUniqueFilenameWithSuffix(
                           AZ::IO::PathView(fullSourceFolderNameInCallback + "/NewAnimGraph.animgraph"));
 
-                      AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotificationBus::Event(
-                          AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::FileCreationNotificationBusId,
-                          &AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::HandleAssetCreatedInEditor,
-                          outFilePath.Native().c_str(),
-                          AZ::Crc32());
-
                       EMotionFX::AnimGraph* animGraph = aznew EMotionFX::AnimGraph();
                       // create the root state machine object
                       EMotionFX::AnimGraphObject* rootSMObject =
@@ -961,6 +955,12 @@ namespace EMotionFX
                           animGraph->SaveToFile(outFilePath.Native().c_str(), serializeContext);
                           delete animGraph;
                       }
+                      AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotificationBus::Event(
+                          AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::FileCreationNotificationBusId,
+                          &AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::HandleAssetCreatedInEditor,
+                          outFilePath.Native().c_str(),
+                          AZ::Crc32(),
+                          true);
                   } });
 
             creators.push_back(
@@ -972,12 +972,6 @@ namespace EMotionFX
                       AZ::IO::FixedMaxPath outFilePath = AzFramework::StringFunc::Path::MakeUniqueFilenameWithSuffix(
                           AZ::IO::PathView(fullSourceFolderNameInCallback + "/NewMotionSet.motionset"));
 
-                      AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotificationBus::Event(
-                          AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::FileCreationNotificationBusId,
-                          &AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::HandleAssetCreatedInEditor,
-                          outFilePath.Native().c_str(),
-                          AZ::Crc32());
-
                       AZ::IO::PathView filePath = outFilePath.c_str();
                       AZStd::string motionSetName = filePath.Stem().Native();
                       EMotionFX::MotionSet* motionSet = aznew EMotionFX::MotionSet(motionSetName.c_str(), /*parentSet=*/nullptr);
@@ -987,6 +981,13 @@ namespace EMotionFX
                           serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
                       motionSet->SaveToFile(outFilePath.Native().c_str(), serializeContext);
                       delete motionSet;
+
+                      AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotificationBus::Event(
+                          AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::FileCreationNotificationBusId,
+                          &AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::HandleAssetCreatedInEditor,
+                          outFilePath.Native().c_str(),
+                          AZ::Crc32(),
+                          true);
                   } });
         }
 

--- a/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
@@ -245,10 +245,11 @@ namespace ScriptCanvasEditor
                 else
                 {
                     AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotificationBus::Event(
-                        AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::FileCreationNotificationBusId
-                        , &AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::HandleAssetCreatedInEditor
-                        , source.AbsolutePath().Native()
-                        , AZ::Crc32());
+                        AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::FileCreationNotificationBusId,
+                        &AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::HandleAssetCreatedInEditor,
+                        source.AbsolutePath().Native(),
+                        AZ::Crc32(),
+                        true);
                 }
 
                 fileStream.Close();


### PR DESCRIPTION
Signed-off-by: Daniel Tamkin <jotamkin@amazon.com>

## What does this PR do?

- Adds a parameter to the ebus call for notifying the editor that an asset has been created, which allows users to have their asset use custom creation logic (such as material and material graphs) and still notify the editor that an asset has been created
- Adds a signal to refresh the refresh the thumbnail view when a new asset has been created
- Partially Fixes #14394  asset renaming still needs to be implemented, will happen in a separate PR

![Editor_QetcmnCa4d](https://user-images.githubusercontent.com/84731577/217668645-b25994eb-f79f-4698-99cc-a411ed1972ab.gif)

## How was this PR tested?

Locally
