### PR TITLE
Further build time improvements

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetCommon.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetCommon.cpp
@@ -14,6 +14,8 @@
 #include <AzCore/std/parallel/lock.h>
 #include <AzCore/std/string/conversions.h>
 
+DECLARE_EBUS_INSTANTIATION(Data::AssetEvents);
+
 namespace AZ::Data
 {
     AssetFilterInfo::AssetFilterInfo(const AssetId& id, const AssetType& assetType, AssetLoadBehavior loadBehavior)

--- a/Code/Framework/AzCore/AzCore/Asset/AssetCommon.h
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetCommon.h
@@ -1267,3 +1267,4 @@ namespace AZStd
     };
 }
 
+DECLARE_EBUS_EXTERN(Data::AssetEvents);

--- a/Code/Framework/AzCore/AzCore/Asset/AssetTypeInfoBus.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetTypeInfoBus.cpp
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Asset/AssetTypeInfoBus.h>
+
+DECLARE_EBUS_INSTANTIATION(AssetTypeInfo);

--- a/Code/Framework/AzCore/AzCore/Asset/AssetTypeInfoBus.h
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetTypeInfoBus.h
@@ -72,3 +72,4 @@ namespace AZ
     using AssetTypeInfoBus = AZ::EBus<AssetTypeInfo>;
 } // namespace AZ
 
+DECLARE_EBUS_EXTERN(AssetTypeInfo);

--- a/Code/Framework/AzCore/AzCore/Component/NonUniformScaleBus.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/NonUniformScaleBus.cpp
@@ -10,6 +10,8 @@
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Math/Vector3.h>
 
+DECLARE_EBUS_INSTANTIATION(NonUniformScaleRequests);
+
 namespace AZ
 {
     void NonUniformScaleRequests::Reflect(ReflectContext* context)

--- a/Code/Framework/AzCore/AzCore/Component/NonUniformScaleBus.h
+++ b/Code/Framework/AzCore/AzCore/Component/NonUniformScaleBus.h
@@ -37,3 +37,5 @@ namespace AZ
 
     using NonUniformScaleRequestBus = AZ::EBus<NonUniformScaleRequests>;
 } // namespace AZ
+
+DECLARE_EBUS_EXTERN(NonUniformScaleRequests);

--- a/Code/Framework/AzCore/AzCore/EBus/EBus.h
+++ b/Code/Framework/AzCore/AzCore/EBus/EBus.h
@@ -632,21 +632,21 @@ namespace AZ
          * @return True if there are any handlers connected to the
          * EBus. Otherwise, false.
          */
-        static inline bool HasHandlers();
+        static bool HasHandlers();
 
         /**
          * Returns whether handlers are connected to this specific address.
          * @return True if there are any handlers connected at the address.
          * Otherwise, false.
          */
-        static inline bool HasHandlers(const BusIdType& id);
+        static bool HasHandlers(const BusIdType& id);
 
         /**
          * Returns whether handlers are connected to the specific cached address.
          * @return True if there are any handlers connected at the cached address.
          * Otherwise, false.
          */
-        static inline bool HasHandlers(const BusPtr& ptr);
+        static bool HasHandlers(const BusPtr& ptr);
 
         /**
          * Gets the ID of the address that is currently receiving an event.

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorObjectSignals.cpp
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorObjectSignals.cpp
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/RTTI/BehaviorObjectSignals.h>
+
+DECLARE_EBUS_INSTANTIATION(BehaviorObjectSignalsInterface);

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorObjectSignals.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorObjectSignals.h
@@ -27,5 +27,7 @@ namespace AZ
         virtual void OnMemberMethodCalled(const BehaviorMethod* method) = 0;
     };
 
-    typedef AZ::EBus<BehaviorObjectSignalsInterface> BehaviorObjectSignals;
+    using BehaviorObjectSignals =  AZ::EBus<BehaviorObjectSignalsInterface>;
 }
+
+DECLARE_EBUS_EXTERN(BehaviorObjectSignalsInterface);

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -26,6 +26,7 @@ set(FILES
     Asset/AssetSerializer.cpp
     Asset/AssetSerializer.h
     Asset/AssetTypeInfoBus.h
+    Asset/AssetTypeInfoBus.cpp
     Asset/AssetInternal/WeakAsset.h
     base.h
     Casting/lossy_cast.h
@@ -480,6 +481,7 @@ set(FILES
     RTTI/BehaviorContextUtilities.h
     RTTI/BehaviorInterfaceProxy.h
     RTTI/BehaviorObjectSignals.h
+    RTTI/BehaviorObjectSignals.cpp
     RTTI/ChronoReflection.cpp
     RTTI/ChronoReflection.h
     RTTI/ReflectContext.h

--- a/Code/Framework/AzCore/AzCore/std/hash.h
+++ b/Code/Framework/AzCore/AzCore/std/hash.h
@@ -34,7 +34,10 @@ namespace AZStd
     {
         typedef T               argument_type;
         typedef AZStd::size_t   result_type;
-        constexpr result_type operator()(const argument_type& value) const { return static_cast<result_type>(value); }
+        // If you implement your own hash operator, consider making it constexpr if it makes sense.
+        // This is intentionally not declared constexpr here, as this would cause every implementation
+        // to require constexpr or suffer a compile error.
+        result_type operator()(const argument_type& value) const { return static_cast<result_type>(value); }
         static bool OnlyUnspecializedTypesShouldHaveThis() { return true; }
     };
 

--- a/Code/Framework/AzCore/AzCore/std/hash.h
+++ b/Code/Framework/AzCore/AzCore/std/hash.h
@@ -41,7 +41,7 @@ namespace AZStd
         // If you end up in a situation where you have implemented a custom constexpr operator() for your custom type
         // and find that it needs to call an existing hash::operator() that is auto-generated from the below non-constexpr,
         // you can add an explicit instantiation for it with constexpr.  See the example of hash<AZ::u64> below.
-        result_type operator()(const argument_type& value) const { return static_cast<result_type>(value); }
+        constexpr result_type operator()(const argument_type& value) const { return static_cast<result_type>(value); }
         static bool OnlyUnspecializedTypesShouldHaveThis() { return true; }
     };
 
@@ -148,123 +148,6 @@ namespace AZStd
         : public hash<const T[N]>
     {
         //typedef T[N]          argument_type;
-    };
-
-    // In the following section, we define template specializations for
-    // signed and unsigned integers of each size, as well as float double, etc, applying
-    // constexpr to them as appropriate.  This allows the code to be backward compatible with
-    // existing implementations that use these primitives inside their own more complicated hash function
-    // and have declared their own hash function as constexpr.  It allows the code to do this without
-    // forcing the generic hash template to be constexpr, which would force all the callers to be the same.
-
-    template<>
-    struct hash<AZ::u8>
-    {
-        typedef AZ::u8 argument_type;
-        typedef AZStd::size_t result_type;
-        constexpr inline result_type operator()(argument_type value) const
-        {
-            return static_cast<result_type>(value);
-        }
-    };
-
-    template<>
-    struct hash<AZ::s8>
-    {
-        typedef AZ::s8 argument_type;
-        typedef AZStd::size_t result_type;
-        constexpr inline result_type operator()(argument_type value) const
-        {
-            return static_cast<result_type>(value);
-        }
-    };
-
-    template<>
-    struct hash<AZ::u16>
-    {
-        typedef AZ::u16 argument_type;
-        typedef AZStd::size_t result_type;
-        constexpr inline result_type operator()(argument_type value) const
-        {
-            return static_cast<result_type>(value);
-        }
-    };
-
-    template<>
-    struct hash<AZ::s16>
-    {
-        typedef AZ::s16 argument_type;
-        typedef AZStd::size_t result_type;
-        constexpr inline result_type operator()(argument_type value) const
-        {
-            return static_cast<result_type>(value);
-        }
-    };
-
-    template<>
-    struct hash<AZ::s32>
-    {
-        typedef AZ::s32 argument_type;
-        typedef AZStd::size_t result_type;
-        constexpr inline result_type operator()(argument_type value) const
-        {
-            return static_cast<result_type>(value);
-        }
-    };
-
-    template<>
-    struct hash<AZ::u32>
-    {
-        typedef AZ::u32 argument_type;
-        typedef AZStd::size_t result_type;
-        constexpr inline result_type operator()(argument_type value) const
-        {
-            return static_cast<result_type>(value);
-        }
-    };
-
-    template<>
-    struct hash<AZ::s64>
-    {
-        typedef AZ::s64 argument_type;
-        typedef AZStd::size_t result_type;
-        constexpr inline result_type operator()(argument_type value) const
-        {
-            return static_cast<result_type>(value);
-        }
-    };
-
-    template<>
-    struct hash<AZ::u64>
-    {
-        typedef AZ::u64 argument_type;
-        typedef AZStd::size_t result_type;
-        constexpr inline result_type operator()(argument_type value) const
-        {
-             return static_cast<result_type>(value); 
-        }
-    };
-
-    template<>
-    struct hash<long>
-    {
-        typedef long argument_type;
-        typedef AZStd::size_t result_type;
-        constexpr inline result_type operator()(argument_type value) const
-        {
-            return static_cast<result_type>(value);
-        }
-    };
-
-    template<>
-    struct hash<unsigned long>
-    {
-        typedef unsigned long argument_type;
-        typedef AZStd::size_t result_type;
-        constexpr inline result_type operator()(argument_type value) const
-        {
-            return static_cast<result_type>(value);
-        }
     };
 
     template<>

--- a/Code/Framework/AzCore/AzCore/std/hash.h
+++ b/Code/Framework/AzCore/AzCore/std/hash.h
@@ -35,8 +35,12 @@ namespace AZStd
         typedef T               argument_type;
         typedef AZStd::size_t   result_type;
         // If you implement your own hash operator, consider making it constexpr if it makes sense.
-        // This is intentionally not declared constexpr here, as this would cause every implementation
-        // to require constexpr or suffer a compile error.
+        // This is intentionally not declared constexpr here, as this would force every implementation
+        // to require constexpr or suffer a compile error in certain compilers.  This means forcing them to implement
+        // their hash function in their headers, without being able to forward declare them.
+        // If you end up in a situation where you have implemented a custom constexpr operator() for your custom type
+        // and find that it needs to call an existing hash::operator() that is auto-generated from the below non-constexpr,
+        // you can add an explicit instantiation for it with constexpr.  See the example of hash<AZ::u64> below.
         result_type operator()(const argument_type& value) const { return static_cast<result_type>(value); }
         static bool OnlyUnspecializedTypesShouldHaveThis() { return true; }
     };
@@ -144,6 +148,17 @@ namespace AZStd
         : public hash<const T[N]>
     {
         //typedef T[N]          argument_type;
+    };
+
+    template<>
+    struct hash<AZ::u64>
+    {
+        typedef AZ::u64 argument_type;
+        typedef AZStd::size_t result_type;
+        constexpr inline result_type operator()(argument_type value) const
+        {
+             return static_cast<result_type>(value); 
+        }
     };
 
     template<>

--- a/Code/Framework/AzCore/AzCore/std/hash.h
+++ b/Code/Framework/AzCore/AzCore/std/hash.h
@@ -34,13 +34,11 @@ namespace AZStd
     {
         typedef T               argument_type;
         typedef AZStd::size_t   result_type;
-        // If you implement your own hash operator, consider making it constexpr if it makes sense.
-        // This is intentionally not declared constexpr here, as this would force every implementation
-        // to require constexpr or suffer a compile error in certain compilers.  This means forcing them to implement
-        // their hash function in their headers, without being able to forward declare them.
-        // If you end up in a situation where you have implemented a custom constexpr operator() for your custom type
-        // and find that it needs to call an existing hash::operator() that is auto-generated from the below non-constexpr,
-        // you can add an explicit instantiation for it with constexpr.  See the example of hash<AZ::u64> below.
+        // You do not need to implement this for your custom type.  Since this function calls
+        // static_cast<result_type>(value); (and result type is usually size_t) you can also, instead of making an
+        // explicit instantiation of hash<T>, supply a
+        // [[nodiscard]] explicit constexpr operator size_t() const
+        // function on your type, which will then get called by this default implementation.
         constexpr result_type operator()(const argument_type& value) const { return static_cast<result_type>(value); }
         static bool OnlyUnspecializedTypesShouldHaveThis() { return true; }
     };

--- a/Code/Framework/AzCore/AzCore/std/hash.h
+++ b/Code/Framework/AzCore/AzCore/std/hash.h
@@ -246,6 +246,28 @@ namespace AZStd
     };
 
     template<>
+    struct hash<long>
+    {
+        typedef long argument_type;
+        typedef AZStd::size_t result_type;
+        constexpr inline result_type operator()(argument_type value) const
+        {
+            return static_cast<result_type>(value);
+        }
+    };
+
+    template<>
+    struct hash<unsigned long>
+    {
+        typedef unsigned long argument_type;
+        typedef AZStd::size_t result_type;
+        constexpr inline result_type operator()(argument_type value) const
+        {
+            return static_cast<result_type>(value);
+        }
+    };
+
+    template<>
     struct hash< float >
     {
         typedef float           argument_type;

--- a/Code/Framework/AzCore/AzCore/std/hash.h
+++ b/Code/Framework/AzCore/AzCore/std/hash.h
@@ -150,6 +150,90 @@ namespace AZStd
         //typedef T[N]          argument_type;
     };
 
+    // In the following section, we define template specializations for
+    // signed and unsigned integers of each size, as well as float double, etc, applying
+    // constexpr to them as appropriate.  This allows the code to be backward compatible with
+    // existing implementations that use these primitives inside their own more complicated hash function
+    // and have declared their own hash function as constexpr.  It allows the code to do this without
+    // forcing the generic hash template to be constexpr, which would force all the callers to be the same.
+
+    template<>
+    struct hash<AZ::u8>
+    {
+        typedef AZ::u8 argument_type;
+        typedef AZStd::size_t result_type;
+        constexpr inline result_type operator()(argument_type value) const
+        {
+            return static_cast<result_type>(value);
+        }
+    };
+
+    template<>
+    struct hash<AZ::s8>
+    {
+        typedef AZ::s8 argument_type;
+        typedef AZStd::size_t result_type;
+        constexpr inline result_type operator()(argument_type value) const
+        {
+            return static_cast<result_type>(value);
+        }
+    };
+
+    template<>
+    struct hash<AZ::u16>
+    {
+        typedef AZ::u16 argument_type;
+        typedef AZStd::size_t result_type;
+        constexpr inline result_type operator()(argument_type value) const
+        {
+            return static_cast<result_type>(value);
+        }
+    };
+
+    template<>
+    struct hash<AZ::s16>
+    {
+        typedef AZ::s16 argument_type;
+        typedef AZStd::size_t result_type;
+        constexpr inline result_type operator()(argument_type value) const
+        {
+            return static_cast<result_type>(value);
+        }
+    };
+
+    template<>
+    struct hash<AZ::s32>
+    {
+        typedef AZ::s32 argument_type;
+        typedef AZStd::size_t result_type;
+        constexpr inline result_type operator()(argument_type value) const
+        {
+            return static_cast<result_type>(value);
+        }
+    };
+
+    template<>
+    struct hash<AZ::u32>
+    {
+        typedef AZ::u32 argument_type;
+        typedef AZStd::size_t result_type;
+        constexpr inline result_type operator()(argument_type value) const
+        {
+            return static_cast<result_type>(value);
+        }
+    };
+
+    template<>
+    struct hash<AZ::s64>
+    {
+        typedef AZ::s64 argument_type;
+        typedef AZStd::size_t result_type;
+        constexpr inline result_type operator()(argument_type value) const
+        {
+            return static_cast<result_type>(value);
+        }
+    };
+
     template<>
     struct hash<AZ::u64>
     {

--- a/Code/Framework/AzFramework/AzFramework/API/ApplicationAPI.cpp
+++ b/Code/Framework/AzFramework/AzFramework/API/ApplicationAPI.cpp
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzFramework/API/ApplicationAPI.h>
+
+DECLARE_EBUS_INSTANTIATION(AzFramework::ApplicationRequests);

--- a/Code/Framework/AzFramework/AzFramework/API/ApplicationAPI.h
+++ b/Code/Framework/AzFramework/AzFramework/API/ApplicationAPI.h
@@ -6,9 +6,6 @@
  *
  */
 
-#ifndef AZFRAMEWORK_APPLICATIONAPI_H
-#define AZFRAMEWORK_APPLICATIONAPI_H
-
 #pragma once
 
 #include <AzCore/base.h>
@@ -252,4 +249,4 @@ namespace AzFramework
     using LevelSystemLifecycleNotificationBus = AZ::EBus<LevelSystemLifecycleNotifications>;
 } // namespace AzFramework
 
-#endif // AZFRAMEWORK_APPLICATIONAPI_H
+DECLARE_EBUS_EXTERN(AzFramework::ApplicationRequests);

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemBus.h
@@ -338,3 +338,5 @@ namespace AzFramework
     using AssetSystemConnectionNotificationsBus = AZ::EBus<AssetSystem::AssetSystemConnectionNotifications>;
     using AssetSystemStatusBus = AZ::EBus<AssetSystem::AssetSystemStatus>;
 } // namespace AzFramework
+
+DECLARE_EBUS_EXTERN(AzFramework::AssetSystem::AssetSystemRequests);

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponent.cpp
@@ -29,6 +29,8 @@
 #include <AzFramework/Asset/Benchmark/BenchmarkCommands.h>
 #include <AzFramework/Network/AssetProcessorConnection.h>
 
+DECLARE_EBUS_INSTANTIATION(AzFramework::AssetSystem::AssetSystemRequests);
+
 AZ_DECLARE_BUDGET(AzFramework);
 
 namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Input/Buses/Requests/InputChannelRequestBus.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Buses/Requests/InputChannelRequestBus.cpp
@@ -10,16 +10,6 @@
 
 DECLARE_EBUS_INSTANTIATION(AzFramework::InputChannelRequests);
 
-namespace AZStd
-{
-    template<> size_t hash<AzFramework::InputChannelRequests::BusIdType>::operator()(const AzFramework::InputChannelRequests::BusIdType& busIdType) const
-    {
-            size_t hashValue = busIdType.m_channelId.GetNameCrc32();
-            AZStd::hash_combine(hashValue, busIdType.m_deviceIndex);
-            return hashValue;
-    };
-}
-
 namespace AzFramework
 {
     const InputChannel* InputChannelRequests::FindInputChannel(const InputChannelId& channelId, AZ::u32 deviceIndex)

--- a/Code/Framework/AzFramework/AzFramework/Input/Buses/Requests/InputChannelRequestBus.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Buses/Requests/InputChannelRequestBus.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzFramework/Input/Buses/Requests/InputChannelRequestBus.h>
+
+DECLARE_EBUS_INSTANTIATION(AzFramework::InputChannelRequests);
+
+namespace AZStd
+{
+    template<> size_t hash<AzFramework::InputChannelRequests::BusIdType>::operator()(const AzFramework::InputChannelRequests::BusIdType& busIdType) const
+    {
+            size_t hashValue = busIdType.m_channelId.GetNameCrc32();
+            AZStd::hash_combine(hashValue, busIdType.m_deviceIndex);
+            return hashValue;
+    };
+}
+
+namespace AzFramework
+{
+    const InputChannel* InputChannelRequests::FindInputChannel(const InputChannelId& channelId, AZ::u32 deviceIndex)
+    {
+        const InputChannel* inputChannel = nullptr;
+        const BusIdType inputChannelRequestId(channelId, deviceIndex);
+        InputChannelRequestBus::EventResult(inputChannel,
+                                            inputChannelRequestId,
+                                            &InputChannelRequests::GetInputChannel);
+        return inputChannel;
+    }
+}

--- a/Code/Framework/AzFramework/AzFramework/Input/Buses/Requests/InputChannelRequestBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Buses/Requests/InputChannelRequestBus.h
@@ -208,31 +208,14 @@ namespace AzFramework
         return !(*this == other);
     }
 
-    ////////////////////////////////////////////////////////////////////////////////////////////////
-    inline const InputChannel* InputChannelRequests::FindInputChannel(const InputChannelId& channelId,
-                                                                      AZ::u32 deviceIndex)
-    {
-        const InputChannel* inputChannel = nullptr;
-        const BusIdType inputChannelRequestId(channelId, deviceIndex);
-        InputChannelRequestBus::EventResult(inputChannel,
-                                            inputChannelRequestId,
-                                            &InputChannelRequests::GetInputChannel);
-        return inputChannel;
-    }
 } // namespace AzFramework
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 namespace AZStd
 {
     ////////////////////////////////////////////////////////////////////////////////////////////////
-    //! Hash structure specialization for InputChannelRequests::BusIdType
-    template<> struct hash<AzFramework::InputChannelRequests::BusIdType>
-    {
-        inline size_t operator()(const AzFramework::InputChannelRequests::BusIdType& busIdType) const
-        {
-            size_t hashValue = busIdType.m_channelId.GetNameCrc32();
-            AZStd::hash_combine(hashValue, busIdType.m_deviceIndex);
-            return hashValue;
-        }
-    };
-} // namespace AZStd
+    // forward declaration of the hash operator() function, to avoid instantiation of the ebus template in the header.
+    template<> size_t hash<AzFramework::InputChannelRequests::BusIdType>::operator()(const AzFramework::InputChannelRequests::BusIdType& busIdType) const;
+}
+
+DECLARE_EBUS_EXTERN(AzFramework::InputChannelRequests);

--- a/Code/Framework/AzFramework/AzFramework/Input/Buses/Requests/InputChannelRequestBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Buses/Requests/InputChannelRequestBus.h
@@ -12,8 +12,6 @@
 
 #include <AzCore/EBus/EBus.h>
 
-#include <AzCore/RTTI/ReflectContext.h>
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 namespace AzFramework
 {
@@ -83,6 +81,14 @@ namespace AzFramework
             // Variables
             InputChannelId m_channelId;   //!< Id of the input channel to address requests
             AZ::u32        m_deviceIndex; //!< Index of the input device to address requests
+
+            //! Size_t conversion operator for std::hash to return a reasonable hash.
+            [[nodiscard]] explicit constexpr operator size_t() const
+            {
+                size_t hashValue = m_channelId.GetNameCrc32();
+                AZStd::hash_combine(hashValue, m_deviceIndex);
+                return hashValue;
+            }       
         };
 
         ////////////////////////////////////////////////////////////////////////////////////////////
@@ -209,13 +215,5 @@ namespace AzFramework
     }
 
 } // namespace AzFramework
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-namespace AZStd
-{
-    ////////////////////////////////////////////////////////////////////////////////////////////////
-    // forward declaration of the hash operator() function, to avoid instantiation of the ebus template in the header.
-    template<> size_t hash<AzFramework::InputChannelRequests::BusIdType>::operator()(const AzFramework::InputChannelRequests::BusIdType& busIdType) const;
-}
 
 DECLARE_EBUS_EXTERN(AzFramework::InputChannelRequests);

--- a/Code/Framework/AzFramework/AzFramework/Input/Buses/Requests/InputDeviceRequestBus.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Buses/Requests/InputDeviceRequestBus.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzFramework/Input/Buses/Requests/InputDeviceRequestBus.h>
+
+DECLARE_EBUS_INSTANTIATION(AzFramework::InputDeviceRequests);
+
+namespace AzFramework
+{
+    // This function is declared in the implementation file to avoid inclusion of
+    // InputDeviceRequestBus instantiating the bus itself.
+    const InputDevice* InputDeviceRequests::FindInputDevice(const InputDeviceId& deviceId)
+    {
+        const InputDevice* inputDevice = nullptr;
+        InputDeviceRequestBus::EventResult(inputDevice, deviceId, &InputDeviceRequests::GetInputDevice);
+        return inputDevice;
+    }
+}

--- a/Code/Framework/AzFramework/AzFramework/Input/Buses/Requests/InputDeviceRequestBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Buses/Requests/InputDeviceRequestBus.h
@@ -168,14 +168,6 @@ namespace AzFramework
     using InputDeviceRequestBus = AZ::EBus<InputDeviceRequests>;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
-    inline const InputDevice* InputDeviceRequests::FindInputDevice(const InputDeviceId& deviceId)
-    {
-        const InputDevice* inputDevice = nullptr;
-        InputDeviceRequestBus::EventResult(inputDevice, deviceId, &InputDeviceRequests::GetInputDevice);
-        return inputDevice;
-    }
-
-    ////////////////////////////////////////////////////////////////////////////////////////////////
     template<class CustomDataType>
     inline void InputDeviceRequests::GetInputChannelIdsWithCustomDataOfType(
         InputChannelIdSet& o_channelIds,
@@ -279,3 +271,5 @@ namespace AzFramework
         InputDeviceType& m_inputDevice; //!< Reference to the input device that owns this handler
     };
 } // namespace AzFramework
+
+DECLARE_EBUS_EXTERN(AzFramework::InputDeviceRequests);

--- a/Code/Framework/AzFramework/AzFramework/Visibility/BoundsBus.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/BoundsBus.cpp
@@ -10,6 +10,8 @@
 
 #include <AzCore/RTTI/BehaviorContext.h>
 
+DECLARE_EBUS_INSTANTIATION(AzFramework::BoundsRequests);
+
 namespace AzFramework
 {
     void BoundsRequests::Reflect(AZ::ReflectContext* context)

--- a/Code/Framework/AzFramework/AzFramework/Visibility/BoundsBus.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/BoundsBus.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include "BoundsBus.h"
+#include <AzFramework/Visibility/BoundsBus.h>
 
 #include <AzCore/RTTI/BehaviorContext.h>
 
@@ -22,5 +22,38 @@ namespace AzFramework
                 ->Event("GetWorldBounds", &BoundsRequestBus::Events::GetWorldBounds)
                 ->Event("GetLocalBounds", &BoundsRequestBus::Events::GetLocalBounds);
         }
+    }
+
+    AZ::Aabb CalculateEntityLocalBoundsUnion(const AZ::Entity* entity)
+    {
+        AZ::EBusReduceResult<AZ::Aabb, AabbUnionAggregator> aabbResult(AZ::Aabb::CreateNull());
+        BoundsRequestBus::EventResult(aabbResult, entity->GetId(), &BoundsRequestBus::Events::GetLocalBounds);
+
+        if (aabbResult.value.IsValid())
+        {
+            return aabbResult.value;
+        }
+
+        return AZ::Aabb::CreateFromMinMax(-AZ::Vector3(0.5f), AZ::Vector3(0.5f));
+    }
+
+    AZ::Aabb CalculateEntityWorldBoundsUnion(const AZ::Entity* entity)
+    {
+        AZ::EBusReduceResult<AZ::Aabb, AabbUnionAggregator> aabbResult(AZ::Aabb::CreateNull());
+        BoundsRequestBus::EventResult(aabbResult, entity->GetId(), &BoundsRequestBus::Events::GetWorldBounds);
+
+        if (aabbResult.value.IsValid())
+        {
+            return aabbResult.value;
+        }
+
+        AZ::TransformInterface* transformInterface = entity->GetTransform();
+        if (!transformInterface)
+        {
+            return AZ::Aabb::CreateNull();
+        }
+
+        const AZ::Vector3 worldTranslation = transformInterface->GetWorldTranslation();
+        return AZ::Aabb::CreateCenterHalfExtents(worldTranslation, AZ::Vector3(0.5f));
     }
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Visibility/BoundsBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/BoundsBus.h
@@ -51,41 +51,12 @@ namespace AzFramework
     //! Returns a union of all local Aabbs provided by components implementing the BoundsRequestBus.
     //! @note It is preferred to call this function as opposed to GetLocalBounds directly as more than one
     //! component may be implementing this bus on an Entity and so only the first result (Aabb) will be returned.
-    inline AZ::Aabb CalculateEntityLocalBoundsUnion(const AZ::Entity* entity)
-    {
-        AZ::EBusReduceResult<AZ::Aabb, AabbUnionAggregator> aabbResult(AZ::Aabb::CreateNull());
-        BoundsRequestBus::EventResult(aabbResult, entity->GetId(), &BoundsRequestBus::Events::GetLocalBounds);
-
-        if (aabbResult.value.IsValid())
-        {
-            return aabbResult.value;
-        }
-
-        return AZ::Aabb::CreateFromMinMax(-AZ::Vector3(0.5f), AZ::Vector3(0.5f));
-    }
+    AZ::Aabb CalculateEntityLocalBoundsUnion(const AZ::Entity* entity);
 
     //! Returns a union of all world Aabbs provided by components implementing the BoundsRequestBus.
     //! @note It is preferred to call this function as opposed to GetWorldBounds directly as more than one
     //! component may be implementing this bus on an Entity and so only the first result (Aabb) will be returned.
-    inline AZ::Aabb CalculateEntityWorldBoundsUnion(const AZ::Entity* entity)
-    {
-        AZ::EBusReduceResult<AZ::Aabb, AabbUnionAggregator> aabbResult(AZ::Aabb::CreateNull());
-        BoundsRequestBus::EventResult(aabbResult, entity->GetId(), &BoundsRequestBus::Events::GetWorldBounds);
-
-        if (aabbResult.value.IsValid())
-        {
-            return aabbResult.value;
-        }
-
-        AZ::TransformInterface* transformInterface = entity->GetTransform();
-        if (!transformInterface)
-        {
-            return AZ::Aabb::CreateNull();
-        }
-
-        const AZ::Vector3 worldTranslation = transformInterface->GetWorldTranslation();
-        return AZ::Aabb::CreateCenterHalfExtents(worldTranslation, AZ::Vector3(0.5f));
-    }
+    AZ::Aabb CalculateEntityWorldBoundsUnion(const AZ::Entity* entity);
 } // namespace AzFramework
 
 DECLARE_EBUS_EXTERN(AzFramework::BoundsRequests);

--- a/Code/Framework/AzFramework/AzFramework/Visibility/BoundsBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/BoundsBus.h
@@ -87,3 +87,5 @@ namespace AzFramework
         return AZ::Aabb::CreateCenterHalfExtents(worldTranslation, AZ::Vector3(0.5f));
     }
 } // namespace AzFramework
+
+DECLARE_EBUS_EXTERN(AzFramework::BoundsRequests);

--- a/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
+++ b/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
@@ -11,6 +11,7 @@ set(FILES
     AzFrameworkModule.h
     AzFrameworkModule.cpp
     API/ApplicationAPI.h
+    API/ApplicationAPI.cpp
     Application/Application.cpp
     Application/Application.h
     Archive/Archive.cpp
@@ -372,7 +373,9 @@ set(FILES
     Input/Buses/Notifications/InputSystemNotificationBus.h
     Input/Buses/Notifications/InputTextNotificationBus.h
     Input/Buses/Requests/InputChannelRequestBus.h
+    Input/Buses/Requests/InputChannelRequestBus.cpp
     Input/Buses/Requests/InputDeviceRequestBus.h
+    Input/Buses/Requests/InputDeviceRequestBus.cpp
     Input/Buses/Requests/InputHapticFeedbackRequestBus.h
     Input/Buses/Requests/InputLightBarRequestBus.h
     Input/Buses/Requests/InputMotionSensorRequestBus.h

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ComponentEntitySelectionBus.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ComponentEntitySelectionBus.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzToolsFramework/API/ComponentEntitySelectionBus.h>
+
+DECLARE_EBUS_INSTANTIATION(AzToolsFramework::EditorComponentSelectionRequests);
+
+namespace AzToolsFramework
+{
+    //! Returns the union of all editor selection bounds on a given Entity.
+    //! @note The returned Aabb is in world space.
+    AZ::Aabb CalculateEditorEntitySelectionBounds(const AZ::EntityId entityId, const AzFramework::ViewportInfo& viewportInfo)
+    {
+        AZ::EBusReduceResult<AZ::Aabb, AzFramework::AabbUnionAggregator> aabbResult(AZ::Aabb::CreateNull());
+        EditorComponentSelectionRequestsBus::EventResult(
+            aabbResult, entityId, &EditorComponentSelectionRequestsBus::Events::GetEditorSelectionBoundsViewport, viewportInfo);
+
+        return aabbResult.value;
+    }
+}

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ComponentEntitySelectionBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ComponentEntitySelectionBus.h
@@ -103,12 +103,7 @@ namespace AzToolsFramework
 
     //! Returns the union of all editor selection bounds on a given Entity.
     //! @note The returned Aabb is in world space.
-    inline AZ::Aabb CalculateEditorEntitySelectionBounds(const AZ::EntityId entityId, const AzFramework::ViewportInfo& viewportInfo)
-    {
-        AZ::EBusReduceResult<AZ::Aabb, AzFramework::AabbUnionAggregator> aabbResult(AZ::Aabb::CreateNull());
-        EditorComponentSelectionRequestsBus::EventResult(
-            aabbResult, entityId, &EditorComponentSelectionRequestsBus::Events::GetEditorSelectionBoundsViewport, viewportInfo);
-
-        return aabbResult.value;
-    }
+    AZ::Aabb CalculateEditorEntitySelectionBounds(const AZ::EntityId entityId, const AzFramework::ViewportInfo& viewportInfo);
 } // namespace AzToolsFramework
+
+DECLARE_EBUS_EXTERN(AzToolsFramework::EditorComponentSelectionRequests);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.cpp
@@ -66,4 +66,4 @@ namespace AzToolsFramework
             isDuringUndoRedo, &ToolsApplicationRequests::IsDuringUndoRedo);
         return isDuringUndoRedo;
     }
-}
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzToolsFramework/API/ToolsApplicationAPI.h>
+
+DECLARE_EBUS_INSTANTIATION(AzToolsFramework::EditorRequests);
+DECLARE_EBUS_INSTANTIATION(AzToolsFramework::ToolsApplicationEvents);
+DECLARE_EBUS_INSTANTIATION(AzToolsFramework::EntitySelectionEvents);
+
+namespace AzToolsFramework
+{
+    ScopedUndoBatch::ScopedUndoBatch(const char* batchName)
+    {
+        ToolsApplicationRequests::Bus::BroadcastResult(
+            m_undoBatch, &ToolsApplicationRequests::Bus::Events::BeginUndoBatch, batchName);
+    }
+
+    ScopedUndoBatch::~ScopedUndoBatch()
+    {
+        ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::Bus::Events::EndUndoBatch);
+    }
+
+    // utility/convenience function for adding dirty entity
+    void ScopedUndoBatch::MarkEntityDirty(const AZ::EntityId& id)
+    {
+        ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::Bus::Events::AddDirtyEntity, id);
+    }
+
+    UndoSystem::URSequencePoint* ScopedUndoBatch::GetUndoBatch() const
+    {
+        return m_undoBatch;
+    }
+
+    void UnregisterViewPane(const char* viewPaneName)
+    {
+        EditorRequests::Bus::Broadcast(&EditorRequests::UnregisterViewPane, viewPaneName);
+    }
+
+    void OpenViewPane(const char* viewPaneName)
+    {
+        EditorRequests::Bus::Broadcast(&EditorRequests::OpenViewPane, viewPaneName);
+    }
+
+    QDockWidget* InstanceViewPane(const char* viewPaneName)
+    {
+        QDockWidget* ret = nullptr;
+        EditorRequests::Bus::BroadcastResult(ret, &EditorRequests::InstanceViewPane, viewPaneName);
+
+        return ret;
+    }
+
+    void CloseViewPane(const char* viewPaneName)
+    {
+        EditorRequests::Bus::Broadcast(&EditorRequests::CloseViewPane, viewPaneName);
+    }
+
+    bool UndoRedoOperationInProgress()
+    {
+        bool isDuringUndoRedo = false;
+        ToolsApplicationRequestBus::BroadcastResult(
+            isDuringUndoRedo, &ToolsApplicationRequests::IsDuringUndoRedo);
+        return isDuringUndoRedo;
+    }
+}

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
@@ -968,28 +968,12 @@ namespace AzToolsFramework
     {
     public:
         AZ_CLASS_ALLOCATOR(ScopedUndoBatch, AZ::SystemAllocator, 0);
-
-        explicit ScopedUndoBatch(const char* batchName)
-        {
-            ToolsApplicationRequests::Bus::BroadcastResult(
-                m_undoBatch, &ToolsApplicationRequests::Bus::Events::BeginUndoBatch, batchName);
-        }
-
-        ~ScopedUndoBatch()
-        {
-            ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::Bus::Events::EndUndoBatch);
-        }
+        explicit ScopedUndoBatch(const char* batchName);
+        ~ScopedUndoBatch();
 
         // utility/convenience function for adding dirty entity
-        static void MarkEntityDirty(const AZ::EntityId& id)
-        {
-            ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::Bus::Events::AddDirtyEntity, id);
-        }
-
-        UndoSystem::URSequencePoint* GetUndoBatch() const
-        {
-            return m_undoBatch;
-        }
+        static void MarkEntityDirty(const AZ::EntityId& id);
+        UndoSystem::URSequencePoint* GetUndoBatch() const;
 
     private:
         AZ_DISABLE_COPY_MOVE(ScopedUndoBatch);
@@ -1038,10 +1022,7 @@ namespace AzToolsFramework
     /// Any currently open view panes of this type will be closed before the view pane handlers are unregistered.
     ///
     /// \param viewPaneName - name of the pane to unregister. Must be the same as the name previously registered with RegisterViewPane.
-    inline void UnregisterViewPane(const char* viewPaneName)
-    {
-        EditorRequests::Bus::Broadcast(&EditorRequests::UnregisterViewPane, viewPaneName);
-    }
+    void UnregisterViewPane(const char* viewPaneName);
 
     /// Returns the widget contained/wrapped in a view pane.
     /// \param name - the name of the pane which contains the widget to be retrieved. This must match the name used for registration.
@@ -1057,41 +1038,25 @@ namespace AzToolsFramework
     /// Opens a view pane if not already open, and activating the view pane if it was already opened.
     ///
     /// \param viewPaneName - name of the pane to open/activate. Must be the same as the name previously registered with RegisterViewPane.
-    inline void OpenViewPane(const char* viewPaneName)
-    {
-        EditorRequests::Bus::Broadcast(&EditorRequests::OpenViewPane, viewPaneName);
-    }
+    void OpenViewPane(const char* viewPaneName);
 
     /// Opens a view pane if not already open, and activating the view pane if it was already opened.
     ///
     /// \param viewPaneName - name of the pane to open/activate. Must be the same as the name previously registered with RegisterViewPane.
-    inline QDockWidget* InstanceViewPane(const char* viewPaneName)
-    {
-        QDockWidget* ret = nullptr;
-        EditorRequests::Bus::BroadcastResult(ret, &EditorRequests::InstanceViewPane, viewPaneName);
-
-        return ret;
-    }
+    QDockWidget* InstanceViewPane(const char* viewPaneName);
 
     /// Closes a view pane if it is currently open.
     ///
     /// \param viewPaneName - name of the pane to open/activate. Must be the same as the name previously registered with RegisterViewPane.
-    inline void CloseViewPane(const char* viewPaneName)
-    {
-        EditorRequests::Bus::Broadcast(&EditorRequests::CloseViewPane, viewPaneName);
-    }
+    void CloseViewPane(const char* viewPaneName);
 
     /**
      * Helper to wrap checking if an undo/redo operation is in progress.
      */
-    inline bool UndoRedoOperationInProgress()
-    {
-        bool isDuringUndoRedo = false;
-        ToolsApplicationRequestBus::BroadcastResult(
-            isDuringUndoRedo, &ToolsApplicationRequests::IsDuringUndoRedo);
-        return isDuringUndoRedo;
-    }
+    bool UndoRedoOperationInProgress();
 } // namespace AzToolsFramework
 
 AZ_DECLARE_BUDGET(AzToolsFramework);
-
+DECLARE_EBUS_EXTERN(AzToolsFramework::EditorRequests);
+DECLARE_EBUS_EXTERN(AzToolsFramework::ToolsApplicationEvents);
+DECLARE_EBUS_EXTERN(AzToolsFramework::EntitySelectionEvents);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorBaseComponentMode.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorBaseComponentMode.cpp
@@ -11,6 +11,9 @@
 
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 
+DECLARE_EBUS_INSTANTIATION(AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequests);
+DECLARE_EBUS_INSTANTIATION_WITH_TRAITS(AzToolsFramework::ComponentModeFramework::ComponentModeDelegateRequests, AzToolsFramework::ComponentModeFramework::ComponentModeMouseViewportRequests)
+
 namespace AzToolsFramework
 {
     namespace ComponentModeFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorComponentModeBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorComponentModeBus.h
@@ -266,3 +266,6 @@ namespace AzToolsFramework
         }
     } // namespace ComponentModeFramework
 } // namespace AzToolsFramework
+
+DECLARE_EBUS_EXTERN(AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequests);
+DECLARE_EBUS_EXTERN_WITH_TRAITS(AzToolsFramework::ComponentModeFramework::ComponentModeDelegateRequests, AzToolsFramework::ComponentModeFramework::ComponentModeMouseViewportRequests)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextBus.h
@@ -5,8 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#ifndef AZTOOLSFRAMEWORK_EDITORENTITYCONTEXTBUS_H
-#define AZTOOLSFRAMEWORK_EDITORENTITYCONTEXTBUS_H
+#pragma once
 
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Math/Uuid.h>
@@ -235,4 +234,4 @@ namespace AzToolsFramework
     using EditorLegacyGameModeNotificationBus = AZ::EBus<EditorLegacyGameModeNotifications>;
 } // namespace AzToolsFramework
 
-#endif // AZTOOLSFRAMEWORK_EDITORENTITYCONTEXTBUS_H
+DECLARE_EBUS_EXTERN(AzToolsFramework::EditorEntityContextRequests);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
@@ -51,6 +51,7 @@
 #include <AzToolsFramework/Prefab/Instance/Instance.h>
 #include <AzToolsFramework/Undo/UndoCacheInterface.h>
 
+DECLARE_EBUS_INSTANTIATION(AzToolsFramework::EditorEntityContextRequests);
 
 namespace AzToolsFramework
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityInfoBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityInfoBus.h
@@ -107,3 +107,5 @@ namespace AzToolsFramework
     };
     using EditorEntityInfoNotificationBus = AZ::EBus<EditorEntityInfoNotifications>;
 }
+
+DECLARE_EBUS_EXTERN(AzToolsFramework::EditorEntityInfoRequests);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.cpp
@@ -30,6 +30,8 @@
 #include <AzToolsFramework/UI/PropertyEditor/InstanceDataHierarchy.h>
 #include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
 
+DECLARE_EBUS_INSTANTIATION(AzToolsFramework::EditorEntityInfoRequests);
+
 #include <QtWidgets/QMessageBox>
 
 namespace

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.cpp
@@ -13,6 +13,8 @@
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 
+DECLARE_EBUS_INSTANTIATION_WITH_TRAITS(AzToolsFramework::Components::EditorComponentDescriptor, AZ::ComponentDescriptorBusTraits);
+
 namespace AzToolsFramework
 {
     namespace Components

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.h
@@ -16,8 +16,7 @@
  * [Editor Components documentation](https://www.o3de.org/docs/user-guide/programming/components/editor-components/).
  */
 
-#ifndef EDITOR_COMPONENT_BASE_H
-#define EDITOR_COMPONENT_BASE_H
+#pragma once
 
 #include <AzCore/base.h>
 #include <AzCore/Asset/AssetCommon.h>
@@ -402,6 +401,4 @@ namespace AzToolsFramework
     } // namespace Components
 } // namespace AzToolsFramework
 
-
-
-#endif
+DECLARE_EBUS_EXTERN_WITH_TRAITS(AzToolsFramework::Components::EditorComponentDescriptor, AZ::ComponentDescriptorBusTraits);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorLockComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorLockComponent.cpp
@@ -11,6 +11,8 @@
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 
+DECLARE_EBUS_INSTANTIATION(AzToolsFramework::EditorEntityLockComponentNotifications);
+
 namespace AzToolsFramework
 {
     namespace Components

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorLockComponentBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorLockComponentBus.h
@@ -60,3 +60,5 @@ namespace AzToolsFramework
     using EditorLockComponentNotificationBus = EditorEntityLockComponentNotificationBus;
 
 } // namespace AzToolsFramework
+
+DECLARE_EBUS_EXTERN(AzToolsFramework::EditorEntityLockComponentNotifications);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorSelectionAccentSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorSelectionAccentSystemComponent.cpp
@@ -15,6 +15,8 @@
 #include <AzFramework/Entity/EntityContextBus.h>
 #include <AzCore/Slice/SliceComponent.h>
 
+DECLARE_EBUS_INSTANTIATION(AzToolsFramework::Components::EditorSelectionAccentingRequests);
+
 namespace AzToolsFramework
 {
     namespace Components

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorSelectionAccentingBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorSelectionAccentingBus.h
@@ -38,3 +38,5 @@ namespace AzToolsFramework
         using EditorSelectionAccentingRequestBus = AZ::EBus<EditorSelectionAccentingRequests>;
     } // namespace Components
 } // namespace AzToolsFramework
+
+DECLARE_EBUS_EXTERN(AzToolsFramework::Components::EditorSelectionAccentingRequests);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorVisibilityBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorVisibilityBus.h
@@ -69,3 +69,5 @@ namespace AzToolsFramework
     using EditorVisibilityNotificationBus = EditorEntityVisibilityNotificationBus;
 
 } // namespace AzToolsFramework
+
+DECLARE_EBUS_EXTERN(AzToolsFramework::EditorEntityVisibilityNotifications);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorVisibilityComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorVisibilityComponent.cpp
@@ -12,6 +12,8 @@
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 
+DECLARE_EBUS_INSTANTIATION(AzToolsFramework::EditorEntityVisibilityNotifications);
+
 namespace AzToolsFramework
 {
     namespace Components

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -83,23 +83,6 @@ namespace AzToolsFramework
             MouseInteractionResult InternalHandleAllMouseInteractions(const MouseInteractionEvent& mouseInteraction);
         };
 
-        inline MouseInteractionResult InternalMouseViewportRequests::InternalHandleAllMouseInteractions(
-            const MouseInteractionEvent& mouseInteraction)
-        {
-            if (InternalHandleMouseManipulatorInteraction(mouseInteraction))
-            {
-                return MouseInteractionResult::Manipulator;
-            }
-            else if (InternalHandleMouseViewportInteraction(mouseInteraction))
-            {
-                return MouseInteractionResult::Viewport;
-            }
-            else
-            {
-                return MouseInteractionResult::None;
-            }
-        }
-
         //! Interface for viewport selection behaviors.
         class ViewportDisplayNotifications
         {
@@ -187,15 +170,7 @@ namespace AzToolsFramework
         using ViewportInteractionRequestBus = AZ::EBus<ViewportInteractionRequests, ViewportRequestsEBusTraits>;
 
         //! Utility function to return a viewport ray using the ViewportInteractionRequestBus.
-        inline ProjectedViewportRay ViewportScreenToWorldRay(
-            const AzFramework::ViewportId viewportId, const AzFramework::ScreenPoint& screenPoint)
-        {
-            ProjectedViewportRay viewportRay{};
-            ViewportInteractionRequestBus::EventResult(
-                viewportRay, viewportId, &ViewportInteractionRequestBus::Events::ViewportScreenToWorldRay, screenPoint);
-
-            return viewportRay;
-        }
+        ProjectedViewportRay ViewportScreenToWorldRay(const AzFramework::ViewportId viewportId, const AzFramework::ScreenPoint& screenPoint);
 
         //! The EBusTraits for ViewportInteractionNotifications.
         class ViewportNotificationsEBusTraits : public AZ::EBusTraits
@@ -344,12 +319,8 @@ namespace AzToolsFramework
 
         using EditorModifierKeyRequestBus = AZ::EBus<EditorModifierKeyRequests>;
 
-        inline KeyboardModifiers QueryKeyboardModifiers()
-        {
-            KeyboardModifiers keyboardModifiers;
-            EditorModifierKeyRequestBus::BroadcastResult(keyboardModifiers, &EditorModifierKeyRequestBus::Events::QueryKeyboardModifiers);
-            return keyboardModifiers;
-        }
+        //! Convenience method to call the above EditorModifierKeyRequestBus's QueryKeyModifiers event
+        KeyboardModifiers QueryKeyboardModifiers();
 
         //! An interface to deal with time requests relating to viewports.
         //! @note The bus is global and not per viewport.
@@ -402,13 +373,7 @@ namespace AzToolsFramework
     } // namespace ViewportInteraction
 
     //! Utility function to return EntityContextId.
-    inline AzFramework::EntityContextId GetEntityContextId()
-    {
-        auto entityContextId = AzFramework::EntityContextId::CreateNull();
-        EditorEntityContextRequestBus::BroadcastResult(entityContextId, &EditorEntityContextRequests::GetEditorEntityContextId);
-
-        return entityContextId;
-    }
+    AzFramework::EntityContextId GetEntityContextId();
 
     //! Performs an intersection test against meshes in the scene, if there is a hit (the ray intersects
     //! a mesh), that position is returned, otherwise a point projected defaultDistance from the
@@ -462,3 +427,5 @@ namespace AzToolsFramework
     //! @note It is possible to pass AzFramework::InvalidViewportId (the default) to perform a Broadcast as opposed to a targeted Event.
     float ManipulatorCicleBoundWidth(AzFramework::ViewportId viewportId = AzFramework::InvalidViewportId);
 } // namespace AzToolsFramework
+
+DECLARE_EBUS_EXTERN_WITH_TRAITS(AzToolsFramework::ViewportInteraction::ViewportInteractionRequests, AzToolsFramework::ViewportInteraction::ViewportRequestsEBusTraits);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -62,11 +62,13 @@ set(FILES
     AzToolsFrameworkModule.h
     AzToolsFrameworkModule.cpp
     API/ToolsApplicationAPI.h
+    API/ToolsApplicationAPI.cpp
     API/EditorAssetSystemAPI.h
     API/EditorAssetSystemAPI.cpp
     API/AssetDatabaseBus.h
     API/ComponentEntityObjectBus.h
     API/ComponentEntitySelectionBus.h
+    API/ComponentEntitySelectionBus.cpp
     API/ComponentModeCollectionInterface.h
     API/EditorCameraBus.h
     API/EditorCameraBus.cpp

--- a/Code/Legacy/CryCommon/CrySystemBus.cpp
+++ b/Code/Legacy/CryCommon/CrySystemBus.cpp
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <CryCommon/CrySystemBus.h>
+
+DECLARE_EBUS_INSTANTIATION(CrySystemRequests);

--- a/Code/Legacy/CryCommon/CrySystemBus.h
+++ b/Code/Legacy/CryCommon/CrySystemBus.h
@@ -6,8 +6,6 @@
  *
  */
 
-#ifndef CRYINCLUDE_CRYCOMMON_CRYSYSTEMBUS_H
-#define CRYINCLUDE_CRYCOMMON_CRYSYSTEMBUS_H
 #pragma once
 
 #include <AzCore/EBus/EBus.h>
@@ -78,4 +76,4 @@ public:
 };
 using CrySystemRequestBus = AZ::EBus<CrySystemRequests>;
 
-#endif // CRYINCLUDE_CRYCOMMON_CRYSYSTEMBUS_H
+DECLARE_EBUS_EXTERN(CrySystemRequests);

--- a/Code/Legacy/CryCommon/crycommon_files.cmake
+++ b/Code/Legacy/CryCommon/crycommon_files.cmake
@@ -42,6 +42,7 @@ set(FILES
     CryListenerSet.h
     CryPath.h
     CrySystemBus.h
+    CrySystemBus.cpp
     CryVersion.h
     MiniQueue.h
     MultiThread_Containers.h

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/IShaderVariantFinder.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/IShaderVariantFinder.h
@@ -107,3 +107,5 @@ namespace AZ
 
     } // namespace RPI
 }// namespace AZ
+
+DECLARE_EBUS_EXTERN(RPI::ShaderVariantFinderNotification);

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAsset.cpp
@@ -21,6 +21,8 @@
 #include <Atom/RPI.Public/Shader/ShaderReloadDebugTracker.h>
 #include <Atom/RPI.Public/Shader/ShaderReloadNotificationBus.h>
 
+DECLARE_EBUS_INSTANTIATION(RPI::ShaderVariantFinderNotification);
+
 namespace AZ
 {
     namespace RPI

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/SceneBus.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/SceneBus.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <GraphCanvas/Components/SceneBus.h>
+
+DECLARE_EBUS_INSTANTIATION(GraphCanvas::SceneRequests);
+
+namespace GraphCanvas
+{
+    void SceneRequests::HandleProposalDaisyChain(const NodeId& startNode, SlotType slotType, ConnectionType connectionType, const QPoint& screenPoint, const QPointF& focusPoint)
+    {
+        HandleProposalDaisyChainWithGroup(startNode, slotType, connectionType, screenPoint, focusPoint, AZ::EntityId());
+    }
+}

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/SceneBus.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/SceneBus.h
@@ -373,11 +373,8 @@ namespace GraphCanvas
 
         virtual void HandleProposalDaisyChainWithGroup(const NodeId& startNode, SlotType slotType, ConnectionType connectionType, const QPoint& screenPoint, const QPointF& focusPoint, AZ::EntityId groupTarget) = 0;
 
-        virtual void HandleProposalDaisyChain(const NodeId& startNode, SlotType slotType, ConnectionType connectionType, const QPoint& screenPoint, const QPointF& focusPoint)
-        {
-            HandleProposalDaisyChainWithGroup(startNode, slotType, connectionType, screenPoint, focusPoint, AZ::EntityId());
-        }
-
+        virtual void HandleProposalDaisyChain(const NodeId& startNode, SlotType slotType, ConnectionType connectionType, const QPoint& screenPoint, const QPointF& focusPoint);
+        
         virtual void StartNudging(const AZStd::unordered_set<AZ::EntityId>& fixedNodes) = 0;
         virtual void FinalizeNudging() = 0;
         virtual void CancelNudging() = 0;
@@ -391,7 +388,6 @@ namespace GraphCanvas
     };
 
     using SceneRequestBus = AZ::EBus<SceneRequests>;
-
 
     //! SceneNotifications
     //! Notifications about changes to the state of scenes.
@@ -591,3 +587,5 @@ namespace GraphCanvas
 
     using SceneMemberNotificationBus = AZ::EBus<SceneMemberNotifications>;    
 }
+
+DECLARE_EBUS_EXTERN(GraphCanvas::SceneRequests);

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/Slots/SlotBus.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/Slots/SlotBus.cpp
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <GraphCanvas/Components/Slots/SlotBus.h>
+
+DECLARE_EBUS_INSTANTIATION(GraphCanvas::SlotRequests);

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/Slots/SlotBus.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/Slots/SlotBus.h
@@ -407,3 +407,5 @@ namespace GraphCanvas
 
     using SlotLayoutRequestBus = AZ::EBus<SlotLayoutRequests>;
 }
+
+DECLARE_EBUS_EXTERN(GraphCanvas::SlotRequests);

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/StyleBus.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/StyleBus.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <GraphCanvas/Components/StyleBus.h>
+
+DECLARE_EBUS_INSTANTIATION(GraphCanvas::StyleManagerNotifications);
+
+namespace GraphCanvas
+{
+    AZStd::string StyledEntityRequests::GetFullStyleElement() const
+    {
+        AZStd::string element = GetElement();
+        AZStd::string subStyle = GetClass();
+
+        if (subStyle.empty())
+        {
+            return element;
+        }
+        else
+        {
+            return AZStd::string::format("%s.%s", element.c_str(), subStyle.c_str());
+        }
+    }
+
+   
+    void PaletteIconConfiguration::ClearPalettes()
+    {
+        m_colorPalettes.clear();
+        m_paletteCrc = AZ::Crc32();
+    }
+
+    void PaletteIconConfiguration::ReservePalettes(size_t size)
+    {
+        m_colorPalettes.reserve(size);
+    }
+
+    void PaletteIconConfiguration::SetColorPalette(AZStd::string_view paletteString)
+    {
+        ClearPalettes();
+        AddColorPalette(paletteString);
+    }
+
+    void PaletteIconConfiguration::AddColorPalette(AZStd::string_view paletteString)
+    {
+        m_colorPalettes.push_back(paletteString);
+        m_paletteCrc.Add(paletteString.data());
+    }
+
+    const AZStd::vector< AZStd::string >& PaletteIconConfiguration::GetColorPalettes() const
+    {
+        return m_colorPalettes;
+    }
+
+    AZ::Crc32 PaletteIconConfiguration::GetPaletteCrc() const
+    {
+        return m_paletteCrc;
+    }
+}

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/StyleBus.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/StyleBus.cpp
@@ -60,4 +60,4 @@ namespace GraphCanvas
     {
         return m_paletteCrc;
     }
-}
+} // namespace GraphCanvas

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/StyleBus.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/StyleBus.h
@@ -9,11 +9,6 @@
 
 #include <AzCore/PlatformDef.h>
 
-AZ_PUSH_DISABLE_WARNING(4251 4800 4244, "-Wunknown-warning-option")
-#include <QColor>
-#include <QPixmap>
-AZ_POP_DISABLE_WARNING
-
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Math/Uuid.h>
@@ -24,6 +19,8 @@ AZ_POP_DISABLE_WARNING
 #include <GraphCanvas/Editor/EditorTypes.h>
 #include <GraphCanvas/Styling/Selector.h>
 
+class QColor;
+class QPixmap;
 class QVariant;
 
 namespace GraphCanvas
@@ -63,20 +60,7 @@ namespace GraphCanvas
         virtual AZStd::string GetClass() const = 0;
 
         //! Returns <element>.<class>
-        virtual AZStd::string GetFullStyleElement() const
-        {
-            AZStd::string element = GetElement();
-            AZStd::string subStyle = GetClass();
-
-            if (subStyle.empty())
-            {
-                return element;
-            }
-            else
-            {
-                return AZStd::string::format("%s.%s", element.c_str(), subStyle.c_str());
-            }
-        }
+        virtual AZStd::string GetFullStyleElement() const;
     };
 
     using StyledEntityRequestBus = AZ::EBus<StyledEntityRequests>;
@@ -92,38 +76,12 @@ namespace GraphCanvas
 
         float m_transitionPercent = 0.1f;
 
-        void ClearPalettes()
-        {
-            m_colorPalettes.clear();
-            m_paletteCrc = AZ::Crc32();
-        }
-
-        void ReservePalettes(size_t size)
-        {
-            m_colorPalettes.reserve(size);
-        }
-
-        void SetColorPalette(AZStd::string_view paletteString)
-        {
-            ClearPalettes();
-            AddColorPalette(paletteString);
-        }
-
-        void AddColorPalette(AZStd::string_view paletteString)
-        {
-            m_colorPalettes.push_back(paletteString);
-            m_paletteCrc.Add(paletteString.data());
-        }
-
-        const AZStd::vector< AZStd::string >& GetColorPalettes() const
-        {
-            return m_colorPalettes;
-        }
-
-        AZ::Crc32 GetPaletteCrc() const
-        {
-            return m_paletteCrc;
-        }
+        void ClearPalettes();
+        void ReservePalettes(size_t size);
+        void SetColorPalette(AZStd::string_view paletteString);
+        void AddColorPalette(AZStd::string_view paletteString);
+        const AZStd::vector< AZStd::string >& GetColorPalettes() const;
+        AZ::Crc32 GetPaletteCrc() const;
 
     private:
         AZ::Crc32 m_paletteCrc;
@@ -226,3 +184,5 @@ namespace GraphCanvas
     ///////////////////////////////////////////////////////////////////////////////////
 
 }
+
+DECLARE_EBUS_EXTERN(GraphCanvas::StyleManagerNotifications);

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Editor/GraphModelBus.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Editor/GraphModelBus.cpp
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <GraphCanvas/Editor/GraphModelBus.h>
+
+DECLARE_EBUS_INSTANTIATION(GraphCanvas::GraphModelRequests);

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Editor/GraphModelBus.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Editor/GraphModelBus.h
@@ -252,3 +252,5 @@ namespace GraphCanvas
 
     using GraphModelNotificationBus = AZ::EBus<GraphModelNotifications>;
 }
+
+DECLARE_EBUS_EXTERN(GraphCanvas::GraphModelRequests);

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/GraphicsItems/GraphicsEffectBus.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/GraphicsItems/GraphicsEffectBus.cpp
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <GraphCanvas/GraphicsItems/GraphicsEffectBus.h>
+
+DECLARE_EBUS_INSTANTIATION(GraphCanvas::GraphicsEffectRequests);

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/GraphicsItems/GraphicsEffectBus.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/GraphicsItems/GraphicsEffectBus.h
@@ -10,8 +10,12 @@
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Component/EntityId.h>
 
+class QGraphicsItem;
+
 namespace GraphCanvas
 {
+    using GraphicsEffectId = AZ::EntityId;
+
     class GraphicsEffectRequests
         : public AZ::EBusTraits
     {

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/GraphicsItems/GraphicsEffectBus.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/GraphicsItems/GraphicsEffectBus.h
@@ -31,3 +31,5 @@ namespace GraphCanvas
     
     using GraphicsEffectRequestBus = AZ::EBus<GraphicsEffectRequests>;
 }
+
+DECLARE_EBUS_EXTERN(GraphCanvas::GraphicsEffectRequests);

--- a/Gems/GraphCanvas/Code/graphcanvas_staticlib_files.cmake
+++ b/Gems/GraphCanvas/Code/graphcanvas_staticlib_files.cmake
@@ -35,13 +35,17 @@ set(FILES
     StaticLib/GraphCanvas/Components/MimeDataHandlerBus.h
     StaticLib/GraphCanvas/Components/PersistentIdBus.h
     StaticLib/GraphCanvas/Components/SceneBus.h
+    StaticLib/GraphCanvas/Components/SceneBus.cpp
     StaticLib/GraphCanvas/Components/StyleBus.h
+    StaticLib/GraphCanvas/Components/StyleBus.cpp
     StaticLib/GraphCanvas/Components/ViewBus.h
     StaticLib/GraphCanvas/Components/VisualBus.h
     StaticLib/GraphCanvas/GraphicsItems/AnimatedPulse.cpp
     StaticLib/GraphCanvas/GraphicsItems/AnimatedPulse.h
     StaticLib/GraphCanvas/GraphicsItems/GlowOutlineGraphicsItem.cpp
     StaticLib/GraphCanvas/GraphicsItems/GlowOutlineGraphicsItem.h
+    StaticLib/GraphCanvas/GraphicsItems/GraphicsEffectBus.h
+    StaticLib/GraphCanvas/GraphicsItems/GraphicsEffectBus.cpp
     StaticLib/GraphCanvas/GraphicsItems/GraphicsEffect.h
     StaticLib/GraphCanvas/GraphicsItems/Occluder.cpp
     StaticLib/GraphCanvas/GraphicsItems/Occluder.h
@@ -73,6 +77,7 @@ set(FILES
     StaticLib/GraphCanvas/Components/Nodes/Group/NodeGroupBus.h
     StaticLib/GraphCanvas/Components/Nodes/Wrapper/WrapperNodeBus.h
     StaticLib/GraphCanvas/Components/Slots/SlotBus.h
+    StaticLib/GraphCanvas/Components/Slots/SlotBus.cpp
     StaticLib/GraphCanvas/Components/Slots/Data/DataSlotBus.h
     StaticLib/GraphCanvas/Components/Slots/Property/PropertySlotBus.h
     StaticLib/GraphCanvas/Editor/AssetEditorBus.h
@@ -82,6 +87,7 @@ set(FILES
     StaticLib/GraphCanvas/Editor/EditorTypes.h
     StaticLib/GraphCanvas/Editor/GraphCanvasProfiler.h
     StaticLib/GraphCanvas/Editor/GraphModelBus.h
+    StaticLib/GraphCanvas/Editor/GraphModelBus.cpp
     StaticLib/GraphCanvas/Styling/definitions.h
     StaticLib/GraphCanvas/Styling/PseudoElement.cpp
     StaticLib/GraphCanvas/Styling/PseudoElement.h

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/AssetRegistry.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/AssetRegistry.cpp
@@ -13,6 +13,8 @@
 #include <ScriptCanvas/Asset/RuntimeAssetHandler.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 
+DECLARE_EBUS_INSTANTIATION(ScriptCanvas::AssetRegistryRequests);
+
 namespace ScriptCanvas
 {
     void AssetRegistry::Unregister()

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/AssetRegistryBus.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/AssetRegistryBus.h
@@ -32,3 +32,5 @@ namespace ScriptCanvas
 
     using AssetRegistryRequestBus = AZ::EBus<AssetRegistryRequests>;
 }
+
+DECLARE_EBUS_EXTERN(ScriptCanvas::AssetRegistryRequests);


### PR DESCRIPTION
## What does this PR do?

I used clang build analyzer to enumerate the top N slowest busses that are used in the most different source files and moved all of them (except those in lmbrcentral) to extern.  The cutoff point was anything that cost more than 10s in the compile.

As part of this, I also moved code found in the bus headers into companion CPP files instead, especially code which would instantiate the bus when the header was included.  Note that externing these reduced the # of times the symbol needed compiling overall, but also had a side effect of reducing the # of times all related types (like hash table storage, since ebuses uses hash table) need to compile too

```
Before vs after (from Clang Build Analyzer)

1838628 ms: AZ::EBus<$>::GetContext (7292 times, avg 252 ms)
vs
1213149 ms: AZ::EBus<$>::GetContext (5147 times, avg 235 ms)
(625s savings)

and
1345553 ms: AZStd::Internal::hash_table_storage<$>::rehash<$> (17688 times, avg 76 ms)
vs
1242149 ms: AZStd::Internal::hash_table_storage<$>::rehash<$> (15554 times, avg 79 ms)
(103s savings)
```

Note that these are not the only savings - each ebus generates many other functions.  But its at least data to support that there are savings, and the savings don't cause other areas to suddenly become more expensive, its across the board lowering of total cost to compile.

Note also that this is on a 12 core machine, so actual wall clock savings will be more like 60s, not 728s assuming perfect parallelization (its not actually), and the 628s is from 625s + 103s - there are probably many more saved functions since ebus generates a lot.

Signed-off-by: Nicholas Lawson <70027408+lawsonamzn@users.noreply.github.com>

## How was this PR tested?

Compiled on clang, as well as msvc, ran editor on msvc and poked around at levels and stuff.
