### PR TITLE
Provide a CharacterNotifications bus to drive association of active PhysX character and Network Character Controllers

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/CharacterBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/CharacterBus.h
@@ -103,4 +103,22 @@ namespace Physics
     };
 
     using CharacterRequestBus = AZ::EBus<CharacterRequests>;
-} // namespace Physics
+
+    /// Messages sent by character controllers.
+    class CharacterNotifications : public AZ::ComponentBus
+    {
+    public:
+        virtual ~CharacterNotifications() = default;
+
+        virtual void OnCharacterActivated()
+        {
+        }
+
+        virtual void OnCharacterDeactivated()
+        {
+        }
+    };
+
+    using CharacterNotificationBus = AZ::EBus<CharacterNotifications>;
+
+    } // namespace Physics

--- a/Code/Framework/AzFramework/AzFramework/Physics/CharacterBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/CharacterBus.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/Component/ComponentBus.h>
+#include <AzCore/Component/Entity.h>
 
 namespace AZ
 {
@@ -107,20 +108,67 @@ namespace Physics
     /// Messages sent by character controllers.
     class CharacterNotifications : public AZ::ComponentBus
     {
+    private:
+        template<class Bus>
+        struct CharacterNotificationsConnectionPolicy : public AZ::EBusConnectionPolicy<Bus>
+        {
+            static void Connect(
+                typename Bus::BusPtr& busPtr,
+                typename Bus::Context& context,
+                typename Bus::HandlerNode& handler,
+                typename Bus::Context::ConnectLockGuard& connectLock,
+                const typename Bus::BusIdType& id = 0)
+            {
+                AZ::EBusConnectionPolicy<Bus>::Connect(busPtr, context, handler, connectLock, id);
+
+                AZ::Entity* entity = nullptr;
+                AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, id);
+                if (entity)
+                {
+                    // Only immediately dispatch if the entity is already active, otherwise when
+                    // entity will get activated it will make the notifications itself.
+                    const AZ::Entity::State entityState = entity->GetState();
+                    if (entityState == AZ::Entity::State::Active)
+                    {
+                        // Only immediately dispatch if the entity is a CharacterRequests' handler.
+                        CharacterRequestBus::EnumerateHandlersId(
+                            id,
+                            [&handler, id](const CharacterRequests* characterHandler)
+                            {
+                                if (characterHandler->IsPresent())
+                                {
+                                    handler->OnCharacterActivated(id);
+                                }
+                                else
+                                {
+                                    handler->OnCharacterDeactivated(id);
+                                }
+                                return true;
+                            });
+                    }
+                }
+            }
+        };
+
     public:
+        /// With this connection policy, CharacterNotifications::OnCharacterActivated and
+        /// CharacterNotifications::OnCharacterDeactivated events will be immediately
+        /// dispatched when a handler connects to the bus.
+        template<class Bus>
+        using ConnectionPolicy = CharacterNotificationsConnectionPolicy<Bus>;
+
         virtual ~CharacterNotifications() = default;
 
-        /// Notifies that the character controller has activated on this entity.
-        /// Other components on the entity that depend on the character controller can't simply rely on the component service
-        /// dependencies because the character controller isn't necessarily activated at component activation.
-        virtual void OnCharacterActivated()
+        /// Notifies that the character controller has activated on an entity.
+        /// Other components that depend on the character controller can't simply rely on the component service
+        /// dependencies because the character controller is activated at OnEntityActivated, after the
+        /// components' activation.
+        virtual void OnCharacterActivated([[maybe_unused]] const AZ::EntityId& entityId)
         {
         }
 
-        // Notifies that the character controller has deactivated on this entity.
-        /// Other components on the entity that depend on the character controller can't simply rely on the component service
-        /// dependencies because the character controller isn't necessarily deactivated at component deactivation.
-        virtual void OnCharacterDeactivated()
+        /// Notifies that the character controller has deactivated on an entity.
+        virtual void OnCharacterDeactivated([[maybe_unused]] const AZ::EntityId& entityId)
         {
         }
     };

--- a/Code/Framework/AzFramework/AzFramework/Physics/CharacterBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/CharacterBus.h
@@ -110,10 +110,16 @@ namespace Physics
     public:
         virtual ~CharacterNotifications() = default;
 
+        /// Notifies that the character controller has activated on this entity.
+        /// Other components on the entity that depend on the character controller can't simply rely on the component service
+        /// dependencies because the character controller isn't necessarily activated at component activation.
         virtual void OnCharacterActivated()
         {
         }
 
+        // Notifies that the character controller has deactivated on this entity.
+        /// Other components on the entity that depend on the character controller can't simply rely on the component service
+        /// dependencies because the character controller isn't necessarily deactivated at component deactivation.
         virtual void OnCharacterDeactivated()
         {
         }

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkCharacterComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkCharacterComponent.h
@@ -10,6 +10,7 @@
 
 #include <Source/AutoGen/NetworkCharacterComponent.AutoComponent.h>
 #include <Multiplayer/Components/NetBindComponent.h>
+#include <AzFramework/Physics/CharacterBus.h>
 
 namespace Physics
 {
@@ -37,6 +38,7 @@ namespace Multiplayer
     //! Provides multiplayer support for game-play player characters.
     class NetworkCharacterComponent
         : public NetworkCharacterComponentBase
+        , protected Physics::CharacterNotificationBus::Handler
     {
         friend class NetworkCharacterComponentController;
 
@@ -52,6 +54,9 @@ namespace Multiplayer
         void OnInit() override {}
         void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
         void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+
+    protected:
+        void OnCharacterActivated() override;
 
     private:
         void OnTranslationChangedEvent(const AZ::Vector3& translation);

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkCharacterComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkCharacterComponent.h
@@ -56,7 +56,7 @@ namespace Multiplayer
         void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
 
     protected:
-        void OnCharacterActivated() override;
+        void OnCharacterActivated(const AZ::EntityId& entityId) override;
 
     private:
         void OnTranslationChangedEvent(const AZ::Vector3& translation);

--- a/Gems/Multiplayer/Code/Source/Components/NetworkCharacterComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetworkCharacterComponent.cpp
@@ -107,7 +107,13 @@ namespace Multiplayer
     {
     }
 
+
     void NetworkCharacterComponent::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+        Physics::CharacterNotificationBus::Handler::BusConnect(GetEntityId());
+    }
+
+    void NetworkCharacterComponent::OnCharacterActivated()
     {
         Physics::CharacterRequests* characterRequests = Physics::CharacterRequestBus::FindFirstHandler(GetEntityId());
         m_physicsCharacter = (characterRequests != nullptr) ? characterRequests->GetCharacter() : nullptr;
@@ -132,7 +138,7 @@ namespace Multiplayer
 
     void NetworkCharacterComponent::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
-        ;
+        Physics::CharacterNotificationBus::Handler::BusDisconnect();
     }
 
     void NetworkCharacterComponent::OnTranslationChangedEvent([[maybe_unused]] const AZ::Vector3& translation)

--- a/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
@@ -107,10 +107,14 @@ namespace PhysX
         Physics::CharacterRequestBus::Handler::BusConnect(entityId);
         Physics::CollisionFilteringRequestBus::Handler::BusConnect(entityId);
         AzPhysics::SimulatedBodyComponentRequestsBus::Handler::BusConnect(entityId);
+
+        Physics::CharacterNotificationBus::Event(entityId, &Physics::CharacterNotificationBus::Events::OnCharacterActivated);
     }
 
     void CharacterControllerComponent::Deactivate()
     {
+        Physics::CharacterNotificationBus::Event(GetEntityId(), & Physics::CharacterNotificationBus::Events::OnCharacterDeactivated);
+
         DisableController();
 
         AZ::EntityBus::Handler::BusDisconnect();

--- a/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
@@ -69,7 +69,7 @@ namespace PhysX
 
     CharacterControllerComponent::~CharacterControllerComponent()
     {
-        DisableController();
+        DestroyController();
     }
 
     // AZ::Component
@@ -97,27 +97,26 @@ namespace PhysX
         AZ::EntityBus::Handler::BusConnect(GetEntityId());
     }
 
-    void CharacterControllerComponent::OnEntityActivated(const AZ::EntityId& entityId)
+    void CharacterControllerComponent::OnEntityActivated([[maybe_unused]] const AZ::EntityId& entityId)
     {
         AZ::EntityBus::Handler::BusDisconnect();
 
         CreateController();
-
-        AZ::TransformNotificationBus::Handler::BusConnect(entityId);
-        Physics::CharacterRequestBus::Handler::BusConnect(entityId);
-        Physics::CollisionFilteringRequestBus::Handler::BusConnect(entityId);
-        AzPhysics::SimulatedBodyComponentRequestsBus::Handler::BusConnect(entityId);
-
-        Physics::CharacterNotificationBus::Event(entityId, &Physics::CharacterNotificationBus::Events::OnCharacterActivated);
     }
 
     void CharacterControllerComponent::Deactivate()
     {
-        Physics::CharacterNotificationBus::Event(GetEntityId(), & Physics::CharacterNotificationBus::Events::OnCharacterDeactivated);
-
-        DisableController();
+        DestroyController();
 
         AZ::EntityBus::Handler::BusDisconnect();
+
+        // The following buses cannot be disconnected inside DestroyController
+        // because while the character is disabled (which internally is the same
+        // as being destroyed in character controllers) the buses need to keep
+        // being responsive (to fake they are created but disabled), for example
+        // to respond false to IsPhysicsEnabled or IsPresent.
+        // These buses' implementation in this class are protected to handle
+        // the body being invalid.
         Physics::CollisionFilteringRequestBus::Handler::BusDisconnect();
         AzPhysics::SimulatedBodyComponentRequestsBus::Handler::BusDisconnect();
         AZ::TransformNotificationBus::Handler::BusDisconnect();
@@ -253,7 +252,7 @@ namespace PhysX
 
     void CharacterControllerComponent::DisablePhysics()
     {
-        DisableController();
+        DestroyController();
     }
 
     bool CharacterControllerComponent::IsPhysicsEnabled() const
@@ -590,30 +589,39 @@ namespace PhysX
                 sceneInterface->RegisterSceneSimulationStartHandler(m_attachedSceneHandle, m_sceneSimulationStartHandler);
             }
         }
+
+        AZ::TransformNotificationBus::Handler::BusConnect(GetEntityId());
+        Physics::CharacterRequestBus::Handler::BusConnect(GetEntityId());
+        Physics::CollisionFilteringRequestBus::Handler::BusConnect(GetEntityId());
+        AzPhysics::SimulatedBodyComponentRequestsBus::Handler::BusConnect(GetEntityId());
+
+        Physics::CharacterNotificationBus::Event(
+            GetEntityId(), &Physics::CharacterNotificationBus::Events::OnCharacterActivated, GetEntityId());
     }
 
-    void CharacterControllerComponent::DisableController()
+    void CharacterControllerComponent::DestroyController()
     {
         if (auto* controller = GetController())
         {
+            Physics::CharacterNotificationBus::Event(
+                GetEntityId(), &Physics::CharacterNotificationBus::Events::OnCharacterDeactivated, GetEntityId());
+
             controller->DisablePhysics();
+
+            // Needs to be disconnected before calling RemoveSimulatedBody otherwise
+            // it will end up re-entring into this same function.
+            m_onSimulatedBodyRemovedHandler.Disconnect(); 
 
             if (auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get())
             {
                 sceneInterface->RemoveSimulatedBody(m_attachedSceneHandle, controller->m_bodyHandle);
             }
 
-            DestroyController();
+            m_controllerBodyHandle = AzPhysics::InvalidSimulatedBodyHandle;
+            m_attachedSceneHandle = AzPhysics::InvalidSceneHandle;
+            m_sceneSimulationStartHandler.Disconnect();
+            m_postSimulateHandler.Disconnect();
+            CharacterControllerRequestBus::Handler::BusDisconnect();
         }
-    }
-
-    void CharacterControllerComponent::DestroyController()
-    {
-        m_controllerBodyHandle = AzPhysics::InvalidSimulatedBodyHandle;
-        m_attachedSceneHandle = AzPhysics::InvalidSceneHandle;
-        m_sceneSimulationStartHandler.Disconnect();
-        m_postSimulateHandler.Disconnect();
-        m_onSimulatedBodyRemovedHandler.Disconnect();
-        CharacterControllerRequestBus::Handler::BusDisconnect();
     }
 } // namespace PhysX

--- a/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.h
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.h
@@ -141,9 +141,8 @@ namespace PhysX
         // Creates the physics character controller in the current default physics scene.
         // This will do nothing if the controller is already created.
         void CreateController();
-        // Removes the physics character controller from the scene and will call DestroyController for clean up.
-        void DisableController();
-        // Cleans up all references and events used with the physics character controller.
+        // Removes the physics character controller from the scene and cleans up all
+        // references and events used with the physics character controller.
         void DestroyController();
 
         void OnPostSimulate(float deltaTime);

--- a/Gems/PhysX/Code/Source/RigidBodyComponent.h
+++ b/Gems/PhysX/Code/Source/RigidBodyComponent.h
@@ -150,7 +150,8 @@ namespace PhysX
 
     private:
         void SetupConfiguration();
-        void CreatePhysics();
+        void CreateRigidBody();
+        void DestroyRigidBody();
         void ApplyPhysxSpecificConfiguration();
         void InitPhysicsTickHandler();
         void PostPhysicsTick(float fixedDeltaTime);

--- a/Gems/PhysX/Code/Source/StaticRigidBodyComponent.h
+++ b/Gems/PhysX/Code/Source/StaticRigidBodyComponent.h
@@ -57,7 +57,8 @@ namespace PhysX
         AzPhysics::SimulatedBody* GetSimulatedBody() override;
 
     private:
-        void InitStaticRigidBody();
+        void CreateRigidBody();
+        void DestroyRigidBody();
 
         // AZ::Component
         void Activate() override;


### PR DESCRIPTION
## What does this PR do?

The recent change to Static Rigid Bodies changed the timing of the Character Controller initialization. It used to occur during the component's Activate(), which meant that other components on the entity could be guaranteed that they could fetch a pointer to the component during their Activate() calls, as long as they had the service dependencies set up correctly.

However, the Character Controller now activates during OnEntityActivated(), which means that other components can no longer rely on the service dependencies to know when the Character Controller is available.

To fix this, the Character Controller now has a new notification bus that it uses to signal when the character is activated and deactivated. Dependent components can listen for these notifications to know when it is safe to communicate with the Character Controller and when it isn't.

## How was this PR tested?

Ran the Multiplayer Sample and verified that the character can once again move around in networked conditions.
Run physx gem unit tests.
Run multiplayer gem unit tests.