### PR TITLE
Fix the misleading prompt in the level selection dialog box.

### DIFF
--- a/Code/Editor/WelcomeScreen/WelcomeScreenDialog.cpp
+++ b/Code/Editor/WelcomeScreen/WelcomeScreenDialog.cpp
@@ -323,9 +323,16 @@ void WelcomeScreenDialog::OnNewLevelBtnClicked([[maybe_unused]] bool checked)
     accept();
 }
 
-void WelcomeScreenDialog::OnNewLevelLabelClicked([[maybe_unused]] const QString& path)
+void WelcomeScreenDialog::OnNewLevelLabelClicked(const QString& path)
 {
-    OnNewLevelBtnClicked(true);
+    if (path == "Create")
+    {
+        OnNewLevelBtnClicked(true);
+    }
+    else
+    {
+        OnOpenLevelBtnClicked(true);
+    }
 }
 
 void WelcomeScreenDialog::OnOpenLevelBtnClicked([[maybe_unused]] bool checked)

--- a/Code/Editor/WelcomeScreen/WelcomeScreenDialog.ui
+++ b/Code/Editor/WelcomeScreen/WelcomeScreenDialog.ui
@@ -527,7 +527,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>No level file created yet for this project. &lt;a href=&quot;#&quot;&gt;Create one&lt;/a&gt; now.</string>
+             <string>No recent level file in this project yet. &lt;a href=&quot;Open&quot;&gt;Open an existing level&lt;/a&gt; or &lt;a href=&quot;Create&quot;&gt;create a new level&lt;/a&gt; now.</string>
             </property>
             <property name="textFormat">
              <enum>Qt::RichText</enum>


### PR DESCRIPTION
When opening an existing project, the prompt information in the level selection dialog box is misleading.

Signed-off-by: Jackie9527 <80555200+Jackie9527@users.noreply.github.com>

## What does this PR do?

Fix the misleading prompt in the level selection dialog box.

![1-0293-1](https://user-images.githubusercontent.com/80555200/217758106-be5fd3e7-d722-436f-aa96-20efdfb16f9e.png)

## How was this PR tested?

Click `Open`
![1-0293-2](https://user-images.githubusercontent.com/80555200/217758145-7e12fd1e-8d93-4f6c-9084-50a357b8939e.png)

Click `Open an existing level`
![1-0293-3](https://user-images.githubusercontent.com/80555200/217758166-b3bb1be9-e281-4fb0-8872-b36164d724fa.png)
