### PR TITLE
Update Far depth cascade if Shadow far clip is modified.

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/DirectionalLightComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/DirectionalLightComponentConfig.h
@@ -17,6 +17,11 @@ namespace AZ
 {
     namespace Render
     {
+        namespace DirectionalLightConstants
+        {
+            static const float MIN_CASCADE_FAR_DEPTH = 0.01f;
+        }
+
         struct DirectionalLightComponentConfig final
             : public ComponentConfig
         {
@@ -139,6 +144,7 @@ namespace AZ
             bool IsShadowFilteringDisabled() const;
             bool IsShadowPcfDisabled() const;
             bool IsEsmDisabled() const;
+            AZ::Crc32 UpdateCascadeFarDepths();
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentConfig.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentConfig.cpp
@@ -127,5 +127,20 @@ namespace AZ
         {
             return !(m_shadowFilterMethod == ShadowFilterMethod::Esm || m_shadowFilterMethod == ShadowFilterMethod::EsmPcf);
         }
+
+        AZ::Crc32 DirectionalLightComponentConfig::UpdateCascadeFarDepths()
+        {
+            if (IsSplitAutomatic())
+            {
+                for (uint32_t i = 0; i < Shadow::MaxNumberOfCascades; ++i)
+                {
+                    m_cascadeFarDepths.SetElement(
+                        i, i < m_cascadeCount ? m_shadowFarClipDistance * (i + 1) / m_cascadeCount : m_shadowFarClipDistance);
+                }
+            }
+            m_cascadeFarDepths =
+                m_cascadeFarDepths.GetClamp(Vector4(DirectionalLightConstants::MIN_CASCADE_FAR_DEPTH), Vector4(m_shadowFarClipDistance));
+            return Edit::PropertyRefreshLevels::AttributesAndValues;
+        }
     } // namespace Render
 } // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorDirectionalLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorDirectionalLightComponent.cpp
@@ -80,7 +80,7 @@ namespace AZ
                         ->DataElement(Edit::UIHandlers::EntityId, &DirectionalLightComponentConfig::m_cameraEntityId, "Camera", "Entity of the camera for cascaded shadowmap view frustum.")
                             ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
                         ->DataElement(Edit::UIHandlers::Default, &DirectionalLightComponentConfig::m_shadowFarClipDistance, "Shadow far clip", "Shadow specific far clip distance.")
-                            ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+                            ->Attribute(Edit::Attributes::ChangeNotify, &DirectionalLightComponentConfig::UpdateCascadeFarDepths)
                         ->DataElement(Edit::UIHandlers::ComboBox, &DirectionalLightComponentConfig::m_shadowmapSize, "Shadowmap size", "Width/Height of shadowmap")
                             ->EnumAttribute(ShadowmapSize::Size256, " 256")
                             ->EnumAttribute(ShadowmapSize::Size512, " 512")
@@ -91,8 +91,10 @@ namespace AZ
                             ->Attribute(Edit::Attributes::Min, 1)
                             ->Attribute(Edit::Attributes::Max, Shadow::MaxNumberOfCascades)
                             ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+                            ->Attribute(Edit::Attributes::ChangeNotify, &DirectionalLightComponentConfig::UpdateCascadeFarDepths)
                         ->DataElement(Edit::UIHandlers::Default, &DirectionalLightComponentConfig::m_isShadowmapFrustumSplitAutomatic, "Automatic splitting",
                             "Switch splitting of shadowmap frustum to cascades automatically or not.")
+                            ->Attribute(Edit::Attributes::ChangeNotify, &DirectionalLightComponentConfig::UpdateCascadeFarDepths)
                         ->DataElement(Edit::UIHandlers::Slider, &DirectionalLightComponentConfig::m_shadowmapFrustumSplitSchemeRatio, "Split ratio",
                             "Ratio to lerp between the two types of frustum splitting scheme.\n"
                             "0 = Uniform scheme which will split the frustum evenly across all cascades.\n"
@@ -104,7 +106,7 @@ namespace AZ
                             ->Attribute(Edit::Attributes::ReadOnly, &DirectionalLightComponentConfig::IsSplitManual)
                         ->DataElement(Edit::UIHandlers::Vector4, &DirectionalLightComponentConfig::m_cascadeFarDepths, "Far depth cascade",
                             "Far depth of each cascade.  The value of the index greater than or equal to cascade count is ignored.")
-                            ->Attribute(Edit::Attributes::Min, 0.01f)
+                            ->Attribute(Edit::Attributes::Min, DirectionalLightConstants::MIN_CASCADE_FAR_DEPTH)
                             ->Attribute(Edit::Attributes::Max, &DirectionalLightComponentConfig::m_shadowFarClipDistance)
                             ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
                             ->Attribute(Edit::Attributes::ReadOnly, &DirectionalLightComponentConfig::IsSplitAutomatic)


### PR DESCRIPTION
Signed-off-by: Zhang-Baochong <zhangbaochong@huawei.com>

## What does this PR do?

Update DirectionalLight `Far depth cascade` if `Shadow far clip` is modified.
Fix the bug that the value of tooltip is not same with edit box if `Shadow far clip` is modified.

![4](https://user-images.githubusercontent.com/124341515/217759007-4fb897e4-80cf-4b87-944f-64abc5c3edb9.png)

Before：

![wrong-farDepthCascade](https://user-images.githubusercontent.com/124341515/217764354-ce7d712f-347d-4595-8040-c516cd3e7cdf.gif)

After:
![update-farDepthCascade](https://user-images.githubusercontent.com/124341515/217761884-5223bae9-8cdb-403f-8c56-ec18de23d532.gif)

## How was this PR tested?
Manually tested in editor.
1.Open Editor.
2.Modify `Shadow far clip`  parameter of Diectional Light Component 
3.Test if the `Far depth cascade` can be updated correctly.
4.Test if the vaule of tooltip is same with edit box.

