### PR TITLE
fix collider debug draw and dynamic rigid body editor world body not …

### DIFF
--- a/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
@@ -639,9 +639,11 @@ namespace PhysX
     void EditorColliderComponent::CreateStaticEditorCollider()
     {
         m_cachedAabbDirty = true;
+        Physics::ColliderComponentEventBus::Event(GetEntityId(), &Physics::ColliderComponentEvents::OnColliderChanged);
 
         if (!GetEntity()->FindComponent<EditorStaticRigidBodyComponent>())
         {
+            m_colliderDebugDraw.ClearCachedGeometry();
             return;
         }
 

--- a/Gems/PhysX/Code/Source/EditorColliderComponent.h
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.h
@@ -265,8 +265,8 @@ namespace PhysX
         // Cylinder collider
         void UpdateCylinderCookedMesh();
 
+        void UpdateCollider();
         void CreateStaticEditorCollider();
-        void ClearStaticEditorCollider();
 
         void BuildDebugDrawMesh() const;
 


### PR DESCRIPTION
…updating when collider is modified

Signed-off-by: greerdv <greerdv@amazon.com>

## What does this PR do?
Fixes a couple of issues:
- collider debug draw was not getting updated when colliders were modified
- if the entity had a dynamic rigid body, the editor world body was not getting updated when colliders were modified

## How was this PR tested?
Manual testing in the editor.