### PR TITLE
Using default editor to open log files.

### DIFF
--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -2652,7 +2652,9 @@ void CCryEditApp::OnEditLevelData()
 //////////////////////////////////////////////////////////////////////////
 void CCryEditApp::OnFileEditLogFile()
 {
-    CFileUtil::EditTextFile(CLogFile::GetLogFileName(), 0, IFileUtil::FILE_TYPE_SCRIPT);
+    QString file = CLogFile::GetLogFileName();
+    QString fullPathName = Path::GamePathToFullPath(file);
+    QDesktopServices::openUrl(QUrl::fromLocalFile(fullPathName));
 }
 
 #ifdef ENABLE_SLICE_EDITOR


### PR DESCRIPTION
Signed-off-by: Jackie9527 <80555200+Jackie9527@users.noreply.github.com>

## What does this PR do?

1. Set LuaIDE as Scripts Editor.
![image](https://user-images.githubusercontent.com/80555200/217826864-a0eb8b12-de4d-4d2f-a799-c38e18627603.png)
2. Open to see log files of Editor.
![6440-1](https://user-images.githubusercontent.com/80555200/217826824-e831f2f5-4ba0-4a80-891a-cf1f0a1e31f7.png)
3. LuaIDE starts and gives a misleading prompt.
![image](https://user-images.githubusercontent.com/80555200/217826876-663ef414-73d0-401e-aa7a-da42027a3117.png)

## How was this PR tested?

Follow the same repo steps, and see.
![image](https://user-images.githubusercontent.com/80555200/217826911-48af7374-6241-4d4e-ba22-f7cac6af1cef.png)

