### PR TITLE
Set `Open a Level` dialog to be `model`.

### DIFF
--- a/Code/Editor/LevelFileDialog.ui
+++ b/Code/Editor/LevelFileDialog.ui
@@ -16,6 +16,9 @@
     <height>430</height>
    </size>
   </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QLabel" name="filterLabel">


### PR DESCRIPTION
Signed-off-by: Jackie9527 <80555200+Jackie9527@users.noreply.github.com>

## What does this PR do?
Click `File` -> `Open Level`.
The dialog can lost focus.

## How was this PR tested?

Set `Open a Level` dialog to be `model`.

