### PR TITLE
Fix memory leak from TrajectoryTracePath object.

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
@@ -961,7 +961,7 @@ namespace AZ::Render
     void AtomActorDebugDraw::UpdateActorInstance(EMotionFX::ActorInstance* actorInstance, float deltaTime)
     {
         // Find the corresponding trajectory trace path for the given actor instance
-        TrajectoryTracePath* trajectoryPath = FindTrajectoryPath(actorInstance);
+        auto trajectoryPath = FindTrajectoryPath(actorInstance);
         if (!trajectoryPath)
         {
             return;
@@ -1084,22 +1084,21 @@ namespace AZ::Render
     // Find the trajectory path for a given actor instance
     AtomActorDebugDraw::TrajectoryTracePath* AtomActorDebugDraw::FindTrajectoryPath(const EMotionFX::ActorInstance* actorInstance)
     {
-        for (TrajectoryTracePath* trajectoryPath : m_trajectoryTracePaths)
+        for (const auto& trajectoryPath : m_trajectoryTracePaths)
         {
             if (trajectoryPath->m_actorInstance == actorInstance)
             {
-                return trajectoryPath;
+                return trajectoryPath.get();
             }
         }
 
         // We haven't created a path for the given actor instance yet, do so
-        TrajectoryTracePath* tracePath = new TrajectoryTracePath();
+        auto tracePath = AZStd::make_unique<TrajectoryTracePath>();
 
         tracePath->m_actorInstance = actorInstance;
         tracePath->m_traceParticles.reserve(512);
 
-        m_trajectoryTracePaths.emplace_back(tracePath);
-        return tracePath;
+        return m_trajectoryTracePaths.emplace_back(AZStd::move(tracePath)).get();
     }
 
     void AtomActorDebugDraw::RenderTrajectoryPath(AzFramework::DebugDisplayRequests* debugDisplay,
@@ -1107,7 +1106,7 @@ namespace AZ::Render
         const AZ::Color& headColor,
         const AZ::Color& pathColor)
     {
-        TrajectoryTracePath* trajectoryPath = FindTrajectoryPath(actorInstance);
+        auto trajectoryPath = FindTrajectoryPath(actorInstance);
         if (!trajectoryPath)
         {
             return;

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.h
@@ -137,7 +137,7 @@ namespace AZ::Render
 
         Physics::CharacterPhysicsDebugDraw m_characterPhysicsDebugDraw;
         // Motion extraction paths
-        AZStd::vector<TrajectoryTracePath*> m_trajectoryTracePaths;
+        AZStd::vector<AZStd::unique_ptr<TrajectoryTracePath>> m_trajectoryTracePaths;
 
         AzFramework::TextDrawParameters m_drawParams;
         AzFramework::FontDrawInterface* m_fontDrawInterface = nullptr;


### PR DESCRIPTION
Signed-off-by: Jackie9527 <80555200+Jackie9527@users.noreply.github.com>

## What does this PR do?

Fix memory leak from `TrajectoryTracePath` object.
Objects of `TrajectoryTracePath` are created but no code to delete them.

## How was this PR tested?

Using `AZStd::unique_ptr` to track the memory allocated with `TrajectoryTracePath`.

![emotionfx-memory-leak-1](https://user-images.githubusercontent.com/80555200/218236067-92bd9953-6c46-49a6-aca2-2f1f7ab218a3.png)
![emotionfx-memory-leak-2](https://user-images.githubusercontent.com/80555200/218236073-64029571-c276-4026-8f3e-01217350a8e6.png)

