### PR TITLE
Fix nested gem dependency checking

### DIFF
--- a/scripts/o3de/o3de/compatibility.py
+++ b/scripts/o3de/o3de/compatibility.py
@@ -73,7 +73,10 @@ def get_incompatible_gem_dependencies(gem_json_data:dict, all_gems_json_data:dic
     return get_incompatible_gem_version_specifiers(gem_json_data, all_gems_json_data, checked_specifiers=set())
 
 
-def get_gem_project_incompatible_objects(gem_json_data:dict, project_path:pathlib.Path, all_gems_json_data:dict = None) -> set:
+def get_gem_project_incompatible_objects(gem_path:pathlib.Path, 
+                                        gem_json_data:dict, 
+                                        project_path:pathlib.Path
+                                        ) -> set:
     """
     Returns any incompatible objects for this gem and project.
     :param gem_json_data: gem json data dictionary
@@ -100,8 +103,10 @@ def get_gem_project_incompatible_objects(gem_json_data:dict, project_path:pathli
         logger.error(f'Failed to load engine.json data based on the engine field in project.json or detect the engine from the current folder')
         return set(f'engine.json (missing)') 
 
-    if not isinstance(all_gems_json_data, dict):
-        all_gems_json_data = manifest.get_gems_json_data_by_name(engine_path, project_path, include_manifest_gems=True)
+    # Include the gem_path for the gem we are adding so it 
+    # and any gems in 'external_subdirectories' it has will be considered 
+    all_gems_json_data = manifest.get_gems_json_data_by_name(engine_path, project_path, 
+        external_subdirectories=[gem_path], include_manifest_gems=True)
 
     # compatibility will be based on the engine the project uses and the gems visible to
     # the engine and project

--- a/scripts/o3de/o3de/enable_gem.py
+++ b/scripts/o3de/o3de/enable_gem.py
@@ -113,17 +113,9 @@ def enable_gem_in_project(gem_name: str = None,
         # do not check compatibility if the project has not been registered with an engine 
         # because most gems depend on engine gems which would not be found 
         if manifest.get_project_engine_path(project_path):
-            enabled_gem_names = cmake.get_enabled_gems(project_enabled_gem_file)
-
-            # it's more efficient to open all gem.json files now instead of 
-            # looking up each by name, which will load many gem.json files multiple times
-            # it takes about 150ms to populate this structure with 137 gems, 4696 bytes in total
-            all_gems_json_data = manifest.get_gems_json_data_by_name(project_path=project_path, include_manifest_gems=True, include_engine_gems=True)
-
             # Note: we don't remove gems that are not active or dependencies
             # because they will be implicitely found and activated via cmake 
-
-            incompatible_objects = compatibility.get_gem_project_incompatible_objects(gem_json_data, project_path, all_gems_json_data)
+            incompatible_objects = compatibility.get_gem_project_incompatible_objects(gem_path, gem_json_data, project_path)
             if incompatible_objects:
                 logger.error(f'{gem_json_data["gem_name"]} has the following dependency compatibility issues and '
                     'requires the --force parameter to activate:\n  '+ 

--- a/scripts/o3de/o3de/manifest.py
+++ b/scripts/o3de/o3de/manifest.py
@@ -443,13 +443,20 @@ def remove_non_dependency_gem_json_data(gem_names:list, gems_json_data_by_name:d
 def get_gems_json_data_by_name(engine_path:pathlib.Path = None, 
                                project_path: pathlib.Path = None, 
                                include_manifest_gems: bool = False,
-                               include_engine_gems: bool = False) -> dict:
+                               include_engine_gems: bool = False,
+                               external_subdirectories: list = None) -> dict:
     """
     Create a dictionary of gem.json data with gem names as keys based on the provided list of
     external subdirectories, engine_path or project_path.  Optionally, include gems
     found using the o3de manifest.
+
+    It's often more efficient to open all gem.json files instead of 
+    looking up each by name, which will load many gem.json files multiple times
+    It takes about 150ms to populate this structure with 137 gems, 4696 bytes in total
+
     param: engine_path optional engine path
     param: project_path optional project path
+    param: gem_path optional gem path
     param: include_manifest_gems if True, include gems found using the o3de manifest 
     param: include_engine_gems if True, include gems found using the engine, 
     will use the current engine if no engine_path is provided and none can be deduced from
@@ -457,7 +464,11 @@ def get_gems_json_data_by_name(engine_path:pathlib.Path = None,
     return: a dictionary of gem_name -> gem.json data
     """
     all_gems_json_data = {}
-    external_subdirectories = list()
+
+    # we don't use a default list() value in the function params
+    # because Python will persist changes to this default list across
+    # multiple function calls which is FUN to debug
+    external_subdirectories = list() if not external_subdirectories else external_subdirectories
 
     if include_manifest_gems:
         external_subdirectories.extend(get_manifest_external_subdirectories())

--- a/scripts/o3de/o3de/manifest.py
+++ b/scripts/o3de/o3de/manifest.py
@@ -456,11 +456,11 @@ def get_gems_json_data_by_name(engine_path:pathlib.Path = None,
 
     param: engine_path optional engine path
     param: project_path optional project path
-    param: gem_path optional gem path
     param: include_manifest_gems if True, include gems found using the o3de manifest 
     param: include_engine_gems if True, include gems found using the engine, 
     will use the current engine if no engine_path is provided and none can be deduced from
     the project_path
+    param: external_subdirectories optional external_subdirectories to include
     return: a dictionary of gem_name -> gem.json data
     """
     all_gems_json_data = {}

--- a/scripts/o3de/o3de/register.py
+++ b/scripts/o3de/o3de/register.py
@@ -421,7 +421,7 @@ def register_gem_path(json_data: dict,
         # because most gems depend on engine gems which would not be found 
         if project_path and manifest.get_project_engine_path(project_path):
             # note this check includes engine and manifest gems
-            incompatible_objects = compatibility.get_gem_project_incompatible_objects(gem_json_data, project_path)
+            incompatible_objects = compatibility.get_gem_project_incompatible_objects(gem_path, gem_json_data, project_path)
             if incompatible_objects: 
                 logger.error(f'{gem_json_data["gem_name"]} is not known to be compatible with the '
                     'following objects/APIs and requires the --force parameter to register:\n  '+
@@ -432,8 +432,11 @@ def register_gem_path(json_data: dict,
             if not engine_json_data:
                 logger.error(f'Failed to load engine.json data needed for registration from {engine_path}')
                 return 1
-            # note this does NOT include o3de manifest gems, just engine gems
-            engine_gems_json_data = manifest.get_gems_json_data_by_name(engine_path=engine_path)
+            # note this does NOT include o3de manifest gems, just engine gems and any gems that may
+            # be nested inside the gem we're adding which will now be available
+            engine_gems_json_data = manifest.get_gems_json_data_by_name(engine_path=engine_path,
+                external_subdirectories=[gem_path])
+
             incompatible_objects = compatibility.get_gem_engine_incompatible_objects(gem_json_data, engine_json_data, engine_gems_json_data)
             if incompatible_objects: 
                 logger.error(f'{gem_json_data["gem_name"]} is not known to be compatible with the '

--- a/scripts/o3de/o3de/register.py
+++ b/scripts/o3de/o3de/register.py
@@ -202,16 +202,20 @@ def register_all_gems_in_folder(gems_path: pathlib.Path,
 
 def register_all_templates_in_folder(templates_path: pathlib.Path,
                                      remove: bool = False,
-                                     engine_path: pathlib.Path = None) -> int:
-    return register_all_o3de_objects_of_type_in_folder(templates_path, 'template', remove, False, None,
-                                                       engine_path=engine_path)
+                                     engine_path: pathlib.Path = None,
+                                     force: bool = False,
+                                     dry_run: bool = False) -> int:
+    return register_all_o3de_objects_of_type_in_folder(templates_path, 'template', remove, force, None,
+                                                       engine_path=engine_path, dry_run=dry_run)
 
 
 def register_all_restricted_in_folder(restricted_path: pathlib.Path,
                                       remove: bool = False,
-                                      engine_path: pathlib.Path = None) -> int:
-    return register_all_o3de_objects_of_type_in_folder(restricted_path, 'restricted', remove, False, None,
-                                                       engine_path=engine_path)
+                                     engine_path: pathlib.Path = None,
+                                     force: bool = False,
+                                     dry_run: bool = False) -> int:
+    return register_all_o3de_objects_of_type_in_folder(restricted_path, 'restricted', remove, force, None,
+                                                       engine_path=engine_path, dry_run=dry_run)
 
 
 def register_all_repos_in_folder(repos_path: pathlib.Path,
@@ -903,9 +907,9 @@ def _run_register(args: argparse) -> int:
     elif args.all_gems_path:
         return register_all_gems_in_folder(args.all_gems_path, args.remove, force=args.force, dry_run=args.dry_run)
     elif args.all_templates_path:
-        return register_all_templates_in_folder(args.all_templates_path, args.remove)
+        return register_all_templates_in_folder(args.all_templates_path, args.remove, force=args.force, dry_run=args.dry_run)
     elif args.all_restricted_path:
-        return register_all_restricted_in_folder(args.all_restricted_path, args.remove)
+        return register_all_restricted_in_folder(args.all_restricted_path, args.remove, force=args.force, dry_run=args.dry_run)
     elif args.all_repo_uri:
         return register_all_repos_in_folder(args.all_restricted_path, args.remove, args.force)
     else:

--- a/scripts/o3de/o3de/register.py
+++ b/scripts/o3de/o3de/register.py
@@ -182,17 +182,22 @@ def register_all_engines_in_folder(engines_path: pathlib.Path,
 
 def register_all_projects_in_folder(projects_path: pathlib.Path,
                                     remove: bool = False,
-                                    engine_path: pathlib.Path = None) -> int:
-    return register_all_o3de_objects_of_type_in_folder(projects_path, 'project', remove, False,
-                                                       stop_on_template_folders, engine_path=engine_path)
+                                    engine_path: pathlib.Path = None,
+                                    force: bool = False,
+                                    dry_run: bool = False) -> int:
+    return register_all_o3de_objects_of_type_in_folder(projects_path, 'project', remove, force,
+                                                       stop_on_template_folders, engine_path=engine_path, 
+                                                       dry_run=dry_run)
 
 
 def register_all_gems_in_folder(gems_path: pathlib.Path,
                                 remove: bool = False,
                                 engine_path: pathlib.Path = None,
-                                project_path: pathlib.Path = None) -> int:
-    return register_all_o3de_objects_of_type_in_folder(gems_path, 'gem', remove, False, stop_on_template_folders,
-                                                       engine_path=engine_path)
+                                project_path: pathlib.Path = None,
+                                force: bool = False,
+                                dry_run: bool = False) -> int:
+    return register_all_o3de_objects_of_type_in_folder(gems_path, 'gem', remove, force, stop_on_template_folders,
+                                                       engine_path=engine_path, dry_run=dry_run)
 
 
 def register_all_templates_in_folder(templates_path: pathlib.Path,
@@ -451,7 +456,7 @@ def register_gem_path(json_data: dict,
                                      dry_run=dry_run)
 
     if result == 0 and dry_run:
-        logger.info('Gem path was not registered because --dry-run option was specified')
+        logger.info(f'Gem path {gem_path} was not registered because the --dry-run option was specified')
 
     return result
 
@@ -894,9 +899,9 @@ def _run_register(args: argparse) -> int:
     elif args.all_engines_path:
         return register_all_engines_in_folder(args.all_engines_path, args.remove, args.force)
     elif args.all_projects_path:
-        return register_all_projects_in_folder(args.all_projects_path, args.remove)
+        return register_all_projects_in_folder(args.all_projects_path, args.remove, force=args.force, dry_run=args.dry_run)
     elif args.all_gems_path:
-        return register_all_gems_in_folder(args.all_gems_path, args.remove)
+        return register_all_gems_in_folder(args.all_gems_path, args.remove, force=args.force, dry_run=args.dry_run)
     elif args.all_templates_path:
         return register_all_templates_in_folder(args.all_templates_path, args.remove)
     elif args.all_restricted_path:

--- a/scripts/o3de/tests/test_enable_gem.py
+++ b/scripts/o3de/tests/test_enable_gem.py
@@ -153,7 +153,9 @@ class TestEnableGemCommand:
         def get_gems_json_data_by_name(engine_path:pathlib.Path = None, 
                                        project_path: pathlib.Path = None, 
                                        include_manifest_gems: bool = False,
-                                       include_engine_gems: bool = False) -> dict:
+                                       include_engine_gems: bool = False,
+                                       external_subdirectories: list = None
+                                       ) -> dict:
             return {}
 
         def get_project_json_data(project_name: str = None, project_path: pathlib.Path = None):
@@ -297,7 +299,9 @@ class TestEnableGemCommand:
         def get_gems_json_data_by_name( engine_path:pathlib.Path = None, 
                                         project_path: pathlib.Path = None, 
                                         include_manifest_gems: bool = False,
-                                        include_engine_gems: bool = False) -> dict:
+                                        include_engine_gems: bool = False,
+                                        external_subdirectories: list = None
+                                        ) -> dict:
             all_gems_json_data = {}
             for gem_name in gem_json_data_by_name.keys():
                 all_gems_json_data[gem_name] = get_gem_json_data(gem_name=gem_name)

--- a/scripts/o3de/tests/test_manifest.py
+++ b/scripts/o3de/tests/test_manifest.py
@@ -494,37 +494,43 @@ class TestManifestProjects:
 
 class TestManifestGetGemsJsonData:
 
-    manifest_external_path = "manifest_gem1"
-    engine_external_path = "engine_gem1"
-    project_external_path = "project_gem1"
+    manifest_external_path = pathlib.Path("manifest_gem1")
+    engine_external_path = pathlib.Path("engine_gem1")
+    project_external_path = pathlib.Path("project_gem1")
+    gem_external_path = pathlib.Path("external_gem1")
 
     @staticmethod
     def resolve(self):
         return self
 
     @pytest.mark.parametrize("engine_path, project_path, include_manifest_gems, include_engine_gems,"\
-                            "expected_result", [
+                            "external_subdirectories, expected_result", [
             # when engine_path provided, expect engine gems
-            pytest.param(pathlib.Path('C:/engine1'), None, False, False, 
-                {'engine_gem1':{'gem_name':'engine_gem1', 'path':'engine_gem1'}}),
+            pytest.param(pathlib.Path('C:/engine1'), None, False, False, list(), 
+                {'engine_gem1':{'gem_name':'engine_gem1', 'path':pathlib.Path('engine_gem1')}}),
             # when project_path provided, expect project gems
-            pytest.param(None, pathlib.Path('C:/project1'), False, False, 
-                {'project_gem1':{'gem_name':'project_gem1', 'path':'project_gem1'}}),
+            pytest.param(None, pathlib.Path('C:/project1'), False, False, list(),
+                {'project_gem1':{'gem_name':'project_gem1', 'path':pathlib.Path('project_gem1')}}),
             # when manifest gems are requested expect manifest gems 
-            pytest.param(None, None, True, False, 
-                {'manifest_gem1':{'gem_name':'manifest_gem1', 'path':'manifest_gem1'}}),
+            pytest.param(None, None, True, False, list(),
+                {'manifest_gem1':{'gem_name':'manifest_gem1', 'path':pathlib.Path('manifest_gem1')}}),
             # when engine gems are requested expect engine gems 
-            pytest.param(None, None, False, True, 
-                {'engine_gem1':{'gem_name':'engine_gem1', 'path':'engine_gem1'}}),
+            pytest.param(None, None, False, True, list(),
+                {'engine_gem1':{'gem_name':'engine_gem1', 'path':pathlib.Path('engine_gem1')}}),
             # when project_path provided and engine gems are requested expect both 
-            pytest.param(None, pathlib.Path('C:/project1'), False, True, 
-                {'project_gem1':{'gem_name':'project_gem1', 'path':'project_gem1'},
-                 'engine_gem1':{'gem_name':'engine_gem1', 'path':'engine_gem1'}}),
+            pytest.param(None, pathlib.Path('C:/project1'), False, True, list(),
+                {'project_gem1':{'gem_name':'project_gem1', 'path':pathlib.Path('project_gem1')},
+                 'engine_gem1':{'gem_name':'engine_gem1', 'path':pathlib.Path('engine_gem1')}}),
+            # when external subdirectories are provided (recursive), expect they are found 
+            pytest.param(None, None, False, False, ['external_gem1'],
+                {'external_gem1':{'gem_name':'external_gem1', 'external_subdirectories':['external_sub_gem2'], 'path':pathlib.Path('external_gem1')},
+                'external_sub_gem2':{'gem_name':'external_sub_gem2', 'path':pathlib.Path('external_gem1/external_sub_gem2')}
+                }),
         ]
     )
     def test_get_gems_json_data_by_name(self, engine_path, project_path, 
                                     include_manifest_gems, include_engine_gems, 
-                                    expected_result):
+                                    external_subdirectories, expected_result):
 
         def get_manifest_external_subdirectories() -> list:
             return [self.manifest_external_path]
@@ -538,16 +544,21 @@ class TestManifestGetGemsJsonData:
         def get_project_engine_path(project_path: pathlib.Path) -> pathlib.Path or None:
             return None
 
-        def get_gem_external_subdirectories(gem_path: pathlib.Path, visited_gem_paths: list, gems_json_data_by_path: dict = None) -> list:
+        def get_gem_json_data(gem_name: str = None, gem_path: str or pathlib.Path = None,
+                            project_path: pathlib.Path = None):
             if gem_path == self.manifest_external_path:
-                gems_json_data_by_path[gem_path] = {'gem_name':'manifest_gem1'}
+                return {'gem_name':'manifest_gem1'}
             elif gem_path == self.engine_external_path:
-                gems_json_data_by_path[gem_path] = {'gem_name':'engine_gem1'}
+                return {'gem_name':'engine_gem1'}
             elif gem_path == self.project_external_path:
-                gems_json_data_by_path[gem_path] = {'gem_name':'project_gem1'}
-            return list() 
+                return {'gem_name':'project_gem1'}
+            elif gem_path == self.gem_external_path:
+                return {'gem_name':'external_gem1', 'external_subdirectories':['external_sub_gem2']}
+            elif gem_path == self.gem_external_path / 'external_sub_gem2':
+                return {'gem_name':'external_sub_gem2'}
+            return  {}
 
-        with patch('o3de.manifest.get_gem_external_subdirectories', side_effect=get_gem_external_subdirectories) as get_gem_external_subdirectories_patch, \
+        with patch('o3de.manifest.get_gem_json_data', side_effect=get_gem_json_data) as get_gem_json_data_patch, \
             patch('o3de.manifest.get_manifest_external_subdirectories', side_effect=get_manifest_external_subdirectories) as get_manifest_external_subdirs_patch, \
             patch('o3de.manifest.get_engine_external_subdirectories', side_effect=get_engine_external_subdirectories) as get_engine_external_subdirs_patch, \
             patch('o3de.manifest.get_project_external_subdirectories', side_effect=get_project_external_subdirectories) as get_project_external_subdirs_patch, \
@@ -558,7 +569,8 @@ class TestManifestGetGemsJsonData:
             all_gems_by_name = manifest.get_gems_json_data_by_name(engine_path=engine_path, 
                                             project_path=project_path,
                                             include_manifest_gems=include_manifest_gems,
-                                            include_engine_gems=include_engine_gems)
+                                            include_engine_gems=include_engine_gems,
+                                            external_subdirectories=external_subdirectories)
             assert all_gems_by_name == expected_result
 
 class TestManifestRemoveNonDependencyGemJsonData:

--- a/scripts/o3de/tests/test_register.py
+++ b/scripts/o3de/tests/test_register.py
@@ -335,7 +335,9 @@ class TestRegisterProject:
         def get_gems_json_data_by_name( engine_path:pathlib.Path = None, 
                                         project_path: pathlib.Path = None, 
                                         include_manifest_gems: bool = False,
-                                        include_engine_gems: bool = False) -> dict:
+                                        include_engine_gems: bool = False,
+                                        external_subdirectories: list = None
+                                        ) -> dict:
             all_gems_json_data = {}
             for gem_name in registered_gem_versions.keys():
                 all_gems_json_data[gem_name] = get_gem_json_data(gem_name=gem_name)


### PR DESCRIPTION
## What does this PR do?
1. Fixes a false compatibility error when a user adds a gem that has multiple nested gems inside it.  The compatibility checks are now updated to consider those gems (found in 'external_subdirectories' in the gem.json).
1. adds `--dry-run` and `--force` support for `--all-projects-path` and `--all-gems-path`
2. unit test updates and new tests for the nested gem compatibility check
3. removed unneeded call to `get_gems_json_data_by_name` and `get_enabled_gems` (unused) in `enable_gem.py`

## How was this PR tested?

- ran existing and new unit tests
- manually tested (and stepped thru the code) registering and unregistering the `o3de-multiplayersample-assets/Gems` path with and without the `--all-gems-path`, `-espp`,  and `--dry-run`
