### PR TITLE
NetworkCharacterComponent cleanup from previous PR feedback

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkCharacterComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkCharacterComponent.h
@@ -57,6 +57,7 @@ namespace Multiplayer
 
     protected:
         void OnCharacterActivated(const AZ::EntityId& entityId) override;
+        void OnCharacterDeactivated(const AZ::EntityId& entityId) override;
 
     private:
         void OnTranslationChangedEvent(const AZ::Vector3& translation);


### PR DESCRIPTION
## What does this PR do?

This addresses the feedback that appeared in #14484 .

1. Added OnCharacterDeactivated() which sets m_physicsCharacter back to null.
2. Moved the network connect / disconnect code into Activate() / Deactivate() instead of OnCharacterActivated() / OnCharacterDeactivated().

## How was this PR tested?

Ran MultiplayerSample and verified the character still moved around successfully.