### PR TITLE
add progress bar for ddgi bake textures.

### DIFF
--- a/Gems/DiffuseProbeGrid/Code/Source/EditorComponents/EditorDiffuseProbeGridComponent.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/EditorComponents/EditorDiffuseProbeGridComponent.cpp
@@ -20,6 +20,7 @@
 AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
 #include <QApplication>
 #include <QMessageBox>
+#include <QProgressDialog>
 AZ_POP_DISABLE_WARNING
 
 namespace AZ
@@ -587,8 +588,25 @@ namespace AZ
             m_bakeInProgress = true;
             m_controller.BakeTextures(bakeTexturesCallback);
 
+            QProgressDialog bakeDialog;
+            bakeDialog.setWindowFlags(bakeDialog.windowFlags() & ~Qt::WindowCloseButtonHint);
+            bakeDialog.setLabelText(QObject::tr("Baking Diffuse Probe Grid..."));
+            bakeDialog.setWindowModality(Qt::WindowModal);
+            bakeDialog.setMaximumSize(QSize(256, 96));
+            bakeDialog.setMaximum(0);
+            bakeDialog.setMinimumDuration(0);
+            bakeDialog.setAutoClose(false);
+            bakeDialog.setCancelButton(nullptr);
+            bakeDialog.show();
+
             while (m_bakeInProgress)
             {
+                if (bakeDialog.wasCanceled())
+                {
+                    m_bakeInProgress = false;
+                    break;
+                }
+
                 QApplication::processEvents();
                 AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(100));
             }


### PR DESCRIPTION
Signed-off-by: Zhang-Baochong <zhangbaochong@huawei.com>

## What does this PR do?

There is no progress bar when DDGI bakes the texture, so user cannot judge if the baking is running.
For this, add a progress bar when baking texture.

![3](https://user-images.githubusercontent.com/124341515/217981528-86f66efb-5be9-4096-9297-2a79754e41f4.png)

## How was this PR tested?
Manually tested in editor.
1.Open Editor.
2.Create a new Entity.
3.Add `Diffuse Probe Grid` Component.
4.Click `Bake Textures` Button
![bake-textures](https://user-images.githubusercontent.com/124341515/217981599-b9eb2696-662f-429b-857a-d161c8fb0787.gif)
