### PR TITLE
Fix memory leak for system object

### DIFF
--- a/Code/LauncherUnified/Launcher.cpp
+++ b/Code/LauncherUnified/Launcher.cpp
@@ -592,8 +592,10 @@ namespace O3DELauncher
         }
     #endif // !defined(_RELEASE)
 
-        delete systemInitParams.pSystem;
+        SAFE_DELETE(systemInitParams.pSystem);
         crySystemLibrary.reset(nullptr);
+    #else
+        SAFE_DELETE(systemInitParams.pSystem);
     #endif // !defined(AZ_MONOLITHIC_BUILD)
 
         gameApplication.Stop();


### PR DESCRIPTION


Signed-off-by: Jackie9527 <80555200+Jackie9527@users.noreply.github.com>

## What does this PR do?

Fix memory leak for system object, which is not freed when `AZ_MONOLITHIC_BUILD` is enabled.

## How was this PR tested?

![launcher-memory-leak-1](https://user-images.githubusercontent.com/80555200/218240198-1297b39d-9c95-4c28-beec-2ddfd4d12d69.png)

