### PR TITLE
For Android, create a public, common bufferpool object for Passes/SRG…

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/BufferPoolDescriptor.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/BufferPoolDescriptor.cpp
@@ -27,7 +27,16 @@ namespace AZ
 
         BufferPoolDescriptor::BufferPoolDescriptor()
         {
-            m_bufferPoolPageSizeInBytes = RHI::RHISystemInterface::Get()->GetPlatformLimitsDescriptor()->m_platformDefaultValues.m_bufferPoolPageSizeInBytes;
+            if (auto device = RHI::RHISystemInterface::Get()->GetDevice())
+            {
+                m_bufferPoolPageSizeInBytes =
+                    RHI::RHISystemInterface::Get()->GetPlatformLimitsDescriptor()->m_platformDefaultValues.m_bufferPoolPageSizeInBytes;
+            }
+            else
+            {
+                m_bufferPoolPageSizeInBytes = RHI::DefaultValues::Memory::BufferPoolPageSizeInBytes;
+            }
+            
         }
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -390,6 +390,20 @@ namespace AZ
             result = m_stagingBufferPool->Init(*this, poolDesc);
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
 
+            {
+                m_constantBufferPool = BufferPool::Create();
+                static int index = 0;
+                m_constantBufferPool->SetName(Name(AZStd::string::format("ConstantPool_%d", ++index)));
+
+                BufferPoolDescriptor bufferPoolDescriptor;
+                bufferPoolDescriptor.m_bindFlags = RHI::BufferBindFlags::Constant;
+                bufferPoolDescriptor.m_heapMemoryLevel = RHI::HeapMemoryLevel::Host;
+                bufferPoolDescriptor.m_bufferPoolPageSizeInBytes =
+                    m_descriptor.m_platformLimitsDescriptor->m_platformDefaultValues.m_bufferPoolPageSizeInBytes;
+                result = m_constantBufferPool->Init(*this, bufferPoolDescriptor);
+                RETURN_RESULT_IF_UNSUCCESSFUL(result);
+            }
+
             const auto& physicalDevice = static_cast<const PhysicalDevice&>(GetPhysicalDevice());
             if (!physicalDevice.IsFeatureSupported(DeviceFeature::NullDescriptor))
             {
@@ -627,6 +641,7 @@ namespace AZ
 
             m_bindlessDescriptorPool.Shutdown();
             m_stagingBufferPool.reset();
+            m_constantBufferPool.reset();
             m_renderPassCache.first.Clear();
             m_framebufferCache.first.Clear();
             m_descriptorSetLayoutCache.first.Clear();
@@ -1216,6 +1231,11 @@ namespace AZ
         Device::ShadingRateImageMode Device::GetImageShadingRateMode() const
         {
             return m_imageShadingRateMode;
+        }
+
+        RHI::Ptr<BufferPool> Device::GetConstantBufferPool()
+        {
+            return m_constantBufferPool;
         }
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.h
@@ -129,6 +129,8 @@ namespace AZ
 
             ShadingRateImageMode GetImageShadingRateMode() const;
 
+            RHI::Ptr<BufferPool> GetConstantBufferPool();
+
         private:
             Device();
 
@@ -185,6 +187,8 @@ namespace AZ
             AZStd::unordered_map<RHI::Format, VkImageUsageFlags> m_imageUsageOfFormat;
 
             RHI::Ptr<BufferPool> m_stagingBufferPool;
+
+            RHI::Ptr<BufferPool> m_constantBufferPool;
 
             ReleaseQueue m_releaseQueue;
             CommandQueueContext m_commandQueueContext;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ShaderResourceGroupPool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ShaderResourceGroupPool.cpp
@@ -34,16 +34,7 @@ namespace AZ
 
             m_descriptorSetCount = RHI::Limits::Device::FrameCountMax;
 
-            const uint32_t constantSize = layout.GetConstantDataSize();
-            if (constantSize > 0)
-            {
-                BufferPoolDescriptor bufferPoolDescriptor;
-                bufferPoolDescriptor.m_bindFlags = RHI::BufferBindFlags::Constant;
-                bufferPoolDescriptor.m_heapMemoryLevel = RHI::HeapMemoryLevel::Host;
-                m_constantBufferPool = BufferPool::Create();
-                m_constantBufferPool->SetName(AZ::Name(AZStd::string::format("%s_ConstantBufferPool", GetName().GetCStr())));
-                m_constantBufferPool->Init(device, bufferPoolDescriptor);
-            }
+            m_constantBufferPool = device.GetConstantBufferPool();
 
             DescriptorSetLayout::Descriptor layoutDescriptor;
             layoutDescriptor.m_device = &device;


### PR DESCRIPTION

Signed-off-by: Jackie9527 <80555200+Jackie9527@users.noreply.github.com>

## What does this PR do?

When using vulkan as backend, for each pass RHI creates a bufferpool object to allocate constant memory blocks.
If RPI creates N pass, such as 70+, then it could consume up to 70 * 16 MB = 1120 MB, which is unacceptable for Android apps.

![srg-bufferpool-11](https://user-images.githubusercontent.com/80555200/218247840-067948b2-594a-4d3d-b1b8-b9dfa0086579.png)
![srg-bufferpool-11-1](https://user-images.githubusercontent.com/80555200/218248016-261bc0d3-5071-40a8-a8f1-27ccd1356b4d.png)


## How was this PR tested?
![srg-bufferpool-04](https://user-images.githubusercontent.com/80555200/218248055-de9683b1-670b-4a80-88e0-cf325a34a41c.png)

For windows, set name for each bufferpool object created for Shader Resource Group.
![srg-bufferpool-02](https://user-images.githubusercontent.com/80555200/218248091-136fd783-05d9-40c4-90a2-2cace2e727ac.png)
![srg-bufferpool-02-1](https://user-images.githubusercontent.com/80555200/218248191-5ecfff1b-d5e9-46c7-ba51-1800541e3339.png)

For Android, set name for the common bufferpool object, and share a single bufferpool object for all the Shader Resource Group objects.

![srg-bufferpool-03-1](https://user-images.githubusercontent.com/80555200/218248148-9fbb455c-c019-4772-8923-c847beb9826f.png)
