### PR TITLE
bugfix for sprite sheet index.

### DIFF
--- a/Gems/LyShine/Code/Source/UiParticleEmitterComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiParticleEmitterComponent.cpp
@@ -1022,6 +1022,51 @@ void UiParticleEmitterComponent::SetOverrideAlpha(float alpha)
     m_isAlphaOverridden = true;
 }
 
+void UiParticleEmitterComponent::SetImageIndex(AZ::u32 index)
+{
+    if (m_spriteSheetCellIndex != index)
+    {
+        m_spriteSheetCellIndex = index;
+        MarkRenderGraphDirty();
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+const AZ::u32 UiParticleEmitterComponent::GetImageIndex()
+{
+    return m_spriteSheetCellIndex;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+const AZ::u32 UiParticleEmitterComponent::GetImageIndexCount()
+{
+    if (m_sprite)
+    {
+        return static_cast<AZ::u32>(m_sprite->GetSpriteSheetCells().size());
+    }
+
+    return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+AZStd::string UiParticleEmitterComponent::GetImageIndexAlias(AZ::u32 index)
+{
+    return m_sprite ? m_sprite->GetCellAlias(index) : AZStd::string();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+void UiParticleEmitterComponent::SetImageIndexAlias(AZ::u32 index, const AZStd::string& alias)
+{
+    m_sprite ? m_sprite->SetCellAlias(index, alias) : AZ_UNUSED(0);
+    MarkRenderGraphDirty();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+AZ::u32 UiParticleEmitterComponent::GetImageIndexFromAlias(const AZStd::string& alias)
+{
+    return m_sprite ? m_sprite->GetCellIndexFromAlias(alias) : 0;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // PUBLIC STATIC MEMBER FUNCTIONS
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1462,6 +1507,7 @@ void UiParticleEmitterComponent::Activate()
     UiVisualBus::Handler::BusConnect(GetEntityId());
     UiCanvasSizeNotificationBus::Handler::BusConnect();
     UiElementNotificationBus::Handler::BusConnect(GetEntityId());
+    UiIndexableImageBus::Handler::BusConnect(GetEntityId());
 
     AZ::EntityId canvasEntityId;
     UiElementBus::EventResult(canvasEntityId, GetEntityId(), &UiElementBus::Events::GetCanvasEntityId);
@@ -1486,6 +1532,7 @@ void UiParticleEmitterComponent::Deactivate()
     UiVisualBus::Handler::BusDisconnect();
     UiCanvasSizeNotificationBus::Handler::BusDisconnect();
     UiElementNotificationBus::Handler::BusDisconnect();
+    UiIndexableImageBus::Handler::BusDisconnect();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/LyShine/Code/Source/UiParticleEmitterComponent.h
+++ b/Gems/LyShine/Code/Source/UiParticleEmitterComponent.h
@@ -14,6 +14,7 @@
 #include <LyShine/Bus/UiRenderBus.h>
 #include <LyShine/Bus/UiCanvasUpdateNotificationBus.h>
 #include <LyShine/Bus/UiVisualBus.h>
+#include <LyShine/Bus/UiIndexableImageBus.h>
 #include <LyShine/UiComponentTypes.h>
 #include <LyShine/IRenderGraph.h>
 
@@ -35,6 +36,7 @@ class UiParticleEmitterComponent
     , public UiCanvasUpdateNotificationBus::Handler
     , public UiElementNotificationBus::Handler
     , public UiVisualBus::Handler
+    , public UiIndexableImageBus::Handler
 {
 public: // member functions
 
@@ -179,6 +181,14 @@ public: // member functions
     void SetOverrideAlpha(float alpha) override;
     // ~UiVisualInterface
 
+    // UiIndexableImageBus
+    void SetImageIndex(AZ::u32 index) override;
+    const AZ::u32 GetImageIndex() override;
+    const AZ::u32 GetImageIndexCount() override;
+    AZStd::string GetImageIndexAlias(AZ::u32 index) override;
+    void SetImageIndexAlias(AZ::u32 index, const AZStd::string& alias) override;
+    AZ::u32 GetImageIndexFromAlias(const AZStd::string& alias) override;
+    // ~UiIndexableImageBus
 public:  // static member functions
 
     static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)


### PR DESCRIPTION
Signed-off-by: Jackie9527 <80555200+Jackie9527@users.noreply.github.com>

## What does this PR do?

with #14552, using sprite edior to set index for each part of image, but cannot list the indices correctly.

![image](https://user-images.githubusercontent.com/80555200/218424970-6c61cb64-19e3-4210-aec6-3c15510763aa.png)

## How was this PR tested?

![image](https://user-images.githubusercontent.com/80555200/218424496-5fcc662b-93e2-4897-8e96-51d9cbf423b4.png)
