### PR TITLE
bugfix for text color.

### DIFF
--- a/Gems/UiBasics/Assets/UI/Slices/Library/Button.slice
+++ b/Gems/UiBasics/Assets/UI/Slices/Library/Button.slice
@@ -246,7 +246,7 @@
 										<Class name="AZStd::pair" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
 											<Class name="AddressType" field="value1" value="AZStd::vector({21786AF0-2606-5B9A-86EB-0892E2820E6C})::Entities·0/AZ::Entity({75651658-8663-478D-9090-2432DFCAFA44})#17165234896122860168·2/AZStd::vector({13D58FF9-1088-5C69-9A1F-C2A144B57B78})::Components·0/UiTextComponent({5B3FB2A7-5DC4-4033-A970-001CEC85B6C4})#3068610810953516373·9/Color({7894072A-9050-4F0F-901B-34B1A0D29417})::Color·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
 											<Class name="any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
-												<Class name="Color" field="m_data" value="1.0000000 1.0000000 1.0000000 -107374176.0000000" type="{7894072A-9050-4F0F-901B-34B1A0D29417}"/>
+												<Class name="Color" field="m_data" value="1.0000000 1.0000000 1.0000000 1.0000000" type="{7894072A-9050-4F0F-901B-34B1A0D29417}"/>
 											</Class>
 										</Class>
 										<Class name="AZStd::pair" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">


### PR DESCRIPTION
Signed-off-by: Jackie9527 <80555200+Jackie9527@users.noreply.github.com>

## What does this PR do?
The color label of `Text` is incorrect, as follows:
![image](https://user-images.githubusercontent.com/80555200/218426208-6e8aab41-d6c2-4eb8-a772-d79eba8ad643.png)
![image](https://user-images.githubusercontent.com/80555200/218426241-2581c14d-98c2-4269-b330-a6c48ad73457.png)

## How was this PR tested?

![image](https://user-images.githubusercontent.com/80555200/218426377-94ce839f-5dc3-4e73-932e-617d8cc4afb3.png)

