### PR TITLE
add prompt when overwriting existing files.

### DIFF
--- a/Gems/LyShine/Code/Editor/EditorWindow.cpp
+++ b/Gems/LyShine/Code/Editor/EditorWindow.cpp
@@ -733,8 +733,7 @@ bool EditorWindow::SaveCanvasToXml(UiCanvasMetadata& canvasMetadata, bool forceA
             QString(),
             dir,
             "*." UICANVASEDITOR_CANVAS_EXTENSION,
-            nullptr,
-            QFileDialog::DontConfirmOverwrite);
+            nullptr);
         if (filename.isEmpty())
         {
             return false;


### PR DESCRIPTION
Signed-off-by: Jackie9527 <80555200+Jackie9527@users.noreply.github.com>

## What does this PR do?

When saving the UI canvas file with an existed filename, UI editor will directly overwrite the existing file without prompting.

## How was this PR tested?

1. Create a1.uicanvas, and save to disk.
2. Create another uicanvas file, using filename as `a1.uicanvas`, and Click Save.
3. UI Editor will prompt if user want to overwrite the existing file.
