### PR TITLE
bugfix for calculation error caused by time unit error.

### DIFF
--- a/Gems/LyShine/Code/Editor/Animation/UiAVSequenceProps.cpp
+++ b/Gems/LyShine/Code/Editor/Animation/UiAVSequenceProps.cpp
@@ -55,7 +55,7 @@ bool CUiAVSequenceProps::OnInitDialog()
 
     Range timeRange = m_pSequence->GetTimeRange();
 
-    m_timeUnit = 1;
+    m_timeUnit = 0;
     ui->START_TIME->setValue(timeRange.start);
     ui->END_TIME->setValue(timeRange.end);
 
@@ -119,7 +119,7 @@ void CUiAVSequenceProps::OnOK()
     timeRange.start = aznumeric_cast<float>(ui->START_TIME->value());
     timeRange.end = aznumeric_cast<float>(ui->END_TIME->value());
 
-    if (m_timeUnit == 0)
+    if (m_timeUnit == 1)
     {
         float invFPS = 1.0f / m_FPS;
         timeRange.start = aznumeric_cast<float>(ui->START_TIME->value() * invFPS);


### PR DESCRIPTION
Signed-off-by: Jackie9527 <80555200+Jackie9527@users.noreply.github.com>

## What does this PR do?

1. Set `Time Unit` as `Frames`, and `EndTime` as `90.0`, Click `OK`.
![image](https://user-images.githubusercontent.com/80555200/218427649-bda5537e-4446-44d5-8a08-8d8acdbe0c3a.png)
2. Edit sequence again, as follows.
The `EndTime` is totally wrong.
![image](https://user-images.githubusercontent.com/80555200/218428076-1fa99aef-db1b-4835-94c2-5261f24d89f6.png)
![image](https://user-images.githubusercontent.com/80555200/218428107-66aaa280-9402-4714-b8ce-45be5aa0ee6c.png)

## How was this PR tested?

Follow the same steps, as follows:
![image](https://user-images.githubusercontent.com/80555200/218428408-d4ff745c-1c54-42c8-8fe9-ff1740e22925.png)
![image](https://user-images.githubusercontent.com/80555200/218428420-99ce4789-3e79-4af3-98dc-656f56e10a10.png)

