### PR TITLE
Model import support transparent material.

### DIFF
--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpMaterialImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpMaterialImporter.cpp
@@ -98,6 +98,7 @@ namespace AZ
                         material->SetSpecularColor(assImpMaterial->GetSpecularColor());
                         material->SetEmissiveColor(assImpMaterial->GetEmissiveColor());
                         material->SetShininess(assImpMaterial->GetShininess());
+                        material->SetOpacity(assImpMaterial->GetOpacity());
 
                         material->SetUseColorMap(assImpMaterial->GetUseColorMap());
                         material->SetBaseColor(assImpMaterial->GetBaseColor());


### PR DESCRIPTION
Signed-off-by: Zhang-Baochong <zhangbaochong@huawei.com>

## What does this PR do?

Import model with transparent material, the material is opaque in o3de editor.
![3](https://user-images.githubusercontent.com/124341515/218470247-b2c80963-237b-4e0e-9b83-074d058f51a7.png)

## How was this PR tested?
Import model with transparent material, check if it is transparent in editor.
![4](https://user-images.githubusercontent.com/124341515/218470652-a91a5dd2-6706-4f85-bb5e-2c4e8d965d02.png)

