### PR TITLE
Add BufferPool unique allocation bytes tracking

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/MemoryUsage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/MemoryUsage.h
@@ -82,6 +82,9 @@ namespace AZ
             // Number of bytes are used for resources or objects. This usually tracks the sub-allocations out of the total resident.
             // It may not exceed the total resident.
             AZStd::atomic_size_t m_usedResidentInBytes{ 0 };
+
+            // Number of bytes used by Unique Allocations
+            AZStd::atomic_size_t m_uniqueAllocationBytes{ 0 };
         };
 
         //!

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/MemoryUsage.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/MemoryUsage.cpp
@@ -33,6 +33,7 @@ namespace AZ
             m_budgetInBytes = rhs.m_budgetInBytes;
             m_totalResidentInBytes = rhs.m_totalResidentInBytes.load();
             m_usedResidentInBytes = rhs.m_usedResidentInBytes.load();
+            m_uniqueAllocationBytes = rhs.m_uniqueAllocationBytes.load();
             m_fragmentation = rhs.m_fragmentation;
             return *this;
         }

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/BufferMemoryAllocator.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/BufferMemoryAllocator.cpp
@@ -185,6 +185,7 @@ namespace AZ
                 // Add the resident usage now that everything succeeded.
                 heapMemoryUsage.m_totalResidentInBytes += alignedSize;
                 heapMemoryUsage.m_usedResidentInBytes += alignedSize;
+                heapMemoryUsage.m_uniqueAllocationBytes += alignedSize;
             }
 
             return BufferMemoryView(AZStd::move(memoryView), BufferMemoryType::Unique);
@@ -195,9 +196,10 @@ namespace AZ
             AZ_Assert(memoryView.GetType() == BufferMemoryType::Unique, "This call only supports unique BufferMemoryView allocations.");
             const size_t sizeInBytes = memoryView.GetSize();
 
-            RHI::HeapMemoryUsage& heapHemoryUsage = *m_descriptor.m_getHeapMemoryUsageFunction();
-            heapHemoryUsage.m_totalResidentInBytes -= sizeInBytes;
-            heapHemoryUsage.m_usedResidentInBytes -= sizeInBytes;
+            RHI::HeapMemoryUsage& heapMemoryUsage = *m_descriptor.m_getHeapMemoryUsageFunction();
+            heapMemoryUsage.m_totalResidentInBytes -= sizeInBytes;
+            heapMemoryUsage.m_usedResidentInBytes -= sizeInBytes;
+            heapMemoryUsage.m_uniqueAllocationBytes -= sizeInBytes;
 
             m_descriptor.m_device->QueueForRelease(memoryView);
         }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/BufferMemoryAllocator.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/BufferMemoryAllocator.cpp
@@ -149,6 +149,7 @@ namespace AZ
             {
                 heapMemoryUsage.m_totalResidentInBytes += alignedSize;
                 heapMemoryUsage.m_usedResidentInBytes += alignedSize;
+                heapMemoryUsage.m_uniqueAllocationBytes += alignedSize;
             }
             return BufferMemoryView(AZStd::move(memoryView), BufferMemoryType::Unique);
         }
@@ -158,9 +159,10 @@ namespace AZ
             AZ_Assert(memoryView.GetType() == BufferMemoryType::Unique, "This call only supports unique BufferMemoryView allocations.");
             const size_t sizeInBytes = memoryView.GetSize();
             
-            RHI::HeapMemoryUsage& heapHemoryUsage = *m_descriptor.m_getHeapMemoryUsageFunction();
-            heapHemoryUsage.m_totalResidentInBytes -= sizeInBytes;
-            heapHemoryUsage.m_usedResidentInBytes -= sizeInBytes;
+            RHI::HeapMemoryUsage& heapMemoryUsage = *m_descriptor.m_getHeapMemoryUsageFunction();
+            heapMemoryUsage.m_totalResidentInBytes -= sizeInBytes;
+            heapMemoryUsage.m_usedResidentInBytes -= sizeInBytes;
+            heapMemoryUsage.m_uniqueAllocationBytes -= sizeInBytes;
             
             m_descriptor.m_device->QueueForRelease(memoryView);
         }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/MemoryTypeAllocator.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/MemoryTypeAllocator.h
@@ -124,15 +124,10 @@ namespace AZ
             {
                 memoryView = AllocateUnique(sizeInBytes);
             }
-
-            if (memoryView.IsValid())
+            else
             {
                 RHI::HeapMemoryUsage* heapMemoryUsage = m_descriptor.m_getHeapMemoryUsageFunction();
                 heapMemoryUsage->m_usedResidentInBytes += memoryView.GetSize();
-                if (forceUnique)
-                {
-                    heapMemoryUsage->m_uniqueAllocationBytes += memoryView.GetSize();
-                }
                 heapMemoryUsage->Validate();
             }
 
@@ -142,17 +137,16 @@ namespace AZ
         template<typename SubAllocator, typename View>
         void MemoryTypeAllocator<SubAllocator, View>::DeAllocate(const View& memoryView)
         {
-            if (memoryView.IsValid())
-            {
-                RHI::HeapMemoryUsage* heapMemoryUsage = m_descriptor.m_getHeapMemoryUsageFunction();
-                heapMemoryUsage->m_usedResidentInBytes -= memoryView.GetSize();
-            }
-
             switch (memoryView.GetAllocationType())
             {
             case MemoryAllocationType::SubAllocated:
             {
                 AZStd::lock_guard<AZStd::mutex> lock(m_subAllocatorMutex);
+                if (memoryView.IsValid())
+                {
+                    RHI::HeapMemoryUsage* heapMemoryUsage = m_descriptor.m_getHeapMemoryUsageFunction();
+                    heapMemoryUsage->m_usedResidentInBytes -= memoryView.GetSize();
+                }
                 m_subAllocator.DeAllocate(memoryView.GetAllocation());
                 break;
             }
@@ -184,6 +178,11 @@ namespace AZ
                 return View();
             }
 
+            RHI::HeapMemoryUsage* heapMemoryUsage = m_descriptor.m_getHeapMemoryUsageFunction();
+            heapMemoryUsage->m_usedResidentInBytes += sizeInBytes;
+            heapMemoryUsage->m_uniqueAllocationBytes += sizeInBytes;
+            heapMemoryUsage->Validate();
+
             const char* name = GetName().IsEmpty() ? "Unique Allocation" : GetName().GetCStr();
             memory->SetName(Name{ name });
             return View(ViewBase(memory, 0, sizeInBytes, 0, MemoryAllocationType::Unique));
@@ -193,6 +192,12 @@ namespace AZ
         void MemoryTypeAllocator<SubAllocator, View>::DeAllocateUnique(const View& memoryView)
         {
             AZ_Assert(memoryView.GetAllocationType() == MemoryAllocationType::Unique, "This call only supports unique MemoryView allocations.");
+
+            RHI::HeapMemoryUsage* heapMemoryUsage = m_descriptor.m_getHeapMemoryUsageFunction();
+            const size_t sizeInBytes = memoryView.GetSize();
+            heapMemoryUsage->m_usedResidentInBytes -= sizeInBytes;
+            heapMemoryUsage->m_uniqueAllocationBytes -= sizeInBytes;
+
             auto memory = memoryView.GetAllocation().m_memory;
             const_cast<typename PageAllocator::ObjectFactoryType&>(m_pageAllocator.GetFactory()).ShutdownObject(*memory);
             static_cast<Device&>(GetDevice()).QueueForRelease(memory);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/MemoryTypeAllocator.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/MemoryTypeAllocator.h
@@ -129,6 +129,10 @@ namespace AZ
             {
                 RHI::HeapMemoryUsage* heapMemoryUsage = m_descriptor.m_getHeapMemoryUsageFunction();
                 heapMemoryUsage->m_usedResidentInBytes += memoryView.GetSize();
+                if (forceUnique)
+                {
+                    heapMemoryUsage->m_uniqueAllocationBytes += memoryView.GetSize();
+                }
                 heapMemoryUsage->Validate();
             }
 

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
@@ -297,6 +297,7 @@ namespace AZ
                 size_t m_allocatedBytes = 0;
                 size_t m_usedBytes = 0;
                 float m_fragmentation = 0.f;
+                size_t m_uniqueBytes = 0;
             };
 
             struct ResourceTableRow
@@ -312,6 +313,7 @@ namespace AZ
             bool m_includeBuffers = true;
             bool m_includeImages = true;
             bool m_includeTransientAttachments = true;
+            bool m_hideEmptyBufferPools = true;
 
             ImGuiTextFilter m_nameFilter;
 

--- a/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
+++ b/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
@@ -1214,81 +1214,90 @@ namespace AZ
                 return;
             }
 
-            if (ImGui::BeginTable("PoolTable", 6, ImGuiTableFlags_Borders | ImGuiTableFlags_Sortable | ImGuiTableFlags_Resizable))
+            if (ImGui::CollapsingHeader("Buffer Pools", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_Framed))
             {
-                ImGui::TableSetupColumn("Pool");
-                ImGui::TableSetupColumn("Heap Type");
-                ImGui::TableSetupColumn("Budget (MB)");
-                ImGui::TableSetupColumn("Allocated (MB)");
-                ImGui::TableSetupColumn("Used (MB)");
-                ImGui::TableSetupColumn("Fragmentation (%)");
-                ImGui::TableHeadersRow();
-                ImGui::TableNextColumn();
-
-                ImGuiTableSortSpecs* sortSpecs = ImGui::TableGetSortSpecs();
-                if (sortSpecs && sortSpecs->SpecsDirty)
+                if (ImGui::BeginTable("PoolTable", 7, ImGuiTableFlags_Borders | ImGuiTableFlags_Sortable | ImGuiTableFlags_Resizable))
                 {
-                    SortPoolTable(sortSpecs);
-                }
+                    ImGui::TableSetupColumn("Pool");
+                    ImGui::TableSetupColumn("Heap Type");
+                    ImGui::TableSetupColumn("Budget (MB)");
+                    ImGui::TableSetupColumn("Allocated (MB)");
+                    ImGui::TableSetupColumn("Used (MB)");
+                    ImGui::TableSetupColumn("Fragmentation (%)");
+                    ImGui::TableSetupColumn("Unique (MB)");
+                    ImGui::TableHeadersRow();
+                    ImGui::TableNextColumn();
 
-                for (const auto& tableRow : m_poolTableRows)
-                {
-                    ImGui::Text("%s", tableRow.m_poolName.GetCStr());
-                    ImGui::TableNextColumn();
-                    ImGui::Text("%s", tableRow.m_deviceHeap ? "Device" : "Host");
-                    ImGui::TableNextColumn();
-                    ImGui::Text("%.4f", 1.0f * tableRow.m_budgetBytes / GpuProfilerImGuiHelper::MB);
-                    ImGui::TableNextColumn();
-                    ImGui::Text("%.4f", 1.0f * tableRow.m_allocatedBytes / GpuProfilerImGuiHelper::MB);
-                    ImGui::TableNextColumn();
-                    ImGui::Text("%.4f", 1.0f * tableRow.m_usedBytes / GpuProfilerImGuiHelper::MB);
-                    ImGui::TableNextColumn();
-                    ImGui::Text("%.4f", tableRow.m_fragmentation);
-                    ImGui::TableNextColumn();
-                }
-            }
-            ImGui::EndTable();
-
-            if (ImGui::BeginTable("Table", 5, ImGuiTableFlags_Borders | ImGuiTableFlags_Sortable | ImGuiTableFlags_Resizable))
-            {
-                ImGui::TableSetupColumn("Parent pool");
-                ImGui::TableSetupColumn("Name");
-                ImGui::TableSetupColumn("Size (MB)");
-                ImGui::TableSetupColumn("Fragmentation (%)");
-                ImGui::TableSetupColumn("BindFlags", ImGuiTableColumnFlags_NoSort);
-                ImGui::TableHeadersRow();
-                ImGui::TableNextColumn();
-
-                ImGuiTableSortSpecs* sortSpecs = ImGui::TableGetSortSpecs();
-                if (sortSpecs && sortSpecs->SpecsDirty)
-                {
-                    SortResourceTable(sortSpecs);
-                }
-
-                // Draw each row in the table
-                for (const auto& tableRow : m_resourceTableRows)
-                {
-                    // Don't draw the row if none of the row's text fields pass the filter
-                    if (!m_nameFilter.PassFilter(tableRow.m_parentPoolName.GetCStr())
-                        && !m_nameFilter.PassFilter(tableRow.m_bufImgName.GetCStr())
-                        && !m_nameFilter.PassFilter(tableRow.m_bindFlags.c_str()))
+                    ImGuiTableSortSpecs* sortSpecs = ImGui::TableGetSortSpecs();
+                    if (sortSpecs && sortSpecs->SpecsDirty)
                     {
-                        continue;
+                        SortPoolTable(sortSpecs);
                     }
 
-                    ImGui::Text("%s", tableRow.m_parentPoolName.GetCStr());
-                    ImGui::TableNextColumn();
-                    ImGui::Text("%s", tableRow.m_bufImgName.GetCStr());
-                    ImGui::TableNextColumn();
-                    ImGui::Text("%.4f", 1.0f * tableRow.m_sizeInBytes / GpuProfilerImGuiHelper::MB);
-                    ImGui::TableNextColumn();
-                    ImGui::Text("%.4f", tableRow.m_fragmentation);
-                    ImGui::TableNextColumn();
-                    ImGui::Text("%s", tableRow.m_bindFlags.c_str());
-                    ImGui::TableNextColumn();
+                    for (const auto& tableRow : m_poolTableRows)
+                    {
+                        ImGui::Text("%s", tableRow.m_poolName.GetCStr());
+                        ImGui::TableNextColumn();
+                        ImGui::Text("%s", tableRow.m_deviceHeap ? "Device" : "Host");
+                        ImGui::TableNextColumn();
+                        ImGui::Text("%.4f", 1.0f * tableRow.m_budgetBytes / GpuProfilerImGuiHelper::MB);
+                        ImGui::TableNextColumn();
+                        ImGui::Text("%.4f", 1.0f * tableRow.m_allocatedBytes / GpuProfilerImGuiHelper::MB);
+                        ImGui::TableNextColumn();
+                        ImGui::Text("%.4f", 1.0f * tableRow.m_usedBytes / GpuProfilerImGuiHelper::MB);
+                        ImGui::TableNextColumn();
+                        ImGui::Text("%.4f", tableRow.m_fragmentation);
+                        ImGui::TableNextColumn();
+                        ImGui::Text("%.4f", 1.0f * tableRow.m_uniqueBytes / GpuProfilerImGuiHelper::MB);
+                        ImGui::TableNextColumn();
+                    }
                 }
+                ImGui::EndTable();
             }
-            ImGui::EndTable();
+
+            if (ImGui::CollapsingHeader("Allocations", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_Framed))
+            {
+                if (ImGui::BeginTable("Table", 5, ImGuiTableFlags_Borders | ImGuiTableFlags_Sortable | ImGuiTableFlags_Resizable))
+                {
+                    ImGui::TableSetupColumn("Parent pool");
+                    ImGui::TableSetupColumn("Name");
+                    ImGui::TableSetupColumn("Size (MB)");
+                    ImGui::TableSetupColumn("Fragmentation (%)");
+                    ImGui::TableSetupColumn("BindFlags", ImGuiTableColumnFlags_NoSort);
+                    ImGui::TableHeadersRow();
+                    ImGui::TableNextColumn();
+
+                    ImGuiTableSortSpecs* sortSpecs = ImGui::TableGetSortSpecs();
+                    if (sortSpecs && sortSpecs->SpecsDirty)
+                    {
+                        SortResourceTable(sortSpecs);
+                    }
+
+                    // Draw each row in the table
+                    for (const auto& tableRow : m_resourceTableRows)
+                    {
+                        // Don't draw the row if none of the row's text fields pass the filter
+                        if (!m_nameFilter.PassFilter(tableRow.m_parentPoolName.GetCStr())
+                            && !m_nameFilter.PassFilter(tableRow.m_bufImgName.GetCStr())
+                            && !m_nameFilter.PassFilter(tableRow.m_bindFlags.c_str()))
+                        {
+                            continue;
+                        }
+
+                        ImGui::Text("%s", tableRow.m_parentPoolName.GetCStr());
+                        ImGui::TableNextColumn();
+                        ImGui::Text("%s", tableRow.m_bufImgName.GetCStr());
+                        ImGui::TableNextColumn();
+                        ImGui::Text("%.4f", 1.0f * tableRow.m_sizeInBytes / GpuProfilerImGuiHelper::MB);
+                        ImGui::TableNextColumn();
+                        ImGui::Text("%.4f", tableRow.m_fragmentation);
+                        ImGui::TableNextColumn();
+                        ImGui::Text("%s", tableRow.m_bindFlags.c_str());
+                        ImGui::TableNextColumn();
+                    }
+                }
+                ImGui::EndTable();
+            }
         }
 
         void ImGuiGpuMemoryView::UpdateTableRows()
@@ -1302,15 +1311,15 @@ namespace AZ
                 auto& deviceHeapUsage = pool.m_memoryUsage.GetHeapMemoryUsage(AZ::RHI::HeapMemoryLevel::Device);
                 auto& hostHeapUsage = pool.m_memoryUsage.GetHeapMemoryUsage(AZ::RHI::HeapMemoryLevel::Host);
 
-                if (deviceHeapUsage.m_totalResidentInBytes > 0 && deviceHeapUsage.m_totalResidentInBytes < static_cast<size_t>(-1))
+                if ((!m_hideEmptyBufferPools || deviceHeapUsage.m_totalResidentInBytes > 0) && deviceHeapUsage.m_totalResidentInBytes < static_cast<size_t>(-1))
                 {
                     m_poolTableRows.push_back({ poolName, true, deviceHeapUsage.m_budgetInBytes, deviceHeapUsage.m_totalResidentInBytes,
-                                                deviceHeapUsage.m_usedResidentInBytes, deviceHeapUsage.m_fragmentation });
+                                                deviceHeapUsage.m_usedResidentInBytes, deviceHeapUsage.m_fragmentation, deviceHeapUsage.m_uniqueAllocationBytes });
                 }
-                if (hostHeapUsage.m_totalResidentInBytes > 0 && hostHeapUsage.m_totalResidentInBytes < static_cast<size_t>(-1))
+                if ((!m_hideEmptyBufferPools || hostHeapUsage.m_totalResidentInBytes > 0) && hostHeapUsage.m_totalResidentInBytes < static_cast<size_t>(-1))
                 {
                     m_poolTableRows.push_back({ poolName, false, hostHeapUsage.m_budgetInBytes, hostHeapUsage.m_totalResidentInBytes,
-                                                hostHeapUsage.m_usedResidentInBytes, hostHeapUsage.m_fragmentation });
+                                                hostHeapUsage.m_usedResidentInBytes, hostHeapUsage.m_fragmentation, hostHeapUsage.m_uniqueAllocationBytes });
                 }
 
                 // Ignore transient pools
@@ -1543,7 +1552,8 @@ namespace AZ
 
                 if (ImGui::Checkbox("Show buffers", &m_includeBuffers)
                     || ImGui::Checkbox("Show images", &m_includeImages)
-                    || ImGui::Checkbox("Show transient attachments", &m_includeTransientAttachments))
+                    || ImGui::Checkbox("Show transient attachments", &m_includeTransientAttachments)
+                    || ImGui::Checkbox("Hide empty pools", &m_hideEmptyBufferPools))
                 {
                     UpdateTableRows(); 
                 }


### PR DESCRIPTION
GPU Profiler memory tracking page now shows how much of a BufferPools allocated memory has gone to unique (non-paged) allocations.
Also added Collapsing sections for the 2 tables in the memory view, Allocations can take a lot of time to render just based on sheer number of entries.
Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>