### PR TITLE
Fixed setting of the C++ backend variables when using Cry Console

### DIFF
--- a/Code/Editor/Lib/Tests/test_EditorPythonBindings.cpp
+++ b/Code/Editor/Lib/Tests/test_EditorPythonBindings.cpp
@@ -48,7 +48,7 @@ namespace EditorPythonBindingsUnitTests
         {
             m_cvarType = cvarType;
             ON_CALL(m_cvarMock, GetType()).WillByDefault(Return(m_cvarType));
-            ON_CALL(m_cvarMock, Set(A<T>())).WillByDefault(Invoke(func));
+            ON_CALL(m_cvarMock, SetImpl(A<T>())).WillByDefault(Invoke(func));
             ON_CALL(m_console, GetCVar(_)).WillByDefault(Return(&m_cvarMock));
             ON_CALL(m_system, GetIConsole()).WillByDefault(Return(&m_console));
             ON_CALL(m_editorMock, GetSystem()).WillByDefault(Return(&m_system));

--- a/Code/Legacy/CryCommon/IConsole.h
+++ b/Code/Legacy/CryCommon/IConsole.h
@@ -153,6 +153,27 @@ using ConsoleCommandFunc = void (*)(IConsoleCmdArgs*);
 // This a definition of the callback function that is called when variable change.
 using ConsoleVarFunc = void (*)(ICVar*);
 
+namespace Cry
+{
+    //! Argument structure which supplies the ICVar::Set method
+    //! configuration data to suppress variable setting
+    struct SetCVarOptions
+    {
+        //! suppress any registered on change callbacks
+        bool m_supressOnChangeFunctions{};
+    };
+
+    //! Argument structure which supplies the IConsole::LoadConfigVar method
+    //! to determine how CVars should be set
+    struct LoadConfigVarOptions
+    {
+        //! Options to forward to any ICVar::Set invocations
+        //! that were invoked throuhg the IConsole::LoadConfigVar call
+        SetCVarOptions m_setCvarOptions{};
+    };
+}
+
+
 /* Summary: Interface to the engine console.
 
   Description:
@@ -451,7 +472,8 @@ struct IConsole
 
     //////////////////////////////////////////////////////////////////////////
     //
-    virtual void LoadConfigVar(const char* sVariable, const char* sValue) = 0;
+    virtual void LoadConfigVar(const char* sVariable, const char* sValue,
+        const Cry::LoadConfigVarOptions& loadConfigVarOptions = {}) = 0;
 
     //////////////////////////////////////////////////////////////////////////
     // Enable or disable the activation key (tilde by default).
@@ -549,7 +571,7 @@ struct ICVar
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // set the string value of the variable
     // @param s string representation the value
-    virtual void Set(const char* s) = 0;
+    virtual void Set(const char* s, const Cry::SetCVarOptions& cvarArgs = {}) = 0;
 
     // Force to set the string value of the variable - can be called
     // from inside code only
@@ -558,11 +580,11 @@ struct ICVar
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // set the float value of the variable
     // @param s float representation the value
-    virtual void Set(float f) = 0;
+    virtual void Set(float f, const Cry::SetCVarOptions& cvarArgs = {}) = 0;
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // set the float value of the variable
     // @param s integer representation the value
-    virtual void Set(int i) = 0;
+    virtual void Set(int i, const Cry::SetCVarOptions& cvarArgs = {}) = 0;
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // clear the specified bits in the flag field
     virtual void ClearFlags (int flags) = 0;

--- a/Code/Legacy/CryCommon/Mocks/ICVarMock.h
+++ b/Code/Legacy/CryCommon/Mocks/ICVarMock.h
@@ -23,10 +23,16 @@ public:
     MOCK_CONST_METHOD0(GetFVal, float());
     MOCK_CONST_METHOD0(GetString, const char*());
     MOCK_CONST_METHOD0(GetDataProbeString, const char*());
-    MOCK_METHOD1(Set, void(const char*));
+    MOCK_METHOD1(SetImpl, void(const char*));
+    void Set(const char* value, const Cry::SetCVarOptions&) override { SetImpl(value); }
+
+    MOCK_METHOD1(SetImpl, void(float));
+    void Set(float value, const Cry::SetCVarOptions&) override { SetImpl(value); }
+
+    MOCK_METHOD1(SetImpl, void(int));
+    void Set(int value, const Cry::SetCVarOptions&) override { SetImpl(value); }
+
     MOCK_METHOD1(ForceSet, void(const char*));
-    MOCK_METHOD1(Set, void(float));
-    MOCK_METHOD1(Set, void(int));
     MOCK_METHOD1(ClearFlags, void(const int));
     MOCK_CONST_METHOD0(GetFlags, int());
     MOCK_METHOD1(SetFlags, int(const int));

--- a/Code/Legacy/CryCommon/Mocks/IConsoleMock.h
+++ b/Code/Legacy/CryCommon/Mocks/IConsoleMock.h
@@ -70,7 +70,7 @@ public:
     MOCK_METHOD1(RemoveConsoleVarSink, void (IConsoleVarSink * pSink));
     MOCK_METHOD1(GetHistoryElement, const char*(bool bUpOrDown));
     MOCK_METHOD1(AddCommandToHistory, void (const char* szCommand));
-    MOCK_METHOD2(LoadConfigVar, void (const char* sVariable, const char* sValue));
+    MOCK_METHOD3(LoadConfigVar, void (const char* sVariable, const char* sValue, const Cry::LoadConfigVarOptions&));
     MOCK_METHOD1(EnableActivationKey, void (bool bEnable));
     MOCK_METHOD2(SetClientDataProbeString, void (const char* pName, const char* pValue));
 

--- a/Code/Legacy/CrySystem/SystemCFG.cpp
+++ b/Code/Legacy/CrySystem/SystemCFG.cpp
@@ -447,17 +447,19 @@ void CSystem::OnLoadConfigurationEntry(const char* szKey, const char* szValue, [
         azConsoleProcessed = static_cast<bool>(console->PerformCommand(command.c_str()));
     }
 
-    if (!azConsoleProcessed)
+    if (!gEnv->pConsole)
     {
-        if (!gEnv->pConsole)
-        {
-            return;
-        }
+        return;
+    }
 
-        if (*szKey != 0)
-        {
-            gEnv->pConsole->LoadConfigVar(szKey, szValue);
-        }
+    if (*szKey != 0)
+    {
+        Cry::LoadConfigVarOptions loadConfigOptions;
+        // When the Az Console sets the CVar variable,
+        // suppress the on change callback from the CXConsoleVariables
+        // to prevent a loop to calling PerformCommand a second time
+        loadConfigOptions.m_setCvarOptions.m_supressOnChangeFunctions = azConsoleProcessed;
+        gEnv->pConsole->LoadConfigVar(szKey, szValue, loadConfigOptions);
     }
 }
 

--- a/Code/Legacy/CrySystem/XConsole.cpp
+++ b/Code/Legacy/CrySystem/XConsole.cpp
@@ -505,7 +505,7 @@ bool CXConsole::CVarNameLess(const std::pair<const char*, ICVar*>& lhs, const st
 }
 
 //////////////////////////////////////////////////////////////////////////
-void CXConsole::LoadConfigVar(const char* sVariable, const char* sValue)
+void CXConsole::LoadConfigVar(const char* sVariable, const char* sValue, const Cry::LoadConfigVarOptions& loadConfigOptions)
 {
     ICVar* pCVar = GetCVar(sVariable);
     if (pCVar)
@@ -537,7 +537,7 @@ void CXConsole::LoadConfigVar(const char* sVariable, const char* sValue)
 
         if (allowChange || ALLOW_CONST_CVAR_MODIFICATIONS)
         {
-            pCVar->Set(sValue);
+            pCVar->Set(sValue, loadConfigOptions.m_setCvarOptions);
             pCVar->SetFlags(pCVar->GetFlags() | VF_WASINCONFIG);
         }
         return;

--- a/Code/Legacy/CrySystem/XConsole.h
+++ b/Code/Legacy/CrySystem/XConsole.h
@@ -191,7 +191,8 @@ public:
     const char* GetHistoryElement(bool bUpOrDown) override;
     void AddCommandToHistory(const char* szCommand) override;
     void SetInputLine(const char* szLine) override;
-    void LoadConfigVar(const char* sVariable, const char* sValue) override;
+    void LoadConfigVar(const char* sVariable, const char* sValue,
+        const Cry::LoadConfigVarOptions& cvarArgs = {}) override;
     void EnableActivationKey(bool bEnable) override;
     void SetClientDataProbeString(const char* pName, const char* pValue) override;
 

--- a/Code/Legacy/CrySystem/XConsoleVariable.cpp
+++ b/Code/Legacy/CrySystem/XConsoleVariable.cpp
@@ -249,7 +249,7 @@ const char* CXConsoleVariableBase::GetDataProbeString() const
     return GetOwnDataProbeString();
 }
 
-void CXConsoleVariableString::Set(const char* s)
+void CXConsoleVariableString::Set(const char* s, const Cry::SetCVarOptions& setCvarArgs)
 {
     if (!s)
     {
@@ -268,13 +268,16 @@ void CXConsoleVariableString::Set(const char* s)
             m_sValue = s;
         }
 
-        CallOnChangeFunctions();
+        if (!setCvarArgs.m_supressOnChangeFunctions)
+        {
+            CallOnChangeFunctions();
+        }
 
         m_pConsole->OnAfterVarChange(this);
     }
 }
 
-void CXConsoleVariableString::Set(float f)
+void CXConsoleVariableString::Set(float f, const Cry::SetCVarOptions& setCvarArgs)
 {
     stack_string s = stack_string::format("%g", f);
 
@@ -284,10 +287,10 @@ void CXConsoleVariableString::Set(float f)
     }
 
     m_nFlags |= VF_MODIFIED;
-    Set(s.c_str());
+    Set(s.c_str(), setCvarArgs);
 }
 
-void CXConsoleVariableString::Set(int i)
+void CXConsoleVariableString::Set(int i, const Cry::SetCVarOptions& setCvarArgs)
 {
     stack_string s = stack_string::format("%d", i);
 
@@ -297,7 +300,7 @@ void CXConsoleVariableString::Set(int i)
     }
 
     m_nFlags |= VF_MODIFIED;
-    Set(s.c_str());
+    Set(s.c_str(), setCvarArgs);
 }
 
 const char* CXConsoleVariableInt::GetString() const
@@ -308,19 +311,19 @@ const char* CXConsoleVariableInt::GetString() const
     return szReturnString;
 }
 
-void CXConsoleVariableInt::Set(const char* s)
+void CXConsoleVariableInt::Set(const char* s, const Cry::SetCVarOptions& setCvarArgs)
 {
     int nValue = TextToInt(s, m_iValue, (m_nFlags & VF_BITFIELD) != 0);
 
-    Set(nValue);
+    Set(nValue, setCvarArgs);
 }
 
-void CXConsoleVariableInt::Set(float f)
+void CXConsoleVariableInt::Set(float f, const Cry::SetCVarOptions& setCvarArgs)
 {
-    Set((int)f);
+    Set(static_cast<int>(f), setCvarArgs);
 }
 
-void CXConsoleVariableInt::Set(int i)
+void CXConsoleVariableInt::Set(int i, const Cry::SetCVarOptions& setCvarArgs)
 {
     if (i == m_iValue && (m_nFlags & VF_ALWAYSONCHANGE) == 0)
     {
@@ -334,7 +337,10 @@ void CXConsoleVariableInt::Set(int i)
         m_nFlags |= VF_MODIFIED;
         m_iValue = i;
 
-        CallOnChangeFunctions();
+        if (!setCvarArgs.m_supressOnChangeFunctions)
+        {
+            CallOnChangeFunctions();
+        }
 
         m_pConsole->OnAfterVarChange(this);
     }
@@ -348,7 +354,7 @@ const char* CXConsoleVariableIntRef::GetString() const
     return szReturnString;
 }
 
-void CXConsoleVariableIntRef::Set(const char* s)
+void CXConsoleVariableIntRef::Set(const char* s, const Cry::SetCVarOptions& setCvarArgs)
 {
     int nValue = TextToInt(s, m_iValue, (m_nFlags & VF_BITFIELD) != 0);
     if (nValue == m_iValue && (m_nFlags & VF_ALWAYSONCHANGE) == 0)
@@ -361,12 +367,15 @@ void CXConsoleVariableIntRef::Set(const char* s)
         m_nFlags |= VF_MODIFIED;
         m_iValue = nValue;
 
-        CallOnChangeFunctions();
+        if (!setCvarArgs.m_supressOnChangeFunctions)
+        {
+            CallOnChangeFunctions();
+        }
         m_pConsole->OnAfterVarChange(this);
     }
 }
 
-void CXConsoleVariableIntRef::Set(float f)
+void CXConsoleVariableIntRef::Set(float f, const Cry::SetCVarOptions& setCvarArgs)
 {
     if ((int)f == m_iValue && (m_nFlags & VF_ALWAYSONCHANGE) == 0)
     {
@@ -380,12 +389,15 @@ void CXConsoleVariableIntRef::Set(float f)
     {
         m_nFlags |= VF_MODIFIED;
         m_iValue = (int)f;
-        CallOnChangeFunctions();
+        if (!setCvarArgs.m_supressOnChangeFunctions)
+        {
+            CallOnChangeFunctions();
+        }
         m_pConsole->OnAfterVarChange(this);
     }
 }
 
-void CXConsoleVariableIntRef::Set(int i)
+void CXConsoleVariableIntRef::Set(int i, const Cry::SetCVarOptions& setCvarArgs)
 {
     if (i == m_iValue && (m_nFlags & VF_ALWAYSONCHANGE) == 0)
     {
@@ -399,7 +411,10 @@ void CXConsoleVariableIntRef::Set(int i)
     {
         m_nFlags |= VF_MODIFIED;
         m_iValue = i;
-        CallOnChangeFunctions();
+        if (!setCvarArgs.m_supressOnChangeFunctions)
+        {
+            CallOnChangeFunctions();
+        }
         m_pConsole->OnAfterVarChange(this);
     }
 }
@@ -412,7 +427,7 @@ const char* CXConsoleVariableFloat::GetString() const
     return szReturnString;
 }
 
-void CXConsoleVariableFloat::Set(const char* s)
+void CXConsoleVariableFloat::Set(const char* s, const Cry::SetCVarOptions& setCvarArgs)
 {
     float fValue = 0;
     if (s)
@@ -430,13 +445,16 @@ void CXConsoleVariableFloat::Set(const char* s)
         m_nFlags |= VF_MODIFIED;
         m_fValue = fValue;
 
-        CallOnChangeFunctions();
+        if (!setCvarArgs.m_supressOnChangeFunctions)
+        {
+            CallOnChangeFunctions();
+        }
 
         m_pConsole->OnAfterVarChange(this);
     }
 }
 
-void CXConsoleVariableFloat::Set(float f)
+void CXConsoleVariableFloat::Set(float f, const Cry::SetCVarOptions& setCvarArgs)
 {
     if (f == m_fValue && (m_nFlags & VF_ALWAYSONCHANGE) == 0)
     {
@@ -450,13 +468,16 @@ void CXConsoleVariableFloat::Set(float f)
         m_nFlags |= VF_MODIFIED;
         m_fValue = f;
 
-        CallOnChangeFunctions();
+        if (!setCvarArgs.m_supressOnChangeFunctions)
+        {
+            CallOnChangeFunctions();
+        }
 
         m_pConsole->OnAfterVarChange(this);
     }
 }
 
-void CXConsoleVariableFloat::Set(int i)
+void CXConsoleVariableFloat::Set(int i, const Cry::SetCVarOptions& setCvarArgs)
 {
     if ((float)i == m_fValue && (m_nFlags & VF_ALWAYSONCHANGE) == 0)
     {
@@ -470,7 +491,10 @@ void CXConsoleVariableFloat::Set(int i)
     {
         m_nFlags |= VF_MODIFIED;
         m_fValue = (float)i;
-        CallOnChangeFunctions();
+        if (!setCvarArgs.m_supressOnChangeFunctions)
+        {
+            CallOnChangeFunctions();
+        }
         m_pConsole->OnAfterVarChange(this);
     }
 }
@@ -483,7 +507,7 @@ const char* CXConsoleVariableFloatRef::GetString() const
     return szReturnString;
 }
 
-void CXConsoleVariableFloatRef::Set(const char *s)
+void CXConsoleVariableFloatRef::Set(const char *s, const Cry::SetCVarOptions& setCvarArgs)
 {
     float fValue = 0;
     if (s)
@@ -500,12 +524,15 @@ void CXConsoleVariableFloatRef::Set(const char *s)
         m_nFlags |= VF_MODIFIED;
         m_fValue = fValue;
 
-        CallOnChangeFunctions();
+        if (!setCvarArgs.m_supressOnChangeFunctions)
+        {
+            CallOnChangeFunctions();
+        }
         m_pConsole->OnAfterVarChange(this);
     }
 }
 
-void CXConsoleVariableFloatRef::Set(float f)
+void CXConsoleVariableFloatRef::Set(float f, const Cry::SetCVarOptions& setCvarArgs)
 {
     if (f == m_fValue && (m_nFlags & VF_ALWAYSONCHANGE) == 0)
     {
@@ -519,12 +546,15 @@ void CXConsoleVariableFloatRef::Set(float f)
     {
         m_nFlags |= VF_MODIFIED;
         m_fValue = f;
-        CallOnChangeFunctions();
+        if (!setCvarArgs.m_supressOnChangeFunctions)
+        {
+            CallOnChangeFunctions();
+        }
         m_pConsole->OnAfterVarChange(this);
     }
 }
 
-void CXConsoleVariableFloatRef::Set(int i)
+void CXConsoleVariableFloatRef::Set(int i, const Cry::SetCVarOptions& setCvarArgs)
 {
     if ((float)i == m_fValue && (m_nFlags & VF_ALWAYSONCHANGE) == 0)
     {
@@ -538,12 +568,15 @@ void CXConsoleVariableFloatRef::Set(int i)
     {
         m_nFlags |= VF_MODIFIED;
         m_fValue = (float)i;
-        CallOnChangeFunctions();
+        if (!setCvarArgs.m_supressOnChangeFunctions)
+        {
+            CallOnChangeFunctions();
+        }
         m_pConsole->OnAfterVarChange(this);
     }
 }
 
-void CXConsoleVariableStringRef::Set(const char *s)
+void CXConsoleVariableStringRef::Set(const char *s, const Cry::SetCVarOptions& setCvarArgs)
 {
     if ((m_sValue == s) && (m_nFlags & VF_ALWAYSONCHANGE) == 0)
     {
@@ -558,7 +591,10 @@ void CXConsoleVariableStringRef::Set(const char *s)
             m_userPtr = m_sValue.c_str();
         }
 
-        CallOnChangeFunctions();
+        if (!setCvarArgs.m_supressOnChangeFunctions)
+        {
+            CallOnChangeFunctions();
+        }
         m_pConsole->OnAfterVarChange(this);
     }
 }

--- a/Code/Legacy/CrySystem/XConsoleVariable.h
+++ b/Code/Legacy/CrySystem/XConsoleVariable.h
@@ -113,9 +113,9 @@ public:
     {
         Set(m_sDefault.c_str());
     }
-    void Set(const char* s) override;
-    void Set(float f) override;
-    void Set(int i) override;
+    void Set(const char* s, const Cry::SetCVarOptions& cvarArgs = {}) override;
+    void Set(float f, const Cry::SetCVarOptions& cvarArgs = {}) override;
+    void Set(int i, const Cry::SetCVarOptions& cvarArgs = {}) override;
     int GetType() override { return CVAR_STRING; }
 
 private: // --------------------------------------------------------------------------------------------
@@ -144,9 +144,9 @@ public:
     float GetFVal() const override { return (float)GetIVal(); }
     const char* GetString() const override;
     void ResetImpl() override { Set(m_iDefault); }
-    void Set(const char* s) override;
-    void Set(float f) override;
-    void Set(int i) override;
+    void Set(const char* s, const Cry::SetCVarOptions& cvarArgs = {}) override;
+    void Set(float f, const Cry::SetCVarOptions& cvarArgs = {}) override;
+    void Set(int i, const Cry::SetCVarOptions& cvarArgs = {}) override;
     int GetType() override { return CVAR_INT; }
 protected: // --------------------------------------------------------------------------------------------
 
@@ -174,9 +174,9 @@ public:
     float GetFVal() const override { return m_fValue; }
     const char* GetString() const override;
     void ResetImpl() override { Set(m_fDefault); }
-    void Set(const char* s) override;
-    void Set(float f) override;
-    void Set(int i) override;
+    void Set(const char* s, const Cry::SetCVarOptions& cvarArgs = {}) override;
+    void Set(float f, const Cry::SetCVarOptions& cvarArgs = {}) override;
+    void Set(int i, const Cry::SetCVarOptions& cvarArgs = {}) override;
     int GetType() override { return CVAR_FLOAT; }
 
 protected:
@@ -217,9 +217,9 @@ public:
     float GetFVal() const override { return (float)m_iValue; }
     const char* GetString() const override;
     void ResetImpl() override { Set(m_iDefault); }
-    void Set(const char* s) override;
-    void Set(float f) override;
-    void Set(int i) override;
+    void Set(const char* s, const Cry::SetCVarOptions& cvarArgs = {}) override;
+    void Set(float f, const Cry::SetCVarOptions& cvarArgs = {}) override;
+    void Set(int i, const Cry::SetCVarOptions& cvarArgs = {}) override;
     int GetType() override { return CVAR_INT; }
 
 private: // --------------------------------------------------------------------------------------------
@@ -254,16 +254,16 @@ public:
         return m_sValue.c_str();
     }
     void ResetImpl() override { Set(m_sDefault.c_str()); }
-    void Set(const char* s) override;
-    void Set(float f) override
+    void Set(const char* s, const Cry::SetCVarOptions& setCvarArgs = {}) override;
+    void Set(float f, const Cry::SetCVarOptions& setCvarArgs = {}) override
     {
         AZStd::fixed_string<32> s = AZStd::fixed_string<32>::format("%g", f);
-        Set(s.c_str());
+        Set(s.c_str(), setCvarArgs);
     }
-    void Set(int i) override
+    void Set(int i, const Cry::SetCVarOptions& setCvarArgs = {}) override
     {
         AZStd::fixed_string<32> s = AZStd::fixed_string<32>::format("%d", i);
-        Set(s.c_str());
+        Set(s.c_str(), setCvarArgs);
     }
     int GetType() override { return CVAR_STRING; }
 
@@ -295,9 +295,9 @@ public:
     float GetFVal() const override { return m_fValue; }
     const char* GetString() const override;
     void ResetImpl() override { Set(m_fDefault); }
-    void Set(const char* s) override;
-    void Set(float f) override;
-    void Set(int i) override;
+    void Set(const char* s, const Cry::SetCVarOptions& cvarArgs = {}) override;
+    void Set(float f, const Cry::SetCVarOptions& cvarArgs = {}) override;
+    void Set(int i, const Cry::SetCVarOptions& cvarArgs = {}) override;
     int GetType() override { return CVAR_FLOAT; }
 
 protected:


### PR DESCRIPTION
The Cry Console CFG loading logic wouldn't set the backend C++ variable that was associated with a Cry Console Command, if that variable was associated with the AZ Console.

The reason why the logic was skipped, was to prevent a second call to AZ Console Perform Command via the OnChange handlers registered with Cry Console Variables.

This change adds support for supplying options to Cry Console Variables Set() functions to skip over invoking OnChangeCallback handlers.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

## How was this PR tested?

Still in testing.
