### PR TITLE
Fix some material params are hidden after hiding enitiy and switching…

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
@@ -289,6 +289,12 @@ namespace AZ
             }
         }
 
+        void EditorMaterialComponent::OnEntityVisibilityChanged(bool visibility)
+        {
+            EditorRenderComponentAdapter::OnEntityVisibilityChanged(visibility);
+            UpdateMaterialSlots();
+        }
+
         AZ::u32 EditorMaterialComponent::OnConfigurationChanged()
         {
             return AZ::Edit::PropertyRefreshLevels::AttributesAndValues;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.h
@@ -51,6 +51,9 @@ namespace AZ
             void OnMaterialSlotLayoutChanged() override;
             void OnMaterialsCreated(const MaterialAssignmentMap& materials) override;
 
+            // AzToolsFramework::EditorEntityVisibilityNotificationBus::Handler overrides
+            void OnEntityVisibilityChanged(bool visibility) override;
+
             // Regenerates the editor component material slots based on the material and
             // LOD mapping from the model or other consumer of materials.
             // If any corresponding material assignments are found in the component


### PR DESCRIPTION
… level.

Signed-off-by: Zhang-Baochong <zhangbaochong@huawei.com>

## What does this PR do?
Open level again after the entity is hidden. The parameters of material are hidden，and there is no way to redisplay parameters.
![1](https://user-images.githubusercontent.com/124341515/218608301-6986400b-efc4-4205-b076-087e33b4d8c9.png)
![2](https://user-images.githubusercontent.com/124341515/218608311-7c68f75b-5a18-4798-a6c2-861bc54e2cf9.png)

## How was this PR tested?
1、Create new entity, set the mesh and material 
2、Hide the entity and save level. 
3、Open other level, and reopen this level
4、Show the entity, check if parameters of material show correctly

![GIF 2023-2-13 21-10-15](https://user-images.githubusercontent.com/124341515/218608324-2d4d065c-3318-475a-a903-ead25273ec56.gif)
