### PR TITLE
Temporarily skip AtomEditorComponents_GlobalSkylightIBLAdded test due to intermittent failure.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Component_02.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Component_02.py
@@ -14,6 +14,7 @@ from ly_test_tools.o3de.editor_test import EditorBatchedTest, EditorTestSuite
 @pytest.mark.parametrize("launcher_platform", ['windows_editor'])
 class TestAutomation(EditorTestSuite):
 
+    @pytest.mark.skip(reason="https://github.com/o3de/o3de/issues/14580")
     @pytest.mark.test_case_id("C32078115")
     class AtomEditorComponents_GlobalSkylightIBLAdded(EditorBatchedTest):
         from Atom.tests import hydra_AtomEditorComponents_GlobalSkylightIBLAdded as test_module


### PR DESCRIPTION
## What does this PR do?
This test is intermittently failing and is going to be temporarily disabled. The root cause will be determined after https://github.com/o3de/o3de/issues/14580 is complete.

## How was this PR tested?
PR was not tested as this is a simple change to temporarily disable it.