### PR TITLE
Add verification before saving material document.

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
@@ -350,6 +350,12 @@ namespace AtomToolsFramework
         }
 
         const QFileInfo saveInfo(savePath.c_str());
+        if (!saveInfo.exists())
+        {
+            QMessageBox::critical(QApplication::activeWindow(), "Error", QObject::tr("Document does not exist:\n%1").arg(savePath.c_str()));
+            return false;
+        }
+
         if (saveInfo.exists() && !saveInfo.isWritable())
         {
             DisplayErrorMessage(


### PR DESCRIPTION
## What does this PR do?
If rename opening material source, then `Ctrl S` save the material, there will be two materials in asset browser.
For this situation, need to add verification before saving material document.
![material-save-2](https://user-images.githubusercontent.com/124341515/218919589-89231090-e3f6-489c-ad8f-2016ca1a3f7a.gif)

## How was this PR tested?
1、create a new material document
2、Open it in explorer， and rename
3、Change any param for origin material, and Ctrl+S to save, Check if the issue has been solved
![add-check-save-material](https://user-images.githubusercontent.com/124341515/218919602-f4df5d8d-3983-4eef-9665-1c79e0b94536.gif)
