### PR TITLE
Fix terrain seed list based on recent material pipeline change.

### DIFF
--- a/Gems/Terrain/Assets/seedList.seed
+++ b/Gems/Terrain/Assets/seedList.seed
@@ -34,11 +34,11 @@
 		</Class>
 		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
 			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{B6798C1D-73B7-5A75-AB9B-1D221498D400}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="AZ::Uuid" field="guid" value="{7431B13A-278B-5C4D-B9BA-108EE44F21B0}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
 				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			</Class>
 			<Class name="unsigned int" field="platformFlags" value="255" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="materials/terrain/terraindetailmaterial.azmaterialtype" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+			<Class name="AZStd::string" field="pathHint" value="materials/terrain/terraindetailmaterial_generated.azmaterialtype" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 		</Class>
 	</Class>
 </ObjectStream>


### PR DESCRIPTION
## What does this PR do?

With the recent material pipeline changes, the "terraindetailmaterial.azmaterialtype" is now "terraindetailmaterial_generated.azmaterialtype".

## How was this PR tested?

Generated a PAK file and verified the new material type file was added to it.
