### PR TITLE
Fixed EditorTransformComponentSelection tests with new action manager enabled

### DIFF
--- a/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
@@ -312,7 +312,14 @@ namespace UnitTest
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // When
         // R - reset entity and manipulator orientation when in Rotation Mode
-        QTest::keyPress(&m_editorActions.m_defaultWidget, Qt::Key_R);
+        if (AzToolsFramework::IsNewActionManagerEnabled())
+        {
+            QTest::keyPress(m_defaultMainWindow, Qt::Key_R);
+        }
+        else
+        {
+            QTest::keyPress(&m_editorActions.m_defaultWidget, Qt::Key_R);
+        }
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -361,7 +368,14 @@ namespace UnitTest
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // When
         // Ctrl+R - reset only manipulator orientation when in Rotation Mode
-        QTest::keyPress(&m_editorActions.m_defaultWidget, Qt::Key_R, Qt::ControlModifier);
+        if (AzToolsFramework::IsNewActionManagerEnabled())
+        {
+            QTest::keyPress(m_defaultMainWindow, Qt::Key_R, Qt::ControlModifier);
+        }
+        else
+        {
+            QTest::keyPress(&m_editorActions.m_defaultWidget, Qt::Key_R, Qt::ControlModifier);
+        }
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -487,7 +501,14 @@ namespace UnitTest
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // When
         // 'Invert Selection' shortcut
-        QTest::keyPress(&m_editorActions.m_defaultWidget, Qt::Key_I, Qt::ControlModifier | Qt::ShiftModifier);
+        if (AzToolsFramework::IsNewActionManagerEnabled())
+        {
+            QTest::keyPress(m_defaultMainWindow, Qt::Key_I, Qt::ControlModifier | Qt::ShiftModifier);
+        }
+        else
+        {
+            QTest::keyPress(&m_editorActions.m_defaultWidget, Qt::Key_I, Qt::ControlModifier | Qt::ShiftModifier);
+        }
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -517,7 +538,14 @@ namespace UnitTest
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // When
         // 'Select All' shortcut
-        QTest::keyPress(&m_editorActions.m_defaultWidget, Qt::Key_A, Qt::ControlModifier);
+        if (AzToolsFramework::IsNewActionManagerEnabled())
+        {
+            QTest::keyPress(m_defaultMainWindow, Qt::Key_A, Qt::ControlModifier);
+        }
+        else
+        {
+            QTest::keyPress(&m_editorActions.m_defaultWidget, Qt::Key_A, Qt::ControlModifier);
+        }
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## What does this PR do?

Fixed several `EditorTransformComponentSelection` unit tests that fail when the new action manager is enabled by default, which was uncovered in this PR (https://github.com/o3de/o3de/pull/14581). These tests failed because they trigger operations by injecting key presses into a dummy widget that gets constructed as part of the test fixture, but these actions are registered in a different workflow when the new action manager is enabled. This required the test fixture to be updated to construct a similar dummy widget for the new action manager to register its default action context with.

## How was this PR tested?

Ran all unit tests with and without the new action manager enabled and verified they all pass.