### PR TITLE
Fix array/vector network serialization to have unique names.

### DIFF
--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/StringifySerializer.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/StringifySerializer.cpp
@@ -136,6 +136,15 @@ namespace AzNetworking
     {
         const AZStd::string keyString = m_prefix + name;
         AZ::CVarFixedString valueString = AZ::ConsoleTypeHelpers::ValueToString(value);
+
+        // Verify that the serialization isn't silently accidentally replacing an existing key with a different value.
+        AZ_Assert(
+            !m_valueMap.contains(keyString) || (m_valueMap[keyString].compare(valueString.c_str()) != 0),
+            "Value map contains '%s' with value '%s', about to be overwritten with '%s'.",
+            keyString.c_str(),
+            m_valueMap[keyString].c_str(),
+            valueString.c_str());
+
         m_valueMap[keyString] = valueString.c_str();
         return true;
     }

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/MultiplayerComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/MultiplayerComponent.h
@@ -180,7 +180,7 @@ namespace Multiplayer
             if (bitset.GetBit(i))
             {
                 serializer.ClearTrackedChangesFlag();
-                serializer.Serialize(value[i], "Element");
+                serializer.Serialize(value[i], AzNetworking::GenerateIndexLabel<SIZE>(i).c_str());
                 if (modifyRecord && !serializer.GetTrackedChangesFlag())
                 {
                     bitset.SetBit(i, false);
@@ -222,7 +222,7 @@ namespace Multiplayer
             if (bitset.GetBit(i))
             {
                 serializer.ClearTrackedChangesFlag();
-                serializer.Serialize(value[i], "Element");
+                serializer.Serialize(value[i], AzNetworking::GenerateIndexLabel<SIZE>(i).c_str());
                 if (modifyRecord && !serializer.GetTrackedChangesFlag())
                 {
                     bitset.SetBit(i, false);


### PR DESCRIPTION
## What does this PR do?

The array and vector network serialization helpers were using "Element" as the base name for every entry in the array/vector. This could lead to inconsistent serialized state like the following:
![image](https://user-images.githubusercontent.com/82224783/219220491-459095c8-efc3-420d-a270-63b768295bdd.png)

Note that the ActiveShots.Size is 0, but there is an entry for an element in ActiveShots. This occurs when multiple weapons states in an array are serialized, where the first one has a size of 1, and the second has a size of 0. The second size overwrites the first, but the rest of the previous entry is left as-is.

The fix changes the helpers to generate unique names like "00", "01", etc for each array entry instead of "Element" for every entry. The assert in StringifySerializer is there to provide more visibility in case something else ends up creating non-unique names in the future.

## How was this PR tested?

Ran MultiplayerSample. First, added the assert and verified that it triggered from state overwrites. Then, added the name fix. Finally, verified that the assert no longer triggers, and manually examined the state to verify that it got multiple adjacent element entries instead of a single merged one.
