### PR TITLE
bugfix: Changing "Expand by" doesn't take effect.

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
@@ -431,8 +431,7 @@ namespace AZ::Render
 
         if (enableStaticAabb)
         {
-            AZ::Aabb aabb;
-            instance->CalcStaticBasedAabb(&aabb);
+            auto& aabb = instance->GetAabb();
             if (aabb.IsValid())
             {
                 auxGeom->DrawAabb(aabb, staticAabbColor, RPI::AuxGeomDraw::DrawStyle::Line);


### PR DESCRIPTION
## What does this PR do?
The default value of `Expand by` is `25%`, as follows:
![image](https://user-images.githubusercontent.com/80555200/219235136-b38928fa-6c92-43a6-9212-908a0bcd001c.png)

When set it to a new value, like `100%`, as follows, but no changes.
![image](https://user-images.githubusercontent.com/80555200/219235155-3b4f62b6-b7ae-4d57-b855-9bc34ee09526.png)

## How was this PR tested?
When my bugfix patch applied, changing "Expand by" takes effect, as follows:
![image](https://user-images.githubusercontent.com/80555200/219235176-0e101d01-a688-4d77-a09b-67c1e78eafb1.png)

