### PR TITLE
bugfix: Editor buttons is lack of tooltips, such as Max/Min/Restore.

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/DockBarButton.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/DockBarButton.cpp
@@ -65,12 +65,14 @@ namespace AzQtComponents
         {
             case DockBarButton::CloseButton:
                 Style::addClass(this, QStringLiteral("close"));
+                setToolTip(tr("Close"));
                 break;
             case DockBarButton::MaximizeButton:
                 SetMaximizeRestoreButton();
                 break;
             case DockBarButton::MinimizeButton:
                 Style::addClass(this, QStringLiteral("minimize"));
+                setToolTip(tr("Minimize"));
                 break;
             case DockBarButton::DividerButton:
                 break;
@@ -153,11 +155,13 @@ namespace AzQtComponents
         {
             Style::removeClass(this, QStringLiteral("maximize"));
             Style::addClass(this, QStringLiteral("restore"));
+            setToolTip(tr("Restore"));
         }
         else
         {
             Style::removeClass(this, QStringLiteral("restore"));
             Style::addClass(this, QStringLiteral("maximize"));
+            setToolTip(tr("Maximize"));
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

Buttons of Editor are lack of tooltips.

## How was this PR tested?

![image](https://user-images.githubusercontent.com/80555200/219283260-01d9217a-c0c3-449a-9a0f-6218e92558e8.png)
![image](https://user-images.githubusercontent.com/80555200/219283267-2dc70e6a-793d-4248-bbf2-e2f36e2c2d6c.png)
![image](https://user-images.githubusercontent.com/80555200/219283344-da268e07-784b-4506-a831-3d3d87879261.png)
![image](https://user-images.githubusercontent.com/80555200/219283358-dbd8b7dd-7dba-441b-bf98-773d7516710f.png)

