### PR TITLE
Reduced recompile time when changing O3DE_STACK_CAPTURE_DEPTH

### DIFF
--- a/Code/Framework/AzCore/AzCore/Memory/PoolAllocator.cpp
+++ b/Code/Framework/AzCore/AzCore/Memory/PoolAllocator.cpp
@@ -62,6 +62,30 @@ namespace
 
 namespace AZ
 {
+    // Definining the PoolAllocator::GetDebugConfig
+    // method in the cpp file to prevent a lengthy recompile
+    // when changing the O3DE_STACK_CAPTURE_DEPTH define
+    AllocatorDebugConfig PoolAllocator::GetDebugConfig()
+    {
+        return AllocatorDebugConfig()
+            .ExcludeFromDebugging(false)
+            .StackRecordLevels(O3DE_STACK_CAPTURE_DEPTH)
+            .MarksUnallocatedMemory(false)
+            .UsesMemoryGuards(false);
+    }
+
+    AllocatorDebugConfig ThreadPoolAllocator::GetDebugConfig()
+    {
+        return AllocatorDebugConfig()
+            .ExcludeFromDebugging(false)
+            .StackRecordLevels(O3DE_STACK_CAPTURE_DEPTH)
+            .MarksUnallocatedMemory(false)
+            .UsesMemoryGuards(false);
+    }
+}
+
+namespace AZ
+{
     //////////////////////////////////////////////////////////////////////////
     //////////////////////////////////////////////////////////////////////////
     // Pool Allocation algorithm

--- a/Code/Framework/AzCore/AzCore/Memory/PoolAllocator.h
+++ b/Code/Framework/AzCore/AzCore/Memory/PoolAllocator.h
@@ -143,7 +143,7 @@ namespace AZ
             using size_type = typename Base::size_type;
             using difference_type = typename Base::difference_type;
 
-            AZ_RTTI((PoolAllocatorHelper, "{813b4b74-7381-4c62-b475-3f66efbcb615}", Schema), Base)
+            AZ_RTTI((PoolAllocatorHelper, "{813b4b74-7381-4c62-b475-3f66efbcb615}", Schema), Base);
 
             PoolAllocatorHelper()
             {
@@ -154,15 +154,6 @@ namespace AZ
             ~PoolAllocatorHelper() override
             {
                 this->PreDestroy();
-            }
-
-            AllocatorDebugConfig GetDebugConfig() override
-            {
-                return AllocatorDebugConfig()
-                    .ExcludeFromDebugging(false)
-                    .StackRecordLevels(O3DE_STACK_CAPTURE_DEPTH)
-                    .MarksUnallocatedMemory(false)
-                    .UsesMemoryGuards(false);
             }
 
             //////////////////////////////////////////////////////////////////////////
@@ -199,7 +190,9 @@ namespace AZ
 
         using Base = Internal::PoolAllocatorHelper<PoolSchema>;
 
-        AZ_RTTI(PoolAllocator, "{D3DC61AF-0949-4BFA-87E0-62FA03A4C025}", Base)
+        AZ_RTTI(PoolAllocator, "{D3DC61AF-0949-4BFA-87E0-62FA03A4C025}", Base);
+
+        AllocatorDebugConfig GetDebugConfig() override;
     };
 
     template<class Allocator>
@@ -217,6 +210,8 @@ namespace AZ
 
         using Base = ThreadPoolBase<ThreadPoolAllocator>;
 
-        AZ_RTTI(ThreadPoolAllocator, "{05B4857F-CD06-4942-99FD-CA6A7BAE855A}", Base)
+        AZ_RTTI(ThreadPoolAllocator, "{05B4857F-CD06-4942-99FD-CA6A7BAE855A}", Base);
+
+        AllocatorDebugConfig GetDebugConfig() override;
     };
 } // namespace AZ

--- a/Code/Framework/AzCore/CMakeLists.txt
+++ b/Code/Framework/AzCore/CMakeLists.txt
@@ -51,9 +51,6 @@ ly_add_target(
             .
             ${pal_dir}
             ${common_dir}
-    COMPILE_DEFINITIONS
-        PUBLIC
-            O3DE_STACK_CAPTURE_DEPTH=${O3DE_STACK_CAPTURE_DEPTH}
 )
 
 ly_add_target(
@@ -94,6 +91,18 @@ ly_add_source_properties(
         AzCore/Component/ComponentApplication.cpp
     PROPERTY COMPILE_DEFINITIONS
     VALUES ${ALLOW_SETTINGS_REGISTRY_DEVELOPMENT_OVERRIDES_FLAG}
+)
+
+# Add the O3DE_STACK_CAPTURE_DEPTH define only to the cpp files for the following allocators
+# This reduces re-compile time when the cache variable value changes.
+set(O3DE_STACK_CAPTURE_DEPTH_DEFINE $<$<NOT:$<STREQUAL:"${O3DE_STACK_CAPTURE_DEPTH}","">>:O3DE_STACK_CAPTURE_DEPTH=${O3DE_STACK_CAPTURE_DEPTH}>)
+ly_add_source_properties(
+    SOURCES
+        AzCore/Memory/OSAllocator.cpp
+        AzCore/Memory/PoolAllocator.cpp
+        AzCore/Memory/SystemAllocator.cpp
+    PROPERTY COMPILE_DEFINITIONS
+    VALUES ${O3DE_STACK_CAPTURE_DEPTH_DEFINE}
 )
 
 if(LY_BUILD_WITH_ADDRESS_SANITIZER)


### PR DESCRIPTION
CMake contains a cache variable called `O3DE_STACK_CAPTURE_DEPTH` which determines the amount of stack frames to capture when a memory leak occurs in the C++ UnitTest.

When that cache variable is changed, it modified the public COMPILE_DEFINITION of `O3DE_STACK_CAPTURE_DEPTH` on the `O3DEKernel` library target.

As the `O3DEKernel` is a dependency of AzCore and AzCore is a dependency on all the other libraries within the code base, this required the entire code base to recompile when the option is changed.

To reduce the time needed to recompile, the `O3DE_STACK_CAPTURE_DEPTH` CMake cache variable will only change the COMPILE_DEFINITION for the `OSAllocator.cpp`, `PoolAllocator.cpp` and `SystemAllocator.cpp`.

Therefore only those 3 files need to recompile.
There is still a cost to relinking AzCore to other libraries, but is a lot less than recompiling every source file.

## How was this PR tested?

Validated that the O3DE_STACK_CAPTURE_DEPTH define were only set for the source files of `OSAllocator.cpp`, `PoolAllocator.cpp` and `SystemAllocator.cpp`
![image](https://user-images.githubusercontent.com/56135373/219499784-46d9ef3e-9cd2-42fd-9b55-d71e5a12fb8c.png)

![image](https://user-images.githubusercontent.com/56135373/219499756-478aa8e7-cb95-45be-a9d4-ba9de8bcadeb.png)

![image](https://user-images.githubusercontent.com/56135373/219499816-e7868b4c-9a4f-4dc8-81c5-dead1e32e8d2.png)

As can be seen it is not set for other files such as Memory.cpp
![image](https://user-images.githubusercontent.com/56135373/219499867-f2549d3a-50c4-4943-b00f-f1dfa6067a10.png)
