### PR TITLE
Fix an issue RenderPass::BindSrg function

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Base.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Base.h
@@ -34,8 +34,6 @@ namespace AZ
 
     namespace RPI
     {
-        using ShaderResourceGroupList = AZStd::fixed_vector<const RHI::ShaderResourceGroup*, RHI::Limits::Pipeline::ShaderResourceGroupCountMax>;
-
         class View;
         using ViewPtr = AZStd::shared_ptr<View>;
         using ConstViewPtr = AZStd::shared_ptr<const View>;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -112,10 +112,6 @@ namespace AZ
 
                 RHI::FrameGraphBuilder* m_frameGraphBuilder = nullptr;
 
-                // This should include SRGs that are higher level than
-                // the Pass, like per-frame and per-scene SRGs.
-                const ShaderResourceGroupList* m_shaderResourceGroupsToBind = nullptr;
-
                 RHI::Scissor m_scissorState;
                 RHI::Viewport m_viewportState;
             };

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
@@ -153,7 +153,7 @@ namespace AZ
 
             // List of all ShaderResourceGroups to be bound during rendering or computing
             // Derived classed may call BindSrg function to add other srgs the list
-            ShaderResourceGroupList m_shaderResourceGroupsToBind;
+            AZStd::unordered_map<uint8_t, const RHI::ShaderResourceGroup*> m_shaderResourceGroupsToBind;
             
             // View tag used to associate a pipeline view for this pass.
             PipelineViewTag m_viewTag;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -407,30 +407,23 @@ namespace AZ
         {
             if (srg)
             {
-                if (!m_shaderResourceGroupsToBind.full())
-                {
-                    m_shaderResourceGroupsToBind.push_back(srg);
-                }
-                else
-                {
-                    AZ_Error("Pass System", false, "Attempting to bind an srg to a RenderPass, but there is no more room.")
-                }
+                m_shaderResourceGroupsToBind[aznumeric_caster(srg->GetBindingSlot())] = srg;
             }
         }
 
         void RenderPass::SetSrgsForDraw(RHI::CommandList* commandList)
         {
-            for (const RHI::ShaderResourceGroup* shaderResourceGroup : m_shaderResourceGroupsToBind)
+            for (auto itr : m_shaderResourceGroupsToBind)
             {
-                commandList->SetShaderResourceGroupForDraw(*shaderResourceGroup);
+                commandList->SetShaderResourceGroupForDraw(*(itr.second));
             }
         }
 
         void RenderPass::SetSrgsForDispatch(RHI::CommandList* commandList)
         {
-            for (const RHI::ShaderResourceGroup* shaderResourceGroup : m_shaderResourceGroupsToBind)
+            for (auto itr : m_shaderResourceGroupsToBind)
             {
-                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup);
+                commandList->SetShaderResourceGroupForDispatch(*(itr.second));
             }
         }
 
@@ -549,7 +542,7 @@ namespace AZ
                 query->EndQuery(context);
             };
 
-            // This scopy query implmentation should be replaced by
+            // This scope query implementation should be replaced by
             // [ATOM-5407] [RHI][Core] - Add GPU timestamp and pipeline statistic support for scopes
             
             // For timestamp query, it's okay to execute across different command lists


### PR DESCRIPTION
## What does this PR do?
Sometime the bindSrg is called for a pass which won't be rendered. This leads to issue that the m_shaderResourceGroupsToBind vector grow without proper clear.

This fix is to solve the issue by setting srg for based on its binding slot (which is limited)

## How was this PR tested?
Editor with AutomatedTesting project
ASV
robotec's test level with rbgd sensors
