### PR TITLE
Adding proper BehaviorContext reflection of AZ Path

### DIFF
--- a/Code/Framework/AzCore/AzCore/IO/Path/Path.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Path/Path.cpp
@@ -132,7 +132,7 @@ namespace AZ::IO::Internal
     }
 
     template <class StringType>
-    constexpr StringType AsUri(const PathView& pathView) noexcept
+    StringType AsUri(const PathView& pathView) noexcept
     {
         StringType resultUri;
         // The syntax for the "file:" URI scheme is documented at https://www.rfc-editor.org/rfc/rfc8089#page-3

--- a/Code/Framework/AzCore/AzCore/IO/Path/Path.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Path/Path.cpp
@@ -50,4 +50,122 @@ namespace AZ::IO
         const PathIterator<const Path>& rhs);
     template bool operator!=<const FixedMaxPath>(const PathIterator<const FixedMaxPath>& lhs,
         const PathIterator<const FixedMaxPath>& rhs);
+
+    // string conversion
+    AZStd::string PathView::String() const
+    {
+        return AZStd::string(m_path);
+    }
+
+    // as_posix
+    AZStd::string PathView::StringAsPosix() const
+    {
+        AZStd::string resultPath(m_path);
+        AZStd::replace(resultPath.begin(), resultPath.end(), AZ::IO::WindowsPathSeparator, AZ::IO::PosixPathSeparator);
+        return resultPath;
+    }
+
+    // as_uri
+    AZStd::string PathView::StringAsUri() const
+    {
+        return Internal::AsUri<AZStd::string>(*this);
+    }
+}
+
+namespace AZ::IO::Internal
+{
+    //! Quotes a URL like path string
+    //! Reference RFC 3986 for quoting: https://www.rfc-editor.org/rfc/rfc3986
+    //! The unreserved characters are left as is https://www.rfc-editor.org/rfc/rfc3986#section-2.3
+    //! and all reserved characters are URL encoded except for the '/' character as that is needed
+    //! in a URI path
+    static constexpr auto URIQuoteTable = []()
+    {
+        // Hex to Character macro for converting nibbles to characters
+        constexpr AZStd::string_view HexToChar = "0123456789ABCDEF";
+        static_assert(HexToChar.size() == 16);
+        constexpr AZStd::string_view UnreservedCharacters = "abcdefghijklmnopqrstuvwxyz"
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            "0123456789"
+            "-._~";
+        static_assert(UnreservedCharacters.size() == 66);
+        constexpr AZStd::string_view AllowedInPathCharacters = "/";
+
+        AZStd::array<AZStd::fixed_string<3>, 256> percentQuoteTable{};
+        for (size_t byteIndex = 0; byteIndex < percentQuoteTable.size(); ++byteIndex)
+        {
+            if (UnreservedCharacters.find_first_of(static_cast<char>(byteIndex)) != AZStd::string_view::npos
+                || AllowedInPathCharacters.find_first_of(static_cast<char>(byteIndex)) != AZStd::string_view::npos)
+            {
+                percentQuoteTable[byteIndex] = static_cast<char>(byteIndex);
+            }
+            else
+            {
+                // Converts an ascii character such as '@' -> "%40"
+                percentQuoteTable[byteIndex] += "%";
+                percentQuoteTable[byteIndex] += HexToChar[(byteIndex / HexToChar.size()) % HexToChar.size()];
+                percentQuoteTable[byteIndex] += HexToChar[byteIndex % HexToChar.size()];
+            }
+        }
+
+        return percentQuoteTable;
+    }();
+
+    // Quick validation of some of quote conversions
+    static_assert(URIQuoteTable['a'] == "a");
+    static_assert(URIQuoteTable['-'] == "-");
+    static_assert(URIQuoteTable[' '] == "%20");
+    static_assert(URIQuoteTable['@'] == "%40");
+    static_assert(URIQuoteTable[0] == "%00");
+    // Allowed path character check
+    static_assert(URIQuoteTable['/'] == "/");
+
+    constexpr FixedMaxPathString UriQuote(AZStd::string_view path)
+    {
+        FixedMaxPathString quotedPath;
+        for (char elem : path)
+        {
+            quotedPath += URIQuoteTable[elem];
+        }
+
+        return quotedPath;
+    }
+
+    template <class StringType>
+    constexpr StringType AsUri(const PathView& pathView) noexcept
+    {
+        StringType resultUri;
+        // The syntax for the "file:" URI scheme is documented at https://www.rfc-editor.org/rfc/rfc8089#page-3
+        if (pathView.IsAbsolute())
+        {
+            const FixedMaxPath path = pathView.LexicallyNormal();
+            if (path.HasRootName())
+            {
+                // Windows style path
+                if (Internal::HasDrivePrefix(path.Native()))
+                {
+                    resultUri += "file:///";
+                    resultUri += path.RootName().Native();
+                    resultUri += AZ::IO::PosixPathSeparator;
+                    resultUri += AZStd::string_view(UriQuote(path.RelativePath().FixedMaxPathStringAsPosix()));
+                }
+                else if (Internal::IsUncPath(path.Native(), path.PreferredSeparator()))
+                {
+                    resultUri += "file:";
+                    resultUri += AZStd::string_view(UriQuote(path.FixedMaxPathStringAsPosix()));
+                }
+            }
+            else
+            {
+                // Posix style path
+                resultUri += "file://";
+                resultUri += AZStd::string_view(UriQuote(path.FixedMaxPathStringAsPosix()));
+            }
+        }
+
+        return resultUri;
+    }
+
+    template AZStd::string AsUri<AZStd::string>(const PathView& pathView) noexcept;
+    template AZStd::fixed_string<MaxPathLength> AsUri<AZStd::fixed_string<MaxPathLength>>(const PathView& pathView) noexcept;
 }

--- a/Code/Framework/AzCore/AzCore/IO/Path/Path.h
+++ b/Code/Framework/AzCore/AzCore/IO/Path/Path.h
@@ -188,9 +188,9 @@ namespace AZ::IO
         // as_uri
         //! Models the Python pathlib as_uri method
         //! Percent encodes the path and appends file: to the front
-        constexpr AZStd::fixed_string<MaxPathLength> AsUri() const noexcept;
+        AZStd::fixed_string<MaxPathLength> AsUri() const noexcept;
         AZStd::string StringAsUri() const;
-        constexpr AZStd::fixed_string<MaxPathLength> FixedMaxPathStringAsUri() const noexcept;
+        AZStd::fixed_string<MaxPathLength> FixedMaxPathStringAsUri() const noexcept;
 
         // decomposition
         //! Given a windows path of "C:\O3DE\foo\bar\name.txt" and a posix path of
@@ -582,9 +582,9 @@ namespace AZ::IO
         // as_uri
         //! Models the Python pathlib as_uri method
         //! Percent encodes the path and appends file: to the front
-        constexpr string_type AsUri() const;
+        string_type AsUri() const;
         AZStd::string StringAsUri() const;
-        constexpr AZStd::fixed_string<MaxPathLength> FixedMaxPathStringAsUri() const noexcept;
+        AZStd::fixed_string<MaxPathLength> FixedMaxPathStringAsUri() const noexcept;
 
         // compare
         //! Performs a compare of each of the path parts for equivalence

--- a/Code/Framework/AzCore/AzCore/IO/Path/Path.h
+++ b/Code/Framework/AzCore/AzCore/IO/Path/Path.h
@@ -167,6 +167,12 @@ namespace AZ::IO
         constexpr int Compare(AZStd::string_view pathString) const noexcept;
         constexpr int Compare(const value_type* pathString) const noexcept;
 
+        // string conversion
+        //! The string and wstring functions cannot be constexpr until AZStd::basic_string is made constexpr.
+        //! This cannot occur until C++20 as operator new/delete cannot be used within constexpr functions
+        //! Returns a new instance of an AZStd::string made from the internal string
+        AZStd::string String() const;
+
         // Extension for fixed strings
         //! extension: fixed string types with MaxPathLength capacity
         //! Returns a new instance of an AZStd::fixed_string with capacity of MaxPathLength
@@ -177,6 +183,14 @@ namespace AZ::IO
         //! Replicates the behavior of the Python pathlib as_posix method
         //! by replacing the Windows Path Separator with the Posix Path Seperator
         constexpr AZStd::fixed_string<MaxPathLength> FixedMaxPathStringAsPosix() const noexcept;
+        AZStd::string StringAsPosix() const;
+
+        // as_uri
+        //! Models the Python pathlib as_uri method
+        //! Percent encodes the path and appends file: to the front
+        constexpr AZStd::fixed_string<MaxPathLength> AsUri() const noexcept;
+        AZStd::string StringAsUri() const;
+        constexpr AZStd::fixed_string<MaxPathLength> FixedMaxPathStringAsUri() const noexcept;
 
         // decomposition
         //! Given a windows path of "C:\O3DE\foo\bar\name.txt" and a posix path of
@@ -237,7 +251,7 @@ namespace AZ::IO
         //!    ^            ^
         //! root part    relative part
         [[nodiscard]] constexpr bool HasRelativePath() const;
-        //! checks whether the path has a parent path that  empty
+        //! checks whether the path has a parent path that is empty
         [[nodiscard]] constexpr bool HasParentPath() const;
         //! Checks whether the filename is empty
         [[nodiscard]] constexpr bool HasFilename() const;
@@ -254,6 +268,9 @@ namespace AZ::IO
         [[nodiscard]] constexpr bool IsRelative() const;
         //! Check whether the path is relative to the base path
         [[nodiscard]] constexpr bool IsRelativeTo(const PathView& base) const;
+
+        //! Returns the preferred separator for this instance
+        constexpr const char PreferredSeparator() const noexcept;
 
         //! Normalizes a path in a purely lexical manner.
         //! # Path separators are converted to their preferred path separator
@@ -557,10 +574,17 @@ namespace AZ::IO
 
         // as_posix
         //! Replicates the behavior of the Python pathlib as_posix method
-        //! by replacing the Windows Path Separator with the Posix Path Seperator
+        //! by replacing the Windows Path Separator with the Posix Path Separator
         constexpr string_type AsPosix() const;
         AZStd::string StringAsPosix() const;
         constexpr AZStd::fixed_string<MaxPathLength> FixedMaxPathStringAsPosix() const noexcept;
+
+        // as_uri
+        //! Models the Python pathlib as_uri method
+        //! Percent encodes the path and appends file: to the front
+        constexpr string_type AsUri() const;
+        AZStd::string StringAsUri() const;
+        constexpr AZStd::fixed_string<MaxPathLength> FixedMaxPathStringAsUri() const noexcept;
 
         // compare
         //! Performs a compare of each of the path parts for equivalence
@@ -648,12 +672,8 @@ namespace AZ::IO
         //! Check whether the path is relative to the base path
         [[nodiscard]] constexpr bool IsRelativeTo(const PathView& base) const;
 
-        // decomposition
-        //! Given a windows path of "C:\O3DE\foo\bar\name.txt" and a posix path of
-        //! "/O3DE/foo/bar/name.txt"
-        //! The following functions return the following
-
-        // query
+        //! Returns the preferred separator for this instance
+        constexpr const char PreferredSeparator() const noexcept;
 
         // relative paths
         //! Normalizes a path in a purely lexical manner.
@@ -739,6 +759,7 @@ namespace AZ::IO
 
 namespace AZ
 {
+    AZ_TYPE_INFO_SPECIALIZE(AZ::IO::PathView, "{A3F81F4A-F87C-4CD6-8328-7E9C9C83D131}");
     AZ_TYPE_INFO_SPECIALIZE(AZ::IO::Path, "{88E0A40F-3085-4CAB-8B11-EF5A2659C71A}");
     AZ_TYPE_INFO_SPECIALIZE(AZ::IO::FixedMaxPath, "{FA6CA49F-376A-417C-9767-DD50744DF203}");
 }

--- a/Code/Framework/AzCore/AzCore/IO/Path/Path.inl
+++ b/Code/Framework/AzCore/AzCore/IO/Path/Path.inl
@@ -13,14 +13,6 @@
 
 #include <AzCore/IO/Path/PathIterable.inl>
 
-namespace AZ::IO::Internal
-{
-    // Helper function for url quoting a relative path string
-    // Only implemented in Path.cpp for AZStd::string and AZStd::fixed_string<MaxPathLength>
-    template <class StringType>
-    StringType AsUri(const PathView& pathView) noexcept;
-}
-
 //! PathView implementation
 namespace AZ::IO
 {
@@ -222,18 +214,6 @@ namespace AZ::IO
         AZStd::fixed_string<MaxPathLength> resultPath(m_path.begin(), m_path.end());
         AZStd::replace(resultPath.begin(), resultPath.end(), AZ::IO::WindowsPathSeparator, AZ::IO::PosixPathSeparator);
         return resultPath;
-    }
-
-    // as_uri
-    // Encodes the path suitable for using in a URI
-    AZStd::fixed_string<MaxPathLength> PathView::AsUri() const noexcept
-    {
-        return FixedMaxPathStringAsUri();
-    }
-
-    AZStd::fixed_string<MaxPathLength> PathView::FixedMaxPathStringAsUri() const noexcept
-    {
-        return Internal::AsUri<AZStd::fixed_string<MaxPathLength>>(*this);
     }
 
     // decomposition
@@ -1052,25 +1032,6 @@ namespace AZ::IO
         AZStd::fixed_string<MaxPathLength> resultPath(m_path.begin(), m_path.end());
         AZStd::replace(resultPath.begin(), resultPath.end(), WindowsPathSeparator, PosixPathSeparator);
         return resultPath;
-    }
-
-    // as_uri
-    // Encodes the path suitable for using in a URI
-    template <typename StringType>
-    auto BasicPath<StringType>::AsUri() const -> string_type
-    {
-        return Internal::AsUri<string_type>(*this);
-    }
-    template <typename StringType>
-    AZStd::string BasicPath<StringType>::StringAsUri() const
-    {
-        return Internal::AsUri<AZStd::string>(*this);
-    }
-
-    template <typename StringType>
-    AZStd::fixed_string<MaxPathLength> BasicPath<StringType>::FixedMaxPathStringAsUri() const noexcept
-    {
-        return Internal::AsUri<AZStd::fixed_string<MaxPathLength>>(*this);
     }
 
     template <typename StringType>

--- a/Code/Framework/AzCore/AzCore/IO/Path/Path.inl
+++ b/Code/Framework/AzCore/AzCore/IO/Path/Path.inl
@@ -18,7 +18,7 @@ namespace AZ::IO::Internal
     // Helper function for url quoting a relative path string
     // Only implemented in Path.cpp for AZStd::string and AZStd::fixed_string<MaxPathLength>
     template <class StringType>
-    extern constexpr StringType AsUri(const PathView& pathView) noexcept;
+    StringType AsUri(const PathView& pathView) noexcept;
 }
 
 //! PathView implementation
@@ -226,12 +226,12 @@ namespace AZ::IO
 
     // as_uri
     // Encodes the path suitable for using in a URI
-    constexpr AZStd::fixed_string<MaxPathLength> PathView::AsUri() const noexcept
+    AZStd::fixed_string<MaxPathLength> PathView::AsUri() const noexcept
     {
         return FixedMaxPathStringAsUri();
     }
 
-    constexpr AZStd::fixed_string<MaxPathLength> PathView::FixedMaxPathStringAsUri() const noexcept
+    AZStd::fixed_string<MaxPathLength> PathView::FixedMaxPathStringAsUri() const noexcept
     {
         return Internal::AsUri<AZStd::fixed_string<MaxPathLength>>(*this);
     }
@@ -1057,7 +1057,7 @@ namespace AZ::IO
     // as_uri
     // Encodes the path suitable for using in a URI
     template <typename StringType>
-    constexpr auto BasicPath<StringType>::AsUri() const -> string_type
+    auto BasicPath<StringType>::AsUri() const -> string_type
     {
         return Internal::AsUri<string_type>(*this);
     }
@@ -1068,7 +1068,7 @@ namespace AZ::IO
     }
 
     template <typename StringType>
-    constexpr AZStd::fixed_string<MaxPathLength> BasicPath<StringType>::FixedMaxPathStringAsUri() const noexcept
+    AZStd::fixed_string<MaxPathLength> BasicPath<StringType>::FixedMaxPathStringAsUri() const noexcept
     {
         return Internal::AsUri<AZStd::fixed_string<MaxPathLength>>(*this);
     }

--- a/Code/Framework/AzCore/AzCore/IO/Path/PathReflect.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Path/PathReflect.cpp
@@ -205,14 +205,14 @@ namespace AZ::IO
             // Conversion function to allow interoperability with PathView class
             ->Method("ToPurePathView", &PathType::operator PathView)
             ->Method("__truediv__", [](const PathType* thisPtr, const AZ::IO::PathView& src) -> PathType { return *thisPtr / src; })
-                ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::Div)
+            ->Method("__div", [](const PathType* thisPtr, const AZ::IO::PathView& src) -> PathType { return *thisPtr / src; }) // Lua operator /
             ->Method("__hash__", [](const PathType* thisPtr) -> AZ::u64 { return static_cast<AZ::u64>(AZ::IO::hash_value(*thisPtr)); })
             ->Method("__str__", &PathType::String)
                 ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::ToString)
             ->Method("__eq__", [](const PathType& left, const PathView& right) -> bool { return left == right; })
-                ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::Equal)
+            ->Method("__eq", [](const PathType& left, const PathView& right) -> bool { return left == right; }) // Lua operator==
             ->Method("__lt__", [](const PathType& left, const PathView& right) -> bool { return left < right; })
-                ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::LessThan)
+            ->Method("__lt", [](const PathType& left, const PathView& right) -> bool { return left < right; }) // Lua operator <
             ->Method("__ne__", [](const PathType& left, const PathView& right) -> bool { return left != right; })
             ->Method("__gt__", [](const PathType& left, const PathView& right) -> bool { return left > right; })
             ->Method("__le__", [](const PathType& left, const PathView& right) -> bool { return left <= right; })

--- a/Code/Framework/AzCore/AzCore/IO/Path/PathReflect.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Path/PathReflect.cpp
@@ -7,10 +7,12 @@
  */
 
 #include <AzCore/IO/Path/Path.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <AzCore/Serialization/Json/PathSerializer.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/functional.h>
+#include <AzCore/StringFunc/StringFunc.h>
 
 namespace AZ::IO
 {
@@ -59,6 +61,229 @@ namespace AZ::IO
         }
     };
 
+    void PathViewBehaviorReflect(AZ::BehaviorContext* behaviorContext)
+    {
+        // Replicates the python 3 pathlib API: https://docs.python.org/3/library/pathlib.html
+        behaviorContext->Class<PathView>("PurePathView")
+            ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+            ->Attribute(AZ::Script::Attributes::Module, "pathlib")
+            ->Attribute(AZ::Script::Attributes::Category, "FilesystemPath")
+            ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
+            ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::Value)
+            // string_view constructor
+            ->template Constructor<AZStd::string_view>()
+            // string_view constructor with preferred path separator
+            ->template Constructor<AZStd::string_view, const char>()
+            // const char* constructor
+            ->template Constructor<const typename PathView::value_type*>()
+            // const char* constructor with preferred path separator
+            ->template Constructor<const typename PathView::value_type*, const char>()
+            // preferred path separator only constructor
+            ->template Constructor<const char>()
+            ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::ToString)
+            ->Method("__truediv__", [](const PathView* thisPtr, const AZ::IO::PathView* src) -> PathView
+            {
+                    return FixedMaxPath(*thisPtr) / *src;
+            })
+                ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::Div)
+            ->Method("__hash__", [](const PathView* thisPtr) -> AZ::u64 { return static_cast<AZ::u64>(AZ::IO::hash_value(*thisPtr)); })
+            ->Method("__str__", &PathView::String)
+                ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::ToString)
+            ->Method("__eq__", [](const PathView* left, const PathView* right) -> bool { return *left == *right; })
+                ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::Equal)
+            ->Method("__lt__", [](const PathView* left, const PathView* right) -> bool { return *left < *right; })
+                ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::LessThan)
+            ->Method("__ne__", [](const PathView* left, const PathView* right) -> bool { return *left != *right; })
+            ->Method("__gt__", [](const PathView* left, const PathView* right) -> bool { return *left > *right; })
+            ->Method("__le__", [](const PathView* left, const PathView* right) -> bool { return *left <= *right; })
+            ->Method("__ge__", [](const PathView* left, const PathView* right) -> bool { return *left >= *right; })
+            // No setters for the path class properties
+            ->Property("parts", [](const PathView* thisPtr) -> AZStd::vector<PathView>
+            {
+                // Initialize the parts with the RootPath value which includes any drive letters and root directory
+                AZStd::vector<PathView> parts{ thisPtr->RootPath()};
+                // Append each relative path part using the Path iterator code
+                PathView postRootNamePath = thisPtr->RelativePath();
+                parts.insert(parts.end(), postRootNamePath.begin(), postRootNamePath.end());
+                return parts;
+            }, nullptr)
+            ->Property("drive", [](const PathView* thisPtr) -> AZStd::string { return thisPtr->RootName().String(); }, nullptr)
+            ->Property("root", [](const PathView* thisPtr) -> AZStd::string { return thisPtr->RootDirectory().String(); }, nullptr)
+            ->Property("anchor", [](const PathView* thisPtr) -> AZStd::string { return thisPtr->RootPath().String(); }, nullptr)
+            ->Property("parents", [](const PathView* thisPtr) -> AZStd::vector<PathView>
+            {
+                AZStd::vector<PathView> parentPaths;
+                AZ::IO::PathView currentPath(*thisPtr);
+                for(AZ::IO::PathView parentPath = currentPath.ParentPath(); parentPath != currentPath; parentPath = currentPath.ParentPath())
+                {
+                    parentPaths.emplace_back(parentPath);
+                    currentPath = parentPath;
+                }
+                return parentPaths;
+            }, nullptr)
+            ->Property("parent", [](const PathView* thisPtr) -> PathView { return thisPtr->ParentPath(); }, nullptr)
+            ->Property("name", [](const PathView* thisPtr) -> AZStd::string { return thisPtr->Filename().String(); }, nullptr)
+            ->Property("suffixes", [](const PathView* thisPtr) -> AZStd::vector<AZStd::string>
+            {
+                AZStd::vector<AZStd::string> suffixes;
+                auto GetSuffixes = [&suffixes](AZStd::string_view token)
+                {
+                    // suffixes are always output with leading <dot> '.'
+                    suffixes.emplace_back(AZStd::string::format(".%.*s", AZ_STRING_ARG(token)));
+                };
+                // Skip past the shortest stem.
+                // Ex. filename.material.materialtype -> material.materialtype
+                AZ::IO::PathView postShortestStem = thisPtr->Filename();
+                AZ::StringFunc::TokenizeNext(postShortestStem.Native(), '.');
+                // Only suffixes of the filename exist at this point so split on the "." character
+                AZ::StringFunc::TokenizeVisitor(postShortestStem.Native(), GetSuffixes, '.');
+                return suffixes;
+            }, nullptr)
+            ->Property("suffix", [](const PathView* thisPtr) -> AZStd::string { return thisPtr->Extension().String(); }, nullptr)
+            ->Property("stem", [](const PathView* thisPtr) -> AZStd::string { return thisPtr->Stem().String(); }, nullptr)
+            ->Method("as_posix", &PathView::StringAsPosix)
+            ->Method("as_uri", &PathView::StringAsUri)
+            ->Method("match", &PathView::Match)
+            ->Method("is_absolute", &PathView::IsAbsolute)
+            ->Method("is_relative_to", &PathView::IsRelativeTo)
+            ->Method("relative_to", &PathView::IsAbsolute)
+            ->Method("with_name", [](const PathView* thisPtr, AZStd::string_view name) -> FixedMaxPath
+            {
+                return thisPtr->LexicallyNormal().ReplaceFilename(name);
+            })
+            ->Method("with_stem", [](const PathView* thisPtr, AZStd::string_view stem) -> PathView
+            {
+                auto stemReplacedFilename = FixedMaxPathString(stem);
+                stemReplacedFilename += thisPtr->Extension().Native();
+                return thisPtr->LexicallyNormal().ReplaceFilename(AZ::IO::PathView(stemReplacedFilename));
+            })
+            ->Method("with_suffix", [](const PathView* thisPtr, AZStd::string_view suffix) -> PathView
+            {
+                return thisPtr->LexicallyNormal().ReplaceExtension(suffix);
+            })
+        ;
+    }
+
+    template <class PathType>
+    void PathBehaviorReflect(AZ::BehaviorContext* behaviorContext)
+    {
+        const char* className = "";
+        if constexpr (AZStd::is_same_v<PathType, Path>)
+        {
+            className = "PurePath";
+        }
+        else if constexpr (AZStd::is_same_v<PathType, FixedMaxPath>)
+        {
+            className = "PureFixedMaxPath";
+        }
+
+        // Replicates the python 3 pathlib API: https://docs.python.org/3/library/pathlib.html
+        behaviorContext->Class<PathType>(className)
+            ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+            ->Attribute(AZ::Script::Attributes::Module, "pathlib")
+            ->Attribute(AZ::Script::Attributes::Category, "FilesystemPath")
+            ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
+            ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::Value)
+            // PathView constructor
+            ->template Constructor<AZ::IO::PathView>()
+            // <string type> constructor
+            ->template Constructor<const typename PathType::string_type&>()
+            // <string type> constructor with preferred path separator
+            ->template Constructor<const typename PathType::string_type&, const char>()
+            // string_view constructor
+            ->template Constructor<AZStd::string_view>()
+            // string_view constructor with preferred path separator
+            ->template Constructor<AZStd::string_view, const char>()
+            // const char* constructor
+            ->template Constructor<const typename PathType::value_type*>()
+            // const char* constructor with preferred path separator
+            ->template Constructor<const typename PathType::value_type*, const char>()
+            // preferred path separator only constructor
+            ->template Constructor<const char>()
+            ->template WrappingMember<const char*>(&PathType::c_str)
+            ->Method("c_str", &PathType::c_str)
+            // Conversion function to allow interoperability with PathView class
+            ->Method("ToPurePathView", &PathType::operator PathView)
+            ->Method("__truediv__", [](const PathType* thisPtr, const AZ::IO::PathView& src) -> PathType { return *thisPtr / src; })
+                ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::Div)
+            ->Method("__hash__", [](const PathType* thisPtr) -> AZ::u64 { return static_cast<AZ::u64>(AZ::IO::hash_value(*thisPtr)); })
+            ->Method("__str__", &PathType::String)
+                ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::ToString)
+            ->Method("__eq__", [](const PathType& left, const PathView& right) -> bool { return left == right; })
+                ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::Equal)
+            ->Method("__lt__", [](const PathType& left, const PathView& right) -> bool { return left < right; })
+                ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::LessThan)
+            ->Method("__ne__", [](const PathType& left, const PathView& right) -> bool { return left != right; })
+            ->Method("__gt__", [](const PathType& left, const PathView& right) -> bool { return left > right; })
+            ->Method("__le__", [](const PathType& left, const PathView& right) -> bool { return left <= right; })
+            ->Method("__ge__", [](const PathType& left, const PathView& right) -> bool { return left >= right; })
+            // No setters for the path class properties
+            ->Property("parts", [](const PathType* thisPtr) -> AZStd::vector<PathType>
+            {
+                // Initialize the parts with the RootPath value which includes any drive letters and root directory
+                AZStd::vector<PathType> parts{ thisPtr->RootPath() };
+                // Append each relative path part using the Path iterator code
+                PathView postRootNamePath = thisPtr->RelativePath();
+                parts.insert(parts.end(), postRootNamePath.begin(), postRootNamePath.end());
+                return parts;
+            }, nullptr)
+            ->Property("drive", [](const PathType* thisPtr) -> AZStd::string { return thisPtr->RootName().String(); }, nullptr)
+            ->Property("root", [](const PathType* thisPtr) -> AZStd::string { return thisPtr->RootDirectory().String(); }, nullptr)
+            ->Property("anchor", [](const PathType* thisPtr) -> AZStd::string { return thisPtr->RootPath().String(); }, nullptr)
+            ->Property("parents", [](const PathType* thisPtr) -> AZStd::vector<PathType>
+            {
+                AZStd::vector<PathType> parentPaths;
+                AZ::IO::PathView currentPath(*thisPtr);
+                for(AZ::IO::PathView parentPath = currentPath.ParentPath(); parentPath != currentPath; parentPath = currentPath.ParentPath())
+                {
+                    parentPaths.emplace_back(parentPath);
+                    currentPath = parentPath;
+                }
+                return parentPaths;
+            }, nullptr)
+            ->Property("parent", [](const PathType* thisPtr) -> PathType { return thisPtr->ParentPath(); }, nullptr)
+            ->Property("name", [](const PathType* thisPtr) -> AZStd::string { return thisPtr->Filename().String(); }, nullptr)
+            ->Property("suffixes", [](const PathType* thisPtr) -> AZStd::vector<AZStd::string>
+            {
+                AZStd::vector<AZStd::string> suffixes;
+                auto GetSuffixes = [&suffixes](AZStd::string_view token)
+                {
+                    // suffixes are always output with leading <dot> '.'
+                    suffixes.emplace_back(AZStd::string::format(".%.*s", AZ_STRING_ARG(token)));
+                };
+                // Skip past the shortest stem.
+                // Ex. filename.material.materialtype -> material.materialtype
+                AZ::IO::PathView postShortestStem = thisPtr->Filename();
+                AZ::StringFunc::TokenizeNext(postShortestStem.Native(), '.');
+                // Only suffixes of the filename exist at this point so split on the "." character
+                AZ::StringFunc::TokenizeVisitor(postShortestStem.Native(), GetSuffixes, '.');
+                return suffixes;
+            }, nullptr)
+            ->Property("suffix", [](const PathType* thisPtr) -> AZStd::string { return thisPtr->Extension().String(); }, nullptr)
+            ->Property("stem", [](const PathType* thisPtr) -> AZStd::string { return thisPtr->Stem().String(); }, nullptr)
+            ->Method("as_posix", &PathType::StringAsPosix)
+            ->Method("as_uri", &PathType::StringAsUri)
+            ->Method("match", &PathType::Match)
+            ->Method("is_absolute", &PathType::IsAbsolute)
+            ->Method("is_relative_to", &PathType::IsRelativeTo)
+            ->Method("relative_to", &PathType::IsAbsolute)
+            ->Method("with_name", [](const PathType* thisPtr, AZStd::string_view name) -> PathType
+            {
+                return PathType(*thisPtr).ReplaceFilename(name);
+            })
+            ->Method("with_stem", [](const PathType* thisPtr, AZStd::string_view stem) -> PathType
+            {
+                auto stemReplacedFilename = typename PathType::string_type(stem);
+                stemReplacedFilename += thisPtr->Extension().Native();
+                return PathType(*thisPtr).ReplaceFilename(AZ::IO::PathView(stemReplacedFilename));
+            })
+            ->Method("with_suffix", [](const PathType* thisPtr, AZStd::string_view suffix) -> PathType
+            {
+                return PathType(*thisPtr).ReplaceExtension(suffix);
+            })
+        ;
+    }
+
     void PathReflect(AZ::ReflectContext* context)
     {
         if (auto serializeContext = azrtti_cast<SerializeContext*>(context); serializeContext != nullptr)
@@ -78,6 +303,12 @@ namespace AZ::IO
             jsonContext->Serializer<JsonPathSerializer>()
                 ->HandlesType<Path>()
                 ->HandlesType<FixedMaxPath>();
+        }
+        else if (auto behaviorContext = azrtti_cast<BehaviorContext*>(context); behaviorContext != nullptr)
+        {
+            PathViewBehaviorReflect(behaviorContext);
+            PathBehaviorReflect<Path>(behaviorContext);
+            PathBehaviorReflect<FixedMaxPath>(behaviorContext);
         }
     }
 }

--- a/Code/Framework/AzCore/AzCore/RTTI/AzStdOnDemandReflection.inl
+++ b/Code/Framework/AzCore/AzCore/RTTI/AzStdOnDemandReflection.inl
@@ -40,10 +40,6 @@ namespace AZStd
     class unordered_set;
     template<AZStd::size_t NumBits>
     class bitset;
-    template<class Element, class Traits, class Allocator>
-    class basic_string;
-    template<class Element>
-    struct char_traits;
 
     template<class T>
     class intrusive_ptr;
@@ -72,45 +68,11 @@ namespace AZ
     namespace CommonOnDemandReflections
     {
         void ReflectCommonString(ReflectContext* context);
+        void ReflectCommonFixedString(ReflectContext* context);
         void ReflectCommonStringView(ReflectContext* context);
         void ReflectStdAny(ReflectContext* context);
         void ReflectVoidOutcome(ReflectContext* context);
     }
-    /// OnDemand reflection for AZStd::basic_string
-    template<class Element, class Traits, class Allocator>
-    struct OnDemandReflection< AZStd::basic_string<Element, Traits, Allocator> >
-    {
-        using ContainerType = AZStd::basic_string<Element, Traits, Allocator>;
-        using SizeType = typename ContainerType::size_type;
-        using ValueType = typename ContainerType::value_type;
-
-        static void Reflect(ReflectContext* context)
-        {
-            constexpr bool is_string = AZStd::is_same_v<Element, char> && AZStd::is_same_v<Traits, AZStd::char_traits<char>>
-                    && AZStd::is_same_v<Allocator, AZStd::allocator>;
-            if constexpr(is_string)
-            {
-                CommonOnDemandReflections::ReflectCommonString(context);
-            }
-            static_assert (is_string, "Unspecialized basic_string<> template reflection requested.");
-        }
-    };
-
-    /// OnDemand reflection for AZStd::basic_string_view
-    template<class Element, class Traits>
-    struct OnDemandReflection< AZStd::basic_string_view<Element, Traits> >
-    {
-        using ContainerType = AZStd::basic_string_view<Element, Traits>;
-        using SizeType = typename ContainerType::size_type;
-        using ValueType = typename ContainerType::value_type;
-
-        static void Reflect(ReflectContext* context)
-        {
-            constexpr bool is_common = AZStd::is_same_v<Element,char> && AZStd::is_same_v<Traits,AZStd::char_traits<char>>;
-            static_assert (is_common, "Unspecialized basic_string_view<> template reflection requested.");
-            CommonOnDemandReflections::ReflectCommonStringView(context);
-        }
-    };
 
     /// OnDemand reflection for AZStd::intrusive_ptr
     template<class T>

--- a/Code/Framework/AzCore/AzCore/RTTI/AzStdOnDemandReflectionLuaFunctions.inl
+++ b/Code/Framework/AzCore/AzCore/RTTI/AzStdOnDemandReflectionLuaFunctions.inl
@@ -30,7 +30,7 @@ namespace AZ
         {
             using ContainerType = AZStd::basic_string_view<Element, Traits>;
 
-            // TODO: Count reflection types for a proper un-reflect 
+            // TODO: Count reflection types for a proper un-reflect
             if (dc.GetNumArguments() == 1)
             {
                 if (dc.IsString(0))
@@ -47,12 +47,10 @@ namespace AZ
             }
         }
 
-        template<class Element, class Traits, class Allocator>
-        inline void ConstructBasicString(AZStd::basic_string<Element, Traits, Allocator>* thisPtr, ScriptDataContext& dc)
+        template<class ContainerType>
+        inline void ConstructBasicString(ContainerType* thisPtr, ScriptDataContext& dc)
         {
-            using ContainerType = AZStd::basic_string<Element, Traits, Allocator>;
-
-            // TODO: Count reflection types for a proper un-reflect 
+            // TODO: Count reflection types for a proper un-reflect
             if (dc.GetNumArguments() == 1)
             {
                 if (dc.IsString(0))
@@ -67,7 +65,7 @@ namespace AZ
                 }
             }
         }
-        
+
         // Read a Lua native string as a C++ string class
         template<typename StringType>
         inline bool StringTypeFromLua(lua_State* lua, int stackIndex, BehaviorArgument& value, BehaviorClass* valueClass, ScriptContext::StackVariableAllocator* stackTempAllocator)

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.cpp
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.cpp
@@ -430,10 +430,18 @@ namespace AZ
         return this;
     }
 
-    //=========================================================================
-    // BehaviorContext
-    //=========================================================================
-    BehaviorContext::BehaviorContext() = default;
+    // Reflect the following types by default
+    // AZStd::string
+    // AZStd::string_view
+    // AZStd::fixed_string<1024>
+    // This skips over the need to reflect the type via OnDemandReflection system
+    // saving build time across the board
+    BehaviorContext::BehaviorContext()
+    {
+        CommonOnDemandReflections::ReflectCommonString(this);
+        CommonOnDemandReflections::ReflectCommonFixedString(this);
+        CommonOnDemandReflections::ReflectCommonStringView(this);
+    }
 
     //=========================================================================
     // ~BehaviorContext

--- a/Code/Framework/AzCore/AzCore/Utils/Utils.cpp
+++ b/Code/Framework/AzCore/AzCore/Utils/Utils.cpp
@@ -94,7 +94,7 @@ namespace AZ::Utils
             }
         }
 
-        // If the O3DEManifest key isn't set in teh settings registry
+        // If the O3DEManifest key isn't set in the settings registry
         // fallback to use the user's home directory with the .o3de folder appended to it
         AZ::IO::FixedMaxPath path = GetHomeDirectory(settingsRegistry);
         path /= ".o3de";

--- a/Code/Framework/AzCore/AzCore/Utils/Utils.cpp
+++ b/Code/Framework/AzCore/AzCore/Utils/Utils.cpp
@@ -229,11 +229,46 @@ namespace AZ::Utils
             settingsRegistry = AZ::SettingsRegistry::Get();
         }
 
-
         if (settingsRegistry != nullptr)
         {
             if (AZ::IO::FixedMaxPathString settingsValue;
                 settingsRegistry->Get(settingsValue, AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectUserPath))
+            {
+                return settingsValue;
+            }
+        }
+        return {};
+    }
+
+    AZ::IO::FixedMaxPathString GetProjectLogPath(AZ::SettingsRegistryInterface* settingsRegistry)
+    {
+        if (settingsRegistry == nullptr)
+        {
+            settingsRegistry = AZ::SettingsRegistry::Get();
+        }
+
+        if (settingsRegistry != nullptr)
+        {
+            if (AZ::IO::FixedMaxPathString settingsValue;
+                settingsRegistry->Get(settingsValue, AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectLogPath))
+            {
+                return settingsValue;
+            }
+        }
+        return {};
+    }
+
+    AZ::IO::FixedMaxPathString GetProjectProductPathForPlatform(AZ::SettingsRegistryInterface* settingsRegistry)
+    {
+        if (settingsRegistry == nullptr)
+        {
+            settingsRegistry = AZ::SettingsRegistry::Get();
+        }
+
+        if (settingsRegistry != nullptr)
+        {
+            if (AZ::IO::FixedMaxPathString settingsValue;
+                settingsRegistry->Get(settingsValue, AZ::SettingsRegistryMergeUtils::FilePathKey_CacheRootFolder))
             {
                 return settingsValue;
             }

--- a/Code/Framework/AzCore/AzCore/Utils/Utils.h
+++ b/Code/Framework/AzCore/AzCore/Utils/Utils.h
@@ -87,6 +87,20 @@ namespace AZ
         //! If nullptr, the AZ::Interface instance of the SettingsRegistry is used
         AZ::IO::FixedMaxPathString GetProjectUserPath(AZ::SettingsRegistryInterface* settingsRegistry = nullptr);
 
+        //! Retrieves the full path to the project log path from the settings registry
+        //! This path defaults to <project-user-path>/logs, but can be overridden via the --project-log-path option
+        //! @param settingsRegistry pointer to the SettingsRegistry to use for lookup
+        //! If nullptr, the AZ::Interface instance of the SettingsRegistry is used
+        AZ::IO::FixedMaxPathString GetProjectLogPath(AZ::SettingsRegistryInterface* settingsRegistry = nullptr);
+
+        //! Retrieves the full path to the project  path for the current asset platform from the settings registry
+        //! This path is based on <project-cache-path>/<asset-platform>,
+        //! where on Windows <asset-platform> = "pc", Linux  <asset-platform> = linux, etc...
+        //! The list of OS -> asst platforms is available in the `AZ::PlatformDefaults::OSPlatformToDefaultAssetPlatform` fuction
+        //! @param settingsRegistry pointer to the SettingsRegistry to use for lookup
+        //! If nullptr, the AZ::Interface instance of the SettingsRegistry is used
+        AZ::IO::FixedMaxPathString GetProjectProductPathForPlatform(AZ::SettingsRegistryInterface* settingsRegistry = nullptr);
+
         //! Retrieves the project name from the settings registry
         //! @param settingsRegistry pointer to the SettingsRegistry to use for lookup
         //! If nullptr, the AZ::Interface instance of the SettingsRegistry is used

--- a/Code/Framework/AzCore/Tests/BehaviorContext.cpp
+++ b/Code/Framework/AzCore/Tests/BehaviorContext.cpp
@@ -43,7 +43,7 @@ namespace UnitTest
             Counter0::Reset();
 
             m_context.Class<Counter0>("Counter0")
-                ->Property("val", static_cast<int& (Counter0::*)()>(&Counter0::val), nullptr);            
+                ->Property("val", static_cast<int& (Counter0::*)()>(&Counter0::val), nullptr);
 
             m_context.Class<TypingStruct>("TypingStruct")
                 ->Property("stringValue", BehaviorValueGetter(&TypingStruct::m_stringValue), BehaviorValueSetter(&TypingStruct::m_stringValue))
@@ -73,7 +73,7 @@ namespace UnitTest
 
         if (findIter != m_typingClass->m_properties.end())
         {
-            EXPECT_EQ(AZ::BehaviorParameter::TR_STRING, findIter->second->m_getter->GetResult()->m_traits & AZ::BehaviorParameter::TR_STRING);            
+            EXPECT_EQ(AZ::BehaviorParameter::TR_STRING, findIter->second->m_getter->GetResult()->m_traits & AZ::BehaviorParameter::TR_STRING);
         }
     }
 
@@ -198,7 +198,7 @@ namespace UnitTest
             ;
     }
 
-    void MethodAcceptingTemplate(const AZStd::string&)
+    void MethodAcceptingTemplate(const AZStd::vector<int>&)
     { }
 
 
@@ -206,15 +206,15 @@ namespace UnitTest
     {
         // Test reflecting with OnDemandReflection
         m_behaviorContext.Method("TestTemplatedOnDemandReflection", &MethodAcceptingTemplate);
-        EXPECT_TRUE(m_behaviorContext.IsOnDemandTypeReflected(azrtti_typeid<AZStd::string>()));
-        EXPECT_NE(m_behaviorContext.m_typeToClassMap.find(azrtti_typeid<AZStd::string>()), m_behaviorContext.m_typeToClassMap.end());
+        EXPECT_TRUE(m_behaviorContext.IsOnDemandTypeReflected(azrtti_typeid<AZStd::vector<int>>()));
+        EXPECT_NE(m_behaviorContext.m_typeToClassMap.find(azrtti_typeid<AZStd::vector<int>>()), m_behaviorContext.m_typeToClassMap.end());
 
         // Test unreflecting OnDemandReflection
         m_behaviorContext.EnableRemoveReflection();
         m_behaviorContext.Method("TestTemplatedOnDemandReflection", &MethodAcceptingTemplate);
         m_behaviorContext.DisableRemoveReflection();
-        EXPECT_FALSE(m_behaviorContext.IsOnDemandTypeReflected(azrtti_typeid<AZStd::string>()));
-        EXPECT_EQ(m_behaviorContext.m_typeToClassMap.find(azrtti_typeid<AZStd::string>()), m_behaviorContext.m_typeToClassMap.end());
+        EXPECT_FALSE(m_behaviorContext.IsOnDemandTypeReflected(azrtti_typeid<AZStd::vector<int>>()));
+        EXPECT_EQ(m_behaviorContext.m_typeToClassMap.find(azrtti_typeid<AZStd::vector<int>>()), m_behaviorContext.m_typeToClassMap.end());
     }
 
     // Used for on demand reflection to pick up the vector and string types
@@ -438,7 +438,6 @@ namespace UnitTest
         const AZ::Uuid stringTypeid = AZ::AzTypeInfo<AZStd::string>::Uuid();
         auto stringClassIt = m_behaviorContext.m_typeToClassMap.find(stringTypeid);
         EXPECT_NE(m_behaviorContext.m_typeToClassMap.end(), stringClassIt);
-        EXPECT_TRUE(m_behaviorContext.IsOnDemandTypeReflected(stringTypeid));
 
         // Validate that OnDemandReflection works for all handler member functions
         const AZ::Uuid stringToStringMapTypeid = AZ::AzTypeInfo<AZStd::unordered_map<AZStd::string, AZStd::string>>::Uuid();

--- a/Code/Framework/AzCore/Tests/IO/Path/PathReflectTests.cpp
+++ b/Code/Framework/AzCore/Tests/IO/Path/PathReflectTests.cpp
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/IO/Path/PathReflect.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/Utils.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace UnitTest
+{
+    template <typename ParamType>
+    class PathSerializationParamFixture
+        : public LeakDetectionFixture
+        , public ::testing::WithParamInterface<ParamType>
+    {
+    public:
+        // We must expose the class for serialization first.
+        void SetUp() override
+        {
+            m_serializeContext = AZStd::make_unique<AZ::SerializeContext>();
+            AZ::IO::PathReflect(m_serializeContext.get());
+
+        }
+
+        void TearDown() override
+        {
+            m_serializeContext->EnableRemoveReflection();
+            AZ::IO::PathReflect(m_serializeContext.get());
+            m_serializeContext->DisableRemoveReflection();
+
+            m_serializeContext.reset();
+        }
+
+    protected:
+        AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;
+    };
+
+    struct PathSerializationParams
+    {
+        const char m_preferredSeparator{};
+        const char* m_testPath{};
+    };
+    using PathSerializationFixture = PathSerializationParamFixture<PathSerializationParams>;
+
+    TEST_P(PathSerializationFixture, PathSerializer_SerializesStringBackedPath_Succeeds)
+    {
+        const auto& testParams = GetParam();
+        {
+            // Path serialization
+            AZ::IO::Path testPath{ testParams.m_testPath, testParams.m_preferredSeparator };
+
+            AZStd::vector<char> byteBuffer;
+            AZ::IO::ByteContainerStream byteStream(&byteBuffer);
+            auto objStream = AZ::ObjectStream::Create(&byteStream, *m_serializeContext, AZ::ObjectStream::ST_XML);
+            objStream->WriteClass(&testPath);
+            objStream->Finalize();
+
+            byteStream.Seek(0, AZ::IO::GenericStream::ST_SEEK_BEGIN);
+
+            AZ::IO::Path loadPath{ testParams.m_preferredSeparator };
+            EXPECT_TRUE(AZ::Utils::LoadObjectFromStreamInPlace(byteStream, loadPath, m_serializeContext.get()));
+            EXPECT_EQ(testPath.LexicallyNormal(), loadPath);
+        }
+
+        {
+            // FixedMaxPath serialization
+            AZ::IO::FixedMaxPath testFixedMaxPath{ testParams.m_testPath, testParams.m_preferredSeparator };
+
+            AZStd::vector<char> byteBuffer;
+            AZ::IO::ByteContainerStream byteStream(&byteBuffer);
+            auto objStream = AZ::ObjectStream::Create(&byteStream, *m_serializeContext, AZ::ObjectStream::ST_XML);
+            objStream->WriteClass(&testFixedMaxPath);
+            objStream->Finalize();
+
+            byteStream.Seek(0, AZ::IO::GenericStream::ST_SEEK_BEGIN);
+
+            AZ::IO::FixedMaxPath loadPath{ testParams.m_preferredSeparator };
+            EXPECT_TRUE(AZ::Utils::LoadObjectFromStreamInPlace(byteStream, loadPath, m_serializeContext.get()));
+            EXPECT_EQ(testFixedMaxPath.LexicallyNormal(), loadPath);
+        }
+    }
+
+    INSTANTIATE_TEST_CASE_P(
+        PathSerialization,
+        PathSerializationFixture,
+        ::testing::Values(
+            PathSerializationParams{ AZ::IO::PosixPathSeparator, "" },
+            PathSerializationParams{ AZ::IO::PosixPathSeparator, "test" },
+            PathSerializationParams{ AZ::IO::PosixPathSeparator, "/test" },
+            PathSerializationParams{ AZ::IO::WindowsPathSeparator, "test" },
+            PathSerializationParams{ AZ::IO::WindowsPathSeparator, "/test" },
+            PathSerializationParams{ AZ::IO::WindowsPathSeparator, "D:test" },
+            PathSerializationParams{ AZ::IO::WindowsPathSeparator, "D:/test" },
+            PathSerializationParams{ AZ::IO::WindowsPathSeparator, "test/foo/../bar" }
+        )
+    );
+
+    template <typename ParamType>
+    class PathBehaviorContextParamFixture
+        : public LeakDetectionFixture
+        , public ::testing::WithParamInterface<ParamType>
+    {
+    public:
+        void SetUp() override
+        {
+            m_behaviorContext = AZStd::make_unique<AZ::BehaviorContext>();
+            AZ::IO::PathReflect(m_behaviorContext.get());
+
+        }
+
+        void TearDown() override
+        {
+            m_behaviorContext.reset();
+        }
+
+    protected:
+        AZStd::unique_ptr<AZ::BehaviorContext> m_behaviorContext;
+    };
+
+    using PathScriptingParamFixture = PathBehaviorContextParamFixture<PathSerializationParams>;
+
+    TEST_P(PathScriptingParamFixture, PathViewClass_IsAccessibleInScripting_Succeeds)
+    {
+        auto testParams = GetParam();
+        const AZ::BehaviorClass* pathClass = m_behaviorContext->FindClassByReflectedName("PurePathView");
+        ASSERT_NE(nullptr, pathClass);
+
+        AZStd::fixed_vector<AZ::BehaviorArgument, 8> behaviorArguments;
+        behaviorArguments.emplace_back(&testParams.m_testPath);
+        behaviorArguments.emplace_back(&testParams.m_preferredSeparator);
+        auto scopedPathViewObject = pathClass->CreateWithScope(behaviorArguments);
+        ASSERT_TRUE(scopedPathViewObject.IsValid());
+        auto pathViewPtr = scopedPathViewObject.m_behaviorObject.m_rttiHelper->Cast<AZ::IO::PathView>(
+            scopedPathViewObject.m_behaviorObject.m_address);
+        ASSERT_NE(nullptr, pathViewPtr) << "Cast to AZ::IO::PathView has failed";
+
+        // Get the PathView string value
+        auto strMethod = pathClass->FindMethodByReflectedName("__str__");
+        ASSERT_NE(nullptr, strMethod);
+
+        AZ::IO::Path result(testParams.m_preferredSeparator);
+        ASSERT_TRUE(strMethod->InvokeResult(result.Native(), pathViewPtr));
+        EXPECT_EQ(testParams.m_testPath, result);
+    }
+
+    TEST_P(PathScriptingParamFixture, PathClass_IsAccessibleInScripting_Succeeds)
+    {
+        {
+            auto testParams = GetParam();
+            const AZ::BehaviorClass* pathClass = m_behaviorContext->FindClassByReflectedName("PurePath");
+            ASSERT_NE(nullptr, pathClass);
+
+            AZStd::fixed_vector<AZ::BehaviorArgument, 8> behaviorArguments;
+
+            // Try with PathView
+            AZ::IO::PathView pathView(testParams.m_testPath, testParams.m_preferredSeparator);
+            behaviorArguments.emplace_back(&pathView);
+            auto scopedPathObject = pathClass->CreateWithScope(behaviorArguments);
+            ASSERT_TRUE(scopedPathObject.IsValid());
+            auto pathPtr = scopedPathObject.m_behaviorObject.m_rttiHelper->Cast<AZ::IO::Path>(
+                scopedPathObject.m_behaviorObject.m_address);
+            ASSERT_NE(nullptr, pathPtr) << "Cast to AZ::IO::Path has failed";
+
+            // Get the PathView string value
+            auto strMethod = pathClass->FindMethodByReflectedName("__str__");
+            ASSERT_NE(nullptr, strMethod);
+
+            AZ::IO::Path result(testParams.m_preferredSeparator);
+            ASSERT_TRUE(strMethod->InvokeResult(result.Native(), pathPtr));
+            EXPECT_EQ(testParams.m_testPath, result);
+
+            // Convert back to Path View
+            auto toPathViewMethod = pathClass->FindMethodByReflectedName("ToPurePathView");
+            ASSERT_NE(nullptr, toPathViewMethod);
+            AZ::IO::PathView pathViewResult(testParams.m_preferredSeparator);
+            ASSERT_TRUE(toPathViewMethod->InvokeResult(pathViewResult, pathPtr));
+            EXPECT_EQ(pathViewResult, *pathPtr);
+        }
+        {
+            auto testParams = GetParam();
+            const AZ::BehaviorClass* pathClass = m_behaviorContext->FindClassByReflectedName("PureFixedMaxPath");
+            ASSERT_NE(nullptr, pathClass);
+
+            // Try with StringView and PathSeparator
+            AZStd::string_view strView(testParams.m_testPath);
+            AZStd::fixed_vector<AZ::BehaviorArgument, 8> behaviorArguments;
+            behaviorArguments.emplace_back(&strView);
+            behaviorArguments.emplace_back(&testParams.m_preferredSeparator);
+            auto scopedPathObject = pathClass->CreateWithScope(behaviorArguments);
+            ASSERT_TRUE(scopedPathObject.IsValid());
+            auto pathPtr = scopedPathObject.m_behaviorObject.m_rttiHelper->Cast<AZ::IO::FixedMaxPath>(
+                scopedPathObject.m_behaviorObject.m_address);
+            ASSERT_NE(nullptr, pathPtr) << "Cast to AZ::IO::FixedMaxPath has failed";
+
+            // Get the PathView string value
+            auto strMethod = pathClass->FindMethodByReflectedName("__str__");
+            ASSERT_NE(nullptr, strMethod);
+
+            AZ::IO::Path result(testParams.m_preferredSeparator);
+            ASSERT_TRUE(strMethod->InvokeResult(result.Native(), pathPtr));
+            EXPECT_EQ(testParams.m_testPath, result);
+
+            // Convert back to Path View
+            auto toPathViewMethod = pathClass->FindMethodByReflectedName("ToPurePathView");
+            ASSERT_NE(nullptr, toPathViewMethod);
+            AZ::IO::PathView pathViewResult(testParams.m_preferredSeparator);
+            ASSERT_TRUE(toPathViewMethod->InvokeResult(pathViewResult, pathPtr));
+            EXPECT_EQ(pathViewResult, *pathPtr);
+        }
+    }
+
+    INSTANTIATE_TEST_CASE_P(
+        PathScripting,
+        PathScriptingParamFixture,
+        ::testing::Values(
+            PathSerializationParams{ AZ::IO::PosixPathSeparator, "" },
+            PathSerializationParams{ AZ::IO::PosixPathSeparator, "test" },
+            PathSerializationParams{ AZ::IO::PosixPathSeparator, "/test" },
+            PathSerializationParams{ AZ::IO::WindowsPathSeparator, "test" },
+            PathSerializationParams{ AZ::IO::WindowsPathSeparator, "/test" },
+            PathSerializationParams{ AZ::IO::WindowsPathSeparator, "D:test" },
+            PathSerializationParams{ AZ::IO::WindowsPathSeparator, "D:/test" },
+            PathSerializationParams{ AZ::IO::WindowsPathSeparator, "test/foo/../bar" }
+        )
+    );
+
+    TEST_F(PathScriptingParamFixture, QueryGetters_Succeed)
+    {
+        constexpr AZ::IO::PathView testPathView(R"(C:\Windows\Very\Long\Path\filename.with.many.suffixes)", AZ::IO::WindowsPathSeparator);
+        const AZ::BehaviorClass* pathClass = m_behaviorContext->FindClassByReflectedName("PurePathView");
+        ASSERT_NE(nullptr, pathClass);
+        {
+            auto method = pathClass->FindGetterByReflectedName("parts");
+            ASSERT_NE(nullptr, method);
+
+            AZStd::vector<AZ::IO::PathView> result;
+            ASSERT_TRUE(method->InvokeResult(result, &testPathView));
+            EXPECT_THAT(result, ::testing::ElementsAre(R"(C:\)", "Windows", "Very", "Long", "Path", "filename.with.many.suffixes"));
+        }
+        {
+            auto method = pathClass->FindGetterByReflectedName("drive");
+            ASSERT_NE(nullptr, method);
+
+            AZStd::string result;
+            ASSERT_TRUE(method->InvokeResult(result, &testPathView));
+            EXPECT_EQ("C:", result);
+        }
+        {
+            auto method = pathClass->FindGetterByReflectedName("root");
+            ASSERT_NE(nullptr, method);
+
+            AZStd::string result;
+            ASSERT_TRUE(method->InvokeResult(result, &testPathView));
+            EXPECT_EQ(R"(\)", result);
+        }
+        {
+            auto method = pathClass->FindGetterByReflectedName("anchor");
+            ASSERT_NE(nullptr, method);
+
+            AZStd::string result;
+            ASSERT_TRUE(method->InvokeResult(result, &testPathView));
+            EXPECT_EQ(R"(C:\)", result);
+        }
+        {
+            auto method = pathClass->FindGetterByReflectedName("parents");
+            ASSERT_NE(nullptr, method);
+
+            AZStd::vector<AZ::IO::PathView> result;
+            ASSERT_TRUE(method->InvokeResult(result, &testPathView));
+            EXPECT_THAT(result, ::testing::ElementsAre(R"(C:\Windows\Very\Long\Path)",
+                R"(C:\Windows\Very\Long)", R"(C:\Windows\Very)", R"(C:\Windows)",
+                R"(C:\)"));
+        }
+        {
+            auto method = pathClass->FindGetterByReflectedName("parent");
+            ASSERT_NE(nullptr, method);
+
+            AZ::IO::PathView result;
+            ASSERT_TRUE(method->InvokeResult(result, &testPathView));
+            EXPECT_EQ(R"(C:\Windows\Very\Long\Path)", result);
+        }
+        {
+            auto method = pathClass->FindGetterByReflectedName("name");
+            ASSERT_NE(nullptr, method);
+
+            AZStd::string result;
+            ASSERT_TRUE(method->InvokeResult(result, &testPathView));
+            EXPECT_EQ("filename.with.many.suffixes", result);
+        }
+        {
+            auto method = pathClass->FindGetterByReflectedName("suffix");
+            ASSERT_NE(nullptr, method);
+
+            AZStd::string result;
+            ASSERT_TRUE(method->InvokeResult(result, &testPathView));
+            EXPECT_EQ(".suffixes", result);
+        }
+        {
+            auto method = pathClass->FindGetterByReflectedName("suffixes");
+            ASSERT_NE(nullptr, method);
+
+            AZStd::vector<AZStd::string> result;
+            ASSERT_TRUE(method->InvokeResult(result, &testPathView));
+            EXPECT_THAT(result, ::testing::ElementsAre(".with", ".many", ".suffixes"));
+        }
+        {
+            auto method = pathClass->FindGetterByReflectedName("stem");
+            ASSERT_NE(nullptr, method);
+
+            AZStd::string result;
+            ASSERT_TRUE(method->InvokeResult(result, &testPathView));
+            EXPECT_EQ("filename.with.many", result);
+        }
+    }
+
+}
+

--- a/Code/Framework/AzCore/Tests/IO/Path/PathTests.cpp
+++ b/Code/Framework/AzCore/Tests/IO/Path/PathTests.cpp
@@ -88,7 +88,7 @@ namespace UnitTest
         static_assert(IsAbsolute());
     }
 
-    // PathView::isRelative test
+    // PathView::IsRelative test
     TEST_F(PathFixture, IsRelative_ReturnsTrue)
     {
         using fixed_max_path = AZ::IO::FixedMaxPath;
@@ -139,6 +139,24 @@ namespace UnitTest
         static_assert(fullPathPosix.Filename() == AZ::IO::PathView("separator.txt", AZ::IO::PosixPathSeparator));
         static_assert(fullPathPosix.Stem() == AZ::IO::PathView("separator", AZ::IO::PosixPathSeparator));
         static_assert(fullPathPosix.Extension() == AZ::IO::PathView(".txt", AZ::IO::PosixPathSeparator));
+    }
+
+    TEST_F(PathFixture, AsUri_Succeeds)
+    {
+        constexpr AZ::IO::PathView fullPathWindows("C:/win path/with\\posix/separator.txt", AZ::IO::WindowsPathSeparator);
+        constexpr AZ::IO::PathView networkPathWindows(R"(\\server\share\path/with\separator.txt)", AZ::IO::WindowsPathSeparator);
+        AZ::IO::FixedMaxPath uriEncodedPath = fullPathWindows.AsUri();
+        EXPECT_EQ(AZ::IO::PathView("file:///C:/win%20path/with/posix/separator.txt"), uriEncodedPath);
+
+        uriEncodedPath = networkPathWindows.AsUri();
+        EXPECT_EQ(AZ::IO::PathView("file://server/share/path/with/separator.txt"), uriEncodedPath);
+
+        constexpr AZ::IO::PathView fullPathPosix("/home/posix path/with/separator.txt", AZ::IO::PosixPathSeparator);
+        uriEncodedPath = fullPathPosix.AsUri();
+        EXPECT_EQ(AZ::IO::PathView("file:///home/posix%20path/with/separator.txt"), uriEncodedPath);
+        constexpr AZ::IO::PathView otherPathPosix(R"(\\server\share\path/with\separator.txt)", AZ::IO::PosixPathSeparator);
+        uriEncodedPath = otherPathPosix.AsUri();
+        EXPECT_EQ(AZ::IO::PathView("file:///server/share/path/with/separator.txt"), uriEncodedPath);
     }
 
     class PathParamFixture

--- a/Code/Framework/AzCore/Tests/Serialization.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization.cpp
@@ -58,8 +58,6 @@
 #include <AzCore/IO/Streamer/Streamer.h>
 #include <AzCore/IO/SystemFile.h>
 #include <AzCore/IO/ByteContainerStream.h>
-#include <AzCore/IO/Path/Path.h>
-#include <AzCore/IO/Path/PathReflect.h>
 #include <AzCore/IO/Streamer/StreamerComponent.h>
 
 #include <AzCore/RTTI/AttributeReader.h>
@@ -8217,92 +8215,4 @@ namespace UnitTest
         m_serializeContext->Class<TestClassWithEnumFieldThatSpecializesTypeInfo>();
         m_serializeContext->DisableRemoveReflection();
     }
-
-    template <typename ParamType>
-    class PathSerializationParamFixture
-        : public LeakDetectionFixture
-        , public ::testing::WithParamInterface<ParamType>
-    {
-    public:
-        // We must expose the class for serialization first.
-        void SetUp() override
-        {
-            m_serializeContext = AZStd::make_unique<AZ::SerializeContext>();
-            AZ::IO::PathReflect(m_serializeContext.get());
-
-        }
-
-        void TearDown() override
-        {
-            m_serializeContext->EnableRemoveReflection();
-            AZ::IO::PathReflect(m_serializeContext.get());
-            m_serializeContext->DisableRemoveReflection();
-
-            m_serializeContext.reset();
-        }
-
-    protected:
-        AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;
-    };
-
-    struct PathSerializationParams
-    {
-        const char m_preferredSeparator{};
-        const char* m_testPath{};
-    };
-    using PathSerializationFixture = PathSerializationParamFixture<PathSerializationParams>;
-
-    TEST_P(PathSerializationFixture, PathSerializer_SerializesStringBackedPath_Succeeds)
-    {
-        const auto& testParams = GetParam();
-        {
-            // Path serialization
-            AZ::IO::Path testPath{ testParams.m_testPath, testParams.m_preferredSeparator };
-
-            AZStd::vector<char> byteBuffer;
-            AZ::IO::ByteContainerStream byteStream(&byteBuffer);
-            auto objStream = AZ::ObjectStream::Create(&byteStream, *m_serializeContext, AZ::ObjectStream::ST_XML);
-            objStream->WriteClass(&testPath);
-            objStream->Finalize();
-
-            byteStream.Seek(0, AZ::IO::GenericStream::ST_SEEK_BEGIN);
-
-            AZ::IO::Path loadPath{ testParams.m_preferredSeparator };
-            EXPECT_TRUE(AZ::Utils::LoadObjectFromStreamInPlace(byteStream, loadPath, m_serializeContext.get()));
-            EXPECT_EQ(testPath.LexicallyNormal(), loadPath);
-        }
-
-        {
-            // FixedMaxPath serialization
-            AZ::IO::FixedMaxPath testFixedMaxPath{ testParams.m_testPath, testParams.m_preferredSeparator };
-
-            AZStd::vector<char> byteBuffer;
-            AZ::IO::ByteContainerStream byteStream(&byteBuffer);
-            auto objStream = AZ::ObjectStream::Create(&byteStream, *m_serializeContext, AZ::ObjectStream::ST_XML);
-            objStream->WriteClass(&testFixedMaxPath);
-            objStream->Finalize();
-
-            byteStream.Seek(0, AZ::IO::GenericStream::ST_SEEK_BEGIN);
-
-            AZ::IO::FixedMaxPath loadPath{ testParams.m_preferredSeparator };
-            EXPECT_TRUE(AZ::Utils::LoadObjectFromStreamInPlace(byteStream, loadPath, m_serializeContext.get()));
-            EXPECT_EQ(testFixedMaxPath.LexicallyNormal(), loadPath);
-        }
-    }
-
-    INSTANTIATE_TEST_CASE_P(
-        PathSerialization,
-        PathSerializationFixture,
-        ::testing::Values(
-            PathSerializationParams{ AZ::IO::PosixPathSeparator, "" },
-            PathSerializationParams{ AZ::IO::PosixPathSeparator, "test" },
-            PathSerializationParams{ AZ::IO::PosixPathSeparator, "/test" },
-            PathSerializationParams{ AZ::IO::WindowsPathSeparator, "test" },
-            PathSerializationParams{ AZ::IO::WindowsPathSeparator, "/test" },
-            PathSerializationParams{ AZ::IO::WindowsPathSeparator, "D:test" },
-            PathSerializationParams{ AZ::IO::WindowsPathSeparator, "D:/test" },
-            PathSerializationParams{ AZ::IO::WindowsPathSeparator, "test/foo/../bar" }
-        )
-    );
 }
-

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -102,6 +102,7 @@ set(FILES
     Geometry2DUtils.cpp
     Interface.cpp
     IO/FileReaderTests.cpp
+    IO/Path/PathReflectTests.cpp
     IO/Path/PathTests.cpp
     IPC.cpp
     Jobs.cpp

--- a/Gems/EditorPythonBindings/Code/Source/PythonMarshalComponent.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonMarshalComponent.cpp
@@ -271,7 +271,7 @@ namespace EditorPythonBindings
                 AZ_Warning("python", false, "Empty behavior object sent in.");
                 return AZStd::nullopt;
             }
-            
+
             AZStd::any* anyValue = CreateAnyValue(behaviorObject.value()->m_typeId, behaviorObject.value()->m_address);
             if (!anyValue)
             {
@@ -432,7 +432,7 @@ namespace EditorPythonBindings
             result.first = MarshalBehaviorValueParameter<BehaviorType, pybind11::float_>(behaviorValue);
             return result;
         }
-    
+
         bool CanConvertPythonToBehaviorValue([[maybe_unused]] PythonMarshalTypeRequests::BehaviorTraits traits, pybind11::object pyObj) const override
         {
             return (PyFloat_Check(pyObj.ptr()) != false);
@@ -468,6 +468,12 @@ namespace EditorPythonBindings
                 outValue.Set<AZStd::string>(stringValue);
                 return { {true, [stringValue]() { delete stringValue; }} };
             }
+            else if (AZ::AzTypeInfo<T>::Uuid() == AZ::AzTypeInfo<AZ::IO::FixedMaxPathString>::Uuid())
+            {
+                auto* stringValue = new AZ::IO::FixedMaxPathString(pybind11::cast<AZ::IO::FixedMaxPathString>(pyObj));
+                outValue.Set<AZ::IO::FixedMaxPathString>(stringValue);
+                return { {true, [stringValue]() { delete stringValue; }} };
+            }
             return AZStd::nullopt;
         }
 
@@ -485,7 +491,7 @@ namespace EditorPythonBindings
     };
 
     // The 'char' type can come in with a variety of type traits:
-    // 
+    //
     class TypeConverterChar
         : public PythonMarshalComponent::TypeConverter
     {
@@ -541,7 +547,7 @@ namespace EditorPythonBindings
             }
             return AZStd::nullopt;
         }
-    
+
         bool CanConvertPythonToBehaviorValue([[maybe_unused]] PythonMarshalTypeRequests::BehaviorTraits traits, pybind11::object pyObj) const override
         {
             return (PyUnicode_Check(pyObj.ptr()) != false);
@@ -901,7 +907,7 @@ namespace EditorPythonBindings
                 return (PyDict_Check(pyObj.ptr()) != false);
             }
         };
-               
+
         class TypeConverterVector
             : public PythonMarshalComponent::TypeConverter
         {
@@ -913,7 +919,7 @@ namespace EditorPythonBindings
             TypeConverterVector(AZ::GenericClassInfo* genericClassInfo, const AZ::SerializeContext::ClassData* classData, const AZ::TypeId& typeId)
                 : m_genericClassInfo(genericClassInfo)
                 , m_classData(classData)
-                , m_typeId(typeId) 
+                , m_typeId(typeId)
             {
             }
 
@@ -1114,7 +1120,7 @@ namespace EditorPythonBindings
 
                     PythonMarshalTypeRequests::PythonValueResult result;
                     result.first = pythonList;
-                    
+
                     if (!deleterList->empty())
                     {
                         AZStd::weak_ptr<AZStd::vector<PythonMarshalTypeRequests::DeallocateFunction>> cleanUp(deleterList);
@@ -1132,7 +1138,7 @@ namespace EditorPythonBindings
                 }
                 return AZStd::nullopt;
             }
-        
+
             bool CanConvertPythonToBehaviorValue([[maybe_unused]] PythonMarshalTypeRequests::BehaviorTraits traits, pybind11::object pyObj) const override
             {
                 AZStd::vector<AZ::Uuid> typeList = AZ::Utils::GetContainedTypes(m_typeId);
@@ -1521,7 +1527,7 @@ namespace EditorPythonBindings
 
                 return PythonMarshalTypeRequests::BehaviorValueResult{ true, pairInstanceDeleter };
             }
-            
+
             AZStd::optional<PythonMarshalTypeRequests::PythonValueResult> BehaviorValueParameterToPython(AZ::BehaviorArgument& behaviorValue) override
             {
                 // the class data must have a container interface
@@ -1546,7 +1552,7 @@ namespace EditorPythonBindings
                 pybind11::object pythonItem0{ pybind11::none() };
                 pybind11::object pythonItem1{ pybind11::none() };
                 size_t itemCount = 0;
-                
+
                 auto pairElementCallback = [cleanUpList, &pythonItem0, &pythonItem1, &itemCount](void* instancePair, const AZ::Uuid& elementClassId, [[maybe_unused]] const AZ::SerializeContext::ClassData* elementGenericClassData, [[maybe_unused]] const AZ::SerializeContext::ClassElement* genericClassElement)
                 {
                     AZ::BehaviorObject behaviorObjectValue(instancePair, elementClassId);
@@ -1766,6 +1772,7 @@ namespace EditorPythonBindings
         RegisterTypeConverter(AZ::AzTypeInfo<float>::Uuid(), AZStd::make_unique<TypeConverterReal<float, float, float>>());
         RegisterTypeConverter(AZ::AzTypeInfo<double>::Uuid(), AZStd::make_unique<TypeConverterReal<double, double, double>>());
         RegisterTypeConverter(AZ::AzTypeInfo<AZStd::string>::Uuid(), AZStd::make_unique<TypeConverterString<AZStd::string>>());
+        RegisterTypeConverter(AZ::AzTypeInfo<AZ::IO::FixedMaxPathString>::Uuid(), AZStd::make_unique<TypeConverterString<AZ::IO::FixedMaxPathString>>());
         RegisterTypeConverter(AZ::AzTypeInfo<AZStd::string_view>::Uuid(), AZStd::make_unique<TypeConverterString<AZStd::string_view>>());
         RegisterTypeConverter(AZ::AzTypeInfo<AZStd::any>::Uuid(), AZStd::make_unique<TypeConverterAny>());
 

--- a/Gems/EditorPythonBindings/Code/Source/PythonReflectionComponent.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonReflectionComponent.cpp
@@ -6,9 +6,9 @@
  *
  */
 
+#include <AzCore/PlatformDef.h>
 #include <PythonReflectionComponent.h>
 
-#include <AzFramework/StringFunc/StringFunc.h>
 
 #include <Source/PythonCommon.h>
 #include <Source/PythonUtility.h>
@@ -18,16 +18,15 @@
 #include <Source/PythonSymbolsBus.h>
 #include <pybind11/embed.h>
 
-#include <AzCore/PlatformDef.h>
+#include <AzCore/IO/SystemFile.h>
 #include <AzCore/RTTI/AttributeReader.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/StringFunc/StringFunc.h>
+#include <AzCore/Utils/Utils.h>
 
-#include <AzCore/PlatformDef.h>
-#include <AzCore/IO/SystemFile.h>
-#include <AzCore/IO/SystemFile.h>
 #include <AzFramework/IO/LocalFileIO.h>
 
 namespace EditorPythonBindings
@@ -163,32 +162,13 @@ namespace EditorPythonBindings
             }
         };
 
-        AZStd::string PyResolvePath(AZStd::string_view path)
-        {
-            char pyPath[AZ_MAX_PATH_LEN];
-            AZ::IO::FileIOBase::GetInstance()->ResolvePath(path.data(), pyPath, AZ_MAX_PATH_LEN);
-            return { pyPath };
-        }
-
-        void RegisterAliasIfExists(pybind11::module pathsModule, AZStd::string_view alias, AZStd::string_view attribute)
-        {
-            const char* aliasPath = AZ::IO::FileIOBase::GetInstance()->GetAlias(alias.data());
-            if (aliasPath)
-            {
-                pathsModule.attr(attribute.data()) = aliasPath;
-            }
-            else
-            {
-                pathsModule.attr(attribute.data()) = "";
-            }
-        }
-
         void RegisterPaths(pybind11::module parentModule)
         {
             pybind11::module pathsModule = parentModule.def_submodule("paths");
-            pathsModule.def("resolve_path", [](const char* path)
+            pathsModule.def("resolve_path", [](const char* path) -> AZStd::string
             {
-                return PyResolvePath(path);
+                AZStd::optional<AZ::IO::FixedMaxPath> pyPath = AZ::IO::FileIOBase::GetInstance()->ResolvePath(path);
+                return pyPath ? pyPath->String() : AZStd::string{};
             });
             pathsModule.def("ensure_alias", [](const char* alias, const char* path)
             {
@@ -199,17 +179,18 @@ namespace EditorPythonBindings
                 }
             });
 
-            RegisterAliasIfExists(pathsModule, "@engroot@", "engroot");
-            RegisterAliasIfExists(pathsModule, "@products@", "products");
-            RegisterAliasIfExists(pathsModule, "@projectroot@", "projectroot");
-            RegisterAliasIfExists(pathsModule, "@log@", "log");
+            pathsModule.attr("engroot") = AZ::Utils::GetEnginePath().c_str();
+            pathsModule.attr("products") = AZ::Utils::GetProjectProductPathForPlatform().c_str();
+            pathsModule.attr("projectroot") = AZ::Utils::GetProjectPath().c_str();
+            pathsModule.attr("log") = AZ::Utils::GetProjectLogPath().c_str();
 
-            const char* executableFolder = nullptr;
-            AZ::ComponentApplicationBus::BroadcastResult(executableFolder, &AZ::ComponentApplicationBus::Events::GetExecutableFolder);
-            if (executableFolder)
+            // Add a gemroot method for querying gem paths
+            pathsModule.def("gemroot", [](const char* gemName) -> AZStd::string
             {
-                pathsModule.attr("executableFolder") = executableFolder;
-            }
+                return AZStd::string(AZ::Utils::GetGemPath(gemName));
+            });
+
+            pathsModule.attr("executableFolder") = AZ::Utils::GetExecutableDirectory().c_str();
         }
     }
 
@@ -366,7 +347,7 @@ namespace EditorPythonBindings
     {
         pybind11::module parentModule = pybind11::cast<pybind11::module>(module);
         std::string pythonModuleName = pybind11::cast<std::string>(parentModule.attr("__name__"));
-        if (AzFramework::StringFunc::Equal(pythonModuleName.c_str(), Internal::s_azlmbr))
+        if (AZ::StringFunc::Equal(pythonModuleName.c_str(), Internal::s_azlmbr))
         {
             // declare the default module to capture behavior that did not define a "Module" attribute
             pybind11::module defaultModule = parentModule.def_submodule(Internal::s_default);


### PR DESCRIPTION
The AZ::IO::Path reflected functions model the python Pathlib API and use the same method names.

Added AsUri function and (StringAsUri/FixedAstringAsUri) functions to `AZ::IO::Path*` classes to allow a path to be encoded as a uri using the `file://` protocol

Other Changes:
* Moved the reflection for AZStd::string and AZStd::string_view to the AzStdOnDemandReflectionSpecializations.cpp file to reduce compilation time
  * Added fixed_string<1024> BehaviorContext reflection also inside of the AzStdOnDemandReflectionSpecializations.cpp file
* Added a utility function for retriving a project's product folder for a platform and the project's log folder

## How was this PR tested?

Added UnitTest that validates the reflected AZ IO Path Scripting functions as well as the `AsUri` function
