### PR TITLE
Add verification that script canvas filename cannot start with a number.

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -1701,6 +1701,15 @@ namespace ScriptCanvasEditor
                 if (AzFramework::StringFunc::Path::GetFileName(filePath.c_str(), fileName))
                 {
                     isValidFileName = !(fileName.empty());
+                    if (isValidFileName)
+                    {
+                        if (AzFramework::StringFunc::FirstCharacter(fileName.c_str()) >= '0' &&
+                            AzFramework::StringFunc::FirstCharacter(fileName.c_str()) <= '9')
+                        {
+                            QMessageBox::warning(this, QObject::tr("Unable to Save"), QObject::tr("File name cannot start with a number"));
+                            return false;
+                        }
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
## What does this PR do?
Scripts canvas will report an error if file name start with a number，so need verification when saving scripts canvas file.

![1-1](https://user-images.githubusercontent.com/124341515/219571275-a69222ce-bdef-4e3e-8cc3-ebb8bf4dfc9f.png)


## How was this PR tested?
Test whether the file name start with number can be verified.
 
![1-2](https://user-images.githubusercontent.com/124341515/219571287-9ccd79c0-684c-4e6b-b051-5d754e4c7278.png)
