### PR TITLE
Fix bug of ScriptTimePoint ToString method.

### DIFF
--- a/Code/Framework/AzCore/AzCore/Script/ScriptTimePoint.cpp
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptTimePoint.cpp
@@ -25,7 +25,6 @@ namespace AZ
                 Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)->
                 Attribute(AZ::Script::Attributes::Module, "script")->
                 Method("ToString", &ScriptTimePoint::ToString)->
-                    Attribute(Script::Attributes::Operator,Script::Attributes::OperatorType::ToString)->
                 Method("GetSeconds", &ScriptTimePoint::GetSeconds)->
                 Method("GetMilliseconds", &ScriptTimePoint::GetMilliseconds)
             ;


### PR DESCRIPTION
## What does this PR do?

Fix the bug that method `ToString` of `ScriptTimePoint` cannot be used in scripts.
![3-1](https://user-images.githubusercontent.com/124341515/219573566-d48a66a5-6d53-44f4-a600-f2fee3aaea45.png)


## How was this PR tested?
Test if method `ToString` of `ScriptTimePoint` can be used in scripts.
![3-2](https://user-images.githubusercontent.com/124341515/219573582-e96ad377-796c-48f8-be9d-06dcce5f77cd.png)
