### PR TITLE
Fix the verification of scriptevents methodname and parametername.

### DIFF
--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventDefinition.cpp
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventDefinition.cpp
@@ -145,11 +145,21 @@ namespace ScriptEvents
                 return outcome;
             }
 
-            if (method.GetName().compare(methodName) == 0)
+            int duplicateCount = 0;
+            for (auto item = m_methods.begin(); item != m_methods.end(); item++)
             {
-                return AZ::Failure(AZStd::string::format("Cannot have duplicate method names (%d: %s) make sure each method name is unique", methodIndex, methodName.c_str()));
+                if (item->GetName().compare(methodName) == 0)
+                {
+                    duplicateCount++;
+                }
+                if (duplicateCount > 1)
+                {
+                    return AZ::Failure(AZStd::string::format(
+                        "Cannot have duplicate method names (%d: %s) make sure each method name is unique",
+                        methodIndex,
+                        methodName.c_str()));
+                }
             }
-
             methodName = method.GetName();
             ++methodIndex;
 

--- a/Gems/ScriptEvents/Code/Source/ScriptEventsMethod.cpp
+++ b/Gems/ScriptEvents/Code/Source/ScriptEventsMethod.cpp
@@ -128,11 +128,20 @@ namespace ScriptEvents
                 return outcome;
             }
 
-            if (parameter.GetName().compare(parameterName) == 0)
+            int duplicateCount = 0;
+            for (auto item = m_parameters.begin(); item != m_parameters.end(); item++)
             {
-                return AZ::Failure(AZStd::string::format(
-                    "Cannot have duplicate parameter names (%d: %s) make sure each parameter name is unique", parameterIndex,
-                    parameterName.c_str()));
+                if (item->GetName().compare(parameterName) == 0)
+                {
+                    duplicateCount++;
+                }
+                if (duplicateCount > 1)
+                {
+                    return AZ::Failure(AZStd::string::format(
+                        "Cannot have duplicate parameter names (%d: %s) make sure each parameter name is unique",
+                        parameterIndex,
+                        parameterName.c_str()));
+                }
             }
 
             parameterName = parameter.GetName();


### PR DESCRIPTION
## What does this PR do?

The varification for whether the scriptevents method name and param name are duplicated is wrong. It is only compared with the next method or param. To judge whether it is duplicated, all methodnames and parametersnames need to be verified.

for such script, it can pass the verification:

![2-1](https://user-images.githubusercontent.com/124341515/219588385-6a4a3284-29c2-485b-8323-fb4faedaead2.png)

## How was this PR tested?
1、Create new scriptevents
2、Set the first and third method name are same
3、Set the first and third parameter name are same
4、See if it can pass the verification

![2-2](https://user-images.githubusercontent.com/124341515/219588398-2851414a-442e-45a7-b423-b489fe68ae89.png)
![2-3](https://user-images.githubusercontent.com/124341515/219588405-fea0d676-4ac6-4f63-a5c0-bbaa67d96784.png)
