### PR TITLE
Fix the bug there are deleted material infos in .prefab file

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
@@ -254,6 +254,7 @@ namespace AZ
                 &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay,
                 AzToolsFramework::Refresh_EntireTree);
 
+            MaterialComponentRequestBus::Event(GetEntityId(), &MaterialComponentRequestBus::Events::ClearMaterialsOnInvalidSlots);
         }
 
         AZ::u32 EditorMeshComponent::OnConfigurationChanged()


### PR DESCRIPTION
## What does this PR do?

1、Create a new entity, add Mesh Componet, selete a mesh (such as the chicken fbx which has three material slots) 
2、Add Material of the Mesh, and select material assets, and save scene.
![4-1](https://user-images.githubusercontent.com/124341515/219598095-7334580d-5aea-4a92-b1aa-042c32cac5ba.png)
![4-2](https://user-images.githubusercontent.com/124341515/219598103-93791465-3239-42a1-aa63-bbce0c79f812.png)

3、Select a different Model Asset of the same Entity,  such as the shaderball fbx, add Material and save the scene.
![4-3](https://user-images.githubusercontent.com/124341515/219598129-ad48524f-7633-44de-b266-45228cbec70a.png)

4、Open the .prefab file of the scene, there is previous residual info of the chicken materials.
![4-4](https://user-images.githubusercontent.com/124341515/219598145-f802c4df-e658-4d58-a3bd-01b9728191a0.png)

## How was this PR tested?
Follow the same steps, and the residual material infos has been deleted.
