### PR TITLE
allow gradient transform to handle asymmetrical shapes

### DIFF
--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/GradientTransformComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/GradientTransformComponent.h
@@ -55,6 +55,7 @@ namespace GradientSignal
 
         bool m_overrideBounds = false;
         AZ::Vector3 m_bounds = AZ::Vector3::CreateOne(); //1m sq default value chosen by design, to start small and expand as needed
+        AZ::Vector3 m_center = AZ::Vector3::CreateZero(); // to handle asymmetrical shapes such as polygon prism
 
         TransformType m_transformType = TransformType::World_ThisEntity;
         bool m_overrideTranslate = false;
@@ -129,6 +130,9 @@ namespace GradientSignal
 
         AZ::Vector3 GetBounds() const override;
         void SetBounds(AZ::Vector3 bounds) override;
+
+        AZ::Vector3 GetCenter() const override;
+        void SetCenter(AZ::Vector3 center) override;
 
         TransformType GetTransformType() const override;
         void SetTransformType(TransformType type) override;

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/GradientTransformComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/GradientTransformComponent.h
@@ -129,10 +129,10 @@ namespace GradientSignal
         void SetOverrideBounds(bool value) override;
 
         AZ::Vector3 GetBounds() const override;
-        void SetBounds(AZ::Vector3 bounds) override;
+        void SetBounds(const AZ::Vector3& bounds) override;
 
         AZ::Vector3 GetCenter() const override;
-        void SetCenter(AZ::Vector3 center) override;
+        void SetCenter(const AZ::Vector3& center) override;
 
         TransformType GetTransformType() const override;
         void SetTransformType(TransformType type) override;
@@ -141,19 +141,19 @@ namespace GradientSignal
         void SetOverrideTranslate(bool value) override;
 
         AZ::Vector3 GetTranslate() const override;
-        void SetTranslate(AZ::Vector3 translate) override;
+        void SetTranslate(const AZ::Vector3& translate) override;
 
         bool GetOverrideRotate() const override;
         void SetOverrideRotate(bool value) override;
 
         AZ::Vector3 GetRotate() const override;
-        void SetRotate(AZ::Vector3 rotate) override;
+        void SetRotate(const AZ::Vector3& rotate) override;
 
         bool GetOverrideScale() const override;
         void SetOverrideScale(bool value) override;
 
         AZ::Vector3 GetScale() const override;
-        void SetScale(AZ::Vector3 scale) override;
+        void SetScale(const AZ::Vector3& scale) override;
 
         float GetFrequencyZoom() const override;
         void SetFrequencyZoom(float frequencyZoom) override;

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Ebuses/GradientTransformModifierRequestBus.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Ebuses/GradientTransformModifierRequestBus.h
@@ -49,10 +49,10 @@ namespace GradientSignal
         virtual void SetOverrideBounds(bool value) = 0;
 
         virtual AZ::Vector3 GetBounds() const = 0;
-        virtual void SetBounds(AZ::Vector3 bounds) = 0;
+        virtual void SetBounds(const AZ::Vector3& bounds) = 0;
 
         virtual AZ::Vector3 GetCenter() const = 0;
-        virtual void SetCenter(AZ::Vector3 center) = 0;
+        virtual void SetCenter(const AZ::Vector3& center) = 0;
 
         virtual TransformType GetTransformType() const = 0;
         virtual void SetTransformType(TransformType type) = 0;
@@ -61,19 +61,19 @@ namespace GradientSignal
         virtual void SetOverrideTranslate(bool value) = 0;
 
         virtual AZ::Vector3 GetTranslate() const = 0;
-        virtual void SetTranslate(AZ::Vector3 translate) = 0;
+        virtual void SetTranslate(const AZ::Vector3& translate) = 0;
 
         virtual bool GetOverrideRotate() const = 0;
         virtual void SetOverrideRotate(bool value) = 0;
 
         virtual AZ::Vector3 GetRotate() const = 0;
-        virtual void SetRotate(AZ::Vector3 rotate) = 0;
+        virtual void SetRotate(const AZ::Vector3& rotate) = 0;
 
         virtual bool GetOverrideScale() const = 0;
         virtual void SetOverrideScale(bool value) = 0;
 
         virtual AZ::Vector3 GetScale() const = 0;
-        virtual void SetScale(AZ::Vector3 scale) = 0;
+        virtual void SetScale(const AZ::Vector3& scale) = 0;
 
         virtual float GetFrequencyZoom() const = 0;
         virtual void SetFrequencyZoom(float frequencyZoom) = 0;

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Ebuses/GradientTransformModifierRequestBus.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Ebuses/GradientTransformModifierRequestBus.h
@@ -51,6 +51,9 @@ namespace GradientSignal
         virtual AZ::Vector3 GetBounds() const = 0;
         virtual void SetBounds(AZ::Vector3 bounds) = 0;
 
+        virtual AZ::Vector3 GetCenter() const = 0;
+        virtual void SetCenter(AZ::Vector3 center) = 0;
+
         virtual TransformType GetTransformType() const = 0;
         virtual void SetTransformType(TransformType type) = 0;
 

--- a/Gems/GradientSignal/Code/Source/Components/GradientTransformComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/GradientTransformComponent.cpp
@@ -33,6 +33,7 @@ namespace GradientSignal
                 ->Field("ShapeReference", &GradientTransformConfig::m_shapeReference)
                 ->Field("OverrideBounds", &GradientTransformConfig::m_overrideBounds)
                 ->Field("Bounds", &GradientTransformConfig::m_bounds)
+                ->Field("Center", &GradientTransformConfig::m_center)
                 ->Field("OverrideTranslate", &GradientTransformConfig::m_overrideTranslate)
                 ->Field("Translate", &GradientTransformConfig::m_translate)
                 ->Field("OverrideRotate", &GradientTransformConfig::m_overrideRotate)
@@ -83,7 +84,9 @@ namespace GradientSignal
                     ->Attribute(AZ::Edit::Attributes::ReadOnly, &GradientTransformConfig::IsAdvancedModeReadOnly)
                     ->DataElement(0, &GradientTransformConfig::m_bounds, "Bounds", "Local (untransformed) bounds of a box used to remap, clamp, wrap, scale incoming coordinates")
                     ->Attribute(AZ::Edit::Attributes::ReadOnly, &GradientTransformConfig::IsBoundsReadOnly)
-                    
+                    ->DataElement(0, &GradientTransformConfig::m_bounds, "Center", "Local (untransformed) center of a box used to remap, clamp, wrap, scale incoming coordinates")
+                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &GradientTransformConfig::IsBoundsReadOnly)
+
                     ->DataElement(0, &GradientTransformConfig::m_overrideTranslate, "Override Translate", "Allow manual override of the associated parameter")
                     ->Attribute(AZ::Edit::Attributes::ReadOnly, &GradientTransformConfig::IsAdvancedModeReadOnly)
                     ->DataElement(0, &GradientTransformConfig::m_translate, "Translate", "")
@@ -113,6 +116,7 @@ namespace GradientSignal
                 ->Property("shapeReference", BehaviorValueProperty(&GradientTransformConfig::m_shapeReference))
                 ->Property("overrideBounds", BehaviorValueProperty(&GradientTransformConfig::m_overrideBounds))
                 ->Property("bounds", BehaviorValueProperty(&GradientTransformConfig::m_bounds))
+                ->Property("center", BehaviorValueProperty(&GradientTransformConfig::m_center))
                 ->Property("transformType",
                     [](GradientTransformConfig* config) { return (AZ::u8&)(config->m_transformType); },
                     [](GradientTransformConfig* config, const AZ::u8& i) { config->m_transformType = (TransformType)i; })
@@ -139,6 +143,7 @@ namespace GradientSignal
             m_shapeReference == other.m_shapeReference &&
             m_overrideBounds == other.m_overrideBounds &&
             m_bounds.IsClose(other.m_bounds) &&
+            m_center.IsClose(other.m_center) &&
             m_transformType == other.m_transformType &&
             m_overrideTranslate == other.m_overrideTranslate &&
             m_translate.IsClose(other.m_translate) &&
@@ -234,6 +239,9 @@ namespace GradientSignal
                 ->Event("GetBounds", &GradientTransformModifierRequestBus::Events::GetBounds)
                 ->Event("SetBounds", &GradientTransformModifierRequestBus::Events::SetBounds)
                 ->VirtualProperty("Bounds", "GetBounds", "SetBounds")
+                ->Event("GetCenter", &GradientTransformModifierRequestBus::Events::GetCenter)
+                ->Event("SetCenter", &GradientTransformModifierRequestBus::Events::SetCenter)
+                ->VirtualProperty("Center", "GetCenter", "SetCenter")
                 ->Event("GetTransformType", &GradientTransformModifierRequestBus::Events::GetTransformType)
                 ->Event("SetTransformType", &GradientTransformModifierRequestBus::Events::SetTransformType)
                 ->VirtualProperty("TransformType", "GetTransformType", "SetTransformType")
@@ -414,6 +422,7 @@ namespace GradientSignal
             if (shapeBounds.IsValid())
             {
                 m_configuration.m_bounds = shapeBounds.GetExtents();
+                m_configuration.m_center = shapeBounds.GetCenter();
             }
         }
 
@@ -435,7 +444,8 @@ namespace GradientSignal
 
         //rebuild bounds from parameters
         m_configuration.m_bounds = m_configuration.m_bounds.GetAbs();
-        shapeBounds = AZ::Aabb::CreateFromMinMax(-m_configuration.m_bounds * 0.5f, m_configuration.m_bounds * 0.5f);
+        shapeBounds = AZ::Aabb::CreateFromMinMax(
+            m_configuration.m_center - m_configuration.m_bounds * 0.5f, m_configuration.m_center + m_configuration.m_bounds * 0.5f);
 
         //rebuild transform from parameters
         AZ::Matrix3x4 shapeTransformFinal;
@@ -511,6 +521,17 @@ namespace GradientSignal
     void GradientTransformComponent::SetBounds(AZ::Vector3 bounds)
     {
         m_configuration.m_bounds = bounds;
+        LmbrCentral::DependencyNotificationBus::Event(GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
+    }
+
+    AZ::Vector3 GradientTransformComponent::GetCenter() const
+    {
+        return m_configuration.m_center;
+    }
+
+    void GradientTransformComponent::SetCenter(AZ::Vector3 center)
+    {
+        m_configuration.m_center = center;
         LmbrCentral::DependencyNotificationBus::Event(GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
     }
 

--- a/Gems/GradientSignal/Code/Source/Components/GradientTransformComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/GradientTransformComponent.cpp
@@ -84,7 +84,7 @@ namespace GradientSignal
                     ->Attribute(AZ::Edit::Attributes::ReadOnly, &GradientTransformConfig::IsAdvancedModeReadOnly)
                     ->DataElement(0, &GradientTransformConfig::m_bounds, "Bounds", "Local (untransformed) bounds of a box used to remap, clamp, wrap, scale incoming coordinates")
                     ->Attribute(AZ::Edit::Attributes::ReadOnly, &GradientTransformConfig::IsBoundsReadOnly)
-                    ->DataElement(0, &GradientTransformConfig::m_bounds, "Center", "Local (untransformed) center of a box used to remap, clamp, wrap, scale incoming coordinates")
+                    ->DataElement(0, &GradientTransformConfig::m_center, "Center", "Local (untransformed) center of a box used to remap, clamp, wrap, scale incoming coordinates")
                     ->Attribute(AZ::Edit::Attributes::ReadOnly, &GradientTransformConfig::IsBoundsReadOnly)
 
                     ->DataElement(0, &GradientTransformConfig::m_overrideTranslate, "Override Translate", "Allow manual override of the associated parameter")
@@ -444,8 +444,7 @@ namespace GradientSignal
 
         //rebuild bounds from parameters
         m_configuration.m_bounds = m_configuration.m_bounds.GetAbs();
-        shapeBounds = AZ::Aabb::CreateFromMinMax(
-            m_configuration.m_center - m_configuration.m_bounds * 0.5f, m_configuration.m_center + m_configuration.m_bounds * 0.5f);
+        shapeBounds = AZ::Aabb::CreateCenterHalfExtents(m_configuration.m_center, 0.5f * m_configuration.m_bounds);
 
         //rebuild transform from parameters
         AZ::Matrix3x4 shapeTransformFinal;

--- a/Gems/GradientSignal/Code/Source/Components/GradientTransformComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/GradientTransformComponent.cpp
@@ -517,7 +517,7 @@ namespace GradientSignal
         return m_configuration.m_bounds;
     }
     
-    void GradientTransformComponent::SetBounds(AZ::Vector3 bounds)
+    void GradientTransformComponent::SetBounds(const AZ::Vector3& bounds)
     {
         m_configuration.m_bounds = bounds;
         LmbrCentral::DependencyNotificationBus::Event(GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
@@ -528,7 +528,7 @@ namespace GradientSignal
         return m_configuration.m_center;
     }
 
-    void GradientTransformComponent::SetCenter(AZ::Vector3 center)
+    void GradientTransformComponent::SetCenter(const AZ::Vector3& center)
     {
         m_configuration.m_center = center;
         LmbrCentral::DependencyNotificationBus::Event(GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
@@ -561,7 +561,7 @@ namespace GradientSignal
         return m_configuration.m_translate;
     }
     
-    void GradientTransformComponent::SetTranslate(AZ::Vector3 translate)
+    void GradientTransformComponent::SetTranslate(const AZ::Vector3& translate)
     {
         m_configuration.m_translate = translate;
         LmbrCentral::DependencyNotificationBus::Event(GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
@@ -583,7 +583,7 @@ namespace GradientSignal
         return m_configuration.m_rotate;
     }
     
-    void GradientTransformComponent::SetRotate(AZ::Vector3 rotate)
+    void GradientTransformComponent::SetRotate(const AZ::Vector3& rotate)
     {
         m_configuration.m_rotate = rotate;
         LmbrCentral::DependencyNotificationBus::Event(GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);
@@ -605,7 +605,7 @@ namespace GradientSignal
         return m_configuration.m_scale;
     }
     
-    void GradientTransformComponent::SetScale(AZ::Vector3 scale)
+    void GradientTransformComponent::SetScale(const AZ::Vector3& scale)
     {
         m_configuration.m_scale = scale;
         LmbrCentral::DependencyNotificationBus::Event(GetEntityId(), &LmbrCentral::DependencyNotificationBus::Events::OnCompositionChanged);

--- a/Gems/GradientSignal/Code/Tests/GradientSignalImageTests.cpp
+++ b/Gems/GradientSignal/Code/Tests/GradientSignalImageTests.cpp
@@ -803,7 +803,7 @@ namespace UnitTest
             MockShapeComponentHandler mockShapeComponentHandler(mockShape->GetId());
             // Create a 2x2 box shape (shapes are inclusive, so that's 3x3 sampling space), so that each pixel in the image directly maps to 1 meter in the box.
             mockShapeComponentHandler.m_GetEncompassingAabb = AZ::Aabb::CreateFromMinMax(AZ::Vector3(0.0f), AZ::Vector3(2.0f));
-            mockShapeComponentHandler.m_GetLocalBounds = mockShapeComponentHandler.m_GetEncompassingAabb;
+            mockShapeComponentHandler.m_GetLocalBounds = AZ::Aabb::CreateFromMinMax(AZ::Vector3(-1.0f), AZ::Vector3(1.0f));
             // Shapes internally just cache the WorldTM, so make sure we've done the same for our test data.
             mockShapeComponentHandler.m_GetTransform = mockShapeTransformHandler.m_GetWorldTMOutput;
 


### PR DESCRIPTION
## What does this PR do?
Allows gradient transforms to handle shapes which are not symmetrical about their centre e.g. shapes with translation offsets, polygon prisms. Related to #13398.

## How was this PR tested?
Manual testing in editor and running unit tests.