### PR TITLE
Multiplayer Waits For Level Load if No Spawner is Found

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
@@ -11,6 +11,7 @@ import os
 import time
 import traceback
 from typing import Callable, Tuple
+from enum import Enum
 
 import azlmbr
 try:
@@ -178,8 +179,11 @@ class TestHelper:
 
         return matching_lines >= expected_lines
 
+    
+    EditorServerMode = Enum('EditorServerMode', ['DEDICATED_SERVER', 'CLIENT_SERVER'])
+
     @staticmethod
-    def multiplayer_enter_game_mode(msgtuple_success_fail: Tuple[str, str]) -> None:
+    def multiplayer_enter_game_mode(msgtuple_success_fail: Tuple[str, str], editor_server_mode: EditorServerMode) -> None:
         """
         :param msgtuple_success_fail: The tuple with the expected/unexpected messages for entering game mode.
 
@@ -191,21 +195,25 @@ class TestHelper:
             # enter game-mode. 
             # game-mode in multiplayer will also launch ServerLauncher.exe and connect to the editor
             general.set_cvar_integer('editorsv_max_connection_attempts', 15)
+
+            general.set_cvar_string('editorsv_clientserver', 'true' if editor_server_mode == TestHelper.EditorServerMode.CLIENT_SERVER else 'false')
+
             multiplayer.PythonEditorFuncs_enter_game_mode()
 
-            # make sure the server launcher is running
-            TestHelper.wait_for_condition(lambda : multiplayer_helper.serverLaunched, 20.0)
-            waiter.wait_for(lambda: process_utils.process_exists("AutomatedTesting.ServerLauncher", ignore_extensions=True), timeout=5.0, exc=AssertionError("AutomatedTesting.ServerLauncher process is not running!"), interval=1.0)
-            Report.critical_result(("AutomatedTesting.ServerLauncher process successfully launched", "AutomatedTesting.ServerLauncher process failed to launch"), process_utils.process_exists("AutomatedTesting.ServerLauncher", ignore_extensions=True))
+            if editor_server_mode == TestHelper.EditorServerMode.DEDICATED_SERVER:
+                # make sure the server launcher is running
+                TestHelper.wait_for_condition(lambda : multiplayer_helper.serverLaunched, 20.0)
+                waiter.wait_for(lambda: process_utils.process_exists("AutomatedTesting.ServerLauncher", ignore_extensions=True), timeout=5.0, exc=AssertionError("AutomatedTesting.ServerLauncher process is not running!"), interval=1.0)
+                Report.critical_result(("AutomatedTesting.ServerLauncher process successfully launched", "AutomatedTesting.ServerLauncher process failed to launch"), process_utils.process_exists("AutomatedTesting.ServerLauncher", ignore_extensions=True))
 
-            TestHelper.wait_for_condition(lambda : multiplayer_helper.editorConnectionAttemptCount > 0, 10.0)
-            Report.critical_result(("Multiplayer Editor attempting server connection.", "Multiplayer Editor never tried connecting to the server."), multiplayer_helper.editorConnectionAttemptCount > 0)
+                TestHelper.wait_for_condition(lambda : multiplayer_helper.editorConnectionAttemptCount > 0, 10.0)
+                Report.critical_result(("Multiplayer Editor attempting server connection.", "Multiplayer Editor never tried connecting to the server."), multiplayer_helper.editorConnectionAttemptCount > 0)
 
-            TestHelper.wait_for_condition(lambda : multiplayer_helper.editorSendingLevelData, 106.0)
-            Report.critical_result(("Multiplayer Editor sent level data to the server.", "Multiplayer Editor never sent the level to the server."), multiplayer_helper.editorSendingLevelData)
+                TestHelper.wait_for_condition(lambda : multiplayer_helper.editorSendingLevelData, 106.0)
+                Report.critical_result(("Multiplayer Editor sent level data to the server.", "Multiplayer Editor never sent the level to the server."), multiplayer_helper.editorSendingLevelData)
 
-            TestHelper.wait_for_condition(lambda : multiplayer_helper.connectToSimulationSuccess, 20.0)
-            Report.critical_result(("Multiplayer Editor successfully connected to server network simuluation.", "Multiplayer Editor failed to connected to server network simuluation."), multiplayer_helper.connectToSimulationSuccess)
+                TestHelper.wait_for_condition(lambda : multiplayer_helper.connectToSimulationSuccess, 20.0)
+                Report.critical_result(("Multiplayer Editor successfully connected to server network simuluation.", "Multiplayer Editor failed to connected to server network simuluation."), multiplayer_helper.connectToSimulationSuccess)
 
         TestHelper.wait_for_condition(lambda : multiplayer.PythonEditorFuncs_is_in_game_mode(), 10.0)
         Report.critical_result(msgtuple_success_fail, multiplayer.PythonEditorFuncs_is_in_game_mode())

--- a/AutomatedTesting/Gem/PythonTests/Multiplayer/tests/Multiplayer_BasicConnectivity_Connects_ClientServer.py
+++ b/AutomatedTesting/Gem/PythonTests/Multiplayer/tests/Multiplayer_BasicConnectivity_Connects_ClientServer.py
@@ -17,7 +17,7 @@ class TestConstants:
 # fmt: on
 
 
-def Multiplayer_BasicConnectivity_Connects():
+def Multiplayer_BasicConnectivity_Connects_ClientServer():
     r"""
     Summary:
     Runs a test to make sure that a networked player can be spawned
@@ -43,10 +43,11 @@ def Multiplayer_BasicConnectivity_Connects():
 
     # 1) Open Level
     helper.open_level("Multiplayer", level_name)
-    general.set_cvar_integer('editorsv_port', 33454)
+    general.set_cvar_integer('editorsv_port', 33455)
+
 
     # 2) Enter game mode
-    helper.multiplayer_enter_game_mode(TestConstants.enter_game_mode, helper.EditorServerMode.DEDICATED_SERVER)
+    helper.multiplayer_enter_game_mode(TestConstants.enter_game_mode, helper.EditorServerMode.CLIENT_SERVER)
 
     # 3) Make sure the network player was spawned
     player_id = general.find_game_entity("Player")
@@ -58,5 +59,5 @@ def Multiplayer_BasicConnectivity_Connects():
 
 if __name__ == "__main__":
     from editor_python_test_tools.utils import Report
-    Report.start_test(Multiplayer_BasicConnectivity_Connects)
+    Report.start_test(Multiplayer_BasicConnectivity_Connects_ClientServer)
     

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -1328,31 +1328,31 @@ namespace Multiplayer
         // Spawn the default player for this host since the host is also a player (not a dedicated server)
         if (m_agentType == MultiplayerAgentType::ClientServer)
         {
+            MultiplayerAgentDatum datum;
+            datum.m_agentType = MultiplayerAgentType::ClientServer;
+            datum.m_id = InvalidConnectionId; //< no network connection: the client is hosting itself.
+            constexpr uint64_t userId = 0; //< user id 0: the client hosting in client-server is always the first player.
+
+            NetworkEntityHandle controlledEntity;
             if (IMultiplayerSpawner* spawner = AZ::Interface<IMultiplayerSpawner>::Get())
             {
                 // Route to spawner implementation
-                MultiplayerAgentDatum datum;
-                datum.m_agentType = MultiplayerAgentType::ClientServer;
-                datum.m_id = InvalidConnectionId;
-                constexpr uint64_t userId = 0;
+                controlledEntity = spawner->OnPlayerJoin(userId, datum);
+            }
 
-                NetworkEntityHandle controlledEntity = spawner->OnPlayerJoin(userId, datum);
-                if (controlledEntity.Exists())
-                {
-                    // A controlled player entity likely doesn't exist at this time.
-                    // Unless IMultiplayerSpawner has a way to return a player without being inside a level, the client-server's player won't be spawned until the next level is loaded.
-                    EnableAutonomousControl(controlledEntity, InvalidConnectionId);
-                }
-                else
-                {
-                    // If there wasn't any player entity, wait until a level loads and check again
-                    m_playersWaitingToBeSpawned.emplace_back(userId, datum, nullptr );
-                }
+            // A controlled player entity likely doesn't exist at this time.
+            // Unless IMultiplayerSpawner has a way to return a player without being inside a level (for example using a system component), the client-server's player won't be
+            // spawned until the level is loaded.
+            if (controlledEntity.Exists())
+            {
+                EnableAutonomousControl(controlledEntity, InvalidConnectionId);
             }
             else
             {
-                AZLOG_ERROR("No IMultiplayerSpawner found for host's default player. Ensure one is registered.");
+                // If there wasn't any player entity, wait until a level loads and check again
+                m_playersWaitingToBeSpawned.emplace_back(userId, datum, nullptr);
             }
+
         }
         AZLOG_INFO("Multiplayer operating in %s mode", GetEnumString(m_agentType));
 


### PR DESCRIPTION
Update Multiplayer System Component to wait for level load if no spawner is found; if the spawner isn't a system component and instead lives in the level, then the level wont be ready when a client-server player starts hosting.
Fixes #14635 

## How was this PR tested?
New Automated Test Added: _Multiplayer_BasicConnectivity_Connects_ClientServer.py_
Open Editor > open a multiplayer level using a Simple Network Player Spawner > Enable client-server mode (editorsv_clientserver) > CTRL+G. Make sure player is spawned into the game.
