### PR TITLE
Added helper for unit test hook with QApplication

### DIFF
--- a/Code/Tools/AssetBundler/tests/tests_main.cpp
+++ b/Code/Tools/AssetBundler/tests/tests_main.cpp
@@ -24,6 +24,7 @@
 #include <tests/main.h>
 #include <source/utils/applicationManager.h>
 
+#include <QApplication>
 
 extern char g_cachedEngineRoot[AZ_MAX_PATH_LEN];
 
@@ -294,6 +295,7 @@ namespace AssetBundler
 int main(int argc, char* argv[])
 {
     AZ::Debug::Trace::HandleExceptions(true);
+    QApplication app(argc, argv);
     AZ::Test::ApplyGlobalParameters(&argc, argv);
 
     INVOKE_AZ_UNIT_TEST_MAIN();

--- a/Code/Tools/DeltaCataloger/CMakeLists.txt
+++ b/Code/Tools/DeltaCataloger/CMakeLists.txt
@@ -50,6 +50,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 AZ::AzFramework
                 AZ::AzTest
                 AZ::AzToolsFramework
+                AZ::AzToolsFrameworkTestCommon
     )
 
     ly_add_googletest(

--- a/Code/Tools/DeltaCataloger/Tests/tests_main.cpp
+++ b/Code/Tools/DeltaCataloger/Tests/tests_main.cpp
@@ -17,6 +17,7 @@
 #include <AzToolsFramework/Application/ToolsApplication.h>
 #include <AzToolsFramework/AssetBundle/AssetBundleAPI.h>
 #include <AzToolsFramework/AssetBundle/AssetBundleComponent.h>
+#include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzCore/Debug/TraceMessageBus.h>
 #include <AzCore/UserSettings/UserSettingsComponent.h>
@@ -172,4 +173,4 @@ TEST_F(AssetBundleComponentTests, RemoveNonAssetEntries_PakAssetEntryWasRemoved_
     EXPECT_EQ(itr, fileEntriesHasCatalog.end());
 }
 
-AZ_UNIT_TEST_HOOK(DEFAULT_UNIT_TEST_ENV);
+AZ_TOOLS_UNIT_TEST_HOOK(DEFAULT_UNIT_TEST_ENV);

--- a/Code/Tools/PythonBindingsExample/tests/TestMain.cpp
+++ b/Code/Tools/PythonBindingsExample/tests/TestMain.cpp
@@ -13,6 +13,7 @@
 #include <AzTest/Utils.h>
 
 #include <AzTest/AzTest.h>
+#include <QApplication>
 DECLARE_AZ_UNIT_TEST_MAIN();
 
 int runDefaultRunner(int argc, char* argv[])
@@ -25,6 +26,7 @@ int main(int argc, char* argv[])
 {
     const AZ::Debug::Trace tracer;
     AZ::Debug::Trace::HandleExceptions(true);
+    QApplication app(argc, argv);
     AZ::Test::ApplyGlobalParameters(&argc, argv);
 
     // ran with no parameters?

--- a/Code/Tools/SerializeContextTools/CMakeLists.txt
+++ b/Code/Tools/SerializeContextTools/CMakeLists.txt
@@ -55,6 +55,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 AZ::AzCore
                 AZ::AzFramework
                 AZ::AzToolsFramework
+                AZ::AzToolsFrameworkTestCommon
                 AZ::AzTest
                 $<TARGET_OBJECTS:SerializeContextTools.Object>
     )

--- a/Code/Tools/SerializeContextTools/Tests/test_main.cpp
+++ b/Code/Tools/SerializeContextTools/Tests/test_main.cpp
@@ -10,9 +10,10 @@
 #include <AzCore/std/string/fixed_string.h>
 #include <AzCore/std/containers/fixed_vector.h>
 #include <AzTest/AzTest.h>
+#include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
 #include <Runner.h>
 
-AZ_UNIT_TEST_HOOK(DEFAULT_UNIT_TEST_ENV)
+AZ_TOOLS_UNIT_TEST_HOOK(DEFAULT_UNIT_TEST_ENV)
 
 
 namespace UnitTest

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Tests/Main.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Tests/Main.cpp
@@ -11,11 +11,10 @@
 #include <AzCore/UserSettings/UserSettingsComponent.h>
 #include <AzTest/AzTest.h>
 #include <AzTest/GemTestEnvironment.h>
+#include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
 #include <AzToolsFramework/UnitTest/ToolsTestApplication.h>
 
 #include <CoreLights/EditorAreaLightComponent.h>
-
-#include <QApplication>
 
 class AtomLyIntegrationHook : public AZ::Test::GemTestEnvironment
 {
@@ -48,15 +47,4 @@ void AtomLyIntegrationHook::PostSystemEntityActivate()
     AZ::UserSettingsComponentRequestBus::Broadcast(&AZ::UserSettingsComponentRequestBus::Events::DisableSaveOnFinalize);
 }
 
-// required to support running integration tests with Qt
-AZTEST_EXPORT int AZ_UNIT_TEST_HOOK_NAME(int argc, char** argv)
-{
-    ::testing::InitGoogleMock(&argc, argv);
-    QApplication app(argc, argv);
-    AZ::Test::printUnusedParametersWarning(argc, argv);
-    AZ::Test::addTestEnvironments({ new AtomLyIntegrationHook });
-    int result = RUN_ALL_TESTS();
-    return result;
-}
-
-IMPLEMENT_TEST_EXECUTABLE_MAIN();
+AZ_TOOLS_UNIT_TEST_HOOK(new AtomLyIntegrationHook)

--- a/Gems/LyShine/Code/CMakeLists.txt
+++ b/Gems/LyShine/Code/CMakeLists.txt
@@ -247,6 +247,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                     AZ::AzTest
                     Legacy::CryCommon
                     AZ::AssetBuilderSDK
+                    AZ::AzToolsFrameworkTestCommon
                     Gem::LyShine.Tools.Static
                     Gem::LyShine.Builders.Static
                     Gem::LmbrCentral.Editor

--- a/Gems/LyShine/Code/Tests/LyShineEditorTest.cpp
+++ b/Gems/LyShine/Code/Tests/LyShineEditorTest.cpp
@@ -15,6 +15,7 @@
 #include <AzCore/UserSettings/UserSettingsComponent.h>
 #include <AzCore/Utils/Utils.h>
 #include <AzToolsFramework/Application/ToolsApplication.h>
+#include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
 #include <LyShineSystemComponent.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <World/UiCanvasAssetRefComponent.h>
@@ -55,7 +56,7 @@
 #include <UiParticleEmitterComponent.h>
 #include <UiCanvasManager.h>
 
-AZ_UNIT_TEST_HOOK(DEFAULT_UNIT_TEST_ENV);
+AZ_TOOLS_UNIT_TEST_HOOK(DEFAULT_UNIT_TEST_ENV);
 
 using namespace AZ;
 using ::testing::NiceMock;

--- a/Gems/NvCloth/Code/Tests/NvClothEditorTestEnvironment.cpp
+++ b/Gems/NvCloth/Code/Tests/NvClothEditorTestEnvironment.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/UserSettings/UserSettingsComponent.h>
 
 #include <AzFramework/IO/LocalFileIO.h>
+#include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
 #include <AzToolsFramework/UnitTest/ToolsTestApplication.h>
 
 #include <System/FabricCooker.h>
@@ -118,4 +119,4 @@ namespace UnitTest
     }
 } // namespace UnitTest
 
-AZ_UNIT_TEST_HOOK(new UnitTest::NvClothEditorTestEnvironment);
+AZ_TOOLS_UNIT_TEST_HOOK(new UnitTest::NvClothEditorTestEnvironment);

--- a/Gems/PhysX/Code/Tests/PhysXEditorTest.cpp
+++ b/Gems/PhysX/Code/Tests/PhysXEditorTest.cpp
@@ -11,9 +11,9 @@
 #include <AzFramework/IO/LocalFileIO.h>
 #include <AzTest/GemTestEnvironment.h>
 #include <AzToolsFramework/Application/ToolsApplication.h>
+#include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
 #include <ComponentDescriptors.h>
 #include <EditorComponentDescriptors.h>
-#include <QApplication>
 #include <SystemComponent.h>
 #include <TestColliderComponent.h>
 #include <Editor/Source/Components/EditorSystemComponent.h>
@@ -137,15 +137,4 @@ namespace Physics
 
 } // namespace Physics
 
-AZTEST_EXPORT int AZ_UNIT_TEST_HOOK_NAME(int argc, char** argv)
-{
-    ::testing::InitGoogleMock(&argc, argv);
-    QApplication app(argc, argv);
-    AZ::Test::ApplyGlobalParameters(&argc, argv);
-    AZ::Test::printUnusedParametersWarning(argc, argv);
-    AZ::Test::addTestEnvironments({ new Physics::PhysXEditorTestEnvironment });
-    int result = RUN_ALL_TESTS();
-    return result;
-}
-
-IMPLEMENT_TEST_EXECUTABLE_MAIN();
+AZ_TOOLS_UNIT_TEST_HOOK(new Physics::PhysXEditorTestEnvironment);

--- a/Gems/Prefab/PrefabBuilder/CMakeLists.txt
+++ b/Gems/Prefab/PrefabBuilder/CMakeLists.txt
@@ -59,6 +59,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         BUILD_DEPENDENCIES
             PRIVATE
                 AZ::AzTest
+                AZ::AzToolsFrameworkTestCommon
                 Gem::PrefabBuilder.Static
     )
     ly_add_googletest(

--- a/Gems/Prefab/PrefabBuilder/PrefabBuilderTests.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabBuilderTests.cpp
@@ -15,6 +15,7 @@
 #include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/UserSettings/UserSettingsComponent.h>
+#include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
 
 namespace UnitTest
 {
@@ -210,4 +211,4 @@ namespace UnitTest
     }
 }
 
-AZ_UNIT_TEST_HOOK(DEFAULT_UNIT_TEST_ENV);
+AZ_TOOLS_UNIT_TEST_HOOK(DEFAULT_UNIT_TEST_ENV);

--- a/Gems/SceneProcessing/Code/CMakeLists.txt
+++ b/Gems/SceneProcessing/Code/CMakeLists.txt
@@ -111,6 +111,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                     Gem::SceneProcessing.Editor.Static
                     AZ::AzTest
                     AZ::SceneData
+                    AZ::AzToolsFrameworkTestCommon
         )
         ly_add_googletest(
             NAME Gem::SceneProcessing.Editor.Tests

--- a/Gems/SceneProcessing/Code/Tests/SceneProcessingConfigEditorTest.cpp
+++ b/Gems/SceneProcessing/Code/Tests/SceneProcessingConfigEditorTest.cpp
@@ -7,5 +7,6 @@
  */
 
 #include <AzTest/AzTest.h>
+#include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
 
-AZ_UNIT_TEST_HOOK(DEFAULT_UNIT_TEST_ENV);
+AZ_TOOLS_UNIT_TEST_HOOK(DEFAULT_UNIT_TEST_ENV);

--- a/Gems/SceneProcessing/Code/Tests/SceneProcessingConfigTest.cpp
+++ b/Gems/SceneProcessing/Code/Tests/SceneProcessingConfigTest.cpp
@@ -7,5 +7,6 @@
  */
 
 #include <AzTest/AzTest.h>
+#include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
 
-AZ_UNIT_TEST_HOOK(DEFAULT_UNIT_TEST_ENV);
+AZ_TOOLS_UNIT_TEST_HOOK(DEFAULT_UNIT_TEST_ENV);

--- a/Gems/SceneProcessing/Code/sceneprocessing_editor_tests_files.cmake
+++ b/Gems/SceneProcessing/Code/sceneprocessing_editor_tests_files.cmake
@@ -16,5 +16,5 @@ set(FILES
     Tests/SceneBuilder/SceneBuilderPhasesTests.cpp
     Tests/SceneBuilder/SceneBuilderTests.cpp
     Tests/SceneBuilder/SceneBuilderConfigTests.cpp
-    Tests/SceneProcessingConfigTest.cpp
+    Tests/SceneProcessingConfigEditorTest.cpp
 )


### PR DESCRIPTION
## What does this PR do?

This change adds a `AZ_TOOLS_UNIT_TEST_HOOK_ENV` macro that defines a `QApplication` before constructing the test environment and running the tests, which is required if any portion of the unit tests construct a `QWidget`.

This came up in some AR failures for https://github.com/o3de/o3de/pull/14581, which enables the new Action Manager that constructs a `QWidget` internally, and so any tests that use the default tools system component end started hitting this failure since it adds the action manager system component as a required component.

I noticed that several tests had manually defined their own main hook in order to construct this `QApplication`, so I'd like to update those to use this new hook as well if this pattern is accepted.

## How was this PR tested?

Ran all unit tests locally with the new action manager both enabled and disabled.