### PR TITLE
Add Client-Server Editor Test to Main Suite

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Multiplayer/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Multiplayer/TestSuite_Main.py
@@ -42,3 +42,7 @@ class TestAutomation(EditorTestSuite):
         def setup(cls, instance, request, workspace):
             save_multiplayer_level_cache_folder_artifact(workspace, "basicconnectivity_connects")
 
+    class test_Multiplayer_BasicConnectivity_Connects_ClientServer(EditorSingleTest):
+        from .tests import Multiplayer_BasicConnectivity_Connects_ClientServer as test_module
+        
+


### PR DESCRIPTION
Ensure the client-server editor test is include in the main test suite

The MainSuite.py file was missing in #14651 