### PR TITLE
bugfix: light color on track is inconsistent.

### DIFF
--- a/Code/Editor/TrackView/TrackViewDopeSheetBase.cpp
+++ b/Code/Editor/TrackView/TrackViewDopeSheetBase.cpp
@@ -2051,7 +2051,8 @@ void CTrackViewDopeSheetBase::OnCurrentColorChange(const AZ::Color& color)
 
 void CTrackViewDopeSheetBase::UpdateColorKey(const QColor& color, bool addToUndo)
 {
-    ColorF colArray(static_cast<f32>(color.redF()), static_cast<f32>(color.greenF()), static_cast<f32>(color.blueF()), static_cast<f32>(color.alphaF()));
+    ColorF colArray(static_cast<f32>(color.red()), static_cast<f32>(color.green()), static_cast<f32>(color.blue()), static_cast<f32>(color.alpha()));
+
 
     CTrackViewSequence* sequence = m_colorUpdateTrack->GetSequence();
     if (nullptr != sequence)


### PR DESCRIPTION
## What does this PR do?
fix color change rule from editor to track.

1. Open Editor, create a level, create an entity with Light Component, named as `light1`.
2. Open Track View.
3. Create a sequence.
4. Add `light1` to sequence, add Color track.
5. Set color value as `255, 0, 0`.
![image](https://user-images.githubusercontent.com/80555200/220010117-6ed79967-f9c8-4833-8f9b-6d3c2f6b9208.png)
6. Create a key frame at color track, set color value as `0, 255, 0`.
![image](https://user-images.githubusercontent.com/80555200/220010131-2591e569-d606-48bf-934b-b00303d40381.png)
7. Click the key frame, open the color picker dialog, don't make any change, just click `Cancel`, then color value is changed.
![image](https://user-images.githubusercontent.com/80555200/220010148-d1a638c4-20af-4685-9e12-c7b4396e19c4.png)

## How was this PR tested?
Follow the same steps.
