### PR TITLE
bugfix: edit event name with its old name.

### DIFF
--- a/Code/Editor/TrackView/TVEventsDialog.cpp
+++ b/Code/Editor/TrackView/TVEventsDialog.cpp
@@ -259,10 +259,10 @@ void CTVEventsDialog::OnBnClickedButtonRemoveEvent()
 void CTVEventsDialog::OnBnClickedButtonRenameEvent()
 {
     const QModelIndex index = m_ui->m_List->currentIndex();
-
+    QString oldName = m_ui->m_List->model()->index(index.row(), 0).data().toString();
     if (index.isValid())
     {
-        const QString newName = QInputDialog::getText(this, tr("Track Event Name"), QString());
+        const QString newName = QInputDialog::getText(this, tr("Track Event Name"), QString(), QLineEdit::Normal, oldName);
         if (!newName.isEmpty())
         {
             m_ui->m_List->model()->setData(index.sibling(index.row(), 0), newName);


### PR DESCRIPTION
## What does this PR do?

1. Open Editor.
2. Click Tools -> Track View.
3. Create a sequence.
4. Right click the sequence to open menus, and click `Edit Events`.
5. Add some events.
![image](https://user-images.githubusercontent.com/80555200/220023450-b62516dc-426a-458f-b458-1925affb2353.png)

## How was this PR tested?

Follow the same steps, as follows:
![image](https://user-images.githubusercontent.com/80555200/220023475-49c71e63-ea08-42ad-b5d1-7f7a9aa1201b.png)
