### PR TITLE
bugfix: remove the unnecessary prompt when deleting unused events.

### DIFF
--- a/Code/Editor/TrackView/TVEventsDialog.cpp
+++ b/Code/Editor/TrackView/TVEventsDialog.cpp
@@ -68,14 +68,28 @@ public:
 
         AzToolsFramework::ScopedUndoBatch undo("Remove Track Event");
 
-        for (int r = row; r < row + count; ++r)
+        for (int r = row, max = row + count; r < max; ++r)
         {
             const QString eventName = index(r, 0).data().toString();
-            beginRemoveRows(QModelIndex(), r, r);
-            result &= sequence->RemoveTrackEvent(eventName.toUtf8().data());
-            endRemoveRows();
+            bool remove = true;
+            float timeFirstUsed;
+            int usageCount = GetNumberOfUsageAndFirstTimeUsed(eventName.toStdString().c_str(), timeFirstUsed);
+            if (usageCount > 0)
+            {
+                remove = QMessageBox::warning(
+                             nullptr,
+                             tr("Remove Event"),
+                             tr("Remove \"") + eventName + tr("\" event might cause some link breakages in Flow Graph.\nStill continue?"),
+                             QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes;
+            }
 
-            undo.MarkEntityDirty(sequence->GetSequenceComponentEntityId());
+            if (remove)
+            {
+                beginRemoveRows(QModelIndex(), r, r);
+                result &= sequence->RemoveTrackEvent(eventName.toUtf8().data());
+                endRemoveRows();
+                undo.MarkEntityDirty(sequence->GetSequenceComponentEntityId());
+            }
         }
 
         return result;
@@ -248,10 +262,7 @@ void CTVEventsDialog::OnBnClickedButtonRemoveEvent()
 
     for (auto index : indexes)
     {
-        if (QMessageBox::warning(this, tr("Remove Event"), tr("This removal might cause some link breakages in Flow Graph.\nStill continue?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes)
-        {
-            m_ui->m_List->model()->removeRow(index.row());
-        }
+        m_ui->m_List->model()->removeRow(index.row());
     }
     m_ui->m_List->setFocus();
 }


### PR DESCRIPTION
## What does this PR do?

Remove the unnecessary prompt when deleting unused events.

1. Open Editor.
2. Click Tools -> Track View.
3. Create a sequence.
4. Right click the sequence to open menus, and click Edit Events.
5. Add some events.
6. Remove one of them, as follows:
![image](https://user-images.githubusercontent.com/80555200/220028902-c4e2e7ea-98e9-411a-97cd-4f0eb2001b90.png)
![image](https://user-images.githubusercontent.com/80555200/220028930-b977b920-03e7-4688-adc1-d11522a24d2e.png)

## How was this PR tested?

Follow the same steps.
