### PR TITLE
Scene queries optimization: Exposed QueryScene function doing no allocations

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/Common/PhysicsSceneQueries.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Common/PhysicsSceneQueries.h
@@ -159,7 +159,7 @@ namespace AzPhysics
     using SceneQueryRequests = AZStd::vector<AZStd::shared_ptr<SceneQueryRequest>>;
 
     //! Casts a ray from a starting pose along a direction returning objects that intersected with the ray.
-    struct RayCastRequest :
+    struct RayCastRequest final :
         public SceneQueryRequest
     {
         AZ_CLASS_ALLOCATOR_DECL;
@@ -181,7 +181,7 @@ namespace AzPhysics
     };
 
     //! Sweeps a shape from a starting pose along a direction returning objects that intersected with the shape.
-    struct ShapeCastRequest :
+    struct ShapeCastRequest final :
         public SceneQueryRequest
     {
         AZ_CLASS_ALLOCATOR_DECL;
@@ -228,7 +228,7 @@ namespace AzPhysics
     } // namespace ShapeCastRequestHelpers
 
     //! Searches a region enclosed by a specified shape for any overlapping objects in the scene.
-    struct OverlapRequest :
+    struct OverlapRequest final :
         public SceneQueryRequest
     {
         AZ_CLASS_ALLOCATOR_DECL;
@@ -269,8 +269,6 @@ namespace AzPhysics
         AZ_CLASS_ALLOCATOR_DECL;
         AZ_TYPE_INFO(SceneQueryHit, "{7A7201B9-67B5-438B-B4EB-F3EEBB78C617}");
         static void Reflect(AZ::ReflectContext* context);
-
-        virtual ~SceneQueryHit() = default;
 
         explicit operator bool() const { return IsValid(); }
         bool IsValid() const { return m_resultFlags != SceneQuery::ResultFlags::Invalid; }

--- a/Code/Framework/AzFramework/AzFramework/Physics/PhysicsScene.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/PhysicsScene.cpp
@@ -51,7 +51,10 @@ namespace AzPhysics
                 ->Attribute(AZ::Script::Attributes::Category, "Physics")
                 ->Method("GetOnGravityChangeEvent", getOnGravityChange)
                     ->Attribute(AZ::Script::Attributes::AzEventDescription, gravityChangedEventDescription)
-                ->Method("QueryScene", &Scene::QueryScene)
+                ->Method("QueryScene", [](Scene* selfPtr, const SceneQueryRequest* request)
+                {
+                    return selfPtr->QueryScene(request);
+                })
                 ;
         }
     }

--- a/Code/Framework/AzFramework/AzFramework/Physics/PhysicsScene.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/PhysicsScene.cpp
@@ -51,9 +51,9 @@ namespace AzPhysics
                 ->Attribute(AZ::Script::Attributes::Category, "Physics")
                 ->Method("GetOnGravityChangeEvent", getOnGravityChange)
                     ->Attribute(AZ::Script::Attributes::AzEventDescription, gravityChangedEventDescription)
-                ->Method("QueryScene", [](Scene* selfPtr, const SceneQueryRequest* request)
+                ->Method("QueryScene", [](Scene* self, const SceneQueryRequest* request)
                 {
-                    return selfPtr->QueryScene(request);
+                    return self->QueryScene(request);
                 })
                 ;
         }

--- a/Code/Framework/AzFramework/AzFramework/Physics/PhysicsScene.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/PhysicsScene.h
@@ -132,6 +132,13 @@ namespace AzPhysics
         //! @return Returns a structure that contains a list of Hits. Depending on flags set in the request, this may only contain 1 result.
         virtual SceneQueryHits QueryScene(SceneHandle sceneHandle, const SceneQueryRequest* request) = 0;
 
+        //! Make a blocking query into the scene.
+        //! @param sceneHandle A handle to the scene to make the scene query with.
+        //! @param request The request to make. Should be one of RayCastRequest || ShapeCastRequest || OverlapRequest
+        //! @param result A structure that contains a list of Hits. Depending on flags set in the request, this may only contain 1 result.
+        //! @return Returns true if there is at least one hit.
+        virtual bool QueryScene(SceneHandle sceneHandle, const SceneQueryRequest* request, SceneQueryHits& result) = 0;
+
         //! Make many blocking queries into the scene.
         //! @param sceneHandle A handle to the scene to make the scene query with.
         //! @param requests A list of requests to make. Each entry should be one of RayCastRequest || ShapeCastRequest || OverlapRequest
@@ -343,6 +350,12 @@ namespace AzPhysics
         //! @param request The request to make. Should be one of RayCastRequest || ShapeCastRequest || OverlapRequest
         //! @return Returns a structure that contains a list of Hits. Depending on flags set in the request, this may only contain 1 result.
         virtual SceneQueryHits QueryScene(const SceneQueryRequest* request) = 0;
+
+        //! Make a blocking query into the scene.
+        //! @param request The request to make. Should be one of RayCastRequest || ShapeCastRequest || OverlapRequest
+        //! @param result A structure that contains a list of Hits. Depending on flags set in the request, this may only contain 1 result.
+        //! @return Returns true if there is at least one hit.
+        virtual bool QueryScene(const SceneQueryRequest* request, SceneQueryHits& result) = 0;
 
         //! Make many blocking queries into the scene.
         //! @param requests A list of requests to make. Each entry should be one of RayCastRequest || ShapeCastRequest || OverlapRequest

--- a/Code/Framework/AzFramework/AzFramework/Physics/Shape.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Shape.h
@@ -85,6 +85,7 @@ namespace Physics
 
         virtual void SetMaterial(const AZStd::shared_ptr<Material>& material) = 0;
         virtual AZStd::shared_ptr<Material> GetMaterial() const = 0;
+        virtual Physics::MaterialId GetMaterialId() const = 0;
 
         virtual void SetCollisionLayer(const AzPhysics::CollisionLayer& layer) = 0;
         virtual AzPhysics::CollisionLayer GetCollisionLayer() const = 0;

--- a/Gems/EMotionFX/Code/Tests/Mocks/PhysicsSystem.h
+++ b/Gems/EMotionFX/Code/Tests/Mocks/PhysicsSystem.h
@@ -193,6 +193,7 @@ namespace Physics
         MOCK_METHOD2(RegisterSceneSimulationFinishHandler, void(AzPhysics::SceneHandle sceneHandle, AzPhysics::SceneEvents::OnSceneSimulationFinishHandler& handler));
         MOCK_CONST_METHOD2(GetLegacyBody, AzPhysics::SimulatedBody* (AzPhysics::SceneHandle sceneHandle, AzPhysics::SimulatedBodyHandle handle));
         MOCK_METHOD2(QueryScene, AzPhysics::SceneQueryHits(AzPhysics::SceneHandle sceneHandle, const AzPhysics::SceneQueryRequest* request));
+        MOCK_METHOD3(QueryScene, bool(AzPhysics::SceneHandle sceneHandle, const AzPhysics::SceneQueryRequest* request, AzPhysics::SceneQueryHits&));
         MOCK_METHOD2(QuerySceneBatch, AzPhysics::SceneQueryHitsList(AzPhysics::SceneHandle sceneHandle, const AzPhysics::SceneQueryRequests& requests));
         MOCK_METHOD4(QuerySceneAsync, bool(AzPhysics::SceneHandle sceneHandle, AzPhysics::SceneQuery::AsyncRequestId requestId,
             const AzPhysics::SceneQueryRequest* request, AzPhysics::SceneQuery::AsyncCallback callback));

--- a/Gems/Multiplayer/Code/Tests/NetworkRigidBodyTests.cpp
+++ b/Gems/Multiplayer/Code/Tests/NetworkRigidBodyTests.cpp
@@ -56,6 +56,7 @@ namespace Multiplayer
         MOCK_METHOD2(GetSimulatedBodyFromHandle, AzPhysics::SimulatedBody*(AzPhysics::SceneHandle, AzPhysics::SimulatedBodyHandle));
         MOCK_CONST_METHOD1(IsEnabled, bool(AzPhysics::SceneHandle));
         MOCK_METHOD2(QueryScene, AzPhysics::SceneQueryHits(AzPhysics::SceneHandle, const AzPhysics::SceneQueryRequest*));
+        MOCK_METHOD3(QueryScene, bool(AzPhysics::SceneHandle sceneHandle, const AzPhysics::SceneQueryRequest* request, AzPhysics::SceneQueryHits&));
         MOCK_METHOD4(
             QuerySceneAsync,
             bool(

--- a/Gems/PhysX/Code/Mocks/PhysX/MockPhysicsShape.h
+++ b/Gems/PhysX/Code/Mocks/PhysX/MockPhysicsShape.h
@@ -25,7 +25,8 @@ namespace UnitTest
         MOCK_CONST_METHOD0(GetContactOffset, float ());
         MOCK_CONST_METHOD3(GetGeometry, void(AZStd::vector<AZ::Vector3>&, AZStd::vector<AZ::u32>&, const AZ::Aabb*));
         MOCK_CONST_METHOD0(GetLocalPose, AZStd::pair<AZ::Vector3, AZ::Quaternion> ());
-        MOCK_CONST_METHOD0(GetMaterial, AZStd::shared_ptr<Physics::Material> ());
+        MOCK_CONST_METHOD0(GetMaterial, AZStd::shared_ptr<Physics::Material>());
+        MOCK_CONST_METHOD0(GetMaterialId, Physics::MaterialId());
         MOCK_METHOD0(GetNativePointer, void* ());
         MOCK_CONST_METHOD0(GetNativePointer, const void*());
         MOCK_CONST_METHOD0(GetRestOffset, float ());

--- a/Gems/PhysX/Code/Mocks/PhysX/MockSceneInterface.h
+++ b/Gems/PhysX/Code/Mocks/PhysX/MockSceneInterface.h
@@ -37,6 +37,7 @@ namespace UnitTest
         MOCK_METHOD2(GetSimulatedBodyFromHandle, AzPhysics::SimulatedBody* (AzPhysics::SceneHandle, AzPhysics::SimulatedBodyHandle));
         MOCK_CONST_METHOD1(IsEnabled, bool(AzPhysics::SceneHandle));
         MOCK_METHOD2(QueryScene, AzPhysics::SceneQueryHits(AzPhysics::SceneHandle, const AzPhysics::SceneQueryRequest*));
+        MOCK_METHOD3(QueryScene, bool(AzPhysics::SceneHandle sceneHandle, const AzPhysics::SceneQueryRequest* request, AzPhysics::SceneQueryHits&));
         MOCK_METHOD4(QuerySceneAsync, bool(AzPhysics::SceneHandle, AzPhysics::SceneQuery::AsyncRequestId, const AzPhysics::
             SceneQueryRequest*, AzPhysics::SceneQuery::AsyncCallback));
         MOCK_METHOD4(QuerySceneAsyncBatch, bool(AzPhysics::SceneHandle, AzPhysics::SceneQuery::AsyncRequestId, const AzPhysics::

--- a/Gems/PhysX/Code/Source/Common/PhysXSceneQueryHelpers.cpp
+++ b/Gems/PhysX/Code/Source/Common/PhysXSceneQueryHelpers.cpp
@@ -103,15 +103,10 @@ namespace PhysX
                     hit.m_physicsMaterialId = physicsMaterial->GetId();
                 }
 #endif
-
             }
             else if (hit.m_shape != nullptr)
             {
-                if (const auto& physicsMaterial = hit.m_shape->GetMaterial();
-                    physicsMaterial.get() != nullptr)
-                {
-                    hit.m_physicsMaterialId = physicsMaterial->GetId();
-                }
+                hit.m_physicsMaterialId = hit.m_shape->GetMaterialId();
             }
             if (hit.m_physicsMaterialId.IsValid())
             {
@@ -335,8 +330,9 @@ namespace PhysX
 #endif
 
         UnboundedOverlapCallback::UnboundedOverlapCallback(const AzPhysics::SceneQuery::UnboundedOverlapHitCallback& hitCallback,
-            AZStd::vector<physx::PxOverlapHit>& hitBuffer)
+            AZStd::vector<physx::PxOverlapHit>& hitBuffer, AzPhysics::SceneQueryHits& hits)
             : m_hitCallback(hitCallback)
+            , m_results(hits)
             , physx::PxHitCallback<physx::PxOverlapHit>(hitBuffer.begin(), static_cast<physx::PxU32>(hitBuffer.size()))
         {}
 

--- a/Gems/PhysX/Code/Source/Common/PhysXSceneQueryHelpers.h
+++ b/Gems/PhysX/Code/Source/Common/PhysXSceneQueryHelpers.h
@@ -98,10 +98,11 @@ namespace PhysX
             void finalizeQuery() override;
 
             const AzPhysics::SceneQuery::UnboundedOverlapHitCallback& m_hitCallback;
-            AzPhysics::SceneQueryHits m_results;
+            AzPhysics::SceneQueryHits& m_results;
 
             UnboundedOverlapCallback(const AzPhysics::SceneQuery::UnboundedOverlapHitCallback& hitCallback,
-                AZStd::vector<physx::PxOverlapHit>& hitBuffer);
+                AZStd::vector<physx::PxOverlapHit>& hitBuffer,
+                AzPhysics::SceneQueryHits& hits);
         };
     } // namespace SceneQueryHelpers
 }

--- a/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
+++ b/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
@@ -267,11 +267,12 @@ namespace PhysX
         }
 
         //helper to perform a ray cast
-        AzPhysics::SceneQueryHits RayCast(const AzPhysics::RayCastRequest* raycastRequest,
+        bool RayCast(const AzPhysics::RayCastRequest* raycastRequest,
             AZStd::vector<physx::PxRaycastHit>& raycastBuffer,
             physx::PxScene* physxScene,
             const physx::PxQueryFilterData queryData,
-            const AZ::u32 sceneMaxResults)
+            const AZ::u32 sceneMaxResults,
+            AzPhysics::SceneQueryHits& hits)
         {
             // if this query need to report multiple hits, we need to prepare a buffer to hold up to the max allowed.
             // The filter should also use the eTOUCH flag to find all contacts with the ray.
@@ -309,7 +310,6 @@ namespace PhysX
                 status = physxScene->raycast(orig, dir, raycastRequest->m_distance, castResult, hitFlags, queryData, &queryFilterCallback);
             }
 
-            AzPhysics::SceneQueryHits hits;
             if (status)
             {
                 if (castResult.hasBlock)
@@ -326,15 +326,16 @@ namespace PhysX
                     }
                 }
             }
-            return hits;
+            return status;
         }
 
         //helper to preform a shape cast
-        AzPhysics::SceneQueryHits ShapeCast(const AzPhysics::ShapeCastRequest* shapecastRequest,
+        bool ShapeCast(const AzPhysics::ShapeCastRequest* shapecastRequest,
             AZStd::vector<physx::PxSweepHit>& shapecastBuffer,
             physx::PxScene* physxScene,
             const physx::PxQueryFilterData queryData,
-            const AZ::u32 sceneMaxResults)
+            const AZ::u32 sceneMaxResults,
+            AzPhysics::SceneQueryHits& hits)
         {
             // if this query need to report multiple hits, we need to prepare a buffer to hold up to the max allowed.
             // The filter should also use the eTOUCH flag to find all contacts with the shape.
@@ -365,7 +366,6 @@ namespace PhysX
             physx::PxGeometryHolder pxGeometry;
             Utils::CreatePxGeometryFromConfig(*(shapecastRequest->m_shapeConfiguration), pxGeometry);
 
-            AzPhysics::SceneQueryHits results;
             if (pxGeometry.any().getType() == physx::PxGeometryType::eSPHERE ||
                 pxGeometry.any().getType() == physx::PxGeometryType::eBOX ||
                 pxGeometry.any().getType() == physx::PxGeometryType::eCAPSULE ||
@@ -388,7 +388,7 @@ namespace PhysX
                 {
                     if (castResult.hasBlock)
                     {
-                        results.m_hits.emplace_back(SceneQueryHelpers::GetHitFromPxHit(castResult.block, castResult.block));
+                        hits.m_hits.emplace_back(SceneQueryHelpers::GetHitFromPxHit(castResult.block, castResult.block));
                     }
 
                     if (shapecastRequest->m_reportMultipleHits)
@@ -396,17 +396,19 @@ namespace PhysX
                         for (auto i = 0u; i < castResult.getNbTouches(); ++i)
                         {
                             const auto& pxHit = castResult.getTouch(i);
-                            results.m_hits.emplace_back(SceneQueryHelpers::GetHitFromPxHit(pxHit, pxHit));
+                            hits.m_hits.emplace_back(SceneQueryHelpers::GetHitFromPxHit(pxHit, pxHit));
                         }
                     }
                 }
+
+                return status;
             }
             else
             {
                 AZ_Warning("World", false, "Invalid geometry type passed to shape cast. Only sphere, box, capsule or convex mesh is supported");
             }
 
-            return results;
+            return false;
         }
 
         bool OverlapGeneric(physx::PxScene* physxScene, const AzPhysics::OverlapRequest* overlapRequest,
@@ -430,11 +432,12 @@ namespace PhysX
             return status;
         }
 
-        AzPhysics::SceneQueryHits OverlapQuery(const AzPhysics::OverlapRequest* overlapRequest,
+        bool OverlapQuery(const AzPhysics::OverlapRequest* overlapRequest,
             AZStd::vector<physx::PxOverlapHit>& overlapBuffer,
             physx::PxScene* physxScene,
             const physx::PxQueryFilterData queryData,
-            const AZ::u32 sceneMaxResults)
+            const AZ::u32 sceneMaxResults,
+            AzPhysics::SceneQueryHits& hits)
         {
             const AZ::u32 maxSize = AZStd::min(overlapRequest->m_maxResults, sceneMaxResults);
             if (overlapBuffer.size() < maxSize)
@@ -444,35 +447,30 @@ namespace PhysX
 
             if (overlapRequest->m_unboundedOverlapHitCallback)
             {
-                SceneQueryHelpers::UnboundedOverlapCallback callback(overlapRequest->m_unboundedOverlapHitCallback, overlapBuffer);
+                SceneQueryHelpers::UnboundedOverlapCallback callback(overlapRequest->m_unboundedOverlapHitCallback, overlapBuffer, hits);
                 const bool status = OverlapGeneric(physxScene, overlapRequest, callback, queryData);
-                if (status)
-                {
-                    return callback.m_results;
-                }
-                return {};
+                return status;
             }
 
             physx::PxOverlapBuffer queryHits(overlapBuffer.begin(), maxSize);
             bool status = OverlapGeneric(physxScene, overlapRequest, queryHits, queryData);
 
-            AzPhysics::SceneQueryHits results;
             if (status)
             {
                 // Process results
                 AZ::u32 hitNum = queryHits.getNbAnyHits();
-                results.m_hits.reserve(hitNum);
+                hits.m_hits.reserve(hits.m_hits.size() + hitNum);
                 for (AZ::u32 i = 0; i < hitNum; ++i)
                 {
                     const AzPhysics::SceneQueryHit hit = SceneQueryHelpers::GetHitFromPxOverlapHit(queryHits.getAnyHit(i));
                     if (hit.IsValid())
                     {
-                        results.m_hits.emplace_back(hit);
+                        hits.m_hits.emplace_back(hit);
                     }
                 }
-                results.m_hits.shrink_to_fit();
             }
-            return results;
+
+            return status;
         }
     }
 
@@ -966,9 +964,16 @@ namespace PhysX
 
     AzPhysics::SceneQueryHits PhysXScene::QueryScene(const AzPhysics::SceneQueryRequest* request)
     {
+        AzPhysics::SceneQueryHits hits;
+        QueryScene(request, hits);
+        return hits;      
+    }
+
+    bool PhysXScene::QueryScene(const AzPhysics::SceneQueryRequest* request, AzPhysics::SceneQueryHits& result)
+    {
         if (request == nullptr)
         {
-            return {}; //return 0 hits
+            return false; // return 0 hits
         }
 
         // Query flags.
@@ -979,25 +984,26 @@ namespace PhysX
         {
         case AzPhysics::SceneQueryRequest::RequestType::Raycast:
             {
-                return Internal::RayCast(
-                    static_cast<const AzPhysics::RayCastRequest*>(request), s_rayCastBuffer, m_pxScene, queryData, m_raycastBufferSize);
+                return Internal::RayCast(static_cast<const AzPhysics::RayCastRequest*>(request),
+                    s_rayCastBuffer, m_pxScene, queryData, m_raycastBufferSize, result);
             }
         case AzPhysics::SceneQueryRequest::RequestType::Shapecast:
             {
-                return Internal::ShapeCast(
-                    static_cast<const AzPhysics::ShapeCastRequest*>(request), s_sweepBuffer, m_pxScene, queryData, m_shapecastBufferSize);
+                return Internal::ShapeCast(static_cast<const AzPhysics::ShapeCastRequest*>(request),
+                    s_sweepBuffer, m_pxScene, queryData, m_shapecastBufferSize, result);
             }
         case AzPhysics::SceneQueryRequest::RequestType::Overlap:
             {
-                return Internal::OverlapQuery(
-                    static_cast<const AzPhysics::OverlapRequest*>(request), s_overlapBuffer, m_pxScene, queryData, m_overlapBufferSize);
+                return Internal::OverlapQuery(static_cast<const AzPhysics::OverlapRequest*>(request),
+                    s_overlapBuffer, m_pxScene, queryData, m_overlapBufferSize, result);
             }
         default:
             {
                 AZ_Warning("Physx", false, "Unknown Scene Query request type.");
-                return {};
             }
         };
+
+        return false;
     }
 
     AzPhysics::SceneQueryHitsList PhysXScene::QuerySceneBatch(const AzPhysics::SceneQueryRequests& requests)

--- a/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
+++ b/Gems/PhysX/Code/Source/Scene/PhysXScene.cpp
@@ -329,7 +329,7 @@ namespace PhysX
             return status;
         }
 
-        //helper to preform a shape cast
+        // helper to preform a shape cast
         bool ShapeCast(const AzPhysics::ShapeCastRequest* shapecastRequest,
             AZStd::vector<physx::PxSweepHit>& shapecastBuffer,
             physx::PxScene* physxScene,

--- a/Gems/PhysX/Code/Source/Scene/PhysXScene.h
+++ b/Gems/PhysX/Code/Source/Scene/PhysXScene.h
@@ -58,6 +58,8 @@ namespace PhysX
         AzPhysics::Joint* GetJointFromHandle(AzPhysics::JointHandle jointHandle) override;
         void RemoveJoint(AzPhysics::JointHandle jointHandle) override;
         AzPhysics::SceneQueryHits QueryScene(const AzPhysics::SceneQueryRequest* request) override;
+        bool QueryScene(const AzPhysics::SceneQueryRequest* request, AzPhysics::SceneQueryHits& result) override;
+
         AzPhysics::SceneQueryHitsList QuerySceneBatch(const AzPhysics::SceneQueryRequests& requests) override;
         [[nodiscard]] bool QuerySceneAsync(AzPhysics::SceneQuery::AsyncRequestId requestId,
             const AzPhysics::SceneQueryRequest* request, AzPhysics::SceneQuery::AsyncCallback callback) override;

--- a/Gems/PhysX/Code/Source/Scene/PhysXSceneInterface.cpp
+++ b/Gems/PhysX/Code/Source/Scene/PhysXSceneInterface.cpp
@@ -186,6 +186,16 @@ namespace PhysX
         return AzPhysics::SceneQueryHits();
     }
 
+    bool PhysXSceneInterface::QueryScene(
+        AzPhysics::SceneHandle sceneHandle, const AzPhysics::SceneQueryRequest* request, AzPhysics::SceneQueryHits& result)
+    {
+        if (AzPhysics::Scene* scene = m_physxSystem->GetScene(sceneHandle))
+        {
+            return scene->QueryScene(request, result);
+        }
+        return false;
+    }
+
     AzPhysics::SceneQueryHitsList PhysXSceneInterface::QuerySceneBatch(
         AzPhysics::SceneHandle sceneHandle, const AzPhysics::SceneQueryRequests& requests)
     {

--- a/Gems/PhysX/Code/Source/Scene/PhysXSceneInterface.h
+++ b/Gems/PhysX/Code/Source/Scene/PhysXSceneInterface.h
@@ -46,6 +46,7 @@ namespace PhysX
         AzPhysics::Joint* GetJointFromHandle(AzPhysics::SceneHandle sceneHandle, AzPhysics::JointHandle jointHandle) override;
         void RemoveJoint(AzPhysics::SceneHandle sceneHandle, AzPhysics::JointHandle jointHandle) override;
         AzPhysics::SceneQueryHits QueryScene(AzPhysics::SceneHandle sceneHandle, const AzPhysics::SceneQueryRequest* request) override;
+        bool QueryScene(AzPhysics::SceneHandle sceneHandle, const AzPhysics::SceneQueryRequest* request, AzPhysics::SceneQueryHits& result) override;
         AzPhysics::SceneQueryHitsList QuerySceneBatch(AzPhysics::SceneHandle sceneHandle, const AzPhysics::SceneQueryRequests& requests) override;
         [[nodiscard]] bool QuerySceneAsync(AzPhysics::SceneHandle sceneHandle, AzPhysics::SceneQuery::AsyncRequestId requestId,
             const AzPhysics::SceneQueryRequest* request, AzPhysics::SceneQuery::AsyncCallback callback) override;

--- a/Gems/PhysX/Code/Source/Shape.cpp
+++ b/Gems/PhysX/Code/Source/Shape.cpp
@@ -129,6 +129,16 @@ namespace PhysX
         return nullptr;
     }
 
+    Physics::MaterialId Shape::GetMaterialId() const
+    {
+        if (!m_materials.empty())
+        {
+            return m_materials[0]->GetId();
+        }
+
+        return {};
+    }
+
     void Shape::SetPhysXMaterials(const AZStd::vector<AZStd::shared_ptr<PhysX::Material>>& materials)
     {
         m_materials = materials;

--- a/Gems/PhysX/Code/Source/Shape.h
+++ b/Gems/PhysX/Code/Source/Shape.h
@@ -45,6 +45,7 @@ namespace PhysX
         // Physics::Shape overrides...
         void SetMaterial(const AZStd::shared_ptr<Physics::Material>& material) override;
         AZStd::shared_ptr<Physics::Material> GetMaterial() const override;
+        Physics::MaterialId GetMaterialId() const override;
         void SetCollisionLayer(const AzPhysics::CollisionLayer& layer) override;
         AzPhysics::CollisionLayer GetCollisionLayer() const override;
         void SetCollisionGroup(const AzPhysics::CollisionGroup& group) override;

--- a/Gems/PhysX/Code/Tests/Benchmarks/PhysXSceneQueryBenchmarks.cpp
+++ b/Gems/PhysX/Code/Tests/Benchmarks/PhysXSceneQueryBenchmarks.cpp
@@ -18,7 +18,8 @@
 #include <Benchmarks/PhysXBenchmarksCommon.h>
 #include <Benchmarks/PhysXBenchmarksUtilities.h>
 
-#include <AzCore/std/chrono/chrono.h>
+#include <PhysX/PhysXLocks.h>
+#include <Scene/PhysXScene.h>
 
 namespace PhysX::Benchmarks
 {
@@ -156,7 +157,69 @@ namespace PhysX::Benchmarks
             next = (next + 1) % m_numBoxes;
         }
 
-        //get the P50, P90, P99 percentiles of each call and the standard deviation and mean
+        // get the P50, P90, P99 percentiles of each call and the standard deviation and mean
+        Utils::ReportPercentiles(state, executionTimes);
+        Utils::ReportStandardDeviationAndMeanCounters(state, executionTimes);
+    }
+
+    BENCHMARK_DEFINE_F(PhysXSceneQueryBenchmarkFixture, BM_RaycastRandomBoxesParallel)(benchmark::State& state)
+    {
+        AzPhysics::RayCastRequest request;
+        request.m_start = AZ::Vector3::CreateZero();
+        request.m_distance = 2000.0f;
+
+        AZStd::vector<int64_t> executionTimes;
+        auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
+
+        auto next = 0;
+        for ([[maybe_unused]] auto _ : state)
+        {
+            request.m_direction = m_boxes[next].GetNormalized();
+
+            auto start = AZStd::chrono::steady_clock::now();
+
+            const size_t numThreads = 4;
+
+            AZStd::vector<AZStd::thread> threads;
+            threads.reserve(numThreads);
+            AzPhysics::SceneHandle testSceneHandle = m_testSceneHandle;
+
+            for (size_t i = 0; i < numThreads; ++i)
+            {
+                threads.emplace_back(
+                    [&testSceneHandle, &request, sceneInterface]()
+                    {
+                        PhysXScene* azScene = static_cast<PhysXScene*>(sceneInterface->GetScene(testSceneHandle));
+                        physx::PxScene* pxScene = static_cast<physx::PxScene*>(azScene->GetNativePointer());
+
+                        PHYSX_SCENE_READ_LOCK(pxScene);
+
+                        const size_t iterationsNum = 1000000;
+
+                        AzPhysics::SceneQueryHits result;
+                        for (size_t k = 0; k < iterationsNum; ++k)
+                        {
+                            sceneInterface->QueryScene(testSceneHandle, &request, result);
+
+                            result.m_hits.clear();
+                        }
+                        benchmark::DoNotOptimize(result);
+                    });
+            }
+
+            for (AZStd::thread& thread : threads)
+            {
+                thread.join();
+            }
+
+            auto timeElasped = AZStd::chrono::duration_cast<AZStd::chrono::nanoseconds>(AZStd::chrono::steady_clock::now() - start);
+
+            executionTimes.emplace_back(timeElasped.count());
+
+            next = (next + 1) % m_numBoxes;
+        }
+
+        // get the P50, P90, P99 percentiles of each call and the standard deviation and mean
         Utils::ReportPercentiles(state, executionTimes);
         Utils::ReportStandardDeviationAndMeanCounters(state, executionTimes);
     }
@@ -234,6 +297,15 @@ namespace PhysX::Benchmarks
         ->Ranges(SceneQueryConstants::BenchmarkConfigs[3])
         ->Unit(::benchmark::kNanosecond)
         ;
+
+    BENCHMARK_REGISTER_F(PhysXSceneQueryBenchmarkFixture, BM_RaycastRandomBoxesParallel)
+        ->RangeMultiplier(2)
+        ->Ranges(SceneQueryConstants::BenchmarkConfigs[0])
+        ->Ranges(SceneQueryConstants::BenchmarkConfigs[1])
+        ->Ranges(SceneQueryConstants::BenchmarkConfigs[2])
+        ->Ranges(SceneQueryConstants::BenchmarkConfigs[3])
+        ->Unit(::benchmark::kNanosecond);
+
     BENCHMARK_REGISTER_F(PhysXSceneQueryBenchmarkFixture, BM_ShapecastRandomBoxes)
         ->RangeMultiplier(2)
         ->Ranges(SceneQueryConstants::BenchmarkConfigs[0])

--- a/Gems/ScriptCanvasPhysics/Code/Tests/ScriptCanvasPhysicsTest.cpp
+++ b/Gems/ScriptCanvasPhysics/Code/Tests/ScriptCanvasPhysicsTest.cpp
@@ -140,6 +140,7 @@ namespace ScriptCanvasPhysicsTests
         MOCK_METHOD2(RegisterSceneSimulationFinishHandler, void(AzPhysics::SceneHandle sceneHandle, AzPhysics::SceneEvents::OnSceneSimulationFinishHandler& handler));
         MOCK_CONST_METHOD2(GetLegacyBody, AzPhysics::SimulatedBody* (AzPhysics::SceneHandle sceneHandle, AzPhysics::SimulatedBodyHandle handle));
         MOCK_METHOD2(QueryScene, AzPhysics::SceneQueryHits(AzPhysics::SceneHandle sceneHandle, const AzPhysics::SceneQueryRequest* request));
+        MOCK_METHOD3(QueryScene, bool(AzPhysics::SceneHandle sceneHandle, const AzPhysics::SceneQueryRequest* request, AzPhysics::SceneQueryHits&));
         MOCK_METHOD2(QuerySceneBatch, AzPhysics::SceneQueryHitsList(AzPhysics::SceneHandle sceneHandle, const AzPhysics::SceneQueryRequests& requests));
         MOCK_METHOD4(QuerySceneAsync, bool(AzPhysics::SceneHandle sceneHandle, AzPhysics::SceneQuery::AsyncRequestId requestId,
             const AzPhysics::SceneQueryRequest* request, AzPhysics::SceneQuery::AsyncCallback callback));
@@ -170,6 +171,7 @@ namespace ScriptCanvasPhysicsTests
         AZ_CLASS_ALLOCATOR(MockShape, AZ::SystemAllocator)
         MOCK_METHOD1(SetMaterial, void(const AZStd::shared_ptr<Physics::Material>& material));
         MOCK_CONST_METHOD0(GetMaterial, AZStd::shared_ptr<Physics::Material>());
+        MOCK_CONST_METHOD0(GetMaterialId, Physics::MaterialId());
         MOCK_METHOD1(SetCollisionLayer, void(const AzPhysics::CollisionLayer& layer));
         MOCK_CONST_METHOD0(GetCollisionLayer, AzPhysics::CollisionLayer());
         MOCK_METHOD1(SetCollisionGroup, void(const AzPhysics::CollisionGroup& group));


### PR DESCRIPTION
## What does this PR do?

Scene queries optimization: Exposed `QueryScene` function doing no allocations + exposed Shape::GetMaterialId to prevent using `shared_ptr` in a performance critical code. 

Benchmark creating 32 threads running 1 million raycasts against 128 boxes, measuring overall execution time:
Before: 48583 ms 
After: 456 ms
CPU: AMD Ryzen Threadripper 3970X (32 cores)

![image](https://user-images.githubusercontent.com/60428010/220052377-03d6d2ce-caa8-4628-af2a-78ab593cc8c0.png)


## How was this PR tested?

Unit tests, benchmarks.


