### PR TITLE
fix auto recording rate inconsistent problem.

### DIFF
--- a/Code/Editor/TrackView/TrackViewDialog.cpp
+++ b/Code/Editor/TrackView/TrackViewDialog.cpp
@@ -505,6 +505,7 @@ void CTrackViewDialog::InitToolbar()
             connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnAutoRecordStep);
             qaction->setCheckable(true);
             qaction->setChecked(i == 1);
+            m_fAutoRecordStep = 1;
             ag->addAction(qaction);
         }
     }


### PR DESCRIPTION
## What does this PR do?

1. Open Editor.
2. Click Tools -> Track View.
3. Create a sequence.
4. Add some nodes to the sequence.
5. Check the default option of `Auto Recording`, `1 sec`, which means 1 frame per 1 second.
![image](https://user-images.githubusercontent.com/80555200/220061584-adc089e8-07a4-4eeb-a93a-9a6426eedd78.png)
6. Click `Auto Recording` to start recording using default option.
7. Check recording result as follows. It takes `0.5` second between two frames, not `1` second.
![image](https://user-images.githubusercontent.com/80555200/220061594-14243091-cd8b-4391-8039-8b2ab6d5b7a8.png)
![image](https://user-images.githubusercontent.com/80555200/220061608-386060f8-1ee7-4aee-9ee8-4d94d81d3cc2.png)

## How was this PR tested?
Follow the same steps, as follows:
![image](https://user-images.githubusercontent.com/80555200/220061538-c7a9c5a3-2a20-4054-b220-e20a65bddfe6.png)
![image](https://user-images.githubusercontent.com/80555200/220061556-e3058a2b-e6b7-4a81-b384-0a03531b205c.png)

