### PR TITLE
Save Frames options in Edit Sequence.

### DIFF
--- a/Code/Editor/TrackView/TVSequenceProps.cpp
+++ b/Code/Editor/TrackView/TVSequenceProps.cpp
@@ -74,12 +74,21 @@ bool CTVSequenceProps::OnInitDialog()
     Range timeRange = m_pSequence->GetTimeRange();
     float invFPS = 1.0f / m_FPS;
 
-    m_timeUnit = Seconds;
     ui->START_TIME->setValue(timeRange.start);
     ui->START_TIME->setSingleStep(invFPS);
     ui->END_TIME->setValue(timeRange.end);
     ui->END_TIME->setSingleStep(invFPS);
 
+    if (m_pSequence->GetFlags() & IAnimSequence::eSeqFlags_DisplayAsFramesOrSeconds)
+    {
+        m_timeUnit = Frames;
+        ui->TO_FRAMES->setChecked(true);
+    }
+    else
+    {
+        m_timeUnit = Seconds;
+        ui->TO_SECONDS->setChecked(true);
+    }
 
     m_outOfRange = 0;
     if (m_pSequence->GetFlags() & IAnimSequence::eSeqFlags_OutOfRangeConstant)
@@ -223,6 +232,15 @@ void CTVSequenceProps::UpdateSequenceProps(const QString& name)
     else
     {
         seqFlags &= (~IAnimSequence::eSeqFlags_EarlyMovieUpdate);
+    }
+
+    if (ui->TO_FRAMES->isChecked())
+    {
+        seqFlags |= IAnimSequence::eSeqFlags_DisplayAsFramesOrSeconds;
+    }
+    else
+    {
+        seqFlags &= (~IAnimSequence::eSeqFlags_DisplayAsFramesOrSeconds);
     }
 
     if (static_cast<IAnimSequence::EAnimSequenceFlags>(seqFlags) != m_pSequence->GetFlags())

--- a/Code/Legacy/CryCommon/IMovieSystem.h
+++ b/Code/Legacy/CryCommon/IMovieSystem.h
@@ -1063,6 +1063,7 @@ struct IAnimSequence
         eSeqFlags_EarlyMovieUpdate    = BIT(15), //!< Turn the 'sys_earlyMovieUpdate' on during the sequence.
         eSeqFlags_LightAnimationSet   = BIT(16), //!< A special unique sequence for light animations
         eSeqFlags_NoMPSyncingNeeded   = BIT(17), //!< this sequence doesn't require MP net syncing
+        eSeqFlags_DisplayAsFramesOrSeconds = BIT(18), //!< Display Start/End time as frames or seconds
     };
 
     virtual ~IAnimSequence() {};


### PR DESCRIPTION
## What does this PR do?

Save Frames options in `Edit Sequence`.
1. Open Editor.
2. Click Tools -> Track View.
3. Create a sequence.
4. Click `Edit Sequence Properties`.
5. Change `Seconds` to `Frames`, and press `OK`.
![image](https://user-images.githubusercontent.com/80555200/220080461-571f8666-cc61-4fb6-85cb-35e8449b7c6a.png)
6. Click `Edit Sequence Properties` again.
![image](https://user-images.githubusercontent.com/80555200/220080481-da76b4ba-f684-4ec1-a218-c0d87d57691a.png)

## How was this PR tested?
Follow the same steps.
