### PR TITLE
Check level is not opened when running 'ed_physxUpdatePrefabsWithColliderComponents' command

### DIFF
--- a/Gems/PhysX/Code/Editor/Source/Components/Conversion/CollidersPrefabConversion.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Components/Conversion/CollidersPrefabConversion.cpp
@@ -123,8 +123,7 @@ namespace PhysX
             prefabSystemEnabled, &AzFramework::ApplicationRequests::IsPrefabSystemEnabled);
         if (!prefabSystemEnabled)
         {
-            AZ_TracePrintf("PhysXColliderConversion", "Prefabs system is not enabled. Prefabs won't be converted.\n");
-            AZ_TracePrintf("PhysXColliderConversion", "\n");
+            AZ_Warning("PhysXColliderConversion", false, "Prefabs system is not enabled. Prefabs won't be converted.\n");
             return;
         }
 
@@ -133,8 +132,10 @@ namespace PhysX
             isLevelOpen, &AzToolsFramework::EditorRequests::Bus::Events::IsLevelDocumentOpen);
         if (isLevelOpen)
         {
-            AZ_TracePrintf("PhysXColliderConversion", "There is a level currently opened in the editor. To run this command please restart the editor and run it before opening any level.\n");
-            AZ_TracePrintf("PhysXColliderConversion", "\n");
+            AZ_Warning(
+                "PhysXColliderConversion", false,
+                "There is a level currently opened in the editor. To run this command please restart the editor and run it before opening "
+                "any level.\n");
             return;
         }
 

--- a/Gems/PhysX/Code/Editor/Source/Components/Conversion/CollidersPrefabConversion.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Components/Conversion/CollidersPrefabConversion.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Console/IConsole.h>
 
 #include <AzFramework/API/ApplicationAPI.h>
+#include <AzToolsFramework/API/ToolsApplicationAPI.h>
 
 #include <EditorColliderComponent.h>
 #include <EditorShapeColliderComponent.h>
@@ -123,6 +124,16 @@ namespace PhysX
         if (!prefabSystemEnabled)
         {
             AZ_TracePrintf("PhysXColliderConversion", "Prefabs system is not enabled. Prefabs won't be converted.\n");
+            AZ_TracePrintf("PhysXColliderConversion", "\n");
+            return;
+        }
+
+        bool isLevelOpen = false;
+        AzToolsFramework::EditorRequests::Bus::BroadcastResult(
+            isLevelOpen, &AzToolsFramework::EditorRequests::Bus::Events::IsLevelDocumentOpen);
+        if (isLevelOpen)
+        {
+            AZ_TracePrintf("PhysXColliderConversion", "There is a level currently opened in the editor. To run this command please restart the editor and run it before opening any level.\n");
             AZ_TracePrintf("PhysXColliderConversion", "\n");
             return;
         }


### PR DESCRIPTION
## What does this PR do?

Fixes #14656

## How was this PR tested?

Run the command with and without a level opened in the editor.
