### PR TITLE
Fix issue with File and Edit menus of the main editor window being unresponsive.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Notifications/ToastNotificationsView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Notifications/ToastNotificationsView.cpp
@@ -17,6 +17,8 @@ namespace AzToolsFramework
     ToastNotificationsView::ToastNotificationsView(QWidget* parent, ToastRequestBusId busId)
         : QWidget(parent)
     {
+        setMaximumSize(QSize(0, 0));
+
         ToastRequestBus::Handler::BusConnect(busId);
     }
 


### PR DESCRIPTION
## What does this PR do?

Sets the maximum width and height of the widget blocking access to the `File` and `Edit` menus in the main editor window's menu bar to 0,0.
Verified that this doesn't preclude the correct behavior of the toast notification system as the same visual feedback shown in the change that introduced the issue ([14197](https://github.com/o3de/o3de/pull/14197)) could be reproduced.

![FileMenuFix](https://user-images.githubusercontent.com/82231674/220147295-9a6a197b-7e82-4ce2-b981-282026d80da9.gif)

Closes #14471

## How was this PR tested?

Manual testing as per gif above.
