### PR TITLE
Fixes for creating a new entry in an existing spot on a sparse vector.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/MultiSparseVector.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/MultiSparseVector.h
@@ -77,7 +77,7 @@ namespace AZ::Render
         template <typename T>
         static void InitializeElement(size_t index, T& container)
         {
-            container.at(index) = {};
+            new (&container.at(index)) (typename T::value_type)();
         }
 
         template <typename T>

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/SparseVector.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/SparseVector.h
@@ -72,7 +72,7 @@ namespace AZ::Render
             // If there's a free slot, then use that space and update the linked list of free slots.
             slotToReturn = m_nextFreeSlot;
             m_nextFreeSlot = reinterpret_cast<size_t&>(m_data.at(m_nextFreeSlot));
-            m_data.at(slotToReturn) = T();
+            new (&m_data.at(slotToReturn)) T();
         }
         else
         {


### PR DESCRIPTION
## What does this PR do?

This fixes a bug in SparseVector and MultiSparseVector where random memory could be treated as a valid object in a copy assignment.

These containers use a vector or multiple vectors to store data in cases where you want a stable index, and don't care about there being holes in the data. The holes have a linked list embedded in them so that the container can just point to the first free slot if it exists, and that slot will point to the next etc. When acquiring a new slot on the list, previously it was initialized with a copy assignment, but this treats the existing memory as a valid object, which can cause problems on any objects with complicated destruction behavior. The fix is to do a placement new to the memory location to avoid any kind of copy or possible calls to a destructor.

This bug was originally found when an intrusive pointer was stored in a MultiSparseVector. When the copy-assignment happened, the object that used to exist in a slot and had already been deleted thought it needed to call its delete function again. This ended up causing unrecoverable errors in the memory allocator.

## How was this PR tested?

Tested with systems that use SparseVector and MultiSparseVector to make sure they still work.
