### PR TITLE
Polygon light bounds fix

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/PolygonLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/PolygonLightFeatureProcessorInterface.h
@@ -33,7 +33,7 @@ namespace AZ
             // Negative sign bit used to indicate if the light emits both directions.
             float m_invAttenuationRadiusSquared = 0.0f;
 
-            AZStd::array<float, 3> m_direction = { 0.0f, 0.0f, 0.0f };
+            AZStd::array<float, 3> m_direction = { 0.0f, 0.0f, 1.0f };
 
             float m_padding = 0.0f;
 

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshCommon.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshCommon.h
@@ -49,7 +49,7 @@ namespace AZ::Render::MeshCommon
         );
     }
 
-    using BoundsVariant = AZStd::variant<Sphere, Hemisphere, Frustum, Aabb, Capsule>;
+    using BoundsVariant = AZStd::variant<AZStd::monostate, Sphere, Hemisphere, Frustum, Aabb, Capsule>;
 
     template <typename BoundsType>
     struct EmptyFilter

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/PolygonLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/PolygonLightFeatureProcessor.cpp
@@ -227,12 +227,12 @@ namespace AZ::Render
     void PolygonLightFeatureProcessor::SetPolygonPoints(LightHandle handle, const Vector3* vertices, const uint32_t vertexCount, const Vector3& direction)
     {
         AZ_Warning("PolygonLightFeatureProcessor", vertexCount <= MaxPolygonPoints, "Too many polygon points on polygon light. Only using the first %lu vertices.", MaxPolygonPoints);
-        AZ_Warning("PolygonLightFeatureProcessor", vertexCount >= 2, "Polygon light must have at least three points - ignoring points.");
+        AZ_Warning("PolygonLightFeatureProcessor", vertexCount > 2, "Polygon light must have at least three points - ignoring points.");
 
         PolygonLightData& data = m_lightData.GetData<0>(handle.GetIndex());
         if (vertexCount < 3)
         {
-            data.SetEndIndex(data.GetStartIndex());
+            data.SetEndIndex(data.GetStartIndex()); // Set the number of points to 0.
         }
         else
         {

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/PolygonLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/PolygonLightFeatureProcessor.cpp
@@ -238,11 +238,10 @@ namespace AZ::Render
         {
             PolygonPoints& pointArray = m_lightData.GetData<1>(handle.GetIndex());
             uint32_t clippedCount = AZ::GetMin<uint32_t>(vertexCount, MaxPolygonPoints);
+
             for (uint32_t i = 0; i < clippedCount; ++i)
             {
-                pointArray.at(i).x = vertices[i].GetX();
-                pointArray.at(i).y = vertices[i].GetY();
-                pointArray.at(i).z = vertices[i].GetZ();
+                vertices[i].StoreToFloat4(&pointArray.at(i).x); // StoreToFloat4 is faster and w is ignored by the shader.
             }
             data.SetEndIndex(data.GetStartIndex() + clippedCount);
             direction.StoreToFloat3(data.m_direction.data());

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/PolygonLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/PolygonLightFeatureProcessor.cpp
@@ -228,26 +228,27 @@ namespace AZ::Render
     {
         AZ_Warning("PolygonLightFeatureProcessor", vertexCount <= MaxPolygonPoints, "Too many polygon points on polygon light. Only using the first %lu vertices.", MaxPolygonPoints);
         AZ_Warning("PolygonLightFeatureProcessor", vertexCount >= 2, "Polygon light must have at least three points - ignoring points.");
-        
+
+        PolygonLightData& data = m_lightData.GetData<0>(handle.GetIndex());
         if (vertexCount < 3)
         {
-            return; // not enough points
+            data.SetEndIndex(data.GetStartIndex());
         }
-
-        PolygonPoints& pointArray = m_lightData.GetData<1>(handle.GetIndex());
-        uint32_t clippedCount = AZ::GetMin<uint32_t>(vertexCount, MaxPolygonPoints);
-        for (uint32_t i = 0; i < clippedCount; ++i)
+        else
         {
-            pointArray.at(i).x = vertices[i].GetX();
-            pointArray.at(i).y = vertices[i].GetY();
-            pointArray.at(i).z = vertices[i].GetZ();
+            PolygonPoints& pointArray = m_lightData.GetData<1>(handle.GetIndex());
+            uint32_t clippedCount = AZ::GetMin<uint32_t>(vertexCount, MaxPolygonPoints);
+            for (uint32_t i = 0; i < clippedCount; ++i)
+            {
+                pointArray.at(i).x = vertices[i].GetX();
+                pointArray.at(i).y = vertices[i].GetY();
+                pointArray.at(i).z = vertices[i].GetZ();
+            }
+            data.SetEndIndex(data.GetStartIndex() + clippedCount);
+            direction.StoreToFloat3(data.m_direction.data());
         }
-        PolygonLightData& data = m_lightData.GetData<0>(handle.GetIndex());
-        data.SetEndIndex(data.GetStartIndex() + clippedCount);
-        direction.StoreToFloat3(data.m_direction.data());
 
         UpdateBounds(handle);
-
         m_deviceBufferNeedsUpdate = true;
     }
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/PolygonLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/PolygonLightFeatureProcessor.cpp
@@ -277,8 +277,12 @@ namespace AZ::Render
         AZ::Vector3 position = AZ::Vector3::CreateFromFloat3(data.m_position.data());
         float radius = LightCommon::GetRadiusFromInvRadiusSquared(abs(data.m_invAttenuationRadiusSquared));
 
-        // Emits both directions is stored in the sign of m_invAttenuationRadiusSquared.
-        if (data.m_invAttenuationRadiusSquared < 0.0f)
+        if (data.GetEndIndex() == data.GetStartIndex() || AZStd::isnan(radius))
+        {
+            // Invalid polygon light, just use an invalid variant.
+            bounds.emplace<AZStd::monostate>();
+        }
+        if (data.m_invAttenuationRadiusSquared < 0.0f) // Emits both directions is stored in the sign of m_invAttenuationRadiusSquared.
         {
             bounds.emplace<Sphere>(AZ::Sphere(position, radius));
         }


### PR DESCRIPTION
## What does this PR do?

This PR fixes a few small issues with the polygon light.
- Depending on the order of initialization, it was possible for AZ::Hemisphere to complain about a non-normalized direction. This happened when the polygon tried updating its bounds before having any points.
- The polygon light would still create a "valid" default initialized sphere when it was invalid
- When the polygon's points are removed and lowered to below 3, it wouldn't update to not render, instead it would retain a brighter version of the last valid point configuration.

## How was this PR tested?

Tested the Polygon light in various configurations.