### PR TITLE
Adds "EditorAndServerLauncher" as a target.

### DIFF
--- a/Code/LauncherUnified/launcher_generator.cmake
+++ b/Code/LauncherUnified/launcher_generator.cmake
@@ -201,6 +201,12 @@ foreach(project_name project_path IN ZIP_LISTS O3DE_PROJECTS_NAME LY_PROJECTS)
 
         # Associate the Servers Gem Variant with each projects ServerLauncher
         ly_set_gem_variant_to_load(TARGETS ${project_name}.ServerLauncher VARIANTS Servers)
+
+        # If the Editor is getting built, it should rebuild the ServerLauncher as well. The Editor's game mode will attempt
+        # to launch it, and things can break if the two are out of sync.
+        if(PAL_TRAIT_BUILD_HOST_TOOLS)
+            ly_add_dependencies(Editor ${project_name}.ServerLauncher)
+        endif()
     endif()
 
     ################################################################################
@@ -257,30 +263,6 @@ foreach(project_name project_path IN ZIP_LISTS O3DE_PROJECTS_NAME LY_PROJECTS)
         # Associate the Unified Gem Variant with each projects UnfiedLauncher
         ly_set_gem_variant_to_load(TARGETS ${project_name}.UnifiedLauncher VARIANTS Unified)
     endif()
-
-    ################################################################################
-    # EditorAndServerLauncher
-    # Creates a target that builds both the Editor and the ServerLauncher to ensure
-    # they both stay in sync with each other.
-    ################################################################################
-    if(PAL_TRAIT_BUILD_HOST_TOOLS)
-        if(PAL_TRAIT_BUILD_SERVER_SUPPORTED)
-            add_custom_target(${project_name}.EditorAndServerLauncher)
-            ly_add_dependencies(${project_name}.EditorAndServerLauncher Editor)
-            ly_add_dependencies(${project_name}.EditorAndServerLauncher ${project_name}.ServerLauncher)
-
-            set_target_properties(${project_name}.EditorAndServerLauncher
-                PROPERTIES 
-                    EXCLUDE_FROM_ALL TRUE
-                    FOLDER ${project_name}
-                    VS_DEBUGGER_COMMAND $<GENEX_EVAL:$<TARGET_FILE:Editor>>
-                    VS_DEBUGGER_COMMAND_ARGUMENTS "--project-path=\"${LY_DEFAULT_PROJECT_PATH}\""
-            )
-        endif()
-    endif()
-
-
-
 endforeach()
 
 #! Defer generation of the StaticModules.inl file needed in monolithic builds until after all the CMake targets are known

--- a/Code/LauncherUnified/launcher_generator.cmake
+++ b/Code/LauncherUnified/launcher_generator.cmake
@@ -257,6 +257,29 @@ foreach(project_name project_path IN ZIP_LISTS O3DE_PROJECTS_NAME LY_PROJECTS)
         # Associate the Unified Gem Variant with each projects UnfiedLauncher
         ly_set_gem_variant_to_load(TARGETS ${project_name}.UnifiedLauncher VARIANTS Unified)
     endif()
+
+    ################################################################################
+    # EditorWithServer
+    ################################################################################
+    if(PAL_TRAIT_BUILD_HOST_TOOLS)
+        if(PAL_TRAIT_BUILD_SERVER_SUPPORTED)
+            add_custom_target(${project_name}.EditorWithServer
+            )
+            ly_add_dependencies(${project_name}.EditorWithServer Editor)
+            ly_add_dependencies(${project_name}.EditorWithServer ${project_name}.ServerLauncher)
+
+            set_target_properties(${project_name}.EditorWithServer
+                PROPERTIES 
+                    EXCLUDE_FROM_ALL TRUE
+                    FOLDER ${project_name}
+                    VS_DEBUGGER_COMMAND $<GENEX_EVAL:$<TARGET_FILE:Editor>>
+                    VS_DEBUGGER_COMMAND_ARGUMENTS "--project-path=\"${LY_DEFAULT_PROJECT_PATH}\""
+            )
+        endif()
+    endif()
+
+
+
 endforeach()
 
 #! Defer generation of the StaticModules.inl file needed in monolithic builds until after all the CMake targets are known

--- a/Code/LauncherUnified/launcher_generator.cmake
+++ b/Code/LauncherUnified/launcher_generator.cmake
@@ -259,16 +259,17 @@ foreach(project_name project_path IN ZIP_LISTS O3DE_PROJECTS_NAME LY_PROJECTS)
     endif()
 
     ################################################################################
-    # EditorWithServer
+    # EditorAndServerLauncher
+    # Creates a target that builds both the Editor and the ServerLauncher to ensure
+    # they both stay in sync with each other.
     ################################################################################
     if(PAL_TRAIT_BUILD_HOST_TOOLS)
         if(PAL_TRAIT_BUILD_SERVER_SUPPORTED)
-            add_custom_target(${project_name}.EditorWithServer
-            )
-            ly_add_dependencies(${project_name}.EditorWithServer Editor)
-            ly_add_dependencies(${project_name}.EditorWithServer ${project_name}.ServerLauncher)
+            add_custom_target(${project_name}.EditorAndServerLauncher)
+            ly_add_dependencies(${project_name}.EditorAndServerLauncher Editor)
+            ly_add_dependencies(${project_name}.EditorAndServerLauncher ${project_name}.ServerLauncher)
 
-            set_target_properties(${project_name}.EditorWithServer
+            set_target_properties(${project_name}.EditorAndServerLauncher
                 PROPERTIES 
                     EXCLUDE_FROM_ALL TRUE
                     FOLDER ${project_name}


### PR DESCRIPTION
## What does this PR do?

This is a small Quality of Life improvement to make it easier to build both the Editor and the Server when working in the Editor. 

When using the Editor with a multiplayer project, it will automatically launch the ServerLauncher for you in game mode. However, building the Editor doesn't automatically build the ServerLauncher, so it's very easy for the two to get out of sync.

This change adds an "EditorAndServerLauncher" target into the project next to the launchers that will simply build both the Editor _and_ the ServerLauncher for that project, and it will run the Editor when the project is run. This makes it much easier to avoid the mistake of forgetting to build the ServerLauncher.

## How was this PR tested?

Built the MultiplayerSample project and verified that the new target worked as expected.

![image](https://user-images.githubusercontent.com/82224783/220212215-085353f9-6d5a-41e8-8b55-fccce645bcf7.png)

