### PR TITLE
Allow editable breadcrumbs to use and display full file paths

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -278,6 +278,7 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
         {
             // No need to select the folder ourselves, callback from Breadcrumbs will take care of that
             m_ui->m_pathBreadCrumbs->pushPath(QString::fromUtf8(folderEntry->GetVisiblePath().c_str()));
+            m_ui->m_pathBreadCrumbs->setFullPath(QString::fromUtf8(folderEntry->GetFullPath().c_str()));
         }
     });
 
@@ -624,15 +625,18 @@ void AzAssetBrowserWindow::UpdateBreadcrumbs(const AzToolsFramework::AssetBrowse
     using namespace AzToolsFramework::AssetBrowser;
 
     QString entryPath;
+    QString fullPath;
     if (selectedEntry)
     {
         const AssetBrowserEntry* folderEntry = Utils::FolderForEntry(selectedEntry);
         if (folderEntry)
         {
             entryPath = QString::fromUtf8(folderEntry->GetVisiblePath().c_str());
+            fullPath = QString::fromUtf8(folderEntry->GetFullPath().c_str());
         }
     }
     m_ui->m_pathBreadCrumbs->pushPath(entryPath);
+    m_ui->m_pathBreadCrumbs->setFullPath(fullPath);
 }
 
 void AzAssetBrowserWindow::SetTwoColumnMode(QWidget* viewToShow)

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -638,8 +638,8 @@ void AzAssetBrowserWindow::UpdateBreadcrumbs(const AzToolsFramework::AssetBrowse
         const AssetBrowserEntry* folderEntry = Utils::FolderForEntry(selectedEntry);
         if (folderEntry)
         {
-            entryPath = FromStdString(folderEntry->GetVisiblePath().c_str());
-            fullPath = FromStdString(folderEntry->GetFullPath().c_str());
+            entryPath = FromStdString(folderEntry->GetVisiblePath());
+            fullPath = FromStdString(folderEntry->GetFullPath());
         }
     }
     m_ui->m_pathBreadCrumbs->pushFullPath(fullPath, entryPath);

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -45,6 +45,14 @@ static constexpr int s_narrowModeThreshold = 700;
 
 using namespace AzToolsFramework::AssetBrowser;
 
+namespace
+{
+    inline QString FromStdString(AZStd::string_view string)
+    {
+        return QString::fromUtf8(string.data(), static_cast<int>(string.size()));
+    }
+}
+
 namespace AzToolsFramework
 {
     namespace AssetBrowser
@@ -277,8 +285,7 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
         if (folderEntry)
         {
             // No need to select the folder ourselves, callback from Breadcrumbs will take care of that
-            m_ui->m_pathBreadCrumbs->pushPath(QString::fromUtf8(folderEntry->GetVisiblePath().c_str()));
-            m_ui->m_pathBreadCrumbs->setFullPath(QString::fromUtf8(folderEntry->GetFullPath().c_str()));
+            m_ui->m_pathBreadCrumbs->pushFullPath(FromStdString(folderEntry->GetFullPath()), FromStdString(folderEntry->GetVisiblePath()));
         }
     });
 
@@ -631,12 +638,11 @@ void AzAssetBrowserWindow::UpdateBreadcrumbs(const AzToolsFramework::AssetBrowse
         const AssetBrowserEntry* folderEntry = Utils::FolderForEntry(selectedEntry);
         if (folderEntry)
         {
-            entryPath = QString::fromUtf8(folderEntry->GetVisiblePath().c_str());
-            fullPath = QString::fromUtf8(folderEntry->GetFullPath().c_str());
+            entryPath = FromStdString(folderEntry->GetVisiblePath().c_str());
+            fullPath = FromStdString(folderEntry->GetFullPath().c_str());
         }
     }
-    m_ui->m_pathBreadCrumbs->pushPath(entryPath);
-    m_ui->m_pathBreadCrumbs->setFullPath(fullPath);
+    m_ui->m_pathBreadCrumbs->pushFullPath(fullPath, entryPath);
 }
 
 void AzAssetBrowserWindow::SetTwoColumnMode(QWidget* viewToShow)

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.cpp
@@ -158,11 +158,6 @@ namespace AzQtComponents
         fillLabel();
     }
 
-    void BreadCrumbs::setFullPath(const QString& newFullPath)
-    {
-        m_fullPath = newFullPath;
-    }
-
     void BreadCrumbs::setDefaultIcon(const QString& icon)
     {
         m_defaultIcon = icon;
@@ -325,6 +320,20 @@ namespace AzQtComponents
         changePath(sanitizedPath);
 
         emitButtonSignals(buttonStates);
+    }
+
+    void BreadCrumbs::pushFullPath(const QString& newFullPath, const QString& newPath)
+    {
+        pushPath(newPath);
+
+        const QString sanitizedPath = toCommonSeparators(newFullPath);
+
+        if (sanitizedPath == m_currentPath)
+        {
+            return;
+        }
+
+        m_fullPath = sanitizedPath;
     }
 
     bool BreadCrumbs::back()

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.cpp
@@ -138,6 +138,11 @@ namespace AzQtComponents
         return m_currentPath;
     }
 
+    QString BreadCrumbs::fullPath() const
+    {
+        return m_fullPath;
+    }
+
     void BreadCrumbs::setCurrentPath(const QString& newPath)
     {
         // clean up the path to use all the first separator in the list of separators
@@ -151,6 +156,11 @@ namespace AzQtComponents
 
         updateGeometry();
         fillLabel();
+    }
+
+    void BreadCrumbs::setFullPath(const QString& newFullPath)
+    {
+        m_fullPath = newFullPath;
     }
 
     void BreadCrumbs::setDefaultIcon(const QString& icon)
@@ -434,6 +444,7 @@ namespace AzQtComponents
             return;
         }
         m_labelEditStack->setCurrentWidget(m_lineEdit);
+        m_lineEdit->setText(m_fullPath);
         m_lineEdit->selectAll();
         m_lineEdit->setFocus();
     }

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.h
@@ -83,8 +83,6 @@ namespace AzQtComponents
         QString fullPath() const;
         //! Sets the current breadcrumb path without updating the navigation stack.
         void setCurrentPath(const QString& newPath);
-        //! Sets the full path of the breadcrumb widget without updating the navigation stack.
-        void setFullPath(const QString& newFullPath);
 
         //! Sets a default icon for path elements.
         void setDefaultIcon(const QString& iconPath);
@@ -129,6 +127,9 @@ namespace AzQtComponents
     public Q_SLOTS:
         //! Pushes a path to be shown in the Breadcrumbs widget.
         void pushPath(const QString& fullPath);
+        //! Pushes a new full path to be displayed in the editable breadcrumbs,
+        //! and a new path to be shown in the breadcrumbs navigation bar.
+        void pushFullPath(const QString& newFullPath, const QString& newPath);
         //! Restores the previous breadcrumb path from the navigation stack if it exists.
         bool back();
         //! Restores the next breadcrumb path from the navigation stack if it exists.

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BreadCrumbs.h
@@ -79,8 +79,12 @@ namespace AzQtComponents
 
         //! Returns a string with the current breadcrumb path.
         QString currentPath() const;
+        //! Returns the full path if the current path is not the full path.
+        QString fullPath() const;
         //! Sets the current breadcrumb path without updating the navigation stack.
         void setCurrentPath(const QString& newPath);
+        //! Sets the full path of the breadcrumb widget without updating the navigation stack.
+        void setFullPath(const QString& newFullPath);
 
         //! Sets a default icon for path elements.
         void setDefaultIcon(const QString& iconPath);
@@ -187,6 +191,7 @@ namespace AzQtComponents
         QStackedWidget* m_labelEditStack = nullptr;
 
         QString m_currentPath;
+        QString m_fullPath;
         AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 4251: 'AzQtComponents::BreadCrumbs::m_backPaths': class 'QStack<QString>' needs to have dll-interface to be used by clients of class 'AzQtComponents::BreadCrumbs'
         QStack<QString> m_backPaths;
         QStack<QString> m_forwardPaths;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -352,9 +352,11 @@ namespace AzToolsFramework
         const AssetBrowserEntry* AssetBrowserTreeView::GetEntryByPath(QStringView path)
         {
             QModelIndex current;
-            for (auto token : AZStd::ranges::split_view(path, '/'))
+            bool currentlyFindingRows = false;
+            AZ::IO::Path p = path.toUtf8().constData();
+            for (auto it = p.begin(); it != p.end(); ++it)
             {
-                QStringView pathPart{ token.begin(), token.end() };
+                QString pathPart = QString::fromUtf8((*it).c_str());
                 const int rows = model()->rowCount(current);
                 bool rowFound = false;
                 for (int row=0; row < rows; ++row)
@@ -367,6 +369,7 @@ namespace AzToolsFramework
                         {
                             current = rowIdx;
                             rowFound = true;
+                            currentlyFindingRows = true;
                             break;
                         }
                     }
@@ -375,10 +378,14 @@ namespace AzToolsFramework
                         return nullptr;
                     }
                 }
-                if (!rowFound)
+                if (!rowFound && currentlyFindingRows)
                 {
                     return nullptr;
                 }
+            }
+            if (!currentlyFindingRows)
+            {
+                return nullptr;
             }
             return GetEntryFromIndex<AssetBrowserEntry>(current);
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -352,14 +352,14 @@ namespace AzToolsFramework
         const AssetBrowserEntry* AssetBrowserTreeView::GetEntryByPath(QStringView path)
         {
             QModelIndex current;
-            for (const auto token : AZStd::ranges::split_view(path, '/'))
+            const QByteArray byteArray = path.toUtf8();
+            const AZ::IO::Path azpath{ AZStd::string_view{ byteArray.constData(), static_cast<size_t>(byteArray.size()) } };
+            for (const auto& pathPart : azpath)
             {
-                auto distance = static_cast<int32_t>(AZStd::distance(token.begin(), token.end()));
-                QString pathPart(token.begin(), distance);
                 QModelIndexList next = model()->match(
                     /*start =*/model()->index(0, 0, current),
                     /*role =*/Qt::DisplayRole,
-                    /*value =*/pathPart,
+                    /*value =*/QString::fromUtf8(pathPart.Native().data(), static_cast<int32_t>(pathPart.Native().size())),
                     /*hits =*/1,
                     /*flags =*/Qt::MatchExactly);
                 if (next.size() == 1)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -353,10 +353,10 @@ namespace AzToolsFramework
         {
             QModelIndex current;
             const QByteArray byteArray = path.toUtf8();
-            const AZ::IO::Path azpath{ AZStd::string_view{ byteArray.constData(), static_cast<size_t>(byteArray.size()) } };
+            const AZ::IO::PathView azpath{ AZStd::string_view{ byteArray.constData(), static_cast<size_t>(byteArray.size()) } };
             for (const auto& pathPart : azpath)
             {
-                QModelIndexList next = model()->match(
+                const QModelIndexList next = model()->match(
                     /*start =*/model()->index(0, 0, current),
                     /*role =*/Qt::DisplayRole,
                     /*value =*/QString::fromUtf8(pathPart.Native().data(), static_cast<int32_t>(pathPart.Native().size())),


### PR DESCRIPTION
## What does this PR do?

- Allows users to paste full file paths from file explorer and have the asset browser navigate to the correct directory
- Display the full file path when editing the URL, allowing users to copy the full file path
- Fixes #14431.

![Editor_GZSoptphT7](https://user-images.githubusercontent.com/84731577/220210363-e0714c8b-799a-46bd-b902-f3ebaaedb7a9.gif)

## How was this PR tested?

Locally
