### PR TITLE
bugfix Render Output File name prefix is not usable.

### DIFF
--- a/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
+++ b/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
@@ -1330,7 +1330,7 @@ void CSequenceBatchRenderDialog::OnKickIdle()
 
         if (canBeginFrameCapture())
         {
-            const AZStd::string fileName = AZStd::string::format("Frame_%06d", m_renderContext.frameNumber);
+            const AZStd::string fileName = AZStd::string::format("%s_%06d", m_renderContext.captureOptions.prefix.c_str(), m_renderContext.frameNumber);
 
             AZStd::string filePath;
             AzFramework::StringFunc::Path::Join(


### PR DESCRIPTION
## What does this PR do?
1. Open Editor.
2. Click Tools -> Track View.
3. Create a sequence.
4. Click Tools -> Render Output, and modify `File prefix`, such as `xxx1`.
![image](https://user-images.githubusercontent.com/80555200/220246526-fe552999-26ca-4542-bda9-f5f31daba742.png)
5. Press `Start`, and wait for its ending.
![image](https://user-images.githubusercontent.com/80555200/220246533-20d94f08-5390-4345-9861-aa293017d63b.png)

The value of `File prefix` does not take effect as expected.
## How was this PR tested?
Follow the same steps, and check the filenames, as follows:
![image](https://user-images.githubusercontent.com/80555200/220246550-5176b9a8-9e41-4851-a4a1-9c33e73bc945.png)
![image](https://user-images.githubusercontent.com/80555200/220246540-c6d3dcec-c6ed-4c00-b220-7dd96708c70e.png)
