### PR TITLE
set shape translation offset feature flag to be on by default

### DIFF
--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/ShapeComponentBus.h
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/ShapeComponentBus.h
@@ -38,7 +38,7 @@ namespace LmbrCentral
     /// See https://github.com/o3de/sig-simulation/issues/26 for more details.
     inline bool IsShapeComponentTranslationEnabled()
     {
-        bool isShapeComponentTranslationEnabled = false;
+        bool isShapeComponentTranslationEnabled = true;
 
         if (auto* registry = AZ::SettingsRegistry::Get())
         {


### PR DESCRIPTION
## What does this PR do?
Sets the shape translation offset feature to be on by default.

## How was this PR tested?
Extensive testing in the editor and addition of unit tests during feature development. 2 QA passes. 