### PR TITLE
Gradient/Terrain benchmark fixes

### DIFF
--- a/Gems/GradientSignal/Code/Tests/GradientSignalTestFixtures.cpp
+++ b/Gems/GradientSignal/Code/Tests/GradientSignalTestFixtures.cpp
@@ -96,12 +96,43 @@ namespace UnitTest
         LmbrCentral::ShapeComponentRequestsBus::GetOrCreateContext();
     }
 
+    GradientSignalBaseFixture::GradientSignalBaseFixture()
+    {
+        // Even though this is an empty function, it needs to appear here so that the destruction code for the unique pointers
+        // is created here instead of inline wherever the GradientSignalTest class is used. This lets us keep the #includes for
+        // these Atom classes private to this file instead of exposing them outward through the header and requiring everything
+        // using this class to include the Atom libs as well.
+    }
+
+    GradientSignalBaseFixture::~GradientSignalBaseFixture()
+    {
+        // This also needs to appear here, even though it's an empty function.
+    }
+
     void GradientSignalBaseFixture::SetupCoreSystems()
     {
+        // Create a stub RHI for use by Atom
+        m_rhiFactory.reset(aznew UnitTest::StubRHI::Factory());
+
+        // Create the Atom RPISystem
+        AZ::RPI::RPISystemDescriptor rpiSystemDescriptor;
+        m_rpiSystem = AZStd::make_unique<AZ::RPI::RPISystem>();
+        m_rpiSystem->Initialize(rpiSystemDescriptor);
+
+        AZ::RPI::ImageSystemDescriptor imageSystemDescriptor;
+        m_imageSystem = AZStd::make_unique<AZ::RPI::ImageSystem>();
+        m_imageSystem->Init(imageSystemDescriptor);
     }
 
     void GradientSignalBaseFixture::TearDownCoreSystems()
     {
+        m_imageSystem->Shutdown();
+        m_rpiSystem->Shutdown();
+
+        m_imageSystem = nullptr;
+        m_rpiSystem = nullptr;
+        m_rhiFactory = nullptr;
+
         AzFramework::LegacyAssetEventBus::ClearQueuedEvents();
     }
 
@@ -414,46 +445,15 @@ namespace UnitTest
         return entity;
     }
 
-    GradientSignalTest::GradientSignalTest()
-    {
-        // Even though this is an empty function, it needs to appear here so that the destruction code for the unique pointers
-        // is created here instead of inline wherever the GradientSignalTest class is used. This lets us keep the #includes for
-        // these Atom classes private to this file instead of exposing them outward through the header and requiring everything
-        // using this class to include the Atom libs as well.
-    }
-
-    GradientSignalTest::~GradientSignalTest()
-    {
-        // This also needs to appear here, even though it's an empty function.
-    }
-
     void GradientSignalTest::SetUp()
     {
         SetupCoreSystems();
-
-        // Create a stub RHI for use by Atom
-        m_rhiFactory.reset(aznew UnitTest::StubRHI::Factory());
-
-        // Create the Atom RPISystem
-        AZ::RPI::RPISystemDescriptor rpiSystemDescriptor;
-        m_rpiSystem = AZStd::make_unique<AZ::RPI::RPISystem>();
-        m_rpiSystem->Initialize(rpiSystemDescriptor);
-
-        AZ::RPI::ImageSystemDescriptor imageSystemDescriptor;
-        m_imageSystem = AZStd::make_unique<AZ::RPI::ImageSystem>();
-        m_imageSystem->Init(imageSystemDescriptor);
     }
 
     void GradientSignalTest::TearDown()
     {
-        m_imageSystem->Shutdown();
-        m_rpiSystem->Shutdown();
-        m_rpiSystem = nullptr;
-        m_rhiFactory = nullptr;
-
         TearDownCoreSystems();
     }
-
 
     void GradientSignalTest::TestFixedDataSampler(const AZStd::vector<float>& expectedOutput, int size, AZ::EntityId gradientEntityId)
     {

--- a/Gems/GradientSignal/Code/Tests/GradientSignalTestFixtures.h
+++ b/Gems/GradientSignal/Code/Tests/GradientSignalTestFixtures.h
@@ -59,6 +59,9 @@ namespace UnitTest
     class GradientSignalBaseFixture
     {
     public:
+        GradientSignalBaseFixture();
+        virtual ~GradientSignalBaseFixture();
+
         void SetupCoreSystems();
         void TearDownCoreSystems();
 
@@ -101,6 +104,11 @@ namespace UnitTest
         AZStd::unique_ptr<AZ::Entity> BuildTestSurfaceAltitudeGradient(float shapeHalfBounds);
         AZStd::unique_ptr<AZ::Entity> BuildTestSurfaceMaskGradient(float shapeHalfBounds);
         AZStd::unique_ptr<AZ::Entity> BuildTestSurfaceSlopeGradient(float shapeHalfBounds);
+
+    protected:
+        AZStd::unique_ptr<UnitTest::StubRHI::Factory> m_rhiFactory;
+        AZStd::unique_ptr<AZ::RPI::RPISystem> m_rpiSystem;
+        AZStd::unique_ptr<AZ::RPI::ImageSystem> m_imageSystem;
     };
 
     struct GradientSignalTest
@@ -108,18 +116,11 @@ namespace UnitTest
         , public ::testing::Test
     {
     protected:
-        GradientSignalTest();
-        ~GradientSignalTest() override;
-
         void SetUp() override;
         void TearDown() override;
 
         void TestFixedDataSampler(const AZStd::vector<float>& expectedOutput, int size, AZ::EntityId gradientEntityId);
         void TestFixedDataSampler(const AZStd::vector<float>& expectedOutput, int size, GradientSignal::GradientSampler& gradientSampler);
-
-        AZStd::unique_ptr<UnitTest::StubRHI::Factory> m_rhiFactory;
-        AZStd::unique_ptr<AZ::RPI::RPISystem> m_rpiSystem;
-        AZStd::unique_ptr<AZ::RPI::ImageSystem> m_imageSystem;
     };
 
 #ifdef HAVE_BENCHMARK

--- a/Gems/GradientSignal/Code/Tests/GradientSignalTestHelpers.h
+++ b/Gems/GradientSignal/Code/Tests/GradientSignalTestHelpers.h
@@ -122,25 +122,21 @@ namespace UnitTest
     BENCHMARK_REGISTER_F(Fixture, Func)                                                                                                   \
         ->Args({ GradientSignalTestHelpers::GetValuePermutation::EBUS_GET_VALUE, 1024 })                                                  \
         ->Args({ GradientSignalTestHelpers::GetValuePermutation::EBUS_GET_VALUE, 2048 })                                                  \
-        ->Args({ GradientSignalTestHelpers::GetValuePermutation::EBUS_GET_VALUE, 4096 })                                                  \
         ->ArgNames({ "EbusGetValue", "size" })                                                                                            \
         ->Unit(::benchmark::kMillisecond);                                                                                                \
     BENCHMARK_REGISTER_F(Fixture, Func)                                                                                                   \
         ->Args({ GradientSignalTestHelpers::GetValuePermutation::EBUS_GET_VALUES, 1024 })                                                 \
         ->Args({ GradientSignalTestHelpers::GetValuePermutation::EBUS_GET_VALUES, 2048 })                                                 \
-        ->Args({ GradientSignalTestHelpers::GetValuePermutation::EBUS_GET_VALUES, 4096 })                                                 \
         ->ArgNames({ "EbusGetValues", "size" })                                                                                           \
         ->Unit(::benchmark::kMillisecond);                                                                                                \
     BENCHMARK_REGISTER_F(Fixture, Func)                                                                                                   \
         ->Args({ GradientSignalTestHelpers::GetValuePermutation::SAMPLER_GET_VALUE, 1024 })                                               \
         ->Args({ GradientSignalTestHelpers::GetValuePermutation::SAMPLER_GET_VALUE, 2048 })                                               \
-        ->Args({ GradientSignalTestHelpers::GetValuePermutation::SAMPLER_GET_VALUE, 4096 })                                               \
         ->ArgNames({ "SamplerGetValue", "size" })                                                                                         \
         ->Unit(::benchmark::kMillisecond);                                                                                                \
     BENCHMARK_REGISTER_F(Fixture, Func)                                                                                                   \
         ->Args({ GradientSignalTestHelpers::GetValuePermutation::SAMPLER_GET_VALUES, 1024 })                                              \
         ->Args({ GradientSignalTestHelpers::GetValuePermutation::SAMPLER_GET_VALUES, 2048 })                                              \
-        ->Args({ GradientSignalTestHelpers::GetValuePermutation::SAMPLER_GET_VALUES, 4096 })                                              \
         ->ArgNames({ "SamplerGetValues", "size" })                                                                                        \
         ->Unit(::benchmark::kMillisecond);
 #endif

--- a/Gems/Terrain/Code/Tests/TerrainSystemBenchmarks.cpp
+++ b/Gems/Terrain/Code/Tests/TerrainSystemBenchmarks.cpp
@@ -157,13 +157,10 @@ namespace UnitTest
     BENCHMARK_REGISTER_F(TerrainSystemBenchmarkFixture, BM_GetHeight)
         ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR) })
         ->Args({ 2048, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR) })
-        ->Args({ 4096, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR) })
         ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::CLAMP) })
         ->Args({ 2048, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::CLAMP) })
-        ->Args({ 4096, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::CLAMP) })
         ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Args({ 2048, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
-        ->Args({ 4096, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Unit(::benchmark::kMillisecond);
 
     BENCHMARK_DEFINE_F(TerrainSystemBenchmarkFixture, BM_ProcessHeightsRegion)(benchmark::State& state)
@@ -192,13 +189,10 @@ namespace UnitTest
     BENCHMARK_REGISTER_F(TerrainSystemBenchmarkFixture, BM_ProcessHeightsRegion)
         ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR) })
         ->Args({ 2048, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR) })
-        ->Args({ 4096, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR) })
         ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::CLAMP) })
         ->Args({ 2048, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::CLAMP) })
-        ->Args({ 4096, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::CLAMP) })
         ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Args({ 2048, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
-        ->Args({ 4096, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Unit(::benchmark::kMillisecond);
 
     BENCHMARK_DEFINE_F(TerrainSystemBenchmarkFixture, BM_ProcessHeightsRegionAsync)(benchmark::State& state)
@@ -240,13 +234,10 @@ namespace UnitTest
     BENCHMARK_REGISTER_F(TerrainSystemBenchmarkFixture, BM_ProcessHeightsRegionAsync)
         ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR) })
         ->Args({ 2048, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR) })
-        ->Args({ 4096, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR) })
         ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::CLAMP) })
         ->Args({ 2048, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::CLAMP) })
-        ->Args({ 4096, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::CLAMP) })
         ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Args({ 2048, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
-        ->Args({ 4096, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Unit(::benchmark::kMillisecond);
 
     BENCHMARK_DEFINE_F(TerrainSystemBenchmarkFixture, BM_ProcessHeightsList)(benchmark::State& state)
@@ -274,13 +265,10 @@ namespace UnitTest
     BENCHMARK_REGISTER_F(TerrainSystemBenchmarkFixture, BM_ProcessHeightsList)
         ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR) })
         ->Args({ 2048, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR) })
-        ->Args({ 4096, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR) })
         ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::CLAMP) })
         ->Args({ 2048, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::CLAMP) })
-        ->Args({ 4096, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::CLAMP) })
         ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Args({ 2048, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
-        ->Args({ 4096, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Unit(::benchmark::kMillisecond);
 
     BENCHMARK_DEFINE_F(TerrainSystemBenchmarkFixture, BM_ProcessHeightsListAsync)(benchmark::State& state)
@@ -320,13 +308,10 @@ namespace UnitTest
     BENCHMARK_REGISTER_F(TerrainSystemBenchmarkFixture, BM_ProcessHeightsListAsync)
         ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR) })
         ->Args({ 2048, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR) })
-        ->Args({ 4096, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::BILINEAR) })
         ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::CLAMP) })
         ->Args({ 2048, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::CLAMP) })
-        ->Args({ 4096, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::CLAMP) })
         ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Args({ 2048, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
-        ->Args({ 4096, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Unit(::benchmark::kMillisecond);
 
     BENCHMARK_DEFINE_F(TerrainSystemBenchmarkFixture, BM_GetNormal)(benchmark::State& state)
@@ -966,16 +951,12 @@ namespace UnitTest
     BENCHMARK_REGISTER_F(TerrainSystemBenchmarkFixture, BM_GetClosestIntersectionRandom)
         ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Args({ 2048, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
-        ->Args({ 4096, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Args({ 1024, 10, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Args({ 2048, 10, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
-        ->Args({ 4096, 10, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Args({ 1024, 100, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Args({ 2048, 100, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
-        ->Args({ 4096, 100, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Args({ 1024, 1000, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Args({ 2048, 1000, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
-        ->Args({ 4096, 1000, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Unit(::benchmark::kMillisecond);
 
     BENCHMARK_DEFINE_F(TerrainSystemBenchmarkFixture, BM_GetClosestIntersectionWorstCase)(benchmark::State& state)
@@ -1006,16 +987,12 @@ namespace UnitTest
     BENCHMARK_REGISTER_F(TerrainSystemBenchmarkFixture, BM_GetClosestIntersectionWorstCase)
         ->Args({ 1024, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Args({ 2048, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
-        ->Args({ 4096, 1, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Args({ 1024, 10, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Args({ 2048, 10, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
-        ->Args({ 4096, 10, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Args({ 1024, 100, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Args({ 2048, 100, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
-        ->Args({ 4096, 100, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Args({ 1024, 1000, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Args({ 2048, 1000, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
-        ->Args({ 4096, 1000, static_cast<int>(AzFramework::Terrain::TerrainDataRequests::Sampler::EXACT) })
         ->Unit(::benchmark::kMillisecond);
 
     // Benchmark a single usage of our more complicated terrain setup.


### PR DESCRIPTION
## What does this PR do?

Fixes #14096 and #14097 :
* Removes the 4M point benchmarks from GradientSignal and Terrain to reduce to overall runtime. These benchmarks weren't providing any additional data beyond what the remaining 1M and 2M benchmarks give.
* Moves the Atom image system init/shutdown code from the GradientSignal unit test fixture to the base fixture. The benchmarks needed these systems in place as well, and since they weren't there, the benchmarks were generating errors about missing asset handlers and leaking memory. With the systems in the base fixture, the benchmarks run cleanly.

## How was this PR tested?

Ran the GradientSignal and Terrain benchmarks and verified the above changes.
