### PR TITLE
Project exporter cli external script prototype

### DIFF
--- a/scripts/o3de.py
+++ b/scripts/o3de.py
@@ -35,7 +35,7 @@ def add_args(parser: argparse.ArgumentParser) -> None:
     sys.path.insert(0, str(o3de_package_dir))
     from o3de import engine_properties, engine_template, gem_properties, \
         global_project, register, print_registration, get_registration, \
-        enable_gem, disable_gem, project_properties, sha256, download
+        enable_gem, disable_gem, project_properties, sha256, download, packaging
     # Remove the temporarily added path
     sys.path = sys.path[1:]
 
@@ -75,6 +75,9 @@ def add_args(parser: argparse.ArgumentParser) -> None:
     # download
     download.add_args(subparsers)
 
+    #packaging
+    packaging.add_args(subparsers)
+
 
 if __name__ == "__main__":
     # parse the command line args
@@ -85,6 +88,7 @@ if __name__ == "__main__":
 
     # parse args
     the_args = the_parser.parse_args()
+
 
     # if empty print help
     if len(sys.argv) == 1:

--- a/scripts/o3de/example_project_export_scripts/newspaper_delivery_project_export.py
+++ b/scripts/o3de/example_project_export_scripts/newspaper_delivery_project_export.py
@@ -1,0 +1,44 @@
+import sys
+# import o3de.packaging as pkg
+from o3de.packaging import *
+import o3de.manifest as man
+import o3de.project_manager_interface as pm
+
+#from other_local_script import *  #our script can import from both o3de CLI and from the local folder it resides in
+
+#this is a simple linear script
+
+#pros for basic python scripting approach
+# very simple to setup
+# data oriented (one workflow per python script)
+# if API is minimal, it is readily accessible, and function arguments can be provided by user
+# both the script's local directory and O3DE CLI are accessible for import logic
+
+#drawbacks
+# requires user to code in python (we have customers that would rather not)
+# it can be daunting as a blank slate. coding patterns are not standardized/enforceable, and is up to user to code out correctly
+# can't do pre-validation of workflow
+# lack of step annotation
+# because the entire workflow is python code, it is non-trivial to parse (and with custom team-code, nigh impossible), and we won't be able to enforce data patterns
+    # from CLI perspective this is not a big deal, but for ProjectManager UI, this can impede our ability to provide meaningful UX feedback or enable automated auditing
+# too much more than what is actually needed for project export use case?
+
+
+package_hi()
+print("Now running the packaging code")
+
+
+#apparently our module script can be pre-injected with known variable values!!!
+#this comes from o3de/packaging.py
+print(o3de_project_path)
+
+
+
+package_windows_standalone_monolithic(project_path= o3de_project_path,
+                                          zipped = False)
+
+
+
+#before doing full compare contrast, get the json version of this working
+
+

--- a/scripts/o3de/o3de/packaging.py
+++ b/scripts/o3de/o3de/packaging.py
@@ -1,0 +1,298 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+import os
+import platform
+import argparse
+import json
+import logging
+import pathlib
+import sys
+import subprocess
+import shutil
+import pathlib
+
+from o3de import manifest, validation, utils, repo
+
+logger = logging.getLogger('o3de.print_registration')
+logging.basicConfig(format=utils.LOG_FORMAT)
+
+SUCCESS = 0
+
+#goal: simple CLI to package and build/automate what we need. This is proven with the prototype, so we're good to start RFC.
+# we will need sufficient time to flesh out the RFC, then the engineering plan. Otherwise it fees.
+# thankfully, I'm not blocking anyone since this is an automation task
+# can I ship this before RFC is accepted (feature flags? or separate branch) talk with Joe if this is acceptable for smallest MVP
+# all this being said, it is better that I do not overengineer at  this point. Better to write the RFC/design, get feedback, and adjust accordingly. Make sure to supply as many relevant considerations as possible
+
+#design review - ask joe about this, or if he still wants me to write RFC first. (do the minimum important things. Let the design sheperd guide you)
+
+#review automated test code for running executables
+#issue with timeouts: this can be extremely difficult
+#if someone clones a mature project...
+# SPIKE: figure out good system for timeouts. It would suck if it stalls out, but it also sucks if it prematurely times out
+# how do we show progress?
+# how do we handle logging?
+
+#add parameters for if we want to expose logging or not? otherwise render progress?
+def process_command(cmd_args, project_path):
+    ret = SUCCESS
+    process = subprocess.Popen(cmd_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd = project_path)
+    while process.poll() is None:
+        line = process.stdout.readline()
+        if not line: break
+        print(line.decode('ascii'))
+    
+    #flush out any remaining text from stdout
+    print(process.stdout.read().decode('ascii'))
+
+    stderr = process.stderr.read()
+
+    process.kill()
+
+    if bool(process.returncode):
+        ret  = process.returncode
+        print("ERROR OCCURRED " + str(ret))
+        print(stderr.decode('ascii'))
+
+    return ret
+
+
+
+def package_none():
+    print("It seems like packaging is not supported for your platform or use case...")
+    return 0
+
+#this is a stand alone proof of concept test function, which just proves it's possible to automate building in Python
+#we will use the remainder of the code to work out the framework we would like to use to funnel building procedures
+#algorithm here is based on main documentation page for monolithic builds:
+#https://www.o3de.org/docs/user-guide/packaging/windows-release-builds/#debugging
+
+#QUESTIONS:
+#1) how do we go about detecting the correct asset processor batch executable? (do we fetch from vs_2022, or vs_2019?)
+#2) how do we formulaically specify the correct cmake generator?
+#3) what commands should we run to pre-build our executables? the o3de docs seem to indicate doing it from the project folder, but @stankowi provides commands from the engine folder
+#4) how do we standardize rules related to the packaging rules file found in the project? What parameters should go in there?
+
+#should we break this into smaller steps?
+# preliminary list:
+# step 1: validation - can we proceed?
+# step 2: preparation - asset processing, etc.
+# step 3: c++ build - actual build of c++ code with config
+# step 4: bundle content for use
+# step 5: prep non c++/non asset content 
+# step 6: prep directory layout with all prepared content
+# step 7: backup then post validation
+# step 8: putting everything into container for distribution (zip file, apk file, ipa file)
+#enable code re-use. This could also inform _how_ we setup our keys
+
+# we can rely on making this code file expandable as a fallback
+# we should provide legacy warnings as code updates progress
+
+# how do we handle with engine customer/contributor
+# RFC will help inform my logistical questions on what needs to be split and when
+# test driven development would help
+def package_windows_standalone_monolithic(project_path: str,
+                                          engine_path:str,
+                                          zipped: bool):
+    result = 0
+
+    #packaging rules should be in a standard location with respect to the project. Note, if this is not found, we need to have reasonable defaults
+    PROJECT_PATH = project_path
+    PACKAGING_RULES_PATH = os.path.join(PROJECT_PATH,  "packaging_config.packagerules")
+
+    packaging_rules = None
+    with open(PACKAGING_RULES_PATH, "r") as prules_file:
+        packaging_rules = json.load(prules_file)
+        print(packaging_rules)
+
+    #note: we need ability to supply a default option!
+    ENGINE_PATH = packaging_rules["engine-path"]
+    THIRD_PARTY_PATH  = packaging_rules["third-party-path"]
+    CMAKE_GENERATOR = packaging_rules["cmake-generator"]
+    CMAKE_CONFIG = packaging_rules["cmake-config"]
+    BUILD_MODE = packaging_rules["project-build-mode"]
+
+    if "zip-name" in packaging_rules:
+        zipped_name = packaging_rules["zip-name"]
+    else:
+        zipped_name = "Monolithic"
+
+    if "zip-folder-path" in packaging_rules:
+        zipped_folder = packaging_rules["zip-folder-path"]
+    else:
+        zipped_folder = ""
+
+    WINDOWS_PRE_ARGS = ['powershell.exe']
+
+    #check automated tests for how we discover executables and output
+    #hard coded paths _must_ be checked, also check for timeouts
+    ASSET_PROCESSOR_BATCH_EXE = os.path.join(ENGINE_PATH, 'build\\windows_vs2022\\bin\\profile\\AssetProcessorBatch.exe')
+    ASSET_PROCESSOR_CMD_ARGS = [ASSET_PROCESSOR_BATCH_EXE, '--platform=pc', f'--project-path={PROJECT_PATH}']
+
+    #build the asset processor batch if not done so yet
+
+    #build all relevant tools first
+    ENGINE_BUILD_CMD_ARGS = ['cmake', '--build', 'build/windows_vs2022', '--target' ,'Editor', '--target', 'AssetProcessorBatch', '--config', 'profile', '--', '-m']
+    if process_command(WINDOWS_PRE_ARGS + ENGINE_BUILD_CMD_ARGS, ENGINE_PATH) != SUCCESS:
+        print("Prebuilding Engine tools failed!")
+        return 1
+
+    #run the command for the asset processor
+    if process_command(ASSET_PROCESSOR_CMD_ARGS, PROJECT_PATH) != SUCCESS:
+        print("Asset Processing Failed!")
+        return 1
+    
+
+    # #get cmake to prep the project
+    CMAKE_PREP_CMD_ARGS = ['cmake', '-B', BUILD_MODE, '-S','.','-G',CMAKE_GENERATOR,
+                            f'-DLY_3RDPARTY_PATH={THIRD_PARTY_PATH}',
+                            '-DLY_MONOLITHIC_GAME=1']
+    if process_command(WINDOWS_PRE_ARGS + CMAKE_PREP_CMD_ARGS, PROJECT_PATH) != SUCCESS:
+        print("CMake Build Prep Failed!")
+        return 1
+    
+    #C:\workspace\projects\NewspaperDeliveryGame\install\bin\Windows\release\Monolithic
+
+    #get cmake to build the project to install directory
+    CMAKE_RELEASE_CMD_ARGS = ['cmake', '--build', BUILD_MODE, '--target', 'install', '--config', CMAKE_CONFIG]
+    if process_command(CMAKE_RELEASE_CMD_ARGS, PROJECT_PATH) != SUCCESS:
+        print("CMake Build Release Failed!")
+        return 1
+    
+    if zipped:
+        print("Zipping contents...")
+        #zip the final file
+        # shutil.make_archive("newspaper_delivery_game", "zip", os.path.join(PROJECT_PATH, "install", "bin", "Windows", CMAKE_CONFIG, "Monolithic"))
+
+
+        build_package_base_path = os.path.join(PROJECT_PATH, "install", "bin", "Windows", CMAKE_CONFIG)
+        build_package_path = os.path.join(build_package_base_path, "Monolithic")
+
+        shutil.make_archive(build_package_path, "zip", build_package_base_path, "Monolithic")
+        
+        #determine which folder to use for zipped file
+        if os.path.isdir(zipped_folder) and zipped_folder != '':
+            zip_dest = zipped_folder
+        else:
+            zip_dest = build_package_base_path
+            
+        print("moving zipped archive to "+zip_dest)
+        shutil.move(os.path.join(build_package_base_path, "Monolithic.zip"), os.path.join(zip_dest, zipped_name+".zip"))
+
+    print("finished packaging")
+    return result
+
+
+#this is where we can run the switchboard logic for determining the right packaging function to run
+#the first layer recognizes what platform we're running packaging from. This may require OS specific prep-logic before running packaging logic
+def _run_packaging(args: argparse) -> int:
+    #can this be made data-driven? what if the platform selection gets renamed?
+    #maybe template functions? that way base packaging script can 'find' correct function based on defined parameters
+    #maybe use function mapping based on parameters
+
+
+    #main question is what should count as a key, or what should count as a parameter
+    #can I make this as many 2-way doors as possible. How configurable can this get
+    #how do we handle fallbacks? if we want fallback, then setting it as parameter makes most sense
+    # function_map = {
+    #     (key) -> func
+    # }
+    #should monolithic be a key, or a parameter? depending on your answer, your forking strategy for functions can be very different
+    #we can be too granular with it
+    # missing in key: host platform vs. target platform (i.e. windows -> android)
+    # key : windows.android.standalone.monolithic
+    # key : windows.standalone.monolithic
+    # key : customer.custom
+
+    if platform.system()  == "Windows":
+        if args.standalone:
+            if args.monolithic:
+                package_windows_standalone_monolithic(project_path = args.project_path,
+                                                      engine_path = args.engine_path,
+                                                      zipped=args.zipped)
+            else:
+                print("Non-monolithic projects not supported!")
+                return 1
+    else:
+        return package_none()
+
+
+
+def add_parser_args(parser):
+    #if no use case is specified, we assume standalone
+    use_case_group = parser.add_mutually_exclusive_group(required=False)
+    use_case_group.add_argument('-s', '--standalone', action='store_true',
+                       default=True,
+                       help='builds as standalone.')
+    
+    #need to get terminology termed out - i.e. packaging.py can be extremely confusing.
+    #need to get dictionary standardized, check with @stankowi on this, need steps and terms fully defined
+
+    #no need to future proof if there's a good off ramp. If our code is easily modifiable, the customer can handle the edge cases
+    #for iterative builds, make sure they are not trapped in a dead end. Need Asset bundling addressed
+
+    #something to also think about: what would a long term GUI look like for this?
+    #GUI can output config files and commands issued in packaging/build process. Robust code echo mode like in Blender
+
+    #try to sit down with carbonated and cyanide for their build processes. They need thrad obfuscation and boundaries, anti-cheat, modding, etc.
+
+    #simulation customers: two challenges
+    #1) live-feed/simulation and human interface use cases. deploying to dedicated enviroments
+    #2) they don't need as much as the game teams, but it could conflict with the pipeline.
+
+    #
+
+    parser.add_argument('-m', '--monolithic', action='store_true',
+                       default=False,
+                       help='bundles as monolithic game release.')
+    parser.add_argument('-z', '--zipped', action='store_true',
+                        default=False,
+                        help='takes the packaged build and zips it')
+    parser.add_argument('-pp', '--project-path', type=pathlib.Path, required=True,
+                        help='Project to package')
+    parser.add_argument('-ep', '--engine-path', type=pathlib.Path, required=True,
+                        help='Engine for building tooling')
+    parser.set_defaults(func=_run_packaging)
+    
+
+def add_args(subparsers):
+    """
+    add_args is called to add subparsers arguments to each command such that it can be
+    a central python file such as o3de.py.
+    It can be run from the o3de.py script as follows
+    call add_args and execute: python o3de.py register-show --engine-projects
+    :param subparsers: the caller instantiates subparsers and passes it in here
+    """
+
+    packaging_subparser = subparsers.add_parser('packaging')
+    add_parser_args(packaging_subparser)
+
+
+def main():
+    """
+    Runs packaging.py script as standalone script
+    """
+    # parse the command line args
+    the_parser = argparse.ArgumentParser()
+
+
+    # add args to the parser
+    add_parser_args(the_parser)
+
+    # parse args
+    the_args = the_parser.parse_args()
+
+    # run
+    ret = the_args.func(the_args) if hasattr(the_args, 'func') else 1
+
+    # return
+    sys.exit(ret)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
this is just a prototype demonstrating the possibilities of project export via loading an external python file.

I've included the export script that resides in the Newspaper Delivery Game Project folder here for reference.

I'm able to import the O3DE CLI (and the packaging script can even pre-inject variable names for the export script to use).

I made comments about pros and cons of this approach, but that is still currently being evaluated, so that list is not final.