### PR TITLE
Disable Revert Override option on entities added as overrides

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
@@ -720,6 +720,12 @@ namespace AzToolsFramework
                         m_prefabOverridePublicInterface->AreOverridesPresent(selectedEntity))
                     {
                         QAction* revertAction = menu->addAction(QObject::tr("Revert Overrides"));
+                        revertAction->setToolTip(QObject::tr("Revert all overrides on this entity to whatever is in the prefab file."));
+                        if (m_prefabOverridePublicInterface->GetOverrideType(selectedEntity) == OverrideType::AddEntity)
+                        {
+                            revertAction->setToolTip(QObject::tr("Cannot revert overrides on entities that are added as overrides."));
+                            revertAction->setEnabled(false);
+                        }
                         QObject::connect(
                             revertAction,
                             &QAction::triggered,


### PR DESCRIPTION
## What does this PR do?

Entities added as overrides cannot be reverted as revert is the same as delete. This change Greys out the RevertOverride option on entities added as overrides and adds a tooltip explaining why.

## How was this PR tested?

Tested in editor