### PR TITLE
Fixes FileExistsError in LTT artifact manager

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/_internal/managers/artifact_manager.py
+++ b/Tools/LyTestTools/ly_test_tools/_internal/managers/artifact_manager.py
@@ -115,14 +115,22 @@ class ArtifactManager(object):
                                  artifact_name if artifact_name is not None else os.path.basename(artifact_path))
         if os.path.exists(dest_path):
             dest_path = self._get_collision_handled_filename(dest_path, amount)
-
         logger.debug("Copying artifact from '{}' to '{}'".format(artifact_path, dest_path))
 
-        if os.path.isdir(artifact_path):
-            shutil.copytree(artifact_path, dest_path)
-        else:
-            shutil.copy(artifact_path, dest_path)
-            os.chmod(dest_path, stat.S_IWRITE | stat.S_IREAD | stat.S_IEXEC)
+        dest_folder, _ = os.path.split(dest_path)
+        try:
+            if not os.path.exists(dest_folder):
+                os.makedirs(dest_folder, exist_ok=True)
+
+            if os.path.isdir(artifact_path):
+                shutil.copytree(artifact_path, dest_path, dirs_exist_ok=True)
+            else:
+                shutil.copy(artifact_path, dest_path)
+                os.chmod(dest_path, stat.S_IWRITE | stat.S_IREAD | stat.S_IEXEC)
+        except FileExistsError as exc:
+            logger.exception(f"Error occurred while trying to save {dest_path}. Printing contents of folder:\n"
+                             f"{os.listdir(dest_folder)}\n")
+            raise exc
         return dest_path
 
     def generate_artifact_file_name(self, artifact_name):

--- a/Tools/LyTestTools/tests/unit/test_artifact_manager.py
+++ b/Tools/LyTestTools/tests/unit/test_artifact_manager.py
@@ -78,6 +78,7 @@ class TestSetTestName(unittest.TestCase):
         assert self.mock_artifact_manager.dest_path == expected_path
 
 
+@mock.patch('os.makedirs', mock.MagicMock())
 class TestSaveArtifact(unittest.TestCase):
 
     def setUp(self):
@@ -102,7 +103,8 @@ class TestSaveArtifact(unittest.TestCase):
         self.mock_artifact_manager.save_artifact(updated_path, mock_artifact_name)
 
         assert self.mock_artifact_manager.dest_path == updated_path
-        mock_copy_tree.assert_called_once_with(updated_path, os.path.join(updated_path, mock_artifact_name[:-5]))
+        mock_copy_tree.assert_called_once_with(updated_path, os.path.join(updated_path, mock_artifact_name[:-5]),
+                                               dirs_exist_ok=True)
         mock_reducer.assert_called_once_with(file_name=mock_artifact_name, max_length=25)
 
     @mock.patch('os.path.exists', mock.MagicMock(return_value=False))
@@ -120,7 +122,7 @@ class TestSaveArtifact(unittest.TestCase):
         assert self.mock_artifact_manager.dest_path == self.mock_artifact_manager.artifact_path
         mock_copy_tree.assert_called_once_with(
             self.mock_artifact_manager.artifact_path,
-            os.path.join(self.mock_artifact_manager.artifact_path, 'pytest_results'))
+            os.path.join(self.mock_artifact_manager.artifact_path, 'pytest_results'), dirs_exist_ok=True)
         mock_reducer.assert_not_called()
 
     @mock.patch('os.path.exists', mock.MagicMock(return_value=False))


### PR DESCRIPTION
## What does this PR do?
Adds exist_ok params to LTT artifact manager mkdir calls and also adds extra debug text when errors are caught.

## How was this PR tested?
Ran unit tests locally.