### PR TITLE
Asset Processor - Metadata Case Mismatch Handling

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
@@ -488,7 +488,8 @@ namespace AssetProcessor
                         return false;
                     }
 
-                    const bool fileExists = fileStateInterface->Exists(sourceAsset.AbsolutePath().c_str());
+                    AssetProcessor::FileStateInfo fileStateInfo;
+                    const bool fileExists = fileStateInterface->GetFileInfo(sourceAsset.AbsolutePath().c_str(), &fileStateInfo) && fileStateInfo.m_absolutePath.compare(sourceAsset.AbsolutePath().c_str()) == 0;
 
                     // Only try to update for files which actually exist
                     if (fileExists)

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -3068,7 +3068,7 @@ namespace AssetProcessor
                 {
                     AssetProcessor::FileStateInfo fileStateInfo;
 
-                    if(AZ::Interface<AssetProcessor::FileStateCache>::Get()->GetFileInfo(
+                    if(AZ::Interface<AssetProcessor::IFileStateRequests>::Get()->GetFileInfo(
                         sourceAssetReference.AbsolutePath().c_str(), &fileStateInfo)
                         && fileStateInfo.m_absolutePath.compare(sourceAssetReference.AbsolutePath().c_str()) != 0)
                     {

--- a/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.h
+++ b/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.h
@@ -15,6 +15,7 @@
 #include <gmock/gmock.h>
 #include <AzCore/UnitTest/Mocks/MockFileIOBase.h>
 #include <AssetManager/FileStateCache.h>
+#include <QDir>
 
 namespace UnitTests
 {
@@ -198,7 +199,7 @@ namespace UnitTests
                         // Any mode besides OPEN_READ_ONLY creates a file
                         if ((systemMode & ~int(IO::SystemFile::SF_OPEN_READ_ONLY)) > 0)
                         {
-                            m_mockFiles[handle] = "";
+                            m_mockFiles[handle] = AZStd::pair<AZStd::string, AZStd::string>(filePath, "");
                         }
 
                         return AZ::IO::Result(AZ::IO::ResultCode::Success);
@@ -218,7 +219,7 @@ namespace UnitTests
                     {
                         auto itr = m_mockFiles.find(handle);
 
-                        size = itr != m_mockFiles.end() ? itr->second.size() : 0;
+                        size = itr != m_mockFiles.end() ? itr->second.second.size() : 0;
 
                         return AZ::IO::ResultCode::Success;
                     }));
@@ -230,7 +231,7 @@ namespace UnitTests
                         auto handle = ComputeHandle(filePath);
                         auto itr = m_mockFiles.find(handle);
 
-                        size = itr != m_mockFiles.end() ? itr->second.size() : 0;
+                        size = itr != m_mockFiles.end() ? itr->second.second.size() : 0;
 
                         return AZ::IO::ResultCode::Success;
                     }));
@@ -254,8 +255,14 @@ namespace UnitTests
 
                         if (itr != m_mockFiles.end())
                         {
-                            m_mockFiles[newHandle] = itr->second;
-                            m_mockFiles.erase(itr);
+                            auto& [path, contents] = itr->second;
+                            path = newPath;
+
+                            if (originalHandle != newHandle)
+                            {
+                                m_mockFiles[newHandle] = itr->second;
+                                m_mockFiles.erase(itr);
+                            }
 
                             return AZ::IO::ResultCode::Success;
                         }
@@ -285,8 +292,8 @@ namespace UnitTests
                             return AZ::IO::ResultCode::Error;
                         }
 
-                        memcpy(buffer, itr->second.c_str(), itr->second.size());
-                        *bytesRead = itr->second.size();
+                        memcpy(buffer, itr->second.second.c_str(), itr->second.second.size());
+                        *bytesRead = itr->second.second.size();
                         return AZ::IO::ResultCode::Success;
                     }));
 
@@ -294,10 +301,10 @@ namespace UnitTests
                 .WillByDefault(Invoke(
                     [this](IO::HandleType fileHandle, const void* buffer, AZ::u64 size, AZ::u64* bytesWritten)
                     {
-                        AZStd::string& file = m_mockFiles[fileHandle];
+                        auto& pair = m_mockFiles[fileHandle];
 
-                        file.resize(size);
-                        memcpy((void*)file.c_str(), buffer, size);
+                        pair.second.resize(size);
+                        memcpy((void*)pair.second.c_str(), buffer, size);
 
                         if (bytesWritten)
                         {
@@ -306,8 +313,26 @@ namespace UnitTests
 
                         return AZ::IO::ResultCode::Success;
                     }));
-        }
 
+            ON_CALL(*m_fileIOMock, FindFiles(_, _, _))
+                .WillByDefault(Invoke(
+                    [this](const char* filePath, const char* filter, auto callback)
+                    {
+                        for (const auto& [hash, pair] : m_mockFiles)
+                        {
+                            const auto& [path, contents] = pair;
+                            if(AZStd::wildcard_match(AZStd::string::format("%s%s", filePath, filter), path))
+                            {
+                                if(!callback(path.c_str()))
+                                {
+                                    return AZ::IO::ResultCode::Success;
+                                }
+                            }
+                        }
+
+                        return AZ::IO::ResultCode::Success;
+                    }));
+        }
         ~MockVirtualFileIO()
         {
             AZ::IO::FileIOBase::SetInstance(nullptr);
@@ -315,7 +340,7 @@ namespace UnitTests
         }
 
         AZ::IO::FileIOBase* m_priorFileIO = nullptr;
-        AZStd::unordered_map<AZ::IO::HandleType, AZStd::string> m_mockFiles;
+        AZStd::unordered_map<AZ::IO::HandleType, AZStd::pair<AZStd::string, AZStd::string>> m_mockFiles;
         AZStd::unique_ptr<testing::NiceMock<AZ::IO::MockFileIOBase>> m_fileIOMock;
     };
 
@@ -328,7 +353,12 @@ namespace UnitTests
                 auto* io = AZ::IO::FileIOBase::GetInstance();
                 AZ::u64 size;
                 io->Size(absolutePath.toUtf8().constData(), size);
-                *foundFileInfo = AssetProcessor::FileStateInfo(absolutePath, QDateTime::fromMSecsSinceEpoch(io->ModificationTime(absolutePath.toUtf8().constData())), size, io->IsDirectory(absolutePath.toUtf8().constData()));
+
+                QString parentPath = AZ::IO::FixedMaxPath(absolutePath.toUtf8().constData()).ParentPath().FixedMaxPathStringAsPosix().c_str();
+                QString relPath = AZ::IO::FixedMaxPath(absolutePath.toUtf8().constData()).Filename().FixedMaxPathStringAsPosix().c_str();
+                AssetUtilities::UpdateToCorrectCase(parentPath, relPath);
+
+                *foundFileInfo = AssetProcessor::FileStateInfo(QDir(parentPath).absoluteFilePath(relPath), QDateTime::fromMSecsSinceEpoch(io->ModificationTime(absolutePath.toUtf8().constData())), size, io->IsDirectory(absolutePath.toUtf8().constData()));
 
                 return true;
             }

--- a/Code/Tools/AssetProcessor/native/tests/UuidManagerTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/UuidManagerTests.cpp
@@ -472,4 +472,44 @@ namespace UnitTests
 
         EXPECT_EQ(uuidB.GetValue(), uuidA.GetValue());
     }
+
+    TEST_F(UuidManagerTests, UpdateCase)
+    {
+        static constexpr AZ::IO::FixedMaxPath TestFile = "c:/somepath/mockfile.txt";
+        static constexpr AZ::IO::FixedMaxPath RenamedFile = "c:/somepath/MockFile.txt";
+        static constexpr AZ::IO::FixedMaxPath MetadataFile = TestFile.Native() + AzToolsFramework::MetadataManager::MetadataFileExtension;
+
+        MakeFile(TestFile);
+
+        // Generate the metadata file
+        auto uuid = m_uuidInterface->GetUuid(AssetProcessor::SourceAssetReference(TestFile));
+
+        EXPECT_TRUE(uuid);
+
+        auto* io = AZ::IO::FileIOBase::GetInstance();
+
+        // Make sure the metadata file exists (this is not a case sensitive check)
+        EXPECT_TRUE(io->Exists(AzToolsFramework::MetadataManager::ToMetadataPath(TestFile.c_str()).c_str()));
+
+        QString relPath = "mockfile.txt";
+        relPath += AzToolsFramework::MetadataManager::MetadataFileExtension;
+
+        // Verify the case of the metadata file is lowercase to start with
+        EXPECT_TRUE(AssetUtilities::UpdateToCorrectCase("c:/somepath", relPath));
+        EXPECT_EQ(relPath, QString("mockfile.txt") + AzToolsFramework::MetadataManager::MetadataFileExtension);
+
+        // Rename the source file from lowercase to uppercase and notify about the old file being removed
+        io->Rename(TestFile.c_str(), RenamedFile.c_str());
+        m_uuidInterface->FileRemoved(TestFile);
+
+        // Request the UUID again, this should automatically update the case of the metadata file
+        m_uuidInterface->GetUuid(AssetProcessor::SourceAssetReference(RenamedFile));
+
+        // Verify the metadata file exists (this is not a case sensitive check)
+        EXPECT_TRUE(io->Exists(AzToolsFramework::MetadataManager::ToMetadataPath(RenamedFile.c_str()).c_str()));
+
+        // Verify the case of the metadata file is actually updated
+        EXPECT_TRUE(AssetUtilities::UpdateToCorrectCase("c:/somepath", relPath));
+        EXPECT_EQ(relPath, QString("MockFile.txt") + AzToolsFramework::MetadataManager::MetadataFileExtension);
+    }
 }


### PR DESCRIPTION
## What does this PR do?

Update UuidManager to automatically update the case of metadata files to match the case of the file they belong to.

## How was this PR tested?

Manually testing with AP running.
Added and ran unit test.
