### PR TITLE
bugfix for inconsistent rotation calculation order.

### DIFF
--- a/Code/Legacy/CryCommon/Cry_Quat.h
+++ b/Code/Legacy/CryCommon/Cry_Quat.h
@@ -395,6 +395,30 @@ struct Quat_tpl
         return q;
     }
 
+    // creatr rotation quatation base on ZYX axis
+    ILINE void SetRotationZYX(const Ang3_tpl<F>& a)
+    {
+        assert(a.IsValid());
+        F sx, cx;
+        sincos_tpl(F(a.x * F(0.5)), &sx, &cx);
+        F sy, cy;
+        sincos_tpl(F(a.y * F(0.5)), &sy, &cy);
+        F sz, cz;
+        sincos_tpl(F(a.z * F(0.5)), &sz, &cz);
+        w = cx * cy * cz - sx * sy * sz;
+        v.x = cx * sy * sz + sx * cy * cz;
+        v.y = cx * sy * cz - sx * cy * sz;
+        v.z = cx * cy * sz + sx * sy * cz;
+    }
+
+    ILINE static Quat_tpl<F> CreateRotationZYX(const Ang3_tpl<F>& a)
+    {
+        assert(a.IsValid());
+        Quat_tpl<F> q;
+        q.SetRotationZYX(a);
+        return q;
+    }
+
     /*!
     * Create rotation-quaternion that about the x-axis.
     *

--- a/Gems/Maestro/Code/Source/Cinematics/CompoundSplineTrack.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/CompoundSplineTrack.cpp
@@ -189,7 +189,7 @@ void CCompoundSplineTrack::GetValue(float time, Quat& value)
         {
             m_subTracks[i]->GetValue(time, angles[i]);
         }
-        value = Quat::CreateRotationXYZ(Ang3(DEG2RAD(angles[0]), DEG2RAD(angles[1]), DEG2RAD(angles[2])));
+        value = Quat::CreateRotationZYX(Ang3(DEG2RAD(angles[0]), DEG2RAD(angles[1]), DEG2RAD(angles[2])));
     }
     else
     {


### PR DESCRIPTION
## What does this PR do?
1. Open Editor.
2. Click Tools -> Track View.
3. Create a sequence.
4. Add some nodes.
5. Record a key frame, modify the rotation of the entity.
![image](https://user-images.githubusercontent.com/80555200/220555469-d23f0bc6-5805-41ea-8561-5285cf7cf34f.png)

## How was this PR tested?
Follow the same steps, as follows:
![image](https://user-images.githubusercontent.com/80555200/220555486-15c7e43e-ee0d-4a34-ad12-81ca10d7e2de.png)
