### PR TITLE
bugfix Active Camera doesn't take effect when playing.

### DIFF
--- a/Code/Editor/TrackView/TrackViewDialog.cpp
+++ b/Code/Editor/TrackView/TrackViewDialog.cpp
@@ -894,10 +894,8 @@ void CTrackViewDialog::Update()
     // 2. The camera which owns this node has been set as the current camera by the director node.
     if (gEnv->pMovieSystem)
     {
-        bool bSequenceCamInUse = gEnv->pMovieSystem->GetCallback() == nullptr ||
-            gEnv->pMovieSystem->GetCallback()->IsSequenceCamUsed();
         AZ::EntityId camId = gEnv->pMovieSystem->GetCameraParams().cameraEntityId;
-        if (camId.IsValid() && bSequenceCamInUse)
+        if (camId.IsValid())
         {
             AZ::Entity* entity = nullptr;
             AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, camId);


### PR DESCRIPTION
## What does this PR do?

1. Open Editor.
2. Click Tools -> Track View.
3. Create a sequence.
4. Add a director node, and some others.
5. Record two key frames at the director track, give camera to 1st frame, give none to 2nd frame.
![image](https://user-images.githubusercontent.com/80555200/220561736-7c8e1996-1e6e-4ff6-b376-1630a7cc8783.png)
6. Play.
![image](https://user-images.githubusercontent.com/80555200/220561706-1961d02c-afd9-4e63-a907-866efad86927.png)

## How was this PR tested?
Follow the same steps, as follows:
1. Before the 1st key frame.
![image](https://user-images.githubusercontent.com/80555200/220561895-b0affc95-235f-4231-8159-5c4cfc7e2deb.png)
2. Between the two key frames.
![image](https://user-images.githubusercontent.com/80555200/220561911-ebbaa8bc-2360-4204-89bc-d14dbf4203c8.png)
3. After the 2nd key frame.
![image](https://user-images.githubusercontent.com/80555200/220561927-43d36efb-f771-45d9-8e74-21eafd0859ad.png)

