### PR TITLE
Command 'ed_physxUpdatePrefabsWithColliderComponents' update

### DIFF
--- a/Gems/PhysX/Code/Editor/Source/Components/Conversion/CollidersPrefabConversion.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Components/Conversion/CollidersPrefabConversion.cpp
@@ -131,7 +131,7 @@ namespace PhysX
                 return false;
             }
 
-            // Once the component is removed from the entity we are responsable for its destruction.
+            // Once the component is removed from the entity we are responsible for its destruction.
             delete editorColliderComponent;
 
             entityModified = true;

--- a/Gems/PhysX/Code/Editor/Source/Components/Conversion/CollidersPrefabConversion.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Components/Conversion/CollidersPrefabConversion.cpp
@@ -13,6 +13,7 @@
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 
 #include <EditorColliderComponent.h>
+#include <EditorMeshColliderComponent.h>
 #include <EditorShapeColliderComponent.h>
 #include <EditorRigidBodyComponent.h>
 #include <EditorStaticRigidBodyComponent.h>
@@ -23,11 +24,13 @@ namespace PhysX
 {
     void UpdatePrefabsWithColliderComponents(const AZ::ConsoleCommandContainer& commandArgs);
 
+    // O3DE_DEPRECATION_NOTICE(GHI-14718)
     AZ_CONSOLEFREEFUNC(
         "ed_physxUpdatePrefabsWithColliderComponents",
         UpdatePrefabsWithColliderComponents,
         AZ::ConsoleFunctorFlags::Null,
-        "Finds entities with collider components and no rigid bodies and updates them to the new pattern which requires a static rigid body component.");
+        "Finds entities with collider components and no rigid bodies and updates them to the new pattern which requires a static rigid body component. "
+        "Finds entities with collider components using physx asset and replace it with a mesh collider component.");
 
     bool AddStaticRigidBodyToPrefabEntity(
         Utils::PrefabInfo& prefabInfo,
@@ -41,8 +44,7 @@ namespace PhysX
             AZ_Warning(
                 "PhysXColliderConversion",
                 false,
-                "Unable to load entity '%s' from prefab '%s'.",
-                entity.GetName().c_str(),
+                "Unable to load entity from prefab '%s'.",
                 prefabInfo.m_prefabFullPath.c_str());
             return false;
         }
@@ -72,6 +74,83 @@ namespace PhysX
         return true;
     }
 
+    bool ConvertCollidersUsingAssetsToMeshCollidersInPrefabEntity(
+        Utils::PrefabInfo& prefabInfo,
+        AzToolsFramework::Prefab::PrefabDomValue& entityPrefab)
+    {
+        AZ::Entity entity;
+        Utils::PrefabEntityIdMapper prefabEntityIdMapper;
+
+        if (!Utils::LoadPrefabEntity(prefabEntityIdMapper, entityPrefab, entity))
+        {
+            AZ_Warning(
+                "PhysXColliderConversion",
+                false,
+                "Unable to load entity from prefab '%s'.",
+                prefabInfo.m_prefabFullPath.c_str());
+            return false;
+        }
+
+        bool entityModified = false;
+
+        for (auto* editorColliderComponent : entity.FindComponents<EditorColliderComponent>())
+        {
+            const EditorProxyShapeConfig& proxyShapeConfig = editorColliderComponent->GetShapeConfiguration();
+
+            if (proxyShapeConfig.m_shapeType != Physics::ShapeType::PhysicsAsset)
+            {
+                continue;
+            }
+
+            EditorProxyAssetShapeConfig newProxyAssetShapeConfig;
+            newProxyAssetShapeConfig.m_configuration = proxyShapeConfig.m_legacyPhysicsAsset.m_configuration;
+            newProxyAssetShapeConfig.m_pxAsset = proxyShapeConfig.m_legacyPhysicsAsset.m_pxAsset;
+            newProxyAssetShapeConfig.m_hasNonUniformScale = proxyShapeConfig.m_hasNonUniformScale;
+            newProxyAssetShapeConfig.m_subdivisionLevel = proxyShapeConfig.m_subdivisionLevel;
+
+            if (!entity.CreateComponent<EditorMeshColliderComponent>(
+                    editorColliderComponent->GetColliderConfiguration(), newProxyAssetShapeConfig))
+            {
+                AZ_Warning(
+                    "PhysXColliderConversion",
+                    false,
+                    "Failed to create static rigid body component for entity '%s' in prefab '%s'.",
+                    entity.GetName().c_str(),
+                    prefabInfo.m_prefabFullPath.c_str());
+                return false;
+            }
+
+            if (!entity.RemoveComponent(editorColliderComponent))
+            {
+                AZ_Warning(
+                    "PhysXColliderConversion",
+                    false,
+                    "Failed to remove EditorColliderComponent in entity '%s' in prefab '%s'.",
+                    entity.GetName().c_str(),
+                    prefabInfo.m_prefabFullPath.c_str());
+                return false;
+            }
+
+            // Once the component is removed from the entity we are responsable for its destruction.
+            delete editorColliderComponent;
+
+            entityModified = true;
+        }
+
+        if (!Utils::StorePrefabEntity(prefabEntityIdMapper, prefabInfo.m_template->GetPrefabDom(), entityPrefab, entity))
+        {
+            AZ_Warning(
+                "PhysXColliderConversion",
+                false,
+                "Unable to store entity '%s' into prefab '%s'.",
+                entity.GetName().c_str(),
+                prefabInfo.m_prefabFullPath.c_str());
+            return false;
+        }
+
+        return entityModified;
+    }
+
     void UpdatePrefabPhysXColliders(Utils::PrefabInfo& prefabInfo)
     {
         bool prefabModified = false;
@@ -94,15 +173,24 @@ namespace PhysX
                 [](const auto* component)
                 {
                     const auto typeId = Utils::GetComponentTypeId(*component);
-                    return typeId == azrtti_typeid<EditorColliderComponent>() || typeId == azrtti_typeid<EditorShapeColliderComponent>();
+                    return typeId == azrtti_typeid<EditorColliderComponent>()
+                        || typeId == azrtti_typeid<EditorMeshColliderComponent>()
+                        || typeId == azrtti_typeid<EditorShapeColliderComponent>();
                 });
 
+            // Adds a static rigid body to entities with a collider and no rigid body present.
             if (rigidBodyMissing && colliderPresent)
             {
                 if (AddStaticRigidBodyToPrefabEntity(prefabInfo, *entity))
                 {
                     prefabModified = true;
                 }
+            }
+
+            // Converts all EditorColliderComponent that use physics assets to EditorMeshColliderComponent.
+            if (ConvertCollidersUsingAssetsToMeshCollidersInPrefabEntity(prefabInfo, *entity))
+            {
+                prefabModified = true;
             }
         }
 


### PR DESCRIPTION
**Note**
This is part of the work to separate PhysX Collider into 2 components: https://github.com/o3de/o3de/pull/14725. Merging into the staging branch `MeshColliderComponent_Staging`.

Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

Command 'ed_physxUpdatePrefabsWithColliderComponents' now also updates all prefabs in a project by detecting PhysX Colliders using physics assets and converting them into PhysX Mesh Colliders.

Deprecation GHI (https://github.com/o3de/o3de/issues/14718)

## How was this PR tested?

Used the command to update all the prefabs in AutomatedTesting project and it worked as expected: https://github.com/o3de/o3de/pull/14730
