### PR TITLE
Updated prefabs in AutomatedTesting by running 'ed_physxUpdatePrefabsWithColliderComponents' command

### DIFF
--- a/AutomatedTesting/Levels/Physics/Collider_PxMeshErrorIfNoMesh/Collider_PxMeshErrorIfNoMesh.prefab
+++ b/AutomatedTesting/Levels/Physics/Collider_PxMeshErrorIfNoMesh/Collider_PxMeshErrorIfNoMesh.prefab
@@ -122,13 +122,9 @@
                         ]
                     }
                 },
-                "Component_[14059406946656899002]": {
-                    "$type": "EditorStaticRigidBodyComponent",
-                    "Id": 14059406946656899002
-                },
-                "Component_[14197962870538087335]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 14197962870538087335,
+                "Component_[12807450387069756224]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 12807450387069756224,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
                             "Slots": [
@@ -138,6 +134,10 @@
                             ]
                         }
                     }
+                },
+                "Component_[14059406946656899002]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 14059406946656899002
                 },
                 "Component_[16543103047436943265]": {
                     "$type": "EditorPendingCompositionComponent",

--- a/AutomatedTesting/Levels/Physics/ForceRegion_ImpulsesPxMeshShapedRigidBody/ForceRegion_ImpulsesPxMeshShapedRigidBody.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_ImpulsesPxMeshShapedRigidBody/ForceRegion_ImpulsesPxMeshShapedRigidBody.prefab
@@ -75,9 +75,9 @@
                         ]
                     }
                 },
-                "Component_[17072051774364123210]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 17072051774364123210,
+                "Component_[16753786343051582737]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 16753786343051582737,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
                             "Slots": [
@@ -87,24 +87,22 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{80F2EABC-5A51-5514-B9F0-55F981549B2E}",
+                                "subId": 1454228742
+                            },
+                            "assetHint": "levels/physics/forceregion_impulsespxmeshshapedrigidbody/physxsedan/_dev_sedan_r0-b.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{80F2EABC-5A51-5514-B9F0-55F981549B2E}",
                                     "subId": 1454228742
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "levels/physics/forceregion_impulsespxmeshshapedrigidbody/physxsedan/_dev_sedan_r0-b.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{80F2EABC-5A51-5514-B9F0-55F981549B2E}",
-                                        "subId": 1454228742
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "levels/physics/forceregion_impulsespxmeshshapedrigidbody/physxsedan/_dev_sedan_r0-b.pxmesh"
-                                }
                             }
                         }
                     }

--- a/AutomatedTesting/Levels/Physics/ForceRegion_PxMeshShapedForce/ForceRegion_PxMeshShapedForce.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_PxMeshShapedForce/ForceRegion_PxMeshShapedForce.prefab
@@ -51,43 +51,6 @@
             "Id": "Entity_[1157170092590]",
             "Name": "Sedan",
             "Components": {
-                "Component_[10040515516141845460]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 10040515516141845460,
-                    "ColliderConfiguration": {
-                        "Trigger": true,
-                        "InSceneQueries": false,
-                        "MaterialSlots": {
-                            "Slots": [
-                                {
-                                    "Name": "Entire object"
-                                }
-                            ]
-                        }
-                    },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
-                                "assetId": {
-                                    "guid": "{2E7408F7-ABCD-5BE3-B50F-061BCCE273A8}",
-                                    "subId": 1454228742
-                                },
-                                "assetHint": "levels/physics/forceregion_pxmeshshapedforce/physxsedan/_dev_sedan_r0-b.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{2E7408F7-ABCD-5BE3-B50F-061BCCE273A8}",
-                                        "subId": 1454228742
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "levels/physics/forceregion_pxmeshshapedforce/physxsedan/_dev_sedan_r0-b.pxmesh"
-                                },
-                                "UseMaterialsFromAsset": false
-                            }
-                        }
-                    }
-                },
                 "Component_[10687836833489077932]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 10687836833489077932,
@@ -120,6 +83,41 @@
                 "Component_[12620083734176463307]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12620083734176463307
+                },
+                "Component_[13533967704497836989]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 13533967704497836989,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    },
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{2E7408F7-ABCD-5BE3-B50F-061BCCE273A8}",
+                                "subId": 1454228742
+                            },
+                            "assetHint": "levels/physics/forceregion_pxmeshshapedforce/physxsedan/_dev_sedan_r0-b.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
+                                "assetId": {
+                                    "guid": "{2E7408F7-ABCD-5BE3-B50F-061BCCE273A8}",
+                                    "subId": 1454228742
+                                },
+                                "loadBehavior": "QueueLoad",
+                                "assetHint": "levels/physics/forceregion_pxmeshshapedforce/physxsedan/_dev_sedan_r0-b.pxmesh"
+                            },
+                            "UseMaterialsFromAsset": false
+                        }
+                    }
                 },
                 "Component_[14428318019156486339]": {
                     "$type": "EditorOnlyEntityComponent",

--- a/AutomatedTesting/Levels/Physics/Joints_Ball2BodiesConstrained/Joints_Ball2BodiesConstrained.prefab
+++ b/AutomatedTesting/Levels/Physics/Joints_Ball2BodiesConstrained/Joints_Ball2BodiesConstrained.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -55,10 +51,6 @@
             "Id": "Entity_[286081428076]",
             "Name": "lead",
             "Components": {
-                "Component_[10023033763705225227]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10023033763705225227
-                },
                 "Component_[13011255769289009335]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 13011255769289009335
@@ -93,9 +85,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 17363654757392362489,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -112,12 +106,17 @@
                         "Gravity Enabled": false,
                         "Compute Mass": false,
                         "Mass": 999.0,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 0.010010000318288803
-                        }
+                        "Inertia tensor": [
+                            0.010010000318288803,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.010010000318288803,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.010010000318288803
+                        ]
                     }
                 },
                 "Component_[2634845782760090713]": {
@@ -199,9 +198,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 1322277184770581793,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -217,6 +218,19 @@
                 "Component_[13337748219983851939]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 13337748219983851939
+                },
+                "Component_[14568534546296452098]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 14568534546296452098,
+                    "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    }
                 },
                 "Component_[16053691607720161901]": {
                     "$type": "EditorEntitySortComponent",
@@ -242,12 +256,17 @@
                         ],
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 },
                 "Component_[2304545190715981019]": {
@@ -257,21 +276,6 @@
                 "Component_[281621200381688046]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 281621200381688046
-                },
-                "Component_[3788104328409405778]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3788104328409405778
-                },
-                "Component_[5053986797366085195]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 5053986797366085195,
-                    "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
-                        }
-                    }
                 },
                 "Component_[7467962597485847042]": {
                     "$type": "EditorBallJointComponent",

--- a/AutomatedTesting/Levels/Physics/Joints_BallBreakable/Joints_BallBreakable.prefab
+++ b/AutomatedTesting/Levels/Physics/Joints_BallBreakable/Joints_BallBreakable.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -55,10 +51,6 @@
             "Id": "Entity_[286081428076]",
             "Name": "lead",
             "Components": {
-                "Component_[10023033763705225227]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10023033763705225227
-                },
                 "Component_[13011255769289009335]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 13011255769289009335
@@ -93,9 +85,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 17363654757392362489,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -112,12 +106,17 @@
                         "Gravity Enabled": false,
                         "Compute Mass": false,
                         "Mass": 999.0,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 0.010010000318288803
-                        }
+                        "Inertia tensor": [
+                            0.010010000318288803,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.010010000318288803,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.010010000318288803
+                        ]
                     }
                 },
                 "Component_[2634845782760090713]": {
@@ -199,9 +198,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 1322277184770581793,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -217,6 +218,19 @@
                 "Component_[13337748219983851939]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 13337748219983851939
+                },
+                "Component_[16042022251133117517]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 16042022251133117517,
+                    "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    }
                 },
                 "Component_[16053691607720161901]": {
                     "$type": "EditorEntitySortComponent",
@@ -242,12 +256,17 @@
                         ],
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 },
                 "Component_[2304545190715981019]": {
@@ -257,21 +276,6 @@
                 "Component_[281621200381688046]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 281621200381688046
-                },
-                "Component_[3788104328409405778]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3788104328409405778
-                },
-                "Component_[5053986797366085195]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 5053986797366085195,
-                    "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
-                        }
-                    }
                 },
                 "Component_[7467962597485847042]": {
                     "$type": "EditorBallJointComponent",

--- a/AutomatedTesting/Levels/Physics/Joints_BallNoLimitsConstrained/Joints_BallNoLimitsConstrained.prefab
+++ b/AutomatedTesting/Levels/Physics/Joints_BallNoLimitsConstrained/Joints_BallNoLimitsConstrained.prefab
@@ -267,6 +267,19 @@
             "Id": "Entity_[333326068332]",
             "Name": "follower",
             "Components": {
+                "Component_[10213185887994260784]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 10213185887994260784,
+                    "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    }
+                },
                 "Component_[13088569405203769999]": {
                     "$type": "EditorLockComponent",
                     "Id": 13088569405203769999
@@ -376,19 +389,6 @@
                 "Component_[281621200381688046]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 281621200381688046
-                },
-                "Component_[5053986797366085195]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 5053986797366085195,
-                    "ColliderConfiguration": {
-                        "MaterialSlots": {
-                            "Slots": [
-                                {
-                                    "Name": "Entire object"
-                                }
-                            ]
-                        }
-                    }
                 },
                 "Component_[7467962597485847042]": {
                     "$type": "EditorBallJointComponent",

--- a/AutomatedTesting/Levels/Physics/Joints_Fixed2BodiesConstrained/Joints_Fixed2BodiesConstrained.prefab
+++ b/AutomatedTesting/Levels/Physics/Joints_Fixed2BodiesConstrained/Joints_Fixed2BodiesConstrained.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -55,10 +51,6 @@
             "Id": "Entity_[286081428076]",
             "Name": "lead",
             "Components": {
-                "Component_[10023033763705225227]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10023033763705225227
-                },
                 "Component_[13011255769289009335]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 13011255769289009335
@@ -93,9 +85,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 17363654757392362489,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -110,12 +104,17 @@
                         "entityId": "",
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 },
                 "Component_[2634845782760090713]": {
@@ -197,9 +196,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 1322277184770581793,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -228,6 +229,19 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 17977051379650702181
                 },
+                "Component_[18223684241057333840]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 18223684241057333840,
+                    "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    }
+                },
                 "Component_[2119963470176591658]": {
                     "$type": "EditorRigidBodyComponent",
                     "Id": 2119963470176591658,
@@ -240,12 +254,17 @@
                         ],
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 },
                 "Component_[2304545190715981019]": {
@@ -255,21 +274,6 @@
                 "Component_[281621200381688046]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 281621200381688046
-                },
-                "Component_[3788104328409405778]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3788104328409405778
-                },
-                "Component_[5053986797366085195]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 5053986797366085195,
-                    "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
-                        }
-                    }
                 },
                 "Component_[8112340781834095734]": {
                     "$type": "EditorFixedJointComponent",

--- a/AutomatedTesting/Levels/Physics/Joints_FixedBreakable/Joints_FixedBreakable.prefab
+++ b/AutomatedTesting/Levels/Physics/Joints_FixedBreakable/Joints_FixedBreakable.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -55,10 +51,6 @@
             "Id": "Entity_[286081428076]",
             "Name": "lead",
             "Components": {
-                "Component_[10023033763705225227]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10023033763705225227
-                },
                 "Component_[13011255769289009335]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 13011255769289009335
@@ -93,9 +85,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 17363654757392362489,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -110,12 +104,17 @@
                         "entityId": "",
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 },
                 "Component_[2634845782760090713]": {
@@ -197,9 +196,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 1322277184770581793,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -215,6 +216,19 @@
                 "Component_[13337748219983851939]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 13337748219983851939
+                },
+                "Component_[14816100269645295762]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 14816100269645295762,
+                    "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    }
                 },
                 "Component_[16053691607720161901]": {
                     "$type": "EditorEntitySortComponent",
@@ -240,12 +254,17 @@
                         ],
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 },
                 "Component_[2304545190715981019]": {
@@ -255,21 +274,6 @@
                 "Component_[281621200381688046]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 281621200381688046
-                },
-                "Component_[3788104328409405778]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3788104328409405778
-                },
-                "Component_[5053986797366085195]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 5053986797366085195,
-                    "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
-                        }
-                    }
                 },
                 "Component_[8112340781834095734]": {
                     "$type": "EditorFixedJointComponent",

--- a/AutomatedTesting/Levels/Physics/Joints_Hinge2BodiesConstrained/Joints_Hinge2BodiesConstrained.prefab
+++ b/AutomatedTesting/Levels/Physics/Joints_Hinge2BodiesConstrained/Joints_Hinge2BodiesConstrained.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -55,10 +51,6 @@
             "Id": "Entity_[286081428076]",
             "Name": "lead",
             "Components": {
-                "Component_[10023033763705225227]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10023033763705225227
-                },
                 "Component_[13011255769289009335]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 13011255769289009335
@@ -93,9 +85,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 17363654757392362489,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -112,12 +106,17 @@
                         "Gravity Enabled": false,
                         "Compute Mass": false,
                         "Mass": 999.0,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 0.010010000318288803
-                        }
+                        "Inertia tensor": [
+                            0.010010000318288803,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.010010000318288803,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.010010000318288803
+                        ]
                     }
                 },
                 "Component_[2634845782760090713]": {
@@ -199,9 +198,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 1322277184770581793,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -242,12 +243,17 @@
                         ],
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 },
                 "Component_[2304545190715981019]": {
@@ -258,17 +264,15 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 281621200381688046
                 },
-                "Component_[3788104328409405778]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3788104328409405778
-                },
-                "Component_[5053986797366085195]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 5053986797366085195,
+                "Component_[4570706956715413878]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 4570706956715413878,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     }

--- a/AutomatedTesting/Levels/Physics/Joints_HingeBreakable/Joints_HingeBreakable.prefab
+++ b/AutomatedTesting/Levels/Physics/Joints_HingeBreakable/Joints_HingeBreakable.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -55,10 +51,6 @@
             "Id": "Entity_[286081428076]",
             "Name": "lead",
             "Components": {
-                "Component_[10023033763705225227]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10023033763705225227
-                },
                 "Component_[13011255769289009335]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 13011255769289009335
@@ -93,9 +85,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 17363654757392362489,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -112,12 +106,17 @@
                         "Gravity Enabled": false,
                         "Compute Mass": false,
                         "Mass": 999.0,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 0.010010000318288803
-                        }
+                        "Inertia tensor": [
+                            0.010010000318288803,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.010010000318288803,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.010010000318288803
+                        ]
                     }
                 },
                 "Component_[2634845782760090713]": {
@@ -162,6 +161,19 @@
             "Id": "Entity_[333326068332]",
             "Name": "follower",
             "Components": {
+                "Component_[12992088971059369562]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 12992088971059369562,
+                    "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    }
+                },
                 "Component_[13088569405203769999]": {
                     "$type": "EditorLockComponent",
                     "Id": 13088569405203769999
@@ -199,9 +211,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 1322277184770581793,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -242,12 +256,17 @@
                         ],
                         "Gravity Enabled": false,
                         "Compute Mass": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        }
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ]
                     }
                 },
                 "Component_[2304545190715981019]": {
@@ -257,21 +276,6 @@
                 "Component_[281621200381688046]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 281621200381688046
-                },
-                "Component_[3788104328409405778]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3788104328409405778
-                },
-                "Component_[5053986797366085195]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 5053986797366085195,
-                    "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
-                        }
-                    }
                 },
                 "Component_[7011723427504493749]": {
                     "$type": "EditorHingeJointComponent",

--- a/AutomatedTesting/Levels/Physics/Material_NoEffectIfNoColliderShape/Material_NoEffectIfNoColliderShape.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_NoEffectIfNoColliderShape/Material_NoEffectIfNoColliderShape.prefab
@@ -114,9 +114,9 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 10233737701874797018
                 },
-                "Component_[11885287454855755410]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 11885287454855755410,
+                "Component_[12353365266794273614]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 12353365266794273614,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
                             "Slots": [

--- a/AutomatedTesting/Levels/Physics/Material_PerFaceMaterialGetsCorrectMaterial/Material_PerFaceMaterialGetsCorrectMaterial.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_PerFaceMaterialGetsCorrectMaterial/Material_PerFaceMaterialGetsCorrectMaterial.prefab
@@ -72,9 +72,21 @@
                         }
                     ]
                 },
-                "Component_[14094829544062915163]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 14094829544062915163,
+                "Component_[15478640155202823409]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15478640155202823409,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            495.0,
+                            572.9000244140625,
+                            41.0
+                        ]
+                    }
+                },
+                "Component_[17049195129311259924]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 17049195129311259924,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
                             "Slots": [
@@ -121,39 +133,25 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{304E0636-42C3-529D-8D9B-89E1E11A3FDD}",
+                                "subId": 4070350670
+                            },
+                            "assetHint": "levels/physics/c4044697_material_perfacematerialvalidation/test.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{304E0636-42C3-529D-8D9B-89E1E11A3FDD}",
                                     "subId": 4070350670
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "levels/physics/c4044697_material_perfacematerialvalidation/test.pxmesh"
                             },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{304E0636-42C3-529D-8D9B-89E1E11A3FDD}",
-                                        "subId": 4070350670
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "levels/physics/c4044697_material_perfacematerialvalidation/test.pxmesh"
-                                },
-                                "UseMaterialsFromAsset": false
-                            }
+                            "UseMaterialsFromAsset": false
                         }
-                    }
-                },
-                "Component_[15478640155202823409]": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 15478640155202823409,
-                    "Parent Entity": "ContainerEntity",
-                    "Transform Data": {
-                        "Translate": [
-                            495.0,
-                            572.9000244140625,
-                            41.0
-                        ]
                     }
                 },
                 "Component_[18224841233377932914]": {

--- a/AutomatedTesting/Levels/Physics/Physics_WorldBodyBusWorksOnEditorComponents/Physics_WorldBodyBusWorksOnEditorComponents.prefab
+++ b/AutomatedTesting/Levels/Physics/Physics_WorldBodyBusWorksOnEditorComponents/Physics_WorldBodyBusWorksOnEditorComponents.prefab
@@ -552,9 +552,13 @@
             "Id": "Entity_[393677621794]",
             "Name": "StaticMesh",
             "Components": {
-                "Component_[10271136976310200923]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 10271136976310200923,
+                "Component_[12545020046919826868]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 12545020046919826868
+                },
+                "Component_[17191132325241197033]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 17191132325241197033,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
                             "Slots": [
@@ -564,30 +568,24 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{6B6C2A7C-DC44-54F6-8A30-DA370189C11B}",
+                                "subId": 1454228742
+                            },
+                            "assetHint": "levels/physics/c29032500_editorcomponents_worldbodybusworks/physxsedan/_dev_sedan_r0-b.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{6B6C2A7C-DC44-54F6-8A30-DA370189C11B}",
                                     "subId": 1454228742
                                 },
                                 "assetHint": "levels/physics/c29032500_editorcomponents_worldbodybusworks/physxsedan/_dev_sedan_r0-b.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{6B6C2A7C-DC44-54F6-8A30-DA370189C11B}",
-                                        "subId": 1454228742
-                                    },
-                                    "assetHint": "levels/physics/c29032500_editorcomponents_worldbodybusworks/physxsedan/_dev_sedan_r0-b.pxmesh"
-                                }
                             }
                         }
                     }
-                },
-                "Component_[12545020046919826868]": {
-                    "$type": "EditorStaticRigidBodyComponent",
-                    "Id": 12545020046919826868
                 },
                 "Component_[17486590914851669702]": {
                     "$type": "EditorEntityIconComponent",
@@ -648,9 +646,9 @@
             "Id": "Entity_[397972589090]",
             "Name": "Mesh",
             "Components": {
-                "Component_[16300212154464470531]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 16300212154464470531,
+                "Component_[15123107725647570474]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 15123107725647570474,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
                             "Slots": [
@@ -660,23 +658,21 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{6B6C2A7C-DC44-54F6-8A30-DA370189C11B}",
+                                "subId": 1454228742
+                            },
+                            "assetHint": "levels/physics/c29032500_editorcomponents_worldbodybusworks/physxsedan/_dev_sedan_r0-b.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{6B6C2A7C-DC44-54F6-8A30-DA370189C11B}",
                                     "subId": 1454228742
                                 },
                                 "assetHint": "levels/physics/c29032500_editorcomponents_worldbodybusworks/physxsedan/_dev_sedan_r0-b.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{6B6C2A7C-DC44-54F6-8A30-DA370189C11B}",
-                                        "subId": 1454228742
-                                    },
-                                    "assetHint": "levels/physics/c29032500_editorcomponents_worldbodybusworks/physxsedan/_dev_sedan_r0-b.pxmesh"
-                                }
                             }
                         }
                     }

--- a/AutomatedTesting/Levels/Physics/RigidBody_COM_ComputingWorks/RigidBody_COM_ComputingWorks.prefab
+++ b/AutomatedTesting/Levels/Physics/RigidBody_COM_ComputingWorks/RigidBody_COM_ComputingWorks.prefab
@@ -43,10 +43,6 @@
             "Component_[8018146290632383969]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 8018146290632383969
-            },
-            "Component_[8452360690590857075]": {
-                "$type": "SelectionComponent",
-                "Id": 8452360690590857075
             }
         }
     },
@@ -59,38 +55,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 11910933043402144506
                 },
-                "Component_[13113720495486511997]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 13113720495486511997,
-                    "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
-                        }
-                    },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
-                                "assetId": {
-                                    "guid": "{B0721305-F525-5FA4-B91D-1BF330115E2A}",
-                                    "subId": 1454228742
-                                },
-                                "assetHint": "levels/physics/rigidbody_com_computingworks/physxsedan/_dev_sedan_r0-b.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{B0721305-F525-5FA4-B91D-1BF330115E2A}",
-                                        "subId": 1454228742
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "levels/physics/rigidbody_com_computingworks/physxsedan/_dev_sedan_r0-b.pxmesh"
-                                }
-                            }
-                        }
-                    }
-                },
                 "Component_[13716743520897531779]": {
                     "$type": "EditorRigidBodyComponent",
                     "Id": 13716743520897531779,
@@ -102,12 +66,17 @@
                             -0.07926200330257416,
                             0.434479296207428
                         ],
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 0.8812907934188843
-                        },
+                        "Inertia tensor": [
+                            0.8812907934188843,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.8812907934188843,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.8812907934188843
+                        ],
                         "Debug Draw Center of Mass": true
                     }
                 },
@@ -121,6 +90,38 @@
                             500.0,
                             40.0
                         ]
+                    }
+                },
+                "Component_[14425780710231336067]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 14425780710231336067,
+                    "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    },
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{B0721305-F525-5FA4-B91D-1BF330115E2A}",
+                                "subId": 1454228742
+                            },
+                            "assetHint": "levels/physics/rigidbody_com_computingworks/physxsedan/_dev_sedan_r0-b.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
+                                "assetId": {
+                                    "guid": "{B0721305-F525-5FA4-B91D-1BF330115E2A}",
+                                    "subId": 1454228742
+                                },
+                                "loadBehavior": "QueueLoad",
+                                "assetHint": "levels/physics/rigidbody_com_computingworks/physxsedan/_dev_sedan_r0-b.pxmesh"
+                            }
+                        }
                     }
                 },
                 "Component_[15954052737015560737]": {
@@ -143,43 +144,6 @@
                     "$type": "EditorLockComponent",
                     "Id": 2663722722650275926
                 },
-                "Component_[5115628589039702205]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 5115628589039702205,
-                    "ColliderConfiguration": {
-                        "Position": [
-                            2.0,
-                            0.0,
-                            0.0
-                        ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
-                        }
-                    },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
-                                "assetId": {
-                                    "guid": "{B0721305-F525-5FA4-B91D-1BF330115E2A}",
-                                    "subId": 1454228742
-                                },
-                                "assetHint": "levels/physics/rigidbody_com_computingworks/physxsedan/_dev_sedan_r0-b.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{B0721305-F525-5FA4-B91D-1BF330115E2A}",
-                                        "subId": 1454228742
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "levels/physics/rigidbody_com_computingworks/physxsedan/_dev_sedan_r0-b.pxmesh"
-                                }
-                            }
-                        }
-                    }
-                },
                 "Component_[5379412457680757329]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 5379412457680757329,
@@ -201,9 +165,42 @@
                         }
                     ]
                 },
-                "Component_[7216909725723276880]": {
-                    "$type": "SelectionComponent",
-                    "Id": 7216909725723276880
+                "Component_[6033112479166872994]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 6033112479166872994,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            2.0,
+                            0.0,
+                            0.0
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    },
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{B0721305-F525-5FA4-B91D-1BF330115E2A}",
+                                "subId": 1454228742
+                            },
+                            "assetHint": "levels/physics/rigidbody_com_computingworks/physxsedan/_dev_sedan_r0-b.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
+                                "assetId": {
+                                    "guid": "{B0721305-F525-5FA4-B91D-1BF330115E2A}",
+                                    "subId": 1454228742
+                                },
+                                "loadBehavior": "QueueLoad",
+                                "assetHint": "levels/physics/rigidbody_com_computingworks/physxsedan/_dev_sedan_r0-b.pxmesh"
+                            }
+                        }
+                    }
                 },
                 "Component_[9522159058993627022]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -252,9 +249,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 12138025353959759635,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -273,12 +272,17 @@
                             0.0,
                             0.0
                         ],
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 6.0
-                        },
+                        "Inertia tensor": [
+                            6.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            6.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            6.0
+                        ],
                         "Debug Draw Center of Mass": true
                     }
                 },
@@ -289,10 +293,6 @@
                 "Component_[16419802654970267859]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 16419802654970267859
-                },
-                "Component_[16528875231383182327]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16528875231383182327
                 },
                 "Component_[4180535836747230322]": {
                     "$type": "EditorEntitySortComponent",
@@ -307,9 +307,11 @@
                             0.0,
                             0.0
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -350,12 +352,17 @@
                             0.0,
                             0.0
                         ],
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 13.223134994506836
-                        },
+                        "Inertia tensor": [
+                            13.223134994506836,
+                            0.0,
+                            0.0,
+                            0.0,
+                            13.223134994506836,
+                            0.0,
+                            0.0,
+                            0.0,
+                            13.223134994506836
+                        ],
                         "Debug Draw Center of Mass": true
                     }
                 },
@@ -371,19 +378,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 15234779330112880964,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
                     "ShapeConfiguration": {
                         "ShapeType": 2
                     }
-                },
-                "Component_[15524182888388782459]": {
-                    "$type": "SelectionComponent",
-                    "Id": 15524182888388782459
                 },
                 "Component_[15590625091539872337]": {
                     "$type": "EditorVisibilityComponent",
@@ -435,9 +440,11 @@
                             0.0,
                             0.0
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -475,12 +482,17 @@
                             0.0,
                             0.0
                         ],
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        },
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ],
                         "Debug Draw Center of Mass": true
                     }
                 },
@@ -501,9 +513,11 @@
                             0.0,
                             0.0
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -515,19 +529,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14555534719461622997,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
                     "ShapeConfiguration": {
                         "ShapeType": 0
                     }
-                },
-                "Component_[17553553989214810742]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17553553989214810742
                 },
                 "Component_[2330725775954221844]": {
                     "$type": "EditorEntitySortComponent",
@@ -592,38 +604,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 11910933043402144506
                 },
-                "Component_[13113720495486511997]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 13113720495486511997,
-                    "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
-                        }
-                    },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
-                                "assetId": {
-                                    "guid": "{B0721305-F525-5FA4-B91D-1BF330115E2A}",
-                                    "subId": 1454228742
-                                },
-                                "assetHint": "levels/physics/rigidbody_com_computingworks/physxsedan/_dev_sedan_r0-b.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{B0721305-F525-5FA4-B91D-1BF330115E2A}",
-                                        "subId": 1454228742
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "levels/physics/rigidbody_com_computingworks/physxsedan/_dev_sedan_r0-b.pxmesh"
-                                }
-                            }
-                        }
-                    }
-                },
                 "Component_[13716743520897531779]": {
                     "$type": "EditorRigidBodyComponent",
                     "Id": 13716743520897531779,
@@ -631,12 +611,17 @@
                         "entityId": "",
                         "Compute Mass": false,
                         "Compute COM": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 0.8130738139152527
-                        },
+                        "Inertia tensor": [
+                            0.8130738139152527,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.8130738139152527,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.8130738139152527
+                        ],
                         "Debug Draw Center of Mass": true
                     }
                 },
@@ -672,43 +657,6 @@
                     "$type": "EditorLockComponent",
                     "Id": 2663722722650275926
                 },
-                "Component_[4624678338655393672]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 4624678338655393672,
-                    "ColliderConfiguration": {
-                        "Position": [
-                            2.0,
-                            0.0,
-                            0.0
-                        ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
-                        }
-                    },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
-                                "assetId": {
-                                    "guid": "{B0721305-F525-5FA4-B91D-1BF330115E2A}",
-                                    "subId": 1454228742
-                                },
-                                "assetHint": "levels/physics/rigidbody_com_computingworks/physxsedan/_dev_sedan_r0-b.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{B0721305-F525-5FA4-B91D-1BF330115E2A}",
-                                        "subId": 1454228742
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "levels/physics/rigidbody_com_computingworks/physxsedan/_dev_sedan_r0-b.pxmesh"
-                                }
-                            }
-                        }
-                    }
-                },
                 "Component_[5379412457680757329]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 5379412457680757329,
@@ -730,9 +678,74 @@
                         }
                     ]
                 },
-                "Component_[7216909725723276880]": {
-                    "$type": "SelectionComponent",
-                    "Id": 7216909725723276880
+                "Component_[6563625479438057813]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 6563625479438057813,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            2.0,
+                            0.0,
+                            0.0
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    },
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{B0721305-F525-5FA4-B91D-1BF330115E2A}",
+                                "subId": 1454228742
+                            },
+                            "assetHint": "levels/physics/rigidbody_com_computingworks/physxsedan/_dev_sedan_r0-b.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
+                                "assetId": {
+                                    "guid": "{B0721305-F525-5FA4-B91D-1BF330115E2A}",
+                                    "subId": 1454228742
+                                },
+                                "loadBehavior": "QueueLoad",
+                                "assetHint": "levels/physics/rigidbody_com_computingworks/physxsedan/_dev_sedan_r0-b.pxmesh"
+                            }
+                        }
+                    }
+                },
+                "Component_[8860646411819717497]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 8860646411819717497,
+                    "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    },
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{B0721305-F525-5FA4-B91D-1BF330115E2A}",
+                                "subId": 1454228742
+                            },
+                            "assetHint": "levels/physics/rigidbody_com_computingworks/physxsedan/_dev_sedan_r0-b.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
+                                "assetId": {
+                                    "guid": "{B0721305-F525-5FA4-B91D-1BF330115E2A}",
+                                    "subId": 1454228742
+                                },
+                                "loadBehavior": "QueueLoad",
+                                "assetHint": "levels/physics/rigidbody_com_computingworks/physxsedan/_dev_sedan_r0-b.pxmesh"
+                            }
+                        }
+                    }
                 },
                 "Component_[9522159058993627022]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -781,9 +794,11 @@
                     "$type": "EditorColliderComponent",
                     "Id": 12138025353959759635,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -798,12 +813,17 @@
                         "entityId": "",
                         "Compute Mass": false,
                         "Compute COM": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 6.0
-                        },
+                        "Inertia tensor": [
+                            6.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            6.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            6.0
+                        ],
                         "Debug Draw Center of Mass": true
                     }
                 },
@@ -814,10 +834,6 @@
                 "Component_[16419802654970267859]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 16419802654970267859
-                },
-                "Component_[16528875231383182327]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16528875231383182327
                 },
                 "Component_[4180535836747230322]": {
                     "$type": "EditorEntitySortComponent",
@@ -832,9 +848,11 @@
                             0.0,
                             0.0
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -871,12 +889,17 @@
                         "entityId": "",
                         "Compute Mass": false,
                         "Compute COM": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 13.223134994506836
-                        },
+                        "Inertia tensor": [
+                            13.223134994506836,
+                            0.0,
+                            0.0,
+                            0.0,
+                            13.223134994506836,
+                            0.0,
+                            0.0,
+                            0.0,
+                            13.223134994506836
+                        ],
                         "Debug Draw Center of Mass": true
                     }
                 },
@@ -892,19 +915,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 15234779330112880964,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
                     "ShapeConfiguration": {
                         "ShapeType": 2
                     }
-                },
-                "Component_[15524182888388782459]": {
-                    "$type": "SelectionComponent",
-                    "Id": 15524182888388782459
                 },
                 "Component_[15590625091539872337]": {
                     "$type": "EditorVisibilityComponent",
@@ -956,9 +977,11 @@
                             0.0,
                             0.0
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -992,12 +1015,17 @@
                         "Gravity Enabled": false,
                         "Compute Mass": false,
                         "Compute COM": false,
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 10.0
-                        },
+                        "Inertia tensor": [
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            10.0
+                        ],
                         "Debug Draw Center of Mass": true
                     }
                 },
@@ -1018,9 +1046,11 @@
                             0.0,
                             0.0
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
@@ -1032,19 +1062,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14555534719461622997,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
                             ]
                         }
                     },
                     "ShapeConfiguration": {
                         "ShapeType": 0
                     }
-                },
-                "Component_[17553553989214810742]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17553553989214810742
                 },
                 "Component_[2330725775954221844]": {
                     "$type": "EditorEntitySortComponent",

--- a/AutomatedTesting/Levels/Prefab/PrefabLevel_OpensLevelWithEntities/PrefabLevel_OpensLevelWithEntities.prefab
+++ b/AutomatedTesting/Levels/Prefab/PrefabLevel_OpensLevelWithEntities/PrefabLevel_OpensLevelWithEntities.prefab
@@ -80,9 +80,9 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 3861913165076405600
                 },
-                "Component_[7103333782129541775]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 7103333782129541775,
+                "Component_[5636198920532941508]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 5636198920532941508,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
                             "Slots": [


### PR DESCRIPTION
**Note**
This is part of the work to separate PhysX Collider into 2 components: https://github.com/o3de/o3de/pull/14725. Merging into the staging branch `MeshColliderComponent_Staging`.

Signed-off-by: moraaar <moraaar@amazon.com>