### PR TITLE
Updating commandline args for EntityOrdering test

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/editor/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/TestSuite_Main.py
@@ -79,6 +79,9 @@ class TestAutomationAutoTestMode(EditorTestSuite):
     class test_EntityOutliner_EntityOrdering(EditorSingleTest):
         from .EditorScripts import EntityOutliner_EntityOrdering as test_module
 
+        # https://github.com/o3de/o3de/issues/10799
+        extra_cmdline_args = ["-rhi=Null", "-NullRenderer"]
+
     class test_Menus_EditMenuOptions_Work(EditorBatchedTest):
         from .EditorScripts import Menus_EditMenuOptions as test_module
 


### PR DESCRIPTION
## What does this PR do?

- Adds "-NullRenderer" arg to specific test that intermittently crashes using "-rhi=Null"

## How was this PR tested?

- Ran updated test without issue
