### PR TITLE
Fixing emissive to work with alpha. 

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Common/TransparentPassVertexAndPixel.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Common/TransparentPassVertexAndPixel.azsli
@@ -45,6 +45,8 @@ ForwardPassOutput PixelShader(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
     float3 diffuse = lightingData.diffuseLighting.rgb;
     diffuse *= surface.alpha;
     
+    diffuse += lightingData.emissiveLighting;
+
     // m_opacityAffectsSpecularFactor controls how much the alpha masks out specular contribution.
     float3 specular = lightingData.specularLighting.rgb;
     specular = lerp(specular, specular * surface.alpha, surface.opacityAffectsSpecularFactor);

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPassVertexAndPixel.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPassVertexAndPixel.azsli
@@ -81,7 +81,8 @@ ForwardPassOutput PixelShader(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
     OUT.m_normal.a = EncodeUnorm2BitFlags(o_enableIBL, o_specularF0_enableMultiScatterCompensation);
 
     // --- Emissive ---
-    OUT.m_diffuseColor.rgb += lightingData.emissiveLighting;
+    // Sending to specular output for historical reasons until sending to diffuse can be validated
+    OUT.m_specularColor.rgb += lightingData.emissiveLighting; 
 
     // --- Subsurface ---
 #if OUTPUT_SUBSURFACE

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPassVertexAndPixel.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPassVertexAndPixel.azsli
@@ -62,7 +62,7 @@ ForwardPassOutput PixelShader(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
 
     // --- Specular Lighting ---
 
-    OUT.m_specularColor.rgb = lightingData.specularLighting.rgb + lightingData.emissiveLighting.rgb;
+    OUT.m_specularColor.rgb = lightingData.specularLighting.rgb;
     OUT.m_specularColor.a = 1.0;
 
     // --- Roughness and Specular ---
@@ -79,6 +79,9 @@ ForwardPassOutput PixelShader(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
 
     OUT.m_normal.rgb = EncodeNormalSignedOctahedron(surface.normal);
     OUT.m_normal.a = EncodeUnorm2BitFlags(o_enableIBL, o_specularF0_enableMultiScatterCompensation);
+
+    // --- Emissive ---
+    OUT.m_diffuseColor.rgb += lightingData.emissiveLighting;
 
     // --- Subsurface ---
 #if OUTPUT_SUBSURFACE

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/EmissivePropertyGroup.json
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/EmissivePropertyGroup.json
@@ -41,6 +41,19 @@
             "softMax": 16
         },
         {
+            "name": "affectedByAlpha",
+            "displayName": "Affected by alpha",
+            "description": "How much the emissive surface is attenuated by diffuse alpha.",
+            "type": "Float",
+            "defaultValue": 0,
+            "min": 0,
+            "max": 1,
+            "connection": {
+                "type": "ShaderInput",
+                "name": "m_emissiveAffectedByAlpha"
+            }
+        },
+        {
             "name": "textureMap",
             "displayName": "Texture",
             "description": "Texture for defining emissive area.",

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR.azsli
@@ -306,7 +306,7 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
         result.m_metallic = GetMetallicInput(inputs.m_metallicMap, inputs.m_sampler, transformedUv[inputs.m_metallicMapUvIndex], inputs.m_metallicFactor, inputs.m_metallic_useTexture);
         result.m_roughness = GetRoughnessInput(inputs.m_roughnessMap, MaterialSrg::m_sampler, transformedUv[inputs.m_roughnessMapUvIndex], inputs.m_roughnessFactor, inputs.m_roughnessLowerBound, inputs.m_roughnessUpperBound, inputs.m_roughness_useTexture);
 
-        result.m_emissiveLighting = GetEmissiveInput(inputs.m_emissiveMap, inputs.m_sampler, transformedUv[inputs.m_emissiveMapUvIndex], inputs.m_emissiveIntensity, inputs.m_emissiveColor.rgb, inputs.m_emissiveEnabled, inputs.m_emissive_useTexture);
+        result.m_emissiveLighting = GetEmissiveInput(inputs.m_emissiveMap, inputs.m_sampler, transformedUv[inputs.m_emissiveMapUvIndex], inputs.m_emissiveIntensity, inputs.m_emissiveColor.rgb, 0.0, 1.0, inputs.m_emissiveEnabled, inputs.m_emissive_useTexture);
         result.m_diffuseAmbientOcclusion = GetOcclusionInput(inputs.m_diffuseOcclusionMap, inputs.m_sampler, transformedUv[inputs.m_diffuseOcclusionMapUvIndex], inputs.m_diffuseOcclusionFactor, inputs.m_diffuseOcclusion_useTexture);
         result.m_specularOcclusion = GetOcclusionInput(inputs.m_specularOcclusionMap, MaterialSrg::m_sampler, transformedUv[inputs.m_specularOcclusionMapUvIndex], inputs.m_specularOcclusionFactor, inputs.m_specularOcclusion_useTexture);
     
@@ -369,6 +369,7 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
         inputs.m_emissiveMapUvIndex = srgLayerPrefix##m_emissiveMapUvIndex;                                            \
         inputs.m_emissiveIntensity = srgLayerPrefix##m_emissiveIntensity;                                              \
         inputs.m_emissiveColor = srgLayerPrefix##m_emissiveColor;                                                      \
+        inputs.m_emissiveAffectedByAlpha = srgLayerPrefix##m_emissiveAffectedByAlpha;                                  \
         inputs.m_emissiveEnabled = optionsLayerPrefix##o_emissiveEnabled;                                              \
         inputs.m_emissive_useTexture = optionsLayerPrefix##o_emissive_useTexture;                                      \
                                                                                                                        \

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/LightingData.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/LightingData.azsli
@@ -87,7 +87,6 @@ void LightingData::CalculateMultiscatterCompensation(float3 specularF0, bool ena
 void LightingData::FinalizeLighting()
 {
     specularLighting *= specularOcclusion;
-    specularLighting += emissiveLighting;
 
     if(!IsSpecularLightingEnabled())
     {

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Surfaces/StandardSurface.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Surfaces/StandardSurface.azsli
@@ -57,6 +57,8 @@ class Surface
     // not apply.
     float opacityAffectsSpecularFactor;
 
+    float opacityAffectsEmissiveFactor; //!< Allows emissive to be attenuated by alpha or not.
+
     //! Surface lighting data
     float3 albedo;              //!< Albedo color of the non-metallic material, will be multiplied against the diffuse lighting value
     float3 specularF0;          //!< Fresnel f0 spectral value of the surface

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_SurfaceEval.azsli
@@ -133,7 +133,7 @@ Surface EvaluateSurface_EnhancedPBR(
     // ------- Emissive -------
 
     float2 emissiveUv = uvs[MaterialSrg::m_emissiveMapUvIndex];
-    surface.emissiveLighting = GetEmissiveInput(MaterialSrg::m_emissiveMap, MaterialSrg::m_sampler, emissiveUv, MaterialSrg::m_emissiveIntensity, MaterialSrg::m_emissiveColor.rgb, o_emissiveEnabled, o_emissive_useTexture);
+    surface.emissiveLighting = GetEmissiveInput(MaterialSrg::m_emissiveMap, MaterialSrg::m_sampler, emissiveUv, MaterialSrg::m_emissiveIntensity, MaterialSrg::m_emissiveColor.rgb, MaterialSrg::m_emissiveAffectedByAlpha, surface.alpha, o_emissiveEnabled, o_emissive_useTexture);
 
     // ------- Occlusion -------
     

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/EmissiveInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/EmissiveInput.azsli
@@ -16,22 +16,23 @@
 // Use the COMMON_SRG_INPUTS_* macro in your material SRG definition, and use the COMMON_OPTIONS_* macro at the global scope in your shader. Then you can pass these variables to the Get*Input() function below.
 // You can optionally provide a prefix for the set of inputs which corresponds to a prefix string supplied by the .materialtype file. This is common for multi-layered material types.
 
-#define COMMON_SRG_INPUTS_EMISSIVE(prefix) \
-float3      prefix##m_emissiveColor;        \
-float       prefix##m_emissiveIntensity;    \
-Texture2D   prefix##m_emissiveMap;          \
-uint        prefix##m_emissiveMapUvIndex;   
+#define COMMON_SRG_INPUTS_EMISSIVE(prefix)     \
+float3      prefix##m_emissiveColor;           \
+float       prefix##m_emissiveAffectedByAlpha; \
+float       prefix##m_emissiveIntensity;       \
+Texture2D   prefix##m_emissiveMap;             \
+uint        prefix##m_emissiveMapUvIndex;
 
 #define COMMON_OPTIONS_EMISSIVE(prefix) \
 option bool prefix##o_emissiveEnabled; \
 option bool prefix##o_emissive_useTexture; 
 
-float3 GetEmissiveInput(Texture2D map, sampler mapSampler, float2 uv, float factor, float3 emissiveColor, bool emissiveEnabled, bool useTexture)
+float3 GetEmissiveInput(Texture2D map, sampler mapSampler, float2 uv, float factor, float3 emissiveColor, float emissiveAffectedByAlpha, float alpha, bool emissiveEnabled, bool useTexture)
 {
     float3 emissive = float3(0,0,0);
     if(emissiveEnabled)
     {
-        emissive = emissiveColor * factor;
+        emissive = emissiveColor * factor * lerp(1, alpha, emissiveAffectedByAlpha);
         if (useTexture)
         {
             float3 sampledValue = map.Sample(mapSampler, uv).rgb;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/EmissiveInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/EmissiveInput.azsli
@@ -32,7 +32,7 @@ float3 GetEmissiveInput(Texture2D map, sampler mapSampler, float2 uv, float fact
     float3 emissive = float3(0,0,0);
     if(emissiveEnabled)
     {
-        emissive = emissiveColor * factor * lerp(1, alpha, emissiveAffectedByAlpha);
+        emissive = factor * lerp(1, alpha, emissiveAffectedByAlpha) * emissiveColor;
         if (useTexture)
         {
             float3 sampledValue = map.Sample(mapSampler, uv).rgb;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_SurfaceEval.azsli
@@ -45,7 +45,7 @@ Surface EvaluateSurface_StandardPBR(
     // ------- Emissive -------
 
     float2 emissiveUv = uvs[MaterialSrg::m_emissiveMapUvIndex];
-    surface.emissiveLighting = GetEmissiveInput(MaterialSrg::m_emissiveMap, MaterialSrg::m_sampler, emissiveUv, MaterialSrg::m_emissiveIntensity, MaterialSrg::m_emissiveColor.rgb, o_emissiveEnabled, o_emissive_useTexture);
+    surface.emissiveLighting = GetEmissiveInput(MaterialSrg::m_emissiveMap, MaterialSrg::m_sampler, emissiveUv, MaterialSrg::m_emissiveIntensity, MaterialSrg::m_emissiveColor.rgb, MaterialSrg::m_emissiveAffectedByAlpha, surface.alpha, o_emissiveEnabled, o_emissive_useTexture);
 
     // ------- Occlusion -------
     


### PR DESCRIPTION
## What does this PR do?

Moved the emissive contribution out of LightingData and into the individual VertexAndPixel shaders (its usage was inconsistent before). Emissive is now added onto diffuse instead of specular. 

![image](https://user-images.githubusercontent.com/1105143/220819162-a32288dd-2f3e-4501-8505-5a28810778fa.png)

Added a new slider to the emissive section of materials to control how much the alpha should affect the emissive contribution.

![image](https://user-images.githubusercontent.com/1105143/220819335-467f5671-7695-4162-864d-c744467033a2.png)


## How was this PR tested?

Tested with atom sample viewer (in progess) and custom materials in the material editor.
