### PR TITLE
Add a toast notification for Script and Material canvas

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/ToastNotificationConfiguration.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/ToastNotificationConfiguration.h
@@ -30,6 +30,7 @@ namespace AzQtComponents
         ToastConfiguration(ToastType toastType, const QString& title, const QString& description);
 
         bool m_closeOnClick = true;
+        bool m_allowDuplicateNotifications = false;
 
         ToastType m_toastType = ToastType::Information;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Notifications/ToastNotificationsView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Notifications/ToastNotificationsView.cpp
@@ -65,10 +65,16 @@ namespace AzToolsFramework
 
     ToastId ToastNotificationsView::ShowToastNotification(const AzQtComponents::ToastConfiguration& toastConfiguration)
     {
-        // reject duplicate messages
-        if (m_rejectDuplicates && DuplicateNotificationInQueue(toastConfiguration))
+        // reject duplicate messages unless toast configuration allows duplicates, if the notification is a duplicate
+        // replace current notification with the new one
+        auto isDuplicate = DuplicateNotificationInQueue(toastConfiguration);
+        if (m_rejectDuplicates && isDuplicate && !toastConfiguration.m_allowDuplicateNotifications)
         {
             return ToastId();
+        }
+        else if (isDuplicate && toastConfiguration.m_allowDuplicateNotifications)
+        {
+            HideToastNotification(m_activeNotification);
         }
 
         ToastId toastId = CreateToastNotification(toastConfiguration); 

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphCanvasGraphicsView/GraphCanvasGraphicsView.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphCanvasGraphicsView/GraphCanvasGraphicsView.cpp
@@ -668,7 +668,6 @@ namespace GraphCanvas
             layout->addWidget(graphicsView);
 
             dialog.setLayout(layout);
-
             dialog.show();
             dialog.hide();
 
@@ -683,6 +682,14 @@ namespace GraphCanvas
 
             graphicsView->render(&localPainter, QRectF(0, 0, windowSize.width(), windowSize.height()), viewportRect);
             localPainter.end();
+
+            AzQtComponents::ToastConfiguration toastConfiguration(
+                AzQtComponents::ToastType::Information,
+                "<b>Screenshot</b>",
+                "Screenshot copied to clipboard!");
+            toastConfiguration.m_duration = AZStd::chrono::milliseconds(2000);
+            toastConfiguration.m_allowDuplicateNotifications = true;
+            m_notificationsView->ShowToastNotification(toastConfiguration);
         }
 
         return image;


### PR DESCRIPTION
## What does this PR do? 

This PR adds a toast notification when a user screenshots using the screenshot button. This addresses https://github.com/o3de/o3de/issues/14722. The issue also mentioned a window that would display for a tick, but this change seems to stop that aswell.


https://user-images.githubusercontent.com/105638312/220892649-639ba050-09bb-475f-9ef7-b6ee8a89ddd0.mp4


## How was this PR tested?
The toast notifications were tested in script and material canvas.