### PR TITLE
Removed uses of deprecated/unused AppearsInSystemComponentMenu "System"

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetManagerComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManagerComponent.cpp
@@ -187,7 +187,6 @@ namespace AZ
                     "Asset Database", "Asset database system functionality")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Engine")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ;
             }
         }

--- a/Code/Framework/AzCore/AzCore/Jobs/JobManagerComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Jobs/JobManagerComponent.cpp
@@ -137,7 +137,6 @@ namespace AZ
                     "Job Manager", "Provides fine grained job system and worker threads")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Engine")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ->DataElement(AZ::Edit::UIHandlers::SpinBox, &JobManagerComponent::m_numberOfWorkerThreads, "Worker threads", "Number of worked threads for this job manager.")
                         ->Attribute(AZ::Edit::Attributes::Min, 0)
                         ->Attribute(AZ::Edit::Attributes::Max, 16)

--- a/Code/Framework/AzCore/AzCore/Script/ScriptSystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptSystemComponent.cpp
@@ -879,7 +879,6 @@ void ScriptSystemComponent::Reflect(ReflectContext* reflection)
                 "Script System", "Initializes and maintains script contexts")
                 ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Engine")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                 ;
         }
     }

--- a/Code/Framework/AzCore/AzCore/Slice/SliceSystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Slice/SliceSystemComponent.cpp
@@ -24,7 +24,6 @@ namespace AZ
                     "Slice System", "Manages the Slice system")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Engine")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ;
             }
         }

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraphSystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraphSystemComponent.cpp
@@ -105,7 +105,6 @@ namespace AZ
                     ("TaskGraph", "System component to create the default executor")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Engine")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                     ;
             }
         }

--- a/Code/Framework/AzCore/AzCore/UserSettings/UserSettingsComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/UserSettings/UserSettingsComponent.cpp
@@ -108,7 +108,6 @@ namespace AZ
                     "User Settings", "Provides userdata storage for all system components")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Editor")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ->DataElement(AZ::Edit::UIHandlers::ComboBox, &UserSettingsComponent::m_providerId, "ProviderId", "The settings group this provider with handle.")
                         ->EnumAttribute(UserSettings::CT_LOCAL, "Local")
                         ->EnumAttribute(UserSettings::CT_GLOBAL, "Global")

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalogComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalogComponent.cpp
@@ -53,7 +53,6 @@ namespace AzFramework
                     "Asset Catalog", "Maintains a catalog of assets")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Engine")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ;
             }
         }

--- a/Code/Framework/AzFramework/AzFramework/Components/AzFrameworkConfigurationSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Components/AzFrameworkConfigurationSystemComponent.cpp
@@ -30,7 +30,6 @@ namespace AzFramework
                     "AzFramework Configuration Component", "System component responsible for configuring AzFramework")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Editor")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ;
             }
         }

--- a/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
@@ -36,7 +36,6 @@ namespace AzFramework
                     "Game Entity Context", "Owns entities in the game runtime, as well as during play-in-editor")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Engine")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ;
             }
         }

--- a/Code/Framework/AzFramework/AzFramework/Input/System/InputSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/System/InputSystemComponent.cpp
@@ -99,7 +99,6 @@ namespace AzFramework
                     "Input System", "Controls which core input devices are made available")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Engine")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ->DataElement(AZ::Edit::UIHandlers::SpinBox, &InputSystemComponent::m_mouseMovementSampleRateHertz,
                         "Mouse Movement Sample Rate", "The mouse movement sample rate in Hertz (cycles per second), which directly\n"
                                                       "correlates to the max number of mouse movement events dispatched each frame.\n"

--- a/Code/Framework/AzFramework/AzFramework/Logging/LoggingComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Logging/LoggingComponent.cpp
@@ -175,7 +175,6 @@ namespace AzFramework
                     "File Logging", "Listens to AZ trace messages and forwards them to a log file")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Profiling")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ->DataElement(AZ::Edit::UIHandlers::Default, &LogComponent::m_logFileBaseName, "Log file name", "The base name of the file to log to")
                     ->DataElement(AZ::Edit::UIHandlers::SpinBox, &LogComponent::m_rolloverLength, "Rollover length", "Max size of a log file before saving and opening a new one")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &LogComponent::m_machineReadable, "Machine Readable", "")

--- a/Code/Framework/AzFramework/AzFramework/Scene/SceneSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Scene/SceneSystemComponent.cpp
@@ -26,7 +26,6 @@ namespace AzFramework
                     "Scene System Component", "System component responsible for owning scenes")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Editor")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ;
             }
         }

--- a/Code/Framework/AzFramework/AzFramework/Script/ScriptRemoteDebugging.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Script/ScriptRemoteDebugging.cpp
@@ -756,7 +756,6 @@ namespace AzFramework
                     "Script Debug Agent", "Provides remote debugging services for script contexts")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Profiling")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ;
             }
         }

--- a/Code/Framework/AzFramework/AzFramework/StreamingInstall/StreamingInstall.cpp
+++ b/Code/Framework/AzFramework/AzFramework/StreamingInstall/StreamingInstall.cpp
@@ -96,7 +96,6 @@ namespace AzFramework
                 {
                     ec->Class<StreamingInstallSystemComponent>("StreamingInstall", "Support for streaming install")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ;
                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/EntityCompositionRequestBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/EntityCompositionRequestBus.h
@@ -207,9 +207,6 @@ namespace AzToolsFramework
     //! ComponentFilter for components that users can add to game entities.
     static bool AppearsInGameComponentMenu(const AZ::SerializeContext::ClassData&);
 
-    //! ComponentFilter for components that can be added to system entities.
-    static bool AppearsInSystemComponentMenu(const AZ::SerializeContext::ClassData&);
-
     //
     // Implementation
     //
@@ -294,11 +291,6 @@ namespace AzToolsFramework
         return false;
     }
 
-    inline bool AppearsInSystemComponentMenu(const AZ::SerializeContext::ClassData& classData)
-    {
-        return AppearsInAddComponentMenu(classData, AZ_CRC("System", 0xc94d118b));
-    }
-
     inline bool AppearsInLayerComponentMenu(const AZ::SerializeContext::ClassData& classData)
     {
         return AppearsInAddComponentMenu(classData, AZ_CRC("Layer", 0xe4db211a));
@@ -311,6 +303,6 @@ namespace AzToolsFramework
 
     inline bool AppearsInAnyComponentMenu(const AZ::SerializeContext::ClassData& classData)
     {
-        return (AppearsInGameComponentMenu(classData) || AppearsInSystemComponentMenu(classData) || AppearsInLayerComponentMenu(classData) || AppearsInLevelComponentMenu(classData));
+        return (AppearsInGameComponentMenu(classData) || AppearsInLayerComponentMenu(classData) || AppearsInLevelComponentMenu(classData));
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Archive/ArchiveComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Archive/ArchiveComponent.cpp
@@ -121,7 +121,6 @@ namespace AzToolsFramework
                     "Archive", "Handles creation and extraction of zip archives.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Editor")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                     ;
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Component/EditorComponentAPIComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Component/EditorComponentAPIComponent.cpp
@@ -180,10 +180,6 @@ namespace AzToolsFramework
                             }
                             break;
                         default:
-                            if (!AzToolsFramework::AppearsInSystemComponentMenu(*componentClass))
-                            {
-                                return true;
-                            }
                             break;
                         }
                         for (int i = 0; i < typesCount; ++i)
@@ -320,10 +316,6 @@ namespace AzToolsFramework
                         }
                         break;
                     default:
-                        if (AzToolsFramework::AppearsInSystemComponentMenu(*componentClass))
-                        {
-                            typeNameList.push_back(componentClass->m_editData->m_name);
-                        }
                         break;
                     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
@@ -92,7 +92,6 @@ namespace AzToolsFramework
                     "Editor Entity Context", "System component responsible for owning the edit-time entity context")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Editor")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ;
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceMetadataEntityContextComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceMetadataEntityContextComponent.cpp
@@ -52,7 +52,6 @@ namespace AzToolsFramework
                     "Slice Metadata Entity Context", "System component responsible for owning the slice metadata entity context")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Editor")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ;
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/SourceControl/PerforceComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/SourceControl/PerforceComponent.cpp
@@ -125,7 +125,6 @@ namespace AzToolsFramework
                     "Perforce Connectivity", "Manages Perforce connectivity and executes Perforce commands.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Editor")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                 ;
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/AzToolsFrameworkConfigurationSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/AzToolsFrameworkConfigurationSystemComponent.cpp
@@ -31,7 +31,6 @@ namespace AzToolsFramework
                     "AzToolsFramework Configuration Component", "System component responsible for configuring AzToolsFramework")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Editor")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ;
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorSelectionAccentSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorSelectionAccentSystemComponent.cpp
@@ -33,7 +33,6 @@ namespace AzToolsFramework
                 {
                     ec->Class<EditorSelectionAccentSystemComponent>("EditorSelectionAccenting", "Used for selection accenting behavior in the viewport")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ;
                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
@@ -321,7 +321,6 @@ namespace AzToolsFramework
                         "Property Manager", "Provides services for registration of property editors")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                             ->Attribute(AZ::Edit::Attributes::Category, "Editor")
-                            ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ;
                 }
             }

--- a/Code/Framework/AzToolsFramework/Tests/EntityInspectorTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EntityInspectorTests.cpp
@@ -185,7 +185,6 @@ namespace UnitTest
                     editContext->Class<Inspector_TestComponent3>("InspectorTestComponent3", "Component 3 for AZ Tools Framework Unit Tests")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::AddableByUser, true)
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::Category, "Inspector Test Components")
                         ->Attribute(AZ::Edit::Attributes::Icon, "Icons/Components/Tag.png")
                         ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Icons/Components/Viewport/Tag.png")

--- a/Gems/AWSClientAuth/Code/Source/AWSClientAuthSystemComponent.cpp
+++ b/Gems/AWSClientAuth/Code/Source/AWSClientAuthSystemComponent.cpp
@@ -39,7 +39,6 @@ namespace AWSClientAuth
             {
                 ec->Class<AWSClientAuthSystemComponent>("AWSClientAuth", "Provides Client Authentication and Authorization implementations")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
             }
             AWSClientAuth::LWAProviderSetting::Reflect(*serialize);

--- a/Gems/AWSClientAuth/Code/Tests/AWSClientAuthSystemComponentTest.cpp
+++ b/Gems/AWSClientAuth/Code/Tests/AWSClientAuthSystemComponentTest.cpp
@@ -73,7 +73,6 @@ namespace AWSClientAuthUnitTest
                 {
                     ec->Class<AWSCoreSystemComponentMock>("AWSCoreMock", "Adds core support for working with AWS")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ;
                 }

--- a/Gems/AWSCore/Code/Source/AWSCoreEditorSystemComponent.cpp
+++ b/Gems/AWSCore/Code/Source/AWSCoreEditorSystemComponent.cpp
@@ -32,7 +32,6 @@ namespace AWSCore
             {
                 ec->Class<AWSCoreEditorSystemComponent>("AWSCoreEditor", "Adds supporting for working with AWS features in the Editor")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/AWSCore/Code/Source/AWSCoreSystemComponent.cpp
+++ b/Gems/AWSCore/Code/Source/AWSCoreSystemComponent.cpp
@@ -53,7 +53,6 @@ namespace AWSCore
             {
                 ec->Class<AWSCoreSystemComponent>("AWSCore", "Adds core support for working with AWS")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/AWSCore/Code/Tests/Editor/Attribution/AWSCoreAttributionSystemComponentTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Editor/Attribution/AWSCoreAttributionSystemComponentTest.cpp
@@ -37,7 +37,6 @@ namespace AWSCoreUnitTest
                 {
                     ec->Class<AWSCoreSystemComponentMock>("AWSCoreMock", "Adds core support for working with AWS")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
                 }
             }

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientSystemComponent.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientSystemComponent.cpp
@@ -51,7 +51,6 @@ namespace AWSGameLift
                         "AWSGameLiftClient",
                         "Create the GameLift client manager that handles communication between game clients and the GameLift service.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
             }
         }

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerSystemComponent.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerSystemComponent.cpp
@@ -41,7 +41,6 @@ namespace AWSGameLift
             {
                 ec->Class<AWSGameLiftServerSystemComponent>("AWSGameLiftServer", "Create the GameLift server manager which manages the server process for hosting a game session via GameLiftServerSDK.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/AWSMetrics/Code/Source/AWSMetricsSystemComponent.cpp
+++ b/Gems/AWSMetrics/Code/Source/AWSMetricsSystemComponent.cpp
@@ -64,7 +64,6 @@ namespace AWSMetrics
             {
                 ec->Class<AWSMetricsSystemComponent>("AWSMetrics", "Generate and submit metrics to the metrics analytics pipeline")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/AWSMetrics/Code/Tests/AWSMetricsSystemComponentTest.cpp
+++ b/Gems/AWSMetrics/Code/Tests/AWSMetricsSystemComponentTest.cpp
@@ -68,7 +68,6 @@ namespace AWSMetrics
                 {
                     ec->Class<AWSCoreSystemComponentMock>("AWSCoreMock", "Adds core support for working with AWS")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ;
                 }

--- a/Gems/Achievements/Code/Source/AchievementsSystemComponent.cpp
+++ b/Gems/Achievements/Code/Source/AchievementsSystemComponent.cpp
@@ -55,7 +55,6 @@ namespace Achievements
             {
                 ec->Class<AchievementDetails>("AchievementDetails", "Struct to hold platform agnostic achievement details for query results")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
             }
         }
@@ -100,7 +99,6 @@ namespace Achievements
             {
                 ec->Class<AchievementsSystemComponent>("Achievements", "Platform agnostic interface for retrieving achievement details and unlocking achievements")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
             }
         }

--- a/Gems/AssetValidation/Code/Source/AssetValidationSystemComponent.cpp
+++ b/Gems/AssetValidation/Code/Source/AssetValidationSystemComponent.cpp
@@ -40,7 +40,6 @@ namespace AssetValidation
             {
                 ec->Class<AssetValidationSystemComponent>("AssetValidation", "[Description of functionality provided by this System Component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnailSystemComponent.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnailSystemComponent.cpp
@@ -39,7 +39,6 @@ namespace ImageProcessingAtom
                 {
                     ec->Class<ImageThumbnailSystemComponent>("ImageThumbnailSystemComponent", "System component for image thumbnails.")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
                 }
             }

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -69,7 +69,6 @@ namespace AZ
                     {
                         ec->Class<BootstrapSystemComponent>("Atom RPI", "Atom Renderer")
                             ->ClassElement(Edit::ClassElements::EditorData, "")
-                            ->Attribute(Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                             ->Attribute(Edit::Attributes::AutoExpand, true)
                         ;
                     }

--- a/Gems/Atom/Feature/Common/Code/Source/CommonSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CommonSystemComponent.cpp
@@ -149,7 +149,6 @@ namespace AZ
                 {
                     ec->Class<CommonSystemComponent>("CommonSystemComponent", "System Component for common render features")
                         ->ClassElement(Edit::ClassElements::EditorData, "")
-                        ->Attribute(Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(Edit::Attributes::AutoExpand, true)
                     ;
                 }

--- a/Gems/Atom/Feature/Common/Code/Source/EditorCommonSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/EditorCommonSystemComponent.cpp
@@ -44,7 +44,6 @@ namespace AZ
                 {
                     ec->Class<EditorCommonSystemComponent>("Common", "Configures editor- and tool-specific functionality for common render features.")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ;
                 }

--- a/Gems/Atom/RHI/Code/Source/RHI.Private/FactoryManagerSystemComponent.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Private/FactoryManagerSystemComponent.cpp
@@ -39,7 +39,6 @@ namespace AZ
                 {
                     ec->Class<FactoryManagerSystemComponent>("Atom RHI Manager", "Atom Renderer")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &FactoryManagerSystemComponent::m_factoriesPriority, "RHI Priority list", "Priorities for RHI Implementations")
                         ->DataElement(AZ::Edit::UIHandlers::ComboBox, &FactoryManagerSystemComponent::m_validationMode, "Validation Layer Mode", "Set the validation mode for the RHI. It only applies for non release builds")

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
@@ -49,7 +49,6 @@ namespace AZ
                 {
                     ec->Class<RPISystemComponent>("Atom RPI", "Atom Renderer")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &RPISystemComponent::m_rpiDescriptor, "RPI System Settings", "Settings for create RPI system")
                         ;

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/GpuQuerySystemDescriptor.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/GpuQuerySystemDescriptor.cpp
@@ -31,7 +31,6 @@ namespace AZ
                 {
                     ec->Class<GpuQuerySystemDescriptor>("Gpu Query System Settings", "Settings for the Gpu Query System")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &GpuQuerySystemDescriptor::m_occlusionQueryCount, "Occlusion GPU Query Count", "The amount of available queries for Occlusion")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &GpuQuerySystemDescriptor::m_statisticsQueryCount, "Statistics GPU Query Count", "The amount of available queries for Pipeline Statistics")

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AtomToolsFrameworkSystemComponent.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AtomToolsFrameworkSystemComponent.cpp
@@ -56,7 +56,6 @@ namespace AtomToolsFramework
             {
                 editContext->Class<AtomToolsFrameworkSystemComponent>("AtomToolsFrameworkSystemComponent", "")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystem.cpp
@@ -57,7 +57,6 @@ namespace AtomToolsFramework
             {
                 editContext->Class<AtomToolsDocumentSystem>("AtomToolsDocumentSystem", "")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettingsSystem.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettingsSystem.cpp
@@ -42,7 +42,6 @@ namespace AtomToolsFramework
             {
                 editContext->Class<EntityPreviewViewportSettingsSystem>("EntityPreviewViewportSettingsSystem", "Manages and serializes settings for the application viewport")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphViewConstructPresets.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphViewConstructPresets.cpp
@@ -22,7 +22,6 @@ namespace AtomToolsFramework
             {
                 editContext->Class<GraphViewConstructPresets>("GraphViewConstructPresets", "")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
             }
         }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphViewSettings.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphViewSettings.cpp
@@ -53,14 +53,12 @@ namespace AtomToolsFramework
             {
                 editContext->Class<GraphViewSettingsPtr>("GraphViewSettingsPtr", "")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                     ;
 
                 editContext->Class<GraphViewSettings>("Graph View Config", "")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Basic Interactions")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererSystemComponent.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererSystemComponent.cpp
@@ -25,7 +25,6 @@ namespace AtomToolsFramework
             {
                 ec->Class<PreviewRendererSystemComponent>("PreviewRendererSystemComponent", "System component that manages a global PreviewRenderer.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomBridgeSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomBridgeSystemComponent.cpp
@@ -50,7 +50,6 @@ namespace AZ
                 {
                     ec->Class<AtomBridgeSystemComponent>("AtomBridge", "[Description of functionality provided by this System Component]")
                         ->ClassElement(Edit::ClassElements::EditorData, "")
-                            ->Attribute(Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                             ->Attribute(Edit::Attributes::AutoExpand, true)
                     ;
                 }

--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/AtomFontSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/AtomFontSystemComponent.cpp
@@ -36,7 +36,6 @@ namespace AZ
                 {
                     ec->Class<AtomFontSystemComponent>("Font", "Manages lifetime of the font subsystem")
                         ->ClassElement(Edit::ClassElements::EditorData, "")
-                            ->Attribute(Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                             ->Attribute(Edit::Attributes::AutoExpand, true)
                         ;
                 }

--- a/Gems/AtomLyIntegration/AtomImGuiTools/Code/Source/AtomImGuiToolsSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomImGuiTools/Code/Source/AtomImGuiToolsSystemComponent.cpp
@@ -29,7 +29,6 @@ namespace AtomImGuiTools
             {
                 ec->Class<AtomImGuiToolsSystemComponent>("AtomImGuiTools", "[Manager of various Atom ImGui tools.]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/AtomLyIntegration/AtomViewportDisplayIcons/Code/Source/AtomViewportDisplayIconsSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayIcons/Code/Source/AtomViewportDisplayIconsSystemComponent.cpp
@@ -54,7 +54,6 @@ namespace AZ::Render
             {
                 ec->Class<AtomViewportDisplayIconsSystemComponent>("Viewport Display Icons", "Provides an interface for drawing simple icons to the Editor viewport")
                     ->ClassElement(Edit::ClassElements::EditorData, "")
-                        ->Attribute(Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
@@ -62,7 +62,6 @@ namespace AZ::Render
             {
                 ec->Class<AtomViewportDisplayInfoSystemComponent>("Viewport Display Info", "Manages debug viewport information through r_displayInfo")
                     ->ClassElement(Edit::ClassElements::EditorData, "")
-                        ->Attribute(Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CommonFeaturesSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CommonFeaturesSystemComponent.cpp
@@ -32,7 +32,6 @@ namespace AZ
                 {
                     ec->Class<AtomLyIntegrationCommonFeaturesSystemComponent>("Common", "[Description of functionality provided by this System Component]")
                         ->ClassElement(Edit::ClassElements::EditorData, "")
-                            ->Attribute(Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                             ->Attribute(Edit::Attributes::AutoExpand, true)
                         ;
                 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/EditorCommonFeaturesSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/EditorCommonFeaturesSystemComponent.cpp
@@ -49,7 +49,6 @@ namespace AZ
                     ec->Class<EditorCommonFeaturesSystemComponent>("AtomEditorCommonFeaturesSystemComponent",
                         "Configures editor- and tool-specific functionality for common render features.")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->DataElement(nullptr, &EditorCommonFeaturesSystemComponent::m_atomLevelDefaultAssetPath, "Atom Level Default Asset Path",
                             "path to the slice the instantiate for a new Atom level")

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -67,7 +67,6 @@ namespace AZ
                 {
                     ec->Class<EditorMaterialSystemComponent>("EditorMaterialSystemComponent", "System component that manages launching and maintaining connections the material editor.")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ;
                 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshSystemComponent.cpp
@@ -27,7 +27,6 @@ namespace AZ
                 {
                     ec->Class<EditorMeshSystemComponent>("EditorMeshSystemComponent", "System component that sets up necessary logic related to EditorMeshComponent..")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ;
                 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/EditorPostFxSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/EditorPostFxSystemComponent.cpp
@@ -29,7 +29,6 @@ namespace AZ
                 {
                     ec->Class<EditorPostFxSystemComponent>("Editor PostFx System", "Manages discovery of PostFx layer categories asset")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ;
                 }

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/EditorModeFeedbackSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/EditorModeFeedbackSystemComponent.cpp
@@ -36,7 +36,6 @@ namespace AZ
                     editContext->Class<EditorModeFeedbackSystemComponent>(
                         "Editor Mode Feedback System", "Manages discovery of Editor Mode Feedback effects")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ;
                 }

--- a/Gems/AudioSystem/Code/Source/AudioSystemGemSystemComponent.cpp
+++ b/Gems/AudioSystem/Code/Source/AudioSystemGemSystemComponent.cpp
@@ -57,7 +57,6 @@ namespace AudioSystemGem
             {
                 ec->Class<AudioSystemGemSystemComponent>("Audio System Gem", "Audio System handles requests and managages data related to the audio sub-system")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/BarrierInput/Code/Source/BarrierInputSystemComponent.cpp
+++ b/Gems/BarrierInput/Code/Source/BarrierInputSystemComponent.cpp
@@ -62,7 +62,6 @@ namespace BarrierInput
             {
                 ec->Class<BarrierInputSystemComponent>("BarrierInput", "Provides functionality related to Barrier input.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/Camera/Code/Source/CameraEditorSystemComponent.cpp
+++ b/Gems/Camera/Code/Source/CameraEditorSystemComponent.cpp
@@ -45,7 +45,6 @@ namespace Camera
                     "Camera Editor Commands", "Performs global camera requests")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Game")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ;
             }
         }

--- a/Gems/Compression/Code/Source/Clients/CompressionSystemComponent.cpp
+++ b/Gems/Compression/Code/Source/Clients/CompressionSystemComponent.cpp
@@ -26,7 +26,6 @@ namespace Compression
             {
                 ec->Class<CompressionSystemComponent>("Compression", "[Description of functionality provided by this System Component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/DebugDraw/Code/Source/DebugDrawSystemComponent.cpp
+++ b/Gems/DebugDraw/Code/Source/DebugDrawSystemComponent.cpp
@@ -48,7 +48,6 @@ namespace DebugDraw
                 ec->Class<DebugDrawSystemComponent>("DebugDraw", "Provides game runtime debug visualization.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Debugging")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                 ;
             }

--- a/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
@@ -383,7 +383,6 @@ namespace EMotionFX
                 {
                     ec->Class<SystemComponent>("EMotion FX Animation", "Enables the EMotion FX animation solution")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &SystemComponent::m_numThreads, "Number of threads", "Number of threads used internally by EMotion FX")
                     ;

--- a/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.cpp
@@ -350,7 +350,6 @@ namespace EditorPythonBindings
             {
                 ec->Class<PythonSystemComponent>("PythonSystemComponent", "The Python interpreter")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/ExpressionEvaluation/Code/Source/ExpressionEvaluationSystemComponent.cpp
+++ b/Gems/ExpressionEvaluation/Code/Source/ExpressionEvaluationSystemComponent.cpp
@@ -144,7 +144,6 @@ namespace ExpressionEvaluation
             {
                 ec->Class<ExpressionEvaluationSystemComponent>("ExpressionEvaluationGem", "[Description of functionality provided by this System Component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/FastNoise/Code/Source/FastNoiseSystemComponent.cpp
+++ b/Gems/FastNoise/Code/Source/FastNoiseSystemComponent.cpp
@@ -25,7 +25,6 @@ namespace FastNoiseGem
             {
                 ec->Class<FastNoiseSystemComponent>("FastNoise", "System component for Fast Noise gradient gem")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/GameState/Code/Source/GameStateSystemComponent.cpp
+++ b/Gems/GameState/Code/Source/GameStateSystemComponent.cpp
@@ -28,7 +28,6 @@ namespace GameState
             {
                 ec->Class<GameStateSystemComponent>("GameState", "A generic framework for managing game states and the transitions between them.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/Gestures/Code/Source/GesturesSystemComponent.cpp
+++ b/Gems/Gestures/Code/Source/GesturesSystemComponent.cpp
@@ -58,7 +58,6 @@ namespace Gestures
             {
                 ec->Class<GesturesSystemComponent>("Gestures", "Interprets raw mouse/touch input in order to detect common gestures like drag, hold, swipe, etc.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->DataElement(0, &GesturesSystemComponent::m_doublePressConfig,
                         "Double Press", "The config used to create the default double press gesture input channel.")

--- a/Gems/GradientSignal/Code/Source/GradientSignalEditorModule.cpp
+++ b/Gems/GradientSignal/Code/Source/GradientSignalEditorModule.cpp
@@ -85,7 +85,6 @@ namespace GradientSignal
             {
                 editContext->Class<GradientSignalEditorSystemComponent>("GradientSignalEditorSystemComponent", "Handles registration of the gradient preview data widget handler")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/GradientSignal/Code/Source/GradientSignalSystemComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/GradientSignalSystemComponent.cpp
@@ -32,7 +32,6 @@ namespace GradientSignal
             {
                 ec->Class<GradientSignalSystemComponent>("GradientSignal", "Manages registration of gradient image assets and reflection of required types")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/GraphCanvas/Code/Source/GraphCanvas.cpp
+++ b/Gems/GraphCanvas/Code/Source/GraphCanvas.cpp
@@ -127,7 +127,6 @@ namespace GraphCanvas
                     "LmbrCentral", "Provides factory methods for Graph Canvas components")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Editor")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ;
             }            
             

--- a/Gems/GraphModel/Code/Source/GraphModelSystemComponent.cpp
+++ b/Gems/GraphModel/Code/Source/GraphModelSystemComponent.cpp
@@ -63,7 +63,6 @@ namespace GraphModel
             {
                 ec->Class<GraphModelSystemComponent>("GraphModel", "A generic node graph data model")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/HttpRequestor/Code/Source/HttpRequestorSystemComponent.cpp
+++ b/Gems/HttpRequestor/Code/Source/HttpRequestorSystemComponent.cpp
@@ -72,7 +72,6 @@ namespace HttpRequestor
                 ec->Class<HttpRequestorSystemComponent>("HttpRequestor", "Will make HTTP Rest calls")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     // ->Attribute(AZ::Edit::Attributes::Category, "") Set a category
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
             }
         }

--- a/Gems/InAppPurchases/Code/Source/InAppPurchasesSystemComponent.cpp
+++ b/Gems/InAppPurchases/Code/Source/InAppPurchasesSystemComponent.cpp
@@ -53,7 +53,6 @@ namespace InAppPurchases
             {
                 ec->Class<SystemComponent>("InAppPurchases", "Adds support for in app purchases on iOS and Android")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/LandscapeCanvas/Code/Source/LandscapeCanvasSystemComponent.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/LandscapeCanvasSystemComponent.cpp
@@ -267,7 +267,6 @@ namespace LandscapeCanvas
             {
                 ec->Class<LandscapeCanvasSystemComponent>("LandscapeCanvas", "Graph canvas representation of Dynamic Vegetation")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/LmbrCentral/Code/Source/Audio/AudioSystemComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Audio/AudioSystemComponent.cpp
@@ -59,7 +59,6 @@ namespace LmbrCentral
                 editContext->Class<AudioSystemComponent>("Audio System", "Provides access to audio system features without the need for an Entity")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Audio")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/LmbrCentral/Code/Source/LmbrCentral.cpp
+++ b/Gems/LmbrCentral/Code/Source/LmbrCentral.cpp
@@ -112,7 +112,6 @@ namespace LmbrCentral
                         "LmbrCentral Allocator Component", "Manages initialization of memory allocators required by LmbrCentral")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Engine")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ;
                 }
             }
@@ -148,7 +147,6 @@ namespace LmbrCentral
                         "LmbrCentral Asset Builder Allocator Component", "Manages initialization of memory allocators required by LmbrCentral during asset building")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Engine")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ;
                 }
             }
@@ -274,7 +272,6 @@ namespace LmbrCentral
                     "LmbrCentral", "Coordinates initialization of systems within LmbrCentral")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Game")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                 ;
             }
         }

--- a/Gems/LocalUser/Code/Source/LocalUserSystemComponent.cpp
+++ b/Gems/LocalUser/Code/Source/LocalUserSystemComponent.cpp
@@ -75,7 +75,6 @@ namespace LocalUser
             {
                 ec->Class<LocalUserSystemComponent>("LocalUser", "Provides functionality for mapping local user ids to local player slots and managing local user profiles.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/LyShine/Code/Editor/LyShineEditorSystemComponent.cpp
+++ b/Gems/LyShine/Code/Editor/LyShineEditorSystemComponent.cpp
@@ -53,7 +53,6 @@ namespace LyShineEditor
                 auto editInfo = ec->Class<LyShineEditorSystemComponent>("UI Canvas Editor", "UI Canvas Editor System Component");
                 editInfo->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "UI")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/LyShine/Code/Source/LyShineSystemComponent.cpp
+++ b/Gems/LyShine/Code/Source/LyShineSystemComponent.cpp
@@ -74,7 +74,6 @@ namespace LyShine
                 auto editInfo = ec->Class<LyShineSystemComponent>("LyShine", "In-game User Interface System");
                 editInfo->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "UI")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
 
                 editInfo->DataElement(0, &LyShineSystemComponent::m_cursorImagePathname, "CursorImagePath", "The cursor image path.")

--- a/Gems/LyShineExamples/Code/Source/LyShineExamplesSystemComponent.cpp
+++ b/Gems/LyShineExamples/Code/Source/LyShineExamplesSystemComponent.cpp
@@ -34,7 +34,6 @@ namespace LyShineExamples
                 ec->Class<LyShineExamplesSystemComponent>("LyShineExamples", "This provides example code using LyShine and code used by sample UI canvases and levels")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "UI")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/Maestro/Code/Source/MaestroSystemComponent.cpp
+++ b/Gems/Maestro/Code/Source/MaestroSystemComponent.cpp
@@ -53,7 +53,6 @@ namespace Maestro
                 ec->Class<MaestroSystemComponent>("Maestro", "Provides the Open 3D Engine Cinematics Service")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         // ->Attribute(AZ::Edit::Attributes::Category, "") Set a category
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/MessagePopup/Code/Source/LyShineMessagePopup.cpp
+++ b/Gems/MessagePopup/Code/Source/LyShineMessagePopup.cpp
@@ -36,7 +36,6 @@ namespace MessagePopup
             {
                 ec->Class<LyShineMessagePopup>("MessagePopup", "[Description of functionality provided by this System Component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/MessagePopup/Code/Source/MessagePopupSystemComponent.cpp
+++ b/Gems/MessagePopup/Code/Source/MessagePopupSystemComponent.cpp
@@ -49,7 +49,6 @@ namespace MessagePopup
             {
                 ec->Class<MessagePopupSystemComponent>("MessagePopup", "[Description of functionality provided by this System Component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/Microphone/Code/Source/MicrophoneSystemComponent.cpp
+++ b/Gems/Microphone/Code/Source/MicrophoneSystemComponent.cpp
@@ -26,7 +26,6 @@ namespace Audio
                 editContext->Class<MicrophoneSystemComponent>("Microphone", "Provides access to a connected Microphone Device to capture and read the data")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Audio")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/MotionMatching/Code/Source/MotionMatchingSystemComponent.cpp
+++ b/Gems/MotionMatching/Code/Source/MotionMatchingSystemComponent.cpp
@@ -60,7 +60,6 @@ namespace EMotionFX::MotionMatching
             {
                 ec->Class<MotionMatchingSystemComponent>("MotionMatching", "[Description of functionality provided by this System Component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/Multiplayer/Multiplayer_ScriptCanvas/Code/Source/ScriptCanvasMultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Multiplayer_ScriptCanvas/Code/Source/ScriptCanvasMultiplayerSystemComponent.cpp
@@ -28,7 +28,6 @@ namespace ScriptCanvasMultiplayer
             {
                 ec->Class<ScriptCanvasMultiplayerSystemComponent>("ScriptCanvasMultiplayer", "Provides various Script Canvas nodes for multiplayer.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                     ->Attribute(AZ::Script::Attributes::Category, "Multiplayer")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)

--- a/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionSystemComponent.cpp
+++ b/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionSystemComponent.cpp
@@ -30,7 +30,6 @@ namespace MultiplayerCompression
             {
                 ec->Class<MultiplayerCompressionSystemComponent>("MultiplayerCompression", "Provides packet compression via an open source library for the Multiplayer Gem")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/NvCloth/Code/Source/System/SystemComponent.cpp
+++ b/Gems/NvCloth/Code/Source/System/SystemComponent.cpp
@@ -147,7 +147,6 @@ namespace NvCloth
             {
                 editContext->Class<SystemComponent>("NvCloth", "Provides functionality for simulating cloth using NvCloth")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/PhysX/Code/Source/SystemComponent.cpp
+++ b/Gems/PhysX/Code/Source/SystemComponent.cpp
@@ -107,7 +107,6 @@ namespace PhysX
                 editContext->Class<SystemComponent>("PhysX", "Global PhysX physics configuration.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "PhysX")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SystemComponent::m_enabled,
                     "Enabled", "Enables the PhysX system component.")

--- a/Gems/PhysXDebug/Code/Source/SystemComponent.cpp
+++ b/Gems/PhysXDebug/Code/Source/SystemComponent.cpp
@@ -170,7 +170,6 @@ namespace PhysXDebug
                 ec->Class<SystemComponent>("PhysX Debug Visualization", "A debug visualization system component for PhysX.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "PhysX")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SystemComponent::m_settings, "Settings", "PhysX debug visualization settings")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SystemComponent::m_culling, "Culling", "PhysX culling options")

--- a/Gems/Presence/Code/Source/PresenceSystemComponent.cpp
+++ b/Gems/Presence/Code/Source/PresenceSystemComponent.cpp
@@ -86,7 +86,6 @@ namespace Presence
             {
                 ec->Class<PresenceSystemComponent>("Presence", "Platform agnostic interface for Presence API requests")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/Profiler/Code/Source/ProfilerImGuiSystemComponent.cpp
+++ b/Gems/Profiler/Code/Source/ProfilerImGuiSystemComponent.cpp
@@ -32,7 +32,6 @@ namespace Profiler
             {
                 ec->Class<ProfilerImGuiSystemComponent>("ProfilerImGui", "Provides in-game visualization of the performance data gathered by the ProfilerSystemComponent")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
             }
         }

--- a/Gems/Profiler/Code/Source/ProfilerSystemComponent.cpp
+++ b/Gems/Profiler/Code/Source/ProfilerSystemComponent.cpp
@@ -100,7 +100,6 @@ namespace Profiler
             {
                 ec->Class<ProfilerSystemComponent>("Profiler", "Provides a custom implementation of the AZ::Debug::Profiler interface for capturing performance data")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
             }
         }

--- a/Gems/RecastNavigation/Code/Source/RecastNavigationSystemComponent.cpp
+++ b/Gems/RecastNavigation/Code/Source/RecastNavigationSystemComponent.cpp
@@ -24,7 +24,6 @@ namespace RecastNavigation
             {
                 editContext->Class<RecastNavigationSystemComponent>("RecastNavigation", "[System Component for the Recast Navigation gem]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/RemoteTools/Code/Source/RemoteToolsSystemComponent.cpp
+++ b/Gems/RemoteTools/Code/Source/RemoteToolsSystemComponent.cpp
@@ -42,7 +42,6 @@ namespace RemoteTools
             {
                 ec->Class<RemoteToolsSystemComponent>("RemoteTools", "[Description of functionality provided by this System Component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/SaveData/Code/Source/SaveDataSystemComponent.cpp
+++ b/Gems/SaveData/Code/Source/SaveDataSystemComponent.cpp
@@ -37,7 +37,6 @@ namespace SaveData
             {
                 ec->Class<SaveDataSystemComponent>("SaveData", "Provides functionality for saving and loading persistent user data.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/SceneProcessing/Code/Source/Config/Components/SceneProcessingConfigSystemComponent.cpp
+++ b/Gems/SceneProcessing/Code/Source/Config/Components/SceneProcessingConfigSystemComponent.cpp
@@ -265,7 +265,6 @@ namespace AZ
                     ec->Class<SceneProcessingConfigSystemComponent>("Scene Processing Config", "Use this component to fine tune the defaults for processing of scene files like FBX.")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                             ->Attribute(AZ::Edit::Attributes::Category, "Assets")
-                            ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                             ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &SceneProcessingConfigSystemComponent::m_softNames,
                             "Soft naming conventions", "Update the naming conventions to suit your project.")

--- a/Gems/ScriptAutomation/Code/Source/ScriptAutomationSystemComponent.cpp
+++ b/Gems/ScriptAutomation/Code/Source/ScriptAutomationSystemComponent.cpp
@@ -111,7 +111,6 @@ namespace ScriptAutomation
             {
                 ec->Class<ScriptAutomationSystemComponent>("ScriptAutomation", "Provides a mechanism for automating various tasks through Lua scripting in the game launchers")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
             }
         }

--- a/Gems/ScriptCanvas/Code/Editor/ReflectComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/ReflectComponent.cpp
@@ -158,7 +158,6 @@ namespace ScriptCanvasEditor
                 ec->Class<ReflectComponent>("Script Canvas Reflections", "Script Canvas Reflect Component")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Scripting")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                     ;
             }
         }

--- a/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
@@ -74,7 +74,6 @@ namespace ScriptCanvasEditor
                 ec->Class<SystemComponent>("Script Canvas Editor", "Script Canvas Editor System Component")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Scripting")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Debugger.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Debugger.cpp
@@ -265,7 +265,6 @@ namespace ScriptCanvas
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                         ->Attribute(AZ::Edit::Attributes::Category, "Scripting")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ;
                 }
             }

--- a/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
@@ -105,7 +105,6 @@ namespace ScriptCanvas
                 ec->Class<SystemComponent>("Script Canvas", "Script Canvas System Component")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Scripting")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SystemComponent::m_infiniteLoopDetectionMaxIterations, "Infinite Loop Protection Max Iterations", "Script Canvas will avoid infinite loops by detecting potentially re-entrant conditions that execute up to this number of iterations.")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SystemComponent::m_maxHandlerStackDepth, "Max Handler Stack Depth", "Script Canvas will avoid infinite loops at run-time by detecting sending Ebus Events while handling said Events. This limits the stack depth of the broadcast.")

--- a/Gems/ScriptCanvasPhysics/Code/Source/ScriptCanvasPhysicsSystemComponent.cpp
+++ b/Gems/ScriptCanvasPhysics/Code/Source/ScriptCanvasPhysicsSystemComponent.cpp
@@ -28,7 +28,6 @@ namespace ScriptCanvasPhysics
             {
                 ec->Class<ScriptCanvasPhysicsSystemComponent>("ScriptCanvasPhysics", "Exposes legacy physics features to scripting through the Behavior Context to Lua and Script Canvas.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ->Attribute(AZ::Script::Attributes::Category, "Physics")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)

--- a/Gems/ScriptCanvasTesting/Code/Source/ScriptCanvasTestingSystemComponent.cpp
+++ b/Gems/ScriptCanvasTesting/Code/Source/ScriptCanvasTestingSystemComponent.cpp
@@ -34,7 +34,6 @@ namespace ScriptCanvasTesting
             {
                 ec->Class<ScriptCanvasTestingSystemComponent>("ScriptCanvasTesting", "")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/SliceFavorites/Code/Source/SliceFavoritesSystemComponent.cpp
+++ b/Gems/SliceFavorites/Code/Source/SliceFavoritesSystemComponent.cpp
@@ -26,7 +26,6 @@ namespace SliceFavorites
             {
                 ec->Class<SliceFavoritesSystemComponent>("SliceFavorites", "[Adds the ability for users to mark slices as favorites for easy instantiation via context menus in the editor]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/Stars/Code/Source/EditorStarsSystemComponent.cpp
+++ b/Gems/Stars/Code/Source/EditorStarsSystemComponent.cpp
@@ -23,7 +23,6 @@ namespace AZ::Render
             {
                 ec->Class<StarsSystemComponent>("Stars", "Stars system component")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/StartingPointInput/Code/Source/StartingPointInputGem.cpp
+++ b/Gems/StartingPointInput/Code/Source/StartingPointInputGem.cpp
@@ -140,7 +140,6 @@ namespace StartingPointInput
                         "Starting point input", "Manages input bindings and events")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Editor")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ;
                 }
             }

--- a/Gems/Streamer/StreamerProfiler/Code/Source/StreamerProfilerSystemComponent.cpp
+++ b/Gems/Streamer/StreamerProfiler/Code/Source/StreamerProfilerSystemComponent.cpp
@@ -74,7 +74,6 @@ namespace Streamer
             {
                 ec->Class<StreamerProfilerSystemComponent>("Streamer Profiler", "Provides profiling visualization for AZ::IO::Streamer.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/SurfaceData/Code/Source/Editor/EditorSurfaceDataSystemComponent.cpp
+++ b/Gems/SurfaceData/Code/Source/Editor/EditorSurfaceDataSystemComponent.cpp
@@ -74,7 +74,6 @@ namespace SurfaceData
             {
                 ec->Class<EditorSurfaceDataSystemComponent>("Editor Surface Data System", "Manages discovery and registration of surface tag list assets")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->DataElement(0, &EditorSurfaceDataSystemComponent::m_configuration, "Configuration", "")
                     ;

--- a/Gems/SurfaceData/Code/Source/SurfaceDataSystemComponent.cpp
+++ b/Gems/SurfaceData/Code/Source/SurfaceDataSystemComponent.cpp
@@ -38,7 +38,6 @@ namespace SurfaceData
             {
                 ec->Class<SurfaceDataSystemComponent>("Surface Data System", "Manages registration of surface data providers and forwards intersection data requests to them")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/Terrain/Code/Source/Components/TerrainSurfaceDataSystemComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainSurfaceDataSystemComponent.cpp
@@ -60,7 +60,6 @@ namespace Terrain
                 editContext->Class<TerrainSurfaceDataSystemComponent>("Terrain Surface Data System", "Manages surface data requests against legacy terrain")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Surface Data")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->DataElement(0, &TerrainSurfaceDataSystemComponent::m_configuration, "Configuration", "")
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)

--- a/Gems/Terrain/Code/Source/Components/TerrainSystemComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainSystemComponent.cpp
@@ -31,7 +31,6 @@ namespace Terrain
             {
                 ec->Class<TerrainSystemComponent>("Terrain", "The Terrain System Component enables Terrain.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                 ;
             }

--- a/Gems/TextureAtlas/Code/Source/TextureAtlasSystemComponent.cpp
+++ b/Gems/TextureAtlas/Code/Source/TextureAtlasSystemComponent.cpp
@@ -52,7 +52,6 @@ namespace TextureAtlasNamespace
                 ec->Class<TextureAtlasSystemComponent>(
                     "TextureAtlas", "This component loads and manages TextureAtlases")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
             }
         }

--- a/Gems/TickBusOrderViewer/Code/Source/TickBusOrderViewerSystemComponent.cpp
+++ b/Gems/TickBusOrderViewer/Code/Source/TickBusOrderViewerSystemComponent.cpp
@@ -26,7 +26,6 @@ namespace TickBusOrderViewer
                     "TickBusOrderViewer", 
                     "Provides a console command for viewing tick bus order, print_tickbus_handlers.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/Twitch/Code/Source/TwitchSystemComponent.cpp
+++ b/Gems/Twitch/Code/Source/TwitchSystemComponent.cpp
@@ -37,7 +37,6 @@ namespace Twitch
                 ec->Class<TwitchSystemComponent>("Twitch", "Provides access to Twitch \"Friends\", \"Rich Presence\" APIs")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         // ->Attribute(AZ::Edit::Attributes::Category, "") Set a category
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/Vegetation/Code/Source/AreaSystemComponent.cpp
+++ b/Gems/Vegetation/Code/Source/AreaSystemComponent.cpp
@@ -306,7 +306,6 @@ namespace Vegetation
                 editContext->Class<AreaSystemComponent>("Vegetation Area System", "Manages registration and processing of vegetation area entities")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Vegetation")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->Attribute(AZ::Edit::Attributes::HelpPageURL, "https://o3de.org/docs/user-guide/components/reference/")
                     ->DataElement(0, &AreaSystemComponent::m_configuration, "Configuration", "")

--- a/Gems/Vegetation/Code/Source/DebugSystemComponent.cpp
+++ b/Gems/Vegetation/Code/Source/DebugSystemComponent.cpp
@@ -42,7 +42,6 @@ namespace Vegetation
                 editContext->Class<DebugSystemComponent>("Vegetation Debug System", "Stores and manages vegetation debug data")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Vegetation")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/Vegetation/Code/Source/Editor/EditorVegetationSystemComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Editor/EditorVegetationSystemComponent.cpp
@@ -40,7 +40,6 @@ namespace Vegetation
                 editContext->Class<EditorVegetationSystemComponent>("Editor Vegetation System", "Manages and discovers surface tag list assets that define the dictionary of selectable tags at edit time")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Vegetation")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/Vegetation/Code/Source/InstanceSystemComponent.cpp
+++ b/Gems/Vegetation/Code/Source/InstanceSystemComponent.cpp
@@ -91,7 +91,6 @@ namespace Vegetation
                 editContext->Class<InstanceSystemComponent>("Vegetation Instance System", "Manages and processes requests to create and destroy vegetation instance render nodes")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Vegetation")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->Attribute(AZ::Edit::Attributes::HelpPageURL, "https://o3de.org/docs/user-guide/components/reference/")
                     ->DataElement(0, &InstanceSystemComponent::m_configuration, "Configuration", "")

--- a/Gems/Vegetation/Code/Source/VegetationSystemComponent.cpp
+++ b/Gems/Vegetation/Code/Source/VegetationSystemComponent.cpp
@@ -88,7 +88,6 @@ namespace Vegetation
                 editContext->Class<VegetationSystemComponent>("Vegetation System", "Reflects types and defines required services for dynamic vegetation systems to function")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Vegetation")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/VideoPlaybackFramework/Code/Source/VideoPlaybackFrameworkSystemComponent.cpp
+++ b/Gems/VideoPlaybackFramework/Code/Source/VideoPlaybackFrameworkSystemComponent.cpp
@@ -76,7 +76,6 @@ namespace VideoPlaybackFramework
             {
                 ec->Class<VideoPlaybackFrameworkSystemComponent>("VideoPlaybackFramework", "Interface framework to play back video during gameplay.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/VirtualGamepad/Code/Source/VirtualGamepadSystemComponent.cpp
+++ b/Gems/VirtualGamepad/Code/Source/VirtualGamepadSystemComponent.cpp
@@ -54,7 +54,6 @@ namespace VirtualGamepad
             {
                 ec->Class<VirtualGamepadSystemComponent>("VirtualGamepad", "Provides an example of a virtual gamepad that can be used by mobile devices with touch screens in place of a physical gamepad.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->DataElement(0, &VirtualGamepadSystemComponent::m_buttonNames, "Button Names", "The button names made available by the virtual gamepad.")
                     ->DataElement(0, &VirtualGamepadSystemComponent::m_thumbStickNames, "Thumb-Stick Names", "The thumb-stick names made available by the virtual gamepad.")

--- a/Gems/WhiteBox/Code/Source/WhiteBoxSystemComponent.cpp
+++ b/Gems/WhiteBox/Code/Source/WhiteBoxSystemComponent.cpp
@@ -26,7 +26,6 @@ namespace WhiteBox
                 ec->Class<WhiteBoxSystemComponent>(
                       "WhiteBox", "[Description of functionality provided by this System Component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
             }
         }


### PR DESCRIPTION
## What does this PR do?

The option to have a component's serialized data show up in a "System" menu has not been available for quite some time, this attribute is not used by any system, thus, it is being removed.

If you need to configure a component using settings, please refer to: https://www.o3de.org/docs/user-guide/settings/developer-api/#load-c-class-objects-with-the-query-api

## How was this PR tested?

Compiled the code
