### PR TITLE
bugfix image format and debuginfo cannot save and load from batch files.

### DIFF
--- a/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
+++ b/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
@@ -74,6 +74,10 @@ namespace
 
     const char customResFormat[] = "Custom(%1 x %2)...";
 
+    const char debugInfo[] = "debuginfo";
+
+    const char format[] = "format";
+
     const int kBatchRenderFileVersion = 2; // This version number should be incremented every time available options like the list of formats,
     // the list of buffers change.
 
@@ -466,7 +470,10 @@ void CSequenceBatchRenderDialog::OnUpdateRenderItem()
 
     // Set up a new render item.
     SRenderItem item;
-    SetUpNewRenderItem(item);
+    if (!SetUpNewRenderItem(item))
+    {
+        return;
+    }
 
     // Check a duplication before updating.
     for (size_t i = 0; i < m_renderItems.size(); ++i)
@@ -1509,6 +1516,10 @@ void CSequenceBatchRenderDialog::OnLoadBatch()
             // folder
             item.folder = itemNode->getAttr("folder");
 
+            itemNode->getAttr(debugInfo, item.disableDebugInfo);
+
+            item.imageFormat = itemNode->getAttr(format);
+
             // cvars
             for (int k = 0; k < itemNode->getChildCount(); ++k)
             {
@@ -1560,6 +1571,10 @@ void CSequenceBatchRenderDialog::OnSaveBatch()
 
             // folder
             itemNode->setAttr("folder", item.folder.toUtf8().data());
+
+            itemNode->setAttr(debugInfo, item.disableDebugInfo);
+
+            itemNode->setAttr(format, item.imageFormat.toUtf8().data());
 
             // cvars
             for (size_t k = 0; k < item.cvars.size(); ++k)


### PR DESCRIPTION
## What does this PR do?

* Save `image format` and `debuginfo` to batch files.
* Load `image format` and `debuginfo` from batch files. 

1. Open Editor.
2. Click Tools -> Track View.
3. Create a sequence.
4. Add some nodes.
![image](https://user-images.githubusercontent.com/80555200/221072326-6494bb82-307c-4d11-b758-f6a29ac0859f.png)
5. Click Tools -> Render Output, Add a batch.
![image](https://user-images.githubusercontent.com/80555200/221074311-a5d61ba3-65dd-48d7-b2a7-c3409ece9424.png)
6. Click `Save Batch...`, and check the batch file.
![image](https://user-images.githubusercontent.com/80555200/221074230-9f9e9c4a-9cf2-4d6e-b83f-2130138fb03e.png)

## How was this PR tested?
Follow the same steps, as follows:
![image](https://user-images.githubusercontent.com/80555200/221074270-1861b18f-9103-45ff-80dc-66c2d8e10946.png)
