### PR TITLE
bugfix the count of image files is not stable when using Render Output.

### DIFF
--- a/Code/Framework/AzCore/AzCore/Time/ITime.h
+++ b/Code/Framework/AzCore/AzCore/Time/ITime.h
@@ -92,11 +92,12 @@ namespace AZ
         //! Setting to 0 disables the override.
         //! @param timeMs The time in milliseconds to use for the tick delta.
         virtual void SetSimulationTickDeltaOverride(TimeMs timeMs) = 0;
+        virtual void SetSimulationTickDeltaOverride(TimeUs timeUs) = 0;
 
         //! Returns the current simulation tick override.
         //! 0 means disabled.
         //! @returns The current simulation tick override in milliseconds.
-        virtual TimeMs GetSimulationTickDeltaOverride() const = 0;
+        virtual TimeUs GetSimulationTickDeltaOverride() const = 0;
 
         //! A scalar amount to adjust the passage of time by, 1.0 == realtime, 0.5 == half realtime, 2.0 == doubletime.
         //! @param scale The scalar value to apply to the simulation time.

--- a/Code/Framework/AzCore/AzCore/Time/TimeSystem.cpp
+++ b/Code/Framework/AzCore/AzCore/Time/TimeSystem.cpp
@@ -27,7 +27,7 @@ namespace AZ
         {
             if (auto* timeSystem = AZ::Interface<ITime>::Get())
             {
-                timeSystem->SetSimulationTickDeltaOverride(static_cast<AZ::TimeMs>(value));
+                timeSystem->SetSimulationTickDeltaOverride(static_cast<AZ::TimeUs>(value));
             }
         }
 
@@ -194,9 +194,17 @@ namespace AZ
         }
     }
 
-    TimeMs TimeSystem::GetSimulationTickDeltaOverride() const
+    void TimeSystem::SetSimulationTickDeltaOverride(TimeUs timeUs)
     {
-        return AZ::TimeUsToMs(m_simulationTickDeltaOverride);
+        if (timeUs != m_simulationTickDeltaOverride)
+        {
+            m_simulationTickDeltaOverride = timeUs;
+        }
+    }
+
+    TimeUs TimeSystem::GetSimulationTickDeltaOverride() const
+    {
+        return m_simulationTickDeltaOverride;
     }
 
     void TimeSystem::SetSimulationTickScale(float scale)

--- a/Code/Framework/AzCore/AzCore/Time/TimeSystem.h
+++ b/Code/Framework/AzCore/AzCore/Time/TimeSystem.h
@@ -39,7 +39,8 @@ namespace AZ
         TimeUs GetRealTickDeltaTimeUs() const override;
         TimeUs GetLastSimulationTickTime() const override;
         void SetSimulationTickDeltaOverride(TimeMs timeMs) override;
-        TimeMs GetSimulationTickDeltaOverride() const override;
+        void SetSimulationTickDeltaOverride(TimeUs timeUs) override;
+        TimeUs GetSimulationTickDeltaOverride() const override;
         void SetSimulationTickScale(float scale) override;
         float GetSimulationTickScale() const override;
         void SetSimulationTickRate(int rate) override;

--- a/Code/Framework/AzCore/AzCore/UnitTest/Mocks/MockITime.h
+++ b/Code/Framework/AzCore/AzCore/UnitTest/Mocks/MockITime.h
@@ -41,7 +41,8 @@ namespace AZ
         MOCK_METHOD1(SetElapsedTimeMsDebug, void(TimeMs));
         MOCK_METHOD1(SetElapsedTimeUsDebug, void(TimeUs));
         MOCK_METHOD1(SetSimulationTickDeltaOverride, void(TimeMs));
-        MOCK_CONST_METHOD0(GetSimulationTickDeltaOverride, TimeMs());
+        MOCK_METHOD1(SetSimulationTickDeltaOverride, void(TimeUs));
+        MOCK_CONST_METHOD0(GetSimulationTickDeltaOverride, TimeUs());
         MOCK_METHOD1(SetSimulationTickScale, void(float));
         MOCK_CONST_METHOD0(GetSimulationTickScale, float());
         MOCK_METHOD1(SetSimulationTickRate, void(int));
@@ -102,9 +103,9 @@ namespace AZ
         {
         }
 
-        virtual TimeMs GetSimulationTickDeltaOverride() const override
+        virtual TimeUs GetSimulationTickDeltaOverride() const override
         {
-            return AZ::Time::ZeroTimeMs; 
+            return AZ::Time::ZeroTimeUs; 
         }
 
         virtual void SetSimulationTickScale([[maybe_unused]] float scale) override

--- a/Gems/Maestro/Code/Source/Cinematics/Movie.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/Movie.cpp
@@ -189,10 +189,10 @@ namespace Internal
     {
         if (auto* timeSystem = AZ::Interface<AZ::ITime>::Get())
         {
-            const AZ::TimeMs deltatimeOverride = timeSystem->GetSimulationTickDeltaOverride();
-            if (deltatimeOverride != AZ::Time::ZeroTimeMs)
+            const AZ::TimeUs deltatimeOverride = timeSystem->GetSimulationTickDeltaOverride();
+            if (deltatimeOverride != AZ::Time::ZeroTimeUs)
             {
-                deltaTime = AZ::TimeMsToSeconds(deltatimeOverride);
+                deltaTime = AZ::TimeUsToSeconds(deltatimeOverride);
             }
         }
         return deltaTime;
@@ -214,7 +214,7 @@ CMovieSystem::CMovieSystem(ISystem* pSystem)
     m_bStartCapture = false;
     m_captureFrame = -1;
     m_bEndCapture = false;
-    m_fixedTimeStepBackUp = AZ::Time::ZeroTimeMs;
+    m_fixedTimeStepBackUp = AZ::Time::ZeroTimeUs;
     m_cvar_capture_frame_once = nullptr;
     m_cvar_capture_folder = nullptr;
     m_cvar_sys_maxTimeStepForMovieSystem = nullptr;
@@ -1500,7 +1500,7 @@ void CMovieSystem::EnableFixedStepForCapture(float step)
     if (auto* timeSystem = AZ::Interface<AZ::ITime>::Get())
     {
         m_fixedTimeStepBackUp = timeSystem->GetSimulationTickDeltaOverride();
-        timeSystem->SetSimulationTickDeltaOverride(AZ::SecondsToTimeMs(step));
+        timeSystem->SetSimulationTickDeltaOverride(AZ::SecondsToTimeUs(step));
     }
 
     if (nullptr == m_cvar_sys_maxTimeStepForMovieSystem)

--- a/Gems/Maestro/Code/Source/Cinematics/Movie.h
+++ b/Gems/Maestro/Code/Source/Cinematics/Movie.h
@@ -239,7 +239,7 @@ private:
     int m_captureFrame;
     bool m_bEndCapture;
     ICaptureKey m_captureKey;
-    AZ::TimeMs m_fixedTimeStepBackUp;
+    AZ::TimeUs m_fixedTimeStepBackUp;
     float m_maxTimeStepForMovieSystemBackUp;
     ICVar* m_cvar_capture_frame_once;
     ICVar* m_cvar_capture_folder;

--- a/Gems/Maestro/Code/Source/Cinematics/SceneNode.h
+++ b/Gems/Maestro/Code/Source/Cinematics/SceneNode.h
@@ -150,7 +150,7 @@ private:
 
     std::vector<SSoundInfo> m_SoundInfo;
 
-    AZ::TimeMs m_simulationTickOverrideBackup = AZ::Time::ZeroTimeMs;
+    AZ::TimeUs m_simulationTickOverrideBackup = AZ::Time::ZeroTimeUs;
     float m_timeScaleBackup = 1.0f;
 };
 


### PR DESCRIPTION
## What does this PR do?

When using Render output to export images, due to time precision problems between ticks, the count of images is not stable, as follows:
1. `Film(24)`, the image file count should be 240, but actual is 243.
![image](https://user-images.githubusercontent.com/80555200/221106355-5edf20a1-6bd5-4bb8-be5b-b2ccaab56fc7.png)
2. `PAL(25)`, the image file count is 250, as expected.
![image](https://user-images.githubusercontent.com/80555200/221106404-94534124-dd64-479a-a21a-17e99d9dd0c2.png)
3. `NTSC(30)`, the image file count should be 300, but actual is 138.
![image](https://user-images.githubusercontent.com/80555200/221106478-70a4a627-c924-47b1-8248-c0a5bb94d030.png)

## How was this PR tested?
Follow the steps:
1. Open Editor.
2. Click Tools -> Track View.
3. Create a sequence.
4. Add some nodes.
![image](https://user-images.githubusercontent.com/80555200/221072326-6494bb82-307c-4d11-b758-f6a29ac0859f.png)
5. Click Tools -> Render Output, Add a batch.
![image](https://user-images.githubusercontent.com/80555200/221074311-a5d61ba3-65dd-48d7-b2a7-c3409ece9424.png)
6. Click Start, and wait for its ending, then check the images files.
6.1 `Film(24)`
![image](https://user-images.githubusercontent.com/80555200/221105575-e7de73c9-2bdf-4be0-b0ed-9609d948ced7.png)
6.2 `PAL(25)`
![image](https://user-images.githubusercontent.com/80555200/221105716-cfcdd025-3ee3-4bd6-84cc-c6fb7536e5d6.png)
6.3 `NTSC(30)`
![image](https://user-images.githubusercontent.com/80555200/221105786-c7bca1ac-ab77-4fa8-a923-8761e266ebca.png)
6.4 `Show(48)`
![image](https://user-images.githubusercontent.com/80555200/221105861-0e37d2b7-ec1f-4baa-9600-512c276c973c.png)
6.5 `PAL Field(50)`
![image](https://user-images.githubusercontent.com/80555200/221105921-887ef741-acf0-4861-a10e-9786b59e2c07.png)
6.6 `NTSC Field(60)`
![image](https://user-images.githubusercontent.com/80555200/221105975-6f8e6593-17d2-4f0b-ba7f-64533e026220.png)

