### PR TITLE
Introduce an interface to get the polygon point buffer of polygon light.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/PolygonLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/PolygonLightFeatureProcessor.cpp
@@ -256,6 +256,11 @@ namespace AZ::Render
         return m_lightBufferHandler.GetBuffer();
     }
 
+    const Data::Instance<RPI::Buffer> PolygonLightFeatureProcessor::GetLightPointBuffer() const
+    {
+        return m_lightPolygonPointBufferHandler.GetBuffer();
+    }
+
     uint32_t PolygonLightFeatureProcessor::GetLightCount() const
     {
         return m_lightBufferHandler.GetElementCount();

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/PolygonLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/PolygonLightFeatureProcessor.h
@@ -51,6 +51,7 @@ namespace AZ
             void SetAttenuationRadius(LightHandle handle, float attenuationRadius) override;
 
             const Data::Instance<RPI::Buffer> GetLightBuffer()const;
+            const Data::Instance<RPI::Buffer> GetLightPointBuffer()const;
             uint32_t GetLightCount()const;
 
         private:


### PR DESCRIPTION
## What does this PR do?

Adds an interface to get the polygon point buffer of a polygon light. This is useful for some custom Gems that needs the polygon light point information.

## How was this PR tested?

Using a custom gem calling this function to get the buffer, and set to another shader resource group, and access it in the shader.