### PR TITLE
fix shape component modes not getting reflected and add shortcuts to …

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -36,6 +36,8 @@
 #include <AzToolsFramework/Component/EditorLevelComponentAPIComponent.h>
 #include <AzToolsFramework/ComponentMode/ComponentModeDelegate.h>
 #include <AzToolsFramework/ComponentModes/BoxComponentMode.h>
+#include <AzToolsFramework/ComponentModes/CapsuleComponentMode.h>
+#include <AzToolsFramework/ComponentModes/SphereComponentMode.h>
 #include <AzToolsFramework/ContainerEntity/ContainerEntitySystemComponent.h>
 #include <AzToolsFramework/Editor/ActionManagerIdentifiers/EditorMenuIdentifiers.h>
 #include <AzToolsFramework/Entity/EditorEntityActionComponent.h>
@@ -409,6 +411,8 @@ namespace AzToolsFramework
         ComponentModeFramework::EditorBaseComponentMode::Reflect(context);
 
         BoxComponentMode::Reflect(context);
+        CapsuleComponentMode::Reflect(context);
+        SphereComponentMode::Reflect(context);
 
         ViewportInteraction::ViewportInteractionReflect(context);
         ViewportEditorModeNotifications::Reflect(context);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentModes/BaseShapeComponentMode.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentModes/BaseShapeComponentMode.cpp
@@ -14,19 +14,18 @@
 #include <AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h>
 #include <AzToolsFramework/ActionManager/Menu/MenuManagerInterface.h>
 #include <AzToolsFramework/Manipulators/ShapeManipulatorRequestBus.h>
+#include <AzToolsFramework/Editor/ActionManagerIdentifiers/EditorContextIdentifiers.h>
+#include <AzToolsFramework/Editor/ActionManagerIdentifiers/EditorMenuIdentifiers.h>
 
 namespace AzToolsFramework
 {
-    static constexpr AZStd::string_view EditorMainWindowActionContextIdentifier = "o3de.context.editor.mainwindow";
-    static constexpr AZStd::string_view EditMenuIdentifier = "o3de.menu.editor.edit";
-
-    namespace
+    namespace BaseShapeComponentModeIdentifiers
     {
         //! Uri's for shortcut actions.
         const AZ::Crc32 SetDimensionsSubModeActionUri = AZ_CRC_CE("org.o3de.action.shape.setdimensionssubmode");
         const AZ::Crc32 SetTranslationOffsetSubModeActionUri = AZ_CRC_CE("org.o3de.action.shape.settranslationoffsetsubmode");
         const AZ::Crc32 ResetSubModeActionUri = AZ_CRC_CE("org.o3de.action.shape.resetsubmode");
-    } // namespace
+    } // namespace BaseShapeComponentModeIdentifiers
 
     void InstallBaseShapeViewportEditFunctions(
         BaseShapeViewportEdit* baseShapeViewportEdit, const AZ::EntityComponentIdPair& entityComponentIdPair)
@@ -209,7 +208,7 @@ namespace AzToolsFramework
         }
 
         ActionOverride setDimensionsModeAction;
-        setDimensionsModeAction.SetUri(SetDimensionsSubModeActionUri);
+        setDimensionsModeAction.SetUri(BaseShapeComponentModeIdentifiers::SetDimensionsSubModeActionUri);
         setDimensionsModeAction.SetKeySequence(QKeySequence(Qt::Key_1));
         setDimensionsModeAction.SetTitle("Set Dimensions Mode");
         setDimensionsModeAction.SetTip("Set dimensions mode");
@@ -221,7 +220,7 @@ namespace AzToolsFramework
             });
 
         ActionOverride setTranslationOffsetModeAction;
-        setTranslationOffsetModeAction.SetUri(SetTranslationOffsetSubModeActionUri);
+        setTranslationOffsetModeAction.SetUri(BaseShapeComponentModeIdentifiers::SetTranslationOffsetSubModeActionUri);
         setTranslationOffsetModeAction.SetKeySequence(QKeySequence(Qt::Key_2));
         setTranslationOffsetModeAction.SetTitle("Set Translation Offset Mode");
         setTranslationOffsetModeAction.SetTip("Set translation offset mode");
@@ -233,7 +232,7 @@ namespace AzToolsFramework
             });
 
         ActionOverride resetModeAction;
-        resetModeAction.SetUri(ResetSubModeActionUri);
+        resetModeAction.SetUri(BaseShapeComponentModeIdentifiers::ResetSubModeActionUri);
         resetModeAction.SetKeySequence(QKeySequence(Qt::Key_R));
         resetModeAction.SetTitle("Reset Current Mode");
         resetModeAction.SetTip("Reset current mode");
@@ -267,7 +266,7 @@ namespace AzToolsFramework
             actionProperties.m_category = category;
 
             actionManagerInterface->RegisterAction(
-                EditorMainWindowActionContextIdentifier,
+                EditorIdentifiers::MainWindowActionContextIdentifier,
                 actionIdentifier,
                 actionProperties,
                 []
@@ -297,7 +296,7 @@ namespace AzToolsFramework
             actionProperties.m_category = category;
 
             actionManagerInterface->RegisterAction(
-                EditorMainWindowActionContextIdentifier,
+                EditorIdentifiers::MainWindowActionContextIdentifier,
                 actionIdentifier,
                 actionProperties,
                 []
@@ -327,7 +326,7 @@ namespace AzToolsFramework
             actionProperties.m_category = category;
 
             actionManagerInterface->RegisterAction(
-                EditorMainWindowActionContextIdentifier,
+                EditorIdentifiers::MainWindowActionContextIdentifier,
                 actionIdentifier,
                 actionProperties,
                 []
@@ -366,9 +365,9 @@ namespace AzToolsFramework
 
         const AZStd::string prefix = AZStd::string::format("o3de.action.%sComponentMode", shapeName);
 
-        menuManagerInterface->AddActionToMenu(EditMenuIdentifier, prefix + ".setDimensionsSubMode", 6000);
-        menuManagerInterface->AddActionToMenu(EditMenuIdentifier, prefix + ".setTranslationOffsetSubMode", 6001);
-        menuManagerInterface->AddActionToMenu(EditMenuIdentifier, prefix + ".resetCurrentMode", 6002);
+        menuManagerInterface->AddActionToMenu(EditorIdentifiers::EditMenuIdentifier, prefix + ".setDimensionsSubMode", 6000);
+        menuManagerInterface->AddActionToMenu(EditorIdentifiers::EditMenuIdentifier, prefix + ".setTranslationOffsetSubMode", 6001);
+        menuManagerInterface->AddActionToMenu(EditorIdentifiers::EditMenuIdentifier, prefix + ".resetCurrentMode", 6002);
     }
 } // namespace AzToolsFramework
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentModes/BaseShapeComponentMode.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentModes/BaseShapeComponentMode.h
@@ -50,8 +50,8 @@ namespace AzToolsFramework
         void SetShapeSubMode(ShapeComponentModeRequests::SubMode mode) override;
         void ResetShapeSubMode() override;
 
-        constexpr static const char* const DimensionsTooltip = "Switch to dimensions mode";
-        constexpr static const char* const TranslationOffsetTooltip = "Switch to translation offset mode";
+        constexpr static const char* const DimensionsTooltip = "Switch to dimensions mode (1)";
+        constexpr static const char* const TranslationOffsetTooltip = "Switch to translation offset mode (2)";
 
     protected:
         void SetupCluster();

--- a/Gems/PhysX/Code/Editor/ColliderComponentMode.cpp
+++ b/Gems/PhysX/Code/Editor/ColliderComponentMode.cpp
@@ -437,11 +437,11 @@ namespace PhysX
         // create and register the buttons
         m_buttonIds.resize(static_cast<size_t>(SubMode::NumModes));
         m_buttonIds[static_cast<size_t>(SubMode::Offset)] =
-            RegisterClusterButton(m_modeSelectionClusterId, "Move", "Switch to translation offset mode");
+            RegisterClusterButton(m_modeSelectionClusterId, "Move", "Switch to translation offset mode (1)");
         m_buttonIds[static_cast<size_t>(SubMode::Rotation)] =
-            RegisterClusterButton(m_modeSelectionClusterId, "Rotate", "Switch to rotation offset mode");
+            RegisterClusterButton(m_modeSelectionClusterId, "Rotate", "Switch to rotation offset mode (2)");
         m_buttonIds[static_cast<size_t>(SubMode::Dimensions)] =
-            RegisterClusterButton(m_modeSelectionClusterId, "Scale", "Switch to dimensions mode");
+            RegisterClusterButton(m_modeSelectionClusterId, "Scale", "Switch to dimensions mode (3)");
 
         SetCurrentMode(SubMode::Offset);
 


### PR DESCRIPTION
…submode tooltips

## What does this PR do?
Fixes a bug where the reflect function for capsule and sphere shape component modes was not being called.
Tidies up some duplicated URIs.
Adds shortcuts to the tooltips for shape component modes and PhysX collider component modes.

## How was this PR tested?
Manual testing in the editor.