### PR TITLE
avoid a crash if the input-image for the TAA pass has no attachment

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.cpp
@@ -134,13 +134,18 @@ namespace AZ::Render
         // Make sure the attachments have images when the pass first loads.
         for (auto i : { 0, 1 })
         {
-            if (m_accumulationAttachments[0] && !m_accumulationAttachments[i]->m_importedResource)
+            if (m_accumulationAttachments[i])
             {
-                attachmentsValid &= UpdateAttachmentImage(i);
+                attachmentsValid = UpdateAttachmentImage(i);
+                if (!attachmentsValid)
+                {
+                    break;
+                }
             }
             else
             {
                 attachmentsValid = false;
+                break;
             }
         }
         if (!attachmentsValid)
@@ -199,7 +204,7 @@ namespace AZ::Render
         if (attachment->m_importedResource && imageDesc.m_size == currentImage->GetDescriptor().m_size)
         {
             // If there's a resource already and the size didn't change, just keep using the old AttachmentImage.
-            return false;
+            return true;
         }
         
         Data::Instance<RPI::AttachmentImagePool> pool = RPI::ImageSystemInterface::Get()->GetSystemAttachmentPool();

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <Atom/RHI.Reflect/Format.h>
 #include <PostProcessing/TaaPass.h>
 
 #include <AzCore/Math/Random.h>
@@ -129,21 +130,27 @@ namespace AZ::Render
         m_accumulationAttachments[0] = FindAttachment(Name("Accumulation1"));
         m_accumulationAttachments[1] = FindAttachment(Name("Accumulation2"));
 
-        bool hasAttachments = m_accumulationAttachments[0] || m_accumulationAttachments[1];
-        AZ_Error("TaaPass", hasAttachments, "TaaPass must have Accumulation1 and Accumulation2 ImageAttachments defined.");
-
-        if (hasAttachments)
+        bool attachmentsValid = true;
+        // Make sure the attachments have images when the pass first loads.
+        for (auto i : { 0, 1 })
         {
-            // Make sure the attachments have images when the pass first loads.
-            for (auto i : { 0, 1 })
+            if (m_accumulationAttachments[0] && !m_accumulationAttachments[i]->m_importedResource)
             {
-                if (!m_accumulationAttachments[i]->m_importedResource)
-                {
-                    UpdateAttachmentImage(i);
-                }
+                attachmentsValid &= UpdateAttachmentImage(i);
+            }
+            else
+            {
+                attachmentsValid = false;
             }
         }
-        
+        if (!attachmentsValid)
+        {
+            this->SetEnabled(false);
+            AZ_Error(
+                "TaaPass", attachmentsValid, "TaaPass disabled because the ImageAttachments Accumulation1 and Accumulation2 are invalid.");
+            return;
+        }
+
         m_inputColorBinding = FindAttachmentBinding(Name("InputColor"));
         AZ_Error("TaaPass", m_inputColorBinding, "TaaPass requires a slot for InputColor.");
         m_lastFrameAccumulationBinding = FindAttachmentBinding(Name("LastFrameAccumulation"));
@@ -169,23 +176,30 @@ namespace AZ::Render
         Base::BuildInternal();
     }
 
-    void TaaPass::UpdateAttachmentImage(uint32_t attachmentIndex)
+    bool TaaPass::UpdateAttachmentImage(uint32_t attachmentIndex)
     {
         RPI::Ptr<RPI::PassAttachment>& attachment = m_accumulationAttachments[attachmentIndex];
         if (!attachment)
         {
-            return;
+            return false;
         }
 
         // update the image attachment descriptor to sync up size and format
         attachment->Update(true);
         RHI::ImageDescriptor& imageDesc = attachment->m_descriptor.m_image;
+
+        // The Format Source had no valid attachment
+        if (imageDesc.m_format == RHI::Format::Unknown)
+        {
+            return false;
+        }
+
         RPI::AttachmentImage* currentImage = azrtti_cast<RPI::AttachmentImage*>(attachment->m_importedResource.get());
 
         if (attachment->m_importedResource && imageDesc.m_size == currentImage->GetDescriptor().m_size)
         {
             // If there's a resource already and the size didn't change, just keep using the old AttachmentImage.
-            return;
+            return false;
         }
         
         Data::Instance<RPI::AttachmentImagePool> pool = RPI::ImageSystemInterface::Get()->GetSystemAttachmentPool();
@@ -206,12 +220,9 @@ namespace AZ::Render
             attachment->m_path = attachmentImage->GetAttachmentId();
             attachment->m_importedResource = attachmentImage;
             m_attachmentImages[attachmentIndex] = attachmentImage;
+            return true;
         }
-        else
-        {
-            AZ_Error("TaaPass", false, "TaaPass disabled because it is unable to create an attachment image.")
-            this->SetEnabled(false);
-        }
+        return false;
     }
 
     void TaaPass::SetupSubPixelOffsets(uint32_t haltonX, uint32_t haltonY, uint32_t length)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.h
@@ -69,7 +69,7 @@ namespace AZ::Render
         void ResetInternal() override;
         void BuildInternal() override;
 
-        void UpdateAttachmentImage(uint32_t attachmentIndex);
+        bool UpdateAttachmentImage(uint32_t attachmentIndex);
 
         void SetupSubPixelOffsets(uint32_t haltonX, uint32_t haltonY, uint32_t length);
         void GenerateFilterWeights(AZ::Vector2 jitterOffset);


### PR DESCRIPTION
## What does this PR do?

Changes the checks if the Attachments of the TAA - pass are valid. Currently wrong attachments lead to a crash, which makes debugging the actual cause somewhat difficult.

## How was this PR tested?

Used with a custom render-pipeline, where the SizeSource - Slot for the TAA - images was connected, but had no actual attachment.