### PR TITLE
better error handling for the BloomCompositePass

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomCompositePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomCompositePass.cpp
@@ -119,9 +119,30 @@ namespace AZ
         {
             RPI::PassAttachmentBinding& parentInBinding = GetInputBinding(0);
             const RPI::Ptr<RPI::PassAttachment>& parentInAttachment = parentInBinding.GetAttachment();
+            if (!parentInAttachment)
+            {
+                AZ_Error(
+                    "PassSystem",
+                    false,
+                    "[BloomCompositePass '%s']: Slot '%s' has no attachment.",
+                    GetPathName().GetCStr(),
+                    parentInBinding.m_name.GetCStr());
+                return;
+            }
 
             RPI::PassAttachmentBinding& parentInOutBinding = GetInputOutputBinding(0);
             const RPI::Ptr<RPI::PassAttachment>& parentInOutAttachment = parentInOutBinding.GetAttachment();
+
+            if (!parentInOutAttachment)
+            {
+                AZ_Error(
+                    "PassSystem",
+                    false,
+                    "[BloomCompositePass '%s']: Slot '%s' has no attachment.",
+                    GetPathName().GetCStr(),
+                    parentInOutBinding.m_name.GetCStr());
+                return;
+            }
 
             // Create input binding, from downsampling pass
             RPI::PassAttachmentBinding inBinding;


### PR DESCRIPTION
## What does this PR do?

Better error handling if the Input-bindings of the BloomCompositePass have no valid attachment. The old version would lead to a somewhat obtuse vulkan-error (Invalid image format or so) somewhere down the way.

## How was this PR tested?

Used with a custom render-pipeline, where one of my output-slots was connected, but had no attachment.
