### PR TITLE
Fix an assert with the normalized direction for polygon lights

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/PolygonLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/PolygonLightFeatureProcessor.cpp
@@ -289,7 +289,7 @@ namespace AZ::Render
         else
         {
             AZ::Vector3 normal = AZ::Vector3::CreateFromFloat3(data.m_direction.data());
-            bounds.emplace<Hemisphere>(AZ::Hemisphere(position, radius, normal));
+            bounds.emplace<Hemisphere>(AZ::Hemisphere(position, radius, normal.GetNormalized()));
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

Placing a polygonal light in the scene would continuously assert, because the direction wasn't normalized.

## How was this PR tested?

Place a Polygonal light in a scene.