### PR TITLE
make hand-written pass-templates more consistent with json serialization

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/BloomDownsample.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/BloomDownsample.pass
@@ -54,7 +54,7 @@
                     },
                     "ImageDescriptor": {
                         "MipLevels": "5",
-                        "SharedQueueMask": 3
+                        "SharedQueueMask": "Copy"
                     }
                 },
                 {
@@ -75,7 +75,7 @@
                     },
                     "ImageDescriptor": {
                         "MipLevels": "5",
-                        "SharedQueueMask": 3
+                        "SharedQueueMask": "Copy"
                     }
                 }
             ],

--- a/Gems/Atom/Feature/Common/Assets/Passes/KawaseShadowBlur.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/KawaseShadowBlur.pass
@@ -60,7 +60,7 @@
             ],
             "Connections": [
                 {
-                    "localSlot": "Output",
+                    "LocalSlot": "Output",
                     "AttachmentRef": {
                         "Pass": "This",
                         "Attachment": "FilteredImage"

--- a/Gems/Atom/Feature/Common/Assets/Passes/SubsurfaceScattering.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/SubsurfaceScattering.pass
@@ -45,7 +45,7 @@
                         "Attachment": "InputDiffuse"
                     },
                     "ImageDescriptor": {
-                        "SharedQueueMask": 3
+                        "SharedQueueMask": "Copy"
                     }
                 }
             ],

--- a/Gems/Atom/Feature/Common/Assets/Passes/Taa.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Taa.pass
@@ -59,8 +59,8 @@
                     },
                     "ImageDescriptor": {
                         "Format": "R16G16B16A16_FLOAT",
-                        "BindFlags": "3",
-                        "SharedQueueMask": "1"
+                        "BindFlags": "ShaderReadWrite",
+                        "SharedQueueMask": "Graphics"
                     }
                 },
                 {
@@ -78,8 +78,8 @@
                     },
                     "ImageDescriptor": {
                         "Format": "R16G16B16A16_FLOAT",
-                        "BindFlags": "3",
-                        "SharedQueueMask": "1"
+                        "BindFlags": "ShaderReadWrite",
+                        "SharedQueueMask": "Graphics"
                     }
                 }
             ],

--- a/Gems/Atom/Feature/Common/Assets/Passes/UIParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/UIParent.pass
@@ -60,7 +60,7 @@
                     ],
                     "PassData": {
                         "$type": "ImGuiPassData",
-                        "IsDefaultImGui": true
+                        "isDefaultImGui": true
                     }
                 }
             ]


### PR DESCRIPTION
## What does this PR do?

Changes a few values in the json templates so they are somewhat more future proof, and stick to the case convention as in the Reflect - functions. Mostly this makes parsing the templates by an external script a bit easier.

## How was this PR tested?

Display a basic scene. The PR didn't introduce any functional difference.
