### PR TITLE
Check recent files entry's validity only for dynamically added entries

### DIFF
--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -2174,15 +2174,14 @@ void EditorActionsHandler::UpdateRecentFileActions()
     // Update all names
     for (int index = 0; (index < maxRecentFiles) || (index < recentFilesSize); ++index)
     {
-        if (!IsRecentFileEntryValid((*recentFiles)[index], gameDirPath))
-        {
-            continue;
-        }
-
         AZStd::string actionIdentifier = AZStd::string::format("o3de.action.file.recent.file%i", counter + 1);
 
         if (index < recentFilesSize)
         {
+            if (!IsRecentFileEntryValid((*recentFiles)[index], gameDirPath))
+            {
+                continue;
+            }
             QString displayName;
             recentFiles->GetDisplayName(displayName, index, sCurDir);
 


### PR DESCRIPTION
## What does this PR do?

In the Editor window: fixes crashing when you click on the File menu

## How was this PR tested?

---
