### PR TITLE
Fix a crash if the number of recently opened files is < 10

### DIFF
--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -2172,7 +2172,7 @@ void EditorActionsHandler::UpdateRecentFileActions()
     int counter = 0;
 
     // Update all names
-    for (int index = 0; (index < maxRecentFiles) || (index < recentFilesSize); ++index)
+    for (int index = 0; (index < maxRecentFiles) && (index < recentFilesSize); ++index)
     {
         if (!IsRecentFileEntryValid((*recentFiles)[index], gameDirPath))
         {


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in the File Menu when the number of recently opened files is less that 10.

## How was this PR tested?

Clicking on the file-menu with 3 recently opened files.