### PR TITLE
Material Canvas: Updated lua scripts to check for missing options before reading them

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/HandleCastShadows.lua
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/HandleCastShadows.lua
@@ -14,11 +14,13 @@ function GetMaterialPropertyDependencies()
 end
 
 function Process(context)
-    -- The only reason we need this script is when the material type uses GeneralCommonPropertyGroup.json
-    -- which does not connect general.cast_shadows, and the only way to add a connection after importing
-    -- a common .json file is to use a lua functor. If we had another way to add a connection to a property
-    -- after defining it via $import, that would probably be simpler.
-    local castShadows = context:GetMaterialPropertyValue_bool("general.cast_shadows")
+    local castShadows = true
+    if context:HasMaterialProperty("general.cast_shadows") then
+        castShadows = context:GetMaterialPropertyValue_bool("general.cast_shadows")
+    end
+
     local shadowMap = context:GetShaderByTag("Shadowmap")
-    shadowMap:SetEnabled(castShadows)
+    if shadowMap then
+        shadowMap:SetEnabled(castShadows)
+    end
 end

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/HandleCastShadows.lua
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/HandleCastShadows.lua
@@ -14,11 +14,13 @@ function GetMaterialPropertyDependencies()
 end
 
 function Process(context)
-    -- The only reason we need this script is when the material type uses GeneralCommonPropertyGroup.json
-    -- which does not connect general.cast_shadows, and the only way to add a connection after importing
-    -- a common .json file is to use a lua functor. If we had another way to add a connection to a property
-    -- after defining it via $import, that would probably be simpler.
-    local castShadows = context:GetMaterialPropertyValue_bool("general.cast_shadows")
+    local castShadows = true
+    if context:HasMaterialProperty("general.cast_shadows") then
+        castShadows = context:GetMaterialPropertyValue_bool("general.cast_shadows")
+    end
+
     local shadowMap = context:GetShaderByTag("Shadowmap")
-    shadowMap:SetEnabled(castShadows)
+    if shadowMap then
+        shadowMap:SetEnabled(castShadows)
+    end
 end

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/HandleOpacityDoubleSided.lua
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/HandleOpacityDoubleSided.lua
@@ -14,10 +14,14 @@ function GetMaterialPropertyDependencies()
 end
  
 function Process(context)
-    local doubleSided = context:GetMaterialPropertyValue_bool("general.double_sided")
+    local doubleSided = false
+    if context:HasMaterialProperty("general.double_sided") then
+        doubleSided = context:GetMaterialPropertyValue_bool("general.double_sided")
+    end
+
     local lastShader = context:GetShaderCount() - 1;
 
-    if(doubleSided) then
+    if doubleSided then
         for i=0,lastShader do
             context:GetShader(i):GetRenderStatesOverride():SetCullMode(CullMode_None)
         end

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/HandleOpacityMode.lua
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/HandleOpacityMode.lua
@@ -47,21 +47,22 @@ function ResetAlphaBlending(shaderItem)
 end
 
 function Process(context)
-    local opacityMode = context:GetMaterialPropertyValue_enum("general.opacity_mode")
+    local opacityMode = OpacityMode_Opaque
+    if context:HasMaterialProperty("general.opacity_mode") then
+        opacityMode = context:GetMaterialPropertyValue_enum("general.opacity_mode")
+    end
 
     local forwardPassEDS = context:GetShaderByTag("ForwardPass_EDS")
-
-    if(opacityMode == OpacityMode_Blended) then
-        ConfigureAlphaBlending(forwardPassEDS)
-        forwardPassEDS:SetDrawListTagOverride("transparent")
-    elseif(opacityMode == OpacityMode_TintedTransparent) then
-        ConfigureDualSourceBlending(forwardPassEDS)
-        forwardPassEDS:SetDrawListTagOverride("transparent")
-    else
-        ResetAlphaBlending(forwardPassEDS)
-        forwardPassEDS:SetDrawListTagOverride("") -- reset to default draw list
+    if forwardPassEDS then
+        if opacityMode == OpacityMode_Blended then
+            ConfigureAlphaBlending(forwardPassEDS)
+            forwardPassEDS:SetDrawListTagOverride("transparent")
+        elseif opacityMode == OpacityMode_TintedTransparent then
+            ConfigureDualSourceBlending(forwardPassEDS)
+            forwardPassEDS:SetDrawListTagOverride("transparent")
+        else
+            ResetAlphaBlending(forwardPassEDS)
+            forwardPassEDS:SetDrawListTagOverride("") -- reset to default draw list
+        end
     end
-end
-
-function ProcessEditor(context)
 end

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/HandleShaderEnable.lua
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/HandleShaderEnable.lua
@@ -39,11 +39,15 @@ function Process(context)
         opacityMode = context:GetMaterialPropertyValue_enum("general.opacity_mode")
     end
 
+    local castShadows = true
+    if context:HasMaterialProperty("general.cast_shadows") then
+        castShadows = context:GetMaterialPropertyValue_bool("general.cast_shadows")
+    end
+
     local displacementMap = nil --context:GetMaterialPropertyValue_Image("parallax.textureMap")
     local useDisplacementMap = 0 --context:GetMaterialPropertyValue_bool("parallax.useTexture")
     local parallaxEnabled = displacementMap ~= nil and useDisplacementMap
     local parallaxPdoEnabled = 0 --context:GetMaterialPropertyValue_bool("parallax.pdo")
-    local castShadows = context:GetMaterialPropertyValue_bool("general.cast_shadows")
     
     local depthPass = context:GetShaderByTag("DepthPass")
     local shadowMap = context:GetShaderByTag("Shadowmap")


### PR DESCRIPTION
## What does this PR do?

Updated base PBR and standard PBR lua scripts that come with material canvas to handle missing shader options. This should only occur when opening the material graph template materials and material types directly, since the options are only added to materials generated from them. The lua functor API should be updated to have default values passed in as a second parameter when reading options and properties.

Resolves https://github.com/o3de/o3de/issues/14800

## How was this PR tested?

Opened base and standard PBR material graph template materials in the material editor without errors.
Created new materials from material canvas and opened those without errors.
Confirmed that options still behave correctly when toggling them on generated materials.