### PR TITLE
remove caching for IsOnGround result

### DIFF
--- a/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterGameplayComponent.cpp
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterGameplayComponent.cpp
@@ -110,29 +110,17 @@ namespace PhysX
     // CharacterGameplayRequestBus
     bool CharacterGameplayComponent::IsOnGround() const
     {
-        if (m_cachedGroundState == CharacterGroundState::NotYetDetermined)
-        {
-            DetermineCachedGroundState();
-        }
-
-        return m_cachedGroundState == CharacterGroundState::Touching;
-    }
-
-    void CharacterGameplayComponent::DetermineCachedGroundState() const
-    {
         Physics::Character* character = nullptr;
         Physics::CharacterRequestBus::EventResult(character, GetEntityId(), &Physics::CharacterRequests::GetCharacter);
         if (!character)
         {
-            m_cachedGroundState = CharacterGroundState::Touching;
-            return;
+            return true;
         }
 
         auto pxController = static_cast<physx::PxController*>(character->GetNativePointer());
         if (!pxController)
         {
-            m_cachedGroundState = CharacterGroundState::Touching;
-            return;
+            return true;
         }
 
         // first check if we can use the character controller state, which should be cheaper than doing a scene query
@@ -145,8 +133,7 @@ namespace PhysX
 
         if (state.touchedActor != nullptr || (state.collisionFlags & physx::PxControllerCollisionFlag::eCOLLISION_DOWN) != 0)
         {
-            m_cachedGroundState = CharacterGroundState::Touching;
-            return;
+            return true;
         }
 
         // if we get to this point it's still unclear whether the character is touching the ground so
@@ -176,16 +163,16 @@ namespace PhysX
             overlapRequest.m_maxResults = 2;
             AZ::EntityId entityId = GetEntityId();
             AzPhysics::SceneQueryHits sceneQueryHits = scene->QueryScene(&overlapRequest);
-            m_cachedGroundState = AZStd::any_of(
-                                      sceneQueryHits.m_hits.begin(),
-                                      sceneQueryHits.m_hits.end(),
-                                      [&entityId](const AzPhysics::SceneQueryHit& hit)
-                                      {
-                                          return hit.m_entityId != entityId;
-                                      })
-                ? CharacterGroundState::Touching
-                : CharacterGroundState::NotTouching;
+            return AZStd::any_of(
+                sceneQueryHits.m_hits.begin(),
+                sceneQueryHits.m_hits.end(),
+                [&entityId](const AzPhysics::SceneQueryHit& hit)
+                {
+                    return hit.m_entityId != entityId;
+                });
         }
+
+        return true;
     }
 
     float CharacterGameplayComponent::GetGravityMultiplier() const
@@ -235,14 +222,6 @@ namespace PhysX
             {
                 OnSceneSimulationStart(fixedDeltaTime);
             }, aznumeric_cast<int32_t>(AzPhysics::SceneEvents::PhysicsStartFinishSimulationPriority::Animation));
-
-        m_sceneSimulationFinishHandler = AzPhysics::SceneEvents::OnSceneSimulationStartHandler(
-            [this](
-                [[maybe_unused]] AzPhysics::SceneHandle sceneHandle,
-                [[maybe_unused]] float fixedDeltaTime)
-            {
-                OnSceneSimulationFinish();
-            }, aznumeric_cast<int32_t>(AzPhysics::SceneEvents::PhysicsStartFinishSimulationPriority::Default));
     }
 
     void CharacterGameplayComponent::Activate()
@@ -260,7 +239,6 @@ namespace PhysX
             m_gravity = sceneInterface->GetGravity(attachedSceneHandle);
             sceneInterface->RegisterSceneGravityChangedEvent(attachedSceneHandle, m_onGravityChangedHandler);
             sceneInterface->RegisterSceneSimulationStartHandler(attachedSceneHandle, m_sceneSimulationStartHandler);
-            sceneInterface->RegisterSceneSimulationFinishHandler(attachedSceneHandle, m_sceneSimulationFinishHandler);
         }
 
         CharacterGameplayRequestBus::Handler::BusConnect(GetEntityId());
@@ -271,18 +249,12 @@ namespace PhysX
         CharacterGameplayRequestBus::Handler::BusDisconnect();
         m_onGravityChangedHandler.Disconnect();
         m_sceneSimulationStartHandler.Disconnect();
-        m_sceneSimulationFinishHandler.Disconnect();
     }
 
     // Physics::SystemEvent
     void CharacterGameplayComponent::OnSceneSimulationStart(float physicsTimestep)
     {
         ApplyGravity(physicsTimestep);
-    }
-
-    void CharacterGameplayComponent::OnSceneSimulationFinish()
-    {
-        m_cachedGroundState = CharacterGroundState::NotYetDetermined;
     }
 
     void CharacterGameplayComponent::OnGravityChanged(const AZ::Vector3& gravity)

--- a/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterGameplayComponent.cpp
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterGameplayComponent.cpp
@@ -123,20 +123,6 @@ namespace PhysX
             return true;
         }
 
-        // first check if we can use the character controller state, which should be cheaper than doing a scene query
-
-        // if the controller is slightly above an object or has not been asked to move downwards, the PxController may
-        // not report a touched actor or downward collision, so this can give false negatives, but should not give
-        // false positives, so it's useful as an early out
-        physx::PxControllerState state;
-        pxController->getState(state);
-
-        if (state.touchedActor != nullptr || (state.collisionFlags & physx::PxControllerCollisionFlag::eCOLLISION_DOWN) != 0)
-        {
-            return true;
-        }
-
-        // if we get to this point it's still unclear whether the character is touching the ground so
         // use an overlap query to see if there's any geometry immediately below the character's foot position
         if (auto* scene = character->GetScene())
         {

--- a/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterGameplayComponent.h
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterGameplayComponent.h
@@ -14,14 +14,6 @@
 
 namespace PhysX
 {
-    //! Used for caching whether the character controller is touching the ground.
-    enum class CharacterGroundState
-    {
-        NotYetDetermined,
-        NotTouching,
-        Touching,
-    };
-
     //! Configuration for storing character gameplay settings.
     class CharacterGameplayConfiguration
     {
@@ -76,7 +68,6 @@ namespace PhysX
 
     private:
         void OnSceneSimulationStart(float physicsTimestep);
-        void OnSceneSimulationFinish();
         void OnGravityChanged(const AZ::Vector3& gravity);
         void ApplyGravity(float deltaTime);
         void DetermineCachedGroundState() const;
@@ -87,8 +78,6 @@ namespace PhysX
         float m_groundDetectionBoxHeight = 0.02f; //!< Vertical size of box to use when testing for ground contact.
 
         AzPhysics::SceneEvents::OnSceneSimulationStartHandler m_sceneSimulationStartHandler;
-        AzPhysics::SceneEvents::OnSceneSimulationFinishHandler m_sceneSimulationFinishHandler;
         AzPhysics::SceneEvents::OnSceneGravityChangedEvent::Handler m_onGravityChangedHandler;
-        mutable CharacterGroundState m_cachedGroundState = CharacterGroundState::NotYetDetermined;
     };
 } // namespace PhysX


### PR DESCRIPTION
## What does this PR do?
Removes the caching behaviour for IsOnGround queries on the character gameplay controller component. The caching was intended to avoid the expense of scene queries, but can lead to incorrect results if the controller or other physics bodies move outside the physics update.

## How was this PR tested?
Unit tests and manual testing in the editor.