### PR TITLE
Moved includes to fix unique_ptr compile issue

### DIFF
--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientSystemComponent.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientSystemComponent.cpp
@@ -12,9 +12,6 @@
 #include <Multiplayer/Session/SessionConfig.h>
 
 #include <AWSCoreBus.h>
-
-#include <AWSGameLiftClientLocalTicketTracker.h>
-#include <AWSGameLiftClientManager.h>
 #include <AWSGameLiftClientSystemComponent.h>
 
 #include <Request/AWSGameLiftAcceptMatchRequest.h>

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientSystemComponent.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientSystemComponent.h
@@ -11,13 +11,12 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 
+#include <AWSGameLiftClientLocalTicketTracker.h>
+#include <AWSGameLiftClientManager.h>
 #include <Request/IAWSGameLiftInternalRequests.h>
 
 namespace AWSGameLift
 {
-    class AWSGameLiftClientManager;
-    class AWSGameLiftClientLocalTicketTracker;
-
     //! Gem client system component. Responsible for creating the gamelift client manager.
     class AWSGameLiftClientSystemComponent
         : public AZ::Component


### PR DESCRIPTION
## What does this PR do?

Moved some includes from the source file to header to fix some compile issues with `unique_ptr` expecting the complete type instead of just a forward declaration.
