### PR TITLE
Register sets engines_path for older projects

### DIFF
--- a/scripts/o3de/o3de/register.py
+++ b/scripts/o3de/o3de/register.py
@@ -225,6 +225,60 @@ def register_all_repos_in_folder(repos_path: pathlib.Path,
     return register_all_o3de_objects_of_type_in_folder(repos_path, 'repo', remove, force, None, engine_path=engine_path)
 
 
+def remove_engine_name_to_path(json_data: dict,
+                               engine_path: pathlib.Path) -> int:
+    """
+    Remove the engine at the specified path if it exist in the o3de manifest
+    :param json_data in-memory json view of the o3de_manifest.json data
+    :param engine_path path to engine to remove from the manifest data
+    returns 0 to indicate no issues has occurred with removal
+    """
+    if engine_path.is_dir() and validation.valid_o3de_engine_json(pathlib.Path(engine_path).resolve() / 'engine.json'):
+        engine_json_data = manifest.get_engine_json_data(engine_path=engine_path)
+        if 'engine_name' in engine_json_data and 'engines_path' in json_data:
+            engine_name = engine_json_data['engine_name']
+            try:
+                del json_data['engines_path'][engine_name]
+            except KeyError:
+                # Attempting to remove a non-existent engine_name is fine
+                pass
+
+    return 0
+
+
+def add_engine_name_to_path(json_data: dict, engine_path: pathlib.Path, force: bool):
+    # This functionality is deprecated and exists to allow older projects
+    # to find newer versions of the engine which no longer require the engine name
+    # exist in "engines_path"
+
+    # Add an engine path JSON object which maps the "engine_name" -> "engine_path"
+    engine_json_data = manifest.get_engine_json_data(engine_path=engine_path)
+    if not engine_json_data:
+        logger.error(f'Unable to retrieve json data from engine.json at path {engine_path.as_posix()}')
+        return 1
+    engines_path_json = json_data.setdefault('engines_path', {})
+    if 'engine_name' not in engine_json_data:
+        logger.error(f'engine.json at path {engine_path.as_posix()} is missing "engine_name" key')
+        return 1
+
+    engine_name = engine_json_data['engine_name']
+    if not force and engine_name in engines_path_json and \
+            pathlib.PurePath(engines_path_json[engine_name]) != engine_path:
+        logger.info(f'Engine successfully registered.')
+        logger.warning(
+            f'Important notice regarding older projects created with engine version 22.10 or earlier:\n'
+            f'An engine named "{engine_name}" is already registered at "{pathlib.Path(engines_path_json[engine_name]).as_posix()}"\n'
+            f'If you have projects created with engine version 22.10 or earlier, and you want them to use this engine'
+            f' you will need to:\n'
+            f'  1. backup the project\'s existing "cmake/EngineFinder.cmake" file\n'
+            f'  2. copy the "Templates/DefaultProject/Template/cmake/EngineFinder.cmake" from this engine into the project.\n'
+            f' Alternately, to force all older projects that use "{engine_name}" to use this engine path, specify the -f/--force option.')
+        return 0
+
+    engines_path_json[engine_name] = engine_path.as_posix()
+    return 0
+
+
 def register_o3de_object_path(json_data: dict,
                               o3de_object_path: str or pathlib.Path,
                               o3de_object_key: str,
@@ -325,8 +379,16 @@ def register_engine_path(json_data: dict,
     def transform_engine_dict_to_string(engine): return engine.get('path', '') if isinstance(engine, dict) else engine
     json_data['engines'] = list(map(transform_engine_dict_to_string, engine_list))
 
-    return register_o3de_object_path(json_data, engine_path, 'engines', 'engine.json',
+    result = register_o3de_object_path(json_data, engine_path, 'engines', 'engine.json',
                                        validation.valid_o3de_engine_json, remove)
+    if result != 0:
+        return result
+
+    # Backwards compatibility to allow older projects to find newer engines
+    if remove:
+        return remove_engine_name_to_path(json_data, engine_path)
+    else:
+        return add_engine_name_to_path(json_data, engine_path, force)
 
 
 def register_external_subdirectory(json_data: dict,


### PR DESCRIPTION
## What does this PR do?

Reverts some code changed in https://github.com/o3de/o3de/pull/14270 that required each engine to be registered in `o3de_manifest.json` in an `engines_path` dictionary.

Older projects rely on this key to find the engine, so users were confused when they installed o3de from dev but their project's failed to find the engine.

This change:
1. registers the engine in the `engines_path` dictionary in the `o3de_manifest.json` if no entry exists
2. prints a warning instead of an error if a different engine is already registered with the engine name in `engines_path` 

Example:
```
$ scripts/o3de.bat register --this-engine
[INFO] o3de.register: Engine successfully registered.
[WARNING] o3de.register: Important notice regarding older projects created with engine version 22.10 or earlier:
An engine named "o3de" is already registered at "D:/git/o3de-dev"
If you have projects created with engine version 22.10 or earlier, and you want them to use this engine you will need to:
  1. backup the project's existing "cmake/EngineFinder.cmake" file
  2. copy the "Templates/DefaultProject/Template/cmake/EngineFinder.cmake" from this engine into the project.
 Alternately, to force all older projects that use "o3de" to use this engine path, specify the -f/--force option.
```

## How was this PR tested?

- ran `register --this-engine` from a new engine with an existing engine and without and verified the warning prints if an existing engine is registered with that name, otherwise no warning is printed.
- in any case, the engine is registered in the `engines` list in `o3de_manifest.json` so new projects can find it