### PR TITLE
remove additional uses of "system" attrib

### DIFF
--- a/AutomatedTesting/Gem/Code/Source/AutomatedTestingSystemComponent.cpp
+++ b/AutomatedTesting/Gem/Code/Source/AutomatedTestingSystemComponent.cpp
@@ -30,7 +30,6 @@ namespace AutomatedTesting
             {
                 ec->Class<AutomatedTestingSystemComponent>("AutomatedTesting", "[Description of functionality provided by this System Component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/AWSClientAuth/Code/Source/AWSClientAuthEditorSystemComponent.cpp
+++ b/Gems/AWSClientAuth/Code/Source/AWSClientAuthEditorSystemComponent.cpp
@@ -28,7 +28,6 @@ namespace AWSClientAuth
             {
                 ec->Class<AWSClientAuthSystemComponent>("AWSClientAuthEditor", "Provides Client Authentication and Authorization implementations")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
             }
         }

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientEditorSystemComponent.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientEditorSystemComponent.cpp
@@ -33,7 +33,6 @@ namespace AWSGameLift
             {
                 editContext->Class<AWSGameLiftClientEditorSystemComponent>("AWSGameLiftClientEditor", "Create the GameLift client manager that handles communication between game clients and the GameLift service.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/AWSMetrics/Code/Source/AWSMetricsEditorSystemComponent.cpp
+++ b/Gems/AWSMetrics/Code/Source/AWSMetricsEditorSystemComponent.cpp
@@ -38,7 +38,6 @@ namespace AWSMetrics
             {
                 ec->Class<AWSMetricsEditorSystemComponent>("AWSMetricsEditor", "Generate and submit metrics to the metrics analytics pipeline")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/AudioEngineWwise/Code/Source/AudioEngineWwiseGemSystemComponent.cpp
+++ b/Gems/AudioEngineWwise/Code/Source/AudioEngineWwiseGemSystemComponent.cpp
@@ -52,7 +52,6 @@ namespace AudioEngineWwiseGem
             {
                 ec->Class<AudioEngineWwiseGemSystemComponent>("Audio Engine Wwise Gem", "Wwise implementation of the Audio Engine interfaces")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Gems/Meshlets/Code/Source/MeshletsSystemComponent.cpp
+++ b/Gems/Meshlets/Code/Source/MeshletsSystemComponent.cpp
@@ -36,7 +36,6 @@ namespace AZ
                 {
                     ec->Class<MeshletsSystemComponent>("Meshlets", "[Description of functionality provided by this System Component]")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                            ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                             ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ;
                 }

--- a/Templates/CppToolGem/Template/Code/Source/Clients/${Name}SystemComponent.cpp
+++ b/Templates/CppToolGem/Template/Code/Source/Clients/${Name}SystemComponent.cpp
@@ -28,7 +28,6 @@ namespace ${SanitizedCppName}
             {
                 ec->Class<${SanitizedCppName}SystemComponent>("${SanitizedCppName}", "[Description of functionality provided by this System Component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Templates/DefaultGem/Template/Code/Source/Clients/${Name}SystemComponent.cpp
+++ b/Templates/DefaultGem/Template/Code/Source/Clients/${Name}SystemComponent.cpp
@@ -28,7 +28,6 @@ namespace ${SanitizedCppName}
             {
                 ec->Class<${SanitizedCppName}SystemComponent>("${SanitizedCppName}", "[Description of functionality provided by this System Component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Templates/DefaultProject/Template/Gem/Source/${Name}SystemComponent.cpp
+++ b/Templates/DefaultProject/Template/Gem/Source/${Name}SystemComponent.cpp
@@ -28,7 +28,6 @@ namespace ${SanitizedCppName}
             {
                 ec->Class<${SanitizedCppName}SystemComponent>("${SanitizedCppName}", "[Description of functionality provided by this System Component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Templates/MinimalProject/Template/Gem/Source/${Name}SystemComponent.cpp
+++ b/Templates/MinimalProject/Template/Gem/Source/${Name}SystemComponent.cpp
@@ -28,7 +28,6 @@ namespace ${SanitizedCppName}
             {
                 ec->Class<${SanitizedCppName}SystemComponent>("${SanitizedCppName}", "[Description of functionality provided by this System Component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }

--- a/Templates/UnifiedMultiplayerGem/Template/Code/Source/Unified/${Name}SystemComponent.cpp
+++ b/Templates/UnifiedMultiplayerGem/Template/Code/Source/Unified/${Name}SystemComponent.cpp
@@ -28,7 +28,6 @@ namespace ${SanitizedCppName}
             {
                 ec->Class<${SanitizedCppName}SystemComponent>("${SanitizedCppName}", "[Description of functionality provided by this System Component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }


### PR DESCRIPTION
This attribute is deprecated

## What does this PR do?

Removes more instances of "system" component attrib
https://github.com/o3de/o3de/pull/14791/


## How was this PR tested?

configured and built