### PR TITLE
Remove dependencies on md5

### DIFF
--- a/Code/Legacy/CrySystem/CMakeLists.txt
+++ b/Code/Legacy/CrySystem/CMakeLists.txt
@@ -26,7 +26,6 @@ ly_add_target(
         PRIVATE
             3rdParty::expat
             3rdParty::lz4
-            3rdParty::md5
             3rdParty::TIFF
             3rdParty::zstd
             Legacy::CryCommon

--- a/Code/Legacy/CrySystem/XML/XmlUtils.cpp
+++ b/Code/Legacy/CrySystem/XML/XmlUtils.cpp
@@ -68,15 +68,6 @@ XmlNodeRef CXmlUtils::LoadXmlFromBuffer(const char* buffer, size_t size, bool bR
     return node;
 }
 
-
-void GetMD5(const char* pSrcBuffer, int nSrcSize, char signatureMD5[16])
-{
-    MD5Context md5c;
-    MD5Init(&md5c);
-    MD5Update(&md5c, (unsigned char*)pSrcBuffer, nSrcSize);
-    MD5Final((unsigned char*)signatureMD5, &md5c);
-}
-
 //////////////////////////////////////////////////////////////////////////
 class CXmlSerializer final : public IXmlSerializer
 {

--- a/Code/Legacy/CrySystem/XML/XmlUtils.cpp
+++ b/Code/Legacy/CrySystem/XML/XmlUtils.cpp
@@ -18,8 +18,6 @@
 
 #include "XMLBinaryReader.h"
 
-#include <md5.h>
-
 //////////////////////////////////////////////////////////////////////////
 #ifdef CRY_COLLECT_XML_NODE_STATS
 SXmlNodeStats* g_pCXmlNode_Stats = 0;

--- a/Gems/Atom/RHI/Code/CMakeLists.txt
+++ b/Gems/Atom/RHI/Code/CMakeLists.txt
@@ -111,7 +111,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                     AZ::AzToolsFramework
                     AZ::AtomCore
                     Gem::Atom_RHI.Public
-                    3rdParty::md5
         )
     endif()
 endif()

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Edit/Utils.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Edit/Utils.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Math/Sha1.h>
 #include <AzCore/std/string/string.h>
 #include <Atom/RHI.Reflect/ShaderStages.h>
 #include <Atom/RHI.Edit/ShaderPlatformInterface.h>
@@ -42,8 +43,8 @@ namespace AZ
             AZStd::vector<Entry> m_entries;
         };
 
-        static constexpr int Md5NumBytes = 16;
-        typedef unsigned char ArrayOfCharForMd5[Md5NumBytes];
+        static constexpr int Sha1NumBytes = sizeof(AZ::Sha1::DigestType);
+        typedef unsigned char ArrayOfCharForSha1[Sha1NumBytes];
 
         struct PrependArguments
         {
@@ -52,7 +53,7 @@ namespace AZ
             const char* m_addSuffixToFileName = nullptr; //!< optional
             const char* m_destinationFolder = nullptr;  //!< optional. if not set, will just use sourceFile's folder
             AZStd::string* m_destinationStringOpt = nullptr;  //!< when not null, PrependFile() will dump the result in that string rather than on disk.
-            ArrayOfCharForMd5* m_digest = nullptr; //! optionally run a hash
+            ArrayOfCharForSha1* m_digest = nullptr; //! optionally run a hash
         };
 
         //! Prepends prependFile to sourceFile and saves the result in a new file whose path is then returned.

--- a/Gems/Atom/RHI/Code/Source/RHI.Edit/Utils.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Edit/Utils.cpp
@@ -19,6 +19,7 @@
 #include <AzCore/IO/SystemFile.h>
 #include <AzCore/std/optional.h>
 #include <AzCore/std/string/regex.h>
+#include <AzCore/Math/Sha1.h>
 #include <AzCore/Platform.h>
 #include <AzCore/std/time.h>
 
@@ -220,11 +221,11 @@ namespace AZ
 
             if (arguments.m_digest)  // if the function's caller requested to compute a digest, let's hash the content and store it in the digest array.
             {            // this is useful for lld/pdb file naming (shader debug symbols) because it's the automatically recognized scheme by PIX and alike.
-                MD5Context md5;
-                MD5Init(&md5);
-                MD5Update(&md5, reinterpret_cast<unsigned char*>(prependFileLoadResult.GetValue().data()), aznumeric_cast<unsigned>(prependFileLoadResult.GetValue().size()));
-                MD5Update(&md5, reinterpret_cast<unsigned char*>(sourceFileLoadResult.GetValue().data()), aznumeric_cast<unsigned>(sourceFileLoadResult.GetValue().size()));
-                MD5Final(*arguments.m_digest, &md5);
+                
+                AZ::Sha1 hasher;
+                hasher.ProcessBytes(reinterpret_cast<AZStd::byte*>(prependFileLoadResult.GetValue().data()), aznumeric_cast<unsigned>(prependFileLoadResult.GetValue().size()));
+                hasher.ProcessBytes(reinterpret_cast<AZStd::byte*>(sourceFileLoadResult.GetValue().data()), aznumeric_cast<unsigned>(sourceFileLoadResult.GetValue().size()));
+                hasher.GetDigest((reinterpret_cast<AZ::Sha1::DigestType>(*arguments.m_digest)));
             }
 
             return combinedFile;

--- a/Gems/Atom/RHI/Code/Source/RHI.Edit/Utils.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Edit/Utils.cpp
@@ -25,8 +25,6 @@
 
 #include <AzFramework/StringFunc/StringFunc.h>
 
-#include <md5.h>
-
 namespace AZ
 {
     namespace RHI

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
@@ -264,9 +264,9 @@ namespace AZ
             if (graphicsDevMode || shaderBuildArguments.m_generateDebugInfo)
             {
                 // prepare .pdb filename:
-                AZStd::string md5hex = RHI::ByteToHexString(sha1);
+                AZStd::string sha1hex = RHI::ByteToHexString(sha1);
                 AZStd::string symbolDatabaseFilePath = dxcInputFile.c_str();  // mutate from source
-                AZStd::string pdbFileName = md5hex + "-" + profileIt->second;   // concatenate the shader profile to disambiguate vs/ps...
+                AZStd::string pdbFileName = sha1hex + "-" + profileIt->second; // concatenate the shader profile to disambiguate vs/ps...
                 AzFramework::StringFunc::Path::ReplaceFullName(symbolDatabaseFilePath, pdbFileName.c_str(), "pdb");
                 // it is possible that another activated platform/profile, already exported that file. (since it's hashed on the source file)
                 // dxc returns an error in such case. we get less surprising effets by just not mentionning an -Fd argument

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
@@ -249,12 +249,12 @@ namespace AZ
                 RHI::ShaderBuildArguments::AppendArguments(dxcArguments, { "-Zi", "-Zss" });
             }
 
-            unsigned char md5[RHI::Md5NumBytes];
+            unsigned char sha1[RHI::Sha1NumBytes];
             RHI::PrependArguments args;
             args.m_sourceFile = shaderSourceFile.c_str();
             args.m_prependFile = PlatformShaderHeader;
             args.m_destinationFolder = tempFolder.c_str();
-            args.m_digest = &md5;
+            args.m_digest = &sha1;
 
             const auto dxcInputFile = RHI::PrependFile(args);  // Prepend PAL header & obtain hash
             // -Fd "Write debug information to the given file, or automatically named file in directory when ending in '\\'"
@@ -264,7 +264,7 @@ namespace AZ
             if (graphicsDevMode || shaderBuildArguments.m_generateDebugInfo)
             {
                 // prepare .pdb filename:
-                AZStd::string md5hex = RHI::ByteToHexString(md5);
+                AZStd::string md5hex = RHI::ByteToHexString(sha1);
                 AZStd::string symbolDatabaseFilePath = dxcInputFile.c_str();  // mutate from source
                 AZStd::string pdbFileName = md5hex + "-" + profileIt->second;   // concatenate the shader profile to disambiguate vs/ps...
                 AzFramework::StringFunc::Path::ReplaceFullName(symbolDatabaseFilePath, pdbFileName.c_str(), "pdb");

--- a/cmake/3rdParty/Platform/Android/BuiltInPackages_android.cmake
+++ b/cmake/3rdParty/Platform/Android/BuiltInPackages_android.cmake
@@ -9,7 +9,6 @@
 # this file allows you to specify all 3p packages (provided by O3DE or the operating system) for Android.
 
 # shared by other platforms:
-ly_associate_package(PACKAGE_NAME md5-2.0-multiplatform              TARGETS md5       PACKAGE_HASH 29e52ad22c78051551f78a40c2709594f0378762ae03b417adca3f4b700affdf)
 ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform TARGETS RapidJSON PACKAGE_HASH 2f5e26ecf86c3b7a262753e7da69ac59928e78e9534361f3d00c1ad5879e4023)
 ly_associate_package(PACKAGE_NAME RapidXML-1.13-rev1-multiplatform   TARGETS RapidXML  PACKAGE_HASH 4b7b5651e47cfd019b6b295cc17bb147b65e53073eaab4a0c0d20a37ab74a246)
 ly_associate_package(PACKAGE_NAME cityhash-1.1-multiplatform         TARGETS cityhash  PACKAGE_HASH 0ace9e6f0b2438c5837510032d2d4109125845c0efd7d807f4561ec905512dd2)

--- a/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux.cmake
+++ b/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux.cmake
@@ -9,7 +9,6 @@
 # this file allows you to specify all 3p packages (provided by O3DE or the operating system) for Linux.
 
 # shared by other platforms:
-# ly_associate_package(PACKAGE_NAME md5-2.0-multiplatform                             TARGETS md5                         PACKAGE_HASH 29e52ad22c78051551f78a40c2709594f0378762ae03b417adca3f4b700affdf)
 ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform                TARGETS RapidJSON                   PACKAGE_HASH 2f5e26ecf86c3b7a262753e7da69ac59928e78e9534361f3d00c1ad5879e4023)
 ly_associate_package(PACKAGE_NAME RapidXML-1.13-rev1-multiplatform                  TARGETS RapidXML                    PACKAGE_HASH 4b7b5651e47cfd019b6b295cc17bb147b65e53073eaab4a0c0d20a37ab74a246)
 ly_associate_package(PACKAGE_NAME pybind11-2.10.0-rev1-multiplatform                TARGETS pybind11                    PACKAGE_HASH 6690acc531d4b8cd453c19b448e2fb8066b2362cbdd2af1ad5df6e0019e6c6c4)

--- a/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux.cmake
+++ b/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux.cmake
@@ -9,7 +9,7 @@
 # this file allows you to specify all 3p packages (provided by O3DE or the operating system) for Linux.
 
 # shared by other platforms:
-ly_associate_package(PACKAGE_NAME md5-2.0-multiplatform                             TARGETS md5                         PACKAGE_HASH 29e52ad22c78051551f78a40c2709594f0378762ae03b417adca3f4b700affdf)
+# ly_associate_package(PACKAGE_NAME md5-2.0-multiplatform                             TARGETS md5                         PACKAGE_HASH 29e52ad22c78051551f78a40c2709594f0378762ae03b417adca3f4b700affdf)
 ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform                TARGETS RapidJSON                   PACKAGE_HASH 2f5e26ecf86c3b7a262753e7da69ac59928e78e9534361f3d00c1ad5879e4023)
 ly_associate_package(PACKAGE_NAME RapidXML-1.13-rev1-multiplatform                  TARGETS RapidXML                    PACKAGE_HASH 4b7b5651e47cfd019b6b295cc17bb147b65e53073eaab4a0c0d20a37ab74a246)
 ly_associate_package(PACKAGE_NAME pybind11-2.10.0-rev1-multiplatform                TARGETS pybind11                    PACKAGE_HASH 6690acc531d4b8cd453c19b448e2fb8066b2362cbdd2af1ad5df6e0019e6c6c4)

--- a/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac.cmake
+++ b/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac.cmake
@@ -9,7 +9,6 @@
 # this file allows you to specify all 3p packages (provided by O3DE or the operating system) for Mac.
 
 # shared by other platforms:
-ly_associate_package(PACKAGE_NAME md5-2.0-multiplatform                             TARGETS md5                         PACKAGE_HASH 29e52ad22c78051551f78a40c2709594f0378762ae03b417adca3f4b700affdf)
 ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform                TARGETS RapidJSON                   PACKAGE_HASH 2f5e26ecf86c3b7a262753e7da69ac59928e78e9534361f3d00c1ad5879e4023)
 ly_associate_package(PACKAGE_NAME RapidXML-1.13-rev1-multiplatform                  TARGETS RapidXML                    PACKAGE_HASH 4b7b5651e47cfd019b6b295cc17bb147b65e53073eaab4a0c0d20a37ab74a246)
 ly_associate_package(PACKAGE_NAME pybind11-2.10.0-rev1-multiplatform                TARGETS pybind11                    PACKAGE_HASH 6690acc531d4b8cd453c19b448e2fb8066b2362cbdd2af1ad5df6e0019e6c6c4)

--- a/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
+++ b/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
@@ -9,7 +9,6 @@
 # this file allows you to specify all 3p packages (provided by O3DE or the operating system) for Windows.
 
 # shared by other platforms:
-ly_associate_package(PACKAGE_NAME md5-2.0-multiplatform                                 TARGETS md5                         PACKAGE_HASH 29e52ad22c78051551f78a40c2709594f0378762ae03b417adca3f4b700affdf)
 ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform                    TARGETS RapidJSON                   PACKAGE_HASH 2f5e26ecf86c3b7a262753e7da69ac59928e78e9534361f3d00c1ad5879e4023)
 ly_associate_package(PACKAGE_NAME RapidXML-1.13-rev1-multiplatform                      TARGETS RapidXML                    PACKAGE_HASH 4b7b5651e47cfd019b6b295cc17bb147b65e53073eaab4a0c0d20a37ab74a246)
 ly_associate_package(PACKAGE_NAME pybind11-2.10.0-rev1-multiplatform                    TARGETS pybind11                    PACKAGE_HASH 6690acc531d4b8cd453c19b448e2fb8066b2362cbdd2af1ad5df6e0019e6c6c4)

--- a/cmake/3rdParty/Platform/iOS/BuiltInPackages_ios.cmake
+++ b/cmake/3rdParty/Platform/iOS/BuiltInPackages_ios.cmake
@@ -9,7 +9,6 @@
 # this file allows you to specify all 3p packages (provided by O3DE or the operating system) for iOS.
 
 # shared by other platforms:
-ly_associate_package(PACKAGE_NAME md5-2.0-multiplatform              TARGETS md5        PACKAGE_HASH 29e52ad22c78051551f78a40c2709594f0378762ae03b417adca3f4b700affdf)
 ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform TARGETS RapidJSON  PACKAGE_HASH 2f5e26ecf86c3b7a262753e7da69ac59928e78e9534361f3d00c1ad5879e4023)
 ly_associate_package(PACKAGE_NAME RapidXML-1.13-rev1-multiplatform   TARGETS RapidXML   PACKAGE_HASH 4b7b5651e47cfd019b6b295cc17bb147b65e53073eaab4a0c0d20a37ab74a246)
 ly_associate_package(PACKAGE_NAME cityhash-1.1-multiplatform         TARGETS cityhash   PACKAGE_HASH 0ace9e6f0b2438c5837510032d2d4109125845c0efd7d807f4561ec905512dd2)


### PR DESCRIPTION
## What does this PR do?
Removes dependency on the MD5 3rd Party package and replaces the only usage of MD5 to use SHA1 as a digest algorithm instead.

## How was this PR tested?
Built and ran AP on Linux and WIndows
Ran internal jenkins validation jobs

