### PR TITLE
Action Manager | Restore Lua Editor as an item in the Tools Menu (+ minor refactoring)

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.cpp
@@ -420,6 +420,20 @@ namespace AzToolsFramework
         return AZ::Success();
     }
 
+    int ActionManager::GenerateActionAlphabeticalSortKey(const AZStd::string& actionIdentifier)
+    {
+        auto actionIterator = m_actions.find(actionIdentifier);
+        if (actionIterator == m_actions.end())
+        {
+            return AZStd::numeric_limits<int>::max();
+        }
+
+        const AZStd::string& actionName = actionIterator->second->GetName();
+
+        // Use the ASCII code of the first character as an integer sort key to sort alphabetically.
+        return static_cast<int>(actionName[0]);
+    }
+
     ActionManagerBooleanResult ActionManager::IsActionEnabled(const AZStd::string& actionIdentifier) const
     {
         auto actionIterator = m_actions.find(actionIdentifier);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.h
@@ -85,6 +85,7 @@ namespace AzToolsFramework
         ActionManagerOperationResult SetActionCategory(const AZStd::string& actionIdentifier, const AZStd::string& category) override;
         ActionManagerGetterResult GetActionIconPath(const AZStd::string& actionIdentifier) override;
         ActionManagerOperationResult SetActionIconPath(const AZStd::string& actionIdentifier, const AZStd::string& iconPath) override;
+        int GenerateActionAlphabeticalSortKey(const AZStd::string& actionIdentifier) override;
         ActionManagerBooleanResult IsActionEnabled(const AZStd::string& actionIdentifier) const override;
         ActionManagerOperationResult TriggerAction(const AZStd::string& actionIdentifier) override;
         ActionManagerOperationResult InstallEnabledStateCallback(const AZStd::string& actionIdentifier, AZStd::function<bool()> enabledStateCallback) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManagerInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManagerInterface.h
@@ -175,6 +175,11 @@ namespace AzToolsFramework
         //! @return A successful outcome object, or a string with a message detailing the error in case of failure.
         virtual ActionManagerOperationResult SetActionIconPath(const AZStd::string& actionIdentifier, const AZStd::string& iconPath) = 0;
 
+        //! Generates a sort key from the action's name that can be used to sort alphabetically.
+        //! @param actionIdentifier The action identifier to query.
+        //! @return A sortKey if the action was found, or the max integer otherwise.
+        virtual int GenerateActionAlphabeticalSortKey(const AZStd::string& actionIdentifier) = 0;
+
         //! Returns the enabled state for the action.
         //! @param actionIdentifier The action identifier to query.
         //! @return A successful outcome object with the enabled state, or a string with a message detailing the error in case of failure.

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -27,6 +27,8 @@
 #include <AzToolsFramework/ActionManager/Menu/MenuManagerInterface.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <AzToolsFramework/API/ViewPaneOptions.h>
+#include <AzToolsFramework/Editor/ActionManagerIdentifiers/EditorContextIdentifiers.h>
+#include <AzToolsFramework/Editor/ActionManagerIdentifiers/EditorMenuIdentifiers.h>
 #include <Editor/LyViewPaneNames.h>
 #include <Material/EditorMaterialComponentInspector.h>
 #include <Material/EditorMaterialSystemComponent.h>
@@ -44,6 +46,9 @@ AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option")
 #include <QPixmap>
 #include <QProcessEnvironment>
 AZ_POP_DISABLE_WARNING
+
+constexpr AZStd::string_view MaterialCanvasActionIdentifier = "o3de.action.tools.material_canvas";
+constexpr AZStd::string_view MaterialEditorActionIdentifier = "o3de.action.tools.material_editor";
 
 void InitMaterialEditorResources()
 {
@@ -379,53 +384,85 @@ namespace AZ
             return AzToolsFramework::AssetBrowser::SourceFileDetails();
         }
 
-        void EditorMaterialSystemComponent::OnMenuBindingHook()
+        void EditorMaterialSystemComponent::OnActionRegistrationHook()
         {
-            auto menuManagerInterface = AZ::Interface<AzToolsFramework::MenuManagerInterface>::Get();
-            AZ_Assert(menuManagerInterface, "EditorMaterialSystemComponent - could not get MenuManagerInterface");
-
             auto actionManagerInterface = AZ::Interface<AzToolsFramework::ActionManagerInterface>::Get();
-            AZ_Assert(menuManagerInterface, "EditorMaterialSystemComponent - could not get ActionManagerInterface");
+            AZ_Assert(actionManagerInterface, "EditorMaterialSystemComponent - could not get ActionManagerInterface");
 
             auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get();
             AZ_Assert(hotKeyManagerInterface, "EditorMaterialSystemComponent - could not get HotKeyManagerInterface");
 
-            constexpr AZStd::string_view ActionContext = "o3de.context.editor.mainwindow";
-            constexpr AZStd::string_view MaterialEditorAction = "o3de.tools.material_editor";
-            constexpr AZStd::string_view ToolsMenuIdentifier = "o3de.menu.editor.tools";
+            {
+                AzToolsFramework::ActionProperties actionProperties;
+                actionProperties.m_name = "Material Editor";
+                actionProperties.m_iconPath = ":/Menu/material_editor.svg";
 
-            AzToolsFramework::ActionProperties actionProperties;
-            actionProperties.m_name = "Material Editor";
-            actionProperties.m_iconPath = ":/Menu/material_editor.svg";
-            auto outcome = actionManagerInterface->RegisterAction(ActionContext, MaterialEditorAction, actionProperties, [this]()
-                {
-                    OpenMaterialEditor("");
-                });
-            AZ_Assert(outcome.IsSuccess(), "Failed to RegisterAction %s", MaterialEditorAction.data());
+                auto outcome = actionManagerInterface->RegisterAction(
+                    EditorIdentifiers::MainWindowActionContextIdentifier,
+                    MaterialEditorActionIdentifier,
+                    actionProperties,
+                    [this]()
+                    {
+                        OpenMaterialEditor("");
+                    }
+                );
+                AZ_Assert(outcome.IsSuccess(), "Failed to RegisterAction %s", MaterialEditorActionIdentifier.data());
 
-            outcome = menuManagerInterface->AddActionToMenu(ToolsMenuIdentifier, MaterialEditorAction, 100);
-            AZ_Assert(outcome.IsSuccess(), "Failed to AddAction %s to Menu %s", MaterialEditorAction.data(), ToolsMenuIdentifier.data());
+                hotKeyManagerInterface->SetActionHotKey(MaterialEditorActionIdentifier, "M");
+            }
 
-            outcome = hotKeyManagerInterface->SetActionHotKey(MaterialEditorAction, "M");
-            AZ_Assert(outcome.IsSuccess(), "Failed to ActionHotKey for %s", MaterialEditorAction.data());
+            {
+                AzToolsFramework::ActionProperties actionProperties;
+                actionProperties.m_name = "Material Canvas (Preview)";
+                actionProperties.m_iconPath = ":/Menu/material_canvas.svg";
 
+                auto outcome = actionManagerInterface->RegisterAction(
+                    EditorIdentifiers::MainWindowActionContextIdentifier,
+                    MaterialCanvasActionIdentifier,
+                    actionProperties,
+                    [this]()
+                    {
+                        OpenMaterialCanvas("");
+                    });
+                AZ_Assert(outcome.IsSuccess(), "Failed to RegisterAction %s", MaterialCanvasActionIdentifier.data());
 
-            constexpr AZStd::string_view MaterialCanvasAction = "o3de.tools.material_canvas";
+                outcome = hotKeyManagerInterface->SetActionHotKey(MaterialCanvasActionIdentifier, "Ctrl+Shift+M");
+                AZ_Assert(outcome.IsSuccess(), "Failed to ActionHotKey for %s", MaterialCanvasActionIdentifier.data());
+            }
 
-            actionProperties.m_name = "Material Canvas (Preview)";
-            actionProperties.m_iconPath = ":/Menu/material_canvas.svg";
-            outcome = actionManagerInterface->RegisterAction(ActionContext, MaterialCanvasAction, actionProperties, [this]()
-                {
-                    OpenMaterialCanvas("");
-                });
-            AZ_Assert(outcome.IsSuccess(), "Failed to RegisterAction %s", MaterialCanvasAction.data());
+        }
 
-            outcome = menuManagerInterface->AddActionToMenu(ToolsMenuIdentifier, MaterialCanvasAction, 101);
-            AZ_Assert(outcome.IsSuccess(), "Failed to AddAction %s to Menu %s", MaterialCanvasAction.data(), ToolsMenuIdentifier.data());
+        void EditorMaterialSystemComponent::OnMenuBindingHook()
+        {
+            auto actionManagerInterface = AZ::Interface<AzToolsFramework::ActionManagerInterface>::Get();
+            AZ_Assert(actionManagerInterface, "EditorMaterialSystemComponent - could not get ActionManagerInterface");
 
-            outcome = hotKeyManagerInterface->SetActionHotKey(MaterialCanvasAction, "Ctrl+Shift+M");
-            AZ_Assert(outcome.IsSuccess(), "Failed to ActionHotKey for %s", MaterialCanvasAction.data());
+            auto menuManagerInterface = AZ::Interface<AzToolsFramework::MenuManagerInterface>::Get();
+            AZ_Assert(menuManagerInterface, "EditorMaterialSystemComponent - could not get MenuManagerInterface");
 
+            {
+                auto outcome = menuManagerInterface->AddActionToMenu(
+                    EditorIdentifiers::ToolsMenuIdentifier,
+                    MaterialEditorActionIdentifier,
+                    actionManagerInterface->GenerateActionAlphabeticalSortKey(MaterialEditorActionIdentifier));
+                AZ_Assert(
+                    outcome.IsSuccess(),
+                    "Failed to AddAction %s to Menu %s",
+                    MaterialEditorActionIdentifier.data(),
+                    EditorIdentifiers::ToolsMenuIdentifier.data());
+            }
+
+            {
+                auto outcome = menuManagerInterface->AddActionToMenu(
+                    EditorIdentifiers::ToolsMenuIdentifier,
+                    MaterialCanvasActionIdentifier,
+                    actionManagerInterface->GenerateActionAlphabeticalSortKey(MaterialCanvasActionIdentifier));
+                AZ_Assert(
+                    outcome.IsSuccess(),
+                    "Failed to AddAction %s to Menu %s",
+                    MaterialCanvasActionIdentifier.data(),
+                    EditorIdentifiers::ToolsMenuIdentifier.data());
+            }
         }
 
         void EditorMaterialSystemComponent::PurgePreviews()

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
@@ -99,6 +99,7 @@ namespace AZ
             void AfterEntitySelectionChanged(const AzToolsFramework::EntityIdList& newlySelectedEntities, const AzToolsFramework::EntityIdList&) override;
 
             // AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler...
+            void OnActionRegistrationHook() override;
             void OnMenuBindingHook() override;
 
             void PurgePreviews();


### PR DESCRIPTION
## What does this PR do?

Restore the `Lua Editor` menu item in the Tools menu.
Took the chance to apply some minor refactorings:
- Split action and menu binding definitions for the Material Editor into separate hooks;
- Added an API call to generate a sort key for an action given its identifier, which can be used to sort alphabetically.

I preferred introducing an API call for this purpose as it makes the call opaque, giving us the chance to change it down the line if we need more granularity, and it makes it easier to expose to Python or other purposes.

## How was this PR tested?

Tested locally, menu item now appears in the menu.

Before
![image](https://user-images.githubusercontent.com/82231674/221910837-5fece75b-863a-42ea-87f3-33f4ed778995.png)

After
![image](https://user-images.githubusercontent.com/82231674/221904354-054a6e5b-c870-4cf1-86b4-42cf221c99c4.png)

