### PR TITLE
Fixed AWS editor system components to not register the base components twice

### DIFF
--- a/Gems/AWSClientAuth/Code/Source/AWSClientAuthEditorSystemComponent.cpp
+++ b/Gems/AWSClientAuth/Code/Source/AWSClientAuthEditorSystemComponent.cpp
@@ -16,17 +16,15 @@ namespace AWSClientAuth
 {
     void AWSClientAuthEditorSystemComponent::Reflect(AZ::ReflectContext* context)
     {
-        AWSClientAuthSystemComponent::Reflect(context);
-
         AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context);
         if (serialize)
         {
-            serialize->Class<AWSClientAuthEditorSystemComponent, AWSClientAuthSystemComponent>()
+            serialize->Class<AWSClientAuthEditorSystemComponent, AZ::Component>()
                 ;
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
-                ec->Class<AWSClientAuthSystemComponent>("AWSClientAuthEditor", "Provides Client Authentication and Authorization implementations")
+                ec->Class<AWSClientAuthEditorSystemComponent>("AWSClientAuthEditor", "Provides Client Authentication and Authorization implementations")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
             }
@@ -52,22 +50,13 @@ namespace AWSClientAuth
     {
     }
 
-    void AWSClientAuthEditorSystemComponent::Init()
-    {
-        AWSClientAuthSystemComponent::Init();
-    }
-
     void AWSClientAuthEditorSystemComponent::Activate()
     {
-        AWSClientAuthSystemComponent::Activate();
-
         AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler::BusConnect();
     }
 
     void AWSClientAuthEditorSystemComponent::Deactivate()
     {
-        AWSClientAuthSystemComponent::Deactivate();
-
         AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler::BusDisconnect();
     }
 

--- a/Gems/AWSClientAuth/Code/Source/AWSClientAuthEditorSystemComponent.h
+++ b/Gems/AWSClientAuth/Code/Source/AWSClientAuthEditorSystemComponent.h
@@ -23,7 +23,7 @@ namespace AWSClientAuth
 {
     //! Gem System Component. Responsible for instantiating and managing Authentication and Authorization Controller
     class AWSClientAuthEditorSystemComponent
-        : public AWSClientAuthSystemComponent
+        : public AZ::Component
         , private AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler
     {
     public:
@@ -40,7 +40,6 @@ namespace AWSClientAuth
 
     protected:
         // AZ::Component interface implementation
-        void Init() override;
         void Activate() override;
         void Deactivate() override;
 

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientEditorSystemComponent.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientEditorSystemComponent.cpp
@@ -15,17 +15,15 @@
 namespace AWSGameLift
 {
     AWSGameLiftClientEditorSystemComponent::AWSGameLiftClientEditorSystemComponent()
-        : AWSGameLiftClientSystemComponent()
+        : AZ::Component()
     {
     }
 
     void AWSGameLiftClientEditorSystemComponent::Reflect(AZ::ReflectContext* context)
     {
-        AWSGameLiftClientSystemComponent::Reflect(context);
-
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<AWSGameLiftClientEditorSystemComponent, AWSGameLiftClientSystemComponent>()
+            serialize->Class<AWSGameLiftClientEditorSystemComponent, AZ::Component>()
                 ->Version(0)
                 ;
 
@@ -61,16 +59,12 @@ namespace AWSGameLift
 
     void AWSGameLiftClientEditorSystemComponent::Activate()
     {
-        AWSGameLiftClientSystemComponent::Activate();
-
         AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler::BusConnect();
     }
 
     void AWSGameLiftClientEditorSystemComponent::Deactivate()
     {
         AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler::BusDisconnect();
-
-        AWSGameLiftClientSystemComponent::Deactivate();
     }
 
     void AWSGameLiftClientEditorSystemComponent::OnMenuBindingHook()

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientEditorSystemComponent.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientEditorSystemComponent.h
@@ -16,11 +16,11 @@ namespace AWSGameLift
 {
     //! Gem client system component. Responsible for creating the gamelift client manager.
     class AWSGameLiftClientEditorSystemComponent
-        : public AWSGameLiftClientSystemComponent
+        : public AZ::Component
         , private AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler
     {
     public:
-        AZ_COMPONENT(AWSGameLiftClientEditorSystemComponent, "{AE1388B1-542A-4B49-8B4F-48988D78AD67}", AWSGameLiftClientSystemComponent);
+        AZ_COMPONENT(AWSGameLiftClientEditorSystemComponent, "{AE1388B1-542A-4B49-8B4F-48988D78AD67}");
 
         AWSGameLiftClientEditorSystemComponent();
 

--- a/Gems/AWSMetrics/Code/Source/AWSMetricsEditorSystemComponent.cpp
+++ b/Gems/AWSMetrics/Code/Source/AWSMetricsEditorSystemComponent.cpp
@@ -26,11 +26,9 @@ namespace AWSMetrics
 
     void AWSMetricsEditorSystemComponent::Reflect(AZ::ReflectContext* context)
     {
-        AWSMetricsSystemComponent::Reflect(context);
-
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<AWSMetricsEditorSystemComponent, AWSMetricsSystemComponent>()
+            serialize->Class<AWSMetricsEditorSystemComponent, AZ::Component>()
                 ->Version(0)
                 ;
 
@@ -65,8 +63,6 @@ namespace AWSMetrics
 
     void AWSMetricsEditorSystemComponent::Activate()
     {
-        AWSMetricsSystemComponent::Activate();
-
         AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler::BusConnect();
 
     }
@@ -162,8 +158,6 @@ namespace AWSMetrics
 
     void AWSMetricsEditorSystemComponent::Deactivate()
     {
-        AWSMetricsSystemComponent::Activate();
-
         AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler::BusDisconnect();
     }
 

--- a/Gems/AWSMetrics/Code/Source/AWSMetricsEditorSystemComponent.h
+++ b/Gems/AWSMetrics/Code/Source/AWSMetricsEditorSystemComponent.h
@@ -23,11 +23,11 @@ namespace AWSMetrics
 
     //! Gem System Component. Responsible for instantiating and managing the Metrics Manager
     class AWSMetricsEditorSystemComponent
-        : public AWSMetricsSystemComponent
+        : public AZ::Component
         , private AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler
     {
     public:
-        AZ_COMPONENT(AWSMetricsEditorSystemComponent, "{6144EDF6-12A6-4C3B-ADF1-7AA3C421BA68}", AWSMetricsSystemComponent);
+        AZ_COMPONENT(AWSMetricsEditorSystemComponent, "{6144EDF6-12A6-4C3B-ADF1-7AA3C421BA68}");
 
         static void Reflect(AZ::ReflectContext* context);
 


### PR DESCRIPTION
## What does this PR do?

Fixed issue with the new AWS gem editor system components deriving from their base editor system components, which was causing asserts due to the base system components getting registered twice, and activated twice (that was causing internal buses from being connected to twice).

## How was this PR tested?

Built/ran all AWS unit tests and verified they pass. Built/ran the Editor and verified there are no asserts and the AWS gem menus still appear/work as expected.