### PR TITLE
Change Physics Asset serialization in Editor Mesh Collider to match the same property paths than previously.

### DIFF
--- a/AutomatedTesting/Editor/Scripts/scene_mesh_to_prefab.py
+++ b/AutomatedTesting/Editor/Scripts/scene_mesh_to_prefab.py
@@ -169,9 +169,11 @@ def update_manifest(scene):
                                       entity_id, "{20382794-0E74-4860-9C35-A19F22DC80D4} EditorMeshColliderComponent")
 
             json_update = json.dumps({
-                "PhysicsAssetShapeConfiguration": {
-                    "Asset": {
-                        "assetHint": os.path.join(source_relative_path, source_filename_only + "_triangle.pxmesh")
+                "ShapeConfiguration": {
+                    "PhysicsAsset": {
+                        "Asset": {
+                            "assetHint": os.path.join(source_relative_path, source_filename_only + "_triangle.pxmesh")
+                        }
                     }
                 }
             })

--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/editor_component/editor_physx_mesh_collider.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/editor_component/editor_physx_mesh_collider.py
@@ -35,10 +35,10 @@ class EditorPhysxMeshCollider:
             and visibility.
         """
         class PhysicsAsset:
-            BASE = 'Physics Asset'
-            PHYSX_MESH = 'Physics Asset|PhysX Mesh'
-            ASSET_SCALE = 'Physics Asset|Configuration|Asset Scale'
-            PHYSICS_MATERIALS_FROM_ASSET = 'Physics Asset|Configuration|Physics materials from asset'
+            BASE = 'Shape Configuration|Asset'
+            PHYSX_MESH = 'Shape Configuration|Asset|PhysX Mesh'
+            ASSET_SCALE = 'Shape Configuration|Asset|Configuration|Asset Scale'
+            PHYSICS_MATERIALS_FROM_ASSET = 'Shape Configuration|Asset|Configuration|Physics materials from asset'
 
         COLLISION_LAYER = 'Collider Configuration|Collision Layer'
         COLLIDES_WITH = 'Collider Configuration|Collides With'

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_MultipleSurfaceSlots.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_MultipleSurfaceSlots.py
@@ -78,8 +78,8 @@ def Collider_MultipleSurfaceSlots():
 
     # 4) Assign the fbx file in PhysX Mesh and Mesh component
     px_asset = Asset.find_asset_by_path(PHYSX_MESH)
-    collider_component.set_component_property_value("Physics Asset|PhysX Mesh", px_asset.id)
-    px_asset.id = collider_component.get_component_property_value("Physics Asset|PhysX Mesh")
+    collider_component.set_component_property_value("Shape Configuration|Asset|PhysX Mesh", px_asset.id)
+    px_asset.id = collider_component.get_component_property_value("Shape Configuration|Asset|PhysX Mesh")
     Report.result(Tests.assign_px_mesh_asset, px_asset.get_path().lower() == PHYSX_MESH.replace(os.sep, "/").lower())
 
     model_asset = Asset.find_asset_by_path(STATIC_MESH)

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_PxMeshAutoAssignedWhenAddingRenderMeshComponent.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_PxMeshAutoAssignedWhenAddingRenderMeshComponent.py
@@ -85,7 +85,7 @@ def Collider_PxMeshAutoAssignedWhenAddingRenderMeshComponent():
     Report.result(Tests.physx_collider_added, test_entity.has_component("PhysX Mesh Collider"))
 
     # 6) The physics asset in PhysX Mesh Collider component is auto-assigned.
-    asset_id = test_component.get_component_property_value("Physics Asset|PhysX Mesh")
+    asset_id = test_component.get_component_property_value("Shape Configuration|Asset|PhysX Mesh")
     test_asset = Asset(asset_id)
     Report.result(Tests.automatic_shape_change, test_asset.get_path().lower() == PHYSX_MESH.replace(os.sep, "/").lower())
 

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_PxMeshAutoAssignedWhenModifyingRenderMeshComponent.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_PxMeshAutoAssignedWhenModifyingRenderMeshComponent.py
@@ -60,7 +60,7 @@ def Collider_PxMeshAutoAssignedWhenModifyingRenderMeshComponent():
 
     MESH_ASSET_PATH = os.path.join("Objects", "SphereBot", "r0-b_body.azmodel")
     MESH_PROPERTY_PATH = "Controller|Configuration|Model Asset"
-    TESTED_PROPERTY_PATH = "Physics Asset|PhysX Mesh"
+    TESTED_PROPERTY_PATH = "Shape Configuration|Asset|PhysX Mesh"
 
     # 1) Load the empty level
     hydra.open_base_level()

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_PxMeshConvexMeshCollides.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_PxMeshConvexMeshCollides.py
@@ -92,8 +92,8 @@ def Collider_PxMeshConvexMeshCollides():
 
     # 4) Select fbx convex mesh in PhysX Mesh Collider component.
     mesh_asset = Asset.find_asset_by_path(MESH_ASSET_PATH)
-    collider_component.set_component_property_value("Physics Asset|PhysX Mesh", mesh_asset.id)
-    mesh_asset.id = collider_component.get_component_property_value("Physics Asset|PhysX Mesh")
+    collider_component.set_component_property_value("Shape Configuration|Asset|PhysX Mesh", mesh_asset.id)
+    mesh_asset.id = collider_component.get_component_property_value("Shape Configuration|Asset|PhysX Mesh")
     Report.result(Tests.assign_fbx_mesh, mesh_asset.get_path().lower() == MESH_ASSET_PATH.replace(os.sep, "/").lower())
 
     # 5) Create terrain entity with physx terrain

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_PxMeshNotAutoAssignedWhenNoPhysicsFbx.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_PxMeshNotAutoAssignedWhenNoPhysicsFbx.py
@@ -90,7 +90,7 @@ def Collider_PxMeshNotAutoAssignedWhenNoPhysicsFbx():
     Report.result(Tests.physx_collider_added, test_entity.has_component("PhysX Mesh Collider"))
 
     # 6) The physics asset in PhysX Mesh Collider component is not auto-assigned.
-    asset_id = test_component.get_component_property_value("Physics Asset|PhysX Mesh")
+    asset_id = test_component.get_component_property_value("Shape Configuration|Asset|PhysX Mesh")
     # Comparing asset_id with Null/Invalid asset azlmbr.asset.AssetId() to check that asset is not auto assigned
     Report.result(Tests.shape_not_assigned, asset_id == azasset.AssetId())
 

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/PhysXColliderSurfaceTagEmitter_E2E_Editor.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/PhysXColliderSurfaceTagEmitter_E2E_Editor.py
@@ -176,11 +176,11 @@ def PhysXColliderSurfaceTagEmitter_E2E_Editor():
     collider_entity.add_component("PhysX Mesh Collider")
     helper.wait_for_condition(lambda: editor.EditorComponentAPIBus(bus.Broadcast, 'IsComponentEnabled',
                                                                    collider_entity.components[1]), 5.0)
-    hydra.get_set_test(collider_entity, component_index=2, path="Physics Asset|PhysX Mesh", value=test_physx_mesh_asset_id)
+    hydra.get_set_test(collider_entity, component_index=2, path="Shape Configuration|Asset|PhysX Mesh", value=test_physx_mesh_asset_id)
 
     # Set the asset scale to match the test heights of the shapes tested
     asset_scale = math.Vector3(1.0, 1.0, 9.0)
-    collider_entity.get_set_test(2, "Physics Asset|Configuration|Asset Scale", asset_scale)
+    collider_entity.get_set_test(2, "Shape Configuration|Asset|Configuration|Asset Scale", asset_scale)
 
     # Test:  Generate a new surface on the collider.
     # There should be one instance at the very top of the collider mesh, and none on the baseline surface

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/large_worlds_utils/editor_dynveg_test_helper.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/large_worlds_utils/editor_dynveg_test_helper.py
@@ -53,8 +53,8 @@ def create_temp_physx_mesh_collider(physx_mesh_id, prefab_filename):
     assert root.has_component("PhysX Mesh Collider") and collider_component.is_enabled() and \
            static_rigid_body_component.is_enabled(), "Failed to add/activate PhysX Mesh Collider component"
     # Assign the specified PhysX Mesh asset to PhysX Mesh Collider
-    collider_component.set_component_property_value("Physics Asset|PhysX Mesh", physx_mesh_id)
-    assert collider_component.get_component_property_value("Physics Asset|PhysX Mesh") == physx_mesh_id, \
+    collider_component.set_component_property_value("Shape Configuration|Asset|PhysX Mesh", physx_mesh_id)
+    assert collider_component.get_component_property_value("Shape Configuration|Asset|PhysX Mesh") == physx_mesh_id, \
         "Failed to assign PhysX Mesh asset"
     # Create and return the temporary/in-memory prefab
     temp_prefab = Prefab.create_prefab([root], prefab_filename)

--- a/Gems/PhysX/Code/Editor/DebugDraw.cpp
+++ b/Gems/PhysX/Code/Editor/DebugDraw.cpp
@@ -220,6 +220,11 @@ namespace PhysX
             m_locallyEnabled = enable;
         }
 
+        bool Collider::IsDisplayFlagEnabled() const
+        {
+            return m_locallyEnabled;
+        }
+
         void Collider::BuildMeshes(const Physics::ShapeConfiguration& shapeConfig, AZ::u32 geomIndex) const
         {
             if (m_geometry.size() <= geomIndex)

--- a/Gems/PhysX/Code/Editor/DebugDraw.h
+++ b/Gems/PhysX/Code/Editor/DebugDraw.h
@@ -64,6 +64,7 @@ namespace PhysX
             void ClearCachedGeometry();
 
             void SetDisplayFlag(bool enable);
+            bool IsDisplayFlagEnabled() const;
 
             void BuildMeshes(const Physics::ShapeConfiguration& shapeConfig, AZ::u32 geomIndex) const;
 

--- a/Gems/PhysX/Code/Editor/Source/Components/Conversion/CollidersPrefabConversion.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Components/Conversion/CollidersPrefabConversion.cpp
@@ -103,13 +103,13 @@ namespace PhysX
             }
 
             EditorProxyAssetShapeConfig newProxyAssetShapeConfig;
-            newProxyAssetShapeConfig.m_configuration = proxyShapeConfig.m_legacyPhysicsAsset.m_configuration;
-            newProxyAssetShapeConfig.m_pxAsset = proxyShapeConfig.m_legacyPhysicsAsset.m_pxAsset;
+            newProxyAssetShapeConfig.m_physicsAsset.m_configuration = proxyShapeConfig.m_legacyPhysicsAsset.m_configuration;
+            newProxyAssetShapeConfig.m_physicsAsset.m_pxAsset = proxyShapeConfig.m_legacyPhysicsAsset.m_pxAsset;
             newProxyAssetShapeConfig.m_hasNonUniformScale = proxyShapeConfig.m_hasNonUniformScale;
             newProxyAssetShapeConfig.m_subdivisionLevel = proxyShapeConfig.m_subdivisionLevel;
 
             auto* editorMeshColliderComponent = entity.CreateComponent<EditorMeshColliderComponent>(
-                editorColliderComponent->GetColliderConfiguration(), newProxyAssetShapeConfig);
+                editorColliderComponent->GetColliderConfiguration(), newProxyAssetShapeConfig, editorColliderComponent->IsDebugDrawDisplayFlagEnabled());
             if (!editorMeshColliderComponent)
             {
                 AZ_Warning(

--- a/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
@@ -243,6 +243,11 @@ namespace PhysX
         return colliderConfiguration;
     }
 
+    bool EditorColliderComponent::IsDebugDrawDisplayFlagEnabled() const
+    {
+        return m_colliderDebugDraw.IsDisplayFlagEnabled();
+    }
+
     EditorProxyShapeConfig::EditorProxyShapeConfig(const Physics::ShapeConfiguration& shapeConfiguration)
     {
         m_shapeType = shapeConfiguration.GetShapeType();

--- a/Gems/PhysX/Code/Source/EditorColliderComponent.h
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.h
@@ -155,6 +155,8 @@ namespace PhysX
         Physics::ColliderConfiguration GetColliderConfigurationScaled() const;
         Physics::ColliderConfiguration GetColliderConfigurationNoOffset() const;
 
+        bool IsDebugDrawDisplayFlagEnabled() const;
+
         // BoundsRequestBus overrides ...
         AZ::Aabb GetWorldBounds() override;
         AZ::Aabb GetLocalBounds() override;

--- a/Gems/PhysX/Code/Source/EditorMeshColliderComponent.h
+++ b/Gems/PhysX/Code/Source/EditorMeshColliderComponent.h
@@ -44,6 +44,16 @@ namespace AzPhysics
 
 namespace PhysX
 {
+    struct EditorProxyPhysicsAsset
+    {
+        AZ_CLASS_ALLOCATOR(EditorProxyPhysicsAsset, AZ::SystemAllocator);
+        AZ_TYPE_INFO(EditorProxyPhysicsAsset, "{1F69C480-CC88-4C2D-B126-B13694E6192B}");
+        static void Reflect(AZ::ReflectContext* context);
+
+        AZ::Data::Asset<Pipeline::MeshAsset> m_pxAsset{ AZ::Data::AssetLoadBehavior::QueueLoad };
+        Physics::PhysicsAssetShapeConfiguration m_configuration;
+    };
+
     //! Edit context wrapper for the physics asset and asset specific parameters in the shape configuration.
     struct EditorProxyAssetShapeConfig
     {
@@ -54,8 +64,7 @@ namespace PhysX
         EditorProxyAssetShapeConfig() = default;
         EditorProxyAssetShapeConfig(const Physics::PhysicsAssetShapeConfiguration& assetShapeConfiguration);
 
-        AZ::Data::Asset<Pipeline::MeshAsset> m_pxAsset{ AZ::Data::AssetLoadBehavior::QueueLoad };
-        Physics::PhysicsAssetShapeConfiguration m_configuration;
+        EditorProxyPhysicsAsset m_physicsAsset;
 
         bool m_hasNonUniformScale = false; //!< Whether there is a non-uniform scale component on this entity.
         AZ::u8 m_subdivisionLevel = 4; //!< The level of subdivision if a primitive shape is replaced with a convex mesh due to scaling.
@@ -99,7 +108,9 @@ namespace PhysX
 
         EditorMeshColliderComponent() = default;
         EditorMeshColliderComponent(
-            const Physics::ColliderConfiguration& colliderConfiguration, const EditorProxyAssetShapeConfig& proxyAssetShapeConfig);
+            const Physics::ColliderConfiguration& colliderConfiguration,
+            const EditorProxyAssetShapeConfig& proxyAssetShapeConfig,
+            bool debugDrawDisplayFlagEnabled = true);
         EditorMeshColliderComponent(
             const Physics::ColliderConfiguration& colliderConfiguration, const Physics::PhysicsAssetShapeConfiguration& assetShapeConfig);
 
@@ -107,6 +118,8 @@ namespace PhysX
         const Physics::ColliderConfiguration& GetColliderConfiguration() const;
         Physics::ColliderConfiguration GetColliderConfigurationScaled() const;
         Physics::ColliderConfiguration GetColliderConfigurationNoOffset() const;
+
+        bool IsDebugDrawDisplayFlagEnabled() const;
 
         // BoundsRequestBus overrides ...
         AZ::Aabb GetWorldBounds() override;

--- a/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
@@ -72,7 +72,7 @@ namespace PhysX
             for (const EditorMeshColliderComponent* collider : entity->FindComponents<EditorMeshColliderComponent>())
             {
                 const EditorProxyAssetShapeConfig& shapeConfigurationProxy = collider->GetShapeConfiguration();
-                if (!shapeConfigurationProxy.m_configuration.m_asset.IsReady())
+                if (!shapeConfigurationProxy.m_physicsAsset.m_configuration.m_asset.IsReady())
                 {
                     continue;
                 }
@@ -80,7 +80,7 @@ namespace PhysX
                 const Physics::ColliderConfiguration colliderConfigurationUnscaled = collider->GetColliderConfiguration();
                 AZStd::vector<AZStd::shared_ptr<Physics::Shape>> shapes;
                 Utils::CreateShapesFromAsset(
-                    shapeConfigurationProxy.m_configuration,
+                    shapeConfigurationProxy.m_physicsAsset.m_configuration,
                     colliderConfigurationUnscaled, hasNonUniformScaleComponent, shapeConfigurationProxy.m_subdivisionLevel, shapes);
 
                 for (const auto& shape : shapes)


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

This is to simplify the transition from old PhysX Colliders and not having to update the property paths on prefabs' patches or python scripts.

Reverted the property paths to PhysX Mesh Collider's properties on python scripts since now it matches the same as before (one less change to do to adapt to PhysX Mesh Colliders).

Exposed collider debug draw display flag so it can be queried when converting from PhysX Collider to PhysX Mesh Collider.

## How was this PR tested?

Tested converting prefabs on complex levels (like MultiplayerSample and loft scene) with `ed_physxUpdatePrefabsWithColliderComponents` and no prefab patching warnings appear anymore after the conversion.
