### PR TITLE
BehaviorContext compile time improvements refactor

### DIFF
--- a/Code/Framework/AzCore/AzCore/RTTI/AzStdOnDemandReflection.inl
+++ b/Code/Framework/AzCore/AzCore/RTTI/AzStdOnDemandReflection.inl
@@ -117,6 +117,7 @@ namespace AZ
                         ->Attribute(AZ::Script::Attributes::ConstructorOverride, &CustomConstructor)
                     ->template WrappingMember<typename ContainerType::value_type>(&ContainerType::get)
                     ->Method("get", &ContainerType::get)
+                    ->Method("__bool__", [](ContainerType* self) { return static_cast<bool>(self); })
                     ;
             }
         }
@@ -164,6 +165,7 @@ namespace AZ
                     ->Attribute(AZ::Script::Attributes::ConstructorOverride, &CustomConstructor)
                     ->template WrappingMember<typename ContainerType::value_type>(&ContainerType::get)
                     ->Method("get", &ContainerType::get)
+                    ->Method("__bool__", [](ContainerType* self) { return static_cast<bool>(self); })
                     ;
             }
         }

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorClassBuilder.cpp
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorClassBuilder.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/RTTI/BehaviorContext.h>
+
+namespace AZ::Internal
+{
+    // Definition of internal ClassBuilderBase non-template member functions
+    ClassBuilderBase::ClassBuilderBase(BehaviorContext* context, BehaviorClass* behaviorClass)
+        : AZ::Internal::GenericAttributes<ClassBuilderBase>(context)
+        , m_class(behaviorClass)
+    {
+        if (behaviorClass)
+        {
+            Base::m_currentAttributes = &behaviorClass->m_attributes;
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    ClassBuilderBase::~ClassBuilderBase()
+    {
+        // process all on demand queued reflections
+        Base::m_context->ExecuteQueuedOnDemandReflections();
+
+        if (m_class && (!Base::m_context->IsRemovingReflection()))
+        {
+            for (const auto& method : m_class->m_methods)
+            {
+                m_class->PostProcessMethod(Base::m_context, *method.second);
+                if (MethodReturnsAzEventByReferenceOrPointer(*method.second))
+                {
+                    ValidateAzEventDescription(*Base::m_context, *method.second);
+                }
+            }
+
+            // Validate the AzEvent description of the class property getter's
+            for (auto&& [propertyName, propertyInst] : m_class->m_properties)
+            {
+                if (propertyInst->m_getter && MethodReturnsAzEventByReferenceOrPointer(*propertyInst->m_getter))
+                {
+                    ValidateAzEventDescription(*Base::m_context, *propertyInst->m_getter);
+                }
+            }
+
+            BehaviorContextBus::Event(Base::m_context, &BehaviorContextBus::Events::OnAddClass, m_class->m_name.c_str(), m_class);
+        }
+    }
+
+    auto ClassBuilderBase::operator->() -> ClassBuilderBase*
+    {
+        return this;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    auto ClassBuilderBase::RequestBus(const char* name) -> ClassBuilderBase*
+    {
+        if (m_class)
+        {
+            m_class->m_requestBuses.insert(name);
+        }
+        return this;
+    }
+
+
+    //////////////////////////////////////////////////////////////////////////
+    auto ClassBuilderBase::NotificationBus(const char* name)-> ClassBuilderBase*
+    {
+        if (m_class)
+        {
+            m_class->m_notificationBuses.insert(name);
+        }
+        return this;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    auto ClassBuilderBase::Allocator(BehaviorClass::AllocateType allocate, BehaviorClass::DeallocateType deallocate) -> ClassBuilderBase*
+    {
+        AZ_Error("BehaviorContext", m_class, "Allocator can be set on valid classes only!");
+        if (m_class)
+        {
+            m_class->m_allocate = allocate;
+            m_class->m_deallocate = deallocate;
+        }
+        return this;
+    }
+
+    auto ClassBuilderBase::UserData(void* userData) -> ClassBuilderBase*
+    {
+        AZ_Error("BehaviorContext", m_class, "UserData can be set on valid classes only!");
+        if (m_class)
+        {
+            m_class->m_userData = userData;
+        }
+        return this;
+    }
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorClassBuilder.inl
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorClassBuilder.inl
@@ -1,0 +1,708 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+namespace AZ::Internal
+{
+    /// Internal structure to maintain class information while we are describing a class.
+    struct ClassBuilderBase : public AZ::Internal::GenericAttributes<ClassBuilderBase>
+    {
+        using Base = AZ::Internal::GenericAttributes<ClassBuilderBase>;
+
+        //////////////////////////////////////////////////////////////////////////
+        /// Internal implementation
+        ClassBuilderBase(BehaviorContext* context, BehaviorClass* behaviorClass);
+        ~ClassBuilderBase();
+        ClassBuilderBase* operator->();
+
+        /**
+        * Sets custom allocator for a class, this function will error if this not inside a class.
+        * This is only for very specific cases when you want to override AZ_CLASS_ALLOCATOR or you are dealing with 3rd party classes, otherwise
+        * you should use AZ_CLASS_ALLOCATOR to control which allocator the class uses.
+        */
+        ClassBuilderBase* Allocator(BehaviorClass::AllocateType allocate, BehaviorClass::DeallocateType deallocate);
+
+        /// Attaches different constructor signatures to the class.
+        template<class C, class... Params>
+        ClassBuilderBase* ConstructorWithClass();
+
+        /// When your class is a wrapper, like smart pointers, you should use this to describe how to unwrap the class.
+        template<class WrappedType>
+        ClassBuilderBase* Wrapping(BehaviorClassUnwrapperFunction unwrapper, void* userData);
+
+        /// Provide a function to unwrap this class (use an underlaying class)
+        template<class WrappedType, class Callable>
+        ClassBuilderBase* WrappingMember(Callable callableFunction);
+
+        /// Sets userdata to a class.
+        ClassBuilderBase* UserData(void* userData);
+
+        /// Setup methods
+        ///< \deprecated Use "Method(const char* name, Function f, const BehaviorParameterOverridesArray<Function>& args, const char* dbgDesc = nullptr)" instead
+        ///< This method does not support passing in argument names and tooltips nor does it support overriding specific parameter Behavior traits
+        template<class Function>
+        ClassBuilderBase* Method(const char* name, Function, BehaviorValues* defaultValues = nullptr, const char* dbgDesc = nullptr);
+
+        ///< \deprecated Use "Method(const char* name, Function f, const char* deprecatedName, const BehaviorParameterOverridesArray<Function>& args, const char* dbgDesc = nullptr)" instead
+        ///< This method does not support passing in argument names and tooltips nor does it support overriding specific parameter Behavior traits
+        template<class Function>
+        ClassBuilderBase* Method(const char* name, Function f, const char* deprecatedName, BehaviorValues* defaultValues = nullptr, const char* dbgDesc = nullptr);
+
+        template<class Function>
+        ClassBuilderBase* Method(const char* name, Function f, const BehaviorParameterOverridesArray<Function>& args, const char* dbgDesc = nullptr);
+
+        template<class Function>
+        ClassBuilderBase* Method(
+            const char* name,
+            Function f,
+            const BehaviorParameterOverrides& classMetadata,
+            const BehaviorParameterOverridesArray<Function>& argsMetadata,
+            const char* dbgDesc = nullptr);
+
+        template<class Function>
+        ClassBuilderBase* Method(const char* name, Function f, const char* deprecatedName, const BehaviorParameterOverridesArray<Function>& args, const char* dbgDesc = nullptr);
+
+        template<class Getter, class Setter>
+        ClassBuilderBase* Property(const char* name, Getter getter, Setter setter);
+
+        /// All enums are treated as the enum type
+        template<auto Value>
+        ClassBuilderBase* Enum(const char* name);
+
+        template<class Getter>
+        ClassBuilderBase* Constant(const char* name, Getter getter);
+
+        /**
+         * You can describe buses that this class uses to communicate. Those buses will be used by tools when
+         * you need to give developers hints as to what buses this class interacts with.
+         * You don't need to reflect all buses that your class uses, just the ones related to
+         * class behavior. Please refer to component documentation for more information on
+         * the pattern of Request and Notification buses.
+         * {@
+         */
+        ClassBuilderBase* RequestBus(const char* busName);
+        ClassBuilderBase* NotificationBus(const char* busName);
+        // @}
+
+        BehaviorClass* m_class;
+    };
+}
+
+namespace AZ::Internal
+{
+    template<class C, class... Params>
+    auto ClassBuilderBase::ConstructorWithClass() -> ClassBuilderBase*
+    {
+        if (!Base::m_context->IsRemovingReflection())
+        {
+            AZ_Error("BehaviorContext", m_class, "You can set constructors only on valid classes!");
+        }
+        if (m_class)
+        {
+            auto Construct = [](C* address, Params... params) { new (address) C(params...); };
+            BehaviorMethod* constructor = aznew BehaviorMethodImpl
+            (static_cast<void(*)(C*, Params...)>(Construct),
+                Base::m_context, AZStd::string::format("%s::Constructor", m_class->m_name.c_str()));
+            m_class->m_constructors.push_back(constructor);
+        }
+        return this;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    template<class WrappedType>
+    auto ClassBuilderBase::Wrapping(BehaviorClassUnwrapperFunction unwrapper, void* userData) -> ClassBuilderBase*
+    {
+        if (!Base::m_context->IsRemovingReflection())
+        {
+            AZ_Error("BehaviorContext", m_class, "You can wrap only valid classes!");
+        }
+        if (m_class)
+        {
+            AZ_Assert(m_class->m_typeId != AzTypeInfo<WrappedType>::Uuid(), "A Wrapping member cannot unwrap to the same type as itself."
+                " As wrapped types are implicitly reflected by the ScriptContext, this prevents a recursive loop");
+            m_class->m_wrappedTypeId = AzTypeInfo<WrappedType>::Uuid();
+            m_class->m_unwrapper = unwrapper;
+            m_class->m_unwrapperUserData = userData;
+        }
+        return this;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    template<class WrappedType, class Callable>
+    auto ClassBuilderBase::WrappingMember(Callable callableFunction) -> ClassBuilderBase*
+    {
+        static_assert(sizeof(Callable) <= sizeof(void*), "Callable cannot be greater than the size of a pointer.\n"
+            "The Callable is stored in a void* and therefore must be able to fit within a pointer");
+
+        auto Unwrap = [](void* classPtr, void*& unwrappedClassPtr, AZ::Uuid& unwrappedClassTypeId, void* userData)
+        {
+            union
+            {
+                void* userData;
+                Callable callablePtr;
+            } u;
+            u.callablePtr = nullptr;
+
+            u.userData = userData;
+            using CallableTraits = AZStd::function_traits<Callable>;
+            if constexpr (!AZStd::is_same_v<typename CallableTraits::class_type, AZStd::Internal::error_type>)
+            {
+                using ClassTypePtr = typename CallableTraits::class_type*;
+                unwrappedClassPtr = const_cast<void*>(reinterpret_cast<const void*>(AZStd::invoke(u.callablePtr, reinterpret_cast<ClassTypePtr>(classPtr))));
+            }
+            else
+            {
+                static_assert(CallableTraits::arity > 0, "Non member Wrapping function must accept at least 1 argument");
+                using ClassTypePtr = typename CallableTraits::template get_arg_t<0>;
+                unwrappedClassPtr = const_cast<void*>(reinterpret_cast<const void*>(AZStd::invoke(u.callablePtr, reinterpret_cast<ClassTypePtr>(classPtr))));
+            }
+            unwrappedClassTypeId = AzTypeInfo<WrappedType>::Uuid();
+        };
+
+        union
+        {
+            Callable callableFunction;
+            void* userData;
+        } u;
+        u.callableFunction = callableFunction;
+
+        return Wrapping<WrappedType>(Unwrap, u.userData);
+    }
+
+    template<class Function>
+    auto ClassBuilderBase::Method(const char* name, Function f, BehaviorValues* defaultValues, const char* dbgDesc) -> ClassBuilderBase*
+    {
+        return Method(name, f, nullptr, defaultValues, dbgDesc);
+    }
+
+    template<class Function>
+    auto ClassBuilderBase::Method(const char* name, Function f, const char* deprecatedName, BehaviorValues* defaultValues, const char* dbgDesc) -> ClassBuilderBase*
+    {
+        BehaviorParameterOverridesArray<Function> parameterOverrides;
+        if (defaultValues)
+        {
+            AZ_Assert(defaultValues->GetNumValues() <= parameterOverrides.size(), "You can't have more default values than the number of function arguments");
+            // Copy default values to parameter override structure
+            size_t startArgumentIndex = parameterOverrides.size() - defaultValues->GetNumValues();
+            for (size_t i = 0; i < defaultValues->GetNumValues(); ++i)
+            {
+                parameterOverrides[startArgumentIndex + i].m_defaultValue = defaultValues->GetDefaultValue(i);
+            }
+            delete defaultValues;
+        }
+
+        return Method(name, f, deprecatedName, parameterOverrides, dbgDesc);
+    }
+
+    template<class Function>
+    auto ClassBuilderBase::Method(const char* name, Function f, const BehaviorParameterOverridesArray<Function>& args, const char* dbgDesc) -> ClassBuilderBase*
+    {
+        return Method(name, f, nullptr, args, dbgDesc);
+    }
+
+    template<class Function>
+    auto ClassBuilderBase::Method(
+        const char* name,
+        Function f,
+        const BehaviorParameterOverrides& classMetadata,
+        const BehaviorParameterOverridesArray<Function>& argsMetadata,
+        const char* dbgDesc) -> ClassBuilderBase*
+    {
+        if (m_class)
+        {
+            using FunctionTraits = AZStd::function_traits<Function>;
+            using FunctionCastType = AZStd::conditional_t<
+                !AZStd::is_same_v<typename FunctionTraits::class_type, AZStd::Internal::error_type>,
+                typename FunctionTraits::type,
+                typename FunctionTraits::function_object_signature*>;
+            BehaviorMethod* method =
+                aznew BehaviorMethodImpl(static_cast<FunctionCastType>(f),
+                    Base::m_context, AZStd::string::format("%s::%s", m_class->m_name.c_str(), name));
+            method->m_debugDescription = dbgDesc;
+
+            auto methodIter = m_class->m_methods.find(name);
+            if (methodIter != m_class->m_methods.end())
+            {
+                if (!methodIter->second->AddOverload(method))
+                {
+                    AZ_Error("BehaviorContext", false, "Method incorrectly reflected as C++ overload");
+                    delete method;
+                    return this;
+                }
+            }
+            else
+            {
+                m_class->m_methods.insert(AZStd::make_pair(name, method));
+            }
+
+            size_t classPtrIndex = 0;
+            if (method->IsMember())
+            {
+                method->SetArgumentName(classPtrIndex, classMetadata.m_name);
+                method->SetArgumentToolTip(classPtrIndex, classMetadata.m_toolTip);
+                method->SetDefaultValue(classPtrIndex, classMetadata.m_defaultValue);
+                method->OverrideParameterTraits(classPtrIndex, classMetadata.m_addTraits, classMetadata.m_removeTraits);
+                classPtrIndex++;
+            }
+
+            for (size_t i = 0; i < argsMetadata.size(); ++i)
+            {
+                method->SetArgumentName(i + classPtrIndex, argsMetadata[i].m_name);
+                method->SetArgumentToolTip(i + classPtrIndex, argsMetadata[i].m_toolTip);
+                method->SetDefaultValue(i + classPtrIndex, argsMetadata[i].m_defaultValue);
+                method->OverrideParameterTraits(i + classPtrIndex, argsMetadata[i].m_addTraits, argsMetadata[i].m_removeTraits);
+            }
+
+            // \note we can start returning a context so we can maintain the scope
+            Base::m_currentAttributes = &method->m_attributes;
+        }
+
+        return this;
+    }
+
+    template<class Function>
+    auto ClassBuilderBase::Method(const char* name, Function f, const char* deprecatedName, const BehaviorParameterOverridesArray<Function>& args, const char* dbgDesc)
+        -> ClassBuilderBase*
+    {
+        if (m_class)
+        {
+            using FunctionTraits = AZStd::function_traits<Function>;
+            using FunctionCastType = AZStd::conditional_t<
+                !AZStd::is_same_v<typename FunctionTraits::class_type, AZStd::Internal::error_type>,
+                typename FunctionTraits::type,
+                typename FunctionTraits::function_object_signature*>;
+            BehaviorMethod* method = aznew BehaviorMethodImpl(static_cast<FunctionCastType>(f),
+                Base::m_context, AZStd::string::format("%s::%s", m_class->m_name.c_str(), name));
+            method->m_debugDescription = dbgDesc;
+
+            /*
+            ** check to see if the deprecated name is used, and ensure its not duplicated.
+            */
+
+            if (deprecatedName != nullptr)
+            {
+                auto itr = m_class->m_methods.find(name);
+                if (itr != m_class->m_methods.end())
+                {
+                    // now check to make sure that the deprecated name is not being used as a identical deprecated name for another method.
+                    bool isDuplicate = false;
+                    for (const auto& i : m_class->m_methods)
+                    {
+                        if (i.second->GetDeprecatedName() == deprecatedName)
+                        {
+                            AZ_Warning("BehaviorContext", false, "Method %s is attempting to use a deprecated name of %s which is already in use for method %s! Deprecated name is ignored!", name, deprecatedName, i.first.c_str());
+                            isDuplicate = true;
+                            break;
+                        }
+                    }
+
+                    if (!isDuplicate)
+                    {
+                        itr->second->SetDeprecatedName(deprecatedName);
+                    }
+                }
+                else
+                {
+                    AZ_Warning("BehaviorContext", false, "Method %s does not exist, so the deprecated name is ignored!", name, deprecatedName);
+                }
+            }
+
+            auto methodIter = m_class->m_methods.find(name);
+            if (methodIter != m_class->m_methods.end())
+            {
+                if (!methodIter->second->AddOverload(method))
+                {
+                    AZ_Error("BehaviorContext", false, "Method incorrectly reflected as C++ overload");
+                    delete method;
+                    return this;
+                }
+            }
+            else
+            {
+                m_class->m_methods.insert(AZStd::make_pair(name, method));
+            }
+
+            size_t classPtrIndex = method->IsMember() ? 1 : 0;
+            for (size_t i = 0; i < args.size(); ++i)
+            {
+                method->SetArgumentName(i + classPtrIndex, args[i].m_name);
+                method->SetArgumentToolTip(i + classPtrIndex, args[i].m_toolTip);
+                method->SetDefaultValue(i + classPtrIndex, args[i].m_defaultValue);
+                method->OverrideParameterTraits(i + classPtrIndex, args[i].m_addTraits, args[i].m_removeTraits);
+            }
+
+            // \note we can start returning a context so we can maintain the scope
+            Base::m_currentAttributes = &method->m_attributes;
+        }
+
+        return this;
+    }
+
+
+    //////////////////////////////////////////////////////////////////////////
+    template<class Getter, class Setter>
+    auto ClassBuilderBase::Property(const char* name, Getter getter, Setter setter) -> ClassBuilderBase*
+    {
+        if (m_class)
+        {
+            BehaviorProperty* prop = aznew BehaviorProperty(Base::m_context);
+            prop->m_name = name;
+            if (!prop->Set(getter, setter, m_class, Base::m_context))
+            {
+                delete prop;
+                return this;
+            }
+
+            m_class->m_properties.insert(AZStd::make_pair(name, prop));
+
+            // \note we can start returning a context so we can maintain the scope
+            Base::m_currentAttributes = &prop->m_attributes;
+        }
+
+        return this;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    template<auto Value>
+    auto ClassBuilderBase::Enum(const char* name) -> ClassBuilderBase*
+    {
+        Property(name, []() { return Value; }, nullptr);
+        ClassBuilderBase::Attribute(AZ::Script::Attributes::ClassConstantValue, true);
+        return this;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    template<class Getter>
+    auto ClassBuilderBase::Constant(const char* name, Getter getter) -> ClassBuilderBase*
+    {
+        Property(name, getter, nullptr);
+        return this;
+    };
+} // namespace AZ::Internal
+
+
+namespace AZ
+{
+    // ClassBuilder implementation containing template functions
+    // that rely on the class T parameter that cannot be implemented
+    // in the base class
+    template <class T>
+    struct BehaviorContext::ClassBuilder : public Internal::ClassBuilderBase
+    {
+        using Internal::ClassBuilderBase::ClassBuilderBase;
+
+        // Add an arrow operator for the derived template class
+        ClassBuilder* operator->();
+
+        // Backward Compatibility functions
+        // As the majority of BehaviorContext class reflection uses operator->
+        // for reflection, definitions for the ClassBuilderBase member functions
+        // have been added to this template class, where it calls the base class function
+
+        template<class U>
+        ClassBuilder* Attribute(const char* id, U value);
+        template<class U>
+        ClassBuilder* Attribute(AZ::Crc32 id, U value);
+
+        //! Attaches different constructor signatures to the class.
+        template<class... Params>
+        ClassBuilder* Constructor();
+
+        template<class WrappedType>
+        ClassBuilder* Wrapping(BehaviorClassUnwrapperFunction unwrapper, void* userData);
+
+        template<class WrappedType, class Callable>
+        ClassBuilder* WrappingMember(Callable callableFunction);
+
+        ClassBuilder* UserData(void* userData);
+
+        template<class Function>
+        ClassBuilder* Method(const char* name, Function,
+            BehaviorValues* defaultValues = nullptr, const char* dbgDesc = nullptr);
+
+        template<class Function>
+        ClassBuilder* Method(const char* name, Function f, const char* deprecatedName,
+            BehaviorValues* defaultValues = nullptr, const char* dbgDesc = nullptr);
+
+        template<class Function>
+        ClassBuilder* Method(const char* name, Function f,
+            const BehaviorParameterOverridesArray<Function>& args, const char* dbgDesc = nullptr);
+
+        template<class Function>
+        ClassBuilder* Method(
+            const char* name,
+            Function f,
+            const BehaviorParameterOverrides& classMetadata,
+            const BehaviorParameterOverridesArray<Function>& argsMetadata,
+            const char* dbgDesc = nullptr);
+
+        template<class Function>
+        ClassBuilder* Method(const char* name, Function f, const char* deprecatedName,
+            const BehaviorParameterOverridesArray<Function>& args, const char* dbgDesc = nullptr);
+
+        template<class Getter, class Setter>
+        ClassBuilder* Property(const char* name, Getter getter, Setter setter);
+
+        template<auto Value>
+        ClassBuilder* Enum(const char* name);
+
+        template<class Getter>
+        ClassBuilder* Constant(const char* name, Getter getter);
+
+        ClassBuilder* RequestBus(const char* busName);
+        ClassBuilder* NotificationBus(const char* busName);
+
+    };
+
+    template<class T>
+    auto BehaviorContext::ClassBuilder<T>::operator->() -> ClassBuilder*
+    {
+        return this;
+    }
+
+
+    template<class T>
+    template<class U>
+    auto BehaviorContext::ClassBuilder<T>::Attribute(const char* id, U value)
+        -> ClassBuilder*
+    {
+        ClassBuilderBase::Attribute(id, AZStd::move(value));
+        return this;
+    }
+
+    template<class T>
+    template<class U>
+    auto BehaviorContext::ClassBuilder<T>::Attribute(AZ::Crc32 id, U value)
+        -> ClassBuilder*
+    {
+        ClassBuilderBase::Attribute(id, AZStd::move(value));
+        return this;
+    }
+
+    template<class T>
+    template<class... Params>
+    auto BehaviorContext::ClassBuilder<T>::Constructor() -> ClassBuilder*
+    {
+        ClassBuilderBase::ConstructorWithClass<T, Params...>();
+        return this;
+    }
+
+    template<class T>
+    template<class WrappedType>
+    auto BehaviorContext::ClassBuilder<T>::Wrapping(BehaviorClassUnwrapperFunction unwrapper, void* userData)
+        -> ClassBuilder*
+    {
+        ClassBuilderBase::Wrapping<WrappedType>(AZStd::move(unwrapper), userData);
+        return this;
+    }
+
+    template<class T>
+    template<class WrappedType, class Callable>
+    auto BehaviorContext::ClassBuilder<T>::WrappingMember(Callable callableFunction)
+        -> ClassBuilder*
+    {
+        ClassBuilderBase::WrappingMember<WrappedType>(AZStd::move(callableFunction));
+        return this;
+    }
+
+    template<class T>
+    auto BehaviorContext::ClassBuilder<T>::UserData(void* userData)
+        -> ClassBuilder*
+    {
+        ClassBuilderBase::UserData(userData);
+        return this;
+    }
+
+    template<class T>
+    template<class Function>
+    auto BehaviorContext::ClassBuilder<T>::Method(const char* name, Function f,
+        BehaviorValues* defaultValues, const char* dbgDesc)
+        -> ClassBuilder*
+    {
+        ClassBuilderBase::Method(name, AZStd::move(f), defaultValues, dbgDesc);
+        return this;
+    }
+
+    template<class T>
+    template<class Function>
+    auto BehaviorContext::ClassBuilder<T>::Method(const char* name, Function f, const char* deprecatedName,
+        BehaviorValues* defaultValues, const char* dbgDesc)
+        -> ClassBuilder*
+    {
+        ClassBuilderBase::Method(name, AZStd::move(f), deprecatedName, defaultValues, dbgDesc);
+        return this;
+    }
+
+    template<class T>
+    template<class Function>
+    auto BehaviorContext::ClassBuilder<T>::Method(const char* name, Function f,
+        const BehaviorParameterOverridesArray<Function>& args, const char* dbgDesc)
+        -> ClassBuilder*
+    {
+        ClassBuilderBase::Method(name, AZStd::move(f), args, dbgDesc);
+        return this;
+    }
+
+    template<class T>
+    template<class Function>
+    auto BehaviorContext::ClassBuilder<T>::Method(
+        const char* name,
+        Function f,
+        const BehaviorParameterOverrides& classMetadata,
+        const BehaviorParameterOverridesArray<Function>& argsMetadata,
+        const char* dbgDesc)
+        -> ClassBuilder*
+    {
+        ClassBuilderBase::Method(name, AZStd::move(f), classMetadata, argsMetadata, dbgDesc);
+        return this;
+    }
+
+    template<class T>
+    template<class Function>
+    auto BehaviorContext::ClassBuilder<T>::Method(const char* name, Function f, const char* deprecatedName,
+        const BehaviorParameterOverridesArray<Function>& args, const char* dbgDesc)
+        -> ClassBuilder*
+    {
+        ClassBuilderBase::Method(name, AZStd::move(f), deprecatedName, args, dbgDesc);
+        return this;
+    }
+
+    template<class T>
+    template<class Getter, class Setter>
+    auto BehaviorContext::ClassBuilder<T>::Property(const char* name, Getter getter, Setter setter)
+        -> ClassBuilder*
+    {
+        ClassBuilderBase::Property(name, AZStd::move(getter), AZStd::move(setter));
+        return this;
+    }
+
+    template<class T>
+    template<auto Value>
+    auto BehaviorContext::ClassBuilder<T>::Enum(const char* name)
+        -> ClassBuilder*
+    {
+        ClassBuilderBase::Enum<Value>(name);
+        return this;
+    }
+
+    template<class T>
+    template<class Getter>
+    auto BehaviorContext::ClassBuilder<T>::Constant(const char* name, Getter getter)
+        -> ClassBuilder*
+    {
+        ClassBuilderBase::Constant(name, AZStd::move(getter));
+        return this;
+    }
+
+    template<class T>
+    auto BehaviorContext::ClassBuilder<T>::RequestBus(const char* busName)
+        -> ClassBuilder*
+    {
+        ClassBuilderBase::RequestBus(busName);
+        return this;
+    }
+    template<class T>
+    auto BehaviorContext::ClassBuilder<T>::NotificationBus(const char* busName)
+        -> ClassBuilder*
+    {
+        ClassBuilderBase::NotificationBus(busName);
+        return this;
+    }
+} // namespace AZ
+
+namespace AZ
+{
+    // Returns a new ClassBuilder instance that can be used to configure a BehaviorClass
+    // representing the type T being reflected
+    template<class T>
+    auto BehaviorContext::Class(const char* name) -> ClassBuilder<T>
+    {
+        if (name == nullptr)
+        {
+            name = AzTypeInfo<T>::Name();
+        }
+
+        AZ::Uuid typeUuid = AzTypeInfo<T>::Uuid();
+        AZ_Assert(!typeUuid.IsNull(), "Type %s has no AZ_TYPE_INFO or AZ_RTTI.  Please use an AZ_RTTI or AZ_TYPE_INFO declaration before trying to use it in reflection contexts.", name ? name : "<Unknown class>");
+        if (typeUuid.IsNull())
+        {
+            return ClassBuilder<T>(this, static_cast<BehaviorClass*>(nullptr));
+        }
+
+        auto classTypeIt = m_typeToClassMap.find(typeUuid);
+        if (IsRemovingReflection())
+        {
+            if (classTypeIt != m_typeToClassMap.end())
+            {
+                // find it in the name category
+                auto nameIt = m_classes.find(name);
+                while (nameIt != m_classes.end())
+                {
+                    if (nameIt->second == classTypeIt->second)
+                    {
+                        m_classes.erase(nameIt);
+                        break;
+                    }
+                }
+                BehaviorContextBus::Event(this, &BehaviorContextBus::Events::OnRemoveClass, name, classTypeIt->second);
+                delete classTypeIt->second;
+                m_typeToClassMap.erase(classTypeIt);
+            }
+            return ClassBuilder<T>(this, static_cast<BehaviorClass*>(nullptr));
+        }
+        else
+        {
+            if (classTypeIt != m_typeToClassMap.end())
+            {
+                AZ_Error("Reflection", false, "Class '%s' is already registered using Uuid: %s!", name, classTypeIt->first.ToFixedString().c_str());
+                return ClassBuilder<T>(this, static_cast<BehaviorClass*>(nullptr));
+            }
+
+            // TODO: make it a set and use the name inside the class
+            if (m_classes.find(name) != m_classes.end())
+            {
+                AZ_Error("Reflection", false, "A class with name '%s' is already registered!", name);
+                return ClassBuilder<T>(this, static_cast<BehaviorClass*>(nullptr));
+            }
+
+            BehaviorClass* behaviorClass = aznew BehaviorClass();
+            behaviorClass->m_typeId = AzTypeInfo<T>::Uuid();
+            behaviorClass->m_azRtti = GetRttiHelper<T>();
+            behaviorClass->m_alignment = AZStd::alignment_of<T>::value;
+            behaviorClass->m_size = sizeof(T);
+            behaviorClass->m_name = name;
+
+            // enumerate all base classes (RTTI), we store only the IDs to allow for our of order reflection
+            // At runtime it will be more efficient to have the pointers to the classes. Analyze in practice and cache them if needed.
+            AZ::RttiEnumHierarchy<T>(
+                [](const AZ::Uuid& typeId, void* userData)
+                {
+                    BehaviorClass* bc = reinterpret_cast<BehaviorClass*>(userData);
+                    AZ_Assert(bc, "behavior class is invalid for typeId: %s", typeId.ToString<AZStd::string>().c_str());
+                    if (bc && typeId != bc->m_typeId)
+                    {
+                        bc->m_baseClasses.push_back(typeId);
+                    }
+                }
+                , behaviorClass
+                    );
+
+            SetClassHasher<T>(behaviorClass);
+            SetClassDefaultAllocator<T>(behaviorClass, typename HasAZClassAllocator<T>::type());
+            SetClassDefaultConstructor<T>(behaviorClass, typename AZStd::conditional< AZStd::is_constructible<T>::value && !AZStd::is_abstract<T>::value, AZStd::true_type, AZStd::false_type>::type());
+            SetClassDefaultDestructor<T>(behaviorClass, typename AZStd::is_destructible<T>::type());
+            SetClassDefaultCopyConstructor<T>(behaviorClass, typename AZStd::conditional< AZStd::is_copy_constructible<T>::value && !AZStd::is_abstract<T>::value, AZStd::true_type, AZStd::false_type>::type());
+            SetClassDefaultMoveConstructor<T>(behaviorClass, typename AZStd::conditional< AZStd::is_move_constructible<T>::value && !AZStd::is_abstract<T>::value, AZStd::true_type, AZStd::false_type>::type());
+
+            // Switch to Set (we store the name in the class)
+            m_classes.insert(AZStd::make_pair(behaviorClass->m_name, behaviorClass));
+            m_typeToClassMap.insert(AZStd::make_pair(behaviorClass->m_typeId, behaviorClass));
+            return ClassBuilder<T>(this, behaviorClass);
+        }
+    };
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.cpp
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.cpp
@@ -726,7 +726,6 @@ namespace AZ
         , m_alignment(0)
         , m_size(0)
         , m_unwrapper(nullptr)
-        , m_unwrapperUserData(nullptr)
         , m_wrappedTypeId(Uuid::CreateNull())
     {
     }
@@ -1143,7 +1142,22 @@ namespace AZ
         return FindAttribute(attributeId) != nullptr;
     }
 
+    // Deleter operator for the unwrapper unique_ptr deleter
+    void UnwrapperFuncDeleter::operator()(void* ptr) const
+    {
+        if (m_deleter && ptr)
+        {
+            m_deleter(ptr);
+        }
+    }
 
+    UnwrapperUserData::UnwrapperUserData() = default;
+    UnwrapperUserData::UnwrapperUserData(UnwrapperUserData&&) = default;
+    UnwrapperUserData& UnwrapperUserData::operator=(UnwrapperUserData&&) = default;
+
+    UnwrapperUserData::~UnwrapperUserData()
+    {
+    }
 
 
     //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.cpp
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.cpp
@@ -1152,12 +1152,9 @@ namespace AZ
     }
 
     UnwrapperUserData::UnwrapperUserData() = default;
-    UnwrapperUserData::UnwrapperUserData(UnwrapperUserData&&) = default;
-    UnwrapperUserData& UnwrapperUserData::operator=(UnwrapperUserData&&) = default;
-
-    UnwrapperUserData::~UnwrapperUserData()
-    {
-    }
+    UnwrapperUserData::UnwrapperUserData(UnwrapperUserData&& other) = default;
+    UnwrapperUserData& UnwrapperUserData::operator=(UnwrapperUserData&& other) = default;
+    UnwrapperUserData::~UnwrapperUserData() = default;
 
 
     //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.cpp
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.cpp
@@ -127,6 +127,153 @@ namespace AZ
         return azEventDescValid;
     }
 
+    // BehaviorParameterOverrides member definitions
+    BehaviorParameterOverrides::BehaviorParameterOverrides(AZStd::string_view name, AZStd::string_view toolTip, BehaviorDefaultValuePtr defaultValue,
+        u32 addTraits, u32 removeTraits)
+        : m_name(name)
+        , m_toolTip(toolTip)
+        , m_defaultValue(defaultValue)
+        , m_addTraits(addTraits)
+        , m_removeTraits(removeTraits)
+    {}
+
+    // BehaviorDefaultValue member definitions
+    BehaviorDefaultValue::~BehaviorDefaultValue()
+    {
+        if (m_value.m_value && m_destructor)
+        {
+            m_destructor(m_value.m_value);
+        }
+    }
+
+    const BehaviorArgument& BehaviorDefaultValue::GetValue() const
+    {
+        return m_value;
+    }
+
+    // BehaviorObject member functions
+    BehaviorObject::BehaviorObject()
+        : m_address(nullptr)
+        , m_typeId(AZ::Uuid::CreateNull())
+    {
+    }
+
+    BehaviorObject::BehaviorObject(void* address, const Uuid& typeId)
+        : m_address(address)
+        , m_typeId(typeId)
+    {
+    }
+
+    BehaviorObject::BehaviorObject(void* address, IRttiHelper* rttiHelper)
+        : m_address(address)
+        , m_rttiHelper(rttiHelper)
+    {
+        m_typeId = rttiHelper ? rttiHelper->GetTypeId() : AZ::Uuid::CreateNull();
+    }
+
+    bool BehaviorObject::IsValid() const
+    {
+        return m_address && !m_typeId.IsNull();
+    }
+
+
+    // BehaviorArgument member functions
+    BehaviorArgument::BehaviorArgument()
+        : m_value(nullptr)
+    {
+        m_name = nullptr;
+        m_typeId = Uuid::CreateNull();
+        m_azRtti = nullptr;
+        m_traits = 0;
+    }
+
+    BehaviorArgument::BehaviorArgument(BehaviorArgument&& other)
+        : BehaviorParameter(AZStd::move(other))
+        , m_value(AZStd::move(other.m_value))
+        , m_onAssignedResult(AZStd::move(other.m_onAssignedResult))
+        , m_tempData(AZStd::move(other.m_tempData))
+    {
+    }
+
+    BehaviorArgument::BehaviorArgument(BehaviorObject* value)
+    {
+        Set(value);
+    }
+
+    BehaviorArgument::BehaviorArgument(BehaviorArgumentValueTypeTag_t, BehaviorObject* value)
+    {
+        Set(BehaviorArgumentValueTypeTag, value);
+    }
+
+    void BehaviorArgument::Set(BehaviorObject* value)
+    {
+        m_value = &value->m_address;
+        m_typeId = value->m_typeId;
+        m_traits = BehaviorParameter::TR_POINTER;
+        m_name = value->m_rttiHelper ? value->m_rttiHelper->GetActualTypeName(value->m_address) : nullptr;
+        m_azRtti = value->m_rttiHelper;
+    }
+
+    void BehaviorArgument::Set(BehaviorArgumentValueTypeTag_t, BehaviorObject* value)
+    {
+        m_value = value->m_address;
+        m_typeId = value->m_typeId;
+        m_traits = BehaviorParameter::TR_NONE;
+        m_name = value->m_rttiHelper ? value->m_rttiHelper->GetActualTypeName(value->m_address) : nullptr;
+        m_azRtti = value->m_rttiHelper;
+    }
+
+    void BehaviorArgument::Set(const BehaviorParameter& param)
+    {
+        *static_cast<BehaviorParameter*>(this) = param;
+    }
+
+    void BehaviorArgument::Set(const BehaviorArgument& param)
+    {
+        *static_cast<BehaviorParameter*>(this) = static_cast<const BehaviorParameter&>(param);
+        m_value = param.m_value;
+        m_onAssignedResult = param.m_onAssignedResult;
+        m_tempData = param.m_tempData;
+    }
+
+    void* BehaviorArgument::GetValueAddress() const
+    {
+        void* valueAddress = m_value;
+        if (m_traits & BehaviorParameter::TR_POINTER)
+        {
+            valueAddress = *reinterpret_cast<void**>(valueAddress); // pointer to a pointer
+        }
+        return valueAddress;
+    }
+
+
+    bool BehaviorArgument::ConvertTo(const AZ::Uuid& typeId)
+    {
+        if (m_azRtti)
+        {
+            void* valueAddress = GetValueAddress();
+            if (valueAddress) // should we make null value to convert to anything?
+            {
+                return AZ::Internal::ConvertValueTo(valueAddress, m_azRtti, typeId, m_value, m_tempData);
+            }
+        }
+        return m_typeId == typeId;
+    }
+
+    BehaviorArgument::operator BehaviorObject() const
+    {
+        return BehaviorObject(m_value, m_azRtti);
+    }
+
+    BehaviorArgument& BehaviorArgument::operator=(BehaviorArgument&& other)
+    {
+        *static_cast<BehaviorParameter*>(this) = AZStd::move(static_cast<BehaviorParameter&&>(other));
+        m_value = AZStd::move(other.m_value);
+        m_onAssignedResult = AZStd::move(other.m_onAssignedResult);
+        m_tempData = AZStd::move(other.m_tempData);
+        return *this;
+    }
+
     //=========================================================================
     // BehaviorMethod
     //=========================================================================
@@ -151,6 +298,21 @@ namespace AZ
         }
 
         m_attributes.clear();
+    }
+
+    void BehaviorMethod::SetDeprecatedName(AZStd::string name)
+    {
+        m_deprecatedName = AZStd::move(name);
+    }
+    const AZStd::string& BehaviorMethod::GetDeprecatedName() const
+    {
+        return m_deprecatedName;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    bool BehaviorMethod::Invoke() const
+    {
+        return Call(nullptr, 0, nullptr);
     }
 
     //=========================================================================
@@ -319,9 +481,15 @@ namespace AZ
     {
     }
 
+
     //=========================================================================
     // BehaviorEBus
     //=========================================================================
+    BehaviorEBus::VirtualProperty::VirtualProperty(BehaviorEBusEventSender* getter, BehaviorEBusEventSender* setter)
+        : m_getter(getter)
+        , m_setter(setter)
+    {}
+
     BehaviorEBus::BehaviorEBus()
         : m_createHandler(nullptr)
         , m_destroyHandler(nullptr)
@@ -975,47 +1143,26 @@ namespace AZ
         return FindAttribute(attributeId) != nullptr;
     }
 
+
+
+
+    //////////////////////////////////////////////////////////////////////////
+    void BehaviorContextEvents::OnAddGlobalMethod(const char*, BehaviorMethod*) {}
+    void BehaviorContextEvents::OnRemoveGlobalMethod(const char*, BehaviorMethod*) {}
+
+    /// Called when a new global property is reflected in behavior context or remove from it
+    void BehaviorContextEvents::OnAddGlobalProperty(const char*, BehaviorProperty*) {}
+    void BehaviorContextEvents::OnRemoveGlobalProperty(const char*, BehaviorProperty*) {}
+
+    /// Called when a class is added or removed
+    void BehaviorContextEvents::OnAddClass(const char*, BehaviorClass*) {}
+    void BehaviorContextEvents::OnRemoveClass(const char*, BehaviorClass*) {}
+
+    /// Called when a ebus is added or removed
+    void BehaviorContextEvents::OnAddEBus(const char*, BehaviorEBus*) {}
+    void BehaviorContextEvents::OnRemoveEBus(const char*, BehaviorEBus*) {}
     //////////////////////////////////////////////////////////////////////////
     //////////////////////////////////////////////////////////////////////////
-    //////////////////////////////////////////////////////////////////////////
-
-    //=========================================================================
-    // InstallGenericHook
-    //=========================================================================
-    bool BehaviorEBusHandler::InstallGenericHook(int index, GenericHookType hook, void* userData)
-    {
-        if (index != -1)
-        {
-            // Check parameters
-            m_events[index].m_isFunctionGeneric = true;
-            m_events[index].m_function = reinterpret_cast<void*>(hook);
-            m_events[index].m_userData = userData;
-            return true;
-        }
-
-        return false;
-    }
-
-    //=========================================================================
-    // InstallGenericHook
-    //=========================================================================
-    bool BehaviorEBusHandler::InstallGenericHook(const char* name, GenericHookType hook, void* userData)
-    {
-        return InstallGenericHook(GetFunctionIndex(name), hook, userData);
-    }
-
-    //=========================================================================
-    // GetEvents
-    //=========================================================================
-    const BehaviorEBusHandler::EventArray& BehaviorEBusHandler::GetEvents() const
-    {
-        return m_events;
-    }
-
-    bool BehaviorEBusHandler::BusForwarderEvent::HasResult() const
-    {
-        return !m_parameters.empty() && !m_parameters.front().m_typeId.IsNull() && m_parameters.front().m_typeId != azrtti_typeid<void>();
-    }
 
     CheckedOperationInfo::CheckedOperationInfo
         ( AZStd::string_view safetyCheckName
@@ -1234,6 +1381,23 @@ namespace AZ
             }
             return enumRttiHelper.GetTypeId();
         }
-    }
 
+        bool ConvertValueTo(void* sourceAddress, const IRttiHelper* sourceRtti, const AZ::Uuid& targetType, void*& targetAddress, BehaviorParameter::TempValueParameterAllocator& tempAllocator)
+        {
+            // Check see if the underlying typeid is an enum whose typeIds match
+            if (GetUnderlyingTypeId(*sourceRtti) == targetType)
+            {
+                return true;
+            }
+            // convert
+            void* convertedAddress = sourceRtti->Cast(sourceAddress, targetType);
+            if (convertedAddress && convertedAddress != sourceAddress) // if we converted as we have a different address
+            {
+                // allocate temp storage and store it
+                targetAddress = tempAllocator.allocate(sizeof(void*), AZStd::alignment_of<void*>::value, 0);
+                *reinterpret_cast<void**>(targetAddress) = convertedAddress;
+            }
+            return convertedAddress != nullptr;
+        }
+    }
 } // namespace AZ

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.h
@@ -129,13 +129,7 @@ namespace AZ
     struct BehaviorParameterOverrides
     {
         BehaviorParameterOverrides(AZStd::string_view name = {}, AZStd::string_view toolTip = {}, BehaviorDefaultValuePtr defaultValue = {},
-            u32 addTraits = BehaviorParameter::Traits::TR_NONE, u32 removeTraits = BehaviorParameter::Traits::TR_NONE)
-            : m_name(name)
-            , m_toolTip(toolTip)
-            , m_defaultValue(defaultValue)
-            , m_addTraits(addTraits)
-            , m_removeTraits(removeTraits)
-        {}
+            u32 addTraits = BehaviorParameter::Traits::TR_NONE, u32 removeTraits = BehaviorParameter::Traits::TR_NONE);
 
         AZStd::string m_name;
         AZStd::string m_toolTip;
@@ -257,18 +251,9 @@ namespace AZ
             }
         }
 
-        ~BehaviorDefaultValue() override
-        {
-            if (m_value.m_value && m_destructor)
-            {
-                m_destructor(m_value.m_value);
-            }
-        }
+        ~BehaviorDefaultValue() override;
 
-        const BehaviorArgument& GetValue() const
-        {
-            return m_value;
-        }
+        const BehaviorArgument& GetValue() const;
 
         BehaviorArgument m_value;
     private:
@@ -329,8 +314,8 @@ namespace AZ
         bool InvokeResult(R& r, Args&&... args) const;
         template<class R>
         bool InvokeResult(R& r) const;
-        void SetDeprecatedName(const AZStd::string& name) { m_deprecatedName = name; }
-        const AZStd::string& GetDeprecatedName() const { return m_deprecatedName; }
+        void SetDeprecatedName(AZStd::string name);
+        const AZStd::string& GetDeprecatedName() const;
 
         virtual bool Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result = nullptr) const = 0;
         bool Call(BehaviorArgument* arguments, unsigned int numArguments, BehaviorArgument* result = nullptr) const;
@@ -354,9 +339,9 @@ namespace AZ
         virtual size_t GetMinNumberOfArguments() const = 0;
         virtual const BehaviorParameter* GetArgument(size_t index) const = 0;
         virtual const AZStd::string* GetArgumentName(size_t index) const = 0;
-        virtual void SetArgumentName(size_t index, const AZStd::string& name) = 0;
+        virtual void SetArgumentName(size_t index, AZStd::string name) = 0;
         virtual const AZStd::string* GetArgumentToolTip(size_t index) const = 0;
-        virtual void SetArgumentToolTip(size_t index, const AZStd::string& name) = 0;
+        virtual void SetArgumentToolTip(size_t index, AZStd::string name) = 0;
         virtual void SetDefaultValue(size_t index, BehaviorDefaultValuePtr defaultValue) = 0;
         virtual BehaviorDefaultValuePtr GetDefaultValue(size_t index) const = 0;
         virtual const BehaviorParameter* GetResult() const = 0;
@@ -457,48 +442,24 @@ namespace AZ
 
         ExplicitOverloadInfo(AZStd::string_view name, AZStd::string_view categoryPath);
 
+        constexpr operator size_t() const
+        {
+            size_t h = 0;
+            hash_combine(h, m_name);
+            return h;
+        }
+
         // \todo replace in hash operations with custom equality check
         bool operator==(const ExplicitOverloadInfo& other) const;
         bool operator!=(const ExplicitOverloadInfo& other) const;
     };
 }
 
-namespace AZStd
-{
-    template<>
-    struct hash<AZ::ExplicitOverloadInfo>
-    {
-        using argument_type = AZ::ExplicitOverloadInfo;
-        using result_type = size_t;
-
-        AZ_INLINE result_type operator() (const argument_type& info) const
-        {
-            size_t h = 0;
-            hash_combine(h, info.m_name);
-            return h;
-        }
-    };
-
-    template<>
-    struct hash<AZ::CheckedOperationInfo>
-    {
-        using argument_type = AZ::CheckedOperationInfo;
-        using result_type = size_t;
-
-        AZ_INLINE result_type operator() (const argument_type& info) const
-        {
-            size_t h = 0;
-            hash_combine(h, info.m_safetyCheckName);
-            return h;
-        }
-    };
-} // namespace AZStd
-
 namespace AZ
 {
     // AZ::Event support
     using BehaviorFunction = AZStd::function<void(BehaviorArgument* result, BehaviorArgument* arguments, int numArguments)>;
-    using EventHandlerCreationFunction = AZStd::function<BehaviorObject(void* , BehaviorFunction&&)>;
+    using EventHandlerCreationFunction = AZStd::function<BehaviorObject(void*, BehaviorFunction&&)>;
 
     struct EventHandlerCreationFunctionHolder
     {
@@ -507,401 +468,179 @@ namespace AZ
 
         EventHandlerCreationFunction m_function;
     };
+}
+namespace AZ::Internal
+{
+    AZ::TypeId GetUnderlyingTypeId(const IRttiHelper& enumRttiHelper);
 
+    // Converts sourceAddress to targetType
+    bool ConvertValueTo(void* sourceAddress, const IRttiHelper* sourceRtti, const AZ::Uuid& targetType, void*& targetAddress, BehaviorParameter::TempValueParameterAllocator& tempAllocator);
+
+    // Assumes parameters array is big enough to store all parameters
+    template<class... Args>
+    void SetParameters(BehaviorParameter* parameters, OnDemandReflectionOwner* onDemandReflection = nullptr);
+
+
+    //! Uses a the BehaviorArgument struct to wrap types that implement the GetO3deType* functions
+    //! This is used by the BehaviorMethod and BehaviorEBus to implement a type-erased structure
+    //! in order to reduce template instantiations from this header
+    //! The BehaviorContext.h header is one of the most expensive headers when it comes to compile
+    //! time within O3DE
+    using BehaviorMethodFunctor = AZStd::function<void(BehaviorArgument*, AZStd::span<BehaviorArgument>)>;
+    //! BehaviorMethod reflection will only support functions up to 32 parameters
+    constexpr size_t MaxBehaviorParameters = 32;
+
+    class BehaviorMethodImpl : public BehaviorMethod
+    {
+    public:
+        using ClassType = void;
+
+        AZ_CLASS_ALLOCATOR(BehaviorMethodImpl, AZ::SystemAllocator);
+
+        static const int s_startArgumentIndex = 1; // +1 for result type
+
+        template <class R, class... Args>
+        BehaviorMethodImpl(R(*functionPointer)(Args...), BehaviorContext* context, AZStd::string name = {});
+
+        template <class R, class C, class... Args>
+        BehaviorMethodImpl(R(C::* functionPointer)(Args...), BehaviorContext* context, AZStd::string name = {});
+
+        template <class R, class C, class... Args>
+        BehaviorMethodImpl(R(C::* functionPointer)(Args...) const, BehaviorContext* context, AZStd::string name = {});
+
+#if __cpp_noexcept_function_type
+        // C++17 makes exception specifications as part of the type in paper P0012R1
+        // Therefore noexcept overloads must be distinguished from non-noexcept overloads
+        template <class R, class... Args>
+        BehaviorMethodImpl(R(*functionPointer)(Args...) noexcept, BehaviorContext* context, AZStd::string name = {});
+
+        template <class R, class C, class... Args>
+        BehaviorMethodImpl(R(C::* functionPointer)(Args...) noexcept, BehaviorContext* context, AZStd::string name = {});
+
+        template <class R, class C, class... Args>
+        BehaviorMethodImpl(R(C::* functionPointer)(Args...) const noexcept, BehaviorContext* context, AZStd::string name = {});
+#endif
+
+        bool Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const override;
+        // The implementation should return true if the method can be called with the specified BehaviorArgument list
+        ResultOutcome IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const override;
+
+        bool HasResult() const override;
+        bool IsMember() const override;
+        bool HasBusId() const override;
+
+        const BehaviorParameter* GetBusIdArgument() const override;
+
+        size_t GetNumArguments() const override;
+        size_t GetMinNumberOfArguments() const override;
+
+        const BehaviorParameter* GetArgument(size_t index) const override;
+        const AZStd::string* GetArgumentName(size_t index) const override;
+        void SetArgumentName(size_t index, AZStd::string name) override;
+        const AZStd::string* GetArgumentToolTip(size_t index) const override;
+        void SetArgumentToolTip(size_t index, AZStd::string name) override;
+        void SetDefaultValue(size_t index, BehaviorDefaultValuePtr defaultValue) override;
+        BehaviorDefaultValuePtr GetDefaultValue(size_t index) const override;
+        const BehaviorParameter* GetResult() const override;
+
+        void OverrideParameterTraits(size_t index, AZ::u32 addTraits, AZ::u32 removeTraits) override;
+
+    protected:
+        BehaviorMethodFunctor m_functor;
+
+        AZStd::fixed_vector<BehaviorParameter, MaxBehaviorParameters> m_parameters;
+        //! Stores the per parameter metadata which is used to add names, tooltips, trait, default values, etc... to the parameters
+        AZStd::fixed_vector<BehaviorParameterMetadata, MaxBehaviorParameters> m_metadataParameters;
+
+    private:
+        int m_startNamedArgumentIndex = s_startArgumentIndex; // +1 for result type
+        bool m_hasNonVoidReturn{};
+        bool m_isMemberFunc{};
+    };
+}
+
+namespace AZ::Internal
+{
+    enum class BehaviorEventType
+    {
+        BE_BROADCAST,
+        BE_EVENT_ID,
+        BE_QUEUE_BROADCAST,
+        BE_QUEUE_EVENT_ID,
+    };
+
+    class BehaviorEBusEvent : public BehaviorMethod
+    {
+    public:
+        static const int s_startArgumentIndex = 1; // +1 for result type
+
+        AZ_CLASS_ALLOCATOR(BehaviorEBusEvent, AZ::SystemAllocator);
+
+        template<class EBus, class R, class BusType, class... Args>
+        BehaviorEBusEvent(R(*functionPointer)(BusType*, Args...), BehaviorContext* context, BehaviorEventType eventType, AZStd::type_identity<EBus>);
+
+        template<class EBus, class R, class C, class... Args>
+        BehaviorEBusEvent(R(C::* functionPointer)(Args...), BehaviorContext* context, BehaviorEventType eventType, AZStd::type_identity<EBus>);
+
+        template<class EBus, class R, class C, class... Args>
+        BehaviorEBusEvent(R(C::* functionPointer)(Args...) const, BehaviorContext* context, BehaviorEventType eventType, AZStd::type_identity<EBus>);
+
+#if __cpp_noexcept_function_type
+        // C++17 makes exception specifications as part of the type in paper P0012R1
+        // Therefore noexcept overloads must be distinguished from non-noexcept overloads
+        template<class EBus, class R, class BusType, class... Args>
+        BehaviorEBusEvent(R(*functionPointer)(BusType*, Args...) noexcept, BehaviorContext* context, BehaviorEventType eventType, AZStd::type_identity<EBus>);
+
+        template<class EBus, class R, class C, class... Args>
+        BehaviorEBusEvent(R(C::* functionPointer)(Args...) noexcept, BehaviorContext* context, BehaviorEventType eventType, AZStd::type_identity<EBus>);
+
+        template<class EBus, class R, class C, class... Args>
+        BehaviorEBusEvent(R(C::* functionPointer)(Args...) const noexcept, BehaviorContext* context, BehaviorEventType eventType, AZStd::type_identity<EBus>);
+#endif
+
+        bool Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const override;
+        ResultOutcome IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result = nullptr) const;
+        bool HasResult() const override;
+        bool IsMember() const override;
+        bool HasBusId() const override;
+
+        const BehaviorParameter* GetBusIdArgument() const override;
+
+        size_t GetNumArguments() const override;
+        size_t GetMinNumberOfArguments() const override;
+
+        const BehaviorParameter* GetArgument(size_t index) const override;
+        const AZStd::string* GetArgumentName(size_t index) const override;
+        void SetArgumentName(size_t index, AZStd::string name) override;
+        const AZStd::string* GetArgumentToolTip(size_t index) const override;
+        void SetArgumentToolTip(size_t index, AZStd::string name) override;
+        void SetDefaultValue(size_t index, BehaviorDefaultValuePtr defaultValue) override;
+        BehaviorDefaultValuePtr GetDefaultValue(size_t index) const override;
+        const BehaviorParameter* GetResult() const override;
+
+        void OverrideParameterTraits(size_t index, AZ::u32 addTraits, AZ::u32 removeTraits) override;
+
+    protected:
+        template<class EBus, class R, class BusType, class... Args>
+        void InitParameters();
+
+        BehaviorMethodFunctor m_functor;
+
+        AZStd::fixed_vector<BehaviorParameter, MaxBehaviorParameters> m_parameters;
+        //! Stores the per parameter metadata which is used to add names, tooltips, trait, default values, etc... to the parameters
+        AZStd::fixed_vector<BehaviorParameterMetadata, MaxBehaviorParameters> m_metadataParameters;
+
+    private:
+        int m_startNamedArgumentIndex = s_startArgumentIndex; // +1 for result type
+        BehaviorEventType m_eventType{};
+        bool m_hasNonVoidReturn{};
+    };
+}
+
+namespace AZ
+{
     namespace Internal
     {
-        AZ::TypeId GetUnderlyingTypeId(const IRttiHelper& enumRttiHelper);
-
-        // Converts sourceAddress to targetType
-        inline bool ConvertValueTo(void* sourceAddress, const IRttiHelper* sourceRtti, const AZ::Uuid& targetType, void*& targetAddress, BehaviorParameter::TempValueParameterAllocator& tempAllocator)
-        {
-            // Check see if the underlying typeid is an enum whose typeIds match
-            if (GetUnderlyingTypeId(*sourceRtti) == targetType)
-            {
-                return true;
-            }
-            // convert
-            void* convertedAddress = sourceRtti->Cast(sourceAddress, targetType);
-            if (convertedAddress && convertedAddress != sourceAddress) // if we converted as we have a different address
-            {
-                // allocate temp storage and store it
-                targetAddress = tempAllocator.allocate(sizeof(void*), AZStd::alignment_of<void*>::value, 0);
-                *reinterpret_cast<void**>(targetAddress) = convertedAddress;
-            }
-            return convertedAddress != nullptr;
-        }
-
-        // Assumes parameters array is big enough to store all parameters
-        template<class... Args>
-        void SetParameters(BehaviorParameter* parameters, OnDemandReflectionOwner* onDemandReflection = nullptr);
-
-        // call helper
-        template<class R, class... Args>
-        struct CallFunction
-        {
-            template<AZStd::size_t... Is, class Function>
-            static inline void Global(Function functionPtr, BehaviorArgument* arguments, BehaviorArgument* result, AZStd::index_sequence<Is...>);
-            template<AZStd::size_t... Is, class C, class Function>
-            static inline void Member(Function functionPtr, C thisPtr, BehaviorArgument* arguments, BehaviorArgument* result, AZStd::index_sequence<Is...>);
-        };
-
-        template<class... Args>
-        struct CallFunction<void, Args...>
-        {
-            template<AZStd::size_t... Is, class Function>
-            static inline void Global(Function functionPtr, BehaviorArgument* arguments, BehaviorArgument* result, AZStd::index_sequence<Is...>)
-            {
-                (void)result; (void)arguments;
-                functionPtr(*arguments[Is].GetAsUnsafe<Args>()...);
-            };
-
-            template<AZStd::size_t... Is, class C, class Function>
-            static inline void Member(Function functionPtr, C thisPtr, BehaviorArgument* arguments, BehaviorArgument* result, AZStd::index_sequence<Is...>)
-            {
-                (void)result; (void)arguments;
-                (thisPtr->*functionPtr)(*arguments[Is].GetAsUnsafe<Args>()...);
-            };
-        };
-
-        template<class Function>
-        class BehaviorMethodImpl;
-
-        template<class R, class... Args>
-        class BehaviorMethodImpl<R(Args...)> : public BehaviorMethod
-        {
-        public:
-            using FunctionPointer = R(*)(Args...);
-            using ClassType = void;
-
-            AZ_CLASS_ALLOCATOR(BehaviorMethodImpl, AZ::SystemAllocator);
-
-            static const int s_startArgumentIndex = 1; // +1 for result type
-            static const int s_startNamedArgumentIndex = s_startArgumentIndex; // +1 for result type
-
-            BehaviorMethodImpl(FunctionPointer functionPointer, BehaviorContext* context, const AZStd::string& name = AZStd::string());
-
-            bool Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const override;
-            // The implementation should return true if the method can be called with the specified BehaviorArgument list
-            ResultOutcome IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const override;
-
-            bool HasResult() const override;
-            bool IsMember() const override;
-            bool HasBusId() const override;
-
-            const BehaviorParameter* GetBusIdArgument() const override;
-
-            size_t GetNumArguments() const override;
-            size_t GetMinNumberOfArguments() const override;
-
-            const BehaviorParameter* GetArgument(size_t index) const override;
-            const AZStd::string* GetArgumentName(size_t index) const override;
-            void SetArgumentName(size_t index, const AZStd::string& name) override;
-            const AZStd::string* GetArgumentToolTip(size_t index) const override;
-            void SetArgumentToolTip(size_t index, const AZStd::string& name) override;
-            void SetDefaultValue(size_t index, BehaviorDefaultValuePtr defaultValue) override;
-            BehaviorDefaultValuePtr GetDefaultValue(size_t index) const override;
-            const BehaviorParameter* GetResult() const override;
-
-            void OverrideParameterTraits(size_t index, AZ::u32 addTraits, AZ::u32 removeTraits) override;
-
-            FunctionPointer m_functionPtr;
-
-            BehaviorParameter m_parameters[sizeof...(Args) + s_startNamedArgumentIndex];
-            AZStd::array<BehaviorParameterMetadata, sizeof...(Args) + s_startNamedArgumentIndex> m_metadataParameters; ///< Stores the per parameter metadata which is used to add names, tooltips, trait, default values, etc... to the parameters
-        };
-
-#if __cpp_noexcept_function_type
-        // C++17 makes exception specifications as part of the type in paper P0012R1
-        // Therefore noexcept overloads must be distinguished from non-noexcept overloads
-        template<class R, class... Args>
-        class BehaviorMethodImpl<R(Args...) noexcept>
-            : public BehaviorMethodImpl<R(Args...)>
-        {
-            using base_type = BehaviorMethodImpl<R(Args...)>;
-        public:
-            using base_type::base_type;
-            using FunctionPointer = R(*)(Args...) noexcept;
-        };
-#endif
-
-        template<class R, class C, class... Args>
-        class BehaviorMethodImpl<R(C::*)(Args...)> : public BehaviorMethod
-        {
-        public:
-            using FunctionPointer = R(C::*)(Args...);
-            using FunctionPointerConst = R(C::*)(Args...) const;
-            typedef C ClassType;
-
-            AZ_CLASS_ALLOCATOR(BehaviorMethodImpl<R(C::*)(Args...)>, AZ::SystemAllocator);
-
-            static const int s_startArgumentIndex = 1; // +1 for result type
-            static const int s_startNamedArgumentIndex = s_startArgumentIndex + 1; // +1 for result type, +1 for class Type (this ptr)
-
-            BehaviorMethodImpl(FunctionPointer functionPointer, BehaviorContext* context, const AZStd::string& name = AZStd::string());
-            BehaviorMethodImpl(FunctionPointerConst functionPointer, BehaviorContext* context, const AZStd::string& name = AZStd::string());
-
-            bool Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const override;
-            ResultOutcome IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const;
-
-            bool HasResult() const override;
-            bool IsMember() const override;
-            bool HasBusId() const override;
-
-            const BehaviorParameter* GetBusIdArgument() const override;
-
-            size_t GetNumArguments() const override;
-            size_t GetMinNumberOfArguments() const override;
-            const BehaviorParameter* GetArgument(size_t index) const override;
-            const AZStd::string* GetArgumentName(size_t index) const override;
-            void SetArgumentName(size_t index, const AZStd::string& name) override;
-            const AZStd::string* GetArgumentToolTip(size_t index) const override;
-            void SetArgumentToolTip(size_t index, const AZStd::string& name) override;
-            void SetDefaultValue(size_t index, BehaviorDefaultValuePtr defaultValue) override;
-            BehaviorDefaultValuePtr GetDefaultValue(size_t index) const override;
-            const BehaviorParameter* GetResult() const override;
-
-            void OverrideParameterTraits(size_t index, AZ::u32 addTraits, AZ::u32 removeTraits) override;
-
-            FunctionPointer m_functionPtr;
-            BehaviorParameter m_parameters[sizeof...(Args) + s_startNamedArgumentIndex];
-            AZStd::array<BehaviorParameterMetadata, sizeof...(Args) + s_startNamedArgumentIndex> m_metadataParameters; ///< Stores the per parameter metadata which is used to add names, tooltips, trait, default values, etc... to the parameters
-        };
-
-#if __cpp_noexcept_function_type
-        // C++17 makes exception specifications as part of the type in paper P0012R1
-        // Therefore noexcept overloads must be distinguished from non-noexcept overloads
-        template<class R, class C, class... Args>
-        class BehaviorMethodImpl<R(C::*)(Args...) noexcept>
-            : public BehaviorMethodImpl<R(C::*)(Args...)>
-        {
-            using base_type = BehaviorMethodImpl<R(C::*)(Args...)>;
-        public:
-            AZ_CLASS_ALLOCATOR(BehaviorMethodImpl, AZ::SystemAllocator)
-            using base_type::base_type;
-            using FunctionPointer = R(C::*)(Args...) noexcept;
-            using FunctionPointerConst = R(C::*)(Args...) const noexcept;
-        };
-#endif
-
-        enum BehaviorEventType
-        {
-            BE_BROADCAST,
-            BE_EVENT_ID,
-            BE_QUEUE_BROADCAST,
-            BE_QUEUE_EVENT_ID,
-        };
-
-        template<BehaviorEventType EventType, class EBus, class R, class... Args>
-        struct EBusCaller;
-
-        template<class EBus, class... Args>
-        struct EBusCaller<BE_BROADCAST, EBus, void, Args...>
-        {
-            template<AZStd::size_t... Is, class Event>
-            static void Call(Event e, BehaviorArgument* arguments, BehaviorArgument* result, AZStd::index_sequence<Is...>)
-            {
-                (void)result; (void)arguments;
-                EBus::Broadcast(e, *arguments[Is].GetAsUnsafe<Args>()...);
-            }
-        };
-
-        template<class EBus, class R, class... Args>
-        struct EBusCaller<BE_BROADCAST, EBus, R, Args...>
-        {
-            template<AZStd::size_t... Is, class Event>
-            static void Call(Event e, BehaviorArgument* arguments, BehaviorArgument* result, AZStd::index_sequence<Is...>)
-            {
-                (void)arguments;
-                if (result)
-                {
-                    EBus::BroadcastResult(*result, e, *arguments[Is].GetAsUnsafe<Args>()...);
-                }
-                else
-                {
-                    EBus::Broadcast(e, *arguments[Is].GetAsUnsafe<Args>()...);
-                }
-            }
-        };
-
-        template<class EBus, class... Args>
-        struct EBusCaller<BE_EVENT_ID, EBus, void, Args...>
-        {
-            template<AZStd::size_t... Is, class Event>
-            static void Call(Event e, BehaviorArgument* arguments, BehaviorArgument* result, AZStd::index_sequence<Is...>)
-            {
-                (void)result;
-                BehaviorArgument& id = arguments[0];
-                ++arguments;
-                EBus::Event(*id.GetAsUnsafe<typename EBus::BusIdType>(), e, *arguments[Is].GetAsUnsafe<Args>()...);
-            }
-        };
-
-        template<class EBus, class R, class... Args>
-        struct EBusCaller<BE_EVENT_ID, EBus, R, Args...>
-        {
-            template<AZStd::size_t... Is, class Event>
-            static void Call(Event e, BehaviorArgument* arguments, BehaviorArgument* result, AZStd::index_sequence<Is...>)
-            {
-                BehaviorArgument& id = *arguments++;
-                if (result)
-                {
-                    EBus::EventResult(*result, *id.GetAsUnsafe<typename EBus::BusIdType>(), e, *arguments[Is].GetAsUnsafe<Args>()...);
-                }
-                else
-                {
-                    EBus::Event(*id.GetAsUnsafe<typename EBus::BusIdType>(), e, *arguments[Is].GetAsUnsafe<Args>()...);
-                }
-            }
-        };
-
-        template<class EBus, class R, class... Args>
-        struct EBusCaller<BE_QUEUE_BROADCAST, EBus, R, Args...>
-        {
-            template<AZStd::size_t... Is, class Event>
-            static void Call(Event e, BehaviorArgument* arguments, BehaviorArgument* result, AZStd::index_sequence<Is...>)
-            {
-                (void)result; (void)arguments;
-                EBus::QueueBroadcast(e, *arguments[Is].GetAsUnsafe<Args>()...);
-            }
-        };
-
-        template<class EBus, class R, class... Args>
-        struct EBusCaller<BE_QUEUE_EVENT_ID, EBus, R, Args...>
-        {
-            template<AZStd::size_t... Is, class Event>
-            static void Call(Event e, BehaviorArgument* arguments, BehaviorArgument* result, AZStd::index_sequence<Is...>)
-            {
-                (void)result;
-                BehaviorArgument& id = *arguments++;
-                EBus::QueueEvent(*id.GetAsUnsafe<typename EBus::BusIdType>(), e, *arguments[Is].GetAsUnsafe<Args>()...);
-            }
-        };
-
-        template<class EBus, BehaviorEventType EventType, class Function>
-        class BehaviorEBusEvent;
-
-        template<class EBus, BehaviorEventType EventType, class R, class BusType, class... Args>
-        class BehaviorEBusEvent<EBus, EventType, R(BusType*, Args...)> : public BehaviorMethod
-        {
-        public:
-            using FunctionPointer = R(*)(BusType*, Args...);
-
-            static constexpr int s_isBusIdParameter = (EventType == BE_EVENT_ID || EventType == BE_QUEUE_EVENT_ID) ? 1 : 0;
-            static const int s_startArgumentIndex = 1; // +1 for result type
-            static const int s_startNamedArgumentIndex =
-                s_startArgumentIndex + s_isBusIdParameter; // +1 for result type, +1 (optional for busID)
-
-            AZ_CLASS_ALLOCATOR(BehaviorEBusEvent, AZ::SystemAllocator);
-
-            BehaviorEBusEvent(FunctionPointer functionPointer, BehaviorContext* context);
-
-            bool Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const override;
-            ResultOutcome IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result = nullptr) const;
-            bool HasResult() const override;
-            bool IsMember() const override;
-            bool HasBusId() const override;
-
-            const BehaviorParameter* GetBusIdArgument() const override;
-
-            size_t GetNumArguments() const override;
-            size_t GetMinNumberOfArguments() const override;
-
-            const BehaviorParameter* GetArgument(size_t index) const override;
-            const AZStd::string* GetArgumentName(size_t index) const override;
-            void SetArgumentName(size_t index, const AZStd::string& name) override;
-            const AZStd::string* GetArgumentToolTip(size_t index) const override;
-            void SetArgumentToolTip(size_t index, const AZStd::string& name) override;
-            void SetDefaultValue(size_t index, BehaviorDefaultValuePtr defaultValue) override;
-            BehaviorDefaultValuePtr GetDefaultValue(size_t index) const override;
-            const BehaviorParameter* GetResult() const override;
-
-            void OverrideParameterTraits(size_t index, AZ::u32 addTraits, AZ::u32 removeTraits) override;
-
-            FunctionPointer m_functionPtr;
-            BehaviorParameter m_parameters[sizeof...(Args) + s_startNamedArgumentIndex];
-            AZStd::array<BehaviorParameterMetadata, sizeof...(Args) + s_startNamedArgumentIndex>
-                m_metadataParameters; ///< Stores the per parameter metadata which is used to add names, tooltips, trait, default values,
-            ///< etc... to the parameters
-        };
-
-#if __cpp_noexcept_function_type
-        // C++17 makes exception specifications as part of the type in paper P0012R1
-        // Therefore noexcept overloads must be distinguished from non-noexcept overloads
-        template<class EBus, BehaviorEventType EventType, class R, class BusType, class... Args>
-        class BehaviorEBusEvent<EBus, EventType, R(BusType*, Args...) noexcept> : public BehaviorEBusEvent<EBus, EventType, R(BusType, Args...)>
-        {
-            using base_type = BehaviorEBusEvent<EBus, EventType, R(BusType*, Args...)>;
-
-        public:
-            using base_type::base_type;
-            using FunctionPointer = R(*)(BusType*, Args...) noexcept;
-        };
-#endif
-
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        class BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)> : public BehaviorMethod
-        {
-        public:
-            using FunctionPointer = R(C::*)(Args...);
-            using FunctionPointerConst = R(C::*)(Args...) const;
-
-            static constexpr int s_isBusIdParameter = (EventType == BE_EVENT_ID || EventType == BE_QUEUE_EVENT_ID) ? 1 : 0;
-            static const int s_startArgumentIndex = 1; // +1 for result type
-            static const int s_startNamedArgumentIndex = s_startArgumentIndex + s_isBusIdParameter; // +1 for result type, +1 (optional for busID)
-
-            AZ_CLASS_ALLOCATOR(BehaviorEBusEvent, AZ::SystemAllocator);
-
-            BehaviorEBusEvent(FunctionPointer functionPointer, BehaviorContext* context);
-            BehaviorEBusEvent(FunctionPointerConst functionPointer, BehaviorContext* context);
-
-            template<bool IsBusId>
-            inline AZStd::enable_if_t<IsBusId> SetBusIdType();
-
-            template<bool IsBusId>
-            inline AZStd::enable_if_t<!IsBusId> SetBusIdType();
-
-            bool Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const override;
-            ResultOutcome IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result = nullptr) const;
-            bool HasResult() const override;
-            bool IsMember() const override;
-            bool HasBusId() const override;
-
-            const BehaviorParameter* GetBusIdArgument() const override;
-
-            size_t GetNumArguments() const override;
-            size_t GetMinNumberOfArguments() const override;
-
-            const BehaviorParameter* GetArgument(size_t index) const override;
-            const AZStd::string* GetArgumentName(size_t index) const override;
-            void SetArgumentName(size_t index, const AZStd::string& name) override;
-            const AZStd::string* GetArgumentToolTip(size_t index) const override;
-            void SetArgumentToolTip(size_t index, const AZStd::string& name) override;
-            void SetDefaultValue(size_t index, BehaviorDefaultValuePtr defaultValue) override;
-            BehaviorDefaultValuePtr GetDefaultValue(size_t index) const override;
-            const BehaviorParameter* GetResult() const override;
-
-            void OverrideParameterTraits(size_t index, AZ::u32 addTraits, AZ::u32 removeTraits) override;
-
-            FunctionPointer m_functionPtr;
-            BehaviorParameter m_parameters[sizeof...(Args)+s_startNamedArgumentIndex];
-            AZStd::array<BehaviorParameterMetadata, sizeof...(Args)+s_startNamedArgumentIndex> m_metadataParameters; ///< Stores the per parameter metadata which is used to add names, tooltips, trait, default values, etc... to the parameters
-        };
-
-#if __cpp_noexcept_function_type
-        // C++17 makes exception specifications as part of the type in paper P0012R1
-        // Therefore noexcept overloads must be distinguished from non-noexcept overloads
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        class BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...) noexcept>
-            : public BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>
-        {
-            using base_type = BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>;
-        public:
-            using base_type::base_type;
-            using FunctionPointer = R(C::*)(Args...) noexcept;
-            using FunctionPointerConst = R(C::*)(Args...) const noexcept;
-        };
-#endif
-
         template<class F>
         struct SetFunctionParameters;
 
@@ -976,13 +715,6 @@ namespace AZ
         template<class... Functions>
         void OnDemandReflectFunctions(OnDemandReflectionOwner* onDemandReflection, AZStd::Internal::pack_traits_arg_sequence<Functions...>);
 
-        template<class T>
-        struct BahaviorDefaultFactory
-        {
-            static void* Create(void* inplaceAddress, void* userData);
-            static void Destroy(void* objectPtr, bool isFreeMemory, void* userData);
-            static void* Clone(void* targetAddress, void* sourceAddress, void* userData);
-        };
 
         template<class Handler>
         struct BehaviorEBusHandlerFactory
@@ -1000,13 +732,13 @@ namespace AZ
             template<class LastValue>
             inline void SetValues(LastValue&& value)
             {
-                m_values[sizeof...(Values)-1] = aznew BehaviorDefaultValue(AZStd::forward<LastValue>(value));
+                m_values[sizeof...(Values) - 1] = aznew BehaviorDefaultValue(AZStd::forward<LastValue>(value));
             }
 
             template<class CurrentValue, class... RestValues>
             inline void SetValues(CurrentValue&& value, RestValues&&... values)
             {
-                m_values[sizeof...(Values)-sizeof...(RestValues)-1] = aznew BehaviorDefaultValue(AZStd::forward<CurrentValue>(value));
+                m_values[sizeof...(Values) - sizeof...(RestValues) - 1] = aznew BehaviorDefaultValue(AZStd::forward<CurrentValue>(value));
                 SetValues(AZStd::forward<RestValues>(values)...);
             };
 
@@ -1072,7 +804,6 @@ namespace AZ
             BehaviorContext* m_context;
         };
 
-        template<typename Bus>
         class EBusAttributes;
 
     } // namespace Internal
@@ -1133,7 +864,7 @@ namespace AZ
         ~BehaviorClass();
 
         /// Hooks to override default memory allocation for the class (AZ_CLASS_ALLOCATOR is used by default)
-        using AllocateType = void*(*)(void* userData);
+        using AllocateType = void* (*)(void* userData);
         using DeallocateType = void(*)(void* address, void* userData);
         /// Default constructor and destructor custom function
         using DefaultConstructorType = void(*)(void* address, void* userData);
@@ -1344,10 +1075,7 @@ namespace AZ
 
         struct VirtualProperty
         {
-            VirtualProperty(BehaviorEBusEventSender* getter, BehaviorEBusEventSender* setter)
-                : m_getter(getter)
-                , m_setter(setter)
-            {}
+            VirtualProperty(BehaviorEBusEventSender* getter, BehaviorEBusEventSender* setter);
 
             BehaviorEBusEventSender* m_getter;
             BehaviorEBusEventSender* m_setter;
@@ -1391,62 +1119,46 @@ namespace AZ
         AZ_RTTI_NO_TYPE_INFO_DECL();
 
         // Since we can share hooks we should probably pass the event name
-        typedef void(*GenericHookType)(void* /*userData*/, const char* /*eventName*/, int /*eventIndex*/, BehaviorArgument* /*result*/, int /*numParameters*/, BehaviorArgument* /*parameters*/);
+        using GenericHookType = void(*)(void* /*userData*/, const char* /*eventName*/, int /*eventIndex*/, BehaviorArgument* /*result*/, int /*numParameters*/, BehaviorArgument* /*parameters*/);
 
         struct BusForwarderEvent
         {
-            BusForwarderEvent()
-                : m_name(nullptr)
-                , m_function(nullptr)
-                , m_isFunctionGeneric(false)
-                , m_userData(nullptr)
-            {
-            }
+            BusForwarderEvent() = default;
 
-            const char* m_name;
+            const char* m_name{};
             AZ::Crc32   m_eventId;
-            void* m_function; ///< Pointer user handler R Function(userData, Args...)
-            bool m_isFunctionGeneric;
-            void* m_userData;
+            void* m_function{}; ///< Pointer user handler R Function(userData, Args...)
+            bool m_isFunctionGeneric{};
+            void* m_userData{};
 
             /// \note, even if this function returns no result, the first parameter is STILL space for the result
             bool HasResult() const;
 
             AZStd::vector<BehaviorParameter> m_parameters; // result, userdata, arguments...
             AZStd::vector<BehaviorParameterMetadata> m_metadataParameters; //< Custom Metadata for the parameter. Contains Names and Tooltips for each parameter.
-                                                           // Not consolidated with the above vector, because existing internal functions expect BehaviorParameters to be laid out contiguously
+            // Not consolidated with the above vector, because existing internal functions expect BehaviorParameters to be laid out contiguously
         };
 
-        typedef AZStd::vector<BusForwarderEvent> EventArray;
+        using EventArray = AZStd::vector<BusForwarderEvent>;
 
-        BehaviorEBusHandler() {}
+        BehaviorEBusHandler() = default;
 
-        virtual ~BehaviorEBusHandler() {}
+        virtual ~BehaviorEBusHandler() = default;
 
         virtual int GetFunctionIndex(const char* name) const = 0;
 
         template<class BusId>
-        bool Connect(BusId id)
-        {
-            BehaviorArgument p(&id);
-            return Connect(&p);
-        }
+        bool Connect(BusId id);
 
         virtual bool Connect(BehaviorArgument* id = nullptr) = 0;
 
         virtual void Disconnect(BehaviorArgument* id = nullptr) = 0;
 
         template<class BusId>
-        void Disconnect(BusId id)
-        {
-            BehaviorArgument p(&id);
-            Disconnect(&p);
-        }
+        void Disconnect(BusId id);
 
         virtual bool IsConnected() = 0;
         virtual bool IsConnectedId(BehaviorArgument* id) = 0;
-
-        //const AZ::Uuid* GetIdTypeId() const = 0;
 
         template<class Hook>
         bool InstallHook(int index, Hook h, void* userData = nullptr);
@@ -1460,27 +1172,13 @@ namespace AZ
 
         const EventArray& GetEvents() const;
 
-#if !defined(_RELEASE) // m_scriptPath is only available in non-Release mode
+#if !defined(AZ_RELEASE_BUILD) // m_scriptPath is only available in non-Release mode
         AZStd::string m_scriptPath;
 #endif
 
-        AZStd::string GetScriptPath() const
-        {
-#if !defined(_RELEASE) // m_scriptPath is only available in non-Release mode
-            return m_scriptPath;
-#else
-            return{};
-#endif
-        }
+        AZStd::string GetScriptPath() const;
 
-        void SetScriptPath(const char* scriptPath)
-        {
-#if !defined(_RELEASE) // m_scriptPath is only available in non-Release mode
-            m_scriptPath = scriptPath;
-#else
-            AZ_UNUSED(scriptPath);
-#endif
-        }
+        void SetScriptPath(const char* scriptPath);
 
     protected:
         template<class Event>
@@ -1497,7 +1195,11 @@ namespace AZ
 
         EventArray m_events;
     };
+} // namespace AZ
 
+
+namespace AZ
+{
     // Behavior context events you can listen for
     class BehaviorContextEvents : public EBusTraits
     {
@@ -1510,20 +1212,20 @@ namespace AZ
         //////////////////////////////////////////////////////////////////////////
 
         /// Called when a new global method is reflected in behavior context or removed from it
-        virtual void OnAddGlobalMethod(const char* methodName, BehaviorMethod* method)      { (void)methodName; (void)method; }
-        virtual void OnRemoveGlobalMethod(const char* methodName, BehaviorMethod* method)   { (void)methodName; (void)method; }
+        virtual void OnAddGlobalMethod(const char* methodName, BehaviorMethod* method);
+        virtual void OnRemoveGlobalMethod(const char* methodName, BehaviorMethod* method);
 
         /// Called when a new global property is reflected in behavior context or remove from it
-        virtual void OnAddGlobalProperty(const char* propertyName, BehaviorProperty* prop)  { (void)propertyName; (void)prop; }
-        virtual void OnRemoveGlobalProperty(const char* propertyName, BehaviorProperty* prop) { (void)propertyName; (void)prop; }
+        virtual void OnAddGlobalProperty(const char* propertyName, BehaviorProperty* prop);
+        virtual void OnRemoveGlobalProperty(const char* propertyName, BehaviorProperty* prop);
 
         /// Called when a class is added or removed
-        virtual void OnAddClass(const char* className, BehaviorClass* behaviorClass)    { (void)className; (void)behaviorClass; }
-        virtual void OnRemoveClass(const char* className, BehaviorClass* behaviorClass) { (void)className; (void)behaviorClass; }
+        virtual void OnAddClass(const char* className, BehaviorClass* behaviorClass);
+        virtual void OnRemoveClass(const char* className, BehaviorClass* behaviorClass);
 
         /// Called when a ebus is added or removed
-        virtual void OnAddEBus(const char* ebusName, BehaviorEBus* ebus)    { (void)ebusName; (void)ebus; }
-        virtual void OnRemoveEBus(const char* ebusName, BehaviorEBus* ebus) { (void)ebusName; (void)ebus; }
+        virtual void OnAddEBus(const char* ebusName, BehaviorEBus* ebus);
+        virtual void OnRemoveEBus(const char* ebusName, BehaviorEBus* ebus);
     };
 
     using BehaviorContextBus = AZ::EBus<BehaviorContextEvents>;
@@ -1541,7 +1243,7 @@ namespace AZ
         void EBusSetIdFeatures(BehaviorEBus* ebus)
         {
             AZ::Internal::SetParameters<typename Bus::BusIdType>(&ebus->m_idParam);
-            ebus->m_getCurrentId = aznew AZ::Internal::BehaviorMethodImpl<const typename Bus::BusIdType*()>(&Bus::GetCurrentBusId, this, AZStd::string(Bus::GetName()) + "::GetCurrentBusId");
+            ebus->m_getCurrentId = aznew AZ::Internal::BehaviorMethodImpl(static_cast<const typename Bus::BusIdType*(*)()>(&Bus::GetCurrentBusId), this, AZStd::string(Bus::GetName()) + "::GetCurrentBusId");
         }
 
         template<class Bus, typename AZStd::enable_if<AZStd::is_same<typename Bus::BusIdType, AZ::NullBusId>::value>::type* = nullptr>
@@ -1558,7 +1260,7 @@ namespace AZ
         template<class Bus, typename AZStd::enable_if<Bus::Traits::EnableEventQueue>::type* = nullptr>
         BehaviorMethod* QueueFunctionMethod()
         {
-            return aznew AZ::Internal::BehaviorMethodImpl<void(BehaviorEBus::QueueFunctionType, void*, void*)>(&QueueFunction<Bus>, this, AZStd::string(Bus::GetName()) + "::QueueFunction");
+            return aznew AZ::Internal::BehaviorMethodImpl(static_cast<void(*)(BehaviorEBus::QueueFunctionType, void*, void*)>(&QueueFunction<Bus>), this, AZStd::string(Bus::GetName()) + "::QueueFunction");
         }
 
         template<class Bus, typename AZStd::enable_if<!Bus::Traits::EnableEventQueue>::type* = nullptr>
@@ -1607,13 +1309,6 @@ namespace AZ
         {
             (void)userData;
             new(address) T();
-        }
-
-        /// Helper function to call generic constructor
-        template<class T, class... Params>
-        static void Construct(T* address, Params... params)
-        {
-            new(address) T(params...);
         }
 
         /// Helper function to destroy an object
@@ -1722,24 +1417,6 @@ namespace AZ
             behaviorClass->m_mover = &DefaultMoveConstruct<T>;
         }
 
-        template<class ClassType, class WrappedType, class Callable>
-        struct WrappedClassCaller
-        {
-            static void Unwrap(void* classPtr, void*& unwrappedClassPtr, AZ::Uuid& unwrappedClassTypeId, void* userData)
-            {
-                union
-                {
-                    void* userData;
-                    Callable callablePtr;
-                } u;
-                u.callablePtr = nullptr;
-
-                u.userData = userData;
-                unwrappedClassPtr = (void*)AZStd::invoke(u.callablePtr, reinterpret_cast<ClassType*>(classPtr));
-                unwrappedClassTypeId = AzTypeInfo<WrappedType>::Uuid();
-            }
-        };
-
     public:
         AZ_CLASS_ALLOCATOR(BehaviorContext, SystemAllocator);
         AZ_TYPE_INFO_WITH_NAME_DECL(BehaviorContext);
@@ -1769,145 +1446,12 @@ namespace AZ
             BehaviorProperty* m_prop;
         };
 
-        /// Internal structure to maintain class information while we are describing a class.
-        template<class C>
-        struct ClassBuilder : public AZ::Internal::GenericAttributes<ClassBuilder<C>>
-        {
-            typedef AZ::Internal::GenericAttributes<ClassBuilder<C>> Base;
-
-            //////////////////////////////////////////////////////////////////////////
-            /// Internal implementation
-            ClassBuilder(BehaviorContext* context, BehaviorClass* behaviorClass);
-            ~ClassBuilder();
-            ClassBuilder* operator->();
-
-            /**
-            * Sets custom allocator for a class, this function will error if this not inside a class.
-            * This is only for very specific cases when you want to override AZ_CLASS_ALLOCATOR or you are dealing with 3rd party classes, otherwise
-            * you should use AZ_CLASS_ALLOCATOR to control which allocator the class uses.
-            */
-            ClassBuilder* Allocator(BehaviorClass::AllocateType allocate, BehaviorClass::DeallocateType deallocate);
-
-            /// Attaches different constructor signatures to the class.
-            template<class... Params>
-            ClassBuilder* Constructor();
-
-            /// When your class is a wrapper, like smart pointers, you should use this to describe how to unwrap the class.
-            template<class WrappedType>
-            ClassBuilder* Wrapping(BehaviorClassUnwrapperFunction unwrapper, void* userData);
-
-            /// Provide a function to unwrap this class (use an underlaying class)
-            template<class WrappedType, class Callable>
-            ClassBuilder* WrappingMember(Callable callableFunction);
-
-            /// Sets userdata to a class.
-            ClassBuilder* UserData(void *userData);
-
-            /// Setup methods
-            ///< \deprecated Use "Method(const char* name, Function f, const BehaviorParameterOverridesArray<Function>& args, const char* dbgDesc = nullptr)" instead
-            ///< This method does not support passing in argument names and tooltips nor does it support overriding specific parameter Behavior traits
-            template<class Function>
-            ClassBuilder* Method(const char* name, Function, BehaviorValues* defaultValues = nullptr, const char* dbgDesc = nullptr);
-
-            ///< \deprecated Use "Method(const char* name, Function f, const char* deprecatedName, const BehaviorParameterOverridesArray<Function>& args, const char* dbgDesc = nullptr)" instead
-            ///< This method does not support passing in argument names and tooltips nor does it support overriding specific parameter Behavior traits
-            template<class Function>
-            ClassBuilder* Method(const char* name, Function f, const char* deprecatedName, BehaviorValues* defaultValues = nullptr, const char* dbgDesc = nullptr);
-
-            template<class Function>
-            ClassBuilder* Method(const char* name, Function f, const BehaviorParameterOverridesArray<Function>& args, const char* dbgDesc = nullptr);
-
-            template<class Function>
-            ClassBuilder* Method(
-                const char* name,
-                Function f,
-                const BehaviorParameterOverrides& classMetadata,
-                const BehaviorParameterOverridesArray<Function>& argsMetadata,
-                const char* dbgDesc = nullptr);
-
-            template<class Function>
-            ClassBuilder* Method(const char* name, Function f, const char* deprecatedName, const BehaviorParameterOverridesArray<Function>& args, const char* dbgDesc = nullptr);
-
-            template<class Getter, class Setter>
-            ClassBuilder* Property(const char* name, Getter getter, Setter setter);
-
-            /// All enums are treated as the enum type
-            template<auto Value>
-            ClassBuilder* Enum(const char* name);
-
-            template<class Getter>
-            ClassBuilder* Constant(const char* name, Getter getter);
-
-            /**
-             * You can describe buses that this class uses to communicate. Those buses will be used by tools when
-             * you need to give developers hints as to what buses this class interacts with.
-             * You don't need to reflect all buses that your class uses, just the ones related to
-             * class behavior. Please refer to component documentation for more information on
-             * the pattern of Request and Notification buses.
-             * {@
-             */
-            ClassBuilder* RequestBus(const char* busName);
-            ClassBuilder* NotificationBus(const char* busName);
-            // @}
-
-
-            BehaviorClass* m_class;
-        };
+        template <class T>
+        struct ClassBuilder;
 
         /// Internal structure to maintain EBus information while describing it.
         template<typename Bus>
-        struct EBusBuilder : public AZ::Internal::EBusAttributes<Bus>
-        {
-            typedef AZ::Internal::EBusAttributes<Bus> Base;
-
-            EBusBuilder(BehaviorContext* context, BehaviorEBus* behaviorEBus);
-            ~EBusBuilder();
-            EBusBuilder* operator->();
-
-            /**
-            * Reflects an EBus event, valid only when used with in the context of an EBus reflection.
-            * We will automatically add all possible variations (Broadcast,Event,QueueBroadcast and QueueEvent)
-            */
-            template<class Function>
-            EBusBuilder* Event(const char* name, Function f, const char* deprecatedName = nullptr);
-
-            template<class Function>
-            EBusBuilder* Event(const char* name, Function f, const BehaviorParameterOverridesArray<Function>& args);
-
-            template<class Function>
-            EBusBuilder* Event(const char* name, Function f, const char* deprecatedName, const BehaviorParameterOverridesArray<Function>& args);
-
-            /**
-            * Every \ref EBus has two components, sending and receiving. Sending is reflected via \ref BehaviorContext::Event calls and Handler/Received
-            * use handled via the receiver class. This class will receive EBus events and forward them to the behavior context functions.
-            * Since we can't write a class (without using a codegen) while reflecting, you will need to implement that class
-            * with the help of \ref AZ_EBUS_BEHAVIOR_BINDER. This class in mandated because you can't hook to individual events at the moment.
-            * In this version of Handler you can provide a custom function to create and destroy that handler (usually where aznew/delete is not
-            * applicable or you have a better pooling schema that our memory allocators already have). For most cases use the function \ref
-            * Handler()
-            */
-            template<typename HandlerType, typename HandlerCreator, typename HandlerDestructor>
-            EBusBuilder* Handler(HandlerCreator creator, HandlerDestructor destructor);
-
-            /** Set the Handler/Receiver for ebus evens that will be forwarded to BehaviorFunctions. This is a helper implementation where aznew/delete
-            * is ready to called on the handler.
-            */
-            template<class H>
-            EBusBuilder* Handler();
-
-            /**
-             * With request buses (please refer to component communication patterns documentation) we ofter have EBus events
-             * that represent a getter and a setter for a value. To allow our tools to take advantage of it, you can reflect
-             * VirtualProperty to indicate which event is the getter and which is the setter.
-             * This function validates that getter event has no argument and a result and setter function has no results and only
-             * one argument which is the same type as the result of the getter.
-             * \note Make sure you call this function after you have reflected the getter and setter events as it will report an error
-             * if we can't find the function
-             */
-            EBusBuilder* VirtualProperty(const char* name, const char* getterEvent, const char* setterEvent);
-
-            BehaviorEBus* m_ebus;
-        };
+        struct EBusBuilder;
 
          BehaviorContext();
         ~BehaviorContext();
@@ -2372,70 +1916,10 @@ namespace AZ
     //////////////////////////////////////////////////////////////////////////
 
     //////////////////////////////////////////////////////////////////////////
-    inline BehaviorObject::BehaviorObject()
-        : m_address(nullptr)
-        , m_typeId(AZ::Uuid::CreateNull())
-    {
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    inline BehaviorObject::BehaviorObject(void* address, const Uuid& typeId)
-        : m_address(address)
-        , m_typeId(typeId)
-    {
-    }
-
-    inline BehaviorObject::BehaviorObject(void* address, IRttiHelper* rttiHelper)
-        : m_address(address)
-        , m_rttiHelper(rttiHelper)
-    {
-        m_typeId = rttiHelper ? rttiHelper->GetTypeId() : AZ::Uuid::CreateNull();
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    inline bool BehaviorObject::IsValid() const
-    {
-        return m_address && !m_typeId.IsNull();
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    //////////////////////////////////////////////////////////////////////////
-    //////////////////////////////////////////////////////////////////////////
-
-    //////////////////////////////////////////////////////////////////////////
-    inline BehaviorArgument::BehaviorArgument()
-        : m_value(nullptr)
-    {
-        m_name = nullptr;
-        m_typeId = Uuid::CreateNull();
-        m_azRtti = nullptr;
-        m_traits = 0;
-    }
-
-    inline BehaviorArgument::BehaviorArgument(BehaviorArgument&& other)
-        : BehaviorParameter(AZStd::move(other))
-        , m_value(AZStd::move(other.m_value))
-        , m_onAssignedResult(AZStd::move(other.m_onAssignedResult))
-        , m_tempData(AZStd::move(other.m_tempData))
-    {
-    }
-
-    //////////////////////////////////////////////////////////////////////////
     template<class T>
     inline BehaviorArgument::BehaviorArgument(T* value)
     {
         Set<T>(value);
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    inline BehaviorArgument::BehaviorArgument(BehaviorObject* value)
-    {
-        Set(value);
-    }
-
-    inline BehaviorArgument::BehaviorArgument(BehaviorArgumentValueTypeTag_t, BehaviorObject* value)
-    {
-        Set(BehaviorArgumentValueTypeTag, value);
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -2462,57 +1946,6 @@ namespace AZ
     }
 
     //////////////////////////////////////////////////////////////////////////
-    AZ_FORCE_INLINE void BehaviorArgument::Set(BehaviorObject* value)
-    {
-        m_value = &value->m_address;
-        m_typeId = value->m_typeId;
-        m_traits = BehaviorParameter::TR_POINTER;
-        m_name = value->m_rttiHelper ? value->m_rttiHelper->GetActualTypeName(value->m_address) : nullptr;
-        m_azRtti = value->m_rttiHelper;
-    }
-
-    inline void BehaviorArgument::Set(BehaviorArgumentValueTypeTag_t, BehaviorObject* value)
-    {
-        m_value = value->m_address;
-        m_typeId = value->m_typeId;
-        m_traits = BehaviorParameter::TR_NONE;
-        m_name = value->m_rttiHelper ? value->m_rttiHelper->GetActualTypeName(value->m_address) : nullptr;
-        m_azRtti = value->m_rttiHelper;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    AZ_FORCE_INLINE void BehaviorArgument::Set(const BehaviorParameter& param)
-    {
-        *static_cast<BehaviorParameter*>(this) = param;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    AZ_FORCE_INLINE void BehaviorArgument::Set(const BehaviorArgument& param)
-    {
-        *static_cast<BehaviorParameter*>(this) = static_cast<const BehaviorParameter&>(param);
-        m_value = param.m_value;
-        m_onAssignedResult = param.m_onAssignedResult;
-        m_tempData = param.m_tempData;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    AZ_FORCE_INLINE void* BehaviorArgument::GetValueAddress() const
-    {
-        void* valueAddress = m_value;
-        if (m_traits & BehaviorParameter::TR_POINTER)
-        {
-            valueAddress = *reinterpret_cast<void**>(valueAddress); // pointer to a pointer
-        }
-        return valueAddress;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    AZ_FORCE_INLINE BehaviorArgument::operator BehaviorObject() const
-    {
-        return BehaviorObject(m_value, m_azRtti);
-    }
-
-    //////////////////////////////////////////////////////////////////////////
     template<class T>
     AZ_FORCE_INLINE bool BehaviorArgument::ConvertTo()
     {
@@ -2520,22 +1953,8 @@ namespace AZ
     }
 
     //////////////////////////////////////////////////////////////////////////
-    AZ_FORCE_INLINE bool BehaviorArgument::ConvertTo(const AZ::Uuid& typeId)
-    {
-        if (m_azRtti)
-        {
-            void* valueAddress = GetValueAddress();
-            if (valueAddress) // should we make null value to convert to anything?
-            {
-                return AZ::Internal::ConvertValueTo(valueAddress, m_azRtti, typeId, m_value, m_tempData);
-            }
-        }
-        return m_typeId == typeId;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
     template<typename T>
-    AZ_FORCE_INLINE AZStd::decay_t<T>*  BehaviorArgument::GetAsUnsafe() const
+    AZ_FORCE_INLINE AZStd::decay_t<T>* BehaviorArgument::GetAsUnsafe() const
     {
         return reinterpret_cast<AZStd::decay_t<T>*>(m_value);
     }
@@ -2611,15 +2030,6 @@ namespace AZ
     template<typename T, typename U>
     constexpr bool SetResult::IsCopyAssignable<T, U, AZStd::void_t<decltype(AZStd::declval<T>() = AZStd::declval<U>())>> = true;
 
-    AZ_FORCE_INLINE BehaviorArgument& BehaviorArgument::operator=(BehaviorArgument&& other)
-    {
-        *static_cast<BehaviorParameter*>(this) = AZStd::move(static_cast<BehaviorParameter&&>(other));
-        m_value = AZStd::move(other.m_value);
-        m_onAssignedResult = AZStd::move(other.m_onAssignedResult);
-        m_tempData = AZStd::move(other.m_tempData);
-        return *this;
-    }
-
     template<typename T>
     AZ_FORCE_INLINE BehaviorArgument& BehaviorArgument::operator=(T&& result)
     {
@@ -2677,12 +2087,6 @@ namespace AZ
     }
 
     //////////////////////////////////////////////////////////////////////////
-    AZ_FORCE_INLINE bool BehaviorMethod::Invoke() const
-    {
-        return Call(nullptr, 0, nullptr);
-    }
-
-    //////////////////////////////////////////////////////////////////////////
     template<class R, class... Args>
     bool BehaviorMethod::InvokeResult(R& r, Args&&... args) const
     {
@@ -2722,7 +2126,6 @@ namespace AZ
     template<class Getter>
     bool BehaviorProperty::SetGetter(Getter getter, BehaviorClass* currentClass, BehaviorContext* context, const AZStd::false_type&)
     {
-        using GetterType = AZ::Internal::BehaviorMethodImpl<typename AZStd::RemoveFunctionConst<AZStd::remove_pointer_t<Getter>>::type>;
         AZStd::string getterPropertyName = currentClass ? currentClass->m_name : AZStd::string{};
         if (!getterPropertyName.empty())
         {
@@ -2730,9 +2133,16 @@ namespace AZ
         }
         getterPropertyName += m_name;
         getterPropertyName += k_PropertyNameGetterSuffix;
-        m_getter = aznew GetterType(getter, context, getterPropertyName);
 
-        if (AZStd::is_class<typename GetterType::ClassType>::value)
+        using GetterFunctionTraits = AZStd::function_traits<Getter>;
+        constexpr bool isClassType = !AZStd::is_same_v<typename GetterFunctionTraits::class_type, AZStd::Internal::error_type>;
+        using GetterCastType = AZStd::conditional_t<
+            isClassType,
+            typename GetterFunctionTraits::type,
+            typename GetterFunctionTraits::function_object_signature*>;
+        m_getter = aznew AZ::Internal::BehaviorMethodImpl(static_cast<GetterCastType>(getter), context, getterPropertyName);
+
+        if constexpr (isClassType)
         {
             AZ_Assert(currentClass, "We should declare class property with in the class!");
 
@@ -2800,7 +2210,6 @@ namespace AZ
     template<class Setter>
     bool BehaviorProperty::SetSetter(Setter setter, BehaviorClass* currentClass, BehaviorContext* context, const AZStd::false_type&)
     {
-        using SetterType = AZ::Internal::BehaviorMethodImpl<typename AZStd::RemoveFunctionConst<AZStd::remove_pointer_t<Setter>>::type>;
         AZStd::string setterPropertyName = currentClass ? currentClass->m_name : AZStd::string{};
         if (!setterPropertyName.empty())
         {
@@ -2808,8 +2217,16 @@ namespace AZ
         }
         setterPropertyName += m_name;
         setterPropertyName += k_PropertyNameSetterSuffix;
-        m_setter = aznew SetterType(setter, context, setterPropertyName);
-        if (AZStd::is_class<typename SetterType::ClassType>::value)
+
+        using SetterFunctionTraits = AZStd::function_traits<Setter>;
+        constexpr bool isClassType = !AZStd::is_same_v<typename SetterFunctionTraits::class_type, AZStd::Internal::error_type>;
+        using SetterCastType = AZStd::conditional_t<
+            isClassType,
+            typename SetterFunctionTraits::type,
+            typename SetterFunctionTraits::function_object_signature*>;
+        m_setter = aznew AZ::Internal::BehaviorMethodImpl(static_cast<SetterCastType>(setter), context, setterPropertyName);
+
+        if constexpr (isClassType)
         {
             AZ_Assert(currentClass, "We should declare class property with in the class!");
 
@@ -2913,175 +2330,81 @@ namespace AZ
     template<class EBus, class Event>
     void BehaviorEBusEventSender::Set(Event e, const char* eventName, BehaviorContext* context)
     {
-        m_broadcast = aznew AZ::Internal::BehaviorEBusEvent<EBus, AZ::Internal::BE_BROADCAST, typename AZStd::RemoveFunctionConst<typename AZStd::remove_pointer<Event>::type>::type>(e, context);
+        using EventTraits = AZStd::function_traits<Event>;
+        using EventCastType = AZStd::conditional_t<
+            !AZStd::is_same_v<typename EventTraits::class_type, AZStd::Internal::error_type>,
+            typename EventTraits::type,
+            typename EventTraits::function_object_signature*>;
+        m_broadcast = aznew AZ::Internal::BehaviorEBusEvent(static_cast<EventCastType>(e), context,
+            AZ::Internal::BehaviorEventType::BE_BROADCAST, AZStd::type_identity<EBus>{});
         m_broadcast->m_name = eventName;
 
         SetEvent<EBus>(e, eventName, context, typename AZStd::is_same<typename EBus::BusIdType, NullBusId>::type());
         SetQueueBroadcast<EBus>(e, eventName, context, typename AZStd::is_same<typename EBus::QueuePolicy::BusMessageCall, typename AZ::Internal::NullBusMessageCall>::type());
-        SetQueueEvent<EBus>(e, eventName, context, typename AZStd::conditional<AZStd::is_same<typename EBus::BusIdType, NullBusId>::value || AZStd::is_same<typename EBus::QueuePolicy::BusMessageCall, typename AZ::Internal::NullBusMessageCall>::value, AZStd::true_type, AZStd::false_type>::type());
+        SetQueueEvent<EBus>(e, eventName, context, typename AZStd::conditional<
+            AZStd::is_same_v<typename EBus::BusIdType, NullBusId> || AZStd::is_same_v<typename EBus::QueuePolicy::BusMessageCall, typename AZ::Internal::NullBusMessageCall>,
+            AZStd::true_type, AZStd::false_type>::type());
     }
 
     //////////////////////////////////////////////////////////////////////////
     template<class EBus, class Event>
-    void BehaviorEBusEventSender::SetEvent(Event e, const char* eventName, BehaviorContext* context, const AZStd::true_type& /*is NullBusId*/)
+    void BehaviorEBusEventSender::SetEvent(Event, const char*, BehaviorContext*, const AZStd::true_type& /*is NullBusId*/)
     {
-        AZ_UNUSED(e); AZ_UNUSED(context); AZ_UNUSED(eventName);
-        m_event = nullptr;
     }
 
     //////////////////////////////////////////////////////////////////////////
     template<class EBus, class Event>
     void BehaviorEBusEventSender::SetEvent(Event e, const char* eventName, BehaviorContext* context, const AZStd::false_type& /*!is NullBusId*/)
     {
-        m_event = aznew AZ::Internal::BehaviorEBusEvent<EBus, AZ::Internal::BE_EVENT_ID, typename AZStd::RemoveFunctionConst<typename AZStd::remove_pointer<Event>::type>::type>(e, context);
+        using EventTraits = AZStd::function_traits<Event>;
+        using EventCastType = AZStd::conditional_t<
+            !AZStd::is_same_v<typename EventTraits::class_type, AZStd::Internal::error_type>,
+            typename EventTraits::type,
+            typename EventTraits::function_object_signature*>;
+        m_event = aznew AZ::Internal::BehaviorEBusEvent(static_cast<EventCastType>(e), context,
+            AZ::Internal::BehaviorEventType::BE_EVENT_ID, AZStd::type_identity<EBus>{});
         m_event->m_name = eventName;
     }
 
     //////////////////////////////////////////////////////////////////////////
     template<class EBus, class Event>
-    void BehaviorEBusEventSender::SetQueueBroadcast(Event e, const char* eventName, BehaviorContext* context, const AZStd::true_type& /*is NullBusId*/)
+    void BehaviorEBusEventSender::SetQueueBroadcast(Event, const char*, BehaviorContext*, const AZStd::true_type& /*is NullBusId*/)
     {
-        AZ_UNUSED(e); AZ_UNUSED(context); AZ_UNUSED(eventName);
-        m_queueBroadcast = nullptr;
     }
 
     //////////////////////////////////////////////////////////////////////////
     template<class EBus, class Event>
     void BehaviorEBusEventSender::SetQueueBroadcast(Event e, const char* eventName, BehaviorContext* context, const AZStd::false_type& /*!is NullBusId*/)
     {
-        m_queueBroadcast = aznew AZ::Internal::BehaviorEBusEvent<EBus, AZ::Internal::BE_QUEUE_BROADCAST, typename AZStd::RemoveFunctionConst<typename AZStd::remove_pointer<Event>::type>::type>(e, context);
+        using EventTraits = AZStd::function_traits<Event>;
+        using EventCastType = AZStd::conditional_t<
+            !AZStd::is_same_v<typename EventTraits::class_type, AZStd::Internal::error_type>,
+            typename EventTraits::type,
+            typename EventTraits::function_object_signature*>;
+        m_queueBroadcast = aznew AZ::Internal::BehaviorEBusEvent(static_cast<EventCastType>(e), context,
+            AZ::Internal::BehaviorEventType::BE_QUEUE_BROADCAST, AZStd::type_identity<EBus>{});
+
         m_queueBroadcast->m_name = eventName;
     }
 
     //////////////////////////////////////////////////////////////////////////
     template<class EBus, class Event>
-    void BehaviorEBusEventSender::SetQueueEvent(Event e, const char* eventName, BehaviorContext* context, const AZStd::true_type& /* is Queue and is BusId valid*/)
+    void BehaviorEBusEventSender::SetQueueEvent(Event, const char*, BehaviorContext*, const AZStd::true_type& /* is Queue and is BusId valid*/)
     {
-        AZ_UNUSED(e); AZ_UNUSED(context); AZ_UNUSED(eventName);
-        m_queueEvent = nullptr;
     }
 
     //////////////////////////////////////////////////////////////////////////
     template<class EBus, class Event>
     void BehaviorEBusEventSender::SetQueueEvent(Event e, const char* eventName, BehaviorContext* context, const AZStd::false_type& /* is Queue and is BusId valid*/)
     {
-        m_queueEvent = aznew AZ::Internal::BehaviorEBusEvent<EBus, AZ::Internal::BE_QUEUE_EVENT_ID, typename AZStd::RemoveFunctionConst<typename AZStd::remove_pointer<Event>::type>::type>(e, context);
+        using EventTraits = AZStd::function_traits<Event>;
+        using EventCastType = AZStd::conditional_t<
+            !AZStd::is_same_v<typename EventTraits::class_type, AZStd::Internal::error_type>,
+            typename EventTraits::type,
+            typename EventTraits::function_object_signature*>;
+        m_queueEvent = aznew AZ::Internal::BehaviorEBusEvent(static_cast<EventCastType>(e), context,
+            AZ::Internal::BehaviorEventType::BE_QUEUE_EVENT_ID, AZStd::type_identity<EBus>{});
         m_queueEvent->m_name = eventName;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    //////////////////////////////////////////////////////////////////////////
-    //////////////////////////////////////////////////////////////////////////
-    template<class Hook>
-    bool BehaviorEBusHandler::InstallHook(int index, Hook h, void* userData)
-    {
-        if (index != -1)
-        {
-            // Check parameters
-            if (!Internal::SetFunctionParameters<typename AZStd::remove_pointer<Hook>::type>::Check(m_events[index].m_parameters))
-            {
-                return false;
-            }
-
-            m_events[index].m_isFunctionGeneric = false;
-            m_events[index].m_function = reinterpret_cast<void*>(h);
-            m_events[index].m_userData = userData;
-            return true;
-        }
-
-        return false;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class Hook>
-    bool BehaviorEBusHandler::InstallHook(const char* name, Hook h, void* userData)
-    {
-        return InstallHook(GetFunctionIndex(name), h, userData);
-    };
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class Event>
-    void BehaviorEBusHandler::SetEvent(Event e, const char* name)
-    {
-        (void)e;
-        int i = GetFunctionIndex(name);
-        if (i != -1)
-        {
-            m_events.resize(i + 1);
-            m_events[i].m_name = name;
-            m_events[i].m_eventId = AZ::Crc32(name);
-            m_events[i].m_function = nullptr;
-            AZ::Internal::SetFunctionParameters<typename AZStd::remove_pointer<Event>::type>::Set(m_events[i].m_parameters);
-            m_events[i].m_metadataParameters.resize(m_events[i].m_parameters.size());
-        }
-    }
-
-    template<class Event>
-    void BehaviorEBusHandler::SetEvent(Event e, AZStd::string_view name, const BehaviorParameterOverridesArray<Event>& args)
-    {
-        (void)e;
-        int i = GetFunctionIndex(name.data());
-        if (i != -1)
-        {
-            m_events.resize(i + 1);
-            m_events[i].m_name = name.data();
-            m_events[i].m_eventId = AZ::Crc32(name.data());
-            m_events[i].m_function = nullptr;
-            AZ::Internal::SetFunctionParameters<typename AZStd::remove_pointer<Event>::type>::Set(m_events[i].m_parameters);
-            m_events[i].m_metadataParameters.resize(m_events[i].m_parameters.size());
-            for (size_t argIndex = 0; argIndex < args.size(); ++argIndex)
-            {
-                m_events[i].m_metadataParameters[AZ::eBehaviorBusForwarderEventIndices::ParameterFirst + argIndex] = { args[argIndex].m_name, args[argIndex].m_toolTip };
-            }
-        }
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class... Args>
-    void BehaviorEBusHandler::Call(int index, Args&&... args) const
-    {
-        const BusForwarderEvent& e = m_events[index];
-        if (e.m_function)
-        {
-            if (e.m_isFunctionGeneric)
-            {
-                BehaviorArgument arguments[sizeof...(args)+1] = { &args... };
-                reinterpret_cast<GenericHookType>(e.m_function)(const_cast<void*>(e.m_userData), e.m_name, index, nullptr, AZ_ARRAY_SIZE(arguments)-1, arguments);
-            }
-            else
-            {
-                typedef void(*FunctionType)(void*, Args...);
-                reinterpret_cast<FunctionType>(e.m_function)(const_cast<void*>(e.m_userData), args...);
-            }
-        }
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-
-    template<class R, class... Args>
-    void BehaviorEBusHandler::CallResult(R& result, int index, Args&&... args) const
-    {
-        const BusForwarderEvent& e = m_events[index];
-        if (e.m_function)
-        {
-            if (e.m_isFunctionGeneric)
-            {
-                BehaviorArgument arguments[sizeof...(args)+1] = { &args... };
-                BehaviorArgument r(&result);
-                reinterpret_cast<GenericHookType>(e.m_function)(const_cast<void*>(e.m_userData), e.m_name, index, &r, AZ_ARRAY_SIZE(arguments) - 1, arguments);
-                // Assign on top of the the value if the param isn't a pointer
-                // (otherwise the pointer just gets overridden and no value is returned).
-                if ((r.m_traits & BehaviorParameter::TR_POINTER) == 0 && r.GetAsUnsafe<R>())
-                {
-                    result = *r.GetAsUnsafe<R>();
-                }
-            }
-            else
-            {
-                typedef R(*FunctionType)(void*, Args...);
-                result = reinterpret_cast<FunctionType>(e.m_function)(const_cast<void*>(e.m_userData), args...);
-            }
-        }
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -3099,195 +2422,7 @@ namespace AZ
         return !IsRemovingReflection() ? aznew AZ::Internal::BehaviorValuesSpecialization<Values...>(AZStd::forward<Values>(values)...) : nullptr;
     }
 
-    //////////////////////////////////////////////////////////////////////////
-    template<class T>
-    BehaviorContext::ClassBuilder<T> BehaviorContext::Class(const char* name)
-    {
-        if (name == nullptr)
-        {
-            name = AzTypeInfo<T>::Name();
-        }
-
-        AZ::Uuid typeUuid = AzTypeInfo<T>::Uuid();
-        AZ_Assert(!typeUuid.IsNull(), "Type %s has no AZ_TYPE_INFO or AZ_RTTI.  Please use an AZ_RTTI or AZ_TYPE_INFO declaration before trying to use it in reflection contexts.", name ? name : "<Unknown class>");
-        if (typeUuid.IsNull())
-        {
-            return ClassBuilder<T>(this, static_cast<BehaviorClass*>(nullptr));
-        }
-
-        auto classTypeIt = m_typeToClassMap.find(typeUuid);
-        if (IsRemovingReflection())
-        {
-            if (classTypeIt != m_typeToClassMap.end())
-            {
-                // find it in the name category
-                auto nameIt = m_classes.find(name);
-                while (nameIt != m_classes.end())
-                {
-                    if (nameIt->second == classTypeIt->second)
-                    {
-                        m_classes.erase(nameIt);
-                        break;
-                    }
-                }
-                BehaviorContextBus::Event(this, &BehaviorContextBus::Events::OnRemoveClass, name, classTypeIt->second);
-                delete classTypeIt->second;
-                m_typeToClassMap.erase(classTypeIt);
-            }
-            return ClassBuilder<T>(this, static_cast<BehaviorClass*>(nullptr));
-        }
-        else
-        {
-            if (classTypeIt != m_typeToClassMap.end())
-            {
-                AZ_Error("Reflection", false, "Class '%s' is already registered using Uuid: %s!", name, classTypeIt->first.ToFixedString().c_str());
-                return ClassBuilder<T>(this, static_cast<BehaviorClass*>(nullptr));
-            }
-
-            // TODO: make it a set and use the name inside the class
-            if (m_classes.find(name) != m_classes.end())
-            {
-                AZ_Error("Reflection", false, "A class with name '%s' is already registered!", name);
-                return ClassBuilder<T>(this, static_cast<BehaviorClass*>(nullptr));
-            }
-
-            BehaviorClass* behaviorClass = aznew BehaviorClass();
-            behaviorClass->m_typeId = AzTypeInfo<T>::Uuid();
-            behaviorClass->m_azRtti = GetRttiHelper<T>();
-            behaviorClass->m_alignment = AZStd::alignment_of<T>::value;
-            behaviorClass->m_size = sizeof(T);
-            behaviorClass->m_name = name;
-
-            // enumerate all base classes (RTTI), we store only the IDs to allow for our of order reflection
-            // At runtime it will be more efficient to have the pointers to the classes. Analyze in practice and cache them if needed.
-            AZ::RttiEnumHierarchy<T>(
-                [](const AZ::Uuid& typeId, void* userData)
-                {
-                    BehaviorClass* bc = reinterpret_cast<BehaviorClass*>(userData);
-                    AZ_Assert(bc, "behavior class is invalid for typeId: %s", typeId.ToString<AZStd::string>().c_str());
-                    if (bc && typeId != bc->m_typeId)
-                    {
-                        bc->m_baseClasses.push_back(typeId);
-                    }
-                }
-                , behaviorClass
-                );
-
-            SetClassHasher<T>(behaviorClass);
-            SetClassDefaultAllocator<T>(behaviorClass, typename HasAZClassAllocator<T>::type());
-            SetClassDefaultConstructor<T>(behaviorClass, typename AZStd::conditional< AZStd::is_constructible<T>::value && !AZStd::is_abstract<T>::value, AZStd::true_type, AZStd::false_type>::type());
-            SetClassDefaultDestructor<T>(behaviorClass, typename AZStd::is_destructible<T>::type());
-            SetClassDefaultCopyConstructor<T>(behaviorClass, typename AZStd::conditional< AZStd::is_copy_constructible<T>::value && !AZStd::is_abstract<T>::value, AZStd::true_type, AZStd::false_type>::type());
-            SetClassDefaultMoveConstructor<T>(behaviorClass, typename AZStd::conditional< AZStd::is_move_constructible<T>::value && !AZStd::is_abstract<T>::value, AZStd::true_type, AZStd::false_type>::type());
-
-            // Switch to Set (we store the name in the class)
-            m_classes.insert(AZStd::make_pair(behaviorClass->m_name, behaviorClass));
-            m_typeToClassMap.insert(AZStd::make_pair(behaviorClass->m_typeId, behaviorClass));
-            return ClassBuilder<T>(this, behaviorClass);
-        }
-    };
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class C>
-    BehaviorContext::ClassBuilder<C>::ClassBuilder(BehaviorContext* context, BehaviorClass* behaviorClass)
-        : AZ::Internal::GenericAttributes<ClassBuilder<C>>(context)
-        , m_class(behaviorClass)
-    {
-        if (behaviorClass)
-        {
-            Base::m_currentAttributes = &behaviorClass->m_attributes;
-        }
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class C>
-    BehaviorContext::ClassBuilder<C>::~ClassBuilder()
-    {
-        // process all on demand queued reflections
-        Base::m_context->ExecuteQueuedOnDemandReflections();
-
-        if (m_class && (!Base::m_context->IsRemovingReflection()))
-        {
-            for (const auto &method : m_class->m_methods)
-            {
-                m_class->PostProcessMethod(Base::m_context, *method.second);
-                if (MethodReturnsAzEventByReferenceOrPointer(*method.second))
-                {
-                    ValidateAzEventDescription(*Base::m_context, *method.second);
-                }
-            }
-
-            // Validate the AzEvent description of the class property getter's
-            for (auto&& [propertyName, propertyInst]: m_class->m_properties)
-            {
-                if (propertyInst->m_getter && MethodReturnsAzEventByReferenceOrPointer(*propertyInst->m_getter))
-                {
-                    ValidateAzEventDescription(*Base::m_context, *propertyInst->m_getter);
-                }
-            }
-
-            BehaviorContextBus::Event(Base::m_context, &BehaviorContextBus::Events::OnAddClass, m_class->m_name.c_str(), m_class);
-        }
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class C>
-    BehaviorContext::ClassBuilder<C>* BehaviorContext::ClassBuilder<C>::operator->()
-    {
-        return this;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class C>
-    template<class... Params>
-    BehaviorContext::ClassBuilder<C>* BehaviorContext::ClassBuilder<C>::Constructor()
-    {
-        if (!Base::m_context->IsRemovingReflection())
-        {
-            AZ_Error("BehaviorContext", m_class, "You can set constructors only on valid classes!");
-        }
-        if (m_class)
-        {
-            BehaviorMethod* constructor = aznew AZ::Internal::BehaviorMethodImpl<void(C* address, Params...)>(&Construct<C, Params...>, Base::m_context, AZStd::string::format("%s::Constructor", m_class->m_name.c_str()));
-            m_class->m_constructors.push_back(constructor);
-        }
-        return this;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class C>
-    template<class WrappedType>
-    BehaviorContext::ClassBuilder<C>* BehaviorContext::ClassBuilder<C>::Wrapping(BehaviorClassUnwrapperFunction unwrapper, void* userData)
-    {
-        static_assert(!AZStd::is_same<AZStd::decay_t<C>, AZStd::decay_t<WrappedType>>::value, "A Wrapping member cannot unwrap to the same type as itself."
-            " As wrapped types are implicitly reflected by the ScriptContext, this prevents a recursive loop");
-        if (!Base::m_context->IsRemovingReflection())
-        {
-            AZ_Error("BehaviorContext", m_class, "You can wrap only valid classes!");
-        }
-        if (m_class)
-        {
-            m_class->m_wrappedTypeId = AzTypeInfo<WrappedType>::Uuid();
-            m_class->m_unwrapper = unwrapper;
-            m_class->m_unwrapperUserData = userData;
-        }
-        return this;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class C>
-    template<class WrappedType, class Callable>
-    BehaviorContext::ClassBuilder<C>* BehaviorContext::ClassBuilder<C>::WrappingMember(Callable callableFunction)
-    {
-        union
-        {
-            Callable callableFunction;
-            void* userData;
-        } u;
-        u.callableFunction = callableFunction;
-        return Wrapping<WrappedType>(&WrappedClassCaller<C, WrappedType, Callable>::Unwrap, u.userData);
-    }
-
+    // BehaviorContext overloads which returns GlobalMethodBuilder instances
     template<class Function>
     BehaviorContext::GlobalMethodBuilder BehaviorContext::Method(const char* name, Function f, BehaviorValues* defaultValues, const char* dbgDesc)
     {
@@ -3338,9 +2473,13 @@ namespace AZ
             return GlobalMethodBuilder(this, nullptr, nullptr);
         }
 
-        AZ_Assert(!AZStd::is_member_function_pointer<Function>::value, "This is a member %s method declared as global! use script.Class<Type>(Name)->Method()->Value()!\n", name);
-        typedef AZ::Internal::BehaviorMethodImpl<typename AZStd::RemoveFunctionConst<typename AZStd::remove_pointer<Function>::type>::type> BehaviorMethodType;
-        BehaviorMethod* method = aznew BehaviorMethodType(f, this, name);
+        static_assert(!AZStd::is_member_function_pointer_v<Function>, "This is a member method declared as global! use script.Class<Type>(Name)->Method()->Value()!\n");
+        using FunctionTraits = AZStd::function_traits<Function>;
+        using FunctionCastType = AZStd::conditional_t<
+            !AZStd::is_same_v<typename FunctionTraits::class_type, AZStd::Internal::error_type>,
+            typename FunctionTraits::type,
+            typename FunctionTraits::function_object_signature*>;
+        BehaviorMethod* method = aznew AZ::Internal::BehaviorMethodImpl(static_cast<FunctionCastType>(f), this, name);
         method->m_debugDescription = dbgDesc;
 
         /*
@@ -3354,7 +2493,7 @@ namespace AZ
             {
                 // now check to make sure that the deprecated name is not being used as a identical deprecated name for another method.
                 bool isDuplicate = false;
-                for (const auto & i : m_methods)
+                for (const auto& i : m_methods)
                 {
                     if (i.second->GetDeprecatedName() == deprecatedName)
                     {
@@ -3393,263 +2532,6 @@ namespace AZ
         }
 
         return GlobalMethodBuilder(this, name, method);
-    }
-
-    template<class C>
-    template<class Function>
-    BehaviorContext::ClassBuilder<C>* BehaviorContext::ClassBuilder<C>::Method(const char* name, Function f, BehaviorValues* defaultValues, const char* dbgDesc)
-    {
-        return Method(name, f, nullptr, defaultValues, dbgDesc);
-    }
-
-    template<class C>
-    template<class Function>
-    BehaviorContext::ClassBuilder<C>* BehaviorContext::ClassBuilder<C>::Method(const char* name, Function f, const char* deprecatedName, BehaviorValues* defaultValues, const char* dbgDesc)
-    {
-        BehaviorParameterOverridesArray<Function> parameterOverrides;
-        if (defaultValues)
-        {
-            AZ_Assert(defaultValues->GetNumValues() <= parameterOverrides.size(), "You can't have more default values than the number of function arguments");
-            // Copy default values to parameter override structure
-            size_t startArgumentIndex = parameterOverrides.size() - defaultValues->GetNumValues();
-            for (size_t i = 0; i < defaultValues->GetNumValues(); ++i)
-            {
-                parameterOverrides[startArgumentIndex + i].m_defaultValue = defaultValues->GetDefaultValue(i);
-            }
-            delete defaultValues;
-        }
-
-        return Method(name, f, deprecatedName, parameterOverrides, dbgDesc);
-    }
-
-    template<class C>
-    template<class Function>
-    BehaviorContext::ClassBuilder<C>* BehaviorContext::ClassBuilder<C>::Method(const char* name, Function f, const BehaviorParameterOverridesArray<Function>& args, const char* dbgDesc)
-    {
-        return Method(name, f, nullptr, args, dbgDesc);
-    }
-
-    template<class C>
-    template<class Function>
-    BehaviorContext::ClassBuilder<C>* BehaviorContext::ClassBuilder<C>::Method(
-        const char* name,
-        Function f,
-        const BehaviorParameterOverrides& classMetadata,
-        const BehaviorParameterOverridesArray<Function>& argsMetadata,
-        const char* dbgDesc)
-    {
-        if (m_class)
-        {
-            typedef AZ::Internal::BehaviorMethodImpl<
-                typename AZStd::RemoveFunctionConst<typename AZStd::remove_pointer<Function>::type>::type>
-                BehaviorMethodType;
-            BehaviorMethod* method =
-                aznew BehaviorMethodType(f, Base::m_context, AZStd::string::format("%s::%s", m_class->m_name.c_str(), name));
-            method->m_debugDescription = dbgDesc;
-
-            auto methodIter = m_class->m_methods.find(name);
-            if (methodIter != m_class->m_methods.end())
-            {
-                if (!methodIter->second->AddOverload(method))
-                {
-                    AZ_Error("BehaviorContext", false, "Method incorrectly reflected as C++ overload");
-                    delete method;
-                    return this;
-                }
-            }
-            else
-            {
-                m_class->m_methods.insert(AZStd::make_pair(name, method));
-            }
-
-            size_t classPtrIndex = 0;
-            if (method->IsMember())
-            {
-                method->SetArgumentName(classPtrIndex, classMetadata.m_name);
-                method->SetArgumentToolTip(classPtrIndex, classMetadata.m_toolTip);
-                method->SetDefaultValue(classPtrIndex, classMetadata.m_defaultValue);
-                method->OverrideParameterTraits(classPtrIndex, classMetadata.m_addTraits, classMetadata.m_removeTraits);
-                classPtrIndex++;
-            }
-
-            for (size_t i = 0; i < argsMetadata.size(); ++i)
-            {
-                method->SetArgumentName(i + classPtrIndex, argsMetadata[i].m_name);
-                method->SetArgumentToolTip(i + classPtrIndex, argsMetadata[i].m_toolTip);
-                method->SetDefaultValue(i + classPtrIndex, argsMetadata[i].m_defaultValue);
-                method->OverrideParameterTraits(i + classPtrIndex, argsMetadata[i].m_addTraits, argsMetadata[i].m_removeTraits);
-            }
-
-            // \note we can start returning a context so we can maintain the scope
-            Base::m_currentAttributes = &method->m_attributes;
-        }
-
-        return this;
-    }
-
-    template<class C>
-    template<class Function>
-    BehaviorContext::ClassBuilder<C>* BehaviorContext::ClassBuilder<C>::Method(const char* name, Function f, const char* deprecatedName, const BehaviorParameterOverridesArray<Function>& args, const char* dbgDesc)
-    {
-        if (m_class)
-        {
-            typedef AZ::Internal::BehaviorMethodImpl<typename AZStd::RemoveFunctionConst<typename AZStd::remove_pointer<Function>::type>::type> BehaviorMethodType;
-            BehaviorMethod* method = aznew BehaviorMethodType(f, Base::m_context, AZStd::string::format("%s::%s", m_class->m_name.c_str(), name));
-            method->m_debugDescription = dbgDesc;
-
-            /*
-            ** check to see if the deprecated name is used, and ensure its not duplicated.
-            */
-
-            if (deprecatedName != nullptr)
-            {
-                auto itr = m_class->m_methods.find(name);
-                if (itr != m_class->m_methods.end())
-                {
-                    // now check to make sure that the deprecated name is not being used as a identical deprecated name for another method.
-                    bool isDuplicate = false;
-                    for (const auto & i : m_class->m_methods)
-                    {
-                        if (i.second->GetDeprecatedName() == deprecatedName)
-                        {
-                            AZ_Warning("BehaviorContext", false, "Method %s is attempting to use a deprecated name of %s which is already in use for method %s! Deprecated name is ignored!", name, deprecatedName, i.first.c_str());
-                            isDuplicate = true;
-                            break;
-                        }
-                    }
-
-                    if (!isDuplicate)
-                    {
-                        itr->second->SetDeprecatedName(deprecatedName);
-                    }
-                }
-                else
-                {
-                    AZ_Warning("BehaviorContext", false, "Method %s does not exist, so the deprecated name is ignored!", name, deprecatedName);
-                }
-            }
-
-            auto methodIter = m_class->m_methods.find(name);
-            if (methodIter != m_class->m_methods.end())
-            {
-                if (!methodIter->second->AddOverload(method))
-                {
-                    AZ_Error("BehaviorContext", false, "Method incorrectly reflected as C++ overload");
-                    delete method;
-                    return this;
-                }
-            }
-            else
-            {
-                m_class->m_methods.insert(AZStd::make_pair(name, method));
-            }
-
-            size_t classPtrIndex = method->IsMember() ? 1 : 0;
-            for (size_t i = 0; i < args.size(); ++i)
-            {
-                method->SetArgumentName(i + classPtrIndex, args[i].m_name);
-                method->SetArgumentToolTip(i + classPtrIndex, args[i].m_toolTip);
-                method->SetDefaultValue(i + classPtrIndex, args[i].m_defaultValue);
-                method->OverrideParameterTraits(i + classPtrIndex, args[i].m_addTraits, args[i].m_removeTraits);
-            }
-
-            // \note we can start returning a context so we can maintain the scope
-            Base::m_currentAttributes = &method->m_attributes;
-        }
-
-        return this;
-    }
-
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class C>
-    template<class Getter, class Setter>
-    BehaviorContext::ClassBuilder<C>* BehaviorContext::ClassBuilder<C>::Property(const char* name, Getter getter, Setter setter)
-    {
-        if (m_class)
-        {
-            BehaviorProperty* prop = aznew BehaviorProperty(Base::m_context);
-            prop->m_name = name;
-            if (!prop->Set(getter, setter, m_class, Base::m_context))
-            {
-                delete prop;
-                return this;
-            }
-
-            m_class->m_properties.insert(AZStd::make_pair(name, prop));
-
-            // \note we can start returning a context so we can maintain the scope
-            Base::m_currentAttributes = &prop->m_attributes;
-        }
-
-        return this;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class C>
-    template<auto Value>
-    BehaviorContext::ClassBuilder<C>* BehaviorContext::ClassBuilder<C>::Enum(const char* name)
-    {
-        Property(name, []() { return Value; }, nullptr);
-        ClassBuilder::Attribute(AZ::Script::Attributes::ClassConstantValue, true);
-        return this;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class C>
-    template<class Getter>
-    BehaviorContext::ClassBuilder<C>* BehaviorContext::ClassBuilder<C>::Constant(const char* name, Getter getter)
-    {
-        Property(name, getter, nullptr);
-        return this;
-    };
-
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class C>
-    BehaviorContext::ClassBuilder<C>* BehaviorContext::ClassBuilder<C>::RequestBus(const char* name)
-    {
-        if (m_class)
-        {
-            m_class->m_requestBuses.insert(name);
-        }
-        return this;
-    }
-
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class C>
-    BehaviorContext::ClassBuilder<C>* BehaviorContext::ClassBuilder<C>::NotificationBus(const char* name)
-    {
-        if (m_class)
-        {
-            m_class->m_notificationBuses.insert(name);
-        }
-        return this;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class C>
-    BehaviorContext::ClassBuilder<C>* BehaviorContext::ClassBuilder<C>::Allocator(BehaviorClass::AllocateType allocate, BehaviorClass::DeallocateType deallocate)
-    {
-        AZ_Error("BehaviorContext", m_class, "Allocator can be set on valid classes only!");
-        if (m_class)
-        {
-            m_class->m_allocate = allocate;
-            m_class->m_deallocate = deallocate;
-        }
-        return this;
-    }
-
-    template<class C>
-    BehaviorContext::ClassBuilder<C>* BehaviorContext::ClassBuilder<C>::UserData(void *userData)
-    {
-        AZ_Error("BehaviorContext", m_class, "UserData can be set on valid classes only!");
-        if (m_class)
-        {
-            m_class->m_userData = userData;
-        }
-        return this;
     }
 
     template<class Getter, class Setter>
@@ -3714,311 +2596,6 @@ namespace AZ
     };
 
     //////////////////////////////////////////////////////////////////////////
-    template<class T>
-    BehaviorContext::EBusBuilder<T>::EBusBuilder(BehaviorContext* context, BehaviorEBus* ebus)
-        : Base(context)
-        , m_ebus(ebus)
-    {
-        Base::m_currentAttributes = &ebus->m_attributes;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class T>
-    BehaviorContext::EBusBuilder<T>::~EBusBuilder()
-    {
-        // process all on demand queued reflections
-        Base::m_context->ExecuteQueuedOnDemandReflections();
-
-        if (!Base::m_context->IsRemovingReflection())
-        {
-            for (auto&& [eventName, eventSender] : m_ebus->m_events)
-            {
-                if (MethodReturnsAzEventByReferenceOrPointer(*eventSender.m_broadcast))
-                {
-                    ValidateAzEventDescription(*Base::m_context, *eventSender.m_broadcast);
-                }
-            }
-            BehaviorContextBus::Event(Base::m_context, &BehaviorContextBus::Events::OnAddEBus, m_ebus->m_name.c_str(), m_ebus);
-        }
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class T>
-    BehaviorContext::EBusBuilder<T>* BehaviorContext::EBusBuilder<T>::operator->()
-    {
-        return this;
-    }
-
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class T>
-    BehaviorContext::EBusBuilder<T> BehaviorContext::EBus(const char* name, const char* deprecatedName /*=nullptr*/, const char* toolTip /*=nullptr*/)
-    {
-        // should we require AzTypeInfo for EBus, technically we should if we want to work around the compiler issue that made us to do it in first place
-        if (IsRemovingReflection())
-        {
-            auto ebusIt = m_ebuses.find(name);
-            if (ebusIt != m_ebuses.end())
-            {
-                BehaviorContextBus::Event(this, &BehaviorContextBus::Events::OnRemoveEBus, name, ebusIt->second);
-
-                // Erase the deprecated name as well
-                auto deprecatedIt = m_ebuses.find(ebusIt->second->m_deprecatedName);
-                if (deprecatedIt != m_ebuses.end())
-                {
-                    m_ebuses.erase(deprecatedIt);
-                }
-
-                delete ebusIt->second;
-                m_ebuses.erase(ebusIt);
-            }
-
-            return EBusBuilder<T>(this, nullptr);
-        }
-        else
-        {
-            AZ_Error("BehaviorContext", m_ebuses.find(name) == m_ebuses.end(), "You shouldn't reflect an EBus multiple times (%s), subsequent reflections will not be registered!", name);
-
-            BehaviorEBus* behaviorEBus = aznew BehaviorEBus();
-            behaviorEBus->m_name = name;
-
-            if(toolTip != nullptr)
-            {
-                behaviorEBus->m_toolTip = toolTip;
-            }
-
-            /*
-            ** If we have a deprecated name, lets make sure the its not in use as an existing bus.
-            */
-
-            if (deprecatedName != nullptr)
-            {
-                if(*deprecatedName == '\0')
-                {
-                    AZ_Warning("BehaviorContext", false, "Deprecated name can't be a empty string!", deprecatedName);
-                }
-                else if (m_ebuses.find(deprecatedName) != m_ebuses.end())
-                {
-                    AZ_Warning("BehaviorContext", false, "EBus %s is attempting to use the deprecated name (%s) that is already used! Ignored!", name, deprecatedName);
-                }
-                else
-                {
-                    behaviorEBus->m_deprecatedName = deprecatedName;
-                }
-            }
-
-            EBusSetIdFeatures<T>(behaviorEBus);
-            behaviorEBus->m_queueFunction = QueueFunctionMethod<T>();
-
-            // Switch to Set (we store the name in the class)
-            m_ebuses.insert(AZStd::make_pair(behaviorEBus->m_name, behaviorEBus));
-            if (!behaviorEBus->m_deprecatedName.empty())
-            {
-                m_ebuses.insert(AZStd::make_pair(behaviorEBus->m_deprecatedName, behaviorEBus));
-            }
-
-            return EBusBuilder<T>(this, behaviorEBus);
-        }
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class Bus>
-    template<class Function>
-    BehaviorContext::EBusBuilder<Bus>* BehaviorContext::EBusBuilder<Bus>::Event(const char* name, Function e, const char *deprecatedName /*=nullptr*/)
-    {
-        BehaviorParameterOverridesArray<Function> parameterOverrides;
-        return Event(name, e, deprecatedName, parameterOverrides);
-    }
-
-    template<class Bus>
-    template<class Function>
-    BehaviorContext::EBusBuilder<Bus>* BehaviorContext::EBusBuilder<Bus>::Event(const char* name, Function e, const char* deprecatedName, const BehaviorParameterOverridesArray<Function>& args)
-    {
-        if (m_ebus)
-        {
-            BehaviorEBusEventSender ebusEvent;
-
-            ebusEvent.Set<Bus>(e, name, Base::m_context);
-
-            auto insertIt = m_ebus->m_events.insert(AZStd::make_pair(name, ebusEvent));
-
-            if (!insertIt.second)
-            {
-                AZ_Error("BehaviorContext", false, "Reflection inserted a duplicate event: '%s' for bus '%s' - please check that you are not reflecting the same event repeatedly. This will cause memory leaks.", name, m_ebus->m_name.c_str());
-            }
-            else
-            {
-                // do we have a deprecated name for this event?
-                if (deprecatedName != nullptr)
-                {
-                    // ensure deprecated name is not in use as a existing name
-                    auto itr = m_ebus->m_events.find(deprecatedName);
-
-                    if (itr != m_ebus->m_events.end())
-                    {
-                        AZ_Warning("BehaviorContext", false, "Event %s is attempting to use %s as a deprecated name, but the deprecated name is already in use! The deprecated name is ignored!", name, deprecatedName);
-                    }
-                    else
-                    {
-                        // ensure that we won't have a duplicate deprecated name
-                        bool isDuplicated = false;
-                        for (const auto & i : m_ebus->m_events)
-                        {
-                            if (i.second.m_deprecatedName == deprecatedName)
-                            {
-                                isDuplicated = true;
-                                AZ_Warning("BehaviorContext", false, "Event %s is attempting to use %s as a deprecated name, but the deprecated name is already used as a deprecated name for the Event %s! The deprecated name is ignored!", name, deprecatedName, i.first.c_str());
-                                break;
-                            }
-                        }
-
-                        if (!isDuplicated)
-                        {
-                            insertIt.first->second.m_deprecatedName = deprecatedName;
-                        }
-                    }
-                }
-
-                for (BehaviorMethod* method : { ebusEvent.m_event, ebusEvent.m_broadcast })
-                {
-                    if (method)
-                    {
-                        size_t busIdParameterIndex = method->HasBusId() ? 1 : 0;
-                        for (size_t i = 0; i < args.size(); ++i)
-                        {
-                            method->SetArgumentName(i + busIdParameterIndex, args[i].m_name);
-                            method->SetArgumentToolTip(i + busIdParameterIndex, args[i].m_toolTip);
-                            method->SetDefaultValue(i + busIdParameterIndex, args[i].m_defaultValue);
-                            method->OverrideParameterTraits(i + busIdParameterIndex, args[i].m_addTraits, args[i].m_removeTraits);
-                        }
-                    }
-                }
-
-                Base::m_currentAttributes = &insertIt.first->second.m_attributes;
-                Base::SetEBusEventSender(&insertIt.first->second);
-            }
-        }
-
-        return this;
-    }
-
-    template<class Bus>
-    template<class Function>
-    BehaviorContext::EBusBuilder<Bus>* BehaviorContext::EBusBuilder<Bus>::Event(const char* name, Function e, const BehaviorParameterOverridesArray<Function>& args)
-    {
-        return Event(name, e, nullptr, args);
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class Bus>
-    template<typename HandlerType, typename HandlerCreator, typename HandlerDestructor >
-    BehaviorContext::EBusBuilder<Bus>* BehaviorContext::EBusBuilder<Bus>::Handler(HandlerCreator creator, HandlerDestructor destructor)
-    {
-        if (m_ebus)
-        {
-            AZ_Assert(creator != nullptr && destructor != nullptr, "Both creator and destructor should be provided!");
-
-            BehaviorMethod* createHandler = aznew AZ::Internal::BehaviorMethodImpl<typename AZStd::remove_pointer<HandlerCreator>::type>(creator, Base::m_context, m_ebus->m_name + "::CreateHandler");
-            BehaviorMethod* destroyHandler = aznew AZ::Internal::BehaviorMethodImpl<typename AZStd::remove_pointer<HandlerDestructor>::type>(destructor, Base::m_context, m_ebus->m_name + "::DestroyHandler");
-            // OnDemandReflect the types in all the handler Event functions
-            m_ebus->m_ebusHandlerOnDemandReflector = AZStd::make_unique<ScopedBehaviorOnDemandReflector>(*Base::m_context);
-            AZ::Internal::OnDemandReflectFunctions(m_ebus->m_ebusHandlerOnDemandReflector.get(), typename HandlerType::EventFunctionsParameterPack{});
-
-            // check than the handler returns the expected type
-            if (createHandler->GetResult()->m_typeId != AzTypeInfo<BehaviorEBusHandler>::Uuid() || destroyHandler->GetArgument(0)->m_typeId != AzTypeInfo<BehaviorEBusHandler>::Uuid())
-            {
-                AZ_Assert(false, "HandlerCreator my return a BehaviorEBusHandler* object and HandlerDestrcutor should have an argument that can handle BehaviorEBusHandler!");
-                delete createHandler;
-                delete destroyHandler;
-                createHandler = nullptr;
-                destroyHandler = nullptr;
-            }
-            else
-            {
-                Base::m_currentAttributes = &createHandler->m_attributes;
-                Base::SetEBusEventSender(nullptr);
-            }
-            m_ebus->m_createHandler = createHandler;
-            m_ebus->m_destroyHandler = destroyHandler;
-        }
-        return this;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class Bus>
-    template<class H>
-    BehaviorContext::EBusBuilder<Bus>* BehaviorContext::EBusBuilder<Bus>::Handler()
-    {
-        Handler<H>(&AZ::Internal::BehaviorEBusHandlerFactory<H>::Create, &AZ::Internal::BehaviorEBusHandlerFactory<H>::Destroy);
-        return this;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    template<class Bus>
-    BehaviorContext::EBusBuilder<Bus>* BehaviorContext::EBusBuilder<Bus>::VirtualProperty(const char* name, const char* getterEvent, const char* setterEvent)
-    {
-        if (m_ebus)
-        {
-            BehaviorEBusEventSender* getter = nullptr;
-            BehaviorEBusEventSender* setter = nullptr;
-            if (getterEvent)
-            {
-                auto getterIt = m_ebus->m_events.find(getterEvent);
-                getter = &getterIt->second;
-                if (getterIt == m_ebus->m_events.end())
-                {
-                    AZ_Error("BehaviorContext", false, "EBus %s, VirtualProperty %s getter event %s is not reflected. Make sure VirtualProperty is reflected after the Event!", m_ebus->m_name.c_str(), name, getterEvent);
-                    return this;
-                }
-
-                // we should always have the broadcast present, so use it for our checks
-                if (!getter->m_broadcast->HasResult())
-                {
-                    AZ_Error("BehaviorContext", false, "EBus %s, VirtualProperty %s getter %s should return result", m_ebus->m_name.c_str(), name, getterEvent);
-                    return this;
-                }
-                if (getter->m_broadcast->GetNumArguments() != 0)
-                {
-                    AZ_Error("BehaviorContext", false, "EBus %s, VirtualProperty %s getter %s can not have arguments only result", m_ebus->m_name.c_str(), name, getterEvent);
-                    return this;
-                }
-            }
-            if (setterEvent)
-            {
-                auto setterIt = m_ebus->m_events.find(setterEvent);
-                if (setterIt == m_ebus->m_events.end())
-                {
-                    AZ_Error("BehaviorContext", false, "EBus %s, VirtualProperty %s setter event %s is not reflected. Make sure VirtualProperty is reflected after the Event!", m_ebus->m_name.c_str(), name, setterEvent);
-                    return this;
-                }
-                setter = &setterIt->second;
-                if (setter->m_broadcast->HasResult())
-                {
-                    AZ_Error("BehaviorContext", false, "EBus %s, VirtualProperty %s setter %s should not return result", m_ebus->m_name.c_str(), name, setterEvent);
-                    return this;
-                }
-                if (setter->m_broadcast->GetNumArguments() != 1)
-                {
-                    AZ_Error("BehaviorContext", false, "EBus %s, VirtualProperty %s setter %s can have only one argument", m_ebus->m_name.c_str(), name, setterEvent);
-                    return this;
-                }
-            }
-
-            if (getter && setter)
-            {
-                if (getter->m_broadcast->GetResult()->m_typeId != setter->m_broadcast->GetArgument(0)->m_typeId)
-                {
-                    AZ_Error("BehaviorContext", false, "EBus %s, VirtualProperty %s getter %s return [%s] and setter %s input argument [%s] types don't match ", m_ebus->m_name.c_str(), name, setterEvent, getter->m_broadcast->GetResult()->m_typeId.ToString<AZStd::string>().c_str(), setter->m_broadcast->GetArgument(0)->m_typeId.ToString<AZStd::string>().c_str());
-                    return this;
-                }
-            }
-
-            m_ebus->m_virtualProperties.insert(AZStd::make_pair(name, BehaviorEBus::VirtualProperty(getter, setter)));
-        }
-        return this;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
     //////////////////////////////////////////////////////////////////////////
     //////////////////////////////////////////////////////////////////////////
     namespace Internal
@@ -4052,11 +2629,11 @@ namespace AZ
         {
             // +1 to avoid zero array size
             Uuid argumentTypes[sizeof...(Args) + 1] = { AzTypeInfo<UnqualifiedRemovePointerUnderlyingType<Args>>::Uuid()... };
-            const char* argumentNames[sizeof...(Args)+1] = { AzTypeInfo<Args>::Name()... };
-            bool argumentIsPointer[sizeof...(Args)+1] = { AZStd::is_pointer_v<AZStd::remove_reference_t<Args>>... };
-            bool argumentIsConst[sizeof...(Args)+1] = { AZStd::is_const_v<AZStd::remove_pointer_t<AZStd::remove_reference_t<Args>>>... };
-            bool argumentIsReference[sizeof...(Args)+1] = { AZStd::is_reference_v<Args>... };
-            IRttiHelper* rttiHelper[sizeof...(Args)+1] = { GetRttiHelper<UnqualifiedRemovePointerUnderlyingType<Args>>()... };
+            const char* argumentNames[sizeof...(Args) + 1] = { AzTypeInfo<Args>::Name()... };
+            bool argumentIsPointer[sizeof...(Args) + 1] = { AZStd::is_pointer_v<AZStd::remove_reference_t<Args>>... };
+            bool argumentIsConst[sizeof...(Args) + 1] = { AZStd::is_const_v<AZStd::remove_pointer_t<AZStd::remove_reference_t<Args>>>... };
+            bool argumentIsReference[sizeof...(Args) + 1] = { AZStd::is_reference_v<Args>... };
+            IRttiHelper* rttiHelper[sizeof...(Args) + 1] = { GetRttiHelper<UnqualifiedRemovePointerUnderlyingType<Args>>()... };
             (void)argumentIsPointer; (void)argumentIsConst; (void)argumentIsReference;
             // function / member function pointer ?
             for (size_t i = 0; i < sizeof...(Args); ++i)
@@ -4079,7 +2656,7 @@ namespace AZ
             if (onDemandReflection)
             {
                 // deal with OnDemand reflection
-                StaticReflectionFunctionPtr reflectHooks[sizeof...(Args)+1] = { OnDemandReflectHook<UnqualifiedRemovePointerUnderlyingType<Args>>::Get()... };
+                StaticReflectionFunctionPtr reflectHooks[sizeof...(Args) + 1] = { OnDemandReflectHook<UnqualifiedRemovePointerUnderlyingType<Args>>::Get()... };
                 for (size_t i = 0; i < sizeof...(Args); ++i)
                 {
                     if (reflectHooks[i])
@@ -4094,965 +2671,14 @@ namespace AZ
         {
             SetParametersStripped<Args...>(parameters, onDemandReflection);
         }
+    }
+}
 
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class... Args>
-        template<AZStd::size_t... Is, class Function>
-        inline void CallFunction<R, Args...>::Global(Function functionPtr, BehaviorArgument* arguments, BehaviorArgument* result, AZStd::index_sequence<Is...>)
-        {
-            (void)arguments;
-            if (result)
-            {
-                result->StoreResult<R>(functionPtr(*arguments[Is].GetAsUnsafe<Args>()...));
-            }
-            else
-            {
-                functionPtr(*arguments[Is].GetAsUnsafe<Args>()...);
-            }
-        };
 
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class... Args>
-        template<AZStd::size_t... Is, class C, class Function>
-        inline void CallFunction<R, Args...>::Member(Function functionPtr, C thisPtr, BehaviorArgument* arguments, BehaviorArgument* result, AZStd::index_sequence<Is...>)
-        {
-            (void)arguments;
-            if (result)
-            {
-                result->StoreResult<R>((thisPtr->*functionPtr)(*arguments[Is].GetAsUnsafe<Args>()...));
-            }
-            else
-            {
-                (thisPtr->*functionPtr)(*arguments[Is].GetAsUnsafe<Args>()...);
-            }
-        };
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class... Args>
-        BehaviorMethodImpl<R(Args...)>::BehaviorMethodImpl(FunctionPointer functionPointer, BehaviorContext* context, const AZStd::string& name)
-            : BehaviorMethod(context)
-            , m_functionPtr(functionPointer)
-        {
-            m_name = name;
-            SetParameters<R>(m_parameters, this);
-            SetParameters<Args...>(&m_parameters[s_startNamedArgumentIndex], this);
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class... Args>
-        bool BehaviorMethodImpl<R(Args...)>::Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const
-        {
-            size_t totalArguments = GetNumArguments();
-            if (arguments.size() < totalArguments)
-            {
-                // We are cloning all arguments on the stack, since Call is called only from Invoke we can reserve bigger "arguments" array
-                // that can always handle all parameters. So far the don't use default values that ofter, so we will optimize for the common case first.
-                AZStd::span<BehaviorArgument> newArguments(reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument) * totalArguments)), totalArguments);
-                // clone the input parameters (we don't need to clone temp buffers, etc. as they will be still on the stack)
-                size_t argIndex = 0;
-                for (; argIndex < arguments.size(); ++argIndex)
-                {
-                    new(&newArguments[argIndex]) BehaviorArgument(arguments[argIndex]);
-                }
-
-                // clone the default parameters if they exist
-                for (; argIndex < totalArguments; ++argIndex)
-                {
-                    BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
-                    if (!defaultValue)
-                    {
-                        AZ_Warning("Behavior", false, "Not enough arguments to make a call! %d needed %d", arguments.size(), totalArguments);
-                        return false;
-                    }
-                    new(&newArguments[argIndex]) BehaviorArgument(defaultValue->GetValue());
-                }
-
-                arguments = newArguments;
-            }
-
-            for (size_t i = s_startArgumentIndex; i < AZ_ARRAY_SIZE(m_parameters); ++i)
-            {
-                // Verify that argument is a pointer for pointer type parameters and a value or reference for value type or reference type parameters
-                bool isArgumentPointer = arguments[i - 1].m_traits & BehaviorParameter::Traits::TR_POINTER;
-                bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
-                if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
-                {
-                    AZ_Warning("Behavior", false, "Invalid parameter type for method '%s'! Can not convert method parameter %d from %s(%s) to %s(%s)",
-                        m_name.c_str(), i - 1, arguments[i - 1].m_name,
-                        arguments[i - 1].m_typeId.ToFixedString().c_str(),
-                        m_parameters[i].m_name, m_parameters[i].m_typeId.ToFixedString().c_str());
-                    return false;
-                }
-                else if (isArgumentPointer != isParameterPointer)
-                {
-                    AZ_Warning("Behavior", false, R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
-                        isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
-                        isParameterPointer ? "pointer" : "value", m_parameters[i].m_name);
-                    return false;
-                }
-            }
-
-            CallFunction<R, Args...>::Global(m_functionPtr, arguments.data(), result, AZStd::make_index_sequence<sizeof...(Args)>());
-
-            return true;
-        }
-
-        template<class R,  class... Args>
-        auto BehaviorMethodImpl<R(Args...)>::IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const
-            -> ResultOutcome
-        {
-            size_t totalArguments = GetNumArguments();
-            if (arguments.size() < totalArguments)
-            {
-                // Clone the arguments on the stack and validate that the method can be invoked with the arguments
-                AZStd::span<BehaviorArgument> newArguments(reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument) * totalArguments)), totalArguments);
-                // clone the input parameters (we don't need to clone temp buffers, etc. as they will be still on the stack)
-                size_t argIndex = 0;
-                for (; argIndex < arguments.size(); ++argIndex)
-                {
-                    new(&newArguments[argIndex]) BehaviorArgument(arguments[argIndex]);
-                }
-
-                // clone the default parameters if they exist
-                for (; argIndex < totalArguments; ++argIndex)
-                {
-                    BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
-                    if (!defaultValue)
-                    {
-                        return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
-                            "Not enough arguments to make call to method %s. %zu supplied, needed %zu",
-                            m_name.c_str(), arguments.size(), newArguments.size()) };
-                    }
-                    new(&newArguments[argIndex]) BehaviorArgument(defaultValue->GetValue());
-                }
-
-                arguments = newArguments;
-            }
-            else if (arguments.size() > totalArguments)
-            {
-                return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
-                    "Too many arguments supplied to method '%s'. Expects %zu arguments, provided %zu",
-                    m_name.c_str(), totalArguments, arguments.size()) };
-            }
-
-            for (size_t i = s_startArgumentIndex; i < AZ_ARRAY_SIZE(m_parameters); ++i)
-            {
-                // Verify that argument is a pointer for pointer type parameters and a value or reference for value type or reference type parameters
-                bool isArgumentPointer = arguments[i - 1].m_traits & BehaviorParameter::Traits::TR_POINTER;
-                bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
-                if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
-                {
-                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
-                        "Invalid parameter type for method '%s'!"
-                        " Can not convert method parameter %zu from %s(%s) to %s(%s)",
-                        m_name.c_str(), i - 1,
-                        arguments[i - 1].m_name, arguments[i - 1].m_typeId.ToFixedString().c_str(),
-                        m_parameters[i].m_name, m_parameters[i].m_typeId.ToFixedString().c_str()
-                    ) };
-                }
-                else if (isArgumentPointer != isParameterPointer)
-                {
-                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
-                        R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
-                        isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
-                        isParameterPointer ? "pointer" : "value", m_parameters[i].m_name) };
-                }
-            }
-
-            if (result != nullptr)
-            {
-                const AZ::BehaviorParameter* returnParam = GetResult();
-                if (bool canStoreResult = result->m_typeId.IsNull() || result->m_typeId == returnParam->m_typeId ||
-                    (returnParam->m_azRtti != nullptr && returnParam->m_azRtti->IsTypeOf(result->m_typeId));
-                    !canStoreResult)
-                {
-                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
-                        "The behavior argument for the return value cannot store the return type %s",
-                        returnParam->m_typeId.ToFixedString().c_str()) };
-                }
-            }
-
-            return AZ::Success();
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class... Args>
-        bool BehaviorMethodImpl<R(Args...)>::HasResult() const
-        {
-            return !AZStd::is_same<R, void>::value;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class... Args>
-        bool BehaviorMethodImpl<R(Args...)>::IsMember() const
-        {
-            return false;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class... Args>
-        bool BehaviorMethodImpl<R(Args...)>::HasBusId() const
-        {
-            return false;
-        }
-
-        template<class R, class... Args>
-        const BehaviorParameter* BehaviorMethodImpl<R(Args...)>::GetBusIdArgument() const
-        {
-            return nullptr;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class... Args>
-        size_t BehaviorMethodImpl<R(Args...)>::GetNumArguments() const
-        {
-            return AZ_ARRAY_SIZE(m_parameters) - s_startArgumentIndex;
-        }
-
-        template<class R, class... Args>
-        size_t BehaviorMethodImpl<R(Args...)>::GetMinNumberOfArguments() const
-        {
-            // Iterate from end of MetadataParameters and count the number of consecutive valid BehaviorValue objects
-            size_t numDefaultArguments = 0;
-            for (size_t i = GetNumArguments() - 1; i >= 0 && GetDefaultValue(i); --i, ++numDefaultArguments)
-            {
-            }
-            return GetNumArguments() - numDefaultArguments;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class... Args>
-        const BehaviorParameter* BehaviorMethodImpl<R(Args...)>::GetArgument(size_t index) const
-        {
-            if (index < GetNumArguments())
-            {
-                return &m_parameters[index + s_startArgumentIndex];
-            }
-            return nullptr;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class... Args>
-        void BehaviorMethodImpl<R(Args...)>::OverrideParameterTraits(size_t index, AZ::u32 addTraits, AZ::u32 removeTraits)
-        {
-            if (index < GetNumArguments())
-            {
-                m_parameters[index + s_startArgumentIndex].m_traits = (m_parameters[index + s_startArgumentIndex].m_traits & ~removeTraits) | addTraits;
-            }
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class... Args>
-        const AZStd::string* BehaviorMethodImpl<R(Args...)>::GetArgumentName(size_t index) const
-        {
-            if (index < GetNumArguments())
-            {
-                return &m_metadataParameters[index + s_startArgumentIndex].m_name;
-            }
-            return nullptr;
-        }
-
-        template<class R, class... Args>
-        void BehaviorMethodImpl<R(Args...)>::SetArgumentName(size_t index, const AZStd::string& name)
-        {
-            if (index < GetNumArguments())
-            {
-                m_metadataParameters[index + s_startArgumentIndex].m_name = name;
-            }
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class... Args>
-        const AZStd::string* BehaviorMethodImpl<R(Args...)>::GetArgumentToolTip(size_t index) const
-        {
-            if (index < GetNumArguments())
-            {
-                return &m_metadataParameters[index + s_startArgumentIndex].m_toolTip;
-            }
-            return nullptr;
-        }
-
-        template<class R, class... Args>
-        void BehaviorMethodImpl<R(Args...)>::SetArgumentToolTip(size_t index, const AZStd::string& toolTip)
-        {
-            if (index < GetNumArguments())
-            {
-                m_metadataParameters[index + s_startArgumentIndex].m_toolTip = toolTip;
-            }
-        }
-
-        template<class R, class... Args>
-        void BehaviorMethodImpl<R(Args...)>::SetDefaultValue(size_t index, BehaviorDefaultValuePtr defaultValue)
-        {
-            if (index < GetNumArguments())
-            {
-                if (defaultValue && defaultValue->GetValue().m_typeId != GetArgument(index)->m_typeId)
-                {
-                    AZ_Assert(false, "Argument %zu default value type, doesn't match! Default value should be the same type! Current type %s!", index, defaultValue->GetValue().m_name);
-                    return;
-                }
-                m_metadataParameters[index + s_startArgumentIndex].m_defaultValue = defaultValue;
-            }
-        }
-
-        template<class R, class... Args>
-        BehaviorDefaultValuePtr BehaviorMethodImpl<R(Args...)>::GetDefaultValue(size_t index) const
-        {
-            if (index < GetNumArguments())
-            {
-                return m_metadataParameters[index + s_startArgumentIndex].m_defaultValue;
-            }
-            return nullptr;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class... Args>
-        const BehaviorParameter* BehaviorMethodImpl<R(Args...)>::GetResult() const
-        {
-            return &m_parameters[0];
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class C, class... Args>
-        BehaviorMethodImpl<R(C::*)(Args...)>::BehaviorMethodImpl(FunctionPointer functionPointer, BehaviorContext* context, const AZStd::string& name)
-            : BehaviorMethod(context)
-            , m_functionPtr(functionPointer)
-        {
-            m_name = name;
-            SetParameters<R>(m_parameters, this);
-            SetParameters<C*>(&m_parameters[s_startArgumentIndex], this);
-            m_parameters[s_startArgumentIndex].m_traits |= BehaviorParameter::TR_THIS_PTR;
-            SetParameters<Args...>(&m_parameters[s_startNamedArgumentIndex], this);
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class C, class... Args>
-        BehaviorMethodImpl<R(C::*)(Args...)>::BehaviorMethodImpl(FunctionPointerConst functionPointer, BehaviorContext* context, const AZStd::string& name)
-            : BehaviorMethodImpl(reinterpret_cast<FunctionPointer>(functionPointer), context, name)
-        {
-            m_isConst = true;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class C, class... Args>
-        bool BehaviorMethodImpl<R(C::*)(Args...)>::Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const
-        {
-            size_t totalArguments = GetNumArguments();
-            if (arguments.size() < totalArguments)
-            {
-                // We are cloning all arguments on the stack, since Call is called only from Invoke we can reserve bigger "arguments" array
-                // that can always handle all parameters. So far the don't use default values that ofter, so we will optimize for the common case first.
-                AZStd::span<BehaviorArgument> newArguments(reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument) * totalArguments)), totalArguments);
-                // clone the input parameters (we don't need to clone temp buffers, etc. as they will be still on the stack)
-                size_t argIndex = 0;
-                for (; argIndex < arguments.size(); ++argIndex)
-                {
-                    new(&newArguments[argIndex]) BehaviorArgument(arguments[argIndex]);
-                }
-
-                // clone the default parameters if they exist
-                for (; argIndex < totalArguments; ++argIndex)
-                {
-                    BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
-                    if (!defaultValue)
-                    {
-                        AZ_Warning("Behavior", false, "Not enough arguments to make a call! %d needed %d", arguments.size(), totalArguments);
-                        return false;
-                    }
-                    new(&newArguments[argIndex]) BehaviorArgument(defaultValue->GetValue());
-                }
-
-                arguments = newArguments;
-            }
-
-            if (!arguments[0].ConvertTo(AzTypeInfo<C>::Uuid()))
-            {
-                // this pointer is invalid
-                AZ_Warning("Behavior", false, "First parameter should be the 'this' pointer for the member function! %s", m_name.c_str());
-                return false;
-            }
-
-            for (size_t i = s_startNamedArgumentIndex; i < AZ_ARRAY_SIZE(m_parameters); ++i)
-            {
-                // Verify that argument is a pointer for pointer type parameters and a value or reference for value type or reference type parameters
-                bool isArgumentPointer = arguments[i - 1].m_traits & BehaviorParameter::Traits::TR_POINTER;
-                bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
-                if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
-                {
-                    AZ_Warning("Behavior", false, "Invalid parameter type for method '%s'! Can not convert method parameter %d from %s(%s) to %s(%s)",
-                        m_name.c_str(), i - 1, arguments[i - 1].m_name,
-                        arguments[i - 1].m_typeId.ToFixedString().c_str(),
-                        m_parameters[i].m_name, m_parameters[i].m_typeId.ToFixedString().c_str());
-                    return false;
-                }
-                else if (isArgumentPointer != isParameterPointer)
-                {
-                    AZ_Warning("Behavior", false, R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
-                        isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
-                        isParameterPointer ? "pointer" : "value", m_parameters[i].m_name);
-                    return false;
-                }
-            }
-
-            CallFunction<R, Args...>::Member(m_functionPtr, *arguments[0].GetAsUnsafe<C*>(), arguments.data() + 1, result, AZStd::make_index_sequence<sizeof...(Args)>());
-
-            BehaviorObjectSignals::Event(
-                (void*)(*arguments[0].GetAsUnsafe<C*>()), &BehaviorObjectSignals::Events::OnMemberMethodCalled, this);
-
-            return true;
-        }
-
-        template<class R, class C, class... Args>
-        auto BehaviorMethodImpl<R(C::*)(Args...)>::IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const
-            -> ResultOutcome
-        {
-            size_t totalArguments = GetNumArguments();
-            if (arguments.size() < totalArguments)
-            {
-                // Clone the arguments on the stack and validate that the method can be invoked with the arguments
-                AZStd::span<BehaviorArgument> newArguments(reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument) * totalArguments)), totalArguments);
-                // clone the input parameters (we don't need to clone temp buffers, etc. as they will be still on the stack)
-                size_t argIndex = 0;
-                for (; argIndex < arguments.size(); ++argIndex)
-                {
-                    new(&newArguments[argIndex]) BehaviorArgument(arguments[argIndex]);
-                }
-
-                // clone the default parameters if they exist
-                for (; argIndex < totalArguments; ++argIndex)
-                {
-                    BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
-                    if (!defaultValue)
-                    {
-                        return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
-                            "Not enough arguments to make call to method %s. %zu supplied, needed %zu",
-                            m_name.c_str(), arguments.size(), newArguments.size()) };
-                    }
-                    new(&newArguments[argIndex]) BehaviorArgument(defaultValue->GetValue());
-                }
-
-                arguments = newArguments;
-            }
-            else if (arguments.size() > totalArguments)
-            {
-                return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
-                    "Too many arguments supplied to method '%s'. Expects %zu arguments, provided %zu",
-                    m_name.c_str(), totalArguments, arguments.size()) };
-            }
-
-            if (!arguments[0].ConvertTo(AzTypeInfo<C>::Uuid()))
-            {
-                return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
-                    "First parameter should be the 'this' pointer for the member function! %s", m_name.c_str()) };
-            }
-
-            for (size_t i = s_startNamedArgumentIndex; i < AZ_ARRAY_SIZE(m_parameters); ++i)
-            {
-                // Verify that argument is a pointer for pointer type parameters and a value or reference for value type or reference type parameters
-                bool isArgumentPointer = arguments[i - 1].m_traits & BehaviorParameter::Traits::TR_POINTER;
-                bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
-                if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
-                {
-                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
-                        "Invalid parameter type for method '%s'!"
-                        " Can not convert method parameter %zu from %s(%s) to %s(%s)",
-                        m_name.c_str(), i - 1,
-                        arguments[i - 1].m_name, arguments[i - 1].m_typeId.ToFixedString().c_str(),
-                        m_parameters[i].m_name, m_parameters[i].m_typeId.ToFixedString().c_str()
-                    ) };
-                }
-                else if (isArgumentPointer != isParameterPointer)
-                {
-                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
-                        R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
-                        isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
-                        isParameterPointer ? "pointer" : "value", m_parameters[i].m_name) };
-                }
-            }
-
-            if (result != nullptr)
-            {
-                const AZ::BehaviorParameter* returnParam = GetResult();
-                if (bool canStoreResult = result->m_typeId.IsNull() || result->m_typeId == returnParam->m_typeId ||
-                    (returnParam->m_azRtti != nullptr && returnParam->m_azRtti->IsTypeOf(result->m_typeId));
-                    !canStoreResult)
-                {
-                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
-                        "The behavior argument for the return value cannot store the return type %s",
-                        returnParam->m_typeId.ToFixedString().c_str()) };
-                }
-            }
-
-            return AZ::Success();
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class C, class... Args>
-        bool BehaviorMethodImpl<R(C::*)(Args...)>::HasResult() const
-        {
-            return !AZStd::is_same<R, void>::value;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class C, class... Args>
-        bool BehaviorMethodImpl<R(C::*)(Args...)>::IsMember() const
-        {
-            return true;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class C, class... Args>
-        bool BehaviorMethodImpl<R(C::*)(Args...)>::HasBusId() const
-        {
-            return false;
-        }
-
-        template<class R, class C, class... Args>
-        const BehaviorParameter* BehaviorMethodImpl<R(C::*)(Args...)>::GetBusIdArgument() const
-        {
-            return nullptr;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class C, class... Args>
-        size_t BehaviorMethodImpl<R(C::*)(Args...)>::GetNumArguments() const
-        {
-            return AZ_ARRAY_SIZE(m_parameters) - s_startArgumentIndex;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class C, class... Args>
-        size_t BehaviorMethodImpl<R(C::*)(Args...)>::GetMinNumberOfArguments() const
-        {
-            // Iterate from end of MetadataParameters and count the number of consecutive valid BehaviorValue objects
-            size_t numDefaultArguments = 0;
-            for (size_t i = GetNumArguments() - 1; i >= 0 && GetDefaultValue(i); --i, ++numDefaultArguments)
-            {
-            }
-            return GetNumArguments() - numDefaultArguments;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class C, class... Args>
-        const BehaviorParameter* BehaviorMethodImpl<R(C::*)(Args...)>::GetArgument(size_t index) const
-        {
-            if (index < GetNumArguments())
-            {
-                return &m_parameters[index + s_startArgumentIndex];
-            }
-            return nullptr;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class C, class... Args>
-        void BehaviorMethodImpl<R(C::*)(Args...)>::OverrideParameterTraits(size_t index, AZ::u32 addTraits, AZ::u32 removeTraits)
-        {
-            if (index < GetNumArguments())
-            {
-                m_parameters[index + s_startArgumentIndex].m_traits = (m_parameters[index + s_startArgumentIndex].m_traits & ~removeTraits) | addTraits;
-            }
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class C, class... Args>
-        const AZStd::string* BehaviorMethodImpl<R(C::*)(Args...)>::GetArgumentName(size_t index) const
-        {
-            if (index < GetNumArguments())
-            {
-                return &m_metadataParameters[index + s_startArgumentIndex].m_name;
-            }
-            return nullptr;
-        }
-
-        template<class R, class C, class... Args>
-        void BehaviorMethodImpl<R(C::*)(Args...)>::SetArgumentName(size_t index, const AZStd::string& name)
-        {
-            if (index < GetNumArguments())
-            {
-                m_metadataParameters[index + s_startArgumentIndex].m_name = name;
-            }
-        }
-
-        template<class R, class C, class... Args>
-        const AZStd::string* BehaviorMethodImpl<R(C::*)(Args...)>::GetArgumentToolTip(size_t index) const
-        {
-            if (index < GetNumArguments())
-            {
-                return &m_metadataParameters[index + s_startArgumentIndex].m_toolTip;
-            }
-            return nullptr;
-        }
-
-        template<class R, class C, class... Args>
-        void BehaviorMethodImpl<R(C::*)(Args...)>::SetArgumentToolTip(size_t index, const AZStd::string& toolTip)
-        {
-            if (index < GetNumArguments())
-            {
-                m_metadataParameters[index + s_startArgumentIndex].m_toolTip = toolTip;
-            }
-        }
-
-        template<class R, class C, class... Args>
-        void BehaviorMethodImpl<R(C::*)(Args...)>::SetDefaultValue(size_t index, BehaviorDefaultValuePtr defaultValue)
-        {
-            if (index < GetNumArguments())
-            {
-                if (defaultValue && defaultValue->GetValue().m_typeId != GetArgument(index)->m_typeId)
-                {
-                    AZ_Assert(false, "Argument %zu default value type, doesn't match! Default value should be the same type! Current type %s!", index, defaultValue->GetValue().m_name);
-                    return;
-                }
-                m_metadataParameters[index + s_startArgumentIndex].m_defaultValue = defaultValue;
-            }
-        }
-
-        template<class R, class C, class... Args>
-        BehaviorDefaultValuePtr BehaviorMethodImpl<R(C::*)(Args...)>::GetDefaultValue(size_t index) const
-        {
-            if (index < GetNumArguments())
-            {
-                return m_metadataParameters[index + s_startArgumentIndex].m_defaultValue;
-            }
-            return nullptr;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class R, class C, class... Args>
-        const BehaviorParameter* BehaviorMethodImpl<R(C::*)(Args...)>::GetResult() const
-        {
-            return &m_parameters[0];
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::BehaviorEBusEvent(FunctionPointer functionPointer, BehaviorContext* context)
-            : BehaviorMethod(context)
-            , m_functionPtr(functionPointer)
-        {
-            SetParameters<R>(m_parameters, this);
-            SetParameters<Args...>(&m_parameters[s_startNamedArgumentIndex], this);
-            // optional ID parameter
-            SetBusIdType<s_isBusIdParameter == 1>();
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::BehaviorEBusEvent(FunctionPointerConst functionPointer, BehaviorContext* context)
-            : BehaviorEBusEvent(reinterpret_cast<FunctionPointer>(functionPointer), context)
-        {
-            m_isConst = true;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        template<bool IsBusId>
-        inline AZStd::enable_if_t<IsBusId> BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::SetBusIdType()
-        {
-            SetParameters<typename EBus::BusIdType>(&m_parameters[s_startArgumentIndex]);
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        template<bool IsBusId>
-        inline AZStd::enable_if_t<!IsBusId> BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::SetBusIdType()
-        {
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        bool BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const
-        {
-            size_t totalArguments = GetNumArguments();
-            if (arguments.size() < totalArguments)
-            {
-                // We are cloning all arguments on the stack, since Call is called only from Invoke we can reserve bigger "arguments" array
-                // that can always handle all parameters. So far the don't use default values that ofter, so we will optimize for the common case first.
-                AZStd::span<BehaviorArgument> newArguments(reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument) * totalArguments)), totalArguments);
-                // clone the input parameters (we don't need to clone temp buffers, etc. as they will be still on the stack)
-                size_t argIndex = 0;
-                for (; argIndex < arguments.size(); ++argIndex)
-                {
-                    new(&newArguments[argIndex]) BehaviorArgument(arguments[argIndex]);
-                }
-
-                // clone the default parameters if they exist
-                for (; argIndex < totalArguments; ++argIndex)
-                {
-                    BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
-                    if (!defaultValue)
-                    {
-                        AZ_Warning("Behavior", false, "Not enough arguments to make a call! %d needed %d", arguments.size(), totalArguments);
-                        return false;
-                    }
-                    new(&newArguments[argIndex]) BehaviorArgument(defaultValue->GetValue());
-                }
-
-                arguments = newArguments;
-            }
-
-            if constexpr (s_isBusIdParameter)
-            {
-                if (!arguments[0].ConvertTo(m_parameters[1].m_typeId))
-                {
-                    AZ_Warning("Behavior", false, "Invalid BusIdType type can't convert! %s -> %s", arguments[0].m_name, m_parameters[1].m_name);
-                    return false;
-                }
-            }
-
-            for (size_t i = s_startNamedArgumentIndex; i < AZ_ARRAY_SIZE(m_parameters); ++i)
-            {
-                // Verify that argument is a pointer for pointer type parameters and a value or reference for value type or reference type parameters
-                bool isArgumentPointer = arguments[i - 1].m_traits & BehaviorParameter::Traits::TR_POINTER;
-                bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
-                if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
-                {
-                    AZ_Warning("Behavior", false, "Invalid parameter type for method '%s'! Can not convert method parameter %d from %s(%s) to %s(%s)",
-                        m_name.c_str(), i - 1, arguments[i - 1].m_name,
-                        arguments[i - 1].m_typeId.ToFixedString().c_str(),
-                        m_parameters[i].m_name, m_parameters[i].m_typeId.ToFixedString().c_str());
-                    return false;
-                }
-                else if (isArgumentPointer != isParameterPointer)
-                {
-                    AZ_Warning("Behavior", false, R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
-                        isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
-                        isParameterPointer ? "pointer" : "value", m_parameters[i].m_name);
-                    return false;
-                }
-            }
-
-            AZ::Internal::EBusCaller<EventType, EBus, R, Args...>::Call(m_functionPtr, arguments.data(), result, AZStd::make_index_sequence<sizeof...(Args)>());
-
-            return true;
-        }
-
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        auto BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const
-            -> ResultOutcome
-        {
-            size_t totalArguments = GetNumArguments();
-            if (arguments.size() < totalArguments)
-            {
-                // Clone the arguments on the stack and validate that the method can be invoked with the arguments
-                AZStd::span<BehaviorArgument> newArguments(reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument) * totalArguments)), totalArguments);
-                // clone the input parameters (we don't need to clone temp buffers, etc. as they will be still on the stack)
-                size_t argIndex = 0;
-                for (; argIndex < arguments.size(); ++argIndex)
-                {
-                    new(&newArguments[argIndex]) BehaviorArgument(arguments[argIndex]);
-                }
-
-                // clone the default parameters if they exist
-                for (; argIndex < totalArguments; ++argIndex)
-                {
-                    BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
-                    if (!defaultValue)
-                    {
-                        return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
-                            "Not enough arguments to make call to method %s. %zu supplied, needed %zu",
-                            m_name.c_str(), arguments.size(), newArguments.size()) };
-                    }
-                    new(&newArguments[argIndex]) BehaviorArgument(defaultValue->GetValue());
-                }
-
-                arguments = newArguments;
-            }
-            else if (arguments.size() > totalArguments)
-            {
-                return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
-                    "Too many arguments supplied to method '%s'. Expects %zu arguments, provided %zu",
-                    m_name.c_str(), totalArguments, arguments.size()) };
-            }
-
-            if constexpr (s_isBusIdParameter)
-            {
-                if (!arguments[0].ConvertTo(m_parameters[1].m_typeId))
-                {
-                    AZ_Warning("Behavior", false, "Invalid BusIdType type can't convert! %s -> %s", arguments[0].m_name, m_parameters[1].m_name);
-                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
-                        "Invalid BusIdType type can't convert! %s -> %s",
-                        arguments[0].m_name, m_parameters[1].m_name) };
-                }
-            }
-
-            for (size_t i = s_startNamedArgumentIndex; i < AZ_ARRAY_SIZE(m_parameters); ++i)
-            {
-                // Verify that argument is a pointer for pointer type parameters and a value or reference for value type or reference type parameters
-                bool isArgumentPointer = arguments[i - 1].m_traits & BehaviorParameter::Traits::TR_POINTER;
-                bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
-                if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
-                {
-                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
-                        "Invalid parameter type for method '%s'!"
-                        " Can not convert method parameter %zu from %s(%s) to %s(%s)",
-                        m_name.c_str(), i - 1,
-                        arguments[i - 1].m_name, arguments[i - 1].m_typeId.ToFixedString().c_str(),
-                        m_parameters[i].m_name, m_parameters[i].m_typeId.ToFixedString().c_str()
-                    ) };
-                }
-                else if (isArgumentPointer != isParameterPointer)
-                {
-                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
-                        R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
-                        isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
-                        isParameterPointer ? "pointer" : "value", m_parameters[i].m_name) };
-                }
-            }
-
-            if (result != nullptr)
-            {
-                const AZ::BehaviorParameter* returnParam = GetResult();
-                if (bool canStoreResult = result->m_typeId.IsNull() || result->m_typeId == returnParam->m_typeId ||
-                    (returnParam->m_azRtti != nullptr && returnParam->m_azRtti->IsTypeOf(result->m_typeId));
-                    !canStoreResult)
-                {
-                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
-                        "The behavior argument for the return value cannot store the return type %s",
-                        returnParam->m_typeId.ToFixedString().c_str()) };
-                }
-            }
-
-            return AZ::Success();
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        bool BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::HasResult() const
-        {
-            return !AZStd::is_same<R, void>::value;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        bool BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::IsMember() const
-        {
-            return false;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        bool BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::HasBusId() const
-        {
-            return s_isBusIdParameter != 0;
-        }
-
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        const BehaviorParameter* BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::GetBusIdArgument() const
-        {
-            return HasBusId() ? GetArgument(0) : nullptr;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        size_t BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::GetNumArguments() const
-        {
-            return AZ_ARRAY_SIZE(m_parameters) - s_startArgumentIndex;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        size_t BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::GetMinNumberOfArguments() const
-        {
-            // Iterate from end of MetadataParameters and count the number of consecutive valid BehaviorValue objects
-            size_t numDefaultArguments = 0;
-            for (size_t i = GetNumArguments() - 1; i >= 0 && GetDefaultValue(i); --i, ++numDefaultArguments)
-            {
-            }
-            return GetNumArguments() - numDefaultArguments;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        const BehaviorParameter* BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::GetArgument(size_t index) const
-        {
-            if (index < GetNumArguments())
-            {
-                return &m_parameters[index + s_startArgumentIndex];
-            }
-            return nullptr;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        void BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::OverrideParameterTraits(size_t index, AZ::u32 addTraits, AZ::u32 removeTraits)
-        {
-            if (index < GetNumArguments())
-            {
-                m_parameters[index + s_startArgumentIndex].m_traits = (m_parameters[index + s_startArgumentIndex].m_traits & ~removeTraits) | addTraits;
-            }
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        const AZStd::string* BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::GetArgumentName(size_t index) const
-        {
-            if (index < GetNumArguments())
-            {
-                return &m_metadataParameters[index + s_startArgumentIndex].m_name;
-            }
-            return nullptr;
-        }
-
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        void BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::SetArgumentName(size_t index, const AZStd::string& name)
-        {
-            if (index < GetNumArguments())
-            {
-                m_metadataParameters[index + s_startArgumentIndex].m_name = name;
-            }
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        const AZStd::string* BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::GetArgumentToolTip(size_t index) const
-        {
-            if (index < GetNumArguments())
-            {
-                return &m_metadataParameters[index + s_startArgumentIndex].m_toolTip;
-            }
-            return nullptr;
-        }
-
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        void BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::SetArgumentToolTip(size_t index, const AZStd::string& toolTip)
-        {
-            if (index < GetNumArguments())
-            {
-                m_metadataParameters[index + s_startArgumentIndex].m_toolTip = toolTip;
-            }
-        }
-
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        void BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::SetDefaultValue(size_t index, BehaviorDefaultValuePtr defaultValue)
-        {
-            if (index < GetNumArguments())
-            {
-                if (defaultValue && defaultValue->GetValue().m_typeId != GetArgument(index)->m_typeId)
-                {
-                    AZ_Assert(false, "Argument %zu default value type, doesn't match! Default value should be the same type! Current type %s!", index, defaultValue->GetValue().m_name);
-                    return;
-                }
-                m_metadataParameters[index + s_startArgumentIndex].m_defaultValue = defaultValue;
-            }
-        }
-
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        BehaviorDefaultValuePtr BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::GetDefaultValue(size_t index) const
-        {
-            if (index < GetNumArguments())
-            {
-                return m_metadataParameters[index + s_startArgumentIndex].m_defaultValue;
-            }
-            return nullptr;
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class EBus, BehaviorEventType EventType, class R, class C, class... Args>
-        const BehaviorParameter* BehaviorEBusEvent<EBus, EventType, R(C::*)(Args...)>::GetResult() const
-        {
-            return &m_parameters[0];
-        }
-
+namespace AZ
+{
+    namespace Internal
+    {
         //////////////////////////////////////////////////////////////////////////
         template<class R, class... Args>
         void SetFunctionParameters<R(Args...)>::Set(AZStd::vector<BehaviorParameter>& params)
@@ -5129,52 +2755,6 @@ namespace AZ
             return true;
         }
 
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class T>
-        void* BahaviorDefaultFactory<T>::Create(void* inplaceAddress, void* userData)
-        {
-            (void)userData;
-            if (inplaceAddress)
-            {
-                return new(inplaceAddress)T();
-            }
-            else
-            {
-                return aznew T();
-            }
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class T>
-        void BahaviorDefaultFactory<T>::Destroy(void* objectPtr, bool isFreeMemory, void* userData)
-        {
-            (void)userData;
-            T* object = reinterpret_cast<T*>(objectPtr);
-            if (isFreeMemory)
-            {
-                delete object;
-            }
-            else
-            {
-                object->~T();
-            }
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        template<class T>
-        void* BahaviorDefaultFactory<T>::Clone(void* targetAddress, void* sourceAddress, void* userData)
-        {
-            (void)userData;
-            if (targetAddress)
-            {
-                return new(targetAddress)T(*reinterpret_cast<T*>(sourceAddress));
-            }
-            else
-            {
-                return aznew T(*reinterpret_cast<T*>(sourceAddress));
-            }
-        }
 
         //////////////////////////////////////////////////////////////////////////
         template<class Handler>
@@ -5273,19 +2853,17 @@ namespace AZ
         };
 
         //////////////////////////////////////////////////////////////////////////
-        // Passed to Attribute::SetContext data, to destroy the behavior method
-        inline void DestroyAttributeMethod(void* contextData)
-        {
-            delete reinterpret_cast<BehaviorMethod*>(contextData);
-        }
-
-        //////////////////////////////////////////////////////////////////////////
         template<class Owner>
         template<class T>
         void GenericAttributes<Owner>::SetAttributeContextData(T value, AZ::Attribute* attribute, const AZStd::true_type& /* is_function<remove_pointer<T>::type> && is_member_function_pointer<T>*/)
         {
-            BehaviorMethod* method = aznew AZ::Internal::BehaviorMethodImpl<typename AZStd::remove_pointer<T>::type>(value, m_context, AZStd::string("Function-Attribute"));
-            attribute->SetContextData(method, &DestroyAttributeMethod);
+            BehaviorMethod* method = aznew AZ::Internal::BehaviorMethodImpl(value, m_context, AZStd::string("Function-Attribute"));
+            auto DestroyAttributeMethod = [](void* contextData)
+            {
+                // Passed to Attribute::SetContext data, to destroy the behavior method
+                delete reinterpret_cast<BehaviorMethod*>(contextData);
+            };
+            attribute->SetContextData(method, DestroyAttributeMethod);
         }
 
         //////////////////////////////////////////////////////////////////////////
@@ -5311,148 +2889,23 @@ namespace AZ
             return static_cast<Owner*>(this);
         }
 
-        template<typename Bus>
-        class EBusAttributes :
-            public AZ::Internal::GenericAttributes<BehaviorContext::EBusBuilder<Bus>>
-        {
-        protected:
-
-            using Base = AZ::Internal::GenericAttributes<BehaviorContext::EBusBuilder<Bus>>;
-
-            EBusAttributes(BehaviorContext* context)
-                : AZ::Internal::GenericAttributes<BehaviorContext::EBusBuilder<Bus>>(context)
-            {
-            }
-
-            void SetEBusEventSender(BehaviorEBusEventSender* ebusSender);
-
-        public:
-            using AZ::Internal::GenericAttributes<BehaviorContext::EBusBuilder<Bus>>::Attribute;
-            template<class T>
-            BehaviorContext::EBusBuilder<Bus>* Attribute(Crc32 idCrc, T value);
-
-            /**
-            * Applies Attribute to the Event BehaviorMethod if an EBusEventSender is set
-            */
-            template<class T>
-            BehaviorContext::EBusBuilder<Bus>* BroadcastAttribute(Crc32 idCrc, const T& value);
-
-            /**
-            * Applies Attribute to the Event BehaviorMethod if the EBusEventSender is set
-            * and the EBus supports firing individual events
-            */
-            template<class T>
-            BehaviorContext::EBusBuilder<Bus>* EventAttribute(Crc32 idCrc, const T& value);
-
-            /**
-            * Applies Attribute to the Event BehaviorMethod if the EBusEventSender is set
-            * and the EBus supports queuing broadcast events
-            */
-            template<class T>
-            BehaviorContext::EBusBuilder<Bus>* QueueBroadcastAttribute(Crc32 idCrc, const T& value);
-
-            /**
-            * Applies Attribute to the Event BehaviorMethod if the EBusEventSender is set
-            * and the EBus supports queuing individual events
-            */
-            template<class T>
-            BehaviorContext::EBusBuilder<Bus>* QueueEventAttribute(Crc32 idCrc, const T& value);
-
-        private:
-            BehaviorEBusEventSender * m_currentEBusSender = nullptr;
-        };
-
-        template<typename Bus>
-        void EBusAttributes<Bus>::SetEBusEventSender(BehaviorEBusEventSender* ebusSender)
-        {
-            m_currentEBusSender = ebusSender;
-        }
-
-        template<class Bus>
-        template<class T>
-        BehaviorContext::EBusBuilder<Bus>* EBusAttributes<Bus>::BroadcastAttribute(Crc32 idCrc, const T& value)
-        {
-            if (m_currentEBusSender &&  m_currentEBusSender->m_broadcast)
-            {
-                AZ::Attribute* eventAttribute = aznew AttributeContainerType<T>(value);
-                Base::template SetAttributeContextData<T>(value, eventAttribute, AZStd::integral_constant<bool, AZStd::is_member_function_pointer<T>::value || AZStd::is_function<typename AZStd::remove_pointer<T>::type>::value>());
-                m_currentEBusSender->m_broadcast->m_attributes.emplace_back(AttributePair(idCrc, eventAttribute));
-            }
-            return static_cast<BehaviorContext::EBusBuilder<Bus>*>(this);
-        }
-
-        template<class Bus>
-        template<class T>
-        BehaviorContext::EBusBuilder<Bus>* EBusAttributes<Bus>::EventAttribute(Crc32 idCrc, const T& value)
-        {
-            if (!Base::m_context->IsRemovingReflection() && m_currentEBusSender && m_currentEBusSender->m_event)
-            {
-                AZ::Attribute* eventAttribute = aznew AttributeContainerType<T>(value);
-                Base::template SetAttributeContextData<T>(value, eventAttribute, AZStd::integral_constant<bool, AZStd::is_member_function_pointer<T>::value || AZStd::is_function<typename AZStd::remove_pointer<T>::type>::value>());
-                m_currentEBusSender->m_event->m_attributes.emplace_back(AttributePair(idCrc, eventAttribute));
-            }
-            return static_cast<BehaviorContext::EBusBuilder<Bus>*>(this);
-        }
-
-        template<class Bus>
-        template<class T>
-        BehaviorContext::EBusBuilder<Bus>* EBusAttributes<Bus>::QueueBroadcastAttribute(Crc32 idCrc, const T& value)
-        {
-            if (!Base::m_context->IsRemovingReflection() && m_currentEBusSender && m_currentEBusSender->m_queueBroadcast)
-            {
-                AZ::Attribute* eventAttribute = aznew AttributeContainerType<T>(value);
-                Base::template SetAttributeContextData<T>(value, eventAttribute, AZStd::integral_constant<bool, AZStd::is_member_function_pointer<T>::value || AZStd::is_function<typename AZStd::remove_pointer<T>::type>::value>());
-                m_currentEBusSender->m_queueBroadcast->m_attributes.emplace_back(AttributePair(idCrc, eventAttribute));
-            }
-            return static_cast<BehaviorContext::EBusBuilder<Bus>*>(this);
-        }
-
-        template<class Bus>
-        template<class T>
-        BehaviorContext::EBusBuilder<Bus>* EBusAttributes<Bus>::QueueEventAttribute(Crc32 idCrc, const T& value)
-        {
-            if (!Base::m_context->IsRemovingReflection() && m_currentEBusSender && m_currentEBusSender->m_queueEvent)
-            {
-                AZ::Attribute* eventAttribute = aznew AttributeContainerType<T>(value);
-                Base::template SetAttributeContextData<T>(value, eventAttribute, AZStd::integral_constant<bool, AZStd::is_member_function_pointer<T>::value || AZStd::is_function<typename AZStd::remove_pointer<T>::type>::value>());
-                m_currentEBusSender->m_queueEvent->m_attributes.emplace_back(AttributePair(idCrc, eventAttribute));
-            }
-            return static_cast<BehaviorContext::EBusBuilder<Bus>*>(this);
-        }
-
-        template<class Bus>
-        template<class T>
-        BehaviorContext::EBusBuilder<Bus>* EBusAttributes<Bus>::Attribute(Crc32 idCrc, T value)
-        {
-            if (Base::m_context->IsRemovingReflection())
-            {
-                return static_cast<BehaviorContext::EBusBuilder<Bus>*>(this);
-            }
-
-            // Apply attributes to each EBusEventSender BehaviorMethods if one is set on this instance
-            BroadcastAttribute(idCrc, value);
-            EventAttribute(idCrc, value);
-            QueueBroadcastAttribute(idCrc, value);
-            QueueEventAttribute(idCrc, value);
-
-            // Apply attribute to the current bound attribute address which could on a EBus, EBusEventSender or Ebus CreateHandler instance
-            if (Base::m_currentAttributes)
-            {
-                AZ::Attribute* ebusAttribute = aznew AttributeContainerType<T>(value);
-                Base::template SetAttributeContextData<T>(value, ebusAttribute, AZStd::integral_constant<bool, AZStd::is_member_function_pointer<T>::value | AZStd::is_function<typename AZStd::remove_pointer<T>::type>::value>());
-                Base::m_currentAttributes->emplace_back(AttributePair(idCrc, ebusAttribute));
-            }
-
-            return static_cast<BehaviorContext::EBusBuilder<Bus>*>(this);
-        }
-
         bool IsInScope(const AttributeArray& attributes, const AZ::Script::Attributes::ScopeFlags scope);
 
     } // namespace Internal
 } // namespace AZ
 
-// Add definitions to allow lambdas to be used with EBus Events on the Behavior Context
-#include <AzCore/RTTI/BehaviorContextEBusEventRawSignature.inl>
+// Include inline implementation of BehaviorMethodImpl constructors
+#include "BehaviorMethodImpl.inl"
+
+// Implement inline functions for the BehaviorEvent constructors
+#include "BehaviorEBusEvent.inl"
+#include "BehaviorEBusHandler.inl"
+
+// Include inline implementation of the ClassBuilder struct for building BehaviorClass instances
+#include "BehaviorClassBuilder.inl"
+
+// Include inline implementation of the ClassBuilder struct for building BehaviorEBus instances
+#include "BehaviorEBusBuilder.inl"
 
 // pull AzStd on demand reflection
 #include <AzCore/RTTI/AzStdOnDemandPrettyName.inl>

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.h
@@ -860,19 +860,17 @@ namespace AZ
     // Wraps storage for the unwrapper functor that cannot be
     // stored within the <= sizeof(void*) amount of storage
     using UnwrapperPtr = AZStd::unique_ptr<void, UnwrapperFuncDeleter>;
-    union UnwrapperUserData
+    struct UnwrapperUserData
     {
         UnwrapperUserData();
         UnwrapperUserData(UnwrapperUserData&&);
         UnwrapperUserData& operator=(UnwrapperUserData&&);
         ~UnwrapperUserData();
 
-        AZStd::byte m_objectStorage[sizeof (void*)]{};
         UnwrapperPtr m_unwrapperPtr;
-
     };
-    using BehaviorClassUnwrapperFunction = void(*)(void* /*classPtr*/, void*& /*unwrappedClass*/,
-        AZ::Uuid& /*unwrappedClassTypeId*/, const UnwrapperUserData& /*userData*/);
+    using BehaviorClassUnwrapperFunction = void(*)(void* /*classPtr*/, BehaviorObject& /*unwrappedBehaviorObject*/,
+        const UnwrapperUserData& /*userData*/);
 
     /**
      * Behavior representation of reflected class.

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorEBusBuilder.cpp
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorEBusBuilder.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/RTTI/BehaviorContext.h>
+
+namespace AZ::Internal
+{
+    // Contains the EBusBuilderBase non-function template member definitions
+    EBusBuilderBase::EBusBuilderBase(BehaviorContext* context, BehaviorEBus* ebus)
+        : Base(context)
+        , m_ebus(ebus)
+    {
+        Base::m_currentAttributes = &ebus->m_attributes;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    EBusBuilderBase::~EBusBuilderBase()
+    {
+        // process all on demand queued reflections
+        Base::m_context->ExecuteQueuedOnDemandReflections();
+
+        if (!Base::m_context->IsRemovingReflection())
+        {
+            for (auto&& [eventName, eventSender] : m_ebus->m_events)
+            {
+                if (MethodReturnsAzEventByReferenceOrPointer(*eventSender.m_broadcast))
+                {
+                    ValidateAzEventDescription(*Base::m_context, *eventSender.m_broadcast);
+                }
+            }
+            BehaviorContextBus::Event(Base::m_context, &BehaviorContextBus::Events::OnAddEBus, m_ebus->m_name.c_str(), m_ebus);
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    auto EBusBuilderBase::operator->() -> EBusBuilderBase*
+    {
+        return this;
+    }
+
+    auto EBusBuilderBase::VirtualProperty(const char* name, const char* getterEvent, const char* setterEvent)
+        -> EBusBuilderBase*
+    {
+        if (m_ebus)
+        {
+            BehaviorEBusEventSender* getter = nullptr;
+            BehaviorEBusEventSender* setter = nullptr;
+            if (getterEvent)
+            {
+                auto getterIt = m_ebus->m_events.find(getterEvent);
+                getter = &getterIt->second;
+                if (getterIt == m_ebus->m_events.end())
+                {
+                    AZ_Error("BehaviorContext", false, "EBus %s, VirtualProperty %s getter event %s is not reflected. Make sure VirtualProperty is reflected after the Event!", m_ebus->m_name.c_str(), name, getterEvent);
+                    return this;
+                }
+
+                // we should always have the broadcast present, so use it for our checks
+                if (!getter->m_broadcast->HasResult())
+                {
+                    AZ_Error("BehaviorContext", false, "EBus %s, VirtualProperty %s getter %s should return result", m_ebus->m_name.c_str(), name, getterEvent);
+                    return this;
+                }
+                if (getter->m_broadcast->GetNumArguments() != 0)
+                {
+                    AZ_Error("BehaviorContext", false, "EBus %s, VirtualProperty %s getter %s can not have arguments only result", m_ebus->m_name.c_str(), name, getterEvent);
+                    return this;
+                }
+            }
+            if (setterEvent)
+            {
+                auto setterIt = m_ebus->m_events.find(setterEvent);
+                if (setterIt == m_ebus->m_events.end())
+                {
+                    AZ_Error("BehaviorContext", false, "EBus %s, VirtualProperty %s setter event %s is not reflected. Make sure VirtualProperty is reflected after the Event!", m_ebus->m_name.c_str(), name, setterEvent);
+                    return this;
+                }
+                setter = &setterIt->second;
+                if (setter->m_broadcast->HasResult())
+                {
+                    AZ_Error("BehaviorContext", false, "EBus %s, VirtualProperty %s setter %s should not return result", m_ebus->m_name.c_str(), name, setterEvent);
+                    return this;
+                }
+                if (setter->m_broadcast->GetNumArguments() != 1)
+                {
+                    AZ_Error("BehaviorContext", false, "EBus %s, VirtualProperty %s setter %s can have only one argument", m_ebus->m_name.c_str(), name, setterEvent);
+                    return this;
+                }
+            }
+
+            if (getter && setter)
+            {
+                if (getter->m_broadcast->GetResult()->m_typeId != setter->m_broadcast->GetArgument(0)->m_typeId)
+                {
+                    AZ_Error("BehaviorContext", false, "EBus %s, VirtualProperty %s getter %s return [%s] and setter %s input argument [%s] types don't match ", m_ebus->m_name.c_str(), name, setterEvent, getter->m_broadcast->GetResult()->m_typeId.ToString<AZStd::string>().c_str(), setter->m_broadcast->GetArgument(0)->m_typeId.ToString<AZStd::string>().c_str());
+                    return this;
+                }
+            }
+
+            m_ebus->m_virtualProperties.insert(AZStd::make_pair(name, BehaviorEBus::VirtualProperty(getter, setter)));
+        }
+        return this;
+    }
+
+    EBusAttributes::EBusAttributes(BehaviorContext* context)
+        : Base(context)
+    {
+    }
+
+    void EBusAttributes::SetEBusEventSender(BehaviorEBusEventSender* ebusSender)
+    {
+        m_currentEBusSender = ebusSender;
+    }
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorEBusBuilder.inl
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorEBusBuilder.inl
@@ -1,0 +1,539 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+namespace AZ::Internal
+{
+    // Contains template definitions for the BehaviorContext EBusBuilder<EBus>
+    // and EBusBuilderBase template functions
+    struct EBusBuilderBase;
+
+    class EBusAttributes
+        : public GenericAttributes<EBusBuilderBase>
+    {
+    protected:
+
+        using Base = GenericAttributes<EBusBuilderBase>;
+
+        EBusAttributes(BehaviorContext* context);
+
+        void SetEBusEventSender(BehaviorEBusEventSender* ebusSender);
+
+    public:
+        using Base::Attribute;
+
+        template<class T>
+        EBusBuilderBase* Attribute(Crc32 idCrc, T value);
+
+        /**
+        * Applies Attribute to the Event BehaviorMethod if an EBusEventSender is set
+        */
+        template<class T>
+        EBusBuilderBase* BroadcastAttribute(Crc32 idCrc, const T& value);
+
+        /**
+        * Applies Attribute to the Event BehaviorMethod if the EBusEventSender is set
+        * and the EBus supports firing individual events
+        */
+        template<class T>
+        EBusBuilderBase* EventAttribute(Crc32 idCrc, const T& value);
+
+        /**
+        * Applies Attribute to the Event BehaviorMethod if the EBusEventSender is set
+        * and the EBus supports queuing broadcast events
+        */
+        template<class T>
+        EBusBuilderBase* QueueBroadcastAttribute(Crc32 idCrc, const T& value);
+
+        /**
+        * Applies Attribute to the Event BehaviorMethod if the EBusEventSender is set
+        * and the EBus supports queuing individual events
+        */
+        template<class T>
+        EBusBuilderBase* QueueEventAttribute(Crc32 idCrc, const T& value);
+
+    private:
+        BehaviorEBusEventSender* m_currentEBusSender = nullptr;
+    };
+
+    /// Internal structure to maintain EBus information while describing it.
+    struct EBusBuilderBase
+        : public AZ::Internal::EBusAttributes
+    {
+        using Base = AZ::Internal::EBusAttributes;
+
+        EBusBuilderBase(BehaviorContext* context, BehaviorEBus* behaviorEBus);
+        ~EBusBuilderBase();
+        EBusBuilderBase* operator->();
+
+        /**
+        * Reflects an EBus event, valid only when used with in the context of an EBus reflection.
+        * We will automatically add all possible variations (Broadcast,Event,QueueBroadcast and QueueEvent)
+        */
+        template<class Bus, class Function>
+        EBusBuilderBase* EventWithBus(const char* name, Function f, const char* deprecatedName = nullptr);
+
+        template<class Bus, class Function>
+        EBusBuilderBase* EventWithBus(const char* name, Function f, const BehaviorParameterOverridesArray<Function>& args);
+
+        template<class Bus, class Function>
+        EBusBuilderBase* EventWithBus(const char* name, Function f, const char* deprecatedName, const BehaviorParameterOverridesArray<Function>& args);
+
+        /**
+        * Every \ref EBus has two components, sending and receiving. Sending is reflected via \ref BehaviorContext::Event calls and Handler/Received
+        * use handled via the receiver class. This class will receive EBus events and forward them to the behavior context functions.
+        * Since we can't write a class (without using a codegen) while reflecting, you will need to implement that class
+        * with the help of \ref AZ_EBUS_BEHAVIOR_BINDER. This class in mandated because you can't hook to individual events at the moment.
+        * In this version of Handler you can provide a custom function to create and destroy that handler (usually where aznew/delete is not
+        * applicable or you have a better pooling schema that our memory allocators already have). For most cases use the function \ref
+        * Handler()
+        */
+        template<typename HandlerType, typename HandlerCreator, typename HandlerDestructor>
+        EBusBuilderBase* Handler(HandlerCreator creator, HandlerDestructor destructor);
+
+        /** Set the Handler/Receiver for ebus evens that will be forwarded to BehaviorFunctions. This is a helper implementation where aznew/delete
+        * is ready to called on the handler.
+        */
+        template<class H>
+        EBusBuilderBase* Handler();
+
+        /**
+         * With request buses (please refer to component communication patterns documentation) we ofter have EBus events
+         * that represent a getter and a setter for a value. To allow our tools to take advantage of it, you can reflect
+         * VirtualProperty to indicate which event is the getter and which is the setter.
+         * This function validates that getter event has no argument and a result and setter function has no results and only
+         * one argument which is the same type as the result of the getter.
+         * \note Make sure you call this function after you have reflected the getter and setter events as it will report an error
+         * if we can't find the function
+         */
+        EBusBuilderBase* VirtualProperty(const char* name, const char* getterEvent, const char* setterEvent);
+
+        BehaviorEBus* m_ebus;
+    };
+}
+
+namespace AZ::Internal
+{
+    //////////////////////////////////////////////////////////////////////////
+    template<class Bus,class Function>
+    auto EBusBuilderBase::EventWithBus(const char* name, Function e, const char* deprecatedName /*=nullptr*/)
+        -> EBusBuilderBase*
+    {
+        BehaviorParameterOverridesArray<Function> parameterOverrides;
+        return EventWithBus<Bus>(name, e, deprecatedName, parameterOverrides);
+    }
+
+    template<class Bus, class Function>
+    auto EBusBuilderBase::EventWithBus(const char* name, Function e, const char* deprecatedName, const BehaviorParameterOverridesArray<Function>& args)
+        -> EBusBuilderBase*
+    {
+        if (m_ebus)
+        {
+            BehaviorEBusEventSender ebusEvent;
+
+            ebusEvent.Set<Bus>(e, name, Base::m_context);
+
+            auto insertIt = m_ebus->m_events.insert(AZStd::make_pair(name, ebusEvent));
+
+            if (!insertIt.second)
+            {
+                AZ_Error("BehaviorContext", false, "Reflection inserted a duplicate event: '%s' for bus '%s' - please check that you are not reflecting the same event repeatedly. This will cause memory leaks.", name, m_ebus->m_name.c_str());
+            }
+            else
+            {
+                // do we have a deprecated name for this event?
+                if (deprecatedName != nullptr)
+                {
+                    // ensure deprecated name is not in use as a existing name
+                    auto itr = m_ebus->m_events.find(deprecatedName);
+
+                    if (itr != m_ebus->m_events.end())
+                    {
+                        AZ_Warning("BehaviorContext", false, "Event %s is attempting to use %s as a deprecated name, but the deprecated name is already in use! The deprecated name is ignored!", name, deprecatedName);
+                    }
+                    else
+                    {
+                        // ensure that we won't have a duplicate deprecated name
+                        bool isDuplicated = false;
+                        for (const auto& i : m_ebus->m_events)
+                        {
+                            if (i.second.m_deprecatedName == deprecatedName)
+                            {
+                                isDuplicated = true;
+                                AZ_Warning("BehaviorContext", false, "Event %s is attempting to use %s as a deprecated name, but the deprecated name is already used as a deprecated name for the Event %s! The deprecated name is ignored!", name, deprecatedName, i.first.c_str());
+                                break;
+                            }
+                        }
+
+                        if (!isDuplicated)
+                        {
+                            insertIt.first->second.m_deprecatedName = deprecatedName;
+                        }
+                    }
+                }
+
+                for (BehaviorMethod* method : { ebusEvent.m_event, ebusEvent.m_broadcast })
+                {
+                    if (method)
+                    {
+                        size_t busIdParameterIndex = method->HasBusId() ? 1 : 0;
+                        for (size_t i = 0; i < args.size(); ++i)
+                        {
+                            method->SetArgumentName(i + busIdParameterIndex, args[i].m_name);
+                            method->SetArgumentToolTip(i + busIdParameterIndex, args[i].m_toolTip);
+                            method->SetDefaultValue(i + busIdParameterIndex, args[i].m_defaultValue);
+                            method->OverrideParameterTraits(i + busIdParameterIndex, args[i].m_addTraits, args[i].m_removeTraits);
+                        }
+                    }
+                }
+
+                Base::m_currentAttributes = &insertIt.first->second.m_attributes;
+                Base::SetEBusEventSender(&insertIt.first->second);
+            }
+        }
+
+        return this;
+    }
+
+    template<class Bus, class Function>
+    auto EBusBuilderBase::EventWithBus(const char* name, Function e, const BehaviorParameterOverridesArray<Function>& args)
+        -> EBusBuilderBase*
+    {
+        return EventWithBus<Bus>(name, e, nullptr, args);
+    }
+    template<typename HandlerType, typename HandlerCreator, typename HandlerDestructor>
+    auto EBusBuilderBase::Handler(HandlerCreator creator, HandlerDestructor destructor)
+        -> EBusBuilderBase*
+    {
+        if (m_ebus)
+        {
+            AZ_Assert(creator != nullptr && destructor != nullptr, "Both creator and destructor should be provided!");
+            using CreatorFunctionTraits = AZStd::function_traits<HandlerCreator>;
+            using CreatorFunctionCastType = AZStd::conditional_t<
+                !AZStd::is_same_v<typename CreatorFunctionTraits::class_type, AZStd::Internal::error_type>,
+                typename CreatorFunctionTraits::type,
+                typename CreatorFunctionTraits::function_object_signature*>;
+            using DestructorFunctionTraits = AZStd::function_traits<HandlerDestructor>;
+            using DestructorFunctionCastType = AZStd::conditional_t<
+                !AZStd::is_same_v<typename DestructorFunctionTraits::class_type, AZStd::Internal::error_type>,
+                typename DestructorFunctionTraits::type,
+                typename DestructorFunctionTraits::function_object_signature*>;
+
+            BehaviorMethod* createHandler = aznew AZ::Internal::BehaviorMethodImpl(static_cast<CreatorFunctionCastType>(creator), Base::m_context, m_ebus->m_name + "::CreateHandler");
+            BehaviorMethod* destroyHandler = aznew AZ::Internal::BehaviorMethodImpl(static_cast<DestructorFunctionCastType>(destructor), Base::m_context, m_ebus->m_name + "::DestroyHandler");
+            // OnDemandReflect the types in all the handler Event functions
+            m_ebus->m_ebusHandlerOnDemandReflector = AZStd::make_unique<ScopedBehaviorOnDemandReflector>(*Base::m_context);
+            AZ::Internal::OnDemandReflectFunctions(m_ebus->m_ebusHandlerOnDemandReflector.get(), typename HandlerType::EventFunctionsParameterPack{});
+
+            // check than the handler returns the expected type
+            if (createHandler->GetResult()->m_typeId != AzTypeInfo<BehaviorEBusHandler>::Uuid() || destroyHandler->GetArgument(0)->m_typeId != AzTypeInfo<BehaviorEBusHandler>::Uuid())
+            {
+                AZ_Assert(false, "HandlerCreator my return a BehaviorEBusHandler* object and HandlerDestrcutor should have an argument that can handle BehaviorEBusHandler!");
+                delete createHandler;
+                delete destroyHandler;
+                createHandler = nullptr;
+                destroyHandler = nullptr;
+            }
+            else
+            {
+                Base::m_currentAttributes = &createHandler->m_attributes;
+                Base::SetEBusEventSender(nullptr);
+            }
+            m_ebus->m_createHandler = createHandler;
+            m_ebus->m_destroyHandler = destroyHandler;
+        }
+        return this;
+    }
+
+    template<class H>
+    auto EBusBuilderBase::Handler() -> EBusBuilderBase*
+    {
+        Handler<H>(&AZ::Internal::BehaviorEBusHandlerFactory<H>::Create, &AZ::Internal::BehaviorEBusHandlerFactory<H>::Destroy);
+        return this;
+    }
+
+    // EBusAttributes members functions
+    template<class T>
+    auto EBusAttributes::BroadcastAttribute(Crc32 idCrc, const T& value)
+        -> EBusBuilderBase*
+    {
+        if (m_currentEBusSender && m_currentEBusSender->m_broadcast)
+        {
+            AZ::Attribute* eventAttribute = aznew AttributeContainerType<T>(value);
+            Base::template SetAttributeContextData<T>(value, eventAttribute,
+                AZStd::bool_constant<AZStd::is_member_function_pointer_v<T> || AZStd::is_function_v<AZStd::remove_pointer_t<T>>>());
+            m_currentEBusSender->m_broadcast->m_attributes.emplace_back(AttributePair(idCrc, eventAttribute));
+        }
+        return static_cast<EBusBuilderBase*>(this);
+    }
+
+    template<class T>
+    auto EBusAttributes::EventAttribute(Crc32 idCrc, const T& value)
+        -> EBusBuilderBase*
+    {
+        if (!Base::m_context->IsRemovingReflection() && m_currentEBusSender && m_currentEBusSender->m_event)
+        {
+            AZ::Attribute* eventAttribute = aznew AttributeContainerType<T>(value);
+            Base::template SetAttributeContextData<T>(value, eventAttribute,
+                AZStd::bool_constant<AZStd::is_member_function_pointer_v<T> || AZStd::is_function_v<AZStd::remove_pointer_t<T>>>());
+            m_currentEBusSender->m_event->m_attributes.emplace_back(AttributePair(idCrc, eventAttribute));
+        }
+        return static_cast<EBusBuilderBase*>(this);
+    }
+
+    template<class T>
+    auto EBusAttributes::QueueBroadcastAttribute(Crc32 idCrc, const T& value)
+        -> EBusBuilderBase*
+    {
+        if (!Base::m_context->IsRemovingReflection() && m_currentEBusSender && m_currentEBusSender->m_queueBroadcast)
+        {
+            AZ::Attribute* eventAttribute = aznew AttributeContainerType<T>(value);
+            Base::template SetAttributeContextData<T>(value, eventAttribute,
+                AZStd::bool_constant<AZStd::is_member_function_pointer_v<T> || AZStd::is_function_v<AZStd::remove_pointer_t<T>>>());
+            m_currentEBusSender->m_queueBroadcast->m_attributes.emplace_back(AttributePair(idCrc, eventAttribute));
+        }
+        return static_cast<EBusBuilderBase*>(this);
+    }
+
+    template<class T>
+    auto EBusAttributes::QueueEventAttribute(Crc32 idCrc, const T& value)
+        -> EBusBuilderBase*
+    {
+        if (!Base::m_context->IsRemovingReflection() && m_currentEBusSender && m_currentEBusSender->m_queueEvent)
+        {
+            AZ::Attribute* eventAttribute = aznew AttributeContainerType<T>(value);
+            Base::template SetAttributeContextData<T>(value, eventAttribute,
+                AZStd::bool_constant<AZStd::is_member_function_pointer_v<T> || AZStd::is_function_v<AZStd::remove_pointer_t<T>>>());
+            m_currentEBusSender->m_queueEvent->m_attributes.emplace_back(AttributePair(idCrc, eventAttribute));
+        }
+        return static_cast<EBusBuilderBase*>(this);
+    }
+
+    template<class T>
+    auto EBusAttributes::Attribute(Crc32 idCrc, T value)
+        -> EBusBuilderBase*
+    {
+        if (Base::m_context->IsRemovingReflection())
+        {
+            return static_cast<EBusBuilderBase*>(this);
+        }
+
+        // Apply attributes to each EBusEventSender BehaviorMethods if one is set on this instance
+        BroadcastAttribute(idCrc, value);
+        EventAttribute(idCrc, value);
+        QueueBroadcastAttribute(idCrc, value);
+        QueueEventAttribute(idCrc, value);
+
+        // Apply attribute to the current bound attribute address which could on a EBus, EBusEventSender or Ebus CreateHandler instance
+        if (Base::m_currentAttributes)
+        {
+            AZ::Attribute* ebusAttribute = aznew AttributeContainerType<T>(value);
+            Base::template SetAttributeContextData<T>(value, ebusAttribute, AZStd::bool_constant<AZStd::is_member_function_pointer_v<T> || AZStd::is_function_v<AZStd::remove_pointer_t<T>>>());
+            Base::m_currentAttributes->emplace_back(AttributePair(idCrc, ebusAttribute));
+        }
+
+        return static_cast<EBusBuilderBase*>(this);
+    }
+} // namespace AZ::Internal
+
+
+namespace AZ
+{
+    template<typename Bus>
+    struct BehaviorContext::EBusBuilder
+        : public Internal::EBusBuilderBase
+    {
+        using Internal::EBusBuilderBase::EBusBuilderBase;
+
+        // arrow operator for derived EBusBuilder class which hides
+        // base class version
+        EBusBuilder* operator->();
+
+        // Backward Compatibility functions
+        // As the majority of BehaviorContext ebus reflection uses operator->
+        // for reflection, definitions for the EBusBuilderBase member functions
+        // have been added to this template class, where it delegates to calling the base class
+        template<class U>
+        EBusBuilder* Attribute(const char* id, U value);
+        template<class U>
+        EBusBuilder* Attribute(AZ::Crc32 id, U value);
+
+        // Legacy Event functions which uses the Bus class template parameter
+        // for calling the EBusBuilderBase EventWithBus<Bus> function
+        template<class Function>
+        EBusBuilder* Event(const char* name, Function f, const char* deprecatedName = nullptr);
+
+        template<class Function>
+        EBusBuilder* Event(const char* name, Function f, const BehaviorParameterOverridesArray<Function>& args);
+
+        template<class Function>
+        EBusBuilder* Event(const char* name, Function f, const char* deprecatedName, const BehaviorParameterOverridesArray<Function>& args);
+
+        template<typename HandlerType, typename HandlerCreator, typename HandlerDestructor>
+        EBusBuilder* Handler(HandlerCreator creator, HandlerDestructor destructor);
+
+        template<class H>
+        EBusBuilder* Handler();
+
+        EBusBuilder* VirtualProperty(const char* name, const char* getterEvent, const char* setterEvent);
+    };
+
+    template<class Bus>
+    auto BehaviorContext::EBusBuilder<Bus>::operator->() -> EBusBuilder*
+    {
+        return this;
+    }
+
+    template<class Bus>
+    template<class U>
+    auto BehaviorContext::EBusBuilder<Bus>::Attribute(const char* id, U value)
+        -> EBusBuilder*
+    {
+        EBusBuilderBase::Attribute(id, AZStd::move(value));
+        return this;
+    }
+
+    template<class Bus>
+    template<class U>
+    auto BehaviorContext::EBusBuilder<Bus>::Attribute(AZ::Crc32 id, U value)
+        -> EBusBuilder*
+    {
+        EBusBuilderBase::Attribute(id, AZStd::move(value));
+        return this;
+    }
+
+
+    template<class Bus>
+    template<class Function>
+    auto BehaviorContext::EBusBuilder<Bus>::Event(const char* name, Function f, const char* deprecatedName)
+        -> EBusBuilder*
+    {
+        EBusBuilderBase::EventWithBus<Bus>(name, AZStd::move(f), deprecatedName);
+        return this;
+    }
+
+    template<class Bus>
+    template<class Function>
+    auto BehaviorContext::EBusBuilder<Bus>::Event(const char* name, Function f, const BehaviorParameterOverridesArray<Function>& args)
+        -> EBusBuilder*
+    {
+        EBusBuilderBase::EventWithBus<Bus>(name, AZStd::move(f), args);
+        return this;
+    }
+
+    template<class Bus>
+    template<class Function>
+    auto BehaviorContext::EBusBuilder<Bus>::Event(const char* name, Function f, const char* deprecatedName, const BehaviorParameterOverridesArray<Function>& args)
+        -> EBusBuilder*
+    {
+        EBusBuilderBase::EventWithBus<Bus>(name, AZStd::move(f), deprecatedName, args);
+        return this;
+    }
+
+    template<class Bus>
+    template<typename HandlerType, typename HandlerCreator, typename HandlerDestructor>
+    auto BehaviorContext::EBusBuilder<Bus>::Handler(HandlerCreator creator, HandlerDestructor destructor)
+        -> EBusBuilder*
+    {
+        EBusBuilderBase::Handler<HandlerType>(AZStd::move(creator), AZStd::move(destructor));
+        return this;
+    }
+
+    template<class Bus>
+    template<class H>
+    auto BehaviorContext::EBusBuilder<Bus>::Handler()
+        -> EBusBuilder*
+    {
+        EBusBuilderBase::Handler<H>();
+        return this;
+    }
+
+    template<class Bus>
+    auto BehaviorContext::EBusBuilder<Bus>::VirtualProperty(const char* name, const char* getterEvent, const char* setterEvent)
+        -> EBusBuilder*
+    {
+        EBusBuilderBase::VirtualProperty(name, getterEvent, setterEvent);
+        return this;
+    }
+} // namespace AZ
+
+namespace AZ
+{
+    // Returns a new EBusBuilder instance that can be used to configure a BehaviorEBus
+    // which can reflect EBus Handlers as well as events to the Behavior Context
+    template<class T>
+    auto BehaviorContext::EBus(const char* name, const char* deprecatedName, const char* toolTip)
+        -> EBusBuilder<T>
+    {
+        // should we require AzTypeInfo for EBus, technically we should if we want to work around the compiler issue that made us to do it in first place
+        if (IsRemovingReflection())
+        {
+            auto ebusIt = m_ebuses.find(name);
+            if (ebusIt != m_ebuses.end())
+            {
+                BehaviorContextBus::Event(this, &BehaviorContextBus::Events::OnRemoveEBus, name, ebusIt->second);
+
+                // Erase the deprecated name as well
+                auto deprecatedIt = m_ebuses.find(ebusIt->second->m_deprecatedName);
+                if (deprecatedIt != m_ebuses.end())
+                {
+                    m_ebuses.erase(deprecatedIt);
+                }
+
+                delete ebusIt->second;
+                m_ebuses.erase(ebusIt);
+            }
+
+            return EBusBuilder<T>(this, nullptr);
+        }
+        else
+        {
+            AZ_Error("BehaviorContext", m_ebuses.find(name) == m_ebuses.end(), "You shouldn't reflect an EBus multiple times (%s), subsequent reflections will not be registered!", name);
+
+            BehaviorEBus* behaviorEBus = aznew BehaviorEBus();
+            behaviorEBus->m_name = name;
+
+            if (toolTip != nullptr)
+            {
+                behaviorEBus->m_toolTip = toolTip;
+            }
+
+            /*
+            ** If we have a deprecated name, lets make sure the its not in use as an existing bus.
+            */
+
+            if (deprecatedName != nullptr)
+            {
+                if (*deprecatedName == '\0')
+                {
+                    AZ_Warning("BehaviorContext", false, "Deprecated name can't be a empty string!", deprecatedName);
+                }
+                else if (m_ebuses.find(deprecatedName) != m_ebuses.end())
+                {
+                    AZ_Warning("BehaviorContext", false, "EBus %s is attempting to use the deprecated name (%s) that is already used! Ignored!", name, deprecatedName);
+                }
+                else
+                {
+                    behaviorEBus->m_deprecatedName = deprecatedName;
+                }
+            }
+
+            EBusSetIdFeatures<T>(behaviorEBus);
+            behaviorEBus->m_queueFunction = QueueFunctionMethod<T>();
+
+            // Switch to Set (we store the name in the class)
+            m_ebuses.insert(AZStd::make_pair(behaviorEBus->m_name, behaviorEBus));
+            if (!behaviorEBus->m_deprecatedName.empty())
+            {
+                m_ebuses.insert(AZStd::make_pair(behaviorEBus->m_deprecatedName, behaviorEBus));
+            }
+
+            return EBusBuilder<T>(this, behaviorEBus);
+        }
+    }
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorEBusEvent.inl
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorEBusEvent.inl
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+namespace AZ::Internal
+{
+    template<class EBus, class Event, class... Args, size_t... Is>
+    void CallEBusMethod(Event eventFunc, BehaviorEventType eventType,
+        BehaviorArgument* arguments, BehaviorArgument* result, AZStd::Internal::pack_traits_arg_sequence<Args...>, AZStd::index_sequence<Is...>)
+    {
+        using R = typename  AZStd::function_traits<Event>::return_type;
+        switch (eventType)
+        {
+        case BehaviorEventType::BE_BROADCAST:
+            if constexpr (AZStd::is_void_v<R>)
+            {
+                EBus::Broadcast(eventFunc, *arguments[Is].GetAsUnsafe<Args>()...);
+            }
+            else
+            {
+                if (result)
+                {
+                    EBus::BroadcastResult(*result, eventFunc, *arguments[Is].GetAsUnsafe<Args>()...);
+                }
+                else
+                {
+                    EBus::Broadcast(eventFunc, *arguments[Is].GetAsUnsafe<Args>()...);
+                }
+            }
+            break;
+        case BehaviorEventType::BE_EVENT_ID:
+            if constexpr (!AZStd::is_same_v<typename EBus::BusIdType, AZ::NullBusId>)
+            {
+                BehaviorArgument& id = *arguments++;
+                if constexpr (AZStd::is_void_v<R>)
+                {
+                    EBus::Event(*id.GetAsUnsafe<typename EBus::BusIdType>(), eventFunc, *arguments[Is].GetAsUnsafe<Args>()...);
+                }
+                else
+                {
+                    if (result)
+                    {
+                        EBus::EventResult(*result, *id.GetAsUnsafe<typename EBus::BusIdType>(), eventFunc, *arguments[Is].GetAsUnsafe<Args>()...);
+                    }
+                    else
+                    {
+                        EBus::Event(*id.GetAsUnsafe<typename EBus::BusIdType>(), eventFunc, *arguments[Is].GetAsUnsafe<Args>()...);
+                    }
+                }
+            }
+            break;
+        case BehaviorEventType::BE_QUEUE_BROADCAST:
+            if constexpr (!AZStd::is_same_v<typename EBus::QueuePolicy::BusMessageCall, AZ::Internal::NullBusMessageCall>)
+            {
+                EBus::QueueBroadcast(eventFunc, *arguments[Is].GetAsUnsafe<Args>()...);
+            }
+            break;
+        case BehaviorEventType::BE_QUEUE_EVENT_ID:
+            if constexpr (!AZStd::is_same_v<typename EBus::BusIdType, AZ::NullBusId>
+                && !AZStd::is_same_v<typename EBus::QueuePolicy::BusMessageCall, AZ::Internal::NullBusMessageCall>)
+            {
+                BehaviorArgument& id = *arguments++;
+                EBus::QueueEvent(*id.GetAsUnsafe<typename EBus::BusIdType>(), eventFunc, *arguments[Is].GetAsUnsafe<Args>()...);
+            }
+            break;
+        }
+    }
+
+    template<class EBus, class R, class BusType, class... Args>
+    BehaviorEBusEvent::BehaviorEBusEvent(R(*functionPointer)(BusType*, Args...), BehaviorContext* context,
+        BehaviorEventType eventType, AZStd::type_identity<EBus>)
+        : BehaviorMethod(context)
+        , m_eventType(eventType)
+        , m_hasNonVoidReturn(!AZStd::is_void_v<R>)
+    {
+        m_functor = [functionPointer, this](BehaviorArgument* result, AZStd::span<BehaviorArgument> arguments)
+        {
+            CallEBusMethod<EBus>(functionPointer, m_eventType, arguments.data(), result,
+                AZStd::Internal::pack_traits_arg_sequence<Args...>{}, AZStd::make_index_sequence<sizeof...(Args)>());
+        };
+
+        InitParameters<EBus, R, BusType, Args...>();
+    }
+
+    template<class EBus, class R, class C, class... Args>
+    BehaviorEBusEvent::BehaviorEBusEvent(R(C::*functionPointer)(Args...), BehaviorContext* context,
+        BehaviorEventType eventType, AZStd::type_identity<EBus>)
+        : BehaviorMethod(context)
+        , m_eventType(eventType)
+        , m_hasNonVoidReturn(!AZStd::is_void_v<R>)
+    {
+        m_functor = [functionPointer, this](BehaviorArgument* result, AZStd::span<BehaviorArgument> arguments)
+        {
+            CallEBusMethod<EBus>(functionPointer, m_eventType, arguments.data(), result,
+                AZStd::Internal::pack_traits_arg_sequence<Args...>{}, AZStd::make_index_sequence<sizeof...(Args)>());
+        };
+
+        InitParameters<EBus, R, C, Args...>();
+    }
+
+    template<class EBus, class R, class C, class... Args>
+    BehaviorEBusEvent::BehaviorEBusEvent(R(C::*functionPointer)(Args...) const, BehaviorContext* context,
+        BehaviorEventType eventType, AZStd::type_identity<EBus>)
+        : BehaviorEBusEvent(reinterpret_cast<R(C::*)(Args...)>(functionPointer), context,
+            eventType, AZStd::type_identity<EBus>{})
+    {
+        m_isConst = true;
+    }
+
+#if __cpp_noexcept_function_type
+    // Delegate to the non-noexcept constructors
+    template<class EBus, class R, class BusType, class... Args>
+    BehaviorEBusEvent::BehaviorEBusEvent(R(*functionPointer)(BusType*, Args...) noexcept, BehaviorContext* context,
+        BehaviorEventType eventType, AZStd::type_identity<EBus>)
+        : BehaviorEBusEvent(reinterpret_cast<R(*)(Args...)>(functionPointer), context,
+            eventType, AZStd::type_identity<EBus>{})
+    {}
+
+    template<class EBus, class R, class C, class... Args>
+    BehaviorEBusEvent::BehaviorEBusEvent(R(C::* functionPointer)(Args...) noexcept, BehaviorContext* context,
+        BehaviorEventType eventType, AZStd::type_identity<EBus>)
+        : BehaviorEBusEvent(reinterpret_cast<R(C::*)(Args...)>(functionPointer), context,
+            eventType, AZStd::type_identity<EBus>{})
+    {}
+
+    template<class EBus, class R, class C, class... Args>
+    BehaviorEBusEvent::BehaviorEBusEvent(R(C::* functionPointer)(Args...) const noexcept, BehaviorContext* context,
+        BehaviorEventType eventType, AZStd::type_identity<EBus>)
+        : BehaviorEBusEvent(reinterpret_cast<R(C::*)(Args...) const>(functionPointer),
+            eventType, AZStd::type_identity<EBus>{})
+    {}
+#endif
+
+    template<class EBus, class R, class BusType, class... Args>
+    void BehaviorEBusEvent::InitParameters()
+    {
+        size_t parameterArraySize = 1 + sizeof...(Args);
+        constexpr bool hasBusId = !AZStd::is_same_v<typename EBus::BusIdType, AZ::NullBusId>;
+        const bool addressById = m_eventType == BehaviorEventType::BE_EVENT_ID
+            || m_eventType == BehaviorEventType::BE_QUEUE_EVENT_ID;
+        if constexpr (hasBusId)
+        {
+            if (addressById)
+            {
+                // There is an additional parameter for the BusId
+                ++parameterArraySize;
+                // The start of the non-bus id parameters is now at offset 2
+                ++m_startNamedArgumentIndex;
+            }
+        }
+
+        // Resize the parameters and meta associated with the parameters
+        m_parameters.resize(parameterArraySize);
+        m_metadataParameters.resize(parameterArraySize);
+
+        SetParameters<R>(m_parameters.data(), this);
+        if constexpr (hasBusId)
+        {
+            if (addressById)
+            {
+                // configure optional ID parameter
+                SetParameters<typename EBus::BusIdType>(m_parameters.data() + s_startArgumentIndex);
+            }
+
+        }
+        SetParameters<Args...>(m_parameters.data() + m_startNamedArgumentIndex, this);
+    }
+} // namespace AZ::Internal

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorEBusHandler.cpp
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorEBusHandler.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/RTTI/BehaviorContext.h>
+
+namespace AZ
+{
+    AZStd::string BehaviorEBusHandler::GetScriptPath() const
+    {
+#if !defined(AZ_RELEASE_BUILD) // m_scriptPath is only available in non-Release mode
+        return m_scriptPath;
+#else
+        return{};
+#endif
+    }
+
+    void BehaviorEBusHandler::SetScriptPath(const char* scriptPath)
+    {
+#if !defined(AZ_RELEASE_BUILD) // m_scriptPath is only available in non-Release mode
+        m_scriptPath = scriptPath;
+#else
+        AZ_UNUSED(scriptPath);
+#endif
+    }
+
+    //=========================================================================
+    // InstallGenericHook
+    //=========================================================================
+    bool BehaviorEBusHandler::InstallGenericHook(int index, GenericHookType hook, void* userData)
+    {
+        if (index != -1)
+        {
+            // Check parameters
+            m_events[index].m_isFunctionGeneric = true;
+            m_events[index].m_function = reinterpret_cast<void*>(hook);
+            m_events[index].m_userData = userData;
+            return true;
+        }
+
+        return false;
+    }
+
+    //=========================================================================
+    // InstallGenericHook
+    //=========================================================================
+    bool BehaviorEBusHandler::InstallGenericHook(const char* name, GenericHookType hook, void* userData)
+    {
+        return InstallGenericHook(GetFunctionIndex(name), hook, userData);
+    }
+
+    //=========================================================================
+    // GetEvents
+    //=========================================================================
+    const BehaviorEBusHandler::EventArray& BehaviorEBusHandler::GetEvents() const
+    {
+        return m_events;
+    }
+
+    bool BehaviorEBusHandler::BusForwarderEvent::HasResult() const
+    {
+        return !m_parameters.empty() && !m_parameters.front().m_typeId.IsNull() && m_parameters.front().m_typeId != azrtti_typeid<void>();
+    }
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorEBusHandler.inl
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorEBusHandler.inl
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+namespace AZ
+{
+    template<class BusId>
+    bool BehaviorEBusHandler::Connect(BusId id)
+    {
+        BehaviorArgument p(&id);
+        return Connect(&p);
+    }
+
+    template<class BusId>
+    void BehaviorEBusHandler::Disconnect(BusId id)
+    {
+        BehaviorArgument p(&id);
+        Disconnect(&p);
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    template<class Hook>
+    bool BehaviorEBusHandler::InstallHook(int index, Hook h, void* userData)
+    {
+        if (index != -1)
+        {
+            // Check parameters
+            if (!Internal::SetFunctionParameters<typename AZStd::remove_pointer<Hook>::type>::Check(m_events[index].m_parameters))
+            {
+                return false;
+            }
+
+            m_events[index].m_isFunctionGeneric = false;
+            m_events[index].m_function = reinterpret_cast<void*>(h);
+            m_events[index].m_userData = userData;
+            return true;
+        }
+
+        return false;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    template<class Hook>
+    bool BehaviorEBusHandler::InstallHook(const char* name, Hook h, void* userData)
+    {
+        return InstallHook(GetFunctionIndex(name), h, userData);
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    template<class Event>
+    void BehaviorEBusHandler::SetEvent(Event e, const char* name)
+    {
+        (void)e;
+        int i = GetFunctionIndex(name);
+        if (i != -1)
+        {
+            m_events.resize(i + 1);
+            m_events[i].m_name = name;
+            m_events[i].m_eventId = AZ::Crc32(name);
+            m_events[i].m_function = nullptr;
+            AZ::Internal::SetFunctionParameters<typename AZStd::remove_pointer<Event>::type>::Set(m_events[i].m_parameters);
+            m_events[i].m_metadataParameters.resize(m_events[i].m_parameters.size());
+        }
+    }
+
+    template<class Event>
+    void BehaviorEBusHandler::SetEvent(Event e, AZStd::string_view name, const BehaviorParameterOverridesArray<Event>& args)
+    {
+        (void)e;
+        int i = GetFunctionIndex(name.data());
+        if (i != -1)
+        {
+            m_events.resize(i + 1);
+            m_events[i].m_name = name.data();
+            m_events[i].m_eventId = AZ::Crc32(name.data());
+            m_events[i].m_function = nullptr;
+            AZ::Internal::SetFunctionParameters<typename AZStd::remove_pointer<Event>::type>::Set(m_events[i].m_parameters);
+            m_events[i].m_metadataParameters.resize(m_events[i].m_parameters.size());
+            for (size_t argIndex = 0; argIndex < args.size(); ++argIndex)
+            {
+                m_events[i].m_metadataParameters[AZ::eBehaviorBusForwarderEventIndices::ParameterFirst + argIndex] = { args[argIndex].m_name, args[argIndex].m_toolTip };
+            }
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    template<class... Args>
+    void BehaviorEBusHandler::Call(int index, Args&&... args) const
+    {
+        const BusForwarderEvent& e = m_events[index];
+        if (e.m_function)
+        {
+            if (e.m_isFunctionGeneric)
+            {
+                BehaviorArgument arguments[sizeof...(args) + 1] = { &args... };
+                reinterpret_cast<GenericHookType>(e.m_function)(const_cast<void*>(e.m_userData), e.m_name, index, nullptr, AZ_ARRAY_SIZE(arguments) - 1, arguments);
+            }
+            else
+            {
+                typedef void(*FunctionType)(void*, Args...);
+                reinterpret_cast<FunctionType>(e.m_function)(const_cast<void*>(e.m_userData), args...);
+            }
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+
+    template<class R, class... Args>
+    void BehaviorEBusHandler::CallResult(R& result, int index, Args&&... args) const
+    {
+        const BusForwarderEvent& e = m_events[index];
+        if (e.m_function)
+        {
+            if (e.m_isFunctionGeneric)
+            {
+                BehaviorArgument arguments[sizeof...(args) + 1] = { &args... };
+                BehaviorArgument r(&result);
+                reinterpret_cast<GenericHookType>(e.m_function)(const_cast<void*>(e.m_userData), e.m_name, index, &r, AZ_ARRAY_SIZE(arguments) - 1, arguments);
+                // Assign on top of the the value if the param isn't a pointer
+                // (otherwise the pointer just gets overridden and no value is returned).
+                if ((r.m_traits & BehaviorParameter::TR_POINTER) == 0 && r.GetAsUnsafe<R>())
+                {
+                    result = *r.GetAsUnsafe<R>();
+                }
+            }
+            else
+            {
+                typedef R(*FunctionType)(void*, Args...);
+                result = reinterpret_cast<FunctionType>(e.m_function)(const_cast<void*>(e.m_userData), args...);
+            }
+        }
+    }
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorMethodImpl.cpp
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorMethodImpl.cpp
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/RTTI/BehaviorContext.h>
+
+
+namespace AZ::Internal
+{
+    bool BehaviorMethodImpl::Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const
+    {
+        size_t totalArguments = GetNumArguments();
+        if (arguments.size() < totalArguments)
+        {
+            // We are cloning all arguments on the stack, since Call is called only from Invoke we can reserve bigger "arguments" array
+            // that can always handle all parameters. So far the don't use default values that ofter, so we will optimize for the common case first.
+            AZStd::span<BehaviorArgument> newArguments(reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument) * totalArguments)), totalArguments);
+            // clone the input parameters (we don't need to clone temp buffers, etc. as they will be still on the stack)
+            size_t argIndex = 0;
+            for (; argIndex < arguments.size(); ++argIndex)
+            {
+                new(&newArguments[argIndex]) BehaviorArgument(arguments[argIndex]);
+            }
+
+            // clone the default parameters if they exist
+            for (; argIndex < totalArguments; ++argIndex)
+            {
+                BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
+                if (!defaultValue)
+                {
+                    AZ_Warning("Behavior", false, "Not enough arguments to make a call! %d needed %d", arguments.size(), totalArguments);
+                    return false;
+                }
+                new(&newArguments[argIndex]) BehaviorArgument(defaultValue->GetValue());
+            }
+
+            arguments = newArguments;
+        }
+
+        auto memberArgument = IsMember() ? GetArgument(0) : nullptr;
+        if (memberArgument != nullptr && !arguments[0].ConvertTo(memberArgument->m_typeId))
+        {
+            // this pointer is invalid
+            AZ_Warning("Behavior", false, "First parameter should be the 'this' pointer for the member function! %s", m_name.c_str());
+            return false;
+        }
+
+        for (size_t i = m_startNamedArgumentIndex; i < m_parameters.size(); ++i)
+        {
+            // Verify that argument is a pointer for pointer type parameters and a value or reference for value type or reference type parameters
+            bool isArgumentPointer = arguments[i - 1].m_traits & BehaviorParameter::Traits::TR_POINTER;
+            bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
+            if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
+            {
+                AZ_Warning("Behavior", false, "Invalid parameter type for method '%s'! Can not convert method parameter %d from %s(%s) to %s(%s)",
+                    m_name.c_str(), i - 1, arguments[i - 1].m_name,
+                    arguments[i - 1].m_typeId.ToFixedString().c_str(),
+                    m_parameters[i].m_name, m_parameters[i].m_typeId.ToFixedString().c_str());
+                return false;
+            }
+            else if (isArgumentPointer != isParameterPointer)
+            {
+                AZ_Warning("Behavior", false, R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
+                    isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
+                    isParameterPointer ? "pointer" : "value", m_parameters[i].m_name);
+                return false;
+            }
+        }
+
+        m_functor(result, arguments);
+
+        return true;
+    }
+
+
+    auto BehaviorMethodImpl::IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const
+        -> ResultOutcome
+    {
+        size_t totalArguments = GetNumArguments();
+        if (arguments.size() < totalArguments)
+        {
+            // Clone the arguments on the stack and validate that the method can be invoked with the arguments
+            AZStd::span<BehaviorArgument> newArguments(reinterpret_cast<BehaviorArgument*>(alloca(sizeof(BehaviorArgument) * totalArguments)), totalArguments);
+            // clone the input parameters (we don't need to clone temp buffers, etc. as they will be still on the stack)
+            size_t argIndex = 0;
+            for (; argIndex < arguments.size(); ++argIndex)
+            {
+                new(&newArguments[argIndex]) BehaviorArgument(arguments[argIndex]);
+            }
+
+            // clone the default parameters if they exist
+            for (; argIndex < totalArguments; ++argIndex)
+            {
+                BehaviorDefaultValuePtr defaultValue = GetDefaultValue(argIndex);
+                if (!defaultValue)
+                {
+                    return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
+                        "Not enough arguments to make call to method %s. %zu supplied, needed %zu",
+                        m_name.c_str(), arguments.size(), newArguments.size()) };
+                }
+                new(&newArguments[argIndex]) BehaviorArgument(defaultValue->GetValue());
+            }
+
+            arguments = newArguments;
+        }
+        else if (arguments.size() > totalArguments)
+        {
+            return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
+                "Too many arguments supplied to method '%s'. Expects %zu arguments, provided %zu",
+                m_name.c_str(), totalArguments, arguments.size()) };
+        }
+
+        auto memberArgument = IsMember() ? GetArgument(0) : nullptr;
+        if (memberArgument != nullptr && !arguments[0].ConvertTo(memberArgument->m_typeId))
+        {
+            return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
+                "First parameter should be the 'this' pointer for the member function! %s", m_name.c_str()) };
+        }
+
+        for (size_t i = m_startNamedArgumentIndex; i < m_parameters.size(); ++i)
+        {
+            // Verify that argument is a pointer for pointer type parameters and a value or reference for value type or reference type parameters
+            bool isArgumentPointer = arguments[i - 1].m_traits & BehaviorParameter::Traits::TR_POINTER;
+            bool isParameterPointer = m_parameters[i].m_traits & BehaviorParameter::Traits::TR_POINTER;
+            if (!arguments[i - 1].ConvertTo(m_parameters[i].m_typeId))
+            {
+                return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
+                    "Invalid parameter type for method '%s'!"
+                    " Can not convert method parameter %zu from %s(%s) to %s(%s)",
+                    m_name.c_str(), i - 1,
+                    arguments[i - 1].m_name, arguments[i - 1].m_typeId.ToFixedString().c_str(),
+                    m_parameters[i].m_name, m_parameters[i].m_typeId.ToFixedString().c_str()
+                ) };
+            }
+            else if (isArgumentPointer != isParameterPointer)
+            {
+                return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
+                    R"(Argument is a "%s" type of %s, while parameter accepts a "%s" type of %s )",
+                    isArgumentPointer ? "pointer" : "value", arguments[i - 1].m_name,
+                    isParameterPointer ? "pointer" : "value", m_parameters[i].m_name) };
+            }
+        }
+
+        if (result != nullptr)
+        {
+            const AZ::BehaviorParameter* returnParam = GetResult();
+            if (bool canStoreResult = result->m_typeId.IsNull() || result->m_typeId == returnParam->m_typeId ||
+                (returnParam->m_azRtti != nullptr && returnParam->m_azRtti->IsTypeOf(result->m_typeId));
+                !canStoreResult)
+            {
+                return ResultOutcome{ AZStd::unexpect, ResultOutcome::ErrorType::format(
+                    "The behavior argument for the return value cannot store the return type %s",
+                    returnParam->m_typeId.ToFixedString().c_str()) };
+            }
+        }
+
+        return AZ::Success();
+    }
+
+    bool BehaviorMethodImpl::HasResult() const
+    {
+        return m_hasNonVoidReturn;
+    }
+
+    bool BehaviorMethodImpl::IsMember() const
+    {
+        return m_isMemberFunc;
+    }
+
+    bool BehaviorMethodImpl::HasBusId() const
+    {
+        return false;
+    }
+
+    const BehaviorParameter* BehaviorMethodImpl::GetBusIdArgument() const
+    {
+        return nullptr;
+    }
+
+    size_t BehaviorMethodImpl::GetNumArguments() const
+    {
+        return m_parameters.size() - s_startArgumentIndex;
+    }
+
+    size_t BehaviorMethodImpl::GetMinNumberOfArguments() const
+    {
+        // Iterate from end of MetadataParameters and count the number of consecutive valid BehaviorValue objects
+        size_t numDefaultArguments = 0;
+        for (size_t i = GetNumArguments(); i > 0 && GetDefaultValue(i - 1); --i, ++numDefaultArguments)
+        {
+        }
+        return GetNumArguments() - numDefaultArguments;
+    }
+
+    const BehaviorParameter* BehaviorMethodImpl::GetArgument(size_t index) const
+    {
+        if (index < GetNumArguments())
+        {
+            return &m_parameters[index + s_startArgumentIndex];
+        }
+        return nullptr;
+    }
+
+    void BehaviorMethodImpl::OverrideParameterTraits(size_t index, AZ::u32 addTraits, AZ::u32 removeTraits)
+    {
+        if (index < GetNumArguments())
+        {
+            m_parameters[index + s_startArgumentIndex].m_traits = (m_parameters[index + s_startArgumentIndex].m_traits & ~removeTraits) | addTraits;
+        }
+    }
+
+    const AZStd::string* BehaviorMethodImpl::GetArgumentName(size_t index) const
+    {
+        if (index < GetNumArguments())
+        {
+            return &m_metadataParameters[index + s_startArgumentIndex].m_name;
+        }
+        return nullptr;
+    }
+
+    void BehaviorMethodImpl::SetArgumentName(size_t index, AZStd::string name)
+    {
+        if (index < GetNumArguments())
+        {
+            m_metadataParameters[index + s_startArgumentIndex].m_name = name;
+        }
+    }
+
+    const AZStd::string* BehaviorMethodImpl::GetArgumentToolTip(size_t index) const
+    {
+        if (index < GetNumArguments())
+        {
+            return &m_metadataParameters[index + s_startArgumentIndex].m_toolTip;
+        }
+        return nullptr;
+    }
+
+    void BehaviorMethodImpl::SetArgumentToolTip(size_t index, AZStd::string toolTip)
+    {
+        if (index < GetNumArguments())
+        {
+            m_metadataParameters[index + s_startArgumentIndex].m_toolTip = AZStd::move(toolTip);
+        }
+    }
+
+    void BehaviorMethodImpl::SetDefaultValue(size_t index, BehaviorDefaultValuePtr defaultValue)
+    {
+        if (index < GetNumArguments())
+        {
+            if (defaultValue && defaultValue->GetValue().m_typeId != GetArgument(index)->m_typeId)
+            {
+                AZ_Assert(false, "Argument %zu default value type, doesn't match! Default value should be the same type! Current type %s!", index, defaultValue->GetValue().m_name);
+                return;
+            }
+            m_metadataParameters[index + s_startArgumentIndex].m_defaultValue = AZStd::move(defaultValue);
+        }
+    }
+
+    BehaviorDefaultValuePtr BehaviorMethodImpl::GetDefaultValue(size_t index) const
+    {
+        if (index < GetNumArguments())
+        {
+            return m_metadataParameters[index + s_startArgumentIndex].m_defaultValue;
+        }
+        return nullptr;
+    }
+
+    const BehaviorParameter* BehaviorMethodImpl::GetResult() const
+    {
+        return &m_parameters[0];
+    }
+
+} // namespace AZ::Internal

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorMethodImpl.inl
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorMethodImpl.inl
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+namespace AZ::Internal
+{
+    // call helper
+    template<class R, class... Args, AZStd::size_t... Is>
+    inline void CallMethodGlobal(R(*functionPtr)(Args...) , BehaviorArgument* arguments, BehaviorArgument* result, AZStd::index_sequence<Is...>)
+    {
+        (void)arguments;
+        if constexpr (AZStd::is_void_v<R>)
+        {
+            functionPtr(*arguments[Is].GetAsUnsafe<Args>()...);
+        }
+        else
+        {
+            if (result)
+            {
+                result->StoreResult<R>(functionPtr(*arguments[Is].GetAsUnsafe<Args>()...));
+            }
+            else
+            {
+                functionPtr(*arguments[Is].GetAsUnsafe<Args>()...);
+            }
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    template<class R, class C, class... Args, AZStd::size_t... Is>
+    inline void CallMethodMember(R(C::* functionPtr)(Args...), C* thisPtr, BehaviorArgument* arguments, BehaviorArgument* result, AZStd::index_sequence<Is...>)
+    {
+        (void)arguments;
+        if constexpr (AZStd::is_void_v<R>)
+        {
+            (thisPtr->*functionPtr)(*arguments[Is].GetAsUnsafe<Args>()...);
+        }
+        else
+        {
+            if (result)
+            {
+                result->StoreResult<R>((thisPtr->*functionPtr)(*arguments[Is].GetAsUnsafe<Args>()...));
+            }
+            else
+            {
+                (thisPtr->*functionPtr)(*arguments[Is].GetAsUnsafe<Args>()...);
+            }
+        }
+    }
+
+    // BehaviorMethodImpl constructors
+    template<class R, class... Args>
+    BehaviorMethodImpl::BehaviorMethodImpl(R(*functionPointer)(Args...), BehaviorContext* context, AZStd::string name)
+        : BehaviorMethod(context)
+        , m_hasNonVoidReturn(!AZStd::is_void_v<R>)
+    {
+        // Wrap the function pointer object in a type erased lambda
+        auto CallFreeFunction = [functionPointer](BehaviorArgument* result, AZStd::span<BehaviorArgument> arguments)
+        {
+            CallMethodGlobal(functionPointer, arguments.data(), result, AZStd::make_index_sequence<sizeof...(Args)>());
+        };
+        m_functor = CallFreeFunction;
+        m_name = AZStd::move(name);
+
+        // The +1 is for the return type
+        constexpr size_t parameterArraySize = 1 + sizeof...(Args);
+        m_parameters.resize(parameterArraySize);
+        m_metadataParameters.resize(parameterArraySize);
+        SetParameters<R>(m_parameters.data(), this);
+        SetParameters<Args...>(m_parameters.data() + m_startNamedArgumentIndex, this);
+    }
+
+
+    template<class R, class C, class... Args>
+    BehaviorMethodImpl::BehaviorMethodImpl(R(C::* functionPointer)(Args...), BehaviorContext* context, AZStd::string name)
+        : BehaviorMethod(context)
+        , m_startNamedArgumentIndex(s_startArgumentIndex + 1)
+        , m_hasNonVoidReturn(!AZStd::is_void_v<R>)
+        , m_isMemberFunc(true)
+    {
+        // Wrap the member function pointer object in a type erased lambda
+        auto CallMemberFunction = [functionPointer, this](BehaviorArgument* result, AZStd::span<BehaviorArgument> arguments)
+        {
+            C* thisPtr = *arguments[0].GetAsUnsafe<C*>();
+            CallMethodMember(functionPointer, thisPtr, arguments.data() + 1, result, AZStd::make_index_sequence<sizeof...(Args)>());
+
+            BehaviorObjectSignals::Event(thisPtr, &BehaviorObjectSignals::Events::OnMemberMethodCalled, this);
+        };
+        m_functor = CallMemberFunction;
+        // Increment the start named argument index since the function is a member
+        m_name = AZStd::move(name);
+
+        // The +2 is for the return type and class type
+        constexpr size_t parameterArraySize = 2 + sizeof...(Args);
+        m_parameters.resize(parameterArraySize);
+        m_metadataParameters.resize(parameterArraySize);
+
+        SetParameters<R>(m_parameters.data(), this);
+        SetParameters<C*>(m_parameters.data() + s_startArgumentIndex, this);
+        m_parameters[s_startArgumentIndex].m_traits |= BehaviorParameter::TR_THIS_PTR;
+        SetParameters<Args...>(m_parameters.data() + m_startNamedArgumentIndex, this);
+    }
+
+    template<class R, class C, class... Args>
+    BehaviorMethodImpl::BehaviorMethodImpl(R(C::* functionPointer)(Args...) const, BehaviorContext* context, AZStd::string name)
+        : BehaviorMethodImpl(reinterpret_cast<R(C::*)(Args...)>(functionPointer), context, AZStd::move(name))
+    {
+        m_isConst = true;
+    }
+
+#if __cpp_noexcept_function_type
+    // Delegate to the non-noexcept constructors
+    template <class R, class... Args>
+    BehaviorMethodImpl::BehaviorMethodImpl(R(*functionPointer)(Args...) noexcept, BehaviorContext* context, AZStd::string name)
+        : BehaviorMethodImpl(reinterpret_cast<R(*)(Args...)>(functionPointer), context, AZStd::move(name))
+    {}
+
+    template <class R, class C, class... Args>
+    BehaviorMethodImpl::BehaviorMethodImpl(R(C::* functionPointer)(Args...) noexcept, BehaviorContext* context, AZStd::string name)
+        : BehaviorMethodImpl(reinterpret_cast<R(C::*)(Args...)>(functionPointer), context, AZStd::move(name))
+    {}
+
+    template <class R, class C, class... Args>
+    BehaviorMethodImpl::BehaviorMethodImpl(R(C::* functionPointer)(Args...) const noexcept, BehaviorContext* context, AZStd::string name)
+        : BehaviorMethodImpl(reinterpret_cast<R(C::*)(Args...) const>(functionPointer), context, AZStd::move(name))
+    {}
+#endif
+} // namespace AZ::Internal

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorObjectSignals.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorObjectSignals.h
@@ -22,8 +22,8 @@ namespace AZ
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
 
         // Keyed off of the void* pointer of the object that is being listened to.
-        typedef void* BusIdType;
-        
+        typedef const void* BusIdType;
+
         virtual void OnMemberMethodCalled(const BehaviorMethod* method) = 0;
     };
 

--- a/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp
@@ -103,11 +103,11 @@ namespace ScriptContextCpp
     // remove Lua packgage.loadlib immediately after loading libraries to prevent use of unsafe function
     void OpenLuaLibraries(lua_State* m_lua)
     {
-        // Lua: 
+        // Lua:
         luaL_openlibs(m_lua);
-        // Lua: 
+        // Lua:
         lua_getglobal(m_lua, "package");
-        // Lua: package 
+        // Lua: package
         AZ_Assert(lua_type(m_lua, -1) == LUA_TTABLE, "package was not a table");
         // Lua: package, package.loadlib
         lua_getfield(m_lua, -1, "loadlib");
@@ -317,7 +317,7 @@ namespace AZ
 
             m_valueByUserData[userdata] = userdata->value;
         }
-        
+
         {
             auto userIter = m_userDataByValue.find(userdata->value);
             if (userIter != m_userDataByValue.end())
@@ -442,12 +442,12 @@ namespace AZ
         {
             lua_pushlightuserdata(lua, (void*)typeId.GetHash());
         }
-        
+
         bool azlua_istable(lua_State* lua, int stackIndex)
         {
             return lua_istable(lua, stackIndex);
         }
-        
+
         bool azlua_isfunction(lua_State* lua, int stackIndex)
         {
             return lua_isfunction(lua, stackIndex);
@@ -822,7 +822,7 @@ namespace AZ
                 {
                     // we have custom index handler
                     lua_pushvalue(l, -5); // duplicate the table (class pointer)
-                    lua_pushvalue(l, -5); // duplicate the index 
+                    lua_pushvalue(l, -5); // duplicate the index
                     lua_pushvalue(l, -5); // duplicate the value
                     lua_call(l, 3, 0);
                 }
@@ -990,14 +990,14 @@ namespace AZ
             }
         }
 
-        
+
 
         //////////////////////////////////////////////////////////////////////////
         int ClassAcquireOwnership(lua_State* l)
         {
             if (LuaIsClass(l,-1))
             {
-                Internal::LuaAcquireClassOwnership(l, -1); 
+                Internal::LuaAcquireClassOwnership(l, -1);
             }
 
             // copy the source as a result
@@ -1036,7 +1036,7 @@ namespace AZ
     {
         // Turn this feature on whenever there is TRACING enabled, which is where things like luaL_error will have any effect.
         // when TRACING is not enabled, chances are luaL_error will not be seen as there will be no listener
-#if defined(AZ_ENABLE_TRACING) 
+#if defined(AZ_ENABLE_TRACING)
         using limits = std::numeric_limits<T>;
         double number = luaL_checknumber(l, index);
 
@@ -1669,7 +1669,7 @@ static int Global_Typeid(lua_State* l)
 
 //=========================================================================
 // LUA Dummy Node Extension
-// Through an environment variable we can ensure that LUA's static 
+// Through an environment variable we can ensure that LUA's static
 // dummynode is safe across DLLs
 // [5/18/2016]
 //=========================================================================
@@ -2547,8 +2547,9 @@ LUA_API const Node* lua_getDummyNode()
                         {
                             if (userData->behaviorClass->m_unwrapper && value.m_typeId == userData->behaviorClass->m_wrappedTypeId)
                             {
-                                void* valueAddress;
-                                userData->behaviorClass->m_unwrapper(userData->value, valueAddress, value.m_typeId, userData->behaviorClass->m_unwrapperUserData);
+                                BehaviorObject unwrappedObject;
+                                userData->behaviorClass->m_unwrapper(userData->value, unwrappedObject, userData->behaviorClass->m_unwrapperUserData);
+                                value.m_typeId = unwrappedObject.m_typeId;
 
                                 if (value.m_traits & BehaviorParameter::TR_POINTER)
                                 {
@@ -2558,11 +2559,11 @@ LUA_API const Node* lua_getDummyNode()
                                         AllocateTempStorageLuaNative<void*>(value, valueClass, *tempAllocator);
                                     }
                                     // check custom storage we should get the full value with storage type in case of smart pointers
-                                    *reinterpret_cast<void**>(value.m_value) = valueAddress;
+                                    *reinterpret_cast<void**>(value.m_value) = unwrappedObject.m_address;
                                 }
                                 else
                                 {
-                                    value.m_value = valueAddress;
+                                    value.m_value = unwrappedObject.m_address;
                                 }
 
                                 return true;
@@ -2631,7 +2632,7 @@ LUA_API const Node* lua_getDummyNode()
                         lua_pop(lua, 2); // pop class table and the non table value (should be nil)
 
                         // since we handle generic pointers elsewhere this should be an asset
-                        AZ_Assert(false, "We should always have metatable as this function is called for reflected types, we handle this outside");                        
+                        AZ_Assert(false, "We should always have metatable as this function is called for reflected types, we handle this outside");
                         return LUA_REFNIL;
                     }
                     else
@@ -2645,11 +2646,11 @@ LUA_API const Node* lua_getDummyNode()
 
                 // get the behavior class
                 lua_rawgeti(lua, metatableIndex, AZ_LUA_CLASS_METATABLE_BEHAVIOR_CLASS);
-                behaviorClass = reinterpret_cast<BehaviorClass*>(lua_touserdata(lua, -1));                
+                behaviorClass = reinterpret_cast<BehaviorClass*>(lua_touserdata(lua, -1));
 
                 lua_pop(lua, 1); // pop behavior class and storage type
                 //////////////////////////////////////////////////////////////////////////
-                
+
                 // <UserData>
                 LuaUserData* userData = reinterpret_cast<LuaUserData*>(lua_newuserdata(lua, sizeof(LuaUserData)));
 
@@ -2670,7 +2671,7 @@ LUA_API const Node* lua_getDummyNode()
                 lua_setmetatable(lua, -2);
                 // </table>
 
-                // </UserData>                
+                // </UserData>
 
                 lua_replace(lua, -3); // replace the class table with the user data
                 lua_pop(lua, 1); // and pop metatable
@@ -2705,8 +2706,8 @@ LUA_API const Node* lua_getDummyNode()
 
                         if (scriptContext)
                         {
-                            scriptContext->Error(ScriptContext::ErrorType::Error, 
-                                true /*print callstack*/, 
+                            scriptContext->Error(ScriptContext::ErrorType::Error,
+                                true /*print callstack*/,
                                 "Object has type Id %s, which is not reflected to the BehaviorContext, or it has the Script::Attributes::Ignore attribute assigned. Nil will be returned.",
                                 typeId.ToString<AZStd::string>().c_str());
                         }
@@ -2754,7 +2755,7 @@ LUA_API const Node* lua_getDummyNode()
 
                     valueSize += behaviorClass->m_size;
                     // make sure we can properly align the userdata
-                    if (behaviorClass->m_alignment > sizeof(L_Umaxalign)) 
+                    if (behaviorClass->m_alignment > sizeof(L_Umaxalign))
                     {
                         valueSize += behaviorClass->m_alignment - sizeof(L_Umaxalign);
                     }
@@ -2797,7 +2798,7 @@ LUA_API const Node* lua_getDummyNode()
                 }
                 else
                 {
-                    // we own only the object that we create, not the one that are passed in, unless the 
+                    // we own only the object that we create, not the one that are passed in, unless the
                     // the developer explicit calls \ref ScrtiptDataContext::ReleaseOwnership.
                     storageType = Script::Attributes::StorageType::RuntimeOwn;
                 }
@@ -2845,14 +2846,9 @@ LUA_API const Node* lua_getDummyNode()
                             // If we have an unwrapper, see if it is for the value type
                             if (userData->behaviorClass->m_unwrapper && value.m_typeId != userData->behaviorClass->m_typeId)
                             {
-                                unwrap = value.m_typeId == userData->behaviorClass->m_wrappedTypeId;
-                                // If not the exact value type, check to see it is a base class of the value type
-                                if (!unwrap)
+                                if (unwrap = value.m_typeId == userData->behaviorClass->m_wrappedTypeId; !unwrap)
                                 {
-                                    AZ::BehaviorContext* behaviorContext{};
-                                    AZ::ComponentApplicationBus::BroadcastResult(behaviorContext, &AZ::ComponentApplicationRequests::GetBehaviorContext);
-                                    auto unwrappedClassIter = behaviorContext->m_typeToClassMap.find(value.m_typeId);
-                                    AZ::BehaviorClass* unwrappedClass = unwrappedClassIter != behaviorContext->m_typeToClassMap.end() ? unwrappedClassIter->second : nullptr;
+                                    const AZ::BehaviorClass* unwrappedClass = AZ::BehaviorContextHelper::GetClass(value.m_typeId);
                                     unwrap = unwrappedClass && unwrappedClass->m_azRtti && unwrappedClass->m_azRtti->ProvidesFullRtti() && unwrappedClass->m_azRtti->IsTypeOf(valueClass->m_typeId);
                                 }
                             }
@@ -2862,8 +2858,10 @@ LUA_API const Node* lua_getDummyNode()
                             // If we found a proper unwrapper, use it
                             if (unwrap)
                             {
-                                userData->behaviorClass->m_unwrapper(userData->value, valueAddress, value.m_typeId, userData->behaviorClass->m_unwrapperUserData);
-                                value.m_typeId = userData->behaviorClass->m_wrappedTypeId;
+                                BehaviorObject unwrappedObject;
+                                userData->behaviorClass->m_unwrapper(userData->value, unwrappedObject, userData->behaviorClass->m_unwrapperUserData);
+                                valueAddress = unwrappedObject.m_address;
+                                value.m_typeId = unwrappedObject.m_typeId;
                             }
                             else
                             {
@@ -2919,7 +2917,7 @@ LUA_API const Node* lua_getDummyNode()
                             AllocateTempStorage(value, valueClass, *tempAllocator);
                             return true;
                         }
-                        else 
+                        else
                             {
                             // we can't have nil references or values
                             value.m_name = "nil";
@@ -3313,7 +3311,7 @@ LUA_API const Node* lua_getDummyNode()
                     // handle specific pointer types
                     Internal::LuaScriptReflectedType::FromStack(result);
                 }
-                
+
                 return result;
             }
 
@@ -3346,7 +3344,7 @@ LUA_API const Node* lua_getDummyNode()
             AZ_Assert(pushToStack != nullptr, "No LuaPushToStack function found for typeid: %s", param.m_typeId.ToString<AZStd::string>().data());
             pushToStack(lua, param);
         }
-        
+
         void StackPush(lua_State* lua, AZ::BehaviorArgument& param)
         {
             StackPush(lua, ScriptContext::FromNativeContext(lua)->GetBoundContext(), param);
@@ -3477,7 +3475,7 @@ LUA_API const Node* lua_getDummyNode()
                 int numElementsOnStack = lua_gettop(lua);
                 if (numElementsOnStack < static_cast<int>(thisPtr->m_method->GetMinNumberOfArguments()))
                 {
-                    // we can here load default parameters 
+                    // we can here load default parameters
                     ScriptContext::FromNativeContext(lua)->Error(ScriptContext::ErrorType::Error, true, "Not enough arguments for %s(%s) method, we expected %d arguments (left to right), provided %d!", thisPtr->m_method->m_name.c_str(), lua_tostring(lua, lua_upvalueindex(2)), thisPtr->m_method->GetMinNumberOfArguments(), numElementsOnStack);
                     return 0;
                 }
@@ -3517,7 +3515,7 @@ LUA_API const Node* lua_getDummyNode()
 
                 if (thisPtr->m_resultToLua)
                 {
-                    result.Set(*thisPtr->m_method->GetResult()); 
+                    result.Set(*thisPtr->m_method->GetResult());
 
                     if (thisPtr->m_prepareResult)
                     {
@@ -3619,7 +3617,7 @@ LUA_API const Node* lua_getDummyNode()
 
                 if (method->GetNumArguments() == 2) // member functions
                 {
-                    // should be a registered type (can't integral or generic) 
+                    // should be a registered type (can't integral or generic)
 
                     m_classPtr = FromLuaStack(context, method->GetArgument(0), m_classPtrClass);
                 }
@@ -3881,7 +3879,7 @@ LUA_API const Node* lua_getDummyNode()
 
                         if (!autoConnect && idFromLua && numArguments > 1)
                         {
-                            ScriptContext::FromNativeContext(lua)->Error(ScriptContext::ErrorType::Warning, true, 
+                            ScriptContext::FromNativeContext(lua)->Error(ScriptContext::ErrorType::Warning, true,
                                 "CreateHandler function called with busId. Please change instances of BusName.CreateHandler(<table>, <id>) to BusName.Connect(<table>, <id>) to avoid loss of functionality in future releases!");
                             autoConnect = true;
                         }
@@ -3894,7 +3892,7 @@ LUA_API const Node* lua_getDummyNode()
                             if (numArguments < 2)
                             {
                                 // Need ID, don't have one
-                                ScriptContext::FromNativeContext(lua)->Error(ScriptContext::ErrorType::Error, true, 
+                                ScriptContext::FromNativeContext(lua)->Error(ScriptContext::ErrorType::Error, true,
                                     "Connect function called without address ID parameter on bus that expects one, please provide address! (e.g., BusName.Connect(self, self.entityId) for component buses)");
                                 lua_pushnil(lua);
                                 return 1;
@@ -3921,7 +3919,7 @@ LUA_API const Node* lua_getDummyNode()
                             ScriptContext::FromNativeContext(lua)->Error(ScriptContext::ErrorType::Error, true, "Create Handler called on a non-reflected class. Please reflect an appropriate EBusHandler into the BehaviorContext in order to successfully create the EBusHandler.");
                             lua_pushnil(lua);
                         }
-                    }                    
+                    }
                     else
                     {
                         // Non-table first argument
@@ -4130,7 +4128,7 @@ LUA_API const Node* lua_getDummyNode()
             {
                 LSV_BEGIN(lua, 0);
 
-                // register LuaHandler metatable 
+                // register LuaHandler metatable
                 // TODO: consider just reflecting the class and using the reflection, we don't do it as we don't want to modify behavior context)
                 lua_createtable(lua, 0, 0);
 
@@ -4274,7 +4272,7 @@ LUA_API const Node* lua_getDummyNode()
                     void* userData1 = lua;
                     void* userData2 = reinterpret_cast<void*>(static_cast<size_t>(cachedIndex));
 
-                    // register the callback               
+                    // register the callback
                     ebus->m_queueFunction->Invoke(&FromBehaviorContext, userData1, userData2);
                 }
                 else
@@ -4311,7 +4309,7 @@ LUA_API const Node* lua_getDummyNode()
                         &AZ::ScriptPropertyBoolean::TryCreateProperty,
                         &AZ::ScriptPropertyNumber::TryCreateProperty,
                         &AZ::ScriptPropertyString::TryCreateProperty,
-                        &AZ::ScriptPropertyGenericClass::TryCreateProperty,                
+                        &AZ::ScriptPropertyGenericClass::TryCreateProperty,
                     }
                 )
                 , m_scriptPropertyArrayFactories(
@@ -4457,7 +4455,7 @@ LUA_API const Node* lua_getDummyNode()
                         lua_pushnil(lua);
                         return 1; // push nil object and return it
                     }
-                    
+
                     // replace the source table with the metatable
                     int metatableIndex = 1;
                     lua_replace(lua, 1);
@@ -4522,7 +4520,7 @@ LUA_API const Node* lua_getDummyNode()
                     {
                         // currently we have the the class table and the instance on the stack
                         // pop the table so we can actually use the default lua call (so it should not be on the stack)
-                        // this is "thisPtr/Value" + parameters 
+                        // this is "thisPtr/Value" + parameters
                         lua_replace(lua, metatableIndex);
                         customConstructor->ManualCall(lua);
                         // push back the value to the top
@@ -4562,7 +4560,7 @@ LUA_API const Node* lua_getDummyNode()
                     if (lua_istable(lua, -1))
                     {
                         // Lua: userdata, class_table
-                        Internal::azlua_pushtypeid(lua, userData->behaviorClass->m_typeId); 
+                        Internal::azlua_pushtypeid(lua, userData->behaviorClass->m_typeId);
                         // Lua: userdata, class_table, typeid
                         lua_rawget(lua, -2);
                         // Lua: userdata, class_table, ?
@@ -4618,7 +4616,7 @@ LUA_API const Node* lua_getDummyNode()
                 // Check for specialized function for scripting void (ScriptContextData&), both as function and as custom attribute
                 if ((method->GetNumArguments() && method->GetArgument(method->GetNumArguments() - 1)->m_typeId == AzTypeInfo<ScriptDataContext>::Uuid()))
                 {
-                    // 
+                    //
                     LuaGenericCaller* caller = aznew LuaGenericCaller(behaviorContext, method);
                     binder = caller;
                     m_genericMethods.insert(caller);
@@ -4658,8 +4656,8 @@ LUA_API const Node* lua_getDummyNode()
                 }
                 else
                 {
-                    // There is no substitution for developer debug description, as we will 
-                    // get context on the issue. When this is missing we will list the types 
+                    // There is no substitution for developer debug description, as we will
+                    // get context on the issue. When this is missing we will list the types
                     // of the parameters we expect to pass from Lua
                     AZStd::string functionName;
                     if (method->HasResult())
@@ -4691,7 +4689,7 @@ LUA_API const Node* lua_getDummyNode()
                     }
 
                     // ScriptDataContext is the parameter when we have generic input/out, the user should provide info what actually are input/output parameters
-                    
+
                     if (AZ::StringFunc::Replace(functionName, "ScriptDataContext", "...", true))
                     {
                         functionName.insert(0, "[=...] ");
@@ -4821,10 +4819,10 @@ LUA_API const Node* lua_getDummyNode()
                             break;
                         case AZ::Script::Attributes::OperatorType::IndexRead:
                             if ((!method->HasResult() && method->GetNumArguments() == 2 && method->GetArgument(1)->m_typeId == AzTypeInfo<ScriptDataContext>::Uuid()) || // generic function
-                                (method->GetNumArguments() == 2 && method->GetArgument(0)->m_typeId == behaviorClass->m_typeId && // it should accept that class pointer + index 
+                                (method->GetNumArguments() == 2 && method->GetArgument(0)->m_typeId == behaviorClass->m_typeId && // it should accept that class pointer + index
                                 method->HasResult())) // we should return result
                             {
-                                methodName = "__AZ_Index"; /// internal name 
+                                methodName = "__AZ_Index"; /// internal name
                             }
                             else
                             {
@@ -4836,7 +4834,7 @@ LUA_API const Node* lua_getDummyNode()
                             if ((!method->HasResult() && method->GetNumArguments() == 2 && method->GetArgument(1)->m_typeId == AzTypeInfo<ScriptDataContext>::Uuid()) || // generic function
                                 (method->GetNumArguments() == 3 && method->GetArgument(0)->m_typeId == behaviorClass->m_typeId)) // it should accept that class pointer + index + value
                             {
-                                methodName = "__AZ_NewIndex"; /// internal name 
+                                methodName = "__AZ_NewIndex"; /// internal name
                             }
                             else
                             {
@@ -4865,7 +4863,7 @@ LUA_API const Node* lua_getDummyNode()
                 }
                 return source;
             }
-            
+
             //////////////////////////////////////////////////////////////////////////
             void BindClassMethodAndProperties(BehaviorClass* behaviorClass)
             {
@@ -4888,14 +4886,14 @@ LUA_API const Node* lua_getDummyNode()
                     {
                         continue; // skip this operator
                     }
-                    
+
                     if (method->m_overload)
                     {
                         auto overload = method;
                         auto overloadNames = GetOverloadNames(*method, methodName);
                         auto overloadName = overloadNames.begin();
- 
-                        do 
+
+                        do
                         {
                             lua_pushstring(m_lua, overloadName->data()); // push method name on the stack
                             BindMethodOnStack(m_context, overload); // push the method
@@ -4987,8 +4985,8 @@ LUA_API const Node* lua_getDummyNode()
                 BindMethodOnStack(m_context, method);
 
                 lua_rawset(m_lua, globalTableIndex); // member function set it in the table
-            }    
-            
+            }
+
             //////////////////////////////////////////////////////////////////////////
             void BindGlobalProperty(BehaviorProperty* prop, int globalTableIndex)
             {
@@ -5081,7 +5079,7 @@ LUA_API const Node* lua_getDummyNode()
                     {
                         customConstructorMethod = reinterpret_cast<BehaviorMethod*>(customConstructorAttr->GetContextData());
                     }
-                    // Check all constructors if they have use ScriptDataContext and if so choose this one 
+                    // Check all constructors if they have use ScriptDataContext and if so choose this one
                     if (!customConstructorMethod)
                     {
                         int overrideIndex = -1;
@@ -5172,7 +5170,7 @@ LUA_API const Node* lua_getDummyNode()
                 Internal::azlua_pushtypeid(m_lua, behaviorClass->m_typeId);
                 lua_rawseti(m_lua, -2, AZ_LUA_CLASS_METATABLE_TYPE_INDEX);
 
-  
+
                 lua_pushinteger(m_lua, static_cast<int>(storageType));
                 lua_rawseti(m_lua, -2, AZ_LUA_CLASS_METATABLE_STORAGE_TYPE_INDEX);
 
@@ -5185,20 +5183,20 @@ LUA_API const Node* lua_getDummyNode()
                 {
                     BindEventSupport();
                 }
-                
+
                 if (storageType != Script::Attributes::StorageType::Value)
                 {
                     lua_pushliteral(m_lua, "AcquireOwnership"); // method name
 
                     // If we are not stored by value add Acquire/Release Ownweship semantics
-                    lua_pushlightuserdata(m_lua, nullptr);                    
+                    lua_pushlightuserdata(m_lua, nullptr);
                     lua_pushliteral(m_lua, "Takes ownership of the object and the object will be deleted from Lua when the last reference is gone.");
                     lua_pushcclosure(m_lua, &Internal::LuaMethodTagHelper, 0);
                     lua_pushcclosure(m_lua, &Internal::ClassAcquireOwnership, 3);
                     lua_rawset(m_lua, -3); // member function set it in the class table
 
-                    lua_pushliteral(m_lua, "ReleaseOwnership");                 
-                    
+                    lua_pushliteral(m_lua, "ReleaseOwnership");
+
                     lua_pushlightuserdata(m_lua, nullptr);
                     lua_pushliteral(m_lua, "Releases ownership of the object, the object should be deleted from the C++ runtime.");
                     lua_pushcclosure(m_lua, &Internal::LuaMethodTagHelper, 0);
@@ -5401,7 +5399,7 @@ LUA_API const Node* lua_getDummyNode()
                 LuaLoadFromStack idFromLua = FromLuaStack(m_context, &ebus->m_idParam, idClass);
 
                 // CreateHandler lua function
-                // Example usage: 
+                // Example usage:
                 //  handler = TickBus.CreateHandler(handlerTable);
                 //  handler:Connect([connectionId]);
                 lua_pushliteral(m_lua, "CreateHandler");
@@ -5415,7 +5413,7 @@ LUA_API const Node* lua_getDummyNode()
                 lua_rawset(m_lua, -3); // store the CreateHandler in the table
 
                 // Connect lua function (shortcut for CreateHandler + calling Connect manually on that handler)
-                // Example usage: 
+                // Example usage:
                 //  handler = TickBus.Connect(handlerTable[, connectionId]);
                 lua_pushliteral(m_lua, "Connect");
                 lua_pushlightuserdata(m_lua, m_context);
@@ -5437,7 +5435,7 @@ LUA_API const Node* lua_getDummyNode()
 
                 Internal::azlua_setglobal(m_lua, ValidateName(ebusName));
             }
-                        
+
             static int ConnectToExposedEvent(lua_State* lua)
             {
                 if (!(lua_isuserdata(lua, -2) && !lua_islightuserdata(lua, -2)))
@@ -5459,12 +5457,12 @@ LUA_API const Node* lua_getDummyNode()
                 AZ::AttributeReader attributeReader(nullptr, eventHandlerCreationFunctionAttribute);
                 AZ::EventHandlerCreationFunctionHolder holder;
                 attributeReader.Read<EventHandlerCreationFunctionHolder>(holder);
-                                
+
                 // Lua: ExposedEvent, lambda
                 lua_pushvalue(lua, -1);
                 // Lua: ExposedEvent, lambda, lambda
                 auto handlerAndType = AZStd::invoke(holder.m_function, userData->value, AZStd::move(ExposedLambda(lua)));
-                // Lua: ExposedEvent, lambda    
+                // Lua: ExposedEvent, lambda
                 Internal::RegisteredObjectToLua(lua, handlerAndType.m_address, handlerAndType.m_typeId, ObjectToLua::ByReference, AcquisitionOnPush::ScriptAcquire);
                 // Lua: ExposedEvent, lambda, handler
                 return 1;
@@ -5535,7 +5533,7 @@ LUA_API const Node* lua_getDummyNode()
             //////////////////////////////////////////////////////////////////////////
             //////////////////////////////////////////////////////////////////////////
             // BehaviorContextBus
-            
+
             //////////////////////////////////////////////////////////////////////////
             void OnAddGlobalMethod(const char* methodName, BehaviorMethod* method) override
             {
@@ -5662,7 +5660,7 @@ LUA_API const Node* lua_getDummyNode()
                 {
                     return lua_isfunction(thread, -1);
                 }
-                
+
                 // If load didn't return 0, handle error
 
                 // If not string, pop it and push a string on.
@@ -5694,7 +5692,7 @@ LUA_API const Node* lua_getDummyNode()
             void Error(ScriptContext::ErrorType error, bool doStackTrace, const char* format, va_list mark)
             {
                 // max size due to requirements of \Legacy\CrySystem\Log.h MAX_TEMP_LENGTH_SIZE(2048) minus room for the time stamp (128)
-                // otherwise if the script passes in a string larger, their script will cause an assert 
+                // otherwise if the script passes in a string larger, their script will cause an assert
                 char message[4096 - 128];
                 azvsnprintf(message, AZ_ARRAY_SIZE(message), format, mark);
 
@@ -5938,14 +5936,14 @@ LUA_API const Node* lua_getDummyNode()
         lua_pop(m_impl->m_lua, 1); // Pop the global
         return ref;
     }
-    
+
     //////////////////////////////////////////////////////////////////////////
     bool ScriptContext::FindGlobal(int cachedIndex, ScriptDataContext& dc)
     {
         if (cachedIndex > -1)
         {
             dc.Reset();
-            Internal::LuaLoadCached(m_impl->m_lua,cachedIndex);            
+            Internal::LuaLoadCached(m_impl->m_lua,cachedIndex);
             if (!lua_isnil(m_impl->m_lua, -1))
             {
                 dc.SetInspect(m_impl->m_lua, lua_gettop(m_impl->m_lua));
@@ -5953,12 +5951,12 @@ LUA_API const Node* lua_getDummyNode()
             }
         }
         return false;
-    }    
+    }
 
     //////////////////////////////////////////////////////////////////////////
     void ScriptContext::ReleaseCached(int cacheIndex)
     {
-        Internal::LuaReleaseCached(m_impl->m_lua, cacheIndex);        
+        Internal::LuaReleaseCached(m_impl->m_lua, cacheIndex);
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -5982,7 +5980,7 @@ LUA_API const Node* lua_getDummyNode()
     bool ScriptContext::CallCached(int cachedIndex, ScriptDataContext& dc)
     {
         dc.Reset();
-        Internal::LuaLoadCached(m_impl->m_lua,cachedIndex);        
+        Internal::LuaLoadCached(m_impl->m_lua,cachedIndex);
         if (lua_isfunction(m_impl->m_lua, -1))
         {
             dc.SetCaller(m_impl->m_lua, lua_gettop(m_impl->m_lua));
@@ -6019,7 +6017,7 @@ LUA_API const Node* lua_getDummyNode()
     bool ScriptContext::InspectTableCached(int cachedIndex, ScriptDataContext& dc)
     {
         dc.Reset();
-        Internal::LuaLoadCached(m_impl->m_lua,cachedIndex);        
+        Internal::LuaLoadCached(m_impl->m_lua,cachedIndex);
         if (lua_istable(m_impl->m_lua, -1))
         {
             dc.SetInspect(m_impl->m_lua, lua_gettop(m_impl->m_lua));  // -1 to account for the actual table

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -478,12 +478,21 @@ set(FILES
     RTTI/AzStdOnDemandReflection.inl
     RTTI/AzStdOnDemandReflectionSpecializations.cpp
     RTTI/AzStdOnDemandReflectionLuaFunctions.inl
+    RTTI/BehaviorClassBuilder.cpp
+    RTTI/BehaviorClassBuilder.inl
     RTTI/BehaviorContext.cpp
     RTTI/BehaviorContext.h
-    RTTI/BehaviorContextEBusEventRawSignature.inl
     RTTI/BehaviorContextUtilities.cpp
     RTTI/BehaviorContextUtilities.h
+    RTTI/BehaviorEBusBuilder.cpp
+    RTTI/BehaviorEBusBuilder.inl
+    RTTI/BehaviorEBusEvent.cpp
+    RTTI/BehaviorEBusEvent.inl
+    RTTI/BehaviorEBusHandler.cpp
+    RTTI/BehaviorEBusHandler.inl
     RTTI/BehaviorInterfaceProxy.h
+    RTTI/BehaviorMethodImpl.cpp
+    RTTI/BehaviorMethodImpl.inl
     RTTI/BehaviorObjectSignals.h
     RTTI/BehaviorObjectSignals.cpp
     RTTI/ChronoReflection.cpp

--- a/Code/Framework/AzCore/AzCore/std/typetraits/function_traits.h
+++ b/Code/Framework/AzCore/AzCore/std/typetraits/function_traits.h
@@ -67,7 +67,7 @@ namespace AZStd
             using type = T;
             /// set to class type if a pointer to member function or pointer to member object is supplied
             using class_type = error_type;
-            /// set to the qualified refernce type of the class type. Suitable for use with Atd::invoke
+            /// set to the qualified reference type of the class type. Suitable for use with Atd::invoke
             using invoke_type = error_type;
             /// return type of function
             using return_type = error_type;
@@ -173,7 +173,7 @@ namespace AZStd
                 using function_type = return_type(invoke_type, Args..., ...) noexcept_qualifier; \
                 using function_object_signature = return_type(Args..., ...) noexcept_qualifier; \
                 template<template<class...> class Container> \
-                using expand_args = Container<invoke_type, Args...>; \
+                using expand_args = Container<Args...>; \
                 \
                 using class_fp_type = type; \
                 using result_type = return_type; \
@@ -235,7 +235,7 @@ namespace AZStd
             using arg_types = Internal::pack_traits_arg_sequence<invoke_type>;
             using non_invoke_arg_types = Internal::pack_traits_arg_sequence<>;
             template<template<class...> class Container>
-            using expand_args = Container<invoke_type>;
+            using expand_args = Container<>;
 
         };
 
@@ -267,7 +267,7 @@ namespace AZStd
             using get_arg_t = Internal::pack_traits_get_arg_t<index, Args...>;
             using arg_sequence = Internal::pack_traits_arg_sequence<Args...>;
         };
-        
+
     #if __cpp_noexcept_function_type
         // C++17 makes exception specifications as part of the type in paper P0012R1
         // Therefore noexcept overloads must distinguished from non-noexcept overloads
@@ -306,7 +306,7 @@ namespace AZStd
             using get_arg_t = Internal::pack_traits_get_arg_t<index, Args...>;
             using arg_sequence = Internal::pack_traits_arg_sequence<Args...>;
         };
-        
+
     #if __cpp_noexcept_function_type
         // C++17 makes exception specifications as part of the type in paper P0012R1
         // Therefore noexcept overloads must distinguished from non-noexcept overloads

--- a/Gems/Achievements/Code/Source/AchievementsSystemComponent.cpp
+++ b/Gems/Achievements/Code/Source/AchievementsSystemComponent.cpp
@@ -61,9 +61,9 @@ namespace Achievements
 
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
-            
+
             behaviorContext->Class<AchievementDetails>()
-                ->Constructor<AchievementDetails&>()
+                ->Constructor<const AchievementDetails&>()
                 ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::Value)
                 ->Property("id", BehaviorValueProperty(&AchievementDetails::id))
                 ->Property("name", BehaviorValueProperty(&AchievementDetails::name))

--- a/Gems/EditorPythonBindings/Code/Source/PythonProxyObject.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonProxyObject.cpp
@@ -96,7 +96,7 @@ namespace EditorPythonBindings
 
             // replace common core template types and name spaces like AZStd
             StripReplace(syntaxName, "AZStd::basic_string<", '<', '>', "string");
-            AZ::StringFunc::Replace(syntaxName, "AZStd", "");            
+            AZ::StringFunc::Replace(syntaxName, "AZStd", "");
 
             AZStd::vector<AZStd::string> tokens;
             AZ::StringFunc::Tokenize(syntaxName, tokens, invalidCharacters, false, false);
@@ -273,7 +273,7 @@ namespace EditorPythonBindings
         return pybind11::cast<pybind11::none>(Py_None);
     }
 
-    bool PythonProxyObject::SetByTypeName(const char* typeName) 
+    bool PythonProxyObject::SetByTypeName(const char* typeName)
     {
         const AZ::BehaviorClass* behaviorClass = AZ::BehaviorContextHelper::GetClass(AZStd::string(typeName));
         if (behaviorClass)
@@ -288,8 +288,8 @@ namespace EditorPythonBindings
         const AZ::BehaviorClass* behaviorClass = AZ::BehaviorContextHelper::GetClass(m_wrappedObject.m_typeId);
         if (behaviorClass)
         {
-            auto behaviorMethodIter = behaviorClass->m_methods.find(methodName);
-            if (behaviorMethodIter != behaviorClass->m_methods.end())
+            if (auto behaviorMethodIter = behaviorClass->m_methods.find(methodName);
+                behaviorMethodIter != behaviorClass->m_methods.end())
             {
                 AZ::BehaviorMethod* method = behaviorMethodIter->second;
                 AZ_Error("python", method, "%s is not a method in class %s!", methodName, m_wrappedObjectTypeName.c_str());
@@ -297,6 +297,33 @@ namespace EditorPythonBindings
                 if (method && PythonProxyObjectManagement::IsMemberLike(*method, m_wrappedObject.m_typeId))
                 {
                     return EditorPythonBindings::Call::ClassMethod(method, m_wrappedObject, pythonArgs);
+                }
+            }
+            else if (behaviorClass->m_unwrapper != nullptr)
+            {
+                // Check if the Behavior Class acts as a wrapper for a pointer type
+
+                AZ::BehaviorObject rawObject;
+                behaviorClass->m_unwrapper(m_wrappedObject.m_address, rawObject, behaviorClass->m_unwrapperUserData);
+                // Check if the rawObject object contains a valid address and typeid
+                if (rawObject.IsValid())
+                {
+                    // Check if the specified method exist on the raw object type being wrapped
+                    if (behaviorClass = AZ::BehaviorContextHelper::GetClass(rawObject.m_typeId);
+                        behaviorClass != nullptr)
+                    {
+                        if (auto rawMethodIter = behaviorClass->m_methods.find(methodName);
+                            rawMethodIter != behaviorClass->m_methods.end())
+                        {
+                            AZ::BehaviorMethod* method = rawMethodIter->second;
+                            AZ_Error("python", method, "%s is not a method in class %s!", methodName, behaviorClass->m_name.c_str());
+
+                            if (method && PythonProxyObjectManagement::IsMemberLike(*method, rawObject.m_typeId))
+                            {
+                                return EditorPythonBindings::Call::ClassMethod(method, rawObject, pythonArgs);
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -320,7 +347,7 @@ namespace EditorPythonBindings
         }
         return AZStd::nullopt;
     }
-    
+
     void PythonProxyObject::PrepareWrappedObject(const AZ::BehaviorClass& behaviorClass)
     {
         m_ownership = Ownership::Owned;
@@ -529,7 +556,7 @@ namespace EditorPythonBindings
 
     pybind11::ssize_t PythonProxyObject::GetWrappedObjectHash()
     {
-        pybind11::object result = GetWrappedObjectRepr(); 
+        pybind11::object result = GetWrappedObjectRepr();
         return pybind11::hash(result.release());
     }
 
@@ -588,7 +615,7 @@ namespace EditorPythonBindings
         rapidjson::Document document;
         AZ::JsonSerializerSettings settings;
         settings.m_keepDefaults = true;
-        
+
         auto resultCode =
             AZ::JsonSerialization::Store(document, document.GetAllocator(), m_wrappedObject.m_address, nullptr, m_wrappedObject.m_typeId, settings);
 
@@ -606,7 +633,7 @@ namespace EditorPythonBindings
             AZ_Error("PythonProxyObject", false, "Failed to write json string: %s", outcome.GetError().c_str());
             return pybind11::cast<pybind11::none>(Py_None);
         }
-        
+
         jsonString.erase(AZStd::remove(jsonString.begin(), jsonString.end(), '\n'), jsonString.end());
         auto pythonCode = AZStd::string::format(
             R"PYTHON(exec("import json") or json.loads("""%s"""))PYTHON", jsonString.c_str());
@@ -667,7 +694,7 @@ namespace EditorPythonBindings
         }
         return false;
     }
-    
+
     namespace PythonProxyObjectManagement
     {
         bool IsMemberLike(const AZ::BehaviorMethod& method, const AZ::TypeId& typeId)

--- a/Gems/Presence/Code/Source/PresenceSystemComponent.cpp
+++ b/Gems/Presence/Code/Source/PresenceSystemComponent.cpp
@@ -56,7 +56,7 @@ namespace Presence
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
             behaviorContext->Class<PresenceDetails>()
-                ->Constructor<PresenceDetails&>()
+                ->Constructor<const PresenceDetails&>()
                 ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::Value)
                 ->Property("localUserId", BehaviorValueProperty(&PresenceDetails::localUserId))
                 ->Property("titleId", BehaviorValueProperty(&PresenceDetails::titleId))

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/BehaviorContextFactoryMethods.h
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/BehaviorContextFactoryMethods.h
@@ -89,7 +89,7 @@ namespace ScriptEvents
             return nullptr;
         }
 
-        void SetArgumentName(size_t /*index*/, const AZStd::string& /*name*/) override
+        void SetArgumentName(size_t /*index*/, AZStd::string /*name*/) override
         {
         }
 
@@ -98,7 +98,7 @@ namespace ScriptEvents
             return nullptr;
         }
 
-        void SetArgumentToolTip(size_t /*index*/, const AZStd::string& /*name*/) override
+        void SetArgumentToolTip(size_t /*index*/, AZStd::string /*name*/) override
         {
         }
 

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventBroadcast.cpp
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventBroadcast.cpp
@@ -103,14 +103,14 @@ namespace ScriptEvents
         m_argumentToolTips.resize(numArguments);
     }
 
-    void ScriptEventBroadcast::SetArgumentName(size_t index, const AZStd::string& name)
+    void ScriptEventBroadcast::SetArgumentName(size_t index, AZStd::string name)
     {
         if (index >= m_argumentNames.size())
         {
             m_argumentNames.resize(index + 1);
         }
 
-        m_argumentNames[index] = name;
+        m_argumentNames[index] = AZStd::move(name);
     }
 
     size_t ScriptEventBroadcast::GetMinNumberOfArguments() const

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventBroadcast.h
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventBroadcast.h
@@ -53,13 +53,13 @@ namespace ScriptEvents
         }
 
         const AZStd::string* GetArgumentName(size_t index) const override { return &m_argumentNames[index]; }
-        void SetArgumentName(size_t index, const AZStd::string& name) override;
+        void SetArgumentName(size_t index, AZStd::string name) override;
 
         const AZ::BehaviorParameter* GetResult() const override { return &m_result; }
         bool HasBusId() const override { return false; }
 
         const AZStd::string* GetArgumentToolTip(size_t index) const override { return &m_argumentToolTips[index]; }
-        void SetArgumentToolTip(size_t index, const AZStd::string& tooltip) override
+        void SetArgumentToolTip(size_t index, AZStd::string tooltip) override
         {
             if (index >= m_argumentToolTips.size())
             {

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventMethod.cpp
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventMethod.cpp
@@ -113,14 +113,14 @@ namespace ScriptEvents
         m_argumentToolTips.resize(numArguments);
     }
 
-    void ScriptEventMethod::SetArgumentName(size_t index, const AZStd::string& name)
+    void ScriptEventMethod::SetArgumentName(size_t index, AZStd::string name)
     {
         if (index >= m_argumentNames.size())
         {
             m_argumentNames.resize(index + 1);
         }
 
-        m_argumentNames[index] = name;
+        m_argumentNames[index] = AZStd::move(name);
     }
 
     size_t ScriptEventMethod::GetMinNumberOfArguments() const

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventMethod.h
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventMethod.h
@@ -53,13 +53,13 @@ namespace ScriptEvents
         }
 
         const AZStd::string* GetArgumentName(size_t index) const override { return &m_argumentNames[index]; }
-        void SetArgumentName(size_t index, const AZStd::string& name) override;
+        void SetArgumentName(size_t index, AZStd::string name) override;
 
         const AZ::BehaviorParameter* GetResult() const override { return &m_result; }
         bool HasBusId() const override { return !m_busIdType.IsNull(); }
 
         const AZStd::string* GetArgumentToolTip(size_t index) const override { return &m_argumentToolTips[index]; }
-        void SetArgumentToolTip(size_t index, const AZStd::string& tooltip) override
+        void SetArgumentToolTip(size_t index, AZStd::string tooltip) override
         {
             if (index >= m_argumentToolTips.size())
             {


### PR DESCRIPTION
Any inline functions or classes that didn't need to be templated in the BehaviorContext were moved to a cpp file. The BehaviorArgument and BehaviorObject inline functions have been moved to the BehaviorContext.cpp file

The BehaviorMethodImpl class is no longer templated and it's member functions have been moved to a new BehaviorMethodImpl.cpp file The constructor functions are still templated as they need to access the function signature of the method being wrapped. These functions have been moved to the BehaviorMethod.inl file

The BehaviorEBusEvent class is also no longer templated and has undergone the same transformation as the BehaviorMethodImpl. Its non-templated functions have been moved to the BehaviorEBusEvent.cpp file, while it's constructors have been relocated to the BehaviorEBusEvent.inl

The BehaviorContext::ClassBuilder has been moved to it's on inline file of BehaviorClassBuilder.inl. A new ClassBuilderBase class has been added which is not templated and can be used to reflect a BehaviorClass without the need of a class template instantiation. The non-template functions of the ClassBuilder has been made member of the ClassBuilderBase class and moved to the BehaviorClassBuilder.cpp file

The BehaviorContext::EbusBuilder has gotten the same treatment as the BehaviorContext::ClassBuilder. There is now an EBusBuilderBase class that is declared in the BehaviorEBusBuilder.inl and implemented in the BehaviorEBusBuilder.cpp

Fixed bug in function_traits where the expand_args alias template would include the class type as part of the expanded arguments.

The BehaviorContext.h went from the 10 most expensive header being included in O3DE to outside of the top 10

Previously was counted as the following on a 32-logical core, 64-hyperthread machine `528988 ms: D:/o3de/o3de/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.h (included 893 times, avg 592 ms), included via:`


## How was this PR tested?

Ran Clang Build Analyzer while performing a Windows clang build of O3DE using the `all` metatarget to gather compile time statistics.

The statistics were compared against the changes to simplify AzTypeInfo from the typeinfo-simplification branch.

[all-with-type-info-changes.txt](https://github.com/aws-lumberyard-dev/o3de/files/10844154/all-with-type-info-changes.txt)
[all-with-type-info+behavior-context.txt](https://github.com/aws-lumberyard-dev/o3de/files/10844151/all-with-type-info%2Bbehavior-context.txt)
