### PR TITLE
Improves mipmap eviction for streaming images

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImageController.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImageController.cpp
@@ -272,25 +272,26 @@ namespace AZ
         bool StreamingImageController::EvictOneMipChain()
         {
             AZStd::lock_guard<AZStd::mutex> lock(m_imageListAccessMutex);
-            if (m_streamableImages.size() == 0)
+            for (auto ritr = m_streamableImages.rbegin(); ritr != m_streamableImages.rend(); ritr++)
             {
-                return false; 
-            }
-            auto ritr = m_streamableImages.rbegin();
-            StreamingImage* image = *ritr;
+                StreamingImage* image = *ritr;
 
-            if (image->IsTrimmable())
-            {
-                RHI::ResultCode success = image->TrimOneMipChain();
-                if (success == RHI::ResultCode::Success)
+                if (image->IsTrimmable())
                 {
-                    StreamingDebugOutput("StreamingImageController", "Image [%s] has one mipchain released; Current resident mip: %d\n",
-                        image->GetRHIImage()->GetName().GetCStr(), image->GetRHIImage()->GetResidentMipLevel());
-                    // update the image's priority and re-insert the image 
-                    m_streamableImages.erase(image);
-                    UpdateImagePriority(image);
-                    m_streamableImages.insert(image);
-                    return true;
+                    RHI::ResultCode success = image->TrimOneMipChain();
+                    if (success == RHI::ResultCode::Success)
+                    {
+                        StreamingDebugOutput(
+                            "StreamingImageController",
+                            "Image [%s] has one mipchain released; Current resident mip: %d\n",
+                            image->GetRHIImage()->GetName().GetCStr(),
+                            image->GetRHIImage()->GetResidentMipLevel());
+                        // update the image's priority and re-insert the image
+                        m_streamableImages.erase(image);
+                        UpdateImagePriority(image);
+                        m_streamableImages.insert(image);
+                        return true;
+                    }
                 }
             }
 


### PR DESCRIPTION
## What does this PR do?

If the set of loaded images have varying numbers of mipmaps, the previous logic wouldn't evict as many mipmaps as it could, because it would stop at the first failure case. For example, if 10 textures have 1 mipmap and 2 textures have 5 mipmaps, it will evict one mipmap from each of those 2 textures, put them at the front of the list, and then stop evicting because it will check a texture with 1 mipmap. With this change, it will keep searching and evict 4 mipmaps from those 2 textures, freeing more memory before failing.

## How was this PR tested?

Ran MultiplayerSample (which uses ~2.5 GB of streaming images) with a budget of 1 GB.

Before (multiple allocation failure warnings and texture corruption):
![image](https://user-images.githubusercontent.com/82224783/222210409-b4fe80e2-c942-49ae-b7d8-4632487a85eb.png)

After (no allocation failure warnings, no texture corruption):
![image](https://user-images.githubusercontent.com/82224783/222210866-01c6328c-7abf-4e5c-8f42-55704689025e.png)

