### PR TITLE
Fix parsing of 'TracerPid' ID to account for spaces AND tabs before the number

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Debug/Trace_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Debug/Trace_UnixLike.cpp
@@ -45,7 +45,7 @@ namespace AZ::Debug
             }
             for (size_t i = tracerPidOffset + tracerPidString.length(); i < numRead; ++i)
             {
-                if (processStatusView[i] != ' ')
+                if (!std::isspace(processStatusView[i]))
                 {
                     return processStatusView[i] != '0';
                 }

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Debug/Trace_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Debug/Trace_UnixLike.cpp
@@ -132,7 +132,7 @@ namespace AZ::Debug
         constexpr int exitCodeSignalBase = 128;
         constexpr int maxExitCode = 255;
         int signalExitCode = exitCodeSignalBase + signal;
-        _exit(signalExitCode<maxExitCode?signalExitCode:maxExitCode);
+        _exit(signalExitCode < maxExitCode ? signalExitCode : maxExitCode);
     }
 #endif
 

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Debug/Trace_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Debug/Trace_UnixLike.cpp
@@ -120,6 +120,22 @@ namespace AZ::Debug
             Debug::Trace::Instance().RawOutput(nullptr, message);
         }
         Debug::Trace::Instance().RawOutput(nullptr, "==================================================================\n");
+
+        // Continue the overridden signal handlers by exiting with the matching exit code based on the signal
+        switch (signal)
+        {
+            case SIGSEGV:
+                _exit(139);
+                break;
+            case SIGKILL:
+                _exit(137);
+                break;
+            case SIGTRAP:
+                _exit(133);
+                break;
+            default:
+                break;
+        }
     }
 #endif
 

--- a/Code/Framework/AzToolsFramework/Tests/EntityOwnershipService/SliceEntityOwnershipTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EntityOwnershipService/SliceEntityOwnershipTests.cpp
@@ -395,7 +395,12 @@ namespace UnitTest
         EXPECT_FALSE(sliceInstanceAddress.IsValid());
     }
 
+#if GTEST_HAS_DEATH_TEST
+#if AZ_TRAIT_DISABLE_FAILED_DEATH_TESTS
+    TEST_F(SliceEntityOwnershipDeathTests, DISABLED_AddEntity_RootSliceAssetAbsent_EntityNotCreated)
+#else
     TEST_F(SliceEntityOwnershipDeathTests, AddEntity_RootSliceAssetAbsent_EntityNotCreated)
+#endif // AZ_TRAIT_DISABLE_FAILED_DEATH_TESTS
     {
         m_sliceEntityOwnershipService->Destroy();
         AZ::Entity testEntity = AZ::Entity("testEntity");
@@ -404,4 +409,5 @@ namespace UnitTest
                 m_sliceEntityOwnershipService->AddEntity(&testEntity);
             }, ".*");
     }
+#endif // GTEST_HAS_DEATH_TEST
 }

--- a/Code/Framework/AzToolsFramework/Tests/EntityOwnershipService/SliceEntityOwnershipTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EntityOwnershipService/SliceEntityOwnershipTests.cpp
@@ -397,9 +397,9 @@ namespace UnitTest
 
 #if GTEST_HAS_DEATH_TEST
 #if AZ_TRAIT_DISABLE_FAILED_DEATH_TESTS
-    TEST_F(SliceEntityOwnershipDeathTests, DISABLED_AddEntity_RootSliceAssetAbsent_EntityNotCreated)
-#else
     TEST_F(SliceEntityOwnershipDeathTests, AddEntity_RootSliceAssetAbsent_EntityNotCreated)
+#else
+    TEST_F(SliceEntityOwnershipDeathTests, DISABLED_AddEntity_RootSliceAssetAbsent_EntityNotCreated)
 #endif // AZ_TRAIT_DISABLE_FAILED_DEATH_TESTS
     {
         m_sliceEntityOwnershipService->Destroy();

--- a/Code/Framework/AzToolsFramework/Tests/EntityOwnershipService/SliceEntityOwnershipTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EntityOwnershipService/SliceEntityOwnershipTests.cpp
@@ -397,9 +397,9 @@ namespace UnitTest
 
 #if GTEST_HAS_DEATH_TEST
 #if AZ_TRAIT_DISABLE_FAILED_DEATH_TESTS
-    TEST_F(SliceEntityOwnershipDeathTests, AddEntity_RootSliceAssetAbsent_EntityNotCreated)
-#else
     TEST_F(SliceEntityOwnershipDeathTests, DISABLED_AddEntity_RootSliceAssetAbsent_EntityNotCreated)
+#else
+    TEST_F(SliceEntityOwnershipDeathTests, AddEntity_RootSliceAssetAbsent_EntityNotCreated)
 #endif // AZ_TRAIT_DISABLE_FAILED_DEATH_TESTS
     {
         m_sliceEntityOwnershipService->Destroy();


### PR DESCRIPTION
## What does this PR do?

This fixes an issue on linux where the detection of a debugger being attached is always reporting 'true' whether or not one is attached at all. The original logic relied on only checking for the space character, but on ubuntu, it was a tab character before the pid.

## How was this PR tested?

Added temporary trace logs to show results for `IsDebuggerPresent` with and without a debugger (lldb) attached.

