### PR TITLE
Despawn entities right away when exiting game mode

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
@@ -610,11 +610,17 @@ namespace AzToolsFramework
 
             // Game entity cleanup is queued onto the next tick via the DespawnEntities call.
             // To avoid both game entities and Editor entities active at the same time
-            // we flush the tick queue to ensure the game entities are cleared first.
+            // we flush the tick queue and the spawnable queue to ensure the game entities are cleared first.
             // The Alert callback that follows the DespawnEntities call will then reactivate the editor entities
             // This should be considered temporary as a move to a less rigid event sequence that supports async entity clean up
             // is the desired direction forward.
             AZ::TickBus::ExecuteQueuedEvents();
+            auto* rootSpawnableInterface = AzFramework::RootSpawnableInterface::Get();
+            if (rootSpawnableInterface)
+            {
+                rootSpawnableInterface->ProcessSpawnableQueue();
+                AzFramework::RootSpawnableNotificationBus::ExecuteQueuedEvents();
+            }
         }
 
         m_playInEditorData.m_isEnabled = false;


### PR DESCRIPTION
## What does this PR do?

When exiting game mode, spawned entities are queued to despawn, but the spawnable queue is processed on the next tick. This caused some batched automated tests to fail because game entities remained active for a frame while the next test ran.

## How was this PR tested?

Tested entering and exiting game mode in Editor. Also ran the tests that were previously failing to make sure they don't fail anymore. Since this is an intermittent failure, I originally ran the tests 100x and saw the failure after about 30 tries. After the fix, the test passed 100x.

Command used for testing:
<project path>\build\windows_vs2019>ctest -C profile -R AutomatedTesting::PrefabTests_Periodic --output-on-failure --repeat until-fail:100