### PR TITLE
Fixed the loading of ScriptProperty types that were serialized using an older typename in JSON Serialization files.

### DIFF
--- a/Code/Framework/AzCore/AzCore/Script/ScriptProperty.cpp
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptProperty.cpp
@@ -15,6 +15,49 @@
 
 namespace AZ
 {
+    // Add TypeInfo and RTTI Reflection within the cpp file
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptProperty, "ScriptProperty", "{D227D737-F1ED-4FB3-A1FB-38E4985D2E7A}");
+    AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptProperty);
+
+    AZ_TYPE_INFO_WITH_NAME_IMPL(FunctionalScriptProperty, "FunctionalScriptProperty", "{57D7418D-6B14-4A02-B50E-2E409D23CFC6}");
+    AZ_RTTI_NO_TYPE_INFO_IMPL(FunctionalScriptProperty, ScriptProperty);
+
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyNil, "ScriptPropertyNil", "{ACAD23F6-5E75-460E-BD77-1B477750264F}");
+    AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyNil, ScriptProperty);
+
+    // ScriptPropertyBoolean is serialized to a prefab file using the type name of AzFramwork::ScriptPropertyBoolean
+    // So make sure the old name is being used
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyBoolean, "AzFramework::ScriptPropertyBoolean", "{EA7335F8-5B9F-4744-B805-FEF9240451BD}");
+    AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyBoolean, ScriptProperty);
+
+    // ScriptPropertyNumber is serialized to a prefab file using the type name of AzFramwork::ScriptPropertyNumber
+    // So make sure the old name is being used
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyNumber, "AzFramework::ScriptPropertyNumber", "{5BCDFDEB-A75D-4E83-BB74-C45299CB9826}");
+    AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyNumber, ScriptProperty);
+
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyString, "ScriptPropertyString", "{A0229C6D-B010-47E7-8985-EE220FC7BFAF}");
+    AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyString, ScriptProperty);
+
+    // ScriptPropertyGenericClass is serialized to a prefab file using the type name of AzFramwork::ScriptPropertyGenericClass
+    // So make sure the old name is being used
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyGenericClass, "AzFramework::ScriptPropertyGenericClass", "{80618224-814C-44D4-A7B8-14B5A36F96ED}");
+    AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyGenericClass, FunctionalScriptProperty);
+
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyNumberArray, "ScriptPropertyNumberArray", "{76609A01-46CA-442E-8BA6-251D529886AF}");
+    AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyNumberArray, ScriptProperty);
+
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyBooleanArray, "ScriptPropertyBooleanArray", "{3A83958C-26C7-4A59-B6D7-A7805B0EC756}");
+    AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyBooleanArray, ScriptProperty);
+
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyStringArray, "ScriptPropertyStringArray", "{899993A5-D717-41BB-B89B-04A27952CA6D}");
+    AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyStringArray, ScriptProperty);
+
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyGenericClassArray, "ScriptPropertyGenericClassArray", "{28E986DD-CF7C-404D-9BEE-EEE067180CD1}");
+    AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyGenericClassArray, ScriptProperty);
+
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyAsset, "ScriptPropertyAsset", "{4D4B7176-A6E1-4BB9-A7B0-5977EC724CCB}");
+    AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyAsset, ScriptProperty);
+
     //////////////////////////
     // ScriptPropertyReflect
     //////////////////////////

--- a/Code/Framework/AzCore/AzCore/Script/ScriptProperty.cpp
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptProperty.cpp
@@ -16,46 +16,46 @@
 namespace AZ
 {
     // Add TypeInfo and RTTI Reflection within the cpp file
-    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptProperty, "ScriptProperty", "{D227D737-F1ED-4FB3-A1FB-38E4985D2E7A}");
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptProperty, "AzFramework::ScriptProperty", "{D227D737-F1ED-4FB3-A1FB-38E4985D2E7A}");
     AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptProperty);
 
     AZ_TYPE_INFO_WITH_NAME_IMPL(FunctionalScriptProperty, "FunctionalScriptProperty", "{57D7418D-6B14-4A02-B50E-2E409D23CFC6}");
     AZ_RTTI_NO_TYPE_INFO_IMPL(FunctionalScriptProperty, ScriptProperty);
 
-    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyNil, "ScriptPropertyNil", "{ACAD23F6-5E75-460E-BD77-1B477750264F}");
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyNil, "AzFramework::ScriptPropertyNil", "{ACAD23F6-5E75-460E-BD77-1B477750264F}");
     AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyNil, ScriptProperty);
 
-    // ScriptPropertyBoolean is serialized to a prefab file using the type name of AzFramwork::ScriptPropertyBoolean
+    // ScriptPropertyBoolean is serialized to a prefab file using the type name of AzFramework::ScriptPropertyBoolean
     // So make sure the old name is being used
     AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyBoolean, "AzFramework::ScriptPropertyBoolean", "{EA7335F8-5B9F-4744-B805-FEF9240451BD}");
     AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyBoolean, ScriptProperty);
 
-    // ScriptPropertyNumber is serialized to a prefab file using the type name of AzFramwork::ScriptPropertyNumber
+    // ScriptPropertyNumber is serialized to a prefab file using the type name of AzFramework::ScriptPropertyNumber
     // So make sure the old name is being used
     AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyNumber, "AzFramework::ScriptPropertyNumber", "{5BCDFDEB-A75D-4E83-BB74-C45299CB9826}");
     AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyNumber, ScriptProperty);
 
-    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyString, "ScriptPropertyString", "{A0229C6D-B010-47E7-8985-EE220FC7BFAF}");
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyString, "AzFramework::ScriptPropertyString", "{A0229C6D-B010-47E7-8985-EE220FC7BFAF}");
     AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyString, ScriptProperty);
 
-    // ScriptPropertyGenericClass is serialized to a prefab file using the type name of AzFramwork::ScriptPropertyGenericClass
+    // ScriptPropertyGenericClass is serialized to a prefab file using the type name of AzFramework::ScriptPropertyGenericClass
     // So make sure the old name is being used
     AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyGenericClass, "AzFramework::ScriptPropertyGenericClass", "{80618224-814C-44D4-A7B8-14B5A36F96ED}");
     AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyGenericClass, FunctionalScriptProperty);
 
-    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyNumberArray, "ScriptPropertyNumberArray", "{76609A01-46CA-442E-8BA6-251D529886AF}");
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyNumberArray, "AzFramework::ScriptPropertyNumberArray", "{76609A01-46CA-442E-8BA6-251D529886AF}");
     AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyNumberArray, ScriptProperty);
 
-    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyBooleanArray, "ScriptPropertyBooleanArray", "{3A83958C-26C7-4A59-B6D7-A7805B0EC756}");
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyBooleanArray, "AzFramework::ScriptPropertyBooleanArray", "{3A83958C-26C7-4A59-B6D7-A7805B0EC756}");
     AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyBooleanArray, ScriptProperty);
 
-    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyStringArray, "ScriptPropertyStringArray", "{899993A5-D717-41BB-B89B-04A27952CA6D}");
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyStringArray, "AzFramework::ScriptPropertyStringArray", "{899993A5-D717-41BB-B89B-04A27952CA6D}");
     AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyStringArray, ScriptProperty);
 
-    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyGenericClassArray, "ScriptPropertyGenericClassArray", "{28E986DD-CF7C-404D-9BEE-EEE067180CD1}");
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyGenericClassArray, "AZ::ScriptPropertyGenericClassArray", "{28E986DD-CF7C-404D-9BEE-EEE067180CD1}");
     AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyGenericClassArray, ScriptProperty);
 
-    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyAsset, "ScriptPropertyAsset", "{4D4B7176-A6E1-4BB9-A7B0-5977EC724CCB}");
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ScriptPropertyAsset, "AZ::ScriptPropertyAsset", "{4D4B7176-A6E1-4BB9-A7B0-5977EC724CCB}");
     AZ_RTTI_NO_TYPE_INFO_IMPL(ScriptPropertyAsset, ScriptProperty);
 
     //////////////////////////

--- a/Code/Framework/AzCore/AzCore/Script/ScriptProperty.h
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptProperty.h
@@ -54,7 +54,8 @@ namespace AZ
         static bool VersionConverter(SerializeContext& context, SerializeContext::DataElementNode& classElement);
 
         virtual ~ScriptProperty() {}
-        AZ_RTTI(ScriptProperty, "{D227D737-F1ED-4FB3-A1FB-38E4985D2E7A}");
+        AZ_TYPE_INFO_WITH_NAME_DECL(ScriptProperty);
+        AZ_RTTI_NO_TYPE_INFO_DECL();
 
         ScriptProperty() {}
         ScriptProperty(const char* name)
@@ -100,7 +101,8 @@ namespace AZ
         : public ScriptProperty
     {
     public:
-        AZ_RTTI(FunctionalScriptProperty, "{57D7418D-6B14-4A02-B50E-2E409D23CFC6}", ScriptProperty);
+        AZ_TYPE_INFO_WITH_NAME_DECL(FunctionalScriptProperty);
+        AZ_RTTI_NO_TYPE_INFO_DECL();
 
         FunctionalScriptProperty();
         FunctionalScriptProperty(const char* name);
@@ -128,7 +130,8 @@ namespace AZ
     {
     public:
         AZ_CLASS_ALLOCATOR(ScriptPropertyNil, AZ::SystemAllocator);
-        AZ_RTTI(ScriptPropertyNil, "{ACAD23F6-5E75-460E-BD77-1B477750264F}", ScriptProperty);
+        AZ_TYPE_INFO_WITH_NAME_DECL(ScriptPropertyNil);
+        AZ_RTTI_NO_TYPE_INFO_DECL();
 
         static void Reflect(AZ::ReflectContext* reflection);
         static ScriptProperty* TryCreateProperty(AZ::ScriptDataContext& context, int valueIndex, const char* name);
@@ -153,7 +156,8 @@ namespace AZ
     {
     public:
         AZ_CLASS_ALLOCATOR(ScriptPropertyBoolean, AZ::SystemAllocator);
-        AZ_RTTI(ScriptPropertyBoolean, "{EA7335F8-5B9F-4744-B805-FEF9240451BD}", ScriptProperty);
+        AZ_TYPE_INFO_WITH_NAME_DECL(ScriptPropertyBoolean);
+        AZ_RTTI_NO_TYPE_INFO_DECL();
 
         static void Reflect(AZ::ReflectContext* reflection);
         static ScriptProperty* TryCreateProperty(AZ::ScriptDataContext& context, int valueIndex, const char* name);
@@ -185,7 +189,8 @@ namespace AZ
     {
     public:
         AZ_CLASS_ALLOCATOR(ScriptPropertyNumber, AZ::SystemAllocator);
-        AZ_RTTI(ScriptPropertyNumber, "{5BCDFDEB-A75D-4E83-BB74-C45299CB9826}", ScriptProperty);
+        AZ_TYPE_INFO_WITH_NAME_DECL(ScriptPropertyNumber);
+        AZ_RTTI_NO_TYPE_INFO_DECL();
 
         static void Reflect(AZ::ReflectContext* reflection);
         static ScriptProperty* TryCreateProperty(AZ::ScriptDataContext& context, int valueIndex, const char* name);
@@ -217,7 +222,8 @@ namespace AZ
     {
     public:
         AZ_CLASS_ALLOCATOR(ScriptPropertyString, AZ::SystemAllocator);
-        AZ_RTTI(ScriptPropertyString, "{A0229C6D-B010-47E7-8985-EE220FC7BFAF}", ScriptProperty);
+        AZ_TYPE_INFO_WITH_NAME_DECL(ScriptPropertyString);
+        AZ_RTTI_NO_TYPE_INFO_DECL();
 
         static void Reflect(AZ::ReflectContext* reflection);
         static ScriptProperty* TryCreateProperty(AZ::ScriptDataContext& context, int valueIndex, const char* name);
@@ -251,7 +257,8 @@ namespace AZ
         friend class AzToolsFramework::Components::ScriptEditorComponent;
     public:
         AZ_CLASS_ALLOCATOR(ScriptPropertyGenericClass, AZ::SystemAllocator);
-        AZ_RTTI(ScriptPropertyGenericClass, "{80618224-814C-44D4-A7B8-14B5A36F96ED}", FunctionalScriptProperty);
+        AZ_TYPE_INFO_WITH_NAME_DECL(ScriptPropertyGenericClass);
+        AZ_RTTI_NO_TYPE_INFO_DECL();
 
         static void Reflect(AZ::ReflectContext* reflection);
         static ScriptProperty* TryCreateProperty(AZ::ScriptDataContext& context, int valueIndex, const char* name);
@@ -322,7 +329,9 @@ namespace AZ
     {
     public:
         AZ_CLASS_ALLOCATOR(ScriptPropertyNumberArray, AZ::SystemAllocator);
-        AZ_RTTI(ScriptPropertyNumberArray, "{76609A01-46CA-442E-8BA6-251D529886AF}", ScriptProperty);
+
+        AZ_TYPE_INFO_WITH_NAME_DECL(ScriptPropertyNumberArray);
+        AZ_RTTI_NO_TYPE_INFO_DECL();
 
         static void Reflect(AZ::ReflectContext* reflection);
         static ScriptProperty* TryCreateProperty(AZ::ScriptDataContext& context, int valueIndex, const char* name);
@@ -353,7 +362,8 @@ namespace AZ
     {
     public:
         AZ_CLASS_ALLOCATOR(ScriptPropertyBooleanArray, AZ::SystemAllocator);
-        AZ_RTTI(ScriptPropertyBooleanArray, "{3A83958C-26C7-4A59-B6D7-A7805B0EC756}", ScriptProperty);
+        AZ_TYPE_INFO_WITH_NAME_DECL(ScriptPropertyBooleanArray);
+        AZ_RTTI_NO_TYPE_INFO_DECL();
 
         static void Reflect(AZ::ReflectContext* reflection);
         static ScriptProperty* TryCreateProperty(AZ::ScriptDataContext& context, int valueIndex, const char* name);
@@ -384,7 +394,8 @@ namespace AZ
     {
     public:
         AZ_CLASS_ALLOCATOR(ScriptPropertyStringArray, AZ::SystemAllocator);
-        AZ_RTTI(ScriptPropertyStringArray, "{899993A5-D717-41BB-B89B-04A27952CA6D}", ScriptProperty);
+        AZ_TYPE_INFO_WITH_NAME_DECL(ScriptPropertyStringArray);
+        AZ_RTTI_NO_TYPE_INFO_DECL();
 
         static void Reflect(AZ::ReflectContext* reflection);
         static ScriptProperty* TryCreateProperty(AZ::ScriptDataContext& context, int valueIndex, const char* name);
@@ -417,7 +428,8 @@ namespace AZ
         typedef AZStd::vector<AZ::DynamicSerializableField> ValueArrayType;
 
         AZ_CLASS_ALLOCATOR(ScriptPropertyGenericClassArray, AZ::SystemAllocator);
-        AZ_RTTI(ScriptPropertyGenericClassArray, "{28E986DD-CF7C-404D-9BEE-EEE067180CD1}", ScriptProperty);
+        AZ_TYPE_INFO_WITH_NAME_DECL(ScriptPropertyGenericClassArray);
+        AZ_RTTI_NO_TYPE_INFO_DECL();
 
         static void Reflect(AZ::ReflectContext* reflection);
         static ScriptProperty* TryCreateProperty(AZ::ScriptDataContext& context, int valueIndex, const char* name);
@@ -464,7 +476,8 @@ namespace AZ
     {
     public:
         AZ_CLASS_ALLOCATOR(ScriptPropertyAsset, AZ::SystemAllocator);
-        AZ_RTTI(ScriptPropertyAsset, "{4D4B7176-A6E1-4BB9-A7B0-5977EC724CCB}", ScriptProperty);
+        AZ_TYPE_INFO_WITH_NAME_DECL(ScriptPropertyAsset);
+        AZ_RTTI_NO_TYPE_INFO_DECL();
 
         static void Reflect(AZ::ReflectContext* reflection);
 


### PR DESCRIPTION
The ScriptPropertyBoolean, ScriptPropertyNumber and ScriptPropertyGenericClass types are serialized with type name of "AzFramework::ScriptPropertyBoolean",
"AzFramework::ScriptPropertyNumber" and
"AzFramework::ScriptPropertyGenericClass" in *.prefab and *.scriptcanvas JSON serialized files.

fixes #14910

## How was this PR tested?

Validated a prefab file that contained an "AzFramework::ScriptPropertyBoolean" deserialized correctly.
