### PR TITLE
Asset Processor - AP Gui settings take command line into account

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -5361,9 +5361,19 @@ namespace AssetProcessor
         m_allowModtimeSkippingFeature = enable;
     }
 
+    bool AssetProcessorManager::GetModtimeSkippingFeatureEnabled() const
+    {
+        return m_allowModtimeSkippingFeature;
+    }
+
     void AssetProcessorManager::SetInitialScanSkippingFeature(bool enable)
     {
         m_initialScanSkippingFeature = enable;
+    }
+
+    bool AssetProcessorManager::GetInitialScanSkippingFeatureEnabled() const
+    {
+        return m_initialScanSkippingFeature;
     }
 
     void AssetProcessorManager::SetQueryLogging(bool enableLogging)

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -194,9 +194,11 @@ namespace AssetProcessor
         //! Controls whether or not we are allowed to skip analysis on a file when the source files modtimes have not changed
         //! and neither have any builders.
         void SetEnableModtimeSkippingFeature(bool enable);
+        bool GetModtimeSkippingFeatureEnabled() const;
 
         //! Controls whether or not startup analysis is enabled or not.
         void SetInitialScanSkippingFeature(bool enable);
+        bool GetInitialScanSkippingFeatureEnabled() const;
 
         //! Query logging will log every asset database query.
         void SetQueryLogging(bool enableLogging);

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
@@ -598,16 +598,24 @@ void MainWindow::Activate()
     AzQtComponents::CheckBox::applyToggleSwitchStyle(ui->disableStartupScanCheckBox);
     AzQtComponents::CheckBox::applyToggleSwitchStyle(ui->debugOutputCheckBox);
 
+    const auto apm = m_guiApplicationManager->GetAssetProcessorManager();
+
     // Note: the settings can't be used in ::MainWindow(), because the application name
     // hasn't been set up and therefore the settings will load from somewhere different than later
     // on.
+    // Read the current settings to give command line options a chance to override the default
     QSettings settings;
     settings.beginGroup("Options");
-    bool zeroAnalysisModeFromSettings = settings.value("EnableZeroAnalysis", QVariant(true)).toBool();
-    bool enableBuilderDebugFlag = settings.value("EnableBuilderDebugFlag", QVariant(false)).toBool();
+    bool zeroAnalysisModeFromSettings = settings.value("EnableZeroAnalysis", QVariant(true)).toBool() || apm->GetModtimeSkippingFeatureEnabled();
+    bool enableBuilderDebugFlag = settings.value("EnableBuilderDebugFlag", QVariant(false)).toBool() || apm->GetBuilderDebugFlag();
+    bool initialScanSkippingEnabled = settings.value("SkipInitialScan", QVariant(false)).toBool() || apm->GetInitialScanSkippingFeatureEnabled();
     settings.endGroup();
 
     // zero analysis flag
+    apm->SetEnableModtimeSkippingFeature(zeroAnalysisModeFromSettings);
+    ui->modtimeSkippingCheckBox->setCheckState(zeroAnalysisModeFromSettings ? Qt::Checked : Qt::Unchecked);
+
+    // Connect after updating settings to avoid saving a command line override
     QObject::connect(ui->modtimeSkippingCheckBox, &QCheckBox::stateChanged, this,
         [this](int newCheckState)
     {
@@ -619,10 +627,10 @@ void MainWindow::Activate()
         settingsInCallback.endGroup();
     });
 
-    m_guiApplicationManager->GetAssetProcessorManager()->SetEnableModtimeSkippingFeature(zeroAnalysisModeFromSettings);
-    ui->modtimeSkippingCheckBox->setCheckState(zeroAnalysisModeFromSettings ? Qt::Checked : Qt::Unchecked);
-
     // output debug flag
+    apm->SetBuilderDebugFlag(enableBuilderDebugFlag);
+    ui->debugOutputCheckBox->setCheckState(enableBuilderDebugFlag ? Qt::Checked : Qt::Unchecked);
+
     QObject::connect(ui->debugOutputCheckBox, &QCheckBox::stateChanged, this,
         [this](int newCheckState)
         {
@@ -634,12 +642,8 @@ void MainWindow::Activate()
             settingsInCallback.endGroup();
         });
 
-    m_guiApplicationManager->GetAssetProcessorManager()->SetBuilderDebugFlag(enableBuilderDebugFlag);
-    ui->debugOutputCheckBox->setCheckState(enableBuilderDebugFlag ? Qt::Checked : Qt::Unchecked);
-
-    settings.beginGroup("Options");
-    bool initialScanSkippingEnabled = settings.value("SkipInitialScan", QVariant(false)).toBool();
-    settings.endGroup();
+    apm->SetInitialScanSkippingFeature(initialScanSkippingEnabled);
+    ui->disableStartupScanCheckBox->setCheckState(initialScanSkippingEnabled ? Qt::Checked : Qt::Unchecked);
 
     QObject::connect(ui->disableStartupScanCheckBox, &QCheckBox::stateChanged, this,
         [](int newCheckState)
@@ -652,9 +656,6 @@ void MainWindow::Activate()
         settingsInCallback.setValue("SkipInitialScan", QVariant(newOption));
         settingsInCallback.endGroup();
     });
-
-    m_guiApplicationManager->GetAssetProcessorManager()->SetInitialScanSkippingFeature(initialScanSkippingEnabled);
-    ui->disableStartupScanCheckBox->setCheckState(initialScanSkippingEnabled ? Qt::Checked : Qt::Unchecked);
 
     // Shared Cache tab:
     SetupAssetServerTab();


### PR DESCRIPTION
## What does this PR do?

Update AP Gui settings logic to take command line arguments into account instead of overriding them.

Previously AP gui settings would only follow what is set in the registry and override any setting specified on the command line.  This change allows command line settings to enable a setting and override previous GUI settings

## How was this PR tested?

Manually ran AP with various combinations of GUI and command line settings
