### PR TITLE
Show in the Asset property of PhysX Mesh Collider the type of shape the asset contains

### DIFF
--- a/Gems/PhysX/Code/Source/EditorMeshColliderComponent.h
+++ b/Gems/PhysX/Code/Source/EditorMeshColliderComponent.h
@@ -70,6 +70,7 @@ namespace PhysX
         AZ::u8 m_subdivisionLevel = 4; //!< The level of subdivision if a primitive shape is replaced with a convex mesh due to scaling.
 
     private:
+        AZStd::string PhysXMeshAssetShapeTypeName() const;
         bool ShowingSubdivisionLevel() const;
         AZ::u32 OnConfigurationChanged();
     };


### PR DESCRIPTION
## What does this PR do?

Show in the Asset property of PhysX Mesh Collider the type of shape the asset contains.

No Asset:
![image](https://user-images.githubusercontent.com/27999040/222747944-fc51537c-9b4e-47a5-8e8c-b58d956a248f.png)

Primitive:
![image](https://user-images.githubusercontent.com/27999040/222748053-f1834826-f1fb-4aab-94bd-445b177b25c2.png)

Convex:
![image](https://user-images.githubusercontent.com/27999040/222748305-0b4eeaa7-71ee-4b63-911e-d39d6322469a.png)

Triangle Mesh:
![image](https://user-images.githubusercontent.com/27999040/222748189-0d22d0fa-5195-4622-ace3-36bb7e34a046.png)

## How was this PR tested?

Manually tested in the editor assigning all the different types of PhysX Assets.
