### PR TITLE
Add missing #include for std::isspace

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Debug/Trace_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Debug/Trace_UnixLike.cpp
@@ -6,11 +6,13 @@
  *
  */
 
+
 #include <AzCore/Debug/StackTracer.h>
 #include <AzCore/Debug/TraceMessageBus.h>
 #include <AzCore/IO/SystemFile.h>
 #include <AzCore/std/string/string_view.h>
 
+#include <cctype>
 #include <signal.h>
 
 namespace AZ::Debug

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Debug/Trace_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Debug/Trace_UnixLike.cpp
@@ -9,6 +9,7 @@
 #include <AzCore/Debug/StackTracer.h>
 #include <AzCore/Debug/TraceMessageBus.h>
 #include <AzCore/IO/SystemFile.h>
+#include <AzCore/std/string/conversions.h>
 #include <AzCore/std/string/string_view.h>
 
 #include <cctype>
@@ -46,7 +47,7 @@ namespace AZ::Debug
             }
             for (size_t i = tracerPidOffset + tracerPidString.length(); i < numRead; ++i)
             {
-                if (!std::isspace(processStatusView[i]))
+                if (!AZStd::isspace(processStatusView[i]))
                 {
                     return processStatusView[i] != '0';
                 }

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Debug/Trace_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Debug/Trace_UnixLike.cpp
@@ -6,7 +6,6 @@
  *
  */
 
-
 #include <AzCore/Debug/StackTracer.h>
 #include <AzCore/Debug/TraceMessageBus.h>
 #include <AzCore/IO/SystemFile.h>


### PR DESCRIPTION
## What does this PR do?

Fixes a unity-build related issue on android

## How was this PR tested?
Built on Linux with non-unity
