### PR TITLE
Add RenderToTexture function to camera component

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/CameraPipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/CameraPipeline.pass
@@ -1,0 +1,392 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "CameraPipeline",
+            "PassClass": "ParentPass",
+            "Slots": [
+                {
+                    "Name": "PipelineOutput",
+                    "SlotType": "InputOutput"
+                }
+            ],
+            "PassData": {
+                "$type": "PassData",
+                "PipelineGlobalConnections": [
+                    {
+                        "GlobalName": "PipelineOutput",
+                        "Slot": "PipelineOutput"
+                    }
+                ]
+            },
+            "PassRequests": [
+                {
+                    "Name": "MorphTargetPass",
+                    "TemplateName": "MorphTargetPassTemplate"
+                },
+                {
+                    "Name": "SkinningPass",
+                    "TemplateName": "SkinningPassTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "SkinnedMeshOutputStream",
+                            "AttachmentRef": {
+                                "Pass": "MorphTargetPass",
+                                "Attachment": "MorphTargetDeltaOutput"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "RayTracingAccelerationStructurePass",
+                    "TemplateName": "RayTracingAccelerationStructurePassTemplate"
+                },
+                {
+                    "Name": "DepthPrePass",
+                    "TemplateName": "DepthParentTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "SkinnedMeshes",
+                            "AttachmentRef": {
+                                "Pass": "SkinningPass",
+                                "Attachment": "SkinnedMeshOutputStream"
+                            }
+                        },
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "PipelineGlobal",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "MotionVectorPass",
+                    "TemplateName": "MotionVectorParentTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "SkinnedMeshes",
+                            "AttachmentRef": {
+                                "Pass": "SkinningPass",
+                                "Attachment": "SkinnedMeshOutputStream"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Depth",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "Depth"
+                            }
+                        },
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "PipelineGlobal",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "LightCullingPass",
+                    "TemplateName": "LightCullingParentTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "SkinnedMeshes",
+                            "AttachmentRef": {
+                                "Pass": "SkinningPass",
+                                "Attachment": "SkinnedMeshOutputStream"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DepthMSAA",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthMSAA"
+                            }
+                        },
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "PipelineGlobal",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "Shadows",
+                    "TemplateName": "ShadowParentTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "SkinnedMeshes",
+                            "AttachmentRef": {
+                                "Pass": "SkinningPass",
+                                "Attachment": "SkinnedMeshOutputStream"
+                            }
+                        },
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "PipelineGlobal",
+                                "Attachment": "PipelineOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Depth",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthMSAA"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "OpaquePass",
+                    "TemplateName": "OpaqueParentTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "DirectionalShadowmap",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "DirectionalShadowmap"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DirectionalESM",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "DirectionalESM"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ProjectedShadowmap",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "ProjectedShadowmap"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ProjectedESM",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "ProjectedESM"
+                            }
+                        },
+                        {
+                            "LocalSlot": "TileLightData",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingPass",
+                                "Attachment": "TileLightData"
+                            }
+                        },
+                        {
+                            "LocalSlot": "LightListRemapped",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingPass",
+                                "Attachment": "LightListRemapped"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DepthLinear",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthLinear"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DepthStencil",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthMSAA"
+                            }
+                        },
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "PipelineGlobal",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TransparentPass",
+                    "TemplateName": "TransparentParentTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "DirectionalShadowmap",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "DirectionalShadowmap"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DirectionalESM",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "DirectionalESM"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ProjectedShadowmap",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "ProjectedShadowmap"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ProjectedESM",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "ProjectedESM"
+                            }
+                        },
+                        {
+                            "LocalSlot": "TileLightData",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingPass",
+                                "Attachment": "TileLightData"
+                            }
+                        },
+                        {
+                            "LocalSlot": "LightListRemapped",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingPass",
+                                "Attachment": "LightListRemapped"
+                            }
+                        },
+                        {
+                            "LocalSlot": "InputLinearDepth",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthLinear"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DepthStencil",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "Depth"
+                            }
+                        },
+                        {
+                            "LocalSlot": "InputOutput",
+                            "AttachmentRef": {
+                                "Pass": "OpaquePass",
+                                "Attachment": "Output"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "DeferredFogPass",
+                    "TemplateName": "DeferredFogPassTemplate",
+                    "Enabled": false,
+                    "Connections": [
+                        {
+                            "LocalSlot": "InputLinearDepth",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthLinear"
+                            }
+                        },
+                        {
+                            "LocalSlot": "InputDepthStencil",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "Depth"
+                            }
+                        },
+                        {
+                            "LocalSlot": "RenderTargetInputOutput",
+                            "AttachmentRef": {
+                                "Pass": "TransparentPass",
+                                "Attachment": "InputOutput"
+                            }
+                        }
+                    ],
+                    "PassData": {
+                        "$type": "FullscreenTrianglePassData",
+                        "ShaderAsset": {
+                            "FilePath": "Shaders/ScreenSpace/DeferredFog.shader"
+                        },
+                        "PipelineViewTag": "MainCamera"
+                    }
+                },
+                {
+                    "Name": "ReflectionCopyFrameBufferPass",
+                    "TemplateName": "ReflectionCopyFrameBufferPassTemplate",
+                    "Enabled": false,
+                    "Connections": [
+                        {
+                            "LocalSlot": "Input",
+                            "AttachmentRef": {
+                                "Pass": "DeferredFogPass",
+                                "Attachment": "RenderTargetInputOutput"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PostProcessPass",
+                    "TemplateName": "PostProcessParentTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "LightingInput",
+                            "AttachmentRef": {
+                                "Pass": "DeferredFogPass",
+                                "Attachment": "RenderTargetInputOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Depth",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "Depth"
+                            }
+                        },
+                        {
+                            "LocalSlot": "MotionVectors",
+                            "AttachmentRef": {
+                                "Pass": "MotionVectorPass",
+                                "Attachment": "MotionVectorOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "PipelineGlobal",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                },
+
+                {
+                    "Name": "CopyToSwapChain",
+                    "TemplateName": "FullscreenCopyTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "Input",
+                            "AttachmentRef": {
+                                "Pass": "PostProcessPass",
+                                "Attachment": "Output"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Output",
+                            "AttachmentRef": {
+                                "Pass": "PipelineGlobal",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
+++ b/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
@@ -41,6 +41,10 @@
                 "Path": "Passes/MainPipeline.pass"
             },
             {
+                "Name": "CameraPipeline",
+                "Path": "Passes/CameraPipeline.pass"
+            },
+            {
                 "Name": "MainPipelineRenderToTexture",
                 "Path": "Passes/MainPipelineRenderToTexture.pass"
             },

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
@@ -98,6 +98,9 @@ namespace AZ
                                                                    const ViewType viewType = ViewType::Default);
             static RenderPipelinePtr CreateRenderPipelineForWindow(Data::Asset<AnyAsset> pipelineAsset, const WindowContext& windowContext);
 
+            // Create a render pipeline which renders to the specified attachment image
+            static RenderPipelinePtr CreateRenderPipelineForImage(const RenderPipelineDescriptor& desc, Data::Asset<AttachmentImageAsset> imageAsset);
+
             // Data type for render pipeline's views' information
             using PipelineViewMap = AZStd::map<PipelineViewTag, PipelineViews, AZNameSortAscending>;
             using ViewToViewTagMap = AZStd::map<const View*, PipelineViewTag>;
@@ -283,6 +286,9 @@ namespace AZ
             // End of functions accessed by Scene class
             //////////////////////////////////////////////////
 
+            // update viewport and scissor based on pass tree's output
+            void UpdateViewportScissor();
+
             RenderMode m_renderMode = RenderMode::RenderEveryTick;
 
             // The Scene this pipeline was added to.
@@ -335,6 +341,10 @@ namespace AZ
 
             // View type associated with the Render Pipeline.
             ViewType m_viewType = ViewType::Default;
+
+            // viewport and scissor for frame update
+            RHI::Viewport m_viewport;
+            RHI::Scissor m_scissor;
         };
 
     } // namespace RPI

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
@@ -98,7 +98,10 @@ namespace AZ
                                                                    const ViewType viewType = ViewType::Default);
             static RenderPipelinePtr CreateRenderPipelineForWindow(Data::Asset<AnyAsset> pipelineAsset, const WindowContext& windowContext);
 
-            // Create a render pipeline which renders to the specified attachment image
+            //! Create a render pipeline which renders to the specified attachment image
+            //! The render pipeline's root pass is created from the pass template specified from RenderPipelineDescriptor::m_rootPassTemplate
+            //! The input AttachmentImageAsset is used to connect to first output attachment of the root pass template
+            //! Note: the AttachmentImageAsset doesn't need to be loaded
             static RenderPipelinePtr CreateRenderPipelineForImage(const RenderPipelineDescriptor& desc, Data::Asset<AttachmentImageAsset> imageAsset);
 
             // Data type for render pipeline's views' information

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -107,6 +107,53 @@ namespace AZ
             return pipeline;
         }
 
+        RenderPipelinePtr RenderPipeline::CreateRenderPipelineForImage(const RenderPipelineDescriptor& desc, Data::Asset<AttachmentImageAsset> imageAsset)
+        {
+            RenderPipelinePtr pipeline{aznew RenderPipeline()};
+            PassSystemInterface* passSystem = PassSystemInterface::Get();
+
+            PassRequest passRequest;
+
+            PassImageAttachmentDesc imageAttachmentDesc;
+            imageAttachmentDesc.m_assetRef.m_assetId = imageAsset.GetId();
+            imageAttachmentDesc.m_lifetime = RHI::AttachmentLifetimeType::Imported;
+            imageAttachmentDesc.m_name = Name("OutputImage");
+            passRequest.m_imageAttachmentOverrides.push_back(imageAttachmentDesc);
+
+            auto passTemplate = passSystem->GetPassTemplate(Name(desc.m_rootPassTemplate));
+
+            PassConnection passConnection;
+
+            // use first output slot for connection
+            for (auto slot : passTemplate->m_slots)
+            {
+                if (slot.m_slotType == RPI::PassSlotType::Output || slot.m_slotType == RPI::PassSlotType::InputOutput)
+                {
+                    passConnection.m_localSlot = slot.m_name;
+                    break;
+                }
+            }
+
+            if (passConnection.m_localSlot.IsEmpty())
+            {
+                AZ_Error("RPI", false, "Failed to create a RenderPipeline: the render pipeline root pass template doesn't have output slot for render target");
+                return nullptr;
+            }
+
+            passConnection.m_attachmentRef.m_pass = "This";
+            passConnection.m_attachmentRef.m_attachment = imageAttachmentDesc.m_name;
+            passRequest.m_passName = desc.m_name;
+            passRequest.m_templateName = desc.m_rootPassTemplate;
+            passRequest.m_connections.push_back(passConnection);
+                        
+            auto rootPass = passSystem->CreatePassFromRequest(&passRequest);
+            pipeline->m_passTree.m_rootPass = azrtti_cast<ParentPass*>(rootPass.get());
+
+            InitializeRenderPipeline(pipeline.get(), desc);
+
+            return pipeline;
+        }
+
         void RenderPipeline::InitializeRenderPipeline(RenderPipeline* pipeline, const RenderPipelineDescriptor& desc)
         {
             pipeline->m_descriptor = desc;
@@ -117,6 +164,35 @@ namespace AZ
             pipeline->m_passTree.m_rootPass->SetRenderPipeline(pipeline);
             pipeline->m_passTree.m_rootPass->m_flags.m_isPipelineRoot = true;
             pipeline->m_passTree.m_rootPass->ManualPipelineBuildAndInitialize();
+
+            pipeline->UpdateViewportScissor();
+        }
+
+        void RenderPipeline::UpdateViewportScissor()
+        {
+            for (PassAttachmentBinding& binding : m_passTree.m_rootPass->m_attachmentBindings)
+            {
+                if (binding.m_slotType == PassSlotType::Output || binding.m_slotType == PassSlotType::InputOutput)
+                {
+                    auto attachment = binding.GetAttachment();
+                    if (attachment && attachment->GetAttachmentType() == RHI::AttachmentType::Image)
+                    {
+                        RHI::ImageDescriptor imageDesc;
+                        if (attachment->m_importedResource)
+                        {
+                            AttachmentImage* image = static_cast<AttachmentImage*>(attachment->m_importedResource.get());
+                            imageDesc = image->GetDescriptor();
+                        }
+                        else
+                        {
+                            imageDesc = attachment->m_descriptor.m_image;
+                        }
+                        m_viewport = RHI::Viewport(0, (float)imageDesc.m_size.m_width, 0, (float)imageDesc.m_size.m_height);
+                        m_scissor = RHI::Scissor(0, 0, imageDesc.m_size.m_width, imageDesc.m_size.m_height);
+                        return;
+                    }
+                }
+            }
         }
 
         RenderPipeline::~RenderPipeline()
@@ -359,6 +435,8 @@ namespace AZ
 
         void RenderPipeline::OnRemovedFromScene([[maybe_unused]] Scene* scene)
         {
+            m_passTree.ClearQueues();
+
             AZ_Assert(m_scene == scene, "Pipeline isn't added to the specified scene");
             m_scene = nullptr;
             PassSystemInterface::Get()->RemoveRenderPipeline(this);
@@ -440,6 +518,8 @@ namespace AZ
                         SceneRequestBus::Event(m_scene->GetId(), &SceneRequest::PipelineStateLookupNeedsRebuild);
                     }
                 }
+                                
+                UpdateViewportScissor();
 
                 // Reset change flags
                 m_pipelinePassChanges = PipelinePassChanges::NoPassChanges;
@@ -498,6 +578,8 @@ namespace AZ
             AZ_PROFILE_FUNCTION(RPI);
             if (GetRenderMode() != RenderPipeline::RenderMode::NoRender)
             {
+                params.m_viewportState = m_viewport;
+                params.m_scissorState = m_scissor;
                 m_passTree.m_rootPass->FrameBegin(params);
             }
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -122,6 +122,12 @@ namespace AZ
 
             auto passTemplate = passSystem->GetPassTemplate(Name(desc.m_rootPassTemplate));
 
+            if (!passTemplate)
+            {
+                AZ_Error("RPI", false, "Failed to create a RenderPipeline: the render pipeline root pass template doesn't exist");
+                return nullptr;
+            }
+
             PassConnection passConnection;
 
             // use first output slot for connection

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -147,6 +147,11 @@ namespace AZ
             passRequest.m_connections.push_back(passConnection);
                         
             auto rootPass = passSystem->CreatePassFromRequest(&passRequest);
+            if (!rootPass)
+            {
+                AZ_Error("RPI", false, "Failed to create a RenderPipeline: failed to create root pass for the render pipeline");
+                return nullptr;
+            }
             pipeline->m_passTree.m_rootPass = azrtti_cast<ParentPass*>(rootPass.get());
 
             InitializeRenderPipeline(pipeline.get(), desc);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
@@ -433,8 +433,14 @@ namespace AZ
 
         void View::SortDrawList(RHI::DrawList& drawList, RHI::DrawListTag tag)
         {
-            const Pass* passWithDrawListTag = (*m_passesByDrawList)[tag];
-            passWithDrawListTag->SortDrawList(drawList);
+            // Note: it's possible that the m_passesByDrawList doesn't have a pass for the input tag.
+            // This is because a View can be used for multiple render pipelines.
+            // So it may contains draw list tag which exists in one render pipeline but not others. 
+            auto itr = m_passesByDrawList->find(tag);
+            if (itr != m_passesByDrawList->end())
+            {
+                itr->second->SortDrawList(drawList);
+            }
         }
 
         void View::ConnectWorldToViewMatrixChangedHandler(MatrixChangedEvent::Handler& handler)

--- a/Gems/AtomTressFX/Assets/Passes/HairShortCutResolveColor.pass
+++ b/Gems/AtomTressFX/Assets/Passes/HairShortCutResolveColor.pass
@@ -37,7 +37,8 @@
                 "ShaderAsset": {
                     // Looking for it in the Shaders directory relative to the Assets directory
                     "FilePath": "Shaders/HairShortCutResolveColor.shader"
-                }
+                },
+                "PipelineViewTag": "MainCamera"
             }
         }
     }

--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -305,10 +305,6 @@ namespace Camera
 
         const AZStd::string pipelineName = "Camera_" + m_entityId.ToString() + "_Pipeline";
 
-        auto defaultPipelineDesc = scene->GetDefaultRenderPipeline()->GetDescriptor();
-
-        // Use default render pipeline for the camera render pipeline
-        // We can add function to use customized render pipeline for camera in the future
         AZ::RPI::RenderPipelineDescriptor pipelineDesc;
         pipelineDesc.m_mainViewTagName = "MainCamera";
         pipelineDesc.m_name = pipelineName;
@@ -317,6 +313,13 @@ namespace Camera
         pipelineDesc.m_allowModification = false;
         m_renderToTexturePipeline = AZ::RPI::RenderPipeline::CreateRenderPipelineForImage(pipelineDesc, m_config.m_renderTextureAsset);
 
+        if (!m_renderToTexturePipeline)
+        {
+            AZStd::string entityName;
+            AZ::ComponentApplicationBus::BroadcastResult(entityName, &AZ::ComponentApplicationRequests::GetEntityName, m_entityId);
+            AZ_Error("Camera", false, "Failed to create render to texture pipeline for camera component in entity %s", entityName.c_str());
+            return;
+        }
         scene->AddRenderPipeline(m_renderToTexturePipeline);
         m_renderToTexturePipeline->SetDefaultView(GetView());
     }

--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -9,10 +9,12 @@
 #include "CameraComponentController.h"
 #include "CameraViewRegistrationBus.h"
 
+#include <Atom/RPI.Public/Pass/PassFilter.h>
 #include <Atom/RPI.Public/View.h>
 #include <Atom/RPI.Public/ViewportContextManager.h>
 #include <Atom/RPI.Public/ViewportContext.h>
 
+#include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/Component/EntityBus.h>
 #include <AzCore/Math/MatrixUtils.h>
 #include <AzCore/Math/Vector2.h>
@@ -26,7 +28,7 @@ namespace Camera
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<CameraComponentConfig, AZ::ComponentConfig>()
-                ->Version(4)
+                ->Version(5)
                 ->Field("Orthographic", &CameraComponentConfig::m_orthographic)
                 ->Field("Orthographic Half Width", &CameraComponentConfig::m_orthographicHalfWidth)
                 ->Field("Field of View", &CameraComponentConfig::m_fov)
@@ -37,6 +39,8 @@ namespace Camera
                 ->Field("FrustumHeight", &CameraComponentConfig::m_frustumHeight)
                 ->Field("EditorEntityId", &CameraComponentConfig::m_editorEntityId)
                 ->Field("MakeActiveViewOnActivation", &CameraComponentConfig::m_makeActiveViewOnActivation)
+                ->Field("RenderToTexture", &CameraComponentConfig::m_renderTextureAsset)
+                ->Field("PipelineTemplate", &CameraComponentConfig::m_pipelineTemplate)
             ;
 
             if (auto editContext = serializeContext->GetEditContext())
@@ -74,6 +78,9 @@ namespace Camera
                         ->Attribute(AZ::Edit::Attributes::Suffix, " m")
                         ->Attribute(AZ::Edit::Attributes::Step, 10.f)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
+                    ->ClassElement(AZ::Edit::ClassElements::Group, "Render To Texture")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &CameraComponentConfig::m_renderTextureAsset, "Target texture", "The render target texture which the camera renders to.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &CameraComponentConfig::m_pipelineTemplate, "Pipeline template", "The root pass template for the camera's render pipeline")
                 ;
             }
         }
@@ -261,6 +268,11 @@ namespace Camera
         CameraBus::Handler::BusConnect();
         CameraNotificationBus::Broadcast(&CameraNotificationBus::Events::OnCameraAdded, m_entityId);
 
+        if (m_config.m_renderTextureAsset.GetId().IsValid())
+        {
+            CreateRenderPipelineForTexture();
+        }
+
         // Only activate if we're configured to do so, and our activation call back indicates that we should
         if (m_config.m_makeActiveViewOnActivation && (!m_shouldActivateFn || m_shouldActivateFn()))
         {
@@ -270,6 +282,13 @@ namespace Camera
 
     void CameraComponentController::Deactivate()
     {
+        if (m_renderToTexturePipeline)
+        {
+            auto scene = AZ::RPI::RPISystemInterface::Get()->GetSceneByName(AZ::Name("Main"));
+            scene->RemoveRenderPipeline(m_renderToTexturePipeline->GetId());
+            m_renderToTexturePipeline = nullptr;
+        }
+
         CameraNotificationBus::Broadcast(&CameraNotificationBus::Events::OnCameraRemoved, m_entityId);
         CameraBus::Handler::BusDisconnect();
         AZ::TransformNotificationBus::Handler::BusDisconnect(m_entityId);
@@ -278,6 +297,28 @@ namespace Camera
         m_atomCameraViewGroup->Deactivate();
        
         DeactivateAtomView();
+    }
+
+    void CameraComponentController::CreateRenderPipelineForTexture()
+    {
+        auto scene = AZ::RPI::RPISystemInterface::Get()->GetSceneByName(AZ::Name("Main"));
+
+        const AZStd::string pipelineName = "Camera_" + m_entityId.ToString() + "_Pipeline";
+
+        auto defaultPipelineDesc = scene->GetDefaultRenderPipeline()->GetDescriptor();
+
+        // Use default render pipeline for the camera render pipeline
+        // We can add function to use customized render pipeline for camera in the future
+        AZ::RPI::RenderPipelineDescriptor pipelineDesc;
+        pipelineDesc.m_mainViewTagName = "MainCamera";
+        pipelineDesc.m_name = pipelineName;
+        pipelineDesc.m_rootPassTemplate = m_config.m_pipelineTemplate;
+        pipelineDesc.m_renderSettings.m_multisampleState = AZ::RPI::RPISystemInterface::Get()->GetApplicationMultisampleState();
+        pipelineDesc.m_allowModification = false;
+        m_renderToTexturePipeline = AZ::RPI::RenderPipeline::CreateRenderPipelineForImage(pipelineDesc, m_config.m_renderTextureAsset);
+
+        scene->AddRenderPipeline(m_renderToTexturePipeline);
+        m_renderToTexturePipeline->SetDefaultView(GetView());
     }
 
     void CameraComponentController::SetConfiguration(const CameraComponentConfig& config)

--- a/Gems/Camera/Code/Source/CameraComponentController.h
+++ b/Gems/Camera/Code/Source/CameraComponentController.h
@@ -8,16 +8,19 @@
 
 #pragma once
 
+#include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TransformBus.h>
 #include <AzFramework/Components/CameraBus.h>
 #include <AzFramework/Viewport/CameraState.h>
+#include <Atom/RPI.Public/AuxGeom/AuxGeomFeatureProcessorInterface.h>
 #include <Atom/RPI.Public/Base.h>
+#include <Atom/RPI.Public/RenderPipeline.h>
 #include <Atom/RPI.Public/ViewGroup.h>
 #include <Atom/RPI.Public/ViewportContextBus.h>
 #include <Atom/RPI.Public/ViewProviderBus.h>
-#include <Atom/RPI.Public/AuxGeom/AuxGeomFeatureProcessorInterface.h>
 #include <Atom/RPI.Public/XR/XRRenderingInterface.h>
+#include <Atom/RPI.Reflect/Image/AttachmentImageAsset.h>
 
 namespace Camera
 {
@@ -55,6 +58,12 @@ namespace Camera
         bool m_makeActiveViewOnActivation = true;
         bool m_orthographic = false;
         float m_orthographicHalfWidth = 5.f;
+
+        // members for render to texture
+        // The texture assets which is used for render to texture feature. It defines the resolution, format etc.
+        AZ::Data::Asset<AZ::RPI::AttachmentImageAsset> m_renderTextureAsset;
+        // The pass template name used for render pipeline's root template
+        AZStd::string m_pipelineTemplate = "CameraPipeline";
     };
 
     class CameraComponentController
@@ -134,6 +143,8 @@ namespace Camera
     private:
         AZ_DISABLE_COPY(CameraComponentController);
 
+        void CreateRenderPipelineForTexture();
+
         void ActivateAtomView();
         void DeactivateAtomView();
         void UpdateCamera();
@@ -155,5 +166,8 @@ namespace Camera
 
         AZStd::function<bool()> m_shouldActivateFn;
         AZStd::function<bool()> m_isLockedFn = []{ return false; };
+
+        // for render to texture
+        AZ::RPI::RenderPipelinePtr m_renderToTexturePipeline;
     };
 } // namespace Camera

--- a/Gems/Camera/Code/Source/CameraComponentController.h
+++ b/Gems/Camera/Code/Source/CameraComponentController.h
@@ -59,7 +59,7 @@ namespace Camera
         bool m_orthographic = false;
         float m_orthographicHalfWidth = 5.f;
 
-        // members for render to texture
+        // Members for render to texture
         // The texture assets which is used for render to texture feature. It defines the resolution, format etc.
         AZ::Data::Asset<AZ::RPI::AttachmentImageAsset> m_renderTextureAsset;
         // The pass template name used for render pipeline's root template

--- a/Gems/Camera/gem.json
+++ b/Gems/Camera/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "Camera",
-    "version": "0.0.0",
+    "version": "0.1.0",
     "display_name": "Camera",
     "license": "Apache-2.0 Or MIT",
     "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",


### PR DESCRIPTION
## What does this PR do?
The camera component can specify an AttachmentImageAsset which it renders to.
The camera component can specify the root pass template it may use for its render pipeline.

To test this feature, we may create a UICanvas which uses this AttachmentImageAsset for its image component. Then add this UICanvas to an entity inside the level via UICanvas Ref component. When enter the game mode in Editor, it should show the render target image on screen in UI. 

## How was this PR tested?

Tested in Editor for AutomatedTesting project. 
Tested with AutomatedTesting.GameLauncher. 

Test steps in Editor:
1. Create a new level
2. Add an entity with camera component and set it as the activate camera for the level
3. Add another entity with camera, set the camera1.attimage (from the following package) to its Render Texture. 
4. Create a new UICanvas file. Add an image element to the canvas, select image type Render Target, then choose the camera1.attimage. 
5. Add an entity in the level with UICanvas AssetRef component. Choose the UICanvas file for this component.
6. Enter game mode in Editor. You should see the captured image showing in the UI

Test resources:
[RenderTargets.zip](https://github.com/o3de/o3de/files/10886646/RenderTargets.zip)

![ezgif-5-eeff6e738f](https://user-images.githubusercontent.com/55564570/222842062-347c6042-b3e9-4967-9b8e-2ea0fbdbdf4f.gif)

## extra info
Related RHI:
https://github.com/o3de/o3de/issues/12834
https://github.com/o3de/o3de/issues/14362
