### PR TITLE
Add constructor params to customize component editor with dpe/adapter

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
@@ -27,7 +27,10 @@ namespace AZ::DocumentPropertyEditor
     {
         AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::BusDisconnect();
         AzToolsFramework::ToolsApplicationEvents::Bus::Handler::BusDisconnect();
-        AzToolsFramework::PropertyEditorEntityChangeNotificationBus::MultiHandler::BusDisconnect(m_componentInstance->GetEntityId());
+        if (m_entityId.IsValid())
+        {
+            AzToolsFramework::PropertyEditorEntityChangeNotificationBus::MultiHandler::BusDisconnect(m_entityId);
+        }
     }
 
     void ComponentAdapter::OnEntityComponentPropertyChanged(AZ::ComponentId componentId)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
@@ -141,16 +141,26 @@ namespace AzToolsFramework
         return allIncompatibleComponents;
     }
 
-    ComponentEditor::ComponentEditor(AZ::SerializeContext* context, IPropertyEditorNotify* notifyTarget /* = nullptr */, QWidget* parent /* = nullptr */)
+    ComponentEditor::ComponentEditor(
+        AZ::SerializeContext* context,
+        IPropertyEditorNotify* notifyTarget /* = nullptr */,
+        QWidget* parent /* = nullptr */,
+        bool replaceRPE /* = false */,
+        AZStd::shared_ptr<AZ::DocumentPropertyEditor::ComponentAdapter> customDpeComponentAdapter /* = nullptr */)
         : AzQtComponents::Card(new ComponentEditorHeader(), parent)
         , m_serializeContext(context)
     {
         GetHeader()->SetTitle(ComponentEditorConstants::kUnknownComponentTitle);
 
-        if (DocumentPropertyEditor::ShouldReplaceRPE())
+        if (replaceRPE)
         {
             // Instantiate the DPE without the RPE
-            m_adapter = AZStd::make_shared<AZ::DocumentPropertyEditor::ComponentAdapter>();
+            m_adapter = customDpeComponentAdapter;
+            if (!m_adapter)
+            {
+                // Create a default component adapter.
+                m_adapter = AZStd::make_shared<AZ::DocumentPropertyEditor::ComponentAdapter>();
+            }
             m_filterAdapter = AZStd::make_shared<AZ::DocumentPropertyEditor::ValueStringFilter>();
             m_dpe = new DocumentPropertyEditor(this);
             m_filterAdapter->SetSourceAdapter(m_adapter);
@@ -199,7 +209,7 @@ namespace AzToolsFramework
 
         m_components.push_back(componentInstance);
 
-        if (DocumentPropertyEditor::ShouldReplaceRPE())
+        if (m_adapter)
         {
             if (!aggregateInstance)
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.hxx
@@ -61,7 +61,11 @@ namespace AzToolsFramework
         using VisitComponentAdapterContentsCallback = AZStd::function<void(const AZ::Dom::Value&)>;
 
         explicit ComponentEditor(
-            AZ::SerializeContext* context, IPropertyEditorNotify* notifyTarget = nullptr, QWidget* parent = nullptr);
+            AZ::SerializeContext* context,
+            IPropertyEditorNotify* notifyTarget = nullptr,
+            QWidget* parent = nullptr,
+            bool replaceRPE = false,
+            AZStd::shared_ptr<AZ::DocumentPropertyEditor::ComponentAdapter> customDpeComponentAdapter = nullptr);
         ~ComponentEditor();
 
         void AddInstance(AZ::Component* componentInstance, AZ::Component* aggregateInstance, AZ::Component* compareInstance);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -1883,12 +1883,15 @@ namespace AzToolsFramework
         if (m_componentEditorsUsed >= m_componentEditors.size())
         {
             //create a new component editor since cache has been exceeded
-            auto componentEditor = new ComponentEditor(
-                m_serializeContext,
-                this,
-                this,
-                DocumentPropertyEditor::ShouldReplaceRPE(),
-                AZStd::make_shared<AZ::DocumentPropertyEditor::ComponentAdapter>()); // Note: this is where a custom prefab adapter will be created when ready
+            bool replaceRPE = DocumentPropertyEditor::ShouldReplaceRPE();
+            AZStd::shared_ptr<AZ::DocumentPropertyEditor::ComponentAdapter> dpeComponentAdapter;
+            if (replaceRPE)
+            {
+                // Create a prefab specific component adapter
+                // Note: this is where a custom prefab adapter (PrefabComponentAdapter) can be created instead of the default
+                dpeComponentAdapter = AZStd::make_shared<AZ::DocumentPropertyEditor::ComponentAdapter>();
+            }
+            auto componentEditor = new ComponentEditor(m_serializeContext, this, this, replaceRPE, dpeComponentAdapter);
             componentEditor->setAcceptDrops(true);
 
             connect(componentEditor, &ComponentEditor::OnExpansionContractionDone, this, [this]()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -1883,7 +1883,12 @@ namespace AzToolsFramework
         if (m_componentEditorsUsed >= m_componentEditors.size())
         {
             //create a new component editor since cache has been exceeded
-            auto componentEditor = new ComponentEditor(m_serializeContext, this, this);
+            auto componentEditor = new ComponentEditor(
+                m_serializeContext,
+                this,
+                this,
+                DocumentPropertyEditor::ShouldReplaceRPE(),
+                AZStd::make_shared<AZ::DocumentPropertyEditor::ComponentAdapter>()); // Note: this is where a custom prefab adapter will be created when ready
             componentEditor->setAcceptDrops(true);
 
             connect(componentEditor, &ComponentEditor::OnExpansionContractionDone, this, [this]()


### PR DESCRIPTION
## What does this PR do?

Move the "ed_enableDPE" registry flag check from ComponentEditor to EntityPropertyEditor because not all tools that use the ComponentEditor class are compatible with the DocumentPropertyEditor.

Also set up a way to hook up a custom component adapter to the ComponentEditor to accompany PR https://github.com/o3de/o3de/pull/14917 which creates a custom prefab component adapter.

## How was this PR tested?

Tested the Editor's inspector and the UI Editor's properties pane to ensure functionality is as expected. Tested with DPE enabled and disabled.