### PR TITLE
Move StopEntity() into the NetBindComponent Deactivate()

### DIFF
--- a/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
@@ -23,9 +23,6 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/std/sort.h>
 
-AZ_CVAR(bool, bg_AssertNetBindOnDeactivationWithoutMarkForRemoval, false, nullptr, AZ::ConsoleFunctorFlags::Null,
-    "If true, assert when a multiplayer entity is deactivated without first calling MarkForRemoval from NetworkEntityManager.");
-
 namespace Multiplayer
 {
     void NetBindComponent::Reflect(AZ::ReflectContext* context)
@@ -216,13 +213,7 @@ namespace Multiplayer
 
     void NetBindComponent::Deactivate()
     {
-        if (bg_AssertNetBindOnDeactivationWithoutMarkForRemoval)
-        {
-            AZ_Assert(
-                m_needsToBeStopped == false,
-                "Entity (%s) appears to have been improperly deleted. Use MarkForRemoval to correctly clean up a networked entity.",
-                GetEntity() ? GetEntity()->GetName().c_str() : "null");
-        }
+        StopEntity();
         m_handleLocalServerRpcMessageEventHandle.Disconnect();
         m_handleLocalAutonomousToAuthorityRpcMessageEventHandle.Disconnect();
         m_handleLocalAuthorityToClientRpcMessageEventHandle.Disconnect();

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
@@ -406,17 +406,12 @@ namespace Multiplayer
 
             if (removeEntity != nullptr)
             {
-                // We need to notify out that our entity is about to deactivate so that other entities can read state before we clean up
-                NetBindComponent* netBindComponent = removeEntity.GetNetBindComponent();
-                AZ_Assert(netBindComponent != nullptr, "NetBindComponent not found on networked entity");
-                netBindComponent->StopEntity();
-
-                // At the moment, we spawn one entity at a time and avoid Prefab API calls and never get a spawn ticket,
-                // so this is the right way for now. Once we support prefabs we can use AzFramework::SpawnableEntitiesContainer
-                // Additionally, prefabs spawning is async! Whereas we currently create entities immediately, see:
-                // @NetworkEntityManager::CreateEntitiesImmediate
+                // If we've spawned entities through @NetworkEntityManager::CreateEntitiesImmediate
+                // then we destroy those entities here by processing the removal list.
+                // Note that if we've spawned entities through @NetworkPrefabSpawnerComponent::SpawnPrefab
+                // we should instead use the SpawnableEntitiesManager to destroy them.
                 AzFramework::GameEntityContextRequestBus::Broadcast(
-                    &AzFramework::GameEntityContextRequestBus::Events::DestroyGameEntity, netBindComponent->GetEntityId());
+                    &AzFramework::GameEntityContextRequestBus::Events::DestroyGameEntity, removeEntity.GetEntity()->GetId());
 
                 m_networkEntityTracker.erase(entityId);
             }


### PR DESCRIPTION
## What does this PR do?

Because StopEntity() was only getting called in the RemoveEntities() flow, it was possible for it to skip getting called when destroying entities in other ways, such as through `AzFramework::SpawnableEntitiesInterface::Get()->DespawnAllEntities(ticket);` .

By moving the call into the NetBindComponent::OnDeactivate(), we can ensure that it is always called as a part of entity destruction. Also, by moving the call, the cvar is no longer necessary for detecting that we've forgotten to call StopEntity().

Addresses #7462 .

## How was this PR tested?

Ran the Multiplayer Sample and verified that gem despawning worked correctly.
