### PR TITLE
Remove unused function SetPropertyVisibility.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/RigidBodyConfiguration.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/RigidBodyConfiguration.cpp
@@ -24,18 +24,6 @@ namespace AzPhysics
             return (flags & property) != 0 ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
         }
 
-        void SetPropertyVisibility(AZ::u16 flags, RigidBodyConfiguration::PropertyVisibility property, bool isVisible)
-        {
-            if (isVisible)
-            {
-                flags |= property;
-            }
-            else
-            {
-                flags &= ~property;
-            }
-        }
-
         bool RigidBodyVersionConverter(AZ::SerializeContext& context, AZ::SerializeContext::DataElementNode& classElement)
         {
             if (classElement.GetVersion() <= 1)


### PR DESCRIPTION
## What does this PR do?

Fix the following warning when building with clang-cl shipped with VS2022.
```
error : parameter 'flags' set but not used [-Werror,-Wunused-but-set-parameter]
```

The I found that the whole function is not used.

## How was this PR tested?

Rebuild o3de using VS2022 cl and clang-cl.