### PR TITLE
Fix linking error duplicate symbols when building with clang-cl.

### DIFF
--- a/Gems/DebugDraw/Code/CMakeLists.txt
+++ b/Gems/DebugDraw/Code/CMakeLists.txt
@@ -59,7 +59,10 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 DEBUGDRAW_GEM_EDITOR=1
         BUILD_DEPENDENCIES
             PRIVATE
-                Gem::DebugDraw.Static
+                AZ::AtomCore
+                Gem::Atom_RPI.Public
+                Gem::Atom_Bootstrap.Headers
+                Legacy::CryCommon
                 AZ::AzToolsFramework
     )
 


### PR DESCRIPTION
## What does this PR do?

Fix linking error duplicate symbols when building with clang-cl.

## How was this PR tested?

Rebuild o3de using VS2022 cl and clang-cl.