### PR TITLE
Fix release compilation due to unused variable

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/DownsampleSinglePassLuminancePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/DownsampleSinglePassLuminancePass.cpp
@@ -256,7 +256,7 @@ namespace AZ::RPI
         // For the setting up of the parameter for SPD shader, refer to:
         // https://github.com/GPUOpen-Effects/FidelityFX-SPD/blob/c52944f547884774a1b33066f740e6bf89f927f5/ffx-spd/ffx_spd.h#L327
 
-        bool succeeded = true;
+        [[maybe_unused]] bool succeeded = true;
         ShaderResourceGroup& srg = *m_shaderResourceGroup;
         succeeded &= srg.SetConstant(
             m_numWorkGroupsIndex,


### PR DESCRIPTION
## What does this PR do?

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_

Fixes a release compilation error due to a variable being unused because it is only used during an `AZ_Assert`.

_Please add links to any issues, RFCs or other items that are relevant to this PR._

N/A

## How was this PR tested?

Confirmed I could successfully compile on Linux: `cmake --build build/linux_mono --target install --config release`
