### PR TITLE
Material Canvas: Support for nodes accessing local and world space vertex attributes

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Common/DepthPass_CustomZ.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Common/DepthPass_CustomZ.azsli
@@ -30,7 +30,7 @@ PsOutput PixelShader(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
     PixelGeometryData geoData = EvaluatePixelGeometry(IN, isFrontFace);
 
     // Pixel clipping can be done here
-    EvaluateSurface(geoData);
+    EvaluateSurface(IN, geoData);
 
     PsOutput OUT;
     OUT.m_depth = IN.position.z;

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Common/TransparentPassVertexAndPixel.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Common/TransparentPassVertexAndPixel.azsli
@@ -30,7 +30,7 @@ ForwardPassOutput PixelShader(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
 
     PixelGeometryData geoData = EvaluatePixelGeometry(IN, isFrontFace);
 
-    Surface surface = EvaluateSurface(geoData);
+    Surface surface = EvaluateSurface(IN, geoData);
 
     LightingData lightingData = EvaluateLighting(surface, IN.position);
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/LowEndPipeline/LowEndForwardPassVertexAndPixel.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/LowEndPipeline/LowEndForwardPassVertexAndPixel.azsli
@@ -31,7 +31,7 @@ ForwardPassOutput PixelShader(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
 
     PixelGeometryData geoData = EvaluatePixelGeometry(IN, isFrontFace);
 
-    Surface surface = EvaluateSurface(geoData);
+    Surface surface = EvaluateSurface(IN, geoData);
 
     LightingData lightingData = EvaluateLighting(surface, IN.position);
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPassVertexAndPixel.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPassVertexAndPixel.azsli
@@ -47,7 +47,7 @@ ForwardPassOutput PixelShader(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
 
     PixelGeometryData geoData = EvaluatePixelGeometry(IN, isFrontFace);
 
-    Surface surface = EvaluateSurface(geoData);
+    Surface surface = EvaluateSurface(IN, geoData);
 
     LightingData lightingData = EvaluateLighting(surface, IN.position);
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MultiView/MultiViewForwardPassVertexAndPixel.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MultiView/MultiViewForwardPassVertexAndPixel.azsli
@@ -31,7 +31,7 @@ ForwardPassOutput PixelShader(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
 
     PixelGeometryData geoData = EvaluatePixelGeometry(IN, isFrontFace);
 
-    Surface surface = EvaluateSurface(geoData);
+    Surface surface = EvaluateSurface(IN, geoData);
 
     LightingData lightingData = EvaluateLighting(surface, IN.position);
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/ReflectionProbe/ReflectionProbeVisualization.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/ReflectionProbe/ReflectionProbeVisualization.azsli
@@ -55,7 +55,7 @@
 
     #include <Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceData.azsli>
 
-    Surface EvaluateSurface(PixelGeometryData geoData)
+    Surface EvaluateSurface(VsOutput IN, PixelGeometryData geoData)
     {
         Surface surface;
         surface.position = geoData.positionWS;

--- a/Gems/Atom/Feature/Common/Assets/Materials/Special/DebugVertexStreams.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Special/DebugVertexStreams.azsl
@@ -102,24 +102,24 @@ PixelOutput MainPS(VSOutput IN)
     float4x4 objectToWorld = ObjectSrg::GetWorldMatrix();
     float3x3 objectToWorldIT = ObjectSrg::GetWorldMatrixInverseTranspose();
 
-    float3 vertexNormal, vertexTangent, vertexBitangent;
-    ConstructTBN(IN.m_normal, IN.m_tangent, objectToWorld, objectToWorldIT, vertexNormal, vertexTangent, vertexBitangent);
+    float3 normalWS, tangentWS, bitangentWS;
+    ConstructTBN(IN.m_normal, IN.m_tangent, objectToWorld, objectToWorldIT, normalWS, tangentWS, bitangentWS);
 
     PixelOutput OUT;
     
-    float3 tangents[UvSetCount] = { vertexTangent, vertexTangent };
-    float3 bitangents[UvSetCount] = { vertexBitangent, vertexBitangent };
+    float3 tangents[UvSetCount] = { tangentWS, tangentWS };
+    float3 bitangents[UvSetCount] = { bitangentWS, bitangentWS };
     
     if(o_bitangentOptions == BitangentOptions::ReconstructBitangent && MaterialSrg::m_uvIndex == 0)
     {
-        bitangents[MaterialSrg::m_uvIndex] = cross(vertexNormal, vertexTangent) * sign(IN.m_tangent.w);
+        bitangents[MaterialSrg::m_uvIndex] = cross(normalWS, tangentWS) * sign(IN.m_tangent.w);
     }
     else if((o_debugVertexStream == DebugVertexStream::Tangents && o_tangentOptions == TangentOptions::UseSurfaceGradient)
     || (o_debugVertexStream == DebugVertexStream::Bitangents && o_bitangentOptions == BitangentOptions::UseSurfaceGradient)
     || MaterialSrg::m_uvIndex > 0)
     {
         const bool isBackface = false;
-        SurfaceGradientNormalMapping_Init(vertexNormal, IN.m_worldPosition, isBackface);
+        SurfaceGradientNormalMapping_Init(normalWS, IN.m_worldPosition, isBackface);
         SurfaceGradientNormalMapping_GenerateTB(IN.m_uv[MaterialSrg::m_uvIndex], tangents[MaterialSrg::m_uvIndex], bitangents[MaterialSrg::m_uvIndex]);
     }
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/EnhancedPBR.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/EnhancedPBR.azsli
@@ -95,7 +95,7 @@
     
     #include "Atom/Feature/Common/Assets/Shaders/Materials/MaterialFunctions/StandardGetAlphaAndClip.azsli"
 
-    void EvaluateSurface(PixelGeometryData geoData)
+    void EvaluateSurface(VsOutput IN, PixelGeometryData geoData)
     {
         GetAlphaAndClip(geoData.uvs);
     }

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR.azsli
@@ -558,7 +558,7 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
         return surface;
     }
 
-    Surface EvaluateSurface_StandardMultilayerPBR(PixelGeometryData geoData)
+    Surface EvaluateSurface_StandardMultilayerPBR(VsOutput IN, PixelGeometryData geoData)
     {
         return EvaluateSurface_StandardMultilayerPBR(
             geoData.positionWS,
@@ -585,7 +585,7 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
         return ShouldHandleParallax();
     }
     
-    void EvaluateSurface(PixelGeometryData geoData)
+    void EvaluateSurface(VsOutput IN, PixelGeometryData geoData)
     {
         // do nothing, this is where alpha clip can be done if it's supported
     }

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR.azsli
@@ -119,14 +119,14 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
     PixelGeometryData EvaluatePixelGeometry_StandardMultilayerPBR(
         inout float4 positionSV,
         float3 positionWS,
-        float3 normal,
-        float3 tangent,
-        float3 bitangent,
+        float3 normalWS,
+        float3 tangentWS,
+        float3 bitangentWS,
         float2 uvs[UvSetCount],
         bool isFrontFace,
         float3 vertexBlendMask)
     {
-        PixelGeometryData geoData = EvaluatePixelGeometry_BasePBR(positionWS, normal, tangent, bitangent, uvs, isFrontFace);
+        PixelGeometryData geoData = EvaluatePixelGeometry_BasePBR(positionWS, normalWS, tangentWS, bitangentWS, uvs, isFrontFace);
 
         geoData.isDisplacementClipped = false;
         geoData.m_vertexBlendMask = vertexBlendMask;
@@ -145,15 +145,15 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
         float4x4 objectToWorld = ObjectSrg::GetWorldMatrix();
         float3x3 objectToWorldIT = ObjectSrg::GetWorldMatrixInverseTranspose();
 
-        float3 vertexNormal, vertexTangent, vertexBitangent;
-        ConstructTBN(IN.normal, IN.tangent, objectToWorld, objectToWorldIT, vertexNormal, vertexTangent, vertexBitangent);
+        float3 normalWS, tangentWS, bitangentWS;
+        ConstructTBN(IN.normal, IN.tangent, objectToWorld, objectToWorldIT, normalWS, tangentWS, bitangentWS);
 
         return EvaluatePixelGeometry_StandardMultilayerPBR(
             IN.position,
             IN.worldPosition,
-            vertexNormal,
-            vertexTangent,
-            vertexBitangent,
+            normalWS,
+            tangentWS,
+            bitangentWS,
             IN.uvs,
             isFrontFace,
             IN.m_blendMask);
@@ -333,7 +333,7 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
         inputs.m_sampler = MaterialSrg::m_sampler;                                                                     \
         inputs.m_vertexUv = uvs;                                                                                       \
         inputs.m_uvMatrix = srgLayerPrefix##m_uvMatrix;                                                                \
-        inputs.m_normal = vertexNormal;                                                                                \
+        inputs.m_normal = normalWS;                                                                                \
         inputs.m_tangents = tangents;                                                                                  \
         inputs.m_bitangents = bitangents;                                                                              \
         inputs.m_isFrontFace = isFrontFace;                                                                            \
@@ -407,7 +407,7 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
 
     Surface EvaluateSurface_StandardMultilayerPBR(
         float3 positionWS,
-        float3 vertexNormal,
+        float3 normalWS,
         float3 tangents[UvSetCount],
         float3 bitangents[UvSetCount],
         float2 uvs[UvSetCount],
@@ -422,7 +422,7 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
         if(o_debugDrawMode == DebugDrawMode::BlendMask)
         {
             float3 blendMaskValues = GetApplicableBlendMaskValues(blendSource, uvs[MaterialSrg::m_blendMaskUvIndex], vertexBlendMask);
-            return MakeDebugSurface(positionWS, vertexNormal, blendMaskValues);
+            return MakeDebugSurface(positionWS, normalWS, blendMaskValues);
         }
     
         if(o_debugDrawMode == DebugDrawMode::Displacement)
@@ -431,13 +431,13 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
             float stopDepth = -MaterialSrg::m_displacementMin;
             float depth = GetNormalizedDepth(startDepth, stopDepth, uvs[MaterialSrg::m_parallaxUvIndex], float2(0,0), float2(0,0));
             float height = 1 - saturate(depth);
-            return MakeDebugSurface(positionWS, vertexNormal, float3(height,height,height));
+            return MakeDebugSurface(positionWS, normalWS, float3(height,height,height));
         }
     
         if(o_debugDrawMode == DebugDrawMode::FinalBlendWeights)
         {
             float3 blendWeights = GetBlendWeights(blendSource, uvs[MaterialSrg::m_blendMaskUvIndex], vertexBlendMask);
-            return MakeDebugSurface(positionWS, vertexNormal, blendWeights);
+            return MakeDebugSurface(positionWS, normalWS, blendWeights);
         }
 
         // ------- Calculate Layer Blend Mask Values -------
@@ -514,8 +514,8 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
             normalTS = ReorientTangentSpaceNormal(normalTS, lightingInputLayer3.m_normalTS);
         }
         // [GFX TODO][ATOM-14591]: This will only work if the normal maps all use the same UV stream. We would need to add support for having them in different UV streams.
-        surface.vertexNormal = vertexNormal;
-        surface.normal = normalize(TangentSpaceToWorld(normalTS, vertexNormal, tangents[MaterialSrg::m_parallaxUvIndex], bitangents[MaterialSrg::m_parallaxUvIndex]));
+        surface.vertexNormal = normalWS;
+        surface.normal = normalize(TangentSpaceToWorld(normalTS, normalWS, tangents[MaterialSrg::m_parallaxUvIndex], bitangents[MaterialSrg::m_parallaxUvIndex]));
         
         // ------- Combine Albedo, roughness, specular, roughness ---------
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR.azsli
@@ -86,7 +86,7 @@
     
     #include "Atom/Feature/Common/Assets/Shaders/Materials/MaterialFunctions/StandardGetAlphaAndClip.azsli"
 
-    void EvaluateSurface(PixelGeometryData geoData)
+    void EvaluateSurface(VsOutput IN, PixelGeometryData geoData)
     {
         GetAlphaAndClip(geoData.uvs);
     }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_LightingEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_LightingEval.azsli
@@ -12,7 +12,7 @@
 // used in your shader. Simply #define EvaluateLighting to your custom definition before including this file
 //
 #ifndef EvaluateLighting
-#define EvaluateLighting(surface, screenPosition)       EvaluateLighting_BasePBR(surface, screenPosition)
+#define EvaluateLighting EvaluateLighting_BasePBR
 #endif
 
 #include <Atom/Features/PBR/Lights/Lights.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_PixelGeometryEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_PixelGeometryEval.azsli
@@ -19,16 +19,16 @@
 
 PixelGeometryData EvaluatePixelGeometry_BasePBR(
     float3 positionWS,
-    float3 normal,
-    float3 tangent,
-    float3 bitangent,
+    float3 normalWS,
+    float3 tangentWS,
+    float3 bitangentWS,
     float2 uvs[UvSetCount],
     bool isFrontFace)
 {
     PixelGeometryData geoData;
 
     geoData.positionWS = positionWS;
-    geoData.vertexNormal = normalize(normal);
+    geoData.vertexNormal = normalize(normalWS);
 
     geoData.uvs = uvs;
     geoData.isFrontFace = isFrontFace;
@@ -38,7 +38,7 @@ PixelGeometryData EvaluatePixelGeometry_BasePBR(
         for (int i = 0; i != UvSetCount; ++i)
         {
             EvaluateTangentFrame(geoData.vertexNormal, positionWS, isFrontFace, uvs[i], i,
-                tangent, bitangent, geoData.tangents[i], geoData.bitangents[i]);
+                tangentWS, bitangentWS, geoData.tangents[i], geoData.bitangents[i]);
         }
     }
 
@@ -50,14 +50,14 @@ PixelGeometryData EvaluatePixelGeometry_BasePBR(VsOutput IN, bool isFrontFace)
     float4x4 objectToWorld = ObjectSrg::GetWorldMatrix();
     float3x3 objectToWorldIT = ObjectSrg::GetWorldMatrixInverseTranspose();
 
-    float3 vertexNormal, vertexTangent, vertexBitangent;
-    ConstructTBN(IN.normal, IN.tangent, objectToWorld, objectToWorldIT, vertexNormal, vertexTangent, vertexBitangent);
+    float3 normalWS, tangentWS, bitangentWS;
+    ConstructTBN(IN.normal, IN.tangent, objectToWorld, objectToWorldIT, normalWS, tangentWS, bitangentWS);
 
     return EvaluatePixelGeometry_BasePBR(
         IN.worldPosition,
-        vertexNormal,
-        vertexTangent,
-        vertexBitangent,
+        normalWS,
+        tangentWS,
+        bitangentWS,
         IN.uvs,
         isFrontFace);
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_PixelGeometryEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_PixelGeometryEval.azsli
@@ -12,7 +12,7 @@
 // used in your shader. Simply #define EvaluatePixelGeometry to your custom definition before including this file
 //
 #ifndef EvaluatePixelGeometry
-#define EvaluatePixelGeometry(IN, isFrontFace)      EvaluatePixelGeometry_BasePBR(IN, isFrontFace)
+#define EvaluatePixelGeometry EvaluatePixelGeometry_BasePBR
 #endif
 
 #include "../MaterialFunctions/EvaluateTangentFrame.azsli"

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceEval.azsli
@@ -64,7 +64,7 @@ Surface EvaluateSurface_BasePBR(
     return surface;
 }
 
-Surface EvaluateSurface_BasePBR(PixelGeometryData geoData)
+Surface EvaluateSurface_BasePBR(VsOutput IN, PixelGeometryData geoData)
 {
     return EvaluateSurface_BasePBR(
         geoData.positionWS,

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceEval.azsli
@@ -12,7 +12,7 @@
 // used in your shader. Simply #define EvaluateSurface to your custom definition before including this file
 //
 #ifndef EvaluateSurface
-#define EvaluateSurface(geoData)        EvaluateSurface_BasePBR(geoData)
+#define EvaluateSurface EvaluateSurface_BasePBR
 #endif
 
 #include <Atom/Features/MatrixUtility.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_VertexEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_VertexEval.azsli
@@ -12,7 +12,7 @@
 // EvaluateVertexGeometry used in your shader. Simply #define EvaluateVertexGeometry before including this file
 //
 #ifndef EvaluateVertexGeometry
-#define EvaluateVertexGeometry(IN)      EvaluateVertexGeometry_BasePBR(IN)
+#define EvaluateVertexGeometry EvaluateVertexGeometry_BasePBR
 #endif
 
 #include <viewsrg.srgi>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/DepthPass_VertexEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/DepthPass_VertexEval.azsli
@@ -9,7 +9,7 @@
 #pragma once
 
 #ifndef EvaluateVertexGeometry
-#define EvaluateVertexGeometry(IN)      EvaluateVertexGeometry_DepthPass(IN)
+#define EvaluateVertexGeometry EvaluateVertexGeometry_DepthPass
 #endif
 
 #include <Atom/RPI/TangentSpace.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_PixelGeometryEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_PixelGeometryEval.azsli
@@ -12,7 +12,7 @@
 // used in your shader. Simply #define EvaluatePixelGeometry to your custom definition before including this file
 //
 #ifndef EvaluatePixelGeometry
-#define EvaluatePixelGeometry(IN, isFrontFace)      EvaluatePixelGeometry_EnhancedPBR(IN, isFrontFace)
+#define EvaluatePixelGeometry EvaluatePixelGeometry_EnhancedPBR
 #endif
 
 #include "../StandardPBR/StandardPBR_PixelGeometryEval.azsli"

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_PixelGeometryEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_PixelGeometryEval.azsli
@@ -22,14 +22,14 @@
 PixelGeometryData EvaluatePixelGeometry_EnhancedPBR(
     inout float4 positionSV,
     float3 positionWS,
-    float3 normal,
-    float3 tangent,
-    float3 bitangent,
+    float3 normalWS,
+    float3 tangentWS,
+    float3 bitangentWS,
     float2 uvs[UvSetCount],
     float2 detailUvs[UvSetCount],
     bool isFrontFace)
 {
-    PixelGeometryData geoData = EvaluatePixelGeometry_BasePBR(positionWS, normal, tangent, bitangent, uvs, isFrontFace);
+    PixelGeometryData geoData = EvaluatePixelGeometry_BasePBR(positionWS, normalWS, tangentWS, bitangentWS, uvs, isFrontFace);
 
     // ------- Detail UVs -------
 
@@ -53,15 +53,15 @@ PixelGeometryData EvaluatePixelGeometry_EnhancedPBR(inout VsOutput IN, bool isFr
     float4x4 objectToWorld = ObjectSrg::GetWorldMatrix();
     float3x3 objectToWorldIT = ObjectSrg::GetWorldMatrixInverseTranspose();
 
-    float3 vertexNormal, vertexTangent, vertexBitangent;
-    ConstructTBN(IN.normal, IN.tangent, objectToWorld, objectToWorldIT, vertexNormal, vertexTangent, vertexBitangent);
+    float3 normalWS, tangentWS, bitangentWS;
+    ConstructTBN(IN.normal, IN.tangent, objectToWorld, objectToWorldIT, normalWS, tangentWS, bitangentWS);
 
     return EvaluatePixelGeometry_EnhancedPBR(
         IN.position,
         IN.worldPosition,
-        vertexNormal,
-        vertexTangent,
-        vertexBitangent,
+        normalWS,
+        tangentWS,
+        bitangentWS,
         IN.uvs,
         IN.detailUvs,
         isFrontFace);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_SurfaceEval.azsli
@@ -20,7 +20,7 @@
 
 Surface EvaluateSurface_EnhancedPBR(
     float3 positionWS,
-    float3 vertexNormal,
+    float3 normalWS,
     float3 tangents[UvSetCount],
     float3 bitangents[UvSetCount],
     float2 uvs[UvSetCount],
@@ -49,12 +49,12 @@ Surface EvaluateSurface_EnhancedPBR(
 
     // ------- Normal -------
     
-    surface.vertexNormal = vertexNormal;
+    surface.vertexNormal = normalWS;
     float2 normalUv = uvs[MaterialSrg::m_normalMapUvIndex];
     float3x3 uvMatrix = MaterialSrg::m_normalMapUvIndex == 0 ? MaterialSrg::m_uvMatrix : CreateIdentity3x3(); // By design, only UV0 is allowed to apply transforms.
     float detailLayerNormalFactor = MaterialSrg::m_detail_normal_factor * detailLayerBlendFactor;
     surface.normal = GetDetailedNormalInputWS(
-        isFrontFace, vertexNormal,
+        isFrontFace, normalWS,
         tangents[MaterialSrg::m_normalMapUvIndex],      bitangents[MaterialSrg::m_normalMapUvIndex],      MaterialSrg::m_normalMap,             MaterialSrg::m_sampler, normalUv, MaterialSrg::m_normalFactor,  MaterialSrg::m_flipNormalX,         MaterialSrg::m_flipNormalY,         uvMatrix,                      o_normal_useTexture,
         tangents[MaterialSrg::m_detail_allMapsUvIndex], bitangents[MaterialSrg::m_detail_allMapsUvIndex], MaterialSrg::m_detail_normal_texture, MaterialSrg::m_sampler, detailUv, detailLayerNormalFactor,      MaterialSrg::m_detail_normal_flipX, MaterialSrg::m_detail_normal_flipY, MaterialSrg::m_detailUvMatrix, o_detail_normal_useTexture);
 
@@ -151,7 +151,7 @@ Surface EvaluateSurface_EnhancedPBR(
             float3x3 uvMatrix = MaterialSrg::m_clearCoatNormalMapUvIndex == 0 ? MaterialSrg::m_uvMatrix : CreateIdentity3x3();
             GetClearCoatInputs(MaterialSrg::m_clearCoatInfluenceMap, uvs[MaterialSrg::m_clearCoatInfluenceMapUvIndex], MaterialSrg::m_clearCoatFactor, o_clearCoat_factor_useTexture,
                                MaterialSrg::m_clearCoatRoughnessMap, uvs[MaterialSrg::m_clearCoatRoughnessMapUvIndex], MaterialSrg::m_clearCoatRoughness, o_clearCoat_roughness_useTexture,
-                               MaterialSrg::m_clearCoatNormalMap,    uvs[MaterialSrg::m_clearCoatNormalMapUvIndex], vertexNormal, o_clearCoat_normal_useTexture, MaterialSrg::m_clearCoatNormalStrength,
+                               MaterialSrg::m_clearCoatNormalMap,    uvs[MaterialSrg::m_clearCoatNormalMapUvIndex], normalWS, o_clearCoat_normal_useTexture, MaterialSrg::m_clearCoatNormalStrength,
                                uvMatrix, tangents[MaterialSrg::m_clearCoatNormalMapUvIndex], bitangents[MaterialSrg::m_clearCoatNormalMapUvIndex],
                                MaterialSrg::m_sampler, isFrontFace,
                                surface.clearCoat.factor, surface.clearCoat.roughness, surface.clearCoat.normal);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_SurfaceEval.azsli
@@ -168,7 +168,7 @@ Surface EvaluateSurface_EnhancedPBR(
     return surface;
 }
 
-Surface EvaluateSurface_EnhancedPBR(PixelGeometryData geoData)
+Surface EvaluateSurface_EnhancedPBR(VsOutput IN, PixelGeometryData geoData)
 {
     return EvaluateSurface_EnhancedPBR(
         geoData.positionWS,

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_SurfaceEval.azsli
@@ -12,7 +12,7 @@
 // used in your shader. Simply #define EvaluateSurface to your custom definition before including this file
 //
 #ifndef EvaluateSurface
-#define EvaluateSurface(geoData)        EvaluateSurface_EnhancedPBR(geoData)
+#define EvaluateSurface EvaluateSurface_EnhancedPBR
 #endif
 
 #include "../StandardPBR/StandardPBR_SurfaceEval.azsli"

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_VertexEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_VertexEval.azsli
@@ -12,7 +12,7 @@
 // EvaluateVertexGeometry used in your shader. Simply #define EvaluateVertexGeometry before including this file
 //
 #ifndef EvaluateVertexGeometry
-#define EvaluateVertexGeometry(IN)      EvaluateVertexGeometry_EnhancedPBR(IN)
+#define EvaluateVertexGeometry EvaluateVertexGeometry_EnhancedPBR
 #endif
 
 #include "../BasePBR/BasePBR_VertexEval.azsli"

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_PixelGeometryEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_PixelGeometryEval.azsli
@@ -12,7 +12,7 @@
 // used in your shader. Simply #define EvaluatePixelGeometry to your custom definition before including this file
 //
 #ifndef EvaluatePixelGeometry
-#define EvaluatePixelGeometry(IN, isFrontFace)      EvaluatePixelGeometry_Eye(IN, isFrontFace)
+#define EvaluatePixelGeometry EvaluatePixelGeometry_Eye
 #endif
 
 #include "../MaterialFunctions/EvaluateTangentFrame.azsli"

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_PixelGeometryEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_PixelGeometryEval.azsli
@@ -22,9 +22,9 @@
 // way to handle this.
 PixelGeometryData EvaluatePixelGeometry_Eye(
     float3 positionWS,
-    float3 normal,
-    float3 tangent,
-    float3 bitangent,
+    float3 normalWS,
+    float3 tangentWS,
+    float3 bitangentWS,
     float2 uvs[UvSetCount],
     bool isFrontFace,
     bool evaluateTangentFrame)
@@ -32,13 +32,13 @@ PixelGeometryData EvaluatePixelGeometry_Eye(
     PixelGeometryData geoData;
 
     geoData.positionWS = positionWS;
-    geoData.vertexNormal = normalize(normal);
+    geoData.vertexNormal = normalize(normalWS);
 
-    geoData.tangents[0] = tangent;
-    geoData.tangents[1] = tangent;
+    geoData.tangents[0] = tangentWS;
+    geoData.tangents[1] = tangentWS;
 
-    geoData.bitangents[0] = bitangent;
-    geoData.bitangents[1] = bitangent;
+    geoData.bitangents[0] = bitangentWS;
+    geoData.bitangents[1] = bitangentWS;
 
     geoData.uvs = uvs;
     geoData.isFrontFace = isFrontFace;
@@ -48,7 +48,7 @@ PixelGeometryData EvaluatePixelGeometry_Eye(
         for (int i = 0; i != UvSetCount; ++i)
         {
             EvaluateTangentFrame(geoData.vertexNormal, positionWS, isFrontFace, uvs[i], i,
-                tangent, bitangent, geoData.tangents[i], geoData.bitangents[i]);
+                tangentWS, bitangentWS, geoData.tangents[i], geoData.bitangents[i]);
         }
     }
 
@@ -57,16 +57,16 @@ PixelGeometryData EvaluatePixelGeometry_Eye(
 
 PixelGeometryData EvaluatePixelGeometry_Eye(
     float3 positionWS,
-    float3 normal,
-    float3 tangent,
-    float3 bitangent,
+    float3 normalWS,
+    float3 tangentWS,
+    float3 bitangentWS,
     float2 uv[UvSetCount],
     float3 localPosition,
     bool isFrontFace)
 {
     // Base PBR Geo Data
     bool evaluateTangentFrame = o_iris_o_normal_useTexture || o_sclera_o_normal_useTexture;
-    PixelGeometryData geoData = EvaluatePixelGeometry_Eye(positionWS, normal, tangent, bitangent, uv, isFrontFace, evaluateTangentFrame);
+    PixelGeometryData geoData = EvaluatePixelGeometry_Eye(positionWS, normalWS, tangentWS, bitangentWS, uv, isFrontFace, evaluateTangentFrame);
 
     // Skin specifics
     geoData.localPosition = localPosition;
@@ -79,16 +79,17 @@ PixelGeometryData EvaluatePixelGeometry_Eye(VsOutput IN, bool isFrontFace)
     float4x4 objectToWorld = ObjectSrg::GetWorldMatrix();
     float3x3 objectToWorldIT = ObjectSrg::GetWorldMatrixInverseTranspose();
 
-    float3 vertexNormal, vertexTangent, vertexBitangent;
-    ConstructTBN(IN.normal, IN.tangent, objectToWorld, objectToWorldIT, vertexNormal, vertexTangent, vertexBitangent);
+    float3 normalWS, tangentWS, bitangentWS;
+    ConstructTBN(IN.normal, IN.tangent, objectToWorld, objectToWorldIT, normalWS, tangentWS, bitangentWS);
+
     // Bitangent is temporarily added back to fix the eye material screenshot test.
-    vertexBitangent = normalize(mul(objectToWorld, float4(IN.bitangent, 0.0)).xyz);
+    bitangentWS = normalize(mul(objectToWorld, float4(IN.bitangent, 0.0)).xyz);
 
     return EvaluatePixelGeometry_Eye(
         IN.worldPosition,
-        vertexNormal,
-        vertexTangent,
-        vertexBitangent,
+        normalWS,
+        tangentWS,
+        bitangentWS,
         IN.uvs,
         IN.localPosition,
         isFrontFace);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_SurfaceEval.azsli
@@ -12,7 +12,7 @@
 // used in your shader. Simply #define EvaluateSurface to your custom definition before including this file
 //
 #ifndef EvaluateSurface
-#define EvaluateSurface(geoData)        EvaluateSurface_Eye(geoData)
+#define EvaluateSurface EvaluateSurface_Eye
 #endif
 
 #include <Atom/Features/MatrixUtility.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_SurfaceEval.azsli
@@ -149,7 +149,7 @@ Surface EvaluateSurface_Eye(
     return surface;
 }
 
-Surface EvaluateSurface_Eye(PixelGeometryData geoData)
+Surface EvaluateSurface_Eye(VsOutput IN, PixelGeometryData geoData)
 {
     return EvaluateSurface_Eye(
         geoData.positionWS,

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_VertexEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_VertexEval.azsli
@@ -12,7 +12,7 @@
 // EvaluateVertexGeometry used in your shader. Simply #define EvaluateVertexGeometry before including this file
 //
 #ifndef EvaluateVertexGeometry
-#define EvaluateVertexGeometry(IN)      EvaluateVertexGeometry_Eye(IN)
+#define EvaluateVertexGeometry EvaluateVertexGeometry_Eye
 #endif
 
 #include <Atom/RPI/TangentSpace.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_PixelGeometryEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_PixelGeometryEval.azsli
@@ -19,16 +19,16 @@
 
 PixelGeometryData EvaluatePixelGeometry_Skin(
     float3 positionWS,
-    float3 normal,
-    float3 tangent,
-    float3 bitangent,
+    float3 normalWS,
+    float3 tangentWS,
+    float3 bitangentWS,
     float2 uvs[UvSetCount],
     float2 detailUv,
     float4 wrinkleBlendFactors,
     bool isFrontFace)
 {
     // Base PBR Geo Data
-    PixelGeometryData geoData = EvaluatePixelGeometry_BasePBR(positionWS, normal, tangent, bitangent, uvs, isFrontFace);
+    PixelGeometryData geoData = EvaluatePixelGeometry_BasePBR(positionWS, normalWS, tangentWS, bitangentWS, uvs, isFrontFace);
 
     // Skin specifics
     geoData.detailUv = detailUv;
@@ -42,14 +42,14 @@ PixelGeometryData EvaluatePixelGeometry_Skin(VsOutput IN, bool isFrontFace)
     float4x4 objectToWorld = ObjectSrg::GetWorldMatrix();
     float3x3 objectToWorldIT = ObjectSrg::GetWorldMatrixInverseTranspose();
 
-    float3 vertexNormal, vertexTangent, vertexBitangent;
-    ConstructTBN(IN.normal, IN.tangent, objectToWorld, objectToWorldIT, vertexNormal, vertexTangent, vertexBitangent);
+    float3 normalWS, tangentWS, bitangentWS;
+    ConstructTBN(IN.normal, IN.tangent, objectToWorld, objectToWorldIT, normalWS, tangentWS, bitangentWS);
 
     return EvaluatePixelGeometry_Skin(
         IN.worldPosition,
-        vertexNormal,
-        vertexTangent,
-        vertexBitangent,
+        normalWS,
+        tangentWS,
+        bitangentWS,
         IN.uvs,
         IN.detailUv,
         IN.wrinkleBlendFactors,

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_PixelGeometryEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_PixelGeometryEval.azsli
@@ -12,7 +12,7 @@
 // used in your shader. Simply #define EvaluatePixelGeometry to your custom definition before including this file
 //
 #ifndef EvaluatePixelGeometry
-#define EvaluatePixelGeometry(IN, isFrontFace)      EvaluatePixelGeometry_Skin(IN, isFrontFace)
+#define EvaluatePixelGeometry EvaluatePixelGeometry_Skin
 #endif
 
 #include "../BasePBR/BasePBR_PixelGeometryEval.azsli"

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_SurfaceEval.azsli
@@ -12,7 +12,7 @@
 // used in your shader. Simply #define EvaluateSurface to your custom definition before including this file
 //
 #ifndef EvaluateSurface
-#define EvaluateSurface(geoData)        EvaluateSurface_Skin(geoData)
+#define EvaluateSurface EvaluateSurface_Skin
 #endif
 
 #include <Atom/Features/MatrixUtility.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_SurfaceEval.azsli
@@ -218,7 +218,7 @@ Surface EvaluateSurface_Skin(
     return surface;
 }
 
-Surface EvaluateSurface_Skin(PixelGeometryData geoData)
+Surface EvaluateSurface_Skin(VsOutput IN, PixelGeometryData geoData)
 {
     return EvaluateSurface_Skin(
         geoData.positionWS,

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_VertexEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_VertexEval.azsli
@@ -12,7 +12,7 @@
 // EvaluateVertexGeometry used in your shader. Simply #define EvaluateVertexGeometry before including this file
 //
 #ifndef EvaluateVertexGeometry
-#define EvaluateVertexGeometry(IN)      EvaluateVertexGeometry_Skin(IN)
+#define EvaluateVertexGeometry EvaluateVertexGeometry_Skin
 #endif
 
 // Indicates whether the vertex input struct's "m_optional_blendMask" is bound. If false, it is not safe to read from m_optional_blendMask.

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_LightingEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_LightingEval.azsli
@@ -12,7 +12,7 @@
 // used in your shader. Simply #define EvaluateLighting to your custom definition before including this file
 //
 #ifndef EvaluateLighting
-#define EvaluateLighting(surface, screenPosition)       EvaluateLighting_StandardPBR(surface, screenPosition)
+#define EvaluateLighting EvaluateLighting_StandardPBR
 #endif
 
 #include "../BasePBR/BasePBR_LightingEval.azsli"

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_PixelGeometryEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_PixelGeometryEval.azsli
@@ -23,13 +23,13 @@
 PixelGeometryData EvaluatePixelGeometry_StandardPBR(
     inout float4 positionSV,
     float3 positionWS,
-    float3 normal,
-    float3 tangent,
-    float3 bitangent,
+    float3 normalWS,
+    float3 tangentWS,
+    float3 bitangentWS,
     float2 uvs[UvSetCount],
     bool isFrontFace)
 {
-    PixelGeometryData geoData = EvaluatePixelGeometry_BasePBR(positionWS, normal, tangent, bitangent, uvs, isFrontFace);
+    PixelGeometryData geoData = EvaluatePixelGeometry_BasePBR(positionWS, normalWS, tangentWS, bitangentWS, uvs, isFrontFace);
 
     // ------- Parallax -------
 
@@ -49,15 +49,15 @@ PixelGeometryData EvaluatePixelGeometry_StandardPBR(inout VsOutput IN, bool isFr
     float4x4 objectToWorld = ObjectSrg::GetWorldMatrix();
     float3x3 objectToWorldIT = ObjectSrg::GetWorldMatrixInverseTranspose();
 
-    float3 vertexNormal, vertexTangent, vertexBitangent;
-    ConstructTBN(IN.normal, IN.tangent, objectToWorld, objectToWorldIT, vertexNormal, vertexTangent, vertexBitangent);
+    float3 normalWS, tangentWS, bitangentWS;
+    ConstructTBN(IN.normal, IN.tangent, objectToWorld, objectToWorldIT, normalWS, tangentWS, bitangentWS);
 
     return EvaluatePixelGeometry_StandardPBR(
         IN.position,
         IN.worldPosition,
-        vertexNormal,
-        vertexTangent,
-        vertexBitangent,
+        normalWS,
+        tangentWS,
+        bitangentWS,
         IN.uvs,
         isFrontFace);
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_PixelGeometryEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_PixelGeometryEval.azsli
@@ -12,7 +12,7 @@
 // used in your shader. Simply #define EvaluatePixelGeometry to your custom definition before including this file
 //
 #ifndef EvaluatePixelGeometry
-#define EvaluatePixelGeometry(IN, isFrontFace)      EvaluatePixelGeometry_StandardPBR(IN, isFrontFace)
+#define EvaluatePixelGeometry EvaluatePixelGeometry_StandardPBR
 #endif
 
 #include "../BasePBR/BasePBR_PixelGeometryEval.azsli"

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_SurfaceEval.azsli
@@ -79,7 +79,7 @@ Surface EvaluateSurface_StandardPBR(
     return surface;
 }
 
-Surface EvaluateSurface_StandardPBR(PixelGeometryData geoData)
+Surface EvaluateSurface_StandardPBR(VsOutput IN, PixelGeometryData geoData)
 {
     return EvaluateSurface_StandardPBR(
         geoData.positionWS,

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_SurfaceEval.azsli
@@ -12,7 +12,7 @@
 // used in your shader. Simply #define EvaluateSurface to your custom definition before including this file
 //
 #ifndef EvaluateSurface
-#define EvaluateSurface(geoData)        EvaluateSurface_StandardPBR(geoData)
+#define EvaluateSurface EvaluateSurface_StandardPBR
 #endif
 
 #include "../BasePBR/BasePBR_SurfaceEval.azsli"

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_Depth.azsl
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_Depth.azsl
@@ -22,7 +22,7 @@ PsDepthOutput MainPS(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
 {
     PixelGeometryData geoData = EvaluatePixelGeometry(IN, isFrontFace);
 
-    Surface surface = EvaluateSurface(geoData);
+    Surface surface = EvaluateSurface(IN, geoData);
 
 #if !FORCE_OPAQUE
     CheckClipping(surface.alpha, 0.5);

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_Depth.azsl
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_Depth.azsl
@@ -21,6 +21,7 @@ struct PsDepthOutput
 PsDepthOutput MainPS(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
 {
     PixelGeometryData geoData = EvaluatePixelGeometry(IN, isFrontFace);
+
     Surface surface = EvaluateSurface(geoData);
 
 #if !FORCE_OPAQUE

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_SurfaceEval.azsli
@@ -12,7 +12,7 @@
 // used in your shader. Simply #define EvaluateSurface to your custom definition before including this file
 //
 #ifndef EvaluateSurface
-#define EvaluateSurface(geoData)        EvaluateSurface_MaterialGraphName(geoData)
+#define EvaluateSurface EvaluateSurface_MaterialGraphName
 #endif
 
 #include <Atom/Features/MatrixUtility.azsli>

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_SurfaceEval.azsli
@@ -20,7 +20,7 @@
 
 Surface EvaluateSurface_MaterialGraphName(
     float3 positionWS,
-    float3 vertexNormal,
+    float3 normalWS,
     float3 tangents[UvSetCount],
     float3 bitangents[UvSetCount],
     float2 uvs[UvSetCount],
@@ -28,13 +28,13 @@ Surface EvaluateSurface_MaterialGraphName(
 {
     #define O3DE_MC_POSITION positionWS
     #define O3DE_MC_UV(index) uvs[clamp(index, 0, UvSetCount-1)];
-    #define O3DE_MC_NORMAL vertexNormal
+    #define O3DE_MC_NORMAL normalWS
     #define O3DE_MC_TANGENT tangents[0]
     #define O3DE_MC_BITANGENT bitangents[0]
     #define O3DE_MC_WORLD_POSITION positionWS
 
     // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inNormal, inBaseColor, inMetallic, inRoughness, inSpecularF0Factor
-    float3 inNormal = vertexNormal;
+    float3 inNormal = normalWS;
     float3 inBaseColor = {1.0, 1.0, 1.0};
     float inMetallic = 0.0;
     float inRoughness = 0.0;
@@ -50,8 +50,8 @@ Surface EvaluateSurface_MaterialGraphName(
 
     Surface surface;
     surface.position = positionWS;
-    surface.vertexNormal = vertexNormal;
-    surface.normal = normalize(o_normal_override_enabled ? GetWorldSpaceNormal((float2)inNormal, vertexNormal, tangents[0], bitangents[0]) : vertexNormal);
+    surface.vertexNormal = normalWS;
+    surface.normal = normalize(o_normal_override_enabled ? GetWorldSpaceNormal((float2)inNormal, normalWS, tangents[0], bitangents[0]) : normalWS);
     surface.roughnessLinear = inRoughness;
     surface.SetAlbedoAndSpecularF0(inBaseColor, inSpecularF0Factor, inMetallic);
     surface.CalculateRoughnessA();

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_SurfaceEval.azsli
@@ -19,6 +19,7 @@
 #include <Atom/RPI/TangentSpace.azsli>
 
 Surface EvaluateSurface_MaterialGraphName(
+    VsOutput IN,
     float3 positionWS,
     float3 normalWS,
     float3 tangents[UvSetCount],
@@ -26,12 +27,16 @@ Surface EvaluateSurface_MaterialGraphName(
     float2 uvs[UvSetCount],
     bool isFrontFace)
 {
-    #define O3DE_MC_POSITION positionWS
+    const float3 bitangent = cross((float3)IN.normal, (float3)IN.tangent);
+    const float3 O3DE_MC_POSITION = (float3)IN.position;
+    const float3 O3DE_MC_NORMAL = (float3)IN.normal;
+    const float3 O3DE_MC_TANGENT = (float3)IN.tangent;
+    const float3 O3DE_MC_BITANGENT = (float3)bitangent;
+    const float3 O3DE_MC_POSITION_WS = positionWS;
+    const float3 O3DE_MC_NORMAL_WS = normalWS;
+    const float3 O3DE_MC_TANGENT_WS = tangents[0];
+    const float3 O3DE_MC_BITANGENT_WS = bitangents[0];
     #define O3DE_MC_UV(index) uvs[clamp(index, 0, UvSetCount-1)];
-    #define O3DE_MC_NORMAL normalWS
-    #define O3DE_MC_TANGENT tangents[0]
-    #define O3DE_MC_BITANGENT bitangents[0]
-    #define O3DE_MC_WORLD_POSITION positionWS
 
     // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inNormal, inBaseColor, inMetallic, inRoughness, inSpecularF0Factor
     float3 inNormal = normalWS;
@@ -41,12 +46,7 @@ Surface EvaluateSurface_MaterialGraphName(
     float inSpecularF0Factor = 0.0;
     // O3DE_GENERATED_INSTRUCTIONS_END
 
-    #undef O3DE_MC_POSITION
     #undef O3DE_MC_UV
-    #undef O3DE_MC_NORMAL
-    #undef O3DE_MC_TANGENT
-    #undef O3DE_MC_BITANGENT
-    #undef O3DE_MC_WORLD_POSITION
 
     Surface surface;
     surface.position = positionWS;
@@ -61,6 +61,7 @@ Surface EvaluateSurface_MaterialGraphName(
 Surface EvaluateSurface_MaterialGraphName(VsOutput IN, PixelGeometryData geoData)
 {
     return EvaluateSurface_MaterialGraphName(
+        IN,
         geoData.positionWS,
         geoData.vertexNormal,
         geoData.tangents,

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_SurfaceEval.azsli
@@ -58,7 +58,7 @@ Surface EvaluateSurface_MaterialGraphName(
     return surface;
 }
 
-Surface EvaluateSurface_MaterialGraphName(PixelGeometryData geoData)
+Surface EvaluateSurface_MaterialGraphName(VsOutput IN, PixelGeometryData geoData)
 {
     return EvaluateSurface_MaterialGraphName(
         geoData.positionWS,

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_VertexEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_VertexEval.azsli
@@ -24,31 +24,29 @@ VsOutput EvaluateVertexGeometry_MaterialGraphName(
     float2 uv0,
     float2 uv1)
 {
-    float3 bitangent = cross(normal, (float3)tangent);
-    float4x4 objectToWorld = ObjectSrg::GetWorldMatrix();
-    float3x3 objectToWorldIT = ObjectSrg::GetWorldMatrixInverseTranspose();
-    float4 positionWS = mul(objectToWorld, float4(position, 1.0));
+    const float4x4 objectToWorld = ObjectSrg::GetWorldMatrix();
+    const float3x3 objectToWorldIT = ObjectSrg::GetWorldMatrixInverseTranspose();
+    const float4 positionWS = mul(objectToWorld, float4(position, 1.0));
+    const float3 bitangent = cross(normal, (float3)tangent);
 
     float3 normalWS, tangentWS, bitangentWS;
     ConstructTBN(normal, tangent, objectToWorld, objectToWorldIT, normalWS, tangentWS, bitangentWS);
 
-    #define O3DE_MC_POSITION position
+    const float3 O3DE_MC_POSITION = position;
+    const float3 O3DE_MC_NORMAL = normal;
+    const float3 O3DE_MC_TANGENT = tangent;
+    const float3 O3DE_MC_BITANGENT = bitangent;
+    const float3 O3DE_MC_POSITION_WS = positionWS;
+    const float3 O3DE_MC_NORMAL_WS = normalWS;
+    const float3 O3DE_MC_TANGENT_WS = tangentWS;
+    const float3 O3DE_MC_BITANGENT_WS = bitangentWS;
     #define O3DE_MC_UV(index) (index == 0 ? uv0 : uv1);
-    #define O3DE_MC_NORMAL normalWS
-    #define O3DE_MC_TANGENT tangentWS
-    #define O3DE_MC_BITANGENT bitangentWS
-    #define O3DE_MC_WORLD_POSITION positionWS
 
     // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inPositionOffset
     float3 inPositionOffset = {0.0, 0.0, 0.0};
     // O3DE_GENERATED_INSTRUCTIONS_END
 
-    #undef O3DE_MC_POSITION
     #undef O3DE_MC_UV
-    #undef O3DE_MC_NORMAL
-    #undef O3DE_MC_TANGENT
-    #undef O3DE_MC_BITANGENT
-    #undef O3DE_MC_WORLD_POSITION
 
     VsOutput output;
     output.worldPosition = (float3)positionWS + (float3)inPositionOffset;

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_VertexEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_VertexEval.azsli
@@ -12,7 +12,7 @@
 // EvaluateVertexGeometry used in your shader. Simply #define EvaluateVertexGeometry before including this file
 //
 #ifndef EvaluateVertexGeometry
-#define EvaluateVertexGeometry(IN)      EvaluateVertexGeometry_MaterialGraphName(IN)
+#define EvaluateVertexGeometry EvaluateVertexGeometry_MaterialGraphName
 #endif
 
 #include <Atom/RPI/TangentSpace.azsli>

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_VertexEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_VertexEval.azsli
@@ -24,16 +24,20 @@ VsOutput EvaluateVertexGeometry_MaterialGraphName(
     float2 uv0,
     float2 uv1)
 {
-    float4x4 objectToWorld = ObjectSrg::GetWorldMatrix();
-    float4 worldPosition = mul(objectToWorld, float4(position, 1.0));
     float3 bitangent = cross(normal, (float3)tangent);
+    float4x4 objectToWorld = ObjectSrg::GetWorldMatrix();
+    float3x3 objectToWorldIT = ObjectSrg::GetWorldMatrixInverseTranspose();
+    float4 positionWS = mul(objectToWorld, float4(position, 1.0));
+
+    float3 normalWS, tangentWS, bitangentWS;
+    ConstructTBN(normal, tangent, objectToWorld, objectToWorldIT, normalWS, tangentWS, bitangentWS);
 
     #define O3DE_MC_POSITION position
     #define O3DE_MC_UV(index) (index == 0 ? uv0 : uv1);
-    #define O3DE_MC_NORMAL normal
-    #define O3DE_MC_TANGENT tangent
-    #define O3DE_MC_BITANGENT bitangent
-    #define O3DE_MC_WORLD_POSITION worldPosition
+    #define O3DE_MC_NORMAL normalWS
+    #define O3DE_MC_TANGENT tangentWS
+    #define O3DE_MC_BITANGENT bitangentWS
+    #define O3DE_MC_WORLD_POSITION positionWS
 
     // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inPositionOffset
     float3 inPositionOffset = {0.0, 0.0, 0.0};
@@ -47,7 +51,7 @@ VsOutput EvaluateVertexGeometry_MaterialGraphName(
     #undef O3DE_MC_WORLD_POSITION
 
     VsOutput output;
-    output.worldPosition = (float3)worldPosition + (float3)inPositionOffset;
+    output.worldPosition = (float3)positionWS + (float3)inPositionOffset;
     output.position = mul(ViewSrg::m_viewProjectionMatrix, float4(output.worldPosition, 1.0));
     output.uvs[0] = uv0;
     output.uvs[1] = uv1;

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Depth.azsl
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Depth.azsl
@@ -22,7 +22,7 @@ PsDepthOutput MainPS(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
 {
     PixelGeometryData geoData = EvaluatePixelGeometry(IN, isFrontFace);
 
-    Surface surface = EvaluateSurface(geoData);
+    Surface surface = EvaluateSurface(IN, geoData);
 
 #if !FORCE_OPAQUE
     CheckClipping(surface.alpha, 0.5);

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Depth.azsl
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Depth.azsl
@@ -21,6 +21,7 @@ struct PsDepthOutput
 PsDepthOutput MainPS(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
 {
     PixelGeometryData geoData = EvaluatePixelGeometry(IN, isFrontFace);
+
     Surface surface = EvaluateSurface(geoData);
 
 #if !FORCE_OPAQUE

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_PixelGeometryEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_PixelGeometryEval.azsli
@@ -12,7 +12,7 @@
 // used in your shader. Simply #define EvaluatePixelGeometry to your custom definition before including this file
 //
 #ifndef EvaluatePixelGeometry
-#define EvaluatePixelGeometry(IN, isFrontFace)      EvaluatePixelGeometry_MaterialGraphName(IN, isFrontFace)
+#define EvaluatePixelGeometry EvaluatePixelGeometry_MaterialGraphName
 #endif
 
 #include <Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_PixelGeometryEval.azsli>

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_PixelGeometryEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_PixelGeometryEval.azsli
@@ -23,16 +23,21 @@
 
 #include <Atom/Features/Debug.azsli>
 
-PixelGeometryData EvaluatePixelGeometry_MaterialGraphName(
-    inout float4 positionSV,
-    float3 positionWS,
-    float3 normal,
-    float3 tangent,
-    float3 bitangent,
-    float2 uvs[UvSetCount],
-    bool isFrontFace)
+PixelGeometryData EvaluatePixelGeometry_MaterialGraphName(inout VsOutput IN, bool isFrontFace)
 {
-    PixelGeometryData geoData = EvaluatePixelGeometry_BasePBR(positionWS, normal, tangent, bitangent, uvs, isFrontFace);
+    float4x4 objectToWorld = ObjectSrg::GetWorldMatrix();
+    float3x3 objectToWorldIT = ObjectSrg::GetWorldMatrixInverseTranspose();
+
+    float3 normalWS, tangentWS, bitangentWS;
+    ConstructTBN(IN.normal, IN.tangent, objectToWorld, objectToWorldIT, normalWS, tangentWS, bitangentWS);
+
+    PixelGeometryData geoData = EvaluatePixelGeometry_BasePBR(
+        IN.worldPosition,
+        normalWS,
+        tangentWS,
+        bitangentWS,
+        IN.uvs,
+        isFrontFace);
 
     // ------- Parallax -------
 
@@ -41,28 +46,18 @@ PixelGeometryData EvaluatePixelGeometry_MaterialGraphName(
 #if ENABLE_PARALLAX
     if(ShouldHandleParallax())
     {
-        SetPixelDepth(geoData.positionWS, geoData.vertexNormal, geoData.tangents, geoData.bitangents,
-                      geoData.uvs, isFrontFace, positionSV.z, positionSV.w, geoData.isDisplacementClipped);
+        SetPixelDepth(
+            geoData.positionWS,
+            geoData.vertexNormal,
+            geoData.tangents,
+            geoData.bitangents,
+            geoData.uvs,
+            isFrontFace,
+            IN.position.z,
+            IN.position.w,
+            geoData.isDisplacementClipped);
     }
 #endif
 
     return geoData;
-}
-
-PixelGeometryData EvaluatePixelGeometry_MaterialGraphName(inout VsOutput IN, bool isFrontFace)
-{
-    float4x4 objectToWorld = ObjectSrg::GetWorldMatrix();
-    float3x3 objectToWorldIT = ObjectSrg::GetWorldMatrixInverseTranspose();
-
-    float3 vertexNormal, vertexTangent, vertexBitangent;
-    ConstructTBN(IN.normal, IN.tangent, objectToWorld, objectToWorldIT, vertexNormal, vertexTangent, vertexBitangent);
-
-    return EvaluatePixelGeometry_MaterialGraphName(
-        IN.position,
-        IN.worldPosition,
-        vertexNormal,
-        vertexTangent,
-        vertexBitangent,
-        IN.uvs,
-        isFrontFace);
 }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
@@ -12,7 +12,7 @@
 // used in your shader. Simply #define EvaluateSurface to your custom definition before including this file
 //
 #ifndef EvaluateSurface
-#define EvaluateSurface(geoData)        EvaluateSurface_MaterialGraphName(geoData)
+#define EvaluateSurface EvaluateSurface_MaterialGraphName
 #endif
 
 #include <Atom/Features/PBR/LightingOptions.azsli>

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
@@ -101,7 +101,7 @@ Surface EvaluateSurface_MaterialGraphName(
     return surface;
 }
 
-Surface EvaluateSurface_MaterialGraphName(PixelGeometryData geoData)
+Surface EvaluateSurface_MaterialGraphName(VsOutput IN, PixelGeometryData geoData)
 {
     return EvaluateSurface_MaterialGraphName(
         geoData.positionWS,

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
@@ -20,6 +20,7 @@
 #include <Atom/RPI/TangentSpace.azsli>
 
 Surface EvaluateSurface_MaterialGraphName(
+    VsOutput IN,
     float3 positionWS,
     float3 normalWS,
     float3 tangents[UvSetCount],
@@ -28,12 +29,16 @@ Surface EvaluateSurface_MaterialGraphName(
     bool isFrontFace,
     bool isDisplacementClipped)
 {
-    #define O3DE_MC_POSITION positionWS
+    const float3 bitangent = cross((float3)IN.normal, (float3)IN.tangent);
+    const float3 O3DE_MC_POSITION = (float3)IN.position;
+    const float3 O3DE_MC_NORMAL = (float3)IN.normal;
+    const float3 O3DE_MC_TANGENT = (float3)IN.tangent;
+    const float3 O3DE_MC_BITANGENT = (float3)bitangent;
+    const float3 O3DE_MC_POSITION_WS = positionWS;
+    const float3 O3DE_MC_NORMAL_WS = normalWS;
+    const float3 O3DE_MC_TANGENT_WS = tangents[0];
+    const float3 O3DE_MC_BITANGENT_WS = bitangents[0];
     #define O3DE_MC_UV(index) uvs[clamp(index, 0, UvSetCount-1)];
-    #define O3DE_MC_NORMAL normalWS
-    #define O3DE_MC_TANGENT tangents[0]
-    #define O3DE_MC_BITANGENT bitangents[0]
-    #define O3DE_MC_WORLD_POSITION positionWS
 
     // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inNormal, inBaseColor, inMetallic, inRoughness, inSpecularF0Factor, inEmissive, inAlpha, inDiffuseAmbientOcclusion, inSpecularOcclusion, inClearCoatFactor, inClearCoatRoughness, inClearCoatNormal, 
     float3 inNormal = normalWS;
@@ -50,12 +55,7 @@ Surface EvaluateSurface_MaterialGraphName(
     float3 inClearCoatNormal = normalWS;
     // O3DE_GENERATED_INSTRUCTIONS_END
 
-    #undef O3DE_MC_POSITION
     #undef O3DE_MC_UV
-    #undef O3DE_MC_NORMAL
-    #undef O3DE_MC_TANGENT
-    #undef O3DE_MC_BITANGENT
-    #undef O3DE_MC_WORLD_POSITION
 
     Surface surface;
     surface.position = positionWS;
@@ -104,6 +104,7 @@ Surface EvaluateSurface_MaterialGraphName(
 Surface EvaluateSurface_MaterialGraphName(VsOutput IN, PixelGeometryData geoData)
 {
     return EvaluateSurface_MaterialGraphName(
+        IN,
         geoData.positionWS,
         geoData.vertexNormal,
         geoData.tangents,

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
@@ -21,7 +21,7 @@
 
 Surface EvaluateSurface_MaterialGraphName(
     float3 positionWS,
-    float3 vertexNormal,
+    float3 normalWS,
     float3 tangents[UvSetCount],
     float3 bitangents[UvSetCount],
     float2 uvs[UvSetCount],
@@ -30,13 +30,13 @@ Surface EvaluateSurface_MaterialGraphName(
 {
     #define O3DE_MC_POSITION positionWS
     #define O3DE_MC_UV(index) uvs[clamp(index, 0, UvSetCount-1)];
-    #define O3DE_MC_NORMAL vertexNormal
+    #define O3DE_MC_NORMAL normalWS
     #define O3DE_MC_TANGENT tangents[0]
     #define O3DE_MC_BITANGENT bitangents[0]
     #define O3DE_MC_WORLD_POSITION positionWS
 
     // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inNormal, inBaseColor, inMetallic, inRoughness, inSpecularF0Factor, inEmissive, inAlpha, inDiffuseAmbientOcclusion, inSpecularOcclusion, inClearCoatFactor, inClearCoatRoughness, inClearCoatNormal, 
-    float3 inNormal = vertexNormal;
+    float3 inNormal = normalWS;
     float3 inBaseColor = {1.0, 1.0, 1.0};
     float inMetallic = 0.0;
     float inRoughness = 0.0;
@@ -47,7 +47,7 @@ Surface EvaluateSurface_MaterialGraphName(
     float inSpecularOcclusion = 1.0;
     float inClearCoatFactor = 0.0;
     float inClearCoatRoughness = 0.0;
-    float3 inClearCoatNormal = vertexNormal;
+    float3 inClearCoatNormal = normalWS;
     // O3DE_GENERATED_INSTRUCTIONS_END
 
     #undef O3DE_MC_POSITION
@@ -59,8 +59,8 @@ Surface EvaluateSurface_MaterialGraphName(
 
     Surface surface;
     surface.position = positionWS;
-    surface.vertexNormal = vertexNormal;
-    surface.normal = normalize(o_normal_override_enabled ? GetWorldSpaceNormal((float2)inNormal, vertexNormal, tangents[0], bitangents[0]) : vertexNormal);
+    surface.vertexNormal = normalWS;
+    surface.normal = normalize(o_normal_override_enabled ? GetWorldSpaceNormal((float2)inNormal, normalWS, tangents[0], bitangents[0]) : normalWS);
     surface.roughnessLinear = inRoughness;
     surface.SetAlbedoAndSpecularF0(inBaseColor, inSpecularF0Factor, inMetallic);
     surface.CalculateRoughnessA();
@@ -91,7 +91,7 @@ Surface EvaluateSurface_MaterialGraphName(
         surface.clearCoat.roughness = max(inClearCoatRoughness, 1e-3);
 
         // Flip normal if back face is rendered   
-        surface.clearCoat.normal = normalize(o_clearCoat_normal_override_enabled ? GetWorldSpaceNormal((float2)inClearCoatNormal, vertexNormal, tangents[0], bitangents[0]) : vertexNormal);
+        surface.clearCoat.normal = normalize(o_clearCoat_normal_override_enabled ? GetWorldSpaceNormal((float2)inClearCoatNormal, normalWS, tangents[0], bitangents[0]) : normalWS);
         surface.clearCoat.normal *= mad(isFrontFace, 2.0, -1.0);
 
         ApplyClearCoatToSpecularF0(surface.specularF0, surface.clearCoat.factor);

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_VertexEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_VertexEval.azsli
@@ -24,31 +24,29 @@ VsOutput EvaluateVertexGeometry_MaterialGraphName(
     float2 uv0,
     float2 uv1)
 {
-    float3 bitangent = cross(normal, (float3)tangent);
-    float4x4 objectToWorld = ObjectSrg::GetWorldMatrix();
-    float3x3 objectToWorldIT = ObjectSrg::GetWorldMatrixInverseTranspose();
-    float4 positionWS = mul(objectToWorld, float4(position, 1.0));
+    const float4x4 objectToWorld = ObjectSrg::GetWorldMatrix();
+    const float3x3 objectToWorldIT = ObjectSrg::GetWorldMatrixInverseTranspose();
+    const float4 positionWS = mul(objectToWorld, float4(position, 1.0));
+    const float3 bitangent = cross(normal, (float3)tangent);
 
     float3 normalWS, tangentWS, bitangentWS;
     ConstructTBN(normal, tangent, objectToWorld, objectToWorldIT, normalWS, tangentWS, bitangentWS);
 
-    #define O3DE_MC_POSITION position
+    const float3 O3DE_MC_POSITION = position;
+    const float3 O3DE_MC_NORMAL = normal;
+    const float3 O3DE_MC_TANGENT = tangent;
+    const float3 O3DE_MC_BITANGENT = bitangent;
+    const float3 O3DE_MC_POSITION_WS = positionWS;
+    const float3 O3DE_MC_NORMAL_WS = normalWS;
+    const float3 O3DE_MC_TANGENT_WS = tangentWS;
+    const float3 O3DE_MC_BITANGENT_WS = bitangentWS;
     #define O3DE_MC_UV(index) (index == 0 ? uv0 : uv1);
-    #define O3DE_MC_NORMAL normalWS
-    #define O3DE_MC_TANGENT tangentWS
-    #define O3DE_MC_BITANGENT bitangentWS
-    #define O3DE_MC_WORLD_POSITION positionWS
 
     // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inPositionOffset
     float3 inPositionOffset = {0.0, 0.0, 0.0};
     // O3DE_GENERATED_INSTRUCTIONS_END
 
-    #undef O3DE_MC_POSITION
     #undef O3DE_MC_UV
-    #undef O3DE_MC_NORMAL
-    #undef O3DE_MC_TANGENT
-    #undef O3DE_MC_BITANGENT
-    #undef O3DE_MC_WORLD_POSITION
 
     VsOutput output;
     output.worldPosition = (float3)positionWS + (float3)inPositionOffset;

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_VertexEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_VertexEval.azsli
@@ -12,7 +12,7 @@
 // EvaluateVertexGeometry used in your shader. Simply #define EvaluateVertexGeometry before including this file
 //
 #ifndef EvaluateVertexGeometry
-#define EvaluateVertexGeometry(IN)      EvaluateVertexGeometry_MaterialGraphName(IN)
+#define EvaluateVertexGeometry EvaluateVertexGeometry_MaterialGraphName
 #endif
 
 #include <Atom/RPI/TangentSpace.azsli>

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_VertexEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_VertexEval.azsli
@@ -24,19 +24,20 @@ VsOutput EvaluateVertexGeometry_MaterialGraphName(
     float2 uv0,
     float2 uv1)
 {
+    float3 bitangent = cross(normal, (float3)tangent);
     float4x4 objectToWorld = ObjectSrg::GetWorldMatrix();
     float3x3 objectToWorldIT = ObjectSrg::GetWorldMatrixInverseTranspose();
-    float4 worldPosition = mul(objectToWorld, float4(position, 1.0));
+    float4 positionWS = mul(objectToWorld, float4(position, 1.0));
 
-    float3 vertexNormal, vertexTangent, vertexBitangent;
-    ConstructTBN(normal, tangent, objectToWorld, objectToWorldIT, vertexNormal, vertexTangent, vertexBitangent);
+    float3 normalWS, tangentWS, bitangentWS;
+    ConstructTBN(normal, tangent, objectToWorld, objectToWorldIT, normalWS, tangentWS, bitangentWS);
 
     #define O3DE_MC_POSITION position
     #define O3DE_MC_UV(index) (index == 0 ? uv0 : uv1);
-    #define O3DE_MC_NORMAL vertexNormal
-    #define O3DE_MC_TANGENT vertexTangent
-    #define O3DE_MC_BITANGENT vertexBitangent
-    #define O3DE_MC_WORLD_POSITION worldPosition
+    #define O3DE_MC_NORMAL normalWS
+    #define O3DE_MC_TANGENT tangentWS
+    #define O3DE_MC_BITANGENT bitangentWS
+    #define O3DE_MC_WORLD_POSITION positionWS
 
     // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inPositionOffset
     float3 inPositionOffset = {0.0, 0.0, 0.0};
@@ -50,7 +51,7 @@ VsOutput EvaluateVertexGeometry_MaterialGraphName(
     #undef O3DE_MC_WORLD_POSITION
 
     VsOutput output;
-    output.worldPosition = (float3)worldPosition + (float3)inPositionOffset;
+    output.worldPosition = (float3)positionWS + (float3)inPositionOffset;
     output.position = mul(ViewSrg::m_viewProjectionMatrix, float4(output.worldPosition, 1.0));
     output.uvs[0] = uv0;
     output.uvs[1] = uv1;

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/Vertex/bitangent.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/Vertex/bitangent.materialgraphnode
@@ -3,25 +3,25 @@
     "Version": 1,
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
-        "id": "{20D18D54-9A1D-4C4E-B676-F72097AC3A93}",
+        "id": "{2D89EC04-B4BB-4B7E-81F6-9CF1B73EA13C}",
         "category": "Vertex",
-        "title": "World Position",
+        "title": "Bitangent",
         "titlePaletteName": "VertexNodeTitlePalette",
-        "description": "The world position of the current vertex or fragment",
+        "description": "The surface bitangent of the current vertex or fragment",
         "slotDataTypeGroups": [
-            "outPosition",
+            "outBitangent",
             "outX|outY|outZ"
         ],
         "outputSlots": [
             {
-                "name": "outPosition",
-                "displayName": "Position",
-                "description": "Position",
+                "name": "outBitangent",
+                "displayName": "Bitangent",
+                "description": "Bitangent",
                 "supportedDataTypeRegex": "float3",
                 "defaultDataType": "float3",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_BITANGENT;"
                     ]
                 }
             },
@@ -33,7 +33,7 @@
                 "defaultDataType": "float",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS.x;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_BITANGENT.x;"
                     ]
                 }
             },
@@ -45,7 +45,7 @@
                 "defaultDataType": "float",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS.y;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_BITANGENT.y;"
                     ]
                 }
             },
@@ -57,7 +57,7 @@
                 "defaultDataType": "float",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS.z;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_BITANGENT.z;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/Vertex/tangent.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/Vertex/tangent.materialgraphnode
@@ -3,25 +3,25 @@
     "Version": 1,
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
-        "id": "{20D18D54-9A1D-4C4E-B676-F72097AC3A93}",
+        "id": "{AFE06E24-AAB9-4843-8C25-12EAA76A5779}",
         "category": "Vertex",
-        "title": "World Position",
+        "title": "Tangent",
         "titlePaletteName": "VertexNodeTitlePalette",
-        "description": "The world position of the current vertex or fragment",
+        "description": "The surface tangent of the current vertex or fragment",
         "slotDataTypeGroups": [
-            "outPosition",
+            "outTangent",
             "outX|outY|outZ"
         ],
         "outputSlots": [
             {
-                "name": "outPosition",
-                "displayName": "Position",
-                "description": "Position",
+                "name": "outTangent",
+                "displayName": "Tangent",
+                "description": "Tangent",
                 "supportedDataTypeRegex": "float3",
                 "defaultDataType": "float3",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_TANGENT;"
                     ]
                 }
             },
@@ -33,7 +33,7 @@
                 "defaultDataType": "float",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS.x;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_TANGENT.x;"
                     ]
                 }
             },
@@ -45,7 +45,7 @@
                 "defaultDataType": "float",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS.y;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_TANGENT.y;"
                     ]
                 }
             },
@@ -57,7 +57,7 @@
                 "defaultDataType": "float",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS.z;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_TANGENT.z;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/Vertex/worldbitangent.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/Vertex/worldbitangent.materialgraphnode
@@ -3,25 +3,25 @@
     "Version": 1,
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
-        "id": "{20D18D54-9A1D-4C4E-B676-F72097AC3A93}",
+        "id": "{11281381-0167-4A1E-8823-FCA303024E4F}",
         "category": "Vertex",
-        "title": "World Position",
+        "title": "World Bitangent",
         "titlePaletteName": "VertexNodeTitlePalette",
-        "description": "The world position of the current vertex or fragment",
+        "description": "The surface bitangent of the current vertex or fragment in world space",
         "slotDataTypeGroups": [
-            "outPosition",
+            "outBitangent",
             "outX|outY|outZ"
         ],
         "outputSlots": [
             {
-                "name": "outPosition",
-                "displayName": "Position",
-                "description": "Position",
+                "name": "outBitangent",
+                "displayName": "Bitangent",
+                "description": "Bitangent",
                 "supportedDataTypeRegex": "float3",
                 "defaultDataType": "float3",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_BITANGENT_WS;"
                     ]
                 }
             },
@@ -33,7 +33,7 @@
                 "defaultDataType": "float",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS.x;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_BITANGENT_WS.x;"
                     ]
                 }
             },
@@ -45,7 +45,7 @@
                 "defaultDataType": "float",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS.y;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_BITANGENT_WS.y;"
                     ]
                 }
             },
@@ -57,7 +57,7 @@
                 "defaultDataType": "float",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS.z;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_BITANGENT_WS.z;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/Vertex/worldnormal.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/Vertex/worldnormal.materialgraphnode
@@ -3,25 +3,25 @@
     "Version": 1,
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
-        "id": "{20D18D54-9A1D-4C4E-B676-F72097AC3A93}",
+        "id": "{F1C815E8-0B44-43EA-8176-D075B5B2EA41}",
         "category": "Vertex",
-        "title": "World Position",
+        "title": "World Normal",
         "titlePaletteName": "VertexNodeTitlePalette",
-        "description": "The world position of the current vertex or fragment",
+        "description": "The surface normal of the current vertex or fragment in world space",
         "slotDataTypeGroups": [
-            "outPosition",
+            "outNormal",
             "outX|outY|outZ"
         ],
         "outputSlots": [
             {
-                "name": "outPosition",
-                "displayName": "Position",
-                "description": "Position",
+                "name": "outNormal",
+                "displayName": "Normal",
+                "description": "Normal",
                 "supportedDataTypeRegex": "float3",
                 "defaultDataType": "float3",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_NORMAL_WS;"
                     ]
                 }
             },
@@ -33,7 +33,7 @@
                 "defaultDataType": "float",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS.x;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_NORMAL_WS.x;"
                     ]
                 }
             },
@@ -45,7 +45,7 @@
                 "defaultDataType": "float",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS.y;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_NORMAL_WS.y;"
                     ]
                 }
             },
@@ -57,7 +57,7 @@
                 "defaultDataType": "float",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS.z;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_NORMAL_WS.z;"
                     ]
                 }
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/Vertex/worldtangent.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/Vertex/worldtangent.materialgraphnode
@@ -3,25 +3,25 @@
     "Version": 1,
     "ClassName": "DynamicNodeConfig",
     "ClassData": {
-        "id": "{20D18D54-9A1D-4C4E-B676-F72097AC3A93}",
+        "id": "{24961A95-2B17-48FF-8C78-2574DEBDBD66}",
         "category": "Vertex",
-        "title": "World Position",
+        "title": "World Tangent",
         "titlePaletteName": "VertexNodeTitlePalette",
-        "description": "The world position of the current vertex or fragment",
+        "description": "The surface tangent of the current vertex or fragment in world space",
         "slotDataTypeGroups": [
-            "outPosition",
+            "outTangent",
             "outX|outY|outZ"
         ],
         "outputSlots": [
             {
-                "name": "outPosition",
-                "displayName": "Position",
-                "description": "Position",
+                "name": "outTangent",
+                "displayName": "Tangent",
+                "description": "Tangent",
                 "supportedDataTypeRegex": "float3",
                 "defaultDataType": "float3",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_TANGENT_WS;"
                     ]
                 }
             },
@@ -33,7 +33,7 @@
                 "defaultDataType": "float",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS.x;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_TANGENT_WS.x;"
                     ]
                 }
             },
@@ -45,7 +45,7 @@
                 "defaultDataType": "float",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS.y;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_TANGENT_WS.y;"
                     ]
                 }
             },
@@ -57,7 +57,7 @@
                 "defaultDataType": "float",
                 "settings": {
                     "instructions": [
-                        "SLOTTYPE SLOTNAME = O3DE_MC_POSITION_WS.z;"
+                        "SLOTTYPE SLOTNAME = O3DE_MC_TANGENT_WS.z;"
                     ]
                 }
             }

--- a/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/AutoBrick_ForwardPass.azsl
+++ b/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/AutoBrick_ForwardPass.azsl
@@ -131,8 +131,8 @@ ForwardPassOutput AutoBrick_ForwardPassPS(VSOutput IN)
     float4x4 objectToWorld = ObjectSrg::GetWorldMatrix();
     float3x3 objectToWorldIT = ObjectSrg::GetWorldMatrixInverseTranspose();
 
-    float3 vertexNormal, vertexTangent, vertexBitangent;
-    ConstructTBN(IN.m_normal, IN.m_tangent, objectToWorld, objectToWorldIT, vertexNormal, vertexTangent, vertexBitangent);
+    float3 normalWS, tangentWS, bitangentWS;
+    ConstructTBN(IN.m_normal, IN.m_tangent, objectToWorld, objectToWorldIT, normalWS, tangentWS, bitangentWS);
 
     float3x3 identityUvMatrix = 
         { 1,0,0,
@@ -145,9 +145,9 @@ ForwardPassOutput AutoBrick_ForwardPassPS(VSOutput IN)
                                                       depthOffset,
                                                       IN.m_uv,
                                                       ViewSrg::m_worldPosition.xyz - IN.m_worldPosition, 
-                                                      vertexTangent,
-                                                      vertexBitangent,
-                                                      vertexNormal,
+                                                      tangentWS,
+                                                      bitangentWS,
+                                                      normalWS,
                                                       identityUvMatrix);
     
     IN.m_uv += tangentOffset.m_offsetTS.xy;
@@ -168,7 +168,7 @@ ForwardPassOutput AutoBrick_ForwardPassPS(VSOutput IN)
     float surfaceDepth;
     float3 surfaceNormal;
     GetSurfaceShape(IN.m_uv, surfaceDepth, surfaceNormal);
-    const float3 surfaceNormalWorld = TangentSpaceToWorld(surfaceNormal, vertexNormal, vertexTangent, vertexBitangent);
+    const float3 surfaceNormalWorld = TangentSpaceToWorld(surfaceNormal, normalWS, tangentWS, bitangentWS);
     
     // ------- Surface -------
 

--- a/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/MaterialPipelineTest_Animated.azsli
+++ b/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/MaterialPipelineTest_Animated.azsli
@@ -79,7 +79,7 @@ void CalcPositions(float3 inPosition, out float3 worldPos, out float4 clipPos)
 
     #include <Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceData.azsli>
 
-    Surface EvaluateSurface(PixelGeometryData geoData)
+    Surface EvaluateSurface(VsOutput IN, PixelGeometryData geoData)
     {
         Surface surface;
         surface.position = geoData.positionWS.xyz;

--- a/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/MaterialPipelineTest_Empty.azsli
+++ b/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/MaterialPipelineTest_Empty.azsli
@@ -63,7 +63,7 @@ void CalcPositions(float3 inPosition, out float3 worldPos, out float4 clipPos)
 
     #include <Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceData.azsli>
 
-    Surface EvaluateSurface(PixelGeometryData geoData)
+    Surface EvaluateSurface(VsOutput IN, PixelGeometryData geoData)
     {
         Surface surface;
         surface.position = geoData.positionWS.xyz;

--- a/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/MinimalPBR_ForwardPass.azsl
+++ b/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/MinimalPBR_ForwardPass.azsl
@@ -60,8 +60,8 @@ ForwardPassOutput MinimalPBR_MainPassPS(VSOutput IN)
     float4x4 objectToWorld = ObjectSrg::GetWorldMatrix();
     float3x3 objectToWorldIT = ObjectSrg::GetWorldMatrixInverseTranspose();
 
-    float3 vertexNormal, vertexTangent, vertexBitangent;
-    ConstructTBN(IN.m_normal, IN.m_tangent, objectToWorld, objectToWorldIT, vertexNormal, vertexTangent, vertexBitangent);
+    float3 normalWS, tangentWS, bitangentWS;
+    ConstructTBN(IN.m_normal, IN.m_tangent, objectToWorld, objectToWorldIT, normalWS, tangentWS, bitangentWS);
 
     // ------- Surface -------
 
@@ -69,8 +69,8 @@ ForwardPassOutput MinimalPBR_MainPassPS(VSOutput IN)
     
     // Position, Normal, Roughness
     surface.position = IN.m_worldPosition.xyz;
-    surface.normal = vertexNormal;
-    surface.vertexNormal = vertexNormal;
+    surface.normal = normalWS;
+    surface.vertexNormal = normalWS;
     surface.roughnessLinear = MinimalPBRSrg::m_roughness;
     surface.CalculateRoughnessA();
 


### PR DESCRIPTION
## What does this PR do?

- Updating shaders to rename normal, tangent, bitangent variables to make it clear they’re in world space
- Cleaning up eval function macro parameters, formatting, and spacing
- Updating material pipeline surface eval functions to pass in untransformed vertex data
- Replacing defines with constants for material canvas integration
- Adding constants for local and world space vertex attributes
- Updating and adding nodes for normal, tangent, bitangent in local and world space

## How was this PR tested?

Confirmed that all automated testing shader, material, and model assets compiled successfully in the AP.
Confirmed that new material canvas local and world normal nodes operate as expected.
Confirmed that atom sample viewer assets compiled successfully in the AP.
Attempting to confirm that all atom sample viewer screenshot tests pass but the full test suite stops progressing after The dynamic material test. Investigating...

Corresponding ASV PR https://github.com/o3de/o3de-atom-sampleviewer/pull/592