### PR TITLE
Material Canvas: Remove invalid display mapper enum option

### DIFF
--- a/Gems/Atom/Feature/Common/Code/3rdParty/ACES/ACES/Aces.h
+++ b/Gems/Atom/Feature/Common/Code/3rdParty/ACES/ACES/Aces.h
@@ -145,8 +145,7 @@ namespace AZ
             AcesLut,
             Passthrough,
             GammaSRGB,
-            Reinhard,
-            Invalid
+            Reinhard
         );
 
         enum class ShaperPresetType

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportToolBar.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportToolBar.cpp
@@ -58,28 +58,20 @@ namespace AtomToolsFramework
 
         // Add mapping selection button
         auto displayMapperAction = addAction(QIcon(":/Icons/toneMapping.svg"), "Tone Mapping", this, [this]() {
-            AZStd::unordered_map<AZ::Render::DisplayMapperOperationType, QString> operationNameMap = {
-                { AZ::Render::DisplayMapperOperationType::Reinhard, "Reinhard" },
-                { AZ::Render::DisplayMapperOperationType::GammaSRGB, "GammaSRGB" },
-                { AZ::Render::DisplayMapperOperationType::Passthrough, "Passthrough" },
-                { AZ::Render::DisplayMapperOperationType::AcesLut, "AcesLut" },
-                { AZ::Render::DisplayMapperOperationType::Aces, "Aces" }
-            };
-
             AZ::Render::DisplayMapperOperationType currentOperationType = {};
             EntityPreviewViewportSettingsRequestBus::EventResult(
                 currentOperationType, m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::GetDisplayMapperOperationType);
 
             QMenu menu;
-            for (auto operationNamePair : operationNameMap)
+            for (const auto& operationEnumPair : AZ::AzEnumTraits<AZ::Render::DisplayMapperOperationType>::Members)
             {
-                auto operationAction = menu.addAction(operationNamePair.second, [this, operationNamePair]() {
+                auto operationAction = menu.addAction(operationEnumPair.m_string.data(), [this, operationEnumPair]() {
                     EntityPreviewViewportSettingsRequestBus::Event(
                         m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::SetDisplayMapperOperationType,
-                        operationNamePair.first);
+                        operationEnumPair.m_value);
                 });
                 operationAction->setCheckable(true);
-                operationAction->setChecked(currentOperationType==operationNamePair.first);
+                operationAction->setChecked(currentOperationType == operationEnumPair.m_value);
             }
             menu.exec(QCursor::pos());
         });


### PR DESCRIPTION
## What does this PR do?

Removing invalid display mapper enum options so that it's not selectable from drop downs.

Resolves https://github.com/o3de/o3de/issues/14896

## How was this PR tested?

Confirmed option is not available or selectable in material editor or material canvas toolbar or viewport settings panel.