### PR TITLE
Material Canvas: Refresh graph view after settings change

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Graph/GraphDocumentView.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Graph/GraphDocumentView.h
@@ -11,6 +11,7 @@
 #if !defined(Q_MOC_RUN)
 #include <AtomToolsFramework/Document/AtomToolsDocumentNotificationBus.h>
 #include <AtomToolsFramework/Graph/GraphView.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 #endif
 
 namespace AtomToolsFramework
@@ -34,7 +35,10 @@ namespace AtomToolsFramework
         void OnDocumentClosed(const AZ::Uuid& documentId) override;
         void OnDocumentDestroyed(const AZ::Uuid& documentId) override;
 
+        void OnSettingsChanged();
+
         const AZ::Uuid m_documentId;
         bool m_openedBefore = false;
+        AZ::SettingsRegistryInterface::NotifyEventHandler m_graphViewSettingsNotifyEventHandler;
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Window/AtomToolsMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Window/AtomToolsMainWindow.h
@@ -54,6 +54,7 @@ namespace AtomToolsFramework
 
         virtual void PopulateSettingsInspector(InspectorWidget* inspector) const;
         virtual void OpenSettingsDialog();
+        virtual void OnSettingsDialogClosed();
 
         virtual AZStd::string GetHelpDialogText() const;
         virtual void OpenHelpDialog();

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
@@ -363,6 +363,12 @@ namespace AtomToolsFramework
         dialog.setMinimumSize(0, 0);
         dialog.setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
         dialog.exec();
+
+        OnSettingsDialogClosed();
+    }
+
+    void AtomToolsMainWindow::OnSettingsDialogClosed()
+    {
     }
 
     AZStd::string AtomToolsMainWindow::GetHelpDialogText() const

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
@@ -114,7 +114,7 @@ namespace MaterialCanvas
     void MaterialCanvasApplication::Destroy()
     {
         // Save all of the graph view configuration settings to the settings registry.
-        AtomToolsFramework::SetSettingsObject("/O3DE/Atom/MaterialCanvas/GraphViewSettings", m_graphViewSettingsPtr);
+        AtomToolsFramework::SetSettingsObject("/O3DE/Atom/GraphView/ViewSettings", m_graphViewSettingsPtr);
 
         m_graphViewSettingsPtr.reset();
         m_window.reset();
@@ -225,7 +225,7 @@ namespace MaterialCanvas
     {
         // This configuration data is passed through the main window and graph views to setup translation data, styling, and node palettes
         m_graphViewSettingsPtr = AtomToolsFramework::GetSettingsObject(
-            "/O3DE/Atom/MaterialCanvas/GraphViewSettings", AZStd::make_shared<AtomToolsFramework::GraphViewSettings>());
+            "/O3DE/Atom/GraphView/ViewSettings", AZStd::make_shared<AtomToolsFramework::GraphViewSettings>());
 
         // Initialize the application specific graph view settings that are not serialized.
         m_graphViewSettingsPtr->m_translationPath = "@products@/materialcanvas/translation/materialcanvas_en_us.qm";
@@ -242,7 +242,7 @@ namespace MaterialCanvas
 
         // Initialize the default group preset names and colors needed by the graph canvas view to create node groups.
         const AZStd::map<AZStd::string, AZ::Color> defaultGroupPresets = AtomToolsFramework::GetSettingsObject(
-            "/O3DE/Atom/MaterialCanvas/GraphViewSettings/DefaultGroupPresets",
+            "/O3DE/Atom/GraphView/DefaultGroupPresets",
             AZStd::map<AZStd::string, AZ::Color>{ { "Logic", AZ::Color(0.188f, 0.972f, 0.243f, 1.0f) },
                                                   { "Function", AZ::Color(0.396f, 0.788f, 0.788f, 1.0f) },
                                                   { "Output", AZ::Color(0.866f, 0.498f, 0.427f, 1.0f) },

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
@@ -220,6 +220,12 @@ namespace MaterialCanvas
         Base::PopulateSettingsInspector(inspector);
     }
 
+    void MaterialCanvasMainWindow::OnSettingsDialogClosed()
+    {
+        AtomToolsFramework::SetSettingsObject("/O3DE/Atom/GraphView/ViewSettings", m_graphViewSettingsPtr);
+        Base::OnSettingsDialogClosed();
+    }
+
     AZStd::string MaterialCanvasMainWindow::GetHelpDialogText() const
     {
         return R"(<html><head/><body>

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.h
@@ -51,6 +51,7 @@ namespace MaterialCanvas
 
         // AtomToolsFramework::AtomToolsDocumentMainWindow overrides...
         void PopulateSettingsInspector(AtomToolsFramework::InspectorWidget* inspector) const override;
+        void OnSettingsDialogClosed() override;
         AZStd::string GetHelpDialogText() const override;
 
     private:

--- a/Gems/Atom/Tools/PassCanvas/Code/Source/PassCanvasApplication.cpp
+++ b/Gems/Atom/Tools/PassCanvas/Code/Source/PassCanvasApplication.cpp
@@ -107,7 +107,7 @@ namespace PassCanvas
     void PassCanvasApplication::Destroy()
     {
         // Save all of the graph view configuration settings to the settings registry.
-        AtomToolsFramework::SetSettingsObject("/O3DE/Atom/PassCanvas/GraphViewSettings", m_graphViewSettingsPtr);
+        AtomToolsFramework::SetSettingsObject("/O3DE/Atom/GraphView/ViewSettings", m_graphViewSettingsPtr);
 
         m_graphViewSettingsPtr.reset();
         m_window.reset();
@@ -170,7 +170,7 @@ namespace PassCanvas
     {
         // This configuration data is passed through the main window and graph views to setup translation data, styling, and node palettes
         m_graphViewSettingsPtr = AtomToolsFramework::GetSettingsObject(
-            "/O3DE/Atom/PassCanvas/GraphViewSettings", AZStd::make_shared<AtomToolsFramework::GraphViewSettings>());
+            "/O3DE/Atom/GraphView/ViewSettings", AZStd::make_shared<AtomToolsFramework::GraphViewSettings>());
 
         // Initialize the application specific graph view settings that are not serialized.
         m_graphViewSettingsPtr->m_translationPath = "@products@/passcanvas/translation/passcanvas_en_us.qm";
@@ -187,7 +187,7 @@ namespace PassCanvas
 
         // Initialize the default group preset names and colors needed by the graph canvas view to create node groups.
         const AZStd::map<AZStd::string, AZ::Color> defaultGroupPresets = AtomToolsFramework::GetSettingsObject(
-            "/O3DE/Atom/PassCanvas/GraphViewSettings/DefaultGroupPresets",
+            "/O3DE/Atom/GraphView/DefaultGroupPresets",
             AZStd::map<AZStd::string, AZ::Color>{});
 
         // Connect the graph view settings to the required buses so that they can be accessed throughout the application.

--- a/Gems/Atom/Tools/PassCanvas/Code/Source/Window/PassCanvasMainWindow.cpp
+++ b/Gems/Atom/Tools/PassCanvas/Code/Source/Window/PassCanvasMainWindow.cpp
@@ -150,27 +150,6 @@ namespace PassCanvas
             "Pass Canvas Settings",
             "Pass Canvas Settings",
             { AtomToolsFramework::CreateSettingsPropertyValue(
-                  "/O3DE/Atom/PassCanvas/EnableFasterShaderBuilds",
-                  "Enable Faster Shader Builds",
-                  "By default, some platforms perform an exhaustive compilation of shaders for multiple RHI. For example, the default "
-                  "Windows shader builder settings automatically compiles shaders for DX12, Vulkan, and the Null renderer.\n\nThis option "
-                  "overrides those registry settings and makes compilation and preview times much faster by only compiling shaders for the "
-                  "currently active platform and RHI.\n\nThis also disables automatic shader variant generation.\n\nChanging this setting "
-                  "requires restarting Pass Canvas and the Asset Processor.\n\nChanging the active RHI with this setting enabled may "
-                  "require clearing the cache to regenerate shaders for the new RHI.\n\nThe settings files containing the overrides will be "
-                  "placed in the user/Registry folder for the current project.",
-                  false),
-              AtomToolsFramework::CreateSettingsPropertyValue(
-                  "/O3DE/Atom/PassCanvas/Viewport/ClearPassOnCompileGraphStarted",
-                  "Clear Viewport Pass When Compiling Starts",
-                  "Clear the viewport model's pass whenever compiling shaders and passes starts.",
-                  true),
-              AtomToolsFramework::CreateSettingsPropertyValue(
-                  "/O3DE/Atom/PassCanvas/Viewport/ClearPassOnCompileGraphFailed",
-                  "Clear Viewport Pass When Compiling Fails",
-                  "Clear the viewport model's pass whenever compiling shaders and passes fails.",
-                  true),
-              AtomToolsFramework::CreateSettingsPropertyValue(
                   "/O3DE/Atom/PassCanvas/CreateDefaultDocumentOnStart",
                   "Create Untitled Graph Document On Start",
                   "Create a default, untitled graph document when Pass Canvas starts",
@@ -195,15 +174,15 @@ namespace PassCanvas
         Base::PopulateSettingsInspector(inspector);
     }
 
+    void PassCanvasMainWindow::OnSettingsDialogClosed()
+    {
+        AtomToolsFramework::SetSettingsObject("/O3DE/Atom/GraphView/ViewSettings", m_graphViewSettingsPtr);
+        Base::OnSettingsDialogClosed();
+    }
+
     AZStd::string PassCanvasMainWindow::GetHelpDialogText() const
     {
         return R"(<html><head/><body>
-            <p><h3><u>Shader Build Settings</u></h3></p>
-            <p>Shaders, passes, and other assets will be generated as changes are applied to the graph.
-            The viewport will update and display the generated passes and shaders once they have been
-            compiled by the Asset Processor. This can take a few seconds. Compilation times and preview
-            responsiveness can be improved by enabling the Minimal Shader Build settings in the Tools->Settings
-            menu. Changing the settings will require restarting Pass Canvas and the Asset Processor.</p>
             <p><h3><u>Camera Controls</u></h3></p>
             <p><b>LMB</b> - rotate camera</p>
             <p><b>RMB</b> or <b>Alt+LMB</b> - orbit camera around target</p>

--- a/Gems/Atom/Tools/PassCanvas/Code/Source/Window/PassCanvasMainWindow.h
+++ b/Gems/Atom/Tools/PassCanvas/Code/Source/Window/PassCanvasMainWindow.h
@@ -51,6 +51,7 @@ namespace PassCanvas
 
         // AtomToolsFramework::AtomToolsDocumentMainWindow overrides...
         void PopulateSettingsInspector(AtomToolsFramework::InspectorWidget* inspector) const override;
+        void OnSettingsDialogClosed() override;
         AZStd::string GetHelpDialogText() const override;
 
     private:


### PR DESCRIPTION
## What does this PR do?

This change adds handlers and notifications for graph view settings changes that cause the graph to refresh.

Resolves https://github.com/o3de/o3de/issues/13559

## How was this PR tested?

Confirmed graph view visibly updates after curve type settings changes