### PR TITLE
Clean up Editor collider components includes. Using python physics consts variables.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/EditorPythonBindings/tests/Editor_ComponentCommands_Works.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonBindings/tests/Editor_ComponentCommands_Works.py
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 import os, sys
 sys.path.append(os.path.dirname(__file__))
 from Editor_TestClass import BaseClass
+from EditorPythonTestTools.consts.physics import PHYSX_MESH_COLLIDER
 
 class Editor_ComponentCommands_Works(BaseClass):
     # Description: 
@@ -25,7 +26,7 @@ class Editor_ComponentCommands_Works(BaseClass):
             return component1.Equal(component2)
 
         # Get Component Types for Mesh and Comment
-        typeNameList = ["Mesh", "Comment", "PhysX Mesh Collider"]
+        typeNameList = ["Mesh", "Comment", PHYSX_MESH_COLLIDER]
         typeIdsList = editor.EditorComponentAPIBus(bus.Broadcast, 'FindComponentTypeIdsByEntityType', typeNameList, entity.EntityType().Game)
 
         BaseClass.check_result(len(typeIdsList) > 0, "Type Ids List returned correctly")
@@ -38,7 +39,7 @@ class Editor_ComponentCommands_Works(BaseClass):
         typeNamesList = editor.EditorComponentAPIBus(bus.Broadcast, 'FindComponentTypeNames', typeIdsList)
         BaseClass.check_result(typeNamesList[0] == "Mesh", "Type Names List contains: Mesh")
         BaseClass.check_result(typeNamesList[1] == "Comment", "Type Names List contains: Comment")
-        BaseClass.check_result(typeNamesList[2] == "PhysX Mesh Collider", "Type Names List contains: PhysX Mesh Collider")
+        BaseClass.check_result(typeNamesList[2] == PHYSX_MESH_COLLIDER, "Type Names List contains: PhysX Mesh Collider")
 
         # Test Component API
         newEntityId = editor.ToolsApplicationRequestBus(bus.Broadcast, 'CreateNewEntity', EntityId())

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/EntityComponentTests/PhysX_Mesh_Collider_Component_CRUD.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/EntityComponentTests/PhysX_Mesh_Collider_Component_CRUD.py
@@ -41,11 +41,11 @@ def PhysX_Mesh_Collider_Component_CRUD():
         CONTACT_OFFSET_TESTS, REST_OFFSET_TESTS)
 
     from consts.general import Strings
+    from consts.physics import PHYSX_MESH_COLLIDER
 
     # 0) Pre-conditions
     physx_mesh = os.path.join("objects", "_primitives", "_box_1x1.pxmesh")
     physx_material = os.path.join("physx", "glass.physxmaterial")
-    component_name = "PhysX Mesh Collider"
 
     TestHelper.init_idle()
     TestHelper.open_level("", "Base")
@@ -58,26 +58,26 @@ def PhysX_Mesh_Collider_Component_CRUD():
         physx_collider = PhysxMeshCollider(phsyx_collider_entity)
 
     # 3) Set General Properties
-        validate_property_switch_toggle("Is Trigger", physx_collider.get_is_trigger, physx_collider.set_is_trigger, component_name)
-        validate_property_switch_toggle("Is Simulated", physx_collider.get_is_simulated, physx_collider.set_is_simulated, component_name)
-        validate_property_switch_toggle("In Scene Queries", physx_collider.get_in_scene_queries, physx_collider.set_in_scene_queries, component_name)
+        validate_property_switch_toggle("Is Trigger", physx_collider.get_is_trigger, physx_collider.set_is_trigger, PHYSX_MESH_COLLIDER)
+        validate_property_switch_toggle("Is Simulated", physx_collider.get_is_simulated, physx_collider.set_is_simulated, PHYSX_MESH_COLLIDER)
+        validate_property_switch_toggle("In Scene Queries", physx_collider.get_in_scene_queries, physx_collider.set_in_scene_queries, PHYSX_MESH_COLLIDER)
 
-        validate_vector3_property("Offset", physx_collider.get_offset, physx_collider.set_offset, component_name, VECTOR3_TESTS_NEGATIVE_EXPECT_PASS)
+        validate_vector3_property("Offset", physx_collider.get_offset, physx_collider.set_offset, PHYSX_MESH_COLLIDER, VECTOR3_TESTS_NEGATIVE_EXPECT_PASS)
 
         # o3de/o3de#13223 - Add Quaternion Property Validator to validate Rotation property
         # o3de/o3de#12634 - Get PhysX Mesh Collider Tag to set properly.
 
-        validate_float_property("Contact Offset", physx_collider.get_contact_offset, physx_collider.set_contact_offset, component_name, CONTACT_OFFSET_TESTS)
-        validate_float_property("Rest Offset", physx_collider.get_rest_offset, physx_collider.set_rest_offset, component_name, REST_OFFSET_TESTS)
+        validate_float_property("Contact Offset", physx_collider.get_contact_offset, physx_collider.set_contact_offset, PHYSX_MESH_COLLIDER, CONTACT_OFFSET_TESTS)
+        validate_float_property("Rest Offset", physx_collider.get_rest_offset, physx_collider.set_rest_offset, PHYSX_MESH_COLLIDER, REST_OFFSET_TESTS)
 
-        validate_property_switch_toggle("Draw Collider", physx_collider.get_draw_collider, physx_collider.set_draw_collider, component_name)
+        validate_property_switch_toggle("Draw Collider", physx_collider.get_draw_collider, physx_collider.set_draw_collider, PHYSX_MESH_COLLIDER)
 
         # o3de/o3de#12503 PhysX Mesh Collider Component's Physic Material field(s) return unintuitive property tree paths.
 
     # 4) Set PhyicsAsset Shape Properties
-        validate_asset_property("PhysX Mesh Asset", physx_collider.get_physx_mesh, physx_collider.set_physx_mesh, component_name, physx_mesh)
-        validate_vector3_property("PhysX Mesh Asset Scale", physx_collider.get_physx_mesh_asset_scale, physx_collider.set_physx_mesh_asset_scale, component_name, VECTOR3_TESTS_NEGATIVE_EXPECT_PASS)
-        validate_property_switch_toggle("Use Physics Materials From Asset", physx_collider.get_use_physics_materials_from_asset, physx_collider.set_use_physics_materials_from_asset, component_name)
+        validate_asset_property("PhysX Mesh Asset", physx_collider.get_physx_mesh, physx_collider.set_physx_mesh, PHYSX_MESH_COLLIDER, physx_mesh)
+        validate_vector3_property("PhysX Mesh Asset Scale", physx_collider.get_physx_mesh_asset_scale, physx_collider.set_physx_mesh_asset_scale, PHYSX_MESH_COLLIDER, VECTOR3_TESTS_NEGATIVE_EXPECT_PASS)
+        validate_property_switch_toggle("Use Physics Materials From Asset", physx_collider.get_use_physics_materials_from_asset, physx_collider.set_use_physics_materials_from_asset, PHYSX_MESH_COLLIDER)
 
     # 5) Delete Component
         physx_collider.component.remove()

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/EntityComponentTests/PhysX_Primitive_Collider_Component_CRUD.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/EntityComponentTests/PhysX_Primitive_Collider_Component_CRUD.py
@@ -45,10 +45,10 @@ def PhysX_Primitive_Collider_Component_CRUD():
         REST_OFFSET_TESTS, CYLINDER_SUBDIVISION_TESTS)
 
     from consts.general import Strings
+    from consts.physics import PHYSX_PRIMITIVE_COLLIDER
 
     # 0) Pre-conditions
     physx_material = os.path.join("physx", "glass.physxmaterial")
-    component_name = "PhysX Primitive Collider"
 
     TestHelper.init_idle()
     TestHelper.open_level("", "Base")
@@ -63,41 +63,41 @@ def PhysX_Primitive_Collider_Component_CRUD():
     # 3) Set Box Shape and Child Properties
         physx_collider.set_box_shape()
 
-        validate_vector3_property("Box Dimensions", physx_collider.get_box_dimensions, physx_collider.set_box_dimensions, component_name, VECTOR3_TESTS_NEGATIVE_EXPECT_PASS)
+        validate_vector3_property("Box Dimensions", physx_collider.get_box_dimensions, physx_collider.set_box_dimensions, PHYSX_PRIMITIVE_COLLIDER, VECTOR3_TESTS_NEGATIVE_EXPECT_PASS)
 
     # 4) Set Capsule Shape and Child Properties
         physx_collider.set_capsule_shape()
 
-        validate_float_property("Capsule Height", physx_collider.get_capsule_height, physx_collider.set_capsule_height, component_name, FLOAT_HEIGHT_TESTS)
+        validate_float_property("Capsule Height", physx_collider.get_capsule_height, physx_collider.set_capsule_height, PHYSX_PRIMITIVE_COLLIDER, FLOAT_HEIGHT_TESTS)
         validate_float_property("Capsule Radius", physx_collider.get_capsule_radius, physx_collider.set_capsule_radius, physx_collider.component.get_component_name(), COLLIDER_RADIUS_TESTS)
 
     # 5) Set Cylinder Shape and Child Properties
         physx_collider.set_cylinder_shape()
 
-        validate_float_property("Cylinder Height", physx_collider.get_cylinder_height, physx_collider.set_cylinder_height, component_name,  CYLINDER_HEIGHT_TESTS)
-        validate_float_property("Cylinder Radius", physx_collider.get_cylinder_radius, physx_collider.set_cylinder_radius, component_name, COLLIDER_RADIUS_TESTS)
+        validate_float_property("Cylinder Height", physx_collider.get_cylinder_height, physx_collider.set_cylinder_height, PHYSX_PRIMITIVE_COLLIDER,  CYLINDER_HEIGHT_TESTS)
+        validate_float_property("Cylinder Radius", physx_collider.get_cylinder_radius, physx_collider.set_cylinder_radius, PHYSX_PRIMITIVE_COLLIDER, COLLIDER_RADIUS_TESTS)
 
-        validate_integer_property("Cylinder Subdivision", physx_collider.get_cylinder_subdivision, physx_collider.set_cylinder_subdivision, component_name, CYLINDER_SUBDIVISION_TESTS)
+        validate_integer_property("Cylinder Subdivision", physx_collider.get_cylinder_subdivision, physx_collider.set_cylinder_subdivision, PHYSX_PRIMITIVE_COLLIDER, CYLINDER_SUBDIVISION_TESTS)
 
     # 6) Set Sphere Shape and Child Properties
         physx_collider.set_sphere_shape()
 
-        validate_float_property("Sphere Radius", physx_collider.get_sphere_radius, physx_collider.set_sphere_radius, component_name, COLLIDER_RADIUS_TESTS)
+        validate_float_property("Sphere Radius", physx_collider.get_sphere_radius, physx_collider.set_sphere_radius, PHYSX_PRIMITIVE_COLLIDER, COLLIDER_RADIUS_TESTS)
 
     # 7) Set General Properties
-        validate_property_switch_toggle("Is Trigger", physx_collider.get_is_trigger, physx_collider.set_is_trigger, component_name)
-        validate_property_switch_toggle("Is Simulated", physx_collider.get_is_simulated, physx_collider.set_is_simulated, component_name)
-        validate_property_switch_toggle("In Scene Queries", physx_collider.get_in_scene_queries, physx_collider.set_in_scene_queries, component_name)
+        validate_property_switch_toggle("Is Trigger", physx_collider.get_is_trigger, physx_collider.set_is_trigger, PHYSX_PRIMITIVE_COLLIDER)
+        validate_property_switch_toggle("Is Simulated", physx_collider.get_is_simulated, physx_collider.set_is_simulated, PHYSX_PRIMITIVE_COLLIDER)
+        validate_property_switch_toggle("In Scene Queries", physx_collider.get_in_scene_queries, physx_collider.set_in_scene_queries, PHYSX_PRIMITIVE_COLLIDER)
 
-        validate_vector3_property("Offset", physx_collider.get_offset, physx_collider.set_offset, component_name, VECTOR3_TESTS_NEGATIVE_EXPECT_PASS)
+        validate_vector3_property("Offset", physx_collider.get_offset, physx_collider.set_offset, PHYSX_PRIMITIVE_COLLIDER, VECTOR3_TESTS_NEGATIVE_EXPECT_PASS)
 
         # o3de/o3de#13223 - Add Quaternion Property Validator to validate Rotation property
         # o3de/o3de#12634 - Get PhysX Primitive Collider Tag to set properly.
 
-        validate_float_property("Contact Offset", physx_collider.get_contact_offset, physx_collider.set_contact_offset, component_name, CONTACT_OFFSET_TESTS)
-        validate_float_property("Rest Offset", physx_collider.get_rest_offset, physx_collider.set_rest_offset, component_name, REST_OFFSET_TESTS)
+        validate_float_property("Contact Offset", physx_collider.get_contact_offset, physx_collider.set_contact_offset, PHYSX_PRIMITIVE_COLLIDER, CONTACT_OFFSET_TESTS)
+        validate_float_property("Rest Offset", physx_collider.get_rest_offset, physx_collider.set_rest_offset, PHYSX_PRIMITIVE_COLLIDER, REST_OFFSET_TESTS)
 
-        validate_property_switch_toggle("Draw Collider", physx_collider.get_draw_collider, physx_collider.set_draw_collider, component_name)
+        validate_property_switch_toggle("Draw Collider", physx_collider.get_draw_collider, physx_collider.set_draw_collider, PHYSX_PRIMITIVE_COLLIDER)
 
         # o3de/o3de#12503 PhysX Primitive Collider Component's Physic Material field(s) return unintuitive property tree paths.
 

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_BoxShapeEditing.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_BoxShapeEditing.py
@@ -47,6 +47,7 @@ def Collider_BoxShapeEditing():
     from editor_python_test_tools.editor_entity_utils import EditorEntity as Entity
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
+    from consts.physics import PHYSX_PRIMITIVE_COLLIDER
 
     # Open 3D Engine Imports
     import azlmbr.math as math
@@ -81,8 +82,8 @@ def Collider_BoxShapeEditing():
     Report.result(Tests.entity_created, test_entity.id.IsValid())
 
     # 3) Add PhysX Primitive Collider component to test entity
-    test_component = test_entity.add_component("PhysX Primitive Collider")
-    Report.result(Tests.collider_added, test_entity.has_component("PhysX Primitive Collider"))
+    test_component = test_entity.add_component(PHYSX_PRIMITIVE_COLLIDER)
+    Report.result(Tests.collider_added, test_entity.has_component(PHYSX_PRIMITIVE_COLLIDER))
 
     # 4) Change the PhysX Primitive Collider shape and store the original dimensions
     test_component.set_component_property_value("Shape Configuration|Shape", BOX_SHAPETYPE_ENUM)

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_CapsuleShapeEditing.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_CapsuleShapeEditing.py
@@ -47,6 +47,7 @@ def Collider_CapsuleShapeEditing():
     from editor_python_test_tools.editor_entity_utils import EditorEntity as Entity
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
+    from consts.physics import PHYSX_PRIMITIVE_COLLIDER
 
     # Open 3D Engine Imports
     import azlmbr.math as math
@@ -82,8 +83,8 @@ def Collider_CapsuleShapeEditing():
     Report.result(Tests.entity_created, test_entity.id.IsValid())
 
     # 3) Add PhysX Primitive Collider component to test entity
-    test_component = test_entity.add_component("PhysX Primitive Collider")
-    Report.result(Tests.collider_added, test_entity.has_component("PhysX Primitive Collider"))
+    test_component = test_entity.add_component(PHYSX_PRIMITIVE_COLLIDER)
+    Report.result(Tests.collider_added, test_entity.has_component(PHYSX_PRIMITIVE_COLLIDER))
 
     # 4) Change the PhysX Primitive Collider shape
     test_component.set_component_property_value("Shape Configuration|Shape", CAPSULE_SHAPETYPE_ENUM)

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_MultipleSurfaceSlots.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_MultipleSurfaceSlots.py
@@ -51,6 +51,7 @@ def Collider_MultipleSurfaceSlots():
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
     from editor_python_test_tools.asset_utils import Asset
+    from consts.physics import PHYSX_MESH_COLLIDER
 
     import editor_python_test_tools.hydra_editor_utils as hydra
 
@@ -73,8 +74,8 @@ def Collider_MultipleSurfaceSlots():
     mesh_component = test_entity.add_component("Mesh")
     Report.result(Tests.mesh_added, test_entity.has_component("Mesh"))
 
-    collider_component = test_entity.add_component("PhysX Mesh Collider")
-    Report.result(Tests.physx_collider_added, test_entity.has_component("PhysX Mesh Collider"))
+    collider_component = test_entity.add_component(PHYSX_MESH_COLLIDER)
+    Report.result(Tests.physx_collider_added, test_entity.has_component(PHYSX_MESH_COLLIDER))
 
     # 4) Assign the fbx file in PhysX Mesh and Mesh component
     px_asset = Asset.find_asset_by_path(PHYSX_MESH)

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_PxMeshAutoAssignedWhenAddingRenderMeshComponent.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_PxMeshAutoAssignedWhenAddingRenderMeshComponent.py
@@ -53,6 +53,7 @@ def Collider_PxMeshAutoAssignedWhenAddingRenderMeshComponent():
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
     from editor_python_test_tools.asset_utils import Asset
+    from consts.physics import PHYSX_MESH_COLLIDER
 
     import editor_python_test_tools.hydra_editor_utils as hydra
 
@@ -81,8 +82,8 @@ def Collider_PxMeshAutoAssignedWhenAddingRenderMeshComponent():
     Report.result(Tests.assign_model_asset, model_asset.get_path().lower() == STATIC_MESH.replace(os.sep, "/").lower())
 
     # 5) Add PhysX Mesh Collider component
-    test_component = test_entity.add_component("PhysX Mesh Collider")
-    Report.result(Tests.physx_collider_added, test_entity.has_component("PhysX Mesh Collider"))
+    test_component = test_entity.add_component(PHYSX_MESH_COLLIDER)
+    Report.result(Tests.physx_collider_added, test_entity.has_component(PHYSX_MESH_COLLIDER))
 
     # 6) The physics asset in PhysX Mesh Collider component is auto-assigned.
     asset_id = test_component.get_component_property_value("Shape Configuration|Asset|PhysX Mesh")

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_PxMeshAutoAssignedWhenModifyingRenderMeshComponent.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_PxMeshAutoAssignedWhenModifyingRenderMeshComponent.py
@@ -52,6 +52,7 @@ def Collider_PxMeshAutoAssignedWhenModifyingRenderMeshComponent():
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
     from editor_python_test_tools.asset_utils import Asset
+    from consts.physics import PHYSX_MESH_COLLIDER
 
     import editor_python_test_tools.hydra_editor_utils as hydra
 
@@ -74,8 +75,8 @@ def Collider_PxMeshAutoAssignedWhenModifyingRenderMeshComponent():
     mesh_component = test_entity.add_component("Mesh")
     Report.result(Tests.mesh_added, test_entity.has_component("Mesh"))
 
-    test_component = test_entity.add_component("PhysX Mesh Collider")
-    Report.result(Tests.physx_collider_added, test_entity.has_component("PhysX Mesh Collider"))
+    test_component = test_entity.add_component(PHYSX_MESH_COLLIDER)
+    Report.result(Tests.physx_collider_added, test_entity.has_component(PHYSX_MESH_COLLIDER))
 
     # 4) Verify no physics asset is auto-assigned
     value_to_test = test_component.get_component_property_value(TESTED_PROPERTY_PATH)

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_PxMeshConvexMeshCollides.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_PxMeshConvexMeshCollides.py
@@ -61,6 +61,8 @@ def Collider_PxMeshConvexMeshCollides():
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
     from editor_python_test_tools.asset_utils import Asset
+    from consts.physics import PHYSX_SHAPE_COLLIDER
+    from consts.physics import PHYSX_MESH_COLLIDER
 
     import azlmbr.math as math
     import editor_python_test_tools.hydra_editor_utils as hydra
@@ -81,8 +83,8 @@ def Collider_PxMeshConvexMeshCollides():
     Report.result(Tests.create_collider_entity, collider.id.IsValid())
 
     # 3) Add PhysX Mesh Collider, PhysX Rigid Body and Mesh components.
-    collider_component = collider.add_component("PhysX Mesh Collider")
-    Report.result(Tests.physx_collider_added, collider.has_component("PhysX Mesh Collider"))
+    collider_component = collider.add_component(PHYSX_MESH_COLLIDER)
+    Report.result(Tests.physx_collider_added, collider.has_component(PHYSX_MESH_COLLIDER))
 
     collider.add_component("PhysX Dynamic Rigid Body")
     Report.result(Tests.physx_rigid_body_added, collider.has_component("PhysX Dynamic Rigid Body"))
@@ -101,8 +103,8 @@ def Collider_PxMeshConvexMeshCollides():
     terrain.add_component("PhysX Static Rigid Body")
     Report.result(Tests.create_terrain, terrain.id.IsValid())
 
-    terrain.add_component("PhysX Shape Collider")
-    Report.result(Tests.add_physx_shape_collider, terrain.has_component("PhysX Shape Collider"))
+    terrain.add_component(PHYSX_SHAPE_COLLIDER)
+    Report.result(Tests.add_physx_shape_collider, terrain.has_component(PHYSX_SHAPE_COLLIDER))
 
     box_shape_component = terrain.add_component("Box Shape")
     Report.result(Tests.add_box_shape, terrain.has_component("Box Shape"))

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_PxMeshNotAutoAssignedWhenNoPhysicsFbx.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_PxMeshNotAutoAssignedWhenNoPhysicsFbx.py
@@ -58,6 +58,7 @@ def Collider_PxMeshNotAutoAssignedWhenNoPhysicsFbx():
     from editor_python_test_tools.utils import TestHelper as helper
     from editor_python_test_tools.utils import Tracer
     from editor_python_test_tools.asset_utils import Asset
+    from consts.physics import PHYSX_MESH_COLLIDER
 
     import editor_python_test_tools.hydra_editor_utils as hydra
 
@@ -86,8 +87,8 @@ def Collider_PxMeshNotAutoAssignedWhenNoPhysicsFbx():
     Report.result(Tests.assign_model_asset, model_asset.get_path().lower() == STATIC_MESH.replace(os.sep, "/").lower())
 
     # 5) Add PhysX Mesh Collider component
-    test_component = test_entity.add_component("PhysX Mesh Collider")
-    Report.result(Tests.physx_collider_added, test_entity.has_component("PhysX Mesh Collider"))
+    test_component = test_entity.add_component(PHYSX_MESH_COLLIDER)
+    Report.result(Tests.physx_collider_added, test_entity.has_component(PHYSX_MESH_COLLIDER))
 
     # 6) The physics asset in PhysX Mesh Collider component is not auto-assigned.
     asset_id = test_component.get_component_property_value("Shape Configuration|Asset|PhysX Mesh")

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_SphereShapeEditing.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_SphereShapeEditing.py
@@ -47,6 +47,7 @@ def Collider_SphereShapeEditing():
     from editor_python_test_tools.editor_entity_utils import EditorEntity as Entity
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
+    from consts.physics import PHYSX_PRIMITIVE_COLLIDER
 
     # Open 3D Engine Imports
     import azlmbr.math as math
@@ -65,8 +66,8 @@ def Collider_SphereShapeEditing():
     Report.result(Tests.entity_created, test_entity.id.IsValid())
 
     # 3) Add PhysX Primitive Collider component to test entity
-    test_component = test_entity.add_component("PhysX Primitive Collider")
-    Report.result(Tests.collider_added, test_entity.has_component("PhysX Primitive Collider"))
+    test_component = test_entity.add_component(PHYSX_PRIMITIVE_COLLIDER)
+    Report.result(Tests.collider_added, test_entity.has_component(PHYSX_PRIMITIVE_COLLIDER))
 
     # 4) Change the PhysX Primitive Collider shape and store the original dimensions
     test_component.set_component_property_value("Shape Configuration|Shape", SPHERE_SHAPETYPE_ENUM)

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/force_region/ForceRegion_WithNonTriggerColliderWarning.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/force_region/ForceRegion_WithNonTriggerColliderWarning.py
@@ -50,6 +50,7 @@ def ForceRegion_WithNonTriggerColliderWarning():
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
     from editor_python_test_tools.utils import Tracer
+    from consts.physics import PHYSX_PRIMITIVE_COLLIDER
 
     # 1) Load the empty level
     hydra.open_base_level()
@@ -67,8 +68,8 @@ def ForceRegion_WithNonTriggerColliderWarning():
     Report.info("Starting warning monitoring")
     with Tracer() as section_tracer:
         # 5) Add the PhysX Primitive Collider component
-        test_entity.add_component("PhysX Primitive Collider")
-        Report.result(Tests.add_physx_collider, test_entity.has_component("PhysX Primitive Collider"))
+        test_entity.add_component(PHYSX_PRIMITIVE_COLLIDER)
+        Report.result(Tests.add_physx_collider, test_entity.has_component(PHYSX_PRIMITIVE_COLLIDER))
         general.idle_wait_frames(1)
     Report.info("Ending warning monitoring")
     

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/shape_collider/ShapeCollider_CanBeAddedWitNoWarnings.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/shape_collider/ShapeCollider_CanBeAddedWitNoWarnings.py
@@ -51,6 +51,9 @@ def ShapeCollider_CanBeAddedWitNoWarnings():
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
     from editor_python_test_tools.utils import Tracer
+    from consts.physics import PHYSX_PRIMITIVE_COLLIDER
+    from consts.physics import PHYSX_SHAPE_COLLIDER
+    from consts.physics import PHYSX_MESH_COLLIDER
 
     import editor_python_test_tools.hydra_editor_utils as hydra
 
@@ -66,8 +69,8 @@ def ShapeCollider_CanBeAddedWitNoWarnings():
     Report.result(Tests.create_collider_entity, collider_entity.id.IsValid())
 
     # 3) Add the PhysX Shape Collider and a Box Shape components
-    collider_entity.add_component("PhysX Shape Collider")
-    Report.result(Tests.add_physx_shape_collider, collider_entity.has_component("PhysX Shape Collider"))
+    collider_entity.add_component(PHYSX_SHAPE_COLLIDER)
+    Report.result(Tests.add_physx_shape_collider, collider_entity.has_component(PHYSX_SHAPE_COLLIDER))
 
     collider_entity.add_component("Box Shape")
     Report.result(Tests.add_box_shape, collider_entity.has_component("Box Shape"))
@@ -75,12 +78,12 @@ def ShapeCollider_CanBeAddedWitNoWarnings():
     # 4) Start the Tracer to catch any warnings while adding the PhysX Collider
     with Tracer() as section_tracer:
         # 5) Add the PhysX Primitive Collider component
-        collider_entity.add_component("PhysX Primitive Collider")
-        Report.result(Tests.add_physx_primitive_collider, collider_entity.has_component("PhysX Primitive Collider"))
+        collider_entity.add_component(PHYSX_PRIMITIVE_COLLIDER)
+        Report.result(Tests.add_physx_primitive_collider, collider_entity.has_component(PHYSX_PRIMITIVE_COLLIDER))
         
         # 6) Add the PhysX Mesh Collider component
-        collider_entity.add_component("PhysX Mesh Collider")
-        Report.result(Tests.add_physx_mesh_collider, collider_entity.has_component("PhysX Mesh Collider"))
+        collider_entity.add_component(PHYSX_MESH_COLLIDER)
+        Report.result(Tests.add_physx_mesh_collider, collider_entity.has_component(PHYSX_MESH_COLLIDER))
 
     # 7) Verify there are no warnings in the entity outliner
     success_condition = not section_tracer.has_warnings and not section_tracer.has_errors

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/shape_collider/ShapeCollider_CylinderShapeCollides.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/shape_collider/ShapeCollider_CylinderShapeCollides.py
@@ -58,6 +58,7 @@ def ShapeCollider_CylinderShapeCollides():
     import azlmbr.math as math
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
+    from consts.physics import PHYSX_SHAPE_COLLIDER
 
     # Global time out
     TIME_OUT = 1.0
@@ -71,8 +72,8 @@ def ShapeCollider_CylinderShapeCollides():
     terrain.add_component("PhysX Static Rigid Body")
     Report.result(Tests.create_terrain, terrain.id.IsValid())
     
-    terrain.add_component("PhysX Shape Collider")
-    Report.result(Tests.add_physx_shape_collider, terrain.has_component("PhysX Shape Collider"))
+    terrain.add_component(PHYSX_SHAPE_COLLIDER)
+    Report.result(Tests.add_physx_shape_collider, terrain.has_component(PHYSX_SHAPE_COLLIDER))
 
     box_shape_component = terrain.add_component("Box Shape")
     Report.result(Tests.add_box_shape, terrain.has_component("Box Shape"))

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/shape_collider/ShapeCollider_InactiveWhenNoShapeComponent.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/shape_collider/ShapeCollider_InactiveWhenNoShapeComponent.py
@@ -53,6 +53,7 @@ def ShapeCollider_InactiveWhenNoShapeComponent():
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.editor_entity_utils import EditorEntity
     from editor_python_test_tools.utils import TestHelper as helper
+    from consts.physics import PHYSX_SHAPE_COLLIDER
 
     import editor_python_test_tools.hydra_editor_utils as hydra
 
@@ -73,13 +74,13 @@ def ShapeCollider_InactiveWhenNoShapeComponent():
     # 2) Add an entity with a PhysX Shape Collider component.
     collider = EditorEntity.create_editor_entity("Collider")
     collider.add_component("PhysX Static Rigid Body")
-    physx_component = collider.add_component("PhysX Shape Collider")
+    physx_component = collider.add_component(PHYSX_SHAPE_COLLIDER)
 
     # 3) Validate Collider Entity
     Report.result(Tests.create_collider_entity, collider.id.IsValid())
 
     # 4) Validate PhysX Shape Collider component is inactive.
-    Report.result(Tests.add_physx_shape_collider, collider.has_component("PhysX Shape Collider"))
+    Report.result(Tests.add_physx_shape_collider, collider.has_component(PHYSX_SHAPE_COLLIDER))
     Report.result(Tests.collider_component_inactive, not is_component_active(physx_component.id))
 
     # 5) Add Shape component to Entity

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/shape_collider/ShapeCollider_LargeNumberOfShapeCollidersWontCrashEditor.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/shape_collider/ShapeCollider_LargeNumberOfShapeCollidersWontCrashEditor.py
@@ -44,6 +44,7 @@ def ShapeCollider_LargeNumberOfShapeCollidersWontCrashEditor():
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
     from editor_python_test_tools.editor_entity_utils import EditorEntity as Entity
+    from consts.physics import PHYSX_SHAPE_COLLIDER
 
     import editor_python_test_tools.hydra_editor_utils as hydra
 
@@ -74,7 +75,7 @@ def ShapeCollider_LargeNumberOfShapeCollidersWontCrashEditor():
         entity.add_component("PhysX Static Rigid Body")
 
         # Add components
-        entity.add_component("PhysX Shape Collider")
+        entity.add_component(PHYSX_SHAPE_COLLIDER)
         if i % 3 == 0:
             shape_component_name = "Capsule Shape"
         elif i % 2 == 0:
@@ -85,7 +86,7 @@ def ShapeCollider_LargeNumberOfShapeCollidersWontCrashEditor():
         entity.add_component(shape_component_name)
 
         # Verify the entity contains the components
-        components_added = entity.has_component("PhysX Shape Collider") and entity.has_component(shape_component_name)
+        components_added = entity.has_component(PHYSX_SHAPE_COLLIDER) and entity.has_component(shape_component_name)
         if not components_added:
             entity_failure = True
             Report.info(f"Entity_{i} failed to add either PhysX Shape Collider or {shape_component_name}")

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_UnderAnotherPrefab.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_UnderAnotherPrefab.py
@@ -18,6 +18,7 @@ def CreatePrefab_UnderAnotherPrefab():
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity
     from editor_python_test_tools.prefab_utils import Prefab
+    from consts.physics import PHYSX_PRIMITIVE_COLLIDER
     import Prefab.tests.PrefabTestUtils as prefab_test_utils
 
     OUTER_PREFAB_FILE_NAME = Path(__file__).stem + 'Outer_prefab'
@@ -29,8 +30,8 @@ def CreatePrefab_UnderAnotherPrefab():
     # Asserts if creation didn't succeed
     entity = EditorEntity.create_editor_entity_at((100.0, 100.0, 100.0), name="TestEntity")
     assert entity.id.IsValid(), "Couldn't create entity"
-    entity.add_component("PhysX Primitive Collider")
-    assert entity.has_component("PhysX Primitive Collider"), "Failed to add a PhysX Primitive Collider"
+    entity.add_component(PHYSX_PRIMITIVE_COLLIDER)
+    assert entity.has_component(PHYSX_PRIMITIVE_COLLIDER), "Failed to add a PhysX Primitive Collider"
 
     # Create a prefab based on that entity and focus it
     outer_prefab, outer_instance = Prefab.create_prefab([entity], OUTER_PREFAB_FILE_NAME)
@@ -39,7 +40,7 @@ def CreatePrefab_UnderAnotherPrefab():
     entity = outer_instance.get_direct_child_entities()[0]
     # We track if that is the same entity by checking the name and if it still contains the component that we created before
     assert entity.get_name() == "TestEntity", f"Entity name inside outer_prefab doesn't match the original name, original:'TestEntity' current:'{entity.get_name()}'"
-    assert entity.has_component("PhysX Primitive Collider"), "Entity name inside outer_prefab doesn't have the collider component it should"
+    assert entity.has_component(PHYSX_PRIMITIVE_COLLIDER), "Entity name inside outer_prefab doesn't have the collider component it should"
 
     # Now, create another prefab, based on the entity that is inside outer_prefab
     inner_prefab, inner_instance = Prefab.create_prefab([entity], INNER_PREFAB_FILE_NAME)
@@ -51,7 +52,7 @@ def CreatePrefab_UnderAnotherPrefab():
     entity = inner_instance.get_direct_child_entities()[0]
     # We track if that is the same entity by checking the name and if it still contains the component that we created before
     assert entity.get_name() == "TestEntity", f"Entity name inside inner_prefab doesn't match the original name, original:'TestEntity' current:'{entity.get_name()}'"
-    assert entity.has_component("PhysX Primitive Collider"), "Entity name inside inner_prefab doesn't have the collider component it should"
+    assert entity.has_component(PHYSX_PRIMITIVE_COLLIDER), "Entity name inside inner_prefab doesn't have the collider component it should"
 
     # Verify hierarchy of entities:
     # Outer_prefab

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_UnderChildEntityOfAnotherPrefab.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_UnderChildEntityOfAnotherPrefab.py
@@ -19,6 +19,7 @@ def CreatePrefab_UnderChildEntityOfAnotherPrefab():
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity
     from editor_python_test_tools.prefab_utils import Prefab
+    from consts.physics import PHYSX_PRIMITIVE_COLLIDER as PHYSX_PRIMITIVE_COLLIDER_NAME
     import Prefab.tests.PrefabTestUtils as prefab_test_utils
 
     OUTER_PREFAB_NAME = 'Outer_prefab'
@@ -27,7 +28,6 @@ def CreatePrefab_UnderChildEntityOfAnotherPrefab():
     INNER_PREFAB_FILE_NAME = Path(__file__).stem + INNER_PREFAB_NAME
     PARENT_ENTITY_NAME = 'ParentEntity'
     CHILD_ENTITY_NAME = 'ChildEntity'
-    PHYSX_PRIMITIVE_COLLIDER_NAME = 'PhysX Primitive Collider'
 
     prefab_test_utils.open_base_tests_level()
 

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_WithNestedEntitiesAndNestedPrefabs.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_WithNestedEntitiesAndNestedPrefabs.py
@@ -20,6 +20,7 @@ def CreatePrefab_WithNestedEntitiesAndNestedPrefabs():
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity
     from editor_python_test_tools.prefab_utils import Prefab
+    from consts.physics import PHYSX_PRIMITIVE_COLLIDER as PHYSX_PRIMITIVE_COLLIDER_NAME
     import Prefab.tests.PrefabTestUtils as prefab_test_utils
 
     NESTED_ENTITIES_PREFAB_FILE_NAME = Path(__file__).stem + '_' + 'nested_entities_prefab'
@@ -28,7 +29,6 @@ def CreatePrefab_WithNestedEntitiesAndNestedPrefabs():
     NESTED_PREFABS_NAME_PREFIX = 'NestedPrefabs_Prefab_'
     FILE_NAME_OF_PREFAB_WITH_NESTED_ENTITIES_AND_NESTED_PREFABS = Path(__file__).stem + '_' + 'new_prefab'
     NESTED_PREFABS_TEST_ENTITY_NAME = 'TestEntity'
-    PHYSX_PRIMITIVE_COLLIDER_NAME = 'PhysX Primitive Collider'
     CREATION_POSITION = azlmbr.math.Vector3(100.0, 100.0, 100.0)
     NUM_NESTED_ENTITIES_LEVELS = 3
     NUM_NESTED_PREFABS_LEVELS = 3

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/delete_prefab/DeletePrefab_ContainingNestedEntitiesAndNestedPrefabs.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/delete_prefab/DeletePrefab_ContainingNestedEntitiesAndNestedPrefabs.py
@@ -23,6 +23,7 @@ def DeletePrefab_ContainingNestedEntitiesAndNestedPrefabs():
     from editor_python_test_tools.editor_entity_utils import EditorEntity
     from editor_python_test_tools.prefab_utils import Prefab, get_all_entity_ids
     from editor_python_test_tools.wait_utils import PrefabWaiter
+    from consts.physics import PHYSX_PRIMITIVE_COLLIDER as PHYSX_PRIMITIVE_COLLIDER_NAME
     import Prefab.tests.PrefabTestUtils as prefab_test_utils
 
     NESTED_ENTITIES_PREFAB_FILE_NAME = Path(__file__).stem + '_' + 'nested_entities_prefab'
@@ -31,7 +32,6 @@ def DeletePrefab_ContainingNestedEntitiesAndNestedPrefabs():
     NESTED_PREFABS_NAME_PREFIX = 'NestedPrefabs_Prefab_'
     FILE_NAME_OF_PREFAB_WITH_NESTED_ENTITIES_AND_NESTED_PREFABS = Path(__file__).stem + '_' + 'new_prefab'
     NESTED_PREFABS_TEST_ENTITY_NAME = 'TestEntity'
-    PHYSX_PRIMITIVE_COLLIDER_NAME = 'PhysX Primitive Collider'
     CREATION_POSITION = azlmbr.math.Vector3(100.0, 100.0, 100.0)
     NUM_NESTED_ENTITIES_LEVELS = 3
     NUM_NESTED_PREFABS_LEVELS = 3

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/duplicate_prefab/DuplicateEntity_WithNestedEntitiesAndNestedPrefabs.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/duplicate_prefab/DuplicateEntity_WithNestedEntitiesAndNestedPrefabs.py
@@ -24,13 +24,13 @@ def DuplicateEntity_WithNestedEntitiesAndNestedPrefabs():
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity
     from editor_python_test_tools.wait_utils import PrefabWaiter
+    from consts.physics import PHYSX_PRIMITIVE_COLLIDER as PHYSX_PRIMITIVE_COLLIDER_NAME
     import Prefab.tests.PrefabTestUtils as prefab_test_utils
 
     NESTED_ENTITIES_NAME_PREFIX = 'NestedEntity_'
     NESTED_PREFABS_FILE_NAME_PREFIX = Path(__file__).stem + '_' + 'nested_prefabs_'
     NESTED_PREFABS_NAME_PREFIX = 'NestedPrefabs_Prefab_'
     NESTED_PREFABS_TEST_ENTITY_NAME = 'TestEntity'
-    PHYSX_PRIMITIVE_COLLIDER_NAME = 'PhysX Primitive Collider'
     PARENT_CREATION_POSITION = azlmbr.math.Vector3(0.0, 0.0, 0.0)
     CHILDREN_CREATION_POSITION = azlmbr.math.Vector3(100.0, 100.0, 100.0)
     NUM_NESTED_ENTITIES_LEVELS = 3

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/duplicate_prefab/DuplicatePrefab_ContainingNestedEntitiesAndNestedPrefabs.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/duplicate_prefab/DuplicatePrefab_ContainingNestedEntitiesAndNestedPrefabs.py
@@ -24,6 +24,7 @@ def DuplicatePrefab_ContainingNestedEntitiesAndNestedPrefabs():
     from editor_python_test_tools.editor_entity_utils import EditorEntity
     from editor_python_test_tools.prefab_utils import Prefab
     from editor_python_test_tools.wait_utils import PrefabWaiter
+    from consts.physics import PHYSX_PRIMITIVE_COLLIDER as PHYSX_PRIMITIVE_COLLIDER_NAME
     import Prefab.tests.PrefabTestUtils as prefab_test_utils
 
     NESTED_ENTITIES_PREFAB_FILE_NAME = Path(__file__).stem + '_' + 'nested_entities_prefab'
@@ -32,7 +33,6 @@ def DuplicatePrefab_ContainingNestedEntitiesAndNestedPrefabs():
     NESTED_PREFABS_NAME_PREFIX = 'NestedPrefabs_Prefab_'
     FILE_NAME_OF_PREFAB_WITH_NESTED_ENTITIES_AND_NESTED_PREFABS = Path(__file__).stem + '_' + 'new_prefab'
     NESTED_PREFABS_TEST_ENTITY_NAME = 'TestEntity'
-    PHYSX_PRIMITIVE_COLLIDER_NAME = 'PhysX Primitive Collider'
     CREATION_POSITION = azlmbr.math.Vector3(100.0, 100.0, 100.0)
     NUM_NESTED_ENTITIES_LEVELS = 3
     NUM_NESTED_PREFABS_LEVELS = 3

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/instantiate_prefab/InstantiatePrefab_WithNestedEntitiesandNestedPrefabs.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/instantiate_prefab/InstantiatePrefab_WithNestedEntitiesandNestedPrefabs.py
@@ -25,6 +25,7 @@ def InstantiatePrefab_WithNestedEntitiesAndNestedPrefabs():
     from editor_python_test_tools.editor_entity_utils import EditorEntity
     from editor_python_test_tools.prefab_utils import Prefab
     from editor_python_test_tools.wait_utils import PrefabWaiter
+    from consts.physics import PHYSX_PRIMITIVE_COLLIDER as PHYSX_PRIMITIVE_COLLIDER_NAME
     import Prefab.tests.PrefabTestUtils as prefab_test_utils
 
     NESTED_ENTITIES_NAME_PREFIX = 'Entity_'
@@ -32,7 +33,6 @@ def InstantiatePrefab_WithNestedEntitiesAndNestedPrefabs():
     NESTED_PREFABS_NAME_PREFIX = 'NestedPrefabs_Prefab_'
     FILE_NAME_OF_PREFAB_WITH_NESTED_ENTITIES_AND_NESTED_PREFABS = Path(__file__).stem + '_new_prefab'
     NESTED_PREFABS_TEST_ENTITY_NAME = 'TestEntity'
-    PHYSX_PRIMITIVE_COLLIDER_NAME = 'PhysX Primitive Collider'
     CREATION_POSITION = math.Vector3(100.0, 100.0, 100.0)
     NUM_NESTED_ENTITIES_LEVELS = 3
     NUM_NESTED_PREFABS_LEVELS = 3

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/open_level/OpenLevel_ContainingTwoEntities.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/open_level/OpenLevel_ContainingTwoEntities.py
@@ -27,6 +27,7 @@ def OpenLevel_ContainingTwoEntities():
 
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
+    from consts.physics import PHYSX_MESH_COLLIDER
 
     import editor_python_test_tools.hydra_editor_utils as hydra
 
@@ -63,7 +64,7 @@ def OpenLevel_ContainingTwoEntities():
     pxentity = find_entity("EntityWithPxCollider")
     Report.result(Tests.find_pxentity, pxentity.IsValid())
 
-    pxcollider_id = hydra.get_component_type_id("PhysX Mesh Collider")
+    pxcollider_id = hydra.get_component_type_id(PHYSX_MESH_COLLIDER)
     hasComponent = azlmbr.editor.EditorComponentAPIBus(azlmbr.bus.Broadcast, 'HasComponentOfType', pxentity, pxcollider_id)
     Report.result(Tests.pxentity_component, hasComponent)
 

--- a/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_SupportsPhysics.py
+++ b/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_SupportsPhysics.py
@@ -51,6 +51,7 @@ def Terrain_SupportsPhysics():
     from editor_python_test_tools.wait_utils import PrefabWaiter
     from editor_python_test_tools.utils import TestHelper as helper
     from editor_python_test_tools.utils import Report, Tracer
+    from consts.physics import PHYSX_PRIMITIVE_COLLIDER
     import editor_python_test_tools.hydra_editor_utils as hydra
     import azlmbr.math as azmath
     import azlmbr.legacy.general as general
@@ -72,7 +73,7 @@ def Terrain_SupportsPhysics():
     # 2) Create 2 test entities, one parent at 512.0, 512.0, 50.0 and one child at the default position and add the required components
     entity1_components_to_add = ["Axis Aligned Box Shape", "Terrain Layer Spawner", "Terrain Height Gradient List", "Terrain Physics Heightfield Collider", "PhysX Heightfield Collider"]
     entity2_components_to_add = ["Shape Reference", "Gradient Transform Modifier", "FastNoise Gradient"]
-    ball_components_to_add = ["Sphere Shape", "PhysX Primitive Collider", "PhysX Dynamic Rigid Body"]
+    ball_components_to_add = ["Sphere Shape", PHYSX_PRIMITIVE_COLLIDER, "PhysX Dynamic Rigid Body"]
     terrain_spawner_entity = hydra.Entity("TestEntity1")
     terrain_spawner_entity.create_entity(azmath.Vector3(512.0, 512.0, 50.0), entity1_components_to_add)
     Report.result(Tests.create_terrain_spawner_entity, terrain_spawner_entity.id.IsValid())

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/PhysXColliderSurfaceTagEmitter_E2E_Editor.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/PhysXColliderSurfaceTagEmitter_E2E_Editor.py
@@ -27,6 +27,8 @@ def PhysXColliderSurfaceTagEmitter_E2E_Editor():
     from largeworlds.large_worlds_utils import editor_dynveg_test_helper as dynveg
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
+    from consts.physics import PHYSX_PRIMITIVE_COLLIDER
+    from consts.physics import PHYSX_MESH_COLLIDER
 
     def validate_behavior_context():
         # Verify that we can create the component through the BehaviorContext
@@ -115,7 +117,7 @@ def PhysXColliderSurfaceTagEmitter_E2E_Editor():
     collider_entity = hydra.Entity("Collider Surface")
     collider_entity.create_entity(
         entity_center_point,
-        ["PhysX Primitive Collider", "PhysX Collider Surface Tag Emitter", "PhysX Static Rigid Body"]
+        [PHYSX_PRIMITIVE_COLLIDER, "PhysX Collider Surface Tag Emitter", "PhysX Static Rigid Body"]
         )
     Report.result(collider_entity_created, collider_entity.id.IsValid())
 
@@ -172,8 +174,8 @@ def PhysXColliderSurfaceTagEmitter_E2E_Editor():
         bus.Broadcast, "GetAssetIdByPath", os.path.join("levels", "physics",
                                                         "Material_PerFaceMaterialGetsCorrectMaterial",
                                                         "test.pxmesh"), math.Uuid(), False)
-    collider_entity.remove_component("PhysX Primitive Collider")
-    collider_entity.add_component("PhysX Mesh Collider")
+    collider_entity.remove_component(PHYSX_PRIMITIVE_COLLIDER)
+    collider_entity.add_component(PHYSX_MESH_COLLIDER)
     helper.wait_for_condition(lambda: editor.EditorComponentAPIBus(bus.Broadcast, 'IsComponentEnabled',
                                                                    collider_entity.components[1]), 5.0)
     hydra.get_set_test(collider_entity, component_index=2, path="Shape Configuration|Asset|PhysX Mesh", value=test_physx_mesh_asset_id)

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/large_worlds_utils/editor_dynveg_test_helper.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/large_worlds_utils/editor_dynveg_test_helper.py
@@ -24,6 +24,7 @@ import editor_python_test_tools.hydra_editor_utils as hydra
 from editor_python_test_tools.editor_entity_utils import EditorEntity
 from editor_python_test_tools.prefab_utils import Prefab
 from editor_python_test_tools.wait_utils import PrefabWaiter
+from consts.physics import PHYSX_MESH_COLLIDER
 
 
 def create_temp_mesh_prefab(model_asset_path, prefab_filename):
@@ -48,9 +49,9 @@ def create_temp_physx_mesh_collider(physx_mesh_id, prefab_filename):
     root = EditorEntity.create_editor_entity(name=prefab_filename)
     assert root.exists(), "Failed to create entity"
     # Add PhysX Mesh Collider component
-    collider_component = root.add_component("PhysX Mesh Collider")
+    collider_component = root.add_component(PHYSX_MESH_COLLIDER)
     static_rigid_body_component = root.add_component("PhysX Static Rigid Body")
-    assert root.has_component("PhysX Mesh Collider") and collider_component.is_enabled() and \
+    assert root.has_component(PHYSX_MESH_COLLIDER) and collider_component.is_enabled() and \
            static_rigid_body_component.is_enabled(), "Failed to add/activate PhysX Mesh Collider component"
     # Assign the specified PhysX Mesh asset to PhysX Mesh Collider
     collider_component.set_component_property_value("Shape Configuration|Asset|PhysX Mesh", physx_mesh_id)

--- a/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
@@ -6,33 +6,18 @@
  *
  */
 
-#include <AzCore/Script/ScriptTimePoint.h>
-#include <AzCore/Serialization/EditContext.h>
-#include <AzCore/std/smart_ptr/shared_ptr.h>
-#include <AzFramework/Physics/ColliderComponentBus.h>
-#include <AzFramework/Physics/SimulatedBodies/RigidBody.h>
-#include <AzFramework/Physics/Common/PhysicsSimulatedBody.h>
+#include <AzFramework/Physics/SystemBus.h>
 #include <AzFramework/Physics/Configuration/StaticRigidBodyConfiguration.h>
-#include <AzFramework/Viewport/ViewportColors.h>
-#include <AzToolsFramework/API/EntityPropertyEditorRequestsBus.h>
-#include <AzToolsFramework/ComponentModes/BoxComponentMode.h>
-#include <AzToolsFramework/Maths/TransformUtils.h>
-#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
-#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
-#include <LmbrCentral/Geometry/GeometrySystemComponentBus.h>
-#include <LmbrCentral/Shape/BoxShapeComponentBus.h>
+
+#include <Editor/ColliderComponentMode.h>
+#include <System/PhysXSystem.h>
+
 #include <Source/BoxColliderComponent.h>
 #include <Source/CapsuleColliderComponent.h>
-#include <Source/EditorColliderComponent.h>
-#include <Source/EditorRigidBodyComponent.h>
-#include <Source/EditorStaticRigidBodyComponent.h>
-#include <Editor/Source/Components/EditorSystemComponent.h>
 #include <Source/SphereColliderComponent.h>
+#include <Source/EditorStaticRigidBodyComponent.h>
 #include <Source/Utils.h>
-
-#include <LyViewPaneNames.h>
-#include <Editor/ConfigurationWindowBus.h>
-#include <Editor/ColliderComponentMode.h>
+#include <Source/EditorColliderComponent.h>
 
 namespace PhysX
 {

--- a/Gems/PhysX/Code/Source/EditorColliderComponent.h
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.h
@@ -12,24 +12,19 @@
 #include <AzCore/Component/NonUniformScaleBus.h>
 #include <AzCore/Math/Quaternion.h>
 
-#include <AzFramework/Entity/EntityDebugDisplayBus.h>
 #include <AzFramework/Physics/Common/PhysicsEvents.h>
-#include <AzFramework/Physics/Common/PhysicsTypes.h>
 #include <AzFramework/Physics/Components/SimulatedBodyComponentBus.h>
-#include <AzFramework/Physics/Shape.h>
 #include <AzFramework/Physics/ShapeConfiguration.h>
 #include <AzFramework/Visibility/BoundsBus.h>
 
-#include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <AzToolsFramework/API/ComponentEntitySelectionBus.h>
 #include <AzToolsFramework/ComponentMode/ComponentModeDelegate.h>
 #include <AzToolsFramework/Manipulators/BoxManipulatorRequestBus.h>
 #include <AzToolsFramework/Manipulators/ShapeManipulatorRequestBus.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
-#include <AzToolsFramework/UI/PropertyEditor/ComponentEditor.hxx>
 
 #include <PhysX/ColliderShapeBus.h>
 #include <PhysX/EditorColliderComponentRequestBus.h>
-#include <System/PhysXSystem.h>
 
 #include <Editor/DebugDraw.h>
 

--- a/Gems/PhysX/Code/Source/EditorMeshColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorMeshColliderComponent.cpp
@@ -6,37 +6,18 @@
  *
  */
 
-#include <AzCore/Asset/AssetSerializer.h>
-#include <AzCore/Script/ScriptTimePoint.h>
-#include <AzCore/Serialization/EditContext.h>
-#include <AzCore/std/smart_ptr/shared_ptr.h>
-#include <AzFramework/Physics/ColliderComponentBus.h>
-#include <AzFramework/Physics/SimulatedBodies/RigidBody.h>
-#include <AzFramework/Physics/Common/PhysicsSimulatedBody.h>
 #include <AzFramework/Physics/Configuration/StaticRigidBodyConfiguration.h>
-#include <AzFramework/Viewport/ViewportColors.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <AzToolsFramework/API/EntityPropertyEditorRequestsBus.h>
-#include <AzToolsFramework/ComponentModes/BoxComponentMode.h>
-#include <AzToolsFramework/Maths/TransformUtils.h>
-#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
-#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
-#include <LmbrCentral/Geometry/GeometrySystemComponentBus.h>
-#include <LmbrCentral/Shape/BoxShapeComponentBus.h>
-#include <Source/BoxColliderComponent.h>
-#include <Source/CapsuleColliderComponent.h>
-#include <Source/EditorMeshColliderComponent.h>
+
+#include <Editor/ColliderComponentMode.h>
+#include <System/PhysXSystem.h>
+
 #include <Source/EditorRigidBodyComponent.h>
 #include <Source/EditorStaticRigidBodyComponent.h>
-#include <Editor/Source/Components/EditorSystemComponent.h>
 #include <Source/MeshColliderComponent.h>
-#include <Source/SphereColliderComponent.h>
 #include <Source/Utils.h>
-#include <Atom/RPI.Reflect/Model/ModelAsset.h>
-
-#include <LyViewPaneNames.h>
-#include <Editor/ConfigurationWindowBus.h>
-#include <Editor/ColliderComponentMode.h>
+#include <Source/EditorMeshColliderComponent.h>
 
 namespace PhysX
 {

--- a/Gems/PhysX/Code/Source/EditorMeshColliderComponent.h
+++ b/Gems/PhysX/Code/Source/EditorMeshColliderComponent.h
@@ -8,31 +8,24 @@
 
 #pragma once
 
-#include <AzCore/Component/TickBus.h>
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/Component/NonUniformScaleBus.h>
 #include <AzCore/Math/Quaternion.h>
 
-#include <AzFramework/Entity/EntityDebugDisplayBus.h>
 #include <AzFramework/Physics/Common/PhysicsEvents.h>
-#include <AzFramework/Physics/Common/PhysicsTypes.h>
 #include <AzFramework/Physics/Components/SimulatedBodyComponentBus.h>
-#include <AzFramework/Physics/Shape.h>
 #include <AzFramework/Physics/ShapeConfiguration.h>
 #include <AzFramework/Visibility/BoundsBus.h>
 
-#include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <AzToolsFramework/API/ComponentEntitySelectionBus.h>
 #include <AzToolsFramework/ComponentMode/ComponentModeDelegate.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
-
 #include <AtomLyIntegration/CommonFeatures/Mesh/MeshComponentBus.h>
-#include <AzToolsFramework/UI/PropertyEditor/ComponentEditor.hxx>
 
 #include <PhysX/ColliderShapeBus.h>
 #include <PhysX/EditorColliderComponentRequestBus.h>
 #include <PhysX/MeshAsset.h>
 #include <PhysX/MeshColliderComponentBus.h>
-#include <System/PhysXSystem.h>
 
 #include <Editor/DebugDraw.h>
 

--- a/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
@@ -20,6 +20,7 @@
 #include <Editor/KinematicDescriptionDialog.h>
 #include <Source/NameConstants.h>
 #include <Source/Utils.h>
+#include <System/PhysXSystem.h>
 #include <PhysX/PhysXLocks.h>
 #include <AzFramework/Physics/PropertyTypes.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyBoolComboBoxCtrl.hxx>


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## How was this PR tested?

- Built Editor with and without unity builds.
- Run all python tests from AutomatedTesting that were affected by this changed:
````
..\python\python.cmd -m pytest .\Gem\PythonTests\EditorPythonBindings\TestSuite_Periodic.py --build-directory=build\windows\bin\profile\
..\python\python.cmd -m pytest .\Gem\PythonTests\largeworlds\dyn_veg\TestSuite_Main.py --build-directory=build\windows\bin\profile\
..\python\python.cmd -m pytest .\Gem\PythonTests\largeworlds\dyn_veg\TestSuite_Periodic.py --build-directory=build\windows\bin\profile\
..\python\python.cmd -m pytest .\Gem\PythonTests\Prefab\TestSuite_Main.py --build-directory=build\windows\bin\profile\
..\python\python.cmd -m pytest .\Gem\PythonTests\Prefab\TestSuite_Periodic.py --build-directory=build\windows\bin\profile\
..\python\python.cmd -m pytest .\Gem\PythonTests\Prefab\LauncherTestSuite_Periodic.py --build-directory=build\windows\bin\profile\
..\python\python.cmd -m pytest .\Gem\PythonTests\Terrain\TestSuite_Main.py --build-directory=build\windows\bin\profile\
..\python\python.cmd -m pytest .\Gem\PythonTests\Terrain\TestSuite_Periodic.py --build-directory=build\windows\bin\profile\
..\python\python.cmd -m pytest .\Gem\PythonTests\Physics\TestSuite_Main.py --build-directory=build\windows\bin\profile\
..\python\python.cmd -m pytest .\Gem\PythonTests\Physics\TestSuite_Periodic.py --build-directory=build\windows\bin\profile\
..\python\python.cmd -m pytest .\Gem\PythonTests\Physics\TestSuite_Sandbox.py --build-directory=build\windows\bin\profile\
````
