### PR TITLE
Added unit tests to cover non-uniform scale in mesh colliders.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/ShapeConfiguration.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/ShapeConfiguration.h
@@ -47,6 +47,9 @@ namespace Physics
         static constexpr float DefaultSphereRadius = 0.5f;
         static const AZ::Vector3 DefaultBoxDimensions = AZ::Vector3::CreateOne();
         static const AZ::Vector3 DefaultScale = AZ::Vector3::CreateOne();
+        static constexpr float DefaultCylinderRadius = 1.0f;
+        static constexpr float DefaultCylinderHeight = 1.0f;
+        static constexpr AZ::u8 DefaultCylinderSubdivisionCount = 16;
     } // namespace ShapeConstants
 
     class ShapeConfiguration

--- a/Gems/PhysX/Code/Source/EditorColliderComponent.h
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.h
@@ -66,9 +66,9 @@ namespace PhysX
         static void Reflect(AZ::ReflectContext* context);
 
         //! Cylinder specific parameters.
-        AZ::u8 m_subdivisionCount = 16;
-        float m_height = 1.0f;
-        float m_radius = 1.0f;
+        AZ::u8 m_subdivisionCount = Physics::ShapeConstants::DefaultCylinderSubdivisionCount;
+        float m_height = Physics::ShapeConstants::DefaultCylinderHeight;
+        float m_radius = Physics::ShapeConstants::DefaultCylinderRadius;
 
         //! Configuration stores the convex geometry for the cylinder and shape scale.
         Physics::CookedMeshShapeConfiguration m_configuration;

--- a/Gems/PhysX/Code/Tests/ColliderScalingTests.cpp
+++ b/Gems/PhysX/Code/Tests/ColliderScalingTests.cpp
@@ -38,11 +38,14 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, BoxCollider_NonUniformScaleComponent_RuntimeShapeConfigReplacedWithConvex)
     {
-        EntityPtr editorEntity = CreateInactiveEditorEntity("Box");
-        editorEntity->CreateComponent<PhysX::EditorColliderComponent>(Physics::ColliderConfiguration(), Physics::BoxShapeConfiguration());
-        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
-        editorEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
-        editorEntity->Activate();
+        const AZ::Vector3 nonUniformScale(2.0f, 2.5f, 0.5f);
+
+        EntityPtr editorEntity = CreateBoxPrimitiveColliderEditorEntity(
+            Physics::ShapeConstants::DefaultBoxDimensions,
+            AZ::Transform::CreateIdentity(),
+            AZ::Vector3::CreateZero(),
+            AZ::Quaternion::CreateIdentity(),
+            nonUniformScale);
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
@@ -54,24 +57,13 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, BoxCollider_NonUniformScale_RuntimePhysicsAabbCorrect)
     {
-        EntityPtr editorEntity = CreateInactiveEditorEntity("Box");
+        const AZ::Vector3 boxDimensions(0.5f, 0.7f, 0.9f);
+        const AZ::Transform transform(AZ::Vector3(5.0f, 6.0f, 7.0f), AZ::Quaternion::CreateRotationX(AZ::DegToRad(30.0f)), 1.5f);
+        const AZ::Vector3 translationOffset(1.0f, 2.0f, 3.0f);
+        const AZ::Quaternion rotationOffset = AZ::Quaternion::CreateRotationZ(AZ::DegToRad(45.0f));
+        const AZ::Vector3 nonUniformScale(0.7f, 0.9f, 1.1f);
 
-        Physics::ColliderConfiguration colliderConfig;
-        colliderConfig.m_rotation = AZ::Quaternion::CreateRotationZ(AZ::DegToRad(45.0f));
-        colliderConfig.m_position = AZ::Vector3(1.0f, 2.0f, 3.0f);
-        Physics::BoxShapeConfiguration boxShapeConfig(AZ::Vector3(0.5f, 0.7f, 0.9f));
-        editorEntity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, boxShapeConfig);
-        editorEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
-        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
-        editorEntity->Activate();
-
-        AZ::EntityId editorId = editorEntity->GetId();
-        AZ::Transform worldTM;
-        worldTM.SetUniformScale(1.5f);
-        worldTM.SetTranslation(AZ::Vector3(5.0f, 6.0f, 7.0f));
-        worldTM.SetRotation(AZ::Quaternion::CreateRotationX(AZ::DegToRad(30.0f)));
-        AZ::TransformBus::Event(editorId, &AZ::TransformBus::Events::SetWorldTM, worldTM);
-        AZ::NonUniformScaleRequestBus::Event(editorId, &AZ::NonUniformScaleRequests::SetScale, AZ::Vector3(0.7f, 0.9f, 1.1f));
+        EntityPtr editorEntity = CreateBoxPrimitiveColliderEditorEntity(boxDimensions, transform, translationOffset, rotationOffset, nonUniformScale);
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
@@ -83,26 +75,16 @@ namespace PhysXEditorTests
         EXPECT_THAT(aabb.GetMax(), UnitTest::IsCloseTolerance(AZ::Vector3(6.4955f, 6.7305f, 13.5662f), 1e-3f));
     }
 
-    TEST_F(PhysXEditorFixture, BoxColliderRigidBody_NonUniformScale_RuntimePhysicsAabbCorrect)
+    TEST_F(PhysXEditorFixture, BoxCollider_WithDynamicRigidBody_NonUniformScale_RuntimePhysicsAabbCorrect)
     {
-        EntityPtr editorEntity = CreateInactiveEditorEntity("Box");
+        const AZ::Vector3 boxDimensions(0.5f, 0.7f, 0.9f);
+        const AZ::Transform transform(AZ::Vector3(5.0f, 6.0f, 7.0f), AZ::Quaternion::CreateRotationX(AZ::DegToRad(30.0f)), 1.5f);
+        const AZ::Vector3 translationOffset(1.0f, 2.0f, 3.0f);
+        const AZ::Quaternion rotationOffset = AZ::Quaternion::CreateRotationZ(AZ::DegToRad(45.0f));
+        const AZ::Vector3 nonUniformScale(0.7f, 0.9f, 1.1f);
 
-        Physics::ColliderConfiguration colliderConfig;
-        colliderConfig.m_rotation = AZ::Quaternion::CreateRotationZ(AZ::DegToRad(45.0f));
-        colliderConfig.m_position = AZ::Vector3(1.0f, 2.0f, 3.0f);
-        Physics::BoxShapeConfiguration boxShapeConfig(AZ::Vector3(0.5f, 0.7f, 0.9f));
-        editorEntity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, boxShapeConfig);
-        editorEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
-        editorEntity->CreateComponent<PhysX::EditorRigidBodyComponent>();
-        editorEntity->Activate();
-
-        AZ::EntityId editorId = editorEntity->GetId();
-        AZ::Transform worldTM;
-        worldTM.SetUniformScale(1.5f);
-        worldTM.SetTranslation(AZ::Vector3(5.0f, 6.0f, 7.0f));
-        worldTM.SetRotation(AZ::Quaternion::CreateRotationX(AZ::DegToRad(30.0f)));
-        AZ::TransformBus::Event(editorId, &AZ::TransformBus::Events::SetWorldTM, worldTM);
-        AZ::NonUniformScaleRequestBus::Event(editorId, &AZ::NonUniformScaleRequests::SetScale, AZ::Vector3(0.7f, 0.9f, 1.1f));
+        EntityPtr editorEntity = CreateBoxPrimitiveColliderEditorEntity(
+            boxDimensions, transform, translationOffset, rotationOffset, nonUniformScale, RigidBodyType::Dynamic);
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
@@ -116,11 +98,15 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, CapsuleCollider_NonUniformScaleComponent_RuntimeShapeConfigReplacedWithConvex)
     {
-        EntityPtr editorEntity = CreateInactiveEditorEntity("Capsule");
-        editorEntity->CreateComponent<PhysX::EditorColliderComponent>(Physics::ColliderConfiguration(), Physics::CapsuleShapeConfiguration());
-        editorEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
-        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
-        editorEntity->Activate();
+        const AZ::Vector3 nonUniformScale(1.0f, 1.5f, 1.0f);
+
+        EntityPtr editorEntity = CreateCapsulePrimitiveColliderEditorEntity(
+            Physics::ShapeConstants::DefaultCapsuleRadius,
+            Physics::ShapeConstants::DefaultCapsuleHeight,
+            AZ::Transform::CreateIdentity(),
+            AZ::Vector3::CreateZero(),
+            AZ::Quaternion::CreateIdentity(),
+            nonUniformScale);
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
@@ -132,24 +118,15 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, CapsuleCollider_NonUniformScale_RuntimePhysicsAabbCorrect)
     {
-        EntityPtr editorEntity = CreateInactiveEditorEntity("Capsule");
+        const float capsuleRadius = 0.3f;
+        const float capsuleHeight = 1.4f;
+        const AZ::Transform transform(AZ::Vector3(3.0f, 1.0f, -4.0f), AZ::Quaternion::CreateRotationY(AZ::DegToRad(90.0f)), 0.5f);
+        const AZ::Vector3 translationOffset(2.0f, 5.0f, 3.0f);
+        const AZ::Quaternion rotationOffset = AZ::Quaternion::CreateRotationX(AZ::DegToRad(90.0f));
+        const AZ::Vector3 nonUniformScale(1.2f, 0.7f, 0.6f);
 
-        Physics::ColliderConfiguration colliderConfig;
-        colliderConfig.m_rotation = AZ::Quaternion::CreateRotationX(AZ::DegToRad(90.0f));
-        colliderConfig.m_position = AZ::Vector3(2.0f, 5.0f, 3.0f);
-        Physics::CapsuleShapeConfiguration capsuleShapeConfig(1.4f, 0.3f);
-        editorEntity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, capsuleShapeConfig);
-        editorEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
-        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
-        editorEntity->Activate();
-
-        AZ::EntityId capsuleId = editorEntity->GetId();
-        AZ::Transform worldTM;
-        worldTM.SetUniformScale(0.5f);
-        worldTM.SetTranslation(AZ::Vector3(3.0f, 1.0f, -4.0f));
-        worldTM.SetRotation(AZ::Quaternion::CreateRotationY(AZ::DegToRad(90.0f)));
-        AZ::TransformBus::Event(capsuleId, &AZ::TransformBus::Events::SetWorldTM, worldTM);
-        AZ::NonUniformScaleRequestBus::Event(capsuleId, &AZ::NonUniformScaleRequests::SetScale, AZ::Vector3(1.2f, 0.7f, 0.6f));
+        EntityPtr editorEntity = CreateCapsulePrimitiveColliderEditorEntity(
+            capsuleRadius, capsuleHeight, transform, translationOffset, rotationOffset, nonUniformScale);
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
@@ -162,26 +139,17 @@ namespace PhysXEditorTests
         EXPECT_THAT(aabb.GetMax(), UnitTest::IsCloseTolerance(AZ::Vector3(3.99f, 2.995f, -5.02f), 1e-3f));
     }
 
-    TEST_F(PhysXEditorFixture, CapsuleColliderRigidBody_NonUniformScale_RuntimePhysicsAabbCorrect)
+    TEST_F(PhysXEditorFixture, CapsuleCollider_WithDynamicRigidBody_NonUniformScale_RuntimePhysicsAabbCorrect)
     {
-        EntityPtr editorEntity = CreateInactiveEditorEntity("Capsule");
+        const float capsuleRadius = 0.3f;
+        const float capsuleHeight = 1.4f;
+        const AZ::Transform transform(AZ::Vector3(3.0f, 1.0f, -4.0f), AZ::Quaternion::CreateRotationY(AZ::DegToRad(90.0f)), 0.5f);
+        const AZ::Vector3 translationOffset(2.0f, 5.0f, 3.0f);
+        const AZ::Quaternion rotationOffset = AZ::Quaternion::CreateRotationX(AZ::DegToRad(90.0f));
+        const AZ::Vector3 nonUniformScale(1.2f, 0.7f, 0.6f);
 
-        Physics::ColliderConfiguration colliderConfig;
-        colliderConfig.m_rotation = AZ::Quaternion::CreateRotationX(AZ::DegToRad(90.0f));
-        colliderConfig.m_position = AZ::Vector3(2.0f, 5.0f, 3.0f);
-        Physics::CapsuleShapeConfiguration capsuleShapeConfig(1.4f, 0.3f);
-        editorEntity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, capsuleShapeConfig);
-        editorEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
-        editorEntity->CreateComponent<PhysX::EditorRigidBodyComponent>();
-        editorEntity->Activate();
-
-        AZ::EntityId capsuleId = editorEntity->GetId();
-        AZ::Transform worldTM;
-        worldTM.SetUniformScale(0.5f);
-        worldTM.SetTranslation(AZ::Vector3(3.0f, 1.0f, -4.0f));
-        worldTM.SetRotation(AZ::Quaternion::CreateRotationY(AZ::DegToRad(90.0f)));
-        AZ::TransformBus::Event(capsuleId, &AZ::TransformBus::Events::SetWorldTM, worldTM);
-        AZ::NonUniformScaleRequestBus::Event(capsuleId, &AZ::NonUniformScaleRequests::SetScale, AZ::Vector3(1.2f, 0.7f, 0.6f));
+        EntityPtr editorEntity = CreateCapsulePrimitiveColliderEditorEntity(
+            capsuleRadius, capsuleHeight, transform, translationOffset, rotationOffset, nonUniformScale, RigidBodyType::Dynamic);
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
@@ -196,11 +164,14 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, SphereCollider_NonUniformScaleComponent_RuntimeShapeConfigReplacedWithConvex)
     {
-        EntityPtr editorEntity = CreateInactiveEditorEntity("Sphere");
-        editorEntity->CreateComponent<PhysX::EditorColliderComponent>(Physics::ColliderConfiguration(), Physics::SphereShapeConfiguration());
-        editorEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
-        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
-        editorEntity->Activate();
+        const AZ::Vector3 nonUniformScale(1.0f, 1.5f, 1.0f);
+
+        EntityPtr editorEntity = CreateSpherePrimitiveColliderEditorEntity(
+            Physics::ShapeConstants::DefaultSphereRadius,
+            AZ::Transform::CreateIdentity(),
+            AZ::Vector3::CreateZero(),
+            AZ::Quaternion::CreateIdentity(),
+            nonUniformScale);
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
@@ -212,24 +183,14 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, SphereCollider_NonUniformScale_RuntimePhysicsAabbCorrect)
     {
-        EntityPtr editorEntity = CreateInactiveEditorEntity("Sphere");
+        const float sphereRadius = 0.7f;
+        const AZ::Transform transform(AZ::Vector3(-2.0f, -1.0f, 3.0f), AZ::Quaternion::CreateRotationX(AZ::DegToRad(90.0f)), 1.2f);
+        const AZ::Vector3 translationOffset(3.0f, -2.0f, 2.0f);
+        const AZ::Quaternion rotationOffset = AZ::Quaternion::CreateRotationY(AZ::DegToRad(90.0f));
+        const AZ::Vector3 nonUniformScale(0.8f, 0.9f, 0.6f);
 
-        Physics::ColliderConfiguration colliderConfig;
-        colliderConfig.m_rotation = AZ::Quaternion::CreateRotationY(AZ::DegToRad(90.0f));
-        colliderConfig.m_position = AZ::Vector3(3.0f, -2.0f, 2.0f);
-        Physics::SphereShapeConfiguration sphereShapeConfig(0.7f);
-        editorEntity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, sphereShapeConfig);
-        editorEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
-        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
-        editorEntity->Activate();
-
-        AZ::EntityId sphereId = editorEntity->GetId();
-        AZ::Transform worldTM;
-        worldTM.SetUniformScale(1.2f);
-        worldTM.SetTranslation(AZ::Vector3(-2.0f, -1.0f, 3.0f));
-        worldTM.SetRotation(AZ::Quaternion::CreateRotationX(AZ::DegToRad(90.0f)));
-        AZ::TransformBus::Event(sphereId, &AZ::TransformBus::Events::SetWorldTM, worldTM);
-        AZ::NonUniformScaleRequestBus::Event(sphereId, &AZ::NonUniformScaleRequests::SetScale, AZ::Vector3(0.8f, 0.9f, 0.6f));
+        EntityPtr editorEntity =
+            CreateSpherePrimitiveColliderEditorEntity(sphereRadius, transform, translationOffset, rotationOffset, nonUniformScale);
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
@@ -242,26 +203,16 @@ namespace PhysXEditorTests
         EXPECT_THAT(aabb.GetMax(), UnitTest::IsCloseTolerance(AZ::Vector3(1.552f, -1.936f, 1.596f), 1e-3f));
     }
 
-    TEST_F(PhysXEditorFixture, SphereColliderRigidBody_NonUniformScale_RuntimePhysicsAabbCorrect)
+    TEST_F(PhysXEditorFixture, SphereCollider_WithDynamicRigidBody_NonUniformScale_RuntimePhysicsAabbCorrect)
     {
-        EntityPtr editorEntity = CreateInactiveEditorEntity("Sphere");
+        const float sphereRadius = 0.7f;
+        const AZ::Transform transform(AZ::Vector3(-2.0f, -1.0f, 3.0f), AZ::Quaternion::CreateRotationX(AZ::DegToRad(90.0f)), 1.2f);
+        const AZ::Vector3 translationOffset(3.0f, -2.0f, 2.0f);
+        const AZ::Quaternion rotationOffset = AZ::Quaternion::CreateRotationY(AZ::DegToRad(90.0f));
+        const AZ::Vector3 nonUniformScale(0.8f, 0.9f, 0.6f);
 
-        Physics::ColliderConfiguration colliderConfig;
-        colliderConfig.m_rotation = AZ::Quaternion::CreateRotationY(AZ::DegToRad(90.0f));
-        colliderConfig.m_position = AZ::Vector3(3.0f, -2.0f, 2.0f);
-        Physics::SphereShapeConfiguration sphereShapeConfig(0.7f);
-        editorEntity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, sphereShapeConfig);
-        editorEntity->CreateComponent<AzToolsFramework::Components::EditorNonUniformScaleComponent>();
-        editorEntity->CreateComponent<PhysX::EditorRigidBodyComponent>();
-        editorEntity->Activate();
-
-        AZ::EntityId sphereId = editorEntity->GetId();
-        AZ::Transform worldTM;
-        worldTM.SetUniformScale(1.2f);
-        worldTM.SetTranslation(AZ::Vector3(-2.0f, -1.0f, 3.0f));
-        worldTM.SetRotation(AZ::Quaternion::CreateRotationX(AZ::DegToRad(90.0f)));
-        AZ::TransformBus::Event(sphereId, &AZ::TransformBus::Events::SetWorldTM, worldTM);
-        AZ::NonUniformScaleRequestBus::Event(sphereId, &AZ::NonUniformScaleRequests::SetScale, AZ::Vector3(0.8f, 0.9f, 0.6f));
+        EntityPtr editorEntity = CreateSpherePrimitiveColliderEditorEntity(
+            sphereRadius, transform, translationOffset, rotationOffset, nonUniformScale, RigidBodyType::Dynamic);
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
@@ -274,14 +225,46 @@ namespace PhysXEditorTests
         EXPECT_THAT(aabb.GetMax(), UnitTest::IsCloseTolerance(AZ::Vector3(1.552f, -1.936f, 1.596f), 1e-3f));
     }
 
+    TEST_F(PhysXEditorFixture, CylinderCollider_RuntimeShapeConfigUsingConvex)
+    {
+        EntityPtr editorEntity = CreateCylinderPrimitiveColliderEditorEntity(
+            Physics::ShapeConstants::DefaultCylinderRadius,
+            Physics::ShapeConstants::DefaultCylinderHeight);
+
+        EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
+
+        // Since there is no cylinder shape in PhysX, the runtime entity should have a BaseColliderComponent with a
+        // cooked mesh shape configuration.
+        ExpectSingleConvexRuntimeConfig(gameEntity.get());
+    }
+
+    TEST_F(PhysXEditorFixture, CylinderCollider_NonUniformScaleComponent_RuntimeShapeConfigUsingConvex)
+    {
+        const AZ::Vector3 nonUniformScale(1.0f, 1.5f, 1.0f);
+
+        EntityPtr editorEntity = CreateCylinderPrimitiveColliderEditorEntity(
+            Physics::ShapeConstants::DefaultCylinderRadius,
+            Physics::ShapeConstants::DefaultCylinderHeight,
+            AZ::Transform::CreateIdentity(),
+            AZ::Vector3::CreateZero(),
+            AZ::Quaternion::CreateIdentity(),
+            nonUniformScale);
+
+        EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
+
+        // Since there is no cylinder shape in PhysX, the runtime entity should have a BaseColliderComponent with a
+        // cooked mesh shape configuration.
+        ExpectSingleConvexRuntimeConfig(gameEntity.get());
+    }
+
     TEST_F(PhysXEditorFixture, EditorColliderComponent_CylinderWithOffset_CorrectEditorStaticBodyGeometry)
     {
+        const float radius = 1.5f;
+        const float height = 7.5f;
         const AZ::Transform transform(AZ::Vector3(3.0f, 3.0f, 5.0f), AZ::Quaternion(0.5f, -0.5f, -0.5f, 0.5f), 1.5f);
         const AZ::Vector3 positionOffset(0.5f, 1.5f, -2.5f);
         const AZ::Quaternion rotationOffset(0.3f, -0.1f, -0.3f, 0.9f);
-        const float radius = 1.5f;
-        const float height = 7.5f;
-        EntityPtr editorEntity = CreateCylinderPrimitiveColliderEditorEntity(transform, positionOffset, rotationOffset, radius, height);
+        EntityPtr editorEntity = CreateCylinderPrimitiveColliderEditorEntity(radius, height, transform, positionOffset, rotationOffset);
 
         const AZ::Aabb aabb = GetSimulatedBodyAabb(editorEntity->GetId());
         // use a relatively large tolerance, because the cylinder will be a convex approximation rather than an exact primitive
@@ -291,13 +274,13 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, EditorColliderComponent_CylinderWithOffset_CorrectEditorDynamicBodyGeometry)
     {
+        const float radius = 3.0f;
+        const float height = 11.0f;
         const AZ::Transform transform(AZ::Vector3(5.0f, 6.0f, 7.0f), AZ::Quaternion(0.1f, 0.5f, -0.7f, 0.5f), 1.0f);
         const AZ::Vector3 positionOffset(-6.0f, -4.0f, -2.0f);
         const AZ::Quaternion rotationOffset(0.4f, 0.8f, 0.2f, 0.4f);
-        const float radius = 3.0f;
-        const float height = 11.0f;
-        EntityPtr editorEntity =
-            CreateCylinderPrimitiveColliderEditorEntity(transform, positionOffset, rotationOffset, radius, height, AZStd::nullopt, RigidBodyType::Dynamic);
+        EntityPtr editorEntity = CreateCylinderPrimitiveColliderEditorEntity(
+            radius, height, transform, positionOffset, rotationOffset, AZStd::nullopt, RigidBodyType::Dynamic);
 
         const AZ::Aabb aabb = GetSimulatedBodyAabb(editorEntity->GetId());
         // use a relatively large tolerance, because the cylinder will be a convex approximation rather than an exact primitive
@@ -307,12 +290,12 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, EditorColliderComponent_CylinderWithOffset_CorrectRuntimeStaticBodyGeometry)
     {
+        const float radius = 0.5f;
+        const float height = 4.0f;
         const AZ::Transform transform(AZ::Vector3(3.0f, 5.0f, -9.0f), AZ::Quaternion(0.7f, -0.1f, 0.1f, 0.7f), 0.5f);
         const AZ::Vector3 positionOffset(2.0f, 5.0f, 6.0f);
         const AZ::Quaternion rotationOffset(-0.9f, 0.1f, -0.3f, 0.3f);
-        const float radius = 0.5f;
-        const float height = 4.0f;
-        EntityPtr editorEntity = CreateCylinderPrimitiveColliderEditorEntity(transform, positionOffset, rotationOffset, radius, height);
+        EntityPtr editorEntity = CreateCylinderPrimitiveColliderEditorEntity(radius, height, transform, positionOffset, rotationOffset);
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
@@ -324,13 +307,13 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, EditorColliderComponent_CylinderWithOffset_CorrectRuntimeDynamicBodyGeometry)
     {
+        const float radius = 1.0f;
+        const float height = 5.5f;
         const AZ::Transform transform(AZ::Vector3(-4.0f, -1.0f, 2.0f), AZ::Quaternion(0.4f, 0.4f, -0.2f, 0.8f), 1.0f);
         const AZ::Vector3 positionOffset(3.0f, 4.0f, 5.0f);
         const AZ::Quaternion rotationOffset(-0.5f, -0.5f, -0.5f, 0.5f);
-        const float radius = 1.0f;
-        const float height = 5.5f;
-        EntityPtr editorEntity =
-            CreateCylinderPrimitiveColliderEditorEntity(transform, positionOffset, rotationOffset, radius, height, AZStd::nullopt, RigidBodyType::Dynamic);
+        EntityPtr editorEntity = CreateCylinderPrimitiveColliderEditorEntity(
+            radius, height, transform, positionOffset, rotationOffset, AZStd::nullopt, RigidBodyType::Dynamic);
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
@@ -342,14 +325,14 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, EditorColliderComponent_CylinderWithOffsetAndNonUniformScale_CorrectEditorStaticBodyGeometry)
     {
-        const AZ::Transform transform(AZ::Vector3(4.0f, -3.0f, -2.0f), AZ::Quaternion(0.3f, 0.9f, -0.3f, 0.1f), 2.0f);
-        const AZ::Vector3 nonUniformScale(0.5f, 2.0f, 2.0f);
-        const AZ::Vector3 positionOffset(0.5f, 0.2f, 0.3f);
-        const AZ::Quaternion rotationOffset(0.5f, -0.5f, -0.5f, 0.5f);
         const float radius = 0.5f;
         const float height = 4.0f;
+        const AZ::Transform transform(AZ::Vector3(4.0f, -3.0f, -2.0f), AZ::Quaternion(0.3f, 0.9f, -0.3f, 0.1f), 2.0f);
+        const AZ::Vector3 positionOffset(0.5f, 0.2f, 0.3f);
+        const AZ::Quaternion rotationOffset(0.5f, -0.5f, -0.5f, 0.5f);
+        const AZ::Vector3 nonUniformScale(0.5f, 2.0f, 2.0f);
         EntityPtr editorEntity =
-            CreateCylinderPrimitiveColliderEditorEntity(transform, positionOffset, rotationOffset, radius, height, nonUniformScale);
+            CreateCylinderPrimitiveColliderEditorEntity(radius, height, transform, positionOffset, rotationOffset, nonUniformScale);
 
         const AZ::Aabb aabb = GetSimulatedBodyAabb(editorEntity->GetId());
         // use a relatively large tolerance, because the cylinder will be a convex approximation rather than an exact primitive
@@ -359,14 +342,14 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, EditorColliderComponent_CylinderWithOffsetAndNonUniformScale_CorrectEditorDynamicBodyGeometry)
     {
-        const AZ::Transform transform(AZ::Vector3(2.0f, 5.0f, -3.0f), AZ::Quaternion(0.7f, -0.1f, 0.1f, 0.7f), 0.5f);
-        const AZ::Vector3 nonUniformScale(1.5f, 1.0f, 0.5f);
-        const AZ::Vector3 positionOffset(-1.0f, -1.0f, 0.5f);
-        const AZ::Quaternion rotationOffset(0.9f, -0.3f, -0.3f, 0.1f);
         const float radius = 1.5f;
         const float height = 9.0f;
+        const AZ::Transform transform(AZ::Vector3(2.0f, 5.0f, -3.0f), AZ::Quaternion(0.7f, -0.1f, 0.1f, 0.7f), 0.5f);
+        const AZ::Vector3 positionOffset(-1.0f, -1.0f, 0.5f);
+        const AZ::Quaternion rotationOffset(0.9f, -0.3f, -0.3f, 0.1f);
+        const AZ::Vector3 nonUniformScale(1.5f, 1.0f, 0.5f);
         EntityPtr editorEntity = CreateCylinderPrimitiveColliderEditorEntity(
-            transform, positionOffset, rotationOffset, radius, height, nonUniformScale, RigidBodyType::Dynamic);
+            radius, height, transform, positionOffset, rotationOffset, nonUniformScale, RigidBodyType::Dynamic);
 
         const AZ::Aabb aabb = GetSimulatedBodyAabb(editorEntity->GetId());
         // use a relatively large tolerance, because the cylinder will be a convex approximation rather than an exact primitive
@@ -376,14 +359,14 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, EditorColliderComponent_CylinderWithOffsetAndNonUniformScale_CorrectRuntimeStaticBodyGeometry)
     {
-        const AZ::Transform transform(AZ::Vector3(5.0f, 4.0f, 2.0f), AZ::Quaternion(0.4f, 0.4f, -0.8f, 0.2f), 0.8f);
-        const AZ::Vector3 nonUniformScale(3.0f, 1.0f, 2.0f);
-        const AZ::Vector3 positionOffset(2.0f, 1.0f, -2.0f);
-        const AZ::Quaternion rotationOffset(0.7f, -0.1f, -0.5f, 0.5f);
         const float radius = 1.0f;
         const float height = 5.0f;
+        const AZ::Transform transform(AZ::Vector3(5.0f, 4.0f, 2.0f), AZ::Quaternion(0.4f, 0.4f, -0.8f, 0.2f), 0.8f);
+        const AZ::Vector3 positionOffset(2.0f, 1.0f, -2.0f);
+        const AZ::Quaternion rotationOffset(0.7f, -0.1f, -0.5f, 0.5f);
+        const AZ::Vector3 nonUniformScale(3.0f, 1.0f, 2.0f);
         EntityPtr editorEntity =
-            CreateCylinderPrimitiveColliderEditorEntity(transform, positionOffset, rotationOffset, radius, height, nonUniformScale);
+            CreateCylinderPrimitiveColliderEditorEntity(radius, height, transform, positionOffset, rotationOffset, nonUniformScale);
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
@@ -395,14 +378,14 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, EditorColliderComponent_CylinderWithOffsetAndNonUniformScale_CorrectRuntimeDynamicBodyGeometry)
     {
-        const AZ::Transform transform(AZ::Vector3(-2.0f, -3.0f, -6.0f), AZ::Quaternion(0.1f, 0.5f, -0.7f, 0.5f), 3.0f);
-        const AZ::Vector3 nonUniformScale(2.0f, 2.0f, 5.0f);
-        const AZ::Vector3 positionOffset(-1.0, 0.5f, -2.0f);
-        const AZ::Quaternion rotationOffset(0.2f, -0.4f, 0.8f, 0.4f);
         const float radius = 2.0f;
         const float height = 7.0f;
+        const AZ::Transform transform(AZ::Vector3(-2.0f, -3.0f, -6.0f), AZ::Quaternion(0.1f, 0.5f, -0.7f, 0.5f), 3.0f);
+        const AZ::Vector3 positionOffset(-1.0, 0.5f, -2.0f);
+        const AZ::Quaternion rotationOffset(0.2f, -0.4f, 0.8f, 0.4f);
+        const AZ::Vector3 nonUniformScale(2.0f, 2.0f, 5.0f);
         EntityPtr editorEntity = CreateCylinderPrimitiveColliderEditorEntity(
-            transform, positionOffset, rotationOffset, radius, height, nonUniformScale, RigidBodyType::Dynamic);
+            radius, height, transform, positionOffset, rotationOffset, nonUniformScale, RigidBodyType::Dynamic);
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 

--- a/Gems/PhysX/Code/Tests/DebugDrawTests.cpp
+++ b/Gems/PhysX/Code/Tests/DebugDrawTests.cpp
@@ -222,12 +222,12 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, ShapeCollider_BoxWithTranslationOffset_DebugDrawCorrect)
     {
-        AZ::Transform transform(AZ::Vector3(1.0f, 2.0f, 3.0f), AZ::Quaternion(0.4f, -0.2f, -0.4f, 0.8f), 0.7f);
-        AZ::Vector3 nonUniformScale(1.0f, 1.5f, 2.0f);
-        AZ::Vector3 boxDimensions(3.0f, 4.0f, 5.0f);
-        AZ::Vector3 translationOffset(2.0f, -5.0f, 3.0f);
+        const AZ::Vector3 boxDimensions(3.0f, 4.0f, 5.0f);
+        const AZ::Transform transform(AZ::Vector3(1.0f, 2.0f, 3.0f), AZ::Quaternion(0.4f, -0.2f, -0.4f, 0.8f), 0.7f);
+        const AZ::Vector3 translationOffset(2.0f, -5.0f, 3.0f);
+        const AZ::Vector3 nonUniformScale(1.0f, 1.5f, 2.0f);
 
-        EntityPtr boxShapeEntity = CreateBoxShapeColliderEditorEntity(transform, boxDimensions, translationOffset, nonUniformScale);
+        EntityPtr boxShapeEntity = CreateBoxShapeColliderEditorEntity(boxDimensions, transform, translationOffset, nonUniformScale);
 
         // turn off the shape visibility, so that only the shape collider component debug draws
         LmbrCentral::EditorShapeComponentRequestsBus::Event(
@@ -241,12 +241,12 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, ShapeCollider_BoxWithTranslationOffset_SamplePointsCorrect)
     {
-        AZ::Transform transform(AZ::Vector3(4.0f, 7.0f, -2.0f), AZ::Quaternion(0.5f, -0.1f, -0.7f, 0.5f), 1.5f);
-        AZ::Vector3 nonUniformScale(2.0f, 1.0f, 1.5f);
-        AZ::Vector3 boxDimensions(6.0f, 2.0f, 7.0f);
-        AZ::Vector3 translationOffset(4.0f, 1.0f, 6.0f);
+        const AZ::Vector3 boxDimensions(6.0f, 2.0f, 7.0f);
+        const AZ::Transform transform(AZ::Vector3(4.0f, 7.0f, -2.0f), AZ::Quaternion(0.5f, -0.1f, -0.7f, 0.5f), 1.5f);
+        const AZ::Vector3 translationOffset(4.0f, 1.0f, 6.0f);
+        const AZ::Vector3 nonUniformScale(2.0f, 1.0f, 1.5f);
 
-        EntityPtr boxShapeEntity = CreateBoxShapeColliderEditorEntity(transform, boxDimensions, translationOffset, nonUniformScale);
+        EntityPtr boxShapeEntity = CreateBoxShapeColliderEditorEntity(boxDimensions, transform, translationOffset, nonUniformScale);
 
         const AZStd::vector<AZ::Vector3> samplePoints =
             boxShapeEntity->FindComponent<PhysX::EditorShapeColliderComponent>()->GetSamplePoints();
@@ -265,8 +265,8 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, ShapeCollider_SphereWithTranslationOffset_DebugDrawCorrect)
     {
         EntityPtr sphereShapeEntity = CreateSphereShapeColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(-5.0f, -3.0f, 1.0f), AZ::Quaternion(-0.3f, 0.9f, -0.1f, 0.3f), 1.4f),
             2.5f,
+            AZ::Transform(AZ::Vector3(-5.0f, -3.0f, 1.0f), AZ::Quaternion(-0.3f, 0.9f, -0.1f, 0.3f), 1.4f),
             AZ::Vector3(4.0f, -4.0f, 6.0f)
         );
 
@@ -284,8 +284,8 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, ShapeCollider_SphereWithTranslationOffset_SamplePointsCorrect)
     {
         EntityPtr sphereShapeEntity = CreateSphereShapeColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(4.0f, -1.0f, -1.0f), AZ::Quaternion(-0.7f, 0.5f, 0.1f, 0.5f), 2.5f),
             0.6f,
+            AZ::Transform(AZ::Vector3(4.0f, -1.0f, -1.0f), AZ::Quaternion(-0.7f, 0.5f, 0.1f, 0.5f), 2.5f),
             AZ::Vector3(-2.0f, 5.0f, -3.0f)
         );
 
@@ -305,9 +305,9 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, ShapeCollider_CapsuleWithTranslationOffset_DebugDrawCorrect)
     {
         EntityPtr capsuleShapeEntity = CreateCapsuleShapeColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(2.0f, 6.0f, -1.0f), AZ::Quaternion(0.9f, 0.1f, 0.3f, 0.3f), 2.0f),
             1.5f,
             6.0f,
+            AZ::Transform(AZ::Vector3(2.0f, 6.0f, -1.0f), AZ::Quaternion(0.9f, 0.1f, 0.3f, 0.3f), 2.0f),
             AZ::Vector3(-3.0f, -4.0f, -5.0f)
         );
 
@@ -325,9 +325,9 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, ShapeCollider_CapsuleWithTranslationOffset_SamplePointsCorrect)
     {
         EntityPtr sphereShapeEntity = CreateCapsuleShapeColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(2.0f, 6.0f, -1.0f), AZ::Quaternion(0.9f, 0.1f, 0.3f, 0.3f), 2.0f),
             1.5f,
             6.0f,
+            AZ::Transform(AZ::Vector3(2.0f, 6.0f, -1.0f), AZ::Quaternion(0.9f, 0.1f, 0.3f, 0.3f), 2.0f),
             AZ::Vector3(-3.0f, -4.0f, -5.0f)
         );
 
@@ -348,12 +348,12 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, Collider_CylinderWithOffset_CorrectDebugDraw)
     {
+        const float radius = 2.0f;
+        const float height = 7.5f;
         const AZ::Transform transform(AZ::Vector3(-1.0f, -3.0f, -4.0f), AZ::Quaternion(0.3f, 0.1f, 0.9f, 0.3f), 1.0f);
         const AZ::Vector3 positionOffset(2.0f, 6.0f, -3.0f);
         const AZ::Quaternion rotationOffset(-0.5f, -0.1f, 0.7f, 0.5f);
-        const float radius = 2.0f;
-        const float height = 7.5f;
-        EntityPtr editorEntity = CreateCylinderPrimitiveColliderEditorEntity(transform, positionOffset, rotationOffset, radius, height);
+        EntityPtr editorEntity = CreateCylinderPrimitiveColliderEditorEntity(radius, height, transform, positionOffset, rotationOffset);
 
         const AZ::Aabb debugDrawAabb = GetDebugDrawAabb(editorEntity->GetId());
 
@@ -364,13 +364,13 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, Collider_CylinderWithOffsetAndRigidBody_CorrectDebugDraw)
     {
+        const float radius = 2.5f;
+        const float height = 9.0f;
         const AZ::Transform transform(AZ::Vector3(4.0f, -2.0f, 4.0f), AZ::Quaternion(0.2f, 0.8f, -0.4f, 0.4f), 1.5f);
         const AZ::Vector3 positionOffset(2.0f, 3.0f, -7.0f);
         const AZ::Quaternion rotationOffset(-0.1f, -0.7f, 0.1f, 0.7f);
-        const float radius = 2.5f;
-        const float height = 9.0f;
-        EntityPtr editorEntity =
-            CreateCylinderPrimitiveColliderEditorEntity(transform, positionOffset, rotationOffset, radius, height, AZStd::nullopt, RigidBodyType::Dynamic);
+        EntityPtr editorEntity = CreateCylinderPrimitiveColliderEditorEntity(
+            radius, height, transform, positionOffset, rotationOffset, AZStd::nullopt, RigidBodyType::Dynamic);
 
         const AZ::Aabb debugDrawAabb = GetDebugDrawAabb(editorEntity->GetId());
 
@@ -381,14 +381,14 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, Collider_CylinderWithOffsetAndNonUniformScale_CorrectDebugDraw)
     {
-        const AZ::Transform transform(AZ::Vector3(2.0f, 4.0f, -7.0f), AZ::Quaternion(0.4f, 0.8f, 0.2f, 0.4f), 0.6f);
-        const AZ::Vector3 nonUniformScale(2.0f, 0.5f, 0.8f);
-        const AZ::Vector3 positionOffset(3.0f, -2.0f, -6.0f);
-        const AZ::Quaternion rotationOffset(0.3f, 0.3f, -0.1f, 0.9f);
         const float radius = 1.5f;
         const float height = 6.0f;
+        const AZ::Transform transform(AZ::Vector3(2.0f, 4.0f, -7.0f), AZ::Quaternion(0.4f, 0.8f, 0.2f, 0.4f), 0.6f);
+        const AZ::Vector3 positionOffset(3.0f, -2.0f, -6.0f);
+        const AZ::Quaternion rotationOffset(0.3f, 0.3f, -0.1f, 0.9f);
+        const AZ::Vector3 nonUniformScale(2.0f, 0.5f, 0.8f);
         EntityPtr editorEntity =
-            CreateCylinderPrimitiveColliderEditorEntity(transform, positionOffset, rotationOffset, radius, height, nonUniformScale);
+            CreateCylinderPrimitiveColliderEditorEntity(radius, height, transform, positionOffset, rotationOffset, nonUniformScale);
 
         const AZ::Aabb debugDrawAabb = GetDebugDrawAabb(editorEntity->GetId());
 
@@ -399,14 +399,14 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, Collider_CylinderWithOffsetNonUniformScaleAndRigidBody_CorrectDebugDraw)
     {
-        const AZ::Transform transform(AZ::Vector3(-3.0f, -2.0f, -4.0f), AZ::Quaternion(0.5f, 0.1f, -0.7f, 0.5f), 1.8f);
-        const AZ::Vector3 nonUniformScale(0.6f, 0.8f, 1.4f);
-        const AZ::Vector3 positionOffset(2.0f, 7.0f, -1.0f);
-        const AZ::Quaternion rotationOffset(0.5f, -0.5f, -0.5f, 0.5f);
         const float radius = 2.5f;
         const float height = 9.0f;
+        const AZ::Transform transform(AZ::Vector3(-3.0f, -2.0f, -4.0f), AZ::Quaternion(0.5f, 0.1f, -0.7f, 0.5f), 1.8f);
+        const AZ::Vector3 positionOffset(2.0f, 7.0f, -1.0f);
+        const AZ::Quaternion rotationOffset(0.5f, -0.5f, -0.5f, 0.5f);
+        const AZ::Vector3 nonUniformScale(0.6f, 0.8f, 1.4f);
         EntityPtr editorEntity = CreateCylinderPrimitiveColliderEditorEntity(
-            transform, positionOffset, rotationOffset, radius, height, nonUniformScale, RigidBodyType::Dynamic);
+            radius, height, transform, positionOffset, rotationOffset, nonUniformScale, RigidBodyType::Dynamic);
 
         const AZ::Aabb debugDrawAabb = GetDebugDrawAabb(editorEntity->GetId());
 

--- a/Gems/PhysX/Code/Tests/EditorColliderComponentTests.cpp
+++ b/Gems/PhysX/Code/Tests/EditorColliderComponentTests.cpp
@@ -107,11 +107,8 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, EditorColliderComponent_ColliderWithBox_CorrectRuntimeGeometry)
     {
         // create an editor entity with a collider component
-        const AZ::Transform transform = AZ::Transform::CreateIdentity();
         const AZ::Vector3 boxDimensions(2.0f, 3.0f, 4.0f);
-        const AZ::Vector3 translationOffset = AZ::Vector3::CreateZero();
-        EntityPtr editorEntity =
-            CreateBoxPrimitiveColliderEditorEntity(transform, boxDimensions, translationOffset);
+        EntityPtr editorEntity = CreateBoxPrimitiveColliderEditorEntity(boxDimensions);
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
@@ -138,11 +135,11 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, EditorColliderComponent_BoxPrimitiveColliderWithTranslationOffset_CorrectEditorStaticBodyGeometry)
     {
-        const AZ::Transform transform(AZ::Vector3(2.0f, -6.0f, 5.0f), AZ::Quaternion(0.3f, -0.3f, 0.1f, 0.9f), 1.6f);
-        const AZ::Vector3 nonUniformScale(2.0f, 2.5f, 0.5f);
         const AZ::Vector3 boxDimensions(5.0f, 8.0f, 6.0f);
+        const AZ::Transform transform(AZ::Vector3(2.0f, -6.0f, 5.0f), AZ::Quaternion(0.3f, -0.3f, 0.1f, 0.9f), 1.6f);
         const AZ::Vector3 translationOffset(-4.0f, 3.0f, -1.0f);
-        EntityPtr editorEntity = CreateBoxPrimitiveColliderEditorEntity(transform, boxDimensions, translationOffset, nonUniformScale);
+        const AZ::Vector3 nonUniformScale(2.0f, 2.5f, 0.5f);
+        EntityPtr editorEntity = CreateBoxPrimitiveColliderEditorEntity(boxDimensions, transform, translationOffset, AZ::Quaternion::CreateIdentity(), nonUniformScale);
 
         AZ::Aabb aabb = GetSimulatedBodyAabb(editorEntity->GetId());
         EXPECT_THAT(aabb.GetMin(), UnitTest::IsClose(AZ::Vector3(-25.488f, -10.16f, -11.448f)));
@@ -151,12 +148,12 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, EditorColliderComponent_BoxPrimitiveColliderWithTranslationOffset_CorrectEditorDynamicBodyGeometry)
     {
-        const AZ::Transform transform(AZ::Vector3(-5.0f, -1.0f, 3.0f), AZ::Quaternion(0.7f, 0.5f, -0.1f, 0.5f), 1.2f);
-        const AZ::Vector3 nonUniformScale(1.5f, 1.5f, 4.0f);
         const AZ::Vector3 boxDimensions(6.0f, 4.0f, 1.0f);
+        const AZ::Transform transform(AZ::Vector3(-5.0f, -1.0f, 3.0f), AZ::Quaternion(0.7f, 0.5f, -0.1f, 0.5f), 1.2f);
         const AZ::Vector3 translationOffset(6.0f, -5.0f, -4.0f);
-        EntityPtr editorEntity =
-            CreateBoxPrimitiveColliderEditorEntity(transform, boxDimensions, translationOffset, nonUniformScale, RigidBodyType::Dynamic);
+        const AZ::Vector3 nonUniformScale(1.5f, 1.5f, 4.0f);
+        EntityPtr editorEntity = CreateBoxPrimitiveColliderEditorEntity(
+            boxDimensions, transform, translationOffset, AZ::Quaternion::CreateIdentity(), nonUniformScale, RigidBodyType::Dynamic);
 
         editorEntity->Deactivate();
         editorEntity->Activate();
@@ -168,11 +165,12 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, EditorColliderComponent_BoxPrimitiveColliderWithTranslationOffset_CorrectRuntimeStaticBodyGeometry)
     {
-        const AZ::Transform transform(AZ::Vector3(7.0f, 2.0f, 4.0f), AZ::Quaternion(0.4f, -0.8f, 0.4f, 0.2f), 2.5f);
-        const AZ::Vector3 nonUniformScale(0.8f, 2.0f, 1.5f);
         const AZ::Vector3 boxDimensions(1.0f, 4.0f, 7.0f);
+        const AZ::Transform transform(AZ::Vector3(7.0f, 2.0f, 4.0f), AZ::Quaternion(0.4f, -0.8f, 0.4f, 0.2f), 2.5f);
         const AZ::Vector3 translationOffset(6.0f, -1.0f, -2.0f);
-        EntityPtr editorEntity = CreateBoxPrimitiveColliderEditorEntity(transform, boxDimensions, translationOffset, nonUniformScale);
+        const AZ::Vector3 nonUniformScale(0.8f, 2.0f, 1.5f);
+        EntityPtr editorEntity = CreateBoxPrimitiveColliderEditorEntity(
+            boxDimensions, transform, translationOffset, AZ::Quaternion::CreateIdentity(), nonUniformScale);
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
         AZ::Aabb aabb = GetSimulatedBodyAabb(gameEntity->GetId());
@@ -182,12 +180,12 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, EditorColliderComponent_BoxPrimitiveColliderWithTranslationOffset_CorrectRuntimeDynamicBodyGeometry)
     {
-        const AZ::Transform transform(AZ::Vector3(4.0f, 4.0f, 2.0f), AZ::Quaternion(0.1f, 0.3f, 0.9f, 0.3f), 0.8f);
-        const AZ::Vector3 nonUniformScale(2.5f, 1.0f, 2.0f);
         const AZ::Vector3 boxDimensions(4.0f, 2.0f, 7.0f);
+        const AZ::Transform transform(AZ::Vector3(4.0f, 4.0f, 2.0f), AZ::Quaternion(0.1f, 0.3f, 0.9f, 0.3f), 0.8f);
         const AZ::Vector3 translationOffset(-2.0f, 7.0f, -1.0f);
-        EntityPtr editorEntity =
-            CreateBoxPrimitiveColliderEditorEntity(transform, boxDimensions, translationOffset, nonUniformScale, RigidBodyType::Dynamic);
+        const AZ::Vector3 nonUniformScale(2.5f, 1.0f, 2.0f);
+        EntityPtr editorEntity = CreateBoxPrimitiveColliderEditorEntity(
+            boxDimensions, transform, translationOffset, AZ::Quaternion::CreateIdentity(), nonUniformScale, RigidBodyType::Dynamic);
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
         AZ::Aabb aabb = GetSimulatedBodyAabb(gameEntity->GetId());
@@ -217,8 +215,8 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, EditorColliderComponent_ColliderWithSphereAndTranslationOffset_CorrectEditorStaticBodyGeometry)
     {
         EntityPtr editorEntity = CreateSpherePrimitiveColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(4.0f, 2.0f, -2.0f), AZ::Quaternion(-0.5f, -0.5f, 0.1f, 0.7f), 3.0f),
             1.6f,
+            AZ::Transform(AZ::Vector3(4.0f, 2.0f, -2.0f), AZ::Quaternion(-0.5f, -0.5f, 0.1f, 0.7f), 3.0f),
             AZ::Vector3(2.0f, 3.0f, -7.0f)
         );
 
@@ -230,9 +228,10 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, EditorColliderComponent_ColliderWithSphereAndTranslationOffset_CorrectEditorDynamicBodyGeometry)
     {
         EntityPtr editorEntity = CreateSpherePrimitiveColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(2.0f, -5.0f, -6.0f), AZ::Quaternion(0.7f, 0.1f, 0.7f, 0.1f), 0.4f),
             3.5f,
+            AZ::Transform(AZ::Vector3(2.0f, -5.0f, -6.0f), AZ::Quaternion(0.7f, 0.1f, 0.7f, 0.1f), 0.4f),
             AZ::Vector3(1.0f, 3.0f, -1.0f),
+            AZ::Quaternion::CreateIdentity(),
             AZStd::nullopt,
             RigidBodyType::Dynamic);
 
@@ -247,8 +246,8 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, EditorColliderComponent_ColliderWithSphereAndTranslationOffset_CorrectRuntimeStaticBodyGeometry)
     {
         EntityPtr editorEntity = CreateSpherePrimitiveColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(4.0f, 4.0f, -1.0f), AZ::Quaternion(0.8f, -0.2f, 0.4f, 0.4f), 2.4f),
             2.0f,
+            AZ::Transform(AZ::Vector3(4.0f, 4.0f, -1.0f), AZ::Quaternion(0.8f, -0.2f, 0.4f, 0.4f), 2.4f),
             AZ::Vector3(5.0f, 6.0f, -8.0f)
         );
 
@@ -262,9 +261,10 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, EditorColliderComponent_ColliderWithSphereAndTranslationOffset_CorrectRuntimeDynamicBodyGeometry)
     {
         EntityPtr editorEntity = CreateSpherePrimitiveColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(2.0f, 2.0f, -5.0f), AZ::Quaternion(0.9f, 0.3f, 0.3f, 0.1f), 5.0f),
             0.4f,
+            AZ::Transform(AZ::Vector3(2.0f, 2.0f, -5.0f), AZ::Quaternion(0.9f, 0.3f, 0.3f, 0.1f), 5.0f),
             AZ::Vector3(4.0f, 7.0f, 3.0f),
+            AZ::Quaternion::CreateIdentity(),
             AZStd::nullopt,
             RigidBodyType::Dynamic);
 
@@ -297,9 +297,9 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, EditorColliderComponent_ColliderWithCapsuleAndTranslationOffset_CorrectEditorStaticBodyGeometry)
     {
         EntityPtr editorEntity = CreateCapsulePrimitiveColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(2.0f, 1.0f, -2.0f), AZ::Quaternion(-0.2f, -0.8f, -0.4f, 0.4f), 4.0f),
             2.0f,
             8.0f,
+            AZ::Transform(AZ::Vector3(2.0f, 1.0f, -2.0f), AZ::Quaternion(-0.2f, -0.8f, -0.4f, 0.4f), 4.0f),
             AZ::Vector3(2.0f, 3.0f, 5.0f)
         );
 
@@ -311,10 +311,11 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, EditorColliderComponent_ColliderWithCapsuleAndTranslationOffset_CorrectEditorDynamicBodyGeometry)
     {
         EntityPtr editorEntity = CreateCapsulePrimitiveColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(7.0f, -9.0f, 2.0f), AZ::Quaternion(0.7f, 0.1f, 0.7f, 0.1f), 0.2f),
             1.0f,
             5.0f,
+            AZ::Transform(AZ::Vector3(7.0f, -9.0f, 2.0f), AZ::Quaternion(0.7f, 0.1f, 0.7f, 0.1f), 0.2f),
             AZ::Vector3(2.0f, 9.0f, -5.0f),
+            AZ::Quaternion::CreateIdentity(),
             AZStd::nullopt,
             RigidBodyType::Dynamic);
 
@@ -329,9 +330,9 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, EditorColliderComponent_ColliderWithCapsuleAndTranslationOffset_CorrectRuntimeStaticBodyGeometry)
     {
         EntityPtr editorEntity = CreateCapsulePrimitiveColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(-4.0f, -3.0f, -1.0f), AZ::Quaternion(0.5f, -0.7f, -0.1f, 0.5f), 0.8f),
             2.0f,
             11.0f,
+            AZ::Transform(AZ::Vector3(-4.0f, -3.0f, -1.0f), AZ::Quaternion(0.5f, -0.7f, -0.1f, 0.5f), 0.8f),
             AZ::Vector3(4.0f, 1.0f, -3.0f)
         );
 
@@ -345,10 +346,11 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, EditorColliderComponent_ColliderWithCapsuleAndTranslationOffset_CorrectRuntimeDynamicBodyGeometry)
     {
         EntityPtr editorEntity = CreateCapsulePrimitiveColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(7.0f, 6.0f, -3.0f), AZ::Quaternion(-0.3f, -0.1f, -0.3f, 0.9f), 6.0f),
             0.4f,
             3.0f,
+            AZ::Transform(AZ::Vector3(7.0f, 6.0f, -3.0f), AZ::Quaternion(-0.3f, -0.1f, -0.3f, 0.9f), 6.0f),
             AZ::Vector3(2.0f, -7.0f, 7.0f),
+            AZ::Quaternion::CreateIdentity(),
             AZStd::nullopt,
             RigidBodyType::Dynamic);
 
@@ -361,21 +363,9 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, EditorColliderComponent_ColliderWithCylinderWithValidRadiusAndValidHeight_CorrectRuntimeGeometry)
     {
-        // create an editor entity with a collider component
-        EntityPtr editorEntity = CreateInactiveEditorEntity("ColliderComponentEditorEntity");
-        auto* colliderComponent = editorEntity->CreateComponent<PhysX::EditorColliderComponent>();
-        editorEntity->CreateComponent<PhysX::EditorStaticRigidBodyComponent>();
-        editorEntity->Activate();
-
-        // Set collider to be a cylinder
-        AZ::EntityComponentIdPair idPair(editorEntity->GetId(), colliderComponent->GetId());
-        PhysX::EditorPrimitiveColliderComponentRequestBus::Event(
-            idPair, &PhysX::EditorPrimitiveColliderComponentRequests::SetShapeType, Physics::ShapeType::Cylinder);
-        
         const float validRadius = 1.0f;
         const float validHeight = 1.0f;
-        PhysX::EditorPrimitiveColliderComponentRequestBus::Event(idPair, &PhysX::EditorPrimitiveColliderComponentRequests::SetCylinderRadius, validRadius);
-        PhysX::EditorPrimitiveColliderComponentRequestBus::Event(idPair, &PhysX::EditorPrimitiveColliderComponentRequests::SetCylinderHeight, validHeight);
+        EntityPtr editorEntity = CreateCylinderPrimitiveColliderEditorEntity(validRadius, validHeight);
         
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
         
@@ -495,11 +485,14 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, EditorColliderComponent_ColliderWithBoxAndRigidBody_CorrectRuntimeEntity)
     {
         // create an editor entity with a collider component
-        const AZ::Transform transform = AZ::Transform::CreateIdentity();
         const AZ::Vector3 boxDimensions(2.0f, 3.0f, 4.0f);
-        const AZ::Vector3 translationOffset = AZ::Vector3::CreateZero();
-        EntityPtr editorEntity =
-            CreateBoxPrimitiveColliderEditorEntity(transform, boxDimensions, translationOffset, AZStd::nullopt, RigidBodyType::Dynamic);
+        EntityPtr editorEntity = CreateBoxPrimitiveColliderEditorEntity(
+            boxDimensions,
+            AZ::Transform::CreateIdentity(),
+            AZ::Vector3::CreateZero(),
+            AZ::Quaternion::CreateIdentity(),
+            AZStd::nullopt,
+            RigidBodyType::Dynamic);
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 

--- a/Gems/PhysX/Code/Tests/EditorMeshColliderComponentTests.cpp
+++ b/Gems/PhysX/Code/Tests/EditorMeshColliderComponentTests.cpp
@@ -140,11 +140,7 @@ namespace PhysXEditorTests
     {
         auto* meshAssetData = AZ::Utils::LoadObjectFromBuffer<PhysX::Pipeline::MeshAssetData>(
             PhysXMeshTestData::SpherePrimitive.data(), PhysXMeshTestData::SpherePrimitive.size());
-        EXPECT_TRUE(meshAssetData != nullptr);
-        if (!meshAssetData)
-        {
-            return;
-        }
+        ASSERT_TRUE(meshAssetData != nullptr);
 
         // create an editor entity with a collider component
         EntityPtr editorEntity = CreateMeshColliderEditorEntity(meshAssetData->CreateMeshAsset());
@@ -186,18 +182,14 @@ namespace PhysXEditorTests
         delete meshAssetData;
     }
 
-    // [GHI-14907]
+    // [o3de/o3de#14907]
     // Asset Scale (with non-uniform value) does not work when the asset contains primitives and there
     // is no non-uniform scale component present.
     TEST_F(PhysXEditorFixture, DISABLED_EditorMeshColliderComponent_AssetWithPrimitive_AssetScale_CorrectShapeTypeGeometryTypeAndAabb)
     {
         auto* meshAssetData = AZ::Utils::LoadObjectFromBuffer<PhysX::Pipeline::MeshAssetData>(
             PhysXMeshTestData::SpherePrimitive.data(), PhysXMeshTestData::SpherePrimitive.size());
-        EXPECT_TRUE(meshAssetData != nullptr);
-        if (!meshAssetData)
-        {
-            return;
-        }
+        ASSERT_TRUE(meshAssetData != nullptr);
 
         const AZ::Vector3 meshAssetScale(2.0f, 1.1f, 3.5f);
 
@@ -253,11 +245,7 @@ namespace PhysXEditorTests
     {
         auto* meshAssetData = AZ::Utils::LoadObjectFromBuffer<PhysX::Pipeline::MeshAssetData>(
             PhysXMeshTestData::SpherePrimitive.data(), PhysXMeshTestData::SpherePrimitive.size());
-        EXPECT_TRUE(meshAssetData != nullptr);
-        if (!meshAssetData)
-        {
-            return;
-        }
+        ASSERT_TRUE(meshAssetData != nullptr);
 
         const AZ::Vector3 nonUniformScale(1.0f, 1.5f, 1.0f);
         const AZ::Vector3 meshAssetScale(2.0f, 1.1f, 3.5f);
@@ -319,11 +307,7 @@ namespace PhysXEditorTests
     {
         auto* meshAssetData = AZ::Utils::LoadObjectFromBuffer<PhysX::Pipeline::MeshAssetData>(
             PhysXMeshTestData::SphereConvex.data(), PhysXMeshTestData::SphereConvex.size());
-        EXPECT_TRUE(meshAssetData != nullptr);
-        if (!meshAssetData)
-        {
-            return;
-        }
+        ASSERT_TRUE(meshAssetData != nullptr);
 
         // create an editor entity with a collider component
         EntityPtr editorEntity = CreateMeshColliderEditorEntity(meshAssetData->CreateMeshAsset());
@@ -371,11 +355,7 @@ namespace PhysXEditorTests
     {
         auto* meshAssetData = AZ::Utils::LoadObjectFromBuffer<PhysX::Pipeline::MeshAssetData>(
             PhysXMeshTestData::SphereConvex.data(), PhysXMeshTestData::SphereConvex.size());
-        EXPECT_TRUE(meshAssetData != nullptr);
-        if (!meshAssetData)
-        {
-            return;
-        }
+        ASSERT_TRUE(meshAssetData != nullptr);
 
         const AZ::Vector3 meshAssetScale(2.0f, 1.1f, 3.5f);
 
@@ -429,11 +409,7 @@ namespace PhysXEditorTests
     {
         auto* meshAssetData = AZ::Utils::LoadObjectFromBuffer<PhysX::Pipeline::MeshAssetData>(
             PhysXMeshTestData::SphereConvex.data(), PhysXMeshTestData::SphereConvex.size());
-        EXPECT_TRUE(meshAssetData != nullptr);
-        if (!meshAssetData)
-        {
-            return;
-        }
+        ASSERT_TRUE(meshAssetData != nullptr);
 
         const AZ::Vector3 nonUniformScale(1.0f, 1.5f, 1.0f);
         const AZ::Vector3 meshAssetScale(2.0f, 1.1f, 3.5f);
@@ -493,11 +469,7 @@ namespace PhysXEditorTests
     {
         auto* meshAssetData = AZ::Utils::LoadObjectFromBuffer<PhysX::Pipeline::MeshAssetData>(
             PhysXMeshTestData::SphereTriangleMesh.data(), PhysXMeshTestData::SphereTriangleMesh.size());
-        EXPECT_TRUE(meshAssetData != nullptr);
-        if (!meshAssetData)
-        {
-            return;
-        }
+        ASSERT_TRUE(meshAssetData != nullptr);
 
         // create an editor entity with a collider component
         EntityPtr editorEntity = CreateMeshColliderEditorEntity(meshAssetData->CreateMeshAsset());
@@ -543,11 +515,7 @@ namespace PhysXEditorTests
     {
         auto* meshAssetData = AZ::Utils::LoadObjectFromBuffer<PhysX::Pipeline::MeshAssetData>(
             PhysXMeshTestData::SphereTriangleMesh.data(), PhysXMeshTestData::SphereTriangleMesh.size());
-        EXPECT_TRUE(meshAssetData != nullptr);
-        if (!meshAssetData)
-        {
-            return;
-        }
+        ASSERT_TRUE(meshAssetData != nullptr);
 
         const AZ::Vector3 meshAssetScale(2.0f, 1.1f, 3.5f);
 
@@ -599,11 +567,7 @@ namespace PhysXEditorTests
     {
         auto* meshAssetData = AZ::Utils::LoadObjectFromBuffer<PhysX::Pipeline::MeshAssetData>(
             PhysXMeshTestData::SphereTriangleMesh.data(), PhysXMeshTestData::SphereTriangleMesh.size());
-        EXPECT_TRUE(meshAssetData != nullptr);
-        if (!meshAssetData)
-        {
-            return;
-        }
+        ASSERT_TRUE(meshAssetData != nullptr);
 
         const AZ::Vector3 nonUniformScale(1.0f, 1.5f, 1.0f);
         const AZ::Vector3 meshAssetScale(2.0f, 1.1f, 3.5f);
@@ -661,11 +625,7 @@ namespace PhysXEditorTests
     {
         auto* meshAssetData = AZ::Utils::LoadObjectFromBuffer<PhysX::Pipeline::MeshAssetData>(
             PhysXMeshTestData::SphereTriangleMesh.data(), PhysXMeshTestData::SphereTriangleMesh.size());
-        EXPECT_TRUE(meshAssetData != nullptr);
-        if (!meshAssetData)
-        {
-            return;
-        }
+        ASSERT_TRUE(meshAssetData != nullptr);
 
         UnitTest::ErrorHandler errorHandler("Cannot use triangle mesh geometry on a dynamic object");
 

--- a/Gems/PhysX/Code/Tests/EditorMeshColliderComponentTests.cpp
+++ b/Gems/PhysX/Code/Tests/EditorMeshColliderComponentTests.cpp
@@ -136,7 +136,7 @@ namespace PhysXEditorTests
         EXPECT_EQ(pxRigidDynamic->getNbShapes(), 0);
     }
 
-    TEST_F(PhysXEditorFixture, EditorMeshColliderComponent_AssetWithPrimitive_CorrectRuntimeEntity)
+    TEST_F(PhysXEditorFixture, EditorMeshColliderComponent_AssetWithPrimitive_CorrectShapeTypeGeometryTypeAndAabb)
     {
         auto* meshAssetData = AZ::Utils::LoadObjectFromBuffer<PhysX::Pipeline::MeshAssetData>(
             PhysXMeshTestData::SpherePrimitive.data(), PhysXMeshTestData::SpherePrimitive.size());
@@ -147,30 +147,175 @@ namespace PhysXEditorTests
         }
 
         // create an editor entity with a collider component
-        EntityPtr editorEntity = CreateMeshColliderEditorEntity(
-            AZ::Transform::CreateIdentity(), meshAssetData->CreateMeshAsset(), AZ::Vector3::CreateZero(), AZStd::nullopt, RigidBodyType::Dynamic);
+        EntityPtr editorEntity = CreateMeshColliderEditorEntity(meshAssetData->CreateMeshAsset());
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
-        // since there was an editor rigid body component, the runtime entity should have a dynamic rigid body
-        const auto* rigidBody = gameEntity->FindComponent<PhysX::RigidBodyComponent>()->GetRigidBody();
-        const auto* pxRigidDynamic = static_cast<const physx::PxRigidDynamic*>(rigidBody->GetNativePointer());
+        // check that the runtime entity has the expected components
+        auto* meshColliderComponent = gameEntity->FindComponent<PhysX::MeshColliderComponent>();
+        auto* staticRigidBodyComponent = gameEntity->FindComponent<PhysX::StaticRigidBodyComponent>();
+        EXPECT_TRUE(meshColliderComponent != nullptr);
+        EXPECT_TRUE(staticRigidBodyComponent != nullptr);
 
-        PHYSX_SCENE_READ_LOCK(pxRigidDynamic->getScene());
+        AzPhysics::ShapeColliderPairList shapeConfigList = meshColliderComponent->GetShapeConfigurations();
+        EXPECT_EQ(shapeConfigList.size(), 1);
+
+        for (const auto& shapeConfigPair : shapeConfigList)
+        {
+            EXPECT_EQ(shapeConfigPair.second->GetShapeType(), Physics::ShapeType::PhysicsAsset);
+        }
+
+        const auto* simulatedBody = staticRigidBodyComponent->GetSimulatedBody();
+        const auto* pxRigidStatic = static_cast<const physx::PxRigidStatic*>(simulatedBody->GetNativePointer());
+
+        PHYSX_SCENE_READ_LOCK(pxRigidStatic->getScene());
 
         // there should be a single shape on the rigid body and it should be a box
-        EXPECT_EQ(pxRigidDynamic->getNbShapes(), 1);
-        if (pxRigidDynamic->getNbShapes() > 0)
+        EXPECT_EQ(pxRigidStatic->getNbShapes(), 1);
+        if (pxRigidStatic->getNbShapes() > 0)
         {
             physx::PxShape* shape = nullptr;
-            pxRigidDynamic->getShapes(&shape, 1, 0);
+            pxRigidStatic->getShapes(&shape, 1, 0);
             EXPECT_EQ(shape->getGeometryType(), physx::PxGeometryType::eSPHERE);
         }
+
+        const AZ::Aabb aabb = simulatedBody->GetAabb();
+        EXPECT_THAT(aabb.GetMin(), UnitTest::IsCloseTolerance(AZ::Vector3(-0.5f, -0.5f, -0.5f), 1e-3f));
+        EXPECT_THAT(aabb.GetMax(), UnitTest::IsCloseTolerance(AZ::Vector3(0.5f, 0.5f, 0.5f), 1e-3f));
 
         delete meshAssetData;
     }
 
-    TEST_F(PhysXEditorFixture, EditorMeshColliderComponent_AssetWithConvex_CorrectRuntimeEntity)
+    // [GHI-14907]
+    // Asset Scale (with non-uniform value) does not work when the asset contains primitives and there
+    // is no non-uniform scale component present.
+    TEST_F(PhysXEditorFixture, DISABLED_EditorMeshColliderComponent_AssetWithPrimitive_AssetScale_CorrectShapeTypeGeometryTypeAndAabb)
+    {
+        auto* meshAssetData = AZ::Utils::LoadObjectFromBuffer<PhysX::Pipeline::MeshAssetData>(
+            PhysXMeshTestData::SpherePrimitive.data(), PhysXMeshTestData::SpherePrimitive.size());
+        EXPECT_TRUE(meshAssetData != nullptr);
+        if (!meshAssetData)
+        {
+            return;
+        }
+
+        const AZ::Vector3 meshAssetScale(2.0f, 1.1f, 3.5f);
+
+        // create an editor entity with a collider component
+        EntityPtr editorEntity = CreateMeshColliderEditorEntity(meshAssetData->CreateMeshAsset());
+
+        AZ::EntityComponentIdPair idPair(editorEntity->GetId(), editorEntity->FindComponent<PhysX::EditorMeshColliderComponent>()->GetId());
+        PhysX::EditorMeshColliderComponentRequestBus::Event(
+            idPair, &PhysX::EditorMeshColliderComponentRequests::SetAssetScale, meshAssetScale);
+
+        EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
+
+        // check that the runtime entity has the expected components
+        auto* meshColliderComponent = gameEntity->FindComponent<PhysX::MeshColliderComponent>();
+        auto* staticRigidBodyComponent = gameEntity->FindComponent<PhysX::StaticRigidBodyComponent>();
+        EXPECT_TRUE(meshColliderComponent != nullptr);
+        EXPECT_TRUE(staticRigidBodyComponent != nullptr);
+
+        // because there is a non-uniform scale applied, the runtime entity should have a MeshColliderComponent with a
+        // cooked mesh shape configuration, rather than a Sphere shape configuration.
+        AzPhysics::ShapeColliderPairList shapeConfigList = meshColliderComponent->GetShapeConfigurations();
+        EXPECT_EQ(shapeConfigList.size(), 1);
+
+        for (const auto& shapeConfigPair : shapeConfigList)
+        {
+            EXPECT_EQ(shapeConfigPair.second->GetShapeType(), Physics::ShapeType::PhysicsAsset);
+        }
+
+        const auto* simulatedBody = staticRigidBodyComponent->GetSimulatedBody();
+        const auto* pxRigidStatic = static_cast<const physx::PxRigidStatic*>(simulatedBody->GetNativePointer());
+
+        PHYSX_SCENE_READ_LOCK(pxRigidStatic->getScene());
+
+        // there should be a single shape on the rigid body and it should be a box
+        EXPECT_EQ(pxRigidStatic->getNbShapes(), 1);
+        if (pxRigidStatic->getNbShapes() > 0)
+        {
+            physx::PxShape* shape = nullptr;
+            pxRigidStatic->getShapes(&shape, 1, 0);
+            // because there is a non-uniform scale applied, the geometry type used should be a convex mesh
+            // rather than a primitive type
+            EXPECT_EQ(shape->getGeometryType(), physx::PxGeometryType::eCONVEXMESH);
+        }
+
+        const AZ::Aabb aabb = simulatedBody->GetAabb();
+        EXPECT_THAT(aabb.GetMin(), UnitTest::IsCloseTolerance(AZ::Vector3(-1.0f, -0.55f, -1.75f), 1e-3f));
+        EXPECT_THAT(aabb.GetMax(), UnitTest::IsCloseTolerance(AZ::Vector3(1.0f, 0.55f, 1.75f), 1e-3f));
+
+        delete meshAssetData;
+    }
+
+    TEST_F(PhysXEditorFixture, EditorMeshColliderComponent_AssetWithPrimitive_AssetScale_NonUniformScale_CorrectShapeTypeGeometryTypeAndAabb)
+    {
+        auto* meshAssetData = AZ::Utils::LoadObjectFromBuffer<PhysX::Pipeline::MeshAssetData>(
+            PhysXMeshTestData::SpherePrimitive.data(), PhysXMeshTestData::SpherePrimitive.size());
+        EXPECT_TRUE(meshAssetData != nullptr);
+        if (!meshAssetData)
+        {
+            return;
+        }
+
+        const AZ::Vector3 nonUniformScale(1.0f, 1.5f, 1.0f);
+        const AZ::Vector3 meshAssetScale(2.0f, 1.1f, 3.5f);
+
+        // create an editor entity with a collider component
+        EntityPtr editorEntity = CreateMeshColliderEditorEntity(
+            meshAssetData->CreateMeshAsset(),
+            AZ::Transform::CreateIdentity(),
+            AZ::Vector3::CreateZero(),
+            AZ::Quaternion::CreateIdentity(),
+            nonUniformScale);
+
+        AZ::EntityComponentIdPair idPair(editorEntity->GetId(), editorEntity->FindComponent<PhysX::EditorMeshColliderComponent>()->GetId());
+        PhysX::EditorMeshColliderComponentRequestBus::Event(
+            idPair, &PhysX::EditorMeshColliderComponentRequests::SetAssetScale, meshAssetScale);
+
+        EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
+
+        // check that the runtime entity has the expected components
+        auto* meshColliderComponent = gameEntity->FindComponent<PhysX::MeshColliderComponent>();
+        auto* staticRigidBodyComponent = gameEntity->FindComponent<PhysX::StaticRigidBodyComponent>();
+        EXPECT_TRUE(meshColliderComponent != nullptr);
+        EXPECT_TRUE(staticRigidBodyComponent != nullptr);
+
+        // because there is a non-uniform scale applied, the runtime entity should have a MeshColliderComponent with a
+        // cooked mesh shape configuration, rather than a Sphere shape configuration.
+        AzPhysics::ShapeColliderPairList shapeConfigList = meshColliderComponent->GetShapeConfigurations();
+        EXPECT_EQ(shapeConfigList.size(), 1);
+
+        for (const auto& shapeConfigPair : shapeConfigList)
+        {
+            EXPECT_EQ(shapeConfigPair.second->GetShapeType(), Physics::ShapeType::PhysicsAsset);
+        }
+
+        const auto* simulatedBody = staticRigidBodyComponent->GetSimulatedBody();
+        const auto* pxRigidStatic = static_cast<const physx::PxRigidStatic*>(simulatedBody->GetNativePointer());
+
+        PHYSX_SCENE_READ_LOCK(pxRigidStatic->getScene());
+
+        // there should be a single shape on the rigid body and it should be a box
+        EXPECT_EQ(pxRigidStatic->getNbShapes(), 1);
+        if (pxRigidStatic->getNbShapes() > 0)
+        {
+            physx::PxShape* shape = nullptr;
+            pxRigidStatic->getShapes(&shape, 1, 0);
+            // because there is a non-uniform scale applied, the geometry type used should be a convex mesh
+            // rather than a primitive type
+            EXPECT_EQ(shape->getGeometryType(), physx::PxGeometryType::eCONVEXMESH);
+        }
+
+        const AZ::Aabb aabb = simulatedBody->GetAabb();
+        EXPECT_THAT(aabb.GetMin(), UnitTest::IsCloseTolerance(AZ::Vector3(-1.0f, -0.825f, -1.75f), 1e-3f));
+        EXPECT_THAT(aabb.GetMax(), UnitTest::IsCloseTolerance(AZ::Vector3(1.0f, 0.825f, 1.75f), 1e-3f));
+
+        delete meshAssetData;
+    }
+
+    TEST_F(PhysXEditorFixture, EditorMeshColliderComponent_AssetWithConvex_CorrectShapeTypeGeometryTypeAndAabb)
     {
         auto* meshAssetData = AZ::Utils::LoadObjectFromBuffer<PhysX::Pipeline::MeshAssetData>(
             PhysXMeshTestData::SphereConvex.data(), PhysXMeshTestData::SphereConvex.size());
@@ -181,30 +326,170 @@ namespace PhysXEditorTests
         }
 
         // create an editor entity with a collider component
-        EntityPtr editorEntity = CreateMeshColliderEditorEntity(
-            AZ::Transform::CreateIdentity(), meshAssetData->CreateMeshAsset(), AZ::Vector3::CreateZero(), AZStd::nullopt, RigidBodyType::Dynamic);
+        EntityPtr editorEntity = CreateMeshColliderEditorEntity(meshAssetData->CreateMeshAsset());
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
-        // since there was an editor rigid body component, the runtime entity should have a dynamic rigid body
-        const auto* rigidBody = gameEntity->FindComponent<PhysX::RigidBodyComponent>()->GetRigidBody();
-        const auto* pxRigidDynamic = static_cast<const physx::PxRigidDynamic*>(rigidBody->GetNativePointer());
+        // check that the runtime entity has the expected components
+        auto* meshColliderComponent = gameEntity->FindComponent<PhysX::MeshColliderComponent>();
+        auto* staticRigidBodyComponent = gameEntity->FindComponent<PhysX::StaticRigidBodyComponent>();
+        EXPECT_TRUE(meshColliderComponent != nullptr);
+        EXPECT_TRUE(staticRigidBodyComponent != nullptr);
 
-        PHYSX_SCENE_READ_LOCK(pxRigidDynamic->getScene());
+        AzPhysics::ShapeColliderPairList shapeConfigList = meshColliderComponent->GetShapeConfigurations();
+        EXPECT_EQ(shapeConfigList.size(), 1);
+
+        for (const auto& shapeConfigPair : shapeConfigList)
+        {
+            EXPECT_EQ(shapeConfigPair.second->GetShapeType(), Physics::ShapeType::PhysicsAsset);
+        }
+
+        const auto* simulatedBody = staticRigidBodyComponent->GetSimulatedBody();
+        const auto* pxRigidStatic = static_cast<const physx::PxRigidStatic*>(simulatedBody->GetNativePointer());
+
+        PHYSX_SCENE_READ_LOCK(pxRigidStatic->getScene());
 
         // there should be a single shape on the rigid body and it should be a box
-        EXPECT_EQ(pxRigidDynamic->getNbShapes(), 1);
-        if (pxRigidDynamic->getNbShapes() > 0)
+        EXPECT_EQ(pxRigidStatic->getNbShapes(), 1);
+        if (pxRigidStatic->getNbShapes() > 0)
         {
             physx::PxShape* shape = nullptr;
-            pxRigidDynamic->getShapes(&shape, 1, 0);
+            pxRigidStatic->getShapes(&shape, 1, 0);
             EXPECT_EQ(shape->getGeometryType(), physx::PxGeometryType::eCONVEXMESH);
         }
+
+        const AZ::Aabb aabb = simulatedBody->GetAabb();
+        // convex shapes used to export the sphere mesh requires a higher toleance
+        // when checking its aabb due to the lower tesselation it does to cover the sphere.
+        EXPECT_THAT(aabb.GetMin(), UnitTest::IsCloseTolerance(AZ::Vector3(-0.5f, -0.5f, -0.5f), 1e-1f));
+        EXPECT_THAT(aabb.GetMax(), UnitTest::IsCloseTolerance(AZ::Vector3(0.5f, 0.5f, 0.5f), 1e-1f));
 
         delete meshAssetData;
     }
 
-    TEST_F(PhysXEditorFixture, EditorMeshColliderComponent_AssetWithTriangleMesh_CorrectRuntimeEntity)
+    TEST_F(PhysXEditorFixture, EditorMeshColliderComponent_AssetWithConvex_AssetScale_CorrectShapeTypeGeometryTypeAndAabb)
+    {
+        auto* meshAssetData = AZ::Utils::LoadObjectFromBuffer<PhysX::Pipeline::MeshAssetData>(
+            PhysXMeshTestData::SphereConvex.data(), PhysXMeshTestData::SphereConvex.size());
+        EXPECT_TRUE(meshAssetData != nullptr);
+        if (!meshAssetData)
+        {
+            return;
+        }
+
+        const AZ::Vector3 meshAssetScale(2.0f, 1.1f, 3.5f);
+
+        // create an editor entity with a collider component
+        EntityPtr editorEntity = CreateMeshColliderEditorEntity(meshAssetData->CreateMeshAsset());
+
+        AZ::EntityComponentIdPair idPair(editorEntity->GetId(), editorEntity->FindComponent<PhysX::EditorMeshColliderComponent>()->GetId());
+        PhysX::EditorMeshColliderComponentRequestBus::Event(
+            idPair, &PhysX::EditorMeshColliderComponentRequests::SetAssetScale, meshAssetScale);
+
+        EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
+
+        // check that the runtime entity has the expected components
+        auto* meshColliderComponent = gameEntity->FindComponent<PhysX::MeshColliderComponent>();
+        auto* staticRigidBodyComponent = gameEntity->FindComponent<PhysX::StaticRigidBodyComponent>();
+        EXPECT_TRUE(meshColliderComponent != nullptr);
+        EXPECT_TRUE(staticRigidBodyComponent != nullptr);
+
+        AzPhysics::ShapeColliderPairList shapeConfigList = meshColliderComponent->GetShapeConfigurations();
+        EXPECT_EQ(shapeConfigList.size(), 1);
+
+        for (const auto& shapeConfigPair : shapeConfigList)
+        {
+            EXPECT_EQ(shapeConfigPair.second->GetShapeType(), Physics::ShapeType::PhysicsAsset);
+        }
+
+        const auto* simulatedBody = staticRigidBodyComponent->GetSimulatedBody();
+        const auto* pxRigidStatic = static_cast<const physx::PxRigidStatic*>(simulatedBody->GetNativePointer());
+
+        PHYSX_SCENE_READ_LOCK(pxRigidStatic->getScene());
+
+        // there should be a single shape on the rigid body and it should be a box
+        EXPECT_EQ(pxRigidStatic->getNbShapes(), 1);
+        if (pxRigidStatic->getNbShapes() > 0)
+        {
+            physx::PxShape* shape = nullptr;
+            pxRigidStatic->getShapes(&shape, 1, 0);
+            EXPECT_EQ(shape->getGeometryType(), physx::PxGeometryType::eCONVEXMESH);
+        }
+
+        const AZ::Aabb aabb = simulatedBody->GetAabb();
+        // convex shapes used to export the sphere mesh requires a higher toleance
+        // when checking its aabb due to the lower tesselation it does to cover the sphere.
+        EXPECT_THAT(aabb.GetMin(), UnitTest::IsCloseTolerance(AZ::Vector3(-1.0f, -0.55f, -1.75f), 1e-1f));
+        EXPECT_THAT(aabb.GetMax(), UnitTest::IsCloseTolerance(AZ::Vector3(1.0f, 0.55f, 1.75f), 1e-1f));
+
+        delete meshAssetData;
+    }
+
+    TEST_F(PhysXEditorFixture, EditorMeshColliderComponent_AssetWithConvex_AssetScale_NonUniformScale_CorrectShapeTypeGeometryTypeAndAabb)
+    {
+        auto* meshAssetData = AZ::Utils::LoadObjectFromBuffer<PhysX::Pipeline::MeshAssetData>(
+            PhysXMeshTestData::SphereConvex.data(), PhysXMeshTestData::SphereConvex.size());
+        EXPECT_TRUE(meshAssetData != nullptr);
+        if (!meshAssetData)
+        {
+            return;
+        }
+
+        const AZ::Vector3 nonUniformScale(1.0f, 1.5f, 1.0f);
+        const AZ::Vector3 meshAssetScale(2.0f, 1.1f, 3.5f);
+
+        // create an editor entity with a collider component
+        EntityPtr editorEntity = CreateMeshColliderEditorEntity(
+            meshAssetData->CreateMeshAsset(),
+            AZ::Transform::CreateIdentity(),
+            AZ::Vector3::CreateZero(),
+            AZ::Quaternion::CreateIdentity(),
+            nonUniformScale);
+
+        AZ::EntityComponentIdPair idPair(editorEntity->GetId(), editorEntity->FindComponent<PhysX::EditorMeshColliderComponent>()->GetId());
+        PhysX::EditorMeshColliderComponentRequestBus::Event(
+            idPair, &PhysX::EditorMeshColliderComponentRequests::SetAssetScale, meshAssetScale);
+
+        EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
+
+        // check that the runtime entity has the expected components
+        auto* meshColliderComponent = gameEntity->FindComponent<PhysX::MeshColliderComponent>();
+        auto* staticRigidBodyComponent = gameEntity->FindComponent<PhysX::StaticRigidBodyComponent>();
+        EXPECT_TRUE(meshColliderComponent != nullptr);
+        EXPECT_TRUE(staticRigidBodyComponent != nullptr);
+
+        AzPhysics::ShapeColliderPairList shapeConfigList = meshColliderComponent->GetShapeConfigurations();
+        EXPECT_EQ(shapeConfigList.size(), 1);
+
+        for (const auto& shapeConfigPair : shapeConfigList)
+        {
+            EXPECT_EQ(shapeConfigPair.second->GetShapeType(), Physics::ShapeType::PhysicsAsset);
+        }
+
+        const auto* simulatedBody = staticRigidBodyComponent->GetSimulatedBody();
+        const auto* pxRigidStatic = static_cast<const physx::PxRigidStatic*>(simulatedBody->GetNativePointer());
+
+        PHYSX_SCENE_READ_LOCK(pxRigidStatic->getScene());
+
+        // there should be a single shape on the rigid body and it should be a box
+        EXPECT_EQ(pxRigidStatic->getNbShapes(), 1);
+        if (pxRigidStatic->getNbShapes() > 0)
+        {
+            physx::PxShape* shape = nullptr;
+            pxRigidStatic->getShapes(&shape, 1, 0);
+            EXPECT_EQ(shape->getGeometryType(), physx::PxGeometryType::eCONVEXMESH);
+        }
+
+        const AZ::Aabb aabb = simulatedBody->GetAabb();
+        // convex shapes used to export the sphere mesh requires a higher toleance
+        // when checking its aabb due to the lower tesselation it does to cover the sphere.
+        EXPECT_THAT(aabb.GetMin(), UnitTest::IsCloseTolerance(AZ::Vector3(-1.0f, -0.825f, -1.75f), 1e-1f));
+        EXPECT_THAT(aabb.GetMax(), UnitTest::IsCloseTolerance(AZ::Vector3(1.0f, 0.825f, 1.75f), 1e-1f));
+
+        delete meshAssetData;
+    }
+
+    TEST_F(PhysXEditorFixture, EditorMeshColliderComponent_AssetWithTriangleMesh_CorrectShapeTypeGeometryTypeAndAabb)
     {
         auto* meshAssetData = AZ::Utils::LoadObjectFromBuffer<PhysX::Pipeline::MeshAssetData>(
             PhysXMeshTestData::SphereTriangleMesh.data(), PhysXMeshTestData::SphereTriangleMesh.size());
@@ -215,13 +500,25 @@ namespace PhysXEditorTests
         }
 
         // create an editor entity with a collider component
-        EntityPtr editorEntity = CreateMeshColliderEditorEntity(
-            AZ::Transform::CreateIdentity(), meshAssetData->CreateMeshAsset(), AZ::Vector3::CreateZero(), AZStd::nullopt, RigidBodyType::Static);
+        EntityPtr editorEntity = CreateMeshColliderEditorEntity(meshAssetData->CreateMeshAsset());
 
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
-        // since there was an editor rigid body component, the runtime entity should have a dynamic rigid body
-        const auto* simulatedBody = gameEntity->FindComponent<PhysX::StaticRigidBodyComponent>()->GetSimulatedBody();
+        // check that the runtime entity has the expected components
+        auto* meshColliderComponent = gameEntity->FindComponent<PhysX::MeshColliderComponent>();
+        auto* staticRigidBodyComponent = gameEntity->FindComponent<PhysX::StaticRigidBodyComponent>();
+        EXPECT_TRUE(meshColliderComponent != nullptr);
+        EXPECT_TRUE(staticRigidBodyComponent != nullptr);
+
+        AzPhysics::ShapeColliderPairList shapeConfigList = meshColliderComponent->GetShapeConfigurations();
+        EXPECT_EQ(shapeConfigList.size(), 1);
+
+        for (const auto& shapeConfigPair : shapeConfigList)
+        {
+            EXPECT_EQ(shapeConfigPair.second->GetShapeType(), Physics::ShapeType::PhysicsAsset);
+        }
+
+        const auto* simulatedBody = staticRigidBodyComponent->GetSimulatedBody();
         const auto* pxRigidStatic = static_cast<const physx::PxRigidStatic*>(simulatedBody->GetNativePointer());
 
         PHYSX_SCENE_READ_LOCK(pxRigidStatic->getScene());
@@ -234,6 +531,128 @@ namespace PhysXEditorTests
             pxRigidStatic->getShapes(&shape, 1, 0);
             EXPECT_EQ(shape->getGeometryType(), physx::PxGeometryType::eTRIANGLEMESH);
         }
+
+        const AZ::Aabb aabb = simulatedBody->GetAabb();
+        EXPECT_THAT(aabb.GetMin(), UnitTest::IsCloseTolerance(AZ::Vector3(-0.5f, -0.5f, -0.5f), 1e-3f));
+        EXPECT_THAT(aabb.GetMax(), UnitTest::IsCloseTolerance(AZ::Vector3(0.5f, 0.5f, 0.5f), 1e-3f));
+
+        delete meshAssetData;
+    }
+
+    TEST_F(PhysXEditorFixture, EditorMeshColliderComponent_AssetWithTriangleMesh_AssetScale_CorrectShapeTypeGeometryTypeAndAabb)
+    {
+        auto* meshAssetData = AZ::Utils::LoadObjectFromBuffer<PhysX::Pipeline::MeshAssetData>(
+            PhysXMeshTestData::SphereTriangleMesh.data(), PhysXMeshTestData::SphereTriangleMesh.size());
+        EXPECT_TRUE(meshAssetData != nullptr);
+        if (!meshAssetData)
+        {
+            return;
+        }
+
+        const AZ::Vector3 meshAssetScale(2.0f, 1.1f, 3.5f);
+
+        // create an editor entity with a collider component
+        EntityPtr editorEntity = CreateMeshColliderEditorEntity(meshAssetData->CreateMeshAsset());
+
+        AZ::EntityComponentIdPair idPair(editorEntity->GetId(), editorEntity->FindComponent<PhysX::EditorMeshColliderComponent>()->GetId());
+        PhysX::EditorMeshColliderComponentRequestBus::Event(
+            idPair, &PhysX::EditorMeshColliderComponentRequests::SetAssetScale, meshAssetScale);
+
+        EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
+
+        // check that the runtime entity has the expected components
+        auto* meshColliderComponent = gameEntity->FindComponent<PhysX::MeshColliderComponent>();
+        auto* staticRigidBodyComponent = gameEntity->FindComponent<PhysX::StaticRigidBodyComponent>();
+        EXPECT_TRUE(meshColliderComponent != nullptr);
+        EXPECT_TRUE(staticRigidBodyComponent != nullptr);
+
+        AzPhysics::ShapeColliderPairList shapeConfigList = meshColliderComponent->GetShapeConfigurations();
+        EXPECT_EQ(shapeConfigList.size(), 1);
+
+        for (const auto& shapeConfigPair : shapeConfigList)
+        {
+            EXPECT_EQ(shapeConfigPair.second->GetShapeType(), Physics::ShapeType::PhysicsAsset);
+        }
+
+        const auto* simulatedBody = staticRigidBodyComponent->GetSimulatedBody();
+        const auto* pxRigidStatic = static_cast<const physx::PxRigidStatic*>(simulatedBody->GetNativePointer());
+
+        PHYSX_SCENE_READ_LOCK(pxRigidStatic->getScene());
+
+        // there should be a single shape on the rigid body and it should be a box
+        EXPECT_EQ(pxRigidStatic->getNbShapes(), 1);
+        if (pxRigidStatic->getNbShapes() > 0)
+        {
+            physx::PxShape* shape = nullptr;
+            pxRigidStatic->getShapes(&shape, 1, 0);
+            EXPECT_EQ(shape->getGeometryType(), physx::PxGeometryType::eTRIANGLEMESH);
+        }
+
+        const AZ::Aabb aabb = simulatedBody->GetAabb();
+        EXPECT_THAT(aabb.GetMin(), UnitTest::IsCloseTolerance(AZ::Vector3(-1.0f, -0.55f, -1.75f), 1e-3f));
+        EXPECT_THAT(aabb.GetMax(), UnitTest::IsCloseTolerance(AZ::Vector3(1.0f, 0.55f, 1.75f), 1e-3f));
+
+        delete meshAssetData;
+    }
+
+    TEST_F(PhysXEditorFixture, EditorMeshColliderComponent_AssetWithTriangleMesh_AssetScale_NonUniformScale_CorrectShapeTypeGeometryTypeAndAabb)
+    {
+        auto* meshAssetData = AZ::Utils::LoadObjectFromBuffer<PhysX::Pipeline::MeshAssetData>(
+            PhysXMeshTestData::SphereTriangleMesh.data(), PhysXMeshTestData::SphereTriangleMesh.size());
+        EXPECT_TRUE(meshAssetData != nullptr);
+        if (!meshAssetData)
+        {
+            return;
+        }
+
+        const AZ::Vector3 nonUniformScale(1.0f, 1.5f, 1.0f);
+        const AZ::Vector3 meshAssetScale(2.0f, 1.1f, 3.5f);
+
+        // create an editor entity with a collider component
+        EntityPtr editorEntity = CreateMeshColliderEditorEntity(
+            meshAssetData->CreateMeshAsset(),
+            AZ::Transform::CreateIdentity(),
+            AZ::Vector3::CreateZero(),
+            AZ::Quaternion::CreateIdentity(),
+            nonUniformScale);
+
+        AZ::EntityComponentIdPair idPair(editorEntity->GetId(), editorEntity->FindComponent<PhysX::EditorMeshColliderComponent>()->GetId());
+        PhysX::EditorMeshColliderComponentRequestBus::Event(
+            idPair, &PhysX::EditorMeshColliderComponentRequests::SetAssetScale, meshAssetScale);
+
+        EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
+
+        // check that the runtime entity has the expected components
+        auto* meshColliderComponent = gameEntity->FindComponent<PhysX::MeshColliderComponent>();
+        auto* staticRigidBodyComponent = gameEntity->FindComponent<PhysX::StaticRigidBodyComponent>();
+        EXPECT_TRUE(meshColliderComponent != nullptr);
+        EXPECT_TRUE(staticRigidBodyComponent != nullptr);
+
+        AzPhysics::ShapeColliderPairList shapeConfigList = meshColliderComponent->GetShapeConfigurations();
+        EXPECT_EQ(shapeConfigList.size(), 1);
+
+        for (const auto& shapeConfigPair : shapeConfigList)
+        {
+            EXPECT_EQ(shapeConfigPair.second->GetShapeType(), Physics::ShapeType::PhysicsAsset);
+        }
+
+        const auto* simulatedBody = staticRigidBodyComponent->GetSimulatedBody();
+        const auto* pxRigidStatic = static_cast<const physx::PxRigidStatic*>(simulatedBody->GetNativePointer());
+
+        PHYSX_SCENE_READ_LOCK(pxRigidStatic->getScene());
+
+        // there should be a single shape on the rigid body and it should be a box
+        EXPECT_EQ(pxRigidStatic->getNbShapes(), 1);
+        if (pxRigidStatic->getNbShapes() > 0)
+        {
+            physx::PxShape* shape = nullptr;
+            pxRigidStatic->getShapes(&shape, 1, 0);
+            EXPECT_EQ(shape->getGeometryType(), physx::PxGeometryType::eTRIANGLEMESH);
+        }
+
+        const AZ::Aabb aabb = simulatedBody->GetAabb();
+        EXPECT_THAT(aabb.GetMin(), UnitTest::IsCloseTolerance(AZ::Vector3(-1.0f, -0.825f, -1.75f), 1e-3f));
+        EXPECT_THAT(aabb.GetMax(), UnitTest::IsCloseTolerance(AZ::Vector3(1.0f, 0.825f, 1.75f), 1e-3f));
 
         delete meshAssetData;
     }
@@ -252,7 +671,12 @@ namespace PhysXEditorTests
 
         // create an editor entity with a collider component
         EntityPtr editorEntity = CreateMeshColliderEditorEntity(
-            AZ::Transform::CreateIdentity(), meshAssetData->CreateMeshAsset(), AZ::Vector3::CreateZero(), AZStd::nullopt, RigidBodyType::Dynamic);
+            meshAssetData->CreateMeshAsset(),
+            AZ::Transform::CreateIdentity(),
+            AZ::Vector3::CreateZero(),
+            AZ::Quaternion::CreateIdentity(), 
+            AZStd::nullopt,
+            RigidBodyType::Dynamic);
 
         EXPECT_EQ(errorHandler.GetExpectedErrorCount(), 1);
 

--- a/Gems/PhysX/Code/Tests/EditorShapeColliderComponentTests.cpp
+++ b/Gems/PhysX/Code/Tests/EditorShapeColliderComponentTests.cpp
@@ -177,11 +177,11 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, EditorShapeColliderComponent_BoxShapeColliderWithTranslationOffset_CorrectEditorStaticBodyGeometry)
     {
-        AZ::Transform transform(AZ::Vector3(2.0f, -6.0f, 5.0f), AZ::Quaternion(0.3f, -0.3f, 0.1f, 0.9f), 1.6f);
-        AZ::Vector3 nonUniformScale(2.0f, 2.5f, 0.5f);
-        AZ::Vector3 boxDimensions(5.0f, 8.0f, 6.0f);
-        AZ::Vector3 translationOffset(-4.0f, 3.0f, -1.0f);
-        EntityPtr editorEntity = CreateBoxShapeColliderEditorEntity(transform, boxDimensions, translationOffset, nonUniformScale);
+        const AZ::Vector3 boxDimensions(5.0f, 8.0f, 6.0f);
+        const AZ::Transform transform(AZ::Vector3(2.0f, -6.0f, 5.0f), AZ::Quaternion(0.3f, -0.3f, 0.1f, 0.9f), 1.6f);
+        const AZ::Vector3 translationOffset(-4.0f, 3.0f, -1.0f);
+        const AZ::Vector3 nonUniformScale(2.0f, 2.5f, 0.5f);
+        EntityPtr editorEntity = CreateBoxShapeColliderEditorEntity(boxDimensions, transform, translationOffset, nonUniformScale);
 
         AZ::Aabb aabb = GetSimulatedBodyAabb(editorEntity->GetId());
         EXPECT_THAT(aabb.GetMin(), UnitTest::IsClose(AZ::Vector3(-25.488f, -10.16f, -11.448f)));
@@ -190,12 +190,12 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, EditorShapeColliderComponent_BoxShapeColliderWithTranslationOffset_CorrectEditorDynamicBodyGeometry)
     {
-        AZ::Transform transform(AZ::Vector3(-5.0f, -1.0f, 3.0f), AZ::Quaternion(0.7f, 0.5f, -0.1f, 0.5f), 1.2f);
-        AZ::Vector3 nonUniformScale(1.5f, 1.5f, 4.0f);
-        AZ::Vector3 boxDimensions(6.0f, 4.0f, 1.0f);
-        AZ::Vector3 translationOffset(6.0f, -5.0f, -4.0f);
+        const AZ::Vector3 boxDimensions(6.0f, 4.0f, 1.0f);
+        const AZ::Transform transform(AZ::Vector3(-5.0f, -1.0f, 3.0f), AZ::Quaternion(0.7f, 0.5f, -0.1f, 0.5f), 1.2f);
+        const AZ::Vector3 translationOffset(6.0f, -5.0f, -4.0f);
+        const AZ::Vector3 nonUniformScale(1.5f, 1.5f, 4.0f);
         EntityPtr editorEntity =
-            CreateBoxShapeColliderEditorEntity(transform, boxDimensions, translationOffset, nonUniformScale, RigidBodyType::Dynamic);
+            CreateBoxShapeColliderEditorEntity(boxDimensions, transform, translationOffset, nonUniformScale, RigidBodyType::Dynamic);
 
         editorEntity->Deactivate();
         editorEntity->Activate();
@@ -207,11 +207,12 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, EditorShapeColliderComponent_BoxShapeColliderWithTranslationOffset_CorrectRuntimeStaticBodyGeometry)
     {
-        AZ::Transform transform(AZ::Vector3(7.0f, 2.0f, 4.0f), AZ::Quaternion(0.4f, -0.8f, 0.4f, 0.2f), 2.5f);
-        AZ::Vector3 nonUniformScale(0.8f, 2.0f, 1.5f);
-        AZ::Vector3 boxDimensions(1.0f, 4.0f, 7.0f);
-        AZ::Vector3 translationOffset(6.0f, -1.0f, -2.0f);
-        EntityPtr editorEntity = CreateBoxShapeColliderEditorEntity(transform, boxDimensions, translationOffset, nonUniformScale, RigidBodyType::Static);
+        const AZ::Vector3 boxDimensions(1.0f, 4.0f, 7.0f);
+        const AZ::Transform transform(AZ::Vector3(7.0f, 2.0f, 4.0f), AZ::Quaternion(0.4f, -0.8f, 0.4f, 0.2f), 2.5f);
+        const AZ::Vector3 translationOffset(6.0f, -1.0f, -2.0f);
+        const AZ::Vector3 nonUniformScale(0.8f, 2.0f, 1.5f);
+        EntityPtr editorEntity =
+            CreateBoxShapeColliderEditorEntity(boxDimensions, transform, translationOffset, nonUniformScale, RigidBodyType::Static);
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
         AZ::Aabb aabb = GetSimulatedBodyAabb(gameEntity->GetId());
@@ -221,12 +222,12 @@ namespace PhysXEditorTests
 
     TEST_F(PhysXEditorFixture, EditorShapeColliderComponent_BoxShapeColliderWithTranslationOffset_CorrectRuntimeDynamicBodyGeometry)
     {
-        AZ::Transform transform(AZ::Vector3(4.0f, 4.0f, 2.0f), AZ::Quaternion(0.1f, 0.3f, 0.9f, 0.3f), 0.8f);
-        AZ::Vector3 nonUniformScale(2.5f, 1.0f, 2.0f);
-        AZ::Vector3 boxDimensions(4.0f, 2.0f, 7.0f);
-        AZ::Vector3 translationOffset(-2.0f, 7.0f, -1.0f);
+        const AZ::Vector3 boxDimensions(4.0f, 2.0f, 7.0f);
+        const AZ::Transform transform(AZ::Vector3(4.0f, 4.0f, 2.0f), AZ::Quaternion(0.1f, 0.3f, 0.9f, 0.3f), 0.8f);
+        const AZ::Vector3 translationOffset(-2.0f, 7.0f, -1.0f);
+        const AZ::Vector3 nonUniformScale(2.5f, 1.0f, 2.0f);
         EntityPtr editorEntity =
-            CreateBoxShapeColliderEditorEntity(transform, boxDimensions, translationOffset, nonUniformScale, RigidBodyType::Dynamic);
+            CreateBoxShapeColliderEditorEntity(boxDimensions, transform, translationOffset, nonUniformScale, RigidBodyType::Dynamic);
         EntityPtr gameEntity = CreateActiveGameEntityFromEditorEntity(editorEntity.get());
 
         AZ::Aabb aabb = GetSimulatedBodyAabb(gameEntity->GetId());
@@ -237,8 +238,8 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, EditorShapeColliderComponent_ShapeColliderWithSphereAndTranslationOffset_CorrectEditorStaticBodyGeometry)
     {
         EntityPtr editorEntity = CreateSphereShapeColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(4.0f, 2.0f, -2.0f), AZ::Quaternion(-0.5f, -0.5f, 0.1f, 0.7f), 3.0f),
             1.6f,
+            AZ::Transform(AZ::Vector3(4.0f, 2.0f, -2.0f), AZ::Quaternion(-0.5f, -0.5f, 0.1f, 0.7f), 3.0f),
             AZ::Vector3(2.0f, 3.0f, -7.0f)
         );
 
@@ -250,8 +251,8 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, EditorShapeColliderComponent_ShapeColliderWithSphereAndTranslationOffset_CorrectEditorDynamicBodyGeometry)
     {
         EntityPtr editorEntity = CreateSphereShapeColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(2.0f, -5.0f, -6.0f), AZ::Quaternion(0.7f, 0.1f, 0.7f, 0.1f), 0.4f),
             3.5f,
+            AZ::Transform(AZ::Vector3(2.0f, -5.0f, -6.0f), AZ::Quaternion(0.7f, 0.1f, 0.7f, 0.1f), 0.4f),
             AZ::Vector3(1.0f, 3.0f, -1.0f),
             AZStd::nullopt,
             RigidBodyType::Dynamic);
@@ -267,8 +268,8 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, EditorShapeColliderComponent_ShapeColliderWithSphereAndTranslationOffset_CorrectRuntimeStaticBodyGeometry)
     {
         EntityPtr editorEntity = CreateSphereShapeColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(4.0f, 4.0f, -1.0f), AZ::Quaternion(0.8f, -0.2f, 0.4f, 0.4f), 2.4f),
             2.0f,
+            AZ::Transform(AZ::Vector3(4.0f, 4.0f, -1.0f), AZ::Quaternion(0.8f, -0.2f, 0.4f, 0.4f), 2.4f),
             AZ::Vector3(5.0f, 6.0f, -8.0f)
         );
 
@@ -282,8 +283,8 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, EditorShapeColliderComponent_ShapeColliderWithSphereAndTranslationOffset_CorrectRuntimeDynamicBodyGeometry)
     {
         EntityPtr editorEntity = CreateSphereShapeColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(2.0f, 2.0f, -5.0f), AZ::Quaternion(0.9f, 0.3f, 0.3f, 0.1f), 5.0f),
             0.4f,
+            AZ::Transform(AZ::Vector3(2.0f, 2.0f, -5.0f), AZ::Quaternion(0.9f, 0.3f, 0.3f, 0.1f), 5.0f),
             AZ::Vector3(4.0f, 7.0f, 3.0f),
             AZStd::nullopt,
             RigidBodyType::Dynamic);
@@ -298,9 +299,9 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, EditorShapeColliderComponent_ShapeColliderWithCapsuleAndTranslationOffset_CorrectEditorStaticBodyGeometry)
     {
         EntityPtr editorEntity = CreateCapsuleShapeColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(2.0f, 1.0f, -2.0f), AZ::Quaternion(-0.2f, -0.8f, -0.4f, 0.4f), 4.0f),
             2.0f,
             8.0f,
+            AZ::Transform(AZ::Vector3(2.0f, 1.0f, -2.0f), AZ::Quaternion(-0.2f, -0.8f, -0.4f, 0.4f), 4.0f),
             AZ::Vector3(2.0f, 3.0f, 5.0f)
         );
 
@@ -312,9 +313,9 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, EditorShapeColliderComponent_ShapeColliderWithCapsuleAndTranslationOffset_CorrectEditorDynamicBodyGeometry)
     {
         EntityPtr editorEntity = CreateCapsuleShapeColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(7.0f, -9.0f, 2.0f), AZ::Quaternion(0.7f, 0.1f, 0.7f, 0.1f), 0.2f),
             1.0f,
             5.0f,
+            AZ::Transform(AZ::Vector3(7.0f, -9.0f, 2.0f), AZ::Quaternion(0.7f, 0.1f, 0.7f, 0.1f), 0.2f),
             AZ::Vector3(2.0f, 9.0f, -5.0f),
             AZStd::nullopt,
             RigidBodyType::Dynamic);
@@ -330,9 +331,9 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, EditorShapeColliderComponent_ShapeColliderWithCapsuleAndTranslationOffset_CorrectRuntimeStaticBodyGeometry)
     {
         EntityPtr editorEntity = CreateCapsuleShapeColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(-4.0f, -3.0f, -1.0f), AZ::Quaternion(0.5f, -0.7f, -0.1f, 0.5f), 0.8f),
             2.0f,
             11.0f,
+            AZ::Transform(AZ::Vector3(-4.0f, -3.0f, -1.0f), AZ::Quaternion(0.5f, -0.7f, -0.1f, 0.5f), 0.8f),
             AZ::Vector3(4.0f, 1.0f, -3.0f)
         );
 
@@ -346,9 +347,9 @@ namespace PhysXEditorTests
     TEST_F(PhysXEditorFixture, EditorShapeColliderComponent_ShapeColliderWithCapsuleAndTranslationOffset_CorrectRuntimeDynamicBodyGeometry)
     {
         EntityPtr editorEntity = CreateCapsuleShapeColliderEditorEntity(
-            AZ::Transform(AZ::Vector3(7.0f, 6.0f, -3.0f), AZ::Quaternion(-0.3f, -0.1f, -0.3f, 0.9f), 6.0f),
             0.4f,
             3.0f,
+            AZ::Transform(AZ::Vector3(7.0f, 6.0f, -3.0f), AZ::Quaternion(-0.3f, -0.1f, -0.3f, 0.9f), 6.0f),
             AZ::Vector3(2.0f, -7.0f, 7.0f),
             AZStd::nullopt,
             RigidBodyType::Dynamic);

--- a/Gems/PhysX/Code/Tests/EditorTestUtilities.cpp
+++ b/Gems/PhysX/Code/Tests/EditorTestUtilities.cpp
@@ -50,8 +50,8 @@ namespace PhysXEditorTests
     }
 
     EntityPtr CreateBoxShapeColliderEditorEntity(
-        const AZ::Transform& transform,
         const AZ::Vector3& boxDimensions,
+        const AZ::Transform& transform,
         const AZ::Vector3& translationOffset,
         AZStd::optional<AZ::Vector3> nonUniformScale,
         RigidBodyType rigidBodyType)
@@ -89,9 +89,9 @@ namespace PhysXEditorTests
     }
 
     EntityPtr CreateCapsuleShapeColliderEditorEntity(
-        const AZ::Transform& transform,
         float radius,
         float height,
+        const AZ::Transform& transform,
         const AZ::Vector3& translationOffset,
         AZStd::optional<AZ::Vector3> nonUniformScale,
         RigidBodyType rigidBodyType)
@@ -131,8 +131,8 @@ namespace PhysXEditorTests
     }
 
     EntityPtr CreateSphereShapeColliderEditorEntity(
-        const AZ::Transform& transform,
         float radius,
+        const AZ::Transform& transform,
         const AZ::Vector3& translationOffset,
         AZStd::optional<AZ::Vector3> nonUniformScale,
         RigidBodyType rigidBodyType)
@@ -169,9 +169,10 @@ namespace PhysXEditorTests
     }
 
     EntityPtr CreateBoxPrimitiveColliderEditorEntity(
-        const AZ::Transform& transform,
         const AZ::Vector3& boxDimensions,
+        const AZ::Transform& transform,
         const AZ::Vector3& translationOffset,
+        const AZ::Quaternion& rotationOffset,
         AZStd::optional<AZ::Vector3> nonUniformScale,
         RigidBodyType rigidBodyType)
     {
@@ -200,6 +201,8 @@ namespace PhysXEditorTests
         AzToolsFramework::BoxManipulatorRequestBus::Event(idPair, &AzToolsFramework::BoxManipulatorRequests::SetDimensions, boxDimensions);
         PhysX::EditorColliderComponentRequestBus::Event(
             idPair, &PhysX::EditorColliderComponentRequests::SetColliderOffset, translationOffset);
+        PhysX::EditorColliderComponentRequestBus::Event(
+            idPair, &PhysX::EditorColliderComponentRequests::SetColliderRotation, rotationOffset);
 
         if (nonUniformScale.has_value())
         {
@@ -210,10 +213,11 @@ namespace PhysXEditorTests
     }
 
     EntityPtr CreateCapsulePrimitiveColliderEditorEntity(
-        const AZ::Transform& transform,
         float radius,
         float height,
+        const AZ::Transform& transform,
         const AZ::Vector3& translationOffset,
+        const AZ::Quaternion& rotationOffset,
         AZStd::optional<AZ::Vector3> nonUniformScale,
         RigidBodyType rigidBodyType)
     {
@@ -243,6 +247,8 @@ namespace PhysXEditorTests
         PhysX::EditorPrimitiveColliderComponentRequestBus::Event(idPair, &PhysX::EditorPrimitiveColliderComponentRequests::SetCapsuleHeight, height);
         PhysX::EditorColliderComponentRequestBus::Event(
             idPair, &PhysX::EditorColliderComponentRequests::SetColliderOffset, translationOffset);
+        PhysX::EditorColliderComponentRequestBus::Event(
+            idPair, &PhysX::EditorColliderComponentRequests::SetColliderRotation, rotationOffset);
 
         if (nonUniformScale.has_value())
         {
@@ -253,9 +259,10 @@ namespace PhysXEditorTests
     }
 
     EntityPtr CreateSpherePrimitiveColliderEditorEntity(
-        const AZ::Transform& transform,
         float radius,
+        const AZ::Transform& transform,
         const AZ::Vector3& translationOffset,
+        const AZ::Quaternion& rotationOffset,
         AZStd::optional<AZ::Vector3> nonUniformScale,
         RigidBodyType rigidBodyType)
     {
@@ -284,6 +291,8 @@ namespace PhysXEditorTests
         PhysX::EditorPrimitiveColliderComponentRequestBus::Event(idPair, &PhysX::EditorPrimitiveColliderComponentRequests::SetSphereRadius, radius);
         PhysX::EditorColliderComponentRequestBus::Event(
             idPair, &PhysX::EditorColliderComponentRequests::SetColliderOffset, translationOffset);
+        PhysX::EditorColliderComponentRequestBus::Event(
+            idPair, &PhysX::EditorColliderComponentRequests::SetColliderRotation, rotationOffset);
 
         if (nonUniformScale.has_value())
         {
@@ -294,11 +303,11 @@ namespace PhysXEditorTests
     }
 
     EntityPtr CreateCylinderPrimitiveColliderEditorEntity(
-        const AZ::Transform& transform,
-        const AZ::Vector3& positionOffset,
-        const AZ::Quaternion& rotationOffset,
         float radius,
         float height,
+        const AZ::Transform& transform,
+        const AZ::Vector3& translationOffset,
+        const AZ::Quaternion& rotationOffset,
         AZStd::optional<AZ::Vector3> nonUniformScale,
         RigidBodyType rigidBodyType)
     {
@@ -325,7 +334,8 @@ namespace PhysXEditorTests
             idPair, &PhysX::EditorPrimitiveColliderComponentRequests::SetShapeType, Physics::ShapeType::Cylinder);
         PhysX::EditorPrimitiveColliderComponentRequestBus::Event(idPair, &PhysX::EditorPrimitiveColliderComponentRequests::SetCylinderRadius, radius);
         PhysX::EditorPrimitiveColliderComponentRequestBus::Event(idPair, &PhysX::EditorPrimitiveColliderComponentRequests::SetCylinderHeight, height);
-        PhysX::EditorColliderComponentRequestBus::Event(idPair, &PhysX::EditorColliderComponentRequests::SetColliderOffset, positionOffset);
+        PhysX::EditorColliderComponentRequestBus::Event(
+            idPair, &PhysX::EditorColliderComponentRequests::SetColliderOffset, translationOffset);
         PhysX::EditorColliderComponentRequestBus::Event(
             idPair, &PhysX::EditorColliderComponentRequests::SetColliderRotation, rotationOffset);
 
@@ -342,9 +352,10 @@ namespace PhysXEditorTests
     }
 
     EntityPtr CreateMeshColliderEditorEntity(
-        const AZ::Transform& transform,
         AZ::Data::Asset<PhysX::Pipeline::MeshAsset> meshAsset,
+        const AZ::Transform& transform,
         const AZ::Vector3& translationOffset,
+        const AZ::Quaternion& rotationOffset,
         AZStd::optional<AZ::Vector3> nonUniformScale,
         RigidBodyType rigidBodyType)
     {
@@ -375,6 +386,8 @@ namespace PhysXEditorTests
         AZ::TransformBus::Event(editorEntityId, &AZ::TransformBus::Events::SetWorldTM, transform);
         PhysX::EditorColliderComponentRequestBus::Event(
             idPair, &PhysX::EditorColliderComponentRequests::SetColliderOffset, translationOffset);
+        PhysX::EditorColliderComponentRequestBus::Event(
+            idPair, &PhysX::EditorColliderComponentRequests::SetColliderRotation, rotationOffset);
 
         if (nonUniformScale.has_value())
         {

--- a/Gems/PhysX/Code/Tests/EditorTestUtilities.h
+++ b/Gems/PhysX/Code/Tests/EditorTestUtilities.h
@@ -43,9 +43,9 @@ namespace PhysXEditorTests
     //! It can be created with either static or dynamic rigid body component and with
     //! or without uniform scale component.
     EntityPtr CreateBoxShapeColliderEditorEntity(
-        const AZ::Transform& transform,
         const AZ::Vector3& boxDimensions,
-        const AZ::Vector3& translationOffset,
+        const AZ::Transform& transform = AZ::Transform::CreateIdentity(),
+        const AZ::Vector3& translationOffset = AZ::Vector3::CreateZero(),
         AZStd::optional<AZ::Vector3> nonUniformScale = AZStd::nullopt,
         RigidBodyType rigidBodyType = RigidBodyType::Static);
 
@@ -53,10 +53,10 @@ namespace PhysXEditorTests
     //! It can be created with either static or dynamic rigid body component and with
     //! or without uniform scale component.
     EntityPtr CreateCapsuleShapeColliderEditorEntity(
-        const AZ::Transform& transform,
         float radius,
         float height,
-        const AZ::Vector3& translationOffset,
+        const AZ::Transform& transform = AZ::Transform::CreateIdentity(),
+        const AZ::Vector3& translationOffset = AZ::Vector3::CreateZero(),
         AZStd::optional<AZ::Vector3> nonUniformScale = AZStd::nullopt,
         RigidBodyType rigidBodyType = RigidBodyType::Static);
 
@@ -64,9 +64,9 @@ namespace PhysXEditorTests
     //! It can be created with either static or dynamic rigid body component and with
     //! or without uniform scale component.
     EntityPtr CreateSphereShapeColliderEditorEntity(
-        const AZ::Transform& transform,
         float radius,
-        const AZ::Vector3& translationOffset,
+        const AZ::Transform& transform = AZ::Transform::CreateIdentity(),
+        const AZ::Vector3& translationOffset = AZ::Vector3::CreateZero(),
         AZStd::optional<AZ::Vector3> nonUniformScale = AZStd::nullopt,
         RigidBodyType rigidBodyType = RigidBodyType::Static);
     
@@ -74,9 +74,10 @@ namespace PhysXEditorTests
     //! It can be created with either static or dynamic rigid body component and with
     //! or without uniform scale component.
     EntityPtr CreateBoxPrimitiveColliderEditorEntity(
-        const AZ::Transform& transform,
         const AZ::Vector3& boxDimensions,
-        const AZ::Vector3& translationOffset,
+        const AZ::Transform& transform = AZ::Transform::CreateIdentity(),
+        const AZ::Vector3& translationOffset = AZ::Vector3::CreateZero(),
+        const AZ::Quaternion& rotationOffset = AZ::Quaternion::CreateIdentity(),
         AZStd::optional<AZ::Vector3> nonUniformScale = AZStd::nullopt,
         RigidBodyType rigidBodyType = RigidBodyType::Static);
 
@@ -84,10 +85,11 @@ namespace PhysXEditorTests
     //! It can be created with either static or dynamic rigid body component and with
     //! or without uniform scale component.
     EntityPtr CreateCapsulePrimitiveColliderEditorEntity(
-        const AZ::Transform& transform,
         float radius,
         float height,
-        const AZ::Vector3& translationOffset,
+        const AZ::Transform& transform = AZ::Transform::CreateIdentity(),
+        const AZ::Vector3& translationOffset = AZ::Vector3::CreateZero(),
+        const AZ::Quaternion& rotationOffset = AZ::Quaternion::CreateIdentity(),
         AZStd::optional<AZ::Vector3> nonUniformScale = AZStd::nullopt,
         RigidBodyType rigidBodyType = RigidBodyType::Static);
 
@@ -95,9 +97,10 @@ namespace PhysXEditorTests
     //! It can be created with either static or dynamic rigid body component and with
     //! or without uniform scale component.
     EntityPtr CreateSpherePrimitiveColliderEditorEntity(
-        const AZ::Transform& transform,
         float radius,
-        const AZ::Vector3& translationOffset,
+        const AZ::Transform& transform = AZ::Transform::CreateIdentity(),
+        const AZ::Vector3& translationOffset = AZ::Vector3::CreateZero(),
+        const AZ::Quaternion& rotationOffset = AZ::Quaternion::CreateIdentity(),
         AZStd::optional<AZ::Vector3> nonUniformScale = AZStd::nullopt,
         RigidBodyType rigidBodyType = RigidBodyType::Static);
 
@@ -105,11 +108,11 @@ namespace PhysXEditorTests
     //! It can be created with either static or dynamic rigid body component and with
     //! or without uniform scale component.
     EntityPtr CreateCylinderPrimitiveColliderEditorEntity(
-        const AZ::Transform& transform,
-        const AZ::Vector3& positionOffset,
-        const AZ::Quaternion& rotationOffset,
         float radius,
         float height,
+        const AZ::Transform& transform = AZ::Transform::CreateIdentity(),
+        const AZ::Vector3& translationOffset = AZ::Vector3::CreateZero(),
+        const AZ::Quaternion& rotationOffset = AZ::Quaternion::CreateIdentity(),
         AZStd::optional<AZ::Vector3> nonUniformScale = AZStd::nullopt,
         RigidBodyType rigidBodyType = RigidBodyType::Static);
 
@@ -117,9 +120,10 @@ namespace PhysXEditorTests
     //! It can be created with either static or dynamic rigid body component and with
     //! or without uniform scale component.
     EntityPtr CreateMeshColliderEditorEntity(
-        const AZ::Transform& transform,
         AZ::Data::Asset<PhysX::Pipeline::MeshAsset> meshAsset,
-        const AZ::Vector3& translationOffset,
+        const AZ::Transform& transform = AZ::Transform::CreateIdentity(),
+        const AZ::Vector3& translationOffset = AZ::Vector3::CreateZero(),
+        const AZ::Quaternion& rotationOffset = AZ::Quaternion::CreateIdentity(),
         AZStd::optional<AZ::Vector3> nonUniformScale = AZStd::nullopt,
         RigidBodyType rigidBodyType = RigidBodyType::Static);
 

--- a/Gems/PhysX/Code/Tests/TestColliderComponent.h
+++ b/Gems/PhysX/Code/Tests/TestColliderComponent.h
@@ -81,11 +81,11 @@ namespace UnitTest
         AZ::Quaternion m_rotation = AZ::Quaternion::CreateIdentity();
         AZ::Transform m_transform = AZ::Transform::CreateIdentity();
         Physics::ShapeType m_shapeType = Physics::ShapeType::Box;
-        float m_sphereRadius = 0.5f;
-        float m_capsuleHeight = 1.0f;
-        float m_capsuleRadius = 0.25f;
-        float m_cylinderHeight = 1.0f;
-        float m_cylinderRadius = 0.25f;
-        AZ::u8 m_subdivisionCount = 16;
+        float m_sphereRadius = Physics::ShapeConstants::DefaultSphereRadius;
+        float m_capsuleHeight = Physics::ShapeConstants::DefaultCapsuleHeight;
+        float m_capsuleRadius = Physics::ShapeConstants::DefaultCapsuleRadius;
+        float m_cylinderHeight = Physics::ShapeConstants::DefaultCylinderHeight;
+        float m_cylinderRadius = Physics::ShapeConstants::DefaultCylinderRadius;
+        AZ::u8 m_subdivisionCount = Physics::ShapeConstants::DefaultCylinderSubdivisionCount;
     };
 } // namespace UnitTest


### PR DESCRIPTION
## What does this PR do?

Also unified arguments of helper functions that create editor colliders (primitive, mesh, shape).

## How was this PR tested?

PhysX gem unit tests pass.
