### PR TITLE
Add sv_useGameLiftServer CVAR to allow local play without GameLift

### DIFF
--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerSystemComponent.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerSystemComponent.cpp
@@ -19,6 +19,8 @@
 
 namespace AWSGameLift
 {
+    AZ_CVAR(bool, sv_useGameLiftServer, false, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Activate GameLift server manager and SDK");
+
     AWSGameLiftServerSystemComponent::AWSGameLiftServerSystemComponent()
         : m_gameLiftServerManager(AZStd::make_unique<AWSGameLiftServerManager>())
     {
@@ -73,14 +75,21 @@ namespace AWSGameLift
 
     void AWSGameLiftServerSystemComponent::Activate()
     {
-        m_gameLiftServerManager->InitializeGameLiftServerSDK();
-        m_gameLiftServerManager->ActivateManager();
+        if (sv_useGameLiftServer)
+        {
+            m_gameLiftServerManager->InitializeGameLiftServerSDK();
+            m_gameLiftServerManager->ActivateManager();
+        }
+        
     }
 
     void AWSGameLiftServerSystemComponent::Deactivate()
     {
-        m_gameLiftServerManager->DeactivateManager();
-        m_gameLiftServerManager->HandleDestroySession();
+        if (sv_useGameLiftServer)
+        {
+            m_gameLiftServerManager->DeactivateManager();
+            m_gameLiftServerManager->HandleDestroySession();
+        }
     }
 
     void AWSGameLiftServerSystemComponent::SetGameLiftServerManager(AZStd::unique_ptr<AWSGameLiftServerManager> gameLiftServerManager)

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerSystemComponent.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerSystemComponent.cpp
@@ -22,7 +22,6 @@ namespace AWSGameLift
     AZ_CVAR(bool, sv_useGameLiftServer, false, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Activate GameLift server manager and SDK");
 
     AWSGameLiftServerSystemComponent::AWSGameLiftServerSystemComponent()
-        : m_gameLiftServerManager(AZStd::make_unique<AWSGameLiftServerManager>())
     {
     }
 
@@ -77,6 +76,7 @@ namespace AWSGameLift
     {
         if (sv_useGameLiftServer)
         {
+            m_gameLiftServerManager = AZStd::make_unique<AWSGameLiftServerManager>();
             m_gameLiftServerManager->InitializeGameLiftServerSDK();
             m_gameLiftServerManager->ActivateManager();
         }
@@ -85,10 +85,11 @@ namespace AWSGameLift
 
     void AWSGameLiftServerSystemComponent::Deactivate()
     {
-        if (sv_useGameLiftServer)
+        if (m_gameLiftServerManager)
         {
             m_gameLiftServerManager->DeactivateManager();
             m_gameLiftServerManager->HandleDestroySession();
+            m_gameLiftServerManager.reset();
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

Addresses https://github.com/o3de/o3de/issues/14848

Some questions I'd like feedback on:
1. what's the best way to _enable_ GameLift for local play, add `sv_useGameLiftServer=true` in the `server.cfg`? Will this work for playing in the Editor?
2. should we have a corresponding CVAR for the client, i.e., `cl_useGameLift`? This would mostly prevent the client from connecting to the various GameLift request buses, which may help performance, but not sure its worth complicating things with an additional setting to flip.

## How was this PR tested?

* Using [o3de-multiplayersample](https://github.com/o3de/o3de-multiplayersample) with AWSGameLift gem enabled, can run `ctrl` + `g` in Editor w/o running GameLiftLocal.
* setting `"sv_useGameLiftServer": "true"` in _commands.multiplayersample_serverlauncher.setreg_ and running server launcher shows connection to GL local
