### PR TITLE
Makes the visuals of physics joint scale as you zoom

### DIFF
--- a/Gems/PhysX/Code/Source/EditorBallJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorBallJointComponent.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
+#include <AzToolsFramework/Viewport/ViewportSettings.h>
 
 #include <Source/EditorBallJointComponent.h>
 #include <Editor/Source/ComponentModes/Joints/JointsComponentMode.h>
@@ -221,8 +222,10 @@ namespace PhysX
         }
 
         const AZ::EntityId entityId = GetEntityId();
-
         AZ::Transform worldTransform = PhysX::Utils::GetEntityWorldTransformWithoutScale(entityId);
+        const AzFramework::CameraState cameraState = AzToolsFramework::GetCameraState(viewportInfo.m_viewportId);
+        // scaleMultiply will represent a scale for the debug draw that makes it remain the same size on screen
+        float scaleMultiply = AzToolsFramework::CalculateScreenToWorldMultiplier(worldTransform.GetTranslation(), cameraState);
 
         AZ::Transform localTransform;
         EditorJointRequestBus::EventResult(localTransform,
@@ -236,20 +239,20 @@ namespace PhysX
         debugDisplay.PushMatrix(worldTransform);
         debugDisplay.PushMatrix(localTransform);
 
-        const float xAxisArrowLength = 2.0f;
+        const float xAxisArrowLength = 2.0f * scaleMultiply;
         debugDisplay.SetColor(AZ::Color(1.0f, 0.0f, 0.0f, 1.0f));
-        debugDisplay.DrawArrow(AZ::Vector3(0.0f, 0.0f, 0.0f), AZ::Vector3(xAxisArrowLength, 0.0f, 0.0f));
+        debugDisplay.DrawArrow(AZ::Vector3(0.0f, 0.0f, 0.0f), AZ::Vector3(xAxisArrowLength, 0.0f, 0.0f), scaleMultiply);
 
         AngleLimitsFloatPair yzSwingAngleLimits(m_swingLimit.m_limitY, m_swingLimit.m_limitZ);
 
         const AZ::u32 numEllipseSamples = 16;
         AZ::Vector3 ellipseSamples[numEllipseSamples];
-        float coneHeight = 3.0f;
+        float coneHeight = 3.0f * scaleMultiply;
 
         // Draw inverted cone if angles are larger than 90 deg.
         if (yzSwingAngleLimits.first > 90.0f || yzSwingAngleLimits.second > 90.0f)
         {
-            coneHeight = -3.0f;
+            coneHeight = -3.0f * scaleMultiply;
         }
 
         const float coney = tan(AZ::DegToRad(yzSwingAngleLimits.first)) * coneHeight;

--- a/Gems/PhysX/Code/Source/EditorHingeJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorHingeJointComponent.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
+#include <AzToolsFramework/Viewport/ViewportSettings.h>
 
 #include <Editor/Source/ComponentModes/Joints/JointsComponentMode.h>
 #include <Editor/Source/ComponentModes/Joints/JointsComponentModeCommon.h>
@@ -233,82 +234,110 @@ namespace PhysX
         AngleLimitsFloatPair currentValue(m_angularLimit.m_limitPositive, m_angularLimit.m_limitNegative);
         AZ::Vector3 axis = AZ::Vector3::CreateAxisX();
 
-        const float size = 2.0f;
-        AZ::Vector3 axisPoint = axis * size * 0.5f;
+        const AZ::EntityId& entityId = GetEntityId();
+        AZ::Transform worldTransform = PhysX::Utils::GetEntityWorldTransformWithoutScale(entityId);
+        const AzFramework::CameraState cameraState = AzToolsFramework::GetCameraState(viewportInfo.m_viewportId);
 
-        AZ::Vector3 points[4] = {
-            -axisPoint
-            , axisPoint
-            , axisPoint
-            , -axisPoint
-        };
+        // scaleMultiply will represent a scale for the debug draw that makes it remain the same size on screen
+        float scaleMultiply = AzToolsFramework::CalculateScreenToWorldMultiplier(worldTransform.GetTranslation(), cameraState);
 
-        if (axis == AZ::Vector3::CreateAxisX())
-        {
-            points[2].SetZ(size);
-            points[3].SetZ(size);
-        }
-        else if (axis == AZ::Vector3::CreateAxisY())
-        {
-            points[2].SetX(size);
-            points[3].SetX(size);
-        }
-        else if (axis == AZ::Vector3::CreateAxisZ())
-        {
-            points[2].SetX(size);
-            points[3].SetX(size);
-        }
+        const float size = 2.0f * scaleMultiply;
 
         AZ::u32 stateBefore = debugDisplay.GetState();
         debugDisplay.CullOff();
         debugDisplay.SetAlpha(s_alpha);
 
-        const AZ::EntityId& entityId = GetEntityId();
-
-        AZ::Transform worldTransform = PhysX::Utils::GetEntityWorldTransformWithoutScale(entityId);
-
         AZ::Transform localTransform;
-        EditorJointRequestBus::EventResult(localTransform, 
+        EditorJointRequestBus::EventResult(
+            localTransform,
             AZ::EntityComponentIdPair(entityId, GetId()),
-            &EditorJointRequests::GetTransformValue, 
+            &EditorJointRequests::GetTransformValue,
             PhysX::JointsComponentModeCommon::ParameterNames::Transform);
 
         debugDisplay.PushMatrix(worldTransform);
         debugDisplay.PushMatrix(localTransform);
 
-        debugDisplay.SetColor(s_colorSweepArc);
-        const float sweepLineDisplaceFactor = 0.5f;
-        const float sweepLineThickness = 1.0f;
-        const float sweepLineGranularity = 1.0f;
-        const AZ::Vector3 zeroVector = AZ::Vector3::CreateZero();
-        const AZ::Vector3 posPosition = axis * sweepLineDisplaceFactor;
-        const AZ::Vector3 negPosition = -posPosition;
-        debugDisplay.DrawArc(posPosition, sweepLineThickness, -currentValue.first, currentValue.first, sweepLineGranularity, -axis);
-        debugDisplay.DrawArc(zeroVector, sweepLineThickness, -currentValue.first, currentValue.first, sweepLineGranularity, -axis);
-        debugDisplay.DrawArc(negPosition, sweepLineThickness, -currentValue.first, currentValue.first, sweepLineGranularity, -axis);
-        debugDisplay.DrawArc(posPosition, sweepLineThickness, 0.0f, abs(currentValue.second), sweepLineGranularity, -axis);
-        debugDisplay.DrawArc(zeroVector, sweepLineThickness, 0.0f, abs(currentValue.second), sweepLineGranularity, -axis);
-        debugDisplay.DrawArc(negPosition, sweepLineThickness, 0.0f, abs(currentValue.second), sweepLineGranularity, -axis);
-
-        AZ::Quaternion firstRotate = AZ::Quaternion::CreateFromAxisAngle(axis, AZ::DegToRad(currentValue.first));
-        AZ::Transform firstTM = AZ::Transform::CreateFromQuaternion(firstRotate);
-        debugDisplay.PushMatrix(firstTM);
+        // draw a cylinder to indicate the axis of revolution.
+        const float cylinderThickness = 0.05f * scaleMultiply;
         debugDisplay.SetColor(s_colorFirst);
-        debugDisplay.DrawQuad(points[0], points[1], points[2], points[3]);
-        debugDisplay.PopMatrix();
+        debugDisplay.DrawSolidCylinder(AZ::Vector3::CreateZero(), AZ::Vector3::CreateAxisX(), cylinderThickness, size, true);
 
-        AZ::Quaternion secondRotate = AZ::Quaternion::CreateFromAxisAngle(axis, AZ::DegToRad(currentValue.second));
-        AZ::Transform secondTM = AZ::Transform::CreateFromQuaternion(secondRotate);
-        debugDisplay.PushMatrix(secondTM);
-        debugDisplay.SetColor(s_colorSecond);
-        debugDisplay.DrawQuad(points[0], points[1], points[2], points[3]);
-        debugDisplay.PopMatrix();
+        if (m_angularLimit.m_standardLimitConfig.m_isLimited)
+        {
+            // if we are angularly limited, then show the limits, with an arc between them:
+            AZ::Vector3 axisPoint = axis * size * 0.5f;
 
-        debugDisplay.SetColor(s_colorDefault);
-        debugDisplay.DrawQuad(points[0], points[1], points[2], points[3]);
+            AZ::Vector3 points[4] = { -axisPoint, axisPoint, axisPoint, -axisPoint };
 
-        debugDisplay.PopMatrix(); //pop local transform
-        debugDisplay.PopMatrix(); //pop global transform
+            if (axis == AZ::Vector3::CreateAxisX())
+            {
+                points[2].SetZ(size);
+                points[3].SetZ(size);
+            }
+            else if (axis == AZ::Vector3::CreateAxisY())
+            {
+                points[2].SetX(size);
+                points[3].SetX(size);
+            }
+            else if (axis == AZ::Vector3::CreateAxisZ())
+            {
+                points[2].SetX(size);
+                points[3].SetX(size);
+            }
+
+            
+            debugDisplay.SetColor(s_colorSweepArc);
+            const float sweepLineDisplaceFactor = 0.5f;
+            const float sweepLineThickness = 1.0f * scaleMultiply;
+            const float sweepLineGranularity = 1.0f;
+            const AZ::Vector3 zeroVector = AZ::Vector3::CreateZero();
+            const AZ::Vector3 posPosition = axis * sweepLineDisplaceFactor * scaleMultiply;
+            const AZ::Vector3 negPosition = -posPosition;
+            debugDisplay.DrawArc(posPosition, sweepLineThickness, -currentValue.first, currentValue.first, sweepLineGranularity, -axis);
+            debugDisplay.DrawArc(zeroVector, sweepLineThickness, -currentValue.first, currentValue.first, sweepLineGranularity, -axis);
+            debugDisplay.DrawArc(negPosition, sweepLineThickness, -currentValue.first, currentValue.first, sweepLineGranularity, -axis);
+            debugDisplay.DrawArc(posPosition, sweepLineThickness, 0.0f, abs(currentValue.second), sweepLineGranularity, -axis);
+            debugDisplay.DrawArc(zeroVector, sweepLineThickness, 0.0f, abs(currentValue.second), sweepLineGranularity, -axis);
+            debugDisplay.DrawArc(negPosition, sweepLineThickness, 0.0f, abs(currentValue.second), sweepLineGranularity, -axis);
+
+            AZ::Quaternion firstRotate = AZ::Quaternion::CreateFromAxisAngle(axis, AZ::DegToRad(currentValue.first));
+            AZ::Transform firstTM = AZ::Transform::CreateFromQuaternion(firstRotate);
+            debugDisplay.PushMatrix(firstTM);
+            debugDisplay.SetColor(s_colorFirst);
+            debugDisplay.DrawQuad(points[0], points[1], points[2], points[3]);
+            debugDisplay.PopMatrix();
+
+            AZ::Quaternion secondRotate = AZ::Quaternion::CreateFromAxisAngle(axis, AZ::DegToRad(currentValue.second));
+            AZ::Transform secondTM = AZ::Transform::CreateFromQuaternion(secondRotate);
+            debugDisplay.PushMatrix(secondTM);
+            debugDisplay.SetColor(s_colorSecond);
+            debugDisplay.DrawQuad(points[0], points[1], points[2], points[3]);
+            debugDisplay.PopMatrix();
+
+            debugDisplay.SetColor(s_colorDefault);
+            debugDisplay.DrawQuad(points[0], points[1], points[2], points[3]);
+        }
+        else // if we are not limited, show direction of revolve instead
+        {
+            debugDisplay.SetColor(s_colorSweepArc);
+            const float circleRadius = 0.6f * scaleMultiply;
+            const float coneRadius = 0.05 * scaleMultiply;
+            const float coneHeight = 0.2f * scaleMultiply;
+            debugDisplay.DrawCircle(AZ::Vector3::CreateZero(), 1.0f * circleRadius, 0);
+            // show tick-marks on the revolve axis that indicate the positive direction of revolution
+            AZ::Vector3 pointOnCircle = circleRadius * AZ::Vector3::CreateAxisY();
+            debugDisplay.DrawWireCone(pointOnCircle, AZ::Vector3::CreateAxisZ(), coneRadius, coneHeight);
+            pointOnCircle = -circleRadius * AZ::Vector3::CreateAxisY();
+            debugDisplay.DrawWireCone(pointOnCircle, -AZ::Vector3::CreateAxisZ(), coneRadius,coneHeight);
+
+            pointOnCircle = circleRadius * AZ::Vector3::CreateAxisZ();
+            debugDisplay.DrawWireCone(pointOnCircle, AZ::Vector3::CreateAxisY(), coneRadius, coneHeight);
+            pointOnCircle = -circleRadius * AZ::Vector3::CreateAxisZ();
+            debugDisplay.DrawWireCone(pointOnCircle, -AZ::Vector3::CreateAxisY(), coneRadius, coneHeight);
+        }
+
+        debugDisplay.PopMatrix(); // pop local transform
+        debugDisplay.PopMatrix(); // pop global transform
         debugDisplay.SetState(stateBefore);
     }
 }

--- a/Gems/PhysX/Code/Source/EditorHingeJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorHingeJointComponent.cpp
@@ -326,9 +326,9 @@ namespace PhysX
             debugDisplay.DrawCircle(AZ::Vector3::CreateZero(), 1.0f * circleRadius, 0);
             // show tick-marks on the revolve axis that indicate the positive direction of revolution
             AZ::Vector3 pointOnCircle = circleRadius * AZ::Vector3::CreateAxisY();
-            debugDisplay.DrawWireCone(pointOnCircle, AZ::Vector3::CreateAxisZ(), coneRadius, coneHeight);
+            debugDisplay.DrawWireCone(pointOnCircle, -AZ::Vector3::CreateAxisZ(), coneRadius, coneHeight);
             pointOnCircle = -circleRadius * AZ::Vector3::CreateAxisY();
-            debugDisplay.DrawWireCone(pointOnCircle, -AZ::Vector3::CreateAxisZ(), coneRadius,coneHeight);
+            debugDisplay.DrawWireCone(pointOnCircle, AZ::Vector3::CreateAxisZ(), coneRadius,coneHeight);
 
             pointOnCircle = circleRadius * AZ::Vector3::CreateAxisZ();
             debugDisplay.DrawWireCone(pointOnCircle, AZ::Vector3::CreateAxisY(), coneRadius, coneHeight);

--- a/Gems/PhysX/Code/Source/EditorPrismaticJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorPrismaticJointComponent.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
+#include <AzToolsFramework/Viewport/ViewportSettings.h>
 
 #include <Source/EditorPrismaticJointComponent.h>
 #include <Source/PrismaticJointComponent.h>
@@ -178,7 +179,6 @@ namespace PhysX
             return;
         }
 
-        const float size = 1.0f;
         const float alpha = 0.6f;
         const AZ::Color colorDefault = AZ::Color(1.0f, 1.0f, 1.0f, alpha);
         const AZ::Color colorLimitLower = AZ::Color(1.0f, 0.0f, 0.0f, alpha);
@@ -191,6 +191,12 @@ namespace PhysX
         const AZ::EntityId& entityId = GetEntityId();
 
         AZ::Transform worldTransform = PhysX::Utils::GetEntityWorldTransformWithoutScale(entityId);
+
+        const AzFramework::CameraState cameraState = AzToolsFramework::GetCameraState(viewportInfo.m_viewportId);
+        // scaleMultiply will represent a scale for the debug draw that makes it remain the same size on screen
+        float scaleMultiply = AzToolsFramework::CalculateScreenToWorldMultiplier(worldTransform.GetTranslation(), cameraState);
+
+        const float size = 1.0f * scaleMultiply;
 
         AZ::Transform localTransform;
         EditorJointRequestBus::EventResult(localTransform,


### PR DESCRIPTION
## What does this PR do?

Previously, if you zoom in far enough the physics joint visuals would cover the entire screen unlike the rest of the gizmos and visualizations.

This change causes the visualizers to remain the same size on screen regardless of your zoom.

This also adds a different visualizer for the revolving joint (the hinge joint with no limits).  I made sure that adding rotation in the positive direction caused the body to rotate in the direction the arrows indicate.

## How was this PR tested?

Manually, by viewing the gizmos at various scales.

Hinge Joint with no limit

![fixed_revolute](https://user-images.githubusercontent.com/70027408/223242940-5e8b23f4-62ae-4813-8d0e-c5898de96457.png)

Hinge joint with limit
![limited](https://user-images.githubusercontent.com/70027408/223213927-79026c3d-9823-4814-b91e-d0b36e48c183.png)

The rest are unchanged, except that they remain a constant size on screen regardless of whether you zoom in or out.
