### PR TITLE
Fixed assert in the ActionManagerSystemComponent::Init

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ActionManagerSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ActionManagerSystemComponent.cpp
@@ -12,6 +12,7 @@
 
 #include <AzToolsFramework/ActionManager/ActionManagerRegistrationNotificationBus.h>
 #include <AzToolsFramework/Editor/ActionManagerUtils.h>
+#include <QApplication>
 
 namespace AzToolsFramework
 {
@@ -26,7 +27,10 @@ namespace AzToolsFramework
 
     void ActionManagerSystemComponent::Init()
     {
-        if (IsNewActionManagerEnabled())
+        // The ActionManagerSystemComponent could be created in a tooling context
+        // where a QGuiApplication does not exist such as the SerializeContextTools
+        auto qAppInstance = QApplication::instance();
+        if (IsNewActionManagerEnabled() && qAppInstance != nullptr)
         {
             m_defaultParentObject = new QWidget();
 


### PR DESCRIPTION
When the ActionManagerSystemComponent is loaded in an Application that hasn't create a QGUIApplication, it asserts when a QWidget is created with the message
> QWidget: Must construct a QApplication before a QWidget

The fix is to avoid creating the QWidget if there is no QApplication.

Side Note: We should investigate why the ActionManagerSystemComponent is creating a QWidget. It is the only SystemComponent that creates a QT GUI Object.

## How was this PR tested?

Successfully loaded activated all the active AutomatedTesting SystemComponents when using loading the Editor gem modules in `SerializeContextTools` application.

The command used were as follows
```
<build-dir>/bin/debug/SerializeContextTools.exe convert --project-path=<engine-root>/AutomatedTesting --specializations=editor --files=<engine-root>/AutomatedTesting/Levels/Physics/Material_PerFaceMaterialGetsCorrectMaterial/test.fbx.assetinfo;<engine-root>/AutomatedTesting/Assets/Physics/Collider_MultipleSurfaceSlots/test.fbx.assetinfo  -ext=json
```
