### PR TITLE
Add box dimensions setter/getter to EditorPrimitiveColliderComponentRequests

### DIFF
--- a/Gems/PhysX/Code/Include/PhysX/EditorColliderComponentRequestBus.h
+++ b/Gems/PhysX/Code/Include/PhysX/EditorColliderComponentRequestBus.h
@@ -130,6 +130,14 @@ namespace PhysX
         //! @param The collider's shape type.
         virtual void SetShapeType(Physics::ShapeType) = 0;
 
+        //! Set the X/Y/Z dimensions of the box collider.
+        //! @param dimensions The X/Y/Z dimensions of the box collider.
+        virtual void SetBoxDimensions(const AZ::Vector3& dimensions) = 0;
+
+        //! Get the X/Y/Z dimensions of the box collider.
+        //! @return The X/Y/Z dimensions of the box collider.
+        virtual AZ::Vector3 GetBoxDimensions() const = 0;
+
         //! Sets the radius of the sphere collider.
         //! @param radius The radius of the sphere collider.
         virtual void SetSphereRadius(float radius) = 0;

--- a/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
@@ -703,13 +703,12 @@ namespace PhysX
 
     AZ::Vector3 EditorColliderComponent::GetDimensions() const
     {
-        return m_proxyShapeConfiguration.m_box.m_dimensions;
+        return GetBoxDimensions();
     }
 
     void EditorColliderComponent::SetDimensions(const AZ::Vector3& dimensions)
     {
-        m_proxyShapeConfiguration.m_box.m_dimensions = dimensions;
-        UpdateCollider();
+        SetBoxDimensions(dimensions);
     }
 
     AZ::Vector3 EditorColliderComponent::GetTranslationOffset() const
@@ -894,6 +893,17 @@ namespace PhysX
     Physics::ShapeType EditorColliderComponent::GetShapeType() const
     {
         return m_proxyShapeConfiguration.m_shapeType;
+    }
+
+    void EditorColliderComponent::SetBoxDimensions(const AZ::Vector3& dimensions)
+    {
+        m_proxyShapeConfiguration.m_box.m_dimensions = dimensions;
+        UpdateCollider();
+    }
+
+    AZ::Vector3 EditorColliderComponent::GetBoxDimensions() const
+    {
+        return m_proxyShapeConfiguration.m_box.m_dimensions;
     }
 
     void EditorColliderComponent::SetSphereRadius(float radius)

--- a/Gems/PhysX/Code/Source/EditorColliderComponent.h
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.h
@@ -217,6 +217,8 @@ namespace PhysX
         
         // PhysX::EditorPrimitiveColliderComponentRequestBus overrides ...
         void SetShapeType(Physics::ShapeType shapeType) override;
+        void SetBoxDimensions(const AZ::Vector3& dimensions) override;
+        AZ::Vector3 GetBoxDimensions() const override;
         void SetSphereRadius(float radius) override;
         float GetSphereRadius() const override;
         void SetCapsuleRadius(float radius) override;

--- a/Gems/PhysX/Code/Tests/EditorColliderComponentTests.cpp
+++ b/Gems/PhysX/Code/Tests/EditorColliderComponentTests.cpp
@@ -531,8 +531,8 @@ namespace PhysXEditorTests
             idPair, &PhysX::EditorPrimitiveColliderComponentRequests::SetShapeType, Physics::ShapeType::Box);
 
         AZ::Vector3 boxDimensions = AZ::Vector3::CreateOne();
-        AzToolsFramework::BoxManipulatorRequestBus::EventResult(
-            boxDimensions, idPair, &AzToolsFramework::BoxManipulatorRequests::GetDimensions);
+        PhysX::EditorPrimitiveColliderComponentRequestBus::EventResult(
+            boxDimensions, idPair, &PhysX::EditorPrimitiveColliderComponentRequests::GetBoxDimensions);
 
         AZ::EntityId editorEntityId = editorEntity->GetId();
 
@@ -573,7 +573,8 @@ namespace PhysXEditorTests
 
         // set some dimensions to child entity box component
         const AZ::Vector3 boxDimensions(2.0f, 3.0f, 4.0f);
-        AzToolsFramework::BoxManipulatorRequestBus::Event(idPair, &AzToolsFramework::BoxManipulatorRequests::SetDimensions, boxDimensions);
+        PhysX::EditorPrimitiveColliderComponentRequestBus::Event(
+            idPair, &PhysX::EditorPrimitiveColliderComponentRequests::SetBoxDimensions, boxDimensions);
 
         // set one entity as parent of another
         AZ::TransformBus::Event(editorChildEntity->GetId(),

--- a/Gems/PhysX/Code/Tests/EditorTestUtilities.cpp
+++ b/Gems/PhysX/Code/Tests/EditorTestUtilities.cpp
@@ -198,7 +198,8 @@ namespace PhysXEditorTests
             idPair, &PhysX::EditorPrimitiveColliderComponentRequests::SetShapeType, Physics::ShapeType::Box);
 
         AZ::TransformBus::Event(editorEntityId, &AZ::TransformBus::Events::SetWorldTM, transform);
-        AzToolsFramework::BoxManipulatorRequestBus::Event(idPair, &AzToolsFramework::BoxManipulatorRequests::SetDimensions, boxDimensions);
+        PhysX::EditorPrimitiveColliderComponentRequestBus::Event(
+            idPair, &PhysX::EditorPrimitiveColliderComponentRequests::SetBoxDimensions, boxDimensions);
         PhysX::EditorColliderComponentRequestBus::Event(
             idPair, &PhysX::EditorColliderComponentRequests::SetColliderOffset, translationOffset);
         PhysX::EditorColliderComponentRequestBus::Event(

--- a/Gems/PhysX/Code/Tests/TestColliderComponent.h
+++ b/Gems/PhysX/Code/Tests/TestColliderComponent.h
@@ -62,6 +62,8 @@ namespace UnitTest
         
         // EditorPrimitiveColliderComponentRequests overrides ...
         void SetShapeType(Physics::ShapeType shapeType) override { m_shapeType = shapeType; }
+        void SetBoxDimensions(const AZ::Vector3& dimensions) override { m_boxDimensions = dimensions; }
+        AZ::Vector3 GetBoxDimensions() const override { return m_boxDimensions; }
         void SetSphereRadius(float radius) override { m_sphereRadius = radius; }
         float GetSphereRadius() const override { return m_sphereRadius; }
         void SetCapsuleRadius(float radius) override { m_capsuleRadius = radius; }
@@ -81,6 +83,7 @@ namespace UnitTest
         AZ::Quaternion m_rotation = AZ::Quaternion::CreateIdentity();
         AZ::Transform m_transform = AZ::Transform::CreateIdentity();
         Physics::ShapeType m_shapeType = Physics::ShapeType::Box;
+        AZ::Vector3 m_boxDimensions = Physics::ShapeConstants::DefaultBoxDimensions;
         float m_sphereRadius = Physics::ShapeConstants::DefaultSphereRadius;
         float m_capsuleHeight = Physics::ShapeConstants::DefaultCapsuleHeight;
         float m_capsuleRadius = Physics::ShapeConstants::DefaultCapsuleRadius;


### PR DESCRIPTION
## What does this PR do?

`EditorPrimitiveColliderComponentRequests` had functions to set the parameters of all the shapes except for box. Before code was using `BoxManipulatorRequestBus` to get/set the box dimensions, which is more appropriate to handle as manipulator rather to set the shape dimentions.

## How was this PR tested?

Changed the test code of Editor Primitive Collider component to use the new functions in `EditorPrimitiveColliderComponentRequests` bus.
Run the Editor PhysX tests and it passes.
