### PR TITLE
NetBind component now removes its entity from network tracking on Deactivate

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/NetworkEntity/INetworkEntityManager.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/NetworkEntity/INetworkEntityManager.h
@@ -125,6 +125,10 @@ namespace Multiplayer
         //! @return a NetworkEntityHandle for the newly added entity
         virtual NetworkEntityHandle AddEntityToEntityMap(NetEntityId netEntityId, AZ::Entity* entity) = 0;
 
+        //! Removes the provided netEntityId from the internal entity map.
+        //! @param netEntityId the identifier to use for the added entity
+        virtual void RemoveEntityFromEntityMap(NetEntityId netEntityId) = 0;
+
         //! Marks the specified entity for removal and deletion.
         //! @param entityHandle the entity to remove and delete
         virtual void MarkForRemoval(const ConstNetworkEntityHandle& entityHandle) = 0;

--- a/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
@@ -223,6 +223,7 @@ namespace Multiplayer
         }
 
         GetNetworkEntityTracker()->UnregisterNetBindComponent(this);
+        GetNetworkEntityManager()->RemoveEntityFromEntityMap(m_netEntityId);
     }
 
     NetEntityRole NetBindComponent::GetNetEntityRole() const

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
@@ -117,6 +117,11 @@ namespace Multiplayer
         return NetworkEntityHandle(entity, &m_networkEntityTracker);
     }
 
+    void NetworkEntityManager::RemoveEntityFromEntityMap(NetEntityId netEntityId)
+    {
+        m_networkEntityTracker.erase(netEntityId);
+    }
+
     void NetworkEntityManager::MarkForRemoval(const ConstNetworkEntityHandle& entityHandle)
     {
         if (entityHandle.Exists())

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.h
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.h
@@ -75,6 +75,7 @@ namespace Multiplayer
         void SetupNetEntity(AZ::Entity* netEntity, PrefabEntityId prefabEntityId, NetEntityRole netEntityRole) override;
         uint32_t GetEntityCount() const override;
         NetworkEntityHandle AddEntityToEntityMap(NetEntityId netEntityId, AZ::Entity* entity) override;
+        void RemoveEntityFromEntityMap(NetEntityId netEntityId) override;
         void MarkForRemoval(const ConstNetworkEntityHandle& entityHandle) override;
         bool IsMarkedForRemoval(const ConstNetworkEntityHandle& entityHandle) const override;
         void ClearEntityFromRemovalList(const ConstNetworkEntityHandle& entityHandle) override;

--- a/Gems/Multiplayer/Code/Tests/CommonBenchmarkSetup.h
+++ b/Gems/Multiplayer/Code/Tests/CommonBenchmarkSetup.h
@@ -216,6 +216,11 @@ namespace Multiplayer
             return NetworkEntityHandle(entity, &m_tracker);
         }
 
+        void RemoveEntityFromEntityMap(NetEntityId netEntityId) override
+        {
+            m_networkEntityMap.erase(netEntityId);
+        }
+
         ConstNetworkEntityHandle GetEntity(NetEntityId netEntityId) const override
         {
             AZ::Entity* entity = m_networkEntityMap[netEntityId];

--- a/Gems/Multiplayer/Code/Tests/MockInterfaces.h
+++ b/Gems/Multiplayer/Code/Tests/MockInterfaces.h
@@ -73,6 +73,7 @@ namespace UnitTest
         MOCK_METHOD3(SetupNetEntity, void(AZ::Entity*, Multiplayer::PrefabEntityId, Multiplayer::NetEntityRole));
         MOCK_CONST_METHOD0(GetEntityCount, uint32_t());
         MOCK_METHOD2(AddEntityToEntityMap, Multiplayer::NetworkEntityHandle(Multiplayer::NetEntityId, AZ::Entity*));
+        MOCK_METHOD1(RemoveEntityFromEntityMap, void(Multiplayer::NetEntityId));
         MOCK_METHOD1(MarkForRemoval, void(const Multiplayer::ConstNetworkEntityHandle&));
         MOCK_CONST_METHOD1(IsMarkedForRemoval, bool(const Multiplayer::ConstNetworkEntityHandle&));
         MOCK_METHOD1(ClearEntityFromRemovalList, void(const Multiplayer::ConstNetworkEntityHandle&));


### PR DESCRIPTION
## What does this PR do?

A previous recent change to the NetBind component made it so that networked prefabs could be despawned just by calling DespawnAllEntities. However, by going through that API instead of the NetworkEntityManager API, this caused a tracking leak where the networked entities still had entries in a network entity table.

This PR fixes the leak by having the NetBind component remove its entity from the tracking table.

## How was this PR tested?

Ran MPS and printed out the tracked network entity counts to verify they no longer kept growing on every round. No other obvious errors or warnings from the change showed up as a result either.
