### PR TITLE
Remove .meta extension from the validator list

### DIFF
--- a/scripts/commit_validation/commit_validation/validators/generated_files_validator.py
+++ b/scripts/commit_validation/commit_validation/validators/generated_files_validator.py
@@ -33,7 +33,6 @@ MSVS_FILE_EXTENSIONS = [
     ".idb",
     ".ilk",
     ".lastbuildstate",
-    ".meta",
     ".ncb",
     ".obj",
     ".opensdf",


### PR DESCRIPTION
## What does this PR do?

Removes the `.meta` extension from the generated files validator. This generally only is created within the build folder by Visual Studio, which is already in `.gitignore`. This extension is being used by the metadata manager in AzToolsFramework here: https://github.com/o3de/o3de/blob/development/Code/Framework/AzToolsFramework/AzToolsFramework/Metadata/MetadataManager.h#L81

This is preventing commits of its files for tests: https://github.com/o3de/o3de/pull/14931

Alternatively, we can have instructions to move test assets to an exclusion list, found here: https://github.com/o3de/o3de/blob/development/scripts/commit_validation/commit_validation/commit_validation.py#L171

## How was this PR tested?

Run in a sandbox Jenkins
