### PR TITLE
Expand coverage to GemSortProxyModel

### DIFF
--- a/Code/Tools/ProjectManager/tests/GemCatalogTests.cpp
+++ b/Code/Tools/ProjectManager/tests/GemCatalogTests.cpp
@@ -588,4 +588,25 @@ namespace O3DE::ProjectManager
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
     }
+
+    TEST_F(GemCatalogMiscFilterTests, GemCatalogFilters_ResetFilters_FiltersReset)
+    {
+        // Set up all filter values that are reset
+        m_proxyModel->SetSearchString("Name");
+        m_proxyModel->SetGemSelected(GemSortFilterProxyModel::GemSelected::Selected);
+        m_proxyModel->SetGemActive(GemSortFilterProxyModel::GemActive::Active);
+        m_proxyModel->SetGemOrigins(GemInfo::GemOrigin::Open3DEngine);
+        m_proxyModel->SetPlatforms(GemInfo::Platform::Windows);
+        m_proxyModel->SetTypes(GemInfo::Type::Code);
+        m_proxyModel->SetFeatures({ "Audio" });
+        
+        m_proxyModel->ResetFilters(true);
+
+        EXPECT_TRUE(m_proxyModel->GetGemSelected() == GemSortFilterProxyModel::GemSelected::NoFilter);
+        EXPECT_TRUE(m_proxyModel->GetGemActive() == GemSortFilterProxyModel::GemActive::NoFilter);
+        EXPECT_TRUE(m_proxyModel->GetGemOrigins() == GemInfo::GemOrigins({}));
+        EXPECT_TRUE(m_proxyModel->GetPlatforms() == GemInfo::Platforms({}));
+        EXPECT_TRUE(m_proxyModel->GetTypes() == GemInfo::Types({}));
+        EXPECT_TRUE(m_proxyModel->GetFeatures().isEmpty());
+    }
 }

--- a/Code/Tools/ProjectManager/tests/GemCatalogTests.cpp
+++ b/Code/Tools/ProjectManager/tests/GemCatalogTests.cpp
@@ -324,6 +324,7 @@ namespace O3DE::ProjectManager
         // Selected dependencies should also be shown
         m_proxyModel->SetGemSelected(GemSortFilterProxyModel::GemSelected::Selected);
 
+        EXPECT_TRUE(m_proxyModel->GetGemSelected() == GemSortFilterProxyModel::GemSelected::Selected);
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Selected].row(), QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[SelectedDep].row(), QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Unselected].row(), QModelIndex()));
@@ -338,6 +339,7 @@ namespace O3DE::ProjectManager
         // Unselected dependencies should also be shown
         m_proxyModel->SetGemSelected(GemSortFilterProxyModel::GemSelected::Unselected);
 
+        EXPECT_TRUE(m_proxyModel->GetGemSelected() == GemSortFilterProxyModel::GemSelected::Unselected);
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Selected].row(), QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[SelectedDep].row(), QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Unselected].row(), QModelIndex()));
@@ -351,6 +353,7 @@ namespace O3DE::ProjectManager
         // Check both un/selected filter
         m_proxyModel->SetGemSelected(GemSortFilterProxyModel::GemSelected::Both);
 
+        EXPECT_TRUE(m_proxyModel->GetGemSelected() == GemSortFilterProxyModel::GemSelected::Both);
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Selected].row(), QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[SelectedDep].row(), QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Unselected].row(), QModelIndex()));
@@ -365,6 +368,7 @@ namespace O3DE::ProjectManager
         // Active dependencies should also be shown
         m_proxyModel->SetGemActive(GemSortFilterProxyModel::GemActive::Active);
 
+        EXPECT_TRUE(m_proxyModel->GetGemActive() == GemSortFilterProxyModel::GemActive::Active);
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Selected].row(), QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[SelectedDep].row(), QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Unselected].row(), QModelIndex()));
@@ -378,6 +382,7 @@ namespace O3DE::ProjectManager
         // Check inactive filter
         m_proxyModel->SetGemActive(GemSortFilterProxyModel::GemActive::Inactive);
 
+        EXPECT_TRUE(m_proxyModel->GetGemActive() == GemSortFilterProxyModel::GemActive::Inactive);
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Selected].row(), QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[SelectedDep].row(), QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Unselected].row(), QModelIndex()));
@@ -445,18 +450,21 @@ namespace O3DE::ProjectManager
     {
         m_proxyModel->SetGemOrigins(GemInfo::GemOrigin::Open3DEngine);
 
+        EXPECT_TRUE(m_proxyModel->GetGemOrigins() == GemInfo::GemOrigin::Open3DEngine);
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
 
         m_proxyModel->SetGemOrigins(GemInfo::GemOrigin::Local);
 
+        EXPECT_TRUE(m_proxyModel->GetGemOrigins() == GemInfo::GemOrigin::Local);
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
 
         m_proxyModel->SetGemOrigins(GemInfo::GemOrigin::Remote);
 
+        EXPECT_TRUE(m_proxyModel->GetGemOrigins() == GemInfo::GemOrigin::Remote);
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
@@ -475,18 +483,21 @@ namespace O3DE::ProjectManager
     {
         m_proxyModel->SetTypes(GemInfo::Type::Code);
 
+        EXPECT_TRUE(m_proxyModel->GetTypes() == GemInfo::Type::Code);
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
 
         m_proxyModel->SetTypes(GemInfo::Type::Tool);
 
+        EXPECT_TRUE(m_proxyModel->GetTypes() == GemInfo::Type::Tool);
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
 
         m_proxyModel->SetTypes(GemInfo::Type::Asset);
 
+        EXPECT_TRUE(m_proxyModel->GetTypes() == GemInfo::Type::Asset);
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
@@ -505,18 +516,21 @@ namespace O3DE::ProjectManager
     {
         m_proxyModel->SetPlatforms(GemInfo::Platform::Windows);
 
+        EXPECT_TRUE(m_proxyModel->GetPlatforms() == GemInfo::Platform::Windows);
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
 
         m_proxyModel->SetPlatforms(GemInfo::Platform::Android);
 
+        EXPECT_TRUE(m_proxyModel->GetPlatforms() == GemInfo::Platform::Android);
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
 
         m_proxyModel->SetPlatforms(GemInfo::Platform::macOS);
 
+        EXPECT_TRUE(m_proxyModel->GetPlatforms() == GemInfo::Platform::macOS);
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
@@ -535,18 +549,21 @@ namespace O3DE::ProjectManager
     {
         m_proxyModel->SetFeatures({ "Audio" });
 
+        EXPECT_TRUE(m_proxyModel->GetFeatures().contains("Audio"));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
 
         m_proxyModel->SetFeatures({ "Tools", });
 
+        EXPECT_TRUE(m_proxyModel->GetFeatures().contains("Tools"));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
 
         m_proxyModel->SetFeatures({ "Environment" });
 
+        EXPECT_TRUE(m_proxyModel->GetFeatures().contains( "Environment" ));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
@@ -556,6 +573,7 @@ namespace O3DE::ProjectManager
     {
         m_proxyModel->SetFeatures({ "Assets", "Framework" });
 
+        EXPECT_TRUE(m_proxyModel->GetFeatures().contains({ "Assets", "Framework" }));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));


### PR DESCRIPTION
## What does this PR do?

Expanding coverage to `GemSortProxyModel` based of latest coverage test results.

Tests added to touch the following areas:

- `GetGemSelected()`
- `GetGemActive()` 
- `GetGemOrigins()` 
- `GetPlatforms()` 
- `GetTypes()`
- `GetFeatures()`
- `ResetFilters()`

_Please describe any testing performed._

Verified that gtests initially failed, then passed after correcting the conditions for passing.

Verified that gtests passed in isolation of the `GemCatalogFilters` as well as passing the entire `ProjectManager.Tests` suite.

```
[       OK ] ProjectManagerApplicationTests.Application_Init_Succeeds (4109 ms)
[----------] 1 test from ProjectManagerApplicationTests (4110 ms total)

[----------] 1 test from GemCatalogTests
[ RUN      ] GemCatalogTests.GemCatalog_GemWithDependencies_DisplaysButDoesNotAddDependencies
[       OK ] GemCatalogTests.GemCatalog_GemWithDependencies_DisplaysButDoesNotAddDependencies (0 ms)
[----------] 1 test from GemCatalogTests (1 ms total)

[----------] 10 tests from GemCatalogSearchFilterTests
[ RUN      ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringName_ShowsNameGems
[       OK ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringName_ShowsNameGems (1 ms)
[ RUN      ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringDisplayName_ShowsDisplayNameGem
[       OK ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringDisplayName_ShowsDisplayNameGem (1 ms)
[ RUN      ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringCreator_ShowsCreatorGem
[       OK ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringCreator_ShowsCreatorGem (0 ms)
[ RUN      ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringSummary_ShowsSummaryGem
[       OK ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringSummary_ShowsSummaryGem (1 ms)
[ RUN      ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringFeatures_ShowsFeatureGem
[       OK ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringFeatures_ShowsFeatureGem (1 ms)
[ RUN      ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringEmpty_ShowsAll
[       OK ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringEmpty_ShowsAll (1 ms)
[ RUN      ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringCommonCharacter_ShowsAll
[       OK ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringCommonCharacter_ShowsAll (1 ms)
[ RUN      ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringDifferentCaseCommonCharacter_ShowsAll
[       OK ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringDifferentCaseCommonCharacter_ShowsAll (1 ms)
[ RUN      ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringNoneContainCharacter_ShowsNone
[       OK ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringNoneContainCharacter_ShowsNone (1 ms)
[ RUN      ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringPartialMatchString_ShowsNone
[       OK ] GemCatalogSearchFilterTests.GemCatalogFilters_SearchStringPartialMatchString_ShowsNone (0 ms)
[----------] 10 tests from GemCatalogSearchFilterTests (13 ms total)

[----------] 7 tests from GemCatalogSelectedActiveFilterTests
[ RUN      ] GemCatalogSelectedActiveFilterTests.GemCatalogFilters_SelectedActiveIntialState_AddedGemsAndDependenciesAreAdded
[       OK ] GemCatalogSelectedActiveFilterTests.GemCatalogFilters_SelectedActiveIntialState_AddedGemsAndDependenciesAreAdded (1 ms)
[ RUN      ] GemCatalogSelectedActiveFilterTests.GemCatalogFilters_SelectedActiveNoFilter_ShowsAll
[       OK ] GemCatalogSelectedActiveFilterTests.GemCatalogFilters_SelectedActiveNoFilter_ShowsAll (1 ms)
[ RUN      ] GemCatalogSelectedActiveFilterTests.GemCatalogFilters_FilterSelected_ShowsSelectedAndDependencies
[       OK ] GemCatalogSelectedActiveFilterTests.GemCatalogFilters_FilterSelected_ShowsSelectedAndDependencies (0 ms)
[ RUN      ] GemCatalogSelectedActiveFilterTests.GemCatalogFilters_FilterUnselected_ShowsUnselectedAndDependencies
[       OK ] GemCatalogSelectedActiveFilterTests.GemCatalogFilters_FilterUnselected_ShowsUnselectedAndDependencies (1 ms)
[ RUN      ] GemCatalogSelectedActiveFilterTests.GemCatalogFilters_FilterSelectedAndUnselected_ShowsAllChangesAndDependencies
[       OK ] GemCatalogSelectedActiveFilterTests.GemCatalogFilters_FilterSelectedAndUnselected_ShowsAllChangesAndDependencies (0 ms)
[ RUN      ] GemCatalogSelectedActiveFilterTests.GemCatalogFilters_FilterActive_ShowsActive
[       OK ] GemCatalogSelectedActiveFilterTests.GemCatalogFilters_FilterActive_ShowsActive (1 ms)
[ RUN      ] GemCatalogSelectedActiveFilterTests.GemCatalogFilters_FilterActive_ShowsInactive
[       OK ] GemCatalogSelectedActiveFilterTests.GemCatalogFilters_FilterActive_ShowsInactive (0 ms)
[----------] 7 tests from GemCatalogSelectedActiveFilterTests (10 ms total)

[----------] 11 tests from GemCatalogMiscFilterTests
[ RUN      ] GemCatalogMiscFilterTests.GemCatalogFilters_MiscNoFilter_ShowsAll
[       OK ] GemCatalogMiscFilterTests.GemCatalogFilters_MiscNoFilter_ShowsAll (1 ms)
[ RUN      ] GemCatalogMiscFilterTests.GemCatalogFilters_FilterSingleOrigin_ShowsOriginMatch
[       OK ] GemCatalogMiscFilterTests.GemCatalogFilters_FilterSingleOrigin_ShowsOriginMatch (1 ms)
[ RUN      ] GemCatalogMiscFilterTests.GemCatalogFilters_FilterMultipleOrigins_ShowsMultipleOriginMatches
[       OK ] GemCatalogMiscFilterTests.GemCatalogFilters_FilterMultipleOrigins_ShowsMultipleOriginMatches (0 ms)
[ RUN      ] GemCatalogMiscFilterTests.GemCatalogFilters_FilterSingleType_ShowsTypeMatch
[       OK ] GemCatalogMiscFilterTests.GemCatalogFilters_FilterSingleType_ShowsTypeMatch (0 ms)
[ RUN      ] GemCatalogMiscFilterTests.GemCatalogFilters_FilterMultipleTypes_ShowsMultipleTypeMatches
[       OK ] GemCatalogMiscFilterTests.GemCatalogFilters_FilterMultipleTypes_ShowsMultipleTypeMatches (0 ms)
[ RUN      ] GemCatalogMiscFilterTests.GemCatalogFilters_FilterSinglePlatform_ShowsPlatformMatch
[       OK ] GemCatalogMiscFilterTests.GemCatalogFilters_FilterSinglePlatform_ShowsPlatformMatch (1 ms)
[ RUN      ] GemCatalogMiscFilterTests.GemCatalogFilters_FilterMultiplePlatforms_ShowsMultiplePlatformMatches
[       OK ] GemCatalogMiscFilterTests.GemCatalogFilters_FilterMultiplePlatforms_ShowsMultiplePlatformMatches (1 ms)
[ RUN      ] GemCatalogMiscFilterTests.GemCatalogFilters_FilterSingleFeature_ShowsFeatureMatch
[       OK ] GemCatalogMiscFilterTests.GemCatalogFilters_FilterSingleFeature_ShowsFeatureMatch (1 ms)
[ RUN      ] GemCatalogMiscFilterTests.GemCatalogFilters_FilterMultipleFeatures_ShowsMultipleFeatureMatches
[       OK ] GemCatalogMiscFilterTests.GemCatalogFilters_FilterMultipleFeatures_ShowsMultipleFeatureMatches (1 ms)
[ RUN      ] GemCatalogMiscFilterTests.GemCatalogFilters_FilterPartialMatchFeature_ShowsNone
[       OK ] GemCatalogMiscFilterTests.GemCatalogFilters_FilterPartialMatchFeature_ShowsNone (1 ms)
[ RUN      ] GemCatalogMiscFilterTests.GemCatalogFilters_ResetFilters_FiltersReset
[       OK ] GemCatalogMiscFilterTests.GemCatalogFilters_ResetFilters_FiltersReset (0 ms)
[----------] 11 tests from GemCatalogMiscFilterTests (14 ms total)

[----------] 9 tests from SettingsTests
[ RUN      ] SettingsTests.Settings_GetUnsetPathBool_ReturnsFalse
[       OK ] SettingsTests.Settings_GetUnsetPathBool_ReturnsFalse (3 ms)
[ RUN      ] SettingsTests.Settings_SetAndGetValueBool_Success
[       OK ] SettingsTests.Settings_SetAndGetValueBool_Success (3 ms)
[ RUN      ] SettingsTests.Settings_GetUnsetPathString_ReturnsFalse
[       OK ] SettingsTests.Settings_GetUnsetPathString_ReturnsFalse (3 ms)
[ RUN      ] SettingsTests.Settings_SetAndGetValueString_Success
[       OK ] SettingsTests.Settings_SetAndGetValueString_Success (2 ms)
[ RUN      ] SettingsTests.Settings_CopyStringRemoveOriginal_SuccessAndRemovesOriginal
[       OK ] SettingsTests.Settings_CopyStringRemoveOriginal_SuccessAndRemovesOriginal (2 ms)
[ RUN      ] SettingsTests.Settings_RemoveProjectManagerKey_RemovesKey
[       OK ] SettingsTests.Settings_RemoveProjectManagerKey_RemovesKey (2 ms)
[ RUN      ] SettingsTests.Settings_GetUnsetBuildPath_ReturnsFalse
[       OK ] SettingsTests.Settings_GetUnsetBuildPath_ReturnsFalse (2 ms)
[ RUN      ] SettingsTests.Settings_SetProjectBuiltSuccessfully_ReturnsTrue
[       OK ] SettingsTests.Settings_SetProjectBuiltSuccessfully_ReturnsTrue (2 ms)
[ RUN      ] SettingsTests.Settings_SetProjectBuiltUnsuccessfully_ReturnsFalse
[       OK ] SettingsTests.Settings_SetProjectBuiltUnsuccessfully_ReturnsFalse (2 ms)
[----------] 9 tests from SettingsTests (25 ms total)

[----------] 3 tests from PythonBindingsTests
[ RUN      ] PythonBindingsTests.PythonBindings_Start_Python_Succeeds
python: Py_GetVersion=3.10.5 (tags/v3.10.5-dirty:f377153, Jul 23 2022, 05:16:17) [MSC v.1916 64 bit (AMD64)]
python: Py_GetPath=(null)
python: Py_GetExecPrefix=(null)
python: Py_GetProgramFullPath=(null)
Python: RedirectOutput installed
[       OK ] PythonBindingsTests.PythonBindings_Start_Python_Succeeds (262 ms)
[ RUN      ] PythonBindingsTests.PythonBindings_Create_Project_Succeeds
python: Py_GetVersion=3.10.5 (tags/v3.10.5-dirty:f377153, Jul 23 2022, 05:16:17) [MSC v.1916 64 bit (AMD64)]
python: Py_GetPath=E:\gws\o3de\build\orgdev\bin\debug\python310_d.zip;E:\gws\o3de\python\runtime\python-3.10.5-rev1-windows\python\DLLs;E:\gws\o3de\python\runtime\python-3.10.5-rev1-windows\python\lib;E:\gws\o3de\build\orgdev\bin\debug
python: Py_GetExecPrefix=E:\gws\o3de\python\runtime\python-3.10.5-rev1-windows\python
python: Py_GetProgramFullPath=E:\gws\o3de\build\orgdev\bin\debug\ProjectManager.Tests.exe
Python: RedirectOutput installed
[       OK ] PythonBindingsTests.PythonBindings_Create_Project_Succeeds (812 ms)
[ RUN      ] PythonBindingsTests.PythonBindings_Print_Percent_Does_Not_Crash
python: Py_GetVersion=3.10.5 (tags/v3.10.5-dirty:f377153, Jul 23 2022, 05:16:17) [MSC v.1916 64 bit (AMD64)]
python: Py_GetPath=E:\gws\o3de\build\orgdev\bin\debug\python310_d.zip;E:\gws\o3de\python\runtime\python-3.10.5-rev1-windows\python\DLLs;E:\gws\o3de\python\runtime\python-3.10.5-rev1-windows\python\lib;E:\gws\o3de\build\orgdev\bin\debug
python: Py_GetExecPrefix=E:\gws\o3de\python\runtime\python-3.10.5-rev1-windows\python
python: Py_GetProgramFullPath=E:\gws\o3de\build\orgdev\bin\debug\ProjectManager.Tests.exe
Python: RedirectOutput installed
[       OK ] PythonBindingsTests.PythonBindings_Print_Percent_Does_Not_Crash (234 ms)
[----------] 3 tests from PythonBindingsTests (1320 ms total)

[----------] 5 tests from ProjectManagerUtilsTests
[ RUN      ] ProjectManagerUtilsTests.MoveProject_MovesExpectedFiles
[       OK ] ProjectManagerUtilsTests.MoveProject_MovesExpectedFiles (4 ms)
[ RUN      ] ProjectManagerUtilsTests.MoveProject_DoesntMoveBuild
[       OK ] ProjectManagerUtilsTests.MoveProject_DoesntMoveBuild (4 ms)
[ RUN      ] ProjectManagerUtilsTests.CopyProject_CopiesExpectedFiles
[       OK ] ProjectManagerUtilsTests.CopyProject_CopiesExpectedFiles (11 ms)
[ RUN      ] ProjectManagerUtilsTests.CopyProject_DoesntCopyBuild
[       OK ] ProjectManagerUtilsTests.CopyProject_DoesntCopyBuild (9 ms)
[ RUN      ] ProjectManagerUtilsTests.ReplaceFile_Succeeds
[       OK ] ProjectManagerUtilsTests.ReplaceFile_Succeeds (4 ms)
[----------] 5 tests from ProjectManagerUtilsTests (45 ms total)

[----------] 6 tests from TextOverflowWidgetTests
[ RUN      ] TextOverflowWidgetTests.ElideText_UnderMaxLength_NoOverflow
[       OK ] TextOverflowWidgetTests.ElideText_UnderMaxLength_NoOverflow (0 ms)
[ RUN      ] TextOverflowWidgetTests.ElideText_UnderMaxLength_NoTruncation
[       OK ] TextOverflowWidgetTests.ElideText_UnderMaxLength_NoTruncation (0 ms)
[ RUN      ] TextOverflowWidgetTests.ElideText_OverMaxLength_ShowOverflow
[       OK ] TextOverflowWidgetTests.ElideText_OverMaxLength_ShowOverflow (0 ms)
[ RUN      ] TextOverflowWidgetTests.ElideText_OverMaxLength_CorrectTruncation
[       OK ] TextOverflowWidgetTests.ElideText_OverMaxLength_CorrectTruncation (0 ms)
[ RUN      ] TextOverflowWidgetTests.ElideText_OverMaxLengthAtOpeningTag_OpeningTagNotIncluded
[       OK ] TextOverflowWidgetTests.ElideText_OverMaxLengthAtOpeningTag_OpeningTagNotIncluded (0 ms)
[ RUN      ] TextOverflowWidgetTests.ElideText_OverMaxLengthAtLinkName_LinkNameTruncatedAndClosingTagIncluded
[       OK ] TextOverflowWidgetTests.ElideText_OverMaxLengthAtLinkName_LinkNameTruncatedAndClosingTagIncluded (0 ms)
[----------] 6 tests from TextOverflowWidgetTests (21 ms total)

[----------] Global test environment tear-down
[==========] 53 tests from 9 test cases ran. (5574 ms total)
[  PASSED  ] 53 tests.
```
