### PR TITLE
Move AtomEditorComponents_GlobalSkylightIBLAdded test to sandbox suite.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Component_02.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Component_02.py
@@ -14,11 +14,6 @@ from ly_test_tools.o3de.editor_test import EditorBatchedTest, EditorTestSuite
 @pytest.mark.parametrize("launcher_platform", ['windows_editor'])
 class TestAutomation(EditorTestSuite):
 
-    @pytest.mark.skip(reason="https://github.com/o3de/o3de/issues/14580")
-    @pytest.mark.test_case_id("C32078115")
-    class AtomEditorComponents_GlobalSkylightIBLAdded(EditorBatchedTest):
-        from Atom.tests import hydra_AtomEditorComponents_GlobalSkylightIBLAdded as test_module
-
     @pytest.mark.test_case_id("C32078122")
     class AtomEditorComponents_GridAdded(EditorBatchedTest):
         from Atom.tests import hydra_AtomEditorComponents_GridAdded as test_module

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Sandbox.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Sandbox.py
@@ -38,3 +38,8 @@ class TestAutomation(EditorTestSuite):
     @pytest.mark.test_case_id("C32078124")
     class AtomEditorComponents_MeshAdded(EditorBatchedTest):
         from Atom.tests import hydra_AtomEditorComponents_MeshAdded as test_module
+
+    # GHI: https://github.com/o3de/o3de/issues/14580
+    @pytest.mark.test_case_id("C32078115")
+    class AtomEditorComponents_GlobalSkylightIBLAdded(EditorBatchedTest):
+        from Atom.tests import hydra_AtomEditorComponents_GlobalSkylightIBLAdded as test_module


### PR DESCRIPTION
## What does this PR do?
This PR moves the AtomEditorComponents_GlobalSkylightIBLAdded test to the sandbox suite as we cannot reproduce the error identified in https://github.com/o3de/o3de/issues/14580 locally so believe it may be a local issue with the AR machines.
For this reason, we are going to move it to the sandbox suite and monitor for intermittent failures there instead of try to reproduce locally.

## How was this PR tested?
Tests are only being moved between suites, so no new testing is required to verify the changes.