### PR TITLE
Atom Tools: Updating asset browser, selectors, and enumeration to ignore the cache and intermediate asset folders

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.cpp
@@ -246,28 +246,31 @@ namespace AzToolsFramework
 
         bool StringFilter::MatchInternal(const AssetBrowserEntry* entry) const
         {
-            // no filter string matches any asset
-            if (m_filterString.isEmpty())
-            {
-                return true;
-            }
+            // Return true if the filter is empty or the display name matches.
+            return m_filterString.isEmpty() || StringMatch(m_filterString, entry->GetDisplayName());
+        }
 
-            // entry's name matches search pattern
-            if (StringMatch(m_filterString, entry->GetDisplayName()))
-            {
-                return true;
-            }
+        //////////////////////////////////////////////////////////////////////////
+        // CustomFilter
+        //////////////////////////////////////////////////////////////////////////
+        CustomFilter::CustomFilter(const AZStd::function<bool(const AssetBrowserEntry*)>& filterFn)
+            : m_filterFn(filterFn)
+        {
+        }
 
-            return false;
+        QString CustomFilter::GetNameInternal() const
+        {
+            return "Custom Filter";
+        }
+
+        bool CustomFilter::MatchInternal(const AssetBrowserEntry* entry) const
+        {
+            return m_filterFn && m_filterFn(entry);
         }
 
         //////////////////////////////////////////////////////////////////////////
         // RegExpFilter
         //////////////////////////////////////////////////////////////////////////
-        RegExpFilter::RegExpFilter()
-        {
-        }
-
         void RegExpFilter::SetFilterPattern(const QRegExp& filterPattern)
         {
             m_filterPattern = filterPattern;
@@ -281,7 +284,7 @@ namespace AzToolsFramework
 
         bool RegExpFilter::MatchInternal(const AssetBrowserEntry* entry) const
         {
-            // entry's name matches regular expression pattern if specified
+            // Return true if the filter is empty or the display name matches.
             return m_filterPattern.isEmpty() || m_filterPattern.exactMatch(entry->GetDisplayName());
         }
 
@@ -428,7 +431,7 @@ namespace AzToolsFramework
 
         bool AssetPathFilter::MatchInternal(const AssetBrowserEntry* entry) const
         {
-            AZ::IO::Path entryPath = entry->GetFullPath();
+            const AZ::IO::Path entryPath = entry->GetFullPath();
             return entryPath.IsRelativeTo(m_assetPath);
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.h
@@ -121,15 +121,33 @@ namespace AzToolsFramework
         };
 
         //////////////////////////////////////////////////////////////////////////
-        // RegExpFilter
+        // CustomFilter
         //////////////////////////////////////////////////////////////////////////
-        //! RegExpFilter filters assets based on a regular expression pattern
-        class RegExpFilter
-            : public AssetBrowserEntryFilter
+        //! CustomFilter filters assets based on a custom filter function 
+        class CustomFilter : public AssetBrowserEntryFilter
         {
             Q_OBJECT
         public:
-            RegExpFilter();
+            CustomFilter(const AZStd::function<bool(const AssetBrowserEntry*)>& filterFn);
+            ~CustomFilter() override = default;
+
+        protected:
+            QString GetNameInternal() const override;
+            bool MatchInternal(const AssetBrowserEntry* entry) const override;
+
+        private:
+            AZStd::function<bool(const AssetBrowserEntry*)> m_filterFn;
+        };
+
+        //////////////////////////////////////////////////////////////////////////
+        // CustomFilter
+        //////////////////////////////////////////////////////////////////////////
+        //! RegExpFilter filters assets based on a regular expression pattern
+        class RegExpFilter : public AssetBrowserEntryFilter
+        {
+            Q_OBJECT
+        public:
+            RegExpFilter() = default;
             ~RegExpFilter() override = default;
 
             void SetFilterPattern(const QRegExp& filterPattern);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -293,6 +293,9 @@ namespace AtomToolsFramework
     //! Collect a set of file paths from all project safe folders matching a wild card
     AZStd::vector<AZStd::string> GetPathsInSourceFoldersMatchingWildcard(const AZStd::string& wildcard);
 
+    //! Return a list of all asset safe folders except for those underneath the cache folder, usually intermediate asset folders.
+    AZStd::vector<AZStd::string> GetNonCacheSourceFolders();
+
     //! Add menu actions for scripts specified in the settings registry
     //! @param menu The menu where the actions will be inserted
     //! @param registryKey The path to the registry setting where script categories are registered

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowser.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowser.cpp
@@ -145,18 +145,20 @@ namespace AtomToolsFramework
     {
         using namespace AzToolsFramework::AssetBrowser;
 
-        QSharedPointer<EntryTypeFilter> sourceFilter(new EntryTypeFilter);
-        sourceFilter->SetEntryType(AssetBrowserEntry::AssetEntryType::Source);
+        auto filterFn = [&](const AssetBrowserEntry* entry)
+        {
+            if (entry->GetEntryType() != AssetBrowserEntry::AssetEntryType::Source &&
+                entry->GetEntryType() != AssetBrowserEntry::AssetEntryType::Folder)
+            {
+                return false;
+            }
 
-        QSharedPointer<EntryTypeFilter> folderFilter(new EntryTypeFilter);
-        folderFilter->SetEntryType(AssetBrowserEntry::AssetEntryType::Folder);
-
-        QSharedPointer<CompositeFilter> sourceOrFolderFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::OR));
-        sourceOrFolderFilter->AddFilter(sourceFilter);
-        sourceOrFolderFilter->AddFilter(folderFilter);
+            const auto& path = entry->GetFullPath();
+            return !AZ::StringFunc::Contains(path, "cache");
+        };
 
         QSharedPointer<CompositeFilter> finalFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::AND));
-        finalFilter->AddFilter(sourceOrFolderFilter);
+        finalFilter->AddFilter(FilterConstType(new CustomFilter(filterFn)));
         finalFilter->AddFilter(m_ui->m_searchWidget->GetFilter());
 
         return finalFilter;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -350,23 +350,30 @@ namespace AtomToolsFramework
             path = GetPathWithoutAlias(path);
         }
 
-        // Build a string list from the supported extensions container that will be used in a regular expression wild card for the asset
-        // selection model.
-        QStringList extensionList;
-        for (const auto& extensionPair : supportedExtensions)
+        // Create a custom filter function to plug into the asset selection model. The filter function will only display source assets
+        // matching one of the supported extensions. It will also ignore files in the cache folder, usually intermediate assets. This is
+        // much faster than the previous iteration using regular expressions.
+        auto filterFn = [&](const AssetBrowserEntry* entry)
         {
-            if (!extensionPair.second.empty())
+            if (entry->GetEntryType() != AssetBrowserEntry::AssetEntryType::Source)
             {
-                extensionList.append(extensionPair.second.c_str());
+                return false;
             }
-        }
 
-        // Build an expression that tells the selection model to only show files with matching extensions.
-        const QString expression = QString("[\\w\\-.]+\\.(%1)").arg(extensionList.join("|"));
-        const QRegExp filter(expression, Qt::CaseInsensitive);
+            const auto& path = entry->GetFullPath();
+            return !AZ::StringFunc::Contains(path, "cache") &&
+                AZStd::any_of(
+                    supportedExtensions.begin(),
+                    supportedExtensions.end(),
+                    [&](const auto& extensionPair)
+                    {
+                        return path.ends_with(AZStd::fixed_string<32>::format(".%s", extensionPair.second.c_str()));
+                    });
+        };
 
-        // Create the selection models of the asset picture only displays files matching the filter.
-        auto selection = AzToolsFramework::AssetBrowser::AssetSelectionModel::SourceAssetTypeSelection(filter);
+        AssetSelectionModel selection;
+        selection.SetDisplayFilter(FilterConstType(new CustomFilter(filterFn)));
+        selection.SetSelectionFilter(FilterConstType(new CustomFilter(filterFn)));
         selection.SetTitle(title.c_str());
         selection.SetMultiselect(multiSelect);
         selection.SetSelectedFilePaths(selectedFilePathsWithoutAliases);
@@ -436,13 +443,9 @@ namespace AtomToolsFramework
 
     bool IsDocumentPathInSupportedFolder(const AZStd::string& path)
     {
-        bool assetFoldersRetrieved = false;
-        AZStd::vector<AZStd::string> assetFolders;
-        AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
-            assetFoldersRetrieved, &AzToolsFramework::AssetSystemRequestBus::Events::GetAssetSafeFolders, assetFolders);
-
-        AZ::IO::FixedMaxPath assetPath = AZ::IO::PathView(GetPathWithoutAlias(path)).LexicallyNormal();
-        for (const auto& assetFolder : assetFolders)
+        const auto& fullPath = GetPathWithoutAlias(path);
+        const AZ::IO::FixedMaxPath assetPath = AZ::IO::PathView(fullPath).LexicallyNormal();
+        for (const auto& assetFolder : GetNonCacheSourceFolders())
         {
             // Check if the path is relative to the asset folder
             if (assetPath.IsRelativeTo(AZ::IO::PathView(assetFolder)))
@@ -661,7 +664,7 @@ namespace AtomToolsFramework
     void VisitFilesInFolder(
         const AZStd::string& folder, const AZStd::function<bool(const AZStd::string&)> visitorFn, bool recurse)
     {
-        if (!visitorFn)
+        if (!visitorFn || AZ::StringFunc::Contains(folder, "cache"))
         {
             return;
         }
@@ -693,10 +696,7 @@ namespace AtomToolsFramework
                     return visitorFn(fullPath);
                 }
 
-                if (recurse && !AZ::StringFunc::Contains(fullPath, "cache"))
-                {
-                    VisitFilesInFolder(fullPath, visitorFn, recurse);
-                }
+                VisitFilesInFolder(fullPath, visitorFn, recurse);
                 return true;
             });
     }
@@ -708,12 +708,7 @@ namespace AtomToolsFramework
             return;
         }
 
-        AZStd::vector<AZStd::string> scanFolders;
-        scanFolders.reserve(100);
-        AzToolsFramework::AssetSystemRequestBus::Broadcast(
-            &AzToolsFramework::AssetSystem::AssetSystemRequest::GetAssetSafeFolders, scanFolders);
-
-        for (const AZStd::string& scanFolder : scanFolders)
+        for (const AZStd::string& scanFolder : GetNonCacheSourceFolders())
         {
             VisitFilesInFolder(scanFolder, visitorFn, true);
         }
@@ -721,10 +716,7 @@ namespace AtomToolsFramework
 
     AZStd::vector<AZStd::string> GetPathsInSourceFoldersMatchingFilter(const AZStd::function<bool(const AZStd::string&)> filterFn)
     {
-        AZStd::vector<AZStd::string> scanFolders;
-        scanFolders.reserve(100);
-        AzToolsFramework::AssetSystemRequestBus::Broadcast(
-            &AzToolsFramework::AssetSystem::AssetSystemRequest::GetAssetSafeFolders, scanFolders);
+        const auto& scanFolders = GetNonCacheSourceFolders();
 
         AZStd::mutex resultsMutex;
         AZStd::vector<AZStd::string> results;
@@ -763,6 +755,18 @@ namespace AtomToolsFramework
             {
                 return AZ::IO::NameMatchesFilter(path, wildcard) && IsDocumentPathEditable(path);
             });
+    }
+
+    AZStd::vector<AZStd::string> GetNonCacheSourceFolders()
+    {
+        AZStd::vector<AZStd::string> scanFolders;
+        scanFolders.reserve(100);
+
+        AzToolsFramework::AssetSystemRequestBus::Broadcast(
+            &AzToolsFramework::AssetSystem::AssetSystemRequest::GetAssetSafeFolders, scanFolders);
+
+        AZStd::erase_if(scanFolders, [](const AZStd::string& path){ return AZ::StringFunc::Contains(path, "cache"); });
+        return scanFolders;
     }
 
     void AddRegisteredScriptToMenu(QMenu* menu, const AZStd::string& registryKey, const AZStd::vector<AZStd::string>& arguments)
@@ -856,6 +860,7 @@ namespace AtomToolsFramework
             addUtilFunc(behaviorContext->Method("GetPathWithoutAlias", GetPathWithoutAlias, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetPathWithAlias", GetPathWithAlias, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetPathsInSourceFoldersMatchingWildcard", GetPathsInSourceFoldersMatchingWildcard, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetNonCacheSourceFolders", GetNonCacheSourceFolders, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetSettingsValue_bool", GetSettingsValue<bool>, nullptr, ""));
             addUtilFunc(behaviorContext->Method("SetSettingsValue_bool", SetSettingsValue<bool>, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetSettingsValue_s64", GetSettingsValue<AZ::s64>, nullptr, ""));


### PR DESCRIPTION
## What does this PR do?

Now that intermediate assets are being used to generate material types and shader permutations, the files are showing up in the asset browser and asset selection controls, adding a lot of noise and confusion because of the extra options.

This PR hides them from the asset browser and asset selection controls in material editor, material canvas, and other tools based on atom tools framework.

A custom, general purpose asset browser entry filter was also added that allows using the standard function instead of creating complex combinations of other filter types.

## How was this PR tested?

Confirmed that cache folder assets don't appear in material editor or material canvas browsers/pickers.