### PR TITLE
Atom Tools: Adding unique suffixes and tooltips to asset selection entries

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionComboBox.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionComboBox.cpp
@@ -80,7 +80,30 @@ namespace AtomToolsFramework
         const QVariant pathItemData(QString::fromUtf8(pathWithAlias.c_str(), static_cast<int>(pathWithAlias.size())));
         if (const int index = findData(pathItemData); index < 0)
         {
-            addItem(GetDisplayNameFromPath(pathWithAlias).c_str(), pathItemData);
+            const auto& pathWithoutAlias = GetPathWithoutAlias(path);
+            const auto& title = GetDisplayNameFromPath(pathWithoutAlias);
+
+            // Compare the item title against all other items and append a suffix until the new title is unique
+            AZStd::string uniqueTitle = title;
+            int uniqueTitleSuffix = 0;
+            bool uniqueTitleFound = true;
+            while (uniqueTitleFound)
+            {
+                uniqueTitleFound = false;
+                for (int i = 0; i < count(); ++i)
+                {
+                    if (uniqueTitle == itemText(i).toUtf8().constData())
+                    {
+                        uniqueTitle = AZStd::string::format("%s (%i)",title.c_str(), ++uniqueTitleSuffix);
+                        uniqueTitleFound = true;
+                        break;
+                    }
+                }
+            }
+
+            addItem(uniqueTitle.c_str(), pathItemData);
+            setItemData(count() - 1, pathWithoutAlias.c_str(), Qt::ToolTipRole);
+
             QueueSort();
             RegisterThumbnail(pathWithAlias);
         }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionGrid.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionGrid.cpp
@@ -104,6 +104,25 @@ namespace AtomToolsFramework
             }
         }
 
+        // Compare the item title against all other items and append a suffix until the new title is unique
+        QString uniqueTitle = title;
+        int uniqueTitleSuffix = 0;
+        bool uniqueTitleFound = true;
+        while (uniqueTitleFound)
+        {
+            uniqueTitleFound = false;
+            for (int i = 0; i < m_ui->m_assetList->count(); ++i)
+            {
+                QListWidgetItem* item = m_ui->m_assetList->item(i);
+                if (uniqueTitle == item->data(Qt::DisplayRole))
+                {
+                    uniqueTitle = title + QString(" (%1)").arg(++uniqueTitleSuffix);
+                    uniqueTitleFound = true;
+                    break;
+                }
+            }
+        }
+
         const int itemBorder =
             aznumeric_cast<int>(AtomToolsFramework::GetSettingsValue<AZ::u64>("/O3DE/AtomToolsFramework/AssetSelectionGrid/ItemBorder", 4));
         const int itemSpacing = aznumeric_cast<int>(
@@ -117,8 +136,9 @@ namespace AtomToolsFramework
             AZStd::max(gridSize.height(), m_tileSize.height() + itemSpacing + headerHeight)));
 
         QListWidgetItem* item = new QListWidgetItem(m_ui->m_assetList);
-        item->setData(Qt::DisplayRole, title);
+        item->setData(Qt::DisplayRole, uniqueTitle);
         item->setData(Qt::UserRole, pathItemData);
+        item->setData(Qt::ToolTipRole, pathWithoutAlias.c_str());
         item->setSizeHint(m_tileSize + QSize(itemBorder, itemBorder + headerHeight));
         m_ui->m_assetList->addItem(item);
 
@@ -128,7 +148,7 @@ namespace AtomToolsFramework
         itemWidget->layout()->setMargin(0);
 
         AzQtComponents::ElidingLabel* header = new AzQtComponents::ElidingLabel(itemWidget);
-        header->setText(title);
+        header->setText(uniqueTitle);
         header->setFixedSize(QSize(m_tileSize.width(), headerHeight));
         header->setMargin(0);
         header->setStyleSheet("background-color: rgb(35, 35, 35)");


### PR DESCRIPTION
## What does this PR do?

Updating asset selection combo box and grid classes to append a unique suffix on to entries with the same display name. In addition to that, tooltips were also added showing the absolute path to the file being referenced.

Resolves https://github.com/o3de/o3de/issues/13507

## How was this PR tested?

Confirmed asset selection drop down and grid operate as before, with the addition of the unique suffix four files with the same display name and the tooltip.