### PR TITLE
Show the 'Is Simulated' option as disabled when the collider is acting as a trigger.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/Shape.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Shape.cpp
@@ -25,7 +25,7 @@ namespace Physics
                 ->Field("Visible", &ColliderConfiguration::m_visible)
                 ->Field("Trigger", &ColliderConfiguration::m_isTrigger)
                 ->Field("Simulated", &ColliderConfiguration::m_isSimulated)
-                ->Field("StubSimulated", &ColliderConfiguration::m_stubIsSimulated)
+                ->Field("DummySimulated", &ColliderConfiguration::m_dummyIsSimulated)
                 ->Field("InSceneQueries", &ColliderConfiguration::m_isInSceneQueries)
                 ->Field("Exclusive", &ColliderConfiguration::m_isExclusive)
                 ->Field("Position", &ColliderConfiguration::m_position)
@@ -48,9 +48,9 @@ namespace Physics
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_isSimulated, "Simulated",
                         "If set, this collider will partake in collision in the physical simulation.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetSimulatedPropertyVisibility)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_stubIsSimulated, "Simulated",
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_dummyIsSimulated, "Simulated",
                         "If set, this collider will partake in collision in the physical simulation. Currently disabled because this collider is acting as a trigger.")
-                        ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetStubSimulatedPropertyVisibility)
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetDummySimulatedPropertyVisibility)
                         ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_isInSceneQueries, "In Scene Queries", "If set, this collider will be visible for scene queries")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetIsTriggerVisibility)
@@ -151,7 +151,7 @@ namespace Physics
         }
     }
 
-    AZ::Crc32 ColliderConfiguration::GetStubSimulatedPropertyVisibility() const
+    AZ::Crc32 ColliderConfiguration::GetDummySimulatedPropertyVisibility() const
     {
         if (GetIsTriggerVisibility() == AZ::Edit::PropertyVisibility::Show)
         {

--- a/Code/Framework/AzFramework/AzFramework/Physics/Shape.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Shape.cpp
@@ -25,6 +25,7 @@ namespace Physics
                 ->Field("Visible", &ColliderConfiguration::m_visible)
                 ->Field("Trigger", &ColliderConfiguration::m_isTrigger)
                 ->Field("Simulated", &ColliderConfiguration::m_isSimulated)
+                ->Field("StubSimulated", &ColliderConfiguration::m_stubIsSimulated)
                 ->Field("InSceneQueries", &ColliderConfiguration::m_isInSceneQueries)
                 ->Field("Exclusive", &ColliderConfiguration::m_isExclusive)
                 ->Field("Position", &ColliderConfiguration::m_position)
@@ -43,10 +44,14 @@ namespace Physics
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_isTrigger, "Trigger", "If set, this collider will act as a trigger")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetIsTriggerVisibility)
-                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_isSimulated, "Simulated", "If set, this collider will partake in collision in the physical simulation")
-                        ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetIsTriggerVisibility)
-                        ->Attribute(AZ::Edit::Attributes::ReadOnly, &ColliderConfiguration::m_isTrigger) // Trigger shapes ignore simulated flag, making it read-only in the UI.
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree) // Necessary so visibility attributes are consumed
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_isSimulated, "Simulated",
+                        "If set, this collider will partake in collision in the physical simulation.")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetSimulatedPropertyVisibility)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_stubIsSimulated, "Simulated",
+                        "If set, this collider will partake in collision in the physical simulation. Currently disabled since this collider is acting as a trigger.")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetStubSimulatedPropertyVisibility)
+                        ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_isInSceneQueries, "In Scene Queries", "If set, this collider will be visible for scene queries")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetIsTriggerVisibility)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_collisionLayer, "Collision Layer", "The collision layer assigned to the collider")
@@ -132,5 +137,29 @@ namespace Physics
     AZ::Crc32 ColliderConfiguration::GetOffsetVisibility() const
     {
         return GetPropertyVisibility(PropertyVisibility::Offset);
+    }
+
+    AZ::Crc32 ColliderConfiguration::GetSimulatedPropertyVisibility() const
+    {
+        if (GetIsTriggerVisibility() == AZ::Edit::PropertyVisibility::Show)
+        {
+            return m_isTrigger ? AZ::Edit::PropertyVisibility::Hide : AZ::Edit::PropertyVisibility::Show;
+        }
+        else
+        {
+            return AZ::Edit::PropertyVisibility::Hide;
+        }
+    }
+
+    AZ::Crc32 ColliderConfiguration::GetStubSimulatedPropertyVisibility() const
+    {
+        if (GetIsTriggerVisibility() == AZ::Edit::PropertyVisibility::Show)
+        {
+            return m_isTrigger ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
+        }
+        else
+        {
+            return AZ::Edit::PropertyVisibility::Hide;
+        }
     }
 }

--- a/Code/Framework/AzFramework/AzFramework/Physics/Shape.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Shape.cpp
@@ -49,7 +49,7 @@ namespace Physics
                         "If set, this collider will partake in collision in the physical simulation.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetSimulatedPropertyVisibility)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_stubIsSimulated, "Simulated",
-                        "If set, this collider will partake in collision in the physical simulation. Currently disabled since this collider is acting as a trigger.")
+                        "If set, this collider will partake in collision in the physical simulation. Currently disabled because this collider is acting as a trigger.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetStubSimulatedPropertyVisibility)
                         ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_isInSceneQueries, "In Scene Queries", "If set, this collider will be visible for scene queries")

--- a/Code/Framework/AzFramework/AzFramework/Physics/Shape.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Shape.h
@@ -72,6 +72,13 @@ namespace Physics
     private:
         void OnRestOffsetChanged();
         void OnContactOffsetChanged();
+
+        // m_stubIsSimulated is used for EditContext only, it will always be false and read-only.
+        // It will be shown instead of the real m_isSimulated property when m_isTrigger is enabled,
+        // this way it'll be clear that when the collider is a trigger it won't be simulated.
+        bool m_stubIsSimulated = false;
+        AZ::Crc32 GetSimulatedPropertyVisibility() const;
+        AZ::Crc32 GetStubSimulatedPropertyVisibility() const;
     };
 
     struct RayCastRequest;

--- a/Code/Framework/AzFramework/AzFramework/Physics/Shape.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Shape.h
@@ -73,12 +73,12 @@ namespace Physics
         void OnRestOffsetChanged();
         void OnContactOffsetChanged();
 
-        // m_stubIsSimulated is used for EditContext only, it will always be false and read-only.
+        // m_dummyIsSimulated is used for EditContext only, it will always be false and read-only.
         // It will be shown instead of the real m_isSimulated property when m_isTrigger is enabled,
         // this way it'll be clear that when the collider is a trigger it won't be simulated.
-        bool m_stubIsSimulated = false;
+        bool m_dummyIsSimulated = false;
         AZ::Crc32 GetSimulatedPropertyVisibility() const;
-        AZ::Crc32 GetStubSimulatedPropertyVisibility() const;
+        AZ::Crc32 GetDummySimulatedPropertyVisibility() const;
     };
 
     struct RayCastRequest;


### PR DESCRIPTION
## What does this PR do?

Show the 'Is Simulated' option as disabled when the collider is acting as a trigger,  this way it'll be clear that when the collider is a trigger it won't be simulated.

![image](https://user-images.githubusercontent.com/27999040/223690687-d717da38-2cc5-4a75-b193-ff1367143c89.png)

## How was this PR tested?

Checked 'Is Simulated' appears disabled when 'Is Trigger' is enabled in Primitive, Mesh and Shape collider components.
