### PR TITLE
Fixed asset scale when Mesh Collider has primitive shapes and improved unit tests.

### DIFF
--- a/Gems/PhysX/Code/Source/BaseColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/BaseColliderComponent.cpp
@@ -328,7 +328,10 @@ namespace PhysX
             return false;
         }
 
-        const bool hasNonUniformScale = (AZ::NonUniformScaleRequestBus::FindFirstHandler(GetEntityId()) != nullptr);
+        const bool isAssetScaleUniform =
+            AZ::IsClose(physicsAssetConfiguration.m_assetScale.GetX(), physicsAssetConfiguration.m_assetScale.GetY()) &&
+            AZ::IsClose(physicsAssetConfiguration.m_assetScale.GetX(), physicsAssetConfiguration.m_assetScale.GetZ());
+        const bool hasNonUniformScale = !isAssetScaleUniform || (AZ::NonUniformScaleRequestBus::FindFirstHandler(GetEntityId()) != nullptr);
         Utils::CreateShapesFromAsset(physicsAssetConfiguration, componentColliderConfiguration, hasNonUniformScale,
             physicsAssetConfiguration.m_subdivisionLevel, m_shapes);
 

--- a/Gems/PhysX/Code/Source/EditorMeshColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorMeshColliderComponent.cpp
@@ -93,6 +93,7 @@ namespace PhysX
     EditorProxyAssetShapeConfig::EditorProxyAssetShapeConfig(
         const Physics::PhysicsAssetShapeConfiguration& assetShapeConfiguration)
     {
+        m_physicsAsset.m_pxAsset = assetShapeConfiguration.m_asset;
         m_physicsAsset.m_configuration = assetShapeConfiguration;
     }
 

--- a/Gems/PhysX/Code/Source/EditorMeshColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorMeshColliderComponent.cpp
@@ -130,30 +130,25 @@ namespace PhysX
                     switch (cookedMeshShapeConfiguration->GetMeshType())
                     {
                     case Physics::CookedMeshShapeConfiguration::MeshType::Convex:
-                        {
-                            shapeTypes.push_back(ShapeType::Convex);
-                        }
+                        shapeTypes.push_back(ShapeType::Convex);
+                        break;
                     case Physics::CookedMeshShapeConfiguration::MeshType::TriangleMesh:
-                        {
-                            shapeTypes.push_back(ShapeType::TriangleMesh);
-                        }
+                        shapeTypes.push_back(ShapeType::TriangleMesh);
+                        break;
                     default:
-                        {
-                            shapeTypes.push_back(ShapeType::Invalid);
-                        }
+                        shapeTypes.push_back(ShapeType::Invalid);
+                        break;
                     }
-                    break;
                 }
+                break;
             case Physics::ShapeType::Sphere:
             case Physics::ShapeType::Box:
             case Physics::ShapeType::Capsule:
-                {
-                    shapeTypes.push_back(ShapeType::Primitive);
-                }
+                shapeTypes.push_back(ShapeType::Primitive);
+                break;
             default:
-                {
-                    shapeTypes.push_back(ShapeType::Invalid);
-                }
+                shapeTypes.push_back(ShapeType::Invalid);
+                break;
             }
         }
 
@@ -174,21 +169,13 @@ namespace PhysX
         switch (shapeTypes[0])
         {
         case ShapeType::Primitive:
-            {
-                return assetName + " (Primitive)";
-            }
+            return assetName + " (Primitive)";
         case ShapeType::Convex:
-            {
-                return assetName + " (Convex)";
-            }
+            return assetName + " (Convex)";
         case ShapeType::TriangleMesh:
-            {
-                return assetName + " (Triangle Mesh)";
-            }
+            return assetName + " (Triangle Mesh)";
         default:
-            {
-                return assetName;
-            }
+            return assetName;
         }
     }
 

--- a/Gems/PhysX/Code/Source/EditorMeshColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorMeshColliderComponent.cpp
@@ -97,77 +97,96 @@ namespace PhysX
         m_physicsAsset.m_configuration = assetShapeConfiguration;
     }
 
-    AZStd::string EditorProxyAssetShapeConfig::PhysXMeshAssetShapeTypeName() const
+    AZStd::vector<EditorProxyAssetShapeConfig::ShapeType> EditorProxyAssetShapeConfig::GetShapeTypesInsideAsset() const
     {
-        const AZStd::string assetName = "Asset";
-
         if (!m_physicsAsset.m_pxAsset.IsReady())
         {
-            return assetName;
+            return {};
         }
 
         Physics::ColliderConfiguration defaultColliderConfiguration;
         Physics::PhysicsAssetShapeConfiguration physicsAssetConfiguration = m_physicsAsset.m_configuration;
         physicsAssetConfiguration.m_asset = m_physicsAsset.m_pxAsset;
+        physicsAssetConfiguration.m_assetScale = AZ::Vector3::CreateOne(); // Remove the scale so it doesn't affect the query for the asset mesh type
+        const bool hasNonUniformScale = false;
 
         AzPhysics::ShapeColliderPairList shapeConfigList;
         Utils::GetColliderShapeConfigsFromAsset(
-            physicsAssetConfiguration,
-            defaultColliderConfiguration,
-            m_hasNonUniformScale,
-            m_subdivisionLevel,
-            shapeConfigList);
+            physicsAssetConfiguration, defaultColliderConfiguration, hasNonUniformScale, m_subdivisionLevel, shapeConfigList);
 
-        if (shapeConfigList.empty())
+        AZStd::vector<ShapeType> shapeTypes;
+        shapeTypes.reserve(shapeConfigList.size());
+        for (const auto& shapeConfig : shapeConfigList)
+        {
+            const Physics::ShapeConfiguration* shapeConfiguration = shapeConfig.second.get();
+            AZ_Assert(shapeConfiguration, "GetShapeTypesInsideAsset: Invalid shape-collider configuration pair");
+
+            switch (shapeConfiguration->GetShapeType())
+            {
+            case Physics::ShapeType::CookedMesh:
+                {
+                    const Physics::CookedMeshShapeConfiguration* cookedMeshShapeConfiguration =
+                        static_cast<const Physics::CookedMeshShapeConfiguration*>(shapeConfiguration);
+                    switch (cookedMeshShapeConfiguration->GetMeshType())
+                    {
+                    case Physics::CookedMeshShapeConfiguration::MeshType::Convex:
+                        {
+                            shapeTypes.push_back(ShapeType::Convex);
+                        }
+                    case Physics::CookedMeshShapeConfiguration::MeshType::TriangleMesh:
+                        {
+                            shapeTypes.push_back(ShapeType::TriangleMesh);
+                        }
+                    default:
+                        {
+                            shapeTypes.push_back(ShapeType::Invalid);
+                        }
+                    }
+                    break;
+                }
+            case Physics::ShapeType::Sphere:
+            case Physics::ShapeType::Box:
+            case Physics::ShapeType::Capsule:
+                {
+                    shapeTypes.push_back(ShapeType::Primitive);
+                }
+            default:
+                {
+                    shapeTypes.push_back(ShapeType::Invalid);
+                }
+            }
+        }
+
+        return shapeTypes;
+    }
+
+    AZStd::string EditorProxyAssetShapeConfig::PhysXMeshAssetShapeTypeName() const
+    {
+        const AZStd::string assetName = "Asset";
+
+        const AZStd::vector<ShapeType> shapeTypes = GetShapeTypesInsideAsset();
+        if (shapeTypes.empty())
         {
             return assetName;
         }
 
-        // It's enough looking at the first shape as the rest would be the same type.
-        const Physics::ShapeConfiguration* shapeConfiguration = shapeConfigList[0].second.get();
-        AZ_Assert(shapeConfiguration, "PhysXMeshAssetShapeTypeName: Invalid shape-collider configuration pair");
-
-        switch (shapeConfiguration->GetShapeType())
+        // Using the first shape type as representative for shapes inside the asset.
+        switch (shapeTypes[0])
         {
-        case Physics::ShapeType::CookedMesh:
-            {
-                const Physics::CookedMeshShapeConfiguration* cookedMeshShapeConfiguration =
-                    static_cast<const Physics::CookedMeshShapeConfiguration*>(shapeConfiguration);
-                switch (cookedMeshShapeConfiguration->GetMeshType())
-                {
-                case Physics::CookedMeshShapeConfiguration::MeshType::Convex:
-                    {
-                        return assetName + " (Convex)";
-                    }
-                case Physics::CookedMeshShapeConfiguration::MeshType::TriangleMesh:
-                    {
-                        return assetName + " (Triangle Mesh)";
-                    }
-                default:
-                    {
-                        AZ_Error(
-                            "EditorProxyAssetShapeConfig",
-                            false,
-                            "PhysXMeshAssetShapeTypeName: Unexpected MeshType %d",
-                            static_cast<AZ::u32>(cookedMeshShapeConfiguration->GetMeshType()));
-                        return assetName;
-                    }
-                }
-                break;
-            }
-        case Physics::ShapeType::Sphere:
-        case Physics::ShapeType::Box:
-        case Physics::ShapeType::Capsule:
+        case ShapeType::Primitive:
             {
                 return assetName + " (Primitive)";
             }
+        case ShapeType::Convex:
+            {
+                return assetName + " (Convex)";
+            }
+        case ShapeType::TriangleMesh:
+            {
+                return assetName + " (Triangle Mesh)";
+            }
         default:
             {
-                AZ_Error(
-                    "EditorProxyAssetShapeConfig",
-                    false,
-                    "PhysXMeshAssetShapeTypeName: Unexpected ShapeType %d.",
-                    static_cast<AZ::u32>(shapeConfiguration->GetShapeType()));
                 return assetName;
             }
         }
@@ -175,7 +194,16 @@ namespace PhysX
 
     bool EditorProxyAssetShapeConfig::ShowingSubdivisionLevel() const
     {
-        return m_hasNonUniformScale;
+        const AZStd::vector<ShapeType> shapeTypes = GetShapeTypesInsideAsset();
+
+        return m_hasNonUniformScale &&
+            AZStd::any_of(
+                   shapeTypes.begin(),
+                   shapeTypes.end(),
+                   [](const ShapeType& shapeType)
+                   {
+                       return shapeType == ShapeType::Primitive;
+                   });
     }
 
     AZ::u32 EditorProxyAssetShapeConfig::OnConfigurationChanged()
@@ -343,15 +371,10 @@ namespace PhysX
         AZ::NonUniformScaleRequestBus::Event(
             entityId, &AZ::NonUniformScaleRequests::RegisterScaleChangedEvent,
             m_nonUniformScaleChangedHandler);
-        m_hasNonUniformScale = (AZ::NonUniformScaleRequestBus::FindFirstHandler(entityId) != nullptr);
-        m_proxyShapeConfiguration.m_hasNonUniformScale = m_hasNonUniformScale;
 
         AZ::TransformBus::EventResult(m_cachedWorldTransform, entityId, &AZ::TransformInterface::GetWorldTM);
         m_cachedNonUniformScale = AZ::Vector3::CreateOne();
-        if (m_hasNonUniformScale)
-        {
-            AZ::NonUniformScaleRequestBus::EventResult(m_cachedNonUniformScale, entityId, &AZ::NonUniformScaleRequests::GetScale);
-        }
+        AZ::NonUniformScaleRequestBus::EventResult(m_cachedNonUniformScale, entityId, &AZ::NonUniformScaleRequests::GetScale);
 
         // Debug drawing
         m_colliderDebugDraw.Connect(entityId);
@@ -846,6 +869,11 @@ namespace PhysX
 
     void EditorMeshColliderComponent::UpdateShapeConfigurationScale()
     {
+        const AZ::Vector3& assetScale = m_proxyShapeConfiguration.m_physicsAsset.m_configuration.m_assetScale;
+        const bool isAssetScaleUniform =
+            AZ::IsClose(assetScale.GetX(), assetScale.GetY()) && AZ::IsClose(assetScale.GetX(), assetScale.GetZ());
+        m_hasNonUniformScale = !isAssetScaleUniform || (AZ::NonUniformScaleRequestBus::FindFirstHandler(GetEntityId()) != nullptr);
+        m_proxyShapeConfiguration.m_hasNonUniformScale = m_hasNonUniformScale;
         m_proxyShapeConfiguration.m_physicsAsset.m_configuration.m_scale = GetWorldTM().ExtractUniformScale() * m_cachedNonUniformScale;
     }
 

--- a/Gems/PhysX/Code/Source/EditorMeshColliderComponent.h
+++ b/Gems/PhysX/Code/Source/EditorMeshColliderComponent.h
@@ -63,6 +63,14 @@ namespace PhysX
         AZ::u8 m_subdivisionLevel = 4; //!< The level of subdivision if a primitive shape is replaced with a convex mesh due to scaling.
 
     private:
+        enum class ShapeType
+        {
+            Invalid,
+            Primitive,
+            Convex,
+            TriangleMesh
+        };
+        AZStd::vector<ShapeType> GetShapeTypesInsideAsset() const;
         AZStd::string PhysXMeshAssetShapeTypeName() const;
         bool ShowingSubdivisionLevel() const;
         AZ::u32 OnConfigurationChanged();

--- a/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
@@ -78,11 +78,18 @@ namespace PhysX
                     continue;
                 }
 
+                const AZ::Vector3& assetScale = shapeConfigurationProxy.m_physicsAsset.m_configuration.m_assetScale;
+                const bool isAssetScaleUniform =
+                    AZ::IsClose(assetScale.GetX(), assetScale.GetY()) && AZ::IsClose(assetScale.GetX(), assetScale.GetZ());
+
                 const Physics::ColliderConfiguration colliderConfigurationUnscaled = collider->GetColliderConfiguration();
                 AZStd::vector<AZStd::shared_ptr<Physics::Shape>> shapes;
                 Utils::CreateShapesFromAsset(
                     shapeConfigurationProxy.m_physicsAsset.m_configuration,
-                    colliderConfigurationUnscaled, hasNonUniformScaleComponent, shapeConfigurationProxy.m_subdivisionLevel, shapes);
+                    colliderConfigurationUnscaled,
+                    hasNonUniformScaleComponent || !isAssetScaleUniform,
+                    shapeConfigurationProxy.m_subdivisionLevel,
+                    shapes);
 
                 for (const auto& shape : shapes)
                 {

--- a/Gems/PhysX/Code/Tests/EditorMeshColliderComponentTests.cpp
+++ b/Gems/PhysX/Code/Tests/EditorMeshColliderComponentTests.cpp
@@ -435,8 +435,6 @@ namespace PhysXEditorTests
 
         EXPECT_TRUE(MeshColliderHasOnePhysicsAssetShapeType(gameEntity->FindComponent<PhysX::MeshColliderComponent>()));
 
-        EXPECT_TRUE(MeshColliderHasOnePhysicsAssetShapeType(gameEntity->FindComponent<PhysX::MeshColliderComponent>()));
-
         delete meshAssetData;
     }
 

--- a/Gems/PhysX/Code/Tests/EditorTestUtilities.cpp
+++ b/Gems/PhysX/Code/Tests/EditorTestUtilities.cpp
@@ -85,6 +85,15 @@ namespace PhysXEditorTests
             AZ::NonUniformScaleRequestBus::Event(editorEntity->GetId(), &AZ::NonUniformScaleRequests::SetScale, *nonUniformScale);
         }
 
+        // If using a dynamic rigid body then reactivate the entity to recreate the editor world body.
+        // This is because the dynamic rigid body only applies the changes in the next simulation tick,
+        // which happens automatically in the editor but not in test environment.
+        if (rigidBodyType == RigidBodyType::Dynamic)
+        {
+            editorEntity->Deactivate();
+            editorEntity->Activate();
+        }
+
         return editorEntity;
     }
 
@@ -127,6 +136,15 @@ namespace PhysXEditorTests
             AZ::NonUniformScaleRequestBus::Event(editorEntity->GetId(), &AZ::NonUniformScaleRequests::SetScale, *nonUniformScale);
         }
 
+        // If using a dynamic rigid body then reactivate the entity to recreate the editor world body.
+        // This is because the dynamic rigid body only applies the changes in the next simulation tick,
+        // which happens automatically in the editor but not in test environment.
+        if (rigidBodyType == RigidBodyType::Dynamic)
+        {
+            editorEntity->Deactivate();
+            editorEntity->Activate();
+        }
+
         return editorEntity;
     }
 
@@ -163,6 +181,15 @@ namespace PhysXEditorTests
         if (nonUniformScale.has_value())
         {
             AZ::NonUniformScaleRequestBus::Event(editorEntity->GetId(), &AZ::NonUniformScaleRequests::SetScale, *nonUniformScale);
+        }
+
+        // If using a dynamic rigid body then reactivate the entity to recreate the editor world body.
+        // This is because the dynamic rigid body only applies the changes in the next simulation tick,
+        // which happens automatically in the editor but not in test environment.
+        if (rigidBodyType == RigidBodyType::Dynamic)
+        {
+            editorEntity->Deactivate();
+            editorEntity->Activate();
         }
 
         return editorEntity;
@@ -208,6 +235,15 @@ namespace PhysXEditorTests
         if (nonUniformScale.has_value())
         {
             AZ::NonUniformScaleRequestBus::Event(editorEntity->GetId(), &AZ::NonUniformScaleRequests::SetScale, *nonUniformScale);
+        }
+
+        // If using a dynamic rigid body then reactivate the entity to recreate the editor world body.
+        // This is because the dynamic rigid body only applies the changes in the next simulation tick,
+        // which happens automatically in the editor but not in test environment.
+        if (rigidBodyType == RigidBodyType::Dynamic)
+        {
+            editorEntity->Deactivate();
+            editorEntity->Activate();
         }
 
         return editorEntity;
@@ -256,6 +292,15 @@ namespace PhysXEditorTests
             AZ::NonUniformScaleRequestBus::Event(editorEntity->GetId(), &AZ::NonUniformScaleRequests::SetScale, *nonUniformScale);
         }
 
+        // If using a dynamic rigid body then reactivate the entity to recreate the editor world body.
+        // This is because the dynamic rigid body only applies the changes in the next simulation tick,
+        // which happens automatically in the editor but not in test environment.
+        if (rigidBodyType == RigidBodyType::Dynamic)
+        {
+            editorEntity->Deactivate();
+            editorEntity->Activate();
+        }
+
         return editorEntity;
     }
 
@@ -298,6 +343,15 @@ namespace PhysXEditorTests
         if (nonUniformScale.has_value())
         {
             AZ::NonUniformScaleRequestBus::Event(editorEntity->GetId(), &AZ::NonUniformScaleRequests::SetScale, *nonUniformScale);
+        }
+
+        // If using a dynamic rigid body then reactivate the entity to recreate the editor world body.
+        // This is because the dynamic rigid body only applies the changes in the next simulation tick,
+        // which happens automatically in the editor but not in test environment.
+        if (rigidBodyType == RigidBodyType::Dynamic)
+        {
+            editorEntity->Deactivate();
+            editorEntity->Activate();
         }
 
         return editorEntity;
@@ -345,9 +399,14 @@ namespace PhysXEditorTests
             AZ::NonUniformScaleRequestBus::Event(editorEntity->GetId(), &AZ::NonUniformScaleRequests::SetScale, *nonUniformScale);
         }
 
-        // reactivate the entity to recreate the editor world body, which happens automatically in the editor but not in test environment
-        editorEntity->Deactivate();
-        editorEntity->Activate();
+        // If using a dynamic rigid body then reactivate the entity to recreate the editor world body.
+        // This is because the dynamic rigid body only applies the changes in the next simulation tick,
+        // which happens automatically in the editor but not in test environment.
+        if (rigidBodyType == RigidBodyType::Dynamic)
+        {
+            editorEntity->Deactivate();
+            editorEntity->Activate();
+        }
 
         return editorEntity;
     }
@@ -395,6 +454,15 @@ namespace PhysXEditorTests
             AZ::NonUniformScaleRequestBus::Event(editorEntity->GetId(), &AZ::NonUniformScaleRequests::SetScale, *nonUniformScale);
         }
 
+        // If using a dynamic rigid body then reactivate the entity to recreate the editor world body.
+        // This is because the dynamic rigid body only applies the changes in the next simulation tick,
+        // which happens automatically in the editor but not in test environment.
+        if (rigidBodyType == RigidBodyType::Dynamic)
+        {
+            editorEntity->Deactivate();
+            editorEntity->Activate();
+        }
+
         return editorEntity;
     }
 
@@ -405,9 +473,7 @@ namespace PhysXEditorTests
             simulatedBody, entityId, &AzPhysics::SimulatedBodyComponentRequests::GetSimulatedBody);
         if (simulatedBody)
         {
-            const auto* pxActor = static_cast<const physx::PxActor*>(simulatedBody->GetNativePointer());
-            PHYSX_SCENE_READ_LOCK(pxActor->getScene());
-            return PxMathConvert(pxActor->getWorldBounds(1.0f));
+            return simulatedBody->GetAabb();
         }
         return AZ::Aabb::CreateNull();
     }

--- a/Gems/PhysX/Code/Tests/EditorTestUtilities.cpp
+++ b/Gems/PhysX/Code/Tests/EditorTestUtilities.cpp
@@ -30,6 +30,16 @@
 
 namespace PhysXEditorTests
 {
+    // This function reactivates the entity to cause the simulated body to be recreated.
+    // This is necessary when modifying properties that affect a dynamic rigid body,
+    // because it will delay applying the changes until the next simulation tick,
+    // which happens automatically in the editor but not in test environment.
+    static void ForceSimulatedBodyRecreation(AZ::Entity& entity)
+    {
+        entity.Deactivate();
+        entity.Activate();
+    }
+
     EntityPtr CreateInactiveEditorEntity(const char* entityName)
     {
         AZ::Entity* entity = nullptr;
@@ -85,13 +95,9 @@ namespace PhysXEditorTests
             AZ::NonUniformScaleRequestBus::Event(editorEntity->GetId(), &AZ::NonUniformScaleRequests::SetScale, *nonUniformScale);
         }
 
-        // If using a dynamic rigid body then reactivate the entity to recreate the editor world body.
-        // This is because the dynamic rigid body only applies the changes in the next simulation tick,
-        // which happens automatically in the editor but not in test environment.
         if (rigidBodyType == RigidBodyType::Dynamic)
         {
-            editorEntity->Deactivate();
-            editorEntity->Activate();
+            ForceSimulatedBodyRecreation(*editorEntity);
         }
 
         return editorEntity;
@@ -136,13 +142,9 @@ namespace PhysXEditorTests
             AZ::NonUniformScaleRequestBus::Event(editorEntity->GetId(), &AZ::NonUniformScaleRequests::SetScale, *nonUniformScale);
         }
 
-        // If using a dynamic rigid body then reactivate the entity to recreate the editor world body.
-        // This is because the dynamic rigid body only applies the changes in the next simulation tick,
-        // which happens automatically in the editor but not in test environment.
         if (rigidBodyType == RigidBodyType::Dynamic)
         {
-            editorEntity->Deactivate();
-            editorEntity->Activate();
+            ForceSimulatedBodyRecreation(*editorEntity);
         }
 
         return editorEntity;
@@ -183,13 +185,9 @@ namespace PhysXEditorTests
             AZ::NonUniformScaleRequestBus::Event(editorEntity->GetId(), &AZ::NonUniformScaleRequests::SetScale, *nonUniformScale);
         }
 
-        // If using a dynamic rigid body then reactivate the entity to recreate the editor world body.
-        // This is because the dynamic rigid body only applies the changes in the next simulation tick,
-        // which happens automatically in the editor but not in test environment.
         if (rigidBodyType == RigidBodyType::Dynamic)
         {
-            editorEntity->Deactivate();
-            editorEntity->Activate();
+            ForceSimulatedBodyRecreation(*editorEntity);
         }
 
         return editorEntity;
@@ -237,13 +235,9 @@ namespace PhysXEditorTests
             AZ::NonUniformScaleRequestBus::Event(editorEntity->GetId(), &AZ::NonUniformScaleRequests::SetScale, *nonUniformScale);
         }
 
-        // If using a dynamic rigid body then reactivate the entity to recreate the editor world body.
-        // This is because the dynamic rigid body only applies the changes in the next simulation tick,
-        // which happens automatically in the editor but not in test environment.
         if (rigidBodyType == RigidBodyType::Dynamic)
         {
-            editorEntity->Deactivate();
-            editorEntity->Activate();
+            ForceSimulatedBodyRecreation(*editorEntity);
         }
 
         return editorEntity;
@@ -292,13 +286,9 @@ namespace PhysXEditorTests
             AZ::NonUniformScaleRequestBus::Event(editorEntity->GetId(), &AZ::NonUniformScaleRequests::SetScale, *nonUniformScale);
         }
 
-        // If using a dynamic rigid body then reactivate the entity to recreate the editor world body.
-        // This is because the dynamic rigid body only applies the changes in the next simulation tick,
-        // which happens automatically in the editor but not in test environment.
         if (rigidBodyType == RigidBodyType::Dynamic)
         {
-            editorEntity->Deactivate();
-            editorEntity->Activate();
+            ForceSimulatedBodyRecreation(*editorEntity);
         }
 
         return editorEntity;
@@ -345,13 +335,9 @@ namespace PhysXEditorTests
             AZ::NonUniformScaleRequestBus::Event(editorEntity->GetId(), &AZ::NonUniformScaleRequests::SetScale, *nonUniformScale);
         }
 
-        // If using a dynamic rigid body then reactivate the entity to recreate the editor world body.
-        // This is because the dynamic rigid body only applies the changes in the next simulation tick,
-        // which happens automatically in the editor but not in test environment.
         if (rigidBodyType == RigidBodyType::Dynamic)
         {
-            editorEntity->Deactivate();
-            editorEntity->Activate();
+            ForceSimulatedBodyRecreation(*editorEntity);
         }
 
         return editorEntity;
@@ -399,13 +385,9 @@ namespace PhysXEditorTests
             AZ::NonUniformScaleRequestBus::Event(editorEntity->GetId(), &AZ::NonUniformScaleRequests::SetScale, *nonUniformScale);
         }
 
-        // If using a dynamic rigid body then reactivate the entity to recreate the editor world body.
-        // This is because the dynamic rigid body only applies the changes in the next simulation tick,
-        // which happens automatically in the editor but not in test environment.
         if (rigidBodyType == RigidBodyType::Dynamic)
         {
-            editorEntity->Deactivate();
-            editorEntity->Activate();
+            ForceSimulatedBodyRecreation(*editorEntity);
         }
 
         return editorEntity;
@@ -454,13 +436,9 @@ namespace PhysXEditorTests
             AZ::NonUniformScaleRequestBus::Event(editorEntity->GetId(), &AZ::NonUniformScaleRequests::SetScale, *nonUniformScale);
         }
 
-        // If using a dynamic rigid body then reactivate the entity to recreate the editor world body.
-        // This is because the dynamic rigid body only applies the changes in the next simulation tick,
-        // which happens automatically in the editor but not in test environment.
         if (rigidBodyType == RigidBodyType::Dynamic)
         {
-            editorEntity->Deactivate();
-            editorEntity->Activate();
+            ForceSimulatedBodyRecreation(*editorEntity);
         }
 
         return editorEntity;


### PR DESCRIPTION
## What does this PR do?

Fixed asset scale when Mesh Collider has primitive shapes. (https://github.com/o3de/o3de/issues/14907)
Subdivision level property now shows when there are primitive shapes.

The tests were checking only the runtime components created from the editor component (which is good to test), but it was missing to check the editor component itself. Refactored the tests to check results in both editor and runtime components.

Fixed bug when creating an `EditorMeshColliderComponent` via its constructor passing physics asset configuration, it was missing to set the proxy's `m_pxAsset` variable from the configuration, which caused the editor on activation to assume there was no asset.

## How was this PR tested?

Run PhysX gem unit tests and passed.
Checked the Asset Scale property inside Mesh Collider Component works properly with all types of shapes (primitive, convex and triangle mesh), also tested with and without a non-uniform scale component.
