### PR TITLE
remove feature flag for shape component translation offset

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Tests/EditorAreaLightComponentTests.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Tests/EditorAreaLightComponentTests.cpp
@@ -28,20 +28,7 @@
 
 namespace UnitTest
 {
-    class EditorAreaLightComponentFixture
-        : public ::testing::Test
-        , RegistryTestHelper
-    {
-        void SetUp() override
-        {
-            RegistryTestHelper::SetUp(LmbrCentral::ShapeComponentTranslationOffsetEnabled, true);
-        }
-
-        void TearDown() override
-        {
-            RegistryTestHelper::TearDown();
-        }
-    };
+    using EditorAreaLightComponentFixture = ::testing::Test;
 
     AZ::Render::AreaLightComponentConfig CreateAreaLightComponentConfig(
         const AZ::Render::AreaLightComponentConfig::LightType lightType,

--- a/Gems/LmbrCentral/Code/Source/LmbrCentralEditor.cpp
+++ b/Gems/LmbrCentral/Code/Source/LmbrCentralEditor.cpp
@@ -119,30 +119,21 @@ namespace LmbrCentral
     {
         EditorSplineComponentMode::RegisterActions();
         EditorTubeShapeComponentMode::RegisterActions();
-        if (IsShapeComponentTranslationEnabled())
-        {
-            AzToolsFramework::BoxComponentMode::RegisterActions();
-        }
+        AzToolsFramework::BoxComponentMode::RegisterActions();
     }
 
     void LmbrCentralEditorModule::OnActionContextModeBindingHook()
     {
         EditorSplineComponentMode::BindActionsToModes();
         EditorTubeShapeComponentMode::BindActionsToModes();
-        if (IsShapeComponentTranslationEnabled())
-        {
-            AzToolsFramework::BoxComponentMode::BindActionsToModes();
-        }
+        AzToolsFramework::BoxComponentMode::BindActionsToModes();
     }
 
     void LmbrCentralEditorModule::OnMenuBindingHook()
     {
         EditorSplineComponentMode::BindActionsToMenus();
         EditorTubeShapeComponentMode::BindActionsToMenus();
-        if (IsShapeComponentTranslationEnabled())
-        {
-            AzToolsFramework::BoxComponentMode::BindActionsToMenus();
-        }
+        AzToolsFramework::BoxComponentMode::BindActionsToMenus();
     }
 
     void LmbrCentralEditorModule::OnPostActionManagerRegistrationHook()

--- a/Gems/LmbrCentral/Code/Source/Shape/BoxShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/BoxShape.cpp
@@ -286,11 +286,6 @@ namespace LmbrCentral
 
     void BoxShape::SetTranslationOffset(const AZ::Vector3& translationOffset)
     {
-        if (!IsShapeComponentTranslationEnabled())
-        {
-            return;
-        }
-
         bool shapeChanged = false;
         {
             AZStd::unique_lock lock(m_mutex);

--- a/Gems/LmbrCentral/Code/Source/Shape/BoxShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/BoxShapeComponent.cpp
@@ -128,8 +128,7 @@ namespace LmbrCentral
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &BoxShapeConfig::m_translationOffset, "Translation Offset", "Translation offset of shape relative to its entity")
                     ->Attribute(AZ::Edit::Attributes::Suffix, " m")
-                    ->Attribute(AZ::Edit::Attributes::Step, 0.05f)
-                    ->Attribute(AZ::Edit::Attributes::Visibility, &IsShapeComponentTranslationEnabled);
+                    ->Attribute(AZ::Edit::Attributes::Step, 0.05f);
             }
         }
 

--- a/Gems/LmbrCentral/Code/Source/Shape/CapsuleShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/CapsuleShape.cpp
@@ -222,11 +222,6 @@ namespace LmbrCentral
 
     void CapsuleShape::SetTranslationOffset(const AZ::Vector3& translationOffset)
     {
-        if (!IsShapeComponentTranslationEnabled())
-        {
-            return;
-        }
-
         bool shapeChanged = false;
         {
             AZStd::unique_lock lock(m_mutex);

--- a/Gems/LmbrCentral/Code/Source/Shape/CapsuleShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/CapsuleShapeComponent.cpp
@@ -154,8 +154,7 @@ namespace LmbrCentral
                         "Translation Offset",
                         "Translation offset of shape relative to its entity")
                     ->Attribute(AZ::Edit::Attributes::Suffix, " m")
-                    ->Attribute(AZ::Edit::Attributes::Step, 0.05f)
-                    ->Attribute(AZ::Edit::Attributes::Visibility, &IsShapeComponentTranslationEnabled);
+                    ->Attribute(AZ::Edit::Attributes::Step, 0.05f);
             }
         }
 

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorAxisAlignedBoxShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorAxisAlignedBoxShapeComponent.cpp
@@ -69,7 +69,7 @@ namespace LmbrCentral
             AZ::EntityComponentIdPair(GetEntityId(), GetId()));
 
         // ComponentMode
-        const bool allowAsymmetricalEditing = IsShapeComponentTranslationEnabled();
+        const bool allowAsymmetricalEditing = true;
         m_componentModeDelegate.ConnectWithSingleComponentMode<
             EditorAxisAlignedBoxShapeComponent, EditorAxisAlignedBoxShapeComponentMode>(
                 AZ::EntityComponentIdPair(GetEntityId(), GetId()), this, allowAsymmetricalEditing);

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorBoxShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorBoxShapeComponent.cpp
@@ -75,7 +75,7 @@ namespace LmbrCentral
         AzToolsFramework::ShapeManipulatorRequestBus::Handler::BusConnect(entityComponentIdPair);
 
         // ComponentMode
-        const bool allowAsymmetricalEditing = IsShapeComponentTranslationEnabled();
+        const bool allowAsymmetricalEditing = true;
         m_componentModeDelegate.ConnectWithSingleComponentMode<EditorBoxShapeComponent, AzToolsFramework::BoxComponentMode>(
             entityComponentIdPair, this, allowAsymmetricalEditing);
     }

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorCapsuleShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorCapsuleShapeComponent.cpp
@@ -82,7 +82,7 @@ namespace LmbrCentral
 
         GenerateVertices();
 
-        const bool allowAsymmetricalEditing = IsShapeComponentTranslationEnabled();
+        const bool allowAsymmetricalEditing = true;
         m_componentModeDelegate.ConnectWithSingleComponentMode<EditorCapsuleShapeComponent, AzToolsFramework::CapsuleComponentMode>(
             entityComponentIdPair, this, allowAsymmetricalEditing);
     }

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorSphereShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorSphereShapeComponent.cpp
@@ -92,7 +92,7 @@ namespace LmbrCentral
         AzToolsFramework::RadiusManipulatorRequestBus::Handler::BusConnect(entityComponentIdPair);
         AzToolsFramework::ShapeManipulatorRequestBus::Handler::BusConnect(entityComponentIdPair);
 
-        const bool allowAsymmetricalEditing = IsShapeComponentTranslationEnabled();
+        const bool allowAsymmetricalEditing = true;
         m_componentModeDelegate.ConnectWithSingleComponentMode<EditorSphereShapeComponent, AzToolsFramework::SphereComponentMode>(
             entityComponentIdPair, this, allowAsymmetricalEditing);
     }

--- a/Gems/LmbrCentral/Code/Source/Shape/SphereShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/SphereShape.cpp
@@ -147,11 +147,6 @@ namespace LmbrCentral
 
     void SphereShape::SetTranslationOffset(const AZ::Vector3& translationOffset)
     {
-        if (!IsShapeComponentTranslationEnabled())
-        {
-            return;
-        }
-
         bool shapeChanged = false;
         {
             AZStd::unique_lock lock(m_mutex);

--- a/Gems/LmbrCentral/Code/Source/Shape/SphereShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/SphereShapeComponent.cpp
@@ -127,8 +127,7 @@ namespace LmbrCentral
                         "Translation Offset",
                         "Translation offset of shape relative to its entity")
                     ->Attribute(AZ::Edit::Attributes::Suffix, " m")
-                    ->Attribute(AZ::Edit::Attributes::Step, 0.05f)
-                    ->Attribute(AZ::Edit::Attributes::Visibility, &IsShapeComponentTranslationEnabled);
+                    ->Attribute(AZ::Edit::Attributes::Step, 0.05f);
             }
         }
 

--- a/Gems/LmbrCentral/Code/Tests/AxisAlignedBoxShapeTest.cpp
+++ b/Gems/LmbrCentral/Code/Tests/AxisAlignedBoxShapeTest.cpp
@@ -23,7 +23,6 @@ namespace UnitTest
 {
     class AxisAlignedBoxShapeTest
         : public LeakDetectionFixture
-        , public RegistryTestHelper
     {
         AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;
         AZStd::unique_ptr<AZ::ComponentDescriptor> m_transformComponentDescriptor;
@@ -34,7 +33,6 @@ namespace UnitTest
         void SetUp() override
         {
             LeakDetectionFixture::SetUp();
-            RegistryTestHelper::SetUp(LmbrCentral::ShapeComponentTranslationOffsetEnabled, true);
             m_serializeContext = AZStd::make_unique<AZ::SerializeContext>();
 
             m_transformComponentDescriptor =
@@ -54,7 +52,6 @@ namespace UnitTest
             m_axisAlignedBoxShapeComponentDescriptor.reset();
             m_axisAlignedBoxShapeDebugDisplayComponentDescriptor.reset();
             m_serializeContext.reset();
-            RegistryTestHelper::TearDown();
             LeakDetectionFixture::TearDown();
         }
     };

--- a/Gems/LmbrCentral/Code/Tests/BoxShapeTest.cpp
+++ b/Gems/LmbrCentral/Code/Tests/BoxShapeTest.cpp
@@ -24,7 +24,6 @@ namespace UnitTest
 {
     class BoxShapeTest
         : public LeakDetectionFixture
-        , public RegistryTestHelper
     {
         AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;
         AZStd::unique_ptr<AZ::ComponentDescriptor> m_transformComponentDescriptor;
@@ -36,7 +35,6 @@ namespace UnitTest
         void SetUp() override
         {
             LeakDetectionFixture::SetUp();
-            RegistryTestHelper::SetUp(LmbrCentral::ShapeComponentTranslationOffsetEnabled, true);
             m_serializeContext = AZStd::make_unique<AZ::SerializeContext>();
 
             m_transformComponentDescriptor = AZStd::unique_ptr<AZ::ComponentDescriptor>(AzFramework::TransformComponent::CreateDescriptor());
@@ -58,7 +56,6 @@ namespace UnitTest
             m_boxShapeDebugDisplayComponentDescriptor.reset();
             m_nonUniformScaleComponentDescriptor.reset();
             m_serializeContext.reset();
-            RegistryTestHelper::TearDown();
             LeakDetectionFixture::TearDown();
         }
     };
@@ -724,11 +721,6 @@ namespace UnitTest
         // time to a minimum.
         const int numIterations = 30000;
         ShapeThreadsafeTest::TestShapeGetSetCallsAreThreadsafe(entity, numIterations, setDimensionFn);
-    }
-
-    TEST_F(BoxShapeTest, TranslationOffsetEnabled)
-    {
-        EXPECT_TRUE(LmbrCentral::IsShapeComponentTranslationEnabled());
     }
 
     TEST_F(BoxShapeTest, UniformRealDistributionRandomPointsAreInAABBWithTranslationOffset)

--- a/Gems/LmbrCentral/Code/Tests/CapsuleShapeTest.cpp
+++ b/Gems/LmbrCentral/Code/Tests/CapsuleShapeTest.cpp
@@ -23,7 +23,6 @@ namespace UnitTest
 {
     class CapsuleShapeTest
         : public LeakDetectionFixture
-        , public RegistryTestHelper
     {
         AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;
         AZStd::unique_ptr<AZ::ComponentDescriptor> m_transformComponentDescriptor;
@@ -35,7 +34,6 @@ namespace UnitTest
         void SetUp() override
         {
             LeakDetectionFixture::SetUp();
-            RegistryTestHelper::SetUp(LmbrCentral::ShapeComponentTranslationOffsetEnabled, true);
             m_serializeContext = AZStd::make_unique<AZ::SerializeContext>();
 
             m_transformComponentDescriptor = AZStd::unique_ptr<AZ::ComponentDescriptor>(AzFramework::TransformComponent::CreateDescriptor());
@@ -55,7 +53,6 @@ namespace UnitTest
             m_capsuleShapeComponentDescriptor.reset();
             m_transformComponentDescriptor.reset();
             m_serializeContext.reset();
-            RegistryTestHelper::TearDown();
             LeakDetectionFixture::TearDown();
         }
     };

--- a/Gems/LmbrCentral/Code/Tests/EditorAxisAlignedBoxShapeComponentTests.cpp
+++ b/Gems/LmbrCentral/Code/Tests/EditorAxisAlignedBoxShapeComponentTests.cpp
@@ -16,7 +16,6 @@ namespace LmbrCentral
 {
     class EditorAxisAlignedBoxShapeComponentFixture
         : public UnitTest::ToolsApplicationFixture<>
-        , public UnitTest::RegistryTestHelper
     {
     public:
         void SetUpEditorFixtureImpl() override;
@@ -32,8 +31,6 @@ namespace LmbrCentral
 
     void EditorAxisAlignedBoxShapeComponentFixture::SetUpEditorFixtureImpl()
     {
-        RegistryTestHelper::SetUp(LmbrCentral::ShapeComponentTranslationOffsetEnabled, true);
-
         AZ::SerializeContext* serializeContext = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
@@ -65,8 +62,6 @@ namespace LmbrCentral
 
         m_editorAxisAlignedBoxShapeComponentDescriptor.reset();
         m_editorSphereShapeComponentDescriptor.reset();
-
-        RegistryTestHelper::TearDown();
     }
 
     using EditorAxisAlignedBoxShapeComponentManipulatorFixture =

--- a/Gems/LmbrCentral/Code/Tests/EditorBoxShapeComponentTests.cpp
+++ b/Gems/LmbrCentral/Code/Tests/EditorBoxShapeComponentTests.cpp
@@ -67,7 +67,6 @@ namespace LmbrCentral
 
     class EditorBoxShapeComponentFixture
         : public UnitTest::ToolsApplicationFixture<>
-        , public UnitTest::RegistryTestHelper
     {
     public:
         void SetUpEditorFixtureImpl() override;
@@ -83,8 +82,6 @@ namespace LmbrCentral
 
     void EditorBoxShapeComponentFixture::SetUpEditorFixtureImpl()
     {
-        RegistryTestHelper::SetUp(LmbrCentral::ShapeComponentTranslationOffsetEnabled, true);
-
         AZ::SerializeContext* serializeContext = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
@@ -117,8 +114,6 @@ namespace LmbrCentral
 
         m_editorBoxShapeComponentDescriptor.reset();
         m_editorSphereShapeComponentDescriptor.reset();
-
-        RegistryTestHelper::TearDown();
     }
 
     using EditorBoxShapeComponentManipulatorFixture =

--- a/Gems/LmbrCentral/Code/Tests/EditorCapsuleShapeComponentTests.cpp
+++ b/Gems/LmbrCentral/Code/Tests/EditorCapsuleShapeComponentTests.cpp
@@ -73,7 +73,6 @@ namespace LmbrCentral
 
     class EditorCapsuleShapeComponentFixture
         : public UnitTest::ToolsApplicationFixture<>
-        , public UnitTest::RegistryTestHelper
     {
     public:
         void SetUpEditorFixtureImpl() override;
@@ -89,8 +88,6 @@ namespace LmbrCentral
 
     void EditorCapsuleShapeComponentFixture::SetUpEditorFixtureImpl()
     {
-        RegistryTestHelper::SetUp(LmbrCentral::ShapeComponentTranslationOffsetEnabled, true);
-
         AZ::SerializeContext* serializeContext = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
@@ -122,8 +119,6 @@ namespace LmbrCentral
 
         m_editorCapsuleShapeComponentDescriptor.reset();
         m_editorSphereShapeComponentDescriptor.reset();
-
-        RegistryTestHelper::TearDown();
     }
 
     using EditorCapsuleShapeComponentManipulatorFixture =

--- a/Gems/LmbrCentral/Code/Tests/EditorSphereShapeComponentTests.cpp
+++ b/Gems/LmbrCentral/Code/Tests/EditorSphereShapeComponentTests.cpp
@@ -61,7 +61,6 @@ namespace LmbrCentral
 
     class EditorSphereShapeComponentFixture
         : public UnitTest::ToolsApplicationFixture<>
-        , public UnitTest::RegistryTestHelper
     {
     public:
         void SetUpEditorFixtureImpl() override;
@@ -77,8 +76,6 @@ namespace LmbrCentral
 
     void EditorSphereShapeComponentFixture::SetUpEditorFixtureImpl()
     {
-        RegistryTestHelper::SetUp(LmbrCentral::ShapeComponentTranslationOffsetEnabled, true);
-
         AZ::SerializeContext* serializeContext = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
@@ -104,8 +101,6 @@ namespace LmbrCentral
         m_entityId.SetInvalid();
 
         m_editorSphereShapeComponentDescriptor.reset();
-
-        RegistryTestHelper::TearDown();
     }
 
     using EditorSphereShapeComponentManipulatorFixture =

--- a/Gems/LmbrCentral/Code/Tests/SphereShapeTest.cpp
+++ b/Gems/LmbrCentral/Code/Tests/SphereShapeTest.cpp
@@ -25,7 +25,6 @@ namespace UnitTest
 {
     class SphereShapeTest
         : public LeakDetectionFixture
-        , public RegistryTestHelper
     {
         AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;
         AZStd::unique_ptr<AZ::ComponentDescriptor> m_transformShapeComponentDescriptor;
@@ -35,7 +34,6 @@ namespace UnitTest
         void SetUp() override
         {
             LeakDetectionFixture::SetUp();
-            RegistryTestHelper::SetUp(LmbrCentral::ShapeComponentTranslationOffsetEnabled, true);
             m_serializeContext = AZStd::make_unique<AZ::SerializeContext>();
             m_transformShapeComponentDescriptor.reset(AzFramework::TransformComponent::CreateDescriptor());
             m_transformShapeComponentDescriptor->Reflect(&(*m_serializeContext));
@@ -51,7 +49,6 @@ namespace UnitTest
             m_sphereShapeComponentDescriptor.reset();
             m_sphereShapeDebugDisplayComponentDescriptor.reset();
             m_serializeContext.reset();
-            RegistryTestHelper::TearDown();
             LeakDetectionFixture::TearDown();
         }
     };

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/ShapeComponentBus.h
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/ShapeComponentBus.h
@@ -31,23 +31,6 @@ namespace LmbrCentral
         ShapeChange ///< The cache is invalid because the shape configuration/properties changed.
     };
 
-    /// Feature flag for work in progress on shape component translation offsets (see https://github.com/o3de/sig-simulation/issues/26).
-    constexpr AZStd::string_view ShapeComponentTranslationOffsetEnabled = "/Amazon/Preferences/EnableShapeComponentTranslationOffset";
-
-    /// Helper function for checking whether feature flag for in progress shape component translation offsets is enabled.
-    /// See https://github.com/o3de/sig-simulation/issues/26 for more details.
-    inline bool IsShapeComponentTranslationEnabled()
-    {
-        bool isShapeComponentTranslationEnabled = true;
-
-        if (auto* registry = AZ::SettingsRegistry::Get())
-        {
-            registry->Get(isShapeComponentTranslationEnabled, ShapeComponentTranslationOffsetEnabled);
-        }
-
-        return isShapeComponentTranslationEnabled;
-    }
-
     /// Wrapper for cache of data used for intersection tests
     template <typename ShapeConfiguration>
     class IntersectionTestDataCache
@@ -194,14 +177,14 @@ namespace LmbrCentral
         /// Get the translation offset for the shape relative to its entity.
         virtual AZ::Vector3 GetTranslationOffset() const
         {
-            AZ_WarningOnce("ShapeComponentRequests", !IsShapeComponentTranslationEnabled(), "GetTranslationOffset not implemented");
+            AZ_WarningOnce("ShapeComponentRequests", false, "GetTranslationOffset not implemented");
             return AZ::Vector3::CreateZero();
         }
 
         /// Set the translation offset for the shape relative to its entity.
         virtual void SetTranslationOffset([[maybe_unused]] const AZ::Vector3& translationOffset)
         {
-            AZ_WarningOnce("ShapeComponentRequests", !IsShapeComponentTranslationEnabled(), "SetTranslationOffset not implemented");
+            AZ_WarningOnce("ShapeComponentRequests", false, "SetTranslationOffset not implemented");
         }
 
         virtual ~ShapeComponentRequests() = default;

--- a/Gems/PhysX/Code/Tests/EditorTestUtilities.cpp
+++ b/Gems/PhysX/Code/Tests/EditorTestUtilities.cpp
@@ -425,8 +425,6 @@ namespace PhysXEditorTests
 
     void PhysXEditorFixture::SetUp()
     {
-        UnitTest::RegistryTestHelper::SetUp(LmbrCentral::ShapeComponentTranslationOffsetEnabled, true);
-
         if (auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get())
         {
             //in case a test modifies the default world config setup a config without getting the default(eg. SetWorldConfiguration_ForwardsConfigChangesToWorldRequestBus)
@@ -452,8 +450,6 @@ namespace PhysXEditorTests
         {
             physicsSystem->RemoveScene(m_defaultSceneHandle);
         }
-
-        UnitTest::RegistryTestHelper::TearDown();
     }
 
     void PhysXEditorFixture::ConnectToPVD()

--- a/Gems/PhysX/Code/Tests/EditorTestUtilities.h
+++ b/Gems/PhysX/Code/Tests/EditorTestUtilities.h
@@ -146,7 +146,6 @@ namespace PhysXEditorTests
     class PhysXEditorFixture
         : public testing::Test
         , public Physics::DefaultWorldBus::Handler
-        , public UnitTest::RegistryTestHelper
     {
     public:
         void SetUp() override;


### PR DESCRIPTION
## What does this PR do?
Removes the feature flag for the shape translation offset feature. The flag was set to on by default on 21st February, and no new issues have surfaced since then, so now the flag is being removed altogether.

## How was this PR tested?
Built editor, ran relevant unit tests.