### PR TITLE
Prevent an infinite loop when a parent entity is invalid

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ContainerEntity/ContainerEntitySystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ContainerEntity/ContainerEntitySystemComponent.cpp
@@ -150,7 +150,13 @@ namespace AzToolsFramework
                     }
                 }
 
-                AZ::TransformBus::EventResult(entityId, entityId, &AZ::TransformBus::Events::GetParentId);
+                AZ::EntityId parentId; // start with an invalid id, in case the parent is invalid.
+                AZ::TransformBus::EventResult(parentId, entityId, &AZ::TransformBus::Events::GetParentId);
+                if (entityId == parentId)
+                {
+                    break; // avoid situation where a GetParentId returns the same id leading to an infinite loop
+                }
+                entityId = parentId;
             }
 
             return highestUnselectedAncestorContainer;
@@ -172,7 +178,13 @@ namespace AzToolsFramework
                 highestSelectableEntityId = entityId;
             }
 
-            AZ::TransformBus::EventResult(entityId, entityId, &AZ::TransformBus::Events::GetParentId);
+            AZ::EntityId parentId; // start with an invalid id, in case the parent is invalid.
+            AZ::TransformBus::EventResult(parentId, entityId, &AZ::TransformBus::Events::GetParentId);
+            if (entityId == parentId)
+            {
+                break; // avoid an infinite loop in the case where the same entity is returned.
+            }
+            entityId = parentId;
         }
 
         return highestSelectableEntityId;


### PR DESCRIPTION
## What does this PR do?

Prevents an infinite loop in the case where a parent entity is invalid.

This can cause the editor to freeze up even if the situation is just temporary and will be 'fixed up' the moment the current undo is complete.

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_
The old behavior was that if you were messing with entity hierarchy and deleting parent entities, or loading old data or dealing with prefabs with overrides that applied to missing entities, then there could be a case where the parent entity is _temporarily_ invalid.

In that case, if this code triggered, what would occur is it would 
* set the entityId up to be the parent entity Id
* while loop until the entityId was valid
   * set the entityId to the parent entity Id using the ebus event method

The problem is that **in general**, if nobody is listening on the bus, this code:
```
someType value = (some valid value);
while (value is valid)
{
   bus::EventResult(value, value, somefunction);
}
```
actually means this (if you look at the impl of Ebus EventResult:
```
someType  value = (some valid value);
while (value is valid)
{
   for (auto& listener : this->m_connectedListeners) // inside ebus impl
   {
       value = listener->somefunction();
   }
}
```

and basically means, if there is no listener connected at that address, the assignment will never occur, since the for loop won't enter its loop body, and value will remain what it was before the bus call was made.

By changing it to use a temporary invalid:

```
someType value = (some valid value);
while (value is valid)
{
   someType newValue = (invalid value);
   bus::EventResult(newValue, value, somefunction);
   value = newValue;
}
```
it ensures that if nobody was listening on the bus, value will become invalid and the loop would be broken.

## How was this PR tested?

Manual testing.  Just messing about in the editor made it pretty easy to repro this - creating and deleting parent entities, moving entities around in the heirarchy inside a prefab with prefab mode off was enough to eventually cause it.  I did it by accident many times while messing with a vehicle sim. 

Each time the editor would freeze and infinite loop here.

After this change, no more infinite loops.  The editor seems to resolve whatever causes this to temporarily happen, too, once it gets past the place it would have looped.