### PR TITLE
Change graph canvas presets dialog selection behavior to entire row and update naming

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphView.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphView.cpp
@@ -275,7 +275,7 @@ namespace AtomToolsFramework
         }, {});
 
         makeSeperator("menuView");
-        m_actionPresetEditor = makeAction("menuView", tr("Preset Editor"), [this](){ OpenPresetsEditor(); }, {});
+        m_actionPresetEditor = makeAction("menuView", tr("Presets Editor"), [this](){ OpenPresetsEditor(); }, {});
 
         makeSeperator("menuView");
         m_actionShowEntireGraph = makeAction("menuView", tr("Show Entire Graph"), [this](){

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/ConstructPresetDialog/ConstructPresetDialog.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/ConstructPresetDialog/ConstructPresetDialog.cpp
@@ -20,7 +20,7 @@ namespace GraphCanvas
         : QAbstractTableModel(parent)
         , m_constructType(ConstructType::Unknown)
         , m_presetsContainer(nullptr)
-    {        
+    {
     }
 
     ConstructPresetsTableModel::~ConstructPresetsTableModel()
@@ -199,10 +199,9 @@ namespace GraphCanvas
         return modifiedData;
     }
 
-    Qt::ItemFlags ConstructPresetsTableModel::flags(const QModelIndex &index) const
+    Qt::ItemFlags ConstructPresetsTableModel::flags(const QModelIndex& index) const
     {
-        Qt::ItemFlags itemFlags = Qt::ItemFlags(Qt::ItemIsEnabled |
-                                                Qt::ItemIsSelectable);
+        Qt::ItemFlags itemFlags = Qt::ItemFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
 
         if (index.column() == ColumnIndex::Name)
         {
@@ -357,6 +356,7 @@ namespace GraphCanvas
         m_ui->constructListing->horizontalHeader()->setSectionResizeMode(ConstructPresetsTableModel::ColumnIndex::Name, QHeaderView::ResizeMode::Stretch);
         m_ui->constructListing->horizontalHeader()->setSectionResizeMode(ConstructPresetsTableModel::ColumnIndex::DefaultPreset, QHeaderView::ResizeMode::Fixed);
         m_ui->constructListing->setItemDelegateForColumn(ConstructPresetsTableModel::ColumnIndex::Name, aznew GraphCanvas::IconDecoratedNameDelegate(m_ui->constructListing));
+        m_ui->constructListing->setSelectionBehavior(QAbstractItemView::SelectionBehavior::SelectRows);
 
         m_ui->removePreset->setEnabled(false);
 
@@ -456,16 +456,10 @@ namespace GraphCanvas
 
     void ConstructPresetDialog::RemoveSelected()
     {
-        auto selectedIndexes = m_ui->constructListing->selectionModel()->selectedIndexes();
-
         AZStd::vector<int> rows;
-
-        for (auto selectedIndex : selectedIndexes)
+        for (const auto& index : m_ui->constructListing->selectionModel()->selectedRows())
         {
-            if (selectedIndex.column() == ConstructPresetsTableModel::ColumnIndex::Name)
-            {
-                rows.push_back(selectedIndex.row());
-            }
+            rows.push_back(index.row());
         }
 
         m_ui->constructListing->clearSelection();


### PR DESCRIPTION
## What does this PR do?

Changes the selection behavior of the graph canvas preset editor table view so that clicking any cell in the table selects the entire row instead of an individual cell. This way, if a user selects the name column or the enable column, they will still be able to remove the entire row.

Also performed research and replace to update references to the dialogue that use consistent naming.

Resolves https://github.com/o3de/o3de/issues/15006 
Resolves https://github.com/o3de/o3de/issues/15004

## How was this PR tested?

Confirmed that selecting any cell in the table selected the entire row.
Confirm that clicking the column with the checkbox still allowed the entire road to be deleted.
Confirmed that the material canvas menu entry displayed the same name as other references.