### PR TITLE
[AWSCore Resource Mapping] Fix broken links, test level and tether to editor lifetime

### DIFF
--- a/AutomatedTesting/Levels/AWS/Core/Core.prefab
+++ b/AutomatedTesting/Levels/AWS/Core/Core.prefab
@@ -38,9 +38,10 @@
                 "$type": "EditorEntityIconComponent",
                 "Id": 5688118765544765547
             },
-            "Component_[6545738857812235305]": {
-                "$type": "SelectionComponent",
-                "Id": 6545738857812235305
+            "Component_[6193509537440135612]": {
+                "$type": "LocalViewBookmarkComponent",
+                "Id": 6193509537440135612,
+                "LocalBookmarkFileName": "Core_16782990514934211.setreg"
             },
             "Component_[7247035804068349658]": {
                 "$type": "EditorPrefabComponent",
@@ -61,10 +62,6 @@
             "Id": "Entity_[1155164325235]",
             "Name": "Sun",
             "Components": {
-                "Component_[10440557478882592717]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10440557478882592717
-                },
                 "Component_[13620450453324765907]": {
                     "$type": "EditorLockComponent",
                     "Id": 13620450453324765907
@@ -131,10 +128,6 @@
             "Id": "Entity_[1159459292531]",
             "Name": "Ground",
             "Components": {
-                "Component_[11701138785793981042]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11701138785793981042
-                },
                 "Component_[12260880513256986252]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 12260880513256986252
@@ -236,10 +229,6 @@
                         ]
                     }
                 },
-                "Component_[18387556550380114975]": {
-                    "$type": "SelectionComponent",
-                    "Id": 18387556550380114975
-                },
                 "Component_[2654521436129313160]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 2654521436129313160
@@ -276,10 +265,6 @@
                 "Component_[11443347433215807130]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 11443347433215807130
-                },
-                "Component_[11779275529534764488]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11779275529534764488
                 },
                 "Component_[14249419413039427459]": {
                     "$type": "EditorInspectorComponent",
@@ -391,10 +376,6 @@
                         }
                     }
                 },
-                "Component_[8056625192494070973]": {
-                    "$type": "SelectionComponent",
-                    "Id": 8056625192494070973
-                },
                 "Component_[8550141614185782969]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 8550141614185782969
@@ -426,10 +407,6 @@
                 "Component_[14988041764659020032]": {
                     "$type": "EditorLockComponent",
                     "Id": 14988041764659020032
-                },
-                "Component_[15808690248755038124]": {
-                    "$type": "SelectionComponent",
-                    "Id": 15808690248755038124
                 },
                 "Component_[15900837685796817138]": {
                     "$type": "EditorVisibilityComponent",
@@ -483,10 +460,6 @@
                             }
                         }
                     }
-                },
-                "Component_[11980494120202836095]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11980494120202836095
                 },
                 "Component_[1428633914413949476]": {
                     "$type": "EditorLockComponent",
@@ -606,10 +579,6 @@
                         ]
                     }
                 },
-                "Component_[3946146016045577093]": {
-                    "$type": "SelectionComponent",
-                    "Id": 3946146016045577093
-                },
                 "Component_[4521094551057628689]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 4521094551057628689
@@ -631,10 +600,6 @@
                 "Component_[14581079376974874313]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 14581079376974874313
-                },
-                "Component_[15354545119837386836]": {
-                    "$type": "SelectionComponent",
-                    "Id": 15354545119837386836
                 },
                 "Component_[15913971829919706180]": {
                     "$type": "EditorEntityIconComponent",
@@ -695,10 +660,6 @@
             "Id": "Entity_[1395130160973]",
             "Name": "lambda",
             "Components": {
-                "Component_[14224781635611846065]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14224781635611846065
-                },
                 "Component_[14532864313352417822]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 14532864313352417822

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -2053,7 +2053,7 @@ void CCryEditApp::OnDocumentationTutorials()
 
 void CCryEditApp::OnDocumentationGlossary()
 {
-    QString webLink = tr("https://docs.o3de.org/docs/user-guide/appendix/glossary/");
+    QString webLink = tr("https://o3de.org/docs/user-guide/appendix/glossary/");
     QDesktopServices::openUrl(QUrl(webLink));
 }
 

--- a/Gems/AWSCore/Code/Source/AWSCoreEditorSystemComponent.cpp
+++ b/Gems/AWSCore/Code/Source/AWSCoreEditorSystemComponent.cpp
@@ -91,6 +91,8 @@ namespace AWSCore
         AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler::BusDisconnect();
 
         AWSCoreEditorRequestBus::Handler::BusDisconnect();
+
+        m_awsCoreEditorMenu.reset();
     }
 
     void AWSCoreEditorSystemComponent::OnMenuBarRegistrationHook()

--- a/Gems/AWSCore/Code/Source/Editor/UI/AWSCoreEditorMenu.cpp
+++ b/Gems/AWSCore/Code/Source/Editor/UI/AWSCoreEditorMenu.cpp
@@ -107,6 +107,7 @@ namespace AWSCore
                 AzFramework::ProcessLauncher::ProcessLaunchInfo processLaunchInfo;
                 processLaunchInfo.m_commandlineParameters = launchCommand;
                 processLaunchInfo.m_showWindow = false;
+                processLaunchInfo.m_tetherLifetime = true;
                 m_resourceMappingToolWatcher = AZStd::unique_ptr<AzFramework::ProcessWatcher>(
                     AzFramework::ProcessWatcher::LaunchProcess(processLaunchInfo, AzFramework::ProcessCommunicationType::COMMUNICATOR_TYPE_NONE));
 

--- a/Gems/AWSCore/Code/Tools/ResourceMappingTool/model/error_messages.py
+++ b/Gems/AWSCore/Code/Tools/ResourceMappingTool/model/error_messages.py
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 ERROR_PAGE_TOOL_SETUP_ERROR_TITLE: str = "AWS credentials are missing or invalid"
 
 ERROR_PAGE_TOOL_SETUP_ERROR_MESSAGE: str = \
-    "Use our <a href=\"https://docs.o3de.org/docs/user-guide/gems/reference/aws/aws-core/configuring-credentials/\">"\
+    "Use our <a href=\"https://o3de.org/docs/user-guide/gems/reference/aws/aws-core/configuring-credentials/\">"\
     "<span style=\"color:#4A90E2;\">documentation</span></a> to setup your AWS credentials. "
 
 VIEW_EDIT_PAGE_SAVING_FAILED_WITH_INVALID_ROW_ERROR_MESSAGE: str = \


### PR DESCRIPTION
## What does this PR do?

* Fixes dead links to docs.o3de.org, should just be o3de.org: https://github.com/o3de/o3de/issues/14923
* Tethers the lifetime of the mapping tool to the editor, if launched by editor to fix:  https://github.com/o3de/o3de/issues/14924
* Cleans up prefab to remove removed SelectionComponent

## How was this PR tested?
* Ran  AWSCore Editor unit tests
* Ran Resource mapping tool unit tests
* Manually confirmed behaviour fix and bad links are fixed.