### PR TITLE
Material Canvas: Use a unique suffix for substitution names if a graph has multiple output nodes

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialGraphCompiler.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialGraphCompiler.h
@@ -126,6 +126,9 @@ namespace MaterialCanvas
             const AZStd::string& templateInputPath,
             const AZStd::string& templateOutputPath) const;
 
+        // Returns the name that will be used to replace material graph name during any substitutions 
+        AZStd::string GetUniqueGraphName() const;
+
         // All slots and nodes will be visited to collect all of the unique include paths.
         AZStd::set<AZStd::string> m_includePaths;
 
@@ -140,6 +143,9 @@ namespace MaterialCanvas
         // Table of values for every slot, on every node, including values redirected from incoming connections, and values upgraded to
         // match types and sizes of values on related slots.
         AZStd::map<GraphModel::ConstSlotPtr, AZStd::any> m_slotValueTable;
+
+        // This counter will be used as a suffix for graph name substitutions in case multiple template nodes are included in the same graph
+        int m_templateNodeCount = 0;
 
         // Container of paths for template files that need to be evaluated and have products generated for the current node.
         AZStd::set<AZStd::string> m_templatePathsForCurrentNode;


### PR DESCRIPTION
## What does this PR do?

Material canvas currently supports multiple output nodes on the same graph. While it’s not typical, this allows generating multiple materials, strategies, or other types of content from the same graph. To keep the generated data of one element node from stopping over the other, a unique suffix will be added onto graph name substitutions for each output node after the first one.

If other issues are encountered, this can be changed to return after the first output is processed and ignore the others.

Resolves https://github.com/o3de/o3de/issues/14903

## How was this PR tested?

Confirmed that having multiple output nodes on the same graph will generate data for both nodes with the new suffix.