### PR TITLE
This fixes sparse vector to be able to handle non-trivial destructors.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/MultiSparseVector.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/MultiSparseVector.h
@@ -23,9 +23,12 @@ namespace AZ::Render
     class MultiSparseVector
     {
     public:
+        static_assert(sizeof(AZStd::tuple_element_t<0, AZStd::tuple<Ts...>>) >= sizeof(size_t),
+            "Data stored in the first element of MultiSparseVector must be at least as large as a size_t.");
 
         MultiSparseVector();
-        
+        ~MultiSparseVector();
+
         //! Reserves elements in the underlying vectors and returns the index to those elements.
         size_t Reserve();
 
@@ -93,11 +96,14 @@ namespace AZ::Render
     template<typename ... Ts>
     MultiSparseVector<Ts...>::MultiSparseVector()
     {
-        static_assert(sizeof(AZStd::tuple_element_t<0, AZStd::tuple<Ts...>>) >= sizeof(size_t),
-            "Data stored in the first element of MultiSparseVector must be at least as large as a size_t.");
-
         // Reserve some initial capacity in the vectors based on InitialReservedCount.
         AZStd::apply(static_cast<Fn>(ReserveCapacityFunction), m_data);
+    }
+
+    template<typename ... Ts>
+    MultiSparseVector<Ts...>::~MultiSparseVector()
+    {
+        Clear();
     }
 
     template<typename ... Ts>
@@ -136,6 +142,59 @@ namespace AZ::Render
     template<typename ... Ts>
     void MultiSparseVector<Ts...>::Clear()
     {
+        // Because the memory in the underlying vector is used to store a linked list of the removed items,
+        // a destructor could be called on bogus memory when the vector is cleared or destroyed. To fix this,
+        // through each free slot and default-construct an object there so it can be safely deleted.
+
+        // First create a tuple which only contains the vectors with non-trivial destructors.
+        auto TuplesToReset = [](auto&... dataVectors)
+        {
+            auto AddVectorToTuple = [](auto& dataVector)
+            {
+                using VectorType = AZStd::remove_cvref_t<decltype(dataVector)>;
+                using ValueType = typename VectorType::value_type;
+                if constexpr (!AZStd::is_trivially_destructible_v<ValueType>)
+                {
+                    return AZStd::tuple<VectorType&>(dataVector);
+                }
+                else
+                {
+                    // Exclude the type if it is trivially destructible from the reset logic
+                    return AZStd::tuple<>{};
+                }
+            };
+            return AZStd::tuple_cat(AddVectorToTuple(dataVectors)...);
+        };
+
+        auto tupleVectorsWithNonTrivialDestructors = AZStd::apply(TuplesToReset, m_data);
+        constexpr bool containsNonTrivialDestructibleVector = AZStd::tuple_size_v<decltype(tupleVectorsWithNonTrivialDestructors)> > 0;
+
+        // If there are any vectors with non-trivial destructors, then go through each one and default-initialize
+        // it so it can be safely deleted when the underlying vector's clear() is called.
+        if constexpr (containsNonTrivialDestructibleVector)
+        {
+            auto ResetAndClear = [this](auto&... vectors)
+            {
+                auto ResetAndClearRow = [](auto&... dataFields)
+                {
+                    auto ResetAndClearEntry = [](auto& dataField)
+                    {
+                        using ValueType = AZStd::remove_cvref_t<decltype(dataField)>;
+                        new (&dataField) ValueType();
+                    };
+                    (ResetAndClearEntry(dataFields), ...);
+                };
+
+                while (m_nextFreeSlot != NoFreeSlot)
+                {
+                    size_t thisSlot = m_nextFreeSlot;
+                    m_nextFreeSlot = reinterpret_cast<size_t&>(AZStd::get<0>(m_data).at(m_nextFreeSlot));
+                    ResetAndClearRow(vectors[thisSlot] ...);
+                }
+            };
+            AZStd::apply(ResetAndClear, tupleVectorsWithNonTrivialDestructors);
+        }
+
         AZStd::apply(static_cast<Fn>(ClearFunction), m_data);
         m_nextFreeSlot = NoFreeSlot;
     }

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/SparseVector.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/SparseVector.h
@@ -26,7 +26,10 @@ namespace AZ::Render
     {
     public:
 
+        static_assert(sizeof(T) >= sizeof(size_t), "Data stored in SparseVector must be at least as large as a size_t.");
+
         SparseVector();
+        ~SparseVector();
 
         //! Reserves an element in the underlying vector and returns the index to that element.
         size_t Reserve();
@@ -59,8 +62,13 @@ namespace AZ::Render
     template<typename T>
     SparseVector<T>::SparseVector()
     {
-        static_assert(sizeof(T) >= sizeof(size_t), "Data stored in SparseVector must be at least as large as a size_t.");
         m_data.reserve(InitialReservedCount);
+    }
+
+    template<typename T>
+    SparseVector<T>::~SparseVector()
+    {
+        Clear();
     }
 
     template<typename T>
@@ -98,6 +106,18 @@ namespace AZ::Render
     template<typename T>
     void SparseVector<T>::Clear()
     {
+        if constexpr (!AZStd::is_trivially_destructible<T>())
+        {
+            // Because the memory in the underlying vector is used to store a linked list of the removed items,
+            // a destructor could be called on bogus memory when the vector is cleared or destroyed. To fix this,
+            // through each free slot and default-construct an object there so it can be safely deleted.
+            while (m_nextFreeSlot != NoFreeSlot)
+            {
+                size_t thisSlot = m_nextFreeSlot;
+                m_nextFreeSlot = reinterpret_cast<size_t&>(m_data.at(m_nextFreeSlot));
+                new (&m_data.at(thisSlot)) T();
+            }
+        }
         m_data.clear();
         m_nextFreeSlot = NoFreeSlot;
     }

--- a/Gems/Atom/Feature/Common/Code/Tests/SparseVectorTests.cpp
+++ b/Gems/Atom/Feature/Common/Code/Tests/SparseVectorTests.cpp
@@ -31,6 +31,18 @@ namespace UnitTest
         bool c = DefaultValueC;
     };
 
+    struct TestDataWithDestructor
+    {
+        bool m_destroyed = false;
+        size_t m_value = 100;
+
+        ~TestDataWithDestructor()
+        {
+            EXPECT_FALSE(m_destroyed);
+            m_destroyed = true;
+        }
+    };
+
     TEST_F(SparseVectorTests, SparseVectorCreate)
     {
         // Simple test to make sure we can create a SparseVector and it initializes with no values.
@@ -274,5 +286,34 @@ namespace UnitTest
 
         container.Clear();
         EXPECT_EQ(0, container.GetSize());
+    }
+
+    TEST_F(SparseVectorTests, SparseVectorNonTrivialDestructor)
+    {
+        constexpr size_t Count = 10;
+
+        SparseVector<TestDataWithDestructor> container;
+        for (size_t i = 0; i < Count; ++i)
+        {
+            container.Reserve();
+        }
+        // Release some elements to call their destructor
+        for (size_t i = 0; i < Count / 2; ++i)
+        {
+            container.Release(i);
+        }
+        container.Clear(); // TestDataWithDestructor checks in its destructor for double-deletes;
+
+        MultiSparseVector<TestDataWithDestructor, TestData> multiContainer;
+        for (size_t i = 0; i < Count; ++i)
+        {
+            multiContainer.Reserve();
+        }
+        // Release some elements to call their destructor
+        for (size_t i = 0; i < Count / 2; ++i)
+        {
+            multiContainer.Release(i);
+        }
+        multiContainer.Clear(); // TestDataWithDestructor checks in its destructor for double-deletes;
     }
 }


### PR DESCRIPTION
## What does this PR do?
Previously it was possible for objects stored in SparseVector or MultiSparseVector to have their destructors called multiple times. This happened because the underlying vector(s) have no knowledge of which objects stored within have already been destroyed and represent empty slots. To fix this, the classes detect if any of the underlying types use non-trivial destructors, and if so, go through the free slots and default-construct objects so they can be safely destroyed later. Generally, SparseVector will only be used with simple data structs, and rarely anything with a non-trivial destructor. In cases where it is using a type with non-trivial destructor, the additional cost will only be on shutdown and when Clear() is called. However, it's worth keeping in mind if the default construction cost is high, this may not be a good container type to use.

SparseVector is only used with a non-trivial destructor in one place,  which happens to be harmless. In SkyAtmosphere there is a struct with a destructor that just resets the values on the struct and isn't really necessary.

## How was this PR tested?

Created new unit tests to make sure SparseVector and MultiSparseVector don't call the destructor multiple times.
