### PR TITLE
Fixes asset processor warning spam

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.cpp
@@ -1442,6 +1442,14 @@ namespace AzToolsFramework
                    m_flags == other.m_flags;//don't compare legacy guid
         }
 
+        bool ProductDatabaseEntry::IsSameLogicalProductAs(const ProductDatabaseEntry& other) const
+        {
+            return m_jobPK == other.m_jobPK &&
+                m_subID == other.m_subID &&
+                m_assetType == other.m_assetType &&
+                AzFramework::StringFunc::Equal(m_productName.c_str(), other.m_productName.c_str());
+        }
+
         AZStd::string ProductDatabaseEntry::ToString() const
         {
             return AZStd::string::format("ProductDatabaseEntry id:%" PRId64 " jobpk: %" PRId64 " subid: %i productname: %s assettype: %s hash: %" PRId64 " flags: %" PRId64,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.h
@@ -243,7 +243,15 @@ namespace AzToolsFramework
                 AZ::Data::AssetType assetType, AZ::Uuid legacyGuid = AZ::Uuid::CreateNull(), AZ::u64 hash = 0, AZStd::bitset<64> flags = 0);
             AZ_DEFAULT_COPY_MOVE(ProductDatabaseEntry);
 
+            // Literal, all-fields equality operator.
+            // This includes the hash of the file and its flags.  Use IsSameLogicalProductAs instead, if you need to
+            //  compare whether its represents the same product as the other rather than identical in every way (including file data).
             bool operator==(const ProductDatabaseEntry& other) const;
+
+            //! Logical equality compare. 
+            //! It will return true if the fields that establish the identify of a product are identical, regardless
+            //! of the equality of things like its flags and hash.
+            bool IsSameLogicalProductAs(const ProductDatabaseEntry& other) const;
 
             AZStd::string ToString() const;
             auto GetColumns();

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -1334,8 +1334,12 @@ namespace AssetProcessor
                 newLegacySubIDs.push_back(product.m_legacySubIDs);
             }
 
+            // To find the set of products that were either new, or updated, this code starts with the new products, and erases
+            // the prior products that are exactly the same from that list.
+            // Note that because it uses operator==, it includes comparing the hash.  This means that if the file data has changed
+            // it won't count as being the same, and will not remove it from the list.  This results in 'updatedProducts' containing
+            // the list of new products that were EITHER literally new, or, had data that was new/changed.
             auto updatedProducts = newProducts;
-
             if(!updatedProducts.empty())
             {
                 for (const auto& priorProductEntry : priorProducts)
@@ -1344,14 +1348,23 @@ namespace AssetProcessor
                 }
             }
 
-            //now we want to remove any lingering product files from the previous build that no longer exist
-            //so subtract the new products from the prior products, whatever is left over in prior products no longer exists
+            // Remove any lingering product files from the previous build that no longer exist.
+            // Get that set by starting with the set of products from last time, and erasing any that were emitted this time
+            // which leaves just the products that were emitted last time, and not this time.
+            // Note that in this case, only care whether the product represents the same logical asset, not whether its hash
+            // changed or not.   Doing it this way will result in priorProducts containing only those products that were emitted last time
+            // and not this time regardless of what the hash or flags may have changed to (only comparing identifier fields).
             if (!priorProducts.empty())
             {
                 for (const auto& pair : newProducts)
                 {
                     const AzToolsFramework::AssetDatabase::ProductDatabaseEntry& newProductEntry = pair.first;
-                    priorProducts.erase(AZStd::remove(priorProducts.begin(), priorProducts.end(), newProductEntry), priorProducts.end());
+                    auto logicalCompare = [&newProductEntry](const AzToolsFramework::AssetDatabase::ProductDatabaseEntry& other)
+                    {
+                        return other.IsSameLogicalProductAs(newProductEntry);
+                    };
+
+                    priorProducts.erase(AZStd::remove_if(priorProducts.begin(), priorProducts.end(), logicalCompare), priorProducts.end());
                 }
             }
 


### PR DESCRIPTION
## What does this PR do?

AssetProcessor would erronously spam warnings with the text "asset name was replaced with a new, but different file."

This fixes that asset spam.

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_

The reason this started happening a while ago is that the flags and hash field were added to the product database, and thus added to the operator==.  

However, theres a blob of code that starts with all the previous assets from the last session, and _subtracts_ the ones from this session, resulting in the assets that used to be there (last time) that are are no longer there (this time) since everything that is here this time has been removed from the list.    It wants to use this list of "stuff that was here, but is no longer here" to delete products from disk that are no longer relevant, so this comparison needs to be done a a logical ("is this representing the same asset?") level, rather than the physical level (has the hash of the file data changed?)

Because it was using the 'all fields' physical comparison operator==, it would consider these 2 assets to be different assets from each other:
```
asseta.azmodel - type model - subid 3 - hash of data 0x12321311
asseta.azmodel - type model - subid 3 - hash of data 0x54214111
```

This lead to the list of "products that were here last time, but are no longer here" being full of assets that had simply changed in hash.  Leading it to spam that warning erroneously.

## How was this PR tested?

Manual (opaque-box testing).  running these functions in a debugger and standalone in a situation where the warning would erroneously appear.

In the name of causing as little damage as possible here, I fixed this by adding a new explicit comparison function, and only called this new function in the one place that causes this above problem.