### PR TITLE
Build with MSVS2022 clang-cl.

### DIFF
--- a/Code/Editor/Platform/Common/Clang/editor_lib_clang.cmake
+++ b/Code/Editor/Platform/Common/Clang/editor_lib_clang.cmake
@@ -5,5 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #
-
-set(LY_COMPILE_OPTIONS PRIVATE -fexceptions)
+if(MSVC)
+    set(LY_COMPILE_OPTIONS PRIVATE /EHsc)
+else()
+    set(LY_COMPILE_OPTIONS PRIVATE -fexceptions)
+endif()

--- a/Code/Tools/ProjectManager/Platform/Common/Clang/projectmanager_clang.cmake
+++ b/Code/Tools/ProjectManager/Platform/Common/Clang/projectmanager_clang.cmake
@@ -6,7 +6,12 @@
 #
 #
 
-set(LY_COMPILE_OPTIONS
+# The macro PYBIND11_EMBEDDED_MODULE uses a try catch block
+if(MSVC)
+    set(LY_COMPILE_OPTIONS PRIVATE /EHsc)
+else()
+    set(LY_COMPILE_OPTIONS
     PRIVATE
-        -fexceptions # The macro PYBIND11_EMBEDDED_MODULE uses a try catch block
-)
+        -fexceptions
+    )
+endif()

--- a/Code/Tools/PythonBindingsExample/source/Platform/Common/Clang/pythonbindingsexample_clang.cmake
+++ b/Code/Tools/PythonBindingsExample/source/Platform/Common/Clang/pythonbindingsexample_clang.cmake
@@ -6,7 +6,11 @@
 #
 #
 
-set(LY_COMPILE_OPTIONS
+if(MSVC)
+    set(LY_COMPILE_OPTIONS PRIVATE /EHsc)
+else()
+    set(LY_COMPILE_OPTIONS
     PRIVATE
         -fexceptions
-)
+    )
+endif()

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Common/Code/Source/Platform/Common/Clang/testimpactframework_clang.cmake
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Common/Code/Source/Platform/Common/Clang/testimpactframework_clang.cmake
@@ -6,4 +6,11 @@
 #
 #
 
-set(LY_COMPILE_OPTIONS PUBLIC -fexceptions)
+if(MSVC)
+    set(LY_COMPILE_OPTIONS PRIVATE /EHsc)
+else()
+    set(LY_COMPILE_OPTIONS
+    PRIVATE
+        -fexceptions
+    )
+endif()

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Native/Code/CMakeLists.txt
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Native/Code/CMakeLists.txt
@@ -10,11 +10,15 @@ if(LY_MONOLITHIC_GAME)
     return()
 endif()
 
+set(common_dir ${CMAKE_CURRENT_LIST_DIR}/Source/Platform/Common)
+
 ly_add_target(
     NAME TestImpact.Frontend.Console.Native.Static STATIC
     NAMESPACE AZ
     FILES_CMAKE
         testimpactframework_frontend_console_native_static_files.cmake
+    PLATFORM_INCLUDE_FILES
+        ${common_dir}/${PAL_TRAIT_COMPILER_ID}/testimpactframework_${PAL_TRAIT_COMPILER_ID_LOWERCASE}.cmake
     INCLUDE_DIRECTORIES
         PRIVATE
             Source
@@ -32,6 +36,8 @@ ly_add_target(
     NAMESPACE AZ
     FILES_CMAKE
         testimpactframework_frontend_console_native_files.cmake
+    PLATFORM_INCLUDE_FILES
+        ${common_dir}/${PAL_TRAIT_COMPILER_ID}/testimpactframework_${PAL_TRAIT_COMPILER_ID_LOWERCASE}.cmake
     INCLUDE_DIRECTORIES
         PRIVATE
             Source

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Native/Code/Source/Platform/Common/Clang/testimpactframework_clang.cmake
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Native/Code/Source/Platform/Common/Clang/testimpactframework_clang.cmake
@@ -1,0 +1,16 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+if(MSVC)
+    set(LY_COMPILE_OPTIONS PRIVATE /EHsc)
+else()
+    set(LY_COMPILE_OPTIONS
+    PRIVATE
+        -fexceptions
+    )
+endif()

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Native/Code/Source/Platform/Common/GCC/testimpactframework_gcc.cmake
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Native/Code/Source/Platform/Common/GCC/testimpactframework_gcc.cmake
@@ -1,0 +1,9 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(LY_COMPILE_OPTIONS PUBLIC -fexceptions)

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Native/Code/Source/Platform/Common/MSVC/testimpactframework_msvc.cmake
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Native/Code/Source/Platform/Common/MSVC/testimpactframework_msvc.cmake
@@ -1,0 +1,9 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(LY_COMPILE_OPTIONS PUBLIC /EHsc)

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Python/Code/CMakeLists.txt
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Python/Code/CMakeLists.txt
@@ -10,11 +10,15 @@ if(LY_MONOLITHIC_GAME)
     return()
 endif()
 
+set(common_dir ${CMAKE_CURRENT_LIST_DIR}/Source/Platform/Common)
+
 ly_add_target(
     NAME TestImpact.Frontend.Console.Python.Static STATIC
     NAMESPACE AZ
     FILES_CMAKE
         testimpactframework_frontend_console_python_static_files.cmake
+    PLATFORM_INCLUDE_FILES
+        ${common_dir}/${PAL_TRAIT_COMPILER_ID}/testimpactframework_${PAL_TRAIT_COMPILER_ID_LOWERCASE}.cmake
     INCLUDE_DIRECTORIES
         PUBLIC
             Include
@@ -37,6 +41,8 @@ ly_add_target(
     NAMESPACE AZ
     FILES_CMAKE
         testimpactframework_frontend_console_python_files.cmake
+    PLATFORM_INCLUDE_FILES
+        ${common_dir}/${PAL_TRAIT_COMPILER_ID}/testimpactframework_${PAL_TRAIT_COMPILER_ID_LOWERCASE}.cmake
     INCLUDE_DIRECTORIES
         PRIVATE
             Source

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Python/Code/Source/Platform/Common/Clang/testimpactframework_clang.cmake
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Python/Code/Source/Platform/Common/Clang/testimpactframework_clang.cmake
@@ -1,0 +1,16 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+if(MSVC)
+    set(LY_COMPILE_OPTIONS PRIVATE /EHsc)
+else()
+    set(LY_COMPILE_OPTIONS
+    PRIVATE
+        -fexceptions
+    )
+endif()

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Python/Code/Source/Platform/Common/GCC/testimpactframework_gcc.cmake
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Python/Code/Source/Platform/Common/GCC/testimpactframework_gcc.cmake
@@ -1,0 +1,9 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(LY_COMPILE_OPTIONS PUBLIC -fexceptions)

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Python/Code/Source/Platform/Common/MSVC/testimpactframework_msvc.cmake
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Python/Code/Source/Platform/Common/MSVC/testimpactframework_msvc.cmake
@@ -1,0 +1,9 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(LY_COMPILE_OPTIONS PUBLIC /EHsc)

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Source/Platform/Common/Clang/testimpactframework_clang.cmake
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Source/Platform/Common/Clang/testimpactframework_clang.cmake
@@ -6,4 +6,11 @@
 #
 #
 
-set(LY_COMPILE_OPTIONS PUBLIC -fexceptions)
+if(MSVC)
+    set(LY_COMPILE_OPTIONS PRIVATE /EHsc)
+else()
+    set(LY_COMPILE_OPTIONS
+    PRIVATE
+        -fexceptions
+    )
+endif()

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Platform/Common/Clang/testimpactframework_clang.cmake
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Platform/Common/Clang/testimpactframework_clang.cmake
@@ -6,4 +6,11 @@
 #
 #
 
-set(LY_COMPILE_OPTIONS PUBLIC -fexceptions)
+if(MSVC)
+    set(LY_COMPILE_OPTIONS PRIVATE /EHsc)
+else()
+    set(LY_COMPILE_OPTIONS
+    PRIVATE
+        -fexceptions
+    )
+endif()

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Platform/Common/Clang/testimpactframework_clang.cmake
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Platform/Common/Clang/testimpactframework_clang.cmake
@@ -6,4 +6,11 @@
 #
 #
 
-set(LY_COMPILE_OPTIONS PUBLIC -fexceptions)
+if(MSVC)
+    set(LY_COMPILE_OPTIONS PRIVATE /EHsc)
+else()
+    set(LY_COMPILE_OPTIONS
+    PRIVATE
+        -fexceptions
+    )
+endif()

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Platform/Common/Clang/imageprocessingatom_editor_static_clang.cmake
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Platform/Common/Clang/imageprocessingatom_editor_static_clang.cmake
@@ -6,7 +6,12 @@
 #
 #
 
-set(LY_COMPILE_OPTIONS
+# ImageLoader/ExrLoader.cpp uses exceptions
+if(MSVC)
+    set(LY_COMPILE_OPTIONS PRIVATE /EHsc)
+else()
+    set(LY_COMPILE_OPTIONS
     PRIVATE
-        -fexceptions #ImageLoader/ExrLoader.cpp uses exceptions
-)
+        -fexceptions
+    )
+endif()

--- a/Gems/Atom/Asset/Shader/Code/Source/Platform/Common/Clang/atom_asset_shader_static_clang.cmake
+++ b/Gems/Atom/Asset/Shader/Code/Source/Platform/Common/Clang/atom_asset_shader_static_clang.cmake
@@ -6,7 +6,12 @@
 #
 #
 
-set(LY_COMPILE_OPTIONS
+# The macro PYBIND11_EMBEDDED_MODULE uses a try catch block
+if(MSVC)
+    set(LY_COMPILE_OPTIONS PRIVATE /EHsc)
+else()
+    set(LY_COMPILE_OPTIONS
     PRIVATE
-        -fexceptions # The macro PYBIND11_EMBEDDED_MODULE uses a try catch block
-)
+        -fexceptions
+    )
+endif()

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/QueryPoolResolver.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/QueryPoolResolver.cpp
@@ -24,7 +24,7 @@ namespace AZ
             , m_device(device)
         {
             m_resolveFence = FenceImpl::Create();
-            m_resolveFence->Init(device, RHI::FenceState::Reset);
+            m_resolveFence->Init(m_device, RHI::FenceState::Reset);
 
         }
 

--- a/Gems/EditorPythonBindings/Code/Source/Platform/Common/Clang/editorpythonbindings_static_clang.cmake
+++ b/Gems/EditorPythonBindings/Code/Source/Platform/Common/Clang/editorpythonbindings_static_clang.cmake
@@ -6,7 +6,12 @@
 #
 #
 
-set(LY_COMPILE_OPTIONS
+# The macro PYBIND11_EMBEDDED_MODULE uses a try catch block
+if(MSVC)
+    set(LY_COMPILE_OPTIONS PRIVATE /EHsc)
+else()
+    set(LY_COMPILE_OPTIONS
     PRIVATE
-        -fexceptions # The macro PYBIND11_EMBEDDED_MODULE uses a try catch block
-)
+        -fexceptions
+    )
+endif()

--- a/Gems/EditorPythonBindings/Code/Source/Platform/Common/Clang/editorpythonbindings_tests_clang.cmake
+++ b/Gems/EditorPythonBindings/Code/Source/Platform/Common/Clang/editorpythonbindings_tests_clang.cmake
@@ -6,7 +6,12 @@
 #
 #
 
-set(LY_COMPILE_OPTIONS
+# The macro PYBIND11_EMBEDDED_MODULE uses a try catch block
+if(MSVC)
+    set(LY_COMPILE_OPTIONS PRIVATE /EHsc)
+else()
+    set(LY_COMPILE_OPTIONS
     PRIVATE
-        -fexceptions # The macro PYBIND11_EMBEDDED_MODULE uses a try catch block
-)
+        -fexceptions
+    )
+endif()

--- a/Gems/GradientSignal/Code/Source/Platform/Common/Clang/gradient_signal_editor_clang.cmake
+++ b/Gems/GradientSignal/Code/Source/Platform/Common/Clang/gradient_signal_editor_clang.cmake
@@ -6,4 +6,11 @@
 #
 #
 
-set(LY_COMPILE_OPTIONS PRIVATE -fexceptions)
+if(MSVC)
+    set(LY_COMPILE_OPTIONS PRIVATE /EHsc)
+else()
+    set(LY_COMPILE_OPTIONS
+    PRIVATE
+        -fexceptions
+    )
+endif()

--- a/Gems/Metastream/Code/Source/Platform/Common/Clang/metastream_clang.cmake
+++ b/Gems/Metastream/Code/Source/Platform/Common/Clang/metastream_clang.cmake
@@ -7,4 +7,11 @@
 #
 
 # CivetHttpServer.cpp uses a try catch block
-set(LY_COMPILE_OPTIONS PRIVATE -fexceptions)
+if(MSVC)
+    set(LY_COMPILE_OPTIONS PRIVATE /EHsc)
+else()
+    set(LY_COMPILE_OPTIONS
+    PRIVATE
+        -fexceptions
+    )
+endif()

--- a/Gems/PythonAssetBuilder/Code/Source/Platform/Common/Clang/pythonassetbuilder_static_clang.cmake
+++ b/Gems/PythonAssetBuilder/Code/Source/Platform/Common/Clang/pythonassetbuilder_static_clang.cmake
@@ -6,7 +6,11 @@
 #
 #
 
-set(LY_COMPILE_OPTIONS
+if(MSVC)
+    set(LY_COMPILE_OPTIONS PRIVATE /EHsc)
+else()
+    set(LY_COMPILE_OPTIONS
     PRIVATE
         -fexceptions
-)
+    )
+endif()

--- a/Gems/PythonAssetBuilder/Code/Source/Platform/Common/Clang/pythonassetbuilder_tests_clang.cmake
+++ b/Gems/PythonAssetBuilder/Code/Source/Platform/Common/Clang/pythonassetbuilder_tests_clang.cmake
@@ -6,7 +6,11 @@
 #
 #
 
-set(LY_COMPILE_OPTIONS
+if(MSVC)
+    set(LY_COMPILE_OPTIONS PRIVATE /EHsc)
+else()
+    set(LY_COMPILE_OPTIONS
     PRIVATE
         -fexceptions
-)
+    )
+endif()

--- a/Gems/QtForPython/Code/Source/Platform/Common/Clang/qtforpython_clang.cmake
+++ b/Gems/QtForPython/Code/Source/Platform/Common/Clang/qtforpython_clang.cmake
@@ -6,7 +6,12 @@
 #
 #
 
-set(LY_COMPILE_OPTIONS
+# QtForPythonSystemComponent uses a try catch block
+if(MSVC)
+    set(LY_COMPILE_OPTIONS PRIVATE /EHsc)
+else()
+    set(LY_COMPILE_OPTIONS
     PRIVATE
-        -fexceptions # QtForPythonSystemComponent uses a try catch block
-)
+        -fexceptions
+    )
+endif()

--- a/cmake/Platform/Common/MSVC/Configurations_clang.cmake
+++ b/cmake/Platform/Common/MSVC/Configurations_clang.cmake
@@ -1,0 +1,92 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+include(cmake/Platform/Common/Configurations_common.cmake)
+
+ly_append_configurations_options(
+    DEFINES_PROFILE
+        _FORTIFY_SOURCE=2
+    DEFINES_RELEASE
+        _FORTIFY_SOURCE=2
+    COMPILATION
+        -Wno-reorder-ctor
+        -Wno-logical-not-parentheses
+        -Wno-logical-op-parentheses
+        -Wno-switch
+        -Wno-undefined-var-template
+        -Wno-inconsistent-missing-override
+        -Wno-parentheses
+        -Wno-unused-parameter
+        -Wno-sign-compare
+        -Wno-ignored-qualifiers
+        -Wno-missing-field-initializers
+
+        # disable warning introduced by -fsized-deallocation, pybind11 used.
+        -Wno-unknown-argument
+
+        
+        /fp:fast        # allows the compiler to reorder, combine, or simplify floating-point operations to optimize floating-point code for speed and space
+        /Gd             # Use _cdecl calling convention for all functions
+        /MP             # Multicore compilation in Visual Studio
+        /nologo         # Suppress Copyright and version number message
+        /W4             # Warning level 4
+        /WX             # Warnings as errors
+        /permissive-    # Conformance with standard
+        /Zc:preprocessor # Forces preprocessor into conformance mode:  https://docs.microsoft.com/en-us/cpp/preprocessor/preprocessor-experimental-overview?view=msvc-170
+        /Zc:forScope    # Force Conformance in for Loop Scope
+        /diagnostics:caret # Compiler diagnostic options: includes the column where the issue was found and places a caret (^) under the location in the line of code where the issue was detected.
+        /Zc:__cplusplus       
+        /bigobj         # Increase number of sections in obj files. Profiling has shown no meaningful impact in memory nore build times
+        /GS             # Enable Buffer security check
+        /sdl
+    COMPILATION_DEBUG
+        /MDd            # defines _DEBUG, _MT, and _DLL and causes the application to use the debug multithread-specific and DLL-specific version of the run-time library.
+                        # It also causes the compiler to place the library name MSVCRTD.lib into the .obj file.
+        /Ob0            # Disables inline expansions
+        /Od             # Disables optimization
+    COMPILATION_PROFILE
+        /GF             # Enable string pooling
+        /Gy             # Function level linking
+        /MD             # Causes the application to use the multithread-specific and DLL-specific version of the run-time library. Defines _MT and _DLL and causes the compiler
+                        # to place the library name MSVCRT.lib into the .obj file.
+        /O2             # Maximinize speed, equivalent to /Og /Oi /Ot /Oy /Ob2 /GF /Gy
+        /Zc:inline      # Removes unreferenced functions or data that are COMDATs or only have internal linkage
+        /Zc:wchar_t     # Use compiler native wchar_t
+        /Zi             # Generate debugging information (no Edit/Continue)
+    COMPILATION_RELEASE
+        /Ox             # Full optimization
+        /Ob2            # Inline any suitable function
+        /Ot             # Favor fast code over small code
+        /Oi             # Use Intrinsic Functions
+        /Oy             # Omit the frame pointer
+    LINK
+        /NOLOGO             # Suppress Copyright and version number message
+        /IGNORE:4099        # 3rdParty linking produces noise with LNK4099
+    LINK_NON_STATIC_PROFILE
+        /OPT:REF            # Eliminates functions and data that are never referenced
+        /OPT:ICF            # Perform identical COMDAT folding. Redundant COMDATs can be removed from the linker output
+        /INCREMENTAL:NO
+        /DEBUG              # Generate pdbs
+    LINK_NON_STATIC_RELEASE
+        /OPT:REF # Eliminates functions and data that are never referenced
+        /OPT:ICF # Perform identical COMDAT folding. Redundant COMDATs can be removed from the linker output
+        /INCREMENTAL:NO
+)
+
+if(LY_BUILD_WITH_ADDRESS_SANITIZER)
+    ly_append_configurations_options(
+        COMPILATION_DEBUG
+            -fsanitize=address
+            -fno-omit-frame-pointer
+        LINK_NON_STATIC_DEBUG
+            -shared-libsan
+            -fsanitize=address
+    )
+endif()
+include(cmake/Platform/Common/TargetIncludeSystemDirectories_supported.cmake)
+

--- a/cmake/Platform/Windows/CMakePresets.json
+++ b/cmake/Platform/Windows/CMakePresets.json
@@ -111,6 +111,19 @@
             ]
         },
         {
+            "name": "windows-ninja-clang-cl",
+            "displayName": "Windows Visual Studio 2022 + ClangCl",
+            "description": "Configure Windows to use the VS2022 generator and the clang-cl compiler",
+            "binaryDir": "${sourceDir}/build/windows_clangcl",
+            "inherits": [
+                "windows-vs2022",
+                "unity"
+            ],
+            "toolset": {
+                "value": "ClangCl"
+            }
+        },
+        {
             "name": "windows-ninja",
             "displayName": "Windows Ninja",
             "description": "Configure Windows using the Ninja Multi-Config generator",

--- a/cmake/Platform/Windows/Configurations_windows.cmake
+++ b/cmake/Platform/Windows/Configurations_windows.cmake
@@ -24,7 +24,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 
-    include(cmake/Platform/Common/Clang/Configurations_clang.cmake)
+    if(MSVC)
+        include(cmake/Platform/Common/MSVC/Configurations_clang.cmake)
+    else()
+        include(cmake/Platform/Common/Clang/Configurations_clang.cmake)
+    endif()
 
     ly_append_configurations_options(
         DEFINES

--- a/cmake/Platform/Windows/platform_windows_files.cmake
+++ b/cmake/Platform/Windows/platform_windows_files.cmake
@@ -9,6 +9,7 @@
 set(FILES
     ../Common/Configurations_common.cmake
     ../Common/MSVC/Configurations_msvc.cmake
+    ../Common/MSVC/Configurations_clang.cmake
     ../Common/MSVC/CodeAnalysis.ruleset
     ../Common/MSVC/Directory.Build.props
     ../Common/MSVC/TestProject.props


### PR DESCRIPTION
## What does this PR do?
Build o3de with `clang-cl` shipped with VS2022.

Configure the engine source with the following commands:
```
set SRC_ROOT=E:\CODE\o3de

cmake -B %SRC_ROOT%\build\windows_clang ^
    -S %SRC_ROOT% ^
    -T ClangCl ^
    -DLY_UNITY_BUILD=ON ^
    -DLY_3RDPARTY_PATH=D:\CODE\o3de\3rd-packages ^
    -DLY_PROJECTS=AutomatedTesting
```

Build the engine source using VS2022, using `O3DE.sln` located in `%SRC_ROOT%\build\windows_clang`

## How was this PR tested?

Build the source.