### PR TITLE
Fix Physics Material Asset property from showing invalid asset in components

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/Material/PhysicsMaterialSlots.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Material/PhysicsMaterialSlots.cpp
@@ -37,6 +37,21 @@ namespace Physics
         }
     };
 
+    static AZ::Data::AssetId GetDefaultPhysicsMaterialAssetId()
+    {
+        // Used for Edit Context.
+        // When the physics material asset property doesn't have an asset assigned it
+        // will show "(default)" to indicate that the default material will be used.
+        if (auto* materialManager = AZ::Interface<Physics::MaterialManager>::Get())
+        {
+            if (AZStd::shared_ptr<Physics::Material> defaultMaterial = materialManager->GetDefaultMaterial())
+            {
+                return defaultMaterial->GetMaterialAsset().GetId();
+            }
+        }
+        return {};
+    }
+
     void MaterialSlots::MaterialSlot::Reflect(AZ::ReflectContext* context)
     {
         if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
@@ -53,7 +68,7 @@ namespace Physics
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &MaterialSlot::m_materialAsset, "", "")
                         ->Attribute(AZ::Edit::Attributes::NameLabelOverride, &MaterialSlot::m_name)
-                        ->Attribute(AZ::Edit::Attributes::DefaultAsset, &MaterialSlot::GetDefaultMaterialAssetId)
+                        ->Attribute(AZ::Edit::Attributes::DefaultAsset, &GetDefaultPhysicsMaterialAssetId)
                         ->Attribute(AZ_CRC_CE("EditButton"), "")
                         ->Attribute(AZ_CRC_CE("EditDescription"), "Open in Asset Editor")
                         ->Attribute(AZ_CRC_CE("DisableEditButtonWhenNoAssetSelected"), true)
@@ -61,21 +76,6 @@ namespace Physics
                     ;
             }
         }
-    }
-
-    AZ::Data::AssetId MaterialSlots::MaterialSlot::GetDefaultMaterialAssetId() const
-    {
-        // Used for Edit Context.
-        // When the physics material asset property doesn't have an asset assigned it
-        // will show "(default)" to indicate that the default material will be used.
-        if (auto* materialManager = AZ::Interface<MaterialManager>::Get())
-        {
-            if (AZStd::shared_ptr<Physics::Material> defaultMaterial = materialManager->GetDefaultMaterial())
-            {
-                return defaultMaterial->GetMaterialAsset().GetId();
-            }
-        }
-        return {};
     }
 
     void MaterialSlots::Reflect(AZ::ReflectContext* context)

--- a/Code/Framework/AzFramework/AzFramework/Physics/Material/PhysicsMaterialSlots.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Material/PhysicsMaterialSlots.cpp
@@ -12,6 +12,7 @@
 #include <AzCore/Serialization/Json/BasicContainerSerializer.h>
 #include <AzCore/Asset/AssetSerializer.h>
 
+#include <AzFramework/Physics/Material/PhysicsMaterialManager.h>
 #include <AzFramework/Physics/Material/PhysicsMaterialSlots.h>
 
 namespace Physics
@@ -67,6 +68,13 @@ namespace Physics
         // Used for Edit Context.
         // When the physics material asset property doesn't have an asset assigned it
         // will show "(default)" to indicate that the default material will be used.
+        if (auto* materialManager = AZ::Interface<MaterialManager>::Get())
+        {
+            if (AZStd::shared_ptr<Physics::Material> defaultMaterial = materialManager->GetDefaultMaterial())
+            {
+                return defaultMaterial->GetMaterialAsset().GetId();
+            }
+        }
         return {};
     }
 

--- a/Code/Framework/AzFramework/AzFramework/Physics/Material/PhysicsMaterialSlots.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Material/PhysicsMaterialSlots.h
@@ -78,9 +78,7 @@ namespace Physics
             AZStd::string m_name;
             AZ::Data::Asset<MaterialAsset> m_materialAsset;
 
-        private:
-            friend class MaterialSlots;
-            AZ::Data::AssetId GetDefaultMaterialAssetId() const;
+            // Used for the ReadOnly attribute of m_materialAsset in edit context.
             bool m_slotsReadOnly = false;
         };
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -1138,9 +1138,9 @@ namespace AzToolsFramework
                 }
                 else
                 {
-                    // The asset might have been created in-memory, for example for the default asset provided
-                    // via DefaultAsset attribute, and therefore it wound't have a job info.
-                    // Only report an asset missing error if the asset doen't exist in the asset manager.
+                    // The asset might have been created in-memory (for example for the default asset provided
+                    // via DefaultAsset attribute) and therefore it doesn't have a job info.
+                    // Only report the asset missing if it doesn't exist in the asset manager.
                     if (!AZ::Data::AssetManager::Instance().FindAsset(assetID, AZ::Data::AssetLoadBehavior::Default))
                     {
                         UpdateErrorButtonWithMessage(AZStd::string::format(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -1138,7 +1138,16 @@ namespace AzToolsFramework
                 }
                 else
                 {
-                    UpdateErrorButtonWithMessage(AZStd::string::format("Asset is missing.\n\nID: %s\nHint:%s", assetID.ToString<AZStd::string>().c_str(), GetCurrentAssetHint().c_str()));
+                    // The asset might have been created in-memory, for example for the default asset provided
+                    // via DefaultAsset attribute, and therefore it wound't have a job info.
+                    // Only report an asset missing error if the asset doen't exist in the asset manager.
+                    if (!AZ::Data::AssetManager::Instance().FindAsset(assetID, AZ::Data::AssetLoadBehavior::Default))
+                    {
+                        UpdateErrorButtonWithMessage(AZStd::string::format(
+                            "Asset is missing.\n\nID: %s\nHint:%s",
+                            assetID.ToString<AZStd::string>().c_str(),
+                            GetCurrentAssetHint().c_str()));
+                    }
                 }
             }
         }
@@ -1289,7 +1298,7 @@ namespace AzToolsFramework
         // if Edit button is in use (shown), enable/disable it depending on the current asset id.
         if (m_showEditButton && m_disableEditButtonWhenNoAssetSelected)
         {
-            m_editButton->setEnabled(GetCurrentAssetID().IsValid());
+            m_editButton->setEnabled(GetSelectedAssetID().IsValid());
         }
     }
 

--- a/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.h
+++ b/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.h
@@ -41,12 +41,14 @@ namespace Terrain
 
         AZStd::vector<AZStd::pair<AZ::u32, AZStd::string>> BuildSelectableTagList() const;
         void SetTagListProvider(const EditorSurfaceTagListProvider* tagListProvider);
-        AZ::Data::AssetId GetDefaultPhysicsAssetId() const;
 
         SurfaceData::SurfaceTag m_surfaceTag;
         AZ::Data::Asset<Physics::MaterialAsset> m_materialAsset;
 
     private:
+        friend class EditorTerrainPhysicsColliderComponent;
+        AZ::Data::AssetId GetDefaultPhysicsMaterialAssetIdEditContext() const;
+
         const EditorSurfaceTagListProvider* m_tagListProvider = nullptr;
     };
 
@@ -57,10 +59,12 @@ namespace Terrain
         AZ_TYPE_INFO(TerrainPhysicsColliderConfig, "{E9EADB8F-C3A5-4B9C-A62D-2DBC86B4CE59}");
         static void Reflect(AZ::ReflectContext* context);
 
-        AZ::Data::AssetId GetDefaultPhysicsAssetId() const;
-
         AZ::Data::Asset<Physics::MaterialAsset> m_defaultMaterialAsset;
         AZStd::vector<TerrainPhysicsSurfaceMaterialMapping> m_surfaceMaterialMappings;
+
+    private:
+        friend class EditorTerrainPhysicsColliderComponent;
+        AZ::Data::AssetId GetDefaultPhysicsMaterialAssetIdEditContext() const;
     };
 
 

--- a/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.h
+++ b/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.h
@@ -46,9 +46,6 @@ namespace Terrain
         AZ::Data::Asset<Physics::MaterialAsset> m_materialAsset;
 
     private:
-        friend class EditorTerrainPhysicsColliderComponent;
-        AZ::Data::AssetId GetDefaultPhysicsMaterialAssetIdEditContext() const;
-
         const EditorSurfaceTagListProvider* m_tagListProvider = nullptr;
     };
 
@@ -61,10 +58,6 @@ namespace Terrain
 
         AZ::Data::Asset<Physics::MaterialAsset> m_defaultMaterialAsset;
         AZStd::vector<TerrainPhysicsSurfaceMaterialMapping> m_surfaceMaterialMappings;
-
-    private:
-        friend class EditorTerrainPhysicsColliderComponent;
-        AZ::Data::AssetId GetDefaultPhysicsMaterialAssetIdEditContext() const;
     };
 
 

--- a/Gems/Terrain/Code/Source/EditorComponents/EditorTerrainPhysicsColliderComponent.cpp
+++ b/Gems/Terrain/Code/Source/EditorComponents/EditorTerrainPhysicsColliderComponent.cpp
@@ -9,6 +9,7 @@
 #include <EditorComponents/EditorTerrainPhysicsColliderComponent.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialManager.h>
 
 namespace Terrain
 {
@@ -37,7 +38,7 @@ namespace Terrain
                     ->Attribute(AZ::Edit::Attributes::EnumValues, &TerrainPhysicsSurfaceMaterialMapping::BuildSelectableTagList)
 
                     ->DataElement(AZ::Edit::UIHandlers::Default, &TerrainPhysicsSurfaceMaterialMapping::m_materialAsset, "Material Asset", "")
-                    ->Attribute(AZ::Edit::Attributes::DefaultAsset, &TerrainPhysicsSurfaceMaterialMapping::GetDefaultPhysicsAssetId)
+                    ->Attribute(AZ::Edit::Attributes::DefaultAsset, &TerrainPhysicsSurfaceMaterialMapping::GetDefaultPhysicsMaterialAssetIdEditContext)
                     ->Attribute(AZ_CRC_CE("EditButton"), "")
                     ->Attribute(AZ_CRC_CE("EditDescription"), "Open in Asset Editor")
                     ->Attribute(AZ_CRC_CE("DisableEditButtonWhenNoAssetSelected"), true)
@@ -51,7 +52,7 @@ namespace Terrain
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &TerrainPhysicsColliderConfig::m_defaultMaterialAsset,
                         "Default Surface Physics Material", "Select a material to be used by unmapped surfaces by default")
-                        ->Attribute(AZ::Edit::Attributes::DefaultAsset, &TerrainPhysicsColliderConfig::GetDefaultPhysicsAssetId)
+                        ->Attribute(AZ::Edit::Attributes::DefaultAsset, &TerrainPhysicsColliderConfig::GetDefaultPhysicsMaterialAssetIdEditContext)
                         ->Attribute(AZ_CRC_CE("EditButton"), "")
                         ->Attribute(AZ_CRC_CE("EditDescription"), "Open in Asset Editor")
                         ->Attribute(AZ_CRC_CE("DisableEditButtonWhenNoAssetSelected"), true)
@@ -167,19 +168,28 @@ namespace Terrain
         m_tagListProvider = tagListProvider;
     }
 
-    AZ::Data::AssetId TerrainPhysicsSurfaceMaterialMapping::GetDefaultPhysicsAssetId() const
+    static AZ::Data::AssetId GetDefaultPhysicsMaterialAssetId()
     {
         // Used for Edit Context.
         // When the physics material asset property doesn't have an asset assigned it
         // will show "(default)" to indicate that the default material will be used.
+        if (auto* materialManager = AZ::Interface<Physics::MaterialManager>::Get())
+        {
+            if (AZStd::shared_ptr<Physics::Material> defaultMaterial = materialManager->GetDefaultMaterial())
+            {
+                return defaultMaterial->GetMaterialAsset().GetId();
+            }
+        }
         return {};
     }
 
-    AZ::Data::AssetId TerrainPhysicsColliderConfig::GetDefaultPhysicsAssetId() const
+    AZ::Data::AssetId TerrainPhysicsSurfaceMaterialMapping::GetDefaultPhysicsMaterialAssetIdEditContext() const
     {
-        // Used for Edit Context.
-        // When the physics material asset property doesn't have an asset assigned it
-        // will show "(default)" to indicate that the default material will be used.
-        return {};
+        return GetDefaultPhysicsMaterialAssetId();
+    }
+
+    AZ::Data::AssetId TerrainPhysicsColliderConfig::GetDefaultPhysicsMaterialAssetIdEditContext() const
+    {
+        return GetDefaultPhysicsMaterialAssetId();
     }
 }

--- a/Gems/Terrain/Code/Source/EditorComponents/EditorTerrainPhysicsColliderComponent.cpp
+++ b/Gems/Terrain/Code/Source/EditorComponents/EditorTerrainPhysicsColliderComponent.cpp
@@ -13,6 +13,21 @@
 
 namespace Terrain
 {
+    static AZ::Data::AssetId GetDefaultPhysicsMaterialAssetId()
+    {
+        // Used for Edit Context.
+        // When the physics material asset property doesn't have an asset assigned it
+        // will show "(default)" to indicate that the default material will be used.
+        if (auto* materialManager = AZ::Interface<Physics::MaterialManager>::Get())
+        {
+            if (AZStd::shared_ptr<Physics::Material> defaultMaterial = materialManager->GetDefaultMaterial())
+            {
+                return defaultMaterial->GetMaterialAsset().GetId();
+            }
+        }
+        return {};
+    }
+
     void EditorTerrainPhysicsColliderComponent::Reflect(AZ::ReflectContext* context)
     {
 
@@ -38,7 +53,7 @@ namespace Terrain
                     ->Attribute(AZ::Edit::Attributes::EnumValues, &TerrainPhysicsSurfaceMaterialMapping::BuildSelectableTagList)
 
                     ->DataElement(AZ::Edit::UIHandlers::Default, &TerrainPhysicsSurfaceMaterialMapping::m_materialAsset, "Material Asset", "")
-                    ->Attribute(AZ::Edit::Attributes::DefaultAsset, &TerrainPhysicsSurfaceMaterialMapping::GetDefaultPhysicsMaterialAssetIdEditContext)
+                    ->Attribute(AZ::Edit::Attributes::DefaultAsset, &GetDefaultPhysicsMaterialAssetId)
                     ->Attribute(AZ_CRC_CE("EditButton"), "")
                     ->Attribute(AZ_CRC_CE("EditDescription"), "Open in Asset Editor")
                     ->Attribute(AZ_CRC_CE("DisableEditButtonWhenNoAssetSelected"), true)
@@ -52,7 +67,7 @@ namespace Terrain
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &TerrainPhysicsColliderConfig::m_defaultMaterialAsset,
                         "Default Surface Physics Material", "Select a material to be used by unmapped surfaces by default")
-                        ->Attribute(AZ::Edit::Attributes::DefaultAsset, &TerrainPhysicsColliderConfig::GetDefaultPhysicsMaterialAssetIdEditContext)
+                        ->Attribute(AZ::Edit::Attributes::DefaultAsset, &GetDefaultPhysicsMaterialAssetId)
                         ->Attribute(AZ_CRC_CE("EditButton"), "")
                         ->Attribute(AZ_CRC_CE("EditDescription"), "Open in Asset Editor")
                         ->Attribute(AZ_CRC_CE("DisableEditButtonWhenNoAssetSelected"), true)
@@ -166,30 +181,5 @@ namespace Terrain
     void TerrainPhysicsSurfaceMaterialMapping::SetTagListProvider(const EditorSurfaceTagListProvider* tagListProvider)
     {
         m_tagListProvider = tagListProvider;
-    }
-
-    static AZ::Data::AssetId GetDefaultPhysicsMaterialAssetId()
-    {
-        // Used for Edit Context.
-        // When the physics material asset property doesn't have an asset assigned it
-        // will show "(default)" to indicate that the default material will be used.
-        if (auto* materialManager = AZ::Interface<Physics::MaterialManager>::Get())
-        {
-            if (AZStd::shared_ptr<Physics::Material> defaultMaterial = materialManager->GetDefaultMaterial())
-            {
-                return defaultMaterial->GetMaterialAsset().GetId();
-            }
-        }
-        return {};
-    }
-
-    AZ::Data::AssetId TerrainPhysicsSurfaceMaterialMapping::GetDefaultPhysicsMaterialAssetIdEditContext() const
-    {
-        return GetDefaultPhysicsMaterialAssetId();
-    }
-
-    AZ::Data::AssetId TerrainPhysicsColliderConfig::GetDefaultPhysicsMaterialAssetIdEditContext() const
-    {
-        return GetDefaultPhysicsMaterialAssetId();
     }
 }


### PR DESCRIPTION
## What does this PR do?

Physics material reflection to edit context does not need an asset assigned, the components handle that if there is no asset it uses the default material. In order to show the text "(default)" when there is no asset assigned Physics materials were passing an null asset to the DefaultAsset property. This was ok before, but after [this change](https://github.com/o3de/o3de/pull/13959) this is reported as an error.

- Fixed by passing the default physics material from the material manager, which is an in-memory asset. 
- This was still reported as error because the asset property handler expected an asset job for the default asset, but since it's an in-memory asset there is no job for it and it was reported it as missing asset. Fixed by only reporting as missing asset if it is not found in asset manager.

## How was this PR tested?

Checked PhysX and terrain components that use physics material property and verified that they don't show as invalid anymore when it doesn't have a material assigned.

Before:
![image](https://user-images.githubusercontent.com/27999040/224011133-05ac37f1-d305-470d-bf92-f2f8a4019beb.png)
![image](https://user-images.githubusercontent.com/27999040/224011246-f8d8d866-1851-4de4-985a-668fcb3e9265.png)

After:
![image](https://user-images.githubusercontent.com/27999040/224005770-0b5037ad-0e1a-44eb-83c9-10c46c93d090.png)
![image](https://user-images.githubusercontent.com/27999040/224005958-72dca6f1-5c34-4503-8582-8c31dc123d84.png)

