### PR TITLE
Replace 'Dynamic' with 'Simulated' to match the property type

### DIFF
--- a/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
@@ -201,7 +201,7 @@ namespace PhysX
                         ->Attribute(AZ::Edit::Attributes::DescriptionTextOverride, &AzPhysics::RigidBodyConfiguration::GetKinematicTooltip)
                         ->Attribute(AZ_CRC_CE("EditButtonVisible"), true)
                         ->Attribute(AZ_CRC_CE("SetTrueLabel"), "Kinematic")
-                        ->Attribute(AZ_CRC_CE("SetFalseLabel"), "Dynamic")
+                        ->Attribute(AZ_CRC_CE("SetFalseLabel"), "Simulated")
                     ->Attribute(
                         AZ_CRC_CE("EditButtonCallback"), AzToolsFramework::GenericEditButtonCallback<bool>(&OnEditButtonClicked))
                         ->Attribute(AZ_CRC_CE("EditButtonToolTip"), "Open Type dialog for a detailed description on the motion types")

--- a/Gems/PhysX/Code/Source/RigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/RigidBodyComponent.cpp
@@ -152,7 +152,7 @@ namespace PhysX
 
         if (m_staticTransformAtActivation)
         {
-            AZ_Warning("PhysX Rigid Body Component", false, "It is not valid to have a PhysX Rigid Body Component "
+            AZ_Warning("RigidBodyComponent", false, "It is not valid to have a PhysX Dynamic Rigid Body Component "
                 "when the Transform Component is marked static.  Entity \"%s\" will behave as a static rigid body.",
                 GetEntity()->GetName().c_str());
 


### PR DESCRIPTION
## What does this PR do?

Also improved warning message in dynamic rigid body component.

Fixes #14972
Fixes #14973

## How was this PR tested?

![image](https://user-images.githubusercontent.com/27999040/224016494-451d89b1-eb1d-4cbe-84a4-b59a0315d485.png)

Warning message is as follows now:

`[Warning] (RigidBodyComponent) - It is not valid to have a PhysX Dynamic Rigid Body Component when the Transform Component is marked static.  Entity "Ball Follower" will behave as a static rigid body.`