### PR TITLE
Add support for 'Coordinate system change' modifier to PhysX tab in Scene Settings

### DIFF
--- a/Gems/PhysX/Code/Source/Pipeline/MeshBehavior.cpp
+++ b/Gems/PhysX/Code/Source/Pipeline/MeshBehavior.cpp
@@ -23,6 +23,7 @@
 #include <SceneAPI/SceneCore/Utilities/SceneGraphSelector.h>
 #include <SceneAPI/SceneData/Groups/MeshGroup.h>
 #include <SceneAPI/SceneCore/Containers/Utilities/SceneGraphUtilities.h>
+#include <SceneAPI/SceneData/Rules/CoordinateSystemRule.h>
 
 #include <Source/Pipeline/MeshBehavior.h>
 #include <Source/Pipeline/MeshGroup.h>
@@ -59,6 +60,31 @@ namespace PhysX
             if (AZ::SceneAPI::Utilities::DoesSceneGraphContainDataLike<AZ::SceneAPI::DataTypes::IMeshData>(scene, false))
             {
                 categories.emplace_back("PhysX", MeshGroup::TYPEINFO_Uuid());
+            }
+        }
+
+        void MeshBehavior::GetAvailableModifiers(
+            AZ::SceneAPI::Events::ManifestMetaInfo::ModifiersList& modifiers,
+            [[maybe_unused]] const AZ::SceneAPI::Containers::Scene& scene,
+            const AZ::SceneAPI::DataTypes::IManifestObject& target)
+        {
+            if (!target.RTTI_IsTypeOf(MeshGroup::TYPEINFO_Uuid()))
+            {
+                return;
+            }
+
+            const MeshGroup* group = azrtti_cast<const MeshGroup*>(&target);
+            const AZ::SceneAPI::Containers::RuleContainer& rules = group->GetRuleContainerConst();
+
+            AZStd::unordered_set<AZ::Uuid> existingRules;
+            const size_t ruleCount = rules.GetRuleCount();
+            for (size_t i = 0; i < ruleCount; ++i)
+            {
+                existingRules.insert(rules.GetRule(i)->RTTI_GetType());
+            }
+            if (existingRules.find(azrtti_typeid<AZ::SceneAPI::SceneData::CoordinateSystemRule>()) == existingRules.end())
+            {
+                modifiers.push_back(azrtti_typeid<AZ::SceneAPI::SceneData::CoordinateSystemRule>());
             }
         }
 

--- a/Gems/PhysX/Code/Source/Pipeline/MeshBehavior.h
+++ b/Gems/PhysX/Code/Source/Pipeline/MeshBehavior.h
@@ -23,15 +23,23 @@ namespace PhysX
         {
         public:
             AZ_COMPONENT(MeshBehavior, "{B6AFB216-2A49-402F-A2B1-C3A17812D53F}", AZ::SceneAPI::SceneCore::BehaviorComponent);
+            static void Reflect(AZ::ReflectContext* context);
 
             ~MeshBehavior() override = default;
 
+            // BehaviorComponent overrides ...
             void Activate() override;
             void Deactivate() override;
-            static void Reflect(AZ::ReflectContext* context);
 
+            // ManifestMetaInfoBus overrides ...
             void GetCategoryAssignments(CategoryRegistrationList& categories, const AZ::SceneAPI::Containers::Scene& scene) override;
+            void GetAvailableModifiers(
+                AZ::SceneAPI::Events::ManifestMetaInfo::ModifiersList& modifiers,
+                const AZ::SceneAPI::Containers::Scene& scene,
+                const AZ::SceneAPI::DataTypes::IManifestObject& target) override;
             void InitializeObject(const AZ::SceneAPI::Containers::Scene& scene, AZ::SceneAPI::DataTypes::IManifestObject& target) override;
+
+            // AssetImportRequestBus overrides ...
             AZ::SceneAPI::Events::ProcessingResult UpdateManifest(AZ::SceneAPI::Containers::Scene& scene, ManifestAction action,
                 RequestingApplication requester) override;
             void GetPolicyName(AZStd::string& result) const override


### PR DESCRIPTION
## What does this PR do?

Added support for "Coordinate system change" modifier to PhysX tab so the users can add the transformation to the PhysX collider to match the transformation applied to the Mesh.

Fixes #14649
Fixes #11330
Fixes #2426

Modifier in Scene settings PhysX tab:
![image](https://user-images.githubusercontent.com/27999040/224111394-33fe1945-b901-4623-a2f9-18c7c80bdead.png)

Before:
![image](https://user-images.githubusercontent.com/27999040/224111018-aa079a7b-d242-409f-8280-fbd5747d791e.png)

After:
![image](https://user-images.githubusercontent.com/27999040/224111461-323cdc78-1072-4ef9-ab14-2ee0ccceead3.png)

## How was this PR tested?

Manually tested in a level using a Mesh Collider with a mesh exported as:
- primitive
- primitive with decomposition
- convex
- convex with decomposition
- triangle mesh

Tested with "Coordinate system change" modifier simple and advance modes.

