### PR TITLE
Remove unused member variable

### DIFF
--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.hxx
@@ -178,7 +178,6 @@ namespace LUAEditor
         AzToolsFramework::ProgressShield *m_pSavingProgressShield;
         AzToolsFramework::ProgressShield *m_pRequestingEditProgressShield;
 
-        int m_breakpointMarker_Waiting;
         bool m_bHasInitialUpdate;
 
         struct BreakpointData


### PR DESCRIPTION
## What does this PR do?

Fixes a linux/clang build error caused by an unused variable

Fixes https://github.com/o3de/o3de/issues/15021 

## How was this PR tested?
Built on Linux
