### PR TITLE
Add support to register sub gem to nearest ancestor gem automatically

### DIFF
--- a/scripts/o3de/tests/__init__.py
+++ b/scripts/o3de/tests/__init__.py
@@ -1,7 +1,0 @@
-#
-# Copyright (c) Contributors to the Open 3D Engine Project.
-# For complete copyright and license terms please see the LICENSE at the root of this distribution.
-#
-# SPDX-License-Identifier: Apache-2.0 OR MIT
-#
-#

--- a/scripts/o3de/tests/test_register.py
+++ b/scripts/o3de/tests/test_register.py
@@ -22,7 +22,7 @@ string_manifest_data = '{}'
         pytest.param(pathlib.PurePath('D:/o3de/o3de'), "o3de", False, 0),
         # Same engine_name and path should result in valid registration
         pytest.param(pathlib.PurePath('D:/o3de/o3de'), "o3de", False, 0),
-        # Same engine_name but different path succeeds 
+        # Same engine_name but different path succeeds
         pytest.param(pathlib.PurePath('D:/o3de/engine-path'), "o3de", False, 0),
         # New engine_name should result in valid registration
         pytest.param(pathlib.PurePath('D:/o3de/engine-path'), "o3de-other", False, 0),
@@ -138,6 +138,26 @@ TEST_GEM_JSON_PAYLOAD = '''
 }
 '''
 
+TEST_SUB_GEM_JSON_PAYLOAD = '''
+{
+    "gem_name": "TestSubGem",
+    "version": "0.0.0",
+    "display_name": "TestSubGem",
+    "license": "What license TestGem uses goes here: i.e. https://opensource.org/licenses/MIT",
+    "origin": "The primary repo for TestSubGem goes here: i.e. http://www.mydomain.com",
+    "type": "Code",
+    "summary": "A short description of TestSubGem.",
+    "canonical_tags": [
+        "Gem"
+    ],
+    "user_tags": [
+        "TestSubGem"
+    ],
+    "icon_path": "preview.png",
+    "requirements": ""
+}
+'''
+
 TEST_PROJECT_JSON_PAYLOAD = '''
 {
     "project_name": "TestProject",
@@ -180,29 +200,39 @@ def init_register_gem_data(request):
     request.cls.o3de_manifest_data = json.loads(TEST_O3DE_MANIFEST_JSON_PAYLOAD)
     request.cls.project_data = json.loads(TEST_PROJECT_JSON_PAYLOAD)
     request.cls.engine_data = json.loads(TEST_ENGINE_JSON_PAYLOAD)
+    request.cls.ancestor_gem_data = json.loads(TEST_GEM_JSON_PAYLOAD)
 
 
 @pytest.mark.usefixtures('init_register_gem_data')
 class TestRegisterGem:
     engine_path = pathlib.PurePath('o3de')
     project_path = pathlib.PurePath('TestProject')
+    ancestor_gem_path = pathlib.PurePath('TestGem')
 
     @staticmethod
     def get_gem_json_data(gem_name: str = None, gem_path: str or pathlib.Path = None,
                         project_path: pathlib.Path = None) -> dict or None:
-        return json.loads(TEST_GEM_JSON_PAYLOAD)
+        if (gem_name and gem_name == "TestSubGem") or \
+            (gem_path and gem_path.name == "TestSubGem"):
+            return json.loads(TEST_SUB_GEM_JSON_PAYLOAD)
+        else:
+            return json.loads(TEST_GEM_JSON_PAYLOAD)
 
     @pytest.mark.parametrize("gem_path, expected_manifest_file, dry_run, expected_result", [
                                  pytest.param(pathlib.PurePath('TestGem'), pathlib.PurePath('o3de_manifest.json'), False, 0),
                                  pytest.param(project_path / 'TestGem', pathlib.PurePath('project.json'), False, 0),
                                  pytest.param(engine_path / 'TestGem', pathlib.PurePath('engine.json'), False, 0),
+                                 pytest.param(pathlib.PurePath('TestGem/TestSubGem') , pathlib.PurePath('gem.json'), False, 0),
                                  pytest.param(pathlib.PurePath('TestGem'), pathlib.PurePath('o3de_manifest.json'), True, 0),
                                  pytest.param(project_path / 'TestGem', pathlib.PurePath('project.json'), True, 0),
                                  pytest.param(engine_path / 'TestGem', pathlib.PurePath('engine.json'), True, 0),
+                                 pytest.param(pathlib.PurePath('TestGem/TestSubGem') , pathlib.PurePath('gem.json'), True, 0),
                              ])
     def test_register_gem_auto_detects_manifest_update(self, gem_path, expected_manifest_file, dry_run, expected_result):
 
         def save_o3de_manifest(manifest_data: dict, manifest_path: pathlib.Path = None) -> bool:
+            if manifest_path == pathlib.Path(TestRegisterGem.ancestor_gem_path).resolve() / 'gem.json':
+                self.ancestor_gem_data = manifest_data
             if manifest_path == pathlib.Path(TestRegisterGem.project_path).resolve() / 'project.json':
                 self.project_data = manifest_data
             elif manifest_path == pathlib.Path(TestRegisterGem.engine_path).resolve() / 'engine.json':
@@ -212,6 +242,8 @@ class TestRegisterGem:
             return True
 
         def load_o3de_manifest(manifest_path: pathlib.Path = None) -> dict:
+            if manifest_path == TestRegisterGem.ancestor_gem_path:
+                return self.ancestor_gem_data
             if manifest_path == TestRegisterGem.project_path:
                 return self.project_data
             elif manifest_path == TestRegisterGem.engine_path:
@@ -227,6 +259,12 @@ class TestRegisterGem:
             return json.loads(TEST_PROJECT_JSON_PAYLOAD)
 
         def find_ancestor_dir(target_file_name: pathlib.PurePath, start_path: pathlib.Path):
+            try:
+                if target_file_name == pathlib.PurePath('gem.json')\
+                        and start_path.relative_to(TestRegisterGem.ancestor_gem_path):
+                    return TestRegisterGem.ancestor_gem_path
+            except ValueError:
+                pass
             try:
                 if target_file_name == pathlib.PurePath('project.json')\
                         and start_path.relative_to(TestRegisterGem.project_path):
@@ -255,13 +293,16 @@ class TestRegisterGem:
             if expected_manifest_file == pathlib.PurePath('o3de_manifest.json'):
                 external_subdirectories = map(lambda subdir: pathlib.PurePath(subdir),
                                         self.o3de_manifest_data.get('external_subdirectories', []))
+            elif expected_manifest_file == pathlib.PurePath('gem.json'):
+                external_subdirectories = map(lambda subdir: TestRegisterGem.ancestor_gem_path / subdir,
+                                       self.ancestor_gem_data.get('external_subdirectories', []))
             elif expected_manifest_file == pathlib.PurePath('project.json'):
                 external_subdirectories = map(lambda subdir: TestRegisterGem.project_path / subdir,
                                        self.project_data.get('external_subdirectories', []))
             elif expected_manifest_file == pathlib.PurePath('engine.json'):
                 external_subdirectories = map(lambda subdir: TestRegisterGem.engine_path / subdir,
                                        self.engine_data.get('external_subdirectories', []))
-            
+
             gem_path = pathlib.Path(gem_path).resolve() if expected_manifest_file == pathlib.PurePath('o3de_manifest.json') else gem_path
             if dry_run:
                 assert gem_path not in external_subdirectories
@@ -299,9 +340,9 @@ class TestRegisterProject:
             # passes when compatible_engines has match
             pytest.param('o3de7', '0.0.0', None, { 'gem1':'' }, None, None, ['gem1'], ['o3de7'], None, None, None, False, False, 0),
             pytest.param('o3de8', '1.2.3', None, { 'gem1':'' }, None, None, ['gem1'], ['o3de8>=1.2.3','o3de-sdk==2.3.4'], None, None, None, False, False, 0),
-            # fails when gem is used that is not known to be compatible with version 1.2.3 
+            # fails when gem is used that is not known to be compatible with version 1.2.3
             pytest.param('o3de9', '1.2.3', None, { 'gem1':'' }, None, None, ['gem1'], ['o3de9'], None, ['o3de==2.3.4'], None, False, False, 1),
-            # passes when gem is used that is known compatible with version 1.2.3 
+            # passes when gem is used that is known compatible with version 1.2.3
             pytest.param('o3de10', '1.2.3', None, { 'gem1':'' }, None, None, ['gem1'], ['o3de10'], None, ['o3de10==1.2.3'], None, False, False, 0),
             # passes when compatible engine not found but compatible api found
             pytest.param('o3de11', '1.2.3', {'api':'1.2.3'}, { 'gem1':'' }, "", "", ['gem1'], ['o3de11==2.3.4'], ['api==1.2.3'], None, None, False, False, 0),
@@ -318,7 +359,7 @@ class TestRegisterProject:
         ]
     )
     def test_register_project(self, test_engine_name, engine_version, engine_api_versions,
-                                registered_gem_versions, project_engine_name, project_engine_version, 
+                                registered_gem_versions, project_engine_name, project_engine_version,
                                 project_gems, project_compatible_engines, project_engine_api_dependencies,
                                 gem_compatible_engines, gem_engine_api_dependencies,
                                 force, dry_run, expected_result):
@@ -338,8 +379,8 @@ class TestRegisterProject:
                 return self.engine_data
             return self.o3de_manifest_data
 
-        def get_gems_json_data_by_name( engine_path:pathlib.Path = None, 
-                                        project_path: pathlib.Path = None, 
+        def get_gems_json_data_by_name( engine_path:pathlib.Path = None,
+                                        project_path: pathlib.Path = None,
                                         include_manifest_gems: bool = False,
                                         include_engine_gems: bool = False,
                                         external_subdirectories: list = None
@@ -370,7 +411,7 @@ class TestRegisterProject:
             if test_engine_name != None:
                 engine_json_data['engine_name'] = test_engine_name
 
-            # we want to allow for testing the case where these fields 
+            # we want to allow for testing the case where these fields
             # are missing or empty
             if engine_version != None:
                 engine_json_data['version'] = engine_version
@@ -384,7 +425,7 @@ class TestRegisterProject:
                                 user: bool = False) -> dict or None:
             project_json_data = json.loads(TEST_PROJECT_JSON_PAYLOAD)
 
-            # we want to allow for testing the case where these fields 
+            # we want to allow for testing the case where these fields
             # are missing or empty
             if project_engine_name != None:
                 project_json_data['engine'] = project_engine_name
@@ -444,5 +485,5 @@ class TestRegisterProject:
             if dry_run:
                 assert TestRegisterProject.project_path not in map(lambda subdir: pathlib.PurePath(subdir),
                                         self.o3de_manifest_data.get('external_subdirectories', []))
-                 
+
             assert result == expected_result

--- a/scripts/o3de/tests/test_register.py
+++ b/scripts/o3de/tests/test_register.py
@@ -218,17 +218,21 @@ class TestRegisterGem:
         else:
             return json.loads(TEST_GEM_JSON_PAYLOAD)
 
-    @pytest.mark.parametrize("gem_path, expected_manifest_file, dry_run, expected_result", [
-                                 pytest.param(pathlib.PurePath('TestGem'), pathlib.PurePath('o3de_manifest.json'), False, 0),
-                                 pytest.param(project_path / 'TestGem', pathlib.PurePath('project.json'), False, 0),
-                                 pytest.param(engine_path / 'TestGem', pathlib.PurePath('engine.json'), False, 0),
-                                 pytest.param(pathlib.PurePath('TestGem/TestSubGem') , pathlib.PurePath('gem.json'), False, 0),
-                                 pytest.param(pathlib.PurePath('TestGem'), pathlib.PurePath('o3de_manifest.json'), True, 0),
-                                 pytest.param(project_path / 'TestGem', pathlib.PurePath('project.json'), True, 0),
-                                 pytest.param(engine_path / 'TestGem', pathlib.PurePath('engine.json'), True, 0),
-                                 pytest.param(pathlib.PurePath('TestGem/TestSubGem') , pathlib.PurePath('gem.json'), True, 0),
+    @pytest.mark.parametrize("gem_path, expected_manifest_file, dry_run, force_o3de_manifest_register, expected_result", [
+                                 pytest.param(pathlib.PurePath('TestGem'), pathlib.PurePath('o3de_manifest.json'), False, False, 0),
+                                 pytest.param(project_path / 'TestGem', pathlib.PurePath('project.json'), False, False, 0),
+                                 pytest.param(project_path / 'TestGem', pathlib.PurePath('o3de_manifest.json'), False, True, 0),
+                                 pytest.param(engine_path / 'TestGem', pathlib.PurePath('engine.json'), False, False, 0),
+                                 pytest.param(engine_path / 'TestGem', pathlib.PurePath('o3de_manifest.json'), False, True, 0),
+                                 pytest.param(pathlib.PurePath('TestGem/TestSubGem') , pathlib.PurePath('gem.json'), False, False, 0),
+                                 pytest.param(pathlib.PurePath('TestGem/TestSubGem') , pathlib.PurePath('o3de_manifest.json'), False, True, 0),
+                                 pytest.param(pathlib.PurePath('TestGem'), pathlib.PurePath('o3de_manifest.json'), True, False, 0),
+                                 pytest.param(project_path / 'TestGem', pathlib.PurePath('project.json'), True, False, 0),
+                                 pytest.param(engine_path / 'TestGem', pathlib.PurePath('engine.json'), True, False, 0),
+                                 pytest.param(pathlib.PurePath('TestGem/TestSubGem') , pathlib.PurePath('gem.json'), True, False, 0),
                              ])
-    def test_register_gem_auto_detects_manifest_update(self, gem_path, expected_manifest_file, dry_run, expected_result):
+    def test_register_gem_auto_detects_manifest_update(self, gem_path, expected_manifest_file, dry_run,
+     force_o3de_manifest_register, expected_result):
 
         def save_o3de_manifest(manifest_data: dict, manifest_path: pathlib.Path = None) -> bool:
             if manifest_path == pathlib.Path(TestRegisterGem.ancestor_gem_path).resolve() / 'gem.json':
@@ -287,7 +291,8 @@ class TestRegisterGem:
                 patch('o3de.utils.find_ancestor_dir_containing_file', side_effect=find_ancestor_dir) as _6,\
                 patch('pathlib.Path.is_dir', return_value=True) as _7,\
                 patch('o3de.validation.valid_o3de_gem_json', return_value=True) as _8:
-            result = register.register(gem_path=gem_path, dry_run=dry_run)
+            result = register.register(gem_path=gem_path, dry_run=dry_run,
+                force_register_with_o3de_manifest=force_o3de_manifest_register)
             assert result == expected_result
 
             if expected_manifest_file == pathlib.PurePath('o3de_manifest.json'):


### PR DESCRIPTION
If the `-esgp`, `-espp`, `-esep` is not supplied when registering a gem path, then the nearest ancestor directory containing a gem.json is used as the location to register the sub gem to it's "external_subdirectories" array.

If there is no ancestor gem path, then the nearest project path is
located.
If there is no nearest project path, then the nearest engine path is
located.
Finally if there is no nearest engine path, the
`~/.o3de/o3de_manifest.json` is where the gem will be registered.

Fixed the test package name discovery for the o3de python package by removing the `__init__.py` script

Added an additional external subdirectory option that is mutually exclusive with `--external-subdirectory-gem-path`, `--external-subdirectory-project-path` and `--external-subdirectory-engine-path`, that forces registration of an external subdirectory with the `~/.o3de/o3de_manifest.json`.
The new option is `--force-register-with-o3de-manifest`

## How was this PR tested?

Ran test_register.py test successfully through VS Code
![image](https://user-images.githubusercontent.com/56135373/224138011-992f6e94-d4ed-46f0-bd45-b619d6df9dec.png)
