### PR TITLE
DebugDraw fix for Unified launchers

### DIFF
--- a/Gems/DebugDraw/Code/CMakeLists.txt
+++ b/Gems/DebugDraw/Code/CMakeLists.txt
@@ -41,6 +41,7 @@ ly_add_target(
 
 # servers do not need debug draw components, only clients
 ly_create_alias(NAME DebugDraw.Clients NAMESPACE Gem TARGETS DebugDraw)
+ly_create_alias(NAME DebugDraw.Unified NAMESPACE Gem TARGETS DebugDraw)
 
 if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(


### PR DESCRIPTION
## What does this PR do?

Enables debug draw gem functionality for Unified launchers.

## How was this PR tested?

Tested with o3de-multiplayersample in Unified launcher.
