### PR TITLE
DPE: Support nested containers and specific patching in ReflectionAdapter

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.h
@@ -80,7 +80,7 @@ namespace AZ::DocumentPropertyEditor
         //! Returns the error information, if any, encountered during the build process.
         const AZStd::string& GetError() const;
         //! Ends the build operation and retrieves the builder result.
-        //! Operations are no longer valid on this builder once this is called.
+        //! Further calls to this builder will be for a new DOM.
         Dom::Value&& FinishAndTakeResult();
 
         template<class PropertyEditorDefinition, class ValueType = AZ::Dom::Value>

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -59,10 +59,13 @@ namespace AZ::DocumentPropertyEditor::Nodes
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumUnderlyingType);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::InternalEnumValueKey);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::ChangeNotify);
-        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::AddNotify);
-        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::RemoveNotify);
-        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::ClearNotify);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::ValueHashed);
+
+        system->RegisterNode<Container>();
+        system->RegisterNodeAttribute<PropertyEditor>(Container::ParentContainerValueType);
+        system->RegisterNodeAttribute<PropertyEditor>(Container::AddNotify);
+        system->RegisterNodeAttribute<PropertyEditor>(Container::RemoveNotify);
+        system->RegisterNodeAttribute<PropertyEditor>(Container::ClearNotify);
 
         system->RegisterPropertyEditor<UIElement>();
         system->RegisterNodeAttribute<UIElement>(UIElement::Handler);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -147,10 +147,14 @@ namespace AZ::DocumentPropertyEditor::Nodes
 
         static constexpr auto ChangeNotify = CallbackAttributeDefinition<PropertyRefreshLevel()>("ChangeNotify");
         static constexpr auto RequestTreeUpdate = CallbackAttributeDefinition<void(PropertyRefreshLevel)>("RequestTreeUpdate");
+    };
 
-        // Container attributes
+    struct Container : NodeWithVisiblityControl
+    {
+        static constexpr auto ParentContainerValueType = TypeIdAttributeDefinition("ParentContainerValueType");
+
         static constexpr auto AddNotify = CallbackAttributeDefinition<void()>("AddNotify");
-        static constexpr auto RemoveNotify = CallbackAttributeDefinition<void(size_t)>("RemoveNotify");
+        static constexpr auto RemoveNotify = CallbackAttributeDefinition<void()>("RemoveNotify");
         static constexpr auto ClearNotify = CallbackAttributeDefinition<void()>("ClearNotify");
     };
 

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -747,19 +747,25 @@ namespace AZ::Reflection
                         nodeData.m_cachedAttributes.push_back(
                             { group, DescriptorAttributes::ParentContainer, Dom::Utils::ValueFromType<void*>(parentContainerInfo) });
 
+                        nodeData.m_cachedAttributes.push_back({
+                            group,
+                            DocumentPropertyEditor::Nodes::Container::ParentContainerValueType.GetName(),
+                              AZ::Dom::Utils::TypeIdToDomValue(parentNode.m_typeId) });
+
                         auto parentContainerInstance =
                             (parentNode.m_parentContainerOverride ? parentNode.m_parentContainerOverride : parentNode.m_instance);
 
-                        nodeData.m_cachedAttributes.push_back({ group,
-                                                                DescriptorAttributes::ParentContainerInstance,
-                                                                Dom::Utils::ValueFromType<void*>(parentContainerInstance) });
+                        nodeData.m_cachedAttributes.push_back({
+                            group,
+                            DescriptorAttributes::ParentContainerInstance,
+                            Dom::Utils::ValueFromType<void*>(parentContainerInstance) });
 
                         if (parentNode.m_containerElementOverride)
                         {
-                            nodeData.m_cachedAttributes.push_back(
-                                { group,
-                                  DescriptorAttributes::ContainerElementOverride,
-                                  Dom::Utils::ValueFromType<void*>(parentNode.m_containerElementOverride) });
+                            nodeData.m_cachedAttributes.push_back({
+                                group,
+                                DescriptorAttributes::ContainerElementOverride,
+                                Dom::Utils::ValueFromType<void*>(parentNode.m_containerElementOverride) });
                         }
 
                         if (nodeData.m_labelOverride.empty())

--- a/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
@@ -158,6 +158,7 @@ namespace DPEDebugView
         int m_readOnlyInt = 33;
         double m_doubleSlider = 3.25;
         AZStd::vector<AZStd::string> m_vector;
+        AZStd::vector<AZStd::vector<int>> m_vectorOfVectors;
         AZStd::map<AZStd::string, float> m_map;
         AZStd::map<AZStd::string, float> m_readOnlyMap;
         AZStd::unordered_map<AZStd::pair<int, double>, int> m_unorderedMap;
@@ -189,6 +190,7 @@ namespace DPEDebugView
                     ->Field("simpleInt", &TestContainer::m_simpleInt)
                     ->Field("doubleSlider", &TestContainer::m_doubleSlider)
                     ->Field("vector", &TestContainer::m_vector)
+                    ->Field("vectorOfVectors", &TestContainer::m_vectorOfVectors)
                     ->Field("map", &TestContainer::m_map)
                     ->Field("unorderedMap", &TestContainer::m_unorderedMap)
                     ->Field("simpleEnum", &TestContainer::m_simpleEnumMap)
@@ -226,6 +228,7 @@ namespace DPEDebugView
                         ->ClassElement(AZ::Edit::ClassElements::Group, "Containers")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_vector, "vector<string>", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_vectorOfVectors, "vector<vector<int>>", "")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_map, "map<string, float>", "")
                         ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
@@ -336,6 +339,9 @@ int main(int argc, char** argv)
     testContainer.m_vector.push_back("one");
     testContainer.m_vector.push_back("two");
     testContainer.m_vector.push_back("the third");
+
+    testContainer.m_vectorOfVectors.push_back({ 0, 1 });
+    testContainer.m_vectorOfVectors.push_back({ 2, 3 });
 
     testContainer.m_map["One"] = 1.f;
     testContainer.m_map["Two"] = 2.f;


### PR DESCRIPTION
DRAFT

Contains:
- Fix for broken nested container action buttons which weren't working due to BoundContainer's combining state for root containers, nested containers, and non-container elements
- Created BoundContainer factory method to simplify their creation and maintenance
- Separated GetContainerNode's visiting into two cases; one for container elements (including nested containers) and one for containers
- Implemented Add/Remove/ClearNotify handlers in ReflectionAdapter::HandleMessage instead of performing DOM fixup in the BoundContainer
- Handler for container Notify messages above passes the root container node (the first container in any container subtree) back through the visitor in order to fixup BoundAdapterMessage paths, labels with container size information, etc

Problems/WIP:
- Re-visiting nodes does not perform as hoped; SerializeContext::EnumerateInstance does not acquire classElement/editData for the instance provided, so parent node data is lost and things like editData, parent container data, and visibility are lost
- Make constexpr strings constexpr, etc