### PR TITLE
Compliant Contacts support to PhysX Materials (PhysX 5 only)

### DIFF
--- a/Gems/PhysX/Code/Include/PhysX/Material/PhysXMaterial.h
+++ b/Gems/PhysX/Code/Include/PhysX/Material/PhysXMaterial.h
@@ -37,7 +37,7 @@ namespace PhysX
     namespace MaterialConstants
     {
         inline constexpr AZStd::string_view MaterialAssetType = "PhysX";
-        inline constexpr AZ::u32 MaterialAssetVersion = 1;
+        inline constexpr AZ::u32 MaterialAssetVersion = 2;
 
         inline constexpr AZStd::string_view DynamicFrictionName = "DynamicFriction";
         inline constexpr AZStd::string_view StaticFrictionName = "StaticFriction";
@@ -45,6 +45,9 @@ namespace PhysX
         inline constexpr AZStd::string_view DensityName = "Density";
         inline constexpr AZStd::string_view RestitutionCombineModeName = "RestitutionCombineMode";
         inline constexpr AZStd::string_view FrictionCombineModeName = "FrictionCombineMode";
+        inline constexpr AZStd::string_view CompliantContactModeEnabledName = "CompliantContactModeEnabled";
+        inline constexpr AZStd::string_view CompliantContactModeDampingName = "CompliantContactModeDamping";
+        inline constexpr AZStd::string_view CompliantContactModeStiffnessName = "CompliantContactModeStiffness";
         inline constexpr AZStd::string_view DebugColorName = "DebugColor";
 
         inline constexpr float MinDensityLimit = 0.01f; //!< Minimum possible value of density.
@@ -109,6 +112,15 @@ namespace PhysX
         float GetDensity() const;
         void SetDensity(float density);
 
+        bool IsCompliantContactModeEnabled() const;
+        void EnableCompliantContactMode(bool enabled);
+
+        float GetCompliantContactModeDamping() const;
+        void SetCompliantContactModeDamping(float damping);
+
+        float GetCompliantContactModeStiffness() const;
+        void SetCompliantContactModeStiffness(float stiffness);
+
         const AZ::Color& GetDebugColor() const;
         void SetDebugColor(const AZ::Color& debugColor);
 
@@ -129,6 +141,9 @@ namespace PhysX
         using PxMaterialUniquePtr = AZStd::unique_ptr<physx::PxMaterial, AZStd::function<void(physx::PxMaterial*)>>;
 
         PxMaterialUniquePtr m_pxMaterial;
+        float m_restitution = 0.5f;
+        float m_compliantContactModeDamping = 1.0f;
+        float m_compliantContactModeStiffness = 1.0f;
         float m_density = 1000.0f;
         AZ::Color m_debugColor = AZ::Colors::White;
     };

--- a/Gems/PhysX/Code/Include/PhysX/Material/PhysXMaterialConfiguration.h
+++ b/Gems/PhysX/Code/Include/PhysX/Material/PhysXMaterialConfiguration.h
@@ -16,6 +16,21 @@
 
 namespace PhysX
 {
+    //! Properties of compliant contact mode.
+    struct CompliantContactModeConfiguration
+    {
+        AZ_TYPE_INFO(PhysX::CompliantContactModeConfiguration, "{1F38A087-E918-4ED1-AEC5-5FEC25A47AD1}");
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        bool m_enabled = false;
+        float m_damping = 1.0f;
+        float m_stiffness = 1.0f;
+
+    private:
+        bool ReadOnlyProperties() const;
+    };
+
     //! Properties of a PhysX material.
     struct MaterialConfiguration
     {
@@ -31,6 +46,8 @@ namespace PhysX
         CombineMode m_restitutionCombine = CombineMode::Average;
         CombineMode m_frictionCombine = CombineMode::Average;
 
+        CompliantContactModeConfiguration m_compliantContactMode;
+
         AZ::Color m_debugColor = AZ::Colors::White;
 
         //! Creates a Physics Material Asset with random Id from the
@@ -42,5 +59,8 @@ namespace PhysX
     private:
         static float GetMinDensityLimit();
         static float GetMaxDensityLimit();
+
+        bool IsRestitutionReadOnly() const;
+        AZ::Crc32 GetCompliantConstantModeVisibility() const;
     };
 } // namespace PhysX

--- a/Gems/PhysX/Code/Source/Material/PhysXMaterial.cpp
+++ b/Gems/PhysX/Code/Source/Material/PhysXMaterial.cpp
@@ -108,6 +108,7 @@ namespace PhysX
     {
         const MaterialConfiguration defaultMaterialConfiguration;
 
+        // Create the PxMaterial with default values
         m_pxMaterial = PxMaterialUniquePtr(
             PxGetPhysics().createMaterial(
                 defaultMaterialConfiguration.m_staticFriction, defaultMaterialConfiguration.m_dynamicFriction, defaultMaterialConfiguration.m_restitution),
@@ -119,6 +120,14 @@ namespace PhysX
         AZ_Assert(m_pxMaterial, "Failed to create physx material");
         m_pxMaterial->userData = this;
 
+        // Assign default values to members
+        m_restitution = defaultMaterialConfiguration.m_restitution;
+        m_compliantContactModeDamping = defaultMaterialConfiguration.m_compliantContactMode.m_damping;
+        m_compliantContactModeStiffness = defaultMaterialConfiguration.m_compliantContactMode.m_stiffness;
+        m_density = defaultMaterialConfiguration.m_density;
+        m_debugColor = defaultMaterialConfiguration.m_debugColor;
+
+        // OnAssetReady it will set all the properties from the material asset
         AZ::Data::AssetBus::Handler::BusConnect(m_materialAsset.GetId());
     }
 
@@ -152,6 +161,18 @@ namespace PhysX
         else if (propertyName == MaterialConstants::FrictionCombineModeName)
         {
             return static_cast<AZ::u32>(GetFrictionCombineMode());
+        }
+        else if (propertyName == MaterialConstants::CompliantContactModeEnabledName)
+        {
+            return IsCompliantContactModeEnabled();
+        }
+        else if (propertyName == MaterialConstants::CompliantContactModeDampingName)
+        {
+            return GetCompliantContactModeDamping();
+        }
+        else if (propertyName == MaterialConstants::CompliantContactModeStiffnessName)
+        {
+            return GetCompliantContactModeStiffness();
         }
         else if (propertyName == MaterialConstants::DebugColorName)
         {
@@ -190,6 +211,18 @@ namespace PhysX
         {
             SetFrictionCombineMode(static_cast<CombineMode>(value.GetValue<AZ::u32>()));
         }
+        else if (propertyName == MaterialConstants::CompliantContactModeEnabledName)
+        {
+            EnableCompliantContactMode(value.GetValue<bool>());
+        }
+        else if (propertyName == MaterialConstants::CompliantContactModeDampingName)
+        {
+            SetCompliantContactModeDamping(value.GetValue<float>());
+        }
+        else if (propertyName == MaterialConstants::CompliantContactModeStiffnessName)
+        {
+            SetCompliantContactModeStiffness(value.GetValue<float>());
+        }
         else if (propertyName == MaterialConstants::DebugColorName)
         {
             SetDebugColor(value.GetValue<AZ::Color>());
@@ -227,7 +260,7 @@ namespace PhysX
 
     float Material::GetRestitution() const
     {
-        return m_pxMaterial->getRestitution();
+        return m_restitution;
     }
 
     void Material::SetRestitution(float restitution)
@@ -236,7 +269,12 @@ namespace PhysX
             "PhysX Material", restitution >= 0.0f && restitution <= 1.0f, "Restitution value %f will be clamped into range [0, 1]",
             restitution);
 
-        m_pxMaterial->setRestitution(AZ::GetClamp(restitution, 0.0f, 1.0f));
+        m_restitution = AZ::GetClamp(restitution, 0.0f, 1.0f);
+
+        if (!IsCompliantContactModeEnabled())
+        {
+            m_pxMaterial->setRestitution(m_restitution);
+        }
     }
 
     CombineMode Material::GetFrictionCombineMode() const
@@ -271,6 +309,72 @@ namespace PhysX
             "Density value %f will be clamped into range [%f, %f].", density, MaterialConstants::MinDensityLimit, MaterialConstants::MaxDensityLimit);
 
         m_density = AZ::GetClamp(density, MaterialConstants::MinDensityLimit, MaterialConstants::MaxDensityLimit);
+    }
+
+    bool Material::IsCompliantContactModeEnabled() const
+    {
+#if (PX_PHYSICS_VERSION_MAJOR >= 5)
+        return m_pxMaterial->getFlags() & physx::PxMaterialFlag::eCOMPLIANT_CONTACT;
+#else
+        return false;
+#endif
+    }
+
+    void Material::EnableCompliantContactMode([[maybe_unused]] bool enabled)
+    {
+#if (PX_PHYSICS_VERSION_MAJOR >= 5)
+        m_pxMaterial->setFlag(physx::PxMaterialFlag::eCOMPLIANT_CONTACT, enabled);
+        if (enabled)
+        {
+            m_pxMaterial->setDamping(m_compliantContactModeDamping);
+            m_pxMaterial->setRestitution(-m_compliantContactModeStiffness); // PxMaterial uses negative values in the restitution property for the stiffness of Compliant Contacts
+        }
+        else
+        {
+            m_pxMaterial->setDamping(0.0f);
+            m_pxMaterial->setRestitution(m_restitution); // Restores restitution value when Compliant Contancts was disabled
+        }
+#endif
+    }
+
+    float Material::GetCompliantContactModeDamping() const
+    {
+        return m_compliantContactModeDamping;
+    }
+
+    void Material::SetCompliantContactModeDamping([[maybe_unused]] float damping)
+    {
+#if (PX_PHYSICS_VERSION_MAJOR >= 5)
+        AZ_Warning("PhysX Material", damping >= 0.0f, "Compliant Contact Mode Damping value %f is out of range, 0 will be used.", damping);
+
+        m_compliantContactModeDamping = AZ::GetMax(0.0f, damping);
+
+        if (IsCompliantContactModeEnabled())
+        {
+            m_pxMaterial->setDamping(m_compliantContactModeDamping);
+        }
+#endif
+    }
+
+    float Material::GetCompliantContactModeStiffness() const
+    {
+        return m_compliantContactModeStiffness;
+    }
+
+    void Material::SetCompliantContactModeStiffness([[maybe_unused]] float stiffness)
+    {
+#if (PX_PHYSICS_VERSION_MAJOR >= 5)
+        AZ_Warning(
+            "PhysX Material", stiffness >= 0.0f, "Compliant Contact Mode Stiffness value %f is out of range, 0 will be used.", stiffness);
+
+        m_compliantContactModeStiffness = AZ::GetMax(0.0f, stiffness);
+
+        if (IsCompliantContactModeEnabled())
+        {
+            // PxMaterial uses negative values in the restitution property for the stiffness of Compliant Contacts
+            m_pxMaterial->setRestitution(-m_compliantContactModeStiffness);
+        }
+#endif
     }
 
     const AZ::Color& Material::GetDebugColor() const

--- a/Gems/PhysX/Code/Source/Material/PhysXMaterialConfiguration.cpp
+++ b/Gems/PhysX/Code/Source/Material/PhysXMaterialConfiguration.cpp
@@ -15,8 +15,53 @@
 
 namespace PhysX
 {
+    void CompliantContactModeConfiguration::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<PhysX::CompliantContactModeConfiguration>()
+                ->Version(1)
+                ->Field("Enabled", &CompliantContactModeConfiguration::m_enabled)
+                ->Field("Damping", &CompliantContactModeConfiguration::m_damping)
+                ->Field("Stiffness", &CompliantContactModeConfiguration::m_stiffness);
+
+            if (auto* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<PhysX::CompliantContactModeConfiguration>("", "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &CompliantContactModeConfiguration::m_enabled,
+                        "Enable",
+                        "When enabled the normal force of the contact is computed using an implicit spring. Restitution properties are not used when enabled.")
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &CompliantContactModeConfiguration::m_damping,
+                        "Damping",
+                        "Higher damping values produce spongy contacts.")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &CompliantContactModeConfiguration::ReadOnlyProperties)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &CompliantContactModeConfiguration::m_stiffness,
+                        "Stiffness",
+                        "Higher stiffness values produce stiffer springs that behave more like a rigid contact.")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &CompliantContactModeConfiguration::ReadOnlyProperties);
+            }
+        }
+    }
+
+    bool CompliantContactModeConfiguration::ReadOnlyProperties() const
+    {
+        return !m_enabled;
+    }
+
     void MaterialConfiguration::Reflect(AZ::ReflectContext* context)
     {
+        CompliantContactModeConfiguration::Reflect(context);
+
         if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<PhysX::MaterialConfiguration>()
@@ -27,6 +72,7 @@ namespace PhysX
                 ->Field("FrictionCombine", &MaterialConfiguration::m_frictionCombine)
                 ->Field("RestitutionCombine", &MaterialConfiguration::m_restitutionCombine)
                 ->Field("Density", &MaterialConfiguration::m_density)
+                ->Field("CompliantContactMode", &MaterialConfiguration::m_compliantContactMode)
                 ->Field("DebugColor", &MaterialConfiguration::m_debugColor)
                 ;
 
@@ -35,6 +81,7 @@ namespace PhysX
 
                 editContext->Class<PhysX::MaterialConfiguration>("", "")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "PhysX Material")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &MaterialConfiguration::m_staticFriction, "Static friction", "Friction coefficient when object is still")
                         ->Attribute(AZ::Edit::Attributes::Min, 0.f)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &MaterialConfiguration::m_dynamicFriction, "Dynamic friction", "Friction coefficient when object is moving")
@@ -42,6 +89,7 @@ namespace PhysX
                     ->DataElement(AZ::Edit::UIHandlers::Default, &MaterialConfiguration::m_restitution, "Restitution", "Restitution coefficient")
                         ->Attribute(AZ::Edit::Attributes::Min, 0.f)
                         ->Attribute(AZ::Edit::Attributes::Max, 1.f)
+                        ->Attribute(AZ::Edit::Attributes::ReadOnly, &MaterialConfiguration::IsRestitutionReadOnly)
                     ->DataElement(AZ::Edit::UIHandlers::ComboBox, &MaterialConfiguration::m_frictionCombine, "Friction combine", "How the friction is combined between colliding objects")
                         ->EnumAttribute(CombineMode::Average, "Average")
                         ->EnumAttribute(CombineMode::Minimum, "Minimum")
@@ -52,10 +100,14 @@ namespace PhysX
                         ->EnumAttribute(CombineMode::Minimum, "Minimum")
                         ->EnumAttribute(CombineMode::Maximum, "Maximum")
                         ->EnumAttribute(CombineMode::Multiply, "Multiply")
+                        ->Attribute(AZ::Edit::Attributes::ReadOnly, &MaterialConfiguration::IsRestitutionReadOnly)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &MaterialConfiguration::m_density, "Density", "Material density")
                         ->Attribute(AZ::Edit::Attributes::Min, &MaterialConfiguration::GetMinDensityLimit)
                         ->Attribute(AZ::Edit::Attributes::Max, &MaterialConfiguration::GetMaxDensityLimit)
                         ->Attribute(AZ::Edit::Attributes::Suffix, " " + Physics::NameConstants::GetDensityUnit())
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MaterialConfiguration::m_compliantContactMode, "Compliant Contact Mode",
+                        "When enabled the normal force of the contact is computed using an implicit spring. Restitution properties are not used when enabled.")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &MaterialConfiguration::GetCompliantConstantModeVisibility)
                     ->DataElement(AZ::Edit::UIHandlers::Color, &MaterialConfiguration::m_debugColor, "Debug Color", "Debug color to use for this material")
                     ;
             }
@@ -76,6 +128,9 @@ namespace PhysX
             {MaterialConstants::DensityName, m_density},
             {MaterialConstants::RestitutionCombineModeName, static_cast<AZ::u32>(m_restitutionCombine)},
             {MaterialConstants::FrictionCombineModeName, static_cast<AZ::u32>(m_frictionCombine)},
+            {MaterialConstants::CompliantContactModeEnabledName, m_compliantContactMode.m_enabled},
+            {MaterialConstants::CompliantContactModeDampingName, m_compliantContactMode.m_damping},
+            {MaterialConstants::CompliantContactModeStiffnessName, m_compliantContactMode.m_stiffness},
             {MaterialConstants::DebugColorName, m_debugColor}
         };
 
@@ -101,28 +156,52 @@ namespace PhysX
             "Material asset '%s' has unexpected material type ('%s'). Expected type is '%.*s'.",
             materialAsset.GetHint().c_str(), materialAsset->GetMaterialType().c_str(), AZ_STRING_ARG(MaterialConstants::MaterialAssetType));
 
-        AZ_Error("MaterialConfiguration", materialAsset->GetVersion() == MaterialConstants::MaterialAssetVersion,
-            "Material asset '%s' has unexpected material version (%u). Expected version is '%u'.",
+        AZ_Error("MaterialConfiguration", materialAsset->GetVersion() <= MaterialConstants::MaterialAssetVersion,
+            "Material asset '%s' has unexpected material version (%u). Expected version is <='%u'.",
             materialAsset.GetHint().c_str(), materialAsset->GetVersion(), MaterialConstants::MaterialAssetVersion);
 
-        const AZStd::fixed_vector materialPropertyNames =
+        auto checkProperties = [materialAsset](AZStd::span<const AZStd::string_view> materialPropertyNames)
         {
-            MaterialConstants::DynamicFrictionName,
-            MaterialConstants::StaticFrictionName,
-            MaterialConstants::RestitutionName,
-            MaterialConstants::DensityName,
-            MaterialConstants::RestitutionCombineModeName,
-            MaterialConstants::FrictionCombineModeName,
-            MaterialConstants::DebugColorName
+            const auto& materialProperties = materialAsset->GetMaterialProperties();
+
+            for (const auto& materialPropertyName : materialPropertyNames)
+            {
+                AZ_Error(
+                    "MaterialConfiguration",
+                    materialProperties.find(materialPropertyName) != materialProperties.end(),
+                    "Material asset '%s' does not have property '%.*s'.",
+                    materialAsset.GetHint().c_str(),
+                    AZ_STRING_ARG(materialPropertyName));
+            }
         };
 
-        const auto& materialProperties = materialAsset->GetMaterialProperties();
-
-        for (const auto& materialPropertyName : materialPropertyNames)
+        // Check properties from version 1
         {
-            AZ_Error("MaterialConfiguration", materialProperties.find(materialPropertyName) != materialProperties.end(),
-                "Material asset '%s' does not have property '%.*s'.",
-                materialAsset.GetHint().c_str(), AZ_STRING_ARG(materialPropertyName));
+            const AZStd::fixed_vector materialPropertyNames =
+            {
+                MaterialConstants::DynamicFrictionName,
+                MaterialConstants::StaticFrictionName,
+                MaterialConstants::RestitutionName,
+                MaterialConstants::DensityName,
+                MaterialConstants::RestitutionCombineModeName,
+                MaterialConstants::FrictionCombineModeName,
+                MaterialConstants::DebugColorName
+            };
+
+            checkProperties(materialPropertyNames);
+        }
+
+        // Check properties from version 2: Added Compliant Contact Mode properties.
+        if (materialAsset->GetVersion() == 2)
+        {
+            const AZStd::fixed_vector materialPropertyNames =
+            {
+                MaterialConstants::CompliantContactModeEnabledName,
+                MaterialConstants::CompliantContactModeDampingName,
+                MaterialConstants::CompliantContactModeStiffnessName
+            };
+
+            checkProperties(materialPropertyNames);
         }
 #endif
     }
@@ -135,5 +214,23 @@ namespace PhysX
     float MaterialConfiguration::GetMaxDensityLimit()
     {
         return MaterialConstants::MaxDensityLimit;
+    }
+
+    bool MaterialConfiguration::IsRestitutionReadOnly() const
+    {
+#if (PX_PHYSICS_VERSION_MAJOR >= 5)
+        return m_compliantContactMode.m_enabled;
+#else
+        return false;
+#endif
+    }
+
+    AZ::Crc32 MaterialConfiguration::GetCompliantConstantModeVisibility() const
+    {
+#if (PX_PHYSICS_VERSION_MAJOR >= 5)
+        return AZ::Edit::PropertyVisibility::Show;
+#else
+        return AZ::Edit::PropertyVisibility::Hide;
+#endif
     }
 } // namespace PhysX


### PR DESCRIPTION
This is a draft PR to get initial feedback on the feature.

## What does this PR do?

It adds compliant Contacts support to PhysX Materials (PhysX 5 only)

![image](https://user-images.githubusercontent.com/27999040/224371928-e206a755-a4b6-49cc-b26f-06ade7e54a75.png)

## How was this PR tested?

At the moment when compliant constraints is used colliders stop working. I'm currently investigating and also getting in contact with nVidia. If you spot errors in the code please let me know ;)
