### PR TITLE
StableDynamicStructOfArrays

### DIFF
--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/StableDynamicStructOfArrays.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/StableDynamicStructOfArrays.h
@@ -157,14 +157,14 @@ namespace AZ
         /// True if this page is completely empty
         bool IsEmpty() const;
 
-        AZStd::tuple<value_types *...> GetItems(size_t index);
+        ItemTupleType GetItems(size_t index);
 
         /**
         * Gets a specific item from the Page
         * Note: may return empty slots.
         */
         template<size_t RowIndex>
-        AZStd::tuple_element_t<RowIndex, AZStd::tuple<value_types...>>* GetItem(size_t index);
+        auto* GetItem(size_t index);
 
         /// Gets the number of items allocated on this page.
         size_t GetItemCount() const;
@@ -197,7 +197,7 @@ namespace AZ
         // TODO: is this operator needed?
         const this_type& operator*() const;
         template <size_t RowIndex>
-        auto* GetItem() const;
+        auto& GetItem() const;
 
         bool operator==(const this_type& rhs) const;
         bool operator!=(const this_type& rhs) const;
@@ -231,7 +231,7 @@ namespace AZ
         explicit const_iterator(Page* firstPage);
 
         template<size_t RowIndex>
-        auto* GetItem() const;
+        auto& GetItem() const;
 
         this_type& operator++();
         this_type operator++(int);
@@ -252,7 +252,7 @@ namespace AZ
 
         const this_type& operator*() const;
         template<size_t RowIndex>
-        auto* GetItem() const;
+        auto& GetItem() const;
 
         bool operator==(const this_type& rhs) const;
         bool operator!=(const this_type& rhs) const;
@@ -282,6 +282,9 @@ namespace AZ
     class StableDynamicStructOfArraysWeakHandle
     {
     public:
+        using ItemTupleType = AZStd::tuple<value_types*...>;
+
+        /// Default constructor creates an invalid handle.
         StableDynamicStructOfArraysWeakHandle() = default;
 
         /// Returns true if this Handle currently holds a valid value.
@@ -290,15 +293,15 @@ namespace AZ
         /// Returns true if this Handle doesn't contain a value (same as !IsValid()).
         bool IsNull() const;
 
-        AZStd::tuple<value_types*...>& operator*();
+        ItemTupleType& operator*();
 
         template <size_t RowIndex>
-        auto* GetItem() const;
+        auto& GetItem() const;
         
     private:
-        StableDynamicStructOfArraysWeakHandle(const AZStd::tuple<value_types*...>& data);
+        StableDynamicStructOfArraysWeakHandle(const ItemTupleType& data);
 
-        AZStd::tuple<value_types*...> m_data;
+        ItemTupleType m_data;
 
         template<typename... value_types>
         friend class StableDynamicStructOfArraysHandle;
@@ -315,6 +318,7 @@ namespace AZ
         template<size_t ElementsPerPage, class Allocator, typename... value_types>
         friend class StableDynamicStructOfArrays;
     public:
+        using ItemTupleType = AZStd::tuple<value_types*...>;
 
         /// Default constructor creates an invalid handle.
         StableDynamicStructOfArraysHandle() = default;
@@ -337,17 +341,17 @@ namespace AZ
         /// Returns true if this Handle doesn't contain a value (same as !IsValid()).
         bool IsNull() const;
 
-        AZStd::tuple<value_types*...>& operator*();
+        ItemTupleType& operator*();
 
         /// Returns a pointer to the item in the row specified by RowIndex
         template <size_t RowIndex>
-        auto* GetItem() const;
+        auto& GetItem() const;
 
         /// Returns a non-owning weak handle to the data
         StableDynamicStructOfArraysWeakHandle<value_types...> GetWeakHandle() const;
     private:
         template<typename PageType>
-        StableDynamicStructOfArraysHandle(AZStd::tuple<value_types *...> data, PageType* page);
+        StableDynamicStructOfArraysHandle(ItemTupleType data, PageType* page);
 
         StableDynamicStructOfArraysHandle(const StableDynamicStructOfArraysHandle&) = delete;
 
@@ -357,7 +361,7 @@ namespace AZ
         /// Called for valid handles on delete so the underlying data can be removed from the StableDynamicArray
         HandleDestructor m_destructorCallback = nullptr; 
         void* m_page = nullptr; ///< The page the data this Handle points to was allocated on.
-        AZStd::tuple<value_types *...> m_data;
+        ItemTupleType m_data;
     };
     
     /// Used for returning information about the internal state of the StableDynamicStructOfArrays.

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/StableDynamicStructOfArrays.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/StableDynamicStructOfArrays.h
@@ -91,6 +91,9 @@ namespace AZ
          * StableDynamicStructOfArrays can be processsed in parallel by iterating through each range on a 
          * different thread. Since StableDynamicStructOfArrays only uses forward iterators, this would be
          * expensive to create external to this class.
+         *
+         * The iterators themselves operate using the bitmask representing used slots in the page, but
+         * they expose access to any row of a page via GetItem<RowIndex>().
          */
         AZStd::vector<AZStd::pair<pageIterator, pageIterator>> GetParallelRanges();
 
@@ -119,6 +122,9 @@ namespace AZ
         const_iterator cend() const;
 
     private:
+
+        template<class... TupleArgs>
+        Handle EmplaceTupleElements(Page* page, size_t elementIndex, TupleArgs&&... tupleArgs);
 
         /// Adds a page and returns its pointer
         Page* AddPage();
@@ -161,7 +167,7 @@ namespace AZ
         ItemTupleType GetItems(size_t index);
 
         /**
-        * Gets a specific item from the Page
+        * Gets a specific item from a specific row of the Page
         * Note: may return empty slots.
         */
         template<size_t RowIndex>
@@ -195,7 +201,6 @@ namespace AZ
         iterator() = default;
         explicit iterator(Page* firstPage);
 
-        // TODO: is this operator needed?
         const this_type& operator*() const;
         template <size_t RowIndex>
         auto& GetItem() const;

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/StableDynamicStructOfArrays.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/StableDynamicStructOfArrays.h
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Math/MathIntrinsics.h>
+#include <AzCore/std/containers/array.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/typetraits/aligned_storage.h>
+#include <AzCore/base.h>
+#include <stdint.h>
+
+namespace AZ
+{
+    /// forward declarations
+    struct StableDynamicStructOfArraysMetrics;
+
+    template<typename ValueType>
+    class StableDynamicStructOfArraysWeakHandle;
+
+    template<typename ValueType>
+    class StableDynamicStructOfArraysHandle;
+
+    /**
+    *   A StableDynamicStructOfArrays uses a variable number of arrays to store data. Basically this container
+    * is a list of arrays, with some information to track usage within those arrays, some
+    * optimization to keep jumping through the list to a minimum, and a forward iterator to traverse
+    * the whole container.
+    *   This container produces better cache locality when iterating on elements (vs a list) and keeps 
+    * appending/removing cost low by reusing empty slots. Resizing is also contained to allocating new
+    * arrays.
+    *   It will always place new items at the front-most slot of the first array with available space.
+    * DefragmentHandle() can be called to reorganize data to reduce the amount of empty slots.
+    **/
+    template<typename T, size_t ElementsPerPage = 512, class Allocator = AZStd::allocator>
+    class StableDynamicStructOfArrays
+    {
+        static_assert(!(ElementsPerPage % 64) && ElementsPerPage > 0, "PageSize must be a multiple of 64.");
+        static constexpr size_t PageSize = ElementsPerPage * sizeof(T);
+
+        using value_type = T;
+
+        class iterator;
+        class const_iterator;
+        class pageIterator;
+
+        friend iterator;
+        friend const_iterator;
+        friend StableDynamicStructOfArraysHandle<T>;
+
+        typedef Allocator allocator_type;
+
+        struct Page;
+
+    public:
+
+        using Handle = StableDynamicStructOfArraysHandle<T>;
+        using WeakHandle = StableDynamicStructOfArraysWeakHandle<T>;
+
+        StableDynamicStructOfArrays() = default;
+        explicit StableDynamicStructOfArrays(allocator_type allocator);
+        ~StableDynamicStructOfArrays();
+
+        /// Reserves and constructs an item of type T and returns a handle to it.
+        Handle insert(const value_type& value);
+        /// Reserves and constructs an item of type T and returns a handle to it.
+        Handle insert(value_type&& value);
+
+        /// Reserves and constructs an item of type T with provided args and returns a handle to it.
+        template<class ... Args>
+        Handle emplace(Args&& ... args);
+
+        /// Destructs and frees the memory associated with a handle, then invalidates the handle.
+        void erase(Handle& handle);
+
+        /// Returns the number of items in this container.
+        size_t size() const;
+
+        /*
+         * Returns pairs of begin and end iterators for that represent contiguous ranges of elements 
+         * in the StableDynamicStructOfArrays. This is useful for cases where all of the items in the
+         * StableDynamicStructOfArrays can be processsed in parallel by iterating through each range on a 
+         * different thread. Since StableDynamicStructOfArrays only uses forward iterators, this would be
+         * expensive to create external to this class.
+         */
+        AZStd::vector<AZStd::pair<pageIterator, pageIterator>> GetParallelRanges();
+
+        /* 
+        * If the memory associated with this handle can be moved to a more compact spot, it will be.
+        * This will change the pointer inside the handle, so should only be called when no other system
+        * is holding on to a direct pointer to the same memory.
+        */
+        void DefragmentHandle(Handle& handle);
+
+        /// Release any empty pages that may exist to free up memory.
+        void ReleaseEmptyPages();
+
+        /*
+        * Returns information about the state of the container, like how many pages are allocated and 
+        * how compact they are.
+        */
+        StableDynamicStructOfArraysMetrics GetMetrics();
+
+        /// Returns a forward iterator to the start of the array
+        iterator begin();
+        const_iterator cbegin() const;
+
+        /// Returns an iterator representing the end of the array.
+        iterator end();
+        const_iterator cend() const;
+
+    private:
+
+        /// Adds a page and returns its pointer
+        Page* AddPage();
+
+        allocator_type m_allocator;
+        Page* m_firstPage = nullptr; ///< First page in the list of pages
+
+        /// Used as an optimization to skip pages that are known to already be full. Generally this will point a page that has space available
+        /// in it, but it could point to a full page as long as there are no other available pages before that full page. When there are no
+        /// pages at all, this will point to nullptr. When all pages are full, this may point to any page, including the last page.
+        Page* m_firstAvailablePage = nullptr;
+
+        size_t m_pageCounter = 0; ///< The total number of pages that have been created (not how many currently exist).
+        size_t m_itemCount = 0; ///< The total number of items in this container.
+    };
+
+    /// Private class used by StableDynamicStructOfArrays to manage the arrays of data.
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    struct StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::Page
+    {
+        static constexpr size_t InvalidPage = std::numeric_limits<size_t>::max();
+        static constexpr uint64_t FullBits = 0xFFFFFFFFFFFFFFFFull;
+        static constexpr size_t NumUint64_t = ElementsPerPage / 64;
+
+        Page();
+        ~Page() = default;
+
+        /// Reserve the next availble index and return it. If no more space is available, returns InvalidPage.
+        size_t Reserve();
+
+        /// Free the given index so it can be reserved again.
+        void Free(T* item);
+
+        /// True if this page is completely full
+        bool IsFull() const;
+
+        /// True if this page is completely empty
+        bool IsEmpty() const;
+
+        /**
+        * Gets a specific item from the Page
+        * Note: may return empty slots.
+        */
+        T* GetItem(size_t index);
+
+        /// Gets the number of items allocated on this page.
+        size_t GetItemCount() const;
+
+        size_t m_bitStartIndex = 0; ///< Index of the first uint64_t that might have space.
+        Page* m_nextPage = nullptr; ///< pointer to the next page.
+        StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>* m_container; ///< pointer to the container this page was allocated from.
+        size_t m_pageIndex = 0; ///< used for comparing pages when items are freed so the earlier page in the list can be cached.
+        size_t m_itemCount = 0; ///< the number of items in the page.
+        AZStd::array<uint64_t, NumUint64_t> m_bits; ///< Bits representing free slots in the array. Free slots are 1, occupied slots are 0.
+        AZStd::aligned_storage_t<PageSize, alignof(T)> m_data; ///< aligned storage for all the actual data.
+    };
+
+    /// Forward iterator for StableDynamicStructOfArrays
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    class StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::iterator
+    {
+        using this_type = iterator;
+        using container_type = StableDynamicStructOfArrays;
+
+    public:
+        using iterator_category = AZStd::forward_iterator_tag;
+        using value_type = T;
+        using reference = T&;
+        using pointer = T*;
+
+        iterator() = default;
+        explicit iterator(Page* firstPage);
+
+        reference operator*() const;
+        pointer operator->() const;
+
+        bool operator==(const this_type& rhs) const;
+        bool operator!=(const this_type& rhs) const;
+
+        this_type& operator++();
+        this_type operator++(int);
+
+    protected:
+
+        bool SkipEmptyPages();
+        void AdvanceIterator();
+
+        Page* m_page = nullptr; ///< Pointer to the current page being iterrated through
+        size_t m_bitGroupIndex = 0; ///< The index of the current bit group in the m_page
+        uint64_t m_remainingBitsInBitGroup = 0; ///< This starts out equivalent to the bits from the current bit group, but trailing 1s are changed to 0s as the iterator increments
+        T* m_item = nullptr; ///< The pointer to the current item
+
+    };
+
+    /// Forward const iterator for StableDynamicStructOfArrays
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    class StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::const_iterator
+        : public StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::iterator
+    {
+        using this_type = const_iterator;
+        using base_type = iterator;
+
+    public:
+        using reference = const T & ;
+        using pointer = const T * ;
+
+        const_iterator() = default;
+        explicit const_iterator(Page* firstPage);
+
+        reference operator*() const;
+        pointer operator->() const;
+
+        this_type& operator++();
+        this_type operator++(int);
+    };
+
+    /// Forward iterator for an individual page in StableDynamicStructOfArrays
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    class StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::pageIterator
+    {
+        using this_type = pageIterator;
+        using container_type = StableDynamicStructOfArrays;
+
+    public:
+        using iterator_category = AZStd::forward_iterator_tag;
+        using value_type = T;
+        using reference = T &;
+        using pointer = T *;
+
+        pageIterator() = default;
+        explicit pageIterator(Page* page);
+
+        reference operator*() const;
+        pointer operator->() const;
+
+        bool operator==(const this_type& rhs) const;
+        bool operator!=(const this_type& rhs) const;
+
+        this_type& operator++();
+        this_type operator++(int);
+
+    private:
+
+        void SkipEmptyBitGroups();
+        void SetItemAndAdvanceIterator();
+
+        Page* m_page = nullptr; ///< Pointer to the current page being iterrated through
+        size_t m_bitGroupIndex = 0; ///< The index of the current bit group in the m_page
+        uint64_t m_remainingBitsInBitGroup = 0; ///< This starts out equivalent to the bits from the current bit group, but trailing 1s are changed to 0s as the iterator increments
+        T* m_item = nullptr; ///< The pointer to the current item
+
+    };
+
+    /**
+    * A weak reference to the data allocated in the array. It can be copied, and will not auto-release the data
+    * when it goes out of scope. There is no guarantee that a weak handle is not dangling, so it should only be used
+    * in cases where it is known that the owning handle has not gone out of scope. This could potentially be augmented in the future
+    * to have a salt/generationId that could be used to determine if it is a dangling reference.
+    */
+    template<typename ValueType>
+    class StableDynamicStructOfArraysWeakHandle
+    {
+    public:
+        StableDynamicStructOfArraysWeakHandle() = default;
+
+        /// Returns true if this Handle currently holds a valid value.
+        bool IsValid() const;
+
+        /// Returns true if this Handle doesn't contain a value (same as !IsValid()).
+        bool IsNull() const;
+
+        ValueType& operator*() const;
+        ValueType* operator->() const;
+        
+    private:
+        StableDynamicStructOfArraysWeakHandle(ValueType* data);
+
+        ValueType* m_data = nullptr;
+
+        template<typename T>
+        friend class StableDynamicStructOfArraysHandle;
+    };
+
+    /**
+    * Handle to the data allocated in the array. This stores extra data internally so that an item can be
+    * quickly marked as free later. Since there is no ref counting, copy is not allowed, only move. When
+    * a handle is used to free it's associated data it is marked as invalid.
+    */
+    template<typename ValueType>
+    class StableDynamicStructOfArraysHandle
+    {
+        template<typename T, size_t ElementsPerPage, class Allocator>
+        friend class StableDynamicStructOfArrays;
+
+        template<typename OtherType>
+        friend class StableDynamicStructOfArraysHandle;
+    public:
+
+        /// Default constructor creates an invalid handle.
+        StableDynamicStructOfArraysHandle() = default;
+
+        /// Move Constructor
+        StableDynamicStructOfArraysHandle(StableDynamicStructOfArraysHandle&& other);
+
+        /// Move constructor that allows converting between handles of different types, as long as they are part of the same inheritance chain
+        template<typename OtherType>
+        StableDynamicStructOfArraysHandle<ValueType>(StableDynamicStructOfArraysHandle<OtherType>&& other);
+        
+        /// Destructor will also destroy its underlying data and free it from the StableDynamicStructOfArrays
+        ~StableDynamicStructOfArraysHandle();
+
+        /// Move Assignment
+        StableDynamicStructOfArraysHandle& operator=(StableDynamicStructOfArraysHandle&& other);
+
+        /// Move assignment that allows converting between handles of different types, as long as they are part of the same inheritance chain
+        template<typename OtherType>
+        StableDynamicStructOfArraysHandle<ValueType>& operator=(StableDynamicStructOfArraysHandle<OtherType>&& other);
+
+        /// Destroy the underlying data and free it from the StableDynamicStructOfArrays. Marks the handle as invalid.
+        void Free();
+
+        /// Returns true if this Handle currently holds a valid value.
+        bool IsValid() const;
+
+        /// Returns true if this Handle doesn't contain a value (same as !IsValid()).
+        bool IsNull() const;
+
+        ValueType& operator*() const;
+        ValueType* operator->() const;
+
+        /// Returns a non-owning weak handle to the data
+        StableDynamicStructOfArraysWeakHandle<ValueType> GetWeakHandle() const;
+
+    private:
+
+        template<typename PageType>
+        StableDynamicStructOfArraysHandle(ValueType* data, PageType* page);
+
+        StableDynamicStructOfArraysHandle(const StableDynamicStructOfArraysHandle&) = delete;
+
+        void Invalidate();
+
+        using HandleDestructor = void(*)(void*);
+        HandleDestructor m_destructorCallback = nullptr; ///< Called for valid handles on delete so the underlying data can be removed from the StableDynamicStructOfArrays
+
+        ValueType* m_data = nullptr; ///< The actual data this handle points to in the StableDynamicStructOfArraysHandle.
+        void* m_page = nullptr; ///< The page the data this Handle points to was allocated on.
+    };
+    
+    /// Used for returning information about the internal state of the StableDynamicStructOfArrays.
+    struct StableDynamicStructOfArraysMetrics
+    {
+        AZStd::vector<size_t> m_elementsPerPage;
+        size_t m_totalElements = 0;
+        size_t m_emptyPages = 0;
+
+        /** 
+        * 1.0 = there are no more pages then there needs to be, 0.5 means there are twice as many pages as needed etc.
+        * This can be used to help decide if it's worth compacting handles into fewer pages.
+        */
+        float m_itemToPageRatio = 0.0f;
+    };
+
+} // end namespace AZ
+
+#include<Atom/Utils/StableDynamicStructOfArrays.inl>

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/StableDynamicStructOfArrays.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/StableDynamicStructOfArrays.inl
@@ -1,0 +1,777 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/std/createdestroy.h>
+
+namespace AZ
+{
+
+    // StableDynamicStructOfArrays
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::StableDynamicStructOfArrays(allocator_type allocator)
+        : m_allocator(allocator)
+    {}
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::~StableDynamicStructOfArrays()
+    {
+        // Deallocate the pages and check for allocated items since that may mean there are
+        // outstanding handles that we should warn the user about.
+
+        size_t occupiedPageCount = 0;
+        size_t orphanedItemCount = 0;
+
+        Page* page = m_firstPage;
+        while (page)
+        {
+            if (!page->IsEmpty())
+            {
+                ++occupiedPageCount;
+                orphanedItemCount += page->GetItemCount();
+            }
+            Page* pageToDelete = page;
+            page = page->m_nextPage;
+            m_allocator.deallocate(pageToDelete, sizeof(Page), AZStd::alignment_of<Page>::value);
+        }
+
+        AZ_Warning("StableDynamicStructOfArrays", occupiedPageCount == 0,
+            "StableDynamicStructOfArrays is being deleted but there are still %zu outstanding handles on %zu pages. Handles that "
+            "are not freed before StableDynamicStructOfArrays is removed will point to garbage memory.",
+            orphanedItemCount, occupiedPageCount
+        );
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::insert(const value_type& value) -> Handle
+    {
+        return emplace(value);
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::insert(value_type&& value) -> Handle
+    {
+        return emplace(AZStd::move(value));
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    template<class ... Args>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::emplace(Args&& ... args)->Handle
+    {
+        // Try to find a page we can fit this in.
+        while (m_firstAvailablePage)
+        {
+            size_t pageItem = m_firstAvailablePage->Reserve();
+            if (pageItem != Page::InvalidPage)
+            {
+                // pageItem is a valid item that's been reserved, so construct a new T on it.
+                T* item = m_firstAvailablePage->GetItem(pageItem);
+                AZStd::Internal::construct<T*>::single(item, AZStd::forward<Args>(args) ...);
+
+                ++m_itemCount;
+                return Handle(item, m_firstAvailablePage);
+            }
+            if (!m_firstAvailablePage->m_nextPage)
+            {
+                // no more pages, break and make a new one.
+                break;
+            }
+            m_firstAvailablePage = m_firstAvailablePage->m_nextPage;
+        }
+
+        // No page to emplace in, so make a new page
+        Page* page = AddPage();
+        if (m_firstAvailablePage)
+        {
+            m_firstAvailablePage->m_nextPage = page;
+        }
+        else
+        {
+            // If m_firstAvailablePage was nullptr, then there were no pages so m_firstPage would also be null, and needs to be set to the new page.
+            m_firstPage = page;
+        }
+
+        // A new page was created since there was no room in any other page, so this new page will also be the first page where slots are available.
+        m_firstAvailablePage = page;
+
+        size_t pageItem = page->Reserve();
+        T* item = m_firstAvailablePage->GetItem(pageItem);
+        AZStd::Internal::construct<T*>::single(item, AZStd::forward<Args>(args) ...);
+        ++m_itemCount;
+        return Handle(item, page);
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    void StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::erase(Handle& handle)
+    {
+        if (!handle.IsValid())
+        {
+            return;
+        }
+
+        // Update the first free page if the page this item is being removed from is earlier in the list.
+        Page* page = reinterpret_cast<Page*>(handle.m_page);
+        if (page->m_pageIndex < m_firstAvailablePage->m_pageIndex)
+        {
+            m_firstAvailablePage = page;
+        }
+
+        // Destroy the data in the handle, invalidate the handle, and free the spot that it points to.
+        handle.m_data->~T();
+        page->Free(handle.m_data);
+        handle.Invalidate();
+        --m_itemCount;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    size_t StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::size() const
+    {
+        return m_itemCount;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::GetParallelRanges() -> AZStd::vector<AZStd::pair<pageIterator, pageIterator>>
+    {
+        AZStd::vector<AZStd::pair<pageIterator, pageIterator>> pageIterators;
+        Page* page = m_firstPage;
+        while (page)
+        {
+            if (!page->IsEmpty())
+            {
+                pageIterators.push_back({ pageIterator(page), pageIterator(nullptr) });
+            }
+            page = page->m_nextPage;
+        }
+        return pageIterators;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    void StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::DefragmentHandle(Handle& handle)
+    {
+        if (!handle.IsValid() || reinterpret_cast<Page*>(handle.m_page)->IsFull())
+        {
+            // If this handle has memory in a full page, it's already compact.
+            return;
+        }
+
+        // Try to find a page we can fit this in.
+        while (m_firstAvailablePage)
+        {
+            // if the first page with space available is the page this item is already in, there's not a better page to be in so let it be.
+            if (m_firstAvailablePage == handle.m_page)
+            {
+                break;
+            }
+
+            size_t pageItemIndex = m_firstAvailablePage->Reserve();
+            if (pageItemIndex != Page::InvalidPage)
+            {
+                // Found a better page, move the data to it.
+                *m_firstAvailablePage->GetItem(pageItemIndex) = AZStd::move(*handle);
+                reinterpret_cast<Page*>(handle.m_page)->Free(handle.m_data);
+                handle.m_data = m_firstAvailablePage->GetItem(pageItemIndex);
+                handle.m_page = m_firstAvailablePage;
+                break;
+            }
+            m_firstAvailablePage = m_firstAvailablePage->m_nextPage;
+        }
+
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    void StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::ReleaseEmptyPages()
+    {
+        Page* page = m_firstPage;
+        Page** previousNextPagePointer = &m_firstPage;
+
+        while (page)
+        {
+            if (page->IsEmpty())
+            {
+                *previousNextPagePointer = page->m_nextPage;
+                Page* pageToDellocate = page;
+                page = page->m_nextPage;
+                m_allocator.deallocate(pageToDellocate, sizeof(Page), AZStd::alignment_of<Page>::value);
+            }
+            else
+            {
+                previousNextPagePointer = &page->m_nextPage;
+                page = page->m_nextPage;
+            }
+        }
+
+        // Start by assuming the first available page is the first page (if there are no pages then both will be nullptr)
+        m_firstAvailablePage = m_firstPage;
+
+        // If there are any pages at all, then recalculate the first available page.
+        if (m_firstAvailablePage)
+        {
+            // If all pages are full this will cause m_firstAvailablePage to point to the last page, otherwise it will be a page with space in it.
+            while (m_firstAvailablePage->m_nextPage && m_firstAvailablePage->IsFull())
+            {
+                m_firstAvailablePage = m_firstAvailablePage->m_nextPage;
+            }
+        }
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    StableDynamicStructOfArraysMetrics StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::GetMetrics()
+    {
+        StableDynamicStructOfArraysMetrics metrics;
+        Page* page = m_firstPage;
+
+        while (page)
+        {
+            size_t itemCount = page->GetItemCount();
+            metrics.m_totalElements += itemCount;
+            metrics.m_elementsPerPage.push_back(itemCount);
+            if (itemCount == 0)
+            {
+                ++metrics.m_emptyPages;
+            }
+            page = page->m_nextPage;
+        }
+
+        size_t pageCount = metrics.m_elementsPerPage.size();
+        size_t pagesWithItems = pageCount - metrics.m_emptyPages;
+
+        // This calculates a number between 0 and 1 that represents how densely the pages are packed. If this number starts to get close
+        // to 0, that means the items are very sparsely packed and it may be worth calling DefragmentHandle() on the handles to repack them
+        // to reduce memory consumption and increase iteration time.
+        if (pagesWithItems > 0)
+        {
+            float elementDensity = float(metrics.m_totalElements) / float(ElementsPerPage);
+            metrics.m_itemToPageRatio = ceil(elementDensity) / pagesWithItems;
+        }
+        else
+        {
+            metrics.m_itemToPageRatio = 0.0f;
+        }
+
+        return metrics;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::begin() -> iterator
+    {
+        return iterator(m_firstPage);
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::cbegin() const -> const_iterator
+    {
+        return const_iterator(m_firstPage);
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::end() -> iterator
+    {
+        return iterator();
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::cend() const -> const_iterator
+    {
+        return const_iterator();
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::AddPage()->Page*
+    {
+        void* pageMemory = m_allocator.allocate(sizeof(Page), AZStd::alignment_of<Page>::value);
+        Page* page = new (pageMemory) Page();
+        page->m_pageIndex = ++m_pageCounter;
+        page->m_container = this;
+        return page;
+    }
+
+
+    // StableDynamicStructOfArrays::Page
+
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::Page::Page()
+    {
+        m_bits.fill(0);
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    size_t StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::Page::Reserve()
+    {
+        for (; m_bitStartIndex < NumUint64_t; ++m_bitStartIndex)
+        {
+            if (m_bits[m_bitStartIndex] != FullBits)
+            {
+                // Find the free slot, mark it, and return the index.
+                uint64_t freeSlot = az_ctz_u64(~m_bits[m_bitStartIndex]);
+                m_bits[m_bitStartIndex] |= 1ull << freeSlot;
+                ++m_itemCount;
+
+                return static_cast<size_t>(freeSlot + 64 * m_bitStartIndex);
+            }
+        }
+        return InvalidPage;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    void StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::Page::Free(T* item)
+    {
+        // use the difference between the item pointer and the page data to find the index
+        size_t index = item - reinterpret_cast<T*>(&m_data);
+        // This item's flag will be in the uint64_t at index >> 6 (index / 64). Mark the appropriate bit as 0 (Free).
+        AZ_Assert(m_bits[index >> 6] & (1ull << (index & 0x3F)), "Freeing item that is already marked as free!"); // The IsValid() check on handles should prevent this ever happening.
+        m_bits[index >> 6] &= ~(1ull << (index & 0x3F));
+        // Set the bit start index so the next Reserve() starts on a uint_64 that likely has space.
+        m_bitStartIndex = AZStd::min(index >> 6, m_bitStartIndex);
+
+        --m_itemCount;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    bool StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::Page::IsFull() const
+    {
+        return m_itemCount == ElementsPerPage;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    bool StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::Page::IsEmpty() const
+    {
+        return m_itemCount == 0;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    T* StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::Page::GetItem(size_t index)
+    {
+        return reinterpret_cast<T*>(&m_data) + index;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    size_t StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::Page::GetItemCount() const
+    {
+        return m_itemCount;
+    }
+
+
+    // StableDynamicStructOfArrays::iterator
+
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::iterator::iterator(Page* firstPage)
+        : m_page(firstPage)
+    {
+        // SkipEmptyPages() will move the iterator past any empty pages at the beginning of the list of pages
+        // and return false if it runs out of pages and they're all empty. If this happens, then don't alter
+        // anything in the iterator so it's equivalent to the .end() iterator.
+        if (SkipEmptyPages())
+        {
+            // Setup the bit group from the first page with items in it
+            m_remainingBitsInBitGroup = m_page->m_bits.at(m_bitGroupIndex);
+
+            // Set up the item pointer and increments the bits.
+            AdvanceIterator();
+        }
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::iterator::operator*() const -> reference
+    {
+        return *m_item;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::iterator::operator->() const -> pointer
+    {
+        return m_item;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    bool StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::iterator::operator==(const this_type& rhs) const
+    {
+        return rhs.m_item == m_item;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    bool StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::iterator::operator!=(const this_type& rhs) const
+    {
+        return !operator==(rhs);
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::iterator::operator++() -> this_type &
+    {
+        // If this bit group is finished, find the next bit group with bits in it.
+        if (m_remainingBitsInBitGroup == 0)
+        {
+            // skip the next bit group in the page until one is found with entries
+            for (++m_bitGroupIndex; m_bitGroupIndex < Page::NumUint64_t && m_page->m_bits.at(m_bitGroupIndex) == 0; ++m_bitGroupIndex)
+            {
+            }
+
+            if (m_bitGroupIndex == Page::NumUint64_t)
+            {
+                // Done with this page, on to the next.
+                m_bitGroupIndex = 0;
+                m_page = m_page->m_nextPage;
+
+                // skip empty pages
+                if (!SkipEmptyPages())
+                {
+                    // If SkipEmptyPages() returns false, it means it reached the last page without finding anything. At this point the iterator is in its end state, so just return;
+                    return *this;
+                }
+            }
+
+            m_remainingBitsInBitGroup = m_page->m_bits.at(m_bitGroupIndex);
+        }
+
+        // Set up the item pointer and increments the bits.
+        AdvanceIterator();
+
+        return *this;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::iterator::operator++(int) -> this_type
+    {
+        this_type temp = *this;
+        ++this;
+        return temp;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    bool StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::iterator::SkipEmptyPages()
+    {
+        // skip all initial empty pages.
+        while (m_page && m_page->IsEmpty())
+        {
+            m_page = m_page->m_nextPage;
+        }
+
+        // If the page is null, it's at the end. This sets m_item to nullptr so that it == StableDynamicStructOfArrays::End().
+        if (m_page == nullptr)
+        {
+            m_item = nullptr;
+            return false;
+        }
+
+        // skip the empty bitfields in the page
+        for (; m_bitGroupIndex < Page::NumUint64_t && m_page->m_bits.at(m_bitGroupIndex) == 0; ++m_bitGroupIndex)
+        {
+        }
+
+        return true;
+    }
+
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    void StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::iterator::AdvanceIterator()
+    {
+        uint64_t index = az_ctz_u64(m_remainingBitsInBitGroup);
+        m_item = m_page->GetItem(m_bitGroupIndex * 64 + index);
+
+        // Lop off the lowest bit to prepare for forward iteration.
+        m_remainingBitsInBitGroup &= (m_remainingBitsInBitGroup - 1);
+    }
+
+    // StableDynamicStructOfArrays::const_iterator
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::const_iterator::const_iterator(Page* firstPage)
+        : base_type(firstPage)
+    {
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::const_iterator::operator*() const -> reference
+    {
+        return *base_type::m_item;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::const_iterator::operator->() const -> pointer
+    {
+        return base_type::m_item;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::const_iterator::operator++() -> this_type &
+    {
+        base_type::operator++();
+        return *this;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::const_iterator::operator++(int) -> this_type
+    {
+        this_type temp = *this;
+        ++this;
+        return temp;
+    }
+
+    // StableDynamicStructOfArrays::pageIterator
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::pageIterator::pageIterator(Page* page)
+        : m_page(page)
+    {
+        if (m_page != nullptr)
+        {
+            // SkipEmptyBitGroups() will skip all the initial empty bit groups that may exist in the page.
+            SkipEmptyBitGroups();
+        }
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::pageIterator::operator*() const -> reference
+    {
+        return *m_item;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::pageIterator::operator->() const -> pointer
+    {
+        return m_item;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    bool StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::pageIterator::operator==(const this_type& rhs) const
+    {
+        return rhs.m_item == m_item;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    bool StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::pageIterator::operator!=(const this_type& rhs) const
+    {
+        return !operator==(rhs);
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::pageIterator::operator++() -> this_type &
+    {
+        // If this bit group is finished, find the next bit group with bits in it.
+        if (m_remainingBitsInBitGroup == 0)
+        {
+            ++m_bitGroupIndex;
+
+            // skip the next bit group in the page until one is found with entries
+            SkipEmptyBitGroups();
+        }
+        else
+        {
+            // Set up the item pointer and increments the bits.
+            SetItemAndAdvanceIterator();
+        }
+
+        return *this;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    auto StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::pageIterator::operator++(int) -> this_type
+    {
+        this_type temp = *this;
+        ++this;
+        return temp;
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    void StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::pageIterator::SkipEmptyBitGroups()
+    {
+        // skip the next bit group in the page until one is found with entries
+        while (m_bitGroupIndex < Page::NumUint64_t && m_page->m_bits.at(m_bitGroupIndex) == 0)
+        {
+            ++m_bitGroupIndex;
+        }
+
+        if (m_bitGroupIndex >= Page::NumUint64_t)
+        {
+            // Done with this page, so it's at the end of the page iterator.
+            m_item = nullptr;
+            return;
+        }
+
+        // Set up the bit group from the index found earlier.
+        m_remainingBitsInBitGroup = m_page->m_bits.at(m_bitGroupIndex);
+
+        // Set up the item pointer and increments the bits.
+        SetItemAndAdvanceIterator();
+
+    }
+
+    template<typename T, size_t ElementsPerPage, class Allocator>
+    void StableDynamicStructOfArrays<T, ElementsPerPage, Allocator>::pageIterator::SetItemAndAdvanceIterator()
+    {
+        uint64_t index = az_ctz_u64(m_remainingBitsInBitGroup);
+        m_item = m_page->GetItem(m_bitGroupIndex * 64 + index);
+
+        // Lop off the lowest bit to prepare for forward iteration.
+        m_remainingBitsInBitGroup &= (m_remainingBitsInBitGroup - 1);
+    }
+
+
+    // StableDynamicStructOfArrays::WeakHandle
+    template<typename ValueType>
+    StableDynamicStructOfArraysWeakHandle<ValueType>::StableDynamicStructOfArraysWeakHandle(ValueType* data)
+        : m_data(data)
+    {
+    }
+
+    template<typename ValueType>
+    bool StableDynamicStructOfArraysWeakHandle<ValueType>::IsValid() const
+    {
+        return m_data != nullptr;
+    }
+
+    template<typename ValueType>
+    bool StableDynamicStructOfArraysWeakHandle<ValueType>::IsNull() const
+    {
+        return m_data == nullptr;
+    }
+
+    template<typename ValueType>
+    ValueType& StableDynamicStructOfArraysWeakHandle<ValueType>::operator*() const
+    {
+        return *m_data;
+    }
+
+    template<typename ValueType>
+    ValueType* StableDynamicStructOfArraysWeakHandle<ValueType>::operator->() const
+    {
+        return m_data;
+    }
+
+    // StableDynamicStructOfArrays::Handle
+
+
+    template<typename ValueType>
+    template<typename PageType>
+    StableDynamicStructOfArraysHandle<ValueType>::StableDynamicStructOfArraysHandle(ValueType* data, PageType* page)
+        : m_data(data)
+        , m_page(page)
+    {
+        // Store container type information in the non-capturing lambda callback so the Handle itself doesn't need it.
+        m_destructorCallback = [](void* typelessHandlePointer)
+        {
+            StableDynamicStructOfArraysHandle* handle = static_cast<StableDynamicStructOfArraysHandle*>(typelessHandlePointer);
+            static_cast<PageType*>(handle->m_page)->m_container->erase(*handle);
+        };
+    }
+
+    template<typename ValueType>
+    StableDynamicStructOfArraysHandle<ValueType>::StableDynamicStructOfArraysHandle(StableDynamicStructOfArraysHandle&& other)
+    {
+        *this = AZStd::move(other);
+    }
+
+    template <typename ValueType>
+    template <typename OtherType>
+    StableDynamicStructOfArraysHandle<ValueType>::StableDynamicStructOfArraysHandle(StableDynamicStructOfArraysHandle<OtherType>&& other)
+    {
+        *this = AZStd::move(other);
+    }
+
+    template<typename ValueType>
+    StableDynamicStructOfArraysHandle<ValueType>::~StableDynamicStructOfArraysHandle()
+    {
+        Free();
+    }
+
+    template<typename ValueType>
+    auto StableDynamicStructOfArraysHandle<ValueType>::operator=(StableDynamicStructOfArraysHandle&& other) -> StableDynamicStructOfArraysHandle&
+    {
+        if (this != static_cast<void*>(&other))
+        {
+            Free();
+            m_data = other.m_data;
+            m_destructorCallback = other.m_destructorCallback;
+            m_page = other.m_page;
+            other.Invalidate();
+        }
+        return *this;
+    }
+
+    template <typename ValueType>
+    template <typename OtherType>
+    auto StableDynamicStructOfArraysHandle<ValueType>::operator=(StableDynamicStructOfArraysHandle<OtherType>&& other) -> StableDynamicStructOfArraysHandle<ValueType>&
+    {
+        static_assert((AZStd::is_base_of<ValueType, OtherType>::value || AZStd::is_base_of<OtherType, ValueType>::value), "Cannot move a StableDynamicStructOfArraysHandle to a handle of an unrelated type.");
+
+        Free();
+        m_data = azrtti_cast<ValueType*>(other.m_data);
+        // Only move the data if the azrtti_cast cast succeeded. Otherwise, leave both handles invalid
+        if (m_data)
+        {
+            m_page = other.m_page;
+            // The destructor callback is a non-capturing lambda, which has no state and can be used as a plain function.
+            // Because the lambda is is created when the original handle is constructed, it captures the underlying type the handle refers to
+            // even if the handle is being moved from BaseClass handle to a DerivedClass handle or vice versa
+            m_destructorCallback = other.m_destructorCallback;
+        }
+        else if (other.m_data)
+        {
+            // If the cast failed, assert here because something is trying to cast between unrelated handle types
+            AZ_Assert(false, "StableDynamicStructOfArraysHandle: Failed to azrtti_cast from %s to %s", OtherType::RTTI_TypeName(), ValueType::RTTI_TypeName());
+
+            // Since we're about to invalidate the other handle, but this handle won't be assuming ownership, free the object referred to by the other handle
+            other.Free();
+        }
+
+        other.Invalidate();
+
+        return *this;
+    }
+
+    template<typename ValueType>
+    void StableDynamicStructOfArraysHandle<ValueType>::Free()
+    {
+        if (IsValid())
+        {
+            m_destructorCallback(this);
+        }
+    }
+
+    template<typename ValueType>
+    bool StableDynamicStructOfArraysHandle<ValueType>::IsValid() const
+    {
+        return m_data != nullptr;
+    }
+
+    template<typename ValueType>
+    bool StableDynamicStructOfArraysHandle<ValueType>::IsNull() const
+    {
+        return m_data == nullptr;
+    }
+
+    template<typename ValueType>
+    ValueType& StableDynamicStructOfArraysHandle<ValueType>::operator*() const
+    {
+        return *m_data;
+    }
+
+    template<typename ValueType>
+    ValueType* StableDynamicStructOfArraysHandle<ValueType>::operator->() const
+    {
+        return m_data;
+    }
+
+    template<typename ValueType>
+    void StableDynamicStructOfArraysHandle<ValueType>::Invalidate()
+    {
+        m_data = nullptr;
+        m_destructorCallback = nullptr;
+        m_page = nullptr;
+    }
+
+    template<typename ValueType>
+    StableDynamicStructOfArraysWeakHandle<ValueType> StableDynamicStructOfArraysHandle<ValueType>::GetWeakHandle() const
+    {
+        return StableDynamicStructOfArraysWeakHandle<ValueType>(m_data);
+    }
+
+} // end namespace AZ

--- a/Gems/Atom/Utils/Code/Tests/StableDynamicArrayTests.cpp
+++ b/Gems/Atom/Utils/Code/Tests/StableDynamicArrayTests.cpp
@@ -286,7 +286,7 @@ namespace UnitTest
         size_t pageCount3 = metrics.m_elementsPerPage.size();
         EXPECT_LT(pageCount3, pageCount2);
 
-        // The the defragmented handles should still have valid weak handles
+        // The the defragmented handles should still have valid weak handles, as long as they are made after the defragmentation
         for (StableDynamicArray<TestItem>::Handle& handle : handles)
         {
             if (handle.IsValid())
@@ -309,7 +309,6 @@ namespace UnitTest
         for (uint32_t i = 0; i < s_testCount; ++i)
         {
             StableDynamicArray<TestItem>::Handle handle = testArray.emplace(i);
-            handle->index = i;
             handles.push_back(AZStd::move(handle));
         }
 
@@ -426,7 +425,6 @@ namespace UnitTest
         for (uint32_t i = 0; i < s_testCount; ++i)
         {
             StableDynamicArray<TestItem>::Handle handle = testArray.emplace(i);
-            handle->index = i;
             handles.push_back(AZStd::move(handle));
         }
 

--- a/Gems/Atom/Utils/Code/Tests/StableDynamicArrayTests.cpp
+++ b/Gems/Atom/Utils/Code/Tests/StableDynamicArrayTests.cpp
@@ -545,6 +545,12 @@ namespace UnitTest
                 StableDynamicArrayHandleTests::s_testItemsConstructed++;
             }
 
+            TestItemImplementation(const TestItemImplementation& testItem)
+                : m_value(testItem.m_value)
+            {
+                StableDynamicArrayHandleTests::s_testItemsConstructed++;
+            }
+
             virtual ~TestItemImplementation()
             {
                 StableDynamicArrayHandleTests::s_testItemsDestructed++;

--- a/Gems/Atom/Utils/Code/Tests/StableDynamicStructOfArraysTests.cpp
+++ b/Gems/Atom/Utils/Code/Tests/StableDynamicStructOfArraysTests.cpp
@@ -69,7 +69,7 @@ namespace UnitTest
         // fill with items
         for (uint32_t i = 0; i < s_testCount; ++i)
         {
-            TestArrayType::Handle handle = testArray.insert(TestItem{}, {});
+            TestArrayType::Handle handle = testArray.insert(TestItem{ i, static_cast<float>(i) }, i);
             TestItem& testItem = handle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>();
             testItem.m_index = i;
             testItem.m_value = static_cast<float>(i);
@@ -104,7 +104,7 @@ namespace UnitTest
         // fill with items
         for (uint32_t i = 0; i < s_testCount; ++i)
         {
-            TestArrayType::Handle handle = testArray.emplace(TestItem{ i, static_cast<float>(i) }, i);
+            TestArrayType::Handle handle = testArray.emplace(AZStd::forward_as_tuple(i, static_cast<float>(i)), AZStd::forward_as_tuple(i));
             handles.push_back(AZStd::move(handle));
         }
 
@@ -179,7 +179,7 @@ namespace UnitTest
         // fill with items
         for (uint32_t i = 0; i < s_testCount; ++i)
         {
-            TestArrayType::Handle handle = testArray.emplace(TestItem{ i, static_cast<float>(i) }, i);
+            TestArrayType::Handle handle = testArray.emplace(AZStd::forward_as_tuple(i, static_cast<float>(i)), AZStd::forward_as_tuple(i));
             handles.push_back(AZStd::move(handle));
         }
 
@@ -249,7 +249,7 @@ namespace UnitTest
         testArray.GetMetrics();
 
         // Test insert
-        handles.push_back(testArray.emplace(item, 0));
+        handles.push_back(testArray.emplace(AZStd::forward_as_tuple(item), AZStd::forward_as_tuple(0)));
         markFirstPageAsEmpty();
 
         // Test defragment
@@ -272,7 +272,7 @@ namespace UnitTest
         for (uint32_t i = 0; i < s_testCount; ++i)
         {
             StableDynamicStructOfArrays<TestElementsPerPage, StructOfArraysTestAllocator, TestItem, uint32_t>::Handle handle =
-                testArray.emplace(TestItem{ i, static_cast<float>(i) }, i);
+                testArray.emplace(AZStd::forward_as_tuple(i, static_cast<float>(i)), AZStd::forward_as_tuple(i));
             TestItem& testItem = handle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>();
             testItem.m_index = i;
             testItem.m_value = static_cast<float>(i);
@@ -341,7 +341,7 @@ namespace UnitTest
         // fill with items
         for (uint32_t i = 0; i < s_testCount; ++i)
         {
-            TestArrayType::Handle handle = testArray.emplace(TestItem{ i, static_cast<float>(i) }, i);
+            TestArrayType::Handle handle = testArray.emplace(AZStd::forward_as_tuple(i, static_cast<float>(i)), AZStd::forward_as_tuple(i));
             handles.push_back(AZStd::move(handle));
         }
 
@@ -405,7 +405,7 @@ namespace UnitTest
         // fill with items
         for (uint32_t i = 0; i < s_testCount; ++i)
         {
-            TestArrayType::Handle handle = testArray.emplace(TestItem{ i, static_cast<float>(i) }, i);
+            TestArrayType::Handle handle = testArray.emplace(AZStd::forward_as_tuple(i, static_cast<float>(i)), AZStd::forward_as_tuple(i));
             handles.push_back(AZStd::move(handle));
         }
 
@@ -469,7 +469,7 @@ namespace UnitTest
         // Fill with items
         for (uint32_t i = 0; i < s_testCount; ++i)
         {
-            TestArrayType::Handle handle = testArray.emplace(TestItem{ i, static_cast<float>(i) }, i);
+            TestArrayType::Handle handle = testArray.emplace(AZStd::forward_as_tuple(i, static_cast<float>(i)), AZStd::forward_as_tuple(i));
             handles.push_back(AZStd::move(handle));
         }
 
@@ -596,6 +596,12 @@ namespace UnitTest
                 StableDynamicStructOfArraysHandleTests::s_testItemsConstructed++;
             }
 
+            TestItemImplementation(const TestItemImplementation& testItem)
+                : m_value(testItem.m_value)
+            {
+                StableDynamicStructOfArraysHandleTests::s_testItemsConstructed++;
+            }
+
             virtual ~TestItemImplementation()
             {
                 StableDynamicStructOfArraysHandleTests::s_testItemsDestructed++;
@@ -619,9 +625,7 @@ namespace UnitTest
     
         OwnerTestArrayType::Handle AcquireItem(int value, int otherValue)
         {
-            // Note: we only truly get emplace behavior when every row of the StructOfArrays has data that can be constructed with exactly 1 argument,
-            // and the number of arguments passed into emplace matches 1:1 with the number of underlying rows in the StructOfArrays
-            return m_testArray.emplace(value, otherValue);
+            return m_testArray.emplace(AZStd::forward_as_tuple(value), AZStd::forward_as_tuple(otherValue));
         }
 
         void ReleaseItem(OwnerTestArrayType::Handle& handle)

--- a/Gems/Atom/Utils/Code/Tests/StableDynamicStructOfArraysTests.cpp
+++ b/Gems/Atom/Utils/Code/Tests/StableDynamicStructOfArraysTests.cpp
@@ -70,7 +70,10 @@ namespace UnitTest
         for (uint32_t i = 0; i < s_testCount; ++i)
         {
             TestArrayType::Handle handle = testArray.insert(TestItem{}, {});
-            handle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->m_index = i;
+            TestItem& testItem = handle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>();
+            testItem.m_index = i;
+            testItem.m_value = static_cast<float>(i);
+            handle.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>() = i;
             handles.push_back(AZStd::move(handle));
         }
 
@@ -268,8 +271,12 @@ namespace UnitTest
         // fill with items
         for (uint32_t i = 0; i < s_testCount; ++i)
         {
-            StableDynamicStructOfArrays<TestElementsPerPage, StructOfArraysTestAllocator, TestItem, uint32_t>::Handle handle = testArray.emplace(TestItem {i, static_cast<float>(i)} , i);
-            handle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->m_index = i;
+            StableDynamicStructOfArrays<TestElementsPerPage, StructOfArraysTestAllocator, TestItem, uint32_t>::Handle handle =
+                testArray.emplace(TestItem{ i, static_cast<float>(i) }, i);
+            TestItem& testItem = handle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>();
+            testItem.m_index = i;
+            testItem.m_value = static_cast<float>(i);
+            handle.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>() = i;
             handles.push_back(AZStd::move(handle));
         }
 
@@ -310,8 +317,16 @@ namespace UnitTest
                 TestArrayType::WeakHandle weakHandle = handle.GetWeakHandle();
                 // The weak handle should be referring to the same data as the owning handle
                 EXPECT_EQ(
-                    handle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->m_index,
-                    weakHandle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->m_index);
+                    handle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().m_index,
+                    weakHandle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().m_index);
+
+                EXPECT_EQ(
+                    handle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().m_value,
+                    weakHandle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().m_value);
+
+                EXPECT_EQ(
+                    handle.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>(),
+                    weakHandle.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>());
             }
         }
 
@@ -327,7 +342,6 @@ namespace UnitTest
         for (uint32_t i = 0; i < s_testCount; ++i)
         {
             TestArrayType::Handle handle = testArray.emplace(TestItem{ i, static_cast<float>(i) }, i);
-            handle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->m_index = i;
             handles.push_back(AZStd::move(handle));
         }
 
@@ -337,7 +351,9 @@ namespace UnitTest
 
         for (auto& item : testArray)
         {
-            success = success && (item.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->m_index == index);
+            success = success && (item.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().m_index == index);
+            success = success && (item.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().m_value == static_cast<float>(index));
+            success = success && (item.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>() == index);
             ++index;
         }
 
@@ -354,7 +370,9 @@ namespace UnitTest
         index = 1;
         for (auto& item : testArray)
         {
-            success = success && (item.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->m_index == index);
+            success = success && (item.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().m_index == index);
+            success = success && (item.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().m_value == static_cast<float>(index));
+            success = success && (item.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>() == index);
             index += 2;
         }
         EXPECT_TRUE(success);
@@ -370,7 +388,9 @@ namespace UnitTest
         index = s_testCount / 2 + 1;
         for (auto& item : testArray)
         {
-            success = success && (item.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->m_index == index);
+            success = success && (item.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().m_index == index);
+            success = success && (item.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().m_value == static_cast<float>(index));
+            success = success && (item.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>() == index);
             index += 2;
         }
         EXPECT_TRUE(success);
@@ -395,7 +415,9 @@ namespace UnitTest
 
         for (auto it = testArray.cbegin(); it != testArray.cend(); ++it)
         {
-            success = success && (it.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->m_index == index);
+            success = success && (it.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().m_index == index);
+            success = success && (it.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().m_value == static_cast<float>(index));
+            success = success && (it.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>() == index);
             ++index;
         }
 
@@ -412,7 +434,9 @@ namespace UnitTest
         index = 1;
         for (auto it = testArray.cbegin(); it != testArray.cend(); ++it)
         {
-            success = success && (it.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->m_index == index);
+            success = success && (it.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().m_index == index);
+            success = success && (it.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().m_value == static_cast<float>(index));
+            success = success && (it.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>() == index);
             index += 2;
         }
         EXPECT_TRUE(success);
@@ -428,7 +452,9 @@ namespace UnitTest
         index = s_testCount / 2 + 1;
         for (auto it = testArray.cbegin(); it != testArray.cend(); ++it)
         {
-            success = success && (it.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->m_index == index);
+            success = success && (it.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().m_index == index);
+            success = success && (it.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().m_value == static_cast<float>(index));
+            success = success && (it.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>() == index);
             index += 2;
         }
         EXPECT_TRUE(success);
@@ -444,7 +470,6 @@ namespace UnitTest
         for (uint32_t i = 0; i < s_testCount; ++i)
         {
             TestArrayType::Handle handle = testArray.emplace(TestItem{ i, static_cast<float>(i) }, i);
-            handle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->m_index = i;
             handles.push_back(AZStd::move(handle));
         }
 
@@ -458,8 +483,10 @@ namespace UnitTest
         {
             for (auto iterator = iteratorPair.first; iterator != iteratorPair.second; ++iterator)
             {
-                TestItem* item = iterator.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>();
-                success = success && (item->m_index == index);
+                TestItem& item = iterator.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>();
+                success = success && (item.m_index == index);
+                success = success && (item.m_value == static_cast<float>(index));
+                success = success && (iterator.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>() == index);
                 ++index;
             }
         }
@@ -479,8 +506,10 @@ namespace UnitTest
         {
             for (auto iterator = iteratorPair.first; iterator != iteratorPair.second; ++iterator)
             {
-                TestItem* item = iterator.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>();
-                success = success && (item->m_index == index);
+                TestItem& item = iterator.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>();
+                success = success && (item.m_index == index);
+                success = success && (item.m_value == static_cast<float>(index));
+                success = success && (iterator.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>() == index);
                 index += 2;
             }
         }
@@ -502,8 +531,10 @@ namespace UnitTest
         {
             for (auto iterator = iteratorPair.first; iterator != iteratorPair.second; ++iterator)
             {
-                TestItem* item = iterator.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>();
-                success = success && (item->m_index == index);
+                TestItem& item = iterator.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>();
+                success = success && (item.m_index == index);
+                success = success && (item.m_value == static_cast<float>(index));
+                success = success && (iterator.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>() == index);
                 index += 2;
             }
         }
@@ -586,11 +617,11 @@ namespace UnitTest
         };
         using OwnerTestArrayType = AZ::StableDynamicStructOfArrays<TestElementsPerPage, StructOfArraysTestAllocator, StableDynamicStructOfArraysOwner::TestItemImplementation, uint32_t>;
     
-        OwnerTestArrayType::Handle AcquireItem(int value)
+        OwnerTestArrayType::Handle AcquireItem(int value, int otherValue)
         {
             // Note: we only truly get emplace behavior when every row of the StructOfArrays has data that can be constructed with exactly 1 argument,
             // and the number of arguments passed into emplace matches 1:1 with the number of underlying rows in the StructOfArrays
-            return m_testArray.emplace( value , value);
+            return m_testArray.emplace(value, otherValue);
         }
 
         void ReleaseItem(OwnerTestArrayType::Handle& handle)
@@ -614,7 +645,7 @@ namespace UnitTest
             {
                 StableDynamicStructOfArraysOwner owner;
 
-                SourceHandle source = owner.AcquireItem(123);
+                SourceHandle source = owner.AcquireItem(123, 124);
                 SourceHandle destination = AZStd::move(source);
 
                 // Source handle should be invalid after move, destination handle should be valid
@@ -624,11 +655,14 @@ namespace UnitTest
                 EXPECT_EQ(destination.IsNull(), false);
 
                 // The destination handle should have the value that came from the source handle
-                EXPECT_EQ(destination.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->GetValue(), 123);
+                EXPECT_EQ(destination.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().GetValue(), 123);
+                EXPECT_EQ(destination.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>(), 124);
 
                 // The destination handle should be pointing to real data that can be modified
-                destination.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->SetValue(789);
-                EXPECT_EQ(destination.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->GetValue(), 789);
+                destination.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().SetValue(789);
+                destination.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>() = 788;
+                EXPECT_EQ(destination.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().GetValue(), 789);
+                EXPECT_EQ(destination.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>(), 788);
 
                 // One item was constructed, none destructed, one modified
                 EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsConstructed, 1);
@@ -643,8 +677,8 @@ namespace UnitTest
             {
                 StableDynamicStructOfArraysOwner owner;
 
-                SourceHandle source = owner.AcquireItem(123);
-                SourceHandle destination = owner.AcquireItem(456);
+                SourceHandle source = owner.AcquireItem(123, 124);
+                SourceHandle destination = owner.AcquireItem(456, 457);
                 destination = AZStd::move(source);
 
                 // Source handle should be invalid after move, destination handle should be valid
@@ -654,11 +688,14 @@ namespace UnitTest
                 EXPECT_EQ(destination.IsNull(), false);
 
                 // The destination handle should have the value that came from the source handle
-                EXPECT_EQ(destination.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->GetValue(), 123);
+                EXPECT_EQ(destination.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().GetValue(), 123);
+                EXPECT_EQ(destination.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>(), 124);
 
                 // The destination handle should be pointing to real data that can be modified
-                destination.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->SetValue(789);
-                EXPECT_EQ(destination.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->GetValue(), 789);
+                destination.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().SetValue(789);
+                destination.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>() = 788;
+                EXPECT_EQ(destination.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().GetValue(), 789);
+                EXPECT_EQ(destination.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>(), 788);
 
                 // Two items were constructed, one destructed, one modified
                 EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsConstructed, 2);
@@ -674,7 +711,7 @@ namespace UnitTest
                 StableDynamicStructOfArraysOwner owner;
                 
                 SourceHandle source;
-                SourceHandle destination = owner.AcquireItem(456);
+                SourceHandle destination = owner.AcquireItem(456, 457);
                 destination = AZStd::move(source);
 
                 // Both handles should be invalid after move
@@ -695,8 +732,8 @@ namespace UnitTest
             {
                 StableDynamicStructOfArraysOwner owner;
 
-                SourceHandle source = owner.AcquireItem(123);
-                SourceHandle destination = owner.AcquireItem(456);
+                SourceHandle source = owner.AcquireItem(123, 124);
+                SourceHandle destination = owner.AcquireItem(456, 457);
                 destination = AZStd::move(source);
 
                 // Attempting to release the invalid source handle should be a no-op
@@ -720,8 +757,8 @@ namespace UnitTest
             {
                 StableDynamicStructOfArraysOwner owner;
 
-                SourceHandle source = owner.AcquireItem(123);
-                SourceHandle destination = owner.AcquireItem(456);
+                SourceHandle source = owner.AcquireItem(123, 124);
+                SourceHandle destination = owner.AcquireItem(456, 457);
                 destination = AZStd::move(source);
 
                 // Attempting to release the invalid source handle should be a no-op
@@ -745,9 +782,9 @@ namespace UnitTest
             {
                 StableDynamicStructOfArraysOwner owner;
                 {
-                    SourceHandle destination = owner.AcquireItem(456);
+                    SourceHandle destination = owner.AcquireItem(456, 457);
                     {
-                        SourceHandle source = owner.AcquireItem(123);
+                        SourceHandle source = owner.AcquireItem(123, 124);
                         destination = AZStd::move(source);
                     }
                     // Letting the invalid source item go out of scope should be a no-op 
@@ -805,28 +842,42 @@ namespace UnitTest
     TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandle_SelfAssignment_DoesNotModifyHandle)
     {
         StableDynamicStructOfArraysOwner owner;
-        StableDynamicStructOfArraysOwner::OwnerTestArrayType::Handle handle = owner.AcquireItem(1);
+        StableDynamicStructOfArraysOwner::OwnerTestArrayType::Handle handle = owner.AcquireItem(1, 2);
         int testValue = 12;
-        handle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->SetValue(testValue);
+        handle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().SetValue(testValue);
+        handle.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>() = testValue + 1;
 
         // Self assignment should not invalidate the handle
         handle = AZStd::move(handle);
         EXPECT_TRUE(handle.IsValid());
         EXPECT_FALSE(handle.IsNull());
-        EXPECT_EQ(handle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->GetValue(), testValue);
+        EXPECT_EQ(handle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().GetValue(), testValue);
+        EXPECT_EQ(handle.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>(), testValue + 1);
     }
     
     TEST_F(StableDynamicStructOfArraysHandleTests, WeakHandle_GetDataFromOwner_CanAccessData)
     {
         StableDynamicStructOfArraysOwner owner;
-        StableDynamicStructOfArraysOwner::OwnerTestArrayType::Handle handle = owner.AcquireItem(1);
+        StableDynamicStructOfArraysOwner::OwnerTestArrayType::Handle handle = owner.AcquireItem(1, 2);
         StableDynamicStructOfArraysOwner::OwnerTestArrayType::WeakHandle weakHandle = handle.GetWeakHandle();
 
         int testValue = 12;
-        weakHandle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->SetValue(testValue);
-        EXPECT_EQ(handle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->GetValue(), testValue);
-        EXPECT_EQ(weakHandle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>()->GetValue(), testValue);
+        weakHandle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().SetValue(testValue);
+        weakHandle.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>() = testValue + 1;
+
+        // Validate the value referenced by the owning handle changed when the data was set via the weak handle
+        EXPECT_EQ(handle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().GetValue(), testValue);
+        EXPECT_EQ(handle.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>(), testValue + 1);
+
+        // Validate the value referenced by the weak handle changed when the data was set via the weak handle
+        EXPECT_EQ(weakHandle.GetItem<TestStableDynamicStructOfArraysRows::TestItemIndex>().GetValue(), testValue);
+        EXPECT_EQ(weakHandle.GetItem<TestStableDynamicStructOfArraysRows::UInt32Index>(), testValue + 1);
+
+        // validate operator*
+        EXPECT_EQ(AZStd::get<TestStableDynamicStructOfArraysRows::TestItemIndex>(*handle)->GetValue(), testValue);
+        EXPECT_EQ(*AZStd::get<TestStableDynamicStructOfArraysRows::UInt32Index>(*handle), testValue + 1);
         EXPECT_EQ(AZStd::get<TestStableDynamicStructOfArraysRows::TestItemIndex>(*weakHandle)->GetValue(), testValue);
+        EXPECT_EQ(*AZStd::get<TestStableDynamicStructOfArraysRows::UInt32Index>(*weakHandle), testValue + 1);
     }
 
 }

--- a/Gems/Atom/Utils/Code/Tests/StableDynamicStructOfArraysTests.cpp
+++ b/Gems/Atom/Utils/Code/Tests/StableDynamicStructOfArraysTests.cpp
@@ -1,0 +1,1021 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/Memory/PoolAllocator.h>
+#include <AzCore/Component/ComponentApplication.h>
+#include <Atom/Utils/StableDynamicStructOfArrays.h>
+
+namespace UnitTest
+{
+    // Fixture that creates a bare-bones app
+
+    class StableDynamicStructOfArraysTests
+        : public LeakDetectionFixture
+    {
+    public:
+        void SetUp() override
+        {
+            LeakDetectionFixture::SetUp();
+
+            handles.reserve(s_testCount);
+        }
+
+        void TearDown() override
+        {
+            handles = AZStd::vector<AZ::StableDynamicStructOfArrays<TestItem>::Handle>(); // force memory deallocation.
+            
+            LeakDetectionFixture::TearDown();
+        }
+
+        struct TestItem
+        {
+            TestItem() = default;
+            TestItem(uint32_t value) : index(value) {}
+            uint32_t index = 0;
+        };
+
+        static constexpr uint32_t s_testCount = 1000000;
+
+        AZStd::vector<AZ::StableDynamicStructOfArrays<TestItem>::Handle> handles;
+    };
+
+    TEST_F(StableDynamicStructOfArraysTests, insert_erase)
+    {
+        using namespace AZ;
+        AZ::StableDynamicStructOfArrays<TestItem> testArray;
+
+        // fill with items
+        for (uint32_t i = 0; i < s_testCount; ++i)
+        {
+            StableDynamicStructOfArrays<TestItem>::Handle handle = testArray.insert({});
+            handle->index = i;
+            handles.push_back(AZStd::move(handle));
+        }
+
+        EXPECT_EQ(testArray.size(), s_testCount);
+
+        StableDynamicStructOfArraysMetrics metrics = testArray.GetMetrics();
+        EXPECT_EQ(metrics.m_totalElements, s_testCount);
+
+        // remove half of the elements
+        for (uint32_t i = 0; i < s_testCount; i += 2)
+        {
+            testArray.erase(handles.at(i));
+        }
+
+        EXPECT_EQ(testArray.size(), s_testCount / 2);
+
+        metrics = testArray.GetMetrics();
+        EXPECT_EQ(metrics.m_totalElements, s_testCount / 2);
+
+        handles.clear(); // cleanup remaining handles.
+    }
+
+    TEST_F(StableDynamicStructOfArraysTests, emplace_Free)
+    {
+        using namespace AZ;
+        AZ::StableDynamicStructOfArrays<TestItem> testArray;
+
+        // fill with items
+        for (uint32_t i = 0; i < s_testCount; ++i)
+        {
+            StableDynamicStructOfArrays<TestItem>::Handle handle = testArray.emplace(i);
+            handles.push_back(AZStd::move(handle));
+        }
+
+        StableDynamicStructOfArraysMetrics metrics = testArray.GetMetrics();
+        EXPECT_EQ(metrics.m_totalElements, s_testCount);
+
+        // remove half of the elements
+        for (uint32_t i = 0; i < s_testCount; i += 2)
+        {
+            handles.at(i).Free();
+        }
+        metrics = testArray.GetMetrics();
+        EXPECT_EQ(metrics.m_totalElements, s_testCount / 2);
+
+        handles.clear(); // cleanup remaining handles.
+    }
+
+    TEST_F(StableDynamicStructOfArraysTests, ReleaseEmptyPages)
+    {
+        using namespace AZ;
+        AZ::StableDynamicStructOfArrays<TestItem> testArray;
+
+        // Test removing items at the end
+
+        // fill with items
+        TestItem item; // test lvalue insert
+        for (uint32_t i = 0; i < s_testCount; ++i)
+        {
+            item.index = i;
+            StableDynamicStructOfArrays<TestItem>::Handle handle = testArray.insert(item);
+            handles.push_back(AZStd::move(handle));
+        }
+
+        StableDynamicStructOfArraysMetrics metrics1 = testArray.GetMetrics();
+        size_t fullPageCount = metrics1.m_elementsPerPage.size();
+
+        // remove the last half of the elements
+        for (uint32_t i = 0; i < s_testCount / 2; ++i)
+        {
+            handles.pop_back();
+        }
+
+        // release the pages at the end that are now empty
+        testArray.ReleaseEmptyPages();
+
+        // Defragmenting a handle should still work after releasing empty pages
+        testArray.DefragmentHandle(handles.back());
+
+        StableDynamicStructOfArraysMetrics metrics2 = testArray.GetMetrics();
+        size_t endReducedPageCount = metrics2.m_elementsPerPage.size();
+
+        // There should be fewer pages now than before
+        EXPECT_LT(endReducedPageCount, fullPageCount);
+
+
+        // Test removing All the items
+
+        handles.clear(); // cleanup remaining handles.
+
+        // release all the pages.
+        testArray.ReleaseEmptyPages();
+
+        StableDynamicStructOfArraysMetrics metrics3 = testArray.GetMetrics();
+        size_t emptyPageCount = metrics3.m_elementsPerPage.size();
+
+        // there should be 0 pages now.
+        EXPECT_EQ(emptyPageCount, 0);
+
+
+        // Test removing items from the beginning
+
+        // fill with items
+        for (uint32_t i = 0; i < s_testCount; ++i)
+        {
+            StableDynamicStructOfArrays<TestItem>::Handle handle = testArray.emplace(i);
+            handles.push_back(AZStd::move(handle));
+        }
+
+        // remove the first half of the elements
+        for (uint32_t i = 0; i < s_testCount / 2; ++i)
+        {
+            handles.at(i).Free();
+        }
+
+        // release the pages at the beginning that are now empty
+        testArray.ReleaseEmptyPages();
+
+        StableDynamicStructOfArraysMetrics metrics4 = testArray.GetMetrics();
+        size_t beginReducedPageCount = metrics4.m_elementsPerPage.size();
+
+        // There should be fewer pages now than before
+        EXPECT_LT(beginReducedPageCount, fullPageCount);
+
+        handles.clear(); // cleanup remaining handles.
+    }
+
+    TEST_F(StableDynamicStructOfArraysTests, CheckForHolesBetweenPages)
+    {
+        constexpr size_t pageSize = 64;
+        using namespace AZ;
+        AZ::StableDynamicStructOfArrays<TestItem, pageSize> testArray;
+
+        // fill with 10 pages of items
+        TestItem item; // test lvalue insert
+        for (uint32_t i = 0; i < pageSize * 10; ++i)
+        {
+            item.index = i;
+            StableDynamicStructOfArrays<TestItem>::Handle handle = testArray.insert(item);
+            handles.push_back(AZStd::move(handle));
+        }
+
+        // Create a hole between the pages by releaseing items in a page
+        for (uint32_t i = pageSize * 5; i < pageSize * 6; ++i)
+        {
+            handles.at(i).Free();
+        }
+        testArray.ReleaseEmptyPages();
+
+        // Use this lambda to force the test array to think the first page may be empty
+        auto markFirstPageAsEmpty = [&]()
+        {
+            // Also free an element in the first page, so that the first empty page is at the beginning
+            testArray.erase(handles.at(0));
+            // Fill the first page back up, so that any further operations will be forced to
+            // iterate past the hole in search of the next available page
+            {
+                TestItem replacementItem;
+                replacementItem.index = 0;
+                StableDynamicStructOfArrays<TestItem>::Handle handle = testArray.insert(replacementItem);
+                handles.at(0) = AZStd::move(handle);
+            }
+        };
+
+        markFirstPageAsEmpty();
+
+        // Each of these operations will attempt to iterate over all the pages
+        // This test is validating that they do not crash because they are properly checking for holes
+        testArray.ReleaseEmptyPages();
+        markFirstPageAsEmpty();
+
+        testArray.GetParallelRanges();
+        testArray.GetMetrics();
+
+        // Test insert
+        handles.push_back(testArray.emplace(item));
+        markFirstPageAsEmpty();
+
+        // Test defragment
+        testArray.DefragmentHandle(handles.back());
+        markFirstPageAsEmpty();
+
+        // Test erase
+        testArray.erase(handles.back());
+
+        handles.clear();
+    }
+
+    TEST_F(StableDynamicStructOfArraysTests, DefragmentHandle)
+    {
+        using namespace AZ;
+        AZ::StableDynamicStructOfArrays<TestItem> testArray;
+        StableDynamicStructOfArraysMetrics metrics;
+
+        // fill with items
+        for (uint32_t i = 0; i < s_testCount; ++i)
+        {
+            StableDynamicStructOfArrays<TestItem>::Handle handle = testArray.emplace(i);
+            handle->index = i;
+            handles.push_back(AZStd::move(handle));
+        }
+
+        metrics = testArray.GetMetrics();
+        size_t pageCount1 = metrics.m_elementsPerPage.size();
+
+        // remove every other elements
+        for (uint32_t i = 0; i < s_testCount; i += 2)
+        {
+            handles.at(i).Free();
+        }
+
+        // release shouldn't be able to do anything since every other element was removed
+        testArray.ReleaseEmptyPages();
+
+        metrics = testArray.GetMetrics();
+        size_t pageCount2 = metrics.m_elementsPerPage.size();
+        EXPECT_EQ(pageCount1, pageCount2);
+
+        // compact the elements
+        for (uint32_t i = 0; i < s_testCount; ++i)
+        {
+            testArray.DefragmentHandle(handles.at(i));
+        }
+
+        // now that the elements are compacted we should be able to remove some pages
+        testArray.ReleaseEmptyPages();
+
+        metrics = testArray.GetMetrics();
+        size_t pageCount3 = metrics.m_elementsPerPage.size();
+        EXPECT_LT(pageCount3, pageCount2);
+
+        // The the defragmented handles should still have valid weak handles
+        for (StableDynamicStructOfArrays<TestItem>::Handle& handle : handles)
+        {
+            if (handle.IsValid())
+            {
+                StableDynamicStructOfArraysWeakHandle<TestItem> weakHandle = handle.GetWeakHandle();
+                // The weak handle should be referring to the same data as the owning handle
+                EXPECT_EQ(handle->index, weakHandle->index);
+            }
+        }
+
+        handles.clear(); // cleanup remaining handles.
+    }
+
+    TEST_F(StableDynamicStructOfArraysTests, Iterator)
+    {
+        using namespace AZ;
+        AZ::StableDynamicStructOfArrays<TestItem> testArray;
+
+        // fill with items
+        for (uint32_t i = 0; i < s_testCount; ++i)
+        {
+            StableDynamicStructOfArrays<TestItem>::Handle handle = testArray.emplace(i);
+            handle->index = i;
+            handles.push_back(AZStd::move(handle));
+        }
+
+        // make sure the iterator hits each item
+        size_t index = 0;
+        bool success = true;
+
+        for (TestItem& item : testArray)
+        {
+            success = success && (item.index == index);
+            ++index;
+        }
+
+        EXPECT_TRUE(success);
+
+        success = true;
+        // remove every other elements
+        for (uint32_t i = 0; i < s_testCount; i += 2)
+        {
+            handles.at(i).Free();
+        }
+
+        // now the iterator should hit every other item (starting at 1 since 0 was freed).
+        index = 1;
+        for (TestItem& item : testArray)
+        {
+            success = success && (item.index == index);
+            index += 2;
+        }
+        EXPECT_TRUE(success);
+
+        // remove the first half completely so there are a bunch of empty pages to skip
+        for (uint32_t i = 0; i < s_testCount / 2; ++i)
+        {
+            handles.at(i).Free();
+        }
+
+        // now the iterator should hit every other item after s_testCount / 2.
+        success = true;
+        index = s_testCount / 2 + 1;
+        for (TestItem& item : testArray)
+        {
+            success = success && (item.index == index);
+            index += 2;
+        }
+        EXPECT_TRUE(success);
+        handles.clear(); // cleanup remaining handles.
+    }
+
+    TEST_F(StableDynamicStructOfArraysTests, ConstIterator)
+    {
+        using namespace AZ;
+        AZ::StableDynamicStructOfArrays<TestItem> testArray;
+
+        // fill with items
+        for (uint32_t i = 0; i < s_testCount; ++i)
+        {
+            StableDynamicStructOfArrays<TestItem>::Handle handle = testArray.emplace(i);
+            handles.push_back(AZStd::move(handle));
+        }
+
+        // make sure the const iterator hits each item
+        size_t index = 0;
+        bool success = true;
+
+        for (auto it = testArray.cbegin(); it != testArray.cend(); ++it)
+        {
+            success = success && (it->index == index);
+            ++index;
+        }
+
+        EXPECT_TRUE(success);
+
+        success = true;
+        // remove every other elements
+        for (uint32_t i = 0; i < s_testCount; i += 2)
+        {
+            handles.at(i).Free();
+        }
+
+        // now the iterator should hit every other item (starting at 1 since 0 was freed).
+        index = 1;
+        for (auto it = testArray.cbegin(); it != testArray.cend(); ++it)
+        {
+            success = success && (it->index == index);
+            index += 2;
+        }
+        EXPECT_TRUE(success);
+
+        // remove the first half completely so there are a bunch of empty pages to skip
+        for (uint32_t i = 0; i < s_testCount / 2; ++i)
+        {
+            handles.at(i).Free();
+        }
+
+        // now the iterator should hit every other item after s_testCount / 2.
+        success = true;
+        index = s_testCount / 2 + 1;
+        for (auto it = testArray.cbegin(); it != testArray.cend(); ++it)
+        {
+            success = success && (it->index == index);
+            index += 2;
+        }
+        EXPECT_TRUE(success);
+        handles.clear(); // cleanup remaining handles.
+    }
+
+    TEST_F(StableDynamicStructOfArraysTests, PageIterator)
+    {
+        using namespace AZ;
+        AZ::StableDynamicStructOfArrays<TestItem> testArray;
+
+        // Fill with items
+        for (uint32_t i = 0; i < s_testCount; ++i)
+        {
+            StableDynamicStructOfArrays<TestItem>::Handle handle = testArray.emplace(i);
+            handle->index = i;
+            handles.push_back(AZStd::move(handle));
+        }
+
+        // Make sure the page iterators hits each item
+
+        size_t index = 0;
+        bool success = true;
+        auto pageIterators = testArray.GetParallelRanges();
+
+        for (auto iteratorPair : pageIterators)
+        {
+            for (auto iterator = iteratorPair.first; iterator != iteratorPair.second; ++iterator)
+            {
+                TestItem& item = *iterator;
+                success = success && (item.index == index);
+                ++index;
+            }
+        }
+        EXPECT_TRUE(success);
+
+        success = true;
+        // Remove every other elements
+        for (uint32_t i = 0; i < s_testCount; i += 2)
+        {
+            handles.at(i).Free();
+        }
+
+        // Now the page iterators should hit every other item (starting at 1 since 0 was freed).
+        index = 1;
+        pageIterators = testArray.GetParallelRanges();
+        for (auto iteratorPair : pageIterators)
+        {
+            for (auto iterator = iteratorPair.first; iterator != iteratorPair.second; ++iterator)
+            {
+                TestItem& item = *iterator;
+                success = success && (item.index == index);
+                index += 2;
+            }
+        }
+        EXPECT_TRUE(success);
+
+        // Remove the first half completely so there are a bunch of empty pages to skip
+        for (uint32_t i = 0; i < s_testCount / 2; ++i)
+        {
+            handles.at(i).Free();
+        }
+
+        // Now the page iterators should hit every other item after s_testCount / 2.
+        // By this passing, it provesthe first few page iterrators begin and end are equal (as they should be for empty pages).
+        success = true;
+        index = s_testCount / 2 + 1;
+        pageIterators = testArray.GetParallelRanges();
+
+        for (auto iteratorPair : pageIterators)
+        {
+            for (auto iterator = iteratorPair.first; iterator != iteratorPair.second; ++iterator)
+            {
+                TestItem& item = *iterator;
+                success = success && (item.index == index);
+                index += 2;
+            }
+        }
+        EXPECT_TRUE(success);
+        handles.clear(); // cleanup remaining handles.
+    }
+
+
+
+    // Fixture for testing handles and ensuring the correct number of objects are created, modified, and/or destroyed
+    class StableDynamicStructOfArraysHandleTests
+        : public UnitTest::LeakDetectionFixture
+    {
+        friend class StableDynamicStructOfArraysOwner;
+        friend class MoveTest;
+    public:
+        void SetUp() override
+        {
+            s_testItemsConstructed = 0;
+            s_testItemsDestructed = 0;
+            s_testItemsModified = 0;
+        }
+
+        // Used to keep track of the number of times a constructor/destructor/function is called
+        // to validate that TestItems are being properly created, destroyed, and modified even when accessed via an interface
+        static int s_testItemsConstructed;
+        static int s_testItemsDestructed;
+        static int s_testItemsModified;
+    };
+
+    int StableDynamicStructOfArraysHandleTests::s_testItemsConstructed = 0;
+    int StableDynamicStructOfArraysHandleTests::s_testItemsDestructed = 0;
+    int StableDynamicStructOfArraysHandleTests::s_testItemsModified = 0;
+
+    // Class used to test that the right number of items are created, modified, and destroyed
+    // Follows similar pattern to what a FeatureProcessor might do
+    class StableDynamicStructOfArraysOwner
+    {
+
+    public:
+        class TestItemInterface
+        {
+        public:
+            AZ_RTTI(TestItemInterface, "{96502D93-8FBC-4492-B3F8-9962D9E6A93B}");
+
+            virtual void SetValue(int value) = 0;
+            virtual int GetValue() const = 0;
+        };
+
+        class TestItemImplementation
+            : public TestItemInterface
+        {
+        public:
+            AZ_RTTI(TestItemImplementation, "{AFE3A7B6-2133-4206-BF91-0E1BB38FC2D1}", TestItemInterface);
+
+            TestItemImplementation(int value)
+                : m_value(value)
+            {
+                StableDynamicStructOfArraysHandleTests::s_testItemsConstructed++;
+            }
+
+            virtual ~TestItemImplementation()
+            {
+                StableDynamicStructOfArraysHandleTests::s_testItemsDestructed++;
+            }
+
+            void SetValue(int value) override
+            {
+                m_value = value;
+                StableDynamicStructOfArraysHandleTests::s_testItemsModified++;
+            }
+
+            int GetValue() const override
+            {
+                return m_value;
+            }
+
+        private:
+            int m_value = 0;
+        };
+
+        class TestItemImplementation2
+            : public TestItemInterface
+        {
+        public:
+            AZ_RTTI(TestItemImplementation2, "{F9B94C63-88C2-459C-B752-5963D263C97D}", TestItemInterface);
+
+            TestItemImplementation2(int value)
+                : m_value(value)
+            {
+            }
+
+            virtual ~TestItemImplementation2()
+            {
+            }
+
+            void SetValue(int value) override
+            {
+                m_value = value;
+            }
+
+            int GetValue() const override
+            {
+                return m_value;
+            }
+
+        private:
+            int m_value = 0;
+        };
+
+        class TestItemImplementationUnrelated
+        {
+        public:
+            AZ_RTTI(TestItemImplementationUnrelated, "{C583B659-E187-4355-82F9-310A97D4E35B}");
+
+            TestItemImplementationUnrelated(int value)
+                : m_value(value)
+            {
+            }
+
+            virtual ~TestItemImplementationUnrelated()
+            {
+            }
+
+            void SetValue(int value)
+            {
+                m_value = value;
+            }
+
+            int GetValue() const
+            {
+                return m_value;
+            }
+
+        private:
+            int m_value = 0;
+        };
+
+        AZ::StableDynamicStructOfArraysHandle<TestItemImplementation> AcquireItem(uint32_t value)
+        {
+            return m_testArray.emplace(value);
+        }
+
+        void ReleaseItem(AZ::StableDynamicStructOfArraysHandle<TestItemInterface>& interfaceHandle)
+        {
+            AZ::StableDynamicStructOfArraysHandle<TestItemImplementation> temp(AZStd::move(interfaceHandle));
+            ReleaseItem(temp);
+        }
+
+        void ReleaseItem(AZ::StableDynamicStructOfArraysHandle<TestItemImplementation>& handle)
+        {
+            m_testArray.erase(handle);
+        }
+
+    private:
+        AZ::StableDynamicStructOfArrays<TestItemImplementation> m_testArray;
+    };
+
+    using SoATestItemInterfaceHandle = AZ::StableDynamicStructOfArraysHandle<StableDynamicStructOfArraysOwner::TestItemInterface>;
+    using SoATestItemHandle = AZ::StableDynamicStructOfArraysHandle<StableDynamicStructOfArraysOwner::TestItemImplementation>;
+    using SoATestItemWeakHandle = AZ::StableDynamicStructOfArraysWeakHandle<StableDynamicStructOfArraysOwner::TestItemImplementation>;
+    using SoATestItemHandleSibling = AZ::StableDynamicStructOfArraysHandle<StableDynamicStructOfArraysOwner::TestItemImplementation2>;
+    using SoATestItemHandleUnrelated = AZ::StableDynamicStructOfArraysHandle<StableDynamicStructOfArraysOwner::TestItemImplementationUnrelated>;
+
+    // This class runs several scenarios around transferring ownership from one handle to another
+    template<typename SourceTestItemType, typename DestinationTestItemType>
+    class SoAMoveTests
+    {
+        using SourceHandle = AZ::StableDynamicStructOfArraysHandle<SourceTestItemType>;
+        using DestinationHandle = AZ::StableDynamicStructOfArraysHandle<DestinationTestItemType>;
+    public:
+        SoAMoveTests() 
+        { 
+            AZ_Assert(SourceTestItemType::RTTI_IsContainType(DestinationTestItemType::RTTI_Type()) || DestinationTestItemType::RTTI_IsContainType(SourceTestItemType::RTTI_Type()), "These tests expect the transfer of ownership from one handle to the other will succeed, and should only be called with compatible types.");
+        }
+
+        void MoveValidSourceToNullDestination_ExpectMoveToSucceed()
+        {
+            {
+                StableDynamicStructOfArraysOwner owner;
+
+                SourceHandle source = owner.AcquireItem(123);
+                DestinationHandle destination = AZStd::move(source);
+
+                // Source handle should be invalid after move, destination handle should be valid
+                EXPECT_EQ(source.IsValid(), false);
+                EXPECT_EQ(source.IsNull(), true);
+                EXPECT_EQ(destination.IsValid(), true);
+                EXPECT_EQ(destination.IsNull(), false);
+
+                // The destination handle should have the value that came from the source handle
+                EXPECT_EQ(destination->GetValue(), 123);
+
+                // The destination handle should be pointing to real data that can be modified
+                destination->SetValue(789);
+                EXPECT_EQ(destination->GetValue(), 789);
+
+                // One item was constructed, none destructed, one modified
+                EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsConstructed, 1);
+                EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsDestructed, 0);
+                EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsModified, 1);
+            }
+            EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsConstructed, StableDynamicStructOfArraysHandleTests::s_testItemsDestructed);
+        }
+
+        void MoveValidSourceToValidDestination_ExpectMoveToSucceed()
+        {
+            {
+                StableDynamicStructOfArraysOwner owner;
+
+                SourceHandle source = owner.AcquireItem(123);
+                DestinationHandle destination = owner.AcquireItem(456);
+                destination = AZStd::move(source);
+
+                // Source handle should be invalid after move, destination handle should be valid
+                EXPECT_EQ(source.IsValid(), false);
+                EXPECT_EQ(source.IsNull(), true);
+                EXPECT_EQ(destination.IsValid(), true);
+                EXPECT_EQ(destination.IsNull(), false);
+
+                // The destination handle should have the value that came from the source handle
+                EXPECT_EQ(destination->GetValue(), 123);
+
+                // The destination handle should be pointing to real data that can be modified
+                destination->SetValue(789);
+                EXPECT_EQ(destination->GetValue(), 789);
+
+                // Two items were constructed, one destructed, one modified
+                EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsConstructed, 2);
+                EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsDestructed, 1);
+                EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsModified, 1);
+            }
+            EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsConstructed, StableDynamicStructOfArraysHandleTests::s_testItemsDestructed);
+        }
+
+        void MoveNullSourceToValidDestination_ExpectMoveToSucceed()
+        {
+            {
+                StableDynamicStructOfArraysOwner owner;
+                
+                SourceHandle source;
+                DestinationHandle destination = owner.AcquireItem(456);
+                destination = AZStd::move(source);
+
+                // Both handles should be invalid after move
+                EXPECT_EQ(source.IsValid(), false);
+                EXPECT_EQ(source.IsNull(), true);
+                EXPECT_EQ(destination.IsValid(), false);
+                EXPECT_EQ(destination.IsNull(), true);
+
+                // One item was constructed and destructed
+                EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsConstructed, 1);
+                EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsDestructed, 1);
+            }
+            EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsConstructed, StableDynamicStructOfArraysHandleTests::s_testItemsDestructed);
+        }
+
+        void MoveHandleAndReleaseByOwner_ExpectMoveToSucceed()
+        {
+            {
+                StableDynamicStructOfArraysOwner owner;
+
+                SourceHandle source = owner.AcquireItem(123);
+                DestinationHandle destination = owner.AcquireItem(456);
+                destination = AZStd::move(source);
+
+                // Attempting to release the invalid source handle should be a no-op
+                owner.ReleaseItem(source);
+                EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsConstructed, 2);
+                EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsDestructed, 1);
+
+                // Releasing the valid destination handle should succeed
+                owner.ReleaseItem(destination);
+                EXPECT_FALSE(destination.IsValid());
+                EXPECT_TRUE(destination.IsNull());
+                // One item was constructed and destructed
+                EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsConstructed, 2);
+                EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsDestructed, 2);
+            }
+            EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsConstructed, StableDynamicStructOfArraysHandleTests::s_testItemsDestructed);
+        }
+
+        void MoveHandleAndReleaseByCallingFreeDirectlyOnHandle_ExpectMoveToSucceed()
+        {
+            {
+                StableDynamicStructOfArraysOwner owner;
+
+                SourceHandle source = owner.AcquireItem(123);
+                DestinationHandle destination = owner.AcquireItem(456);
+                destination = AZStd::move(source);
+
+                // Attempting to release the invalid source handle should be a no-op
+                source.Free();
+                EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsConstructed, 2);
+                EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsDestructed, 1);
+
+                // Releasing the valid destination handle should succeed
+                destination.Free();
+                EXPECT_FALSE(destination.IsValid());
+                EXPECT_TRUE(destination.IsNull());
+                // One item was constructed and destructed
+                EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsConstructed, 2);
+                EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsDestructed, 2);
+            }
+            EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsConstructed, StableDynamicStructOfArraysHandleTests::s_testItemsDestructed);
+        }
+
+        void MoveHandleAndReleaseByLettingHandleGoOutOfScope_ExpectMoveToSucceed()
+        {
+            {
+                StableDynamicStructOfArraysOwner owner;
+                {
+                    DestinationHandle destination = owner.AcquireItem(456);
+                    {
+                        SourceHandle source = owner.AcquireItem(123);
+                        destination = AZStd::move(source);
+                    }
+                    // Letting the invalid source item go out of scope should be a no-op 
+                    EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsConstructed, 2);
+                    EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsDestructed, 1);
+                    EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsModified, 0);
+                }
+
+                // Releasing the valid destination handle by letting it go out of scope should succeed
+                EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsConstructed, 2);
+                EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsDestructed, 2);
+                EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsModified, 0);
+            }
+            EXPECT_EQ(StableDynamicStructOfArraysHandleTests::s_testItemsConstructed, StableDynamicStructOfArraysHandleTests::s_testItemsDestructed);
+        }
+    };
+
+    // Move TestItem->TestItem
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandle_FromValidSoATestItemHandleToNullSoATestItemHandle_SourceTestItemMovedToDestination)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemImplementation, StableDynamicStructOfArraysOwner::TestItemImplementation> moveTest;
+        moveTest.MoveValidSourceToNullDestination_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandle_FromValidSoATestItemHandleToValidSoATestItemHandle_DestinationTestItemReleasedThenSourceTestItemMoved)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemImplementation, StableDynamicStructOfArraysOwner::TestItemImplementation> moveTest;
+        moveTest.MoveValidSourceToValidDestination_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandle_FromNullSoATestItemHandleToValidSoATestItemHandle_DestinationTestItemReleased)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemImplementation, StableDynamicStructOfArraysOwner::TestItemImplementation> moveTest;
+        moveTest.MoveNullSourceToValidDestination_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandleAndReleaseByOwner_FromValidSoATestItemHandleToValidSoATestItemHandle_DestinationTestItemReleased)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemImplementation, StableDynamicStructOfArraysOwner::TestItemImplementation> moveTest;
+        moveTest.MoveHandleAndReleaseByOwner_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandleAndReleaseByCallingFreeDirectlyOnHandle_FromValidSoATestItemHandleToValidSoATestItemHandle_DestinationTestItemReleased)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemImplementation, StableDynamicStructOfArraysOwner::TestItemImplementation> moveTest;
+        moveTest.MoveHandleAndReleaseByCallingFreeDirectlyOnHandle_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandleAndReleaseByLettingHandleGoOutOfScope_FromValidSoATestItemHandleToValidSoATestItemHandle_DestinationTestItemReleased)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemImplementation, StableDynamicStructOfArraysOwner::TestItemImplementation> moveTest;
+        moveTest.MoveHandleAndReleaseByLettingHandleGoOutOfScope_ExpectMoveToSucceed();
+    }
+
+    // Move TestItem->Interface
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandle_FromValidSoATestItemHandleToNullInterfaceHandle_SourceTestItemMovedToDestination)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemImplementation, StableDynamicStructOfArraysOwner::TestItemInterface> moveTest;
+        moveTest.MoveValidSourceToNullDestination_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandle_FromValidSoATestItemHandleToValidInterfaceHandle_DestinationTestItemReleasedThenSourceTestItemMoved)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemImplementation, StableDynamicStructOfArraysOwner::TestItemInterface> moveTest;
+        moveTest.MoveValidSourceToValidDestination_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandle_FromNullSoATestItemHandleToValidInterfaceHandle_DestinationTestItemReleased)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemImplementation, StableDynamicStructOfArraysOwner::TestItemInterface> moveTest;
+        moveTest.MoveNullSourceToValidDestination_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandleAndReleaseByOwner_FromValidSoATestItemHandleToValidInterfaceHandle_DestinationTestItemReleased)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemImplementation, StableDynamicStructOfArraysOwner::TestItemInterface> moveTest;
+        moveTest.MoveHandleAndReleaseByOwner_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandleAndReleaseByCallingFreeDirectlyOnHandle_FromValidSoATestItemHandleToValidInterfaceHandle_DestinationTestItemReleased)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemImplementation, StableDynamicStructOfArraysOwner::TestItemInterface> moveTest;
+        moveTest.MoveHandleAndReleaseByCallingFreeDirectlyOnHandle_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandleAndReleaseByLettingHandleGoOutOfScope_FromValidSoATestItemHandleToValidInterfaceHandle_DestinationTestItemReleased)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemImplementation, StableDynamicStructOfArraysOwner::TestItemInterface> moveTest;
+        moveTest.MoveHandleAndReleaseByLettingHandleGoOutOfScope_ExpectMoveToSucceed();
+    }
+
+    // Move Interface->TestItem
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandle_FromValidInterfaceHandleToNullSoATestItemHandle_SourceTestItemMovedToDestination)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemInterface, StableDynamicStructOfArraysOwner::TestItemImplementation> moveTest;
+        moveTest.MoveValidSourceToNullDestination_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandle_FromValidInterfaceHandleToValidSoATestItemHandle_DestinationTestItemReleasedThenSourceTestItemMoved)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemInterface, StableDynamicStructOfArraysOwner::TestItemImplementation> moveTest;
+        moveTest.MoveValidSourceToValidDestination_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandle_FromNullInterfaceHandleToValidSoATestItemHandle_DestinationTestItemReleased)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemInterface, StableDynamicStructOfArraysOwner::TestItemImplementation> moveTest;
+        moveTest.MoveNullSourceToValidDestination_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandleAndReleaseByOwner_FromValidInterfaceHandleToValidSoATestItemHandle_DestinationTestItemReleased)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemInterface, StableDynamicStructOfArraysOwner::TestItemImplementation> moveTest;
+        moveTest.MoveHandleAndReleaseByOwner_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandleAndReleaseByCallingFreeDirectlyOnHandle_FromValidInterfaceHandleToValidSoATestItemHandle_DestinationTestItemReleased)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemInterface, StableDynamicStructOfArraysOwner::TestItemImplementation> moveTest;
+        moveTest.MoveHandleAndReleaseByCallingFreeDirectlyOnHandle_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandleAndReleaseByLettingHandleGoOutOfScope_FromValidInterfaceHandleToValidSoATestItemHandle_DestinationTestItemReleased)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemInterface, StableDynamicStructOfArraysOwner::TestItemImplementation> moveTest;
+        moveTest.MoveHandleAndReleaseByLettingHandleGoOutOfScope_ExpectMoveToSucceed();
+    }
+
+    // Move Interface->Interface
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandle_FromValidInterfaceHandleToNullInterfaceHandle_SourceTestItemMovedToDestination)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemInterface, StableDynamicStructOfArraysOwner::TestItemInterface> moveTest;
+        moveTest.MoveValidSourceToNullDestination_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandle_FromValidInterfaceHandleToValidInterfaceHandle_DestinationTestItemReleasedThenSourceTestItemMoved)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemInterface, StableDynamicStructOfArraysOwner::TestItemInterface> moveTest;
+        moveTest.MoveValidSourceToValidDestination_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandle_FromNullInterfaceHandleToValidInterfaceHandle_DestinationTestItemReleased)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemInterface, StableDynamicStructOfArraysOwner::TestItemInterface> moveTest;
+        moveTest.MoveNullSourceToValidDestination_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandleAndReleaseByOwner_FromValidInterfaceHandleToValidInterfaceHandle_DestinationTestItemReleased)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemInterface, StableDynamicStructOfArraysOwner::TestItemInterface> moveTest;
+        moveTest.MoveHandleAndReleaseByOwner_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandleAndReleaseByCallingFreeDirectlyOnHandle_FromValidInterfaceHandleToValidInterfaceHandle_DestinationTestItemReleased)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemInterface, StableDynamicStructOfArraysOwner::TestItemInterface> moveTest;
+        moveTest.MoveHandleAndReleaseByCallingFreeDirectlyOnHandle_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandleAndReleaseByLettingHandleGoOutOfScope_FromValidInterfaceHandleToValidInterfaceHandle_DestinationTestItemReleased)
+    {
+        SoAMoveTests<StableDynamicStructOfArraysOwner::TestItemInterface, StableDynamicStructOfArraysOwner::TestItemInterface> moveTest;
+        moveTest.MoveHandleAndReleaseByLettingHandleGoOutOfScope_ExpectMoveToSucceed();
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandle_SelfAssignment_DoesNotModifyHandle)
+    {
+        StableDynamicStructOfArraysOwner owner;
+        SoATestItemHandle handle = owner.AcquireItem(1);
+        int testValue = 12;
+        handle->SetValue(testValue);
+
+        // Self assignment should not invalidate the handle
+        handle = AZStd::move(handle);
+        EXPECT_TRUE(handle.IsValid());
+        EXPECT_FALSE(handle.IsNull());
+        EXPECT_EQ(handle->GetValue(), testValue);
+    }
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, WeakHandle_GetDataFromOwner_CanAccessData)
+    {
+        StableDynamicStructOfArraysOwner owner;
+        SoATestItemHandle handle = owner.AcquireItem(1);
+        SoATestItemWeakHandle weakHandle = handle.GetWeakHandle();
+
+        int testValue = 12;
+        weakHandle->SetValue(testValue);
+        EXPECT_EQ(handle->GetValue(), testValue);
+        EXPECT_EQ(weakHandle->GetValue(), testValue);
+        EXPECT_EQ((*weakHandle).GetValue(), testValue);
+    }
+
+    //
+    // Invalid cases
+    //
+
+    TEST_F(StableDynamicStructOfArraysHandleTests, MoveHandleBetweenDifferentTypes_FromInterfaceToASiblingHandle_AssertsAndLeavesBothHandlesInvalid)
+    {
+        {
+            StableDynamicStructOfArraysOwner owner;
+
+            // The the underlying type that the interface handle refers to is a TestItemImplementation
+            SoATestItemInterfaceHandle interfaceHandle = owner.AcquireItem(1);
+
+            AZ_TEST_START_ASSERTTEST;
+            // The interface handle is referring to a TestItemImplementation, so you should not be able to move it to a handle to a TestItemImplementation2
+            SoATestItemHandleSibling testItemHandle2FromInterface = AZStd::move(interfaceHandle);
+            AZ_TEST_STOP_ASSERTTEST(1);
+            EXPECT_FALSE(interfaceHandle.IsValid());
+            EXPECT_TRUE(interfaceHandle.IsNull());
+            EXPECT_FALSE(testItemHandle2FromInterface.IsValid());
+            EXPECT_TRUE(testItemHandle2FromInterface.IsNull());
+        }
+        EXPECT_EQ(s_testItemsConstructed, s_testItemsDestructed);
+    }
+
+
+}

--- a/Gems/Atom/Utils/Code/atom_utils_files.cmake
+++ b/Gems/Atom/Utils/Code/atom_utils_files.cmake
@@ -27,6 +27,8 @@ set(FILES
     Include/Atom/Utils/PpmFile.h
     Include/Atom/Utils/StableDynamicArray.h
     Include/Atom/Utils/StableDynamicArray.inl
+    Include/Atom/Utils/StableDynamicStructOfArrays.h
+    Include/Atom/Utils/StableDynamicStructOfArrays.inl
     Include/Atom/Utils/Utils.h
     Include/Atom/Utils/Utils.inl
     Include/Atom/Utils/AssetCollectionAsyncLoader.h

--- a/Gems/Atom/Utils/Code/atom_utils_tests_files.cmake
+++ b/Gems/Atom/Utils/Code/atom_utils_tests_files.cmake
@@ -10,4 +10,5 @@ set(FILES
     Tests/ImageComparisonTests.cpp
     Tests/PngFileTests.cpp
     Tests/StableDynamicArrayTests.cpp
+    Tests/StableDynamicStructOfArraysTests.cpp
 )


### PR DESCRIPTION
## What does this PR do?

This PR introduces a modified version of StableDynamicArray, which is a container that stores data in pages. StableDynamicStructOfArrays has multiple 'rows', such that each row exists in its own chunk of memory, and systems that only need to iterate over part of the data can do so with better cache efficiency. The motivation is that the MeshFeatureProcessor, which uses StableDynamicArray, has object data that has grown over time, and it is now slow to iterate over due to its size. StableDynamicStructOfArrays will allow the MeshFeatureProcessor to split that data up, and when only a subset of the data needs to be iterated over, it can do so more efficiently. This is especially useful for mesh instancing, which has a post-culling process that is only interested in a small subset of the data from a ModelDataInstance.

To review this change, I recommend looking at a diff between the first commit of the change and the final commit. The first commit is an exact copy-paste of StableDynamicArray, only renamed to StableDynamicStructOfArrays. Starting from there, you can see the difference between StableDynamicArray and StableDynamicStructOfArrays.

One feature of StableDynamicArray that I did not support was the ability to move handles between types. This was originally implemented to support a pattern that we no longer use in Atom, which was to have a RenderProxy type associated with a feature processor, and have a RenderProxyInterface that was exposed to outside gems such as AtomLyIntegration. That pattern is no longer used (everything goes through a FeatureProcessorInterface instead), so I recommend we deprecate that functionality from the StableDynamicArray as well.

There are two pieces of syntactic sugar that I left out of this initial commit, which I think it would benefit from long term.
1. Rows must be accessed by index, not by type. AZStd::tuple::get<> supports both type and index based access. The type based access is friendlier to use, but it's less generic since it will not work if there are multiple rows of the same type.
2. Iterators can only access data via a GetItem<> function, instead of via operator* or operator->. This is because they need to know which row to access, and GetItem<> is templated to specify which row. I think it would be beneficial to have typed iterators that know which specific row they are iterating over, such that they can only access data from that row, and can then use operator* or operator-> to access the data like the original StableDynamicArray.

With these two changes, I think we could deprecate the original StableDynamicArray completely, and use StableDynamicStructOfArrays with a single row for cases where StableDynamicArray is used now, since StableDynamicStructOfArrays is a generalization of the single row use-case. But they are out of scope for the initial commit.

## How was this PR tested?

Unit tests. An earlier iteration of this container was tested in the MeshInstancing prototype (and confirmed the performance improvements gained by splitting up the data), but it has been through several rounds of updates since that have only been tested with the unit tests.
