### PR TITLE
Asset Processor - Update Legacy Relocator to handle meta types

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/SourceFileRelocator.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/SourceFileRelocator.h
@@ -89,12 +89,19 @@ namespace AssetProcessor
 
     struct SourceFileRelocationInfo
     {
-        SourceFileRelocationInfo(AzToolsFramework::AssetDatabase::SourceDatabaseEntry sourceEntry, AZStd::unordered_map<int, AzToolsFramework::AssetDatabase::ProductDatabaseEntry> products, const AZStd::string& oldRelativePath, const ScanFolderInfo* scanFolder)
-            : m_sourceEntry(AZStd::move(sourceEntry)),
-            m_products(AZStd::move(products)),
-            m_oldRelativePath(oldRelativePath)
+        SourceFileRelocationInfo(
+            AzToolsFramework::AssetDatabase::SourceDatabaseEntry sourceEntry,
+            AZStd::unordered_map<int, AzToolsFramework::AssetDatabase::ProductDatabaseEntry> products,
+            const AZStd::string& oldRelativePath,
+            const ScanFolderInfo* scanFolder,
+            bool isMetadataEnabledType)
+            : m_sourceEntry(AZStd::move(sourceEntry))
+            , m_products(AZStd::move(products))
+            , m_oldRelativePath(oldRelativePath)
+            , m_isMetadataEnabledType(isMetadataEnabledType)
         {
-            AzFramework::StringFunc::Path::ConstructFull(scanFolder->ScanPath().toUtf8().constData(), m_oldRelativePath.c_str(), m_oldAbsolutePath, false);
+            AzFramework::StringFunc::Path::ConstructFull(
+                scanFolder->ScanPath().toUtf8().constData(), m_oldRelativePath.c_str(), m_oldAbsolutePath, false);
             m_oldAbsolutePath = AssetUtilities::NormalizeFilePath(m_oldAbsolutePath.c_str()).toUtf8().constData();
         }
 
@@ -119,6 +126,7 @@ namespace AssetProcessor
         bool m_hasPathDependencies = false;
         SourceFileRelocationStatus m_operationStatus = SourceFileRelocationStatus::None;
         bool m_isMetaDataFile = false;
+        bool m_isMetadataEnabledType = false; // Indicates if this file uses metadata relocation
         // This is a cached index of the SourceFile in the SourceFileRelocationContainer.
         // This is only used by the metadata file to determine the destination path if needed.
         int m_sourceFileIndex = AssetProcessor::SourceFileRelocationInvalidIndex;

--- a/Code/Tools/AssetProcessor/native/AssetManager/SourceFileRelocator.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/SourceFileRelocator.h
@@ -125,7 +125,9 @@ namespace AssetProcessor
         AZStd::string m_newAbsolutePath;
         bool m_hasPathDependencies = false;
         SourceFileRelocationStatus m_operationStatus = SourceFileRelocationStatus::None;
-        bool m_isMetaDataFile = false;
+        // If >= 0, this is a metadata file.  This is the index into the
+        // PlatformConfiguration metadata list (use with GetMetaDataFileTypeAt)
+        int m_metadataIndex = SourceFileRelocationInvalidIndex;
         bool m_isMetadataEnabledType = false; // Indicates if this file uses metadata relocation
         // This is a cached index of the SourceFile in the SourceFileRelocationContainer.
         // This is only used by the metadata file to determine the destination path if needed.

--- a/Code/Tools/AssetProcessor/native/tests/SourceFileRelocatorTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/SourceFileRelocatorTests.cpp
@@ -403,6 +403,10 @@ namespace UnitTests
 
         QTemporaryDir m_tempDir{ QDir::tempPath() + QLatin1String("/AssetProcessorUnitTest-XXXXXX") };
 
+        AzToolsFramework::UuidUtilComponent m_uuidUtil;
+        AzToolsFramework::MetadataManager m_metadataManager;
+        AssetProcessor::UuidManager m_uuidManager;
+
         // we store the above data in a unique_ptr so that its memory can be cleared during TearDown() in one call, before we destroy the memory
         // allocator, reducing the chance of missing or forgetting to destroy one in the future.
         AZStd::unique_ptr<StaticData> m_data;

--- a/Code/Tools/AssetProcessor/native/tests/SourceFileRelocatorTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/SourceFileRelocatorTests.cpp
@@ -12,6 +12,7 @@
 #include <AzCore/Jobs/JobManager.h>
 #include <AzCore/Jobs/JobManagerDesc.h>
 #include <AzCore/Memory/PoolAllocator.h>
+#include <AzCore/Utils/Utils.h>
 #include "AssetProcessorTest.h"
 #include "AzToolsFramework/API/AssetDatabaseBus.h"
 #if !defined(Q_MOC_RUN)
@@ -62,6 +63,9 @@ namespace UnitTests
             m_data->m_databaseLocation = tempPath.absoluteFilePath("test_database.sqlite").toUtf8().constData();
             m_data->m_databaseLocationListener.BusConnect();
 
+            m_settingsRegistry = AZStd::make_unique<AZ::SettingsRegistryImpl>();
+            AZ::SettingsRegistry::Register(m_settingsRegistry.get());
+
             {
                 using namespace testing;
 
@@ -78,6 +82,7 @@ namespace UnitTests
 
             m_data->m_platformConfig.AddMetaDataType("metadataextension", "metadatatype");
             m_data->m_platformConfig.AddMetaDataType("bar", "foo");
+            m_data->m_platformConfig.ReadMetaDataFromSettingsRegistry();
 
             AZStd::vector<AssetBuilderSDK::PlatformInfo> platforms;
             m_data->m_platformConfig.PopulatePlatformsForScanFolder(platforms);
@@ -202,6 +207,8 @@ namespace UnitTests
                 AZ::IO::FileIOBase::SetInstance(nullptr);
             }
             m_localFileIo.reset();
+
+            AZ::SettingsRegistry::Unregister(m_settingsRegistry.get());
 
             AZ::JobContext::SetGlobalContext(nullptr);
             delete m_data->m_jobContext;
@@ -406,6 +413,7 @@ namespace UnitTests
         AzToolsFramework::UuidUtilComponent m_uuidUtil;
         AzToolsFramework::MetadataManager m_metadataManager;
         AssetProcessor::UuidManager m_uuidManager;
+        AZStd::unique_ptr<AZ::SettingsRegistryImpl> m_settingsRegistry;
 
         // we store the above data in a unique_ptr so that its memory can be cleared during TearDown() in one call, before we destroy the memory
         // allocator, reducing the chance of missing or forgetting to destroy one in the future.
@@ -825,6 +833,44 @@ namespace UnitTests
         ASSERT_EQ(successResult.m_moveSuccessCount, 1);
         ASSERT_EQ(successResult.m_moveFailureCount, 0);
         ASSERT_EQ(successResult.m_moveTotalCount, 1);
+        ASSERT_EQ(successResult.m_updateTotalCount, 0);
+    }
+
+    TEST_F(SourceFileRelocatorTest, MoveMetadataEnabledType_Real_Succeeds)
+    {
+        QDir tempPath(m_tempDir.path());
+
+        auto filePath = QDir(tempPath.absoluteFilePath(m_data->m_scanFolder1.m_scanFolder.c_str())).absoluteFilePath("duplicate/file1.tif");
+        auto newFilePath =
+            QDir(tempPath.absoluteFilePath(m_data->m_scanFolder1.m_scanFolder.c_str())).absoluteFilePath("someOtherPlace/renamed.tif");
+        auto metadataPath = AzToolsFramework::MetadataManager::ToMetadataPath(filePath.toUtf8().constData());
+        auto newMetadataPath = AzToolsFramework::MetadataManager::ToMetadataPath(newFilePath.toUtf8().constData());
+
+        ASSERT_TRUE(AZ::IO::FileIOBase::GetInstance()->Exists(filePath.toUtf8().constData()));
+
+        auto* uuidInterface = AZ::Interface<AssetProcessor::IUuidRequests>::Get();
+        ASSERT_TRUE(uuidInterface);
+
+        uuidInterface->EnableGenerationForTypes({ ".tif" });
+
+        AZ::Utils::WriteFile("unit test file", metadataPath.c_str());
+
+        auto result = m_data->m_reporter->Move(filePath.toUtf8().constData(), "someOtherPlace/renamed.tif", false);
+
+        auto* io = AZ::IO::FileIOBase::GetInstance();
+        ASSERT_TRUE(io);
+
+        ASSERT_TRUE(result.IsSuccess());
+        ASSERT_FALSE(io->Exists(filePath.toUtf8().constData()));
+        ASSERT_TRUE(io->Exists(newFilePath.toUtf8().constData()));
+        ASSERT_FALSE(io->Exists(metadataPath.c_str()));
+        ASSERT_TRUE(io->Exists(newMetadataPath.c_str()));
+
+        RelocationSuccess successResult = result.TakeValue();
+
+        ASSERT_EQ(successResult.m_moveSuccessCount, 2);
+        ASSERT_EQ(successResult.m_moveFailureCount, 0);
+        ASSERT_EQ(successResult.m_moveTotalCount, 2);
         ASSERT_EQ(successResult.m_updateTotalCount, 0);
     }
 


### PR DESCRIPTION
## What does this PR do?

Updated the legacy find-and-replace asset relocator to ignore dependencies for metadata-enabled types.

Also fixed a bug that prevented metadata files from being properly renamed with the source file.

## How was this PR tested?

Manually running editor and using the rename command
Added and ran unit test
