### PR TITLE
Make inheritance of parent entity's transform optional at runtime

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/TransformBus.h
+++ b/Code/Framework/AzCore/AzCore/Component/TransformBus.h
@@ -29,6 +29,13 @@ namespace AZ
     enum class ChildChangeType { Added, Removed };
     using ChildChangedEvent = Event<ChildChangeType, EntityId>;
 
+    //! Used to control the behavior of an entity's transform when its parent's transform changes at runtime.
+    enum class OnParentChangedBehavior : AZ::u8
+    {
+        Update, //!< Update this entity's transform based on the parent's new world transform and this entity's local transform.
+        DoNotUpdate //!< Do not update this entity's world transform when the parent's transform changes.
+    };
+
     //! Interface for AZ::TransformBus, which is an EBus that receives requests
     //! to translate (position), rotate, and scale an entity in 3D space. It
     //! also receives requests to get and set the parent of an entity and get
@@ -286,6 +293,9 @@ namespace AZ
         //! A static transform is unmovable and does not respond to requests that would move it.
         virtual void SetIsStaticTransform([[maybe_unused]] bool isStatic) {}
         //! @}
+
+        //! Set the behavior at runtime when this entity's parent's transform changes.
+        virtual void SetOnParentChangedBehavior([[maybe_unused]] OnParentChangedBehavior onParentChangedBehavior) {}
     };
 
     //! The EBus for requests to position and parent an entity.

--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
@@ -642,7 +642,7 @@ namespace AzFramework
                 // but keeps our world transform unchanged. Do not send any notifications here, because our world
                 // transform has not changed, and with this OnParentChangedBehavior setting the expectation is that
                 // another system will update our transform, and the notification will be triggered then.
-                m_localTM = m_parentTM->GetWorldTM().GetInverse() * m_worldTM;
+                m_localTM = parentWorldTM.GetInverse() * m_worldTM;
             }
         }
     }

--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.h
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.h
@@ -136,6 +136,7 @@ namespace AzFramework
         AZStd::vector<AZ::EntityId> GetAllDescendants() override;
         AZStd::vector<AZ::EntityId> GetEntityAndAllDescendants() override;
         bool IsStaticTransform() override;
+        void SetOnParentChangedBehavior(AZ::OnParentChangedBehavior onParentChangedBehavior);
 
         //! Methods implementing parent support.
         //! @{
@@ -186,5 +187,7 @@ namespace AzFramework
         bool m_parentActive = false; ///< Keeps track of the state of the parent entity.
         bool m_onNewParentKeepWorldTM = true; ///< If set, recompute localTM instead of worldTM when parent becomes active.
         bool m_isStatic = false; ///< If true, the transform is static and doesn't move while entity is active.
+        /// Behaviour for this entity's transform when its parent's transform changes.
+        AZ::OnParentChangedBehavior m_onParentChangedBehavior = AZ::OnParentChangedBehavior::Update;
     };
 }   // namespace AZ

--- a/Gems/PhysX/Code/Source/RigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/RigidBodyComponent.cpp
@@ -404,6 +404,8 @@ namespace PhysX
         m_interpolator = std::make_unique<TransformForwardTimeInterpolator>();
         m_interpolator->Reset(transform.GetTranslation(), rotation);
 
+        GetEntity()->GetTransform()->SetOnParentChangedBehavior(AZ::OnParentChangedBehavior::DoNotUpdate);
+
         Physics::RigidBodyNotificationBus::Event(GetEntityId(), &Physics::RigidBodyNotificationBus::Events::OnPhysicsEnabled, GetEntityId());
     }
 
@@ -415,6 +417,8 @@ namespace PhysX
         }
 
         SetSimulationEnabled(false);
+
+        GetEntity()->GetTransform()->SetOnParentChangedBehavior(AZ::OnParentChangedBehavior::Update);
 
         Physics::RigidBodyNotificationBus::Event(GetEntityId(), &Physics::RigidBodyNotificationBus::Events::OnPhysicsDisabled, GetEntityId());
     }


### PR DESCRIPTION
## What does this PR do?
Implements https://github.com/o3de/sig-simulation/issues/57. Adds an option to the Transform interface which allows the behaviour of updating a child entity's transform when its parent's transform changes to be disabled at runtime.

## How was this PR tested?
Manual testing in the editor.

https://user-images.githubusercontent.com/82226198/224714366-26ff36a4-fa3e-4cf2-b052-59bc2879d014.mp4

