### PR TITLE
Sky Atmosphere rhi null test automation

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Component_03.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Component_03.py
@@ -40,6 +40,9 @@ class TestAutomation(EditorTestSuite):
     class AtomEditorComponents_ReflectionProbeAdded(EditorBatchedTest):
         from Atom.tests import hydra_AtomEditorComponents_ReflectionProbeAdded as test_module
 
+    class AtomEditorComponents_SkyAtmosphereAdded(EditorBatchedTest):
+        from Atom.tests import hydra_AtomEditorComponents_SkyAtmosphereAdded as test_module
+
     @pytest.mark.test_case_id("C36525666")
     class AtomEditorComponents_SSAOAdded(EditorBatchedTest):
         from Atom.tests import hydra_AtomEditorComponents_SSAOAdded as test_module

--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
@@ -1312,21 +1312,21 @@ class AtomComponentProperties:
     def sky_atmosphere(property: str = 'name') -> str:
         """
         Sky Atmosphere component properties
-          - 'Ground albedo' Additional light from the surface of the ground (Vector3 RGB integer 0-255) default (0,0,0)
+          - 'Ground albedo' Additional light from the surface of the ground (Vector3 float) default (0.0,0.0,0.0)
           - 'Ground radius' Kilometers 0.0 to 100000.0 (float) default 6360.0
           - 'Origin' The origin to use for the atmosphere (int)
           - 'Atmosphere height' Kilometers 0.0 to 10000.0 (float) default 100.0
           - 'Illuminance factor' An additional factor to brighten or darken the overall atmosphere (Vector3 float) default (1.0,1.0,1.0)
           - 'Mie absorption Scale' 0.0 to 1.0 (float) default 0.004
-          - 'Mie absorption' (Vector3 RGB integer 0-255) default (255,255,255)
+          - 'Mie absorption' (Vector3 float) default (1.0,1.0,1.0)
           - 'Mie exponential distribution' Altitude in kilometers at which Mie scattering is reduced to roughly 40%. 0.0 to 400.0 (float) default 1.2
           - 'Mie scattering Scale' 0.0 to 1.0 (float) default 0.004
-          - 'Mie scattering' Mie scattering coefficients from aerosole molecules at surface of the planet. (Vector3 RGB integer 0-255) default (255,255,255)
+          - 'Mie scattering' Mie scattering coefficients from aerosole molecules at surface of the planet. (Vector3 float) default (1.0,1.0,1.0)
           - 'Ozone Absorption Scale' Ozone molecule absorption scale 0.0 to 1.0 (float) default 0.001881
-          - 'Ozone Absorption' Absorption coefficients from ozone molecules (Vector3 RGB integer 0-255) default (255,255,255)
+          - 'Ozone Absorption' Absorption coefficients from ozone molecules (Vector3 float) default (1.0,1.0,1.0)
           - 'Rayleigh exponential distribution' Altitude in kilometers at which Rayleigh scattering is reduced to roughly 40%. 0.0 to 400.0 (float) default 8.0
           - 'Rayleigh scattering Scale' 0.0 to 1.0 (float) default 0.033100f
-          - 'Rayleigh scattering' Raleigh scattering coefficients from air molecules at surface of the planet. (Vector3 RGB integer 0-255) default (255,255,255)
+          - 'Rayleigh scattering' Raleigh scattering coefficients from air molecules at surface of the planet. (Vector3 float) default (1.0,1.0,1.0)
           - 'Show sun' display a sun (bool) default True
           - 'Sun color' (azlmbr.math.Color RGBA) default (255.0,255.0,255.0,255.0)
           - 'Sun falloff factor' 0.0 to 200.0 (float) default 1.0

--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
@@ -179,6 +179,13 @@ DIRECTIONAL_LIGHT_SHADOW_FILTER_METHOD = {
     'PCF+ESM': 3,
 }
 
+#Origin type for Sky Atmosphere component
+ATMOSPHERE_ORIGIN = {
+    'GroundAtWorldOrigin': 0,
+    'GroundAtLocalOrigin': 1,
+    'PlanetCenterAtLocalOrigin': 2,
+}
+
 # Level list used in Editor Level Load Test
 # WARNING: "Sponza" level is sandboxed due to an intermittent failure.
 LEVEL_LIST = ["hermanubis", "hermanubis_high", "macbeth_shaderballs", "PbrMaterialChart", "ShadowTest"]
@@ -1298,6 +1305,74 @@ class AtomComponentProperties:
             'Length': 'Controller|Configuration|Inner Extents|Length',
             'Width': 'Controller|Configuration|Inner Extents|Width',
             'Baked Cubemap Path': 'Cubemap|Baked Cubemap Path',
+        }
+        return properties[property]
+
+    @staticmethod
+    def sky_atmosphere(property: str = 'name') -> str:
+        """
+        Sky Atmosphere component properties
+          - 'Ground albedo' Additional light from the surface of the ground (Vector3 RGB integer 0-255) default (0,0,0)
+          - 'Ground radius' Kilometers 0.0 to 100000.0 (float) default 6360.0
+          - 'Origin' The origin to use for the atmosphere (int)
+          - 'Atmosphere height' Kilometers 0.0 to 10000.0 (float) default 100.0
+          - 'Illuminance factor' An additional factor to brighten or darken the overall atmosphere (Vector3 float) default (1.0,1.0,1.0)
+          - 'Mie absorption Scale' 0.0 to 1.0 (float) default 0.004
+          - 'Mie absorption' (Vector3 RGB integer 0-255) default (255,255,255)
+          - 'Mie exponential distribution' Altitude in kilometers at which Mie scattering is reduced to roughly 40%. 0.0 to 400.0 (float) default 1.2
+          - 'Mie scattering Scale' 0.0 to 1.0 (float) default 0.004
+          - 'Mie scattering' Mie scattering coefficients from aerosole molecules at surface of the planet. (Vector3 RGB integer 0-255) default (255,255,255)
+          - 'Ozone Absorption Scale' Ozone molecule absorption scale 0.0 to 1.0 (float) default 0.001881
+          - 'Ozone Absorption' Absorption coefficients from ozone molecules (Vector3 RGB integer 0-255) default (255,255,255)
+          - 'Rayleigh exponential distribution' Altitude in kilometers at which Rayleigh scattering is reduced to roughly 40%. 0.0 to 400.0 (float) default 8.0
+          - 'Rayleigh scattering Scale' 0.0 to 1.0 (float) default 0.033100f
+          - 'Rayleigh scattering' Raleigh scattering coefficients from air molecules at surface of the planet. (Vector3 RGB integer 0-255) default (255,255,255)
+          - 'Show sun' display a sun (bool) default True
+          - 'Sun color' (azlmbr.math.Color RGBA) default (255.0,255.0,255.0,255.0)
+          - 'Sun falloff factor' 0.0 to 200.0 (float) default 1.0
+          - 'Sun limb color' for adjusting outer edge color of sun. (azlmbr.math.Color RGBA) default (255.0,255.0,255.0,255.0)
+          - 'Sun luminance factor' 0.0 to 100000.0 (float) default 0.05
+          - 'Sun orientation' Optional sun entity to use for orientation (EntityId)
+          - 'Sun radius factor' 0.0 to 100.0 (float) default 1.0
+          - 'Enable shadows' (bool) default False
+          - 'Fast sky' (bool) default True
+          - 'Max samples' 1 to 64 (unsigned int) default 14
+          - 'Min samples' 1 to 64 (unsigned int) default 4
+          - 'Near Clip' 0.0 to inf (float) default 0.0
+          - 'Near Fade Distance' 0.0 to inf (float) default 0.0
+        :param property: From the last element of the property tree path. Default 'name' for component name string.
+        :return: Full property path OR component name if no property specified.
+        """
+        properties = {
+            'name': 'Sky Atmosphere',
+            'Ground albedo': 'Controller|Configuration|Planet|Ground albedo',
+            'Ground radius': 'Controller|Configuration|Planet|Ground radius',
+            'Origin': 'Controller|Configuration|Planet|Origin',
+            'Atmosphere height': 'Controller|Configuration|Atmosphere|Atmosphere height',
+            'Illuminance factor': 'Controller|Configuration|Atmosphere|Illuminance factor',
+            'Mie absorption Scale': 'Controller|Configuration|Atmosphere|Mie absorption Scale',
+            'Mie absorption': 'Controller|Configuration|Atmosphere|Mie absorption',
+            'Mie exponential distribution': 'Controller|Configuration|Atmosphere|Mie exponential distribution',
+            'Mie scattering Scale': 'Controller|Configuration|Atmosphere|Mie scattering Scale',
+            'Mie scattering': 'Controller|Configuration|Atmosphere|Mie scattering',
+            'Ozone Absorption Scale': 'Controller|Configuration|Atmosphere|Ozone Absorption Scale',
+            'Ozone Absorption': 'Controller|Configuration|Atmosphere|Ozone Absorption',
+            'Rayleigh exponential distribution': 'Controller|Configuration|Atmosphere|Rayleigh exponential distribution',
+            'Rayleigh scattering Scale': 'Controller|Configuration|Atmosphere|Rayleigh scattering Scale',
+            'Rayleigh scattering': 'Controller|Configuration|Atmosphere|Rayleigh scattering',
+            'Show sun': 'Controller|Configuration|Sun|Show sun',
+            'Sun color': 'Controller|Configuration|Sun|Sun color',
+            'Sun falloff factor': 'Controller|Configuration|Sun|Sun falloff factor',
+            'Sun limb color': 'Controller|Configuration|Sun|Sun limb color',
+            'Sun luminance factor': 'Controller|Configuration|Sun|Sun luminance factor',
+            'Sun orientation': 'Controller|Configuration|Sun|Sun orientation',
+            'Sun radius factor': 'Controller|Configuration|Sun|Sun radius factor',
+            'Enable shadows': 'Controller|Configuration|Advanced|Enable shadows',
+            'Fast sky': 'Controller|Configuration|Advanced|Fast sky',
+            'Max samples': 'Controller|Configuration|Advanced|Max samples',
+            'Min samples': 'Controller|Configuration|Advanced|Min samples',
+            'Near Clip': 'Controller|Configuration|Advanced|Near Clip',
+            'Near Fade Distance': 'Controller|Configuration|Advanced|Near Fade Distance',
         }
         return properties[property]
 

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_SkyAtmosphereAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_SkyAtmosphereAdded.py
@@ -1,0 +1,521 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+
+class Tests:
+    sky_atmosphere_creation = (
+        "Sky AtmosphereEntity successfully created",
+        "P0: Sky AtmosphereEntity failed to be created")
+    sky_atmosphere_component = (
+        "Entity has a Sky Atmosphere component",
+        "P0: Entity failed to find Sky Atmosphere component")
+    sky_atmosphere_component_removal = (
+        "Sky Atmosphere component successfully removed",
+        "P0: Sky Atmosphere component failed to be removed")
+    removal_undo = (
+        "UNDO Sky Atmosphere component removal success",
+        "P0: UNDO Sky Atmosphere component removal failed")
+    sky_atmosphere_disabled = (
+        "Sky Atmosphere component disabled",
+        "P0: Sky Atmosphere component was not disabled")
+    sky_atmosphere_enabled = (
+        "Sky Atmosphere component enabled",
+        "P0: Sky Atmosphere component was not enabled")
+    ground_albedo = (
+        "Ground albedo property set",
+        "P1: 'Ground albedo' property failed to set")
+    ground_radius = (
+        "Ground radius property set",
+        "P1: 'Ground radius' property failed to set")
+    atmosphere_height = (
+        "Atmosphere height property set",
+        "P1: 'Atmosphere height' property failed to set")
+    illuminance_factor = (
+        "Illuminance factor property set",
+        "P1: 'Illuminance factor' property failed to set")
+    mie_absorption_scale = (
+        "Mie absorption Scale property set",
+        "P1: 'Mie absorption Scale' property failed to set")
+    mie_absorption = (
+        "Mie absorption property set",
+        "P1: 'Mie absorption' property failed to set")
+    mie_exponential_distribution = (
+        "Mie exponential distribution property set",
+        "P1: 'Mie exponential distribution' property failed to set")
+    mie_scattering_scale = (
+        "Mie scattering Scale property set",
+        "P1: 'Mie scattering Scale' property failed to set")
+    mie_scattering = (
+        "Mie scattering property set",
+        "P1: 'Mie scattering' property failed to set")
+    ozone_absorption_scale = (
+        "Ozone Absorption Scale property set",
+        "P1: 'Ozone Absorption Scale' property failed to set")
+    ozone_absorption = (
+        "Ozone Absorption property set",
+        "P1: 'Ozone Absorption' property failed to set")
+    rayleigh_exponential_distribution = (
+        "Rayleigh exponential distribution property set",
+        "P1: 'Rayleigh exponential distribution' property failed to set")
+    rayleigh_scattering_scale = (
+        "Rayleigh scattering Scale property set",
+        "P1: 'Rayleigh scattering Scale' property failed to set")
+    rayleigh_scattering = (
+        "Rayleigh scattering property set",
+        "P1: 'Rayleigh scattering' property failed to set")
+    show_sun = (
+        "Show sun property set",
+        "P1: 'Show sun' property failed to set")
+    sun_color = (
+        "Sun color property set",
+        "P1: 'Sun color' property failed to set")
+    sun_falloff_factor = (
+        "Sun falloff factor property set",
+        "P1: 'Sun falloff factor' property failed to set")
+    sun_limb_color = (
+        "Sun limb color property set",
+        "P1: 'Sun limb color' property failed to set")
+    sun_luminance_factor = (
+        "Sun luminance factor property set",
+        "P1: 'Sun luminance factor' property failed to set")
+    sun_orientation = (
+        "Sun orientation property set",
+        "P1: 'Sun orientation' property failed to set")
+    sun_radius_factor = (
+        "Sun radius factor property set",
+        "P1: 'Sun radius factor' property failed to set")
+    enable_shadows = (
+        "Enable shadows property set",
+        "P1: 'Enable shadows' property failed to set")
+    fast_sky = (
+        "Fast sky property set",
+        "P1: 'Fast sky' property failed to set")
+    max_samples = (
+        "Max samples property set",
+        "P1: 'Max samples' property failed to set")
+    min_samples = (
+        "Min samples property set",
+        "P1: 'Min samples' property failed to set")
+    near_clip = (
+        "Near Clip property set",
+        "P1: 'Near Clip' property failed to set")
+    near_fade_distance = (
+        "Near Fade Distance property set",
+        "P1: 'Near Fade Distance' property failed to set")
+    enter_game_mode = (
+        "Entered game mode",
+        "P0: Failed to enter game mode")
+    exit_game_mode = (
+        "Exited game mode",
+        "P0: Couldn't exit game mode")
+    is_visible = (
+        "Entity is visible",
+        "P0: Entity was not visible")
+    is_hidden = (
+        "Entity is hidden",
+        "P0: Entity was not hidden")
+    entity_deleted = (
+        "Entity deleted",
+        "P0: Entity was not deleted")
+    deletion_undo = (
+        "UNDO deletion success",
+        "P0: UNDO deletion failed")
+    deletion_redo = (
+        "REDO deletion success",
+        "P0: REDO deletion failed")
+
+
+def AtomEditorComponents_SkyAtmosphere_AddedToEntity():
+    """
+    Summary:
+    Tests the Sky Atmosphere component can be added to an entity and has the expected functionality.
+
+    Test setup:
+    - Wait for Editor idle loop.
+    - Open the "Base" level.
+
+    Expected Behavior:
+    The component can be added, used in game mode, hidden/shown, deleted, and has accurate required components.
+    Creation and deletion undo/redo should also work.
+
+    Test Steps:
+    1) Create an Sky Atmosphere entity with no components.
+    2) Add Sky Atmosphere component to Sky Atmosphere entity.
+    3) Remove the Sky Atmosphere component.
+    4) Undo Sky Atmosphere component removal.
+    5) Verify Sky Atmosphere component is enabled.
+    6) Set a value for 'Ground albedo' property
+    7) Set a value for 'Ground radius' property
+    8) Set a value for 'Origin' property
+    9) Set a value for 'Atmosphere height' property
+    10) Set a value for 'Illuminance factor' property
+    11) Set a value for 'Mie absorption Scale' property
+    12) Set a value for 'Mie absorption' property
+    13) Set a value for 'Mie exponential distribution' property
+    14) Set a value for 'Mie scattering Scale' property
+    15) Set a value for 'Mie scattering' property
+    16) Set a value for 'Ozone Absorption Scale' property
+    17) Set a value for 'Ozone Absorption' property
+    18) Set a value for 'Rayleigh exponential distribution' property
+    19) Set a value for 'Rayleigh scattering Scale' property
+    20) Set a value for 'Rayleigh scattering' property
+    21) Set a value for 'Show sun' property
+    22) Set a value for 'Sun color' property
+    23) Set a value for 'Sun falloff factor' property
+    24) Set a value for 'Sun limb color' property
+    25) Set a value for 'Sun luminance factor' property
+    26) Set a value for 'Sun orientation' property
+    27) Set a value for 'Sun radius factor' property
+    28) Set a value for 'Enable shadows' property
+    29) Set a value for 'Fast sky' property
+    30) Set a value for 'Max samples' property
+    31) Set a value for 'Min samples' property
+    32) Set a value for 'Near Clip' property
+    33) Set a value for 'Near Fade Distance' property
+    34) Enter/Exit game mode.
+    35) Test IsHidden.
+    36) Test IsVisible.
+    37) Delete Sky Atmosphere entity.
+    38) UNDO deletion.
+    39) REDO deletion.
+    40) Look for errors and asserts.
+
+    :return: None
+    """
+
+    import azlmbr.legacy.general as general
+
+    from azlmbr.math import Vector3, Color
+
+    from editor_python_test_tools.editor_entity_utils import EditorEntity
+    from editor_python_test_tools.wait_utils import PrefabWaiter
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+    from Atom.atom_utils.atom_constants import AtomComponentProperties, ATMOSPHERE_ORIGIN
+
+    with Tracer() as error_tracer:
+        # Test setup begins.
+        # Setup: Wait for Editor idle loop before executing Python hydra scripts then open "Base" level.
+        TestHelper.init_idle()
+        TestHelper.open_level("Graphics", "base_empty")
+
+        # Test steps begin.
+        # 1. Create an Sky Atmosphere entity with no components.
+        sky_atmosphere_entity = EditorEntity.create_editor_entity(AtomComponentProperties.sky_atmosphere())
+        Report.critical_result(Tests.sky_atmosphere_creation, sky_atmosphere_entity.exists())
+
+        # 2. Add Sky Atmosphere component to Sky Atmosphere entity.
+        sky_atmosphere_component = sky_atmosphere_entity.add_component(AtomComponentProperties.sky_atmosphere())
+        Report.critical_result(Tests.sky_atmosphere_component,
+                               sky_atmosphere_entity.has_component(AtomComponentProperties.sky_atmosphere()))
+
+        # 3. Remove the Sky Atmosphere component.
+        sky_atmosphere_component.remove()
+        PrefabWaiter.wait_for_propagation()
+        Report.critical_result(Tests.sky_atmosphere_component_removal,
+                               not sky_atmosphere_entity.has_component(AtomComponentProperties.sky_atmosphere()))
+
+        # 4. Undo Sky Atmosphere component removal.
+        general.undo()
+        PrefabWaiter.wait_for_propagation()
+        Report.result(Tests.removal_undo,
+                      sky_atmosphere_entity.has_component(AtomComponentProperties.sky_atmosphere()))
+
+        # 5. Verify Sky Atmosphere component is enabled.
+        Report.result(Tests.sky_atmosphere_enabled, sky_atmosphere_component.is_enabled())
+
+        # 6. Set a value for 'Ground albedo' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Ground albedo'), Vector3(0.0, 1.0, 0.0))
+        Report.result(
+            Tests.ground_albedo,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Ground albedo')) == Vector3(0.0, 1.0, 0.0))
+
+        # 7. Set a value for 'Ground radius' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Ground radius'), 100000.0)
+        Report.result(
+            Tests.ground_radius,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Ground radius')) == 100000.0)
+
+        # 8. Set a value for 'Origin' property
+        for origin_type in ATMOSPHERE_ORIGIN:
+            test_origin = (
+                f"Origin property set to {origin_type}",
+                f"P1: 'Origin' property failed to set {origin_type}")
+            sky_atmosphere_component.set_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Origin'), ATMOSPHERE_ORIGIN[origin_type])
+            Report.result(
+                test_origin,
+                sky_atmosphere_component.get_component_property_value(
+                    AtomComponentProperties.sky_atmosphere('Origin')) == ATMOSPHERE_ORIGIN[origin_type])
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Origin'), ATMOSPHERE_ORIGIN['GroundAtWorldOrigin'])
+
+        # 9. Set a value for 'Atmosphere height' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Atmosphere height'), 10000.0)
+        Report.result(
+            Tests.atmosphere_height,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Atmosphere height')) == 10000.0)
+
+        # 10. Set a value for 'Illuminance factor' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Illuminance factor'), Vector3(100.0,100.0,100.0))
+        Report.result(
+            Tests.illuminance_factor,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Illuminance factor')) == Vector3(100.0,100.0,100.0))
+
+        # 11. Set a value for 'Mie absorption Scale' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Mie absorption Scale'), 1.0)
+        Report.result(
+            Tests.mie_absorption_scale,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Mie absorption Scale')) == 1.0)
+
+        # 12. Set a value for 'Mie absorption' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Mie absorption'), Vector3(0.5,0.0,0.5))
+        Report.result(
+            Tests.mie_absorption,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Mie absorption')) == Vector3(0.5,0.0,0.5))
+
+        # 13. Set a value for 'Mie exponential distribution' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Mie exponential distribution'), 400.0)
+        Report.result(
+            Tests.mie_exponential_distribution,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Mie exponential distribution')) == 400.0)
+
+        # 14. Set a value for 'Mie scattering Scale' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Mie scattering Scale'), 1.0)
+        Report.result(
+            Tests.mie_scattering_scale,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Mie scattering Scale')) == 1.0)
+
+        # 15. Set a value for 'Mie scattering' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Mie scattering'), Vector3(1.0,0.0,0.0))
+        Report.result(
+            Tests.mie_scattering,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Mie scattering')) == Vector3(1.0,0.0,0.0))
+
+        # 16. Set a value for 'Ozone Absorption Scale' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Ozone Absorption Scale'), 1.0)
+        Report.result(
+            Tests.ozone_absorption_scale,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Ozone Absorption Scale')) == 1.0)
+
+        # 17. Set a value for 'Ozone Absorption' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Ozone Absorption'), Vector3(0.5,0.5,0.0))
+        Report.result(
+            Tests.ozone_absorption,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Ozone Absorption')) == Vector3(0.5,0.5,0.0))
+
+        # 18. Set a value for 'Rayleigh exponential distribution' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Rayleigh exponential distribution'), 400.0)
+        Report.result(
+            Tests.rayleigh_exponential_distribution,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Rayleigh exponential distribution')) == 400.0)
+
+        # 19. Set a value for 'Rayleigh scattering Scale' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Rayleigh scattering Scale'), 1.0)
+        Report.result(
+            Tests.rayleigh_scattering_scale,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Rayleigh scattering Scale')) == 1.0)
+
+        # 20. Set a value for 'Rayleigh scattering' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Rayleigh scattering'), Vector3(1.0,1.0,1.0))
+        Report.result(
+            Tests.rayleigh_scattering,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Rayleigh scattering')) == Vector3(1.0,1.0,1.0))
+
+        # 21. Set a value for 'Show sun' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Show sun'), False)
+        Report.result(
+            Tests.show_sun,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Show sun')) is False)
+
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Show sun'), True)
+        Report.result(
+            Tests.show_sun,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Show sun')) is True)
+
+        # 22. Set a value for 'Sun color' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Sun color'), Color(0.0,0.0,0.0,255.0))
+        Report.result(
+            Tests.sun_color,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Sun color')) == Color(0.0,0.0,0.0,255.0))
+
+        # 23. Set a value for 'Sun falloff factor' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Sun falloff factor'), 200.0)
+        Report.result(
+            Tests.sun_falloff_factor,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Sun falloff factor')) == 200.0)
+
+        # 24. Set a value for 'Sun limb color' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Sun limb color'), Color(0.0,0.0,0.0,255.0))
+        Report.result(
+            Tests.sun_limb_color,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Sun limb color')) == Color(0.0,0.0,0.0,255.0))
+
+        # 25. Set a value for 'Sun luminance factor' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Sun luminance factor'), 100000.0)
+        Report.result(
+            Tests.sun_luminance_factor,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Sun luminance factor')) == 100000.0)
+
+        # 26. Set a value for 'Sun orientation' property
+        sun_entity = EditorEntity.create_editor_entity_at((10.0,0.0,0.0), name='Sun')
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Sun orientation'), sun_entity.id)
+        Report.result(
+            Tests.sun_orientation,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Sun orientation')) == sun_entity.id)
+
+        # 27. Set a value for 'Sun radius factor' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Sun radius factor'), 100.0)
+        Report.result(
+            Tests.sun_radius_factor,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Sun radius factor')) == 100.0)
+
+        # 28. Set a value for 'Enable shadows' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Enable shadows'), True)
+        Report.result(
+            Tests.enable_shadows,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Enable shadows')) is True)
+
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Enable shadows'), False)
+        Report.result(
+            Tests.enable_shadows,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Enable shadows')) is False)
+
+        # 29. Set a value for 'Fast sky' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Fast sky'), False)
+        Report.result(
+            Tests.fast_sky,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Fast sky')) is False)
+
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Fast sky'), True)
+        Report.result(
+            Tests.fast_sky,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Fast sky')) is True)
+
+        # 30. Set a value for 'Max samples' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Max samples'), 64)
+        Report.result(
+            Tests.max_samples,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Max samples')) == 64)
+
+        # 31. Set a value for 'Min samples' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Min samples'), 64)
+        Report.result(
+            Tests.min_samples,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Min samples')) == 64)
+
+        # 32. Set a value for 'Near Clip' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Near Clip'), 10.0)
+        Report.result(
+            Tests.near_clip,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Near Clip')) == 10.0)
+
+        # 33. Set a value for 'Near Fade Distance' property
+        sky_atmosphere_component.set_component_property_value(
+            AtomComponentProperties.sky_atmosphere('Near Fade Distance'), 20.0)
+        Report.result(
+            Tests.near_fade_distance,
+            sky_atmosphere_component.get_component_property_value(
+                AtomComponentProperties.sky_atmosphere('Near Fade Distance')) == 20.0)
+
+        # 34. Enter/Exit game mode.
+        TestHelper.enter_game_mode(Tests.enter_game_mode)
+        PrefabWaiter.wait_for_propagation()
+        TestHelper.exit_game_mode(Tests.exit_game_mode)
+
+        # 35. Test IsHidden.
+        sky_atmosphere_entity.set_visibility_state(False)
+        Report.result(Tests.is_hidden, sky_atmosphere_entity.is_hidden() is True)
+
+        # 36. Test IsVisible.
+        sky_atmosphere_entity.set_visibility_state(True)
+        PrefabWaiter.wait_for_propagation()
+        Report.result(Tests.is_visible, sky_atmosphere_entity.is_visible() is True)
+
+        # 37. Delete Sky Atmosphere entity.
+        sky_atmosphere_entity.delete()
+        PrefabWaiter.wait_for_propagation()
+        Report.result(Tests.entity_deleted, not sky_atmosphere_entity.exists())
+
+        # 38. UNDO deletion.
+        general.undo()
+        PrefabWaiter.wait_for_propagation()
+        Report.result(Tests.deletion_undo, sky_atmosphere_entity.exists())
+
+        # 39. REDO deletion.
+        general.redo()
+        PrefabWaiter.wait_for_propagation()
+        Report.result(Tests.deletion_redo, not sky_atmosphere_entity.exists())
+
+        # 40. Look for errors and asserts.
+        TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+        for error_info in error_tracer.errors:
+            Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+        for assert_info in error_tracer.asserts:
+            Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(AtomEditorComponents_SkyAtmosphere_AddedToEntity)


### PR DESCRIPTION
## What does this PR do?
Sky Atmosphere component tests with `-rhi=null`. Testing component property limits and basic instantiation of component.

## How was this PR tested?
in editor `pyRunFile ../../Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_SkyAtmosphereAdded.py`
```
Report:
[SUCCESS] Success: Sky AtmosphereEntity successfully created
[SUCCESS] Success: Entity has a Sky Atmosphere component
[SUCCESS] Success: Sky Atmosphere component successfully removed
[SUCCESS] Success: UNDO Sky Atmosphere component removal success
[SUCCESS] Success: Sky Atmosphere component enabled
[SUCCESS] Success: Ground albedo property set
[SUCCESS] Success: Ground radius property set
[SUCCESS] Success: Origin property set to GroundAtWorldOrigin
[SUCCESS] Success: Origin property set to GroundAtLocalOrigin
[SUCCESS] Success: Origin property set to PlanetCenterAtLocalOrigin
[SUCCESS] Success: Atmosphere height property set
[SUCCESS] Success: Illuminance factor property set
[SUCCESS] Success: Mie absorption Scale property set
[SUCCESS] Success: Mie absorption property set
[SUCCESS] Success: Mie exponential distribution property set
[SUCCESS] Success: Mie scattering Scale property set
[SUCCESS] Success: Mie scattering property set
[SUCCESS] Success: Ozone Absorption Scale property set
[SUCCESS] Success: Ozone Absorption property set
[SUCCESS] Success: Rayleigh exponential distribution property set
[SUCCESS] Success: Rayleigh scattering Scale property set
[SUCCESS] Success: Rayleigh scattering property set
[SUCCESS] Success: Show sun property set
[SUCCESS] Success: Show sun property set
[SUCCESS] Success: Sun color property set
[SUCCESS] Success: Sun falloff factor property set
[SUCCESS] Success: Sun limb color property set
[SUCCESS] Success: Sun luminance factor property set
[SUCCESS] Success: Sun orientation property set
[SUCCESS] Success: Sun radius factor property set
[SUCCESS] Success: Enable shadows property set
[SUCCESS] Success: Enable shadows property set
[SUCCESS] Success: Fast sky property set
[SUCCESS] Success: Fast sky property set
[SUCCESS] Success: Max samples property set
[SUCCESS] Success: Min samples property set
[SUCCESS] Success: Near Clip property set
[SUCCESS] Success: Near Fade Distance property set
[SUCCESS] Success: Entered game mode
[SUCCESS] Success: Exited game mode
[SUCCESS] Success: Entity is hidden
[SUCCESS] Success: Entity is visible
[SUCCESS] Success: Entity deleted
[SUCCESS] Success: UNDO deletion success
[SUCCESS] Success: REDO deletion success
Test result:  SUCCESS
```

at command line `.\python\python.cmd -m pytest --build-directory atom_dev/bin/profile  .\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_Null_Render_Component_03.py`
```
============================================= test session starts
platform win32 -- Python 3.10.5, pytest-7.2.0, pluggy-0.13.1
rootdir: D:\workspace\o3de, configfile: pytest.ini
plugins: mock-3.8.2, timeout-2.1.0, ly-test-tools-1.0.0
timeout: 1200.0s
timeout method: thread
timeout func_only: False
collected 11 items

AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_Null_Render_Component_03.py ............[100%]

============================================= 12 passed in 35.67s
```

and with ctest `.\scripts\ctest\ctest_entrypoint.cmd --build-path atom_dev --suite main --ctest-executable "C:\Program Files\CMake\bin\ctest.exe" --config profile --tests-regex "AutomatedTesting::Atom_Main_Null" --generate-xml`
```
    Start 182: AutomatedTesting::Atom_Main_Null_Render_MaterialEditor.main::TEST_RUN
1/6 Test #182: AutomatedTesting::Atom_Main_Null_Render_MaterialEditor.main::TEST_RUN ...   Passed   62.79 sec
    Start 175: AutomatedTesting::Atom_Main_Null_Render_01.main::TEST_RUN
2/6 Test #175: AutomatedTesting::Atom_Main_Null_Render_01.main::TEST_RUN ...............   Passed   34.84 sec
    Start 177: AutomatedTesting::Atom_Main_Null_Render_03.main::TEST_RUN
3/6 Test #177: AutomatedTesting::Atom_Main_Null_Render_03.main::TEST_RUN ...............   Passed   36.79 sec
    Start 183: AutomatedTesting::Atom_Main_Null_Render_MaterialCanvas.main::TEST_RUN
4/6 Test #183: AutomatedTesting::Atom_Main_Null_Render_MaterialCanvas.main::TEST_RUN ...   Passed   35.42 sec
    Start 176: AutomatedTesting::Atom_Main_Null_Render_02.main::TEST_RUN
5/6 Test #176: AutomatedTesting::Atom_Main_Null_Render_02.main::TEST_RUN ...............   Passed   32.84 sec
    Start 174: AutomatedTesting::Atom_Main_Null_Render_Level_Loads.main::TEST_RUN
6/6 Test #174: AutomatedTesting::Atom_Main_Null_Render_Level_Loads.main::TEST_RUN ......   Passed   30.55 sec

100% tests passed, 0 tests failed out of 6
```