### PR TITLE
Fix for component alias not being initialized

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
@@ -34,7 +34,8 @@ namespace AzToolsFramework::Prefab
     {
         // Set the component alias before calling SetValue() in base SetComponent().
         // Otherwise, an empty component alias will be used in DOM data.
-        m_componentAlias = componentInstance->GetSerializedIdentifier();
+        AZ_Assert(componentInstance, "PrefabComponentAdapter::SetComponent - component is null.")
+        m_componentAlias = PrefabDomUtils::GetComponentAliasWithInitialization(*componentInstance);
         AZ_Assert(!m_componentAlias.empty(), "PrefabComponentAdapter::SetComponent - Component alias should not be empty.");
 
         ComponentAdapter::SetComponent(componentInstance);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -545,6 +545,16 @@ namespace AzToolsFramework
                 return prefabBuffer.GetString();
             }
 
+            AZStd::string GetComponentAliasWithInitialization(AZ::Component& component)
+            {
+                AZStd::string componentAlias = component.GetSerializedIdentifier();
+                if (componentAlias.empty())
+                {
+                    componentAlias = AZStd::string::format("Component_[%llu]", component.GetId());
+                    component.SetSerializedIdentifier(componentAlias);
+                }
+                return componentAlias;
+            }
         } // namespace PrefabDomUtils
     } // namespace Prefab
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
@@ -214,6 +214,8 @@ namespace AzToolsFramework
 
             AZStd::string PrefabDomValueToString(const PrefabDomValue& prefabDomValue);
 
+            AZStd::string GetComponentAliasWithInitialization(AZ::Component& component);
+
             //! An empty struct for passing to JsonSerializerSettings.m_metadata that is consumed by InstanceSerializer::Store.
             //! If present in metadata, linkIds will be stored to instance dom.
             struct LinkIdMetadata


### PR DESCRIPTION
## What does this PR do?

Add a helper to get the component alias and initialize it if it hasn't been initialized yet.
This fix will need some tweaks when we remove the component Id dependency on the alias.

## How was this PR tested?

Manual testing in editor.