### PR TITLE
Fix server entities not ticking when outside of a camera frustum view

### DIFF
--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -1534,6 +1534,7 @@ namespace Multiplayer
             serverRateSeconds
         );
 
+#ifdef AZ_TRAIT_CLIENT
         if (Camera::ActiveCameraRequestBus::HasHandlers())
         {
             // If there's a camera, update only what's visible
@@ -1598,6 +1599,7 @@ namespace Multiplayer
             }
         }
         else
+#endif // on servers update all net entities
         {
             // If there's no camera, fall back to updating all net entities
             for (auto& iter : *(m_networkEntityManager.GetNetworkEntityTracker()))

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -1534,7 +1534,7 @@ namespace Multiplayer
             serverRateSeconds
         );
 
-#ifdef AZ_TRAIT_CLIENT
+#if AZ_TRAIT_CLIENT
         if (Camera::ActiveCameraRequestBus::HasHandlers())
         {
             // If there's a camera, update only what's visible


### PR DESCRIPTION
## What does this PR do?

On a server with a camera, even with -rhi=null, only the entities within the camera frustum would tick. This results in an incorrect root transform for the players and their animation actors. In turns, this breaks bones' positions, and the firing ends up broken as well, since the server disagrees with the client on the origin of the shot based on the shooting bone.

## How was this PR tested?

in o3de-multiplayer with a dedicated server with camera looking away from players
