### PR TITLE
Add new hard-coded clearshadow shader.

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/seedList.seed
+++ b/Gems/Atom/Feature/Common/Assets/seedList.seed
@@ -392,6 +392,14 @@
 			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridraytracinganyhit.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{3ED0319F-603A-59E3-83C7-3183649A9A94}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="shaders/shadow/clearshadow.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
 	</Class>
 </ObjectStream>
 


### PR DESCRIPTION
## What does this PR do?

A recent PR added a new hard-coded "clearshadow.azshader". This PR adds that shader to the Atom seed list, so that it will end up in generated Asset Bundles.

## How was this PR tested?

Generated Asset Bundles for MPS and verified that the shader now loads correctly instead of giving an asset not found error.
