### PR TITLE
Prefab Override | Enable override in Entity Outliner by default

### DIFF
--- a/AutomatedTesting/Registry/editorpreferences.setreg
+++ b/AutomatedTesting/Registry/editorpreferences.setreg
@@ -7,7 +7,7 @@
     "O3DE": {
         "Preferences": {
             "Prefabs": {
-                "EnableOutlinerOverrideManagement": false,
+                "EnableOutlinerOverrideManagement": true,
                 "EnableInspectorOverrideManagement": false
             }
         }

--- a/Registry/prefab.editor.setreg
+++ b/Registry/prefab.editor.setreg
@@ -17,5 +17,12 @@
                 }
             }
         }
+    },
+    "O3DE": {
+        "Preferences": {
+            "Prefabs": {
+                "EnableOutlinerOverrideManagement": true
+            }
+        }
     }
 }


### PR DESCRIPTION
## What does this PR do?

This PR enables the new prefab override feature in Entity Outliner by default.

Once enabled, prefab containers can be manually expanded or collapsed. Any override edits would be stored in the _prefab that is being edited_ (highlighted with blue capsule). The level prefab is in edit mode by default.

<img height=200 src="https://user-images.githubusercontent.com/11157226/224847931-25ff6c02-bd47-4472-a07b-9ddca0a83bb9.png">

(Blue "o" icon indicates there is an override edit; Blue "+" icon indicates the entity is added as an override)

See more in [prefab override user guide](https://development--o3deorg.netlify.app/docs/learning-guide/tutorials/entities-and-prefabs/override-a-prefab/).

See RFC: https://github.com/o3de/sig-content/issues/75

See the [known issue list](https://github.com/o3de/o3de/issues?q=is%3Aopen+is%3Aissue+label%3Afeature%2Fprefabs+%22prefab+overrides%22) for prefab override.

### How to turn off this feature?

If it causes any issue to any workflow, you can manually turn this feature off by setting this flag in `<project_root>/user/Registry/editorpreferences.setreg`:

```json
{
    "O3DE": {
        "Preferences": {
            "Prefabs": {
                "EnableOutlinerOverrideManagement": false
            }
        }
    }
}
```

## How was this PR tested?

- [x] Functionality has been manually tested in editor.
- [x] We have unit tests and automated tests that cover the supported operations.
- [x] Validated the flag is on by default in AutomatedTesting and any new project if users create.
- [x] Verified other project repos do not have existing dependencies on the flag, so we don't need to update those flags manually.
