### PR TITLE
[Spawnable] Simplify inheritance chain of `EntityAliasVisitor`

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/Spawnable.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/Spawnable.h
@@ -69,27 +69,43 @@ namespace AzFramework
         using EntityList = AZStd::vector<AZStd::unique_ptr<AZ::Entity>>;
         using EntityAliasList = AZStd::vector<EntityAlias>;
 
-    private:
-        class EntityAliasVisitorBase
+        class EntityAliasConstVisitor
         {
         protected:
-            bool IsValid(const EntityAliasList* aliases) const;
-
-            bool HasAliases(const EntityAliasList* aliases) const;
-            bool AreAllSpawnablesReady(const EntityAliasList* aliases) const;
-
-            EntityAliasList::const_iterator begin(const EntityAliasList* aliases) const;
-            EntityAliasList::const_iterator end(const EntityAliasList* aliases) const;
-            EntityAliasList::const_iterator cbegin(const EntityAliasList* aliases) const;
-            EntityAliasList::const_iterator cend(const EntityAliasList* aliases) const;
-
             using ListTargetSpawanblesCallback = AZStd::function<void(const AZ::Data::Asset<Spawnable>& targetSpawnable)>;
-            void ListTargetSpawnables(const EntityAliasList* aliases, const ListTargetSpawanblesCallback& callback) const;
-            void ListTargetSpawnables(const EntityAliasList* aliases, AZ::Crc32 tag, const ListTargetSpawanblesCallback& callback) const;
+
+        public:
+            EntityAliasConstVisitor(const Spawnable& owner, const EntityAliasList* entityAliasList);
+            ~EntityAliasConstVisitor();
+
+            EntityAliasConstVisitor(EntityAliasConstVisitor&& rhs);
+            EntityAliasConstVisitor& operator=(EntityAliasConstVisitor&& rhs);
+
+            EntityAliasConstVisitor(const EntityAliasConstVisitor& rhs) = delete;
+            EntityAliasConstVisitor& operator=(const EntityAliasConstVisitor& rhs) = delete;
+
+            //! Checks if the visitor was able to retrieve data. This needs to be checked before calling any other functions.
+            bool IsValid() const;
+
+            bool HasAliases() const;
+            bool AreAllSpawnablesReady() const;
+
+            // Modification of aliases is limited to specific changes that can only be done through the available modification functions.
+            // For this reason access through iterators is limited to unmodifiable constant iterators.
+            EntityAliasList::const_iterator begin() const;
+            EntityAliasList::const_iterator end() const;
+            EntityAliasList::const_iterator cbegin() const;
+            EntityAliasList::const_iterator cend() const;
+
+            void ListTargetSpawnables(const ListTargetSpawanblesCallback& callback) const;
+            void ListTargetSpawnables(AZ::Crc32 tag, const ListTargetSpawanblesCallback& callback) const;
+
+        protected:
+            const Spawnable& m_owner;
+            const EntityAliasList* m_entityAliasList{};
         };
 
-    public:
-        class EntityAliasVisitor final : public EntityAliasVisitorBase
+        class EntityAliasVisitor final : public EntityAliasConstVisitor
         {
         public:
             EntityAliasVisitor(Spawnable& owner, EntityAliasList* m_entityAliasList);
@@ -100,23 +116,6 @@ namespace AzFramework
 
             EntityAliasVisitor(const EntityAliasVisitor& rhs) = delete;
             EntityAliasVisitor& operator=(const EntityAliasVisitor& rhs) = delete;
-
-            //! Checks if the visitor was able to retrieve data. This needs to be checked before calling any other functions.
-            bool IsValid() const;
-
-            bool HasAliases() const;
-            bool AreAllSpawnablesReady() const;
-
-            // Modification of aliases is limited to specific changes that can only be done through the available modification functions.
-            // For this reason access through iterators is limited to unmodifiable constant iterators.
-
-            EntityAliasList::const_iterator begin() const;
-            EntityAliasList::const_iterator end() const;
-            EntityAliasList::const_iterator cbegin() const;
-            EntityAliasList::const_iterator cend() const;
-            
-            void ListTargetSpawnables(const ListTargetSpawanblesCallback& callback) const;
-            void ListTargetSpawnables(AZ::Crc32 tag, const ListTargetSpawanblesCallback& callback) const;
 
             void AddAlias(
                 AZ::Data::Asset<Spawnable> targetSpawnable,
@@ -143,34 +142,9 @@ namespace AzFramework
             void Optimize();
 
         private:
-            Spawnable& m_owner;
-            EntityAliasList* m_entityAliasList{ nullptr };
+            EntityAliasList* GetEntityAliasList() const;
+
             bool m_dirty{ false };
-        };
-
-        class EntityAliasConstVisitor final : public EntityAliasVisitorBase
-        {
-        public:
-            EntityAliasConstVisitor(const Spawnable& owner, const EntityAliasList* entityAliasList);
-            ~EntityAliasConstVisitor();
-
-            //! Checks if the visitor was able to retrieve data. This needs to be checked before calling any other functions.
-            bool IsValid() const;
-
-            bool HasAliases() const;
-            bool AreAllSpawnablesReady() const;
-
-            EntityAliasList::const_iterator begin() const;
-            EntityAliasList::const_iterator end() const;
-            EntityAliasList::const_iterator cbegin() const;
-            EntityAliasList::const_iterator cend() const;
-
-            void ListTargetSpawnables(const ListTargetSpawanblesCallback& callback) const;
-            void ListTargetSpawnables(AZ::Crc32 tag, const ListTargetSpawanblesCallback& callback) const;
-
-        private:
-            const Spawnable& m_owner;
-            const EntityAliasList* m_entityAliasList;
         };
 
         inline static constexpr const char* DefaultMainSpawnableName = "Root";


### PR DESCRIPTION
The classes `EntityAliasVisitor` and `EntityAliasConstVisitor` both inherited from `EntityAliasVisitorBase`, which defines a number of protected methods, each taking a `const EntityAliasList*`. Then, the individual derived classes `EntityAliasVisitor` and `EntityAliasConstVisitor` both store a `EntityAliasList*`, the only difference being that the one stored in `EntityAliasConstVisitor` is `const`. This design was chosen to have single implementations of the methods declared in the base class, that work for both the `const` and non-`const` member of the derived classes.

However, this design can be simplified. All of the base class's methods are `protected`, only called by public methods of the derived classes. If the same code works for both `const` and non-`const` members, then it can be defined once in the `EntityAliasConstVisitor` class, and inherited by the non-const `Visitor`. That reduces 3 separate functions down to 1.

This change moves the `EntityAliasConstVisitor` to serve the role that the `EntityAliasVisitorBase` did previously. It defines `const Spawnable&` and `const EntityAliasList*` members. All the methods in the const visitor class are `const` already, so they do not need to be adjusted.

The non-`const` Visitor gains a private `GetEntityAliasList()` method, that uses a `const_cast`, which always requires some further explanation. The `EntityAliasVisitor()` constructor accepts a non-`const` `EntityAliasList*`, so the caller has to already have a mutable type. It is merely stored in the base type's `const` member. Because a non-const variable must be used to construct the non-const Visitor, it is always allowed to read that member in a non-const way.
