### PR TITLE
Fix material editor not launching when motion matching is enabled

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
@@ -10,21 +10,18 @@
 #include <AtomToolsFramework/Application/AtomToolsApplication.h>
 #include <AtomToolsFramework/Util/Util.h>
 #include <AtomToolsFramework/Window/AtomToolsMainWindowRequestBus.h>
-
 #include <AzCore/Component/ComponentApplicationLifecycle.h>
 #include <AzCore/IO/Path/Path.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/Utils/Utils.h>
-
 #include <AzFramework/Asset/AssetSystemComponent.h>
 #include <AzFramework/IO/LocalFileIO.h>
 #include <AzFramework/Network/AssetProcessorConnection.h>
 #include <AzFramework/StringFunc/StringFunc.h>
-
 #include <AzQtComponents/Components/GlobalEventFilter.h>
-
 #include <AzToolsFramework/API/EditorPythonConsoleBus.h>
 #include <AzToolsFramework/API/EditorPythonRunnerRequestsBus.h>
+#include <AzToolsFramework/ActionManager/ActionManagerSystemComponent.h>
 #include <AzToolsFramework/Asset/AssetSystemComponent.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserComponent.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserEntry.h>
@@ -146,12 +143,12 @@ namespace AtomToolsFramework
         components.insert(
             components.end(),
             {
-                azrtti_typeid<AzToolsFramework::AssetSystem::AssetSystemComponent>(),
+                azrtti_typeid<AzToolsFramework::ActionManagerSystemComponent>(),
                 azrtti_typeid<AzToolsFramework::AssetBrowser::AssetBrowserComponent>(),
                 azrtti_typeid<AzToolsFramework::AssetSystem::AssetSystemComponent>(),
-                azrtti_typeid<AzToolsFramework::Thumbnailer::ThumbnailerComponent>(),
                 azrtti_typeid<AzToolsFramework::Components::PropertyManagerComponent>(),
                 azrtti_typeid<AzToolsFramework::PerforceComponent>(),
+                azrtti_typeid<AzToolsFramework::Thumbnailer::ThumbnailerComponent>(),
             });
 
         return components;

--- a/Gems/Atom/Tools/MaterialCanvas/Registry/gem_autoload.materialcanvas.setreg
+++ b/Gems/Atom/Tools/MaterialCanvas/Registry/gem_autoload.materialcanvas.setreg
@@ -149,6 +149,13 @@
                     }
                 }
             },
+            "MotionMatching": {
+                "Targets": {
+                    "MotionMatching.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
             "EMotionFX": {
                 "Targets": {
                     "EMotionFX.Editor": {

--- a/Gems/Atom/Tools/MaterialEditor/Registry/gem_autoload.materialeditor.setreg
+++ b/Gems/Atom/Tools/MaterialEditor/Registry/gem_autoload.materialeditor.setreg
@@ -149,6 +149,13 @@
                     }
                 }
             },
+            "MotionMatching": {
+                "Targets": {
+                    "MotionMatching.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
             "EMotionFX": {
                 "Targets": {
                     "EMotionFX.Editor": {

--- a/Gems/Atom/Tools/PassCanvas/Registry/gem_autoload.passcanvas.setreg
+++ b/Gems/Atom/Tools/PassCanvas/Registry/gem_autoload.passcanvas.setreg
@@ -149,6 +149,13 @@
                     }
                 }
             },
+            "MotionMatching": {
+                "Targets": {
+                    "MotionMatching.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
             "EMotionFX": {
                 "Targets": {
                     "EMotionFX.Editor": {

--- a/Gems/Atom/Tools/ShaderManagementConsole/Registry/gem_autoload.shadermanagementconsole.setreg
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Registry/gem_autoload.shadermanagementconsole.setreg
@@ -149,6 +149,13 @@
                     }
                 }
             },
+            "MotionMatching": {
+                "Targets": {
+                    "MotionMatching.Editor": {
+                        "AutoLoad": false
+                    }
+                }
+            },
             "EMotionFX": {
                 "Targets": {
                     "EMotionFX.Editor": {


### PR DESCRIPTION
## What does this PR do?

Also initializing action manager to prevent crash if gems that require it are enabled

Resolves https://github.com/o3de/o3de/issues/7113 for the existing gem combinations but need to add UI to disable the disable gem feature and documentation

## How was this PR tested?

Enabled all gems that could be enabled for the automated testing project.
Launched material editor and saw errors indicating that motion matching system component could not be initialized.
Updated settings files to disable motion matching which allowed material editor to launch.
Deleted settings files to see material editor crashing because action manager was not initialized.
Initialized action manager and restarted material editor successfully.