### PR TITLE
fix title casing in sky atmo tests and component

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
@@ -1317,15 +1317,15 @@ class AtomComponentProperties:
           - 'Origin' The origin to use for the atmosphere (int)
           - 'Atmosphere height' Kilometers 0.0 to 10000.0 (float) default 100.0
           - 'Illuminance factor' An additional factor to brighten or darken the overall atmosphere (Vector3 float) default (1.0,1.0,1.0)
-          - 'Mie absorption Scale' 0.0 to 1.0 (float) default 0.004
+          - 'Mie absorption scale' 0.0 to 1.0 (float) default 0.004
           - 'Mie absorption' (Vector3 float) default (1.0,1.0,1.0)
           - 'Mie exponential distribution' Altitude in kilometers at which Mie scattering is reduced to roughly 40%. 0.0 to 400.0 (float) default 1.2
-          - 'Mie scattering Scale' 0.0 to 1.0 (float) default 0.004
+          - 'Mie scattering scale' 0.0 to 1.0 (float) default 0.004
           - 'Mie scattering' Mie scattering coefficients from aerosole molecules at surface of the planet. (Vector3 float) default (1.0,1.0,1.0)
-          - 'Ozone Absorption Scale' Ozone molecule absorption scale 0.0 to 1.0 (float) default 0.001881
-          - 'Ozone Absorption' Absorption coefficients from ozone molecules (Vector3 float) default (1.0,1.0,1.0)
+          - 'Ozone absorption scale' Ozone molecule absorption scale 0.0 to 1.0 (float) default 0.001881
+          - 'Ozone absorption' Absorption coefficients from ozone molecules (Vector3 float) default (1.0,1.0,1.0)
           - 'Rayleigh exponential distribution' Altitude in kilometers at which Rayleigh scattering is reduced to roughly 40%. 0.0 to 400.0 (float) default 8.0
-          - 'Rayleigh scattering Scale' 0.0 to 1.0 (float) default 0.033100f
+          - 'Rayleigh scattering scale' 0.0 to 1.0 (float) default 0.033100f
           - 'Rayleigh scattering' Raleigh scattering coefficients from air molecules at surface of the planet. (Vector3 float) default (1.0,1.0,1.0)
           - 'Show sun' display a sun (bool) default True
           - 'Sun color' (azlmbr.math.Color RGBA) default (255.0,255.0,255.0,255.0)
@@ -1338,8 +1338,8 @@ class AtomComponentProperties:
           - 'Fast sky' (bool) default True
           - 'Max samples' 1 to 64 (unsigned int) default 14
           - 'Min samples' 1 to 64 (unsigned int) default 4
-          - 'Near Clip' 0.0 to inf (float) default 0.0
-          - 'Near Fade Distance' 0.0 to inf (float) default 0.0
+          - 'Near clip' 0.0 to inf (float) default 0.0
+          - 'Near fade distance' 0.0 to inf (float) default 0.0
         :param property: From the last element of the property tree path. Default 'name' for component name string.
         :return: Full property path OR component name if no property specified.
         """
@@ -1350,15 +1350,15 @@ class AtomComponentProperties:
             'Origin': 'Controller|Configuration|Planet|Origin',
             'Atmosphere height': 'Controller|Configuration|Atmosphere|Atmosphere height',
             'Illuminance factor': 'Controller|Configuration|Atmosphere|Illuminance factor',
-            'Mie absorption Scale': 'Controller|Configuration|Atmosphere|Mie absorption Scale',
+            'Mie absorption scale': 'Controller|Configuration|Atmosphere|Mie absorption scale',
             'Mie absorption': 'Controller|Configuration|Atmosphere|Mie absorption',
             'Mie exponential distribution': 'Controller|Configuration|Atmosphere|Mie exponential distribution',
-            'Mie scattering Scale': 'Controller|Configuration|Atmosphere|Mie scattering Scale',
+            'Mie scattering scale': 'Controller|Configuration|Atmosphere|Mie scattering scale',
             'Mie scattering': 'Controller|Configuration|Atmosphere|Mie scattering',
-            'Ozone Absorption Scale': 'Controller|Configuration|Atmosphere|Ozone Absorption Scale',
-            'Ozone Absorption': 'Controller|Configuration|Atmosphere|Ozone Absorption',
+            'Ozone absorption scale': 'Controller|Configuration|Atmosphere|Ozone absorption scale',
+            'Ozone absorption': 'Controller|Configuration|Atmosphere|Ozone absorption',
             'Rayleigh exponential distribution': 'Controller|Configuration|Atmosphere|Rayleigh exponential distribution',
-            'Rayleigh scattering Scale': 'Controller|Configuration|Atmosphere|Rayleigh scattering Scale',
+            'Rayleigh scattering scale': 'Controller|Configuration|Atmosphere|Rayleigh scattering scale',
             'Rayleigh scattering': 'Controller|Configuration|Atmosphere|Rayleigh scattering',
             'Show sun': 'Controller|Configuration|Sun|Show sun',
             'Sun color': 'Controller|Configuration|Sun|Sun color',
@@ -1371,8 +1371,8 @@ class AtomComponentProperties:
             'Fast sky': 'Controller|Configuration|Advanced|Fast sky',
             'Max samples': 'Controller|Configuration|Advanced|Max samples',
             'Min samples': 'Controller|Configuration|Advanced|Min samples',
-            'Near Clip': 'Controller|Configuration|Advanced|Near Clip',
-            'Near Fade Distance': 'Controller|Configuration|Advanced|Near Fade Distance',
+            'Near clip': 'Controller|Configuration|Advanced|Near clip',
+            'Near fade distance': 'Controller|Configuration|Advanced|Near fade distance',
         }
         return properties[property]
 

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_SkyAtmosphereAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_SkyAtmosphereAdded.py
@@ -275,11 +275,11 @@ def AtomEditorComponents_SkyAtmosphere_AddedToEntity():
 
         # 11. Set a value for 'Mie absorption Scale' property
         sky_atmosphere_component.set_component_property_value(
-            AtomComponentProperties.sky_atmosphere('Mie absorption Scale'), 1.0)
+            AtomComponentProperties.sky_atmosphere('Mie absorption scale'), 1.0)
         Report.result(
             Tests.mie_absorption_scale,
             sky_atmosphere_component.get_component_property_value(
-                AtomComponentProperties.sky_atmosphere('Mie absorption Scale')) == 1.0)
+                AtomComponentProperties.sky_atmosphere('Mie absorption scale')) == 1.0)
 
         # 12. Set a value for 'Mie absorption' property
         sky_atmosphere_component.set_component_property_value(
@@ -299,11 +299,11 @@ def AtomEditorComponents_SkyAtmosphere_AddedToEntity():
 
         # 14. Set a value for 'Mie scattering Scale' property
         sky_atmosphere_component.set_component_property_value(
-            AtomComponentProperties.sky_atmosphere('Mie scattering Scale'), 1.0)
+            AtomComponentProperties.sky_atmosphere('Mie scattering scale'), 1.0)
         Report.result(
             Tests.mie_scattering_scale,
             sky_atmosphere_component.get_component_property_value(
-                AtomComponentProperties.sky_atmosphere('Mie scattering Scale')) == 1.0)
+                AtomComponentProperties.sky_atmosphere('Mie scattering scale')) == 1.0)
 
         # 15. Set a value for 'Mie scattering' property
         sky_atmosphere_component.set_component_property_value(
@@ -315,19 +315,19 @@ def AtomEditorComponents_SkyAtmosphere_AddedToEntity():
 
         # 16. Set a value for 'Ozone Absorption Scale' property
         sky_atmosphere_component.set_component_property_value(
-            AtomComponentProperties.sky_atmosphere('Ozone Absorption Scale'), 1.0)
+            AtomComponentProperties.sky_atmosphere('Ozone absorption scale'), 1.0)
         Report.result(
             Tests.ozone_absorption_scale,
             sky_atmosphere_component.get_component_property_value(
-                AtomComponentProperties.sky_atmosphere('Ozone Absorption Scale')) == 1.0)
+                AtomComponentProperties.sky_atmosphere('Ozone absorption scale')) == 1.0)
 
         # 17. Set a value for 'Ozone Absorption' property
         sky_atmosphere_component.set_component_property_value(
-            AtomComponentProperties.sky_atmosphere('Ozone Absorption'), Vector3(0.5,0.5,0.0))
+            AtomComponentProperties.sky_atmosphere('Ozone absorption'), Vector3(0.5,0.5,0.0))
         Report.result(
             Tests.ozone_absorption,
             sky_atmosphere_component.get_component_property_value(
-                AtomComponentProperties.sky_atmosphere('Ozone Absorption')) == Vector3(0.5,0.5,0.0))
+                AtomComponentProperties.sky_atmosphere('Ozone absorption')) == Vector3(0.5,0.5,0.0))
 
         # 18. Set a value for 'Rayleigh exponential distribution' property
         sky_atmosphere_component.set_component_property_value(
@@ -339,11 +339,11 @@ def AtomEditorComponents_SkyAtmosphere_AddedToEntity():
 
         # 19. Set a value for 'Rayleigh scattering Scale' property
         sky_atmosphere_component.set_component_property_value(
-            AtomComponentProperties.sky_atmosphere('Rayleigh scattering Scale'), 1.0)
+            AtomComponentProperties.sky_atmosphere('Rayleigh scattering scale'), 1.0)
         Report.result(
             Tests.rayleigh_scattering_scale,
             sky_atmosphere_component.get_component_property_value(
-                AtomComponentProperties.sky_atmosphere('Rayleigh scattering Scale')) == 1.0)
+                AtomComponentProperties.sky_atmosphere('Rayleigh scattering scale')) == 1.0)
 
         # 20. Set a value for 'Rayleigh scattering' property
         sky_atmosphere_component.set_component_property_value(
@@ -465,19 +465,19 @@ def AtomEditorComponents_SkyAtmosphere_AddedToEntity():
 
         # 32. Set a value for 'Near Clip' property
         sky_atmosphere_component.set_component_property_value(
-            AtomComponentProperties.sky_atmosphere('Near Clip'), 10.0)
+            AtomComponentProperties.sky_atmosphere('Near clip'), 10.0)
         Report.result(
             Tests.near_clip,
             sky_atmosphere_component.get_component_property_value(
-                AtomComponentProperties.sky_atmosphere('Near Clip')) == 10.0)
+                AtomComponentProperties.sky_atmosphere('Near clip')) == 10.0)
 
         # 33. Set a value for 'Near Fade Distance' property
         sky_atmosphere_component.set_component_property_value(
-            AtomComponentProperties.sky_atmosphere('Near Fade Distance'), 20.0)
+            AtomComponentProperties.sky_atmosphere('Near fade distance'), 20.0)
         Report.result(
             Tests.near_fade_distance,
             sky_atmosphere_component.get_component_property_value(
-                AtomComponentProperties.sky_atmosphere('Near Fade Distance')) == 20.0)
+                AtomComponentProperties.sky_atmosphere('Near fade distance')) == 20.0)
 
         # 34. Enter/Exit game mode.
         TestHelper.enter_game_mode(Tests.enter_game_mode)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SkyAtmosphere/EditorSkyAtmosphereComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SkyAtmosphere/EditorSkyAtmosphereComponent.cpp
@@ -70,7 +70,7 @@ namespace AZ::Render
                         ->DataElement(AZ::Edit::UIHandlers::Slider, &SkyAtmosphereComponentConfig::m_luminanceFactor, "Illuminance factor", "An additional factor to brighten or darken the overall atmosphere")
                             ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                             ->Attribute(AZ::Edit::Attributes::Max, 100.0f)
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &SkyAtmosphereComponentConfig::m_rayleighScatteringScale, "Rayleigh scattering Scale", "Raleigh scattering scale")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &SkyAtmosphereComponentConfig::m_rayleighScatteringScale, "Rayleigh scattering scale", "Raleigh scattering scale")
                             ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                             ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
                         ->DataElement(AZ::Edit::UIHandlers::Color, &SkyAtmosphereComponentConfig::m_rayleighScattering, "Rayleigh scattering", "Raleigh scattering coefficients from air molecules at surface of the planet")
@@ -84,7 +84,7 @@ namespace AZ::Render
                             ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
                         ->DataElement(AZ::Edit::UIHandlers::Color, &SkyAtmosphereComponentConfig::m_mieScattering, "Mie scattering", "Mie scattering coefficients from aerosole molecules at surface of the planet")
 
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &SkyAtmosphereComponentConfig::m_mieAbsorptionScale, "Mie absorption Scale", "Mie absorption scale")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &SkyAtmosphereComponentConfig::m_mieAbsorptionScale, "Mie absorption scale", "Mie absorption scale")
                             ->Attribute(AZ::Edit::Attributes::Min, 0.00f)
                             ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
                         ->DataElement(AZ::Edit::UIHandlers::Color, &SkyAtmosphereComponentConfig::m_mieAbsorption, "Mie absorption", "Mie absorption coefficients from aerosole molecules at surface of the planet")


### PR DESCRIPTION
## What does this PR do?

fix title casing in sky atmo tests and component that was causing the pytests to fail

## How was this PR tested?

Ran the tests on Windows and verified they passed:
```
$ python/python.cmd -m pytest --build-directory build/windows_vs2019/bin/profile  AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Null_Render_Component_03.py
Pytest custom argument "--output-path" was not provided, defaulting Test Results output to: build/windows_vs2019/bin/profile\Testing\LyTestTools\pytest_results\2023-03-14T11-53-07-207054
================================================================= test session starts ==================================================================
platform win32 -- Python 3.10.5, pytest-7.2.0, pluggy-0.13.1
rootdir: D:\git\o3de-dev, configfile: pytest.ini
plugins: mock-3.8.2, timeout-2.1.0, ly-test-tools-1.0.0
timeout: 1200.0s
timeout method: thread
timeout func_only: False
collected 11 items

AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_Null_Render_Component_03.py ............   [100%]
```
