### PR TITLE
Fixing cached shadows not clearing properly for their initial render.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
@@ -190,7 +190,6 @@ namespace AZ
                     }
                 }
             }
-            m_forceRenderNextFrame = false;
 
             if (m_clearShadowDrawPacket)
             {
@@ -210,6 +209,17 @@ namespace AZ
                 ++offset;
             }
             Base::SubmitDrawItems(context, startIndex, endIndex, offset);
+        }
+
+        void ShadowmapPass::FrameEndInternal()
+        {
+            if (m_clearShadowDrawPacket)
+            {
+                // If m_clearShadowDrawPacket is valid, then this pass would have rendered this frame if
+                // m_forceRenderNextFrame was set to true, so set it to false now. This can't be done safely
+                // in SubmitDrawItems because it may be called multiple times from different threads.
+                m_forceRenderNextFrame = false;
+            }
         }
 
     } // namespace Render

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
@@ -220,6 +220,7 @@ namespace AZ
                 // in SubmitDrawItems because it may be called multiple times from different threads.
                 m_forceRenderNextFrame = false;
             }
+            Base::FrameEndInternal();
         }
 
     } // namespace Render

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.h
@@ -75,6 +75,7 @@ namespace AZ
             // RHI::Pass overrides...
             void BuildInternal() override;
             void SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph) override;
+            void FrameEndInternal() override;
 
             // RPI::RasterPass overrides...
             void SubmitDrawItems(const RHI::FrameGraphExecuteContext& context, uint32_t startIndex, uint32_t endIndex, uint32_t indexOffset) const override;

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.h
@@ -80,6 +80,9 @@ namespace AZ
             // RPI::RasterPass overrides...
             void SubmitDrawItems(const RHI::FrameGraphExecuteContext& context, uint32_t startIndex, uint32_t endIndex, uint32_t indexOffset) const override;
 
+            // Gets the number of expected draws, taking into account if this shadow is static.
+            uint32_t GetNumDraws() const;
+
             RHI::ConstPtr<RHI::DrawPacket> m_clearShadowDrawPacket;
             RHI::DrawItemProperties m_clearShadowDrawItemProperties;
             RHI::Handle<uint32_t> m_casterMovedBit;


### PR DESCRIPTION
## What does this PR do?

Cached shadows weren't correctly handling the case of multithreaded draw submits with regards to their first render when cached shadows were initially turned on. Depending on the order things were called, it was possible for `m_forceRenderNextFrame` to be set to false before the clear draw packet was actually submitted since `SubmitDrawItems()` can be called multiple times per frame on different threads. This fixes it so `m_forceRenderNextFrame` isn't set to false until `FrameEndInternal()` which will be called only once per frame.

## How was this PR tested?

Tested in warehouse scene with 108 light views and a fair number of draws.
