### PR TITLE
Fix material editor/canvas viewport settings inspector data corruption

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Utils/EditorLightingPreset.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Utils/EditorLightingPreset.cpp
@@ -126,6 +126,9 @@ namespace AZ
                             ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &LightingPreset::m_exposure, "Exposure", "Exposure")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &LightingPreset::m_lights, "Lights", "Lights")
+                            ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                            ->Attribute(AZ::Edit::Attributes::AddNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                            ->Attribute(AZ::Edit::Attributes::RemoveNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
                         ;
                 }
             }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettingsInspector.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettingsInspector.cpp
@@ -164,6 +164,7 @@ namespace AtomToolsFramework
                 m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::SetModelPreset, AZ::Render::ModelPreset());
             EntityPreviewViewportSettingsRequestBus::Event(
                 m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::SaveModelPreset, savePath);
+            OnViewportSettingsChanged();
         }
     }
 
@@ -180,6 +181,7 @@ namespace AtomToolsFramework
         m_modelPresetDialog->setMinimumSize(0, 0);
         m_modelPresetDialog->setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
         m_modelPresetDialog->exec();
+        OnViewportSettingsChanged();
     }
 
     void EntityPreviewViewportSettingsInspector::SaveModelPreset()
@@ -196,6 +198,7 @@ namespace AtomToolsFramework
                 m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::SetModelPreset, m_modelPreset);
             EntityPreviewViewportSettingsRequestBus::Event(
                 m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::SaveModelPreset, savePath);
+            OnViewportSettingsChanged();
         }
     }
 
@@ -241,6 +244,7 @@ namespace AtomToolsFramework
                 m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::SetLightingPreset, AZ::Render::LightingPreset());
             EntityPreviewViewportSettingsRequestBus::Event(
                 m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::SaveLightingPreset, savePath);
+            OnViewportSettingsChanged();
         }
     }
 
@@ -257,6 +261,7 @@ namespace AtomToolsFramework
         m_lightingPresetDialog->setMinimumSize(0, 0);
         m_lightingPresetDialog->setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
         m_lightingPresetDialog->exec();
+        OnViewportSettingsChanged();
     }
 
     void EntityPreviewViewportSettingsInspector::SaveLightingPreset()
@@ -273,6 +278,7 @@ namespace AtomToolsFramework
                 m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::SetLightingPreset, m_lightingPreset);
             EntityPreviewViewportSettingsRequestBus::Event(
                 m_toolId, &EntityPreviewViewportSettingsRequestBus::Events::SaveLightingPreset, savePath);
+            OnViewportSettingsChanged();
         }
     }
 
@@ -317,7 +323,7 @@ namespace AtomToolsFramework
     void EntityPreviewViewportSettingsInspector::OnViewportSettingsChanged()
     {
         LoadSettings();
-        RefreshAll();
+        RebuildAll();
     }
 
     void EntityPreviewViewportSettingsInspector::OnModelPresetAdded(const AZStd::string& path)


### PR DESCRIPTION
## What does this PR do?

The viewport settings panel was refreshing after selection and property changes but not rebuilding itself or the embedded property editors after changes that affected container sizes. This led to displaying and manipulating corrupt lighting data.

Resolves https://github.com/o3de/o3de/issues/12237

## How was this PR tested?

Tested creating and cycling through multiple lighting presets, adding and removing directional lights from the configuration.