### PR TITLE
Fix graph model integer slot precision to only show scientific notation for large numbers

### DIFF
--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/FloatDataInterface.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/FloatDataInterface.h
@@ -29,9 +29,6 @@ namespace GraphModelIntegration
         double GetNumber() const override;
         void SetNumber(double value) override;
 
-        int GetDecimalPlaces() const override;
-        int GetDisplayDecimalPlaces() const override;
-
         double GetMin() const override;
         double GetMax() const override;
 

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/IntegerDataInterface.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/IntegerDataInterface.h
@@ -61,11 +61,6 @@ namespace GraphModelIntegration
             return 0;
         }
 
-        int GetDisplayDecimalPlaces() const
-        {
-            return 0;
-        }
-
         double GetMin() const
         {
             return static_cast<double>(AZStd::numeric_limits<T>::min());

--- a/Gems/GraphModel/Code/Source/Integration/FloatDataInterface.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/FloatDataInterface.cpp
@@ -46,19 +46,11 @@ namespace GraphModelIntegration
         }
     }
 
-    int FloatDataInterface::GetDecimalPlaces() const
-    {
-        return 7;
-    }
-    int FloatDataInterface::GetDisplayDecimalPlaces() const
-    {
-        return 4;
-    }
-
     double FloatDataInterface::GetMin() const
     {
         return std::numeric_limits<float>::lowest();
     }
+
     double FloatDataInterface::GetMax() const
     {
         return std::numeric_limits<float>::max();


### PR DESCRIPTION
## What does this PR do?

Resolves https://github.com/o3de/o3de/issues/14258

## How was this PR tested?

Created and edited multiple floating point and integer nodes in material canvas.
Confirmed that integer based nodes do not allow entering digits after the decimal point.
Confirmed that integer based nodes only display scientific notation for numbers >= 10000.