### PR TITLE
Moved xr pipeline names to cvars so they can be overridden easily

### DIFF
--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -46,7 +46,10 @@
 #include <AzCore/Console/IConsole.h>
 #include <BootstrapSystemComponent_Traits_Platform.h>
 
-AZ_CVAR(AZ::CVarFixedString, r_default_pipeline_name, AZ_TRAIT_BOOTSTRAPSYSTEMCOMPONENT_PIPELINE_NAME, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default Render pipeline name");
+AZ_CVAR(AZ::CVarFixedString, r_default_pipeline_name, AZ_TRAIT_BOOTSTRAPSYSTEMCOMPONENT_PIPELINE_NAME, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default render pipeline name");
+AZ_CVAR(AZ::CVarFixedString, r_default_openxr_pipeline_name, "passes/MultiViewRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr render pipeline name");
+AZ_CVAR(AZ::CVarFixedString, r_default_openxr_left_pipeline_name, "passes/XRLeftRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr Left eye render pipeline name");
+AZ_CVAR(AZ::CVarFixedString, r_default_openxr_right_pipeline_name, "passes/XRRightRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr Right eye render pipeline name");
 AZ_CVAR(uint32_t, r_width, 1920, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting window width in pixels.");
 AZ_CVAR(uint32_t, r_height, 1080, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting window height in pixels.");
 AZ_CVAR(uint32_t, r_fullscreen, false, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting fullscreen state.");
@@ -406,7 +409,7 @@ namespace AZ
                         ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::QueryApplicationType, appType);
                         if (appType.IsGame())
                         {
-                            pipelineName = "passes/MultiViewRenderPipeline.azasset";
+                            pipelineName = r_default_openxr_pipeline_name;
                         }
                     }
 
@@ -452,8 +455,8 @@ namespace AZ
                             ? AZ::RPI::ViewType::XrLeft
                             : AZ::RPI::ViewType::XrRight;
                         const AZStd::string_view xrPipelineAssetName = (viewType == AZ::RPI::ViewType::XrLeft)
-                            ? "passes/XRLeftRenderPipeline.azasset"
-                            : "passes/XRRightRenderPipeline.azasset";
+                            ? static_cast<AZ::CVarFixedString>(r_default_openxr_left_pipeline_name)
+                            : static_cast<AZ::CVarFixedString>(r_default_openxr_right_pipeline_name);
 
                         if (!LoadPipeline(scene, viewportContext, xrPipelineAssetName, viewType, multisampleState))
                         {


### PR DESCRIPTION
Related PR - https://github.com/o3de/o3de-extras/pull/219

## How was this PR tested?
Tested OpenXrTest project on Quest 2
