### PR TITLE
Asset Processor - Improve handling of legacy UUIDs

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.cpp
@@ -713,6 +713,11 @@ namespace AzToolsFramework
                     SqlParam<const char*>(":productname"),
                     SqlParam<const char*>(":platform"));
 
+            static const char* QUERY_SOURCEDEPENDENCY = "AzToolsFramework::AssetDatabase::QuerySourceDependency";
+            static const char* QUERY_SOURCEDEPENDENCY_STATEMENT = "SELECT * FROM SourceDependency";
+
+            static const auto s_querySourceDependency = MakeSqlQuery(QUERY_SOURCEDEPENDENCY, QUERY_SOURCEDEPENDENCY_STATEMENT, LOG_NAME);
+
             static const char* QUERY_SOURCEDEPENDENCY_BY_SOURCEDEPENDENCYID = "AzToolsFramework::AssetDatabase::QuerySourceDependencyBySourceDependencyID";
             static const char* QUERY_SOURCEDEPENDENCY_BY_SOURCEDEPENDENCYID_STATEMENT =
                 "SELECT * FROM SourceDependency WHERE "
@@ -1932,6 +1937,7 @@ namespace AzToolsFramework
             AddStatement(m_databaseConnection, s_queryCombinedLikeProductname);
             AddStatement(m_databaseConnection, s_queryCombinedLikeProductnamePlatform);
 
+            AddStatement(m_databaseConnection, s_querySourceDependency);
             AddStatement(m_databaseConnection, s_querySourcedependencyBySourcedependencyid);
             AddStatement(m_databaseConnection, s_querySourceDependencyByDependsOnSource);
             AddStatement(m_databaseConnection, s_querySourceDependencyByDependsOnSourceWildcard);
@@ -2615,7 +2621,13 @@ namespace AzToolsFramework
             return found && succeeded;
         }
 
-        bool AssetDatabaseConnection::QuerySourceDependencyBySourceDependencyId(AZ::s64 sourceDependencyID, sourceFileDependencyHandler handler)
+        bool AssetDatabaseConnection::QuerySourceDependencies(sourceFileDependencyHandler handler)
+        {
+            return s_querySourceDependency.BindAndQuery(*m_databaseConnection, handler, &GetSourceDependencyResult);
+        }
+
+        bool AssetDatabaseConnection::QuerySourceDependencyBySourceDependencyId(
+            AZ::s64 sourceDependencyID, sourceFileDependencyHandler handler)
         {
             return s_querySourcedependencyBySourcedependencyid.BindAndQuery(*m_databaseConnection, handler, &GetSourceDependencyResult, sourceDependencyID);
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.h
@@ -248,7 +248,7 @@ namespace AzToolsFramework
             //  compare whether its represents the same product as the other rather than identical in every way (including file data).
             bool operator==(const ProductDatabaseEntry& other) const;
 
-            //! Logical equality compare. 
+            //! Logical equality compare.
             //! It will return true if the fields that establish the identify of a product are identical, regardless
             //! of the equality of things like its flags and hash.
             bool IsSameLogicalProductAs(const ProductDatabaseEntry& other) const;
@@ -621,7 +621,9 @@ namespace AzToolsFramework
 
 
             //SourceDependency
-            /// direct query - look up table row by row ID
+            //! Query all source dependencies
+            bool QuerySourceDependencies(sourceFileDependencyHandler handler);
+            //! direct query - look up table row by row ID
             bool QuerySourceDependencyBySourceDependencyId(AZ::s64 sourceDependencyID, sourceFileDependencyHandler handler);
 
             //! Query sources which depend on 'dependsOnSource'

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/PathOrUuid.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/PathOrUuid.cpp
@@ -74,6 +74,16 @@ namespace AzToolsFramework::AssetDatabase
 
         return !rhs.IsUuid() && m_path == rhs.m_path;
     }
+
+    PathOrUuid::operator bool() const
+    {
+        if (!m_uuid.IsNull())
+        {
+            return true;
+        }
+
+        return !m_path.empty();
+    }
 }
 
 AZStd::size_t AZStd::hash<AzToolsFramework::AssetDatabase::PathOrUuid>::operator()(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/PathOrUuid.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/PathOrUuid.h
@@ -30,6 +30,7 @@ namespace AzToolsFramework::AssetDatabase
         const AZStd::string& ToString() const;
 
         bool operator==(const PathOrUuid& rhs) const;
+        // Returns true if a non-empty path or non-null UUID has been set
         explicit operator bool() const;
 
     private:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/PathOrUuid.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/PathOrUuid.h
@@ -30,6 +30,7 @@ namespace AzToolsFramework::AssetDatabase
         const AZStd::string& ToString() const;
 
         bool operator==(const PathOrUuid& rhs) const;
+        explicit operator bool() const;
 
     private:
         AZ::Uuid m_uuid;

--- a/Code/Tools/AssetProcessor/assetprocessor_test_files.cmake
+++ b/Code/Tools/AssetProcessor/assetprocessor_test_files.cmake
@@ -44,6 +44,8 @@ set(FILES
     native/tests/assetmanager/IntermediateAssetTests.h
     native/tests/assetmanager/DelayRelocationTests.cpp
     native/tests/assetmanager/DelayRelocationTests.h
+    native/tests/assetmanager/SourceDependencyTests.cpp
+    native/tests/assetmanager/SourceDependencyTests.h
     native/tests/assetmanager/Validators/LfsPointerFileValidatorTests.cpp
     native/tests/assetmanager/Validators/LfsPointerFileValidatorTests.h
     native/tests/utilities/assetUtilsTest.cpp

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
@@ -637,7 +637,7 @@ namespace AssetProcessor
                                 canonicalUuid && canonicalUuid != entry.m_dependsOnSource.GetUuid())
                             {
                                 update = true;
-                                entry.m_dependsOnSource = AzToolsFramework::AssetDatabase::PathOrUuid::PathOrUuid(canonicalUuid.value());
+                                entry.m_dependsOnSource = AzToolsFramework::AssetDatabase::PathOrUuid(canonicalUuid.value());
                             }
                         }
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
@@ -587,11 +587,23 @@ namespace AssetProcessor
                     AzToolsFramework::AssetSystem::JobStatus::Any,
                     true); /*we still need legacy IDs - hardly anyone else does*/
 
+                auto* uuidInterface = AZ::Interface<IUuidRequests>::Get();
+                AZ_Assert(uuidInterface, "Programmer Error - IUuidRequests is not available.");
+
+                AzToolsFramework::AssetDatabase::ProductDependencyDatabaseEntryContainer productDependenciesToUpdate;
+
                 m_db->QueryProductDependenciesTable(
-                    [this, &platform](AZ::Data::AssetId& assetId, AzToolsFramework::AssetDatabase::ProductDependencyDatabaseEntry& entry)
+                    [this, &platform, uuidInterface, &productDependenciesToUpdate](AZ::Data::AssetId& assetId, AzToolsFramework::AssetDatabase::ProductDependencyDatabaseEntry& entry)
                     {
                         if (AzFramework::StringFunc::Equal(entry.m_platform.c_str(), platform.toUtf8().data()))
                         {
+                            // Attempt to update the dependency UUID to the canonical UUID if possible
+                            if (auto canonicalUuid = uuidInterface->GetCanonicalUuid(entry.m_dependencySourceGuid); canonicalUuid && canonicalUuid.value() != entry.m_dependencySourceGuid)
+                            {
+                                entry.m_dependencySourceGuid = canonicalUuid.value();
+                                productDependenciesToUpdate.emplace_back(entry);
+                            }
+
                             m_registries[platform].RegisterAssetDependency(
                                 assetId,
                                 AZ::Data::ProductDependency{ AZ::Data::AssetId(entry.m_dependencySourceGuid, entry.m_dependencySubID),
@@ -601,10 +613,59 @@ namespace AssetProcessor
                         return true;
                     });
 
+                AzToolsFramework::AssetDatabase::SourceFileDependencyEntryContainer sourceDependenciesToUpdate;
+                m_db->QuerySourceDependencies(
+                    [&sourceDependenciesToUpdate, &uuidInterface](AzToolsFramework::AssetDatabase::SourceFileDependencyEntry& entry)
+                    {
+                        bool update = false;
+
+                        // Check if the sourceGuid needs to be updated
+                        if (auto canonicalUuid = uuidInterface->GetCanonicalUuid(entry.m_sourceGuid);
+                            canonicalUuid && canonicalUuid.value() != entry.m_sourceGuid)
+                        {
+                            if (canonicalUuid.value() != entry.m_sourceGuid)
+                            {
+                                update = true;
+                                entry.m_sourceGuid = canonicalUuid.value();
+                            }
+                        }
+
+                        // Check if the dependency uses a UUID and if it needs to be updated
+                        if (entry.m_dependsOnSource.IsUuid())
+                        {
+                            if (auto canonicalUuid = uuidInterface->GetCanonicalUuid(entry.m_dependsOnSource.GetUuid());
+                                canonicalUuid && canonicalUuid != entry.m_dependsOnSource.GetUuid())
+                            {
+                                update = true;
+                                entry.m_dependsOnSource = AzToolsFramework::AssetDatabase::PathOrUuid::PathOrUuid(canonicalUuid.value());
+                            }
+                        }
+
+                        if (update)
+                        {
+                            sourceDependenciesToUpdate.emplace_back(entry);
+                        }
+
+                        return true; // Iterate all entries
+                    });
+
                 // Update any old source UUIDs
                 for (auto& sourceDatabaseEntry : sourceEntriesToUpdate)
                 {
                     m_db->SetSource(sourceDatabaseEntry);
+                }
+
+                // Update any old product dependencies
+                for (auto& productDependencyEntry : productDependenciesToUpdate)
+                {
+                    m_db->SetProductDependency(productDependencyEntry);
+                }
+
+                // Update any old source dependencies
+                if (!sourceDependenciesToUpdate.empty())
+                {
+                    m_db->RemoveSourceFileDependencies(sourceDependenciesToUpdate);
+                    m_db->SetSourceFileDependencies(sourceDependenciesToUpdate);
                 }
 
                 AZ_TracePrintf(
@@ -1585,11 +1646,11 @@ namespace AssetProcessor
 
         if (auto result = uuidInterface->FindHighestPriorityFileByUuid(assetId.m_guid); result)
         {
-            sourceAsset = SourceAssetReference(result.TakeValue());
+            sourceAsset = SourceAssetReference(result.value());
             return true;
         }
 
-        // Check the database first
+        // Check the database next
         {
             AZStd::lock_guard<AZStd::mutex> lock(m_databaseMutex);
             AzToolsFramework::AssetDatabase::SourceDatabaseEntry entry;

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -4843,6 +4843,79 @@ namespace AssetProcessor
             }
         }
 
+        // Try checking the UuidManager, it keeps track of legacy UUIDs
+        auto* uuidInterface = AZ::Interface<AssetProcessor::IUuidRequests>::Get();
+        AZ_Assert(uuidInterface, "Programmer Error - IUuidRequests interface is not available.");
+
+        if(auto sources = uuidInterface->FindFilesByUuid(sourceUuid); !sources.empty())
+        {
+            // Do not cache the result in the above map, a file could be moved and retain the same UUID, resulting in incorrect info
+            // The UuidManager will take care of caching.
+            if (sources.size() == 1)
+            {
+                result = SourceAssetReference(sources[0]);
+                return true;
+            }
+            else
+            {
+                // There are multiple files with the same legacy UUID, resolve to the highest priority one (highest priority scanfolder, oldest creation time)
+
+                // Convert all the paths into SourceAssetReferences which will get the scanfolder ID
+                AZStd::vector<SourceAssetReference> sourceReferences;
+                for (const auto& filePath : sources)
+                {
+                    sourceReferences.emplace_back(filePath);
+                }
+
+                // Sort the list based on scanfolder ID
+                AZStd::stable_sort(
+                    sourceReferences.begin(),
+                    sourceReferences.end(),
+                    [](const SourceAssetReference& left, const SourceAssetReference& right)
+                    {
+                        return left.ScanFolderId() < right.ScanFolderId();
+                    });
+
+                // Get the range of files from the highest priority scanfolder (having the same scanfolder ID)
+                AZ::s64 highestPriorityScanFolder = sourceReferences.front().ScanFolderId();
+                //auto highestPriorityFileRange = std::equal_range(
+                //    sourceReferences.begin(),
+                //    sourceReferences.end(),
+                //    sourceReferences.front().ScanFolderId(),
+                //    [](const SourceAssetReference& left, AZ::s64 value)
+                //    {
+                //        return left.ScanFolderId() < value;
+                //    });
+
+                AZ::u64 oldestFileTime = AZStd::numeric_limits<AZ::u64>::max();
+                SourceAssetReference* oldestFile{};
+
+                // From the files in the highest priority scanfolder, pick the oldest one
+                for (auto& source : sourceReferences)
+                {
+                    if (source.ScanFolderId() > highestPriorityScanFolder)
+                    {
+                        // Only consider sources from the first, highest priority scanfolder
+                        break;
+                    }
+
+                    auto entryDetails = uuidInterface->GetUuidDetails(source);
+
+                    if (entryDetails)
+                    {
+                        if (entryDetails.GetValue().m_millisecondsSinceUnixEpoch <= oldestFileTime)
+                        {
+                            oldestFile = &source;
+                            oldestFileTime = entryDetails.GetValue().m_millisecondsSinceUnixEpoch;
+                        }
+                    }
+                }
+
+                result = *oldestFile;
+                return true;
+            }
+        }
+
         // try the database next:
         AzToolsFramework::AssetDatabase::SourceDatabaseEntry sourceDatabaseEntry;
         if (m_stateData->GetSourceBySourceGuid(sourceUuid, sourceDatabaseEntry))

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -462,7 +462,7 @@ namespace AssetProcessor
         *   If there's a problem that makes it unusable (such as no fields being filled in), the string will be blank
         *     and this function will return false.
         */
-        bool ResolveSourceFileDependencyPath(const AssetBuilderSDK::SourceFileDependency& sourceDependency, QString& resultDatabaseSourceNames, QStringList& resolvedDependencyList);
+        bool ResolveSourceFileDependencyPath(AssetBuilderSDK::SourceFileDependency& sourceDependency, QString& resultDatabaseSourceNames, QStringList& resolvedDependencyList);
         //! Updates the database with all the changes related to source dependency / job dependency:
         void UpdateSourceFileDependenciesDatabase(JobToProcessEntry& entry);
 

--- a/Code/Tools/AssetProcessor/native/tests/ApplicationManagerTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/ApplicationManagerTests.cpp
@@ -81,7 +81,7 @@ namespace UnitTests
         LeakDetectionFixture::TearDown();
     }
 
-    using BatchApplicationManagerTest = UnitTest::LeakDetectionFixture;
+    using BatchApplicationManagerTest = ::UnitTest::LeakDetectionFixture;
 
     TEST_F(ApplicationManagerTest, FileWatcherEventsTriggered_ProperlySignalledOnCorrectThread_SUITE_sandbox)
     {

--- a/Code/Tools/AssetProcessor/native/tests/BuilderManagerTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/BuilderManagerTests.cpp
@@ -16,7 +16,7 @@
 
 namespace UnitTests
 {
-    class BuilderManagerTest : public UnitTest::LeakDetectionFixture
+    class BuilderManagerTest : public ::UnitTest::LeakDetectionFixture
     {
 
     };

--- a/Code/Tools/AssetProcessor/native/tests/PathDependencyManagerTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/PathDependencyManagerTests.cpp
@@ -483,7 +483,7 @@ namespace UnitTests
     };
 
     struct PathDependencyTestValidation
-        : UnitTest::LeakDetectionFixture
+        : ::UnitTest::LeakDetectionFixture
         , PathDependencyBenchmarks
     {
         void SetUp() override

--- a/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.h
+++ b/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.h
@@ -165,6 +165,49 @@ namespace UnitTests
         AssetProcessor::ScanFolderInfo m_scanFolderInfo;
     };
 
+    struct MockMultiPathConversion : AZ::Interface<AssetProcessor::IPathConversion>::Registrar
+    {
+        bool ConvertToRelativePath(QString fullFileName, QString& databaseSourceName, QString& scanFolderName) const override
+        {
+            auto scanfolder = GetScanFolderForFile(fullFileName);
+            EXPECT_TRUE(scanfolder);
+            //EXPECT_TRUE(fullFileName.startsWith(m_scanFolderInfo.ScanPath(), Qt::CaseInsensitive));
+
+            scanFolderName = scanfolder->ScanPath();
+            databaseSourceName = fullFileName.mid(scanFolderName.size() + 1);
+
+            return true;
+        }
+
+        const AssetProcessor::ScanFolderInfo* GetScanFolderForFile(const QString& fullFileName) const override
+        {
+            for (const auto& scanfolder : m_scanFolderInfo)
+            {
+                if (AZ::IO::PathView(fullFileName.toUtf8().constData())
+                    .IsRelativeTo(AZ::IO::PathView(scanfolder.ScanPath().toUtf8().constData())))
+                {
+                    return &scanfolder;
+                }
+            }
+
+            return nullptr;
+        }
+
+        const AssetProcessor::ScanFolderInfo* GetScanFolderById(AZ::s64 id) const override
+        {
+            return &m_scanFolderInfo[id - 1];
+        }
+
+        void AddScanfolder(QString path, QString name)
+        {
+            m_scanFolderInfo.push_back(
+                AssetProcessor::ScanFolderInfo(path, name, name, false, true, { AssetBuilderSDK::PlatformInfo{ "pc", {} } }, 0, m_scanFolderInfo.size() + 1));
+        }
+
+    private:
+        AZStd::vector<AssetProcessor::ScanFolderInfo> m_scanFolderInfo;
+    };
+
     struct MockVirtualFileIO
     {
         static constexpr AZ::u32 ComputeHandle(AZ::IO::PathView path)

--- a/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.h
+++ b/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.h
@@ -171,7 +171,6 @@ namespace UnitTests
         {
             auto scanfolder = GetScanFolderForFile(fullFileName);
             EXPECT_TRUE(scanfolder);
-            //EXPECT_TRUE(fullFileName.startsWith(m_scanFolderInfo.ScanPath(), Qt::CaseInsensitive));
 
             scanFolderName = scanfolder->ScanPath();
             databaseSourceName = fullFileName.mid(scanFolderName.size() + 1);

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetManagerTestingBase.h
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetManagerTestingBase.h
@@ -124,10 +124,13 @@ namespace UnitTests
             bool hasExtraFile = false);
 
         AssetBuilderSDK::CreateJobFunction CreateJobStage(
-            const AZStd::string& name, bool commonPlatform, const AZStd::string& sourceDependencyPath = "");
+            const AZStd::string& name, bool commonPlatform, const AzToolsFramework::AssetDatabase::PathOrUuid& sourceDependency = {});
 
         AssetBuilderSDK::ProcessJobFunction ProcessJobStage(
-            const AZStd::string& outputExtension, AssetBuilderSDK::ProductOutputFlags flags, bool outputExtraFile);
+            const AZStd::string& outputExtension,
+            AssetBuilderSDK::ProductOutputFlags flags,
+            bool outputExtraFile,
+            AZ::Data::AssetId productDependency = {});
 
         void CreateBuilder(
             const char* name,

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/IntermediateAssetTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/IntermediateAssetTests.cpp
@@ -600,12 +600,13 @@ namespace UnitTests
     TEST_F(IntermediateAssetTests, IntermediateAsset_SourceDependencyOnSourceAsset_Reprocesses)
     {
         using namespace AssetBuilderSDK;
+        using namespace AzToolsFramework::AssetDatabase;
 
         CreateBuilder("stage1", "*.stage1", "stage2", true, ProductOutputFlags::IntermediateAsset);
 
         m_builderInfoHandler.CreateBuilderDesc(
             "stage2", AZ::Uuid::CreateRandom().ToFixedString().c_str(), { AssetBuilderPattern{ "*.stage2", AssetBuilderPattern::Wildcard } },
-            CreateJobStage("stage2", false, "one.test"),
+            CreateJobStage("stage2", false, PathOrUuid("one.test")),
             ProcessJobStage("stage3", ProductOutputFlags::ProductAsset, false), "fingerprint");
 
         CreateBuilder("normal file builder", "*.test", "test", false, ProductOutputFlags::ProductAsset);

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/SourceDependencyTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/SourceDependencyTests.cpp
@@ -131,7 +131,7 @@ namespace UnitTests
             "fingerprint");
 
         // Process the file
-        ProcessFileMultiStage(1, false, testB);
+        ProcessFileMultiStage(1, false, testB.AbsolutePath().c_str());
 
         // Fetch and check the source dependency
         SourceFileDependencyEntryContainer dependencies;

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/SourceDependencyTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/SourceDependencyTests.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <QCoreApplication>
+#include <native/tests/assetmanager/SourceDependencyTests.h>
+#include <native/unittests/UnitTestUtils.h>
+#include <AzFramework/IO/LocalFileIO.h>
+#include <AzCore/Utils/Utils.h>
+
+namespace UnitTests
+{
+    void SourceDependencyTests::SetUp()
+    {
+        AssetManagerTestingBase::SetUp();
+
+        AZ::Data::AssetId::Reflect(m_serializeContext.get());
+        AZ::Data::AssetData::Reflect(m_serializeContext.get());
+
+        using namespace AssetBuilderSDK;
+
+        m_uuidInterface = AZ::Interface<AssetProcessor::IUuidRequests>::Get();
+        ASSERT_TRUE(m_uuidInterface);
+
+        m_uuidInterface->EnableGenerationForTypes({ ".stage1" });
+
+        m_assetProcessorManager->SetMetaCreationDelay(MetadataProcessingDelayMs);
+
+        CreateBuilder("stage1", "*.stage1", "stage2", false, ProductOutputFlags::ProductAsset);
+        ProcessFileMultiStage(1, true);
+        QCoreApplication::processEvents();
+    }
+
+    TEST_F(SourceDependencyTests, ExistingSourceDependency_OnCatalogStartup_LegacyUuidsUpgraded)
+    {
+        // Test that a Source dependency between two files where both UUIDs are legacy UUIDs and are both upgraded during catalog setup
+        using namespace AssetProcessor;
+        using namespace AzToolsFramework::AssetDatabase;
+
+        SourceAssetReference testA = SourceAssetReference(m_testFilePath.c_str());
+
+        AZ::IO::Path scanFolderDir(m_scanfolder.m_scanFolder);
+        AZStd::string testFilename = "testB.stage1";
+        SourceAssetReference testB(scanFolderDir / testFilename);
+
+        AZ::Utils::WriteFile("unit test file", testB.AbsolutePath().c_str());
+
+        auto testAUuids = m_uuidInterface->GetLegacyUuids(testA);
+        ASSERT_TRUE(testAUuids);
+
+        auto testBUuids = m_uuidInterface->GetLegacyUuids(testB);
+        ASSERT_TRUE(testBUuids);
+
+        // Inject a source dependency into the db using legacy UUIDs on both ends
+        auto builderId = AZ::Uuid::CreateRandom();
+        SourceFileDependencyEntry dep{ builderId,
+                                       *testAUuids.GetValue().begin(),
+                                       PathOrUuid(*testBUuids.GetValue().begin()),
+                                       SourceFileDependencyEntry::DEP_SourceToSource,
+                                       true,
+                                       "" };
+
+        ASSERT_TRUE(m_stateData->SetSourceFileDependency(dep));
+
+        // Run the catalog startup which handles the updating
+        auto catalog = AZStd::make_unique<AssetCatalog>(nullptr, m_platformConfig.get());
+        catalog->BuildRegistry();
+
+        // Check that the db entry has been updated
+        auto testAUuid = m_uuidInterface->GetUuid(testA).GetValue();
+
+        SourceFileDependencyEntryContainer updatedEntry;
+        EXPECT_TRUE(m_stateData->GetSourceFileDependenciesByBuilderGUIDAndSource(builderId, testAUuid, SourceFileDependencyEntry::DEP_Any, updatedEntry));
+
+        ASSERT_EQ(updatedEntry.size(), 1);
+        EXPECT_STREQ(updatedEntry[0].m_dependsOnSource.ToString().c_str(), m_uuidInterface->GetUuid(testB).GetValue().ToFixedString(false, false).c_str());
+        EXPECT_STREQ(updatedEntry[0].m_sourceGuid.ToFixedString().c_str(), testAUuid.ToFixedString().c_str());
+    }
+
+    TEST_F(SourceDependencyTests, NewlyCreatedSourceAndProductDependency_UpgradedBeforeSaving)
+    {
+        // Test that a Source dependency using a legacy UUID reference is upgraded before being saved to the database during processing
+        using namespace AssetProcessor;
+        using namespace AzToolsFramework::AssetDatabase;
+        using namespace AssetBuilderSDK;
+
+        SourceAssetReference testA = SourceAssetReference(m_testFilePath.c_str());
+
+        AZ::IO::Path scanFolderDir(m_scanfolder.m_scanFolder);
+        AZStd::string testFilename = "testB.src";
+        SourceAssetReference testB(scanFolderDir / testFilename);
+
+        AZ::Utils::WriteFile("unit test file", testB.AbsolutePath().c_str());
+
+        auto testAUuids = m_uuidInterface->GetLegacyUuids(testA);
+        ASSERT_TRUE(testAUuids);
+
+        auto testBUuids = m_uuidInterface->GetLegacyUuids(testB);
+        ASSERT_TRUE(testBUuids);
+
+        // Builder which will say B depends on legacy A with a source dependency and a product dependency
+        const auto testASubId = 0;
+        auto builderId = AZ::Uuid::CreateRandom();
+        m_builderInfoHandler.CreateBuilderDesc(
+            "DependencyBuilder",
+            builderId.ToFixedString().c_str(),
+            { AssetBuilderPattern{ "*.src", AssetBuilderPattern::Wildcard } },
+            CreateJobStage("DependencyBuilder", false, PathOrUuid(*testAUuids.GetValue().begin())),
+            ProcessJobStage("bin", ProductOutputFlags::ProductAsset, false, AZ::Data::AssetId(*testAUuids.GetValue().begin(), testASubId)),
+            "fingerprint");
+
+        // Process the file
+        ProcessFileMultiStage(1, false, testB);
+
+        // Fetch and check the source dependency
+        SourceFileDependencyEntryContainer dependencies;
+        EXPECT_TRUE(m_stateData->GetSourceFileDependenciesByBuilderGUIDAndSource(
+            builderId, m_uuidInterface->GetUuid(testB).GetValue(), SourceFileDependencyEntry::DEP_Any, dependencies));
+
+        auto testAUuid = m_uuidInterface->GetUuid(testA).GetValue();
+
+        ASSERT_EQ(dependencies.size(), 1);
+        EXPECT_STREQ(
+            dependencies[0].m_dependsOnSource.GetUuid().ToFixedString().c_str(),
+            testAUuid.ToFixedString().c_str());
+
+        // Fetch and check the product dependency
+        ProductDependencyDatabaseEntryContainer productDependencies;
+        EXPECT_TRUE(m_stateData->GetProductDependencies(productDependencies));
+
+        ASSERT_EQ(productDependencies.size(), 1);
+        EXPECT_STREQ(productDependencies[0].m_dependencySourceGuid.ToFixedString().c_str(), testAUuid.ToFixedString().c_str());
+    }
+} // namespace UnitTests

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/SourceDependencyTests.h
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/SourceDependencyTests.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <native/tests/assetmanager/AssetManagerTestingBase.h>
+
+namespace UnitTests
+{
+    class SourceDependencyTests : public AssetManagerTestingBase
+    {
+    public:
+        void SetUp() override;
+
+        AssetProcessor::IUuidRequests* m_uuidInterface{};
+    };
+} // namespace UnitTests

--- a/Code/Tools/AssetProcessor/native/ui/SourceAssetDetailsPanel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/SourceAssetDetailsPanel.cpp
@@ -17,6 +17,7 @@
 #include <native/ui/ui_GoToButton.h>
 #include <native/ui/ui_SourceAssetDetailsPanel.h>
 #include <native/utilities/assetUtils.h>
+#include <utilities/UuidManager.h>
 
 namespace AssetProcessor
 {
@@ -232,6 +233,18 @@ namespace AssetProcessor
                             displayString = dependencyDetails.m_sourceName;
                             return false;
                         });
+
+                    if (displayString.empty())
+                    {
+                        auto* uuidInterface = AZ::Interface<IUuidRequests>::Get();
+                        AZ_Assert(uuidInterface, "Programmer Error - IUuidRequests is not available");
+
+                        if (auto result = uuidInterface->FindHighestPriorityFileByUuid(sourceFileDependencyEntry.m_dependsOnSource.GetUuid()); result)
+                        {
+                            displayString = SourceAssetReference(result.GetValue()).RelativePath().c_str();
+                            dependencyDetails.m_sourceName = displayString;
+                        }
+                    }
 
                     if (displayString.empty())
                     {

--- a/Code/Tools/AssetProcessor/native/ui/SourceAssetDetailsPanel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/SourceAssetDetailsPanel.cpp
@@ -236,18 +236,6 @@ namespace AssetProcessor
 
                     if (displayString.empty())
                     {
-                        auto* uuidInterface = AZ::Interface<IUuidRequests>::Get();
-                        AZ_Assert(uuidInterface, "Programmer Error - IUuidRequests is not available");
-
-                        if (auto result = uuidInterface->FindHighestPriorityFileByUuid(sourceFileDependencyEntry.m_dependsOnSource.GetUuid()); result)
-                        {
-                            displayString = SourceAssetReference(result.GetValue()).RelativePath().c_str();
-                            dependencyDetails.m_sourceName = displayString;
-                        }
-                    }
-
-                    if (displayString.empty())
-                    {
                         displayString = sourceFileDependencyEntry.m_dependsOnSource.GetUuid().ToFixedString();
                     }
                 }

--- a/Code/Tools/AssetProcessor/native/utilities/UuidManager.h
+++ b/Code/Tools/AssetProcessor/native/utilities/UuidManager.h
@@ -39,7 +39,10 @@ namespace AssetProcessor
         //! Returns the file(s) matching the provided UUID.  If the UUID provided is a legacy UUID there may be multiple matches.
         virtual AZStd::vector<AZ::IO::Path> FindFilesByUuid(AZ::Uuid uuid) = 0;
         //! Returns the highest priority file matching the provided UUID.
-        virtual AZ::Outcome<AZ::IO::Path> FindHighestPriorityFileByUuid(AZ::Uuid uuid) = 0;
+        //! In the case of a legacy UUID provided which matches multiple files, the oldest file in the highest priority scanfolder will be returned.
+        virtual AZStd::optional<AZ::IO::Path> FindHighestPriorityFileByUuid(AZ::Uuid uuid) = 0;
+        //! Upgrades a potentially legacy UUID to the canonical UUID associated with the asset
+        virtual AZStd::optional<AZ::Uuid> GetCanonicalUuid(AZ::Uuid legacyUuid) = 0;
 
         //! Notifies the manager a metadata file has changed so the cache can be cleared.
         //! @param file Absolute path to the metadata file that changed.
@@ -78,7 +81,8 @@ namespace AssetProcessor
         AZ::Outcome<AZStd::unordered_set<AZ::Uuid>, AZStd::string> GetLegacyUuids(const SourceAssetReference& sourceAsset) override;
         AZ::Outcome<AzToolsFramework::MetaUuidEntry, AZStd::string> GetUuidDetails(const SourceAssetReference& sourceAsset) override;
         AZStd::vector<AZ::IO::Path> FindFilesByUuid(AZ::Uuid uuid) override;
-        AZ::Outcome<AZ::IO::Path> FindHighestPriorityFileByUuid(AZ::Uuid uuid) override;
+        AZStd::optional<AZ::IO::Path> FindHighestPriorityFileByUuid(AZ::Uuid uuid) override;
+        AZStd::optional<AZ::Uuid> GetCanonicalUuid(AZ::Uuid legacyUuid) override;
         void FileChanged(AZ::IO::PathView file) override;
         void FileRemoved(AZ::IO::PathView file) override;
         void EnableGenerationForTypes(AZStd::unordered_set<AZStd::string> types) override;

--- a/Code/Tools/AssetProcessor/native/utilities/UuidManager.h
+++ b/Code/Tools/AssetProcessor/native/utilities/UuidManager.h
@@ -38,6 +38,8 @@ namespace AssetProcessor
         virtual AZ::Outcome<AzToolsFramework::MetaUuidEntry, AZStd::string> GetUuidDetails(const SourceAssetReference& sourceAsset) = 0;
         //! Returns the file(s) matching the provided UUID.  If the UUID provided is a legacy UUID there may be multiple matches.
         virtual AZStd::vector<AZ::IO::Path> FindFilesByUuid(AZ::Uuid uuid) = 0;
+        //! Returns the highest priority file matching the provided UUID.
+        virtual AZ::Outcome<AZ::IO::Path> FindHighestPriorityFileByUuid(AZ::Uuid uuid) = 0;
 
         //! Notifies the manager a metadata file has changed so the cache can be cleared.
         //! @param file Absolute path to the metadata file that changed.
@@ -76,6 +78,7 @@ namespace AssetProcessor
         AZ::Outcome<AZStd::unordered_set<AZ::Uuid>, AZStd::string> GetLegacyUuids(const SourceAssetReference& sourceAsset) override;
         AZ::Outcome<AzToolsFramework::MetaUuidEntry, AZStd::string> GetUuidDetails(const SourceAssetReference& sourceAsset) override;
         AZStd::vector<AZ::IO::Path> FindFilesByUuid(AZ::Uuid uuid) override;
+        AZ::Outcome<AZ::IO::Path> FindHighestPriorityFileByUuid(AZ::Uuid uuid) override;
         void FileChanged(AZ::IO::PathView file) override;
         void FileRemoved(AZ::IO::PathView file) override;
         void EnableGenerationForTypes(AZStd::unordered_set<AZStd::string> types) override;

--- a/Code/Tools/AssetProcessor/native/utilities/UuidManager.h
+++ b/Code/Tools/AssetProcessor/native/utilities/UuidManager.h
@@ -37,11 +37,17 @@ namespace AssetProcessor
         //! Returns the full set of UUID entry details for the given asset.
         virtual AZ::Outcome<AzToolsFramework::MetaUuidEntry, AZStd::string> GetUuidDetails(const SourceAssetReference& sourceAsset) = 0;
         //! Returns the file(s) matching the provided UUID.  If the UUID provided is a legacy UUID there may be multiple matches.
+        //! Note this API relies on the internal cache and expects all files to have had Get(Legacy)Uuid(s) called at least once already.
+        //! This is expected to happened already as part of normal AP operations.
         virtual AZStd::vector<AZ::IO::Path> FindFilesByUuid(AZ::Uuid uuid) = 0;
         //! Returns the highest priority file matching the provided UUID.
         //! In the case of a legacy UUID provided which matches multiple files, the oldest file in the highest priority scanfolder will be returned.
+        //! Note this API relies on the internal cache and expects all files to have had Get(Legacy)Uuid(s) called at least once already.
+        //! This is expected to happened already as part of normal AP operations.
         virtual AZStd::optional<AZ::IO::Path> FindHighestPriorityFileByUuid(AZ::Uuid uuid) = 0;
-        //! Upgrades a potentially legacy UUID to the canonical UUID associated with the asset
+        //! Upgrades a potentially legacy UUID to the canonical UUID associated with the asset.
+        //! Note this API relies on the internal cache and expects all files to have had Get(Legacy)Uuid(s) called at least once already.
+        //! This is expected to happened already as part of normal AP operations.
         virtual AZStd::optional<AZ::Uuid> GetCanonicalUuid(AZ::Uuid legacyUuid) = 0;
 
         //! Notifies the manager a metadata file has changed so the cache can be cleared.


### PR DESCRIPTION
## What does this PR do?

Updates UuidManager to track and provide APIs for looking up legacy UUIDs.
Updates asset catalog to convert legacy UUIDs in source and product dependencies to the current canonical UUID on startup.
Updates asset processor manager to convert newly created source/product dependencies that reference legacy UUIDs into canonical UUIDs before saving to the database.
Updates some of the exposed APIs which lookup sources by UUID to attempt to lookup an asset using a legacy UUID.

## How was this PR tested?

Manual testing + added and ran unit tests
