### PR TITLE
Enable output callstack for main thread for error.log

### DIFF
--- a/Code/Legacy/CrySystem/DebugCallStack.cpp
+++ b/Code/Legacy/CrySystem/DebugCallStack.cpp
@@ -52,6 +52,10 @@ static bool IsFloatingPointException(EXCEPTION_POINTERS* pex);
 extern LONG WINAPI CryEngineExceptionFilterWER(struct _EXCEPTION_POINTERS* pExceptionPointers);
 extern LONG WINAPI CryEngineExceptionFilterMiniDump(struct _EXCEPTION_POINTERS* pExceptionPointers, const char* szDumpPath, MINIDUMP_TYPE mdumpValue);
 
+void MarkThisThreadForDebugging(const char* name);
+void UnmarkThisThreadFromDebugging();
+void UpdateFPExceptionsMaskForThreads();
+
 //=============================================================================
 CONTEXT CaptureCurrentContext()
 {
@@ -139,6 +143,8 @@ void DebugCallStack::installErrorHandler(ISystem* pSystem)
 {
     m_pSystem = pSystem;
     prevExceptionHandler = (void*)SetUnhandledExceptionFilter(CryUnhandledExceptionHandler);
+
+    MarkThisThreadForDebugging("main");
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## What does this PR do?

The current error log only contains the call stack for the thread where the exception happened. Sometime this is not enough and including the main thread's call stack would help to diagnose the crash. 
This PR enables output call stack for main thread if error thread is a job thread. 
And this may help find the root cause for this issue which only happens on jenkins AR runs: https://github.com/o3de/o3de/issues/10799

## How was this PR tested?

Run editor with an intentional nullptr crash which happens in a job thread. Check the error.log file under %project%/user/log/ folder. Noticed that the call stack for main thread is added after the call stack of the crashing job thread.

example error.log file

[error.log](https://github.com/o3de/o3de/files/10984541/error.log)
