### PR TITLE
Fix unused variable error by deleting unnecessary code

### DIFF
--- a/Gems/RemoteTools/Code/Source/RemoteToolsSystemComponent.cpp
+++ b/Gems/RemoteTools/Code/Source/RemoteToolsSystemComponent.cpp
@@ -564,14 +564,6 @@ namespace RemoteTools
             m_joinThread->Start();
         }
 
-        // Check if there are any active connections, if not stop the outbox thread
-        [[maybe_unused]] bool hasActiveConnection = false;
-        for (auto registryIt = m_entryRegistry.begin(); registryIt != m_entryRegistry.end(); ++registryIt)
-        {
-            hasActiveConnection =
-                AZ::Interface<AzNetworking::INetworking>::Get()->RetrieveNetworkInterface(registryIt->second.m_name) != nullptr;
-        }
-
     }
 
 } // namespace RemoteTools

--- a/Gems/RemoteTools/Code/Source/RemoteToolsSystemComponent.cpp
+++ b/Gems/RemoteTools/Code/Source/RemoteToolsSystemComponent.cpp
@@ -565,7 +565,7 @@ namespace RemoteTools
         }
 
         // Check if there are any active connections, if not stop the outbox thread
-        bool hasActiveConnection = false;
+        [[maybe_unused]] bool hasActiveConnection = false;
         for (auto registryIt = m_entryRegistry.begin(); registryIt != m_entryRegistry.end(); ++registryIt)
         {
             hasActiveConnection =


### PR DESCRIPTION
## What does this PR do?

Fixes a Linux/Clang compile error:
```
In file included from /home/github/o3de/build/linux_aarch64/External/RemoteTools-bd846853/Code/CMakeFiles/RemoteTools.Private.Static.dir/Unity/unity_0_cxx.cxx:3:
/home/github/o3de/Gems/RemoteTools/Code/Source/RemoteToolsSystemComponent.cpp:568:14: error: variable 'hasActiveConnection' set but not used [-Werror,-Wunused-but-set-variable]
        bool hasActiveConnection = false;
             ^
```


## How was this PR tested?

Built locally on Linux
