### PR TITLE
fix PACKAGE_VERSION_COMPATIBLE not set

### DIFF
--- a/AutomatedTesting/cmake/EngineFinder.cmake
+++ b/AutomatedTesting/cmake/EngineFinder.cmake
@@ -139,6 +139,10 @@ endforeach()
 
 if(O3DE_MOST_COMPATIBLE_ENGINE_PATH)
     message(STATUS "Selecting engine '${O3DE_MOST_COMPATIBLE_ENGINE_PATH}'")
+    # Make sure PACKAGE_VERSION_COMPATIBLE is set so Findo3de.cmake knows
+    # compatibility was checked
+    set(PACKAGE_VERSION_COMPATIBLE True)
+    set(PACKAGE_VERSION O3DE_MOST_COMPATIBLE_ENGINE_VERSION)
     list(APPEND CMAKE_MODULE_PATH "${O3DE_MOST_COMPATIBLE_ENGINE_PATH}/cmake")
     return()
 endif()

--- a/Templates/DefaultProject/Template/cmake/EngineFinder.cmake
+++ b/Templates/DefaultProject/Template/cmake/EngineFinder.cmake
@@ -139,6 +139,10 @@ endforeach()
 
 if(O3DE_MOST_COMPATIBLE_ENGINE_PATH)
     message(STATUS "Selecting engine '${O3DE_MOST_COMPATIBLE_ENGINE_PATH}'")
+    # Make sure PACKAGE_VERSION_COMPATIBLE is set so Findo3de.cmake knows
+    # compatibility was checked
+    set(PACKAGE_VERSION_COMPATIBLE True)
+    set(PACKAGE_VERSION O3DE_MOST_COMPATIBLE_ENGINE_VERSION)
     list(APPEND CMAKE_MODULE_PATH "${O3DE_MOST_COMPATIBLE_ENGINE_PATH}/cmake")
     return()
 endif()

--- a/Templates/MinimalProject/Template/cmake/EngineFinder.cmake
+++ b/Templates/MinimalProject/Template/cmake/EngineFinder.cmake
@@ -139,6 +139,10 @@ endforeach()
 
 if(O3DE_MOST_COMPATIBLE_ENGINE_PATH)
     message(STATUS "Selecting engine '${O3DE_MOST_COMPATIBLE_ENGINE_PATH}'")
+    # Make sure PACKAGE_VERSION_COMPATIBLE is set so Findo3de.cmake knows
+    # compatibility was checked
+    set(PACKAGE_VERSION_COMPATIBLE True)
+    set(PACKAGE_VERSION O3DE_MOST_COMPATIBLE_ENGINE_VERSION)
     list(APPEND CMAKE_MODULE_PATH "${O3DE_MOST_COMPATIBLE_ENGINE_PATH}/cmake")
     return()
 endif()


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where Findo3de.cmake would throw this error:
```
-- Selecting engine 'D:/git/o3de-stab-worktree'
CMake Error at C:/Program Files/CMake/share/cmake-3.23/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  This engine was not found to be compatible with your project, or no
  compatibility checks were done.  For more information, run the command
  again with '--log-level VERBOSE'.  (missing: PACKAGE_VERSION_COMPATIBLE)
```

Cmake finds and selects a compatible engine, but there is a case where PACKAGE_VERSION_COMPATIBLE isn't set - this happens when the last engine checked is incompatible.  This fix sets PACKAGE_VERSION_COMPATIBLE when a compatible engine is found.

## How was this PR tested?

Configured, built and ran AutomatedTesting from a build folder inside AutomatedTesting
```
cd d:\git\o3de\AutomatedTesting
cmake -B build/windows_vs2019 -G "Visual Studio 16" -DLY_3RDPARTY_PATH="d:/git/3rdparty"
```
