### PR TITLE
Split the `Parallel_Thread.Test` unit test into smaller UnitTest

### DIFF
--- a/Code/Framework/AzCore/Tests/AZStd/Parallel.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Parallel.cpp
@@ -20,16 +20,13 @@
 #include <AzCore/std/parallel/threadbus.h>
 
 #include <AzCore/std/parallel/thread.h>
-#include <AzCore/std/delegate/delegate.h>
 #include <AzCore/std/chrono/chrono.h>
 
 #include <AzCore/Memory/SystemAllocator.h>
 
 namespace UnitTest
 {
-
     using namespace AZStd;
-    using namespace AZStd::placeholders;
     using namespace UnitTestInternal;
 
     /**
@@ -44,10 +41,9 @@ namespace UnitTest
 
     TEST(Parallel, RecursiveMutex)
     {
-
         recursive_mutex m1;
         m1.lock();
-        AZ_TEST_ASSERT(m1.try_lock());  // we should be able to lock it from the same thread again...
+        EXPECT_TRUE(m1.try_lock());  // we should be able to lock it from the same thread again...
         m1.unlock();
         m1.unlock();
         {
@@ -155,8 +151,9 @@ namespace UnitTest
     class Parallel_Thread
         : public LeakDetectionFixture
     {
-        int m_data;
-        int m_dataMax;
+    protected:
+        int m_data{};
+        int m_dataMax{};
 
         static const int m_threadStackSize = 32 * 1024;
         thread_desc      m_desc[3];
@@ -175,152 +172,18 @@ namespace UnitTest
             this_thread::sleep_for(time);
         }
 
-        void do_nothing()
-        {}
-
-        void test_thread_id_for_default_constructed_thread_is_default_constructed_id()
-        {
-            AZStd::thread t;
-            AZ_TEST_ASSERT(t.get_id() == AZStd::thread::id());
-        }
-
-        void test_thread_id_for_running_thread_is_not_default_constructed_id()
-        {
-            const thread_desc desc = m_numThreadDesc ? m_desc[0] : thread_desc{};
-            AZStd::thread t(desc, AZStd::bind(&Parallel_Thread::do_nothing, this));
-            AZ_TEST_ASSERT(t.get_id() != AZStd::thread::id());
-            t.join();
-        }
-
-        void test_different_threads_have_different_ids()
-        {
-            const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
-            const thread_desc desc2 = m_numThreadDesc ? m_desc[1] : thread_desc{};
-            AZStd::thread t(desc1, AZStd::bind(&Parallel_Thread::do_nothing, this));
-            AZStd::thread t2(desc2, AZStd::bind(&Parallel_Thread::do_nothing, this));
-            AZ_TEST_ASSERT(t.get_id() != t2.get_id());
-            t.join();
-            t2.join();
-        }
-
-        void test_thread_ids_have_a_total_order()
-        {
-            const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
-            const thread_desc desc2 = m_numThreadDesc ? m_desc[1] : thread_desc{};
-            const thread_desc desc3 = m_numThreadDesc ? m_desc[2] : thread_desc{};
-
-            AZStd::thread t(desc1, AZStd::bind(&Parallel_Thread::do_nothing, this));
-            AZStd::thread t2(desc2, AZStd::bind(&Parallel_Thread::do_nothing, this));
-            AZStd::thread t3(desc3, AZStd::bind(&Parallel_Thread::do_nothing, this));
-            AZ_TEST_ASSERT(t.get_id() != t2.get_id());
-            AZ_TEST_ASSERT(t.get_id() != t3.get_id());
-            AZ_TEST_ASSERT(t2.get_id() != t3.get_id());
-
-            AZ_TEST_ASSERT((t.get_id() < t2.get_id()) != (t2.get_id() < t.get_id()));
-            AZ_TEST_ASSERT((t.get_id() < t3.get_id()) != (t3.get_id() < t.get_id()));
-            AZ_TEST_ASSERT((t2.get_id() < t3.get_id()) != (t3.get_id() < t2.get_id()));
-
-            AZ_TEST_ASSERT((t.get_id() > t2.get_id()) != (t2.get_id() > t.get_id()));
-            AZ_TEST_ASSERT((t.get_id() > t3.get_id()) != (t3.get_id() > t.get_id()));
-            AZ_TEST_ASSERT((t2.get_id() > t3.get_id()) != (t3.get_id() > t2.get_id()));
-
-            AZ_TEST_ASSERT((t.get_id() < t2.get_id()) == (t2.get_id() > t.get_id()));
-            AZ_TEST_ASSERT((t2.get_id() < t.get_id()) == (t.get_id() > t2.get_id()));
-            AZ_TEST_ASSERT((t.get_id() < t3.get_id()) == (t3.get_id() > t.get_id()));
-            AZ_TEST_ASSERT((t3.get_id() < t.get_id()) == (t.get_id() > t3.get_id()));
-            AZ_TEST_ASSERT((t2.get_id() < t3.get_id()) == (t3.get_id() > t2.get_id()));
-            AZ_TEST_ASSERT((t3.get_id() < t2.get_id()) == (t2.get_id() > t3.get_id()));
-
-            AZ_TEST_ASSERT((t.get_id() < t2.get_id()) == (t2.get_id() >= t.get_id()));
-            AZ_TEST_ASSERT((t2.get_id() < t.get_id()) == (t.get_id() >= t2.get_id()));
-            AZ_TEST_ASSERT((t.get_id() < t3.get_id()) == (t3.get_id() >= t.get_id()));
-            AZ_TEST_ASSERT((t3.get_id() < t.get_id()) == (t.get_id() >= t3.get_id()));
-            AZ_TEST_ASSERT((t2.get_id() < t3.get_id()) == (t3.get_id() >= t2.get_id()));
-            AZ_TEST_ASSERT((t3.get_id() < t2.get_id()) == (t2.get_id() >= t3.get_id()));
-
-            AZ_TEST_ASSERT((t.get_id() <= t2.get_id()) == (t2.get_id() > t.get_id()));
-            AZ_TEST_ASSERT((t2.get_id() <= t.get_id()) == (t.get_id() > t2.get_id()));
-            AZ_TEST_ASSERT((t.get_id() <= t3.get_id()) == (t3.get_id() > t.get_id()));
-            AZ_TEST_ASSERT((t3.get_id() <= t.get_id()) == (t.get_id() > t3.get_id()));
-            AZ_TEST_ASSERT((t2.get_id() <= t3.get_id()) == (t3.get_id() > t2.get_id()));
-            AZ_TEST_ASSERT((t3.get_id() <= t2.get_id()) == (t2.get_id() > t3.get_id()));
-
-            if ((t.get_id() < t2.get_id()) && (t2.get_id() < t3.get_id()))
-            {
-                AZ_TEST_ASSERT(t.get_id() < t3.get_id());
-            }
-            else if ((t.get_id() < t3.get_id()) && (t3.get_id() < t2.get_id()))
-            {
-                AZ_TEST_ASSERT(t.get_id() < t2.get_id());
-            }
-            else if ((t2.get_id() < t3.get_id()) && (t3.get_id() < t.get_id()))
-            {
-                AZ_TEST_ASSERT(t2.get_id() < t.get_id());
-            }
-            else if ((t2.get_id() < t.get_id()) && (t.get_id() < t3.get_id()))
-            {
-                AZ_TEST_ASSERT(t2.get_id() < t3.get_id());
-            }
-            else if ((t3.get_id() < t.get_id()) && (t.get_id() < t2.get_id()))
-            {
-                AZ_TEST_ASSERT(t3.get_id() < t2.get_id());
-            }
-            else if ((t3.get_id() < t2.get_id()) && (t2.get_id() < t.get_id()))
-            {
-                AZ_TEST_ASSERT(t3.get_id() < t.get_id());
-            }
-            else
-            {
-                AZ_TEST_ASSERT(false);
-            }
-
-            AZStd::thread::id default_id;
-
-            AZ_TEST_ASSERT(default_id < t.get_id());
-            AZ_TEST_ASSERT(default_id < t2.get_id());
-            AZ_TEST_ASSERT(default_id < t3.get_id());
-
-            AZ_TEST_ASSERT(default_id <= t.get_id());
-            AZ_TEST_ASSERT(default_id <= t2.get_id());
-            AZ_TEST_ASSERT(default_id <= t3.get_id());
-
-            AZ_TEST_ASSERT(!(default_id > t.get_id()));
-            AZ_TEST_ASSERT(!(default_id > t2.get_id()));
-            AZ_TEST_ASSERT(!(default_id > t3.get_id()));
-
-            AZ_TEST_ASSERT(!(default_id >= t.get_id()));
-            AZ_TEST_ASSERT(!(default_id >= t2.get_id()));
-            AZ_TEST_ASSERT(!(default_id >= t3.get_id()));
-
-            t.join();
-            t2.join();
-            t3.join();
-        }
-
         void get_thread_id(AZStd::thread::id* id)
         {
             *id = this_thread::get_id();
-        }
-
-        void test_thread_id_of_running_thread_returned_by_this_thread_get_id()
-        {
-            const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
-
-            AZStd::thread::id id;
-            AZStd::thread t(desc1, AZStd::bind(&Parallel_Thread::get_thread_id, this, &id));
-            AZStd::thread::id t_id = t.get_id();
-            t.join();
-            AZ_TEST_ASSERT(id == t_id);
         }
 
 
         class MfTest
         {
         public:
-            mutable unsigned int m_hash;
+            mutable unsigned int m_hash{};
 
-            MfTest()
-                : m_hash(0) {}
+            MfTest() = default;
 
             int f0() { f1(17); return 0; }
             int g0() const { g1(17); return 0; }
@@ -355,52 +218,11 @@ namespace UnitTest
             *my_id = this_thread::get_id();
         }
 
-        void test_move_on_construction()
-        {
-            const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
-            AZStd::thread::id the_id;
-            AZStd::thread x;
-            x = AZStd::thread(desc1, AZStd::bind(&Parallel_Thread::do_nothing_id, this, &the_id));
-            AZStd::thread::id x_id = x.get_id();
-            x.join();
-            AZ_TEST_ASSERT(the_id == x_id);
-        }
-
         AZStd::thread make_thread(AZStd::thread::id* the_id)
         {
             const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
-            return AZStd::thread(desc1, AZStd::bind(&Parallel_Thread::do_nothing_id, this, the_id));
+            return AZStd::thread(desc1, [this](AZStd::thread::id* threadId) { do_nothing_id(threadId); }, the_id);
         }
-
-        void test_move_from_function_return()
-        {
-            AZStd::thread::id the_id;
-            AZStd::thread x;
-            x = make_thread(&the_id);
-            AZStd::thread::id x_id = x.get_id();
-            x.join();
-            AZ_TEST_ASSERT(the_id == x_id);
-        }
-
-        /*void test_move_from_function_return_lvalue()
-        {
-            thread::id the_id;
-            thread x=make_thread_return_lvalue(&the_id);
-            thread::id x_id=x.get_id();
-            x.join();
-            AZ_TEST_ASSERT(the_id==x_id);
-        }
-
-        void test_move_assign()
-        {
-            thread::id the_id;
-            thread x(do_nothing_id,&the_id);
-            thread y;
-            y=AZStd::move(x);
-            thread::id y_id=y.get_id();
-            y.join();
-            AZ_TEST_ASSERT(the_id==y_id);
-        }*/
 
         void simple_thread()
         {
@@ -411,41 +233,12 @@ namespace UnitTest
         {
             AZStd::thread::id const my_id = this_thread::get_id();
 
-            AZ_TEST_ASSERT(my_id != parent);
+            EXPECT_NE(parent, my_id);
             AZStd::thread::id const my_id2 = this_thread::get_id();
-            AZ_TEST_ASSERT(my_id == my_id2);
+            EXPECT_EQ(my_id2, my_id);
 
             AZStd::thread::id const no_thread_id = AZStd::thread::id();
-            AZ_TEST_ASSERT(my_id != no_thread_id);
-        }
-
-        void do_test_creation()
-        {
-            const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
-            m_data = 0;
-            AZStd::thread t(desc1, AZStd::bind(&Parallel_Thread::simple_thread, this));
-            t.join();
-            AZ_TEST_ASSERT(m_data == 999);
-        }
-
-        void test_creation()
-        {
-            //timed_test(&do_test_creation, 1);
-            do_test_creation();
-        }
-
-        void do_test_id_comparison()
-        {
-            const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
-            AZStd::thread::id self = this_thread::get_id();
-            AZStd::thread thrd(desc1, AZStd::bind(&Parallel_Thread::comparison_thread, this, self));
-            thrd.join();
-        }
-
-        void test_id_comparison()
-        {
-            //timed_test(&do_test_id_comparison, 1);
-            do_test_id_comparison();
+            EXPECT_NE(no_thread_id, my_id);
         }
 
         struct non_copyable_functor
@@ -464,182 +257,337 @@ namespace UnitTest
             non_copyable_functor(const non_copyable_functor&);
             non_copyable_functor& operator=(const non_copyable_functor&);
         };
-
-        void do_test_creation_through_reference_wrapper()
-        {
-            const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
-            non_copyable_functor f;
-
-            AZStd::thread thrd(desc1, AZStd::ref(f));
-            thrd.join();
-            AZ_TEST_ASSERT(f.value == 999);
-        }
-
-        void test_creation_through_reference_wrapper()
-        {
-            do_test_creation_through_reference_wrapper();
-        }
-
-        void test_swap()
-        {
-            const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
-            const thread_desc desc2 = m_numThreadDesc ? m_desc[1] : thread_desc{};
-            AZStd::thread t(desc1, AZStd::bind(&Parallel_Thread::simple_thread, this));
-            AZStd::thread t2(desc2, AZStd::bind(&Parallel_Thread::simple_thread, this));
-            AZStd::thread::id id1 = t.get_id();
-            AZStd::thread::id id2 = t2.get_id();
-
-            t.swap(t2);
-            AZ_TEST_ASSERT(t.get_id() == id2);
-            AZ_TEST_ASSERT(t2.get_id() == id1);
-
-            swap(t, t2);
-            AZ_TEST_ASSERT(t.get_id() == id1);
-            AZ_TEST_ASSERT(t2.get_id() == id2);
-
-            t.detach();
-            t2.detach();
-        }
-
-        void run()
-        {
-            const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
-
-            // We need to have at least one processor
-            AZ_TEST_ASSERT(AZStd::thread::hardware_concurrency() >= 1);
-
-            // Create thread to increment data till we need to
-            m_data = 0;
-            m_dataMax = 10;
-            AZStd::thread tr(desc1, AZStd::bind(&Parallel_Thread::increment_data, this));
-            tr.join();
-            AZ_TEST_ASSERT(m_data == m_dataMax);
-
-            m_data = 0;
-            AZStd::thread trDel(desc1, make_delegate(this, &Parallel_Thread::increment_data));
-            trDel.join();
-            AZ_TEST_ASSERT(m_data == m_dataMax);
-
-            chrono::steady_clock::time_point startTime = chrono::steady_clock::now();
-            {
-                AZStd::thread tr1(desc1, AZStd::bind(&Parallel_Thread::sleep_thread, this, chrono::milliseconds(100)));
-                tr1.join();
-            }
-            auto sleepTime = chrono::steady_clock::now() - startTime;
-            //printf("\nSleeptime: %d Ms\n",(unsigned int)  ());
-            // On Windows we use Sleep. Sleep is dependent on MM timers.
-            // 99000 can be used only if we support 1 ms resolution timeGetDevCaps() and we set it timeBeginPeriod(1) timeEndPeriod(1)
-            // We will need to drag mmsystem.h and we don't really need to test the OS jus our math.
-            AZ_TEST_ASSERT(sleepTime.count() >= /*99000*/ 50000);
-
-            //////////////////////////////////////////////////////////////////////////
-            test_creation();
-            test_id_comparison();
-            test_creation_through_reference_wrapper();
-            test_swap();
-            //////////////////////////////////////////////////////////////////////////
-
-            //////////////////////////////////////////////////////////////////////////
-            // Thread id
-            test_thread_id_for_default_constructed_thread_is_default_constructed_id();
-            test_thread_id_for_running_thread_is_not_default_constructed_id();
-            test_different_threads_have_different_ids();
-            test_thread_ids_have_a_total_order();
-            test_thread_id_of_running_thread_returned_by_this_thread_get_id();
-            //////////////////////////////////////////////////////////////////////////
-
-            //////////////////////////////////////////////////////////////////////////
-            // Member function tests
-            // 0
-            {
-                MfTest x;
-                AZStd::function<void ()> func = AZStd::bind(&MfTest::f0, &x);
-                AZStd::thread(desc1, func).join();
-                func = AZStd::bind(&MfTest::f0, AZStd::ref(x));
-                AZStd::thread(desc1, func).join();
-                func = AZStd::bind(&MfTest::g0, &x);
-                AZStd::thread(desc1, func).join();
-                func = AZStd::bind(&MfTest::g0, x);
-                AZStd::thread(desc1, func).join();
-                func = AZStd::bind(&MfTest::g0, AZStd::ref(x));
-                AZStd::thread(desc1, func).join();
-
-                //// 1
-                //thread( AZStd::bind(desc1, &MfTest::f1, &x, 1)).join();
-                //thread( AZStd::bind(desc1, &MfTest::f1, AZStd::ref(x), 1)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g1, &x, 1)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g1, x, 1)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g1, AZStd::ref(x), 1)).join();
-
-                //// 2
-                //thread( AZStd::bind(desc1, &MfTest::f2, &x, 1, 2)).join();
-                //thread( AZStd::bind(desc1, &MfTest::f2, AZStd::ref(x), 1, 2)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g2, &x, 1, 2)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g2, x, 1, 2)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g2, AZStd::ref(x), 1, 2)).join();
-
-                //// 3
-                //thread( AZStd::bind(desc1, &MfTest::f3, &x, 1, 2, 3)).join();
-                //thread( AZStd::bind(desc1, &MfTest::f3, AZStd::ref(x), 1, 2, 3)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g3, &x, 1, 2, 3)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g3, x, 1, 2, 3)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g3, AZStd::ref(x), 1, 2, 3)).join();
-
-                //// 4
-                //thread( AZStd::bind(desc1, &MfTest::f4, &x, 1, 2, 3, 4)).join();
-                //thread( AZStd::bind(desc1, &MfTest::f4, AZStd::ref(x), 1, 2, 3, 4)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g4, &x, 1, 2, 3, 4)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g4, x, 1, 2, 3, 4)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g4, AZStd::ref(x), 1, 2, 3, 4)).join();
-
-                //// 5
-                //thread( AZStd::bind(desc1, &MfTest::f5, &x, 1, 2, 3, 4, 5)).join();
-                //thread( AZStd::bind(desc1, &MfTest::f5, AZStd::ref(x), 1, 2, 3, 4, 5)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g5, &x, 1, 2, 3, 4, 5)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g5, x, 1, 2, 3, 4, 5)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g5, AZStd::ref(x), 1, 2, 3, 4, 5)).join();
-
-                //// 6
-                //thread( AZStd::bind(desc1, &MfTest::f6, &x, 1, 2, 3, 4, 5, 6)).join();
-                //thread( AZStd::bind(desc1, &MfTest::f6, AZStd::ref(x), 1, 2, 3, 4, 5, 6)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g6, &x, 1, 2, 3, 4, 5, 6)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g6, x, 1, 2, 3, 4, 5, 6)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g6, AZStd::ref(x), 1, 2, 3, 4, 5, 6)).join();
-
-                //// 7
-                //thread( AZStd::bind(desc1, &MfTest::f7, &x, 1, 2, 3, 4, 5, 6, 7)).join();
-                //thread( AZStd::bind(desc1, &MfTest::f7, AZStd::ref(x), 1, 2, 3, 4, 5, 6, 7)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g7, &x, 1, 2, 3, 4, 5, 6, 7)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g7, x, 1, 2, 3, 4, 5, 6, 7)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g7, AZStd::ref(x), 1, 2, 3, 4, 5, 6, 7)).join();
-
-                //// 8
-                //thread( AZStd::bind(desc1, &MfTest::f8, &x, 1, 2, 3, 4, 5, 6, 7, 8)).join();
-                //thread( AZStd::bind(desc1, &MfTest::f8, AZStd::ref(x), 1, 2, 3, 4, 5, 6, 7, 8)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g8, &x, 1, 2, 3, 4, 5, 6, 7, 8)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g8, x, 1, 2, 3, 4, 5, 6, 7, 8)).join();
-                //thread( AZStd::bind(desc1, &MfTest::g8, AZStd::ref(x), 1, 2, 3, 4, 5, 6, 7, 8)).join();
-
-                AZ_TEST_ASSERT(x.m_hash == 1366);
-            }
-            //////////////////////////////////////////////////////////////////////////
-
-            //////////////////////////////////////////////////////////////////////////
-            // Move
-            test_move_on_construction();
-
-            test_move_from_function_return();
-            //////////////////////////////////////////////////////////////////////////
-        }
     };
 
 #if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
-    TEST_F(Parallel_Thread, DISABLED_Test)
+    TEST_F(Parallel_Thread, DISABLED_ThreadSanityTest)
 #else
-    TEST_F(Parallel_Thread, Test)
+    TEST_F(Parallel_Thread, ThreadSanityTest)
 #endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
     {
-        run();
+        const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
+
+        // We need to have at least one processor
+        EXPECT_GE(AZStd::thread::hardware_concurrency(), 1);
+
+        // Create thread to increment data till we need to
+        m_data = 0;
+        m_dataMax = 10;
+        AZStd::thread tr(
+            desc1,
+            [this]()
+            {
+                increment_data();
+            });
+        tr.join();
+        EXPECT_EQ(m_dataMax, m_data);
+
+        chrono::steady_clock::time_point startTime = chrono::steady_clock::now();
+        {
+            AZStd::thread tr1(desc1, [this](AZStd::chrono::milliseconds waitTime) { sleep_thread(waitTime); },
+                chrono::milliseconds(100));
+            tr1.join();
+        }
+        auto sleepTime = chrono::steady_clock::now() - startTime;
+        // printf("\nSleeptime: %d Ms\n",(unsigned int)  ());
+        //  On Windows use Sleep. Sleep is dependent on MM timers.
+        //  99000 can be used only if the OS supports 1 ms resolution timeGetDevCaps() and it is set to timeBeginPeriod(1) timeEndPeriod(1)
+        EXPECT_GE(sleepTime.count(), 50000);
+    }
+
+#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    TEST_F(Parallel_Thread, DISABLED_ThreadCreation_Succeeds)
+#else
+    TEST_F(Parallel_Thread, ThreadCreation_Succeeds)
+#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    {
+        const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
+        m_data = 0;
+        AZStd::thread t(
+            desc1,
+            [this]()
+            {
+                simple_thread();
+            });
+        t.join();
+        EXPECT_EQ(999, m_data);
+    }
+
+#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    TEST_F(Parallel_Thread, DISABLED_ThreadCreationThroughRefWrapper_Succeeds)
+#else
+    TEST_F(Parallel_Thread, ThreadCreationThroughRefWrapper_Succeeds)
+#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    {
+        const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
+        non_copyable_functor f;
+
+        AZStd::thread thrd(desc1, AZStd::ref(f));
+        thrd.join();
+        EXPECT_EQ(999, f.value);
+    }
+
+#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    TEST_F(Parallel_Thread, DISABLED_ThreadCreation_Succeeds)
+#else
+    TEST_F(Parallel_Thread, ThreadIdIsComparable_Succeeds)
+#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    {
+        const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
+        m_data = 0;
+        AZStd::thread t(
+            desc1,
+            [this]()
+            {
+                this->simple_thread();
+            });
+        t.join();
+        EXPECT_EQ(999, m_data);
+    }
+
+#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    TEST_F(Parallel_Thread, DISABLED_TestSwapThread_Succeeds)
+#else
+    TEST_F(Parallel_Thread, TestSwapThread_Succeeds)
+#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    {
+        const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
+        const thread_desc desc2 = m_numThreadDesc ? m_desc[1] : thread_desc{};
+        AZStd::thread t(desc1, [this]() { simple_thread(); });
+        AZStd::thread t2(desc2, [this]() { simple_thread(); });
+        AZStd::thread::id id1 = t.get_id();
+        AZStd::thread::id id2 = t2.get_id();
+
+        t.swap(t2);
+        EXPECT_EQ(id2, t.get_id());
+        EXPECT_EQ(id1, t2.get_id());
+
+        swap(t, t2);
+        EXPECT_EQ(id1, t.get_id());
+        EXPECT_EQ(id2, t2.get_id());
+
+        t.join();
+        t2.join();
+    }
+
+#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    TEST_F(Parallel_Thread, DISABLED_ThreadIdIsDefaultConstructForThread_Succeeds)
+#else
+    TEST_F(Parallel_Thread, ThreadIdIsDefaultConstructForThread_Succeeds)
+#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    {
+        AZStd::thread t;
+        EXPECT_EQ(AZStd::thread::id(), t.get_id());
+    }
+
+#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    TEST_F(Parallel_Thread, DISABLED_ThreadIdForCurrentThread_IsNotDefaultConstructed_Succeeds)
+#else
+    TEST_F(Parallel_Thread, ThreadIdForCurrentThread_IsNottDefaultConstructed_Succeeds)
+#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    {
+        const thread_desc desc = m_numThreadDesc ? m_desc[0] : thread_desc{};
+        AZStd::thread t(desc, [](){});
+        EXPECT_NE(AZStd::thread::id(), t.get_id());
+        t.join();
+    }
+
+#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    TEST_F(Parallel_Thread, DISABLED_DifferentThreadsHaveDifferentThreadIds_Succeeds)
+#else
+    TEST_F(Parallel_Thread, DifferentThreadsHaveDifferentThreadIds_Succeeds)
+#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    {
+        const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
+        const thread_desc desc2 = m_numThreadDesc ? m_desc[1] : thread_desc{};
+        AZStd::thread t(desc1, [](){});
+        AZStd::thread t2(desc2, [](){});
+        EXPECT_NE(t.get_id(), t2.get_id());
+        t.join();
+        t2.join();
+    }
+
+#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    TEST_F(Parallel_Thread, DISABLED_ThreadIdsAreTotallyOrdered_Succeeds)
+#else
+    TEST_F(Parallel_Thread, ThreadIdsAreTotallyOrdered_Succeeds)
+#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    {
+        const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
+        const thread_desc desc2 = m_numThreadDesc ? m_desc[1] : thread_desc{};
+        const thread_desc desc3 = m_numThreadDesc ? m_desc[2] : thread_desc{};
+
+        AZStd::thread t(desc1, [](){});
+        AZStd::thread t2(desc2, [](){});
+        AZStd::thread t3(desc3, [](){});
+        EXPECT_NE(t2.get_id(), t.get_id());
+        EXPECT_NE(t3.get_id(), t.get_id());
+        EXPECT_NE(t3.get_id(), t2.get_id());
+
+        EXPECT_NE((t2.get_id() < t.get_id()), (t.get_id() < t2.get_id()));
+        EXPECT_NE((t3.get_id() < t.get_id()), (t.get_id() < t3.get_id()));
+        EXPECT_NE((t3.get_id() < t2.get_id()), (t2.get_id() < t3.get_id()));
+
+        EXPECT_NE((t2.get_id() > t.get_id()), (t.get_id() > t2.get_id()));
+        EXPECT_NE((t3.get_id() > t.get_id()), (t.get_id() > t3.get_id()));
+        EXPECT_NE((t3.get_id() > t2.get_id()), (t2.get_id() > t3.get_id()));
+
+        EXPECT_EQ((t2.get_id() > t.get_id()), (t.get_id() < t2.get_id()));
+        EXPECT_EQ((t.get_id() > t2.get_id()), (t2.get_id() < t.get_id()));
+        EXPECT_EQ((t3.get_id() > t.get_id()), (t.get_id() < t3.get_id()));
+        EXPECT_EQ((t.get_id() > t3.get_id()), (t3.get_id() < t.get_id()));
+        EXPECT_EQ((t3.get_id() > t2.get_id()), (t2.get_id() < t3.get_id()));
+        EXPECT_EQ((t2.get_id() > t3.get_id()), (t3.get_id() < t2.get_id()));
+
+        EXPECT_EQ((t2.get_id() >= t.get_id()), (t.get_id() < t2.get_id()));
+        EXPECT_EQ((t.get_id() >= t2.get_id()), (t2.get_id() < t.get_id()));
+        EXPECT_EQ((t3.get_id() >= t.get_id()), (t.get_id() < t3.get_id()));
+        EXPECT_EQ((t.get_id() >= t3.get_id()), (t3.get_id() < t.get_id()));
+        EXPECT_EQ((t3.get_id() >= t2.get_id()), (t2.get_id() < t3.get_id()));
+        EXPECT_EQ((t2.get_id() >= t3.get_id()), (t3.get_id() < t2.get_id()));
+
+        EXPECT_EQ((t2.get_id() > t.get_id()), (t.get_id() <= t2.get_id()));
+        EXPECT_EQ((t.get_id() > t2.get_id()), (t2.get_id() <= t.get_id()));
+        EXPECT_EQ((t3.get_id() > t.get_id()), (t.get_id() <= t3.get_id()));
+        EXPECT_EQ((t.get_id() > t3.get_id()), (t3.get_id() <= t.get_id()));
+        EXPECT_EQ((t3.get_id() > t2.get_id()), (t2.get_id() <= t3.get_id()));
+        EXPECT_EQ((t2.get_id() > t3.get_id()), (t3.get_id() <= t2.get_id()));
+
+        if ((t.get_id() < t2.get_id()) && (t2.get_id() < t3.get_id()))
+        {
+            EXPECT_LT(t.get_id(), t3.get_id());
+        }
+        else if ((t.get_id() < t3.get_id()) && (t3.get_id() < t2.get_id()))
+        {
+            EXPECT_LT(t.get_id(), t2.get_id());
+        }
+        else if ((t2.get_id() < t3.get_id()) && (t3.get_id() < t.get_id()))
+        {
+            EXPECT_LT(t2.get_id(), t.get_id());
+        }
+        else if ((t2.get_id() < t.get_id()) && (t.get_id() < t3.get_id()))
+        {
+            EXPECT_LT(t2.get_id(), t3.get_id());
+        }
+        else if ((t3.get_id() < t.get_id()) && (t.get_id() < t2.get_id()))
+        {
+            EXPECT_LT(t3.get_id(), t2.get_id());
+        }
+        else if ((t3.get_id() < t2.get_id()) && (t2.get_id() < t.get_id()))
+        {
+            EXPECT_LT(t3.get_id(), t.get_id());
+        }
+        else
+        {
+            GTEST_FAIL();
+        }
+
+        AZStd::thread::id default_id;
+
+        EXPECT_LT(default_id, t.get_id());
+        EXPECT_LT(default_id, t2.get_id());
+        EXPECT_LT(default_id, t3.get_id());
+
+        EXPECT_LE(default_id, t.get_id());
+        EXPECT_LE(default_id, t2.get_id());
+        EXPECT_LE(default_id, t3.get_id());
+
+        EXPECT_FALSE(default_id > t.get_id());
+        EXPECT_FALSE(default_id > t2.get_id());
+        EXPECT_FALSE(default_id > t3.get_id());
+
+        EXPECT_FALSE(default_id >= t.get_id());
+        EXPECT_FALSE(default_id >= t2.get_id());
+        EXPECT_FALSE(default_id >= t3.get_id());
+
+        t.join();
+        t2.join();
+        t3.join();
+    }
+
+#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    TEST_F(Parallel_Thread, DISABLED_ThreadIdOfCurrentThreadReturnedByThisThreadId_Succeeds)
+#else
+    TEST_F(Parallel_Thread, ThreadIdOfCurrentThreadReturnedByThisThreadId_Succeeds)
+#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    {
+        const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
+
+        AZStd::thread::id id;
+        AZStd::thread t(desc1, [this, &id]() { get_thread_id(&id); });
+        AZStd::thread::id t_id = t.get_id();
+        t.join();
+        EXPECT_EQ(t_id, id);
+    }
+
+#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    TEST_F(Parallel_Thread, DISABLED_ThreadInvokesMemberFunction_Succeeds)
+#else
+    TEST_F(Parallel_Thread, ThreadInvokesMemberFunction_Succeeds)
+#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    {
+        const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
+        MfTest x;
+        AZStd::function<void()> func = [xPtr = &x]()
+        {
+            xPtr->f0();
+        };
+        AZStd::thread(desc1, func).join();
+
+        func = [&x]
+        {
+            x.f0();
+        };
+        AZStd::thread(desc1, func).join();
+
+        func = [xPtr = &x]
+        {
+            xPtr->g0();
+        };
+        AZStd::thread(desc1, func).join();
+
+        func = [x]
+        {
+            x.g0();
+        };
+        AZStd::thread(desc1, func).join();
+
+        func = [&x]
+        {
+            x.g0();
+        };
+        AZStd::thread(desc1, func).join();
+
+        EXPECT_EQ(1366, x.m_hash);
+    }
+
+#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    TEST_F(Parallel_Thread, DISABLED_ThreadCanBeMovedAssigned_Succeeds)
+#else
+    TEST_F(Parallel_Thread, ThreadCanBeMovedAssigned_Succeeds)
+#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    {
+        const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
+        AZStd::thread::id the_id;
+        AZStd::thread x;
+        x = AZStd::thread(desc1, [this, &the_id]() { do_nothing_id(&the_id); });
+        AZStd::thread::id x_id = x.get_id();
+        x.join();
+        EXPECT_EQ(x_id, the_id);
+    }
+
+#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    TEST_F(Parallel_Thread, DISABLED_ThreadMoveConstructorIsInvokedOnReturn_Succeeds)
+#else
+    TEST_F(Parallel_Thread, ThreadMoveConstructorIsInvokedOnReturn_Succeeds)
+#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
+    {
+        AZStd::thread::id the_id;
+        AZStd::thread x;
+        x = make_thread(&the_id);
+        AZStd::thread::id x_id = x.get_id();
+        x.join();
+        EXPECT_EQ(x_id, the_id);
     }
 
     TEST_F(Parallel_Thread, Hashable)
@@ -685,7 +633,7 @@ namespace UnitTest
             {
                 combinable<TestStruct> c;
                 TestStruct& s = c.local();
-                AZ_TEST_ASSERT(s.m_x == 42);
+                EXPECT_EQ(42, s.m_x);
             }
 
             //detect first initialization
@@ -693,21 +641,21 @@ namespace UnitTest
                 combinable<int> c;
                 bool exists;
                 int& v1 = c.local(exists);
-                AZ_TEST_ASSERT(!exists);
+                EXPECT_FALSE(exists);
                 v1 = 42;
 
                 int& v2 = c.local(exists);
-                AZ_TEST_ASSERT(exists);
-                AZ_TEST_ASSERT(v2 == 42);
+                EXPECT_TRUE(exists);
+                EXPECT_EQ(42, v2);
 
                 int& v3 = c.local();
-                AZ_TEST_ASSERT(v3 == 42);
+                EXPECT_EQ(42, v3);
             }
 
             //custom initializer
             {
                 combinable<int> c(&Initializer);
-                AZ_TEST_ASSERT(c.local() == 43);
+                EXPECT_EQ(43, c.local());
             }
 
             //clear
@@ -715,14 +663,14 @@ namespace UnitTest
                 combinable<int> c(&Initializer);
                 bool exists;
                 int& v1 = c.local(exists);
-                AZ_TEST_ASSERT(v1 == 43);
-                AZ_TEST_ASSERT(!exists);
+                EXPECT_EQ(43, v1);
+                EXPECT_FALSE(exists);
                 v1 = 44;
 
                 c.clear();
                 int& v2 = c.local(exists);
-                AZ_TEST_ASSERT(v2 == 43);
-                AZ_TEST_ASSERT(!exists);
+                EXPECT_EQ(43, v2);
+                EXPECT_FALSE(exists);
             }
 
             //copy constructor and assignment
@@ -732,10 +680,10 @@ namespace UnitTest
                 v = 45;
 
                 combinable<int> c3(c1);
-                AZ_TEST_ASSERT(c3.local() == 45);
+                EXPECT_EQ(45, c3.local());
 
                 c2 = c1;
-                AZ_TEST_ASSERT(c2.local() == 45);
+                EXPECT_EQ(45, c2.local());
             }
 
             //combine
@@ -743,10 +691,10 @@ namespace UnitTest
                 combinable<int> c(&Initializer);
 
                 //default value when no other values
-                AZ_TEST_ASSERT(c.combine(plus<int>()) == 43);
+                EXPECT_EQ(43, c.combine(plus<int>()));
 
                 c.local() = 50;
-                AZ_TEST_ASSERT(c.combine(plus<int>()) == 50);
+                EXPECT_EQ(50, c.combine(plus<int>()));
             }
 
             //combine_each
@@ -754,30 +702,30 @@ namespace UnitTest
                 combinable<int> c(&Initializer);
 
                 m_numCombinerCalls = 0;
-                c.combine_each(bind(&Parallel_Combinable::MyCombiner, this, _1));
-                AZ_TEST_ASSERT(m_numCombinerCalls == 0);
+                c.combine_each([this](int value) { MyCombiner(value); });
+                EXPECT_EQ(0, m_numCombinerCalls);
 
                 m_numCombinerCalls = 0;
                 m_combinerTotal = 0;
                 c.local() = 50;
-                c.combine_each(bind(&Parallel_Combinable::MyCombiner, this, _1));
-                AZ_TEST_ASSERT(m_numCombinerCalls == 1);
-                AZ_TEST_ASSERT(m_combinerTotal == 50);
+                c.combine_each([this](int value) { MyCombiner(value); });
+                EXPECT_EQ(1, m_numCombinerCalls);
+                EXPECT_EQ(50, m_combinerTotal);
             }
 
             //multithread test
             {
                 AZStd::thread_desc desc;
                 desc.m_name = "Test Thread 1";
-                AZStd::thread t1(bind(&Parallel_Combinable::MyThreadFunc, this, 0, 10), &desc);
+                AZStd::thread t1(desc, [this](int start, int end) { MyThreadFunc(start, end); }, 0, 10);
                 desc.m_name = "Test Thread 2";
-                AZStd::thread t2(bind(&Parallel_Combinable::MyThreadFunc, this, 10, 20), &desc);
+                AZStd::thread t2(desc, [this](int start, int end) { MyThreadFunc(start, end); }, 10, 20);
                 desc.m_name = "Test Thread 3";
-                AZStd::thread t3(bind(&Parallel_Combinable::MyThreadFunc, this, 20, 500), &desc);
+                AZStd::thread t3(desc, [this](int start, int end) { MyThreadFunc(start, end); }, 20, 500);
                 desc.m_name = "Test Thread 4";
-                AZStd::thread t4(bind(&Parallel_Combinable::MyThreadFunc, this, 500, 510), &desc);
+                AZStd::thread t4(desc, [this](int start, int end) { MyThreadFunc(start, end); }, 500, 510);
                 desc.m_name = "Test Thread 5";
-                AZStd::thread t5(bind(&Parallel_Combinable::MyThreadFunc, this, 510, 2001), &desc);
+                AZStd::thread t5(desc, [this](int start, int end) { MyThreadFunc(start, end); }, 510, 2001);
 
                 t1.join();
                 t2.join();
@@ -787,11 +735,11 @@ namespace UnitTest
 
                 m_numCombinerCalls = 0;
                 m_combinerTotal = 0;
-                m_threadCombinable.combine_each(bind(&Parallel_Combinable::MyCombiner, this, _1));
-                AZ_TEST_ASSERT(m_numCombinerCalls == 5);
-                AZ_TEST_ASSERT(m_combinerTotal == 2001000);
+                m_threadCombinable.combine_each([this](int value) { MyCombiner(value); });
+                EXPECT_EQ(5, m_numCombinerCalls);
+                EXPECT_EQ(2001000, m_combinerTotal);
 
-                AZ_TEST_ASSERT(m_threadCombinable.combine(plus<int>()) == 2001000);
+                EXPECT_EQ(2001000, m_threadCombinable.combine(plus<int>()));
 
                 m_threadCombinable.clear();
             }
@@ -926,17 +874,17 @@ namespace UnitTest
 
                 AZStd::thread_desc desc;
                 desc.m_name = "Test Reader 1";
-                AZStd::thread t1(bind(&Parallel_SharedMutex::Reader, this, 0), &desc);
+                AZStd::thread t1(desc, [this](int index){ Reader(index); }, 0);
                 desc.m_name = "Test Reader 2";
-                AZStd::thread t2(bind(&Parallel_SharedMutex::Reader, this, 1), &desc);
+                AZStd::thread t2(desc, [this](int index){ Reader(index); }, 1);
                 desc.m_name = "Test Reader 3";
-                AZStd::thread t3(bind(&Parallel_SharedMutex::Reader, this, 2), &desc);
+                AZStd::thread t3(desc, [this](int index){ Reader(index); }, 2);
                 desc.m_name = "Test Reader 4";
-                AZStd::thread t4(bind(&Parallel_SharedMutex::Reader, this, 3), &desc);
+                AZStd::thread t4(desc, [this](int index){ Reader(index); }, 3);
                 desc.m_name = "Test Writer 1";
-                AZStd::thread t5(bind(&Parallel_SharedMutex::Writer, this), &desc);
+                AZStd::thread t5(desc, [this](){ Writer(); });
                 desc.m_name = "Test Writer 2";
-                AZStd::thread t6(bind(&Parallel_SharedMutex::Writer, this), &desc);
+                AZStd::thread t6(desc, [this](){ Writer(); });
 
                 t1.join();
                 t2.join();


### PR DESCRIPTION
This is being done to better debug failures in the future that occurs on Linux

Fixed the AZStd::thread creation calls to properly supply the thread descriptor argument as the first argument to `AZStd::thread`

Fixed intermittent memory leak in Parallel thread unit test due to the thread swap unit test detaching the thread and not joining.

This created a race condition where a thread can still be running at the end of the Parallel_Thread.Test when the memory leak 
checker is checking for existing allocations.

Most of the changes involve spliting up the singular`run()` function into discrete methods that test more fine grained pieces of the `AZStd::thread` API

fixes #14536



## How was this PR tested?

Ran all `Parallel_Thread.*` test 1000 times successfully on Windows and Linux
![image](https://user-images.githubusercontent.com/56135373/225478469-afa46bc7-ed8e-4141-afa0-61ab333e1cab.png)
![image](https://user-images.githubusercontent.com/56135373/225686540-f13474cf-1e74-400b-8064-37424b1a1f49.png)
