### PR TITLE
Fix to avoid physics material asset handler to be registered twice when running Asset Processor

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/Material/PhysicsMaterialSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Material/PhysicsMaterialSystemComponent.cpp
@@ -27,7 +27,6 @@ namespace Physics
         {
             serialize->Class<Physics::MaterialSystemComponent, AZ::Component>()
                 ->Version(1)
-                ->Attribute(AZ::Edit::Attributes::SystemComponentTags, AZStd::vector<AZ::Crc32>({ AZ_CRC_CE("AssetBuilder") }))
                 ;
         }
     }

--- a/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.cpp
@@ -62,13 +62,13 @@ namespace PhysX
     void EditorSystemComponent::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         required.push_back(AZ_CRC_CE("PhysicsService"));
-        required.push_back(AZ_CRC_CE("PhysicsMaterialService"));
     }
 
     void EditorSystemComponent::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)
     {
         dependent.push_back(AZ_CRC_CE("AssetDatabaseService"));
         dependent.push_back(AZ_CRC_CE("AssetCatalogService"));
+        dependent.push_back(AZ_CRC_CE("PhysicsMaterialService"));
     }
 
     void EditorSystemComponent::Activate()

--- a/Gems/PhysX/Code/Source/SystemComponent.cpp
+++ b/Gems/PhysX/Code/Source/SystemComponent.cpp
@@ -127,13 +127,13 @@ namespace PhysX
 
     void SystemComponent::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
     {
-        required.push_back(AZ_CRC_CE("PhysicsMaterialService"));
     }
 
     void SystemComponent::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)
     {
         dependent.push_back(AZ_CRC_CE("AssetDatabaseService"));
         dependent.push_back(AZ_CRC_CE("AssetCatalogService"));
+        dependent.push_back(AZ_CRC_CE("PhysicsMaterialService"));
     }
 
     SystemComponent::SystemComponent()


### PR DESCRIPTION
## What does this PR do?

Fixes #10825

`Physics::MaterialSystemComponent`, which is the system that registers the physics material asset handler, is already activated since it's part of `Application::GetRequiredSystemComponents()`, so it doesn't need to be tagged as `AssetBuilder`, which was causing to be activated again in the asset processor.

## How was this PR tested?

Run PhysX unit tests
Debugged Asset Builder and checked physics material asset handler is only registered once.
Run Asset Processor and checked the error doesn't appear anymore.
Rebuild all assets in AutomatedTesting and checked physics material assets are correctly generated.
Run Editor and tested different physics materials in a level.
Run Launcher and checked the level using different physics materials work.
