### PR TITLE
Add operation name in undo/redo console log

### DIFF
--- a/Code/Editor/Undo/Undo.cpp
+++ b/Code/Editor/Undo/Undo.cpp
@@ -324,6 +324,13 @@ void CUndoManager::Redo(int numSteps)
             m_bRedoing = true;
             CUndoStep* redo = m_redoStack.back();
             redo->Redo();
+
+            GetIEditor()->GetLogFile()->FormatLine(
+                "(Undo: %d, Redo: %d) - Redo last operation: '%s'",
+                m_undoStack.size(),
+                m_redoStack.size(),
+                redo->GetName().toUtf8().constData());
+
             m_redoStack.pop_back();
             // Push undo object to redo stack.
             m_undoStack.push_back(redo);
@@ -335,7 +342,6 @@ void CUndoManager::Redo(int numSteps)
     {
         GetIEditor()->UpdateViews(eUpdateObjects);
     }
-    GetIEditor()->GetLogFile()->FormatLine("Redo (Undo:%d,Redo:%d)", m_undoStack.size(), m_redoStack.size());
     GetIEditor()->GetObjectManager()->InvalidateVisibleList();
 
     m_bRedoing = true;
@@ -379,6 +385,13 @@ void CUndoManager::Undo(int numSteps)
             m_bUndoing = true;
             CUndoStep* undo = m_undoStack.back();
             undo->Undo(true);
+
+            GetIEditor()->GetLogFile()->FormatLine(
+                "(Undo: %d, Redo: %d) - Undo last operation: '%s'",
+                m_undoStack.size(),
+                m_redoStack.size(),
+                undo->GetName().toUtf8().constData());
+
             m_undoStack.pop_back();
             // Push undo object to redo stack.
             m_redoStack.push_back(undo);
@@ -391,7 +404,6 @@ void CUndoManager::Undo(int numSteps)
     {
         GetIEditor()->UpdateViews(eUpdateObjects);
     }
-    GetIEditor()->GetLogFile()->FormatLine("Undo (Undo:%d,Redo:%d)", m_undoStack.size(), m_redoStack.size());
     GetIEditor()->GetObjectManager()->InvalidateVisibleList();
 
     m_bUndoing = true;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityActionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityActionComponent.cpp
@@ -326,7 +326,7 @@ namespace AzToolsFramework
 
         void EditorEntityActionComponent::EnableComponents(const AZStd::vector<AZ::Component*>& components)
         {
-            ScopedUndoBatch undoBatch("Enabling components.");
+            ScopedUndoBatch undoBatch("Enable Component(s)");
 
             // Enable all the components requested
             for (auto component : components)
@@ -383,7 +383,7 @@ namespace AzToolsFramework
 
         void EditorEntityActionComponent::DisableComponents(const AZStd::vector<AZ::Component*>& components)
         {
-            ScopedUndoBatch undoBatch("Disabling components.");
+            ScopedUndoBatch undoBatch("Disable Component(s)");
 
             // Disable all the components requested
             for (auto component : components)
@@ -442,7 +442,7 @@ namespace AzToolsFramework
         {
             EntityToRemoveComponentsResultMap resultMap;
             {
-                ScopedUndoBatch undoBatch("Removing components.");
+                ScopedUndoBatch undoBatch("Remove Component(s)");
 
                 // Only remove, do not delete components until we know it was successful
                 AZStd::vector<AZ::Component*> removedComponents;
@@ -580,7 +580,7 @@ namespace AzToolsFramework
                 componentsToAddClassData.push_back(componentClassData);
             }
 
-            ScopedUndoBatch undo("Adding components to entity");
+            ScopedUndoBatch undo("Add Component(s) to Entity");
             EntityToAddedComponentsMap entityToAddedComponentsMap;
             {
                 for (auto& entityId : entityIds)
@@ -644,7 +644,7 @@ namespace AzToolsFramework
                 return AZ::Failure(AZStd::string("Null entity provided to AddExistingComponentsToEntity"));
             }
 
-            ScopedUndoBatch undo("Add existing components to entity");
+            ScopedUndoBatch undo("Add Existing Component(s) to Entity");
 
             AddComponentsResults addComponentsResults;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/BaseManipulator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/BaseManipulator.cpp
@@ -39,7 +39,7 @@ namespace AzToolsFramework
         {
             BeginAction();
             ToolsApplicationRequests::Bus::BroadcastResult(
-                m_undoBatch, &ToolsApplicationRequests::Bus::Events::BeginUndoBatch, "ManipulatorLeftMouseDown");
+                m_undoBatch, &ToolsApplicationRequests::Bus::Events::BeginUndoBatch, "Manipulator Left Mouse Down");
 
             for (const AZ::EntityComponentIdPair& entityComponentId : m_entityComponentIdPairs)
             {
@@ -65,7 +65,7 @@ namespace AzToolsFramework
         {
             BeginAction();
             ToolsApplicationRequests::Bus::BroadcastResult(
-                m_undoBatch, &ToolsApplicationRequests::Bus::Events::BeginUndoBatch, "ManipulatorRightMouseDown");
+                m_undoBatch, &ToolsApplicationRequests::Bus::Events::BeginUndoBatch, "Manipulator Right Mouse Down");
 
             for (const AZ::EntityComponentIdPair& entityComponentId : m_entityComponentIdPairs)
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
@@ -983,13 +983,13 @@ namespace AzToolsFramework
             return false;
         }
 
-        ScopedUndoBatch undo("Reparent Entities");
+        ScopedUndoBatch undo("Reparent Entity(s)");
         // The new parent is dirty due to sort change(s)
         undo.MarkEntityDirty(GetEntityIdForSortInfo(newParentId));
 
         EntityIdList processedEntityIds;
         {
-            ScopedUndoBatch undo2("Reparent Entities");
+            ScopedUndoBatch undo2("Reparent Entity(s)");
 
             for (AZ::EntityId entityId : selectedEntityIds)
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -2315,7 +2315,7 @@ namespace AzToolsFramework
 
             if (entityList.size())
             {
-                ScopedUndoBatch undoBatch("ModifyEntityName");
+                ScopedUndoBatch undoBatch("Modify Entity Name");
 
                 for (AZ::Entity* entity : entityList)
                 {
@@ -3709,7 +3709,7 @@ namespace AzToolsFramework
             // Need to queue an update for all inspectors in case multiples are viewing the same entity and the removal of a component internally triggers an invalidate call
             AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(&AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_EntireTree);
 
-            ScopedUndoBatch undoBatch("Removing components.");
+            ScopedUndoBatch undoBatch("Remove Component(s)");
 
             AzToolsFramework::RemoveComponents(components);
         }
@@ -3728,7 +3728,7 @@ namespace AzToolsFramework
             QueuePropertyRefresh();
 
             //intentionally not using EntityCompositionRequests::CutComponents because we only want to copy components from first selected entity
-            ScopedUndoBatch undoBatch("Cut components.");
+            ScopedUndoBatch undoBatch("Cut Component(s)");
             CopyComponents();
             DeleteComponents();
         }
@@ -3747,7 +3747,7 @@ namespace AzToolsFramework
     {
         if (!m_selectedEntityIds.empty() && CanPasteComponentsOnSelectedEntities())
         {
-            ScopedUndoBatch undoBatch("Paste components.");
+            ScopedUndoBatch undoBatch("Paste Component(s)");
 
             AZ::Entity::ComponentArrayType selectedComponents = GetSelectedComponents();
 
@@ -3825,7 +3825,7 @@ namespace AzToolsFramework
             return;
         }
 
-        ScopedUndoBatch undoBatch("Move components up.");
+        ScopedUndoBatch undoBatch("Move Component(s) Up");
 
         ComponentEditorVector componentEditors = m_componentEditors;
         for (size_t sourceComponentEditorIndex = 1; sourceComponentEditorIndex < componentEditors.size(); ++sourceComponentEditorIndex)
@@ -3853,7 +3853,7 @@ namespace AzToolsFramework
             return;
         }
 
-        ScopedUndoBatch undoBatch("Move components down.");
+        ScopedUndoBatch undoBatch("Move Component(s) Down");
 
         ComponentEditorVector componentEditors = m_componentEditors;
         for (size_t targetComponentEditorIndex = componentEditors.size() - 1; targetComponentEditorIndex > 0; --targetComponentEditorIndex)
@@ -3881,7 +3881,7 @@ namespace AzToolsFramework
             return;
         }
 
-        ScopedUndoBatch undoBatch("Move components to top.");
+        ScopedUndoBatch undoBatch("Move Component(s) to Top");
 
         AZ::Entity::ComponentArrayType componentsOnEntity;
 
@@ -3923,7 +3923,7 @@ namespace AzToolsFramework
             return;
         }
 
-        ScopedUndoBatch undoBatch("Move components to bottom.");
+        ScopedUndoBatch undoBatch("Move Component(s) to Bottom");
 
         AZ::Entity::ComponentArrayType componentsOnEntity;
 


### PR DESCRIPTION
## What does this PR do?

This PR adds the operation names in undo/redo logs in console.

Before:
<img height=100 src="https://user-images.githubusercontent.com/11157226/225700713-5b32a641-96bc-42de-b7db-a4fa9804f1a9.png">

After:
<img height=250 src="https://user-images.githubusercontent.com/11157226/225700728-60f1d7f4-eca1-4f07-9f95-5d3e2fc27159.png">


## How was this PR tested?

Tested in editor
