### PR TITLE
Action Manager | Fixes to Entity Outliner context menu items

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.h
@@ -90,6 +90,7 @@ namespace AzToolsFramework
             void OnWidgetActionRegistrationHook() override;
             void OnMenuBindingHook() override;
             void OnToolBarBindingHook() override;
+            void OnPostActionManagerRegistrationHook() override;
 
         private:
             // PrefabPublicNotificationBus overrides ...


### PR DESCRIPTION
## What does this PR do?
Introduces a few fixes to menu items in the Entity Outliner context menu:

- The `Delete` context menu no longer appears when right-clicking on the container entity for the currently focused prefab instance.
![image](https://user-images.githubusercontent.com/82231674/225735781-b4331de3-b9c8-424d-867e-0f77d9dea974.png)
-  The 'Duplicate' context menu no longer appears when right-clicking on the container entity for the currently focused prefab instance, and on entities owned by instances that are descendants of the current focus.
![image](https://user-images.githubusercontent.com/82231674/225736087-c698cc75-1849-432b-8513-fb5313e10976.png)
- The 'Instantiate Prefab...` and `Instantiate Procedural Prefab...` menu items no longer appear when right-clicking on entities owned by instances that are descendants of the current focus.

Note that in all of these cases, the menu items would just do nothing in those situations since additional checks were included in the triggered functions that filtered out invalid cases.

## How was this PR tested?

Manual testing.