### PR TITLE
white box material fix

### DIFF
--- a/Gems/WhiteBox/Assets/materials/WhiteBoxDefault.material
+++ b/Gems/WhiteBox/Assets/materials/WhiteBoxDefault.material
@@ -1,0 +1,5 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "parentMaterial": "@gemroot:Atom_Feature_Common@/Assets/Materials/Presets/PBR/default_grid.material"
+}

--- a/Gems/WhiteBox/Assets/materials/checker_material.mtl
+++ b/Gems/WhiteBox/Assets/materials/checker_material.mtl
@@ -1,8 +1,0 @@
-<Material MtlFlags="524288" DccMaterialHash="0" Shader="Illum" GenMask="200A00000000003" StringGenMask="%ALLOW_SILHOUETTE_POM%ALLOW_SPECULAR_ANTIALIASING%NORMAL_MAP%SPECULAR_MAP%SUBSURFACE_SCATTERING" SurfaceType="mat_default" Diffuse="1,1,1,1" Specular="0.043735031,0.043735031,0.043735031,0.58823532" Opacity="1" Shininess="150" vertModifType="0" LayerAct="1">
- <Textures>
-  <Texture Map="Diffuse" File="textures/default/_dev_Middle_Gray_Checker.dds"/>
-  <Texture Map="Specular" File="textures/default/_dev_Middle_Gray_Checker_spec.dds"/>
-  <Texture Map="Bumpmap" File="textures/default/_dev_Middle_Gray_Checker_ddn.dds"/>
- </Textures>
- <PublicParams EmittanceMapGamma="1" SSSIndex="0" IndirectColor="0.25,0.25,0.25"/>
-</Material>

--- a/Gems/WhiteBox/Assets/materials/default_material.mtl
+++ b/Gems/WhiteBox/Assets/materials/default_material.mtl
@@ -1,8 +1,0 @@
-<Material MtlFlags="524288" DccMaterialHash="0" Shader="Illum" GenMask="200A00000000003" StringGenMask="%ALLOW_SILHOUETTE_POM%ALLOW_SPECULAR_ANTIALIASING%NORMAL_MAP%SPECULAR_MAP%SUBSURFACE_SCATTERING" SurfaceType="mat_default" Diffuse="1,1,1,1" Specular="0.043735031,0.043735031,0.043735031,0.58823532" Opacity="1" Shininess="150" vertModifType="0" LayerAct="1">
- <Textures>
-  <Texture Map="Diffuse" File="textures/default/_dev_Middle_Gray_Checker.dds"/>
-  <Texture Map="Specular" File="textures/default/_dev_Middle_Gray_Checker_spec.dds"/>
-  <Texture Map="Bumpmap" File="textures/default/_dev_Middle_Gray_Checker_ddn.dds"/>
- </Textures>
- <PublicParams EmittanceMapGamma="1" SSSIndex="0" IndirectColor="0.25,0.25,0.25"/>
-</Material>

--- a/Gems/WhiteBox/Assets/materials/solid_material.mtl
+++ b/Gems/WhiteBox/Assets/materials/solid_material.mtl
@@ -1,6 +1,0 @@
-<Material MtlFlags="524288" DccMaterialHash="0" Shader="Illum" GenMask="800000000003" StringGenMask="%ALLOW_SILHOUETTE_POM%ALLOW_SPECULAR_ANTIALIASING%SUBSURFACE_SCATTERING" SurfaceType="mat_default" Diffuse="1,1,1,1" Specular="0.043735031,0.043735031,0.043735031,1" Opacity="1" Shininess="150" vertModifType="0" LayerAct="1">
- <Textures>
-  <Texture Map="Diffuse" File="textures/default/_dev_solid_fill.dds"/>
- </Textures>
- <PublicParams EmittanceMapGamma="1" SSSIndex="0" IndirectColor="0.25,0.25,0.25"/>
-</Material>

--- a/Gems/WhiteBox/Assets/seedList.seed
+++ b/Gems/WhiteBox/Assets/seedList.seed
@@ -1,0 +1,13 @@
+<ObjectStream version="3">
+	<Class name="AZStd::vector" type="{82FC5264-88D0-57CD-9307-FC52E4DAD550}">
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{69FE164E-0656-5AEE-9CE7-B954A44A519F}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="255" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="materials/whiteboxdefault.azmaterial" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+	</Class>
+</ObjectStream>
+

--- a/Gems/WhiteBox/Assets/textures/default/_dev_Middle_Gray_Checker.tif
+++ b/Gems/WhiteBox/Assets/textures/default/_dev_Middle_Gray_Checker.tif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57d6744696768f9fb8a5fe5fee9aa36fee1eb87a9dbc1e60d4a35ed3c39d68e6
-size 810620

--- a/Gems/WhiteBox/Assets/textures/default/_dev_Middle_Gray_Checker_ddn.tif
+++ b/Gems/WhiteBox/Assets/textures/default/_dev_Middle_Gray_Checker_ddn.tif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1b56097f0df01da7ed49311462002f5e1a61b8496306c7ab3b12e17c27afb28a
-size 793918

--- a/Gems/WhiteBox/Assets/textures/default/_dev_Middle_Gray_Checker_spec.tif
+++ b/Gems/WhiteBox/Assets/textures/default/_dev_Middle_Gray_Checker_spec.tif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ba52ff6d59f50b4b5dea6e266572c9e7feb92d5fd85bd0738e0d07d42d234bf7
-size 810996

--- a/Gems/WhiteBox/Assets/textures/default/_dev_Solid_Fill.tif
+++ b/Gems/WhiteBox/Assets/textures/default/_dev_Solid_Fill.tif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e7ab4ef3a6c9f6ee4eb7e36848feced650ad226e5a43e87612772b3ebc26a5f
-size 994552

--- a/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxAtomRenderMesh.h
+++ b/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxAtomRenderMesh.h
@@ -106,8 +106,7 @@ namespace WhiteBox
         bool m_visible = true;
 
         //! Default white box mesh material.
-        static constexpr AZStd::string_view TexturedMaterialPath = "materials/defaultpbr.azmaterial";
-        static constexpr AZStd::string_view SolidMaterialPath = "materials/defaultpbr.azmaterial";
+        static constexpr AZStd::string_view TexturedMaterialPath = "materials/whiteboxdefault.azmaterial";
         static constexpr AZ::RPI::ModelMaterialSlot::StableId OneMaterialSlotId = 0;
 
         //! White box model name.


### PR DESCRIPTION
## What does this PR do?
This fix the issue https://github.com/o3de/o3de/issues/15116

The changes include:
- Added missing material used for whitebox.
- Renamed the material from DefaultPBR.material to WhiteBoxDefault.material.
- Deleted some unused mtl files (old ly material files) and unused texture files.
- Added a seed file to include the white box material asset.

## How was this PR tested?

Cleaned cache and tested in Editor with AutomatedTesting project.
