### PR TITLE
Updating graph model reflection and unbinding function causing AP asserts

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialCanvas_Atom_BasicTests.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialCanvas_Atom_BasicTests.py
@@ -152,7 +152,7 @@ def MaterialCanvas_BasicFunctionalityChecks_AllChecksPass():
         world_position_node = material_canvas_utils.create_node_by_name(material_graph, "World Position")
         Report.result(
             Tests.world_position_node_created,
-            world_position_node.typename == "AZStd::shared_ptr<Node const>")
+            world_position_node.typename == "AZStd::shared_ptr<Node>")
 
         # 10. Add the world_position_node to the material_graph.
         # This test will be verified when the nodes are connected as if it doesn't exist the connection won't be made.
@@ -162,7 +162,7 @@ def MaterialCanvas_BasicFunctionalityChecks_AllChecksPass():
         standard_pbr_node = material_canvas_utils.create_node_by_name(material_graph, "Standard PBR")
         Report.result(
             Tests.standard_pbr_node_created,
-            standard_pbr_node.typename == "AZStd::shared_ptr<Node const>")
+            standard_pbr_node.typename == "AZStd::shared_ptr<Node>")
 
         # 12. Add the standard_pbr_node to the material_graph.
         # This test will be verified when the nodes are connected as if it doesn't exist the connection won't be made.

--- a/Gems/GraphModel/Code/Include/GraphModel/Model/Common.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Model/Common.h
@@ -29,12 +29,11 @@ namespace GraphModel
     using Endpoint = AZStd::pair<NodeId, SlotId>;
 
     class DataType;
-    using DataTypePtr = AZStd::shared_ptr<const DataType>; //!< All pointers are const since this data is immutable anyway
+    using DataTypePtr = AZStd::shared_ptr<DataType>;
     using DataTypeList = AZStd::vector<DataTypePtr>;
 
     class GraphContext;
     using GraphContextPtr = AZStd::shared_ptr<GraphContext>;
-    using ConstGraphContextPtr = AZStd::shared_ptr<const GraphContext>;
 
     class Graph;
     using GraphPtr = AZStd::shared_ptr<Graph>;

--- a/Gems/GraphModel/Code/Include/GraphModel/Model/GraphContext.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Model/GraphContext.h
@@ -14,6 +14,7 @@
 #include <AzCore/std/string/string.h>
 
 // GraphModel
+#include <GraphModel/Model/Common.h>
 #include <GraphModel/Model/DataType.h>
 
 namespace GraphModel
@@ -29,8 +30,6 @@ namespace GraphModel
         AZ_CLASS_ALLOCATOR(GraphContext, AZ::SystemAllocator);
         AZ_RTTI(GraphContext, "{4CD3C171-A7AA-4B62-96BB-F09F398A73E7}");
         static void Reflect(AZ::ReflectContext* context);
-
-        using DataTypeList = AZStd::vector<DataTypePtr>;
 
         GraphContext() = default;
         GraphContext(const AZStd::string& systemName, const AZStd::string& moduleExtension, const DataTypeList& dataTypes);
@@ -78,7 +77,7 @@ namespace GraphModel
         AZStd::string m_systemName;
         AZStd::string m_moduleExtension;
         DataTypeList m_dataTypes;
-        GraphModel::ModuleGraphManagerPtr m_moduleGraphManager;
+        ModuleGraphManagerPtr m_moduleGraphManager;
     };
 
 } // namespace GraphModel

--- a/Gems/GraphModel/Code/Source/GraphModelSystemComponent.cpp
+++ b/Gems/GraphModel/Code/Source/GraphModelSystemComponent.cpp
@@ -33,22 +33,32 @@ namespace GraphModel
     void GraphModelSystemComponent::Reflect(AZ::ReflectContext* context)
     {
         // Reflect core graph classes
-        GraphModel::Graph::Reflect(context);
-        GraphModel::DataType::Reflect(context);
+        DataType::Reflect(context);
+        GraphContext::Reflect(context);
+        GraphElement::Reflect(context);
+        SlotId::Reflect(context);
+        Slot::Reflect(context);
+        Node::Reflect(context);
+        Connection::Reflect(context);
+        Graph::Reflect(context);
+
+        // Reflect module node data types
+        BaseInputOutputNode::Reflect(context);
+        GraphInputNode::Reflect(context);
+        GraphOutputNode::Reflect(context);
+        ModuleNode::Reflect(context);
+
+        // Reflect data types for integrating graph model with graph canvas
         GraphModelIntegration::GraphCanvasMetadata::Reflect(context);
 
-        // Mime Events for Graph Canvas nodes
+        // Reflect MIME events for graph canvas nodes
         GraphModelIntegration::CreateGraphCanvasNodeMimeEvent::Reflect(context);
         GraphModelIntegration::CreateNodeGroupNodeMimeEvent::Reflect(context);
         GraphModelIntegration::CreateCommentNodeMimeEvent::Reflect(context);
 
-        // Reflect all the nodes needed to support ModuleNode
-        GraphModel::BaseInputOutputNode::Reflect(context);
-        GraphModel::GraphInputNode::Reflect(context);
-        GraphModel::GraphOutputNode::Reflect(context);
-        GraphModel::ModuleNode::Reflect(context);
-        GraphModelIntegration::CreateInputOutputNodeMimeEvent<GraphModel::GraphInputNode>::Reflect(context);
-        GraphModelIntegration::CreateInputOutputNodeMimeEvent<GraphModel::GraphOutputNode>::Reflect(context);
+        // Reflect MIME events for module node
+        GraphModelIntegration::CreateInputOutputNodeMimeEvent<GraphInputNode>::Reflect(context);
+        GraphModelIntegration::CreateInputOutputNodeMimeEvent<GraphOutputNode>::Reflect(context);
         GraphModelIntegration::CreateModuleNodeMimeEvent::Reflect(context);
 
         if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))
@@ -57,8 +67,8 @@ namespace GraphModel
                 ->Version(0)
                 ;
 
-            serialize->RegisterGenericType<GraphModel::NodePtrList>();
-            serialize->RegisterGenericType<GraphModel::SlotPtrList>();
+            serialize->RegisterGenericType<NodePtrList>();
+            serialize->RegisterGenericType<SlotPtrList>();
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {

--- a/Gems/GraphModel/Code/Source/GraphModelSystemComponent.cpp
+++ b/Gems/GraphModel/Code/Source/GraphModelSystemComponent.cpp
@@ -61,18 +61,15 @@ namespace GraphModel
         GraphModelIntegration::CreateInputOutputNodeMimeEvent<GraphOutputNode>::Reflect(context);
         GraphModelIntegration::CreateModuleNodeMimeEvent::Reflect(context);
 
-        if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<GraphModelSystemComponent, AZ::Component>()
+            serializeContext->Class<GraphModelSystemComponent, AZ::Component>()
                 ->Version(0)
                 ;
 
-            serialize->RegisterGenericType<NodePtrList>();
-            serialize->RegisterGenericType<SlotPtrList>();
-
-            if (AZ::EditContext* ec = serialize->GetEditContext())
+            if (auto editContext = serializeContext->GetEditContext())
             {
-                ec->Class<GraphModelSystemComponent>("GraphModel", "A generic node graph data model")
+                editContext->Class<GraphModelSystemComponent>("GraphModel", "A generic node graph data model")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;

--- a/Gems/GraphModel/Code/Source/Model/Connection.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Connection.cpp
@@ -49,6 +49,8 @@ namespace GraphModel
                 ->Field("m_sourceEndpoint", &Connection::m_sourceEndpoint)
                 ->Field("m_targetEndpoint", &Connection::m_targetEndpoint)
                 ;
+
+            serializeContext->RegisterGenericType<ConnectionPtr>();
         }
 
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))

--- a/Gems/GraphModel/Code/Source/Model/DataType.cpp
+++ b/Gems/GraphModel/Code/Source/Model/DataType.cpp
@@ -27,6 +27,9 @@ namespace GraphModel
                 ->Field("m_cppName", &DataType::m_cppName)
                 ->Field("m_displayName", &DataType::m_displayName)
                 ;
+
+            serializeContext->RegisterGenericType<DataTypePtr>();
+            serializeContext->RegisterGenericType<DataTypeList>();
         }
 
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))

--- a/Gems/GraphModel/Code/Source/Model/Graph.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Graph.cpp
@@ -24,13 +24,6 @@ namespace GraphModel
 
     void Graph::Reflect(AZ::ReflectContext* context)
     {
-        GraphContext::Reflect(context);
-        GraphElement::Reflect(context);
-        Node::Reflect(context);
-        SlotId::Reflect(context);
-        Slot::Reflect(context);
-        Connection::Reflect(context);
-
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<Graph>()

--- a/Gems/GraphModel/Code/Source/Model/GraphContext.cpp
+++ b/Gems/GraphModel/Code/Source/Model/GraphContext.cpp
@@ -26,6 +26,8 @@ namespace GraphModel
             serializeContext->Class<GraphContext>()
                 ->Version(0)
                 ;
+
+            serializeContext->RegisterGenericType<GraphContextPtr>();
         }
 
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
@@ -36,7 +38,7 @@ namespace GraphModel
                 ->Attribute(AZ::Script::Attributes::Module, "editor.graph")
                 ->Method("GetSystemName", &GraphContext::GetSystemName)
                 ->Method("GetModuleFileExtension", &GraphContext::GetModuleFileExtension)
-                ->Method("GetAllDataTypes", &GraphContext::GetAllDataTypes)
+                //->Method("GetAllDataTypes", &GraphContext::GetAllDataTypes) // GHI-15121 Unbinding until asserts with AP behavior context reflection are resolved
                 ->Method("GetDataTypeByEnum", static_cast<DataTypePtr (GraphContext::*)(DataType::Enum) const>(&GraphContext::GetDataType))
                 ->Method("GetDataTypeByName", static_cast<DataTypePtr (GraphContext::*)(const AZStd::string&) const>(&GraphContext::GetDataType))
                 ->Method("GetDataTypeByUuid", static_cast<DataTypePtr (GraphContext::*)(const AZ::Uuid&) const>(&GraphContext::GetDataType))
@@ -75,7 +77,7 @@ namespace GraphModel
         return m_moduleGraphManager;
     }
 
-    const AZStd::vector<DataTypePtr>& GraphContext::GetAllDataTypes() const
+    const DataTypeList& GraphContext::GetAllDataTypes() const
     {
         return m_dataTypes;
     }

--- a/Gems/GraphModel/Code/Source/Model/GraphElement.cpp
+++ b/Gems/GraphModel/Code/Source/Model/GraphElement.cpp
@@ -24,6 +24,8 @@ namespace GraphModel
             serializeContext->Class<GraphElement>()
                 ->Version(0)
                 ;
+
+            serializeContext->RegisterGenericType<GraphElementPtr>();
         }
 
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))

--- a/Gems/GraphModel/Code/Source/Model/Node.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Node.cpp
@@ -36,6 +36,9 @@ namespace GraphModel
                 ->Field("m_inputDataSlots", &Node::m_inputDataSlots)
                 ->Field("m_extendableSlots", &Node::m_extendableSlots)
                 ;
+
+            serializeContext->RegisterGenericType<NodePtr>();
+            serializeContext->RegisterGenericType<NodePtrList>();
         }
 
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))

--- a/Gems/GraphModel/Code/Source/Model/Slot.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Slot.cpp
@@ -261,6 +261,9 @@ namespace GraphModel
                 ->Field("m_value", &Slot::m_value)
                 ->Field("m_subId", &Slot::m_subId)
                 ;
+
+            serializeContext->RegisterGenericType<SlotPtr>();
+            serializeContext->RegisterGenericType<SlotPtrList>();
         }
 
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))


### PR DESCRIPTION
## What does this PR do?

This change reorders reflection calls and removes a behavior context binding for a graph model graph controller function that was causing asserts in the AP.

Resolves https://github.com/o3de/o3de/issues/15121

## How was this PR tested?

Confirmed that asserts no longer appear in the AP log after changes.