### PR TITLE
Fix for Baked DiffuseProbeGrids on non-RT capable devices

### DIFF
--- a/Gems/DiffuseProbeGrid/Assets/Passes/DiffuseProbeGridPreparePassRequest.azasset
+++ b/Gems/DiffuseProbeGrid/Assets/Passes/DiffuseProbeGridPreparePassRequest.azasset
@@ -1,0 +1,10 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassRequest",
+    "ClassData": {
+        "Name": "DiffuseProbeGridPreparePass",
+        "TemplateName": "DiffuseProbeGridPreparePassTemplate",
+        "Enabled": true
+    }
+}

--- a/Gems/DiffuseProbeGrid/Assets/Passes/DiffuseProbeGridUpdate.pass
+++ b/Gems/DiffuseProbeGrid/Assets/Passes/DiffuseProbeGridUpdate.pass
@@ -8,10 +8,6 @@
             "PassClass": "ParentPass",
             "PassRequests": [
                 {
-                    "Name": "DiffuseProbeGridPreparePass",
-                    "TemplateName": "DiffuseProbeGridPreparePassTemplate"
-                },
-                {
                     "Name": "DiffuseProbeGridRayTracingPass",
                     "TemplateName": "DiffuseProbeGridRayTracingPassTemplate"
                 },

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
@@ -797,7 +797,8 @@ namespace AZ
 
             if (!diffuseProbeGridUpdatePass)
             {
-                AddPassRequest(renderPipeline, "Passes/DiffuseProbeGridUpdatePassRequest.azasset", "DepthPrePass");
+                AddPassRequest(renderPipeline, "Passes/DiffuseProbeGridPreparePassRequest.azasset", "DepthPrePass");
+                AddPassRequest(renderPipeline, "Passes/DiffuseProbeGridUpdatePassRequest.azasset", "DiffuseProbeGridPreparePass");
                 AddPassRequest(renderPipeline, "Passes/DiffuseProbeGridRenderPassRequest.azasset", "ForwardSubsurface");
 
                 // add the fullscreen query pass for SSR raytracing fallback color


### PR DESCRIPTION
Moved the DiffuseProbeGridPreparePass out of the DiffuseProbeGridUpdatePass since it is needed for the DiffuseProbeGridRenderPass on non-RT capable devices.

Tested AtomSampleViewer DX12/Vulkan
Tested Editor DX12/Vulkan
