### PR TITLE
Fix build linux/android in release

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/editor/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/TestSuite_Main.py
@@ -32,6 +32,7 @@ class TestAutomationNoAutoTestMode(EditorTestSuite):
     class test_BasicEditorWorkflows_ExistingLevel_EntityComponentCRUD(EditorBatchedTest):
         from .EditorScripts import BasicEditorWorkflows_ExistingLevel_EntityComponentCRUD as test_module
 
+    @pytest.mark.xfail(reason="https://github.com/o3de/o3de/issues/15172")
     class test_BasicEditorWorkflows_LevelEntityComponentCRUD(EditorSingleTest):
 
         # Custom setup and teardown to remove level created during test

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraph.h
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraph.h
@@ -90,7 +90,7 @@ namespace AZ
         AZStd::binary_semaphore m_semaphore;
         AZStd::atomic_int       m_waitCount = 0;
         TaskExecutor*           m_executor = nullptr;
-        const char* m_label;
+        [[maybe_unused]] const char* m_label;
     };
 
     // The TaskGraph encapsulates a set of tasks and their interdependencies. After adding

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraph.h
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraph.h
@@ -90,7 +90,7 @@ namespace AZ
         AZStd::binary_semaphore m_semaphore;
         AZStd::atomic_int       m_waitCount = 0;
         TaskExecutor*           m_executor = nullptr;
-        [[maybe_unused]] const char* m_label;
+        [[maybe_unused]] const char* m_label = nullptr;
     };
 
     // The TaskGraph encapsulates a set of tasks and their interdependencies. After adding

--- a/Gems/RemoteTools/Code/Source/RemoteToolsSystemComponent.cpp
+++ b/Gems/RemoteTools/Code/Source/RemoteToolsSystemComponent.cpp
@@ -563,15 +563,6 @@ namespace RemoteTools
             m_joinThread->Join();
             m_joinThread->Start();
         }
-
-        // Check if there are any active connections, if not stop the outbox thread
-        bool hasActiveConnection = false;
-        for (auto registryIt = m_entryRegistry.begin(); registryIt != m_entryRegistry.end(); ++registryIt)
-        {
-            hasActiveConnection =
-                AZ::Interface<AzNetworking::INetworking>::Get()->RetrieveNetworkInterface(registryIt->second.m_name) != nullptr;
-        }
-
     }
 
 } // namespace RemoteTools


### PR DESCRIPTION
## What does this PR do?

Fixes Linux and android on release configurations. `TaskGraphEvent::m_label` is only used inside `AZ_Assert` statements, so it was warning as not used in release, causing build to fail.

Marking as well `test_BasicEditorWorkflows_LevelEntityComponentCRUD` as xfail since it's regularly failing affecting the speed to submit bug fixes to stabilization branch. (#15172)

Fixed also the following error introduced in #15112 (tagging @galibzon)
````
/data/workspace/o3de/Gems/RemoteTools/Code/Source/RemoteToolsSystemComponent.cpp:568:14: error: variable 'hasActiveConnection' set but not used [-Werror,-Wunused-but-set-variable]
        bool hasActiveConnection = false;
              ^
````

## How was this PR tested?

Built Linux and android on release successfully.

Signed-off-by: moraaar <moraaar@amazon.com>