### PR TITLE
Action Manager | Prevent entity deletion while in Entity Picker mode

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -21,6 +21,7 @@
 #include <AzToolsFramework/ActionManager/Action/ActionManagerInterface.h>
 #include <AzToolsFramework/ActionManager/Menu/MenuManagerInterface.h>
 #include <AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h>
+#include <AzToolsFramework/API/ViewportEditorModeTrackerInterface.h>
 #include <AzToolsFramework/Commands/EntityManipulatorCommand.h>
 #include <AzToolsFramework/Commands/SelectionCommand.h>
 #include <AzToolsFramework/ComponentMode/ComponentModeSwitcher.h>
@@ -2651,6 +2652,17 @@ namespace AzToolsFramework
                 {
                     AZ_PROFILE_FUNCTION(AzToolsFramework);
 
+                    // Don't allow users to delete entities while in Entity Picker mode.
+                    if (auto viewportEditorModeTracker = AZ::Interface<AzToolsFramework::ViewportEditorModeTrackerInterface>::Get())
+                    {
+                        auto viewportEditorModes =
+                            viewportEditorModeTracker->GetViewportEditorModes({ AzToolsFramework::GetEntityContextId() });
+                        if (viewportEditorModes->IsModeActive(AzToolsFramework::ViewportEditorMode::Pick))
+                        {
+                            return;
+                        }
+                    }
+
                     ScopedUndoBatch undoBatch(DeleteUndoRedoDesc);
 
                     CreateEntityManipulatorDeselectCommand(undoBatch);
@@ -2667,6 +2679,17 @@ namespace AzToolsFramework
                 actionIdentifier,
                 []() -> bool
                 {
+                    // Disable this action in Entity Picker mode.
+                    if (auto viewportEditorModeTracker = AZ::Interface<AzToolsFramework::ViewportEditorModeTrackerInterface>::Get())
+                    {
+                        auto viewportEditorModes =
+                            viewportEditorModeTracker->GetViewportEditorModes({ AzToolsFramework::GetEntityContextId() });
+                        if (viewportEditorModes->IsModeActive(AzToolsFramework::ViewportEditorMode::Pick))
+                        {
+                            return false;
+                        }
+                    }
+
                     auto readOnlyEntityPublicInterface = AZ::Interface<AzToolsFramework::ReadOnlyEntityPublicInterface>::Get();
                     if (!readOnlyEntityPublicInterface)
                     {
@@ -2693,8 +2716,9 @@ namespace AzToolsFramework
                 }
             );
 
-            // Trigger update whenever entity selection changes.
+            // Update this action's enabled state whenever entity selection changes, or entity pick mode is triggered.
             m_actionManagerInterface->AddActionToUpdater(EditorIdentifiers::EntitySelectionChangedUpdaterIdentifier, actionIdentifier);
+            m_actionManagerInterface->AddActionToUpdater(EditorIdentifiers::EntityPickingModeChangedUpdaterIdentifier, actionIdentifier);
 
             // This action is only accessible outside of Component Modes
             m_actionManagerInterface->AssignModeToAction(DefaultActionContextModeIdentifier, actionIdentifier);


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/14998

Disables the `Delete` action when the Entity Picker mode is enabled. This prevents edge cases where users can try and delete the currently selected entity while picking an entity for a property of one of its components, causing a crash.

## How was this PR tested?

Manual testing.
