### PR TITLE
Fix EMotionFX and NvCloth unit tests by making sure ActorInstance has a valid aabb

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/ActorInstance.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/ActorInstance.cpp
@@ -140,6 +140,13 @@ namespace EMotionFX
         {
             UpdateMeshDeformers(0.0f, true); // TODO: not really thread safe because of shared meshes, although it probably will output correctly
             UpdateStaticBasedAabbDimensions();
+
+            // If the aabb is still not valid, this can happen for example when the actor has no nodes,
+            // generate a valid aabb at the global location.
+            if (!m_staticAabb.IsValid())
+            {
+                m_staticAabb.AddPoint(m_worldTransform.m_position);
+            }
         }
 
         // update the bounds
@@ -1425,7 +1432,11 @@ namespace EMotionFX
             return;
         }
 
-        *outResult = m_actor->GetStaticAabb().GetTransformedAabb(m_worldTransform.ToAZTransform());
+        if (const AZ::Aabb& staticAabb = m_actor->GetStaticAabb();
+            staticAabb.IsValid())
+        {
+            *outResult = staticAabb.GetTransformedAabb(m_worldTransform.ToAZTransform());
+        }
     }
 
     // adjust the anim graph instance


### PR DESCRIPTION
## What does this PR do?

EMotionFX and NvCloth unit tests fail when running on debug due to the following math assert in Aabb (that is only reported on debug).

````
D:\workspace\o3de\Code\Framework\AzCore\AzCore/Math/Aabb.inl(36): error: Min must be less than Max
````
https://jenkins.build.o3de.org/blue/organizations/jenkins/O3DE_periodic-incremental-daily/detail/stabilization%2F2305/2/pipeline/2217/

The issue is that there are edge cases where `ActorInstance` can be left with an invalid aabb, for example when the actor doesn't have any nodes, which is a case tested by unit tests and therefore failing because it's doing operation with the aabb when it's invalid.

To fix it now the code is protected so it doesn't do operations on invalid aabb and `ActorInstance` now guarantees to have a valid aabb when it's created.

NvCloth unit tests were failing due to the same issue when testing cloth on actors.

## How was this PR tested?

Run EMotionFX and NvCloth unit tests in debug and now they pass.
