### PR TITLE
Add OnObjectSrgCreated event

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
@@ -36,8 +36,12 @@ namespace AZ
             friend class MeshLoader;
 
         public:
+            using ObjectSrgCreatedEvent = MeshFeatureProcessorInterface::ObjectSrgCreatedEvent;
+
             const Data::Instance<RPI::Model>& GetModel() { return m_model; }
             const RPI::Cullable& GetCullable() { return m_cullable; }
+
+            ObjectSrgCreatedEvent& GetObjectSrgCreatedEvent() { return m_objectSrgCreatedEvent; }
 
         private:
             class MeshLoader
@@ -113,6 +117,7 @@ namespace AZ
 
             //! List of object SRGs used by meshes in this model 
             AZStd::vector<Data::Instance<RPI::ShaderResourceGroup>> m_objectSrgList;
+            MeshFeatureProcessorInterface::ObjectSrgCreatedEvent m_objectSrgCreatedEvent;
             AZStd::unique_ptr<MeshLoader> m_meshLoader;
             RPI::Scene* m_scene = nullptr;
             RHI::DrawItemSortKey m_sortKey;
@@ -179,6 +184,7 @@ namespace AZ
             void SetCustomMaterials(const MeshHandle& meshHandle, const CustomMaterialMap& materials) override;
             const CustomMaterialMap& GetCustomMaterials(const MeshHandle& meshHandle) const override;
             void ConnectModelChangeEventHandler(const MeshHandle& meshHandle, ModelChangedEvent::Handler& handler) override;
+            void ConnectObjectSrgCreatedEventHandler(const MeshHandle& meshHandle, ObjectSrgCreatedEvent::Handler& handler) override;
 
             void SetTransform(const MeshHandle& meshHandle, const AZ::Transform& transform,
                 const AZ::Vector3& nonUniformScale = AZ::Vector3::CreateOne()) override;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
@@ -74,6 +74,7 @@ namespace AZ
 
             using MeshHandle = StableDynamicArrayHandle<ModelDataInstance>;
             using ModelChangedEvent = Event<const Data::Instance<RPI::Model>>;
+            using ObjectSrgCreatedEvent = Event<const Data::Instance<RPI::ShaderResourceGroup>&>;
 
             //! Returns the object id for a mesh handle.
             virtual TransformServiceFeatureProcessorInterface::ObjectId GetObjectId(const MeshHandle& meshHandle) const = 0;
@@ -115,6 +116,9 @@ namespace AZ
             virtual const CustomMaterialMap& GetCustomMaterials(const MeshHandle& meshHandle) const = 0;
             //! Connects a handler to any changes to an RPI::Model. Changes include loading and reloading.
             virtual void ConnectModelChangeEventHandler(const MeshHandle& meshHandle, ModelChangedEvent::Handler& handler) = 0;
+
+            //! Connects a handler to ObjectSrg creation
+            virtual void ConnectObjectSrgCreatedEventHandler(const MeshHandle& meshHandle, ObjectSrgCreatedEvent::Handler& handler) = 0;
 
             //! Sets the transform for a given mesh handle.
             virtual void SetTransform(const MeshHandle& meshHandle, const Transform& transform,

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -443,6 +443,14 @@ namespace AZ
             }
         }
 
+        void MeshFeatureProcessor::ConnectObjectSrgCreatedEventHandler(const MeshHandle& meshHandle, ObjectSrgCreatedEvent::Handler& handler)
+        {
+            if (meshHandle.IsValid())
+            {
+                handler.Connect(meshHandle->GetObjectSrgCreatedEvent());
+            }
+        }
+
         void MeshFeatureProcessor::SetTransform(const MeshHandle& meshHandle, const AZ::Transform& transform, const AZ::Vector3& nonUniformScale)
         {
             if (meshHandle.IsValid())
@@ -1019,6 +1027,7 @@ namespace AZ
                         AZ_Warning("MeshFeatureProcessor", false, "Failed to create a new shader resource group, skipping.");
                         continue;
                     }
+                    m_objectSrgCreatedEvent.Signal(meshObjectSrg);
                     m_objectSrgList.push_back(meshObjectSrg);
                 }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Mesh/MeshComponentBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Mesh/MeshComponentBus.h
@@ -113,6 +113,9 @@ namespace AZ
             //! Notifies listeners when the instance of the model for this component is about to be released.
             virtual void OnModelPreDestroy() {}
 
+            //! Notifies listeners when a new ObjectSrg was created (this is where you'd like to update your custom ObjectSrg)
+            virtual void OnObjectSrgCreated(const Data::Instance<RPI::ShaderResourceGroup>& /*objectSrg*/) {}
+
             /**
              * When connecting to this bus if the asset is ready you will immediately get an OnModelReady event
              */

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
@@ -408,6 +408,11 @@ namespace AZ
             }
         }
 
+        void MeshComponentController::HandleObjectSrgCreate(const Data::Instance<RPI::ShaderResourceGroup>& objectSrg)
+        {
+            MeshComponentNotificationBus::Event(m_entityComponentIdPair.GetEntityId(), &MeshComponentNotificationBus::Events::OnObjectSrgCreated, objectSrg);
+        }
+
         void MeshComponentController::RegisterModel()
         {
             if (m_meshFeatureProcessor && m_configuration.m_modelAsset.GetId().IsValid())
@@ -427,6 +432,7 @@ namespace AZ
                 meshDescriptor.m_isAlwaysDynamic = m_configuration.m_isAlwaysDynamic;
                 m_meshHandle = m_meshFeatureProcessor->AcquireMesh(meshDescriptor, ConvertToCustomMaterialMap(materials));
                 m_meshFeatureProcessor->ConnectModelChangeEventHandler(m_meshHandle, m_changeEventHandler);
+                m_meshFeatureProcessor->ConnectObjectSrgCreatedEventHandler(m_meshHandle, m_objectSrgCreatedHandler);
 
                 const AZ::Transform& transform =
                     m_transformInterface ? m_transformInterface->GetWorldTM() : AZ::Transform::CreateIdentity();

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
@@ -160,6 +160,7 @@ namespace AZ
             static bool RequiresCloning(const Data::Asset<RPI::ModelAsset>& modelAsset);
 
             void HandleModelChange(Data::Instance<RPI::Model> model);
+            void HandleObjectSrgCreate(const Data::Instance<RPI::ShaderResourceGroup>& objectSrg);
             void RegisterModel();
             void UnregisterModel();
             void RefreshModelRegistration();
@@ -181,6 +182,11 @@ namespace AZ
             MeshFeatureProcessorInterface::ModelChangedEvent::Handler m_changeEventHandler
             {
                 [&](Data::Instance<RPI::Model> model) { HandleModelChange(model); }
+            };
+            
+            MeshFeatureProcessorInterface::ObjectSrgCreatedEvent::Handler m_objectSrgCreatedHandler
+            {
+                [&](const Data::Instance<RPI::ShaderResourceGroup>& objectSrg) { HandleObjectSrgCreate(objectSrg); }
             };
 
             AZ::NonUniformScaleChangedEvent::Handler m_nonUniformScaleChangedHandler

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
@@ -680,6 +680,7 @@ namespace AZ::Render
 
             m_meshHandle = AZStd::make_shared<MeshFeatureProcessorInterface::MeshHandle>(
                 m_meshFeatureProcessor->AcquireMesh(meshDescriptor, ConvertToCustomMaterialMap(materials)));
+            m_meshFeatureProcessor->ConnectObjectSrgCreatedEventHandler(*m_meshHandle, m_objectSrgCreatedHandler);
         }
 
         // If render proxies already exist, they will be auto-freed
@@ -806,6 +807,11 @@ namespace AZ::Render
                 }
             }
         }
+    }
+
+    void AtomActorInstance::HandleObjectSrgCreate(const Data::Instance<RPI::ShaderResourceGroup>& objectSrg)
+    {
+        MeshComponentNotificationBus::Event(m_entityId, &MeshComponentNotificationBus::Events::OnObjectSrgCreated, objectSrg);
     }
 
     const MeshFeatureProcessorInterface::MeshHandle* AtomActorInstance::GetMeshHandle() const

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.h
@@ -202,6 +202,8 @@ namespace AZ
             void InitWrinkleMasks();
             void UpdateWrinkleMasks();
 
+            void HandleObjectSrgCreate(const Data::Instance<RPI::ShaderResourceGroup>& objectSrg);
+
             // Debug geometry rendering
             AZStd::unique_ptr<AtomActorDebugDraw> m_atomActorDebugDraw;
 
@@ -222,6 +224,11 @@ namespace AZ
 
             AZStd::vector<Data::Instance<RPI::Image>> m_wrinkleMasks;
             AZStd::vector<float> m_wrinkleMaskWeights;
+            
+            MeshFeatureProcessorInterface::ObjectSrgCreatedEvent::Handler m_objectSrgCreatedHandler
+            {
+                [&](const Data::Instance<RPI::ShaderResourceGroup>& objectSrg) { HandleObjectSrgCreate(objectSrg); }
+            };
         };
 
     } // namespace Render


### PR DESCRIPTION
## What does this PR do?

This PR adds an event to know when a new ObjectSrg is created for a mesh or an actor.

This allows to easily sets custom per-object data using only a few lines of code, usage example at the end.

The main issue is that when you acquire a mesh handle, ObjectSrg have not yet been created, and except waiting for the next tick there's not way to get them.

This PR adds a new MeshComponent event which allows us to be able to know when a new ObjectSrg has been created by the mesh feature processor. This way we can configure it using our already configured data, or query all object SRGs when data changes.

## How was this PR tested?

This PR was tested using a similar simple component as present at the end of this PR, adding the component, instancing a prefab containing a mesh/material and colored components and changing the color at will.

## Usage example


```hlsl
// full shader not included
partial ShaderResourceGroup ObjectSrg : SRG_PerObject
{
    float4 m_objectColor;
}
```

```cpp
#pragma once

#include <AzCore/Component/Component.h>
#include <AtomLyIntegration/CommonFeatures/Mesh/MeshComponentBus.h>
#include <AtomLyIntegration/CommonFeatures/Mesh/MeshHandleStateBus.h>
#include <MyProject/Types.h>
#include <MyProject/Rendering/ColoredMaterialBus.h>

namespace MyProject
{
	class ColoredMaterialComponentBase
		: private ColoredMaterialBus::Handler
		, private AZ::Render::MeshComponentNotificationBus::Handler
		, private AZ::Render::MeshHandleStateNotificationBus::Handler
	{
	public:
		AZ_TYPE_INFO(ColoredMaterialComponentBase, ColoredMaterialComponentBaseGuid);

		static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);

		const AZ::Color& GetColor() const;

		void SetColorIndex(const AZ::Color& color) override;

	protected:
		void Activate(AZ::EntityId entityId);
		void Deactivate();

		/////////////////////////////////////////////////////////////////////////////////
		// MeshComponentNotificationBus overrides
		void OnModelReady(const AZ::Data::Asset<AZ::RPI::ModelAsset>& modelAsset, const AZ::Data::Instance<AZ::RPI::Model>& model) override;
		void OnObjectSrgCreated(const AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>& objectSrg) override;
		/////////////////////////////////////////////////////////////////////////////////

		/////////////////////////////////////////////////////////////////////////////////
		// MeshComponentNotificationBus overrides
		void OnMeshHandleSet(const AZ::Render::MeshFeatureProcessorInterface::MeshHandle* meshHandle) override;
		/////////////////////////////////////////////////////////////////////////////////

		void UpdateObjectSrgs();
		void UpdateObjectSrgs(const AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>* objectSrgs, size_t srgCount);

		AZ::EntityId m_entityId;
		AZ::Color m_color;
		const AZ::Render::MeshFeatureProcessorInterface::MeshHandle* m_meshHandle = nullptr;
	};
}
```

```cpp
#include "ColoredMaterialComponentBase.h"

#include <AzCore/Asset/AssetSerializer.h>
#include <AzCore/RTTI/ReflectContext.h>
#include <AzCore/Serialization/EditContext.h>
#include <AzCore/Serialization/SerializeContext.h>
#include <Atom/RPI.Public/Scene.h>
#include <cmath>

namespace MyProject
{
	void ColoredMaterialComponentBase::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
	{
		required.push_back(AZ_CRC("MaterialProviderService"));
	}

	const AZ::Color& ColoredMaterialComponentBase::GetColorIndex() const
	{
		return m_color;
	}

	void ColoredMaterialComponentBase::SetColorIndex(const AZ::Color& color)
	{
		m_color = color;

		UpdateObjectSrgs();
	}

	void ColoredMaterialComponentBase::Activate(AZ::EntityId entityId)
	{
		m_entityId = entityId;

		ColoredMaterialBus::Handler::BusConnect(entityId);
		AZ::Render::MeshComponentNotificationBus::Handler::BusConnect(entityId);
		AZ::Render::MeshHandleStateNotificationBus::Handler::BusConnect(entityId);
	}

	void ColoredMaterialComponentBase::Deactivate()
	{
		ColoredMaterialBus::Handler::BusDisconnect();
		AZ::Render::MeshComponentNotificationBus::Handler::BusDisconnect();
		AZ::Render::MeshHandleStateNotificationBus::Handler::BusDisconnect();

		m_entityId.SetInvalid();
		m_meshHandle = nullptr;
	}

	void ColoredMaterialComponentBase::OnModelReady(const AZ::Data::Asset<AZ::RPI::ModelAsset>& /*modelAsset*/, const AZ::Data::Instance<AZ::RPI::Model>& /*model*/)
	{
		UpdateObjectSrgs();
	}

	void ColoredMaterialComponentBase::OnObjectSrgCreated(const AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>& objectSrg)
	{
		UpdateObjectSrgs(&objectSrg, 1);
	}
	
	void ColoredMaterialComponentBase::OnMeshHandleSet(const AZ::Render::MeshFeatureProcessorInterface::MeshHandle* meshHandle)
	{
		m_meshHandle = meshHandle;
		UpdateObjectSrgs();
	}

	void ColoredMaterialComponentBase::UpdateObjectSrgs()
	{
		if (!m_entityId.IsValid())
			return;

		if (!m_meshHandle || !m_meshHandle->IsValid())
			return;

		auto* meshFeatureProcessor = AZ::RPI::Scene::GetFeatureProcessorForEntity<AZ::Render::MeshFeatureProcessorInterface>(m_entityId);
		if (!meshFeatureProcessor)
			return;

		const AZStd::vector<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>>& objectSrgs = meshFeatureProcessor->GetObjectSrgs(*m_meshHandle);
		if (objectSrgs.empty())
			return;

		UpdateObjectSrgs(objectSrgs.data(), objectSrgs.size());
		meshFeatureProcessor->QueueObjectSrgForCompile(*m_meshHandle);
	}
	
	void ColoredMaterialComponentBase::UpdateObjectSrgs(const AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>* objectSrgs, size_t srgCount)
	{
		for (size_t i = 0; i < srgCount; ++i)
		{
			AZ::RHI::ShaderInputConstantIndex colorIndex = objectSrgs[i]->FindShaderInputConstantIndex(AZ::Name("m_objectColor"));
			if (colorIndex.IsValid())
			{
				objectSrgs[i]->SetConstant(colorIndex, m_color);
			}
		}
	}
}
```
