### PR TITLE
Action Manager | Fix shortcuts in Script Canvas Variable Widget

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/ScriptCanvasContextIdentifiers.h
+++ b/Gems/ScriptCanvas/Code/Editor/ScriptCanvasContextIdentifiers.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/string/string_view.h>
+
+namespace ScriptCanvasIdentifiers
+{
+    // Main Window
+    inline constexpr AZStd::string_view ScriptCanvasActionContextIdentifier = "o3de.context.editor.scriptcanvas";
+
+    // Main Window Widgets
+    inline constexpr AZStd::string_view ScriptCanvasVariablesActionContextIdentifier = "o3de.context.editor.scriptcanvas.variables";
+
+} // namespace EditorIdentifiers

--- a/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
@@ -31,6 +31,7 @@
 #include <QFileInfo>
 #include <QDir>
 #include <QMenu>
+#include <ScriptCanvasContextIdentifiers.h>
 #include <ScriptCanvas/Bus/EditorScriptCanvasBus.h>
 #include <ScriptCanvas/Components/EditorGraph.h>
 #include <ScriptCanvas/Components/EditorGraphVariableManagerComponent.h>
@@ -387,15 +388,14 @@ namespace ScriptCanvasEditor
 
     void SystemComponent::OnActionContextRegistrationHook()
     {
-        static constexpr AZStd::string_view ScriptCanvasActionContextIdentifier = "o3de.context.editor.scriptcanvas";
-
         if (auto actionManagerInterface = AZ::Interface<AzToolsFramework::ActionManagerInterface>::Get())
         {
             AzToolsFramework::ActionContextProperties contextProperties;
             contextProperties.m_name = "O3DE Script Canvas";
 
-            // Register a custom action context to allow duplicated shortcut hotkeys to work
-            actionManagerInterface->RegisterActionContext(ScriptCanvasActionContextIdentifier, contextProperties);
+            // Register custom action contexts to allow duplicated shortcut hotkeys to work
+            actionManagerInterface->RegisterActionContext(ScriptCanvasIdentifiers::ScriptCanvasActionContextIdentifier, contextProperties);
+            actionManagerInterface->RegisterActionContext(ScriptCanvasIdentifiers::ScriptCanvasVariablesActionContextIdentifier, contextProperties);
         }
     }
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.cpp
@@ -30,11 +30,14 @@
 
 #include <Editor/View/Widgets/ScriptCanvasNodePaletteDockWidget.h>
 #include <Editor/View/Widgets/NodePalette/VariableNodePaletteTreeItemTypes.h>
+#include <ScriptCanvasContextIdentifiers.h>
 #include <ScriptCanvas/Asset/RuntimeAsset.h>
 #include <ScriptCanvas/Bus/RequestBus.h>
 #include <ScriptCanvas/Bus/EditorScriptCanvasBus.h>
 
+#include <AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <AzToolsFramework/Editor/ActionManagerUtils.h>
 #include <ScriptCanvas/Variable/GraphVariable.h>
 
 namespace ScriptCanvasEditor
@@ -1151,6 +1154,28 @@ namespace ScriptCanvasEditor
 
         setMinimumSize(0, 0);
         ResizeColumns();
+
+        if (AzToolsFramework::IsNewActionManagerEnabled())
+        {
+            if (auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get())
+            {
+                hotKeyManagerInterface->AssignWidgetToActionContext(
+                    ScriptCanvasIdentifiers::ScriptCanvasVariablesActionContextIdentifier, this);
+            }
+        }
+    }
+
+    GraphVariablesTableView::~GraphVariablesTableView()
+    {
+        if (AzToolsFramework::IsNewActionManagerEnabled())
+        {
+            if (auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get())
+            {
+                hotKeyManagerInterface->RemoveWidgetFromActionContext(
+                    ScriptCanvasIdentifiers::ScriptCanvasVariablesActionContextIdentifier, this);
+            }
+        }
+
     }
 
     void GraphVariablesTableView::SetActiveScene(const ScriptCanvas::ScriptCanvasId& scriptCanvasId)

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.h
@@ -142,6 +142,7 @@ namespace ScriptCanvasEditor
 
         AZ_CLASS_ALLOCATOR(GraphVariablesTableView, AZ::SystemAllocator);
         GraphVariablesTableView(QWidget* parent);
+        ~GraphVariablesTableView();
 
         void SetActiveScene(const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
         void SetFilter(const QString& filterString);

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -146,11 +146,11 @@
 #include <Editor/Include/ScriptCanvas/Components/EditorGraph.h>
 ////
 
+#include <ScriptCanvasContextIdentifiers.h>
 #include <Editor/Assets/ScriptCanvasAssetHelpers.h>
 #include <ScriptCanvas/Asset/AssetDescription.h>
 #include <ScriptCanvas/Asset/SubgraphInterfaceAsset.h>
 #include <ScriptCanvas/Components/EditorScriptCanvasComponent.h>
-
 
 #include <Editor/QtMetaTypes.h>
 #include <GraphCanvas/Components/SceneBus.h>
@@ -443,11 +443,9 @@ namespace ScriptCanvasEditor
 
         if (AzToolsFramework::IsNewActionManagerEnabled())
         {
-            static constexpr AZStd::string_view ScriptCanvasActionContextIdentifier = "o3de.context.editor.scriptcanvas";
-
             if(auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get())
             {
-                hotKeyManagerInterface->AssignWidgetToActionContext(ScriptCanvasActionContextIdentifier, this);
+                hotKeyManagerInterface->AssignWidgetToActionContext(ScriptCanvasIdentifiers::ScriptCanvasActionContextIdentifier, this);
             }
         }
 
@@ -688,11 +686,9 @@ namespace ScriptCanvasEditor
 
         if (AzToolsFramework::IsNewActionManagerEnabled())
         {
-            static constexpr AZStd::string_view ScriptCanvasActionContextIdentifier = "o3de.context.editor.scriptcanvas";
-
             if (auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get())
             {
-                hotKeyManagerInterface->RemoveWidgetFromActionContext(ScriptCanvasActionContextIdentifier, this);
+                hotKeyManagerInterface->RemoveWidgetFromActionContext(ScriptCanvasIdentifiers::ScriptCanvasActionContextIdentifier, this);
             }
         }
 

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_editor_files.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_editor_files.cmake
@@ -7,6 +7,7 @@
 #
 
 set(FILES
+    Editor/ScriptCanvasContextIdentifiers.h
     Editor/ScriptCanvasEditorGem.cpp
     Editor/Settings.h
     Editor/Settings.cpp


### PR DESCRIPTION
## What does this PR do?

Fixes #14977

Ensures shortcuts in the Script Canvas Variable Widget are accessible with the Action Manager enabled.

## How was this PR tested?

Manual testing, verified the issue mentioned above is fixed.
