### PR TITLE
Updating atom tools auto load registry settings to disable AWS modules

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
@@ -191,7 +191,8 @@ namespace AtomToolsFramework
         AzToolsFramework::SourceControlConnectionRequestBus::Broadcast(
             &AzToolsFramework::SourceControlConnectionRequests::EnableSourceControl, enableSourceControl);
 
-        if (!AZ::RPI::RPISystemInterface::Get()->IsInitialized())
+        auto rpiInterface = AZ::RPI::RPISystemInterface::Get();
+        if (rpiInterface && !rpiInterface->IsInitialized())
         {
             AZ::RPI::RPISystemInterface::Get()->InitializeSystemAssets();
         }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
@@ -601,16 +601,14 @@ namespace AtomToolsFramework
 
     void AtomToolsMainWindow::UpdateWindowTitle()
     {
-        AZ::Name apiName = AZ::RHI::Factory::Get().GetName();
-        if (!apiName.IsEmpty())
+        if (AZ::RHI::Factory::IsReady())
         {
-            QString title = QString{ "%1 (%2)" }.arg(QApplication::applicationName()).arg(apiName.GetCStr());
-            setWindowTitle(title);
+            const AZ::Name apiName = AZ::RHI::Factory::Get().GetName();
+            setWindowTitle(tr("%1 (%2)").arg(QApplication::applicationName()).arg(apiName.GetCStr()));
+            AZ_Error("AtomToolsMainWindow", !apiName.IsEmpty(), "Render API name not found");
+            return;
         }
-        else
-        {
-            AZ_Assert(false, "Render API name not found");
-            setWindowTitle(QApplication::applicationName());
-        }
+
+        setWindowTitle(QApplication::applicationName());
     }
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/MaterialCanvas/Registry/gem_autoload.materialcanvas.setreg
+++ b/Gems/Atom/Tools/MaterialCanvas/Registry/gem_autoload.materialcanvas.setreg
@@ -170,13 +170,6 @@
                     }
                 }
             },
-            "AWSGameLift": {
-                "Targets": {
-                    "AWSGameLift.Editor": {
-                        "AutoLoad": false
-                    }
-                }
-            },
             "ImGui": {
                 "Targets": {
                     "ImGui.Editor": {
@@ -315,6 +308,24 @@
                     },
                     "AWSCore.Editor": {
                         "AutoLoad": false
+                    },
+                    "AWSCore.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Tests": {
+                        "AutoLoad": false
                     }
                 }
             },
@@ -325,6 +336,49 @@
                     },
                     "AWSClientAuth.Editor": {
                         "AutoLoad": false
+                    },
+                    "AWSClientAuth.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Tests": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "AWSGameLift": {
+                "Targets": {
+                    "AWSGameLift": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Editor": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Builders": {
+                        "AutoLoad": false
                     }
                 }
             },
@@ -334,6 +388,24 @@
                         "AutoLoad": false
                     },
                     "AWSMetrics.Editor": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Tests": {
                         "AutoLoad": false
                     }
                 }

--- a/Gems/Atom/Tools/MaterialEditor/Registry/gem_autoload.materialeditor.setreg
+++ b/Gems/Atom/Tools/MaterialEditor/Registry/gem_autoload.materialeditor.setreg
@@ -170,13 +170,6 @@
                     }
                 }
             },
-            "AWSGameLift": {
-                "Targets": {
-                    "AWSGameLift.Editor": {
-                        "AutoLoad": false
-                    }
-                }
-            },
             "ImGui": {
                 "Targets": {
                     "ImGui.Editor": {
@@ -329,6 +322,24 @@
                     },
                     "AWSCore.Editor": {
                         "AutoLoad": false
+                    },
+                    "AWSCore.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Tests": {
+                        "AutoLoad": false
                     }
                 }
             },
@@ -339,6 +350,49 @@
                     },
                     "AWSClientAuth.Editor": {
                         "AutoLoad": false
+                    },
+                    "AWSClientAuth.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Tests": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "AWSGameLift": {
+                "Targets": {
+                    "AWSGameLift": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Editor": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Builders": {
+                        "AutoLoad": false
                     }
                 }
             },
@@ -348,6 +402,24 @@
                         "AutoLoad": false
                     },
                     "AWSMetrics.Editor": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Tests": {
                         "AutoLoad": false
                     }
                 }

--- a/Gems/Atom/Tools/PassCanvas/Registry/gem_autoload.passcanvas.setreg
+++ b/Gems/Atom/Tools/PassCanvas/Registry/gem_autoload.passcanvas.setreg
@@ -170,13 +170,6 @@
                     }
                 }
             },
-            "AWSGameLift": {
-                "Targets": {
-                    "AWSGameLift.Editor": {
-                        "AutoLoad": false
-                    }
-                }
-            },
             "ImGui": {
                 "Targets": {
                     "ImGui.Editor": {
@@ -315,6 +308,24 @@
                     },
                     "AWSCore.Editor": {
                         "AutoLoad": false
+                    },
+                    "AWSCore.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Tests": {
+                        "AutoLoad": false
                     }
                 }
             },
@@ -325,6 +336,49 @@
                     },
                     "AWSClientAuth.Editor": {
                         "AutoLoad": false
+                    },
+                    "AWSClientAuth.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Tests": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "AWSGameLift": {
+                "Targets": {
+                    "AWSGameLift": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Editor": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Builders": {
+                        "AutoLoad": false
                     }
                 }
             },
@@ -334,6 +388,24 @@
                         "AutoLoad": false
                     },
                     "AWSMetrics.Editor": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Tests": {
                         "AutoLoad": false
                     }
                 }

--- a/Gems/Atom/Tools/ShaderManagementConsole/Registry/gem_autoload.shadermanagementconsole.setreg
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Registry/gem_autoload.shadermanagementconsole.setreg
@@ -170,13 +170,6 @@
                     }
                 }
             },
-            "AWSGameLift": {
-                "Targets": {
-                    "AWSGameLift.Editor": {
-                        "AutoLoad": false
-                    }
-                }
-            },
             "ImGui": {
                 "Targets": {
                     "ImGui.Editor": {
@@ -315,6 +308,24 @@
                     },
                     "AWSCore.Editor": {
                         "AutoLoad": false
+                    },
+                    "AWSCore.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Tests": {
+                        "AutoLoad": false
                     }
                 }
             },
@@ -325,6 +336,49 @@
                     },
                     "AWSClientAuth.Editor": {
                         "AutoLoad": false
+                    },
+                    "AWSClientAuth.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Tests": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "AWSGameLift": {
+                "Targets": {
+                    "AWSGameLift": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Editor": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Builders": {
+                        "AutoLoad": false
                     }
                 }
             },
@@ -334,6 +388,24 @@
                         "AutoLoad": false
                     },
                     "AWSMetrics.Editor": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Tests": {
                         "AutoLoad": false
                     }
                 }

--- a/Gems/RemoteTools/Code/Source/RemoteToolsSystemComponent.cpp
+++ b/Gems/RemoteTools/Code/Source/RemoteToolsSystemComponent.cpp
@@ -138,7 +138,7 @@ namespace RemoteTools
             netInterface->SetTimeoutMs(AZ::TimeMs(0));
         }
 
-        if (!m_joinThread->IsRunning())
+        if (m_joinThread && !m_joinThread->IsRunning())
         {
             m_joinThread->Join();
             m_joinThread->Start();


### PR DESCRIPTION
## What does this PR do?

Disabling additional modules that should have no direct impact on material editor, material canvas, etc. Some AWS game lift modules were missed in the last iteration. All of the tools launched successfully with those exhaustively disabled. Would be great if the auto load feature supported wild cards.

Resolves https://github.com/o3de/o3de/issues/7113

## How was this PR tested?

More exhaustive testing between all atom tools, changing the settings for one tool to do A/B comparison against another before updating settings for the remaining tools. Confirmed that all load with game lift and the other AWS modules enabled.