### PR TITLE
Fix sfmt value repetition bugs

### DIFF
--- a/Code/Framework/AtomCore/AtomCore/Instance/InstanceDatabase.h
+++ b/Code/Framework/AtomCore/AtomCore/Instance/InstanceDatabase.h
@@ -391,8 +391,8 @@ namespace AZ
             // there might be a bug / race condition in the id generator. The same assert also occurs *after*
             // instance creation to help differentiate between a non-random id vs recursive creation of the same id.
             AZ_Assert(
-                m_database.contains(id),
-                "Database already contains an instance for this id, possibly a random id generation collision?",
+                !m_database.contains(id),
+                "Database already contains an instance for this id (%s), possibly a random id generation collision?",
                 id.ToFixedString().c_str());
 
             // Emplace a new instance and return it.
@@ -411,10 +411,10 @@ namespace AZ
             if (instance)
             {
                 AZ_Assert(
-                    m_database.find(id) == m_database.end(),
+                    !m_database.contains(id),
                     "Instance creation for asset id %s resulted in a recursive creation of that asset, which was unexpected. "
                     "This asset might be erroneously referencing itself as a dependent asset.",
-                    id.ToString<AZStd::string>().c_str());
+                    id.ToFixedString().c_str());
 
                 instance->m_id = id;
                 instance->m_parentDatabase = this;

--- a/Code/Framework/AtomCore/AtomCore/Instance/InstanceDatabase.h
+++ b/Code/Framework/AtomCore/AtomCore/Instance/InstanceDatabase.h
@@ -387,6 +387,14 @@ namespace AZ
         Data::Instance<Type> InstanceDatabase<Type>::EmplaceInstance(
             const InstanceId& id, const Data::Asset<AssetData>& asset, const AZStd::any* param)
         {
+            // This assert is here to catch any potential non-randomness in our id generation. If it triggers,
+            // there might be a bug / race condition in the id generator. The same assert also occurs *after*
+            // instance creation to help differentiate between a non-random id vs recursive creation of the same id.
+            AZ_Assert(
+                m_database.find(id) == m_database.end(),
+                "Database already contains an instance for this id, possibly a random id generation collision?",
+                id.ToString<AZStd::string>().c_str());
+
             // Emplace a new instance and return it.
             // It's possible for the m_createFunction call to recursively trigger another FindOrCreate call, so be aware that
             // the contents of m_database may change within this call.

--- a/Code/Framework/AtomCore/AtomCore/Instance/InstanceDatabase.h
+++ b/Code/Framework/AtomCore/AtomCore/Instance/InstanceDatabase.h
@@ -391,9 +391,9 @@ namespace AZ
             // there might be a bug / race condition in the id generator. The same assert also occurs *after*
             // instance creation to help differentiate between a non-random id vs recursive creation of the same id.
             AZ_Assert(
-                m_database.find(id) == m_database.end(),
+                m_database.contains(id),
                 "Database already contains an instance for this id, possibly a random id generation collision?",
-                id.ToString<AZStd::string>().c_str());
+                id.ToFixedString().c_str());
 
             // Emplace a new instance and return it.
             // It's possible for the m_createFunction call to recursively trigger another FindOrCreate call, so be aware that

--- a/Code/Framework/AtomCore/AtomCore/Instance/InstanceDatabase.h
+++ b/Code/Framework/AtomCore/AtomCore/Instance/InstanceDatabase.h
@@ -393,7 +393,7 @@ namespace AZ
             AZ_Assert(
                 !m_database.contains(id),
                 "Database already contains an instance for this id (%s), possibly a random id generation collision?",
-                id.ToFixedString().c_str());
+                id.ToString<AZStd::string>().c_str());
 
             // Emplace a new instance and return it.
             // It's possible for the m_createFunction call to recursively trigger another FindOrCreate call, so be aware that
@@ -414,7 +414,7 @@ namespace AZ
                     !m_database.contains(id),
                     "Instance creation for asset id %s resulted in a recursive creation of that asset, which was unexpected. "
                     "This asset might be erroneously referencing itself as a dependent asset.",
-                    id.ToFixedString().c_str());
+                    id.ToString<AZStd::string>().c_str());
 
                 instance->m_id = id;
                 instance->m_parentDatabase = this;

--- a/Code/Framework/AtomCore/AtomCore/Instance/InstanceDatabase.h
+++ b/Code/Framework/AtomCore/AtomCore/Instance/InstanceDatabase.h
@@ -393,7 +393,7 @@ namespace AZ
             AZ_Assert(
                 !m_database.contains(id),
                 "Database already contains an instance for this id (%s), possibly a random id generation collision?",
-                id.ToString<AZStd::string>().c_str());
+                id.ToString<AZStd::fixed_string<64>>().c_str());
 
             // Emplace a new instance and return it.
             // It's possible for the m_createFunction call to recursively trigger another FindOrCreate call, so be aware that
@@ -414,7 +414,7 @@ namespace AZ
                     !m_database.contains(id),
                     "Instance creation for asset id %s resulted in a recursive creation of that asset, which was unexpected. "
                     "This asset might be erroneously referencing itself as a dependent asset.",
-                    id.ToString<AZStd::string>().c_str());
+                    id.ToString<AZStd::fixed_string<64>>().c_str());
 
                 instance->m_id = id;
                 instance->m_parentDatabase = this;

--- a/Code/Framework/AzCore/AzCore/Math/Sfmt.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Sfmt.cpp
@@ -392,6 +392,8 @@ namespace AZ
     //=========================================================================
     void Sfmt::Seed(AZ::u32* keys, int numKeys)
     {
+        AZStd::lock_guard<decltype(m_generationMutex)> lock(m_generationMutex);
+
         using SfmtInternal::N;
         using SfmtInternal::N32;
         int i, j, count;
@@ -551,6 +553,8 @@ namespace AZ
     //=========================================================================
     void Sfmt::FillArray32(AZ::u32* array, int size)
     {
+        AZStd::lock_guard<decltype(m_generationMutex)> lock(m_generationMutex);
+
         AZ_MATH_ASSERT(m_index == SfmtInternal::N32, "Invalid m_index! Reinitialize!");
         AZ_MATH_ASSERT(size % 4 == 0, "Size must be multiple of 4!");
         AZ_MATH_ASSERT(size >= SfmtInternal::N32, "Size must be bigger than %d GetMinArray32Size()!", SfmtInternal::N32);
@@ -565,6 +569,8 @@ namespace AZ
     //=========================================================================
     void Sfmt::FillArray64(AZ::u64* array, int size)
     {
+        AZStd::lock_guard<decltype(m_generationMutex)> lock(m_generationMutex);
+
         AZ_MATH_ASSERT(m_index == SfmtInternal::N32, "Invalid m_index! Reinitialize!");
         AZ_MATH_ASSERT(size % 4 == 0, "Size must be multiple of 4!");
         AZ_MATH_ASSERT(size >= SfmtInternal::N64, "Size must be bigger than %d GetMinArray64Size()!", SfmtInternal::N64);

--- a/Code/Framework/AzCore/AzCore/Math/Sfmt.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Sfmt.cpp
@@ -553,7 +553,7 @@ namespace AZ
     //=========================================================================
     void Sfmt::FillArray32(AZ::u32* array, int size)
     {
-        AZStd::lock_guard<decltype(m_generationMutex)> lock(m_generationMutex);
+        AZStd::scoped_lock lock(m_generationMutex);
 
         AZ_MATH_ASSERT(m_index == SfmtInternal::N32, "Invalid m_index! Reinitialize!");
         AZ_MATH_ASSERT(size % 4 == 0, "Size must be multiple of 4!");

--- a/Code/Framework/AzCore/AzCore/Math/Sfmt.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Sfmt.cpp
@@ -10,7 +10,7 @@
 
 #include <AzCore/Math/Random.h>
 #include <AzCore/Module/Environment.h>
-#include <AzCore/std/parallel/lock.h>
+#include <AzCore/std/parallel/scoped_lock.h>
 
 #include <string.h> // for memset
 
@@ -392,7 +392,7 @@ namespace AZ
     //=========================================================================
     void Sfmt::Seed(AZ::u32* keys, int numKeys)
     {
-        AZStd::lock_guard<decltype(m_generationMutex)> lock(m_generationMutex);
+        AZStd::scoped_lock lock(m_sfmtMutex);
 
         using SfmtInternal::N;
         using SfmtInternal::N32;
@@ -517,7 +517,7 @@ namespace AZ
     //=========================================================================
     AZ::u32 Sfmt::Rand32()
     {
-        AZStd::lock_guard<decltype(m_generationMutex)> lock(m_generationMutex);
+        AZStd::scoped_lock lock(m_sfmtMutex);
 
         m_index++;
         if (m_index >= SfmtInternal::N32)
@@ -535,7 +535,7 @@ namespace AZ
     //=========================================================================
     AZ::u64 Sfmt::Rand64()
     {
-        AZStd::lock_guard<decltype(m_generationMutex)> lock(m_generationMutex);
+        AZStd::scoped_lock lock(m_sfmtMutex);
 
         m_index += 2;
         if (m_index >= (SfmtInternal::N32 - 1))
@@ -553,7 +553,7 @@ namespace AZ
     //=========================================================================
     void Sfmt::FillArray32(AZ::u32* array, int size)
     {
-        AZStd::scoped_lock lock(m_generationMutex);
+        AZStd::scoped_lock lock(m_sfmtMutex);
 
         AZ_MATH_ASSERT(m_index == SfmtInternal::N32, "Invalid m_index! Reinitialize!");
         AZ_MATH_ASSERT(size % 4 == 0, "Size must be multiple of 4!");
@@ -569,7 +569,7 @@ namespace AZ
     //=========================================================================
     void Sfmt::FillArray64(AZ::u64* array, int size)
     {
-        AZStd::scoped_lock lock(m_generationMutex);
+        AZStd::scoped_lock lock(m_sfmtMutex);
 
         AZ_MATH_ASSERT(m_index == SfmtInternal::N32, "Invalid m_index! Reinitialize!");
         AZ_MATH_ASSERT(size % 4 == 0, "Size must be multiple of 4!");

--- a/Code/Framework/AzCore/AzCore/Math/Sfmt.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Sfmt.cpp
@@ -569,7 +569,7 @@ namespace AZ
     //=========================================================================
     void Sfmt::FillArray64(AZ::u64* array, int size)
     {
-        AZStd::lock_guard<decltype(m_generationMutex)> lock(m_generationMutex);
+        AZStd::scoped_lock lock(m_generationMutex);
 
         AZ_MATH_ASSERT(m_index == SfmtInternal::N32, "Invalid m_index! Reinitialize!");
         AZ_MATH_ASSERT(size % 4 == 0, "Size must be multiple of 4!");

--- a/Code/Framework/AzCore/AzCore/Math/Sfmt.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Sfmt.cpp
@@ -347,7 +347,7 @@ namespace AZ
     // Seed
     // [4/10/2012]
     //=========================================================================
-    Sfmt::Sfmt(AZ::u32* keys, int numKeys)
+    Sfmt::Sfmt(const AZ::u32* keys, int numKeys)
     {
         m_psfmt32 = &m_sfmt[0].u[0];
         m_psfmt64 = reinterpret_cast<AZ::u64*>(m_psfmt32);
@@ -390,7 +390,7 @@ namespace AZ
     // Seed
     // [4/10/2012]
     //=========================================================================
-    void Sfmt::Seed(AZ::u32* keys, int numKeys)
+    void Sfmt::Seed(const AZ::u32* keys, int numKeys)
     {
         AZStd::scoped_lock lock(m_sfmtMutex);
 

--- a/Code/Framework/AzCore/AzCore/Math/Sfmt.h
+++ b/Code/Framework/AzCore/AzCore/Math/Sfmt.h
@@ -110,6 +110,6 @@ namespace AZ
         AZ::u32*                    m_psfmt32; ///  Read only tables of pre-generated random numbers
         AZ::u64*                    m_psfmt64;
 
-        AZStd::mutex                m_generationMutex;
+        AZStd::mutex                m_sfmtMutex;   /// Guards access to m_index and m_sfmt
     };
 }

--- a/Code/Framework/AzCore/AzCore/Math/Sfmt.h
+++ b/Code/Framework/AzCore/AzCore/Math/Sfmt.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <AzCore/base.h>
-#include <AzCore/std/parallel/atomic.h>
 #include <AzCore/std/parallel/mutex.h>
 #include <AzCore/std/typetraits/static_storage.h>
 #include <AzCore/Math/Internal/MathTypes.h>
@@ -106,10 +105,10 @@ namespace AZ
         void    PeriodCertification();
 
         SfmtInternal::w128_t        m_sfmt[SfmtInternal::N];
-        size_t                      m_index;   ///  Index into the pre-generated tables
-        AZ::u32*                    m_psfmt32; ///  Read only tables of pre-generated random numbers
-        AZ::u64*                    m_psfmt64;
+        size_t                      m_index = 0;         ///  Index into the pre-generated tables
+        AZ::u32*                    m_psfmt32 = nullptr; ///  Read only tables of pre-generated random numbers
+        AZ::u64*                    m_psfmt64 = nullptr;
 
-        AZStd::mutex                m_sfmtMutex;   /// Guards access to m_index and m_sfmt
+        AZStd::mutex                m_sfmtMutex;         /// Guards access to m_index and m_sfmt
     };
 }

--- a/Code/Framework/AzCore/AzCore/Math/Sfmt.h
+++ b/Code/Framework/AzCore/AzCore/Math/Sfmt.h
@@ -106,10 +106,10 @@ namespace AZ
         void    PeriodCertification();
 
         SfmtInternal::w128_t        m_sfmt[SfmtInternal::N];
-        AZStd::atomic_int           m_index;   ///  Index into the pre-generated tables
+        size_t                      m_index;   ///  Index into the pre-generated tables
         AZ::u32*                    m_psfmt32; ///  Read only tables of pre-generated random numbers
         AZ::u64*                    m_psfmt64;
 
-        AZStd::recursive_mutex      m_generationMutex;
+        AZStd::mutex                m_generationMutex;
     };
 }

--- a/Code/Framework/AzCore/AzCore/Math/Sfmt.h
+++ b/Code/Framework/AzCore/AzCore/Math/Sfmt.h
@@ -59,12 +59,12 @@ namespace AZ
         /// By default we seed with Seed()
         Sfmt();
         /// Seed the generator with user defined seed Seed(AZ::u32* keys, int numKeys)
-        Sfmt(AZ::u32* keys, int numKeys);
+        Sfmt(const AZ::u32* keys, int numKeys);
 
         /// Seed the generator, with the best pseudo-random number the system can generate \ref BetterPseudoRandom
         void Seed();
         /// Seed the generator with user defined seed.
-        void Seed(AZ::u32* keys, int numKeys);
+        void Seed(const AZ::u32* keys, int numKeys);
 
         /// Return u32 pseudo random integer
         AZ::u32 Rand32();

--- a/Code/Framework/AzCore/AzCore/Math/Uuid.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Uuid.cpp
@@ -29,11 +29,9 @@ namespace AZ
         Uuid id;
         Sfmt& smft = Sfmt::GetInstance();
 
-        AZ::u32* id32 = reinterpret_cast<AZ::u32*>(&id);
-        id32[0] = smft.Rand32();
-        id32[1] = smft.Rand32();
-        id32[2] = smft.Rand32();
-        id32[3] = smft.Rand32();
+        AZ::u64* id64 = reinterpret_cast<AZ::u64*>(&id);
+        id64[0] = smft.Rand64();
+        id64[1] = smft.Rand64();
 
         // variant VAR_RFC_4122
         id.m_data[8] &= AZStd::byte(0xBF);

--- a/Code/Framework/AzCore/Tests/Math/SfmtTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/SfmtTests.cpp
@@ -116,10 +116,11 @@ namespace UnitTest
             Sfmt sfmt;
 
             // Arbitrary but deterministic seed values to guarantee that we get the same random numbers produced every time.
-            AZ::u32 buffer[32] = { 0x8236ed73, 0x854aa369, 0xc7b68864, 0x5f1e49da, 0x58ea5a08, 0xa33fc74b, 0x0336bd81, 0x8d3c11ac,
-                                   0x7312bc57, 0x92fee3d1, 0x4b852f9f, 0xa7ac02ad, 0x4d72fb7a, 0x630641c6, 0x1edbeebf, 0xc18fdabe,
-                                   0xc6588dba, 0x6a821cf5, 0xec7e24b3, 0x44246d7e, 0x24af2f32, 0x4f64d44c, 0x44b24116, 0x65585572,
-                                   0x0f95038d, 0xd3e4c521, 0x6eea6bc1, 0x6d651ab5, 0x25dfc39e, 0x7502d183, 0xd32fc9bf, 0x9854093f };
+            constexpr AZ::u32 buffer[32] = {
+                0x8236ed73, 0x854aa369, 0xc7b68864, 0x5f1e49da, 0x58ea5a08, 0xa33fc74b, 0x0336bd81, 0x8d3c11ac,
+                0x7312bc57, 0x92fee3d1, 0x4b852f9f, 0xa7ac02ad, 0x4d72fb7a, 0x630641c6, 0x1edbeebf, 0xc18fdabe,
+                0xc6588dba, 0x6a821cf5, 0xec7e24b3, 0x44246d7e, 0x24af2f32, 0x4f64d44c, 0x44b24116, 0x65585572,
+                0x0f95038d, 0xd3e4c521, 0x6eea6bc1, 0x6d651ab5, 0x25dfc39e, 0x7502d183, 0xd32fc9bf, 0x9854093f };
 
             // Seed the sfmt generator.
             sfmt.Seed(buffer, AZ_ARRAY_SIZE(buffer));
@@ -147,7 +148,7 @@ namespace UnitTest
                     for (int i = 0; i < NumResultsPerThread; ++i)
                     {
                         // Call Rand32 when uint32_t is the passed-in type, and Rand64 if uint64_t is the passed-in type.
-                        if constexpr (AZStd::is_same<ResultType, uint32_t>::value)
+                        if constexpr (AZStd::is_same_v<ResultType, uint32_t>)
                         {
                             results[startOffset + i] = sfmt.Rand32();
                         }

--- a/Code/Framework/AzCore/Tests/Math/SfmtTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/SfmtTests.cpp
@@ -226,10 +226,6 @@ namespace UnitTest
     TEST_F(MATH_SfmtTest, TestParallel64)
     {
         // This test verifies that we can call Rand64() successfully in parallel.
-        // It also performs a reasonable verification that we haven't reintroduced a race condition in which the random number
-        // sequence could get repeated for periods of time if multiple threads hit the point where Sfmt refills its number cache
-        // simultaneously. Because it was a race condition, this test isn't foolproof, but the test conditions set below were
-        // causing a near-100% failure rate with the previous race condition and has a 100% success rate with the fix.
 
         // The following numbers were chosen to be high enough to expose the problem at least once per run but low enough to keep
         // the overall test runtime down.

--- a/Code/Framework/AzCore/Tests/Math/SfmtTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/SfmtTests.cpp
@@ -9,6 +9,8 @@
 #include <AzCore/Math/Sfmt.h>
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzCore/Math/Vector4.h>
+#include <AzCore/std/sort.h>
+#include <AzCore/std/parallel/semaphore.h>
 
 using namespace AZ;
 
@@ -107,6 +109,82 @@ namespace UnitTest
                 EXPECT_EQ(array64_2[i], g.Rand64());
             }
         }
+
+        template<size_t NumThreads, size_t NumResultsPerThread, typename ResultType>
+        bool ParallelTest()
+        {
+            Sfmt sfmt;
+
+            // Arbitrary but deterministic seed values to guarantee that we get the same random numbers produced every time.
+            AZ::u32 buffer[32] = { 0x8236ed73, 0x854aa369, 0xc7b68864, 0x5f1e49da, 0x58ea5a08, 0xa33fc74b, 0x0336bd81, 0x8d3c11ac,
+                                   0x7312bc57, 0x92fee3d1, 0x4b852f9f, 0xa7ac02ad, 0x4d72fb7a, 0x630641c6, 0x1edbeebf, 0xc18fdabe,
+                                   0xc6588dba, 0x6a821cf5, 0xec7e24b3, 0x44246d7e, 0x24af2f32, 0x4f64d44c, 0x44b24116, 0x65585572,
+                                   0x0f95038d, 0xd3e4c521, 0x6eea6bc1, 0x6d651ab5, 0x25dfc39e, 0x7502d183, 0xd32fc9bf, 0x9854093f };
+
+            // Seed the sfmt generator.
+            sfmt.Seed(buffer, AZ_ARRAY_SIZE(buffer));
+
+            // Create a single array that will hold all the results, but we'll partition it so that each thread will write
+            // its results to a different subset.
+            AZStd::array<ResultType, NumResultsPerThread * NumThreads> results;
+            AZStd::thread threads[NumThreads];
+
+            // Use a semaphore to block thread execution until all the threads are created so that we can synchronize
+            // their start times to the best of our ability.
+            AZStd::semaphore startSync;
+
+            // Spawn a set of threads that will each loop through and call the RandMethod (Rand32 or Rand64) for
+            // a given number of times.
+            for (size_t threadIdx = 0; threadIdx < AZ_ARRAY_SIZE(threads); ++threadIdx)
+            {
+                const size_t startOffset = NumResultsPerThread * threadIdx;
+
+                auto threadFunc = [&startSync, startOffset, &results, &sfmt]()
+                {
+                    // Block so that we can start all the threads at the same time after creation.
+                    startSync.acquire();
+
+                    for (int i = 0; i < NumResultsPerThread; ++i)
+                    {
+                        // Call Rand32 when uint32_t is the passed-in type, and Rand64 if uint64_t is the passed-in type.
+                        if constexpr (AZStd::is_same<ResultType, uint32_t>::value)
+                        {
+                            results[startOffset + i] = sfmt.Rand32();
+                        }
+                        else
+                        {
+                            results[startOffset + i] = sfmt.Rand64();
+                        }
+                    }
+                };
+                threads[threadIdx] = AZStd::thread(threadFunc);
+            }
+
+            // Now that all the threads are created, signal them to start.
+            startSync.release(NumThreads);
+
+            // Wait for all the threads to complete.
+            for (auto& thread : threads)
+            {
+                thread.join();
+            }
+
+            // Sort the results from all the threads so that we can easily detect duplicates.
+            AZStd::sort(results.begin(), results.end());
+
+            // Look for duplicates and stop if we find one, since that's a full test failure. There's no need to keep iterating.
+            for (size_t idx = 1; idx < results.size(); idx++)
+            {
+                if (results[idx - 1] == results[idx])
+                {
+                    EXPECT_NE(results[idx - 1], results[idx]);
+                    return false;
+                }
+            }
+
+            // Test was successful
+            return true;
+        }
     };
 
     TEST_F(MATH_SfmtTest, Test32Bit)
@@ -121,45 +199,53 @@ namespace UnitTest
 
     TEST_F(MATH_SfmtTest, TestParallel32)
     {
-        Sfmt sfmt;
-        auto threadFunc = [&sfmt]()
-        {
-            for (int i = 0; i < 10000; ++i)
-            {
-                sfmt.Rand32();
-            }
-        };
-        AZStd::thread threads[8];
-        for (size_t threadIdx = 0; threadIdx < AZ_ARRAY_SIZE(threads); ++threadIdx)
-        {
-            threads[threadIdx] = AZStd::thread(threadFunc);
-        }
+        // This test verifies that we can call Rand32() successfully in parallel.
+        // It also performs a reasonable verification that we haven't reintroduced a race condition in which the random number
+        // sequence could get repeated for periods of time if multiple threads hit the point where Sfmt refills its number cache
+        // simultaneously. Because it was a race condition, this test isn't foolproof, but the test conditions set below were
+        // causing a near-100% failure rate with the previous race condition and has a 100% success rate with the fix.
 
-        for (auto& thread : threads)
+        // The following numbers were chosen to be high enough to expose the problem at least once per run but low enough to keep
+        // the overall test runtime down.
+        constexpr size_t NumIterations = 5;
+        constexpr size_t NumThreads = 8;
+        constexpr size_t NumResultsPerThread = 2000;
+
+        // Run the test single-threaded once to verify that we don't have any numerical collisions in our test set and test size.
+        bool testSetHasNoNumericalCollisions = ParallelTest<1, NumThreads * NumResultsPerThread, uint32_t>();
+        ASSERT_TRUE(testSetHasNoNumericalCollisions);
+
+        // Now run multi-threaded across multiple iterations to verify that we don't hit the race condition.
+        for (size_t iterations = 0; iterations < NumIterations; iterations++)
         {
-            thread.join();
+            bool parallelHasNoNumericalCollisions = ParallelTest<NumThreads, NumResultsPerThread, uint32_t>();
+            ASSERT_TRUE(parallelHasNoNumericalCollisions);
         }
     }
 
     TEST_F(MATH_SfmtTest, TestParallel64)
     {
-        Sfmt sfmt;
-        auto threadFunc = [&sfmt]()
-        {
-            for (int i = 0; i < 10000; ++i)
-            {
-                sfmt.Rand64();
-            }
-        };
-        AZStd::thread threads[8];
-        for (size_t threadIdx = 0; threadIdx < AZ_ARRAY_SIZE(threads); ++threadIdx)
-        {
-            threads[threadIdx] = AZStd::thread(threadFunc);
-        }
+        // This test verifies that we can call Rand64() successfully in parallel.
+        // It also performs a reasonable verification that we haven't reintroduced a race condition in which the random number
+        // sequence could get repeated for periods of time if multiple threads hit the point where Sfmt refills its number cache
+        // simultaneously. Because it was a race condition, this test isn't foolproof, but the test conditions set below were
+        // causing a near-100% failure rate with the previous race condition and has a 100% success rate with the fix.
 
-        for (auto& thread : threads)
+        // The following numbers were chosen to be high enough to expose the problem at least once per run but low enough to keep
+        // the overall test runtime down.
+        constexpr size_t NumIterations = 5;
+        constexpr size_t NumThreads = 8;
+        constexpr size_t NumResultsPerThread = 2000;
+
+        // Run the test single-threaded once to verify that we don't have any numerical collisions in our test set and test size.
+        bool testSetHasNoNumericalCollisions = ParallelTest<1, NumThreads * NumResultsPerThread, uint64_t>();
+        ASSERT_TRUE(testSetHasNoNumericalCollisions);
+
+        // Now run multi-threaded across multiple iterations to verify that we don't hit the race condition.
+        for (size_t iterations = 0; iterations < NumIterations; iterations++)
         {
-            thread.join();
+            bool parallelHasNoNumericalCollisions = ParallelTest<NumThreads, NumResultsPerThread, uint64_t>();
+            ASSERT_TRUE(parallelHasNoNumericalCollisions);
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

The Sfmt code had some subtle (and some not-so-subtle) bugs that led to race conditions which led to O3DE producing the same "random" UUIDs far more often than the odds would predict. This manifested as an intermittent assert ("Instance creation for asset id X resulted in a recursive creation of that asset, which was unexpected. This asset might be erroneously referencing itself as a dependent asset.") from Atom in the Instance database, since it is the most frequent consumer of parallel random UUID generation.

Thanks to @amzn-tommy for providing the unit test that made this bug nearly 100% reproducible!

The heart of the problem was some bad overly-clever threading logic that attempted to remain lockless as much as possible, but introduced bugs that were thread-unsafe and logically incorrect. For reference, here is the incorrect code:
```c++
        int index = m_index.fetch_add(1);
        if (index >= SfmtInternal::N32)
        {
            AZStd::lock_guard<decltype(m_generationMutex)> lock(m_generationMutex);
            // if this thread is the one that sets m_index to 0, then this thread
            // does the generation
            index += 1; // compare against the result of fetch_add(1) above
            if (m_index.compare_exchange_strong(index, 0))
            {
                SfmtInternal::gen_rand_all(*this);
            }
            // try again, with the new table
            return Rand32();
        }
        return m_psfmt32[index];
```
The problems are as follows:
1. m_index was getting set to 0 _before_ calling gen_rand_all(). If another thread then calls Rand32() before gen_rand_all() is called, it won't enter the locking path and will return a sequence of m_psfmt32 values that have already been used. This led to entire identical 128-bit UUIDs getting recreated. It might seem like this could be solved by delaying the m_index reset until after the gen_rand_all() call, but...
2. If a thread grabbed an index value and then was swapped out before using it, it's possible for the index to roll all the way back around and get used twice on the same m_psfmt32 table generation, meaning that the same 32-bit (or 64-bit) value will get returned multiple times. This is _less_ problematic than 1, because at least it doesn't cause an entire series of numbers to repeat, but it's still a problem for code that expects 32-bit or 64-bit numbers to collide very infrequently.
3. Other functions such as Seed() or FillArray32() modified the m_psfmt32 table without locking a mutex, so the table could get modified on one thread while in the midst of using it on a different thread. This isn't _necessarily_ a problem, but the algorithm will certainly be affected in unpredictable ways if two threads start modifying the table at the same time.

At the end of the day, the easiest and most verifiably correct solution is to guard all use of the m_psfmt32 table with a mutex. It might be possible to invent an alternate solution that can remain mostly-lockless, but it would likely be complicated by tracking a separate value to account for the number of table regenerations, and then continuously retrying until the table regeneration count remains stable during the entire lookup. Or it could be done with a boolean array to ensure each value is only used once per table generation. etc. They're all more complicated and not obviously-better solutions than just a good old-fashioned simple mutex.

The fixes consist of the following:
* Simplified the threading logic in Sfmt to simply be a mutex in each function that needs to run exclusively from the other functions. Also removed the sketchy "recursive retry" logic in Rand32/Rand64 since it's no longer necessary.
* Added a second assert to InstanceDatabase to help distinguish between duplicate IDs and recursive asset creation.
* Changed UUID creation to use 2 Rand64() calls instead of 4 Rand32() calls for improved performance.
* Added unit tests from @amzn-tommy to verify (as best as we can) that the race conditions no longer exist.

Fixes #13791 .

## How was this PR tested?

Ran the unit tests for Sfmt and UUID.
Ran the Editor / MultiplayerSample to spot-check that everything still behaved normally.

