### PR TITLE
Add material instance null pointer check in editor material component

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
@@ -282,7 +282,10 @@ namespace AZ
             // PSO-impacting property changes are allowed in the editor because the saved data can be analyzed to pre-compile the necessary PSOs.
             for (auto& materialAssignment : materials)
             {
-                materialAssignment.second.m_materialInstance->SetPsoHandlingOverride(AZ::RPI::MaterialPropertyPsoHandling::Allowed);
+                if (materialAssignment.second.m_materialInstance)
+                {
+                    materialAssignment.second.m_materialInstance->SetPsoHandlingOverride(AZ::RPI::MaterialPropertyPsoHandling::Allowed);
+                }
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

This change fixes a potential crash if a material component config has slots referencing bad material assets or no material w/ model UV overrides

## How was this PR tested?

Compiled code successfully
