### PR TITLE
Added support for custom external

### DIFF
--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -37,6 +37,7 @@ AZ_POP_DISABLE_WARNING
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QDialogButtonBox>
+#include <QUrlQuery>
 
 // AzCore
 #include <AzCore/Casting/numeric_cast.h>
@@ -161,6 +162,10 @@ static const char O3DEEditorClassName[] = "O3DEEditorClass";
 static const char O3DEApplicationName[] = "O3DEApplication";
 
 static AZ::EnvironmentVariable<bool> inEditorBatchMode = nullptr;
+
+namespace Platform {
+    bool OpenUri(const QUrl& uri);
+}
 
 RecentFileList::RecentFileList()
 {
@@ -3748,11 +3753,68 @@ CMainFrame * CCryEditApp::GetMainFrame() const
 }
 
 
+void CCryEditApp::OpenExternalLuaDebugger(AZStd::string_view luaDebuggerUri, AZStd::string_view projectPath, AZStd::string_view enginePath, const char* files)
+{
+    // Put together the whole Url Query String:
+    QUrlQuery query;
+    query.addQueryItem("projectPath", QString::fromUtf8(projectPath.data(), aznumeric_cast<int>(projectPath.size())));
+    if (!enginePath.empty())
+    {
+        query.addQueryItem("enginePath", QString::fromUtf8(enginePath.data(), aznumeric_cast<int>(enginePath.size())));
+    }
+
+    auto ParseFilesList = [&](AZStd::string_view filePath)
+    {
+        bool fullPathFound = false;
+        auto GetFullSourcePath = [&]
+        (AzToolsFramework::AssetSystem::AssetSystemRequest* assetSystemRequests)
+        {
+            AZ::IO::Path assetFullPath;
+            if(assetSystemRequests->GetFullSourcePathFromRelativeProductPath(filePath, assetFullPath.Native()))
+            {
+                fullPathFound = true;
+                query.addQueryItem("files[]", QString::fromUtf8(assetFullPath.c_str()));
+            }
+        };
+        AzToolsFramework::AssetSystemRequestBus::Broadcast(AZStd::move(GetFullSourcePath));
+        // If the full source path could be found through the Asset System, then
+        // attempt to resolve the path using the FileIO instance
+        if (!fullPathFound)
+        {
+            AZ::IO::FixedMaxPath resolvedFilePath;
+            if (auto fileIo = AZ::IO::FileIOBase::GetInstance();
+                fileIo != nullptr && fileIo->ResolvePath(resolvedFilePath, filePath)
+                && fileIo->Exists(resolvedFilePath.c_str()))
+            {
+                query.addQueryItem("files[]", QString::fromUtf8(resolvedFilePath.c_str()));
+            }
+        }
+    };
+    AZ::StringFunc::TokenizeVisitor(files, ParseFilesList, "|");
+
+    QUrl luaDebuggerUrl(QString::fromUtf8(luaDebuggerUri.data(), aznumeric_cast<int>(luaDebuggerUri.size())));
+    luaDebuggerUrl.setQuery(query);
+
+    AZ_VerifyError("CCryEditApp", Platform::OpenUri(luaDebuggerUrl),
+        "Failed to start external lua debugger with URI: %s", luaDebuggerUrl.toString().toUtf8().constData());
+
+}
+
 void CCryEditApp::OpenLUAEditor(const char* files)
 {
     AZ::IO::FixedMaxPathString enginePath = AZ::Utils::GetEnginePath();
-
     AZ::IO::FixedMaxPathString projectPath = AZ::Utils::GetProjectPath();
+
+    auto registry = AZ::SettingsRegistry::Get();
+    if (registry)
+    {
+        AZStd::string luaDebuggerUri;
+        if (registry->Get(luaDebuggerUri, LuaDebuggerUriRegistryKey))
+        {
+            OpenExternalLuaDebugger(luaDebuggerUri, projectPath, enginePath, files);
+            return;
+        }
+    }
 
     AZStd::string filename = "LuaIDE";
     AZ::IO::FixedMaxPath executablePath = AZ::Utils::GetExecutableDirectory();

--- a/Code/Editor/CryEdit.h
+++ b/Code/Editor/CryEdit.h
@@ -344,6 +344,20 @@ AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 private:
     static inline constexpr const char* DefaultLevelTemplateName = "Prefabs/Default_Level.prefab";
 
+    // Optional Uri to start an external lua debugger. If not specified,
+    // then the Editor will open LuaIDE.exe.
+    // For example, if using The Visual Studio Debugger Extension provided by lumbermixalot
+    // The value will be: "vscode://lumbermixalot.o3de-lua-debug/debug?"
+    // The following parameters will be added to the URI at runtime:
+    // "projectPath". Absolute path of the game projec root.
+    // "enginePath". Absolute path of the engine root. if not specified, it will be assume to be one directory above the game project root.
+    // "files[]". A list of files, 
+    // Full example using the Uri shown below:
+    // "vscode://lumbermixalot.o3de-lua-debug/debug?projectPath=D:\mydir\myproject&enginePath=C:\GIT\o3de&files[]=D:\mydir\myproject\scripts\something.lua&files[]=D:\mydir\myproject\scripts\utils\something2.lua"
+    // or
+    // "vscode://lumbermixalot.o3de-lua-debug/debug?projectPath=D:\GIT\o3de\AutomatedTesting&files[]=D:\GIT\o3de\AutomatedTesting\Assets\Scripts\something.lua"
+    static constexpr AZStd::string_view LuaDebuggerUriRegistryKey = "/O3DE/Lua/Debugger/Uri";
+
     struct PythonOutputHandler;
     AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     AZStd::shared_ptr<PythonOutputHandler> m_pythonOutputHandler;
@@ -374,6 +388,9 @@ private:
     void OnOpenAudioControlsEditor();
     void OnOpenUICanvasEditor();
     void OnOpenQuickAccessBar();
+
+    // @param files: A list of file paths, separated by '|';
+    void OpenExternalLuaDebugger(AZStd::string_view luaDebuggerUri, AZStd::string_view enginePath, AZStd::string_view projectPath, const char * files);
 
 public:
     void ExportLevel(bool bExportToGame, bool bExportTexture, bool bAutoExport);

--- a/Code/Editor/Util/FileUtil.cpp
+++ b/Code/Editor/Util/FileUtil.cpp
@@ -55,7 +55,9 @@
 namespace Platform
 {
     // Forward declare platform specific functions
-    bool RunEditorWithArg(const QString editor, const QString arg);
+    bool RunCommandWithArguments(const QString& command, const QString& args);
+    bool RunEditorWithArg(const QString& editor, const QString& arg);
+    bool OpenUri(const QUrl& uri);
     QString GetDefaultEditor(const Common::EditFileType fileType);
     QString MakePlatformFileEditString(QString pathToEdit, int lineToEdit);
     bool CreatePath(const QString& strPath);

--- a/Code/Editor/Util/Platform/Windows/FileUtil_Windows.cpp
+++ b/Code/Editor/Util/Platform/Windows/FileUtil_Windows.cpp
@@ -14,20 +14,31 @@
 
 namespace Platform
 {
-    bool RunEditorWithArg(const QString editor, const QString arg)
+    bool RunCommandWithArguments(const QString& command, const QString& args)
     {
         bool success = false;
 
-        // Use the Win32API calls as they aren't limited to running items in the path.
-        QString fullTexturePathFixedForWindows = QString(arg.data()).replace('/', '\\');
+        HINSTANCE hInst = ShellExecuteW( nullptr,
+            L"open",
+            command.toStdWString().c_str(),
+            args.isEmpty() ? NULL : args.toStdWString().c_str(),
+            NULL, SW_SHOWNORMAL);
 
-        HINSTANCE hInst = ShellExecuteW(
-            nullptr, L"open", editor.toStdWString().c_str(), fullTexturePathFixedForWindows.toStdWString().c_str(), NULL,
-            SW_SHOWNORMAL);
-        
         success = ((DWORD_PTR)hInst > 32);
 
         return success;
+    }
+
+    bool OpenUri(const QUrl& uri)
+    {
+        return RunCommandWithArguments(uri.toString(), "");
+    }
+
+    bool RunEditorWithArg(const QString& editor, const QString& arg)
+    {
+        // Use the Win32API calls as they aren't limited to running items in the path.
+        QString fullTexturePathFixedForWindows = QString(arg.data()).replace('/', '\\');
+        return RunCommandWithArguments(editor, fullTexturePathFixedForWindows);
     }
 
     QString GetDefaultEditor(const Common::EditFileType fileType)
@@ -114,4 +125,5 @@ namespace Platform
     {
         return "LuaCompiler.exe";
     }
+
 }


### PR DESCRIPTION
debuggers like vscode via a user
customizable URI per the registry key:
`/O3DE/Lua/Debugger/Uri

If the above Uri is not specified,
then the Editor will open LuaIDE.exe.

For example, if using The Visual Studio Debugger Extension provided by lumbermixalot The value will be: "vscode://lumbermixalot.o3de-lua-debug/debug?" The following parameters will be added to the URI at runtime, as part of the query:
    - "projectPath". Absolute path of the game projec root.
    - "enginePath". Absolute path of the engine root. if not specified,
                    it will be assume to be one directory above the game project root.
    - "files[]". A list of files.

Full example of a complete Uri Query that the Editor would dispatch to the OS to open two files with a particular vscode debugger: REMARK: The special characters would be properly escaped because the code uses QUrl and QUrlQuery classes for encoding.

Example with two files to open:
`vscode://lumbermixalot.o3de-lua-debug/debug?projectPath=D:\mydir\myproject&enginePath=C:\GIT\o3de&files[]=D:\mydir\myproject\scripts\something.lua&files[]=D:\mydir\myproject\scripts\utils\something2.lua`

Exampled wit only one file to open (most common scenario). `vscode://lumbermixalot.o3de-lua-debug/debug?projectPath=D:\GIT\o3de\AutomatedTesting&files[]=D:\GIT\o3de\AutomatedTesting\Assets\Scripts\something.lua`

## What does this PR do?

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_

_Please add links to any issues, RFCs or other items that are relevant to this PR._

## How was this PR tested?

_Please describe any testing performed._
