### PR TITLE
Added benchmark to measure the activation time of PhysX Rigid Bodies.

### DIFF
--- a/Gems/PhysX/Code/Tests/Benchmarks/PhysXBenchmarksUtilities.cpp
+++ b/Gems/PhysX/Code/Tests/Benchmarks/PhysXBenchmarksUtilities.cpp
@@ -27,7 +27,8 @@ namespace PhysX::Benchmarks
             int benchmarkObjectType,
             GenerateColliderFuncPtr* genColliderFuncPtr /*= nullptr*/, GenerateSpawnPositionFuncPtr* genSpawnPosFuncPtr /*= nullptr*/,
             GenerateSpawnOrientationFuncPtr* genSpawnOriFuncPtr /*= nullptr*/, GenerateMassFuncPtr* genMassFuncPtr /*= nullptr*/,
-            GenerateEntityIdFuncPtr* genEntityIdFuncPtr /*= nullptr*/
+            GenerateEntityIdFuncPtr* genEntityIdFuncPtr /*= nullptr*/,
+            bool activateEntities /*= true*/
         )
         {
             BenchmarkRigidBodies benchmarkRigidBodies;
@@ -110,7 +111,10 @@ namespace PhysX::Benchmarks
                     entity->CreateComponent<PhysX::RigidBodyComponent>(rigidBodyConfig, sceneHandle);
 
                     entity->Init();
-                    entity->Activate();
+                    if (activateEntities)
+                    {
+                        entity->Activate();
+                    }
 
                     AZStd::get_if<PhysX::EntityList>(&benchmarkRigidBodies)->push_back(entity);
                 }

--- a/Gems/PhysX/Code/Tests/Benchmarks/PhysXBenchmarksUtilities.h
+++ b/Gems/PhysX/Code/Tests/Benchmarks/PhysXBenchmarksUtilities.h
@@ -68,7 +68,8 @@ namespace PhysX::Benchmarks
             int benchmarkObjectType,
             GenerateColliderFuncPtr* genColliderFuncPtr = nullptr, GenerateSpawnPositionFuncPtr* genSpawnPosFuncPtr = nullptr,
             GenerateSpawnOrientationFuncPtr* genSpawnOriFuncPtr = nullptr, GenerateMassFuncPtr* genMassFuncPtr = nullptr,
-            GenerateEntityIdFuncPtr* genEntityIdFuncPtr = nullptr
+            GenerateEntityIdFuncPtr* genEntityIdFuncPtr = nullptr,
+            bool activateEntities = true
         );
 
         //! Helper that takes a list of SimulatedBodyHandles to Rigid Bodies and return RigidBody pointers

--- a/Gems/PhysX/Code/Tests/Benchmarks/PhysXRigidBodyBenchmarks.cpp
+++ b/Gems/PhysX/Code/Tests/Benchmarks/PhysXRigidBodyBenchmarks.cpp
@@ -75,6 +75,19 @@ namespace PhysX::Benchmarks
             //! Number of iterations for each test
             static const int NumIterations = 3;
         } // namespace BenchmarkRange
+
+        //! Settings used to setup the activation benchmark
+        namespace ActivationBenchmarkSettings
+        {
+            //! Values passed to activation benchmark to select the number of rigid bodies to activate during each test
+            //! Current values will run tests between StartRange to EndRange (inclusive), multiplying by RangeMultiplier each step.
+            static const int StartRange = 100;
+            static const int EndRange = 100000;
+            static const int RangeMultipler = 10;
+
+            //! Number of iterations for each test
+            static const int NumIterations = 10;
+        } // namespace ActivationBenchmarkSettings
     } // namespace RigidBodyConstants
 
     namespace Utils
@@ -132,6 +145,58 @@ namespace PhysX::Benchmarks
             AzPhysics::SimulatedBodyEvents::OnCollisionPersist::Handler m_onCollisionPersistHandler;
             AzPhysics::SimulatedBodyEvents::OnCollisionEnd::Handler m_onCollisionEndHandler;
         };
+
+        //! Class to mock a runtime component that needs a rigid body during activation.
+        class MockRigidBodyDependantComponent
+            : public AZ::Component
+            , protected Physics::RigidBodyNotificationBus::Handler
+        {
+        public:
+            AZ_COMPONENT(MockRigidBodyDependantComponent, "{3122D81F-525A-4577-A8D7-5F0A2D474F78}");
+            static void Reflect(AZ::ReflectContext* context)
+            {
+                if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+                {
+                    serializeContext->Class<MockRigidBodyDependantComponent, AZ::Component>()
+                        ->Version(1);
+                }
+            }
+
+            MockRigidBodyDependantComponent() = default;
+            ~MockRigidBodyDependantComponent() = default;
+
+        protected:
+            static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+            {
+                required.push_back(AZ_CRC_CE("TransformService"));
+                required.push_back(AZ_CRC_CE("PhysicsDynamicRigidBodyService"));
+            }
+
+            void Activate() override
+            {
+                // During activation the simulated bodies are not created yet.
+                // Connect to RigidBodyNotificationBus to listen when it's enabled after creation.
+                Physics::RigidBodyNotificationBus::Handler::BusConnect(GetEntityId());
+            }
+
+            void Deactivate() override
+            {
+                Physics::RigidBodyNotificationBus::Handler::BusDisconnect();
+            }
+
+            void OnPhysicsEnabled(const AZ::EntityId& entityId) override
+            {
+                m_physicsRigidBodyComponent = Physics::RigidBodyRequestBus::FindFirstHandler(entityId);
+                AZ_Assert(m_physicsRigidBodyComponent, "Physics Rigid Body is required on entity %s", GetEntity()->GetName().c_str());
+            }
+
+            void OnPhysicsDisabled([[maybe_unused]] const AZ::EntityId& entityId) override
+            {
+                m_physicsRigidBodyComponent = nullptr;
+            }
+
+            Physics::RigidBodyRequests* m_physicsRigidBodyComponent = nullptr;
+        };
     } // namespace Utils
 
     //! Rigid body performance fixture.
@@ -142,6 +207,16 @@ namespace PhysX::Benchmarks
     protected:
         virtual void internalSetUp()
         {
+            // Register MockRigidBodyDependantComponent with the serialize context
+            AZ::SerializeContext* serializeContext = nullptr;
+            AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
+            if (serializeContext)
+            {
+                m_mockRigidBodyDependantComponentDescriptor =
+                    AZStd::unique_ptr<AZ::ComponentDescriptor>(Utils::MockRigidBodyDependantComponent::CreateDescriptor());
+                m_mockRigidBodyDependantComponentDescriptor->Reflect(serializeContext);
+            }
+
             PhysXBaseBenchmarkFixture::SetUpInternal();
             //need to get the Physics::System to be able to spawn the rigid bodies
             m_system = AZ::Interface<Physics::System>::Get();
@@ -153,6 +228,15 @@ namespace PhysX::Benchmarks
         {
             m_terrainEntity = nullptr;
             PhysXBaseBenchmarkFixture::TearDownInternal();
+
+            // Unregister MockRigidBodyDependantComponent with the serialize context
+            AZ::SerializeContext* serializeContext = nullptr;
+            AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
+            if (serializeContext)
+            {
+                serializeContext->UnregisterType(azrtti_typeid<Utils::MockRigidBodyDependantComponent>());
+            }
+            m_mockRigidBodyDependantComponentDescriptor.reset();
         }
     public:
         void SetUp(const benchmark::State&) override
@@ -188,6 +272,7 @@ namespace PhysX::Benchmarks
 
         Physics::System *m_system;
         EntityPtr m_terrainEntity;
+        AZStd::unique_ptr<AZ::ComponentDescriptor> m_mockRigidBodyDependantComponentDescriptor;
     };
 
     void PhysXRigidbodyBenchmarkFixture::SetLabel(benchmark::State& state, int rigidBodyType)
@@ -370,6 +455,98 @@ namespace PhysX::Benchmarks
         Utils::ReportFrameStandardDeviationAndMeanCounters(state, tickTimes, subTickTracker.GetSubTickTimes());
 
         SetLabel(state, bodyType);
+    }
+
+    //! BM_RigidBody_Activation - This test will create the requested number of rigid bodies, including
+    //! mock components that depend on the rigid bodies, and measure the time it takes to activate them.
+    BENCHMARK_DEFINE_F(PhysXRigidbodyBenchmarkFixture, BM_RigidBody_Activation)(benchmark::State& state)
+    {
+        // get the request number of rigid bodies and prepare to spawn them
+        const int numRigidBodies = aznumeric_cast<int>(state.range(0));
+
+        const float boxSize = 1.0f;
+        const float boxSpacing = 0.25f;
+
+        // common settings for each rigid body
+        const float boxSizeWithSpacing = boxSize + boxSpacing;
+        const int boxesPerCol = static_cast<const int>(RigidBodyConstants::TerrainSize / boxSizeWithSpacing) - 1;
+        int spawnColIdx = 0;
+        int spawnRowIdx = 0;
+
+        // function to generate the rigid bodies position / orientation / mass
+        Utils::GenerateSpawnPositionFuncPtr posGenerator =
+            [boxSize, boxSizeWithSpacing, boxesPerCol, &spawnColIdx, &spawnRowIdx]([[maybe_unused]] int idx) -> const AZ::Vector3
+        {
+            const float x = boxSizeWithSpacing + (boxSizeWithSpacing * spawnColIdx);
+            const float y = boxSizeWithSpacing + (boxSizeWithSpacing * spawnRowIdx);
+            const float z = boxSize / 2.0f;
+
+            // advance to the next position to spawn the next rigid body
+            spawnColIdx++;
+            if (spawnColIdx >= boxesPerCol)
+            {
+                spawnColIdx = 0;
+                spawnRowIdx++;
+            }
+            return AZ::Vector3(x, y, z);
+        };
+
+        auto boxShapeConfiguration =
+            AZStd::make_shared<Physics::BoxShapeConfiguration>(AZ::Vector3(RigidBodyConstants::RigidBodys::BoxSize));
+        Utils::GenerateColliderFuncPtr colliderGenerator = [&boxShapeConfiguration]([[maybe_unused]] int idx)
+        {
+            return boxShapeConfiguration;
+        };
+
+        // spawn the rigid bodies without activating them
+        Utils::BenchmarkRigidBodies rigidBodies = Utils::CreateRigidBodies(
+            numRigidBodies,
+            GetDefaultSceneHandle(),
+            RigidBodyConstants::CCDEnabled,
+            RigidBodyEntity,
+            &colliderGenerator,
+            &posGenerator,
+            nullptr /*genSpawnOriFuncPtr*/,
+            nullptr /*genMassFuncPtr*/,
+            nullptr /*genEntityIdFuncPtr*/,
+            false /*activateEntities*/);
+
+        auto& entityList = AZStd::get<PhysX::EntityList>(rigidBodies);
+
+        // Add mock component that depend on rigid body during activation and
+        // therefore are require to use RigidBodyNotification bus.
+        for (auto& entity : entityList)
+        {
+            entity->CreateComponent<Utils::MockRigidBodyDependantComponent>();
+        }
+
+        Types::TimeList activationTimes;
+
+        for ([[maybe_unused]] auto _ : state)
+        {
+            // Measure time to activate the entities
+            auto start = AZStd::chrono::steady_clock::now();
+
+            for (auto& entity : entityList)
+            {
+                entity->Activate();
+            }
+
+            auto tickElapsedMilliseconds = Types::double_milliseconds(AZStd::chrono::steady_clock::now() - start);
+            activationTimes.emplace_back(tickElapsedMilliseconds.count());
+
+            // Deactivate the entities for the next state iteration
+            for (auto& entity : entityList)
+            {
+                entity->Deactivate();
+            }
+        }
+
+        entityList.clear();
+
+        // sort the activation times and get the P50, P90, P99 percentiles
+        Utils::ReportPercentiles(state, activationTimes);
+        Utils::ReportStandardDeviationAndMeanCounters(state, activationTimes);
     }
 
     //! Same as the PhysXRigidbodyBenchmarkFixture, adds a world event handler to receive collision events
@@ -588,6 +765,14 @@ namespace PhysX::Benchmarks
                    { RigidBodyApiObject, RigidBodyEntity } })
         ->Unit(benchmark::kMillisecond)
         ->Iterations(RigidBodyConstants::BenchmarkSettings::NumIterations)
+        ->MeasureProcessCPUTime();
+        ;
+
+    BENCHMARK_REGISTER_F(PhysXRigidbodyBenchmarkFixture, BM_RigidBody_Activation)
+        ->RangeMultiplier(RigidBodyConstants::ActivationBenchmarkSettings::RangeMultipler)
+        ->Ranges({ { RigidBodyConstants::ActivationBenchmarkSettings::StartRange, RigidBodyConstants::ActivationBenchmarkSettings::EndRange } })
+        ->Unit(benchmark::kMillisecond)
+        ->Iterations(RigidBodyConstants::ActivationBenchmarkSettings::NumIterations)
         ->MeasureProcessCPUTime();
         ;
 

--- a/Gems/PhysX/Code/Tests/Benchmarks/PhysXRigidBodyBenchmarks.cpp
+++ b/Gems/PhysX/Code/Tests/Benchmarks/PhysXRigidBodyBenchmarks.cpp
@@ -470,23 +470,23 @@ namespace PhysX::Benchmarks
         // common settings for each rigid body
         const float boxSizeWithSpacing = boxSize + boxSpacing;
         const int boxesPerCol = static_cast<const int>(RigidBodyConstants::TerrainSize / boxSizeWithSpacing) - 1;
-        int spawnColIdx = 0;
-        int spawnRowIdx = 0;
+        int spawnColIndex = 0;
+        int spawnRowIndex = 0;
 
         // function to generate the rigid bodies position / orientation / mass
         Utils::GenerateSpawnPositionFuncPtr posGenerator =
-            [boxSize, boxSizeWithSpacing, boxesPerCol, &spawnColIdx, &spawnRowIdx]([[maybe_unused]] int idx) -> const AZ::Vector3
+            [boxSize, boxSizeWithSpacing, boxesPerCol, &spawnColIndex, &spawnRowIndex]([[maybe_unused]] int idx) -> const AZ::Vector3
         {
-            const float x = boxSizeWithSpacing + (boxSizeWithSpacing * spawnColIdx);
-            const float y = boxSizeWithSpacing + (boxSizeWithSpacing * spawnRowIdx);
+            const float x = boxSizeWithSpacing + (boxSizeWithSpacing * spawnColIndex);
+            const float y = boxSizeWithSpacing + (boxSizeWithSpacing * spawnRowIndex);
             const float z = boxSize / 2.0f;
 
             // advance to the next position to spawn the next rigid body
-            spawnColIdx++;
-            if (spawnColIdx >= boxesPerCol)
+            spawnColIndex++;
+            if (spawnColIndex >= boxesPerCol)
             {
-                spawnColIdx = 0;
-                spawnRowIdx++;
+                spawnColIndex = 0;
+                spawnRowIndex++;
             }
             return AZ::Vector3(x, y, z);
         };
@@ -513,8 +513,8 @@ namespace PhysX::Benchmarks
 
         auto& entityList = AZStd::get<PhysX::EntityList>(rigidBodies);
 
-        // Add mock component that depend on rigid body during activation and
-        // therefore are require to use RigidBodyNotification bus.
+        // Add mock components that depend on rigid body during activation and
+        // therefore are required to use RigidBodyNotification bus.
         for (auto& entity : entityList)
         {
             entity->CreateComponent<Utils::MockRigidBodyDependantComponent>();


### PR DESCRIPTION
## What does this PR do?

Added benchmark `BM_RigidBody_Activation` to PhysX Gem. This test will create 100, 1K, 10K and 100K entities with rigid bodies, colliders and mock components that depend on the rigid bodies, and it measures the time it takes to activate them. It will do 10 iterations of each and calculate the mean, standard deviation, P50, P90, P99, Fastest and Slowest times.

## How was this PR tested?

````
---------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                         Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------------------------------------------------------------
PhysXRigidbodyBenchmarkFixture/BM_RigidBody_Activation/100/iterations:10/process_time          1.22 ms         1.56 ms           10 Fastest=0.9314 Mean=1.035 P50=0.9314 P90=1.3424 P99=1.561 Slowest=1.561 StDev=0.217
PhysXRigidbodyBenchmarkFixture/BM_RigidBody_Activation/1000/iterations:10/process_time         12.1 ms         12.5 ms           10 Fastest=9.5636 Mean=9.922 P50=9.5636 P90=10.8593 P99=13.7622 Slowest=13.7622 StDev=1.39
PhysXRigidbodyBenchmarkFixture/BM_RigidBody_Activation/10000/iterations:10/process_time         147 ms          147 ms           10 Fastest=107.661 Mean=111.466 P50=107.661 P90=116.95 P99=144.285 Slowest=144.285 StDev=11.633
PhysXRigidbodyBenchmarkFixture/BM_RigidBody_Activation/100000/iterations:10/process_time       1695 ms         1695 ms           10 Fastest=1.17721k Mean=1.21228k P50=1.17721k P90=1.19776k P99=1.57493k Slowest=1.57493k StDev=122.94
````
