### PR TITLE
Asset Processor - Handle edge case of product prefix conflict

### DIFF
--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rcjob.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rcjob.cpp
@@ -813,7 +813,7 @@ namespace AssetProcessor
 
             if (isSourceMetadataEnabled)
             {
-                ProductOutputUtil::ModifyProductPath(outputFilename, params.m_rcJob->GetJobEntry().m_sourceAssetReference.ScanFolderId());
+                ProductOutputUtil::GetTempProductPath(outputFilename, params.m_rcJob->GetJobEntry().m_sourceAssetReference.ScanFolderId());
             }
 
             if(outputToCache)

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rcjob.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rcjob.cpp
@@ -813,7 +813,11 @@ namespace AssetProcessor
 
             if (isSourceMetadataEnabled)
             {
-                ProductOutputUtil::GetTempProductPath(outputFilename, params.m_rcJob->GetJobEntry().m_sourceAssetReference.ScanFolderId());
+                // For metadata enabled files, the output file needs to be prefixed to handle multiple files with the same relative path.
+                // This phase will just use a temporary prefix which is longer and less likely to result in accidental conflicts.
+                // During AssetProcessed_Impl in APM, the prefixing will be resolved to figure out which file is highest priority and gets renamed
+                // back to the non-prefixed, backwards compatible format and every other file with the same rel path will be re-prefixed to a finalized form.
+                ProductOutputUtil::GetInterimProductPath(outputFilename, params.m_rcJob->GetJobEntry().m_sourceAssetReference.ScanFolderId());
             }
 
             if(outputToCache)

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -380,6 +380,9 @@ public:
 
         using namespace AssetBuilderSDK;
 
+        // Set up a custom builder with a ProcessJob stage that will output 2 files, one of which is intentionally
+        // designed to output a product with a name that conflicts with the prefixing scheme (the (2) prefix).
+        // .stage1 is the input and .stage2 is the output.  This unit test framework currently requires those extensions.
         m_builderInfoHandler.CreateBuilderDesc(
             "stage1",
             AZ::Uuid::CreateRandom().ToFixedString().c_str(),

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -380,7 +380,44 @@ public:
 
         using namespace AssetBuilderSDK;
 
-        CreateBuilder("stage1", "*.stage1", "stage2", false, ProductOutputFlags::ProductAsset);
+        m_builderInfoHandler.CreateBuilderDesc(
+            "stage1",
+            AZ::Uuid::CreateRandom().ToFixedString().c_str(),
+            { AssetBuilderPattern{ "*.stage1", AssetBuilderPattern::Wildcard } },
+            CreateJobStage("stage1", false),
+            [](const ProcessJobRequest& request, ProcessJobResponse& response)
+            {
+                AZ::IO::FixedMaxPath outputFile = AZ::IO::FixedMaxPath(request.m_sourceFile);
+                outputFile.ReplaceExtension("stage2");
+                outputFile = outputFile.Filename();
+
+                AZ::IO::Result result = AZ::IO::FileIOBase::GetInstance()->Copy(
+                    request.m_fullPath.c_str(), (AZ::IO::FixedMaxPath(request.m_tempDirPath) / outputFile).c_str());
+
+                EXPECT_TRUE(result);
+
+                auto product = JobProduct{ outputFile.c_str(), AZ::Data::AssetType::CreateName("stage2"), AssetSubId };
+
+                product.m_outputFlags = ProductOutputFlags::ProductAsset;
+                product.m_dependenciesHandled = true;
+
+                // Output an extra product which is already prefixed
+                // This tests an edge case where removing the prefixes during finalization in the wrong order can result in overwriting the main product
+                auto extraFilePath =
+                    AZ::IO::Path(request.m_tempDirPath) / "(2)file.stage2";
+
+                AZ::Utils::WriteFile("unit test file", extraFilePath.Native());
+
+                auto extraProduct = JobProduct{ extraFilePath.c_str(), AZ::Data::AssetType::CreateName("extra"), ExtraAssetSubId };
+
+                extraProduct.m_outputFlags = ProductOutputFlags::ProductAsset;
+                extraProduct.m_dependenciesHandled = true;
+
+                response.m_outputProducts.push_back(extraProduct);
+                response.m_outputProducts.push_back(product);
+                response.m_resultCode = ProcessJobResult_Success;
+            },
+            "fingerprint");
 
         // Enable metadata for our file type
         AZ::Interface<IUuidRequests>::Get()->EnableGenerationForTypes({ ".stage1" });
@@ -390,7 +427,7 @@ public:
         m_sourceB = SourceAssetReference{ assetRootDir / "folder2" / "subfolder" / "file.stage1" };
     }
 
-    void SetupScanfolders(AZ::IO::Path assetRootDir, const AZStd::vector<AssetBuilderSDK::PlatformInfo>& platforms)
+    void SetupScanfolders(AZ::IO::Path assetRootDir, const AZStd::vector<AssetBuilderSDK::PlatformInfo>& platforms) override
     {
         UnitTests::AssetManagerTestingBase::SetupScanfolders(assetRootDir, platforms);
 
@@ -405,14 +442,27 @@ public:
         EXPECT_EQ(products.size(), 1);
 
         products = {};
-        EXPECT_TRUE(m_stateData->GetProductsByProductName(
-            AZStd::string::format("pc/subfolder/%sfile.stage2", ProductOutputUtil::GetPrefix(m_sourceB.ScanFolderId()).c_str()).c_str(), products));
+        auto productName =
+            AZStd::string::format("pc/subfolder/%sfile.stage2", ProductOutputUtil::GetFinalPrefix(m_sourceB.ScanFolderId()).c_str());
+        EXPECT_TRUE(m_stateData->GetProductsByProductName(productName.c_str(), products));
         EXPECT_EQ(products.size(), 1);
 
         auto io = AZ::IO::FileIOBase::GetInstance();
+        // SourceA
+        // SourceA is highest priority so its files should exist without the prefix
         EXPECT_TRUE(io->Exists(MakePath("subfolder/file.stage2", false).c_str()));
-        EXPECT_FALSE(io->Exists(MakePath("subfolder/(2)file.stage2", false).c_str()));
-        EXPECT_TRUE(io->Exists(MakePath("subfolder/(3)file.stage2", false).c_str()));
+        EXPECT_TRUE(io->Exists(MakePath("subfolder/(2)file.stage2", false).c_str()));
+
+        auto prefix = ProductOutputUtil::GetFinalPrefix(m_sourceA.ScanFolderId());
+
+        EXPECT_FALSE(io->Exists(MakePath(AZStd::string::format("subfolder/%s(2)file.stage2", prefix.c_str()).c_str(), false).c_str()));
+
+        // SourceB
+        // SourceB is lower priority so its files should exist with the prefix
+        prefix = ProductOutputUtil::GetFinalPrefix(m_sourceB.ScanFolderId());
+
+        EXPECT_TRUE(io->Exists(MakePath(AZStd::string::format("subfolder/%sfile.stage2", prefix.c_str()).c_str(), false).c_str()));
+        EXPECT_TRUE(io->Exists(MakePath(AZStd::string::format("subfolder/%s(2)file.stage2", prefix.c_str()).c_str(), false).c_str()));
 
         auto fileContentsResult = AZ::Utils::ReadFile(MakePath("subfolder/file.stage2", false).c_str());
 
@@ -447,8 +497,11 @@ TEST_F(MetadataOverrides, MetadataOverrides_LowestPriorityProcessedFirst_Outputs
     ProcessFileMultiStage(1, false, m_sourceB);
 
     auto io = AZ::IO::FileIOBase::GetInstance();
+    auto prefix = ProductOutputUtil::GetFinalPrefix(m_sourceB.ScanFolderId());
     EXPECT_FALSE(io->Exists(MakePath("subfolder/file.stage2", false).c_str()));
-    EXPECT_TRUE(io->Exists(MakePath("subfolder/(3)file.stage2", false).c_str()));
+    EXPECT_FALSE(io->Exists(MakePath("subfolder/(2)file.stage2", false).c_str()));
+    EXPECT_TRUE(io->Exists(MakePath(AZStd::string::format("subfolder/%sfile.stage2", prefix.c_str()).c_str(), false).c_str()));
+    EXPECT_TRUE(io->Exists(MakePath(AZStd::string::format("subfolder/%s(2)file.stage2", prefix.c_str()).c_str(), false).c_str()));
 
     ProcessFileMultiStage(1, false, m_sourceA);
 
@@ -463,7 +516,7 @@ TEST_F(MetadataOverrides, MetadataOverrides_LowestPriorityCreatedFirst_OutputsCo
 
     auto io = AZ::IO::FileIOBase::GetInstance();
     EXPECT_TRUE(io->Exists(MakePath("subfolder/file.stage2", false).c_str()));
-    EXPECT_FALSE(io->Exists(MakePath("subfolder/(3)file.stage2", false).c_str()));
+    EXPECT_TRUE(io->Exists(MakePath("subfolder/(2)file.stage2", false).c_str()));
 
     // Create and process the high priority file second
     AZ::Utils::WriteFile("unit test file A", m_sourceA.AbsolutePath().c_str());
@@ -1171,7 +1224,7 @@ TEST_F(AssetProcessorIntermediateAssetSourceDependencyTests, SourceDependencyIsI
     receiver.WaitForFinish();
 
     QCoreApplication::processEvents(); // RCJob::Finished : Once more to trigger the JobFinished event
-    QCoreApplication::processEvents(); // RCController::FinishJob : Again to trigger the Finished event 
+    QCoreApplication::processEvents(); // RCController::FinishJob : Again to trigger the Finished event
 
     // Product B shouldn't exist yet because A was processed first.
     EXPECT_FALSE(AZ::IO::FileIOBase::GetInstance()->Exists(m_secondProductPath.c_str()));
@@ -1226,7 +1279,7 @@ TEST_F(AssetProcessorIntermediateAssetSourceDependencyTests, SourceDependencyIsI
     receiver.WaitForFinish();
 
     QCoreApplication::processEvents(); // RCJob::Finished : Once more to trigger the JobFinished event
-    QCoreApplication::processEvents(); // RCController::FinishJob : Again to trigger the Finished event 
+    QCoreApplication::processEvents(); // RCController::FinishJob : Again to trigger the Finished event
 
     // Mark this asset as processed, so AP will move on to the next steps.
     m_assetProcessorManager->AssetProcessed(m_processedJobEntry, m_processJobResponse);

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/IntermediateAssetTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/IntermediateAssetTests.cpp
@@ -9,7 +9,7 @@
 #include <native/tests/assetmanager/IntermediateAssetTests.h>
 #include <QCoreApplication>
 #include <native/unittests/UnitTestUtils.h>
-
+#include <native/utilities/ProductOutputUtil.h>
 #include <AzFramework/IO/LocalFileIO.h>
 
 namespace UnitTests
@@ -96,8 +96,8 @@ namespace UnitTests
 
         auto builderUuid = builders[0].m_busId;
         auto sourceUuid = AssetUtilities::GetSourceUuid(AssetProcessor::SourceAssetReference(m_testFilePath.c_str()));
-        auto actualIntermediateUuid =
-            AssetUtilities::GetSourceUuid(AssetProcessor::SourceAssetReference(MakePath("(2)test.stage2", true).c_str()));
+        auto actualIntermediateUuid = AssetUtilities::GetSourceUuid(AssetProcessor::SourceAssetReference(
+            MakePath(AZStd::string::format("%stest.stage2", AssetProcessor::ProductOutputUtil::GetTempPrefix(2).c_str()).c_str(), true).c_str()));
 
         ASSERT_TRUE(sourceUuid);
         ASSERT_TRUE(actualIntermediateUuid);

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/IntermediateAssetTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/IntermediateAssetTests.cpp
@@ -96,8 +96,8 @@ namespace UnitTests
 
         auto builderUuid = builders[0].m_busId;
         auto sourceUuid = AssetUtilities::GetSourceUuid(AssetProcessor::SourceAssetReference(m_testFilePath.c_str()));
-        auto actualIntermediateUuid = AssetUtilities::GetSourceUuid(AssetProcessor::SourceAssetReference(
-            MakePath(AZStd::string::format("%stest.stage2", AssetProcessor::ProductOutputUtil::GetInterimPrefix(2).c_str()).c_str(), true).c_str()));
+        auto actualIntermediateUuid =
+            AssetUtilities::GetSourceUuid(AssetProcessor::SourceAssetReference(MakePath("test.stage2", true).c_str()));
 
         ASSERT_TRUE(sourceUuid);
         ASSERT_TRUE(actualIntermediateUuid);
@@ -110,7 +110,7 @@ namespace UnitTests
 
         auto expectedIntermediateUuid = AZ::Uuid::CreateName(uuidFormat);
 
-        EXPECT_EQ(actualIntermediateUuid.GetValue(), expectedIntermediateUuid);
+        EXPECT_STREQ(actualIntermediateUuid.GetValue().ToFixedString().c_str(), expectedIntermediateUuid.ToFixedString().c_str());
     }
 
     TEST_F(IntermediateAssetTests, IntermediateOutputWithWrongPlatform_CausesFailure)

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/IntermediateAssetTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/IntermediateAssetTests.cpp
@@ -97,7 +97,7 @@ namespace UnitTests
         auto builderUuid = builders[0].m_busId;
         auto sourceUuid = AssetUtilities::GetSourceUuid(AssetProcessor::SourceAssetReference(m_testFilePath.c_str()));
         auto actualIntermediateUuid = AssetUtilities::GetSourceUuid(AssetProcessor::SourceAssetReference(
-            MakePath(AZStd::string::format("%stest.stage2", AssetProcessor::ProductOutputUtil::GetTempPrefix(2).c_str()).c_str(), true).c_str()));
+            MakePath(AZStd::string::format("%stest.stage2", AssetProcessor::ProductOutputUtil::GetInterimPrefix(2).c_str()).c_str(), true).c_str()));
 
         ASSERT_TRUE(sourceUuid);
         ASSERT_TRUE(actualIntermediateUuid);

--- a/Code/Tools/AssetProcessor/native/utilities/ProductOutputUtil.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ProductOutputUtil.cpp
@@ -159,7 +159,7 @@ namespace AssetProcessor
             AZ_Error(
                 "ProductOutputUtil",
                 false,
-                "Product " AZ_STRING_FORMAT " is expected to be prefixed but was not",
+                "Programmer Error - Product " AZ_STRING_FORMAT " is expected to be prefixed but was not",
                 AZ_STRING_ARG(product.m_productFileName));
             return false;
         }

--- a/Code/Tools/AssetProcessor/native/utilities/ProductOutputUtil.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ProductOutputUtil.cpp
@@ -14,7 +14,7 @@
 
 namespace AssetProcessor
 {
-    AZStd::string ProductOutputUtil::GetTempPrefix(AZ::s64 scanfolderId)
+    AZStd::string ProductOutputUtil::GetInterimPrefix(AZ::s64 scanfolderId)
     {
         return AZStd::string::format("(TMP%" PRId64 "___)", int64_t(scanfolderId));
     }
@@ -24,9 +24,9 @@ namespace AssetProcessor
         return AZStd::string::format("(%" PRId64 ")", int64_t(scanfolderId));
     }
 
-    void ProductOutputUtil::GetTempProductPath(QString& outputFilename, AZ::s64 sourceScanfolderId)
+    void ProductOutputUtil::GetInterimProductPath(QString& outputFilename, AZ::s64 sourceScanfolderId)
     {
-        auto prefix = GetTempPrefix(sourceScanfolderId);
+        auto prefix = GetInterimPrefix(sourceScanfolderId);
         outputFilename = QStringLiteral("%1%2").arg(prefix.c_str()).arg(outputFilename);
     }
 
@@ -87,7 +87,7 @@ namespace AssetProcessor
                 for (auto& product : products)
                 {
                     AZStd::string newName;
-                    if (!ComputeFinalProductName(GetTempPrefix(sourceAsset.ScanFolderId()), "", product, newName))
+                    if (!ComputeFinalProductName(GetInterimPrefix(sourceAsset.ScanFolderId()), "", product, newName))
                     {
                         // Error handling is done by function
                         continue;
@@ -128,7 +128,7 @@ namespace AssetProcessor
                 {
                     AZStd::string newName;
 
-                    if (!ComputeFinalProductName(GetTempPrefix(sourceAsset.ScanFolderId()), GetFinalPrefix(sourceAsset.ScanFolderId()), product, newName))
+                    if (!ComputeFinalProductName(GetInterimPrefix(sourceAsset.ScanFolderId()), GetFinalPrefix(sourceAsset.ScanFolderId()), product, newName))
                     {
                         continue;
                     }

--- a/Code/Tools/AssetProcessor/native/utilities/ProductOutputUtil.h
+++ b/Code/Tools/AssetProcessor/native/utilities/ProductOutputUtil.h
@@ -19,14 +19,14 @@ namespace AssetProcessor
     {
         //! Gets the prefix to apply to products when copying into the cache before being finalized.
         //! This is different from the final prefix version to avoid conflicts unprefixed assets that may use the same prefix as the final prefix.
-        //! The temp prefix shouldn't show up in any UI so its longer and uglier.
-        static AZStd::string GetTempPrefix(AZ::s64 scanfolderId);
+        //! The interim prefix shouldn't show up in any UI, so use a longer, less-likely-to-conflict version.
+        static AZStd::string GetInterimPrefix(AZ::s64 scanfolderId);
         //! Gets the prefix to apply to products when finalizing.
         static AZStd::string GetFinalPrefix(AZ::s64 scanfolderId);
 
-        //! Modifies product paths to have the temporary prefixed version while waiting on final processing.
+        //! Modifies product paths to have the interim prefixed version while waiting on final processing.
         //! This needs to be done before the files are copied into the cache to avoid overwriting the legacy non-prepended version.
-        static void GetTempProductPath(QString& outputFilename, AZ::s64 sourceScanfolderId);
+        static void GetInterimProductPath(QString& outputFilename, AZ::s64 sourceScanfolderId);
         //! Modifies product paths to the final prefixed version for the cache.
         static void GetFinalProductPath(QString& outputFilename, AZ::s64 sourceScanfolderId);
 

--- a/Code/Tools/AssetProcessor/native/utilities/ProductOutputUtil.h
+++ b/Code/Tools/AssetProcessor/native/utilities/ProductOutputUtil.h
@@ -17,15 +17,22 @@ namespace AssetProcessor
 {
     struct ProductOutputUtil
     {
-        static AZStd::string GetPrefix(AZ::s64 scanfolderId);
+        //! Gets the prefix to apply to products when copying into the cache before being finalized.
+        //! This is different from the final prefix version to avoid conflicts unprefixed assets that may use the same prefix as the final prefix.
+        //! The temp prefix shouldn't show up in any UI so its longer and uglier.
+        static AZStd::string GetTempPrefix(AZ::s64 scanfolderId);
+        //! Gets the prefix to apply to products when finalizing.
+        static AZStd::string GetFinalPrefix(AZ::s64 scanfolderId);
 
-        // Modifies product paths to have the scanfolder prepended to the filename
-        // This needs to be done before the files are copied into the cache to avoid overwriting the legacy non-prepended version
-        static void ModifyProductPath(QString& outputFilename, AZ::s64 sourceScanfolderId);
+        //! Modifies product paths to have the temporary prefixed version while waiting on final processing.
+        //! This needs to be done before the files are copied into the cache to avoid overwriting the legacy non-prepended version.
+        static void GetTempProductPath(QString& outputFilename, AZ::s64 sourceScanfolderId);
+        //! Modifies product paths to the final prefixed version for the cache.
+        static void GetFinalProductPath(QString& outputFilename, AZ::s64 sourceScanfolderId);
 
-        // For meta types, does an override check to see if the provided source is the highest priority
-        // If so, the products are renamed back to the non-prefixed version and any existing un-prefixed products
-        // are prefixed
+        //! For meta types, does an override check to see if the provided source is the highest priority
+        //! If so, the products are renamed back to the non-prefixed version and any existing un-prefixed products
+        //! are prefixed
         static void FinalizeProduct(
             AZStd::shared_ptr<AssetDatabaseConnection> db,
             const PlatformConfiguration* platformConfig,
@@ -38,5 +45,18 @@ namespace AssetProcessor
             AZStd::shared_ptr<AssetDatabaseConnection> db,
             AzToolsFramework::AssetDatabase::ProductDatabaseEntry existingProduct,
             const AzToolsFramework::AssetDatabase::SourceDatabaseEntry& sourceEntry);
+
+        static bool ComputeFinalProductName(
+            const AZStd::string& currentPrefix,
+            const AZStd::string& newPrefix,
+            const AssetBuilderSDK::JobProduct& product,
+            AZStd::string& newName);
+
+        static auto GetPaths(
+            const AssetBuilderSDK::JobProduct& product,
+            AZStd::string_view platformIdentifier,
+            const AssetUtilities::ProductPath& newProductPath);
+
+        static bool DoFileRename(const AZStd::string& oldAbsolutePath, const AZStd::string& newAbsolutePath);
     };
 } // namespace AssetProcessor

--- a/Code/Tools/AssetProcessor/native/utilities/UuidManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/UuidManager.cpp
@@ -245,6 +245,16 @@ namespace AssetProcessor
             return AZ::Failure(AZStd::string("Programmer Error - IFileStateRequests interface is not available"));
         }
 
+        if (!fileStateInterface->Exists(sourceAsset.AbsolutePath().c_str()))
+        {
+            AZ_Error(
+                "UuidManager",
+                false,
+                "Programmer Error - cannot request UUID for file which does not exist - %s",
+                sourceAsset.AbsolutePath().c_str());
+            return AZ::Failure(AZStd::string("Programmer Error - cannot request UUID for file which does not exist"));
+        }
+
         const AZ::IO::Path metadataFilePath = AzToolsFramework::MetadataManager::ToMetadataPath(sourceAsset.AbsolutePath().c_str());
         AssetProcessor::FileStateInfo metadataFileInfo;
         bool metadataFileExists = fileStateInterface->GetFileInfo(metadataFilePath.c_str(), &metadataFileInfo);
@@ -328,16 +338,6 @@ namespace AssetProcessor
                     return AZ::Failure(outcome.GetError());
                 }
             }
-        }
-
-        if (!fileStateInterface->Exists(sourceAsset.AbsolutePath().c_str()))
-        {
-            AZ_Error(
-                "UuidManager",
-                false,
-                "Programmer Error - cannot request UUID for file which does not exist - %s",
-                sourceAsset.AbsolutePath().c_str());
-            return AZ::Failure(AZStd::string("Programmer Error - cannot request UUID for file which does not exist"));
         }
 
         // Last resort - generate a new UUID and save it to the metadata file


### PR DESCRIPTION
## What does this PR do?

Fixes an edge case where asset products could be overwritten if they used the same naming scheme as is used for override prefixing.

When files are copied to the cache they now are given a temporary but longer prefix that shouldn't accidentally conflict with an asset naming scheme.

## How was this PR tested?

Added and ran unit test
