### PR TITLE
Moving spawnables tests into main suite

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Prefab/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/CMakeLists.txt
@@ -20,16 +20,16 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
         LABELS REQUIRES_tiaf
     )
 
-    ly_add_pytest(
-        NAME AutomatedTesting::PrefabTests_Periodic
-        TEST_SUITE periodic
-        TEST_SERIAL
-        PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite_Periodic.py
-        RUNTIME_DEPENDENCIES
-            Legacy::Editor
-            AZ::AssetProcessor
-            AutomatedTesting.Assets
-    )
+    #ly_add_pytest(
+    #    NAME AutomatedTesting::PrefabTests_Periodic
+    #    TEST_SUITE periodic
+    #    TEST_SERIAL
+    #    PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite_Periodic.py
+    #    RUNTIME_DEPENDENCIES
+    #        Legacy::Editor
+    #        AZ::AssetProcessor
+    #        AutomatedTesting.Assets
+    #)
 
     ly_add_pytest(
         NAME AutomatedTesting::PrefabLauncherTests_Periodic

--- a/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Main.py
@@ -142,6 +142,38 @@ class TestAutomationOverridesDisabled(EditorTestSuite):
     class test_ReparentEntity_UnderEntityHierarchies(EditorBatchedTest):
         from .tests.reparent_prefab import ReparentEntity_UnderEntityHierarchies as test_module
 
+    # Spawnables Tests
+
+    class test_SC_Spawnables_DespawnOnEntityDeactivate(EditorBatchedTest):
+        from .tests.spawnables import SC_Spawnables_DespawnOnEntityDeactivate as test_module
+
+    class test_SC_Spawnables_EntityClearedOnGameModeExit(EditorBatchedTest):
+        from .tests.spawnables import SC_Spawnables_EntityClearedOnGameModeExit as test_module
+
+    class test_SC_Spawnables_MultipleSpawnsFromSingleTicket(EditorBatchedTest):
+        from .tests.spawnables import SC_Spawnables_MultipleSpawnsFromSingleTicket as test_module
+
+    class test_SC_Spawnables_NestedSpawn(EditorBatchedTest):
+        from .tests.spawnables import SC_Spawnables_NestedSpawn as test_module
+
+    class test_SC_Spawnables_SimpleSpawnAndDespawn(EditorBatchedTest):
+        from .tests.spawnables import SC_Spawnables_SimpleSpawnAndDespawn as test_module
+
+    class test_Lua_Spawnables_DespawnOnEntityDeactivate(EditorBatchedTest):
+        from .tests.spawnables import Lua_Spawnables_DespawnOnEntityDeactivate as test_module
+
+    class test_Lua_Spawnables_EntityClearedOnGameModeExit(EditorBatchedTest):
+        from .tests.spawnables import Lua_Spawnables_EntityClearedOnGameModeExit as test_module
+
+    class test_Lua_Spawnables_MultipleSpawnsFromSingleTicket(EditorBatchedTest):
+        from .tests.spawnables import Lua_Spawnables_MultipleSpawnsFromSingleTicket as test_module
+
+    class test_Lua_Spawnables_NestedSpawn(EditorBatchedTest):
+        from .tests.spawnables import Lua_Spawnables_NestedSpawn as test_module
+
+    class test_Lua_Spawnables_SimpleSpawnAndDespawn(EditorBatchedTest):
+        from .tests.spawnables import Lua_Spawnables_SimpleSpawnAndDespawn as test_module
+
 
 @pytest.mark.SUITE_main
 @pytest.mark.parametrize("launcher_platform", ['windows_editor'])

--- a/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Periodic.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Periodic.py
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 
 import pytest
 
-from ly_test_tools.o3de.editor_test import EditorBatchedTest, EditorTestSuite
+from ly_test_tools.o3de.editor_test import EditorBatchedTest, EditorSingleTest, EditorTestSuite
 
 
 @pytest.mark.SUITE_periodic
@@ -18,34 +18,6 @@ class TestAutomationNoOverrides(EditorTestSuite):
     # These tests will execute with prefab outliner overrides disabled
     EditorTestSuite.global_extra_cmdline_args.append("--regset=O3DE/Preferences/Prefabs/EnableOutlinerOverrideManagement=false")
 
-    # Spawnables Tests
-
-    class test_SC_Spawnables_DespawnOnEntityDeactivate(EditorBatchedTest):
-        from .tests.spawnables import SC_Spawnables_DespawnOnEntityDeactivate as test_module
-
-    class test_SC_Spawnables_EntityClearedOnGameModeExit(EditorBatchedTest):
-        from .tests.spawnables import SC_Spawnables_EntityClearedOnGameModeExit as test_module
-
-    class test_SC_Spawnables_MultipleSpawnsFromSingleTicket(EditorBatchedTest):
-        from .tests.spawnables import SC_Spawnables_MultipleSpawnsFromSingleTicket as test_module
-
-    class test_SC_Spawnables_NestedSpawn(EditorBatchedTest):
-        from .tests.spawnables import SC_Spawnables_NestedSpawn as test_module
-
-    class test_SC_Spawnables_SimpleSpawnAndDespawn(EditorBatchedTest):
-        from .tests.spawnables import SC_Spawnables_SimpleSpawnAndDespawn as test_module
-
-    class test_Lua_Spawnables_DespawnOnEntityDeactivate(EditorBatchedTest):
-        from .tests.spawnables import Lua_Spawnables_DespawnOnEntityDeactivate as test_module
-
-    class test_Lua_Spawnables_EntityClearedOnGameModeExit(EditorBatchedTest):
-        from .tests.spawnables import Lua_Spawnables_EntityClearedOnGameModeExit as test_module
-
-    class test_Lua_Spawnables_MultipleSpawnsFromSingleTicket(EditorBatchedTest):
-        from .tests.spawnables import Lua_Spawnables_MultipleSpawnsFromSingleTicket as test_module
-
-    class test_Lua_Spawnables_NestedSpawn(EditorBatchedTest):
-        from .tests.spawnables import Lua_Spawnables_NestedSpawn as test_module
-
-    class test_Lua_Spawnables_SimpleSpawnAndDespawn(EditorBatchedTest):
-        from .tests.spawnables import Lua_Spawnables_SimpleSpawnAndDespawn as test_module
+    @pytest.mark.skip(reason="Single test case to avoid suite failure. Can be removed when other tests are added.")
+    class test_DummyTest(EditorSingleTest):
+        pass


### PR DESCRIPTION
## What does this PR do?

- Moves spawnables tests back into the main suite
- Resolves https://github.com/o3de/o3de/issues/9789

## How was this PR tested?

Ran spawnables tests 100x locally without failure.
Ran updated main test suite without failure.
Ran updated periodic suite to ensure dummy test does not cause a failure.
