### PR TITLE
Prism/merge cmake fix to stab

### DIFF
--- a/AutomatedTesting/cmake/EngineFinder.cmake
+++ b/AutomatedTesting/cmake/EngineFinder.cmake
@@ -139,6 +139,10 @@ endforeach()
 
 if(O3DE_MOST_COMPATIBLE_ENGINE_PATH)
     message(STATUS "Selecting engine '${O3DE_MOST_COMPATIBLE_ENGINE_PATH}'")
+    # Make sure PACKAGE_VERSION_COMPATIBLE is set so Findo3de.cmake knows
+    # compatibility was checked
+    set(PACKAGE_VERSION_COMPATIBLE True)
+    set(PACKAGE_VERSION O3DE_MOST_COMPATIBLE_ENGINE_VERSION)
     list(APPEND CMAKE_MODULE_PATH "${O3DE_MOST_COMPATIBLE_ENGINE_PATH}/cmake")
     return()
 endif()

--- a/Templates/DefaultProject/Template/cmake/EngineFinder.cmake
+++ b/Templates/DefaultProject/Template/cmake/EngineFinder.cmake
@@ -139,6 +139,10 @@ endforeach()
 
 if(O3DE_MOST_COMPATIBLE_ENGINE_PATH)
     message(STATUS "Selecting engine '${O3DE_MOST_COMPATIBLE_ENGINE_PATH}'")
+    # Make sure PACKAGE_VERSION_COMPATIBLE is set so Findo3de.cmake knows
+    # compatibility was checked
+    set(PACKAGE_VERSION_COMPATIBLE True)
+    set(PACKAGE_VERSION O3DE_MOST_COMPATIBLE_ENGINE_VERSION)
     list(APPEND CMAKE_MODULE_PATH "${O3DE_MOST_COMPATIBLE_ENGINE_PATH}/cmake")
     return()
 endif()

--- a/Templates/MinimalProject/Template/cmake/EngineFinder.cmake
+++ b/Templates/MinimalProject/Template/cmake/EngineFinder.cmake
@@ -139,6 +139,10 @@ endforeach()
 
 if(O3DE_MOST_COMPATIBLE_ENGINE_PATH)
     message(STATUS "Selecting engine '${O3DE_MOST_COMPATIBLE_ENGINE_PATH}'")
+    # Make sure PACKAGE_VERSION_COMPATIBLE is set so Findo3de.cmake knows
+    # compatibility was checked
+    set(PACKAGE_VERSION_COMPATIBLE True)
+    set(PACKAGE_VERSION O3DE_MOST_COMPATIBLE_ENGINE_VERSION)
     list(APPEND CMAKE_MODULE_PATH "${O3DE_MOST_COMPATIBLE_ENGINE_PATH}/cmake")
     return()
 endif()

--- a/engine.json
+++ b/engine.json
@@ -4,7 +4,7 @@
     "O3DEVersion": "0.1.0.0",
     "O3DEBuildNumber": 0,
     "display_version":"00.00",
-    "version":"1.1.0",
+    "version":"1.2.0",
     "api_versions": {
         "editor":"1.0.0",
         "framework":"1.0.0",


### PR DESCRIPTION
## What does this PR do?

- Merges the fixes from https://github.com/o3de/o3de/pull/15131
- Increments the engine's minor version from `1.1.0` to `1.2.0` per https://github.com/o3de/sig-core/issues/44 so there are fewer commits in the stabilization branch with the same engine version as development branch.


## How was this PR tested?

See https://github.com/o3de/o3de/pull/15131 for testing details