### PR TITLE
Fix for DiffuseProbeGrid mode when exiting Play Game

### DIFF
--- a/Gems/DiffuseProbeGrid/Code/Source/EditorComponents/EditorDiffuseProbeGridComponent.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/EditorComponents/EditorDiffuseProbeGridComponent.cpp
@@ -210,6 +210,8 @@ namespace AZ
 
         void EditorDiffuseProbeGridComponent::Deactivate()
         {
+            m_editorModeSet = false;
+
             m_boxChangedByGridHandler.Disconnect();
             AzToolsFramework::EditorEntityInfoNotificationBus::Handler::BusDisconnect();
             AZ::TickBus::Handler::BusDisconnect();


### PR DESCRIPTION
Restore the selected Editor DiffuseProbeGrid mode (RealTime or Baked) when exiting Game mode and returning to the Editor.
