### PR TITLE
Fix streaming issue when changing resolution on Linux

### DIFF
--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.cpp
@@ -275,9 +275,18 @@ namespace AzFramework
     void XcbNativeWindow::ResizeClientArea(WindowSize clientAreaSize, const WindowPosOptions& options)
     {
         const uint32_t values[] = { clientAreaSize.m_width, clientAreaSize.m_height };
-
+        
+        if (m_activated)
+        {
+            xcb_unmap_window(m_xcbConnection, m_xcbWindow);
+        }
         xcb_configure_window(m_xcbConnection, m_xcbWindow, XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT, values);
-
+        
+        if (m_activated)
+        {
+            xcb_map_window(m_xcbConnection, m_xcbWindow);
+            xcb_flush(m_xcbConnection);
+        }
         //Notify the RHI to rebuild swapchain and swapchain images after updating the surface
         WindowSizeChanged(clientAreaSize.m_width, clientAreaSize.m_height);
     }


### PR DESCRIPTION
## What does this PR do?
Run GameLauncher process on Euler or Ubuntu System. This process can encode video and streaming. If I change resolution during the process is running, the image of encoding and streaming will stop. This PR can fix this issue.

## How was this PR tested?
1. Strat a virtual window using "Startx";
2. Export virtual window and run GameLauncher process on Euler or Ubuntu System;
3. Change resolution using code below
EBUS_EVENT(AzFramework::WindowRequestBus, ResizeClientArea, AzFramework::WindowSize(width, height));
4. Check whether streaming of GameLauncher process if normal;
