### PR TITLE
Action Manager | Introduce "Create" context sub-menu, restore "Create multiplayer entity" menu item.

### DIFF
--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -1849,6 +1849,11 @@ void EditorActionsHandler::OnMenuRegistrationHook()
         menuProperties.m_name = "Viewport Context Menu";
         m_menuManagerInterface->RegisterMenu(EditorIdentifiers::ViewportContextMenuIdentifier, menuProperties);
     }
+    {
+        AzToolsFramework::MenuProperties menuProperties;
+        menuProperties.m_name = "Create";
+        m_menuManagerInterface->RegisterMenu(EditorIdentifiers::EntityCreationMenuIdentifier, menuProperties);
+    }
 
 }
 
@@ -2022,6 +2027,8 @@ void EditorActionsHandler::OnMenuBindingHook()
     }
 
     // Entity Outliner Context Menu
+    m_menuManagerInterface->AddSubMenuToMenu(
+        EditorIdentifiers::EntityOutlinerContextMenuIdentifier, EditorIdentifiers::EntityCreationMenuIdentifier, 200);
     m_menuManagerInterface->AddSeparatorToMenu(EditorIdentifiers::EntityOutlinerContextMenuIdentifier, 10000);
     m_menuManagerInterface->AddSeparatorToMenu(EditorIdentifiers::EntityOutlinerContextMenuIdentifier, 20000);
     m_menuManagerInterface->AddSeparatorToMenu(EditorIdentifiers::EntityOutlinerContextMenuIdentifier, 30000);
@@ -2034,6 +2041,8 @@ void EditorActionsHandler::OnMenuBindingHook()
     m_menuManagerInterface->AddActionToMenu(EditorIdentifiers::EntityOutlinerContextMenuIdentifier, "o3de.action.view.centerOnSelection", 80100);
 
     // Viewport Context Menu
+    m_menuManagerInterface->AddSubMenuToMenu(
+        EditorIdentifiers::ViewportContextMenuIdentifier, EditorIdentifiers::EntityCreationMenuIdentifier, 200);
     m_menuManagerInterface->AddSeparatorToMenu(EditorIdentifiers::ViewportContextMenuIdentifier, 10000);
     m_menuManagerInterface->AddSeparatorToMenu(EditorIdentifiers::ViewportContextMenuIdentifier, 20000);
     m_menuManagerInterface->AddSeparatorToMenu(EditorIdentifiers::ViewportContextMenuIdentifier, 30000);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/ActionManagerIdentifiers/EditorMenuIdentifiers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/ActionManagerIdentifiers/EditorMenuIdentifiers.h
@@ -51,4 +51,7 @@ namespace EditorIdentifiers
 
     // Editor Widget Menus
     inline constexpr AZStd::string_view EntityOutlinerContextMenuIdentifier = "o3de.menu.editor.entityOutliner.context";
+
+    // Entity creation menu
+    inline constexpr AZStd::string_view EntityCreationMenuIdentifier = "o3de.menu.entity.create";
 }

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.h
@@ -19,6 +19,7 @@
 #include <AzFramework/Process/ProcessWatcher.h>
 #include <AzFramework/Process/ProcessCommunicatorTracePrinter.h>
 #include <AzFramework/Viewport/ScreenGeometry.h>
+#include <AzToolsFramework/ActionManager/ActionManagerRegistrationNotificationBus.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <AzToolsFramework/Prefab/Spawnable/PrefabToInMemorySpawnableNotificationBus.h>
 #include <AzToolsFramework/Editor/EditorContextMenuBus.h>
@@ -54,6 +55,7 @@ namespace Multiplayer
         , private AzToolsFramework::Prefab::PrefabToInMemorySpawnableNotificationBus::Handler
         , private AzToolsFramework::EditorEntityContextNotificationBus::Handler
         , private AzToolsFramework::EditorContextMenuBus::Handler
+        , private AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler
     {
     public:
         AZ_COMPONENT(MultiplayerEditorSystemComponent, "{9F335CC0-5574-4AD3-A2D8-2FAEF356946C}");
@@ -95,14 +97,18 @@ namespace Multiplayer
         //! @{
         void OnStartPlayInEditorBegin() override;
         void OnStartPlayInEditor() override;
+        void OnStopPlayInEditorBegin() override;
         //! @}
 
         //! AzToolsFramework::EditorContextMenu::Bus::Handler overrides
         //! @{
         void PopulateEditorGlobalContextMenu(QMenu* menu, const AZStd::optional<AzFramework::ScreenPoint>& point, int flags) override;
         int GetMenuPosition() const override;
-        void OnStopPlayInEditorBegin() override;
         //! @}
+
+        // AzToolsFramework::ActionManagerRegistrationNotificationBus overrides ...
+        void OnActionRegistrationHook() override;
+        void OnMenuBindingHook() override;
 
         //! AzToolsFramework::Prefab::PrefabToInMemorySpawnableNotificationBus::Handler overrides
         //! @{


### PR DESCRIPTION
## What does this PR do?
- Introduces a "Create" sub-menu to the Outliner and Viewport context menus. This can be used to provide entity presets to streamline entity creation.
- Restores the "Create multiplayer entity" menu item that was present before the migration to the new Action Manager system. This is now included in the "Create" sub-menu described above.

## How was this PR tested?
Verified a multiplayer entity is created correctly.

In verifying this change, I realized that in both the new Action Manager and the legacy system the behavior for creating entities by right-clicking in the viewport is inconsistent. I'm working on a follow-up PR to standardize the behavior and possibly provide helper functions to simplify adding new menu items to the "Create" menu down the line with consistent behavior.

![image](https://user-images.githubusercontent.com/82231674/226710916-a5e08d97-e9cf-4c95-ac4e-ad95d312eb44.png)