### PR TITLE
Action Manager | Expose additional Menu and ToolBar functionality to Python

### DIFF
--- a/Gems/EditorPythonBindings/Code/Source/ActionManager/MenuManagerBus.h
+++ b/Gems/EditorPythonBindings/Code/Source/ActionManager/MenuManagerBus.h
@@ -28,17 +28,25 @@ namespace EditorPythonBindings
         virtual AzToolsFramework::MenuManagerOperationResult RegisterMenu(
             const AZStd::string& identifier, const AzToolsFramework::MenuProperties& properties) = 0;
 
-        //! Bind an action to a menu.
+        //! Bind an Action to a Menu.
         virtual AzToolsFramework::MenuManagerOperationResult AddActionToMenu(
             const AZStd::string& menuIdentifier, const AZStd::string& actionIdentifier, int sortIndex) = 0;
 
-        //! Add a separator to a menu.
+        //! Add a Separator to a Menu.
         virtual AzToolsFramework::MenuManagerOperationResult AddSeparatorToMenu(
             const AZStd::string& menuIdentifier, int sortIndex) = 0;
 
-        //! Add a sub-menu to a menu.
+        //! Add a Sub-Menu to a Menu.
         virtual AzToolsFramework::MenuManagerOperationResult AddSubMenuToMenu(
             const AZStd::string& menuIdentifier, const AZStd::string& subMenuIdentifier, int sortIndex) = 0;
+
+        //! Add a Widget to a Menu.
+        virtual AzToolsFramework::MenuManagerOperationResult AddWidgetToMenu(
+            const AZStd::string& menuIdentifier, const AZStd::string& widgetActionIdentifier, int sortIndex) = 0;
+
+        //! Add a Menu to a Menu Bar.
+        virtual AzToolsFramework::MenuManagerOperationResult AddMenuToMenuBar(
+            const AZStd::string& menuBarIdentifier, const AZStd::string& menuIdentifier, int sortIndex) = 0;
     };
 
     using MenuManagerRequestBus = AZ::EBus<MenuManagerRequests>;

--- a/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.cpp
@@ -85,6 +85,13 @@ namespace EditorPythonBindings
                 ->Event("UpdateAction", &ActionManagerRequestBus::Handler::UpdateAction)
                 ;
 
+            behaviorContext->Class<AzToolsFramework::MenuProperties>("MenuProperties")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                ->Attribute(AZ::Script::Attributes::Category, "Action")
+                ->Attribute(AZ::Script::Attributes::Module, "action")
+                ->Property("name", BehaviorValueProperty(&AzToolsFramework::MenuProperties::m_name))
+                ;
+
             behaviorContext
                 ->EBus<MenuManagerRequestBus>("MenuManagerPythonRequestBus")
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
@@ -94,6 +101,15 @@ namespace EditorPythonBindings
                 ->Event("AddActionToMenu", &MenuManagerRequestBus::Handler::AddActionToMenu)
                 ->Event("AddSeparatorToMenu", &MenuManagerRequestBus::Handler::AddSeparatorToMenu)
                 ->Event("AddSubMenuToMenu", &MenuManagerRequestBus::Handler::AddSubMenuToMenu)
+                ->Event("AddWidgetToMenu", &MenuManagerRequestBus::Handler::AddWidgetToMenu)
+                ->Event("AddMenuToMenuBar", &MenuManagerRequestBus::Handler::AddMenuToMenuBar)
+                ;
+
+            behaviorContext->Class<AzToolsFramework::ToolBarProperties>("ToolBarProperties")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                ->Attribute(AZ::Script::Attributes::Category, "Action")
+                ->Attribute(AZ::Script::Attributes::Module, "action")
+                ->Property("name", BehaviorValueProperty(&AzToolsFramework::ToolBarProperties::m_name))
                 ;
 
             behaviorContext
@@ -206,6 +222,18 @@ namespace EditorPythonBindings
         const AZStd::string& menuIdentifier, const AZStd::string& subMenuIdentifier, int sortIndex)
     {
         return m_menuManagerInterface->AddSubMenuToMenu(menuIdentifier, subMenuIdentifier, sortIndex);
+    }
+
+    AzToolsFramework::MenuManagerOperationResult PythonActionManagerHandler::AddWidgetToMenu(
+        const AZStd::string& menuIdentifier, const AZStd::string& widgetActionIdentifier, int sortIndex)
+    {
+        return m_menuManagerInterface->AddWidgetToMenu(menuIdentifier, widgetActionIdentifier, sortIndex);
+    }
+
+    AzToolsFramework::MenuManagerOperationResult PythonActionManagerHandler::AddMenuToMenuBar(
+        const AZStd::string& menuBarIdentifier, const AZStd::string& menuIdentifier, int sortIndex)
+    {
+        return m_menuManagerInterface->AddMenuToMenuBar(menuBarIdentifier, menuIdentifier, sortIndex);
     }
 
     AzToolsFramework::ToolBarManagerOperationResult PythonActionManagerHandler::RegisterToolBar(

--- a/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.h
+++ b/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.h
@@ -63,6 +63,10 @@ namespace EditorPythonBindings
             const AZStd::string& menuIdentifier, int sortIndex) override;
         AzToolsFramework::MenuManagerOperationResult AddSubMenuToMenu(
             const AZStd::string& menuIdentifier, const AZStd::string& subMenuIdentifier, int sortIndex) override;
+        AzToolsFramework::MenuManagerOperationResult AddWidgetToMenu(
+            const AZStd::string& menuIdentifier, const AZStd::string& widgetActionIdentifier, int sortIndex) override;
+        AzToolsFramework::MenuManagerOperationResult AddMenuToMenuBar(
+            const AZStd::string& menuBarIdentifier, const AZStd::string& menuIdentifier, int sortIndex) override;
 
         // ToolBarManagerRequestBus overrides ...
         AzToolsFramework::ToolBarManagerOperationResult RegisterToolBar(


### PR DESCRIPTION
## What does this PR do?

Exposes the following functionality to be used in Python:
- `AddWidgetToMenu` in `MenuManagerPythonRequestBus`
- `AddMenuToMenuBar` in `MenuManagerPythonRequestBus`
- `MenuProperties`
- `ToolBarProperties`

## How was this PR tested?

Verified via the following script
```
import azlmbr.action as action
import azlmbr.bus as bus

# Create an Action
actionProperties = action.ActionProperties()
actionProperties.name = "Custom Action"
actionProperties.description = "A custom action defined via Python"
actionProperties.category = "Python"

def someCustomAction():
    print("Hello")

action.ActionManagerPythonRequestBus(bus.Broadcast, "RegisterAction", "o3de.context.editor.mainwindow", "o3de.action.python.test", actionProperties, someCustomAction)

# Create a Menu
menuProperties = action.MenuProperties()
menuProperties.name = "Python Menu"

action.MenuManagerPythonRequestBus(bus.Broadcast, "RegisterMenu", "o3de.menu.test", menuProperties)

# Add Action to Menu
action.MenuManagerPythonRequestBus(bus.Broadcast, "AddActionToMenu", "o3de.menu.test", "o3de.action.python.test", 100)

# Add Menu to Menu Bar
action.MenuManagerPythonRequestBus(bus.Broadcast, "AddMenuToMenuBar", "o3de.menubar.editor.mainwindow", "o3de.menu.test", 1000)
```

which produces the following result
![image](https://user-images.githubusercontent.com/82231674/226642529-c25c08e8-d08b-41ea-b090-997669048c5c.png)
