### PR TITLE
Fixed string line edit only allowing a single character to be entered at a time

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.cpp
@@ -38,8 +38,6 @@ namespace AzToolsFramework
         setLayout(pLayout);
         setFocusProxy(m_pLineEdit);
         setFocusPolicy(m_pLineEdit->focusPolicy());
-
-        ConnectWidgets();
     };
 
     void PropertyStringLineEditCtrl::setValue(AZStd::string& value)
@@ -76,12 +74,6 @@ namespace AzToolsFramework
         m_pLineEdit->blockSignals(false);
     }
 
-    void PropertyStringLineEditCtrl::onChildLineEditValueChange(const QString& newValue)
-    {
-        AZStd::string changedVal(newValue.toUtf8().data());
-        emit valueChanged(changedVal);
-    }
-
     PropertyStringLineEditCtrl::~PropertyStringLineEditCtrl()
     {
     }
@@ -101,21 +93,13 @@ namespace AzToolsFramework
         // There's only one QT widget on this property.
     }
 
-    void PropertyStringLineEditCtrl::ConnectWidgets()
-    {
-        connect(m_pLineEdit, SIGNAL(textChanged(const QString&)), this, SLOT(onChildLineEditValueChange(const QString&)));
-        connect(m_pLineEdit, &QLineEdit::editingFinished, this, [this]()
-        {
-            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, this);
-        });
-    }
-
     QWidget* StringPropertyLineEditHandler::CreateGUI(QWidget* pParent)
     {
         PropertyStringLineEditCtrl* newCtrl = aznew PropertyStringLineEditCtrl(pParent);
-        connect(newCtrl, &PropertyStringLineEditCtrl::valueChanged, this, [newCtrl]()
+        connect(newCtrl->GetLineEdit(), &QLineEdit::editingFinished, this, [newCtrl]()
             {
-                PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
+                PropertyEditorGUIMessagesBus::Broadcast(&PropertyEditorGUIMessages::RequestWrite, newCtrl);
+                PropertyEditorGUIMessagesBus::Broadcast(&PropertyEditorGUIMessages::OnEditingFinished, newCtrl);
             });
         return newCtrl;
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.hxx
@@ -41,18 +41,11 @@ namespace AzToolsFramework
         QWidget* GetLastInTabOrder();
         void UpdateTabOrder();
 
-    signals:
-        void valueChanged(AZStd::string& newValue);
-
     public slots:
         virtual void setValue(AZStd::string& val);
         void setMaxLen(int maxLen);
 
-    protected slots:
-        void onChildLineEditValueChange(const QString& value);
-
     protected:
-        virtual void ConnectWidgets();
         virtual void focusInEvent(QFocusEvent* e);
 
         QLineEdit* m_pLineEdit;
@@ -67,7 +60,7 @@ namespace AzToolsFramework
     public:
         AZ_CLASS_ALLOCATOR(StringPropertyLineEditHandler, AZ::SystemAllocator);
 
-        virtual AZ::u32 GetHandlerName(void) const override  { return AZ_CRC("LineEdit", 0x3f15f4ba); }
+        virtual AZ::u32 GetHandlerName(void) const override  { return AZ::Edit::UIHandlers::LineEdit; }
         virtual bool IsDefaultHandler() const override { return true; }
         virtual QWidget* GetFirstInTabOrder(PropertyStringLineEditCtrl* widget) override { return widget->GetFirstInTabOrder(); }
         virtual QWidget* GetLastInTabOrder(PropertyStringLineEditCtrl* widget) override { return widget->GetLastInTabOrder(); }

--- a/Gems/LyShine/Code/Editor/PropertyHandlerChar.cpp
+++ b/Gems/LyShine/Code/Editor/PropertyHandlerChar.cpp
@@ -15,10 +15,12 @@ QWidget* PropertyHandlerChar::CreateGUI(QWidget* pParent)
 {
     AzToolsFramework::PropertyStringLineEditCtrl* ctrl = aznew AzToolsFramework::PropertyStringLineEditCtrl(pParent);
     ctrl->setMaxLen(1);
-    QObject::connect(ctrl, &AzToolsFramework::PropertyStringLineEditCtrl::valueChanged, this, [ctrl]()
+    QObject::connect(ctrl->GetLineEdit(), &QLineEdit::editingFinished, this, [ctrl]()
         {
-            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
-                &AzToolsFramework::PropertyEditorGUIMessages::Bus::Events::RequestWrite, ctrl);
+            AzToolsFramework::PropertyEditorGUIMessagesBus::Broadcast(
+                &AzToolsFramework::PropertyEditorGUIMessages::RequestWrite, ctrl);
+            AzToolsFramework::PropertyEditorGUIMessagesBus::Broadcast(
+                &AzToolsFramework::PropertyEditorGUIMessages::OnEditingFinished, ctrl);
         });
 
     return ctrl;


### PR DESCRIPTION
## What does this PR do?

Fixes #4994 

The root issue is that the `PropertyStringLineEditCtrl` was signaling a write request anytime the text was changed, which in turn triggered a full property refresh which deselected the string input field. This has instead been changed to use the signal from the `QLineEdit` when the editing is finished (after enter or return is pressed, or if the input field loses focus and the value has changed).

## How was this PR tested?

Tested reproduction steps as mentioned and verified user can now enter multiple characters without the input field being deselected.