### PR TITLE
Action Manager | Correctly refresh the Outliner/Viewport context menus on Duplicate.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
@@ -576,10 +576,12 @@ namespace AzToolsFramework
                             selectedEntities, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::GetSelectedEntities);
 
                         return CanCreatePrefabWithCurrentSelection(selectedEntities);
-                    });
+                    }
+                );
 
-                // Trigger update whenever entity selection changes.
+                // Trigger update whenever entity selection changes, and after prefab instance propagation.
                 m_actionManagerInterface->AddActionToUpdater(EditorIdentifiers::EntitySelectionChangedUpdaterIdentifier, actionIdentifier);
+                m_actionManagerInterface->AddActionToUpdater(PrefabIdentifiers::PrefabInstancePropagationEndUpdaterIdentifier, actionIdentifier);
 
                 // This action is only accessible outside of Component Modes
                 m_actionManagerInterface->AssignModeToAction(DefaultActionContextModeIdentifier, actionIdentifier);
@@ -666,7 +668,10 @@ namespace AzToolsFramework
                     }
                 );
 
+                // Trigger update whenever entity selection changes, and after prefab instance propagation.
                 m_actionManagerInterface->AddActionToUpdater(EditorIdentifiers::EntitySelectionChangedUpdaterIdentifier, actionIdentifier);
+                m_actionManagerInterface->AddActionToUpdater(
+                    PrefabIdentifiers::PrefabInstancePropagationEndUpdaterIdentifier, actionIdentifier);
 
                 // This action is only accessible outside of Component Modes
                 m_actionManagerInterface->AssignModeToAction(DefaultActionContextModeIdentifier, actionIdentifier);
@@ -694,7 +699,8 @@ namespace AzToolsFramework
                         {
                             ContextMenu_InstantiateProceduralPrefab();
                         }
-                    });
+                    }
+                );
 
                 m_actionManagerInterface->InstallEnabledStateCallback(
                     actionIdentifier,
@@ -705,9 +711,13 @@ namespace AzToolsFramework
                             selectedEntities, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::GetSelectedEntities);
 
                         return CanInstantiatePrefabWithCurrentSelection(selectedEntities);
-                    });
+                    }
+                );
 
+                // Trigger update whenever entity selection changes, and after prefab instance propagation.
                 m_actionManagerInterface->AddActionToUpdater(EditorIdentifiers::EntitySelectionChangedUpdaterIdentifier, actionIdentifier);
+                m_actionManagerInterface->AddActionToUpdater(
+                    PrefabIdentifiers::PrefabInstancePropagationEndUpdaterIdentifier, actionIdentifier);
 
                 // This action is only accessible outside of Component Modes
                 m_actionManagerInterface->AssignModeToAction(DefaultActionContextModeIdentifier, actionIdentifier);
@@ -998,6 +1008,16 @@ namespace AzToolsFramework
                     return false;
                 }
             );
+
+            // Update the duplicate action after Prefab instance propagation.
+            m_actionManagerInterface->AddActionToUpdater(
+                PrefabIdentifiers::PrefabInstancePropagationEndUpdaterIdentifier, "o3de.action.edit.duplicate");
+
+            // Update the move up/move down actions after Prefab instance propagation.
+            m_actionManagerInterface->AddActionToUpdater(
+                PrefabIdentifiers::PrefabInstancePropagationEndUpdaterIdentifier, "o3de.action.entitySorting.moveUp");
+            m_actionManagerInterface->AddActionToUpdater(
+                PrefabIdentifiers::PrefabInstancePropagationEndUpdaterIdentifier, "o3de.action.entitySorting.moveDown");
         }
 
         int PrefabIntegrationManager::GetMenuPosition() const


### PR DESCRIPTION
## What does this PR do?
Fixes #15212

Correctly refreshes the Outliner and Viewport menu items after duplicating an entity.
To address this, I added action updates after entity propagation since that may introduce changes to the selection.

## How was this PR tested?
Tested locally and verified it addresses the issue.

![ContextMenuRefresh](https://user-images.githubusercontent.com/82231674/226707835-d7f25e36-da2d-457d-86b4-31fcdfb36cf5.gif)