### PR TITLE
Stop SplashScreen from Modifying App TickScale

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/SplashScreen/SplashScreenPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SplashScreen/SplashScreenPass.cpp
@@ -71,17 +71,6 @@ namespace AZ::Render
     void SplashScreenPass::FrameBeginInternal([[maybe_unused]] FramePrepareParams params)
     {
         FullscreenTrianglePass::FrameBeginInternal(params);
-
-        if (m_beginTimer)
-        {
-            // Scale the tick time to 0 to stop other system from updating until splash screen finishes.
-            // This is not ideal. It may cause conflicts when multiple sources are trying to set the value.
-            // We should replace this with some control from the core system about when to render the splash screen.
-            if (auto* timeSystem = AZ::Interface<ITime>::Get())
-            {
-                timeSystem->SetSimulationTickScale(0.0f);
-            }
-        }
     }
 
     void SplashScreenPass::FrameEndInternal()
@@ -94,12 +83,6 @@ namespace AZ::Render
 
             // Disable the pass after life time passes.
             SetEnabled(false);
-
-            // Reset the tick scale
-            if (auto* timeSystem = AZ::Interface<ITime>::Get())
-            {
-                timeSystem->SetSimulationTickScale(1.0f);
-            }
         }
     }
 


### PR DESCRIPTION
Stops the splash screen from setting tickrate to 0. This was originally introduced as a stop-gap to stop systems from updating until a better system could be implemented, but caused problems in multiplayer when the server would send its 0 tickrate to the client but never setting it back to 1. 

Alternatively, this could be fixed specifically for multiplayer, but I propose remove tickscale. Instead, for a future PR,  we can implement a callback solution where any system can register as a handler for a splash-screen e-bus, and the splash screen system can iterate over each handler and check if any system still wants the splash screen visible.

## How was this PR tested?
- Ran game launcher and still see splash screen is visible.
- Ensured multiplayer simulation on server and client and editor are all working as expected with a normal 1.0 tick scale.
