### PR TITLE
Material Canvas: Fixing utility nodes to be editable in the inspector and have a title palette color

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Graph/GraphDocument.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Graph/GraphDocument.h
@@ -95,6 +95,8 @@ namespace AtomToolsFramework
 
         void BuildEditablePropertyGroups();
 
+        DocumentObjectInfoVector GetObjectInfoForGraphCanvasNodes() const;
+
         AZ::Entity* m_sceneEntity = {};
         GraphCanvas::GraphId m_graphId;
         GraphModel::GraphPtr m_graph;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphDocument.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphDocument.cpp
@@ -24,6 +24,8 @@
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/std/sort.h>
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+#include <GraphCanvas/Components/GraphCanvasPropertyBus.h>
 #include <GraphCanvas/Components/SceneBus.h>
 #include <GraphCanvas/GraphCanvasBus.h>
 #include <GraphModel/Model/Connection.h>
@@ -136,6 +138,12 @@ namespace AtomToolsFramework
     DocumentObjectInfoVector GraphDocument::GetObjectInfo() const
     {
         DocumentObjectInfoVector objects = AtomToolsDocument::GetObjectInfo();
+
+        // Build a container of reflected object info specifically for the specialized graph canvas nodes that are not covered by graph model.
+        DocumentObjectInfoVector objectInfoForGraphCanvasNodes = GetObjectInfoForGraphCanvasNodes();
+        objects.insert(objects.end(), objectInfoForGraphCanvasNodes.begin(), objectInfoForGraphCanvasNodes.end());
+
+        // Reserve and register reflected objects for all of the property group in the document.
         objects.reserve(objects.size() + m_groups.size());
 
         for (const auto& group : m_groups)
@@ -149,11 +157,6 @@ namespace AtomToolsFramework
                 objectInfo.m_description = group->m_description;
                 objectInfo.m_objectType = azrtti_typeid<DynamicPropertyGroup>();
                 objectInfo.m_objectPtr = const_cast<DynamicPropertyGroup*>(group.get());
-                objectInfo.m_nodeIndicatorFunction = [](const AzToolsFramework::InstanceDataNode* /*node*/)
-                {
-                    // There are currently no indicators for graph nodes.
-                    return nullptr;
-                };
                 objects.emplace_back(AZStd::move(objectInfo));
             }
         }
@@ -574,5 +577,78 @@ namespace AtomToolsFramework
         }
 
         AtomToolsDocumentNotificationBus::Event(m_toolId, &AtomToolsDocumentNotificationBus::Events::OnDocumentObjectInfoInvalidated, m_id);
-    };
+    }
+
+    DocumentObjectInfoVector GraphDocument::GetObjectInfoForGraphCanvasNodes() const
+{
+        DocumentObjectInfoVector objects;
+
+        // Reserve and register reflected objects for all of the selected graph canvas nodes that do not mirror any of the graph model nodes
+        // that have been added to the graph. This should cover bookmarks, comments, and groups.
+        AZStd::vector<AZ::EntityId> selections;
+        GraphCanvas::SceneRequestBus::EventResult(selections, m_graphId, &GraphCanvas::SceneRequests::GetSelectedItems);
+        objects.reserve(objects.size() + selections.size());
+
+        // The order that selected nodes appear in the container is not deterministic. To compensate for this, we sort by position to ensure
+        // that nodes always appear in the inspector in a consistent order.
+        AZStd::sort(
+            selections.begin(),
+            selections.end(),
+            [](const auto& selection1, const auto& selection2)
+            {
+                AZ::Vector2 selectionPosition1{};
+                GraphCanvas::GeometryRequestBus::EventResult(selectionPosition1, selection1, &GraphCanvas::GeometryRequests::GetPosition);
+                AZ::Vector2 selectionPosition2{};
+                GraphCanvas::GeometryRequestBus::EventResult(selectionPosition2, selection2, &GraphCanvas::GeometryRequests::GetPosition);
+                return selectionPosition1.IsLessThan(selectionPosition2);
+            });
+
+        // Some graph canvas node property components do not have any visible properties, like the bookmark anchor visual component. These
+        // will not be added to the graph document inspector.
+        const AZStd::unordered_set<AZ::Uuid> ignoredTypeIds{
+            AZ::Uuid::CreateString("{AD921E77-962B-417F-88FB-500FA679DFDF}") // BookmarkAnchorVisualComponent
+        };
+
+        // After all of the selected graph canvas nodes have been sorted, search for those with editable property components and add them to
+        // the list of reflected objects.
+        for (const auto& selection : selections)
+        {
+            // Some graph canvas nodes have multiple editable property components, like groups and bookmarks. All of the property components
+            // will be added in relative order except for those in the ignore list.
+            DocumentObjectInfoVector selectionObjects;
+            GraphCanvas::GraphCanvasPropertyBus::EnumerateHandlersId(
+                selection,
+                [&](GraphCanvas::GraphCanvasPropertyInterface* propertyInterface) -> bool
+                {
+                    AZ::Component* component = propertyInterface->GetPropertyComponent();
+                    if (AzToolsFramework::ShouldInspectorShowComponent(component) && !ignoredTypeIds.contains(component->RTTI_GetType()))
+                    {
+                        DocumentObjectInfo objectInfo;
+                        objectInfo.m_visible = true;
+                        objectInfo.m_name = GetSymbolNameFromText(component->RTTI_GetTypeName());
+                        objectInfo.m_displayName = objectInfo.m_description = GetDisplayNameFromText(component->RTTI_GetTypeName());
+                        objectInfo.m_objectType = component->RTTI_GetType();
+                        objectInfo.m_objectPtr = component;
+                        selectionObjects.emplace_back(AZStd::move(objectInfo));
+                    }
+
+                    // Continue enumeration.
+                    return true;
+                });
+
+            // In addition to presorting nodes by position we will sort all of the property components by name to guarantee a consistent
+            // order in the inspector.
+            AZStd::sort(
+                selectionObjects.begin(),
+                selectionObjects.end(),
+                [](const auto& objectInfo1, const auto& objectInfo2)
+                {
+                    return objectInfo1.m_displayName < objectInfo2.m_displayName;
+                });
+
+            objects.insert(objects.end(), selectionObjects.begin(), selectionObjects.end());
+        }
+
+        return objects;
+    }
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphDocument.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphDocument.cpp
@@ -619,7 +619,7 @@ namespace AtomToolsFramework
         // Some graph canvas node property components do not have any visible properties, like the bookmark anchor visual component. These
         // will not be added to the graph document inspector.
         const AZStd::unordered_set<AZ::Uuid> ignoredTypeIds{
-            AZ::Uuid::CreateString("{AD921E77-962B-417F-88FB-500FA679DFDF}") // BookmarkAnchorVisualComponent
+            AZ::Uuid("{AD921E77-962B-417F-88FB-500FA679DFDF}") // BookmarkAnchorVisualComponent
         };
 
         // After all of the selected graph canvas nodes have been sorted, search for those with editable property components and add them to

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/StyleSheet/materialcanvas_style.json
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/StyleSheet/materialcanvas_style.json
@@ -2104,6 +2104,13 @@
     "background-color": "#AF937B"
   },
   {
+    "selectors": [ "UtilityNodeTitlePalette" ],
+    "palette-style": "solid",
+    "line-color": "#FFFFFF",
+    "background-color": "#FFFFFF",
+    "color": "#ffffff"
+  },
+  {
     "selectors": [ "DefaultNodeTitlePalette" ],
     "palette-style": "solid",
     "line-color": "#333333",

--- a/Gems/Atom/Tools/PassCanvas/Assets/PassCanvas/StyleSheet/passcanvas_style.json
+++ b/Gems/Atom/Tools/PassCanvas/Assets/PassCanvas/StyleSheet/passcanvas_style.json
@@ -2104,6 +2104,13 @@
     "background-color": "#AF937B"
   },
   {
+    "selectors": [ "UtilityNodeTitlePalette" ],
+    "palette-style": "solid",
+    "line-color": "#FFFFFF",
+    "background-color": "#FFFFFF",
+    "color": "#ffffff"
+  },
+  {
     "selectors": [ "DefaultNodeTitlePalette" ],
     "palette-style": "solid",
     "line-color": "#333333",


### PR DESCRIPTION
## What does this PR do?

Material canvas primarily uses graph model and dynamic nodes that hide most of the graph canvas implementation. Graph model does not implement wrapper nodes for common, utility types like groups, comments, and bookmarks. This change adds support for editing those types as well as a style sheet entry so they don’t have a blank icon in the node palette.

Resolves https://github.com/o3de/o3de/issues/12494

## How was this PR tested?

Tested dragging, dropping, configuring, undo, and redo with comments, groups, and bookmarks.

![image](https://user-images.githubusercontent.com/82461473/226800401-4608331b-4d0e-4b5d-bf4d-5da245d0ec05.png)
