### PR TITLE
[ShaderManagementConsole] Add functionality for system option handling

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Handle.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Handle.h
@@ -108,6 +108,7 @@ namespace AZ
                     ->Attribute(AZ::Script::Attributes::Category, "RHI")
                     ->Attribute(AZ::Script::Attributes::Module, "rhi")
                     ->Method("IsValid", &Handle<T, NamespaceType>::IsValid)
+                    ->Method("GetIndex", &Handle<T, NamespaceType>::GetIndex)
                     ;
             }
         }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Shader/ShaderVariantListSourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Shader/ShaderVariantListSourceData.h
@@ -28,6 +28,7 @@ namespace AZ
             AZ_CLASS_ALLOCATOR(ShaderVariantListSourceData, AZ::SystemAllocator);
 
             static constexpr const char* Extension = "shadervariantlist";
+            static constexpr const char* DefaultTarget = "gfx1035";
 
             static void Reflect(ReflectContext* context);
 
@@ -35,6 +36,22 @@ namespace AZ
             struct VariantInfo
             {
                 AZ_TYPE_INFO(AZ::RPI::ShaderVariantListSourceData::VariantInfo, "{C0E1DF8C-D1BE-4AF4-8100-5D71788399BA}");
+
+                VariantInfo() = default;
+
+                VariantInfo(AZ::u32 id, ShaderOptionValuesSourceData options)
+                    : m_stableId(id)
+                    , m_options(options)
+                    , m_enableRegisterAnalysis(false)
+                    , m_asic(DefaultTarget)
+                {}
+
+                VariantInfo(AZ::u32 id, ShaderOptionValuesSourceData options, bool enableAnalysis, AZStd::string asic)
+                    : m_stableId(id)
+                    , m_options(options)
+                    , m_enableRegisterAnalysis(enableAnalysis)
+                    , m_asic(asic)
+                {}
 
                 // See ShaderVariantStableId.
                 AZ::u32 m_stableId = 0;
@@ -54,7 +71,7 @@ namespace AZ
                 // The value depends on the version of RGA we use
                 // Current RGA is 2.6.2
                 // Supported values: gfx900 gfx902 gfx906 gfx90c gfx1010 gfx1011 gfx1012 gfx1030 gfx1031 gfx1032 gfx1034 gfx1035 
-                AZStd::string m_asic = AZStd::string("gfx1035");
+                AZStd::string m_asic = AZStd::string(DefaultTarget);
             };
 
             AZStd::string m_shaderFilePath; // .shader file.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderOptionGroupLayout.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderOptionGroupLayout.h
@@ -154,6 +154,9 @@ namespace AZ
             //! Gets the name for the option value.
             Name GetValueName(ShaderOptionValue value) const;
 
+            //! Gets the name for the option value.
+            Name GetValueName(uint32_t valueIndex) const;
+
             bool operator == (const ShaderOptionDescriptor&) const;
             bool operator != (const ShaderOptionDescriptor&) const;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/ShaderCollection.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/ShaderCollection.cpp
@@ -96,7 +96,7 @@ namespace AZ
                     ->Method("GetShaderAssetId", &Item::GetShaderAssetId)
                     ->Method("GetShaderVariantId", &Item::GetShaderVariantId)
                     ->Method("GetShaderOptionGroup", &Item::GetShaderOptionGroup)
-                ;
+                    ->Method("MaterialOwnsShaderOption", static_cast<bool (Item::*)(const Name&) const>(&Item::MaterialOwnsShaderOption));
             }
         }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderOptionGroupLayout.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderOptionGroupLayout.cpp
@@ -109,8 +109,13 @@ namespace AZ
                     ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::RuntimeOwn)
                     ->Method("GetName", &ShaderOptionDescriptor::GetName)
                     ->Method("GetDefaultValue", &ShaderOptionDescriptor::GetDefaultValue)
-                    ->Method("GetValueName", &ShaderOptionDescriptor::GetValueName)
+                    ->Method("GetValueName", static_cast<Name (ShaderOptionDescriptor::*)(ShaderOptionValue) const>(&ShaderOptionDescriptor::GetValueName))
                     ->Method("FindValue", &ShaderOptionDescriptor::FindValue)
+                    ->Method("GetMinValue", &ShaderOptionDescriptor::GetMinValue)
+                    ->Method("GetMaxValue", &ShaderOptionDescriptor::GetMaxValue)
+                    ->Method("GetValuesCount", &ShaderOptionDescriptor::GetValuesCount)
+                    ->Method("GetType", &ShaderOptionDescriptor::GetType)
+                    ->Method("GetValueNameWithInt", static_cast<Name (ShaderOptionDescriptor::*)(uint32_t) const>(&ShaderOptionDescriptor::GetValueName))
                     ;
             }   
         }
@@ -379,6 +384,11 @@ namespace AZ
             }
             auto name = m_nameReflectionForValues.Find(value);
             return name;
+        }
+
+        Name ShaderOptionDescriptor::GetValueName(uint32_t valueIndex) const
+        {
+            return GetValueName(ShaderOptionValue{ valueIndex });
         }
 
         void ShaderOptionDescriptor::EncodeBits(ShaderVariantKey& shaderVariantKey, uint32_t value) const

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderOptionGroupLayout.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderOptionGroupLayout.cpp
@@ -115,7 +115,7 @@ namespace AZ
                     ->Method("GetMaxValue", &ShaderOptionDescriptor::GetMaxValue)
                     ->Method("GetValuesCount", &ShaderOptionDescriptor::GetValuesCount)
                     ->Method("GetType", &ShaderOptionDescriptor::GetType)
-                    ->Method("GetValueNameWithInt", static_cast<Name (ShaderOptionDescriptor::*)(uint32_t) const>(&ShaderOptionDescriptor::GetValueName))
+                    ->Method("GetValueNameByIndex", static_cast<Name (ShaderOptionDescriptor::*)(uint32_t) const>(&ShaderOptionDescriptor::GetValueName))
                     ;
             }   
         }

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.h
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.h
@@ -65,6 +65,15 @@ namespace ShaderManagementConsole
         // Read shader source data from JSON then find all references to to populate the shader variant list and initialize the document
         bool LoadShaderVariantListSourceData();
 
+        // Copy shaderVariantIN to shaderVariantOUT, if the targetOption exist, update the value to targetValue
+        // Return value is stableId += size of shaderVariantIN
+        AZ::u32 UpdateOptionValue(
+            AZStd::vector<AZ::RPI::ShaderVariantListSourceData::VariantInfo>& shaderVariantIN,
+            AZStd::vector<AZ::RPI::ShaderVariantListSourceData::VariantInfo>& shaderVariantOUT,
+            AZ::Name targetOption,
+            AZ::Name targetValue,
+            AZ::u32 stableId);
+
         // Source data for shader variant list
         AZ::RPI::ShaderVariantListSourceData m_shaderVariantListSourceData;
 

--- a/Gems/Atom/Tools/ShaderManagementConsole/Scripts/GenerateShaderVariantListForAllShaders.py
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Scripts/GenerateShaderVariantListForAllShaders.py
@@ -16,7 +16,7 @@ def main():
         azlmbr.bus.Broadcast, 
         'GetAllMaterialAssetIds'
     )
-    GenerateShaderVariantListUtil.create_shadervariantlists_from_material(assetIds)
+    GenerateShaderVariantListUtil.save_shadervariantlists_for_materials(assetIds)
 
     print("==== Finish generate shader variant list for all built material assets ==========")
 

--- a/Gems/Atom/Tools/ShaderManagementConsole/Scripts/GenerateShaderVariantListForMaterials.py
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Scripts/GenerateShaderVariantListForMaterials.py
@@ -8,7 +8,6 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 import sys
 import GenerateShaderVariantListUtil
 
-
 def main():
     print("==== Begin shader variant script ==========================================================")
 
@@ -23,13 +22,13 @@ def main():
         print("The input argument for the script is not a valid .shader file")
         return
 
-    shaderVariantList, defaultShaderVariantListFilePath = GenerateShaderVariantListUtil.create_shadervariantlist_for_shader(filename)
-    
+    shaderVariantList = GenerateShaderVariantListUtil.create_shadervariantlist_for_shader(filename)
+
     # Create shader variant list document
     documentId = azlmbr.atomtools.AtomToolsDocumentSystemRequestBus(
-       azlmbr.bus.Broadcast,
-       'CreateDocumentFromTypeName',
-       'Shader Variant List'
+        azlmbr.bus.Broadcast,
+        'CreateDocumentFromTypeName',
+        'Shader Variant List'
     )
     # Update shader variant list
     azlmbr.shadermanagementconsole.ShaderManagementConsoleDocumentRequestBus(

--- a/Gems/Atom/Tools/ShaderManagementConsole/Scripts/GenerateShaderVariantListUtil.py
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Scripts/GenerateShaderVariantListUtil.py
@@ -163,11 +163,13 @@ def create_shadervariantlist_for_shader(filename):
         shaderAssetInfo.relativePath
     )
 
+    
+    shaderVariantList = azlmbr.shader.ShaderVariantListSourceData()
+    shaderVariantList.shaderFilePath = shaderAssetInfo.relativePath
+
     if len(materialAssetIds) == 0:
         # No material is using this shader, so we can't get ShaderOptionDescriptor in the script
         # Return early and handle user assigned system option after shaderAsset is loaded
-        shaderVariantList = azlmbr.shader.ShaderVariantListSourceData()
-        shaderVariantList.shaderFilePath = shaderAssetInfo.relativePath
         return shaderVariantList
     
     # This loop collects all uniquely-identified shader items used by the materials based on its shader variant id. 
@@ -221,8 +223,6 @@ def create_shadervariantlist_for_shader(filename):
             systemOptionDict = json.load(systemOptionFile)
 
     # Generate the shader variant list data by collecting shader option name-value pairs.s
-    shaderVariantList = azlmbr.shader.ShaderVariantListSourceData()
-    shaderVariantList.shaderFilePath = shaderAssetInfo.relativePath
     shaderVariants = []
     systemOptionDescriptor = {} 
     stableId = 1
@@ -266,7 +266,7 @@ def create_shadervariantlist_for_shader(filename):
         totalShaderVariants = []
         
         for index in range(valueMin.GetIndex(), valueMax.GetIndex() + 1):
-            optionValue = optionDescriptor.GetValueNameWithInt(index)
+            optionValue = optionDescriptor.GetValueNameByIndex(index)
             if optionValue != defaultValue:
                 tempShaderVariants, stableId = updateOptionValue(shaderVariants, systemOptionName, optionValue, stableId) 
                 totalShaderVariants.extend(tempShaderVariants)

--- a/Gems/Atom/Tools/ShaderManagementConsole/Scripts/GenerateShaderVariantListUtil.py
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Scripts/GenerateShaderVariantListUtil.py
@@ -15,13 +15,14 @@ import azlmbr.paths
 import azlmbr.shadermanagementconsole
 import azlmbr.shader
 from PySide2 import QtWidgets
+import json
 
 PROJECT_SHADER_VARIANTS_FOLDER = "ShaderVariants"
 
-# input is Material Asset id list
-def create_shadervariantlists_from_material(materialAssetIds):
+# Input is Material Asset id list
+# For all material in the asset database, save a shader variant list in the project's ShaderVariants folder
+def save_shadervariantlists_for_materials(materialAssetIds):
 
-    shaderVarintIdDict = {}     # Key: ShaderAssetId, Value: ShaderVarintId list
     shaderOptionGroupsDict = {} # Key: ShaderAssetId, Value: ShaderOptionGroups list
 
     progressDialog = QtWidgets.QProgressDialog("Gather shader variant information...", "Cancel", 0, len(materialAssetIds))
@@ -38,40 +39,34 @@ def create_shadervariantlists_from_material(materialAssetIds):
             shaderAssetId = shaderItem.GetShaderAsset().get_id()
             shaderVariantId = shaderItem.GetShaderVariantId()
 
-            if shaderVarintIdDict.get(shaderAssetId) == None:
-                shaderVarintIdDict[shaderAssetId] = []
-                shaderOptionGroupsDict[shaderAssetId] = []
-                if not shaderVariantId.IsEmpty():
-                    shaderVarintIdDict[shaderAssetId].append(shaderVariantId)
+            if not shaderVariantId.IsEmpty():
+                if shaderOptionGroupsDict.get(shaderAssetId) == None:
+                    shaderOptionGroupsDict[shaderAssetId] = []
                     shaderOptionGroupsDict[shaderAssetId].append(shaderItem.GetShaderOptionGroup())
-            else:
-                if not shaderVariantId.IsEmpty():
-                    # Check for repeat shader variant ids. We are using a list here
-                    # instead of a set to check for duplicates on shaderVariantIds because
-                    # shaderVariantId is not hashed by the ID like it is in the C++ side. 
+                else:
+                    # check for repetition
                     has_repeat = False
-                    for variantId in shaderVarintIdDict[shaderAssetId]:
+                    for shaderOptionGroup in shaderOptionGroupsDict[shaderAssetId]:
+                        variantId = shaderOptionGroup.GetShaderVariantId()
                         if shaderVariantId == variantId:
                             has_repeat = True
                             break
                     if has_repeat:
                         continue
 
-                    shaderVarintIdDict[shaderAssetId].append(shaderVariantId)
                     shaderOptionGroupsDict[shaderAssetId].append(shaderItem.GetShaderOptionGroup())
 
         progressDialog.setValue(i)
         if progressDialog.wasCanceled():
             return
-
     progressDialog.close()
-
 
     progressDialog = QtWidgets.QProgressDialog("Generating .shadervariantlist files...", "Cancel", 0, len(shaderOptionGroupsDict))
     progressDialog.setMaximumWidth(400)
     progressDialog.setMaximumHeight(100)
     progressDialog.setModal(True)
     progressDialog.setWindowTitle("Generating Shader Variant Lists")
+
     # Generate the shader variant list for each shader asset
     for i, shaderAssetId in enumerate(shaderOptionGroupsDict):
 
@@ -117,10 +112,7 @@ def create_shadervariantlists_from_material(materialAssetIds):
         if shaderVariants:
             shaderVariantList.shaderVariants = shaderVariants
             pre, ext = os.path.splitext(relativeShaderPath)
-            if "Intermediate Assets" in fullShaderPath:
-                projectShaderVariantListFilePath = os.path.join(azlmbr.paths.projectroot, PROJECT_SHADER_VARIANTS_FOLDER, "Cache", "Intermediate Assets", f'{pre}.shadervariantlist')
-            else:
-                projectShaderVariantListFilePath = os.path.join(azlmbr.paths.projectroot, PROJECT_SHADER_VARIANTS_FOLDER, f'{pre}.shadervariantlist')
+            projectShaderVariantListFilePath = os.path.join(azlmbr.paths.projectroot, PROJECT_SHADER_VARIANTS_FOLDER, f'{pre}.shadervariantlist')
             
             # clean previously generated shader variant list file so they don't clash.
             if os.path.exists(projectShaderVariantListFilePath):
@@ -131,11 +123,30 @@ def create_shadervariantlists_from_material(materialAssetIds):
         progressDialog.setValue(i)
         if progressDialog.wasCanceled():
             return
-    
     progressDialog.close()
 
+# Make a copy of shaderVariants, update target option value and return copy, accumulate stableId
+def updateOptionValue(shaderVariants, targetOptionName, targetValue, stableId):
+    tempShaderVariants = []
+    
+    for variantInfo in shaderVariants:
+        tempVariantInfo = azlmbr.shader.ShaderVariantInfo()
+        options = {}
 
-# Input is .shader
+        for optionName in variantInfo.options:
+            if targetOptionName == optionName:
+                options[optionName] = targetValue
+            else:
+                options[optionName] = variantInfo.options[optionName]
+
+        tempVariantInfo.options = options
+        tempVariantInfo.stableId = stableId
+        tempShaderVariants.append(tempVariantInfo)
+        stableId += 1
+
+    return tempShaderVariants, stableId
+
+# Input is one .shader
 def create_shadervariantlist_for_shader(filename):
     
     # Get info such as relative path of the file and asset id
@@ -144,6 +155,7 @@ def create_shadervariantlist_for_shader(filename):
         'GetSourceAssetInfo', 
         filename
     )
+
     # retrieves a list of all material source files that use the shader. Note that materials inherit from materialtype files, which are actual files that refer to shader files.
     materialAssetIds = azlmbr.shadermanagementconsole.ShaderManagementConsoleRequestBus(
         azlmbr.bus.Broadcast, 
@@ -151,16 +163,24 @@ def create_shadervariantlist_for_shader(filename):
         shaderAssetInfo.relativePath
     )
 
-
+    if len(materialAssetIds) == 0:
+        # No material is using this shader, so we can't get ShaderOptionDescriptor in the script
+        # Return early and handle user assigned system option after shaderAsset is loaded
+        shaderVariantList = azlmbr.shader.ShaderVariantListSourceData()
+        shaderVariantList.shaderFilePath = shaderAssetInfo.relativePath
+        return shaderVariantList
+    
     # This loop collects all uniquely-identified shader items used by the materials based on its shader variant id. 
     shader_file = os.path.basename(filename)
     shaderVariantIds = []
-    shaderVariantListShaderOptionGroups = []
+    shaderOptionGroups = []
+
     progressDialog = QtWidgets.QProgressDialog(f"Generating .shadervariantlist file for:\n{shader_file}", "Cancel", 0, len(materialAssetIds))
     progressDialog.setMaximumWidth(400)
     progressDialog.setMaximumHeight(100)
     progressDialog.setModal(True)
     progressDialog.setWindowTitle("Generating Shader Variant List")
+
     for i, materialAssetId in enumerate(materialAssetIds):
         materialInstanceShaderItems = azlmbr.shadermanagementconsole.ShaderManagementConsoleRequestBus(azlmbr.bus.Broadcast, 'GetMaterialInstanceShaderItems', materialAssetId)
 
@@ -181,7 +201,8 @@ def create_shadervariantlist_for_shader(filename):
                         continue
 
                     shaderVariantIds.append(shaderVariantId)
-                    shaderVariantListShaderOptionGroups.append(shaderItem.GetShaderOptionGroup())
+                    shaderOptionGroups.append(shaderItem.GetShaderOptionGroup())
+                    
 
         progressDialog.setValue(i)
         if progressDialog.wasCanceled():
@@ -189,12 +210,24 @@ def create_shadervariantlist_for_shader(filename):
 
     progressDialog.close()
 
+    # Read from shaderPath.systemoptions to get user assigned system option value
+    pre, ext = os.path.splitext(filename)
+    systemOptionFilePath = f'{pre}.systemoptions'
+    systemOptionFilePath = systemOptionFilePath.replace("\\", "/")
+    systemOptionDict = {}
+
+    if os.path.isfile(systemOptionFilePath):
+        with open(systemOptionFilePath, "r") as systemOptionFile:
+            systemOptionDict = json.load(systemOptionFile)
+
     # Generate the shader variant list data by collecting shader option name-value pairs.s
     shaderVariantList = azlmbr.shader.ShaderVariantListSourceData()
     shaderVariantList.shaderFilePath = shaderAssetInfo.relativePath
     shaderVariants = []
+    systemOptionDescriptor = {} 
     stableId = 1
-    for shaderOptionGroup in shaderVariantListShaderOptionGroups:
+
+    for shaderOptionGroup in shaderOptionGroups:
         variantInfo = azlmbr.shader.ShaderVariantInfo()
         variantInfo.stableId = stableId
         options = {}
@@ -209,16 +242,36 @@ def create_shadervariantlist_for_shader(filename):
             valueName = shaderOptionDescriptor.GetValueName(optionValue)
             options[optionName] = valueName
 
+            # Check user assigned value
+            optionNameString = optionName.ToString()
+            if optionNameString in systemOptionDict:
+                if systemOptionDict[optionNameString] != "":
+                    options[optionName] = azlmbr.name.Name(systemOptionDict[optionNameString])
+                else:
+                    # Value is unset, expansion handling later
+                    systemOptionDescriptor[optionName] = shaderOptionDescriptor
+
         if len(options) != 0:
             variantInfo.options = options
             shaderVariants.append(variantInfo)
             stableId += 1
 
+    # Expand the unset system option
+    for systemOptionName in systemOptionDescriptor:
+        optionDescriptor = systemOptionDescriptor[systemOptionName]
+        defaultValue = optionDescriptor.GetDefaultValue()
+        
+        valueMin = optionDescriptor.GetMinValue()
+        valueMax = optionDescriptor.GetMaxValue()
+        totalShaderVariants = []
+        
+        for index in range(valueMin.GetIndex(), valueMax.GetIndex() + 1):
+            optionValue = optionDescriptor.GetValueNameWithInt(index)
+            if optionValue != defaultValue:
+                tempShaderVariants, stableId = updateOptionValue(shaderVariants, systemOptionName, optionValue, stableId) 
+                totalShaderVariants.extend(tempShaderVariants)
+            
+        shaderVariants.extend(totalShaderVariants)
+
     shaderVariantList.shaderVariants = shaderVariants
-
-    pre, ext = os.path.splitext(filename)
-    defaultShaderVariantListFilePath = f'{pre}.shadervariantlist'
-    defaultShaderVariantListFilePath = defaultShaderVariantListFilePath.replace("\\", "/")
-
-    return shaderVariantList, defaultShaderVariantListFilePath
-
+    return shaderVariantList


### PR DESCRIPTION
## What does this PR do?

Add the functionality to process user-provided system option setting files, extension ".systemoptions", live in the same path as the ",shader" file. 
The setting file is a json looks like this
```
{
       "o_option1": "true",
       "o_option2": "2",
       "o_option3": "Modulate::None"
       "o_option4": ""     // value unset
}
``` 

Users can generate ShaderVariantList with `GenerateShaderVariantListForMaterials.py` as they used to, only now the script will try to read ".systemoptions" and process the value.
If the value is set, it will replace the value set in `GenerateShaderVariantListForMaterials.py`, if the value is unset,
it will be automatically expanded with all the possible combination

Note there is duplicate functionality in c++ and python, because we can't get the `ShaderOptionDescriptor` in the script if there is no material using the shader, so we have to handle it in c++.

## How was this PR tested?

Test locally on my PC
