### PR TITLE
Merge stabilization/2305 to development

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialCanvas_Atom_BasicTests.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialCanvas_Atom_BasicTests.py
@@ -152,7 +152,7 @@ def MaterialCanvas_BasicFunctionalityChecks_AllChecksPass():
         world_position_node = material_canvas_utils.create_node_by_name(material_graph, "World Position")
         Report.result(
             Tests.world_position_node_created,
-            world_position_node.typename == "AZStd::shared_ptr<Node const>")
+            world_position_node.typename == "AZStd::shared_ptr<Node>")
 
         # 10. Add the world_position_node to the material_graph.
         # This test will be verified when the nodes are connected as if it doesn't exist the connection won't be made.
@@ -162,7 +162,7 @@ def MaterialCanvas_BasicFunctionalityChecks_AllChecksPass():
         standard_pbr_node = material_canvas_utils.create_node_by_name(material_graph, "Standard PBR")
         Report.result(
             Tests.standard_pbr_node_created,
-            standard_pbr_node.typename == "AZStd::shared_ptr<Node const>")
+            standard_pbr_node.typename == "AZStd::shared_ptr<Node>")
 
         # 12. Add the standard_pbr_node to the material_graph.
         # This test will be verified when the nodes are connected as if it doesn't exist the connection won't be made.

--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/EditorWorkflow_EditorCameraInBeThisCameraReturnsToOriginalPositionWhenLeavingGameMode.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/EditorWorkflow_EditorCameraInBeThisCameraReturnsToOriginalPositionWhenLeavingGameMode.py
@@ -1,0 +1,108 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+
+class Tests:
+    camera_moved_to_entity_position_game_mode = (
+        "Editor camera view moved to the camera entity position in game mode"
+        "Editor camera view did not move to the camera entity position in game mode"
+    )
+
+    camera_returned_to_initial_position = (
+        "Editor camera view restored after returning from game mode"
+        "Editor camera view was not restored after returning from game mode"
+    )
+
+
+def EditorWorkflow_EditorCameraInBeThisCameraReturnsToOriginalPositionWhenLeavingGameMode():
+    """
+    Summary:
+    Test camera position when entering/leaving game mode
+
+    Expected Behavior:
+    Editor camera view returns to original editor camera position after leaving game mode
+    """
+
+    import azlmbr.bus as bus
+    import azlmbr.camera as camera
+    import azlmbr.editor as editor
+    import azlmbr.components as components
+    import azlmbr.legacy.general as general
+    import azlmbr.math as math
+
+    from editor_python_test_tools.editor_entity_utils import EditorEntity
+    from editor_python_test_tools.editor_test_helper import EditorTestHelper
+    from editor_python_test_tools.utils import Report, TestHelper
+
+    def get_current_view_position_as_vector3() -> math.Vector3:
+        view_position = general.get_current_view_position()
+        x = view_position.get_property('x')
+        y = view_position.get_property('y')
+        z = view_position.get_property('z')
+        return math.Vector3(float(x), float(y), float(z))
+
+    helper = EditorTestHelper(log_prefix="Editor Camera")
+
+    helper.open_level("Base")
+
+    # where we expect the camera to end up
+    entity_camera_position = math.Vector3(20.0, 40.0, 60.0)
+
+    # begin recording an undo batch for the newly created entity
+    editor.ToolsApplicationRequestBus(bus.Broadcast, 'BeginUndoBatch', "Create camera entity")
+
+    # create a new entity with a camera component
+    camera_entity = EditorEntity.create_editor_entity(name="CameraEntity")
+    camera_entity.add_component("Camera")
+
+    # explicitly track the entity in the newly created undo batch
+    editor.ToolsApplicationRequestBus(bus.Broadcast, 'AddDirtyEntity', camera_entity.id)
+
+    # position the entity in the world
+    components.TransformBus(bus.Event, "SetWorldTranslation",
+                            camera_entity.id, entity_camera_position)
+
+    # after modifying the entity, end the undo batch (this will ensure the change is tracked
+    # when moving to/from game mode)
+    editor.ToolsApplicationRequestBus(bus.Broadcast, 'EndUndoBatch')
+
+    general.idle_wait_frames(1)
+
+    # trigger 'Be this camera'
+    camera.EditorCameraViewRequestBus(
+        bus.Event, "ToggleCameraAsActiveView", camera_entity.id)
+    
+    general.idle_wait_frames(1)
+
+    # note: this will match the entity transform
+    initial_camera_position = get_current_view_position_as_vector3()
+
+    # enter/exit game mode
+    general.enter_game_mode()
+    helper.wait_for_condition(lambda: general.is_in_game_mode(), 5.0)
+
+    game_mode_camera_position = get_current_view_position_as_vector3()
+
+    position_changed_game_mode = game_mode_camera_position.IsClose(entity_camera_position)
+    Report.result(Tests.camera_moved_to_entity_position_game_mode, position_changed_game_mode)
+
+    general.exit_game_mode()
+    helper.wait_for_condition(lambda: not general.is_in_game_mode(), 5.0)
+
+    # ensure camera position has returned to the position it was when starting 'be this camera'
+    actual_camera_position = get_current_view_position_as_vector3()
+
+    position_restored = actual_camera_position.IsClose(initial_camera_position)
+
+    # verify the position has been updated
+    Report.result(Tests.camera_returned_to_initial_position, position_restored)
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(
+        EditorWorkflow_EditorCameraInBeThisCameraReturnsToOriginalPositionWhenLeavingGameMode)

--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/EditorWorkflow_EditorCameraReturnsToOriginalPositionWhenLeavingFullscreenGameMode.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/EditorWorkflow_EditorCameraReturnsToOriginalPositionWhenLeavingFullscreenGameMode.py
@@ -1,0 +1,82 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+
+class Tests:
+    camera_moved_to_position_edit_mode = (
+        "Editor camera view moved to the new position in edit mode"
+        "Editor camera view did not move to the new position in edit mode"
+    )
+
+    camera_returned_to_initial_position_in_edit_mode_after_fullscreen_preview = (
+        "Editor camera view restored after returning from game mode in fullscreen"
+        "Editor camera view was not restored after returning from game mode in fullscreen"
+    )
+
+
+def EditorWorkflow_EditorCameraReturnsToOriginalPositionWhenLeavingFullscreenGameMode():
+    """
+    Summary:
+    Test camera position when entering/leaving game mode fullscreen preview
+
+    Expected Behavior:
+    Editor camera view returns to original editor camera position after leaving game mode fullscreen preview
+    """
+
+    import azlmbr.bus as bus
+    import azlmbr.editor as editor
+    import azlmbr.components as components
+    import azlmbr.legacy.general as general
+    import azlmbr.math as math
+
+    from editor_python_test_tools.editor_entity_utils import EditorEntity
+    from editor_python_test_tools.editor_test_helper import EditorTestHelper
+    from editor_python_test_tools.utils import Report, TestHelper
+
+    def get_current_view_position_as_vector3() -> math.Vector3:
+        view_position = general.get_current_view_position()
+        x = view_position.get_property('x')
+        y = view_position.get_property('y')
+        z = view_position.get_property('z')
+        return math.Vector3(float(x), float(y), float(z))
+
+    def set_current_view_position_with_vector3(view_position: math.Vector3):
+        general.set_current_view_position(
+            view_position.x, view_position.y, view_position.z)
+
+    helper = EditorTestHelper(log_prefix="Editor Camera")
+
+    helper.open_level("Base")
+
+    # where we expect the editor camera to end up
+    editor_camera_position = math.Vector3(20.0, 40.0, 60.0)
+    set_current_view_position_with_vector3(editor_camera_position)
+
+    general.idle_wait_frames(1)
+
+    initial_camera_position = get_current_view_position_as_vector3()
+    initial_camera_position_position_set = initial_camera_position.IsClose(editor_camera_position)
+    Report.result(Tests.camera_moved_to_position_edit_mode, initial_camera_position_position_set)
+
+    # enter/exit game mode
+    general.enter_game_mode_fullscreen()
+    helper.wait_for_condition(lambda: general.is_in_game_mode(), 5.0)
+
+    general.exit_game_mode()
+    helper.wait_for_condition(lambda: not general.is_in_game_mode(), 5.0)
+
+    # ensure camera position has returned to the initial camera position
+    actual_camera_position = get_current_view_position_as_vector3()
+    position_restored = actual_camera_position.IsClose(initial_camera_position)
+    # verify the position has been updated
+    Report.result(Tests.camera_returned_to_initial_position_in_edit_mode_after_fullscreen_preview, position_restored)
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(
+        EditorWorkflow_EditorCameraReturnsToOriginalPositionWhenLeavingFullscreenGameMode)

--- a/AutomatedTesting/Gem/PythonTests/editor/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/TestSuite_Main.py
@@ -117,6 +117,12 @@ class TestAutomation(EditorTestSuite):
     class test_EditorWorkflow_EditorCameraReturnsToOriginalPositionWhenLeavingGameMode(EditorSingleTest):
         from .EditorScripts import EditorWorkflow_EditorCameraReturnsToOriginalPositionWhenLeavingGameMode as test_module
 
+    class test_EditorWorkflow_EditorCameraInBeThisCameraReturnsToOriginalPositionWhenLeavingGameMode(EditorSingleTest):
+        from .EditorScripts import EditorWorkflow_EditorCameraInBeThisCameraReturnsToOriginalPositionWhenLeavingGameMode as test_module
+
+    class test_EditorWorkflow_EditorCameraReturnsToOriginalPositionWhenLeavingFullscreenGameMode(EditorSingleTest):
+        from .EditorScripts import EditorWorkflow_EditorCameraReturnsToOriginalPositionWhenLeavingFullscreenGameMode as test_module
+
     class test_EditorWorkflow_EditorCameraTransformCanBeModifiedWhileInBeThisCamera(EditorSingleTest):
         from .EditorScripts import EditorWorkflow_EditorCameraTransformCanBeModifiedWhileInBeThisCamera as test_module
 

--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -1849,6 +1849,11 @@ void EditorActionsHandler::OnMenuRegistrationHook()
         menuProperties.m_name = "Viewport Context Menu";
         m_menuManagerInterface->RegisterMenu(EditorIdentifiers::ViewportContextMenuIdentifier, menuProperties);
     }
+    {
+        AzToolsFramework::MenuProperties menuProperties;
+        menuProperties.m_name = "Create";
+        m_menuManagerInterface->RegisterMenu(EditorIdentifiers::EntityCreationMenuIdentifier, menuProperties);
+    }
 
 }
 
@@ -2022,6 +2027,8 @@ void EditorActionsHandler::OnMenuBindingHook()
     }
 
     // Entity Outliner Context Menu
+    m_menuManagerInterface->AddSubMenuToMenu(
+        EditorIdentifiers::EntityOutlinerContextMenuIdentifier, EditorIdentifiers::EntityCreationMenuIdentifier, 200);
     m_menuManagerInterface->AddSeparatorToMenu(EditorIdentifiers::EntityOutlinerContextMenuIdentifier, 10000);
     m_menuManagerInterface->AddSeparatorToMenu(EditorIdentifiers::EntityOutlinerContextMenuIdentifier, 20000);
     m_menuManagerInterface->AddSeparatorToMenu(EditorIdentifiers::EntityOutlinerContextMenuIdentifier, 30000);
@@ -2034,6 +2041,8 @@ void EditorActionsHandler::OnMenuBindingHook()
     m_menuManagerInterface->AddActionToMenu(EditorIdentifiers::EntityOutlinerContextMenuIdentifier, "o3de.action.view.centerOnSelection", 80100);
 
     // Viewport Context Menu
+    m_menuManagerInterface->AddSubMenuToMenu(
+        EditorIdentifiers::ViewportContextMenuIdentifier, EditorIdentifiers::EntityCreationMenuIdentifier, 200);
     m_menuManagerInterface->AddSeparatorToMenu(EditorIdentifiers::ViewportContextMenuIdentifier, 10000);
     m_menuManagerInterface->AddSeparatorToMenu(EditorIdentifiers::ViewportContextMenuIdentifier, 20000);
     m_menuManagerInterface->AddSeparatorToMenu(EditorIdentifiers::ViewportContextMenuIdentifier, 30000);

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -603,6 +603,7 @@ void EditorViewportWidget::OnEditorNotifyEvent(EEditorNotifyEvent event)
                 }
 
                 m_preGameModeViewTM = GetViewTM();
+
                 // this should only occur for the main viewport and no others.
                 ShowCursor();
 
@@ -891,6 +892,13 @@ void EditorViewportWidget::SetViewportId(int id)
     layout->setContentsMargins(QMargins());
     layout->addWidget(m_renderViewport);
 
+    UpdateScene();
+
+    if (m_pPrimaryViewport == this)
+    {
+        SetAsActiveViewport();
+    }
+
     m_renderViewport->GetControllerList()->Add(AZStd::make_shared<SandboxEditor::ViewportManipulatorController>());
 
     m_editorModularViewportCameraComposer =
@@ -899,13 +907,6 @@ void EditorViewportWidget::SetViewportId(int id)
 
     m_editorViewportSettings.Connect(AzFramework::ViewportId(id));
 
-    UpdateScene();
-
-    if (m_pPrimaryViewport == this)
-    {
-        SetAsActiveViewport();
-    }
-
     m_editorViewportSettingsCallbacks = SandboxEditor::CreateEditorViewportSettingsCallbacks();
 
     m_gridShowingHandler = SandboxEditor::GridShowingChangedEvent::Handler(
@@ -913,8 +914,7 @@ void EditorViewportWidget::SetViewportId(int id)
         {
             AzToolsFramework::ViewportInteraction::ViewportSettingsNotificationBus::Event(
                 id, &AzToolsFramework::ViewportInteraction::ViewportSettingsNotificationBus::Events::OnGridShowingChanged, showing);
-        }
-    );
+        });
     m_editorViewportSettingsCallbacks->SetGridShowingChangedEvent(m_gridShowingHandler);
 
     m_gridSnappingHandler = SandboxEditor::GridSnappingChangedEvent::Handler(
@@ -922,8 +922,7 @@ void EditorViewportWidget::SetViewportId(int id)
         {
             AzToolsFramework::ViewportInteraction::ViewportSettingsNotificationBus::Event(
                 id, &AzToolsFramework::ViewportInteraction::ViewportSettingsNotificationBus::Events::OnGridSnappingChanged, snapping);
-        }
-    );
+        });
     m_editorViewportSettingsCallbacks->SetGridSnappingChangedEvent(m_gridSnappingHandler);
 
     m_angleSnappingHandler = SandboxEditor::AngleSnappingChangedEvent::Handler(
@@ -931,8 +930,7 @@ void EditorViewportWidget::SetViewportId(int id)
         {
             AzToolsFramework::ViewportInteraction::ViewportSettingsNotificationBus::Event(
                 id, &AzToolsFramework::ViewportInteraction::ViewportSettingsNotificationBus::Events::OnAngleSnappingChanged, snapping);
-        }
-    );
+        });
     m_editorViewportSettingsCallbacks->SetAngleSnappingChangedEvent(m_angleSnappingHandler);
 
     m_cameraSpeedScaleHandler = SandboxEditor::CameraSpeedScaleChangedEvent::Handler(
@@ -940,8 +938,7 @@ void EditorViewportWidget::SetViewportId(int id)
         {
             AzToolsFramework::ViewportInteraction::ViewportSettingsNotificationBus::Event(
                 id, &AzToolsFramework::ViewportInteraction::ViewportSettingsNotificationBus::Events::OnCameraSpeedScaleChanged, scale);
-        }
-    );
+        });
     m_editorViewportSettingsCallbacks->SetCameraSpeedScaleChangedEvent(m_cameraSpeedScaleHandler);
 
     m_perspectiveChangeHandler = SandboxEditor::PerspectiveChangedEvent::Handler(
@@ -962,16 +959,14 @@ void EditorViewportWidget::SetViewportId(int id)
         [this]([[maybe_unused]] float nearPlaneDistance)
         {
             OnDefaultCameraNearFarChanged();
-        }
-    );
+        });
     m_editorViewportSettingsCallbacks->SetNearPlaneDistanceChangedEvent(m_nearPlaneDistanceHandler);
 
     m_farPlaneDistanceHandler = SandboxEditor::NearFarPlaneChangedEvent::Handler(
         [this]([[maybe_unused]] float farPlaneDistance)
         {
             OnDefaultCameraNearFarChanged();
-        }
-    );
+        });
     m_editorViewportSettingsCallbacks->SetFarPlaneDistanceChangedEvent(m_farPlaneDistanceHandler);
 }
 

--- a/Code/Editor/PythonEditorFuncs.cpp
+++ b/Code/Editor/PythonEditorFuncs.cpp
@@ -31,6 +31,7 @@
 #include "Objects/BaseObject.h"
 #include "Commands/CommandManager.h"
 
+AZ_CVAR_EXTERNED(bool, ed_previewGameInFullscreen_once);
 
 namespace
 {
@@ -164,6 +165,12 @@ namespace
         {
             GetIEditor()->GetGameEngine()->RequestSetGameMode(true);
         }
+    }
+
+    void PyEnterGameModeFullscreen()
+    {
+        ed_previewGameInFullscreen_once = true;
+        PyEnterGameMode();
     }
 
     void PyExitGameMode()
@@ -1091,6 +1098,7 @@ namespace AzToolsFramework
             addLegacyGeneral(behaviorContext->Method("run_console", PyRunConsole, nullptr, "Runs a console command."));
 
             addLegacyGeneral(behaviorContext->Method("enter_game_mode", PyEnterGameMode, nullptr, "Enters the editor game mode."));
+            addLegacyGeneral(behaviorContext->Method("enter_game_mode_fullscreen", PyEnterGameModeFullscreen, nullptr, "Enters the editor game mode in fullscreen."));
             addLegacyGeneral(behaviorContext->Method("is_in_game_mode", PyIsInGameMode, nullptr, "Queries if it's in the game mode or not."));
             addLegacyGeneral(behaviorContext->Method("exit_game_mode", PyExitGameMode, nullptr, "Exits the editor game mode."));
 

--- a/Code/Framework/AtomCore/AtomCore/Instance/InstanceDatabase.h
+++ b/Code/Framework/AtomCore/AtomCore/Instance/InstanceDatabase.h
@@ -387,6 +387,14 @@ namespace AZ
         Data::Instance<Type> InstanceDatabase<Type>::EmplaceInstance(
             const InstanceId& id, const Data::Asset<AssetData>& asset, const AZStd::any* param)
         {
+            // This assert is here to catch any potential non-randomness in our id generation. If it triggers,
+            // there might be a bug / race condition in the id generator. The same assert also occurs *after*
+            // instance creation to help differentiate between a non-random id vs recursive creation of the same id.
+            AZ_Assert(
+                !m_database.contains(id),
+                "Database already contains an instance for this id (%s), possibly a random id generation collision?",
+                id.ToString<AZStd::fixed_string<64>>().c_str());
+
             // Emplace a new instance and return it.
             // It's possible for the m_createFunction call to recursively trigger another FindOrCreate call, so be aware that
             // the contents of m_database may change within this call.
@@ -403,10 +411,10 @@ namespace AZ
             if (instance)
             {
                 AZ_Assert(
-                    m_database.find(id) == m_database.end(),
+                    !m_database.contains(id),
                     "Instance creation for asset id %s resulted in a recursive creation of that asset, which was unexpected. "
                     "This asset might be erroneously referencing itself as a dependent asset.",
-                    id.ToString<AZStd::string>().c_str());
+                    id.ToString<AZStd::fixed_string<64>>().c_str());
 
                 instance->m_id = id;
                 instance->m_parentDatabase = this;

--- a/Code/Framework/AzCore/AzCore/Math/Sfmt.h
+++ b/Code/Framework/AzCore/AzCore/Math/Sfmt.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <AzCore/base.h>
-#include <AzCore/std/parallel/atomic.h>
 #include <AzCore/std/parallel/mutex.h>
 #include <AzCore/std/typetraits/static_storage.h>
 #include <AzCore/Math/Internal/MathTypes.h>
@@ -60,12 +59,12 @@ namespace AZ
         /// By default we seed with Seed()
         Sfmt();
         /// Seed the generator with user defined seed Seed(AZ::u32* keys, int numKeys)
-        Sfmt(AZ::u32* keys, int numKeys);
+        Sfmt(const AZ::u32* keys, int numKeys);
 
         /// Seed the generator, with the best pseudo-random number the system can generate \ref BetterPseudoRandom
         void Seed();
         /// Seed the generator with user defined seed.
-        void Seed(AZ::u32* keys, int numKeys);
+        void Seed(const AZ::u32* keys, int numKeys);
 
         /// Return u32 pseudo random integer
         AZ::u32 Rand32();
@@ -106,10 +105,10 @@ namespace AZ
         void    PeriodCertification();
 
         SfmtInternal::w128_t        m_sfmt[SfmtInternal::N];
-        AZStd::atomic_int           m_index;   ///  Index into the pre-generated tables
-        AZ::u32*                    m_psfmt32; ///  Read only tables of pre-generated random numbers
-        AZ::u64*                    m_psfmt64;
+        size_t                      m_index = 0;         ///  Index into the pre-generated tables
+        AZ::u32*                    m_psfmt32 = nullptr; ///  Read only tables of pre-generated random numbers
+        AZ::u64*                    m_psfmt64 = nullptr;
 
-        AZStd::recursive_mutex      m_generationMutex;
+        AZStd::mutex                m_sfmtMutex;         /// Guards access to m_index and m_sfmt
     };
 }

--- a/Code/Framework/AzCore/AzCore/Math/Uuid.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Uuid.cpp
@@ -29,11 +29,9 @@ namespace AZ
         Uuid id;
         Sfmt& smft = Sfmt::GetInstance();
 
-        AZ::u32* id32 = reinterpret_cast<AZ::u32*>(&id);
-        id32[0] = smft.Rand32();
-        id32[1] = smft.Rand32();
-        id32[2] = smft.Rand32();
-        id32[3] = smft.Rand32();
+        AZ::u64* id64 = reinterpret_cast<AZ::u64*>(&id);
+        id64[0] = smft.Rand64();
+        id64[1] = smft.Rand64();
 
         // variant VAR_RFC_4122
         id.m_data[8] &= AZStd::byte(0xBF);

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraph.h
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraph.h
@@ -90,7 +90,7 @@ namespace AZ
         AZStd::binary_semaphore m_semaphore;
         AZStd::atomic_int       m_waitCount = 0;
         TaskExecutor*           m_executor = nullptr;
-        const char* m_label;
+        [[maybe_unused]] const char* m_label = nullptr;
     };
 
     // The TaskGraph encapsulates a set of tasks and their interdependencies. After adding

--- a/Code/Framework/AzCore/Tests/Math/SfmtTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/SfmtTests.cpp
@@ -9,6 +9,8 @@
 #include <AzCore/Math/Sfmt.h>
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzCore/Math/Vector4.h>
+#include <AzCore/std/sort.h>
+#include <AzCore/std/parallel/semaphore.h>
 
 using namespace AZ;
 
@@ -107,6 +109,83 @@ namespace UnitTest
                 EXPECT_EQ(array64_2[i], g.Rand64());
             }
         }
+
+        template<size_t NumThreads, size_t NumResultsPerThread, typename ResultType>
+        bool ParallelTest()
+        {
+            Sfmt sfmt;
+
+            // Arbitrary but deterministic seed values to guarantee that we get the same random numbers produced every time.
+            constexpr AZ::u32 buffer[32] = {
+                0x8236ed73, 0x854aa369, 0xc7b68864, 0x5f1e49da, 0x58ea5a08, 0xa33fc74b, 0x0336bd81, 0x8d3c11ac,
+                0x7312bc57, 0x92fee3d1, 0x4b852f9f, 0xa7ac02ad, 0x4d72fb7a, 0x630641c6, 0x1edbeebf, 0xc18fdabe,
+                0xc6588dba, 0x6a821cf5, 0xec7e24b3, 0x44246d7e, 0x24af2f32, 0x4f64d44c, 0x44b24116, 0x65585572,
+                0x0f95038d, 0xd3e4c521, 0x6eea6bc1, 0x6d651ab5, 0x25dfc39e, 0x7502d183, 0xd32fc9bf, 0x9854093f };
+
+            // Seed the sfmt generator.
+            sfmt.Seed(buffer, AZ_ARRAY_SIZE(buffer));
+
+            // Create a single array that will hold all the results, but we'll partition it so that each thread will write
+            // its results to a different subset.
+            AZStd::array<ResultType, NumResultsPerThread * NumThreads> results;
+            AZStd::thread threads[NumThreads];
+
+            // Use a semaphore to block thread execution until all the threads are created so that we can synchronize
+            // their start times to the best of our ability.
+            AZStd::semaphore startSync;
+
+            // Spawn a set of threads that will each loop through and call the RandMethod (Rand32 or Rand64) for
+            // a given number of times.
+            for (size_t threadIdx = 0; threadIdx < AZ_ARRAY_SIZE(threads); ++threadIdx)
+            {
+                const size_t startOffset = NumResultsPerThread * threadIdx;
+
+                auto threadFunc = [&startSync, startOffset, &results, &sfmt]()
+                {
+                    // Block so that we can start all the threads at the same time after creation.
+                    startSync.acquire();
+
+                    for (int i = 0; i < NumResultsPerThread; ++i)
+                    {
+                        // Call Rand32 when uint32_t is the passed-in type, and Rand64 if uint64_t is the passed-in type.
+                        if constexpr (AZStd::is_same_v<ResultType, uint32_t>)
+                        {
+                            results[startOffset + i] = sfmt.Rand32();
+                        }
+                        else
+                        {
+                            results[startOffset + i] = sfmt.Rand64();
+                        }
+                    }
+                };
+                threads[threadIdx] = AZStd::thread(threadFunc);
+            }
+
+            // Now that all the threads are created, signal them to start.
+            startSync.release(NumThreads);
+
+            // Wait for all the threads to complete.
+            for (auto& thread : threads)
+            {
+                thread.join();
+            }
+
+            // Sort the results from all the threads so that we can easily detect duplicates.
+            AZStd::sort(results.begin(), results.end());
+
+            // Look for duplicates and stop if we find one, since that's a full test failure. There's no need to keep iterating.
+            for (size_t idx = 1; idx < results.size(); idx++)
+            {
+                if (results[idx - 1] == results[idx])
+                {
+                    EXPECT_NE(results[idx - 1], results[idx]);
+                    return false;
+                }
+            }
+
+            // Test was successful
+            return true;
+        }
     };
 
     TEST_F(MATH_SfmtTest, Test32Bit)
@@ -121,45 +200,49 @@ namespace UnitTest
 
     TEST_F(MATH_SfmtTest, TestParallel32)
     {
-        Sfmt sfmt;
-        auto threadFunc = [&sfmt]()
-        {
-            for (int i = 0; i < 10000; ++i)
-            {
-                sfmt.Rand32();
-            }
-        };
-        AZStd::thread threads[8];
-        for (size_t threadIdx = 0; threadIdx < AZ_ARRAY_SIZE(threads); ++threadIdx)
-        {
-            threads[threadIdx] = AZStd::thread(threadFunc);
-        }
+        // This test verifies that we can call Rand32() successfully in parallel.
+        // It also performs a reasonable verification that we haven't reintroduced a race condition in which the random number
+        // sequence could get repeated for periods of time if multiple threads hit the point where Sfmt refills its number cache
+        // simultaneously. Because it was a race condition, this test isn't foolproof, but the test conditions set below were
+        // causing a near-100% failure rate with the previous race condition and has a 100% success rate with the fix.
 
-        for (auto& thread : threads)
+        // The following numbers were chosen to be high enough to expose the problem at least once per run but low enough to keep
+        // the overall test runtime down.
+        constexpr size_t NumIterations = 5;
+        constexpr size_t NumThreads = 8;
+        constexpr size_t NumResultsPerThread = 2000;
+
+        // Run the test single-threaded once to verify that we don't have any numerical collisions in our test set and test size.
+        bool testSetHasNoNumericalCollisions = ParallelTest<1, NumThreads * NumResultsPerThread, uint32_t>();
+        ASSERT_TRUE(testSetHasNoNumericalCollisions);
+
+        // Now run multi-threaded across multiple iterations to verify that we don't hit the race condition.
+        for (size_t iterations = 0; iterations < NumIterations; iterations++)
         {
-            thread.join();
+            bool parallelHasNoNumericalCollisions = ParallelTest<NumThreads, NumResultsPerThread, uint32_t>();
+            ASSERT_TRUE(parallelHasNoNumericalCollisions);
         }
     }
 
     TEST_F(MATH_SfmtTest, TestParallel64)
     {
-        Sfmt sfmt;
-        auto threadFunc = [&sfmt]()
-        {
-            for (int i = 0; i < 10000; ++i)
-            {
-                sfmt.Rand64();
-            }
-        };
-        AZStd::thread threads[8];
-        for (size_t threadIdx = 0; threadIdx < AZ_ARRAY_SIZE(threads); ++threadIdx)
-        {
-            threads[threadIdx] = AZStd::thread(threadFunc);
-        }
+        // This test verifies that we can call Rand64() successfully in parallel.
 
-        for (auto& thread : threads)
+        // The following numbers were chosen to be high enough to expose the problem at least once per run but low enough to keep
+        // the overall test runtime down.
+        constexpr size_t NumIterations = 5;
+        constexpr size_t NumThreads = 8;
+        constexpr size_t NumResultsPerThread = 2000;
+
+        // Run the test single-threaded once to verify that we don't have any numerical collisions in our test set and test size.
+        bool testSetHasNoNumericalCollisions = ParallelTest<1, NumThreads * NumResultsPerThread, uint64_t>();
+        ASSERT_TRUE(testSetHasNoNumericalCollisions);
+
+        // Now run multi-threaded across multiple iterations to verify that we don't hit the race condition.
+        for (size_t iterations = 0; iterations < NumIterations; iterations++)
         {
-            thread.join();
+            bool parallelHasNoNumericalCollisions = ParallelTest<NumThreads, NumResultsPerThread, uint64_t>();
+            ASSERT_TRUE(parallelHasNoNumericalCollisions);
         }
     }
 

--- a/Code/Framework/AzFramework/AzFramework/Physics/Material/PhysicsMaterialSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Material/PhysicsMaterialSystemComponent.cpp
@@ -27,7 +27,6 @@ namespace Physics
         {
             serialize->Class<Physics::MaterialSystemComponent, AZ::Component>()
                 ->Version(1)
-                ->Attribute(AZ::Edit::Attributes::SystemComponentTags, AZStd::vector<AZ::Crc32>({ AZ_CRC_CE("AssetBuilder") }))
                 ;
         }
     }

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/ToastNotification.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/ToastNotification.cpp
@@ -96,7 +96,7 @@ namespace AzQtComponents
             QPainter p(this);
             p.setPen(Qt::transparent);
             QColor painterColor;
-            painterColor.setRgbF(0, 0, 0, 255);
+            painterColor.setRgbF(0.f, 0.f, 0.f, 1.f);
             p.setBrush(painterColor);
             p.setRenderHint(QPainter::Antialiasing);
             p.drawRoundedRect(rect(), m_borderRadius, m_borderRadius);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/ActionManagerIdentifiers/EditorMenuIdentifiers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/ActionManagerIdentifiers/EditorMenuIdentifiers.h
@@ -51,4 +51,7 @@ namespace EditorIdentifiers
 
     // Editor Widget Menus
     inline constexpr AZStd::string_view EntityOutlinerContextMenuIdentifier = "o3de.menu.editor.entityOutliner.context";
+
+    // Entity creation menu
+    inline constexpr AZStd::string_view EntityCreationMenuIdentifier = "o3de.menu.entity.create";
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUpdateLink.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUpdateLink.cpp
@@ -36,43 +36,30 @@ namespace AzToolsFramework
             UpdateLink(m_redoPatch, instanceToExclude);
         }
 
-        void PrefabUndoUpdateLink::SetLink(LinkId linkId)
-        {
-            m_link = m_prefabSystemComponentInterface->FindLink(linkId);
-            if (!m_link.has_value())
-            {
-                AZ_Assert(false,
-                    "PrefabUndoUpdateLink::Capture - Link with id '%llu' not found",
-                    static_cast<AZ::u64>(linkId));
-                return;
-            }
-            
-            m_templateId = m_link->get().GetTargetTemplateId();
-            if (m_templateId == InvalidTemplateId)
-            {
-                AZ_Assert(false,
-                    "PrefabUndoUpdateLink::Capture - Link with id '%llu' contains incorrect target template id",
-                    static_cast<AZ::u64>(linkId));
-                return;
-            }
-        }
-
         void PrefabUndoUpdateLink::Capture(const PrefabDom& linkedInstancePatch, LinkId linkId)
         {
-            SetLink(linkId);
+            m_linkId = linkId;
+            LinkReference link = m_prefabSystemComponentInterface->FindLink(m_linkId);
+            if (!link.has_value())
+            {
+                AZ_Error("Prefab", false, "PrefabUndoUpdateLink::Capture - Could not get the link.");
+                return;
+            }
+
+            m_templateId = link->get().GetTargetTemplateId();
 
             //Cache current link DOM for undo link update.
-            m_link->get().GetLinkDom(m_undoPatch, m_undoPatch.GetAllocator());
+            link->get().GetLinkDom(m_undoPatch, m_undoPatch.GetAllocator());
 
             //Get DOM of the link's source template.
-            TemplateId sourceTemplateId = m_link->get().GetSourceTemplateId();
+            TemplateId sourceTemplateId = link->get().GetSourceTemplateId();
             TemplateReference sourceTemplate = m_prefabSystemComponentInterface->FindTemplate(sourceTemplateId);
             AZ_Assert(sourceTemplate.has_value(),
                 "PrefabUndoUpdateLink::GenerateUndoUpdateLinkPatches - Source template not found");
             PrefabDom& sourceDom = sourceTemplate->get().GetPrefabDom();
 
             //Get DOM of instance that the link points to.
-            PrefabDomValueReference instanceDomRef = m_link->get().GetLinkedInstanceDom();
+            PrefabDomValueReference instanceDomRef = link->get().GetLinkedInstanceDom();
             AZ_Assert(instanceDomRef.has_value(),
                 "PrefabUndoUpdateLink::GenerateUndoUpdateLinkPatches -Linked Instance DOM not found");
             PrefabDom instanceDom;
@@ -116,21 +103,17 @@ namespace AzToolsFramework
             }
         }
 
-        void PrefabUndoUpdateLink::UpdateLink(const PrefabDom& linkDom,
-            InstanceOptionalConstReference instanceToExclude)
+        void PrefabUndoUpdateLink::UpdateLink(const PrefabDom& linkDom, InstanceOptionalConstReference instanceToExclude)
         {
-            if (!m_link.has_value())
+            LinkReference link = m_prefabSystemComponentInterface->FindLink(m_linkId);
+            if (link.has_value())
             {
-                AZ_Assert(false,
-                    "PrefabUndoUpdateLink::UpdateLink - m_link is still invalid");
-                return;
+                link->get().SetLinkDom(linkDom);
+                link->get().UpdateTarget();
+
+                m_prefabSystemComponentInterface->PropagateTemplateChanges(m_templateId, instanceToExclude);
+                m_prefabSystemComponentInterface->SetTemplateDirtyFlag(m_templateId, true);
             }
-
-            m_link->get().SetLinkDom(linkDom);
-            m_link->get().UpdateTarget();
-
-            m_prefabSystemComponentInterface->PropagateTemplateChanges(m_templateId, instanceToExclude);
-            m_prefabSystemComponentInterface->SetTemplateDirtyFlag(m_templateId, true);
         }
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUpdateLink.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUpdateLink.h
@@ -34,11 +34,11 @@ namespace AzToolsFramework
             void Capture(const PrefabDom& linkedInstancePatch, LinkId linkId);
 
         protected:
-            void SetLink(LinkId linkId);
-            void UpdateLink(const PrefabDom& linkDom,
-                InstanceOptionalConstReference instanceToExclude = AZStd::nullopt);
+            // The function to update link during undo and redo.
+            void UpdateLink(const PrefabDom& linkDom, InstanceOptionalConstReference instanceToExclude = AZStd::nullopt);
 
-            LinkReference m_link = AZStd::nullopt;
+            // Link that connects the linked instance and the focused instance.
+            LinkId m_linkId = InvalidLinkId;
         };
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.h
@@ -90,6 +90,7 @@ namespace AzToolsFramework
             void OnWidgetActionRegistrationHook() override;
             void OnMenuBindingHook() override;
             void OnToolBarBindingHook() override;
+            void OnPostActionManagerRegistrationHook() override;
 
         private:
             // PrefabPublicNotificationBus overrides ...

--- a/Code/Tools/ProjectManager/Source/PythonBindings.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.h
@@ -63,7 +63,10 @@ namespace O3DE::ProjectManager
         DetailedOutcome AddProject(const QString& path) override;
         DetailedOutcome RemoveProject(const QString& path) override;
         AZ::Outcome<void, AZStd::string> UpdateProject(const ProjectInfo& projectInfo) override;
-        AZ::Outcome<void, AZStd::string> AddGemToProject(const QString& gemPath, const QString& projectPath) override;
+        AZ::Outcome<QStringList, AZStd::string> GetIncompatibleProjectGems(
+            const QStringList& gemPaths, const QStringList& gemNames, const QString& projectPath) override;
+        DetailedOutcome AddGemsToProject(
+            const QStringList& gemPaths, const QStringList& gemNames, const QString& projectPath, bool force = false) override;
         AZ::Outcome<void, AZStd::string> RemoveGemFromProject(const QString& gemPath, const QString& projectPath) override;
         bool RemoveInvalidProjects() override;
 

--- a/Code/Tools/ProjectManager/Source/PythonBindingsInterface.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindingsInterface.h
@@ -21,6 +21,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <QHash>
+#include <QStringList>
 #endif
 
 
@@ -236,12 +237,23 @@ namespace O3DE::ProjectManager
         virtual AZ::Outcome<void, AZStd::string> UpdateProject(const ProjectInfo& projectInfo) = 0;
 
         /**
-         * Add a gem to a project
-         * @param gemPath the absolute path to the gem 
+         * Add multiple gems to a project
+         * @param gemPaths the absolute paths to the gems
+         * @param gemNames the names of the gems to add with optional version specifiers
          * @param projectPath the absolute path to the project
-         * @return An outcome with the success flag as well as an error message in case of a failure.
+         * @param force whether to bypass compatibility checks and activate the gems or not 
+         * @return an outcome with a pair of string error and detailed messages on failure.
          */
-        virtual AZ::Outcome<void, AZStd::string> AddGemToProject(const QString& gemPath, const QString& projectPath) = 0;
+        virtual DetailedOutcome AddGemsToProject(const QStringList& gemPaths, const QStringList& gemNames, const QString& projectPath, bool force = false) = 0;
+
+        /**
+         * Get gems that are incompatibile with this project 
+         * @param gemPaths the absolute paths to the gems
+         * @param gemNames the names of the gems to add with optional version specifiers
+         * @param projectPath the absolute path to the project
+         * @return An outcome with the a list of incompatible gems or an error message on failure.
+         */
+        virtual AZ::Outcome<QStringList, AZStd::string> GetIncompatibleProjectGems(const QStringList& gemPaths, const QStringList& gemNames, const QString& projectPath) = 0;
 
         /**
          * Remove gem to a project

--- a/Code/Tools/ProjectManager/tests/MockPythonBindings.h
+++ b/Code/Tools/ProjectManager/tests/MockPythonBindings.h
@@ -40,7 +40,8 @@ namespace O3DE::ProjectManager
         MOCK_METHOD1(AddProject, DetailedOutcome(const QString&));
         MOCK_METHOD1(RemoveProject, DetailedOutcome(const QString&));
         MOCK_METHOD1(UpdateProject, AZ::Outcome<void, AZStd::string>(const ProjectInfo&));
-        MOCK_METHOD2(AddGemToProject, AZ::Outcome<void, AZStd::string>(const QString&, const QString&));
+        MOCK_METHOD3(GetIncompatibleProjectGems, AZ::Outcome<QStringList, AZStd::string>(const QStringList&, const QStringList&, const QString&));
+        MOCK_METHOD4(AddGemsToProject, DetailedOutcome(const QStringList&, const QStringList&, const QString&, bool));
         MOCK_METHOD2(RemoveGemFromProject, AZ::Outcome<void, AZStd::string>(const QString&, const QString&));
         MOCK_METHOD0(RemoveInvalidProjects, bool());
 

--- a/Gems/Atom/Feature/Common/Assets/Passes/SubsurfaceScattering.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/SubsurfaceScattering.pass
@@ -45,7 +45,7 @@
                         "Attachment": "InputDiffuse"
                     },
                     "ImageDescriptor": {
-                        "SharedQueueMask": "Copy"
+                        "SharedQueueMask": "Graphics"
                     }
                 }
             ],

--- a/Gems/Atom/Feature/Common/Assets/seedList.seed
+++ b/Gems/Atom/Feature/Common/Assets/seedList.seed
@@ -50,86 +50,6 @@
 		</Class>
 		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
 			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{34E20A18-CB2E-5D93-84CF-C2B9E144DA75}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridblenddistance.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{F70A2001-CC2C-5DFE-BC87-B98A4E0E57EB}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridblendirradiance.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{44260D05-99D8-5A86-83E7-B7C5EC48F297}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridborderupdaterow.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{F60AFD1E-1CED-5E33-930E-17DB4EAA1F81}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridborderupdatecolumn.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{7547FD2E-1630-58B1-9293-F4C9F33E0D72}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridclassification.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{5A28BC26-22C8-5DC2-870B-3EE03A6DC723}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridrender.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{55BDC206-9859-52D8-AE08-457F5664F509}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridraytracing.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{3E4941A5-56BF-5ECD-95B3-64E6D6803159}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridraytracingclosesthit.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{EB5538D4-1028-534C-9FC0-1421E0926E31}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridraytracingmiss.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{582D6038-5953-585B-8840-CA5B993B5B08}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridrelocation.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
 				<Class name="AZ::Uuid" field="guid" value="{B1E8CBB8-00F8-552B-AA3F-07F3DAA9C79C}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
 				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			</Class>
@@ -314,83 +234,11 @@
 		</Class>
 		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
 			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{E1A185DF-DC80-58B1-B77B-CE8BEDB61D3B}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="passes/diffuseprobegridupdatepassrequest.azasset" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{522C32A8-CB02-51CE-B450-C4B8E38C084D}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="passes/diffuseprobegridrenderpassrequest.azasset" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{B428ED95-3E5F-50D5-98A7-A2AECEAA1898}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="passes/diffuseprobegridvisualizationpassrequest.azasset" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{8CC9B575-39D7-5914-AC42-92A77833E63A}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="268692035" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="models/diffuseprobesphere.azmodel" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{A6F9D127-D963-5D78-B19F-A31E73C5C2B5}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="passes/diffuseprobegridtemplates.azasset" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{49D6CA83-7AE4-5BF5-9428-636B9EB6DCC7}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridprepare.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{D20ADC05-ECF9-5305-93FC-F0A88AB2072D}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridquery.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{B3B664B6-4340-5A35-9A67-DC00A5361D62}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridvisualizationprepare.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
 				<Class name="AZ::Uuid" field="guid" value="{06E16462-E7A0-5780-A87D-BA165F18C297}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
 				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			</Class>
 			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			<Class name="AZStd::string" field="pathHint" value="shaders/postprocessing/displaymappersrgb.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{CD367E6F-EB15-5DDF-AA96-7F6D48C365DA}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridraytracinganyhit.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 		</Class>
 		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
 			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
@@ -423,6 +271,14 @@
 			</Class>
 			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			<Class name="AZStd::string" field="pathHint" value="materials/occlusioncullingplane/occlusioncullingplanetransparentvisualization.azmaterial" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{8CC9B575-39D7-5914-AC42-92A77833E63A}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="268692035" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="models/diffuseprobesphere.azmodel" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 		</Class>
 	</Class>
 </ObjectStream>

--- a/Gems/Atom/Feature/Common/Code/Source/SplashScreen/SplashScreenPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SplashScreen/SplashScreenPass.cpp
@@ -71,17 +71,6 @@ namespace AZ::Render
     void SplashScreenPass::FrameBeginInternal([[maybe_unused]] FramePrepareParams params)
     {
         FullscreenTrianglePass::FrameBeginInternal(params);
-
-        if (m_beginTimer)
-        {
-            // Scale the tick time to 0 to stop other system from updating until splash screen finishes.
-            // This is not ideal. It may cause conflicts when multiple sources are trying to set the value.
-            // We should replace this with some control from the core system about when to render the splash screen.
-            if (auto* timeSystem = AZ::Interface<ITime>::Get())
-            {
-                timeSystem->SetSimulationTickScale(0.0f);
-            }
-        }
     }
 
     void SplashScreenPass::FrameEndInternal()
@@ -94,12 +83,6 @@ namespace AZ::Render
 
             // Disable the pass after life time passes.
             SetEnabled(false);
-
-            // Reset the tick scale
-            if (auto* timeSystem = AZ::Interface<ITime>::Get())
-            {
-                timeSystem->SetSimulationTickScale(1.0f);
-            }
         }
     }
 

--- a/Gems/Atom/Feature/Common/Code/Source/Utils/EditorLightingPreset.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Utils/EditorLightingPreset.cpp
@@ -126,7 +126,7 @@ namespace AZ
                             ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &LightingPreset::m_exposure, "Exposure", "Exposure")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &LightingPreset::m_lights, "Lights", "Lights")
-                            ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                            ->Attribute(AZ::Edit::Attributes::ClearNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
                             ->Attribute(AZ::Edit::Attributes::AddNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
                             ->Attribute(AZ::Edit::Attributes::RemoveNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
                         ;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
@@ -366,16 +366,30 @@ namespace AZ
             if (usagesAndAccesses.size() > 1)
             {
                 // The Attachment is used multiple times: If all usages/accesses are the same type, we can determine the
-                // vk image layout from the first usage. If not, use the fallback VK_IMAGE_LAYOUT_GENERAL for now.
+                // vk image layout from the first usage. If not, we check if all usages are depth/stencil read only (because we can use
+                // the VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL for all those cases).
+                // Finally we just use the fallback VK_IMAGE_LAYOUT_GENERAL that can be applied for multiple uses.
                 // [GFX TODO][ATOM-4779] -Multiple Usage/Access can be further optimized.
-
+                bool sameUsageAndAccess = true;
+                bool readOnlyDepthStencil = true;
                 const auto& first = usagesAndAccesses.front();
-                for (int i = 1; i < usagesAndAccesses.size(); ++i)
+                for (int i = 0; i < usagesAndAccesses.size(); ++i)
                 {
                     if (usagesAndAccesses[i].m_access != first.m_access || usagesAndAccesses[i].m_usage != first.m_usage)
                     {
-                        return VK_IMAGE_LAYOUT_GENERAL;
+                        sameUsageAndAccess = false;
                     }
+
+                    if (usagesAndAccesses[i].m_access != RHI::ScopeAttachmentAccess::Read ||
+                        (usagesAndAccesses[i].m_usage != RHI::ScopeAttachmentUsage::DepthStencil && usagesAndAccesses[i].m_usage != RHI::ScopeAttachmentUsage::Shader))
+                    {
+                        readOnlyDepthStencil = false;
+                    }
+                }
+
+                if (!sameUsageAndAccess)
+                {
+                    return readOnlyDepthStencil ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL : VK_IMAGE_LAYOUT_GENERAL;
                 }
             }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -103,6 +103,7 @@ namespace AZ
             m_enabledDeviceFeatures.sparseResidencyImage2D = deviceFeatures.sparseResidencyImage2D;
             m_enabledDeviceFeatures.sparseResidencyImage3D = deviceFeatures.sparseResidencyImage3D;
             m_enabledDeviceFeatures.sparseResidencyAliased = deviceFeatures.sparseResidencyAliased;
+            m_enabledDeviceFeatures.independentBlend = deviceFeatures.independentBlend;
 
             if (deviceFeatures.geometryShader)
             {

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/GraphicsPipeline.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/GraphicsPipeline.cpp
@@ -460,7 +460,15 @@ namespace AZ
             m_colorBlendAttachments.resize(info.attachmentCount);
             for (uint32_t index = 0; index < info.attachmentCount; ++index)
             {
-                FillColorBlendAttachmentState(blendState.m_targets[index], m_colorBlendAttachments[index]);
+                // If m_independentBlendEnable is not enabled, we use the values from attachment 0 (same as D3D12)
+                if (index == 0 || blendState.m_independentBlendEnable)
+                {
+                    FillColorBlendAttachmentState(blendState.m_targets[index], m_colorBlendAttachments[index]);
+                }
+                else
+                {
+                    m_colorBlendAttachments[index] = m_colorBlendAttachments[0];
+                }
             }
             info.pAttachments = m_colorBlendAttachments.empty() ? nullptr : m_colorBlendAttachments.data();
             for (uint32_t index = 0; index < BlendConstantsCount; ++index)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/EntityPreviewViewport/EntityPreviewViewportSettingsInspector.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/EntityPreviewViewport/EntityPreviewViewportSettingsInspector.h
@@ -81,5 +81,7 @@ namespace AtomToolsFramework
         AZStd::unique_ptr<AssetSelectionGrid> m_lightingPresetDialog;
 
         EntityPreviewViewportSettings m_viewportSettings;
+
+        bool m_wasPropertyEdit = false;
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
@@ -191,7 +191,8 @@ namespace AtomToolsFramework
         AzToolsFramework::SourceControlConnectionRequestBus::Broadcast(
             &AzToolsFramework::SourceControlConnectionRequests::EnableSourceControl, enableSourceControl);
 
-        if (!AZ::RPI::RPISystemInterface::Get()->IsInitialized())
+        auto rpiInterface = AZ::RPI::RPISystemInterface::Get();
+        if (rpiInterface && !rpiInterface->IsInitialized())
         {
             AZ::RPI::RPISystemInterface::Get()->InitializeSystemAssets();
         }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettingsInspector.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettingsInspector.cpp
@@ -317,13 +317,18 @@ namespace AtomToolsFramework
     void EntityPreviewViewportSettingsInspector::Reset()
     {
         LoadSettings();
+        m_wasPropertyEdit = false;
         InspectorWidget::Reset();
     }
 
     void EntityPreviewViewportSettingsInspector::OnViewportSettingsChanged()
     {
-        LoadSettings();
-        RebuildAll();
+        if (!m_wasPropertyEdit)
+        {
+            LoadSettings();
+            RebuildAll();
+        }
+        m_wasPropertyEdit = false;
     }
 
     void EntityPreviewViewportSettingsInspector::OnModelPresetAdded(const AZStd::string& path)
@@ -338,11 +343,13 @@ namespace AtomToolsFramework
 
     void EntityPreviewViewportSettingsInspector::AfterPropertyModified([[maybe_unused]] AzToolsFramework::InstanceDataNode* pNode)
     {
+        m_wasPropertyEdit = true;
         SaveSettings();
     }
 
     void EntityPreviewViewportSettingsInspector::SetPropertyEditingComplete([[maybe_unused]] AzToolsFramework::InstanceDataNode* pNode)
     {
+        m_wasPropertyEdit = true;
         SaveSettings();
     }
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
@@ -601,16 +601,14 @@ namespace AtomToolsFramework
 
     void AtomToolsMainWindow::UpdateWindowTitle()
     {
-        AZ::Name apiName = AZ::RHI::Factory::Get().GetName();
-        if (!apiName.IsEmpty())
+        if (AZ::RHI::Factory::IsReady())
         {
-            QString title = QString{ "%1 (%2)" }.arg(QApplication::applicationName()).arg(apiName.GetCStr());
-            setWindowTitle(title);
+            const AZ::Name apiName = AZ::RHI::Factory::Get().GetName();
+            setWindowTitle(tr("%1 (%2)").arg(QApplication::applicationName()).arg(apiName.GetCStr()));
+            AZ_Error("AtomToolsMainWindow", !apiName.IsEmpty(), "Render API name not found");
+            return;
         }
-        else
-        {
-            AZ_Assert(false, "Render API name not found");
-            setWindowTitle(QApplication::applicationName());
-        }
+
+        setWindowTitle(QApplication::applicationName());
     }
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/MaterialCanvas/Registry/gem_autoload.materialcanvas.setreg
+++ b/Gems/Atom/Tools/MaterialCanvas/Registry/gem_autoload.materialcanvas.setreg
@@ -170,13 +170,6 @@
                     }
                 }
             },
-            "AWSGameLift": {
-                "Targets": {
-                    "AWSGameLift.Editor": {
-                        "AutoLoad": false
-                    }
-                }
-            },
             "ImGui": {
                 "Targets": {
                     "ImGui.Editor": {
@@ -315,6 +308,24 @@
                     },
                     "AWSCore.Editor": {
                         "AutoLoad": false
+                    },
+                    "AWSCore.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Tests": {
+                        "AutoLoad": false
                     }
                 }
             },
@@ -325,6 +336,49 @@
                     },
                     "AWSClientAuth.Editor": {
                         "AutoLoad": false
+                    },
+                    "AWSClientAuth.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Tests": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "AWSGameLift": {
+                "Targets": {
+                    "AWSGameLift": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Editor": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Builders": {
+                        "AutoLoad": false
                     }
                 }
             },
@@ -334,6 +388,24 @@
                         "AutoLoad": false
                     },
                     "AWSMetrics.Editor": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Tests": {
                         "AutoLoad": false
                     }
                 }

--- a/Gems/Atom/Tools/MaterialEditor/Registry/gem_autoload.materialeditor.setreg
+++ b/Gems/Atom/Tools/MaterialEditor/Registry/gem_autoload.materialeditor.setreg
@@ -170,13 +170,6 @@
                     }
                 }
             },
-            "AWSGameLift": {
-                "Targets": {
-                    "AWSGameLift.Editor": {
-                        "AutoLoad": false
-                    }
-                }
-            },
             "ImGui": {
                 "Targets": {
                     "ImGui.Editor": {
@@ -329,6 +322,24 @@
                     },
                     "AWSCore.Editor": {
                         "AutoLoad": false
+                    },
+                    "AWSCore.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Tests": {
+                        "AutoLoad": false
                     }
                 }
             },
@@ -339,6 +350,49 @@
                     },
                     "AWSClientAuth.Editor": {
                         "AutoLoad": false
+                    },
+                    "AWSClientAuth.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Tests": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "AWSGameLift": {
+                "Targets": {
+                    "AWSGameLift": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Editor": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Builders": {
+                        "AutoLoad": false
                     }
                 }
             },
@@ -348,6 +402,24 @@
                         "AutoLoad": false
                     },
                     "AWSMetrics.Editor": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Tests": {
                         "AutoLoad": false
                     }
                 }

--- a/Gems/Atom/Tools/PassCanvas/Registry/gem_autoload.passcanvas.setreg
+++ b/Gems/Atom/Tools/PassCanvas/Registry/gem_autoload.passcanvas.setreg
@@ -170,13 +170,6 @@
                     }
                 }
             },
-            "AWSGameLift": {
-                "Targets": {
-                    "AWSGameLift.Editor": {
-                        "AutoLoad": false
-                    }
-                }
-            },
             "ImGui": {
                 "Targets": {
                     "ImGui.Editor": {
@@ -315,6 +308,24 @@
                     },
                     "AWSCore.Editor": {
                         "AutoLoad": false
+                    },
+                    "AWSCore.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Tests": {
+                        "AutoLoad": false
                     }
                 }
             },
@@ -325,6 +336,49 @@
                     },
                     "AWSClientAuth.Editor": {
                         "AutoLoad": false
+                    },
+                    "AWSClientAuth.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Tests": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "AWSGameLift": {
+                "Targets": {
+                    "AWSGameLift": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Editor": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Builders": {
+                        "AutoLoad": false
                     }
                 }
             },
@@ -334,6 +388,24 @@
                         "AutoLoad": false
                     },
                     "AWSMetrics.Editor": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Tests": {
                         "AutoLoad": false
                     }
                 }

--- a/Gems/Atom/Tools/ShaderManagementConsole/Registry/gem_autoload.shadermanagementconsole.setreg
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Registry/gem_autoload.shadermanagementconsole.setreg
@@ -170,13 +170,6 @@
                     }
                 }
             },
-            "AWSGameLift": {
-                "Targets": {
-                    "AWSGameLift.Editor": {
-                        "AutoLoad": false
-                    }
-                }
-            },
             "ImGui": {
                 "Targets": {
                     "ImGui.Editor": {
@@ -315,6 +308,24 @@
                     },
                     "AWSCore.Editor": {
                         "AutoLoad": false
+                    },
+                    "AWSCore.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSCore.Tests": {
+                        "AutoLoad": false
                     }
                 }
             },
@@ -325,6 +336,49 @@
                     },
                     "AWSClientAuth.Editor": {
                         "AutoLoad": false
+                    },
+                    "AWSClientAuth.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSClientAuth.Tests": {
+                        "AutoLoad": false
+                    }
+                }
+            },
+            "AWSGameLift": {
+                "Targets": {
+                    "AWSGameLift": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Editor": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSGameLift.Builders": {
+                        "AutoLoad": false
                     }
                 }
             },
@@ -334,6 +388,24 @@
                         "AutoLoad": false
                     },
                     "AWSMetrics.Editor": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Servers": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Clients": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Unified": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Tools": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Builders": {
+                        "AutoLoad": false
+                    },
+                    "AWSMetrics.Tests": {
                         "AutoLoad": false
                     }
                 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
@@ -282,7 +282,10 @@ namespace AZ
             // PSO-impacting property changes are allowed in the editor because the saved data can be analyzed to pre-compile the necessary PSOs.
             for (auto& materialAssignment : materials)
             {
-                materialAssignment.second.m_materialInstance->SetPsoHandlingOverride(AZ::RPI::MaterialPropertyPsoHandling::Allowed);
+                if (materialAssignment.second.m_materialInstance)
+                {
+                    materialAssignment.second.m_materialInstance->SetPsoHandlingOverride(AZ::RPI::MaterialPropertyPsoHandling::Allowed);
+                }
             }
         }
 

--- a/Gems/DiffuseProbeGrid/Assets/Passes/DiffuseProbeGridPreparePassRequest.azasset
+++ b/Gems/DiffuseProbeGrid/Assets/Passes/DiffuseProbeGridPreparePassRequest.azasset
@@ -1,0 +1,10 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassRequest",
+    "ClassData": {
+        "Name": "DiffuseProbeGridPreparePass",
+        "TemplateName": "DiffuseProbeGridPreparePassTemplate",
+        "Enabled": true
+    }
+}

--- a/Gems/DiffuseProbeGrid/Assets/Passes/DiffuseProbeGridUpdate.pass
+++ b/Gems/DiffuseProbeGrid/Assets/Passes/DiffuseProbeGridUpdate.pass
@@ -8,10 +8,6 @@
             "PassClass": "ParentPass",
             "PassRequests": [
                 {
-                    "Name": "DiffuseProbeGridPreparePass",
-                    "TemplateName": "DiffuseProbeGridPreparePassTemplate"
-                },
-                {
                     "Name": "DiffuseProbeGridRayTracingPass",
                     "TemplateName": "DiffuseProbeGridRayTracingPassTemplate"
                 },

--- a/Gems/DiffuseProbeGrid/Assets/seedList.seed
+++ b/Gems/DiffuseProbeGrid/Assets/seedList.seed
@@ -1,0 +1,173 @@
+<ObjectStream version="3">
+	<Class name="AZStd::vector&lt;SeedInfo, allocator&gt;" type="{82FC5264-88D0-57CD-9307-FC52E4DAD550}">
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{34E20A18-CB2E-5D93-84CF-C2B9E144DA75}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridblenddistance.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{F70A2001-CC2C-5DFE-BC87-B98A4E0E57EB}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridblendirradiance.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{44260D05-99D8-5A86-83E7-B7C5EC48F297}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridborderupdaterow.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{F60AFD1E-1CED-5E33-930E-17DB4EAA1F81}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridborderupdatecolumn.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{7547FD2E-1630-58B1-9293-F4C9F33E0D72}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridclassification.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{5A28BC26-22C8-5DC2-870B-3EE03A6DC723}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridrender.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{55BDC206-9859-52D8-AE08-457F5664F509}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridraytracing.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{3E4941A5-56BF-5ECD-95B3-64E6D6803159}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridraytracingclosesthit.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{EB5538D4-1028-534C-9FC0-1421E0926E31}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridraytracingmiss.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{582D6038-5953-585B-8840-CA5B993B5B08}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridrelocation.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{E1A185DF-DC80-58B1-B77B-CE8BEDB61D3B}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="passes/diffuseprobegridupdatepassrequest.azasset" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{522C32A8-CB02-51CE-B450-C4B8E38C084D}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="passes/diffuseprobegridrenderpassrequest.azasset" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{B428ED95-3E5F-50D5-98A7-A2AECEAA1898}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="passes/diffuseprobegridvisualizationpassrequest.azasset" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{A6F9D127-D963-5D78-B19F-A31E73C5C2B5}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="passes/diffuseprobegridtemplates.azasset" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{49D6CA83-7AE4-5BF5-9428-636B9EB6DCC7}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridprepare.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{D20ADC05-ECF9-5305-93FC-F0A88AB2072D}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridquery.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{B3B664B6-4340-5A35-9A67-DC00A5361D62}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridvisualizationprepare.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{CD367E6F-EB15-5DDF-AA96-7F6D48C365DA}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridraytracinganyhit.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{82253586-BC83-5289-8E14-4DF83E7032D2}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="passes/diffuseprobegridscreenspacereflectionsquerypassrequest.azasset" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{2AAC574D-E80D-5D41-BE12-32B192306FD1}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="shaders/diffuseglobalillumination/diffuseprobegridqueryfullscreenwithalbedo.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{8BC56BD7-1477-5396-A410-D8A36D4DDB25}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="passes/diffuseprobegridpreparepassrequest.azasset" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+	</Class>
+</ObjectStream>
+

--- a/Gems/DiffuseProbeGrid/Code/Source/EditorComponents/EditorDiffuseProbeGridComponent.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/EditorComponents/EditorDiffuseProbeGridComponent.cpp
@@ -210,6 +210,8 @@ namespace AZ
 
         void EditorDiffuseProbeGridComponent::Deactivate()
         {
+            m_editorModeSet = false;
+
             m_boxChangedByGridHandler.Disconnect();
             AzToolsFramework::EditorEntityInfoNotificationBus::Handler::BusDisconnect();
             AZ::TickBus::Handler::BusDisconnect();

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
@@ -797,7 +797,8 @@ namespace AZ
 
             if (!diffuseProbeGridUpdatePass)
             {
-                AddPassRequest(renderPipeline, "Passes/DiffuseProbeGridUpdatePassRequest.azasset", "DepthPrePass");
+                AddPassRequest(renderPipeline, "Passes/DiffuseProbeGridPreparePassRequest.azasset", "DepthPrePass");
+                AddPassRequest(renderPipeline, "Passes/DiffuseProbeGridUpdatePassRequest.azasset", "DiffuseProbeGridPreparePass");
                 AddPassRequest(renderPipeline, "Passes/DiffuseProbeGridRenderPassRequest.azasset", "ForwardSubsurface");
 
                 // add the fullscreen query pass for SSR raytracing fallback color

--- a/Gems/EMotionFX/Code/EMotionFX/Source/ActorInstance.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/ActorInstance.cpp
@@ -140,6 +140,13 @@ namespace EMotionFX
         {
             UpdateMeshDeformers(0.0f, true); // TODO: not really thread safe because of shared meshes, although it probably will output correctly
             UpdateStaticBasedAabbDimensions();
+
+            // If the aabb is still not valid, this can happen for example when the actor has no nodes,
+            // generate a valid aabb at the global location.
+            if (!m_staticAabb.IsValid())
+            {
+                m_staticAabb.AddPoint(m_worldTransform.m_position);
+            }
         }
 
         // update the bounds
@@ -1425,7 +1432,11 @@ namespace EMotionFX
             return;
         }
 
-        *outResult = m_actor->GetStaticAabb().GetTransformedAabb(m_worldTransform.ToAZTransform());
+        if (const AZ::Aabb& staticAabb = m_actor->GetStaticAabb();
+            staticAabb.IsValid())
+        {
+            *outResult = staticAabb.GetTransformedAabb(m_worldTransform.ToAZTransform());
+        }
     }
 
     // adjust the anim graph instance

--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendSpaceNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendSpaceNode.cpp
@@ -17,7 +17,6 @@
 #include <EMotionFX/Source/EMotionFXManager.h>
 #include <MCore/Source/Config.h>
 
-
 namespace EMotionFX
 {
     AZ_CLASS_ALLOCATOR_IMPL(BlendSpaceNode, AnimGraphAllocator)

--- a/Gems/EditorPythonBindings/Code/Source/ActionManager/MenuManagerBus.h
+++ b/Gems/EditorPythonBindings/Code/Source/ActionManager/MenuManagerBus.h
@@ -28,17 +28,25 @@ namespace EditorPythonBindings
         virtual AzToolsFramework::MenuManagerOperationResult RegisterMenu(
             const AZStd::string& identifier, const AzToolsFramework::MenuProperties& properties) = 0;
 
-        //! Bind an action to a menu.
+        //! Bind an Action to a Menu.
         virtual AzToolsFramework::MenuManagerOperationResult AddActionToMenu(
             const AZStd::string& menuIdentifier, const AZStd::string& actionIdentifier, int sortIndex) = 0;
 
-        //! Add a separator to a menu.
+        //! Add a Separator to a Menu.
         virtual AzToolsFramework::MenuManagerOperationResult AddSeparatorToMenu(
             const AZStd::string& menuIdentifier, int sortIndex) = 0;
 
-        //! Add a sub-menu to a menu.
+        //! Add a Sub-Menu to a Menu.
         virtual AzToolsFramework::MenuManagerOperationResult AddSubMenuToMenu(
             const AZStd::string& menuIdentifier, const AZStd::string& subMenuIdentifier, int sortIndex) = 0;
+
+        //! Add a Widget to a Menu.
+        virtual AzToolsFramework::MenuManagerOperationResult AddWidgetToMenu(
+            const AZStd::string& menuIdentifier, const AZStd::string& widgetActionIdentifier, int sortIndex) = 0;
+
+        //! Add a Menu to a Menu Bar.
+        virtual AzToolsFramework::MenuManagerOperationResult AddMenuToMenuBar(
+            const AZStd::string& menuBarIdentifier, const AZStd::string& menuIdentifier, int sortIndex) = 0;
     };
 
     using MenuManagerRequestBus = AZ::EBus<MenuManagerRequests>;

--- a/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.cpp
@@ -85,6 +85,13 @@ namespace EditorPythonBindings
                 ->Event("UpdateAction", &ActionManagerRequestBus::Handler::UpdateAction)
                 ;
 
+            behaviorContext->Class<AzToolsFramework::MenuProperties>("MenuProperties")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                ->Attribute(AZ::Script::Attributes::Category, "Action")
+                ->Attribute(AZ::Script::Attributes::Module, "action")
+                ->Property("name", BehaviorValueProperty(&AzToolsFramework::MenuProperties::m_name))
+                ;
+
             behaviorContext
                 ->EBus<MenuManagerRequestBus>("MenuManagerPythonRequestBus")
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
@@ -94,6 +101,15 @@ namespace EditorPythonBindings
                 ->Event("AddActionToMenu", &MenuManagerRequestBus::Handler::AddActionToMenu)
                 ->Event("AddSeparatorToMenu", &MenuManagerRequestBus::Handler::AddSeparatorToMenu)
                 ->Event("AddSubMenuToMenu", &MenuManagerRequestBus::Handler::AddSubMenuToMenu)
+                ->Event("AddWidgetToMenu", &MenuManagerRequestBus::Handler::AddWidgetToMenu)
+                ->Event("AddMenuToMenuBar", &MenuManagerRequestBus::Handler::AddMenuToMenuBar)
+                ;
+
+            behaviorContext->Class<AzToolsFramework::ToolBarProperties>("ToolBarProperties")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                ->Attribute(AZ::Script::Attributes::Category, "Action")
+                ->Attribute(AZ::Script::Attributes::Module, "action")
+                ->Property("name", BehaviorValueProperty(&AzToolsFramework::ToolBarProperties::m_name))
                 ;
 
             behaviorContext
@@ -206,6 +222,18 @@ namespace EditorPythonBindings
         const AZStd::string& menuIdentifier, const AZStd::string& subMenuIdentifier, int sortIndex)
     {
         return m_menuManagerInterface->AddSubMenuToMenu(menuIdentifier, subMenuIdentifier, sortIndex);
+    }
+
+    AzToolsFramework::MenuManagerOperationResult PythonActionManagerHandler::AddWidgetToMenu(
+        const AZStd::string& menuIdentifier, const AZStd::string& widgetActionIdentifier, int sortIndex)
+    {
+        return m_menuManagerInterface->AddWidgetToMenu(menuIdentifier, widgetActionIdentifier, sortIndex);
+    }
+
+    AzToolsFramework::MenuManagerOperationResult PythonActionManagerHandler::AddMenuToMenuBar(
+        const AZStd::string& menuBarIdentifier, const AZStd::string& menuIdentifier, int sortIndex)
+    {
+        return m_menuManagerInterface->AddMenuToMenuBar(menuBarIdentifier, menuIdentifier, sortIndex);
     }
 
     AzToolsFramework::ToolBarManagerOperationResult PythonActionManagerHandler::RegisterToolBar(

--- a/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.h
+++ b/Gems/EditorPythonBindings/Code/Source/ActionManager/PythonActionManagerHandler.h
@@ -63,6 +63,10 @@ namespace EditorPythonBindings
             const AZStd::string& menuIdentifier, int sortIndex) override;
         AzToolsFramework::MenuManagerOperationResult AddSubMenuToMenu(
             const AZStd::string& menuIdentifier, const AZStd::string& subMenuIdentifier, int sortIndex) override;
+        AzToolsFramework::MenuManagerOperationResult AddWidgetToMenu(
+            const AZStd::string& menuIdentifier, const AZStd::string& widgetActionIdentifier, int sortIndex) override;
+        AzToolsFramework::MenuManagerOperationResult AddMenuToMenuBar(
+            const AZStd::string& menuBarIdentifier, const AZStd::string& menuIdentifier, int sortIndex) override;
 
         // ToolBarManagerRequestBus overrides ...
         AzToolsFramework::ToolBarManagerOperationResult RegisterToolBar(

--- a/Gems/GraphModel/Code/Include/GraphModel/Model/Common.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Model/Common.h
@@ -29,12 +29,11 @@ namespace GraphModel
     using Endpoint = AZStd::pair<NodeId, SlotId>;
 
     class DataType;
-    using DataTypePtr = AZStd::shared_ptr<const DataType>; //!< All pointers are const since this data is immutable anyway
+    using DataTypePtr = AZStd::shared_ptr<DataType>;
     using DataTypeList = AZStd::vector<DataTypePtr>;
 
     class GraphContext;
     using GraphContextPtr = AZStd::shared_ptr<GraphContext>;
-    using ConstGraphContextPtr = AZStd::shared_ptr<const GraphContext>;
 
     class Graph;
     using GraphPtr = AZStd::shared_ptr<Graph>;

--- a/Gems/GraphModel/Code/Include/GraphModel/Model/GraphContext.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Model/GraphContext.h
@@ -14,6 +14,7 @@
 #include <AzCore/std/string/string.h>
 
 // GraphModel
+#include <GraphModel/Model/Common.h>
 #include <GraphModel/Model/DataType.h>
 
 namespace GraphModel
@@ -29,8 +30,6 @@ namespace GraphModel
         AZ_CLASS_ALLOCATOR(GraphContext, AZ::SystemAllocator);
         AZ_RTTI(GraphContext, "{4CD3C171-A7AA-4B62-96BB-F09F398A73E7}");
         static void Reflect(AZ::ReflectContext* context);
-
-        using DataTypeList = AZStd::vector<DataTypePtr>;
 
         GraphContext() = default;
         GraphContext(const AZStd::string& systemName, const AZStd::string& moduleExtension, const DataTypeList& dataTypes);
@@ -78,7 +77,7 @@ namespace GraphModel
         AZStd::string m_systemName;
         AZStd::string m_moduleExtension;
         DataTypeList m_dataTypes;
-        GraphModel::ModuleGraphManagerPtr m_moduleGraphManager;
+        ModuleGraphManagerPtr m_moduleGraphManager;
     };
 
 } // namespace GraphModel

--- a/Gems/GraphModel/Code/Source/GraphModelSystemComponent.cpp
+++ b/Gems/GraphModel/Code/Source/GraphModelSystemComponent.cpp
@@ -33,36 +33,43 @@ namespace GraphModel
     void GraphModelSystemComponent::Reflect(AZ::ReflectContext* context)
     {
         // Reflect core graph classes
-        GraphModel::Graph::Reflect(context);
-        GraphModel::DataType::Reflect(context);
+        DataType::Reflect(context);
+        GraphContext::Reflect(context);
+        GraphElement::Reflect(context);
+        SlotId::Reflect(context);
+        Slot::Reflect(context);
+        Node::Reflect(context);
+        Connection::Reflect(context);
+        Graph::Reflect(context);
+
+        // Reflect module node data types
+        BaseInputOutputNode::Reflect(context);
+        GraphInputNode::Reflect(context);
+        GraphOutputNode::Reflect(context);
+        ModuleNode::Reflect(context);
+
+        // Reflect data types for integrating graph model with graph canvas
         GraphModelIntegration::GraphCanvasMetadata::Reflect(context);
 
-        // Mime Events for Graph Canvas nodes
+        // Reflect MIME events for graph canvas nodes
         GraphModelIntegration::CreateGraphCanvasNodeMimeEvent::Reflect(context);
         GraphModelIntegration::CreateNodeGroupNodeMimeEvent::Reflect(context);
         GraphModelIntegration::CreateCommentNodeMimeEvent::Reflect(context);
 
-        // Reflect all the nodes needed to support ModuleNode
-        GraphModel::BaseInputOutputNode::Reflect(context);
-        GraphModel::GraphInputNode::Reflect(context);
-        GraphModel::GraphOutputNode::Reflect(context);
-        GraphModel::ModuleNode::Reflect(context);
-        GraphModelIntegration::CreateInputOutputNodeMimeEvent<GraphModel::GraphInputNode>::Reflect(context);
-        GraphModelIntegration::CreateInputOutputNodeMimeEvent<GraphModel::GraphOutputNode>::Reflect(context);
+        // Reflect MIME events for module node
+        GraphModelIntegration::CreateInputOutputNodeMimeEvent<GraphInputNode>::Reflect(context);
+        GraphModelIntegration::CreateInputOutputNodeMimeEvent<GraphOutputNode>::Reflect(context);
         GraphModelIntegration::CreateModuleNodeMimeEvent::Reflect(context);
 
-        if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<GraphModelSystemComponent, AZ::Component>()
+            serializeContext->Class<GraphModelSystemComponent, AZ::Component>()
                 ->Version(0)
                 ;
 
-            serialize->RegisterGenericType<GraphModel::NodePtrList>();
-            serialize->RegisterGenericType<GraphModel::SlotPtrList>();
-
-            if (AZ::EditContext* ec = serialize->GetEditContext())
+            if (auto editContext = serializeContext->GetEditContext())
             {
-                ec->Class<GraphModelSystemComponent>("GraphModel", "A generic node graph data model")
+                editContext->Class<GraphModelSystemComponent>("GraphModel", "A generic node graph data model")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;

--- a/Gems/GraphModel/Code/Source/Model/Connection.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Connection.cpp
@@ -49,6 +49,8 @@ namespace GraphModel
                 ->Field("m_sourceEndpoint", &Connection::m_sourceEndpoint)
                 ->Field("m_targetEndpoint", &Connection::m_targetEndpoint)
                 ;
+
+            serializeContext->RegisterGenericType<ConnectionPtr>();
         }
 
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))

--- a/Gems/GraphModel/Code/Source/Model/DataType.cpp
+++ b/Gems/GraphModel/Code/Source/Model/DataType.cpp
@@ -27,6 +27,9 @@ namespace GraphModel
                 ->Field("m_cppName", &DataType::m_cppName)
                 ->Field("m_displayName", &DataType::m_displayName)
                 ;
+
+            serializeContext->RegisterGenericType<DataTypePtr>();
+            serializeContext->RegisterGenericType<DataTypeList>();
         }
 
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))

--- a/Gems/GraphModel/Code/Source/Model/Graph.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Graph.cpp
@@ -24,13 +24,6 @@ namespace GraphModel
 
     void Graph::Reflect(AZ::ReflectContext* context)
     {
-        GraphContext::Reflect(context);
-        GraphElement::Reflect(context);
-        Node::Reflect(context);
-        SlotId::Reflect(context);
-        Slot::Reflect(context);
-        Connection::Reflect(context);
-
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<Graph>()

--- a/Gems/GraphModel/Code/Source/Model/GraphContext.cpp
+++ b/Gems/GraphModel/Code/Source/Model/GraphContext.cpp
@@ -26,6 +26,8 @@ namespace GraphModel
             serializeContext->Class<GraphContext>()
                 ->Version(0)
                 ;
+
+            serializeContext->RegisterGenericType<GraphContextPtr>();
         }
 
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
@@ -36,7 +38,7 @@ namespace GraphModel
                 ->Attribute(AZ::Script::Attributes::Module, "editor.graph")
                 ->Method("GetSystemName", &GraphContext::GetSystemName)
                 ->Method("GetModuleFileExtension", &GraphContext::GetModuleFileExtension)
-                ->Method("GetAllDataTypes", &GraphContext::GetAllDataTypes)
+                //->Method("GetAllDataTypes", &GraphContext::GetAllDataTypes) // GHI-15121 Unbinding until asserts with AP behavior context reflection are resolved
                 ->Method("GetDataTypeByEnum", static_cast<DataTypePtr (GraphContext::*)(DataType::Enum) const>(&GraphContext::GetDataType))
                 ->Method("GetDataTypeByName", static_cast<DataTypePtr (GraphContext::*)(const AZStd::string&) const>(&GraphContext::GetDataType))
                 ->Method("GetDataTypeByUuid", static_cast<DataTypePtr (GraphContext::*)(const AZ::Uuid&) const>(&GraphContext::GetDataType))
@@ -75,7 +77,7 @@ namespace GraphModel
         return m_moduleGraphManager;
     }
 
-    const AZStd::vector<DataTypePtr>& GraphContext::GetAllDataTypes() const
+    const DataTypeList& GraphContext::GetAllDataTypes() const
     {
         return m_dataTypes;
     }

--- a/Gems/GraphModel/Code/Source/Model/GraphElement.cpp
+++ b/Gems/GraphModel/Code/Source/Model/GraphElement.cpp
@@ -24,6 +24,8 @@ namespace GraphModel
             serializeContext->Class<GraphElement>()
                 ->Version(0)
                 ;
+
+            serializeContext->RegisterGenericType<GraphElementPtr>();
         }
 
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))

--- a/Gems/GraphModel/Code/Source/Model/Node.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Node.cpp
@@ -36,6 +36,9 @@ namespace GraphModel
                 ->Field("m_inputDataSlots", &Node::m_inputDataSlots)
                 ->Field("m_extendableSlots", &Node::m_extendableSlots)
                 ;
+
+            serializeContext->RegisterGenericType<NodePtr>();
+            serializeContext->RegisterGenericType<NodePtrList>();
         }
 
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))

--- a/Gems/GraphModel/Code/Source/Model/Slot.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Slot.cpp
@@ -261,6 +261,9 @@ namespace GraphModel
                 ->Field("m_value", &Slot::m_value)
                 ->Field("m_subId", &Slot::m_subId)
                 ;
+
+            serializeContext->RegisterGenericType<SlotPtr>();
+            serializeContext->RegisterGenericType<SlotPtrList>();
         }
 
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/ShapeComponentBus.h
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/ShapeComponentBus.h
@@ -177,7 +177,6 @@ namespace LmbrCentral
         /// Get the translation offset for the shape relative to its entity.
         virtual AZ::Vector3 GetTranslationOffset() const
         {
-            AZ_WarningOnce("ShapeComponentRequests", false, "GetTranslationOffset not implemented");
             return AZ::Vector3::CreateZero();
         }
 

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.h
@@ -19,6 +19,7 @@
 #include <AzFramework/Process/ProcessWatcher.h>
 #include <AzFramework/Process/ProcessCommunicatorTracePrinter.h>
 #include <AzFramework/Viewport/ScreenGeometry.h>
+#include <AzToolsFramework/ActionManager/ActionManagerRegistrationNotificationBus.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <AzToolsFramework/Prefab/Spawnable/PrefabToInMemorySpawnableNotificationBus.h>
 #include <AzToolsFramework/Editor/EditorContextMenuBus.h>
@@ -54,6 +55,7 @@ namespace Multiplayer
         , private AzToolsFramework::Prefab::PrefabToInMemorySpawnableNotificationBus::Handler
         , private AzToolsFramework::EditorEntityContextNotificationBus::Handler
         , private AzToolsFramework::EditorContextMenuBus::Handler
+        , private AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler
     {
     public:
         AZ_COMPONENT(MultiplayerEditorSystemComponent, "{9F335CC0-5574-4AD3-A2D8-2FAEF356946C}");
@@ -95,14 +97,18 @@ namespace Multiplayer
         //! @{
         void OnStartPlayInEditorBegin() override;
         void OnStartPlayInEditor() override;
+        void OnStopPlayInEditorBegin() override;
         //! @}
 
         //! AzToolsFramework::EditorContextMenu::Bus::Handler overrides
         //! @{
         void PopulateEditorGlobalContextMenu(QMenu* menu, const AZStd::optional<AzFramework::ScreenPoint>& point, int flags) override;
         int GetMenuPosition() const override;
-        void OnStopPlayInEditorBegin() override;
         //! @}
+
+        // AzToolsFramework::ActionManagerRegistrationNotificationBus overrides ...
+        void OnActionRegistrationHook() override;
+        void OnMenuBindingHook() override;
 
         //! AzToolsFramework::Prefab::PrefabToInMemorySpawnableNotificationBus::Handler overrides
         //! @{

--- a/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.cpp
@@ -62,13 +62,13 @@ namespace PhysX
     void EditorSystemComponent::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         required.push_back(AZ_CRC_CE("PhysicsService"));
-        required.push_back(AZ_CRC_CE("PhysicsMaterialService"));
     }
 
     void EditorSystemComponent::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)
     {
         dependent.push_back(AZ_CRC_CE("AssetDatabaseService"));
         dependent.push_back(AZ_CRC_CE("AssetCatalogService"));
+        dependent.push_back(AZ_CRC_CE("PhysicsMaterialService"));
     }
 
     void EditorSystemComponent::Activate()

--- a/Gems/PhysX/Code/Source/SystemComponent.cpp
+++ b/Gems/PhysX/Code/Source/SystemComponent.cpp
@@ -127,13 +127,13 @@ namespace PhysX
 
     void SystemComponent::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
     {
-        required.push_back(AZ_CRC_CE("PhysicsMaterialService"));
     }
 
     void SystemComponent::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)
     {
         dependent.push_back(AZ_CRC_CE("AssetDatabaseService"));
         dependent.push_back(AZ_CRC_CE("AssetCatalogService"));
+        dependent.push_back(AZ_CRC_CE("PhysicsMaterialService"));
     }
 
     SystemComponent::SystemComponent()

--- a/Gems/PhysX/Code/Tests/Benchmarks/PhysXBenchmarksUtilities.cpp
+++ b/Gems/PhysX/Code/Tests/Benchmarks/PhysXBenchmarksUtilities.cpp
@@ -27,7 +27,8 @@ namespace PhysX::Benchmarks
             int benchmarkObjectType,
             GenerateColliderFuncPtr* genColliderFuncPtr /*= nullptr*/, GenerateSpawnPositionFuncPtr* genSpawnPosFuncPtr /*= nullptr*/,
             GenerateSpawnOrientationFuncPtr* genSpawnOriFuncPtr /*= nullptr*/, GenerateMassFuncPtr* genMassFuncPtr /*= nullptr*/,
-            GenerateEntityIdFuncPtr* genEntityIdFuncPtr /*= nullptr*/
+            GenerateEntityIdFuncPtr* genEntityIdFuncPtr /*= nullptr*/,
+            bool activateEntities /*= true*/
         )
         {
             BenchmarkRigidBodies benchmarkRigidBodies;
@@ -110,7 +111,10 @@ namespace PhysX::Benchmarks
                     entity->CreateComponent<PhysX::RigidBodyComponent>(rigidBodyConfig, sceneHandle);
 
                     entity->Init();
-                    entity->Activate();
+                    if (activateEntities)
+                    {
+                        entity->Activate();
+                    }
 
                     AZStd::get_if<PhysX::EntityList>(&benchmarkRigidBodies)->push_back(entity);
                 }

--- a/Gems/PhysX/Code/Tests/Benchmarks/PhysXBenchmarksUtilities.h
+++ b/Gems/PhysX/Code/Tests/Benchmarks/PhysXBenchmarksUtilities.h
@@ -68,7 +68,8 @@ namespace PhysX::Benchmarks
             int benchmarkObjectType,
             GenerateColliderFuncPtr* genColliderFuncPtr = nullptr, GenerateSpawnPositionFuncPtr* genSpawnPosFuncPtr = nullptr,
             GenerateSpawnOrientationFuncPtr* genSpawnOriFuncPtr = nullptr, GenerateMassFuncPtr* genMassFuncPtr = nullptr,
-            GenerateEntityIdFuncPtr* genEntityIdFuncPtr = nullptr
+            GenerateEntityIdFuncPtr* genEntityIdFuncPtr = nullptr,
+            bool activateEntities = true
         );
 
         //! Helper that takes a list of SimulatedBodyHandles to Rigid Bodies and return RigidBody pointers

--- a/Gems/RemoteTools/Code/Source/RemoteToolsSystemComponent.cpp
+++ b/Gems/RemoteTools/Code/Source/RemoteToolsSystemComponent.cpp
@@ -138,7 +138,7 @@ namespace RemoteTools
             netInterface->SetTimeoutMs(AZ::TimeMs(0));
         }
 
-        if (!m_joinThread->IsRunning())
+        if (m_joinThread && !m_joinThread->IsRunning())
         {
             m_joinThread->Join();
             m_joinThread->Start();
@@ -563,7 +563,6 @@ namespace RemoteTools
             m_joinThread->Join();
             m_joinThread->Start();
         }
-
     }
 
 } // namespace RemoteTools

--- a/Gems/ScriptCanvas/Code/Editor/ScriptCanvasContextIdentifiers.h
+++ b/Gems/ScriptCanvas/Code/Editor/ScriptCanvasContextIdentifiers.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/string/string_view.h>
+
+namespace ScriptCanvasIdentifiers
+{
+    // Main Window
+    inline constexpr AZStd::string_view ScriptCanvasActionContextIdentifier = "o3de.context.editor.scriptcanvas";
+
+    // Main Window Widgets
+    inline constexpr AZStd::string_view ScriptCanvasVariablesActionContextIdentifier = "o3de.context.editor.scriptcanvas.variables";
+
+} // namespace ScriptCanvasIdentifiers

--- a/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
@@ -31,6 +31,7 @@
 #include <QFileInfo>
 #include <QDir>
 #include <QMenu>
+#include <ScriptCanvasContextIdentifiers.h>
 #include <ScriptCanvas/Bus/EditorScriptCanvasBus.h>
 #include <ScriptCanvas/Components/EditorGraph.h>
 #include <ScriptCanvas/Components/EditorGraphVariableManagerComponent.h>
@@ -387,15 +388,14 @@ namespace ScriptCanvasEditor
 
     void SystemComponent::OnActionContextRegistrationHook()
     {
-        static constexpr AZStd::string_view ScriptCanvasActionContextIdentifier = "o3de.context.editor.scriptcanvas";
-
         if (auto actionManagerInterface = AZ::Interface<AzToolsFramework::ActionManagerInterface>::Get())
         {
             AzToolsFramework::ActionContextProperties contextProperties;
             contextProperties.m_name = "O3DE Script Canvas";
 
-            // Register a custom action context to allow duplicated shortcut hotkeys to work
-            actionManagerInterface->RegisterActionContext(ScriptCanvasActionContextIdentifier, contextProperties);
+            // Register custom action contexts to allow duplicated shortcut hotkeys to work
+            actionManagerInterface->RegisterActionContext(ScriptCanvasIdentifiers::ScriptCanvasActionContextIdentifier, contextProperties);
+            actionManagerInterface->RegisterActionContext(ScriptCanvasIdentifiers::ScriptCanvasVariablesActionContextIdentifier, contextProperties);
         }
     }
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.cpp
@@ -30,11 +30,14 @@
 
 #include <Editor/View/Widgets/ScriptCanvasNodePaletteDockWidget.h>
 #include <Editor/View/Widgets/NodePalette/VariableNodePaletteTreeItemTypes.h>
+#include <ScriptCanvasContextIdentifiers.h>
 #include <ScriptCanvas/Asset/RuntimeAsset.h>
 #include <ScriptCanvas/Bus/RequestBus.h>
 #include <ScriptCanvas/Bus/EditorScriptCanvasBus.h>
 
+#include <AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <AzToolsFramework/Editor/ActionManagerUtils.h>
 #include <ScriptCanvas/Variable/GraphVariable.h>
 
 namespace ScriptCanvasEditor
@@ -1151,6 +1154,28 @@ namespace ScriptCanvasEditor
 
         setMinimumSize(0, 0);
         ResizeColumns();
+
+        if (AzToolsFramework::IsNewActionManagerEnabled())
+        {
+            if (auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get())
+            {
+                hotKeyManagerInterface->AssignWidgetToActionContext(
+                    ScriptCanvasIdentifiers::ScriptCanvasVariablesActionContextIdentifier, this);
+            }
+        }
+    }
+
+    GraphVariablesTableView::~GraphVariablesTableView()
+    {
+        if (AzToolsFramework::IsNewActionManagerEnabled())
+        {
+            if (auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get())
+            {
+                hotKeyManagerInterface->RemoveWidgetFromActionContext(
+                    ScriptCanvasIdentifiers::ScriptCanvasVariablesActionContextIdentifier, this);
+            }
+        }
+
     }
 
     void GraphVariablesTableView::SetActiveScene(const ScriptCanvas::ScriptCanvasId& scriptCanvasId)

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.h
@@ -141,7 +141,8 @@ namespace ScriptCanvasEditor
         static bool HandleVariablePaste(const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
 
         AZ_CLASS_ALLOCATOR(GraphVariablesTableView, AZ::SystemAllocator);
-        GraphVariablesTableView(QWidget* parent);
+        explicit GraphVariablesTableView(QWidget* parent);
+        ~GraphVariablesTableView();
 
         void SetActiveScene(const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
         void SetFilter(const QString& filterString);

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -146,11 +146,11 @@
 #include <Editor/Include/ScriptCanvas/Components/EditorGraph.h>
 ////
 
+#include <ScriptCanvasContextIdentifiers.h>
 #include <Editor/Assets/ScriptCanvasAssetHelpers.h>
 #include <ScriptCanvas/Asset/AssetDescription.h>
 #include <ScriptCanvas/Asset/SubgraphInterfaceAsset.h>
 #include <ScriptCanvas/Components/EditorScriptCanvasComponent.h>
-
 
 #include <Editor/QtMetaTypes.h>
 #include <GraphCanvas/Components/SceneBus.h>
@@ -443,11 +443,9 @@ namespace ScriptCanvasEditor
 
         if (AzToolsFramework::IsNewActionManagerEnabled())
         {
-            static constexpr AZStd::string_view ScriptCanvasActionContextIdentifier = "o3de.context.editor.scriptcanvas";
-
             if(auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get())
             {
-                hotKeyManagerInterface->AssignWidgetToActionContext(ScriptCanvasActionContextIdentifier, this);
+                hotKeyManagerInterface->AssignWidgetToActionContext(ScriptCanvasIdentifiers::ScriptCanvasActionContextIdentifier, this);
             }
         }
 
@@ -688,11 +686,9 @@ namespace ScriptCanvasEditor
 
         if (AzToolsFramework::IsNewActionManagerEnabled())
         {
-            static constexpr AZStd::string_view ScriptCanvasActionContextIdentifier = "o3de.context.editor.scriptcanvas";
-
             if (auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get())
             {
-                hotKeyManagerInterface->RemoveWidgetFromActionContext(ScriptCanvasActionContextIdentifier, this);
+                hotKeyManagerInterface->RemoveWidgetFromActionContext(ScriptCanvasIdentifiers::ScriptCanvasActionContextIdentifier, this);
             }
         }
 

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_editor_files.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_editor_files.cmake
@@ -7,6 +7,7 @@
 #
 
 set(FILES
+    Editor/ScriptCanvasContextIdentifiers.h
     Editor/ScriptCanvasEditorGem.cpp
     Editor/Settings.h
     Editor/Settings.cpp

--- a/Gems/WhiteBox/Assets/materials/WhiteBoxDefault.material
+++ b/Gems/WhiteBox/Assets/materials/WhiteBoxDefault.material
@@ -1,0 +1,5 @@
+{
+    "materialType": "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "parentMaterial": "@gemroot:Atom_Feature_Common@/Assets/Materials/Presets/PBR/default_grid.material"
+}

--- a/Gems/WhiteBox/Assets/materials/checker_material.mtl
+++ b/Gems/WhiteBox/Assets/materials/checker_material.mtl
@@ -1,8 +1,0 @@
-<Material MtlFlags="524288" DccMaterialHash="0" Shader="Illum" GenMask="200A00000000003" StringGenMask="%ALLOW_SILHOUETTE_POM%ALLOW_SPECULAR_ANTIALIASING%NORMAL_MAP%SPECULAR_MAP%SUBSURFACE_SCATTERING" SurfaceType="mat_default" Diffuse="1,1,1,1" Specular="0.043735031,0.043735031,0.043735031,0.58823532" Opacity="1" Shininess="150" vertModifType="0" LayerAct="1">
- <Textures>
-  <Texture Map="Diffuse" File="textures/default/_dev_Middle_Gray_Checker.dds"/>
-  <Texture Map="Specular" File="textures/default/_dev_Middle_Gray_Checker_spec.dds"/>
-  <Texture Map="Bumpmap" File="textures/default/_dev_Middle_Gray_Checker_ddn.dds"/>
- </Textures>
- <PublicParams EmittanceMapGamma="1" SSSIndex="0" IndirectColor="0.25,0.25,0.25"/>
-</Material>

--- a/Gems/WhiteBox/Assets/materials/default_material.mtl
+++ b/Gems/WhiteBox/Assets/materials/default_material.mtl
@@ -1,8 +1,0 @@
-<Material MtlFlags="524288" DccMaterialHash="0" Shader="Illum" GenMask="200A00000000003" StringGenMask="%ALLOW_SILHOUETTE_POM%ALLOW_SPECULAR_ANTIALIASING%NORMAL_MAP%SPECULAR_MAP%SUBSURFACE_SCATTERING" SurfaceType="mat_default" Diffuse="1,1,1,1" Specular="0.043735031,0.043735031,0.043735031,0.58823532" Opacity="1" Shininess="150" vertModifType="0" LayerAct="1">
- <Textures>
-  <Texture Map="Diffuse" File="textures/default/_dev_Middle_Gray_Checker.dds"/>
-  <Texture Map="Specular" File="textures/default/_dev_Middle_Gray_Checker_spec.dds"/>
-  <Texture Map="Bumpmap" File="textures/default/_dev_Middle_Gray_Checker_ddn.dds"/>
- </Textures>
- <PublicParams EmittanceMapGamma="1" SSSIndex="0" IndirectColor="0.25,0.25,0.25"/>
-</Material>

--- a/Gems/WhiteBox/Assets/materials/solid_material.mtl
+++ b/Gems/WhiteBox/Assets/materials/solid_material.mtl
@@ -1,6 +1,0 @@
-<Material MtlFlags="524288" DccMaterialHash="0" Shader="Illum" GenMask="800000000003" StringGenMask="%ALLOW_SILHOUETTE_POM%ALLOW_SPECULAR_ANTIALIASING%SUBSURFACE_SCATTERING" SurfaceType="mat_default" Diffuse="1,1,1,1" Specular="0.043735031,0.043735031,0.043735031,1" Opacity="1" Shininess="150" vertModifType="0" LayerAct="1">
- <Textures>
-  <Texture Map="Diffuse" File="textures/default/_dev_solid_fill.dds"/>
- </Textures>
- <PublicParams EmittanceMapGamma="1" SSSIndex="0" IndirectColor="0.25,0.25,0.25"/>
-</Material>

--- a/Gems/WhiteBox/Assets/seedList.seed
+++ b/Gems/WhiteBox/Assets/seedList.seed
@@ -1,0 +1,13 @@
+<ObjectStream version="3">
+	<Class name="AZStd::vector" type="{82FC5264-88D0-57CD-9307-FC52E4DAD550}">
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{69FE164E-0656-5AEE-9CE7-B954A44A519F}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="255" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="materials/whiteboxdefault.azmaterial" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+	</Class>
+</ObjectStream>
+

--- a/Gems/WhiteBox/Assets/textures/default/_dev_Middle_Gray_Checker.tif
+++ b/Gems/WhiteBox/Assets/textures/default/_dev_Middle_Gray_Checker.tif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57d6744696768f9fb8a5fe5fee9aa36fee1eb87a9dbc1e60d4a35ed3c39d68e6
-size 810620

--- a/Gems/WhiteBox/Assets/textures/default/_dev_Middle_Gray_Checker_ddn.tif
+++ b/Gems/WhiteBox/Assets/textures/default/_dev_Middle_Gray_Checker_ddn.tif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1b56097f0df01da7ed49311462002f5e1a61b8496306c7ab3b12e17c27afb28a
-size 793918

--- a/Gems/WhiteBox/Assets/textures/default/_dev_Middle_Gray_Checker_spec.tif
+++ b/Gems/WhiteBox/Assets/textures/default/_dev_Middle_Gray_Checker_spec.tif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ba52ff6d59f50b4b5dea6e266572c9e7feb92d5fd85bd0738e0d07d42d234bf7
-size 810996

--- a/Gems/WhiteBox/Assets/textures/default/_dev_Solid_Fill.tif
+++ b/Gems/WhiteBox/Assets/textures/default/_dev_Solid_Fill.tif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e7ab4ef3a6c9f6ee4eb7e36848feced650ad226e5a43e87612772b3ebc26a5f
-size 994552

--- a/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxAtomRenderMesh.h
+++ b/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxAtomRenderMesh.h
@@ -106,8 +106,7 @@ namespace WhiteBox
         bool m_visible = true;
 
         //! Default white box mesh material.
-        static constexpr AZStd::string_view TexturedMaterialPath = "materials/defaultpbr.azmaterial";
-        static constexpr AZStd::string_view SolidMaterialPath = "materials/defaultpbr.azmaterial";
+        static constexpr AZStd::string_view TexturedMaterialPath = "materials/whiteboxdefault.azmaterial";
         static constexpr AZ::RPI::ModelMaterialSlot::StableId OneMaterialSlotId = 0;
 
         //! White box model name.

--- a/scripts/o3de/o3de/compatibility.py
+++ b/scripts/o3de/o3de/compatibility.py
@@ -139,18 +139,12 @@ def get_incompatible_gem_dependencies(gem_json_data:dict, all_gems_json_data:dic
     return get_incompatible_gem_version_specifiers(gem_json_data, all_gems_json_data, checked_specifiers=set())
 
 
-def get_gem_project_incompatible_objects(gem_path:pathlib.Path, 
-                                        gem_json_data:dict, 
-                                        project_path:pathlib.Path,
-                                        gem_name:str = None
-                                        ) -> set:
+def get_gems_project_incompatible_objects(gem_paths:list, gem_names:list, project_path:pathlib.Path) -> set():
     """
-    Returns any incompatible objects for this gem and project.
-    :param gem_json_data: gem json data dictionary
+    Returns any incompatible objects for the gem names provided and project.
+    :param gem_names: names of all the gems 
+    :param gem_paths: paths of all the gems 
     :param project_path: path to the project
-    :param all_gems_json_data: optional dictionary containing data for all gems to use in compatibility checks. 
-    If not provided, uses all gems from the manifest, engine and project.
-    :param gem_name: optional gem name with version specifier to use for gem dependency resolution 
     """
     # early out if this project has no assigned engine
     engine_path = manifest.get_project_engine_path(project_path=project_path)
@@ -168,30 +162,20 @@ def get_gem_project_incompatible_objects(gem_path:pathlib.Path,
         logger.error('Failed to load engine.json data based on the engine field in project.json or detect the engine from the current folder')
         return set(f'engine.json (missing)') 
 
-    # Include the gem_path for the gem we are adding so it 
-    # and any gems in 'external_subdirectories' it has will be considered 
+    # include the gem_paths for the gems we are adding so their
+    # 'external_subdirectories' will be considered 
     all_gems_json_data = manifest.get_gems_json_data_by_name(engine_path, project_path, 
-        external_subdirectories=[gem_path], include_manifest_gems=True)
-    
+        external_subdirectories=gem_paths, include_manifest_gems=True)
+
     # Verify we can resolve all dependencies after adding this new gem
     active_gem_names = engine_json_data.get('gem_names',[])
     active_gem_names.extend(project_json_data.get('gem_names',[]))
     enabled_gems_file = manifest.get_enabled_gem_cmake_file(project_path=project_path)
     if enabled_gems_file and enabled_gems_file.is_file():
         active_gem_names.extend(manifest.get_enabled_gems(enabled_gems_file))
+    active_gem_names.extend(gem_names)
+
     active_gem_names = utils.get_gem_names_set(active_gem_names)
-
-    if not gem_name:
-        gem_name = gem_json_data['gem_name']
-        gem_version = gem_json_data.get('version')
-        if gem_version:
-            # try to match the name and version from this specific gem json data
-            gem_name = f'{gem_name}=={gem_version}'
-        else:
-            # match any gem with this name
-            gem_name = f'{gem_name}>=0.0.0'
-
-    active_gem_names.add(gem_name)
 
     # Dependency resolution takes into account gem and engine requirements so if 
     # it succeeds, all is well
@@ -373,7 +357,7 @@ def has_compatible_version(name_and_version_specifier_list:list, object_name:str
 
 class GemRequirement(namedtuple("GemRequirement", ["name", "specifier"])):
     def __repr__(self):
-        return f"<GemRequirement({self.name}{self.specifier})>"
+        return f'<GemRequirement({self.name}{self.specifier if self.specifier else ""})>'
 
     def identify(self):
         # IMPORTANT don't use the specifier or we will get multiple mappings
@@ -381,7 +365,7 @@ class GemRequirement(namedtuple("GemRequirement", ["name", "specifier"])):
         return f"GemRequirement:{self.name}"
 
     def failure_reason(self, object_name):
-        return f'{object_name} requires {self.name}{self.specifier}'
+        return f'{object_name} requires {self.name}{self.specifier if self.specifier else ""}'
 
 class EngineRequirement(namedtuple("EngineRequirement", ["gem_json_data"])):
     def __repr__(self):
@@ -457,7 +441,9 @@ class GemDependencyProvider(AbstractProvider):
         elif isinstance(candidate, GemCandidate) and isinstance(requirement,GemRequirement):
             return (
                 candidate.name == requirement.name
-                and candidate.version in requirement.specifier
+                # It's much faster to check if specifier is None
+                # than to check if candidate.version in ">=0.0.0"
+                and (requirement.specifier is None or candidate.version in requirement.specifier)
             )
         else:
             # GemCandidates do no satisfy EngineRequirements
@@ -492,10 +478,10 @@ def resolve_gem_dependencies(gem_names:list, all_gem_json_data:dict, engine_json
             gem_dependency_names = utils.get_gem_names_set(gem_dependencies, include_optional=include_optional)
             for gem_dependency in gem_dependency_names:
                 dep_name, dep_version_specifier = utils.get_object_name_and_optional_version_specifier(gem_dependency)
-                if not dep_version_specifier:
-                    dep_version_specifier = ">=0.0.0"
+                if dep_version_specifier:
+                    dep_version_specifier = SpecifierSet(dep_version_specifier)
 
-                requirements.append(GemRequirement(dep_name, SpecifierSet(dep_version_specifier)))
+                requirements.append(GemRequirement(dep_name, dep_version_specifier))
             
             # Add engine requirements. Technically "compatible_engines" should not
             # be used for incompatibility, and this should be addressed in the future.
@@ -515,14 +501,21 @@ def resolve_gem_dependencies(gem_names:list, all_gem_json_data:dict, engine_json
     project_gem_requirements = set()
     for gem_name in gem_names:
         dep_name, dep_version_specifier = utils.get_object_name_and_optional_version_specifier(gem_name)
-        if not dep_version_specifier:
-            dep_version_specifier = ">=0.0.0"
-        project_gem_requirements.add(GemRequirement(dep_name, SpecifierSet(dep_version_specifier)))
+        if dep_version_specifier:
+            dep_version_specifier = SpecifierSet(dep_version_specifier)
+        project_gem_requirements.add(GemRequirement(dep_name, dep_version_specifier))
 
     result_mapping = None
     errors = None
+
+    # the resolver uses a single "round" to try and pin a single dependency
+    # so we need at least enough rounds as we have gems in the dependency tree
+    # for comparison, pypip uses 2 million rounds
+    # https://github.com/pypa/pip/blob/main/src/pip/_internal/resolution/resolvelib/resolver.py#L91
+    num_gems = sum(len(gem_versions) for _,gem_versions in all_gem_json_data.items()) 
+    try_to_avoid_resolution_too_deep = max(2000000, num_gems)
     try:
-        result = resolver.resolve(requirements=project_gem_requirements)
+        result = resolver.resolve(requirements=project_gem_requirements, max_rounds=try_to_avoid_resolution_too_deep)
 
         # Remove any EngineCandidates that may appear in the mappings
         result_mapping = {k: v for k, v in result.mapping.items() if isinstance(v, GemCandidate)}

--- a/scripts/o3de/o3de/disable_gem.py
+++ b/scripts/o3de/o3de/disable_gem.py
@@ -33,7 +33,7 @@ def disable_gem_in_project(gem_name: str = None,
     :param project_name: name of the project to add the gem to
     :param project_path: path to the project to add the gem to
     :param enabled_gem_file: File to remove enabled gem from
-    :return: 0 for success or non 0 failure code
+    :return: 0 for success, 2 if gem was not found, 1 on any other error  
     """
 
     # we need either a project name or path
@@ -84,7 +84,7 @@ def disable_gem_in_project(gem_name: str = None,
     ret_val = 0
 
     # Remove the gem from the deprecated enabled_gems.cmake file
-    gem_enabled_in_cmake = False
+    gem_found_in_cmake = False
     if not enabled_gem_file:
         enabled_gem_file = manifest.get_enabled_gem_cmake_file(project_path=project_path)
     if enabled_gem_file.is_file():
@@ -107,7 +107,7 @@ def disable_gem_in_project(gem_name: str = None,
 
     if not gem_found_in_cmake and not gem_found_in_gem_names:
         # No gems found to remove with this name
-        return 1
+        return 2
 
     ret_val = project_properties.edit_project_props(project_path,
                                                     delete_gem_names=gem_name) or ret_val

--- a/scripts/o3de/o3de/enable_gem.py
+++ b/scripts/o3de/o3de/enable_gem.py
@@ -84,6 +84,9 @@ def enable_gem_in_project(gem_name: str = None,
         logger.error(f'Could not read gem.json content under {gem_path}.')
         return 1
 
+    # include the version specifier if provided e.g. gem==1.2.3
+    gem_name = gem_name or gem_json_data['gem_name']
+
     # check compatibility
     if force:
         logger.info(f'Bypassing version compatibility check for {gem_json_data["gem_name"]}.')
@@ -93,7 +96,7 @@ def enable_gem_in_project(gem_name: str = None,
         if manifest.get_project_engine_path(project_path):
             # Note: we don't remove gems that are not active or dependencies
             # because they will be implicitly found and activated via cmake 
-            incompatible_objects = compatibility.get_gem_project_incompatible_objects(gem_path, gem_json_data, project_path, gem_name=gem_name)
+            incompatible_objects = compatibility.get_gems_project_incompatible_objects([gem_path], [gem_name], project_path)
             if incompatible_objects:
                 logger.error(f'{gem_json_data["gem_name"]} has the following dependency compatibility issues and '
                     'requires the --force parameter to activate:\n  '+ 
@@ -103,9 +106,6 @@ def enable_gem_in_project(gem_name: str = None,
         if dry_run:
             logger.info(f'{gem_json_data["gem_name"]} is compatible with this project')
             return 0
-
-    # include the version specifier if provided e.g. gem==1.2.3
-    gem_name = gem_name or gem_json_data['gem_name']
 
     return project_properties.edit_project_props(proj_path=project_path,
                                                  new_gem_names=gem_name,

--- a/scripts/o3de/o3de/project_manager_interface.py
+++ b/scripts/o3de/o3de/project_manager_interface.py
@@ -11,7 +11,7 @@ Contains functions for the project manager to call that gather data from o3de sc
 
 import logging
 
-from o3de import manifest, utils
+from o3de import manifest, utils, compatibility, enable_gem
 
 logger = logging.getLogger('o3de.project_manager_interface')
 logging.basicConfig(format=utils.LOG_FORMAT)
@@ -171,14 +171,57 @@ def set_project_info(project_info: dict):
     pass
 
 
-def add_gem_to_project(gem_path: str, project_path: str):
+def get_incompatible_project_gems(gem_paths:list, gem_names: list, project_path: str) -> set():
+    """
+        Checks for compatibility issues between the provided gems and project
+
+        :param gem_paths: Gem paths for the gems to check
+        :param gem_names: Gem names with optional version specifiers
+        :param project_path: Project path 
+        :return a set of all incompatible gems
+    """
+    # we need to know the engine to check compatibility 
+    engine_path = manifest.get_project_engine_path(project_path)
+    if not engine_path:
+        return set()
+
+    # check compatibility for all gems at once for speeeeeeeeed
+    incompatible_objects = compatibility.get_gems_project_incompatible_objects(
+        gem_paths=gem_paths, gem_names=gem_names, project_path=project_path)
+    if incompatible_objects:
+        logger.error(f"The following dependency issues were found:\n"
+            "\n  ".join(incompatible_objects))
+    return incompatible_objects
+
+def add_gems_to_project(gem_paths:list, gem_names: list, project_path: str, force: bool = False) -> int:
     """
         Activates gem_path in project_path
 
-        :param gem_path: Gem path to activate
-        :param project_path: Project path to activate
+        :param gem_names: Gem names to activate
+        :param project_path: Project path 
+        :return 0 on success, non-zero on error
     """
-    pass
+    if not force:
+        # we need to know the engine to check compatibility 
+        engine_path = manifest.get_project_engine_path(project_path)
+        if engine_path:
+            # check compatibility for all gems at once for speeeeeeeeed
+            incompatible_objects = compatibility.get_gems_project_incompatible_objects(
+                gem_paths=gem_paths, gem_names=gem_names, project_path=project_path)
+            if incompatible_objects:
+                logger.error(f"The following dependency issues were found:\n"
+                    "\n  ".join(incompatible_objects))
+                return 1
+
+    # compatibility passed, force add gems to avoid additional compatibility checks
+    result = 0
+    for index in range(len(gem_paths)):
+       result = enable_gem.enable_gem_in_project(gem_name=gem_names[index], 
+                                                 gem_path=gem_paths[index], 
+                                                 project_path=project_path, 
+                                                 force=True) or result
+
+    return result
 
 def remove_gem_from_project(gem_path: str, project_path: str):
     """

--- a/scripts/o3de/o3de/register.py
+++ b/scripts/o3de/o3de/register.py
@@ -448,7 +448,7 @@ def register_gem_path(json_data: dict,
         # because most gems depend on engine gems which would not be found
         if project_path and manifest.get_project_engine_path(project_path):
             # note this check includes engine and manifest gems
-            incompatible_objects = compatibility.get_gem_project_incompatible_objects(gem_path, gem_json_data, project_path)
+            incompatible_objects = compatibility.get_gems_project_incompatible_objects([gem_path], [gem_json_data['gem_name']], project_path)
             if incompatible_objects:
                 logger.error(f'{gem_json_data["gem_name"]} is not known to be compatible with the '
                     'following objects/APIs and requires the --force parameter to register:\n  '+

--- a/scripts/o3de/o3de/utils.py
+++ b/scripts/o3de/o3de/utils.py
@@ -357,7 +357,14 @@ def get_gem_names_set(gems: list, include_optional:bool = True) -> set:
     :param include_optional: If false, exclude optional gems
     :return: A set of gem name strings
     """
-    return set([gem['name'] if isinstance(gem, dict) and (include_optional or not gem.get('optional', False)) else gem for gem in gems])
+    def should_include_gem(gem: str or dict) -> bool:
+        if not isinstance(gem, dict) or include_optional:
+            return True
+        else:
+            # only include required gems 
+            return not gem.get('optional', False)
+
+    return set([gem['name'] if isinstance(gem, dict) else gem for gem in gems if should_include_gem(gem)])
 
 
 def contains_object_name(object_name:str, candidates:list) -> bool:

--- a/scripts/o3de/tests/test_disable_gem.py
+++ b/scripts/o3de/tests/test_disable_gem.py
@@ -132,7 +132,7 @@ class TestDisableGemCommand:
         # when requested to remove a gem with matching version expect success
         pytest.param('TestGem==1.0.0', None, 'TestGem==1.0.0', None, pathlib.PurePath('TestProject'), False, False, False, 0),
         # when a gem specifier is included but the gem doesn't match, expect failure
-        pytest.param('TestGem', 'None', 'TestGem==1.0.0', None, pathlib.PurePath('TestProject'), False, False, False, 1),
+        pytest.param('TestGem', 'None', 'TestGem==1.0.0', None, pathlib.PurePath('TestProject'), False, False, False, 2),
         # when a gem name with no specifier is provided, expect any gem with that name is removed 
         pytest.param('TestGem==1.2.3', '1.2.3', 'TestGem', None, pathlib.PurePath('TestProject'), False, False, False, 0),
         ]

--- a/scripts/o3de/tests/test_utils.py
+++ b/scripts/o3de/tests/test_utils.py
@@ -54,3 +54,15 @@ def test_validate_uuid4(value, expected_result):
 def test_remove_gem_duplicates(in_list, out_list):
     result = utils.remove_gem_duplicates(in_list)
     assert result == out_list
+
+@pytest.mark.parametrize(
+    "gems, include_optional, expected_result", [
+        pytest.param(['GemA', {'name':'GemC'}], True, ['GemA', 'GemC']),
+        pytest.param(['GemA', {'name':'GemC','optional':True}], True, ['GemA', 'GemC']),
+        pytest.param(['GemA', {'name':'GemC','optional':True}], False, ['GemA' ]),
+        pytest.param(['GemA', {'name':'GemC','optional':False}], True, ['GemA', 'GemC'])
+    ]
+)
+def test_get_gem_names_set(gems, include_optional, expected_result):
+    result = utils.get_gem_names_set(gems=gems, include_optional=include_optional)
+    assert result == set(expected_result)


### PR DESCRIPTION
Merged up to https://github.com/o3de/o3de/commit/42ff15450b from stabilization/2305

The following files conflicted:

- `CONFLICT (content): Merge conflict in Gems/EMotionFX/Code/EMotionFX/Source/BlendSpaceNode.cpp `
Trivial include line conflicted, solved.

- `CONFLICT (content): Merge conflict in Gems/RemoteTools/Code/Source/RemoteToolsSystemComponent.cpp`
Trivial new line conflicted, solved.

- `CONFLICT (content): Merge conflict in engine.json` 
Engine version in stabilization was incremented from 1.1.0 to 1.2.0, which conflicted with version 2.0.0 in development. Resolved by keeping 2.0.0 in development.

