### PR TITLE
Confirmation dialog for file deletions

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.cpp
@@ -276,6 +276,27 @@ namespace AzToolsFramework
                                 canDelete = false;
                             }
                         }
+                        else
+                        {
+                            QMessageBox warningBox;
+                            warningBox.setWindowTitle(QObject::tr(isFolder ? "Folder Deletion - Warning" : "Asset Deletion - Warning"));
+                            warningBox.setText(
+                                QObject::tr("O3DE is unable to detect if this file is being used inside a level, prefab, or asset."
+                                            "By deleting these asset(s), you understand this might break a connection if it's still in use."));
+                            warningBox.setInformativeText(
+                                QObject::tr("Currently, delete is a permanent action and cannot be undone.\n"
+                                    "Do you wish to proceed with this deletion?"));
+                            warningBox.setIcon(QMessageBox::Warning);
+                            warningBox.addButton(QMessageBox::Cancel);
+                            warningBox.addButton(QObject::tr("Delete"), QMessageBox::YesRole);
+                            warningBox.setDefaultButton(QMessageBox::Yes);
+                            warningBox.setFixedWidth(600);
+                            if (warningBox.exec() == QMessageBox::Cancel)
+                            {
+                                canDelete = false;
+                            }
+                        }
+
                         if (canDelete)
                         {
                             AssetChangeReportRequest deleteRequest(


### PR DESCRIPTION
## What does this PR do?
It is very easy to delete files that are not being referenced to in the asset browser, so this adds a confirmation dialog for those files.

Fixes #13488 

## How was this PR tested?

Locally
