### PR TITLE
Action Manager | Allow action registration hooks usage for python scripts

### DIFF
--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -1809,11 +1809,8 @@ bool CCryEditApp::InitInstance()
         QtViewPaneManager::instance()->RestoreLayout(restoreDefaults);
     }
 
-    // TEST
-
-    AzToolsFramework::ActionManagerSystemComponent::TriggerRegistrationHooks();
-
-    // TEST END
+    // Trigger the Action Manager registration hooks once all systems and Gems are initialized and listening.
+    AzToolsFramework::ActionManagerSystemComponent::TriggerRegistrationNotifications();
 
     CloseSplashScreen();
 

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -60,6 +60,7 @@ AZ_POP_DISABLE_WARNING
 #include <AzFramework/Spawnable/RootSpawnableInterface.h>
 
 // AzToolsFramework
+#include <AzToolsFramework/ActionManager/ActionManagerSystemComponent.h>
 #include <AzToolsFramework/Component/EditorComponentAPIBus.h>
 #include <AzToolsFramework/Component/EditorLevelComponentAPIBus.h>
 #include <AzToolsFramework/UI/UICore/ProgressShield.hxx>
@@ -1807,6 +1808,12 @@ bool CCryEditApp::InitInstance()
         bool restoreDefaults = !mainWindowWrapper->restoreGeometryFromSettings();
         QtViewPaneManager::instance()->RestoreLayout(restoreDefaults);
     }
+
+    // TEST
+
+    AzToolsFramework::ActionManagerSystemComponent::TriggerRegistrationHooks();
+
+    // TEST END
 
     CloseSplashScreen();
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ActionManagerSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ActionManagerSystemComponent.cpp
@@ -16,6 +16,98 @@
 
 namespace AzToolsFramework
 {
+    namespace Internal
+    {
+        struct ActionManagerRegistrationNotificationBusHandler final
+            : public ActionManagerRegistrationNotificationBus::Handler
+            , public AZ::BehaviorEBusHandler
+        {
+            AZ_EBUS_BEHAVIOR_BINDER(
+                ActionManagerRegistrationNotificationBusHandler,
+                "{A9397A5D-0B04-4552-814F-0B4F385A3890}",
+                AZ::SystemAllocator,
+                OnActionContextRegistrationHook,
+                OnActionContextModeRegistrationHook,
+                OnActionUpdaterRegistrationHook,
+                OnMenuBarRegistrationHook,
+                OnMenuRegistrationHook,
+                OnToolBarAreaRegistrationHook,
+                OnToolBarRegistrationHook,
+                OnActionRegistrationHook,
+                OnWidgetActionRegistrationHook,
+                OnActionContextModeBindingHook,
+                OnMenuBindingHook,
+                OnToolBarBindingHook,
+                OnPostActionManagerRegistrationHook
+            );
+
+            void OnActionContextRegistrationHook() override
+            {
+                Call(FN_OnActionContextRegistrationHook);
+            }
+
+            void OnActionContextModeRegistrationHook() override
+            {
+                Call(FN_OnActionContextModeRegistrationHook);
+            }
+
+            void OnActionUpdaterRegistrationHook() override
+            {
+                Call(FN_OnActionUpdaterRegistrationHook);
+            }
+
+            void OnMenuBarRegistrationHook() override
+            {
+                Call(FN_OnMenuBarRegistrationHook);
+            }
+
+            void OnMenuRegistrationHook() override
+            {
+                Call(FN_OnMenuRegistrationHook);
+            }
+
+            void OnToolBarAreaRegistrationHook() override
+            {
+                Call(FN_OnToolBarAreaRegistrationHook);
+            }
+
+            void OnToolBarRegistrationHook() override
+            {
+                Call(FN_OnToolBarRegistrationHook);
+            }
+
+            void OnActionRegistrationHook() override
+            {
+                Call(FN_OnActionRegistrationHook);
+            }
+
+            void OnWidgetActionRegistrationHook() override
+            {
+                Call(FN_OnWidgetActionRegistrationHook);
+            }
+
+            void OnActionContextModeBindingHook() override
+            {
+                Call(FN_OnActionContextModeBindingHook);
+            }
+
+            void OnMenuBindingHook() override
+            {
+                Call(FN_OnMenuBindingHook);
+            }
+
+            void OnToolBarBindingHook() override
+            {
+                Call(FN_OnToolBarBindingHook);
+            }
+
+            void OnPostActionManagerRegistrationHook() override
+            {
+                Call(FN_OnPostActionManagerRegistrationHook);
+            }
+        };
+    } // namespace Internal
+
     ActionManagerSystemComponent::~ActionManagerSystemComponent()
     {
         if (m_defaultParentObject)
@@ -59,13 +151,36 @@ namespace AzToolsFramework
 
     void ActionManagerSystemComponent::Reflect(AZ::ReflectContext* context)
     {
+        MenuManager::Reflect(context);
+        ToolBarManager::Reflect(context);
+
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<ActionManagerSystemComponent, AZ::Component>()->Version(1);
         }
 
-        MenuManager::Reflect(context);
-        ToolBarManager::Reflect(context);
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->EBus<ActionManagerRegistrationNotificationBus>("ActionManagerRegistrationNotificationBus")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                ->Attribute(AZ::Script::Attributes::Category, "Action")
+                ->Attribute(AZ::Script::Attributes::Module, "action")
+                ->Handler<Internal::ActionManagerRegistrationNotificationBusHandler>()
+                ->Event("OnActionContextRegistrationHook", &ActionManagerRegistrationNotifications::OnActionContextRegistrationHook)
+                ->Event("OnActionContextModeRegistrationHook", &ActionManagerRegistrationNotifications::OnActionContextModeRegistrationHook)
+                ->Event("OnActionUpdaterRegistrationHook", &ActionManagerRegistrationNotifications::OnActionUpdaterRegistrationHook)
+                ->Event("OnMenuBarRegistrationHook", &ActionManagerRegistrationNotifications::OnMenuBarRegistrationHook)
+                ->Event("OnMenuRegistrationHook", &ActionManagerRegistrationNotifications::OnMenuRegistrationHook)
+                ->Event("OnToolBarAreaRegistrationHook", &ActionManagerRegistrationNotifications::OnToolBarAreaRegistrationHook)
+                ->Event("OnToolBarRegistrationHook", &ActionManagerRegistrationNotifications::OnToolBarRegistrationHook)
+                ->Event("OnActionRegistrationHook", &ActionManagerRegistrationNotifications::OnActionRegistrationHook)
+                ->Event("OnWidgetActionRegistrationHook", &ActionManagerRegistrationNotifications::OnWidgetActionRegistrationHook)
+                ->Event("OnActionContextModeBindingHook", &ActionManagerRegistrationNotifications::OnActionContextModeBindingHook)
+                ->Event("OnMenuBindingHook", &ActionManagerRegistrationNotifications::OnMenuBindingHook)
+                ->Event("OnToolBarBindingHook", &ActionManagerRegistrationNotifications::OnToolBarBindingHook)
+                ->Event("OnPostActionManagerRegistrationHook", &ActionManagerRegistrationNotifications::OnPostActionManagerRegistrationHook)
+                ;
+        }
     }
 
     void ActionManagerSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
@@ -81,7 +196,8 @@ namespace AzToolsFramework
     {
     }
 
-    void ActionManagerSystemComponent::NotifyMainWindowInitialized(QMainWindow* /* mainWindow */)
+    //void ActionManagerSystemComponent::NotifyMainWindowInitialized(QMainWindow* /* mainWindow */)
+    void ActionManagerSystemComponent::TriggerRegistrationHooks()
     {
         // Broadcast synchronization hooks.
         // Order is important since latter elements may have depencencies on earlier ones.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ActionManagerSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ActionManagerSystemComponent.cpp
@@ -8,6 +8,7 @@
 
 #include <AzToolsFramework/ActionManager/ActionManagerSystemComponent.h>
 
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
 #include <AzToolsFramework/ActionManager/ActionManagerRegistrationNotificationBus.h>
@@ -135,20 +136,11 @@ namespace AzToolsFramework
 
     void ActionManagerSystemComponent::Activate()
     {
-        if (IsNewActionManagerEnabled())
-        {
-            AzToolsFramework::EditorEventsBus::Handler::BusConnect();
-        }
     }
 
     void ActionManagerSystemComponent::Deactivate()
     {
-        if (IsNewActionManagerEnabled())
-        {
-            AzToolsFramework::EditorEventsBus::Handler::BusDisconnect();
-        }
     }
-
     void ActionManagerSystemComponent::Reflect(AZ::ReflectContext* context)
     {
         MenuManager::Reflect(context);
@@ -196,8 +188,7 @@ namespace AzToolsFramework
     {
     }
 
-    //void ActionManagerSystemComponent::NotifyMainWindowInitialized(QMainWindow* /* mainWindow */)
-    void ActionManagerSystemComponent::TriggerRegistrationHooks()
+    void ActionManagerSystemComponent::TriggerRegistrationNotifications()
     {
         // Broadcast synchronization hooks.
         // Order is important since latter elements may have depencencies on earlier ones.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ActionManagerSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ActionManagerSystemComponent.h
@@ -37,7 +37,9 @@ namespace AzToolsFramework
         void Deactivate() override;
 
         // EditorEvents overrides ...
-        void NotifyMainWindowInitialized(QMainWindow* mainWindow) override;
+        //void NotifyMainWindowInitialized(QMainWindow* mainWindow) override;
+
+        static void TriggerRegistrationHooks();
 
         static void Reflect(AZ::ReflectContext* context);
         static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ActionManagerSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ActionManagerSystemComponent.h
@@ -16,14 +16,12 @@
 #include <AzToolsFramework/ActionManager/HotKey/HotKeyManager.h>
 #include <AzToolsFramework/ActionManager/Menu/MenuManager.h>
 #include <AzToolsFramework/ActionManager/ToolBar/ToolBarManager.h>
-#include <AzToolsFramework/API/ToolsApplicationAPI.h>
 
 namespace AzToolsFramework
 {
     //! System Component to handle the Action Manager system and subsystems.
     class ActionManagerSystemComponent final
         : public AZ::Component
-        , public AzToolsFramework::EditorEventsBus::Handler
     {
     public:
         AZ_COMPONENT(ActionManagerSystemComponent, "{47925132-7373-42EE-9131-F405EE4B0F1A}");
@@ -36,10 +34,7 @@ namespace AzToolsFramework
         void Activate() override;
         void Deactivate() override;
 
-        // EditorEvents overrides ...
-        //void NotifyMainWindowInitialized(QMainWindow* mainWindow) override;
-
-        static void TriggerRegistrationHooks();
+        static void TriggerRegistrationNotifications();
 
         static void Reflect(AZ::ReflectContext* context);
         static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h
@@ -25,6 +25,7 @@
 #include <AZTestShared/Math/MathTestHelpers.h>
 #include <AZTestShared/Utils/Utils.h>
 #include <AzFramework/UnitTest/TestDebugDisplayRequests.h>
+#include <AzToolsFramework/ActionManager/ActionManagerSystemComponent.h>
 #include <AzToolsFramework/ActionManager/Action/ActionManagerInterface.h>
 #include <AzToolsFramework/ActionManager/Action/ActionManagerInternalInterface.h>
 #include <AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h>
@@ -327,7 +328,8 @@ namespace UnitTest
 
                 hotKeyManagerInterface->AssignWidgetToActionContext(EditorIdentifiers::MainWindowActionContextIdentifier, m_defaultMainWindow);
 
-                AzToolsFramework::EditorEventsBus::Broadcast(&AzToolsFramework::EditorEvents::NotifyMainWindowInitialized, m_defaultMainWindow);
+                //AzToolsFramework::EditorEventsBus::Broadcast(&AzToolsFramework::EditorEvents::NotifyMainWindowInitialized, m_defaultMainWindow);
+                AzToolsFramework::ActionManagerSystemComponent::TriggerRegistrationHooks();
             }
 
             SetUpEditorFixtureImpl();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h
@@ -328,8 +328,7 @@ namespace UnitTest
 
                 hotKeyManagerInterface->AssignWidgetToActionContext(EditorIdentifiers::MainWindowActionContextIdentifier, m_defaultMainWindow);
 
-                //AzToolsFramework::EditorEventsBus::Broadcast(&AzToolsFramework::EditorEvents::NotifyMainWindowInitialized, m_defaultMainWindow);
-                AzToolsFramework::ActionManagerSystemComponent::TriggerRegistrationHooks();
+                AzToolsFramework::ActionManagerSystemComponent::TriggerRegistrationNotifications();
             }
 
             SetUpEditorFixtureImpl();


### PR DESCRIPTION
Introduces changes to allow Gems to register Action Manager items in their `bootstrap.py` scripts via Python:

- Refactors the order of operations in the initialization of the Editor to ensure `bootstrap.py` scripts are run before the Action Manager Registration Hooks are triggered;
- Exposes the Action Manager Registration Notification Bus calls ("Hooks") to be usable in Python.

The following sample code now works as intended in `bootstrap.py` files:

```
import azlmbr.action as action
import azlmbr.bus as bus

def someCustomAction():
    print("Hello")
    
def OnActionRegistrationHook(parameters):
    # Create an Action
    actionProperties = action.ActionProperties()
    actionProperties.name = "Custom Action"
    actionProperties.description = "A custom action defined via Python"
    actionProperties.category = "Python"

    action.ActionManagerPythonRequestBus(bus.Broadcast, "RegisterAction", "o3de.context.editor.mainwindow", "o3de.action.python.test", actionProperties, someCustomAction)

def OnMenuRegistrationHook(parameters):
    # Create a Menu
    menuProperties = action.MenuProperties()
    menuProperties.name = "Python Menu"

    action.MenuManagerPythonRequestBus(bus.Broadcast, "RegisterMenu", "o3de.menu.test", menuProperties)

def OnMenuBindingHook(parameters):
    # Add Action to Menu
    action.MenuManagerPythonRequestBus(bus.Broadcast, "AddActionToMenu", "o3de.menu.test", "o3de.action.python.test", 100)

    # Add Menu to Menu Bar
    action.MenuManagerPythonRequestBus(bus.Broadcast, "AddMenuToMenuBar", "o3de.menubar.editor.mainwindow", "o3de.menu.test", 1000)

handler = action.ActionManagerRegistrationNotificationBusHandler()
handler.connect()
handler.add_callback('OnActionRegistrationHook', OnActionRegistrationHook)
handler.add_callback('OnMenuRegistrationHook', OnMenuRegistrationHook)
handler.add_callback('OnMenuBindingHook', OnMenuBindingHook)
```