### PR TITLE
Suppress Android Clang compiler warning that occurs when building the IntersectSegment.cpp

### DIFF
--- a/Code/Framework/AzCore/Platform/Android/platform_android_files.cmake
+++ b/Code/Framework/AzCore/Platform/Android/platform_android_files.cmake
@@ -95,6 +95,6 @@ endif()
 # algorithm, which gets broken by the fast-math optimizations.
 ly_add_source_properties(
     SOURCES ${CMAKE_CURRENT_LIST_DIR}/../../AzCore/Math/IntersectSegment.cpp
-    PROPERTY COMPILE_FLAGS
-    VALUES -fno-fast-math
+    PROPERTY COMPILE_OPTIONS
+    VALUES -fno-fast-math -Wno-overriding-t-option
 )


### PR DESCRIPTION

On android the IntersectSegement.cpp specified the `-fno-fast-math` option to turn off fast math, which implicit changes the `-ffp-contract` option to be "on".
As the `-ffast-math` option is by default enabled in the Configurations_android.cmake

That causes the following warning to occur
```
FAILED: Code/Framework/AzCore/CMakeFiles/AzCore.dir/debug/AzCore/Math/IntersectSegment.cpp.o
D:\lumberyard-employee-dm\Android\Sdk\ndk\25.1.8937393\toolchains\llvm\prebuilt\windows-x86_64\bin\clang++.exe --target=aarch64-none-linux-android24 --sysroot=D:/lumberyard-employee-dm/Android/Sdk/ndk/25.1.8937393/toolchains/llvm/prebuilt/windows-x86_64/sysroot -DANDROID -DAZ_BUILD_CONFIGURATION_TYPE=\"debug\" -DAZ_DEBUG_BUILD -DAZ_ENABLE_DEBUG_TOOLS -DAZ_ENABLE_TRACING -DENABLE_TYPE_INFO -DLINUX -DLINUX64 -DMOBILE -DNDK_REV_MAJOR=25 -DNDK_REV_MINOR=1 -D_DEBUG -D_HAS_C9X -D_HAS_EXCEPTIONS=0 -D_LINUX -D__ARM_NEON__ -DCMAKE_INTDIR=\"debug\" -ID:/o3de/o3de/Code/Framework/AzCore/. -ID:/o3de/o3de/Code/Framework/AzCore/Platform/Android -ID:/o3de/o3de/Code/Framework/AzCore/Platform/Common -isystem D:/3rdParty/packages/Lua-5.4.4-rev1-android/Lua/include -isystem D:/3rdParty/packages/RapidJSON-1.1.0-rev1-multiplatform/RapidJSON/include -isystem D:/3rdParty/packages/RapidXML-1.13-rev1-multiplatform/RapidXML/include -isystem D:/3rdParty/packages/zlib-1.2.11-rev5-android/zlib/include -isystem D:/3rdParty/packages/zstd-1.35-multiplatform/zstd/lib -isystem D:/3rdParty/packages/cityhash-1.1-multiplatform/cityhash/src -fno-exceptions -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Werror -Wno-inconsistent-missing-override -Wrange-loop-analysis -Wno-unknown-warning-option -Wno-parentheses -Wno-reorder -Wno-switch -Wno-undefined-var-template -femulated-tls -ffast-math -fno-aligned-allocation -fms-extensions -fno-aligned-allocation -stdlib=libc++  -O0 -g -fno-inline -fstack-protector-all -fstack-check -gdwarf-2 -fPIC -std=c++17 -fno-fast-math -MD -MT Code/Framework/AzCore/CMakeFiles/AzCore.dir/debug/AzCore/Math/IntersectSegment.cpp.o -MF Code\Framework\AzCore\CMakeFiles\AzCore.dir\debug\AzCore\Math\IntersectSegment.cpp.o.d -o Code/Framework/AzCore/CMakeFiles/AzCore.dir/debug/AzCore/Math/IntersectSegment.cpp.o -c D:/o3de/o3de/Code/Framework/AzCore/AzCore/Math/IntersectSegment.cpp
clang++: error: overriding '-ffp-contract=fast' option with '-ffp-contract=on' [-Werror,-Woverriding-t-option]
```

## How was this PR tested?

Successfully built AzCore.Tests target on Android
