### PR TITLE
Make bootstrap scripts execution assert on failure

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorPythonRunnerRequestsBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorPythonRunnerRequestsBus.h
@@ -28,11 +28,17 @@ namespace AzToolsFramework
         virtual void ExecuteByString([[maybe_unused]] AZStd::string_view script, [[maybe_unused]] bool printResult) {}
 
         //! executes a Python script using a filename
-        virtual void ExecuteByFilename([[maybe_unused]] AZStd::string_view filename) {}
+        virtual bool ExecuteByFilename([[maybe_unused]] AZStd::string_view filename)
+        {
+            return false;
+        }
 
         //! executes a Python script using a filename and args
-        virtual void ExecuteByFilenameWithArgs(
-            [[maybe_unused]] AZStd::string_view filename, [[maybe_unused]] const AZStd::vector<AZStd::string_view>& args) {}
+        virtual bool ExecuteByFilenameWithArgs(
+            [[maybe_unused]] AZStd::string_view filename, [[maybe_unused]] const AZStd::vector<AZStd::string_view>& args)
+        {
+            return false;
+        }
 
         //! executes a Python script as a test
         virtual bool ExecuteByFilenameAsTest(

--- a/Code/Tools/SceneAPI/SceneData/Tests/SceneManifest/SceneManifestRuleTests.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Tests/SceneManifest/SceneManifestRuleTests.cpp
@@ -63,8 +63,8 @@ namespace AZ
         }
 
         MOCK_METHOD2(ExecuteByString, void(AZStd::string_view, bool));
-        MOCK_METHOD1(ExecuteByFilename, void(AZStd::string_view));
-        MOCK_METHOD2(ExecuteByFilenameWithArgs, void(AZStd::string_view, const AZStd::vector<AZStd::string_view>&));
+        MOCK_METHOD1(ExecuteByFilename, bool(AZStd::string_view));
+        MOCK_METHOD2(ExecuteByFilenameWithArgs, bool(AZStd::string_view, const AZStd::vector<AZStd::string_view>&));
         MOCK_METHOD3(ExecuteByFilenameAsTest, bool(AZStd::string_view, AZStd::string_view, const AZStd::vector<AZStd::string_view>&));
     };
 

--- a/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.cpp
@@ -546,7 +546,8 @@ namespace EditorPythonBindings
             AzFramework::StringFunc::Path::Join(path.c_str(), "bootstrap.py", bootstrapPath);
             if (AZ::IO::SystemFile::Exists(bootstrapPath.c_str()))
             {
-                ExecuteByFilename(bootstrapPath);
+                [[maybe_unused]] bool success = ExecuteByFilename(bootstrapPath);
+                AZ_Assert(success, "Error while executing bootstrap script: %s", bootstrapPath.c_str());
             }
         }
     }
@@ -722,12 +723,12 @@ namespace EditorPythonBindings
         }
     }
 
-    void PythonSystemComponent::ExecuteByFilename(AZStd::string_view filename)
+    bool PythonSystemComponent::ExecuteByFilename(AZStd::string_view filename)
     {
         AZStd::vector<AZStd::string_view> args;
         AzToolsFramework::EditorPythonScriptNotificationsBus::Broadcast(
             &AzToolsFramework::EditorPythonScriptNotificationsBus::Events::OnStartExecuteByFilename, filename);
-        ExecuteByFilenameWithArgs(filename, args);
+        return ExecuteByFilenameWithArgs(filename, args);
     }
 
     bool PythonSystemComponent::ExecuteByFilenameAsTest(AZStd::string_view filename, AZStd::string_view testCase, const AZStd::vector<AZStd::string_view>& args)
@@ -739,11 +740,12 @@ namespace EditorPythonBindings
         return evalResult == Result::Okay;
     }
 
-    void PythonSystemComponent::ExecuteByFilenameWithArgs(AZStd::string_view filename, const AZStd::vector<AZStd::string_view>& args)
+    bool PythonSystemComponent::ExecuteByFilenameWithArgs(AZStd::string_view filename, const AZStd::vector<AZStd::string_view>& args)
     {
         AzToolsFramework::EditorPythonScriptNotificationsBus::Broadcast(
             &AzToolsFramework::EditorPythonScriptNotificationsBus::Events::OnStartExecuteByFilenameWithArgs, filename, args);
-        EvaluateFile(filename, args);
+        const Result result = EvaluateFile(filename, args);
+        return result == Result::Okay;
     }
 
     PythonSystemComponent::Result PythonSystemComponent::EvaluateFile(AZStd::string_view filename, const AZStd::vector<AZStd::string_view>& args)

--- a/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.h
+++ b/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.h
@@ -57,8 +57,8 @@ namespace EditorPythonBindings
         ////////////////////////////////////////////////////////////////////////
         // AzToolsFramework::EditorPythonRunnerRequestBus::Handler interface implementation
         void ExecuteByString(AZStd::string_view script, bool printResult) override;
-        void ExecuteByFilename(AZStd::string_view filename) override;
-        void ExecuteByFilenameWithArgs(AZStd::string_view filename, const AZStd::vector<AZStd::string_view>& args) override;
+        bool ExecuteByFilename(AZStd::string_view filename) override;
+        bool ExecuteByFilenameWithArgs(AZStd::string_view filename, const AZStd::vector<AZStd::string_view>& args) override;
         bool ExecuteByFilenameAsTest(AZStd::string_view filename, AZStd::string_view testCase, const AZStd::vector<AZStd::string_view>& args) override;
         ////////////////////////////////////////////////////////////////////////
         


### PR DESCRIPTION
## What does this PR do?

While debugging a separate issue, I realized that our execution of python bootstrap scripts continues even if the script(s) failed, which was masking a problem, so I've changed them to assert on failure so we can catch issues sooner.

Executing scripts manually or through the scripts tool will not trigger the assert.

## How was this PR tested?

Inserted issue into a bootstrap script and verified the Editor now asserts on bootstrap. Tested executing other scripts while running the Editor and verified they do not trigger the assert.