### PR TITLE
Splash Screen Disables Itself When Invalid Texture is Used

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/SplashScreen/SplashScreenPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SplashScreen/SplashScreenPass.cpp
@@ -48,6 +48,9 @@ namespace AZ::Render
 
         if (!m_splashScreenImage)
         {
+            // Could not find an image based on the setreg path provided
+            AZ_Error("SplashScreen", false, "Image path '%s' not found. Please update the /O3DE/Atom/Feature/SplashScreen/ImagePath setreg to a valid asset cache image file.", m_settings.m_imagePath.c_str());
+            SetEnabled(false);
             return;
         }
 


### PR DESCRIPTION
Ensure splash screen disables itself if there's no image found.  Otherwise, there's just a black screen on game startup and it never goes away.

## How was this PR tested?
Assign an invalid value to /O3DE/Atom/Feature/SplashScreen/ImagePath and see that the game still loads up