### PR TITLE
Mac Build fix for AzCore.Tests

### DIFF
--- a/Code/Framework/AzCore/Tests/AZStd/Parallel.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Parallel.cpp
@@ -259,11 +259,7 @@ namespace UnitTest
         };
     };
 
-#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
-    TEST_F(Parallel_Thread, DISABLED_ThreadSanityTest)
-#else
     TEST_F(Parallel_Thread, ThreadSanityTest)
-#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
     {
         const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
 
@@ -295,11 +291,7 @@ namespace UnitTest
         EXPECT_GE(sleepTime.count(), 50000);
     }
 
-#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
-    TEST_F(Parallel_Thread, DISABLED_ThreadCreation_Succeeds)
-#else
     TEST_F(Parallel_Thread, ThreadCreation_Succeeds)
-#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
     {
         const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
         m_data = 0;
@@ -313,11 +305,7 @@ namespace UnitTest
         EXPECT_EQ(999, m_data);
     }
 
-#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
-    TEST_F(Parallel_Thread, DISABLED_ThreadCreationThroughRefWrapper_Succeeds)
-#else
     TEST_F(Parallel_Thread, ThreadCreationThroughRefWrapper_Succeeds)
-#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
     {
         const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
         non_copyable_functor f;
@@ -327,11 +315,7 @@ namespace UnitTest
         EXPECT_EQ(999, f.value);
     }
 
-#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
-    TEST_F(Parallel_Thread, DISABLED_ThreadCreation_Succeeds)
-#else
     TEST_F(Parallel_Thread, ThreadIdIsComparable_Succeeds)
-#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
     {
         const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
         m_data = 0;
@@ -345,11 +329,7 @@ namespace UnitTest
         EXPECT_EQ(999, m_data);
     }
 
-#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
-    TEST_F(Parallel_Thread, DISABLED_TestSwapThread_Succeeds)
-#else
     TEST_F(Parallel_Thread, TestSwapThread_Succeeds)
-#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
     {
         const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
         const thread_desc desc2 = m_numThreadDesc ? m_desc[1] : thread_desc{};
@@ -370,21 +350,13 @@ namespace UnitTest
         t2.join();
     }
 
-#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
-    TEST_F(Parallel_Thread, DISABLED_ThreadIdIsDefaultConstructForThread_Succeeds)
-#else
     TEST_F(Parallel_Thread, ThreadIdIsDefaultConstructForThread_Succeeds)
-#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
     {
         AZStd::thread t;
         EXPECT_EQ(AZStd::thread::id(), t.get_id());
     }
 
-#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
-    TEST_F(Parallel_Thread, DISABLED_ThreadIdForCurrentThread_IsNotDefaultConstructed_Succeeds)
-#else
     TEST_F(Parallel_Thread, ThreadIdForCurrentThread_IsNottDefaultConstructed_Succeeds)
-#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
     {
         const thread_desc desc = m_numThreadDesc ? m_desc[0] : thread_desc{};
         AZStd::thread t(desc, [](){});
@@ -392,11 +364,7 @@ namespace UnitTest
         t.join();
     }
 
-#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
-    TEST_F(Parallel_Thread, DISABLED_DifferentThreadsHaveDifferentThreadIds_Succeeds)
-#else
     TEST_F(Parallel_Thread, DifferentThreadsHaveDifferentThreadIds_Succeeds)
-#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
     {
         const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
         const thread_desc desc2 = m_numThreadDesc ? m_desc[1] : thread_desc{};
@@ -407,11 +375,7 @@ namespace UnitTest
         t2.join();
     }
 
-#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
-    TEST_F(Parallel_Thread, DISABLED_ThreadIdsAreTotallyOrdered_Succeeds)
-#else
     TEST_F(Parallel_Thread, ThreadIdsAreTotallyOrdered_Succeeds)
-#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
     {
         const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
         const thread_desc desc2 = m_numThreadDesc ? m_desc[1] : thread_desc{};
@@ -505,11 +469,7 @@ namespace UnitTest
         t3.join();
     }
 
-#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
-    TEST_F(Parallel_Thread, DISABLED_ThreadIdOfCurrentThreadReturnedByThisThreadId_Succeeds)
-#else
     TEST_F(Parallel_Thread, ThreadIdOfCurrentThreadReturnedByThisThreadId_Succeeds)
-#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
     {
         const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
 
@@ -520,11 +480,7 @@ namespace UnitTest
         EXPECT_EQ(t_id, id);
     }
 
-#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
-    TEST_F(Parallel_Thread, DISABLED_ThreadInvokesMemberFunction_Succeeds)
-#else
     TEST_F(Parallel_Thread, ThreadInvokesMemberFunction_Succeeds)
-#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
     {
         const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
         MfTest x;
@@ -561,11 +517,7 @@ namespace UnitTest
         EXPECT_EQ(1366, x.m_hash);
     }
 
-#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
-    TEST_F(Parallel_Thread, DISABLED_ThreadCanBeMovedAssigned_Succeeds)
-#else
     TEST_F(Parallel_Thread, ThreadCanBeMovedAssigned_Succeeds)
-#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
     {
         const thread_desc desc1 = m_numThreadDesc ? m_desc[0] : thread_desc{};
         AZStd::thread::id the_id;
@@ -576,11 +528,7 @@ namespace UnitTest
         EXPECT_EQ(x_id, the_id);
     }
 
-#if AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
-    TEST_F(Parallel_Thread, DISABLED_ThreadMoveConstructorIsInvokedOnReturn_Succeeds)
-#else
     TEST_F(Parallel_Thread, ThreadMoveConstructorIsInvokedOnReturn_Succeeds)
-#endif // AZ_TRAIT_DISABLE_ASSET_JOB_PARALLEL_TESTS
     {
         AZStd::thread::id the_id;
         AZStd::thread x;


### PR DESCRIPTION
The failure was due to 2 entries for the`Parallel_Thread.DISABLED_ThreadCreation_Succeeds` test.

Instead of keeping the test disabled on Mac, the test have been enabled and validated that they run successfully


## How was this PR tested?

Verified that all the `Parallel_Thread*` test build and pass on Mac
```bash
a483e72e0e72:o3de lumberyard-employee-dm$ build/mac_xcode/bin/profile/AzTestRunner libAzCore.Tests AzRunUnitTests --gtest_filter=Parallel_Thread*
cwd = /Users/Shared/Developer/o3de/o3de
LIB: libAzCore.Tests
Loading: libAzCore.Tests
OKAY Library loaded: libAzCore.Tests
OKAY Symbol found: AzRunUnitTests
Note: Google Test filter = Parallel_Thread*
[==========] Running 14 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 14 tests from Parallel_Thread
[ RUN      ] Parallel_Thread.ThreadSanityTest
[       OK ] Parallel_Thread.ThreadSanityTest (105 ms)
[ RUN      ] Parallel_Thread.ThreadCreation_Succeeds
[       OK ] Parallel_Thread.ThreadCreation_Succeeds (0 ms)
[ RUN      ] Parallel_Thread.ThreadCreationThroughRefWrapper_Succeeds
[       OK ] Parallel_Thread.ThreadCreationThroughRefWrapper_Succeeds (0 ms)
[ RUN      ] Parallel_Thread.ThreadIdIsComparable_Succeeds
[       OK ] Parallel_Thread.ThreadIdIsComparable_Succeeds (1 ms)
[ RUN      ] Parallel_Thread.TestSwapThread_Succeeds
[       OK ] Parallel_Thread.TestSwapThread_Succeeds (0 ms)
[ RUN      ] Parallel_Thread.ThreadIdIsDefaultConstructForThread_Succeeds
[       OK ] Parallel_Thread.ThreadIdIsDefaultConstructForThread_Succeeds (0 ms)
[ RUN      ] Parallel_Thread.ThreadIdForCurrentThread_IsNottDefaultConstructed_Succeeds
[       OK ] Parallel_Thread.ThreadIdForCurrentThread_IsNottDefaultConstructed_Succeeds (0 ms)
[ RUN      ] Parallel_Thread.DifferentThreadsHaveDifferentThreadIds_Succeeds
[       OK ] Parallel_Thread.DifferentThreadsHaveDifferentThreadIds_Succeeds (0 ms)
[ RUN      ] Parallel_Thread.ThreadIdsAreTotallyOrdered_Succeeds
[       OK ] Parallel_Thread.ThreadIdsAreTotallyOrdered_Succeeds (1 ms)
[ RUN      ] Parallel_Thread.ThreadIdOfCurrentThreadReturnedByThisThreadId_Succeeds
[       OK ] Parallel_Thread.ThreadIdOfCurrentThreadReturnedByThisThreadId_Succeeds (0 ms)
[ RUN      ] Parallel_Thread.ThreadInvokesMemberFunction_Succeeds
[       OK ] Parallel_Thread.ThreadInvokesMemberFunction_Succeeds (2 ms)
[ RUN      ] Parallel_Thread.ThreadCanBeMovedAssigned_Succeeds
[       OK ] Parallel_Thread.ThreadCanBeMovedAssigned_Succeeds (0 ms)
[ RUN      ] Parallel_Thread.ThreadMoveConstructorIsInvokedOnReturn_Succeeds
[       OK ] Parallel_Thread.ThreadMoveConstructorIsInvokedOnReturn_Succeeds (0 ms)
[ RUN      ] Parallel_Thread.Hashable
[       OK ] Parallel_Thread.Hashable (6 ms)
[----------] 14 tests from Parallel_Thread (115 ms total)

[----------] Global test environment tear-down
[==========] 14 tests from 1 test case ran. (115 ms total)
[  PASSED  ] 14 tests.
OKAY AzRunUnitTests() returned 0
Returning code: 0
```
