### PR TITLE
Merging BugFix https://github.com/o3de/o3de/pull/15189

### DIFF
--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -37,6 +37,7 @@ AZ_POP_DISABLE_WARNING
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QDialogButtonBox>
+#include <QUrlQuery>
 
 // AzCore
 #include <AzCore/Casting/numeric_cast.h>
@@ -161,6 +162,11 @@ static const char O3DEEditorClassName[] = "O3DEEditorClass";
 static const char O3DEApplicationName[] = "O3DEApplication";
 
 static AZ::EnvironmentVariable<bool> inEditorBatchMode = nullptr;
+
+namespace Platform
+{
+    bool OpenUri(const QUrl& uri);
+}
 
 RecentFileList::RecentFileList()
 {
@@ -3748,11 +3754,68 @@ CMainFrame * CCryEditApp::GetMainFrame() const
 }
 
 
+void CCryEditApp::OpenExternalLuaDebugger(AZStd::string_view luaDebuggerUri, AZStd::string_view projectPath, AZStd::string_view enginePath, const char* files)
+{
+    // Put together the whole Url Query String:
+    QUrlQuery query;
+    query.addQueryItem("projectPath", QString::fromUtf8(projectPath.data(), aznumeric_cast<int>(projectPath.size())));
+    if (!enginePath.empty())
+    {
+        query.addQueryItem("enginePath", QString::fromUtf8(enginePath.data(), aznumeric_cast<int>(enginePath.size())));
+    }
+
+    auto ParseFilesList = [&](AZStd::string_view filePath)
+    {
+        bool fullPathFound = false;
+        auto GetFullSourcePath = [&]
+        (AzToolsFramework::AssetSystem::AssetSystemRequest* assetSystemRequests)
+        {
+            AZ::IO::Path assetFullPath;
+            if(assetSystemRequests->GetFullSourcePathFromRelativeProductPath(filePath, assetFullPath.Native()))
+            {
+                fullPathFound = true;
+                query.addQueryItem("files[]", QString::fromUtf8(assetFullPath.c_str()));
+            }
+        };
+        AzToolsFramework::AssetSystemRequestBus::Broadcast(AZStd::move(GetFullSourcePath));
+        // If the full source path could be found through the Asset System, then
+        // attempt to resolve the path using the FileIO instance
+        if (!fullPathFound)
+        {
+            AZ::IO::FixedMaxPath resolvedFilePath;
+            if (auto fileIo = AZ::IO::FileIOBase::GetInstance();
+                fileIo != nullptr && fileIo->ResolvePath(resolvedFilePath, filePath)
+                && fileIo->Exists(resolvedFilePath.c_str()))
+            {
+                query.addQueryItem("files[]", QString::fromUtf8(resolvedFilePath.c_str()));
+            }
+        }
+    };
+    AZ::StringFunc::TokenizeVisitor(files, ParseFilesList, "|");
+
+    QUrl luaDebuggerUrl(QString::fromUtf8(luaDebuggerUri.data(), aznumeric_cast<int>(luaDebuggerUri.size())));
+    luaDebuggerUrl.setQuery(query);
+
+    AZ_VerifyError("CCryEditApp", Platform::OpenUri(luaDebuggerUrl),
+        "Failed to start external lua debugger with URI: %s", luaDebuggerUrl.toString().toUtf8().constData());
+
+}
+
 void CCryEditApp::OpenLUAEditor(const char* files)
 {
     AZ::IO::FixedMaxPathString enginePath = AZ::Utils::GetEnginePath();
-
     AZ::IO::FixedMaxPathString projectPath = AZ::Utils::GetProjectPath();
+
+    auto registry = AZ::SettingsRegistry::Get();
+    if (registry)
+    {
+        AZStd::string luaDebuggerUri;
+        if (registry->Get(luaDebuggerUri, LuaDebuggerUriRegistryKey))
+        {
+            OpenExternalLuaDebugger(luaDebuggerUri, projectPath, enginePath, files);
+            return;
+        }
+    }
 
     AZStd::string filename = "LuaIDE";
     AZ::IO::FixedMaxPath executablePath = AZ::Utils::GetExecutableDirectory();

--- a/Code/Editor/CryEdit.h
+++ b/Code/Editor/CryEdit.h
@@ -344,6 +344,20 @@ AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 private:
     static inline constexpr const char* DefaultLevelTemplateName = "Prefabs/Default_Level.prefab";
 
+    // Optional Uri to start an external lua debugger. If not specified,
+    // then the Editor will open LuaIDE.exe.
+    // For example, if using The Visual Studio Debugger Extension provided by lumbermixalot
+    // The value will be: "vscode://lumbermixalot.o3de-lua-debug/debug?"
+    // The following parameters will be added to the URI at runtime:
+    // "projectPath". Absolute path of the game projec root.
+    // "enginePath". Absolute path of the engine root. if not specified, it will be assume to be one directory above the game project root.
+    // "files[]". A list of files, 
+    // Full example using the Uri shown below:
+    // "vscode://lumbermixalot.o3de-lua-debug/debug?projectPath=D:\mydir\myproject&enginePath=C:\GIT\o3de&files[]=D:\mydir\myproject\scripts\something.lua&files[]=D:\mydir\myproject\scripts\utils\something2.lua"
+    // or
+    // "vscode://lumbermixalot.o3de-lua-debug/debug?projectPath=D:\GIT\o3de\AutomatedTesting&files[]=D:\GIT\o3de\AutomatedTesting\Assets\Scripts\something.lua"
+    static constexpr AZStd::string_view LuaDebuggerUriRegistryKey = "/O3DE/Lua/Debugger/Uri";
+
     struct PythonOutputHandler;
     AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     AZStd::shared_ptr<PythonOutputHandler> m_pythonOutputHandler;
@@ -374,6 +388,9 @@ private:
     void OnOpenAudioControlsEditor();
     void OnOpenUICanvasEditor();
     void OnOpenQuickAccessBar();
+
+    // @param files: A list of file paths, separated by '|';
+    void OpenExternalLuaDebugger(AZStd::string_view luaDebuggerUri, AZStd::string_view enginePath, AZStd::string_view projectPath, const char * files);
 
 public:
     void ExportLevel(bool bExportToGame, bool bExportTexture, bool bAutoExport);

--- a/Code/Editor/Util/FileUtil.cpp
+++ b/Code/Editor/Util/FileUtil.cpp
@@ -55,7 +55,9 @@
 namespace Platform
 {
     // Forward declare platform specific functions
-    bool RunEditorWithArg(const QString editor, const QString arg);
+    bool RunCommandWithArguments(const QString& command, const QStringList& argsList);
+    bool RunEditorWithArg(const QString& editor, const QString& arg);
+    bool OpenUri(const QUrl& uri);
     QString GetDefaultEditor(const Common::EditFileType fileType);
     QString MakePlatformFileEditString(QString pathToEdit, int lineToEdit);
     bool CreatePath(const QString& strPath);

--- a/Code/Editor/Util/Platform/Linux/FileUtil_Linux.cpp
+++ b/Code/Editor/Util/Platform/Linux/FileUtil_Linux.cpp
@@ -16,9 +16,19 @@
 
 namespace Platform
 {
-    bool RunEditorWithArg(const QString editor, const QString arg)
+    bool RunCommandWithArguments(const QString& command, const QStringList& argsList)
     {
-        return QProcess::startDetached(gSettings.textureEditor, { editor });
+        return QProcess::startDetached(command, argsList);
+    }
+
+    bool RunEditorWithArg(const QString& editor, const QString& arg)
+    {
+        return RunCommandWithArguments(gSettings.textureEditor, { editor });
+    }
+
+    bool OpenUri(const QUrl& uri)
+    {
+        return RunCommandWithArguments("xdg-open", { uri.toString() });
     }
 
     QString GetDefaultEditor(const Common::EditFileType fileType)

--- a/Code/Editor/Util/Platform/Mac/FileUtil_Mac.cpp
+++ b/Code/Editor/Util/Platform/Mac/FileUtil_Mac.cpp
@@ -16,9 +16,19 @@
 
 namespace Platform
 {
+    bool RunCommandWithArguments(const QString& command, const QStringList& argsList)
+    {
+        return QProcess::startDetached(command, argsList);
+    }
+
     bool RunEditorWithArg(const QString editor, const QString arg)
     {
-        return QProcess::execute(QString("/usr/bin/open"), { "-a", gSettings.textureEditor, editor }) == 0;
+        return RunCommandWithArguments(QString("/usr/bin/open"), { "-a", gSettings.textureEditor, editor });
+    }
+
+    bool OpenUri(const QUrl& uri)
+    {
+        return RunCommandWithArguments(QString("/usr/bin/open"), { uri.toString() });
     }
 
     QString GetDefaultEditor(const Common::EditFileType fileType)

--- a/Code/Editor/Util/Platform/Windows/FileUtil_Windows.cpp
+++ b/Code/Editor/Util/Platform/Windows/FileUtil_Windows.cpp
@@ -14,20 +14,36 @@
 
 namespace Platform
 {
-    bool RunEditorWithArg(const QString editor, const QString arg)
+    bool RunCommandWithArguments(const QString& command, const QStringList& argsList)
     {
         bool success = false;
+        QString args;
+        if (!argsList.isEmpty())
+        {
+            args = argsList.join(" ");
+        }
 
-        // Use the Win32API calls as they aren't limited to running items in the path.
-        QString fullTexturePathFixedForWindows = QString(arg.data()).replace('/', '\\');
+        HINSTANCE hInst = ShellExecuteW( nullptr,
+            L"open",
+            command.toStdWString().c_str(),
+            args.isEmpty() ? NULL : args.toStdWString().c_str(),
+            NULL, SW_SHOWNORMAL);
 
-        HINSTANCE hInst = ShellExecuteW(
-            nullptr, L"open", editor.toStdWString().c_str(), fullTexturePathFixedForWindows.toStdWString().c_str(), NULL,
-            SW_SHOWNORMAL);
-        
         success = ((DWORD_PTR)hInst > 32);
 
         return success;
+    }
+
+    bool OpenUri(const QUrl& uri)
+    {
+        return RunCommandWithArguments(uri.toString(), {});
+    }
+
+    bool RunEditorWithArg(const QString& editor, const QString& arg)
+    {
+        // Use the Win32API calls as they aren't limited to running items in the path.
+        QString fullTexturePathFixedForWindows = QString(arg.data()).replace('/', '\\');
+        return RunCommandWithArguments(editor, { fullTexturePathFixedForWindows });
     }
 
     QString GetDefaultEditor(const Common::EditFileType fileType)
@@ -114,4 +130,5 @@ namespace Platform
     {
         return "LuaCompiler.exe";
     }
+
 }

--- a/Code/Framework/AzCore/AzCore/Script/ScriptContextDebug.cpp
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptContextDebug.cpp
@@ -823,7 +823,11 @@ ScriptContextDebug::StepOut()
         }
         else
         {
-            m_stepStackLevel = 0;
+            // -1 forces to exit the current function at the top of the callstack.
+            // This is important, because if set to 0, StepOut would behave like a
+            // StepOver event and that's not the right user experience when using
+            // debuggers.
+            m_stepStackLevel = -1; 
         }
     }
     else

--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/AzFramework_Traits_Linux.h
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/AzFramework_Traits_Linux.h
@@ -15,3 +15,8 @@
 #define AZ_TRAIT_AZFRAMEWORK_PYTHON_SHELL "python.sh"
 #define AZ_TRAIT_AZFRAMEWORK_USE_PROJECT_MANAGER 1
 #define AZ_TRAIT_AZFRAMEWORK_PROCESSLAUNCH_DEFAULT 0
+
+// Very important to enable this trait on Linux, otherwise
+// the whole OS gets stuck with an invisible mouse
+// cursor when debugging Lua code.
+#define AZ_TRAIT_AZFRAMEWORK_SHOW_MOUSE_ON_LUA_BREAKPOINT 1

--- a/Code/Framework/AzFramework/Platform/Mac/AzFramework/AzFramework_Traits_Mac.h
+++ b/Code/Framework/AzFramework/Platform/Mac/AzFramework/AzFramework_Traits_Mac.h
@@ -15,3 +15,9 @@
 #define AZ_TRAIT_AZFRAMEWORK_PYTHON_SHELL "python.sh"
 #define AZ_TRAIT_AZFRAMEWORK_USE_PROJECT_MANAGER 1
 #define AZ_TRAIT_AZFRAMEWORK_PROCESSLAUNCH_DEFAULT 0
+
+// Not tested on MacOS, but for now will leave as disabled.
+// On Windows it is left as disabled too, but on Linux it is necessary
+// to enable, otherwise the Mouse Cursor disappears and the whole
+// OS becomes unuable when debugging Lua code.
+#define AZ_TRAIT_AZFRAMEWORK_SHOW_MOUSE_ON_LUA_BREAKPOINT 0

--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/AzFramework_Traits_Windows.h
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/AzFramework_Traits_Windows.h
@@ -15,3 +15,11 @@
 #define AZ_TRAIT_AZFRAMEWORK_PYTHON_SHELL "python.cmd"
 #define AZ_TRAIT_AZFRAMEWORK_USE_PROJECT_MANAGER 1
 #define AZ_TRAIT_AZFRAMEWORK_PROCESSLAUNCH_DEFAULT 0
+
+// On Linux is necessary, on Windows is not necessary to display
+// the mouse when Lua hits a breakpoint. On Windows, for the most part
+// it is harmless, but there's an annoying effect if enabling
+// this trait because it causes the mouse pointer to reposition
+// itself close to the client area of the render viewport.
+// To avoid this minor annoyance we set this to 0 on windows.
+#define AZ_TRAIT_AZFRAMEWORK_SHOW_MOUSE_ON_LUA_BREAKPOINT 0 


### PR DESCRIPTION
This is the final PR to merge https://github.com/o3de/o3de/pull/15189
into stabilization/2305, which fixes a critical bug that was not allowing to debug Lua scripts on Linux.

Fixes two bugs that occur when debugging Lua scripts. The bug occur with both LuaIDE and VSCode Dbg extension. In other words these two bugs occur regardless of the type of debugger that the Editor.exe is connected to.

The first bug is minor and occurs on all platforms and it is related with the StepOut event when
debugging (Both, with LuaIDE and VSCode Debugger extension). When at the top of the callstack, in ScriptContextDebug.cpp set `m_stepStackLevel = -1;` instead of 0 for properly exiting the current function.
Without this minor fix, the StepOut behaved just like StepOver.

The second bug was major and it impacted user experience on Linux. In ScriptRemoteDebugging.cpp, when hitting a breakpoint,
 the code enters into a loop that blocks the main thread,
 only allowing to process network events. This works fine on Windows,
 but on Linux the mouse pointer doesn't show up when the user ALT+TAB out of the Editor window.

The Fix was to make the mouse cursor visible again before entering the while loop and it fixes all the Linux  problems, and it doesn't hurt Windows either. After exiting the while loop the mouse is made invisible again which is the expectation of Game Mode.

Added AZ_TRAIT_AZFRAMEWORK_SHOW_MOUSE_ON_LUA_BREAKPOINT so each host platform can choose whether to hide & show the mouse cursor when hitting a Lua breakpoint. For now, only Linux needs it enabled.

Added support for custom external debuggers like vscode via a user
customizable URI per the registry key:
`/O3DE/Lua/Debugger/Uri

If the above Uri is not specified,
then the Editor will open LuaIDE.exe.

For example, if using The Visual Studio Debugger Extension provided by lumbermixalot The value will be: "vscode://lumbermixalot.o3de-lua-debug/debug?" The following parameters will be added to the URI at runtime, as part of the query:
    - "projectPath". Absolute path of the game projec root.
    - "enginePath". Absolute path of the engine root. if not specified,
                    it will be assume to be one directory above the game project root.
    - "files[]". A list of files.

Full example of a complete Uri Query that the Editor would dispatch to the OS to open two files with a particular vscode debugger: REMARK: The special characters would be properly escaped because the code uses QUrl and QUrlQuery classes for encoding.

Example with two files to open:
`vscode://lumbermixalot.o3de-lua-debug/debug?projectPath=D:\mydir\myproject&enginePath=C:\GIT\o3de&files[]=D:\mydir\myproject\scripts\something.lua&files[]=D:\mydir\myproject\scripts\utils\something2.lua`

Exampled wit only one file to open (most common scenario). `vscode://lumbermixalot.o3de-lua-debug/debug?projectPath=D:\GIT\o3de\AutomatedTesting&files[]=D:\GIT\o3de\AutomatedTesting\Assets\Scripts\something.lua`









