### PR TITLE
Action Manager | Fix shortcut dispatching in the Console Widget

### DIFF
--- a/Code/Editor/Controls/ConsoleSCB.cpp
+++ b/Code/Editor/Controls/ConsoleSCB.cpp
@@ -375,12 +375,6 @@ CConsoleSCB::CConsoleSCB(QWidget* parent)
 
     connect(ui->lineEdit, &ConsoleLineEdit::variableEditorRequested, this, &CConsoleSCB::showVariableEditor);
 
-    if (GetIEditor()->IsInConsolewMode())
-    {
-        // Attach / register edit box
-        //CLogFile::AttachEditBox(m_edit.GetSafeHwnd()); // FIXME
-    }
-
     AzToolsFramework::EditorPreferencesNotificationBus::Handler::BusConnect();
 }
 

--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -203,6 +203,15 @@ void EditorActionsHandler::OnActionContextRegistrationHook()
             EditorIdentifiers::EditorAssetBrowserActionContextIdentifier, contextProperties);
     }
 
+    // Editor Console
+    {
+        AzToolsFramework::ActionContextProperties contextProperties;
+        contextProperties.m_name = "O3DE Editor - Console";
+
+        m_actionManagerInterface->RegisterActionContext(
+            EditorIdentifiers::EditorConsoleActionContextIdentifier, contextProperties);
+    }
+
     // Editor Entity Property Editor (Entity Inspector)
     {
         AzToolsFramework::ActionContextProperties contextProperties;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManagerInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManagerInterface.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Interface/Interface.h>
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/RTTI/TypeInfoSimple.h>
 #include <AzCore/RTTI/RTTIMacros.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManagerInternalInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManagerInternalInterface.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Interface/Interface.h>
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/std/string/string.h>
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Interface/Interface.h>
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/RTTI/TypeInfoSimple.h>
 #include <AzCore/RTTI/RTTIMacros.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/HotKey/HotKeyManagerInternalInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/HotKey/HotKeyManagerInternalInterface.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Interface/Interface.h>
 #include <AzCore/RTTI/TypeInfoSimple.h>
 #include <AzCore/RTTI/RTTIMacros.h>
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/MenuManagerInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/MenuManagerInterface.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Interface/Interface.h>
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/RTTI/TypeInfoSimple.h>
 #include <AzCore/RTTI/RTTIMacros.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/MenuManagerInternalInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/MenuManagerInternalInterface.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Interface/Interface.h>
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/RTTI/TypeInfoSimple.h>
 #include <AzCore/RTTI/RTTIMacros.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ToolBar/ToolBarManagerInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ToolBar/ToolBarManagerInterface.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Interface/Interface.h>
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/RTTI/TypeInfoSimple.h>
 #include <AzCore/RTTI/RTTIMacros.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ToolBar/ToolBarManagerInternalInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ToolBar/ToolBarManagerInternalInterface.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Interface/Interface.h>
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/RTTI/TypeInfoSimple.h>
 #include <AzCore/RTTI/RTTIMacros.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/ActionManagerIdentifiers/EditorContextIdentifiers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/ActionManagerIdentifiers/EditorContextIdentifiers.h
@@ -17,5 +17,6 @@ namespace EditorIdentifiers
 
     // Main Window Widgets
     inline constexpr AZStd::string_view EditorAssetBrowserActionContextIdentifier = "o3de.context.editor.assetbrowser";
+    inline constexpr AZStd::string_view EditorConsoleActionContextIdentifier = "o3de.context.editor.console";
     inline constexpr AZStd::string_view EditorEntityPropertyEditorActionContextIdentifier = "o3de.context.editor.entitypropertyeditor";
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ConsoleTextEdit.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ConsoleTextEdit.cpp
@@ -7,7 +7,10 @@
  */
 
 #include <AzCore/Debug/Trace.h>
+#include <AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h>
+#include <AzToolsFramework/Editor/ActionManagerIdentifiers/EditorContextIdentifiers.h>
 #include <AzToolsFramework/UI/UICore/ConsoleTextEdit.hxx>
+
 #include <QMenu>
 
 namespace AzToolsFramework
@@ -83,7 +86,21 @@ namespace AzToolsFramework
                     clearAction->setEnabled(false);
                     selectAllAction->setEnabled(false);
                 }
-            });
+            }
+        );
+
+        if (auto hotKeyManagerInterface = AZ::Interface<HotKeyManagerInterface>::Get())
+        {
+            hotKeyManagerInterface->AssignWidgetToActionContext(EditorIdentifiers::EditorConsoleActionContextIdentifier, this);
+        }
+    }
+
+    ConsoleTextEdit::~ConsoleTextEdit()
+    {
+        if (auto hotKeyManagerInterface = AZ::Interface<HotKeyManagerInterface>::Get())
+        {
+            hotKeyManagerInterface->RemoveWidgetFromActionContext(EditorIdentifiers::EditorConsoleActionContextIdentifier, this);
+        }
     }
 
     bool ConsoleTextEdit::searchEnabled()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ConsoleTextEdit.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ConsoleTextEdit.hxx
@@ -15,8 +15,6 @@
 
 #endif
 
-#include <AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h>
-
 class QMenu;
 
 namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ConsoleTextEdit.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ConsoleTextEdit.hxx
@@ -15,6 +15,8 @@
 
 #endif
 
+#include <AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h>
+
 class QMenu;
 
 namespace AzToolsFramework
@@ -25,6 +27,8 @@ namespace AzToolsFramework
         Q_PROPERTY(bool searchEnabled READ searchEnabled WRITE setSearchEnabled)
     public:
         explicit ConsoleTextEdit(QWidget* parent = nullptr);
+        ~ConsoleTextEdit();
+
         virtual bool event(QEvent* theEvent) override;
 
         bool searchEnabled();


### PR DESCRIPTION
## What does this PR do?
Fixes the shortcut dispatching for the Console widget in the Editor.
For example, pressing Ctrl+A while focusing on the Console in the current editor leads to all entities being selected instead.
![ConsoleActionsBefore](https://user-images.githubusercontent.com/82231674/227226622-81ed0e9a-8cbc-4f4b-b426-ad68a00d25f1.gif)

After this fix, the test is selected as expected again.
![ConsoleActions](https://user-images.githubusercontent.com/82231674/227225818-9eeab6e1-6075-4051-b434-050cf595170e.gif)

The same applies to all other shortcuts in the Console's context menu.
![image](https://user-images.githubusercontent.com/82231674/227226703-a1216c2a-e4f0-43a1-a90e-eeeb2c65d130.png)

## How was this PR tested?
Manual testing.
