### PR TITLE
EMFX: Fix crash caused by non-loading MotionSets

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/Importer/Importer.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Importer/Importer.cpp
@@ -544,9 +544,12 @@ namespace EMotionFX
         }
 
         EMotionFX::MotionSet* motionSet = EMotionFX::MotionSet::LoadFromBuffer(memoryStart, lengthInBytes, context);
-        if (settings)
+        if (motionSet)
         {
-            motionSet->SetIsOwnedByRuntime(settings->m_isOwnedByRuntime);
+	    if (settings)
+            {
+                motionSet->SetIsOwnedByRuntime(settings->m_isOwnedByRuntime);
+            }
         }
         return motionSet;
     }

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Importer/Importer.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Importer/Importer.cpp
@@ -546,7 +546,7 @@ namespace EMotionFX
         EMotionFX::MotionSet* motionSet = EMotionFX::MotionSet::LoadFromBuffer(memoryStart, lengthInBytes, context);
         if (motionSet)
         {
-	    if (settings)
+            if (settings)
             {
                 motionSet->SetIsOwnedByRuntime(settings->m_isOwnedByRuntime);
             }


### PR DESCRIPTION
## What does this PR do?
Fix crash seen on Linux when EMFX data cannot be loaded

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  EMotionFX::MotionSet::SetIsOwnedByRuntime (this=0x0, isOwnedByRuntime=true) at /data/workspace/o3de/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.cpp:604
b#1  0x00007f05e715cd1a in EMotionFX::Importer::LoadMotionSet (this=<optimized out>, memoryStart=<optimized out>, lengthInBytes=130, settings=0x7f0532d765c8)
    at /data/workspace/o3de/Gems/EMotionFX/Code/EMotionFX/Source/Importer/Importer.cpp:549
#2  0x00007f05e74bd77a in EMotionFX::Integration::MotionSetAssetHandler::OnInitAsset (this=<optimized out>, asset=...)
    at /data/workspace/o3de/Gems/EMotionFX/Code/Source/Integration/Assets/MotionSetAsset.cpp:143
#3  0x00007f05e6aecd13 in EMotionFX::Integration::EMotionFXAssetHandler<EMotionFX::Integration::MotionSetAsset>::InitAsset (this=0x55f8bf366cc8, asset=..., 
    loadStageSucceeded=false, isReload=false) at /data/workspace/o3de/Gems/EMotionFX/Code/Source/Integration/Assets/AssetCommon.h:138
#4  0x00007f06bc9c2adf in AZ::Data::AssetManager::PostLoad (this=<optimized out>, asset=..., loadSucceeded=true, isReload=false, assetHandler=0x55f8bf366cc8)
    at /data/workspace/o3de/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp:2322
```

## How was this PR tested?

* Built MPS, ran in Editor, crashed
* Made this change, ran again, no longer crashing

Need to investigate further why MotionSets cannot be loaded.
