### PR TITLE
Add Splash Screen Render Pass to Seed List

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/seedList.seed
+++ b/Gems/Atom/Feature/Common/Assets/seedList.seed
@@ -280,6 +280,14 @@
 			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			<Class name="AZStd::string" field="pathHint" value="models/diffuseprobesphere.azmodel" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{CE88A231-2B78-5107-9B6C-0A2051276E2C}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="1" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="passes/splashscreenpassrequest.azasset" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
 	</Class>
 </ObjectStream>
 


### PR DESCRIPTION
Adding splash screen render pass to seedlist. This is required because the shader pass is referenced in code (not a dependency of any other seed asset) and injected into the render pipeline

Stops a crash from occurring in _Gems\Atom\Feature\Common\Code\Source\SplashScreen\SplashScreenFeatureProcessor.cpp_

`AddPassRequestToRenderPipeline(renderPipeline, "Passes/SplashScreenPassRequest.azasset", "CopyToSwapChain", true);
`


## How was this PR tested?
Generated engine_pc.pak and see that PAK build no longer crashes
_.\MultiplayerSample.GameLauncher.exe -bg_ConnectToAssetProcessor=0 -sys_PakPriority=2_