### PR TITLE
Scroll to the selected index when changing the selection in the Viewport Camera Selector

### DIFF
--- a/Gems/Camera/Code/Source/ViewportCameraSelectorWindow.cpp
+++ b/Gems/Camera/Code/Source/ViewportCameraSelectorWindow.cpp
@@ -227,6 +227,12 @@ namespace Camera
         {
             if (current.row() != previous.row())
             {
+                // Make sure the selected item is always visible (e.g. when using the arrow keys to change selection)
+                if (current.isValid())
+                {
+                    scrollTo(current);
+                }
+
                 QScopedValueRollback<bool> rb(m_ignoreViewportViewEntityChanged, true);
 
                 const AZ::EntityId entityId = selectionModel()->currentIndex().data(Qt::CameraIdRole).value<AZ::EntityId>();


### PR DESCRIPTION
## What does this PR do?

Fixes #14925 

The Viewport Camera Selector has logic to change the selection in the list view with the arrow keys, but wasn't ensuring the selection was visible. This change will ensure the selection remains visible by scrolling to the currently selected index, if it isn't already visible in the list view.

![ViewportCameraSelectorScrollToSelected](https://user-images.githubusercontent.com/7519264/227288070-2931bb35-84f6-4b34-a8d5-b60e4631ac04.gif)

## How was this PR tested?

Created many camera entities and resized the Viewport Camera Selector widget so that only a few of them were visible. Then used the arrow keys to change the selection and verified the list will scroll to the new selection if it is hidden. Also testing wrapping around the front/end of the list.