### PR TITLE
Fix movement issues when client input id wraps around.

### DIFF
--- a/Gems/Multiplayer/Code/Tests/ClientHierarchyTests.cpp
+++ b/Gems/Multiplayer/Code/Tests/ClientHierarchyTests.cpp
@@ -461,7 +461,8 @@ namespace Multiplayer
         {
             NetEntityIdSet inputProcessedEntities;
             size_t processInputCallCounter = 0;
-            auto processInputCallback = [&inputProcessedEntities, &processInputCallCounter](NetEntityId netEntityId)
+            auto processInputCallback = [&inputProcessedEntities, &processInputCallCounter](
+                NetEntityId netEntityId, [[maybe_unused]] Multiplayer::NetworkInput& input, [[maybe_unused]] float deltaTime)
             {
                 inputProcessedEntities.insert(netEntityId);
                 processInputCallCounter++;

--- a/Gems/Multiplayer/Code/Tests/TestMultiplayerComponent.cpp
+++ b/Gems/Multiplayer/Code/Tests/TestMultiplayerComponent.cpp
@@ -64,20 +64,32 @@ namespace MultiplayerTest
 
     void TestMultiplayerComponentController::CreateInput(Multiplayer::NetworkInput& input, [[maybe_unused]] float deltaTime)
     {
-        auto* networkInput = input.FindComponentInput<TestMultiplayerComponentNetworkInput>();
-        networkInput->m_ownerId = GetParent().GetId();
+        if (auto* networkInput = input.FindComponentInput<TestMultiplayerComponentNetworkInput>(); networkInput)
+        {
+            networkInput->m_ownerId = GetParent().GetId();
+        }
+        
+        if (const auto& component = GetParent(); component.m_createInputCallback)
+        {
+            component.m_createInputCallback(GetNetEntityId(), input, deltaTime);
+        }
     }
 
     void TestMultiplayerComponentController::ProcessInput(Multiplayer::NetworkInput& input, [[maybe_unused]] float deltaTime)
     {
         const auto& component = GetParent();
-        [[maybe_unused]] const auto* networkInput = input.FindComponentInput<TestMultiplayerComponentNetworkInput>();
-        AZ_Assert(networkInput->m_ownerId == component.GetId(), "Input Id doesn't match the owner component Id on entity %llu",
-            aznumeric_cast<AZ::u64>(GetEntityId()));
+
+        if (const auto* networkInput = input.FindComponentInput<TestMultiplayerComponentNetworkInput>(); networkInput)
+        {
+            AZ_Assert(
+                networkInput->m_ownerId == component.GetId(),
+                "Input Id doesn't match the owner component Id on entity %llu",
+                aznumeric_cast<AZ::u64>(GetEntityId()));
+        }
 
         if (component.m_processInputCallback)
         {
-            component.m_processInputCallback(GetNetEntityId());
+            component.m_processInputCallback(GetNetEntityId(), input, deltaTime);
         }
     }
 }

--- a/Gems/Multiplayer/Code/Tests/TestMultiplayerComponent.h
+++ b/Gems/Multiplayer/Code/Tests/TestMultiplayerComponent.h
@@ -41,7 +41,8 @@ namespace MultiplayerTest
         void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
         void OnNetworkActivated() override;
 
-        AZStd::function<void(Multiplayer::NetEntityId)> m_processInputCallback;
+        AZStd::function<void(Multiplayer::NetEntityId, Multiplayer::NetworkInput& input, float deltaTime)> m_createInputCallback;
+        AZStd::function<void(Multiplayer::NetEntityId, Multiplayer::NetworkInput& input, float deltaTime)> m_processInputCallback;
     };
 
     // Multiplayer controller for the test component


### PR DESCRIPTION
## What does this PR do?

The ClientInputId is defined as a uint16 that is incremented every frame. At 60 fps, it takes ~18.2 minutes for this value to wrap around back to 0. However, the LocalPredictionPlayerInputComponent wasn't accounting for wraparound, so it had logic like this:
```
if (clientInputId <= m_lastClientInputId) { return; }
```
Once m_lastClientInputId reached 65535, the clientInputId would always be <= m_lastClientInputId, and no further inputs could get processed. This manifested as a bug in MultiplayerSample where the player could still move around locally and could still see other players moving around, but the server version of their player didn't move and nobody else saw them move. They also couldn't interact with the environment since the server version didn't move.

This changes the logic so that it correctly handles value wraparounds.

While testing, I also noticed that the logic for handling the first input array sent was a little bit fragile. "m_lastClientId" is always initialized to 0, so if the first client id received is 50, it would try to process 50 inputs, which means processing the 8th input 42 times, and then the other 7 inputs once. Now it initializes the m_lastClientId to the oldest ClientInputId in the array.

Note that the existing logic always assumed that the entire array is filled out with valid entries, so I've preserved that assumption. It seems like it _should_ look for invalid entries based on invalid host frame id values or something, but since the SendClientInput is always filling out the whole array, I guess it isn't necessary. It could always be done as a separate cleanup if desired though.

The changes to the test code are just some preliminary changes that will be needed when writing a unit test to test out this new logic. The unit test itself will be submitted in a separate PR once it's finished being written.

## How was this PR tested?

Ran the MultiplayerSample client and server with the m_clientInputId and m_lastCorrectionInputId locally initialized to 65000 instead of 0. Verified that the loss of movement occurred after about 30 seconds when the ID rolled over. Ran the same situation again with this fix and verified that movement continued to work through the rollover.

Ran the Multiplayer unit tests and verified they continued to pass.
