### PR TITLE
Prefab Overrides: Fix invalid string data in DPE reflection adapter

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/Attribute.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/Attribute.h
@@ -21,8 +21,8 @@ namespace AZ::Reflection
         using IterationCallback =
             AZStd::function<void(Name group, Name name, const AttributeDataType& attribute)>;
 
-        virtual AttributeDataType Find(Name name) const = 0;
-        virtual AttributeDataType Find(Name group, Name name) const = 0;
+        virtual const AttributeDataType* Find(Name name) const = 0;
+        virtual const AttributeDataType* Find(Name group, Name name) const = 0;
         virtual void ListAttributes(const IterationCallback& callback) const = 0;
     };
 }

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -150,13 +150,14 @@ namespace AZ::DocumentPropertyEditor
 
         AZStd::string_view GetPropertyEditor(const Reflection::IAttributes& attributes)
         {
-            const Dom::Value handler = attributes.Find(Reflection::DescriptorAttributes::Handler);
-            if (handler.IsString())
+            auto handler = attributes.Find(Reflection::DescriptorAttributes::Handler);
+            if (handler && handler->IsString())
             {
-                return handler.GetString();
+                return handler->GetString();
             }
             // Special case defaulting to ComboBox for enum types, as ComboBox isn't a default handler.
-            if (!attributes.Find(Nodes::PropertyEditor::EnumType.GetName()).IsNull())
+            if (auto enumTypeHandler = attributes.Find(Nodes::PropertyEditor::EnumType.GetName());
+                enumTypeHandler && !enumTypeHandler->IsNull())
             {
                 return Nodes::ComboBox::Name;
             }
@@ -166,9 +167,9 @@ namespace AZ::DocumentPropertyEditor
         AZStd::string_view ExtractSerializedPath(const Reflection::IAttributes& attributes)
         {
             if (auto serializedPathAttribute = attributes.Find(Reflection::DescriptorAttributes::SerializedPath);
-                serializedPathAttribute.IsString())
+                serializedPathAttribute && serializedPathAttribute->IsString())
             {
-                return serializedPathAttribute.GetString();
+                return serializedPathAttribute->GetString();
             }
             else
             {
@@ -179,10 +180,10 @@ namespace AZ::DocumentPropertyEditor
         void ExtractAndCreateLabel(const Reflection::IAttributes& attributes)
         {
             if (auto labelAttribute = attributes.Find(Reflection::DescriptorAttributes::Label);
-                labelAttribute.IsString())
+                labelAttribute && labelAttribute->IsString())
             {
                 AZStd::string_view serializedPath = ExtractSerializedPath(attributes);
-                m_adapter->CreateLabel(&m_builder, labelAttribute.GetString(), serializedPath);
+                m_adapter->CreateLabel(&m_builder, labelAttribute->GetString(), serializedPath);
             }
         }
 
@@ -308,9 +309,13 @@ namespace AZ::DocumentPropertyEditor
         template<class T>
         void VisitPrimitive(T& value, const Reflection::IAttributes& attributes)
         {
-            auto visibilityAttribute = attributes.Find(Nodes::PropertyEditor::Visibility.GetName());
-            Nodes::PropertyVisibility visibility =
-                Nodes::PropertyEditor::Visibility.DomToValue(visibilityAttribute).value_or(Nodes::PropertyVisibility::Show);
+            Nodes::PropertyVisibility visibility = Nodes::PropertyVisibility::Show;
+
+            if (auto visibilityAttribute = attributes.Find(Nodes::PropertyEditor::Visibility.GetName()); visibilityAttribute)
+            {
+                visibility = Nodes::PropertyEditor::Visibility.DomToValue(*visibilityAttribute).value_or(Nodes::PropertyVisibility::Show);
+            }
+
             if (visibility == Nodes::PropertyVisibility::Hide || visibility == Nodes::PropertyVisibility::ShowChildrenOnly)
             {
                 return;
@@ -397,18 +402,19 @@ namespace AZ::DocumentPropertyEditor
         {
             auto parentContainerAttribute = attributes.Find(AZ::Reflection::DescriptorAttributes::ParentContainer);
             auto parentContainerInstanceAttribute = attributes.Find(AZ::Reflection::DescriptorAttributes::ParentContainerInstance);
-            if (!parentContainerAttribute.IsNull() && !parentContainerInstanceAttribute.IsNull())
+            if (parentContainerAttribute && !parentContainerAttribute->IsNull() &&
+                parentContainerInstanceAttribute && !parentContainerInstanceAttribute->IsNull())
             {
-                auto parentContainer = AZ::Dom::Utils::ValueToTypeUnsafe<AZ::SerializeContext::IDataContainer*>(parentContainerAttribute);
-                auto parentContainerInstance = AZ::Dom::Utils::ValueToTypeUnsafe<void*>(parentContainerInstanceAttribute);
+                auto parentContainer = AZ::Dom::Utils::ValueToTypeUnsafe<AZ::SerializeContext::IDataContainer*>(*parentContainerAttribute);
+                auto parentContainerInstance = AZ::Dom::Utils::ValueToTypeUnsafe<void*>(*parentContainerInstanceAttribute);
 
                 // check if this element is actually standing in for a direct child of a container. This is used in scenarios like
                 // maps, where the direct children are actually pairs of key/value, but we need to only show the value as an editable item
                 // who pretends that they can be removed directly from the container
                 auto containerElementOverrideAttribute = attributes.Find(AZ::Reflection::DescriptorAttributes::ContainerElementOverride);
-                if (!containerElementOverrideAttribute.IsNull())
+                if (containerElementOverrideAttribute && !containerElementOverrideAttribute->IsNull())
                 {
-                    instance = AZ::Dom::Utils::ValueToTypeUnsafe<void*>(containerElementOverrideAttribute);
+                    instance = AZ::Dom::Utils::ValueToTypeUnsafe<void*>(*containerElementOverrideAttribute);
                 }
 
                 m_containers.SetValue(m_builder.GetCurrentPath(), BoundContainer{ parentContainer, parentContainerInstance, instance });
@@ -420,8 +426,14 @@ namespace AZ::DocumentPropertyEditor
                     m_builder.Attribute(Nodes::PropertyEditor::UseMinimumWidth, true);
                     m_builder.Attribute(Nodes::PropertyEditor::Alignment, Nodes::PropertyEditor::Align::AlignRight);
                     m_builder.Attribute(Nodes::ContainerActionButton::Action, Nodes::ContainerAction::RemoveElement);
-                    auto ancestorDisabledValue = attributes.Find(Nodes::NodeWithVisiblityControl::AncestorDisabled.GetName());
-                    bool isAncestorDisabledValue = ancestorDisabledValue.IsBool() && ancestorDisabledValue.GetBool();
+
+                    bool isAncestorDisabledValue = false;
+                    if (auto ancestorDisabledValue = attributes.Find(Nodes::NodeWithVisiblityControl::AncestorDisabled.GetName());
+                        ancestorDisabledValue && ancestorDisabledValue->IsBool())
+                    {
+                        isAncestorDisabledValue = ancestorDisabledValue->GetBool();
+                    }
+
                     if (isAncestorDisabledValue)
                     {
                         m_builder.Attribute(Nodes::PropertyEditor::AncestorDisabled, true);
@@ -434,9 +446,13 @@ namespace AZ::DocumentPropertyEditor
 
         void VisitObjectBegin(Reflection::IObjectAccess& access, const Reflection::IAttributes& attributes) override
         {
-            auto visibilityAttribute = attributes.Find(Nodes::PropertyEditor::Visibility.GetName());
-            Nodes::PropertyVisibility visibility =
-                Nodes::PropertyEditor::Visibility.DomToValue(visibilityAttribute).value_or(Nodes::PropertyVisibility::Show);
+            Nodes::PropertyVisibility visibility = Nodes::PropertyVisibility::Show;
+
+            if (auto visibilityAttribute = attributes.Find(Nodes::PropertyEditor::Visibility.GetName()); visibilityAttribute)
+            {
+                visibility = Nodes::PropertyEditor::Visibility.DomToValue(*visibilityAttribute).value_or(Nodes::PropertyVisibility::Show);
+            }
+
             if (visibility == Nodes::PropertyVisibility::Hide || visibility == Nodes::PropertyVisibility::ShowChildrenOnly)
             {
                 return;
@@ -446,10 +462,9 @@ namespace AZ::DocumentPropertyEditor
 
             for (const auto& attribute : Nodes::Row::RowAttributes)
             {
-                auto attributeValue = attributes.Find(attribute->GetName());
-                if (!attributeValue.IsNull())
+                if (auto attributeValue = attributes.Find(attribute->GetName()); attributeValue && !attributeValue->IsNull())
                 {
-                    m_builder.Attribute(attribute->GetName(), attributeValue);
+                    m_builder.Attribute(attribute->GetName(), *attributeValue);
                 }
             }
 
@@ -474,13 +489,13 @@ namespace AZ::DocumentPropertyEditor
             else
             {
                 auto containerAttribute = attributes.Find(Reflection::DescriptorAttributes::Container);
-                if (!containerAttribute.IsNull())
+                if (containerAttribute && !containerAttribute->IsNull())
                 {
-                    auto container = AZ::Dom::Utils::ValueToTypeUnsafe<AZ::SerializeContext::IDataContainer*>(containerAttribute);
+                    auto container = AZ::Dom::Utils::ValueToTypeUnsafe<AZ::SerializeContext::IDataContainer*>(*containerAttribute);
                     m_containers.SetValue(m_builder.GetCurrentPath(), BoundContainer{ container, access.Get() });
 
-                    Reflection::AttributeDataType labelAttribute = attributes.Find(Reflection::DescriptorAttributes::Label);
-                    if (!labelAttribute.IsNull() && labelAttribute.IsString())
+                    auto labelAttribute = attributes.Find(Reflection::DescriptorAttributes::Label);
+                    if (labelAttribute && !labelAttribute->IsNull() && labelAttribute->IsString())
                     {
                         AZStd::string_view serializedPath = ExtractSerializedPath(attributes);
 
@@ -489,22 +504,25 @@ namespace AZ::DocumentPropertyEditor
                         {
                             m_adapter->CreateLabel(
                                 &m_builder,
-                                AZStd::string::format("%s (1 element)", labelAttribute.GetString().data()),
+                                AZStd::string::format("%s (1 element)", labelAttribute->GetString().data()),
                                 serializedPath);
                         }
                         else
                         {
                             m_adapter->CreateLabel(
                                 &m_builder,
-                                AZStd::string::format("%s (%zu elements)", labelAttribute.GetString().data(), containerSize),
+                                AZStd::string::format("%s (%zu elements)", labelAttribute->GetString().data(), containerSize),
                                 serializedPath);
                         }
                     }
 
                     if (!container->IsFixedSize())
                     {
-                        auto disabledValue = attributes.Find(Nodes::NodeWithVisiblityControl::Disabled.GetName());
-                        bool isDisabled = disabledValue.IsBool() && disabledValue.GetBool();
+                        bool isDisabled = false;
+                        if (auto disabledValue = attributes.Find(Nodes::NodeWithVisiblityControl::Disabled.GetName()); disabledValue)
+                        {
+                            isDisabled = disabledValue->IsBool() && disabledValue->GetBool();
+                        }
 
                         m_builder.BeginPropertyEditor<Nodes::ContainerActionButton>();
                         m_builder.Attribute(Nodes::ContainerActionButton::Action, Nodes::ContainerAction::AddElement);
@@ -598,9 +616,13 @@ namespace AZ::DocumentPropertyEditor
 
         void VisitObjectEnd([[maybe_unused]] Reflection::IObjectAccess& access, const Reflection::IAttributes& attributes) override
         {
-            auto visibilityAttribute = attributes.Find(Nodes::PropertyEditor::Visibility.GetName());
-            Nodes::PropertyVisibility visibility =
-                Nodes::PropertyEditor::Visibility.DomToValue(visibilityAttribute).value_or(Nodes::PropertyVisibility::Show);
+            Nodes::PropertyVisibility visibility = Nodes::PropertyVisibility::Show;
+
+            if (auto visibilityAttribute = attributes.Find(Nodes::PropertyEditor::Visibility.GetName()); visibilityAttribute)
+            {
+                visibility = Nodes::PropertyEditor::Visibility.DomToValue(*visibilityAttribute).value_or(Nodes::PropertyVisibility::Show);
+            }
+
             if (visibility == Nodes::PropertyVisibility::Hide || visibility == Nodes::PropertyVisibility::ShowChildrenOnly)
             {
                 return;


### PR DESCRIPTION
## What does this PR do?

Behind flag: `ed_enableDPE` and `EnableInspectorOverrideManagement`

This PR fixes an issue that extracted string data from attribute data would become invalid.

```html
<PropertyEditor Type="PrefabOverrideLabel" Text="Tags (0 elements)" RelativePath="/Components/Component_[123]/�q+�" IsOverridden="false" />
<PropertyEditor Type="PrefabOverrideLabel" Text="Static" RelativePath="/Components/Component_[123]/XЄ9�" IsOverridden="false" />
```

This could fix an issue that _sometimes_ override icon does not show up on the overridden property because the path to query is invalid.

<img height=80 src="https://user-images.githubusercontent.com/11157226/227330867-11c9e3a6-8966-4987-b407-9d638e8d9d59.png">

**Cause:**

In a previous PR https://github.com/o3de/o3de/pull/14970, I added a helper function [ExtractSerializedPath()](https://github.com/o3de/o3de/blob/3311941a9204b1593f9406db614f87641f12e1a5/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp#L166) to extract serialized path from attributes and return it as view. Since [Find()](https://github.com/o3de/o3de/blob/50b62ead332fa1523a8f5c7e763f408ca9b60ce4/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp#L881) returns a 'Dom::Value', not a reference, we're making a local copy of 'Dom::Value' inside this function. Then, it returns the view of the string data which might become invalid.

```cpp
AZStd::string_view ExtractSerializedPath(const Reflection::IAttributes& attributes) {
    if (Dom::Value serializedPathAttribute = attributes.Find(Reflection::DescriptorAttributes::SerializedPath); serializedPathAttribute.IsString())
        return serializedPathAttribute.GetString();
    else
        return {};
}
```

In most cases, it works fine. If the string data is `SharedStringType` (see [GetString()](https://github.com/o3de/o3de/blob/50b62ead332fa1523a8f5c7e763f408ca9b60ce4/Code/Framework/AzCore/AzCore/DOM/DomValue.cpp#L1009-L1009)), the string data is managed in attributes and any new copy of 'Dom::Value' still references the data (e.g. label text). However, if the string data is `ShortStringType` ([AZStd::fixed_string](https://github.com/o3de/o3de/blob/development/Code/Framework/AzCore/AzCore/std/string/fixed_string.h)), there would be a new copy in the function when 'Dom::Value' is returned from `Find()`. That copy would become invalid after the function returns, which happens before we set the attribute for the property node.

**Alternative Solution:**

Alternatively, we can just keep `Find()` returning a value of 'Dom::Value' and remove (and prevent) usage of `ExtractSerializedPath()`, and add comments about the issue. After changing `Find()` to return pointers/references, we need to add more code for nullability check before dereferencing.

## How was this PR tested?

Tested in editor. The paths are valid and icons show up for overridden properties.