### PR TITLE
Fix file handle starvation linux

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicator.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicator.cpp
@@ -45,13 +45,15 @@ namespace AzFramework
     void ProcessCommunicator::ReadIntoProcessOutput(ProcessOutput& processOutput)
     {
         OutputStatus status;
-        char readBuffer[s_readBufferSize];
 
         // read from the process until the handle is no longer valid
         while (true)
         {
             WaitForReadyOutputs(status);
-            ReadFromOutputs(processOutput, status, readBuffer, s_readBufferSize);
+            if (status.shouldReadErrors || status.shouldReadOutput)
+            {
+                ReadFromOutputs(processOutput, status);
+            }
 
             if (!status.outputDeviceReady && !status.errorsDeviceReady)
             {
@@ -60,27 +62,26 @@ namespace AzFramework
         }
     }
 
-    void ProcessCommunicator::ReadFromOutputs(ProcessOutput& processOutput, OutputStatus& status, char* buffer, AZ::u32 bufferSize)
+    void ProcessCommunicator::ReadFromOutputs(ProcessOutput& processOutput, OutputStatus& status)
     {
         AZ::u32 bytesRead = 0;
+        // Send in the size + 1 to leave room for us to write out the 0 in
+        char readBuffer[s_readBufferSize+1];
 
         if (status.shouldReadOutput)
         {
-            // Send in the size - 1 to leave room for us to write out the 0 in
-            // bytesRead position on the next line
-            bytesRead = ReadOutput(buffer, bufferSize - 1);
-            buffer[bytesRead] = 0;
-            processOutput.outputResult.append(buffer, bytesRead);
+            bytesRead = ReadOutput(readBuffer, s_readBufferSize);
+            readBuffer[bytesRead] = 0;
+            processOutput.outputResult.append(readBuffer, bytesRead);
         }
 
         if (status.shouldReadErrors)
         {
-            // Send in the size - 1 to leave room for us to write out the 0 in
-            // bytesRead position on the next line
-            bytesRead = ReadError(buffer, bufferSize - 1);
-            buffer[bytesRead] = 0;
-            processOutput.errorResult.append(buffer, bytesRead);
+            bytesRead = ReadError(readBuffer, s_readBufferSize);
+            readBuffer[bytesRead] = 0;
+            processOutput.errorResult.append(readBuffer, bytesRead);
         }
+
     }
 
     AZ::u32 ProcessCommunicatorForChildProcess::BlockUntilInputAvailable(AZStd::string& readBuffer)

--- a/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicator.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicator.cpp
@@ -141,6 +141,7 @@ namespace AzFramework
         m_stdInWrite->Close();
         m_stdOutRead->Close();
         m_stdErrRead->Close();
+        m_communicatorData.reset();
         m_initialized = false;
     }
 

--- a/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicator.h
+++ b/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicator.h
@@ -85,11 +85,11 @@ namespace AzFramework
     protected:
         AZ_DISABLE_COPY(ProcessCommunicator);
         
-        // Waits for output or error to be ready for reading
-        virtual void WaitForReadyOutputs(OutputStatus& outputStatus) const = 0;
+        // Waits for stdout or stderr to be ready for reading.  Note that its non-const
+        // because it can detect if the outputs break and update them to be "broken".
+        virtual void WaitForReadyOutputs(OutputStatus& outputStatus) = 0;
 
-        void ReadFromOutputs(ProcessOutput& processOutput,
-            OutputStatus& status, char* buffer, AZ::u32 bufferSize);
+        void ReadFromOutputs(ProcessOutput& processOutput, OutputStatus& status);
 
     private:
         static const size_t s_readBufferSize = 16 * 1024;
@@ -193,7 +193,7 @@ namespace AzFramework
 
         //////////////////////////////////////////////////////////////////////////
         // AzFramework::ProcessCommunicator overrides
-        void WaitForReadyOutputs(OutputStatus& outputStatus) const override;
+        void WaitForReadyOutputs(OutputStatus& outputStatus) override;
         //////////////////////////////////////////////////////////////////////////
 
         AZStd::unique_ptr<CommunicatorHandleImpl> m_stdInWrite;

--- a/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicator.h
+++ b/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicator.h
@@ -149,6 +149,15 @@ namespace AzFramework
         virtual bool CreatePipesForProcess(AzFramework::ProcessData* processData) = 0;
     };
 
+    //! Platform-specific class, default does nothing, but you can derive from it
+    //! and supply it in your platform-specific implementation.  
+    class StdInOutProcessCommunicatorData
+    {
+        public:
+            StdInOutProcessCommunicatorData() = default;
+            virtual ~StdInOutProcessCommunicatorData() = default;
+    };
+
     /**
     * Communicator to talk to processes via std::in and std::out
     *
@@ -190,6 +199,10 @@ namespace AzFramework
         AZStd::unique_ptr<CommunicatorHandleImpl> m_stdInWrite;
         AZStd::unique_ptr<CommunicatorHandleImpl> m_stdOutRead;
         AZStd::unique_ptr<CommunicatorHandleImpl> m_stdErrRead;
+
+        //! OPTIONAL - platform-specific classes can plug in additional arbitrary platform
+        //! specific data in here.  or leave it nullptr.
+        AZStd::unique_ptr<StdInOutProcessCommunicatorData> m_communicatorData;
         bool m_initialized = false;
     };
 

--- a/Code/Framework/AzFramework/Platform/Android/AzFramework/Process/ProcessCommunicator_Android.cpp
+++ b/Code/Framework/AzFramework/Platform/Android/AzFramework/Process/ProcessCommunicator_Android.cpp
@@ -31,7 +31,7 @@ namespace AzFramework
         return false;
     }
 
-    void StdInOutProcessCommunicator::WaitForReadyOutputs([[maybe_unused]] OutputStatus& status) const
+    void StdInOutProcessCommunicator::WaitForReadyOutputs([[maybe_unused]] OutputStatus& status)
     {
         status.outputDeviceReady = false;
         status.errorsDeviceReady = false;

--- a/Code/Framework/AzFramework/Platform/Common/Default/AzFramework/Process/ProcessCommunicator_Default.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Default/AzFramework/Process/ProcessCommunicator_Default.cpp
@@ -32,7 +32,7 @@ namespace AzFramework
         return false;
     }
 
-    void StdInOutProcessCommunicator::WaitForReadyOutputs([[maybe_unused]] OutputStatus& status) const
+    void StdInOutProcessCommunicator::WaitForReadyOutputs([[maybe_unused]] OutputStatus& status)
     {
         status.outputDeviceReady = false;
         status.errorsDeviceReady = false;

--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/Process/ProcessCommon.h
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/Process/ProcessCommon.h
@@ -15,16 +15,18 @@ namespace AzFramework
     public:
         ~CommunicatorHandleImpl() = default;
 
-        bool IsValid() const;
-        bool IsBroken() const;
-        int GetHandle() const;
+        [[nodiscard]] bool IsValid() const;
+        [[nodiscard]] bool IsBroken() const;
+        [[nodiscard]] int GetHandle() const;
+        [[nodiscard]] int GetEPollHandle() const;
 
         void Break();
         void Close();
-        void SetHandle(int handle);
+        [[nodiscard]] bool SetHandle(int handle, bool createEPollHandle);
 
     protected:
         int m_handle = -1;
+        int m_epollHandle = -1;
         bool m_broken = false;
     };
 

--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/Process/ProcessCommunicator_Linux.cpp
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/Process/ProcessCommunicator_Linux.cpp
@@ -287,7 +287,7 @@ namespace AzFramework
         return true;
     }
 
-    void StdInOutProcessCommunicator::WaitForReadyOutputs(OutputStatus& status) const
+    void StdInOutProcessCommunicator::WaitForReadyOutputs(OutputStatus& status)
     {
         using namespace ProcessCommunicatorLinuxInternal;
 

--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/Process/ProcessCommunicator_Linux.cpp
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/Process/ProcessCommunicator_Linux.cpp
@@ -21,7 +21,7 @@ namespace ProcessCommunicatorLinuxInternal
 
     class CommunicatorDataImpl : public AzFramework::StdInOutProcessCommunicatorData
     {
-        public:
+    public:
         AZ_CLASS_ALLOCATOR(CommunicatorDataImpl, AZ::SystemAllocator);
         CommunicatorDataImpl() = default;
         virtual ~CommunicatorDataImpl()
@@ -80,7 +80,7 @@ namespace AzFramework
     {
         m_handle = handle;
         // also create an epoll handle
-        if ((handle != -1)&&(createEPollHandle))
+        if ( (handle != -1) && (createEPollHandle) )
         {
             int m_epollHandle = epoll_create1(0);
 

--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/Process/ProcessCommunicator_Linux.cpp
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/Process/ProcessCommunicator_Linux.cpp
@@ -11,7 +11,32 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <sys/ioctl.h>
+#include <sys/epoll.h>
+
 #include <AzFramework/Process/ProcessCommunicator.h>
+#include <AzCore/Memory/SystemAllocator.h>
+
+namespace ProcessCommunicatorLinuxInternal
+{
+
+    class CommunicatorDataImpl : public AzFramework::StdInOutProcessCommunicatorData
+    {
+        public:
+        AZ_CLASS_ALLOCATOR(CommunicatorDataImpl, AZ::SystemAllocator);
+        CommunicatorDataImpl() = default;
+        virtual ~CommunicatorDataImpl()
+        {
+            if (m_stdInAndOutPollHandle != -1)
+            {
+                close(m_stdInAndOutPollHandle);
+            }
+        }
+        int m_stdInAndOutPollHandle = -1;
+        
+        AZ_DISABLE_COPY_MOVE(CommunicatorDataImpl);
+    };
+
+}
 
 namespace AzFramework
 {
@@ -30,6 +55,11 @@ namespace AzFramework
         return m_handle;
     }
 
+    int CommunicatorHandleImpl::GetEPollHandle() const
+    {
+        return m_epollHandle;
+    }
+
     void CommunicatorHandleImpl::Break()
     {
         m_broken = true;
@@ -38,12 +68,40 @@ namespace AzFramework
     void CommunicatorHandleImpl::Close()
     {
         close(m_handle);
+        if (m_epollHandle != -1)
+        {
+            close(m_epollHandle);
+            m_epollHandle = -1;
+        }
         m_handle = -1;
     }
 
-    void CommunicatorHandleImpl::SetHandle(int handle)
+    bool CommunicatorHandleImpl::SetHandle(int handle, bool createEPollHandle)
     {
         m_handle = handle;
+        // also create an epoll handle
+        if ((handle != -1)&&(createEPollHandle))
+        {
+            int m_epollHandle = epoll_create1(0);
+
+            AZ_Assert(m_epollHandle -1, "Failed to create epoll handle");
+            if (m_epollHandle == -1) 
+            {
+                return false;
+            }
+            struct epoll_event event;
+
+            event.events = EPOLLIN;
+            event.data.fd = GetHandle();
+            if(epoll_ctl(m_epollHandle, EPOLL_CTL_ADD, event.data.fd, &event))
+            {
+                AZ_Assert(false, "Unable to add a file descriptor to epoll");
+                close(m_epollHandle);
+                m_epollHandle = -1;
+                return false;
+            }
+        }
+        return true;
     }
 
     AZ::u32 StdInOutCommunication::PeekHandle(StdProcessCommunicatorHandle& handle)
@@ -71,25 +129,15 @@ namespace AzFramework
             return 0;
         }
 
-        //Block if buffersize == 0
+        // Block until data is ready if buffersize == 0
         if (bufferSize == 0)
         {
-            fd_set set;
-            FD_ZERO(&set);
-            FD_SET(handle->GetHandle(), &set);
-
-            [[maybe_unused]] int numReady = select(handle->GetHandle() + 1, &set, nullptr, nullptr, nullptr);
-
-            // if numReady == -1 and errno == EINTR then the child process died unexpectedly and
-            // the handle was closed. Not something to assert about in regards to trying to read
-            // data from the child as there is not anything useful we can say or do in that case.
-            // Normal code/data flow will work and we as the parent will know that the child is
-            // dead and return any error codes the child may have written to the error stream.
-            AZ_Assert(numReady != -1 || errno == EINTR, "Could not determine if any data is available for reading due to an error. Errno: %d", errno);
-
-            [[maybe_unused]] const bool wasSet = FD_ISSET(handle->GetHandle(), &set);
-            AZ_Assert(wasSet, "handle was not set when we selected it for read");
-
+            if (handle->GetEPollHandle() == -1)
+            {
+                return 0;
+            }
+            struct epoll_event event;
+            epoll_wait(handle->GetEPollHandle(), &event, 1, -1);
             return 0;
         }
 
@@ -144,6 +192,7 @@ namespace AzFramework
 
     bool StdInOutProcessCommunicator::CreatePipesForProcess(ProcessData* processData)
     {
+        using namespace ProcessCommunicatorLinuxInternal;
         int pipeFileDescriptors[2] = { 0 };
 
         // Create a pipe to monitor process std in (output from us)
@@ -155,7 +204,14 @@ namespace AzFramework
         }
 
         processData->m_startupInfo.m_inputHandleForChild = pipeFileDescriptors[0];
-        m_stdInWrite->SetHandle(pipeFileDescriptors[1]);
+        // we don't need to create an epoll handle for the child's stdin, since we don't use
+        // epoll for it.
+        if (!m_stdInWrite->SetHandle(pipeFileDescriptors[1], /*create epoll handle*/false))
+        {
+            processData->m_startupInfo.CloseAllHandles();
+            CloseAllHandles();
+            return false;
+        }
 
         // Create a pipe to monitor process std out (input to us)
         result = pipe(pipeFileDescriptors);
@@ -164,12 +220,16 @@ namespace AzFramework
         {
             processData->m_startupInfo.CloseAllHandles();
             CloseAllHandles();
-
             return false;
         }
 
-        m_stdOutRead->SetHandle(pipeFileDescriptors[0]);
         processData->m_startupInfo.m_outputHandleForChild = pipeFileDescriptors[1];
+        if (!m_stdOutRead->SetHandle(pipeFileDescriptors[0], /*create epoll handle*/true))
+        {
+            processData->m_startupInfo.CloseAllHandles();
+            CloseAllHandles();
+            return false;
+        }
 
         // Create a pipe to monitor process std error (input to us)
         result = pipe(pipeFileDescriptors);
@@ -178,12 +238,50 @@ namespace AzFramework
         {
             processData->m_startupInfo.CloseAllHandles();
             CloseAllHandles();
-
             return false;
         }
 
-        m_stdErrRead->SetHandle(pipeFileDescriptors[0]);
         processData->m_startupInfo.m_errorHandleForChild = pipeFileDescriptors[1];
+        if (!m_stdErrRead->SetHandle(pipeFileDescriptors[0], /*create epoll handle*/true))
+        {
+            processData->m_startupInfo.CloseAllHandles();
+            CloseAllHandles();
+            return false;
+        }
+
+        // create an epoll file descriptor for both inputs (stderr and stdout)
+        m_communicatorData.reset(aznew CommunicatorDataImpl());
+        CommunicatorDataImpl* platformImpl = static_cast<CommunicatorDataImpl*>(m_communicatorData.get());
+        platformImpl->m_stdInAndOutPollHandle = epoll_create1(0);
+
+        AZ_Assert(platformImpl->m_stdInAndOutPollHandle != -1, "Failed to create epoll handle to monitor output process");
+        if (platformImpl->m_stdInAndOutPollHandle == -1) 
+        {
+            processData->m_startupInfo.CloseAllHandles();
+            CloseAllHandles();
+            return false;
+        }
+        
+        struct epoll_event event;
+        event.events = EPOLLIN;
+        event.data.fd = m_stdOutRead->GetHandle();
+        if(epoll_ctl(platformImpl->m_stdInAndOutPollHandle, EPOLL_CTL_ADD, event.data.fd, &event))
+        {
+            AZ_Assert(false, "Unable to add a file descriptor for stdOut to epoll");
+            processData->m_startupInfo.CloseAllHandles();
+            CloseAllHandles();
+            return false;
+        }
+
+        event.events = EPOLLIN;
+        event.data.fd = m_stdErrRead->GetHandle();
+        if(epoll_ctl(platformImpl->m_stdInAndOutPollHandle, EPOLL_CTL_ADD, event.data.fd, &event))
+        {
+            AZ_Assert(false, "Unable to add a file descriptor for stdErr to epoll");
+            processData->m_startupInfo.CloseAllHandles();
+            CloseAllHandles();
+            return false;
+        }
 
         m_initialized = true;
         return true;
@@ -191,48 +289,53 @@ namespace AzFramework
 
     void StdInOutProcessCommunicator::WaitForReadyOutputs(OutputStatus& status) const
     {
+        using namespace ProcessCommunicatorLinuxInternal;
+
         status.outputDeviceReady = m_stdOutRead->IsValid() && !m_stdOutRead->IsBroken();
         status.errorsDeviceReady = m_stdErrRead->IsValid() && !m_stdErrRead->IsBroken();
         status.shouldReadOutput = status.shouldReadErrors = false;
 
+        CommunicatorDataImpl* platformImpl = static_cast<CommunicatorDataImpl*>(m_communicatorData.get());
         if (status.outputDeviceReady || status.errorsDeviceReady)
         {
-            fd_set readSet;
-            int maxHandle = 0;
-
-            FD_ZERO(&readSet);
-
-            if (status.outputDeviceReady)
+            struct epoll_event events[2];
+            if (int numberSignalled = epoll_wait(platformImpl->m_stdInAndOutPollHandle, events, 1, -1) > -1)
             {
-                int currentHandle = m_stdOutRead->GetHandle();
-                FD_SET(currentHandle, &readSet);
-                maxHandle = currentHandle > maxHandle ? currentHandle : maxHandle;
-            }
-
-            if (status.errorsDeviceReady)
-            {
-                int currentHandle = m_stdErrRead->GetHandle();
-                FD_SET(currentHandle, &readSet);
-                maxHandle = currentHandle > maxHandle ? currentHandle : maxHandle;
-            }
-
-            if (select(maxHandle + 1, &readSet, nullptr, nullptr, nullptr) != -1)
-            {
-                status.shouldReadOutput = (status.outputDeviceReady && FD_ISSET(m_stdOutRead->GetHandle(), &readSet));
-                status.shouldReadErrors = (status.errorsDeviceReady && FD_ISSET(m_stdErrRead->GetHandle(), &readSet));
+                for (int readEventIndex = 0; readEventIndex < numberSignalled; ++ readEventIndex)
+                {
+                    if (events[readEventIndex].data.fd == m_stdOutRead->GetHandle())
+                    {
+                        status.shouldReadOutput = true;
+                    }
+                    else if (events[readEventIndex].data.fd == m_stdErrRead->GetHandle())
+                    {
+                        status.shouldReadErrors = true;
+                    }
+                }
             }
         }
     }
 
     bool StdInOutProcessCommunicatorForChildProcess::AttachToExistingPipes()
     {
-        m_stdInRead->SetHandle(STDIN_FILENO);
+        m_initialized = false;
+
+        if (!m_stdInRead->SetHandle(STDIN_FILENO,/*create epoll handle*/false))
+        {
+            return false;
+        }
         AZ_Assert(m_stdInRead->IsValid(), "In read handle is invalid");
 
-        m_stdOutWrite->SetHandle(STDOUT_FILENO);
+        if (!m_stdOutWrite->SetHandle(STDOUT_FILENO, /*create epoll handle*/ true))
+        {
+            return false;
+        }
         AZ_Assert(m_stdOutWrite->IsValid(), "Output write handle is invalid");
 
-        m_stdErrWrite->SetHandle(STDERR_FILENO);
+        if (!m_stdErrWrite->SetHandle(STDERR_FILENO, /*create epoll handle*/ true))
+        {
+            return false;
+        }
         AZ_Assert(m_stdErrWrite->IsValid(), "Error write handle is invalid");
 
         m_initialized = m_stdInRead->IsValid() && m_stdOutWrite->IsValid() && m_stdErrWrite->IsValid();

--- a/Code/Framework/AzFramework/Platform/Mac/AzFramework/Process/ProcessCommunicator_Mac.cpp
+++ b/Code/Framework/AzFramework/Platform/Mac/AzFramework/Process/ProcessCommunicator_Mac.cpp
@@ -186,7 +186,7 @@ namespace AzFramework
         return true;
     }
 
-    void StdInOutProcessCommunicator::WaitForReadyOutputs(OutputStatus& status) const
+    void StdInOutProcessCommunicator::WaitForReadyOutputs(OutputStatus& status)
     {
         status.outputDeviceReady = m_stdOutRead->IsValid() && !m_stdOutRead->IsBroken();
         status.errorsDeviceReady = m_stdErrRead->IsValid() && !m_stdErrRead->IsBroken();

--- a/Code/Framework/AzFramework/Platform/iOS/AzFramework/Process/ProcessCommunicator_iOS.cpp
+++ b/Code/Framework/AzFramework/Platform/iOS/AzFramework/Process/ProcessCommunicator_iOS.cpp
@@ -31,7 +31,7 @@ namespace AzFramework
         return false;
     }
 
-    void StdInOutProcessCommunicator::WaitForReadyOutputs([[maybe_unused]] OutputStatus& status) const
+    void StdInOutProcessCommunicator::WaitForReadyOutputs([[maybe_unused]] OutputStatus& status)
     {
         status.outputDeviceReady = false;
         status.errorsDeviceReady = false;

--- a/Code/Framework/AzFramework/Tests/ProcessLaunchMain.cpp
+++ b/Code/Framework/AzFramework/Tests/ProcessLaunchMain.cpp
@@ -56,9 +56,8 @@ int main(int argc, char** argv)
             size_t endLength = strlen(s_endToken);
             auto spamABunchOfLines = [&](FILE *fileDescriptor)
             {
-                int currentBytesOutput = 0;
                 fwrite(s_beginToken, beginLength, 1, fileDescriptor);
-                currentBytesOutput += beginLength;
+                size_t currentBytesOutput = beginLength;
                 while (currentBytesOutput < s_numOutputBytesInPlentyMode - endLength)
                 {
                     fwrite(s_midToken, midLength, 1, fileDescriptor);

--- a/Code/Framework/AzFramework/Tests/ProcessLaunchMain.cpp
+++ b/Code/Framework/AzFramework/Tests/ProcessLaunchMain.cpp
@@ -6,7 +6,7 @@
  *
  */
 #include <iostream>
-
+#include <AzCore/std/utility/charconv.h>
 #include <AzFramework/CommandLine/CommandLine.h>
 
 // this is an intentional relative local include so that it can be shared between two unrelated projects
@@ -43,6 +43,8 @@ int main(int argc, char** argv)
         if (commandLine.GetNumSwitchValues("exitCode") > 0)
         {
             exitCode = atoi(commandLine.GetSwitchValue("exitCode").c_str());
+            const AZStd::string& exitCodeStr = commandLine.GetSwitchValue("exitCode");
+            AZStd::from_chars(exitCodeStr.begin(), exitCodeStr.end(), exitCode);
         }
 
         if (commandLine.HasSwitch("plentyOfOutput"))

--- a/Code/Framework/AzFramework/Tests/ProcessLaunchMain.cpp
+++ b/Code/Framework/AzFramework/Tests/ProcessLaunchMain.cpp
@@ -5,11 +5,13 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#include <iostream>
 
-#include <AzCore/Memory/AllocatorManager.h>
 #include <AzFramework/CommandLine/CommandLine.h>
 
-#include <iostream>
+// this is an intentional relative local include so that it can be shared between two unrelated projects
+// namely this one shot test executable, and the tests which run it in a different project with no relation.
+#include "ProcessLaunchTestTokens.h"
 
 void OutputArgs(const AzFramework::CommandLine& commandLine)
 {
@@ -29,12 +31,55 @@ void OutputArgs(const AzFramework::CommandLine& commandLine)
 
 int main(int argc, char** argv)
 {
+    using namespace ProcessLaunchTestInternal;
+
     const AZ::Debug::Trace tracer;
+    int exitCode = 0;
     {
         AzFramework::CommandLine commandLine;
 
         commandLine.Parse(argc, argv);
-        OutputArgs(commandLine);
+
+        if (commandLine.GetNumSwitchValues("exitCode") > 0)
+        {
+            exitCode = atoi(commandLine.GetSwitchValue("exitCode").c_str());
+        }
+
+        if (commandLine.HasSwitch("plentyOfOutput"))
+        {
+            // special case - plenty of output mode requires that it output an easily recognizable begin
+            // then plentiful output (enough to saturate any buffers) then output a recognizable end.
+            // this makes sure that if there are any buffers that get filled up or overwritten we can detect
+            // deadlock or buffer starvation or buffer overflows.
+            size_t midLength = strlen(s_midToken);
+            size_t beginLength = strlen(s_beginToken);
+            size_t endLength = strlen(s_endToken);
+            auto spamABunchOfLines = [&](FILE *fileDescriptor)
+            {
+                int currentBytesOutput = 0;
+                fwrite(s_beginToken, beginLength, 1, fileDescriptor);
+                currentBytesOutput += beginLength;
+                while (currentBytesOutput < s_numOutputBytesInPlentyMode - endLength)
+                {
+                    fwrite(s_midToken, midLength, 1, fileDescriptor);
+                    currentBytesOutput += midLength;
+                }
+                fwrite(s_endToken, endLength, 1, fileDescriptor);
+            };
+
+            spamABunchOfLines(stdout);
+
+            if (exitCode != 0)
+            {
+                // note that stderr is unbuffered so this will take longer!
+                spamABunchOfLines(stderr);
+            }
+        }
+        else
+        {
+            OutputArgs(commandLine);
+        }
+        
     }
-    return 0;
+    return exitCode;
 }

--- a/Code/Framework/AzFramework/Tests/ProcessLaunchParseTests.cpp
+++ b/Code/Framework/AzFramework/Tests/ProcessLaunchParseTests.cpp
@@ -15,6 +15,9 @@
 #include <AzCore/StringFunc/StringFunc.h>
 #include <AzCore/IO/Path/Path.h>
 
+// this is an intentional relative local include so that it can be shared between two unrelated projects
+// namely this one test file as well as the one shot executable that these tests invoke.
+#include "ProcessLaunchTestTokens.h"
 
 namespace UnitTest
 {
@@ -81,6 +84,58 @@ namespace UnitTest
 
         EXPECT_EQ(launchReturn, true);
         EXPECT_EQ(processOutput.outputResult.empty(), false);
+    }
+
+    TEST_F(ProcessLaunchParseTests, LaunchProcessAndRetrieveOutput_LargeDataNoError_ContainsEntireOutput)
+    {
+        using namespace ProcessLaunchTestInternal;
+
+        AzFramework::ProcessOutput processOutput;
+        AzFramework::ProcessLauncher::ProcessLaunchInfo processLaunchInfo;
+
+        processLaunchInfo.m_commandlineParameters.emplace<AZStd::vector<AZStd::string>>(
+            AZStd::vector<AZStd::string>{(AZ::IO::Path(AZ::Test::GetCurrentExecutablePath()) / "ProcessLaunchTest").Native(), "-plentyOfOutput"});
+
+        processLaunchInfo.m_workingDirectory = AZ::Test::GetCurrentExecutablePath();
+        processLaunchInfo.m_showWindow = false;
+        bool launchReturn = AzFramework::ProcessWatcher::LaunchProcessAndRetrieveOutput(processLaunchInfo, AzFramework::ProcessCommunicationType::COMMUNICATOR_TYPE_STDINOUT, processOutput);
+
+        EXPECT_TRUE(launchReturn);
+        EXPECT_FALSE(processOutput.outputResult.empty());
+        EXPECT_FALSE(processOutput.HasError());
+
+        const auto& output = processOutput.outputResult;
+        EXPECT_EQ(output.length(), s_numOutputBytesInPlentyMode);
+        EXPECT_TRUE(output.starts_with(s_beginToken));
+        EXPECT_TRUE(output.ends_with(s_endToken));
+    }
+    
+    // this also tests that it can separately read error and stdout, and that the stream way of doing it works.
+    TEST_F(ProcessLaunchParseTests, LaunchProcessAndRetrieveOutput_LargeDataWithError_ContainsEntireOutput)
+    {
+        using namespace ProcessLaunchTestInternal;
+
+        AzFramework::ProcessOutput processOutput;
+        AzFramework::ProcessLauncher::ProcessLaunchInfo processLaunchInfo;
+
+        processLaunchInfo.m_commandlineParameters.emplace<AZStd::vector<AZStd::string>>(
+            AZStd::vector<AZStd::string>{(AZ::IO::Path(AZ::Test::GetCurrentExecutablePath()) / "ProcessLaunchTest").Native(), "-plentyOfOutput", "-exitCode", "1"});
+
+        processLaunchInfo.m_workingDirectory = AZ::Test::GetCurrentExecutablePath();
+        processLaunchInfo.m_showWindow = false;
+        bool launchReturn = AzFramework::ProcessWatcher::LaunchProcessAndRetrieveOutput(processLaunchInfo, AzFramework::ProcessCommunicationType::COMMUNICATOR_TYPE_STDINOUT, processOutput);
+
+        EXPECT_TRUE(launchReturn);
+        EXPECT_TRUE(processOutput.HasOutput());
+        EXPECT_TRUE(processOutput.HasError());
+
+        EXPECT_EQ(processOutput.outputResult.length(), s_numOutputBytesInPlentyMode);
+        EXPECT_TRUE(processOutput.outputResult.starts_with(s_beginToken));
+        EXPECT_TRUE(processOutput.outputResult.ends_with(s_endToken));
+
+        EXPECT_EQ(processOutput.errorResult.length(), s_numOutputBytesInPlentyMode);
+        EXPECT_TRUE(processOutput.errorResult.starts_with(s_beginToken));
+        EXPECT_TRUE(processOutput.errorResult.ends_with(s_endToken));
     }
    
     TEST_F(ProcessLaunchParseTests, ProcessLauncher_BasicParameter_Success)

--- a/Code/Framework/AzFramework/Tests/ProcessLaunchTestTokens.h
+++ b/Code/Framework/AzFramework/Tests/ProcessLaunchTestTokens.h
@@ -15,8 +15,8 @@ namespace ProcessLaunchTestInternal
     // the default buffer size for stdout/stdin on some platforms is 4k.  This number
     // should just be higher than a couple multiples of buffer sizes to ensure that it overwhelms
     // any buffer and reveals any deadlock caused by not reading from stdout/stderr when its full.
-    const int s_numOutputBytesInPlentyMode = 16 * 1024 ; 
-    const char* s_beginToken = "BEGIN\n";
-    const char* s_endToken = "END\n";
+    const size_t s_numOutputBytesInPlentyMode = 16 * 1024 ; 
+    const char* s_beginToken = "BEGIN";
+    const char* s_endToken = "END";
     const char* s_midToken = "x";
 }

--- a/Code/Framework/AzFramework/Tests/ProcessLaunchTestTokens.h
+++ b/Code/Framework/AzFramework/Tests/ProcessLaunchTestTokens.h
@@ -15,8 +15,8 @@ namespace ProcessLaunchTestInternal
     // the default buffer size for stdout/stdin on some platforms is 4k.  This number
     // should just be higher than a couple multiples of buffer sizes to ensure that it overwhelms
     // any buffer and reveals any deadlock caused by not reading from stdout/stderr when its full.
-    const size_t s_numOutputBytesInPlentyMode = 16 * 1024 ; 
-    const char* s_beginToken = "BEGIN";
-    const char* s_endToken = "END";
-    const char* s_midToken = "x";
+    constexpr const size_t s_numOutputBytesInPlentyMode = 16 * 1024 ; 
+    constexpr const char* s_beginToken = "BEGIN";
+    constexpr const char* s_endToken = "END";
+    constexpr const char* s_midToken = "x";
 }

--- a/Code/Framework/AzFramework/Tests/ProcessLaunchTestTokens.h
+++ b/Code/Framework/AzFramework/Tests/ProcessLaunchTestTokens.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+// shared between the tests (ProcessLaunchParseTests.cpp) and the simple exe that they use to test
+// themselves (ProcessLaunchMain.cpp).  The targets are unrelated to each other in CMake but still
+// need to include this file in both.
+
+namespace ProcessLaunchTestInternal
+{
+    // the default buffer size for stdout/stdin on some platforms is 4k.  This number
+    // should just be higher than a couple multiples of buffer sizes to ensure that it overwhelms
+    // any buffer and reveals any deadlock caused by not reading from stdout/stderr when its full.
+    const int s_numOutputBytesInPlentyMode = 16 * 1024 ; 
+    const char* s_beginToken = "BEGIN\n";
+    const char* s_endToken = "END\n";
+    const char* s_midToken = "x";
+}

--- a/Code/Framework/AzFramework/Tests/process_launch_test_files.cmake
+++ b/Code/Framework/AzFramework/Tests/process_launch_test_files.cmake
@@ -8,4 +8,5 @@
 
 set(FILES
     ProcessLaunchMain.cpp
+    ProcessLaunchTestTokens.h
 )

--- a/Registry/Platform/Mac/streamer.editor.setreg
+++ b/Registry/Platform/Mac/streamer.editor.setreg
@@ -19,7 +19,7 @@
                             {
                                 "$type": "AzFramework::RemoteStorageDriveConfig",
                                 "$stack_after": "Drive",
-                                "MaxFileHandles": 1024
+                                "MaxFileHandles": 128
                             }
                         }
                     }

--- a/Registry/Platform/Windows/streamer.editor.setreg
+++ b/Registry/Platform/Windows/streamer.editor.setreg
@@ -15,7 +15,7 @@
                             {
                                 "$type": "AZ::IO::WindowsStorageDriveConfig",
                                 "$stack_after": "Drive",
-                                "MaxFileHandles": 1024,
+                                "MaxFileHandles": 128,
                                 "MaxMetaDataCache": 1024,
                                 "Overcommit": 8,
                                 "EnableFileSharing": true,

--- a/Registry/Platform/Windows/streamer.game.debug.setreg
+++ b/Registry/Platform/Windows/streamer.game.debug.setreg
@@ -24,7 +24,7 @@
                             "Drive":
                             {
                                 "$type": "AZ::IO::WindowsStorageDriveConfig",
-                                "MaxFileHandles": 1024,
+                                "MaxFileHandles": 128,
                                 "MaxMetaDataCache": 1024,
                                 "Overcommit": 8,
                                 "EnableFileSharing": true,

--- a/Registry/Platform/Windows/streamer.game.profile.setreg
+++ b/Registry/Platform/Windows/streamer.game.profile.setreg
@@ -24,7 +24,7 @@
                             "Drive":
                             {
                                 "$type": "AZ::IO::WindowsStorageDriveConfig",
-                                "MaxFileHandles": 1024,
+                                "MaxFileHandles": 128,
                                 "MaxMetaDataCache": 1024,
                                 "Overcommit": 8,
                                 "EnableFileSharing": true,

--- a/Registry/Platform/Windows/streamer.test.setreg
+++ b/Registry/Platform/Windows/streamer.test.setreg
@@ -16,7 +16,7 @@
                             {
                                 "$type": "AZ::IO::WindowsStorageDriveConfig",
                                 "$stack_after": "Drive",
-                                "MaxFileHandles": 1024,
+                                "MaxFileHandles": 128,
                                 "MaxMetaDataCache": 1024,
                                 "Overcommit": 8,
                                 "EnableFileSharing": true,

--- a/Registry/streamer.editor.setreg
+++ b/Registry/streamer.editor.setreg
@@ -16,7 +16,8 @@
                                 "$type": "AzFramework::RemoteStorageDriveConfig",
                                 "$stack_after": "Drive",
                                 // The maximum number of file handles that the drive will cache.
-                                "MaxFileHandles": 1024
+                                // The Streamer will not close handles until it has at least this many handles open
+                                "MaxFileHandles": 128
                             }
                         }
                     }

--- a/Registry/streamer.game.debug.setreg
+++ b/Registry/streamer.game.debug.setreg
@@ -15,7 +15,7 @@
                             {
                                 "$type": "AzFramework::RemoteStorageDriveConfig",
                                 "$stack_after": "Splitter",
-                                "MaxFileHandles": 1024 
+                                "MaxFileHandles": 128 
                             }
                         }
                     },
@@ -26,12 +26,12 @@
                             "Drive":
                             {
                                 "$type": "AZ::IO::StorageDriveConfig",
-                                "MaxFileHandles": 1024 
+                                "MaxFileHandles": 128 
                             },
                             "Remote drive":
                             {
                                 "$type": "AzFramework::RemoteStorageDriveConfig",
-                                "MaxFileHandles": 1024 
+                                "MaxFileHandles": 128 
                             }
                         }
                     }

--- a/Registry/streamer.game.profile.setreg
+++ b/Registry/streamer.game.profile.setreg
@@ -15,7 +15,7 @@
                             {
                                 "$type": "AzFramework::RemoteStorageDriveConfig",
                                 "$stack_after": "Splitter",
-                                "MaxFileHandles": 1024 
+                                "MaxFileHandles": 128 
                             }
                         }
                     },
@@ -26,12 +26,12 @@
                             "Drive":
                             {
                                 "$type": "AZ::IO::StorageDriveConfig",
-                                "MaxFileHandles": 1024 
+                                "MaxFileHandles": 128 
                             },
                             "Remote drive":
                             {
                                 "$type": "AzFramework::RemoteStorageDriveConfig",
-                                "MaxFileHandles": 1024 
+                                "MaxFileHandles": 128 
                             }
                         }
                     }

--- a/Registry/streamer.game.setreg
+++ b/Registry/streamer.game.setreg
@@ -15,6 +15,7 @@
                             {
                                 "$type": "AZ::IO::StorageDriveConfig",
                                 // The maximum number of file handles that the drive will cache.
+                                // The Streamer will not close handles until it has at least this many handles open
                                 "MaxFileHandles": 32 
                             },
                             "Splitter":

--- a/Registry/streamer.setreg
+++ b/Registry/streamer.setreg
@@ -19,7 +19,8 @@
                             {
                                 "$type": "AZ::IO::StorageDriveConfig",
                                 // The maximum number of file handles that the drive will cache.
-                                "MaxFileHandles": 1024 
+                                // The Streamer will not close handles until it has at least this many handles open
+                                "MaxFileHandles": 128 
                             }
                         }
                     }

--- a/Registry/streamer.test.setreg
+++ b/Registry/streamer.test.setreg
@@ -15,7 +15,7 @@
                             "Drive":
                             {
                                 "$type": "AZ::IO::StorageDriveConfig",
-                                "MaxFileHandles": 1024
+                                "MaxFileHandles": 128
                             },
                             "Splitter":
                             {


### PR DESCRIPTION
## What does this PR do?
fixes #15332 and also fixes a deadlock discovered by fixing that fix, in windows.
The original bug was discovered here: https://github.com/o3de/o3de-extras/issues/118 and applies to o3de-extras, but the actual problem is in the o3de source code.

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_
see the bug report above for a description of the problem.
For the windows deadlock, the same PR (this one) also fixes the windows deadlock which was always there, but the new test reveals.

Order that this happened in
1. discover the bug on linux and develop a fix using epoll, yay!
2. write a test to ensure its working correctly and that all the data is present and read regardless of flush/buffered
3. run the test all green on linux, push to branch!
4. test branch on windows and find a deadlock even though no windows code was modified at all.  turns out we had a deadlock all along!
5. Find a workaround for deadlock on windows.  File https://github.com/o3de/o3de/issues/15330 to cover a more long term fix for it.

## How was this PR tested?
Auto test, and manual test, on linux and windows.
