### PR TITLE
Fixes #15149

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.cpp
@@ -248,6 +248,9 @@ namespace AZ
                 return false;
             }
 
+            // This step is very important, because it declares product dependency between ShaderAsset and the root ShaderVariantAssets (one for each supervariant).
+            // This will guarantee that when the ShaderAsset is loaded at runtime, the ShaderAsset will report OnAssetReady only after the root ShaderVariantAssets
+            // are already fully loaded and ready.
             AssetBuilderSDK::JobProduct shaderJobProduct;
             if (!AssetBuilderSDK::OutputObject(shaderAsset.Get(), shaderAssetOutputPath, azrtti_typeid<RPI::ShaderAsset>(),
                 aznumeric_cast<uint32_t>(RPI::ShaderAssetSubId::ShaderAsset), shaderJobProduct))

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
@@ -43,6 +43,7 @@ namespace AZ
         //! operation is always performed.
         class Material
             : public Data::InstanceData
+            , Data::AssetBus::Handler
             , public ShaderReloadNotificationBus::MultiHandler
         {
             friend class MaterialSystem;
@@ -147,6 +148,9 @@ namespace AZ
             //! Standard init path from asset data.
             static Data::Instance<Material> CreateInternal(MaterialAsset& materialAsset);
             RHI::ResultCode Init(MaterialAsset& materialAsset);
+
+            // AssetBus overrides...
+            void OnAssetReady(Data::Asset<Data::AssetData> asset) override;
 
             ///////////////////////////////////////////////////////////////////
             // ShaderReloadNotificationBus overrides...

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialAsset.h
@@ -59,6 +59,8 @@ namespace AZ
             MaterialAsset();
             virtual ~MaterialAsset();
 
+            bool InitializeNonSerializedData();
+
             //! Returns the MaterialTypeAsset.
             const Data::Asset<MaterialTypeAsset>& GetMaterialTypeAsset() const;
 
@@ -154,6 +156,8 @@ namespace AZ
             //! The materialTypeVersion this materialAsset was based off. If the versions do not match at runtime when a
             //! materialTypeAsset is loaded, automatic updates will be attempted.
             uint32_t m_materialTypeVersion = UnspecifiedMaterialTypeVersion;
+
+            bool m_isNonSerializedDataInitialized = false;
         };
        
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialTypeAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialTypeAsset.h
@@ -151,6 +151,8 @@ namespace AZ
             //! @return true if the property was renamed
             bool ApplyPropertyRenames(Name& propertyId) const;
 
+            bool InitializeNonSerializedData();
+
         private:
 
             bool PostLoadInit() override;
@@ -200,6 +202,8 @@ namespace AZ
 
             //! Contains actions to perform for each material update version.
             MaterialVersionUpdates m_materialVersionUpdates;
+
+            bool m_isNonSerializedDataInitialized = false;
         };
 
         class MaterialTypeAssetHandler : public AssetHandler<MaterialTypeAsset>

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/ShaderCollection.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/ShaderCollection.h
@@ -92,7 +92,7 @@ namespace AZ
                 //! Returns the shader tag used to identify this item
                 const AZ::Name& GetShaderTag() const;
 
-                //! Id the AssetId of @newShaderAsset matches the AssetId of @m_shaderAsset,
+                //! If the AssetId of @newShaderAsset matches the AssetId of @m_shaderAsset,
                 //! then @m_shaderAsset will be updated to @newShaderAsset, AND m_shaderOptionGroup
                 //! will be updated too.
                 void TryReplaceShaderAsset(const Data::Asset<ShaderAsset>& newShaderAsset);
@@ -127,6 +127,16 @@ namespace AZ
             bool HasShaderTag(const AZ::Name& shaderTag) const;
             Item& operator[](const AZ::Name& shaderTag);
             const Item& operator[](const AZ::Name& shaderTag) const;
+
+            //! Convenience function that loops through all @m_shaderItems
+            //! and calls TryReplaceShaderAsset on all of them.
+            void TryReplaceShaderAsset(const Data::Asset<ShaderAsset>& newShaderAsset);
+
+            //! Loops through all items in the collection and calls Item::InitializeShaderOptionGroup().
+            //! Returns true if all Item::InitializeShaderOptionGroup() return true,
+            //! otherwise returns false.
+            bool InitializeShaderOptionGroups();
+
         private:
             using NameReflectionMapForIndex = RHI::NameIdReflectionMap<RHI::Handle<uint32_t>>;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/ShaderCollection.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/ShaderCollection.h
@@ -92,6 +92,15 @@ namespace AZ
                 //! Returns the shader tag used to identify this item
                 const AZ::Name& GetShaderTag() const;
 
+                //! Id the AssetId of @newShaderAsset matches the AssetId of @m_shaderAsset,
+                //! then @m_shaderAsset will be updated to @newShaderAsset, AND m_shaderOptionGroup
+                //! will be updated too.
+                void TryReplaceShaderAsset(const Data::Asset<ShaderAsset>& newShaderAsset);
+
+                // Returns true if was able to initialized the non-serialized @m_shaderOptionGroup.
+                // Only returns false if @m_shaderAsset is not ready.
+                bool InitializeShaderOptionGroup();
+
             private:
                 Data::Asset<ShaderAsset> m_shaderAsset;
                 ShaderVariantId m_shaderVariantId;       //!< Temporarily holds the ShaderVariantId, used for serialization. This will be copied to/from m_shaderOptionGroup.

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
@@ -67,6 +67,20 @@ namespace AZ
             m_materialPipelineData = {};
             m_materialAsset = { &materialAsset, AZ::Data::AssetLoadBehavior::PreLoad };
             ShaderReloadNotificationBus::MultiHandler::BusDisconnect();
+            Data::AssetBus::Handler::BusDisconnect();
+            if (!m_materialAsset.IsReady())
+            {
+                // We will call this function again later when the asset is ready.
+                Data::AssetBus::Handler::BusConnect(m_materialAsset.GetId());
+                return RHI::ResultCode::Success;
+            }
+
+            if (!m_materialAsset->InitializeNonSerializedData())
+            {
+                AZ_Error(s_debugTraceName, false, "Material::InitializeNonSerializedData is not supposed to fail. materialAsset uuid=%s",
+                    materialAsset.GetId().ToFixedString().c_str());
+                return RHI::ResultCode::Fail;
+            }
 
             // Cache off pointers to some key data structures from the material type...
             auto srgLayout = m_materialAsset->GetMaterialSrgLayout();
@@ -282,7 +296,7 @@ namespace AZ
 
         bool Material::CanCompile() const
         {
-            return !m_shaderResourceGroup || !m_shaderResourceGroup->IsQueuedForCompile();
+            return m_materialAsset.IsReady() && (!m_shaderResourceGroup || !m_shaderResourceGroup->IsQueuedForCompile());
         }
 
         ///////////////////////////////////////////////////////////////////
@@ -819,6 +833,14 @@ namespace AZ
         {
             return m_materialProperties.GetMaterialPropertiesLayout();
         }
+
+        // AssetBus overrides...
+        void Material::OnAssetReady(Data::Asset<Data::AssetData> asset)
+        {
+            Data::AssetBus::Handler::BusDisconnect();
+            Init(*static_cast<MaterialAsset*>(asset.Get()));
+        }
+        // AssetBus overrides end
 
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
@@ -67,7 +67,6 @@ namespace AZ
             m_materialPipelineData = {};
             m_materialAsset = { &materialAsset, AZ::Data::AssetLoadBehavior::PreLoad };
             ShaderReloadNotificationBus::MultiHandler::BusDisconnect();
-            Data::AssetBus::Handler::BusDisconnect();
             if (!m_materialAsset.IsReady())
             {
                 // We will call this function again later when the asset is ready.
@@ -144,6 +143,7 @@ namespace AZ
 
         Material::~Material()
         {
+            Data::AssetBus::Handler::BusDisconnect();
             ShaderReloadNotificationBus::MultiHandler::BusDisconnect();
         }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialAsset.cpp
@@ -50,6 +50,20 @@ namespace AZ
             AssetInitBus::Handler::BusDisconnect();
         }
 
+        bool MaterialAsset::InitializeNonSerializedData()
+        {
+            if (m_isNonSerializedDataInitialized)
+            {
+                return true;
+            }
+            if (!m_materialTypeAsset || !m_materialTypeAsset.IsReady())
+            {
+                return false;
+            }
+            m_isNonSerializedDataInitialized = m_materialTypeAsset->InitializeNonSerializedData();
+            return m_isNonSerializedDataInitialized;
+        }
+
         const Data::Asset<MaterialTypeAsset>& MaterialAsset::GetMaterialTypeAsset() const
         {
             return m_materialTypeAsset;

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialAsset.cpp
@@ -56,7 +56,7 @@ namespace AZ
             {
                 return true;
             }
-            if (!m_materialTypeAsset || !m_materialTypeAsset.IsReady())
+            if (!m_materialTypeAsset.IsReady())
             {
                 return false;
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAsset.cpp
@@ -88,7 +88,10 @@ namespace AZ
             }
             for (auto& materialPipelinePair : m_materialPipelinePayloads)
             {
-                materialPipelinePair.second.m_shaderCollection.InitializeShaderOptionGroups();
+                if (!materialPipelinePair.second.m_shaderCollection.InitializeShaderOptionGroups())
+                {
+                    return false;
+                }
             }
             m_isNonSerializedDataInitialized = true;
             return true;

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAsset.cpp
@@ -82,23 +82,13 @@ namespace AZ
             {
                 return true;
             }
-            for (auto& shaderItem : m_generalShaderCollection)
+            if (!m_generalShaderCollection.InitializeShaderOptionGroups())
             {
-                if (!shaderItem.InitializeShaderOptionGroup())
-                {
-                    return false;
-                }
+                return false;
             }
-
             for (auto& materialPipelinePair : m_materialPipelinePayloads)
             {
-                for (auto& shaderItem : materialPipelinePair.second.m_shaderCollection)
-                {
-                    if (!shaderItem.InitializeShaderOptionGroup())
-                    {
-                        return false;
-                    }
-                }
+                materialPipelinePair.second.m_shaderCollection.InitializeShaderOptionGroups();
             }
             m_isNonSerializedDataInitialized = true;
             return true;
@@ -264,18 +254,11 @@ namespace AZ
             // The order of asset reloads is non-deterministic. If the MaterialTypeAsset reloads before these
             // dependency assets, this will make sure the MaterialTypeAsset gets the latest ones when they reload.
             // Or in some cases a these assets could get updated and reloaded without reloading the MaterialTypeAsset at all.
-
-            for (auto& shaderItem : m_generalShaderCollection)
-            {
-                shaderItem.TryReplaceShaderAsset(asset);
-            }
+            m_generalShaderCollection.TryReplaceShaderAsset(asset);
 
             for (auto& materialPipelinePair : m_materialPipelinePayloads)
             {
-                for (auto& shaderItem : materialPipelinePair.second.m_shaderCollection)
-                {
-                    shaderItem.TryReplaceShaderAsset(asset);
-                }
+                materialPipelinePair.second.m_shaderCollection.TryReplaceShaderAsset(asset);
             }
         }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/ShaderCollection.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/ShaderCollection.cpp
@@ -34,14 +34,6 @@ namespace AZ
             {
                 ShaderCollection::Item* shaderVariantReference = reinterpret_cast<ShaderCollection::Item*>(classPtr);
 
-                // Dependent asset references aren't guaranteed to finish loading by the time this asset is serialized, only by
-                // the time this asset load is completed.  But since the data is needed here, we will deliberately block until the
-                // shader asset has finished loading.
-                if (shaderVariantReference->m_shaderAsset.QueueLoad())
-                {
-                    shaderVariantReference->m_shaderAsset.BlockUntilLoadComplete();
-                }
-
                 if (shaderVariantReference->m_shaderAsset.IsReady())
                 {
                     shaderVariantReference->m_shaderOptionGroup = ShaderOptionGroup{
@@ -51,8 +43,13 @@ namespace AZ
                 }
                 else
                 {
+                    // No worries, eventually the Material::Init will end up
+                    // calling InitializeShaderOptionGroup() and @m_shaderOptionGroup
+                    // will get proper data.
                     shaderVariantReference->m_shaderOptionGroup = {};
+                    shaderVariantReference->m_shaderAsset.QueueLoad(); // Not necessaru to call QueueLoad, but doesn't hurt either.
                 }
+
             }
         };
 
@@ -265,6 +262,30 @@ namespace AZ
         const AZ::RPI::ShaderOptionGroup& ShaderCollection::Item::GetShaderOptionGroup() const
         {
             return m_shaderOptionGroup;
+        }
+
+        bool ShaderCollection::Item::InitializeShaderOptionGroup()
+        {
+            if (!m_shaderAsset.IsReady())
+            {
+                return false;
+            }
+            m_shaderOptionGroup = ShaderOptionGroup{
+                m_shaderAsset->GetShaderOptionGroupLayout(),
+                m_shaderVariantId };
+            return true;
+        }
+
+        void ShaderCollection::Item::TryReplaceShaderAsset(const Data::Asset<ShaderAsset>& newShaderAsset)
+        {
+            if (newShaderAsset.GetId() != m_shaderAsset.GetId())
+            {
+                return;
+            }
+            m_shaderAsset = newShaderAsset;
+            [[maybe_unused]] bool success = InitializeShaderOptionGroup();
+            AZ_Assert(success, "Failed to InitializeShaderOptionGroup using shaderAsset with uuid=%s and hint=%s"
+                , newShaderAsset.GetId().ToString<AZStd::string>().c_str(), newShaderAsset.GetHint().c_str());
         }
 
     } // namespace RPI

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/ShaderCollection.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/ShaderCollection.cpp
@@ -47,7 +47,7 @@ namespace AZ
                     // calling InitializeShaderOptionGroup() and @m_shaderOptionGroup
                     // will get proper data.
                     shaderVariantReference->m_shaderOptionGroup = {};
-                    shaderVariantReference->m_shaderAsset.QueueLoad(); // Not necessaru to call QueueLoad, but doesn't hurt either.
+                    shaderVariantReference->m_shaderAsset.QueueLoad(); // Not necessary to call QueueLoad, but doesn't hurt either.
                 }
 
             }
@@ -150,6 +150,26 @@ namespace AZ
         bool ShaderCollection::HasShaderTag(const AZ::Name& shaderTag) const
         {
             return (m_shaderTagIndexMap.Find(shaderTag).IsValid());
+        }
+
+        void ShaderCollection::TryReplaceShaderAsset(const Data::Asset<ShaderAsset>& newShaderAsset)
+        {
+            for (auto& shaderItem : m_shaderItems)
+            {
+                shaderItem.TryReplaceShaderAsset(newShaderAsset);
+            }
+        }
+
+        bool ShaderCollection::InitializeShaderOptionGroups()
+        {
+            for (auto& shaderItem : m_shaderItems)
+            {
+                if (!shaderItem.InitializeShaderOptionGroup())
+                {
+                    return false;
+                }
+            }
+            return true;
         }
 
         ShaderCollection::Item::Item(const Data::Asset<ShaderAsset>& shaderAsset, const AZ::Name& shaderTag, ShaderVariantId variantId)
@@ -285,7 +305,7 @@ namespace AZ
             m_shaderAsset = newShaderAsset;
             [[maybe_unused]] bool success = InitializeShaderOptionGroup();
             AZ_Assert(success, "Failed to InitializeShaderOptionGroup using shaderAsset with uuid=%s and hint=%s"
-                , newShaderAsset.GetId().ToString<AZStd::string>().c_str(), newShaderAsset.GetHint().c_str());
+                , newShaderAsset.GetId().ToFixedString().c_str(), newShaderAsset.GetHint().c_str());
         }
 
     } // namespace RPI


### PR DESCRIPTION
## What does this PR do?

Fixes the dealock by removing the call to
`m_shaderAsset.BlockUntilLoadComplete()`
in ShaderVariantReferenceSerializationEvents::OnWriteEnd().

The idea is that higher layers of class like MaterialAsset and MaterialtypeAsset will cascade back into calling
ShaderCollection::Item::InitializeShaderOptionGroup() and/or ShaderCollection::Item::TryReplaceShaderAsset() which will initialize the m_shaderOptionGroup once the ShaderAssets are loaded asynchronously.

## How was this PR tested?

Tested with MultiplayerSampler, LoftSample, AutomatedTesting and AtomSampleViewer.
