### PR TITLE
Add support for better gpu marker labels amongst many other fixes.

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Factory.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Factory.h
@@ -17,8 +17,7 @@
 #include <renderdoc_app.h>
 #endif
 
-AZ_CVAR(bool, r_gpuMarkersMergeGroups, false, nullptr, AZ::ConsoleFunctorFlags::Null, "Enable merging of gpu markers in order to track payload (i.e all the scopes) per command list.");
-
+AZ_CVAR_EXTERNED(bool, r_gpuMarkersMergeGroups);
 
 namespace AZ
 {

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Factory.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Factory.h
@@ -17,7 +17,7 @@
 #include <renderdoc_app.h>
 #endif
 
-AZ_CVAR(bool, r_gpuMarkersMergeGroups, false, nullptr, AZ::ConsoleFunctorFlags::Null, "Enable merging of gpu markers related to scopes per command list.");
+AZ_CVAR(bool, r_gpuMarkersMergeGroups, false, nullptr, AZ::ConsoleFunctorFlags::Null, "Enable merging of gpu markers in order to track payload (i.e all the scopes) per command list.");
 
 
 namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Factory.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Factory.h
@@ -11,10 +11,14 @@
 #include <Atom/RHI/PhysicalDevice.h>
 #include <AzCore/Debug/Budget.h>
 #include <AzCore/Name/Name.h>
+#include <AzCore/Console/IConsole.h>
 
 #if defined(USE_RENDERDOC)
 #include <renderdoc_app.h>
 #endif
+
+AZ_CVAR(bool, r_gpuMarkersMergeGroups, false, nullptr, AZ::ConsoleFunctorFlags::Null, "Enable merging of gpu markers related to scopes per command list.");
+
 
 namespace AZ
 {
@@ -55,6 +59,8 @@ namespace AZ
         static const APIPriority APITopPriority = 1;
         static const APIPriority APILowPriority = 10;
         static const APIPriority APIMiddlePriority = (APILowPriority - APITopPriority) / 2;
+
+        
 
         //! The factory is an interface for creating RHI data structures. The platform system should
         //! register itself with the factory by calling Register, and unregister on shutdown with

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystem.h
@@ -46,8 +46,8 @@ namespace AZ
             void UnregisterXRSystem();
 
             //! Get/Set functions for the number of active pipelines in use in a frame 
-            void SetNumActivePipelines(uint16_t numActivePipelines);
-            uint16_t GetNumActivePipelines() const;
+            void SetNumActiveRenderPipelines(uint16_t numActiveRenderPipelines);
+            uint16_t GetNumActiveRenderPipelines() const;
 
             //////////////////////////////////////////////////////////////////////////
             // RHISystemInterface Overrides
@@ -78,7 +78,7 @@ namespace AZ
             XRRenderingInterface* m_xrSystem = nullptr;
 
             //Used for better verbosity related to gpu markers
-            uint16_t m_numActivePipelines = 0;
+            uint16_t m_numActiveRenderPipelines = 0;
         };
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystem.h
@@ -41,9 +41,13 @@ namespace AZ
             //! Invokes the frame scheduler. The provided callback is invoked prior to compilation of the graph.
             void FrameUpdate(FrameGraphCallback frameGraphCallback);
 
-            // Register/Unregister xr system
+            //! Register/Unregister xr system
             void RegisterXRSystem(XRRenderingInterface* xrRenderingInterface);
             void UnregisterXRSystem();
+
+            //! Get/Set functions for the number of active pipelines in use in a frame 
+            void SetNumActivePipelines(uint16_t numActivePipelines);
+            uint16_t GetNumActivePipelines() const;
 
             //////////////////////////////////////////////////////////////////////////
             // RHISystemInterface Overrides
@@ -72,6 +76,9 @@ namespace AZ
             RHI::Ptr<RHI::DrawListTagRegistry> m_drawListTagRegistry;
             RHI::Ptr<RHI::PipelineStateCache> m_pipelineStateCache;
             XRRenderingInterface* m_xrSystem = nullptr;
+
+            //Used for better verbosity related to gpu markers
+            uint16_t m_numActivePipelines = 0;
         };
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystemInterface.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystemInterface.h
@@ -58,6 +58,8 @@ namespace AZ
 
             virtual double GetCpuFrameTime() const = 0;
 
+            virtual uint16_t GetNumActivePipelines() const = 0;
+
             virtual const RHI::TransientAttachmentStatistics* GetTransientAttachmentStatistics() const = 0;
 
             virtual const RHI::MemoryStatistics* GetMemoryStatistics() const = 0;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystemInterface.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystemInterface.h
@@ -58,7 +58,7 @@ namespace AZ
 
             virtual double GetCpuFrameTime() const = 0;
 
-            virtual uint16_t GetNumActivePipelines() const = 0;
+            virtual uint16_t GetNumActiveRenderPipelines() const = 0;
 
             virtual const RHI::TransientAttachmentStatistics* GetTransientAttachmentStatistics() const = 0;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Scope.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Scope.h
@@ -60,6 +60,9 @@ namespace AZ
             /// Returns the scope id associated with this scope.
             const ScopeId& GetId() const;
 
+            /// Returns the string view to the gpu marker
+            AZStd::string_view GetMarkerLabel() const;
+
             /**
              * Returns the index in the array of scopes in FrameSchedulerBase::GetScopes. The indices
              * are dependency ordered, so a scope with a greater index *may* depend on a scope from a lesser
@@ -184,8 +187,15 @@ namespace AZ
 
             //////////////////////////////////////////////////////////////////////////
 
+            /// Scope name
             ScopeId m_id;
 
+            /// Stripped Gpu marker name with no pipeline name 
+            AZStd::string_view m_marker;
+
+            /// Stripped Gpu marker name with pipeline name
+            AZStd::string_view m_markerWithPipelineName;
+            
             /// The sorted index is exposed via GetIndex, and maps to the topologically sorted scope list.
             Handle<uint32_t> m_index;
 

--- a/Gems/Atom/RHI/Code/Source/RHI/Factory.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Factory.cpp
@@ -151,14 +151,14 @@ namespace AZ
 
             if (Validation::IsEnabled())
             {
-                bool enableGpuMargerMergeGroups = false;
+                bool enableGpuMarkerMergeGroups = false;
                 if (auto* console = AZ::Interface<AZ::IConsole>::Get(); console != nullptr)
                 {
-                    console->GetCvarValue("r_gpuMarkersMergeGroups", enableGpuMargerMergeGroups);
+                    console->GetCvarValue("r_gpuMarkersMergeGroups", enableGpuMarkerMergeGroups);
 
                     // push the cvar value so Dx12/Vk/Metal back-end dlls can access it directly.
                     console->PerformCommand(
-                        AZStd::string::format("r_gpuMarkersMergeGroups %s", enableGpuMargerMergeGroups ? "true" : "false").c_str());
+                        AZStd::string::format("r_gpuMarkersMergeGroups %s", enableGpuMarkerMergeGroups ? "true" : "false").c_str());
                 }
             }
         }

--- a/Gems/Atom/RHI/Code/Source/RHI/Factory.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Factory.cpp
@@ -30,6 +30,8 @@ static bool s_pixGpuMarkersEnabled = true;
 #endif
 
 static bool s_usingWarpDevice = false;
+AZ_CVAR(bool, r_gpuMarkersMergeGroups, false, nullptr, AZ::ConsoleFunctorFlags::Null, "Enable merging of gpu markers in order to track payload (i.e all the scopes) per command list.");
+
 
 namespace AZ
 {
@@ -147,19 +149,6 @@ namespace AZ
             if (AZ::SystemTickBus::FindFirstHandler()) // resolving limitations in unittests
             {
                 AZ::SystemTickBus::QueueFunction(logFunc);
-            }
-
-            if (Validation::IsEnabled())
-            {
-                bool enableGpuMarkerMergeGroups = false;
-                if (auto* console = AZ::Interface<AZ::IConsole>::Get(); console != nullptr)
-                {
-                    console->GetCvarValue("r_gpuMarkersMergeGroups", enableGpuMarkerMergeGroups);
-
-                    // push the cvar value so Dx12/Vk/Metal back-end dlls can access it directly.
-                    console->PerformCommand(
-                        AZStd::string::format("r_gpuMarkersMergeGroups %s", enableGpuMarkerMergeGroups ? "true" : "false").c_str());
-                }
             }
         }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/Factory.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Factory.cpp
@@ -148,6 +148,19 @@ namespace AZ
             {
                 AZ::SystemTickBus::QueueFunction(logFunc);
             }
+
+            if (Validation::IsEnabled())
+            {
+                bool enableGpuMargerMergeGroups = false;
+                if (auto* console = AZ::Interface<AZ::IConsole>::Get(); console != nullptr)
+                {
+                    console->GetCvarValue("r_gpuMarkersMergeGroups", enableGpuMargerMergeGroups);
+
+                    // push the cvar value so Dx12/Vk/Metal back-end dlls can access it directly.
+                    console->PerformCommand(
+                        AZStd::string::format("r_gpuMarkersMergeGroups %s", enableGpuMargerMergeGroups ? "true" : "false").c_str());
+                }
+            }
         }
 
         void Factory::Unregister(Factory* instance)

--- a/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
@@ -294,14 +294,14 @@ namespace AZ
             return m_frameScheduler.GetTransientAttachmentPoolDescriptor();
         }
 
-        void RHISystem::SetNumActivePipelines(uint16_t numActivePipelines)
+        void RHISystem::SetNumActiveRenderPipelines(uint16_t numActiveRenderPipelines)
         {
-            m_numActivePipelines = numActivePipelines;
+            m_numActiveRenderPipelines = numActiveRenderPipelines;
         }
 
-        uint16_t RHISystem::GetNumActivePipelines() const
+        uint16_t RHISystem::GetNumActiveRenderPipelines() const
         {
-            return m_numActivePipelines;
+            return m_numActiveRenderPipelines;
         }
 
         ConstPtr<PlatformLimitsDescriptor> RHISystem::GetPlatformLimitsDescriptor(int deviceIndex) const

--- a/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
@@ -294,6 +294,16 @@ namespace AZ
             return m_frameScheduler.GetTransientAttachmentPoolDescriptor();
         }
 
+        void RHISystem::SetNumActivePipelines(uint16_t numActivePipelines)
+        {
+            m_numActivePipelines = numActivePipelines;
+        }
+
+        uint16_t RHISystem::GetNumActivePipelines() const
+        {
+            return m_numActivePipelines;
+        }
+
         ConstPtr<PlatformLimitsDescriptor> RHISystem::GetPlatformLimitsDescriptor(int deviceIndex) const
         {
             return m_devices[deviceIndex]->GetDescriptor().m_platformLimitsDescriptor;

--- a/Gems/Atom/RHI/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Scope.cpp
@@ -145,7 +145,7 @@ namespace AZ
                 return m_id.GetStringView();
             }
 
-            if (RHI::RHISystemInterface::Get()->GetNumActivePipelines() > 1)
+            if (RHI::RHISystemInterface::Get()->GetNumActiveRenderPipelines() > 1)
             {
                 return m_markerWithPipelineName;
             }

--- a/Gems/Atom/RHI/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Scope.cpp
@@ -9,6 +9,7 @@
 #include <Atom/RHI/ResourcePoolDatabase.h>
 #include <Atom/RHI/ImagePoolBase.h>
 #include <Atom/RHI/BufferPoolBase.h>
+#include <Atom/RHI/RHISystemInterface.h>
 
 namespace AZ
 {
@@ -30,6 +31,28 @@ namespace AZ
             AZ_Assert(IsInitialized() == false, "Scope was previously initialized.");
             SetName(scopeId);
             m_id = scopeId;
+
+            if (Validation::IsEnabled())
+            {
+                // Cache the string views for better gpu marker verbosity
+                size_t firstDotPos = m_id.GetStringView().find_first_of(".");
+                if (firstDotPos == AZStd::string::npos)
+                {
+                    m_markerWithPipelineName = m_id.GetStringView();
+                    m_marker = m_id.GetStringView();
+                }
+                else
+                {
+                    // Strip the first token before the first "." to extract the marker label with pipeline name
+                    m_markerWithPipelineName = m_id.GetStringView().substr(firstDotPos + 1, m_id.GetStringView().length() - firstDotPos + 1);
+
+                    // Strip the second token before "." to extract the marker label without pipeline name
+                    firstDotPos = m_markerWithPipelineName.find_first_of(".");
+                    m_marker = firstDotPos != AZStd::string::npos ? m_markerWithPipelineName.substr(firstDotPos + 1, m_markerWithPipelineName.length() - firstDotPos + 1)
+                        : m_markerWithPipelineName;
+                }
+            }
+
             m_hardwareQueueClass = hardwareQueueClass;
             InitInternal();
             m_isInitialized = true;
@@ -113,6 +136,23 @@ namespace AZ
         const ScopeId& Scope::GetId() const
         {
             return m_id;
+        }
+
+        AZStd::string_view Scope::GetMarkerLabel() const
+        {
+            if(!Validation::IsEnabled())
+            {
+                return m_id.GetStringView();
+            }
+
+            if (RHI::RHISystemInterface::Get()->GetNumActivePipelines() > 1)
+            {
+                return m_markerWithPipelineName;
+            }
+            else
+            {
+                return m_marker;
+            }
         }
 
         uint32_t Scope::GetIndex() const

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
@@ -340,10 +340,27 @@ namespace AZ
 
             // set the global root signature
             const RayTracingPipelineState* rayTracingPipelineState = static_cast<const RayTracingPipelineState*>(dispatchRaysItem.m_rayTracingPipelineState);
+            if (!rayTracingPipelineState)
+            {
+                AZ_Assert(false, "Pipeline state not provided");
+                return;
+            }
+
             commandList->SetComputeRootSignature(rayTracingPipelineState->GetGlobalRootSignature());
 
             const PipelineState* globalPipelineState = static_cast<const PipelineState*>(dispatchRaysItem.m_globalPipelineState);
+            if (!globalPipelineState)
+            {
+                AZ_Assert(false, "Global Pipeline state not provided");
+                return;
+            }
+
             const PipelineLayout* globalPipelineLayout = globalPipelineState->GetPipelineLayout();              
+            if (!globalPipelineLayout)
+            {
+                AZ_Assert(false, "Pipeline layout is null.");
+                return;
+            }
 
             // bind ShaderResourceGroups
             for (uint32_t srgIndex = 0; srgIndex < dispatchRaysItem.m_shaderResourceGroupCount; ++srgIndex)

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <Atom/RHI/DispatchRaysItem.h>
-#include <Atom/RHI/Factory.h>
-#include <Atom/RHI/IndirectArguments.h>
 #include <RHI/CommandList.h>
 #include <RHI/Conversions.h>
 #include <RHI/Buffer.h>
@@ -27,6 +24,9 @@
 #include <RHI/RayTracingPipelineState.h>
 #include <RHI/RayTracingShaderTable.h>
 #include <RHI/BufferPool.h>
+#include <Atom/RHI/DispatchRaysItem.h>
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/IndirectArguments.h>
 
 // Conditionally disable timing at compile-time based on profile policy
 #if DX12_GPU_PROFILE_MODE == DX12_GPU_PROFILE_MODE_DETAIL

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
@@ -27,6 +27,7 @@
 #define DX12_GPU_PROFILE_MODE_BASIC     1       // Profiles command list lifetime
 #define DX12_GPU_PROFILE_MODE_DETAIL    2       // Profiles draw call state changes
 #define DX12_GPU_PROFILE_MODE DX12_GPU_PROFILE_MODE_BASIC
+#define PIX_MARKER_CMDLIST_COL 0xFF0000FF
 
 namespace AZ
 {
@@ -283,7 +284,7 @@ namespace AZ
                 return false;
             }
             
-            const PipelineLayout* pipelineLayout = &pipelineState->GetPipelineLayout();
+            const PipelineLayout* pipelineLayout = pipelineState->GetPipelineLayout();
             if (!pipelineLayout)
             {
                 AZ_Assert(false, "Pipeline layout is null.");

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
@@ -27,7 +27,7 @@
 #define DX12_GPU_PROFILE_MODE_BASIC     1       // Profiles command list lifetime
 #define DX12_GPU_PROFILE_MODE_DETAIL    2       // Profiles draw call state changes
 #define DX12_GPU_PROFILE_MODE DX12_GPU_PROFILE_MODE_BASIC
-#define PIX_MARKER_CMDLIST_COL 0xFF0000FF
+#define PIX_MARKER_CMDLIST_COL 0xFF00FF00
 
 namespace AZ
 {

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/IndirectBufferSignature.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/IndirectBufferSignature.cpp
@@ -70,11 +70,11 @@ namespace AZ
                         return RHI::ResultCode::InvalidArgument;
                     }
 
-                    const PipelineLayoutDescriptor& pipelineLayoutDesc = static_cast<const PipelineLayoutDescriptor&>(pipelineState->GetPipelineLayout().GetPipelineLayoutDescriptor());
+                    const PipelineLayoutDescriptor& pipelineLayoutDesc = static_cast<const PipelineLayoutDescriptor&>(pipelineState->GetPipelineLayout()->GetPipelineLayoutDescriptor());
                     argDesc.Type = D3D12_INDIRECT_ARGUMENT_TYPE_CONSTANT;
                     argDesc.Constant.DestOffsetIn32BitValues = 0;
                     argDesc.Constant.Num32BitValuesToSet = pipelineLayoutDesc.GetRootConstantBinding().m_constantCount;
-                    argDesc.Constant.RootParameterIndex = pipelineState->GetPipelineLayout().GetRootConstantsRootParameterIndex().GetIndex();
+                    argDesc.Constant.RootParameterIndex = pipelineState->GetPipelineLayout()->GetRootConstantsRootParameterIndex().GetIndex();
 
                     m_stride += sizeof(uint32_t) * argDesc.Constant.Num32BitValuesToSet;
                     break;
@@ -85,7 +85,7 @@ namespace AZ
                 }
             }
 
-            ID3D12RootSignature* rootSignature = pipelineState ? pipelineState->GetPipelineLayout().Get() : nullptr;
+            ID3D12RootSignature* rootSignature = pipelineState ? pipelineState->GetPipelineLayout()->Get() : nullptr;
 
             D3D12_COMMAND_SIGNATURE_DESC desc = {};
             desc.ByteStride = m_stride;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/IndirectBufferSignature.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/IndirectBufferSignature.cpp
@@ -70,11 +70,18 @@ namespace AZ
                         return RHI::ResultCode::InvalidArgument;
                     }
 
-                    const PipelineLayoutDescriptor& pipelineLayoutDesc = static_cast<const PipelineLayoutDescriptor&>(pipelineState->GetPipelineLayout()->GetPipelineLayoutDescriptor());
+                    const PipelineLayout* pipelineLayout = pipelineState->GetPipelineLayout();
+                    if (!pipelineLayout)
+                    {
+                        AZ_Assert(pipelineState, "PipelineLayout is null");
+                        return RHI::ResultCode::InvalidArgument;
+                    }
+
+                    const PipelineLayoutDescriptor& pipelineLayoutDesc = static_cast<const PipelineLayoutDescriptor&>(pipelineLayout->GetPipelineLayoutDescriptor());
                     argDesc.Type = D3D12_INDIRECT_ARGUMENT_TYPE_CONSTANT;
                     argDesc.Constant.DestOffsetIn32BitValues = 0;
                     argDesc.Constant.Num32BitValuesToSet = pipelineLayoutDesc.GetRootConstantBinding().m_constantCount;
-                    argDesc.Constant.RootParameterIndex = pipelineState->GetPipelineLayout()->GetRootConstantsRootParameterIndex().GetIndex();
+                    argDesc.Constant.RootParameterIndex = pipelineLayout->GetRootConstantsRootParameterIndex().GetIndex();
 
                     m_stride += sizeof(uint32_t) * argDesc.Constant.Num32BitValuesToSet;
                     break;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/PipelineState.cpp
@@ -19,9 +19,9 @@ namespace AZ
             return aznew PipelineState;
         }
 
-        const PipelineLayout& PipelineState::GetPipelineLayout() const
+        const PipelineLayout* PipelineState::GetPipelineLayout() const
         {
-            return *m_pipelineLayout;
+            return m_pipelineLayout.get();
         }
 
         ID3D12PipelineState* PipelineState::Get() const

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/PipelineState.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/PipelineState.h
@@ -46,7 +46,7 @@ namespace AZ
             static RHI::Ptr<PipelineState> Create();
 
             /// Returns the pipeline layout associated with this PSO.
-            const PipelineLayout& GetPipelineLayout() const;
+            const PipelineLayout* GetPipelineLayout() const;
 
             /// Returns the platform pipeline state object.
             ID3D12PipelineState* Get() const;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingPipelineState.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingPipelineState.cpp
@@ -118,8 +118,8 @@ namespace AZ
             subObjects[currentIndex++] = shaderConfigSubObject;
 
             // add global root signature
-            const PipelineLayout& pipelineLayout = static_cast<const PipelineState*>(descriptor->GetPipelineState())->GetPipelineLayout();
-            m_globalRootSignature = pipelineLayout.Get();
+            const PipelineLayout* pipelineLayout = static_cast<const PipelineState*>(descriptor->GetPipelineState())->GetPipelineLayout();
+            m_globalRootSignature = pipelineLayout->Get();
             D3D12_STATE_SUBOBJECT globalRootSignatureSubObject = {};
             globalRootSignatureSubObject.Type = D3D12_STATE_SUBOBJECT_TYPE_GLOBAL_ROOT_SIGNATURE;
             globalRootSignatureSubObject.pDesc = &m_globalRootSignature;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.cpp
@@ -317,19 +317,16 @@ namespace AZ
             AZ_PROFILE_FUNCTION(RHI);
 
             commandList.GetValidator().BeginScope(*this);
-
-            PIXBeginEvent(0xFFFF00FF, GetId().GetCStr());
-
-            if (RHI::Factory::Get().PixGpuEventsEnabled())
-            {
-                PIXBeginEvent(commandList.GetCommandList(), 0xFFFF00FF, GetId().GetCStr());
-            }
-
             commandList.SetAftermathEventMarker(GetId().GetCStr());
             
             const bool isPrologue = commandListIndex == 0;
             if (isPrologue)
             {
+                if (RHI::Factory::Get().PixGpuEventsEnabled())
+                {
+                    PIXBeginEvent(commandList.GetCommandList(), PIX_MARKER_CMDLIST_COL, GetMarkerLabel().data());
+                }
+
                 for (const auto& barrier : m_preDiscardTransitionBarrierRequests)
                 {
                     commandList.QueueTransitionBarrier(barrier);
@@ -436,13 +433,12 @@ namespace AZ
                 {
                     commandList.QueueTransitionBarrier(request);
                 }
-            }
 
-            if (RHI::Factory::Get().PixGpuEventsEnabled())
-            {
-                PIXEndEvent(commandList.GetCommandList());
+                if (RHI::Factory::Get().PixGpuEventsEnabled())
+                {
+                    PIXEndEvent(commandList.GetCommandList());
+                }
             }
-            PIXEndEvent();
 
             commandList.GetValidator().EndScope();
         }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
@@ -25,9 +25,9 @@ namespace AZ
             return aznew PipelineState;
         }
 
-        const PipelineLayout& PipelineState::GetPipelineLayout() const
+        const PipelineLayout* PipelineState::GetPipelineLayout() const
         {
-            return *m_pipelineLayout;
+            return m_pipelineLayout.get();
         }
 
         id<MTLRenderPipelineState> PipelineState::GetGraphicsPipelineState() const

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.h
@@ -39,7 +39,7 @@ namespace AZ
             //PipelineType GetType() const;
 
             /// Returns the pipeline layout associated with this PSO.
-            const PipelineLayout& GetPipelineLayout() const;
+            const PipelineLayout* GetPipelineLayout() const;
 
             /// Returns the platform pipeline state object.
             id<MTLRenderPipelineState> GetGraphicsPipelineState() const;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -616,20 +616,11 @@ namespace AZ
 
             VkResult vkResult = static_cast<Device&>(GetDevice()).GetContext().BeginCommandBuffer(m_nativeCommandBuffer, &beginInfo);
             AssertSuccess(vkResult);
-            if (vkResult == VK_SUCCESS && !GetName().IsEmpty())
-            {
-                BeginDebugLabel(GetName().GetCStr());
-            }
         }
 
         void CommandList::EndCommandBuffer()
         {
             AZ_Assert(m_isUpdating, "Not in updating state");
-
-            if (!GetName().IsEmpty())
-            {
-                EndDebugLabel();
-            }
 
             m_state.m_framebuffer = nullptr;
             m_state.m_subpassIndex = 0;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroup.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroup.cpp
@@ -68,6 +68,7 @@ namespace AZ
 
             CommandList::InheritanceInfo inheritanceInfo{ m_renderPassContext.m_framebuffer.get(), m_subpassIndex };
             commandList->BeginCommandBuffer(&inheritanceInfo);
+            commandList->BeginDebugLabel(commandList->GetName().GetCStr());
             m_scope->Begin(*commandList);
         }
 
@@ -75,6 +76,7 @@ namespace AZ
         {
             CommandList& commandList = static_cast<CommandList&>(*context.GetCommandList());
             m_scope->End(commandList);
+            commandList.EndDebugLabel();
             commandList.EndCommandBuffer();
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupHandler.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupHandler.cpp
@@ -77,7 +77,11 @@ namespace AZ
         void FrameGraphExecuteGroupHandler::EndInternal()
         {
             RHI::Ptr<CommandList> commandList = m_device->AcquireCommandList(m_hardwareQueueClass);
+            const Scope* scope = static_cast<const FrameGraphExecuteGroup*>(m_executeGroups[0])->GetScopes()[0];
+
             commandList->BeginCommandBuffer();
+            commandList->BeginDebugLabel(scope->GetMarkerLabel().data());
+
             // First emit all scope barriers outside of the renderpass.
             EmitScopeBarriers(*commandList, Scope::BarrierSlot::Aliasing);
             ProcessClearRequests(*commandList);
@@ -104,6 +108,8 @@ namespace AZ
             commandList->EndRenderPass();
             // Emit epilogue barriers outside the renderpass.
             EmitScopeBarriers(*commandList, Scope::BarrierSlot::Epilogue);
+
+            commandList->EndDebugLabel();
             commandList->EndCommandBuffer();
 
             m_workRequest.m_commandList = commandList;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupMerged.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupMerged.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#include <Atom/RHI/Factory.h>
 #include <RHI/FrameGraphExecuteGroupMerged.h>
 #include <RHI/Scope.h>
 #include <RHI/SwapChain.h>
@@ -61,11 +62,20 @@ namespace AZ
         {
             m_commandList = AcquireCommandList(VK_COMMAND_BUFFER_LEVEL_PRIMARY);
             m_commandList->BeginCommandBuffer();
+            if (r_gpuMarkersMergeGroups)
+            {
+                m_commandList->BeginDebugLabel(m_commandList->GetName().GetCStr());
+            }
+            
             m_workRequest.m_commandList = m_commandList;
         }
 
         void FrameGraphExecuteGroupMerged::EndInternal()
         {
+            if (r_gpuMarkersMergeGroups)
+            {
+                m_commandList->EndDebugLabel();
+            }
             m_commandList->EndCommandBuffer();
         }
 
@@ -74,8 +84,10 @@ namespace AZ
             uint32_t contextIndex)
         {
             AZ_Assert(static_cast<uint32_t>(m_lastCompletedScope + 1) == contextIndex, "Contexts must be recorded in order!");
-
+           
             const Scope* scope = m_scopes[contextIndex];
+            m_commandList->SetName(m_mergedCommandListName);
+            m_commandList->BeginDebugLabel(scope->GetMarkerLabel().data());
             context.SetCommandList(*m_commandList);
 
             scope->EmitScopeBarriers(*m_commandList, Scope::BarrierSlot::Aliasing);
@@ -111,6 +123,8 @@ namespace AZ
             scope->ResolveMSAAAttachments(*commandList);
             scope->End(*commandList);
             scope->EmitScopeBarriers(*m_commandList, Scope::BarrierSlot::Epilogue);
+
+            commandList->EndDebugLabel();
         }
 
         AZStd::span<const Scope* const> FrameGraphExecuteGroupMerged::GetScopes() const

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupMerged.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupMerged.cpp
@@ -84,7 +84,7 @@ namespace AZ
             uint32_t contextIndex)
         {
             AZ_Assert(static_cast<uint32_t>(m_lastCompletedScope + 1) == contextIndex, "Contexts must be recorded in order!");
-           
+
             const Scope* scope = m_scopes[contextIndex];
             m_commandList->SetName(m_mergedCommandListName);
             m_commandList->BeginDebugLabel(scope->GetMarkerLabel().data());

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupMerged.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupMerged.h
@@ -61,6 +61,8 @@ namespace AZ
             RHI::Ptr<CommandList> m_commandList;
             // List of renderpasses and framebuffers used by the scopes in the group.
             AZStd::span<const RenderPassContext> m_renderPassContexts;
+            // Name used by the command list encoding the work for this group
+            const AZ::Name m_mergedCommandListName{ "Merged" };
         };
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupMergedHandler.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupMergedHandler.cpp
@@ -23,7 +23,7 @@ namespace AZ
             AZ_Assert(executeGroups.size() == 1, "Too many execute groups when initializing context");
             FrameGraphExecuteGroupMerged* group = static_cast<FrameGraphExecuteGroupMerged*>(executeGroups.back());
             AZ_Assert(group, "Invalid execute group for FrameGraphExecuteGroupMergedHandler");
-            // Creates the renderpasses and framebufers that will be used.
+            // Creates the renderpasses and framebuffers that will be used.
             auto groupScopes = group->GetScopes();
             m_renderPassContexts.resize(groupScopes.size());
             for (uint32_t i = 0; i < groupScopes.size(); ++i)

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.cpp
@@ -82,9 +82,7 @@ namespace AZ
 
         void Scope::Begin(CommandList& commandList) const
         {
-            commandList.SetName(GetId());
             commandList.GetValidator().BeginScope(*this);
-            commandList.BeginDebugLabel(AZStd::string::format("%s Scope", GetId().GetCStr()).c_str());
 
             for (RHI::ResourcePoolResolver* resolverBase : GetResourcePoolResolves())
             {
@@ -95,7 +93,6 @@ namespace AZ
 
         void Scope::End(CommandList& commandList) const
         {
-            commandList.EndDebugLabel();
             commandList.GetValidator().EndScope();
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/StreamingImagePoolResolver.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/StreamingImagePoolResolver.cpp
@@ -53,7 +53,8 @@ namespace AZ
 
             for (auto it = barriers.begin(); it != barriers.end(); ++it)
             {
-                vkCmdPipelineBarrier(commandList.GetNativeCommandBuffer(),
+                device.GetContext().CmdPipelineBarrier(
+                    commandList.GetNativeCommandBuffer(),
                     VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                     it->first,
                     VK_DEPENDENCY_BY_REGION_BIT,

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
@@ -191,9 +191,9 @@ namespace AZ
                 return m_drawFilterTagRegistry;
             }
 
-            uint16_t GetActivePipelines() const
+            uint16_t GetActiveRenderPipelines() const
             {
-                return m_numActivePipelines;
+                return m_numActiveRenderPipelines;
             }
 
         protected:
@@ -304,7 +304,7 @@ namespace AZ
             float m_simulationTime = 0.0;
             RHI::ShaderInputNameIndex m_prevTimeInputIndex = "m_prevTime";
             float m_prevSimulationTime = 0.0;
-            uint16_t m_numActivePipelines = 0;
+            uint16_t m_numActiveRenderPipelines = 0;
         };
 
         // --- Template functions ---

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
@@ -191,6 +191,11 @@ namespace AZ
                 return m_drawFilterTagRegistry;
             }
 
+            uint16_t GetActivePipelines() const
+            {
+                return m_numActivePipelines;
+            }
+
         protected:
             // SceneFinder overrides...
             void OnSceneNotifictaionHandlerConnected(SceneNotification* handler);
@@ -213,7 +218,6 @@ namespace AZ
             // Update and compile scene and view srgs
             // This is called after PassSystem's FramePrepare so passes can still modify view srgs in its FramePrepareIntenal function before they are submitted to command list
             void UpdateSrgs();
-
 
         private:
             Scene();
@@ -300,6 +304,7 @@ namespace AZ
             float m_simulationTime = 0.0;
             RHI::ShaderInputNameIndex m_prevTimeInputIndex = "m_prevTime";
             float m_prevSimulationTime = 0.0;
+            uint16_t m_numActivePipelines = 0;
         };
 
         // --- Template functions ---

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -314,12 +314,12 @@ namespace AZ
             }
 
             //Collect all the active pipelines running in this frame.
-            uint16_t numActivePipelines = 0;
+            uint16_t numActiveRenderPipelines = 0;
             for (auto& scenePtr : m_scenes)
             {
-                numActivePipelines += scenePtr->GetActivePipelines();
+                numActiveRenderPipelines += scenePtr->GetActiveRenderPipelines();
             }
-            m_rhiSystem.SetNumActivePipelines(numActivePipelines);
+            m_rhiSystem.SetNumActiveRenderPipelines(numActiveRenderPipelines);
 
             m_rhiSystem.FrameUpdate(
                 [this](RHI::FrameGraphBuilder& frameGraphBuilder)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -313,6 +313,14 @@ namespace AZ
                 scenePtr->PrepareRender(m_prepareRenderJobPolicy, m_currentSimulationTime);
             }
 
+            //Collect all the active pipelines running in this frame.
+            uint16_t numActivePipelines = 0;
+            for (auto& scenePtr : m_scenes)
+            {
+                numActivePipelines += scenePtr->GetActivePipelines();
+            }
+            m_rhiSystem.SetNumActivePipelines(numActivePipelines);
+
             m_rhiSystem.FrameUpdate(
                 [this](RHI::FrameGraphBuilder& frameGraphBuilder)
                 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -485,6 +485,11 @@ namespace AZ
         {
             AZ_PROFILE_SCOPE(RPI, "Scene: Simulate");
 
+            if (!m_activated)
+            {
+                return;
+            }
+
             m_prevSimulationTime = m_simulationTime;
             m_simulationTime = simulationTime;
 
@@ -706,6 +711,11 @@ namespace AZ
         {
             AZ_PROFILE_SCOPE(RPI, "Scene: PrepareRender");
 
+            if (!m_activated)
+            {
+                return;
+            }
+
             if (m_taskGraphActive)
             {
                 WaitAndCleanTGEvent();
@@ -733,6 +743,8 @@ namespace AZ
                     }
                 }
             }
+
+            m_numActivePipelines = aznumeric_cast<uint16_t>(activePipelines.size());
 
             // the pipeline states might have changed during the OnStartFrame, rebuild the lookup
             if (m_pipelineStatesLookupNeedsRebuild)
@@ -879,6 +891,11 @@ namespace AZ
 
         void Scene::UpdateSrgs()
         {
+            if (!m_activated)
+            {
+                return;
+            }
+
             PrepareSceneSrg();
 
             for (auto& view : m_renderPacket.m_views)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -744,7 +744,7 @@ namespace AZ
                 }
             }
 
-            m_numActivePipelines = aznumeric_cast<uint16_t>(activePipelines.size());
+            m_numActiveRenderPipelines = aznumeric_cast<uint16_t>(activePipelines.size());
 
             // the pipeline states might have changed during the OnStartFrame, rebuild the lookup
             if (m_pipelineStatesLookupNeedsRebuild)


### PR DESCRIPTION
## What does this PR do?

- Cleans up GPU markers related verbosity and management.
- Adds support for flattened markers for dx12 and Vk related gpu captures. 
- Add support to add pipeline name to the gpu capture if more than one pipeline is active
- Add support to better manage parallel encoding related markers. 
- Add support for merged groups via a cvar (r_gpuMarkersMergeGroups) in case a graphics engineer want to track payload per command list
- Add support to skip Scene updates if they are not active. 
- Other minor fixes

## How was this PR tested?

Tested ASV and MPS on dx12 and vulkan backends

- Vulkan with one pipeline (contains parallel encoding related scopes)

![image](https://user-images.githubusercontent.com/47460854/227343024-4ff4ee50-d4dc-4439-ae55-89c5ae7d298d.png)

- Vulkan with multiple pipelines

![image](https://user-images.githubusercontent.com/47460854/227344027-16b3350f-76fd-4ec2-a243-c9ad3d1089b8.png)

- Vulkan with merged group cvar enabled

![image](https://user-images.githubusercontent.com/47460854/227346219-78e30323-1646-4ad5-afad-e321284866e1.png)

- DX12 with one pipeline (contains parallel encoding related scopes)

![image](https://user-images.githubusercontent.com/47460854/227369355-7e996eca-7b8d-46be-8641-66337ac20d75.png)
