### PR TITLE
Added DebugDraw.API target to avoid linking

### DIFF
--- a/Gems/DebugDraw/Code/CMakeLists.txt
+++ b/Gems/DebugDraw/Code/CMakeLists.txt
@@ -6,6 +6,20 @@
 #
 #
 
+# The DebugDraw.API target declares the common interface that users of this gem should depend on in their targets to avoid linking.
+ly_add_target(
+    NAME DebugDraw.API INTERFACE
+    NAMESPACE Gem
+    FILES_CMAKE
+        debugdraw_api_files.cmake
+    INCLUDE_DIRECTORIES
+        INTERFACE
+            Include
+    BUILD_DEPENDENCIES
+        INTERFACE
+           AZ::AzCore
+)
+
 ly_add_target(
     NAME DebugDraw.Static STATIC
     NAMESPACE Gem

--- a/Gems/DebugDraw/Code/debugdraw_api_files.cmake
+++ b/Gems/DebugDraw/Code/debugdraw_api_files.cmake
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+    Include/DebugDraw/DebugDrawBus.h
+)

--- a/Gems/RecastNavigation/Code/CMakeLists.txt
+++ b/Gems/RecastNavigation/Code/CMakeLists.txt
@@ -124,7 +124,7 @@ ly_add_target(
             RecastNavigation::Detour
             RecastNavigation::Recast
             Gem::LmbrCentral.Static
-            Gem::DebugDraw.Static
+            Gem::DebugDraw.API
 )
 
 # Here add RecastNavigation target, it depends on the Private Object library and Public API interface
@@ -194,7 +194,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 AZ::AzToolsFramework
                 Gem::RecastNavigation.Private.Object
                 Gem::LmbrCentral.Static
-                Gem::DebugDraw.Static
+                Gem::DebugDraw.API
     )
 
     ly_add_target(


### PR DESCRIPTION
## What does this PR do?

Provide a new cmake target to avoid linking when using DebugDraw gem.

## How was this PR tested?

Compiled the engine and tested against Recast Navigation gem use of DebugDraw interface.
