### PR TITLE
Reenable checking for vulkan validation in non release builds

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/ValidationLayer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ValidationLayer.cpp
@@ -26,7 +26,7 @@ namespace AZ
 
         ValidationMode ReadValidationMode()
         {
-#if 1 //JJS defined(AZ_RELEASE_BUILD)
+#if defined(AZ_RELEASE_BUILD)
             // Always disabled in Release configuration.
             return ValidationMode::Disabled;
 #else


### PR DESCRIPTION
## What does this PR do?

Commit https://github.com/o3de/o3de/commit/d23949373490b39745e4b4314c1728631f0970cf disabled Vulkan validation on all build types. The change was probably commited accidentally (@jjjoness).
Vulkan device validation is now enabled in Debug builds by default again and the command line parameter "rhi-device-validation" is checked again.

## How was this PR tested?

Windows & Vulkan. Tested the command line parameter "rhi-device-validation"
