### PR TITLE
Fix for camera go-to-entity functionality when looking directly up or down

### DIFF
--- a/Code/Editor/EditorViewportCamera.h
+++ b/Code/Editor/EditorViewportCamera.h
@@ -109,6 +109,17 @@ namespace SandboxEditor
     //! @param transform The transform of the camera in world space.
     SANDBOX_API void HandleDefaultViewportCameraTransitionFromSetting(const AZ::Transform& transform);
 
+    //! Returns a transform that will aim to have the entity fill the screen (determined by the current
+    //! camera transform, field of view and position and radius of the entity).
+    //! @param cameraTransform The current transform of the camera.
+    //! @param fovRadians The field of view of the camera (in radians).
+    //! @param center The entity position in world space.
+    //! @param radius The radius of the bounding sphere of the entity (usually calculated from the entity Aabb).
+    //! @return Returns the new transform for the camera to fill the screen with the entity. If the cameraTransform
+    //! and center match, an empty optional is returned.
+    SANDBOX_API AZStd::optional<AZ::Transform> CalculateGoToEntityTransform(
+        const AZ::Transform& cameraTransform, float fovRadians, const AZ::Vector3& center, float radius);
+
     //! Returns a quaternion representing a pitch/yaw rotation for a camera.
     //! @param pitch Amount of pitch in radians.
     //! @param yaw Amount of yaw in radians.

--- a/Code/Editor/Lib/Tests/Camera/test_EditorCamera.cpp
+++ b/Code/Editor/Lib/Tests/Camera/test_EditorCamera.cpp
@@ -961,6 +961,8 @@ namespace UnitTest
         EXPECT_THAT(SandboxEditor::CameraFocusChannelId(), Eq(initialCameraFocusChannelId));
     }
 
+    static constexpr float CameraTransformTolerance = 0.001f;
+
     TEST(EditorViewportCamera, CalculateGoToEntityTransformHandlesNormalCaseLookingForward)
     {
         const AZStd::optional<AZ::Transform> nextCameraTransform = SandboxEditor::CalculateGoToEntityTransform(
@@ -968,34 +970,54 @@ namespace UnitTest
 
         EXPECT_THAT(
             *nextCameraTransform,
-            IsClose(
-                AZ::Transform::CreateFromQuaternionAndTranslation(AZ::Quaternion::CreateIdentity(), AZ::Vector3(0.0f, -1.87499f, 0.5f))));
+            IsCloseTolerance(
+                AZ::Transform::CreateFromQuaternionAndTranslation(AZ::Quaternion::CreateIdentity(), AZ::Vector3(0.0f, -1.87499f, 0.5f)),
+                CameraTransformTolerance));
     }
 
+    // camera starts over look down point, looking forwards
     TEST(EditorViewportCamera, CalculateGoToEntityTransformHandlesDegenerateCaseLookingDown)
     {
         const AZStd::optional<AZ::Transform> nextCameraTransform = SandboxEditor::CalculateGoToEntityTransform(
             AZ::Transform::CreateTranslation(AZ::Vector3(0.0f, 0.0f, 3.0f)), AZ::DegToRad(60.0f), AZ::Vector3::CreateAxisZ(0.5f), 0.866f);
 
+        const auto expectedTransform = AZ::Transform::CreateFromQuaternionAndTranslation(
+            AZ::Quaternion(-0.675590217f, 0.0f, 0.0f, 0.737277329f), AZ::Vector3(0.0f, -0.163416f, 2.367864f));
+
+        EXPECT_THAT(nextCameraTransform->GetTranslation(), IsCloseTolerance(expectedTransform.GetTranslation(), CameraTransformTolerance));
         EXPECT_THAT(
-            *nextCameraTransform,
-            IsClose(AZ::Transform::CreateFromQuaternionAndTranslation(
-                AZ::Quaternion(-0.675590217f, 0.0f, 0.0f, 0.737277329f), AZ::Vector3(0.0f, -0.163416f, 2.367864f))));
+            nextCameraTransform->GetUniformScale(), ::testing::FloatNear(expectedTransform.GetUniformScale(), CameraTransformTolerance));
+        // it's possible for either rotation to be valid - both represent the same rotation/orientation
+        EXPECT_THAT(
+            nextCameraTransform->GetRotation(),
+            ::testing::AnyOf(
+                IsCloseTolerance(expectedTransform.GetRotation(), CameraTransformTolerance),
+                IsCloseTolerance(-expectedTransform.GetRotation(), CameraTransformTolerance)));
     }
 
+    // camera starts under look down point, looking up
     TEST(EditorViewportCamera, CalculateGoToEntityTransformHandlesDegenerateCaseLookingUp)
     {
         const AZStd::optional<AZ::Transform> nextCameraTransform = SandboxEditor::CalculateGoToEntityTransform(
             AZ::Transform::CreateFromQuaternionAndTranslation(
-                AZ::Quaternion::CreateRotationZ(AZ::DegToRad(-90.0f)) * AZ::Quaternion::CreateRotationX(AZ::DegToRad(90.0f)),
+                AZ::Quaternion::CreateRotationZ(AZ::DegToRad(-90.0f)) *
+                    AZ::Quaternion::CreateRotationX(AZ::DegToRad(90.0f) - AzFramework::CameraPitchTolerance),
                 AZ::Vector3(0.0f, 0.0f, 5.0f)),
             AZ::DegToRad(60.0f),
             AZ::Vector3::CreateAxisZ(10.0f),
             0.866f);
 
+        const auto expectedTransform = AZ::Transform::CreateFromQuaternionAndTranslation(
+            AZ::Quaternion(-0.477643281f, 0.477785647f, 0.521411479f, -0.521256149f), AZ::Vector3(-0.163416952f, 0.0f, 8.13213539f));
+
+        EXPECT_THAT(nextCameraTransform->GetTranslation(), IsCloseTolerance(expectedTransform.GetTranslation(), CameraTransformTolerance));
         EXPECT_THAT(
-            *nextCameraTransform,
-            IsClose(AZ::Transform::CreateFromQuaternionAndTranslation(
-                AZ::Quaternion(-0.477643281f, 0.477785647f, 0.521411479f, -0.521256149f), AZ::Vector3(-0.163416952f, 0.0f, 8.13213539f))));
+            nextCameraTransform->GetUniformScale(), ::testing::FloatNear(expectedTransform.GetUniformScale(), CameraTransformTolerance));
+        // it's possible for either rotation to be valid - both represent the same rotation/orientation
+        EXPECT_THAT(
+            nextCameraTransform->GetRotation(),
+            ::testing::AnyOf(
+                IsCloseTolerance(expectedTransform.GetRotation(), CameraTransformTolerance),
+                IsCloseTolerance(-expectedTransform.GetRotation(), CameraTransformTolerance)));
     }
 } // namespace UnitTest

--- a/Code/Editor/Lib/Tests/Camera/test_EditorCamera.cpp
+++ b/Code/Editor/Lib/Tests/Camera/test_EditorCamera.cpp
@@ -960,4 +960,42 @@ namespace UnitTest
         EXPECT_THAT(SandboxEditor::CameraOrbitPanChannelId(), Eq(initialCameraOrbitPanChannelId));
         EXPECT_THAT(SandboxEditor::CameraFocusChannelId(), Eq(initialCameraFocusChannelId));
     }
+
+    TEST(EditorViewportCamera, CalculateGoToEntityTransformHandlesNormalCaseLookingForward)
+    {
+        const AZStd::optional<AZ::Transform> nextCameraTransform = SandboxEditor::CalculateGoToEntityTransform(
+            AZ::Transform::CreateTranslation(AZ::Vector3(0.0f, -5.0f, 0.5f)), AZ::DegToRad(60.0f), AZ::Vector3::CreateAxisZ(0.5f), 0.866f);
+
+        EXPECT_THAT(
+            *nextCameraTransform,
+            IsClose(
+                AZ::Transform::CreateFromQuaternionAndTranslation(AZ::Quaternion::CreateIdentity(), AZ::Vector3(0.0f, -1.87499f, 0.5f))));
+    }
+
+    TEST(EditorViewportCamera, CalculateGoToEntityTransformHandlesDegenerateCaseLookingDown)
+    {
+        const AZStd::optional<AZ::Transform> nextCameraTransform = SandboxEditor::CalculateGoToEntityTransform(
+            AZ::Transform::CreateTranslation(AZ::Vector3(0.0f, 0.0f, 3.0f)), AZ::DegToRad(60.0f), AZ::Vector3::CreateAxisZ(0.5f), 0.866f);
+
+        EXPECT_THAT(
+            *nextCameraTransform,
+            IsClose(AZ::Transform::CreateFromQuaternionAndTranslation(
+                AZ::Quaternion(-0.675590217f, 0.0f, 0.0f, 0.737277329f), AZ::Vector3(0.0f, -0.163416f, 2.367864f))));
+    }
+
+    TEST(EditorViewportCamera, CalculateGoToEntityTransformHandlesDegenerateCaseLookingUp)
+    {
+        const AZStd::optional<AZ::Transform> nextCameraTransform = SandboxEditor::CalculateGoToEntityTransform(
+            AZ::Transform::CreateFromQuaternionAndTranslation(
+                AZ::Quaternion::CreateRotationZ(AZ::DegToRad(-90.0f)) * AZ::Quaternion::CreateRotationX(AZ::DegToRad(90.0f)),
+                AZ::Vector3(0.0f, 0.0f, 5.0f)),
+            AZ::DegToRad(60.0f),
+            AZ::Vector3::CreateAxisZ(10.0f),
+            0.866f);
+
+        EXPECT_THAT(
+            *nextCameraTransform,
+            IsClose(AZ::Transform::CreateFromQuaternionAndTranslation(
+                AZ::Quaternion(-0.477643281f, 0.477785647f, 0.521411479f, -0.521256149f), AZ::Vector3(-0.163416952f, 0.0f, 8.13213539f))));
+    }
 } // namespace UnitTest

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -1818,36 +1818,21 @@ void SandboxIntegrationManager::GoToEntitiesInViewports(const AzToolsFramework::
     AZ::Vector3 center;
     aabb.GetAsSphere(center, radius);
 
-    // minimum center size is 40cm
-    const float minSelectionRadius = 0.4f;
-    const float selectionSize = AZ::GetMax(minSelectionRadius, radius);
-
     auto viewportContextManager = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get();
-
     const int viewCount = GetIEditor()->GetViewManager()->GetViewCount(); // legacy call
     for (int viewIndex = 0; viewIndex < viewCount; ++viewIndex)
     {
         if (auto viewportContext = viewportContextManager->GetViewportContextById(viewIndex))
         {
-            const AZ::Transform cameraTransform = viewportContext->GetCameraTransform();
-            // do not attempt to interpolate to where we currently are
-            if (cameraTransform.GetTranslation().IsClose(center))
+            if (const AZStd::optional<AZ::Transform> nextCameraTransform = SandboxEditor::CalculateGoToEntityTransform(
+                    viewportContext->GetCameraTransform(),
+                    AzFramework::RetrieveFov(viewportContext->GetCameraProjectionMatrix()),
+                    center,
+                    radius);
+                nextCameraTransform.has_value())
             {
-                continue;
+                SandboxEditor::HandleDefaultViewportCameraTransitionFromSetting(*nextCameraTransform);
             }
-
-            const AZ::Vector3 forward = (center - cameraTransform.GetTranslation()).GetNormalized();
-
-            // move camera 25% further back than required
-            const float centerScale = 1.25f;
-            // compute new camera transform
-            const float fov = AzFramework::RetrieveFov(viewportContext->GetCameraProjectionMatrix());
-            const float fovScale = (1.0f / AZStd::tan(fov * 0.5f));
-            const float distanceToLookAt = selectionSize * fovScale * centerScale;
-            const AZ::Transform nextCameraTransform =
-                AZ::Transform::CreateLookAt(aabb.GetCenter() - (forward * distanceToLookAt), aabb.GetCenter());
-
-            SandboxEditor::HandleDefaultViewportCameraTransitionFromSetting(nextCameraTransform);
         }
     }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/14894
Fixes https://github.com/o3de/o3de/issues/9151
Fixes https://github.com/o3de/o3de/issues/6243

The crux of the change is updating...

```c++
const AZ::Vector3 forward = (center - cameraTransform.GetTranslation()).GetNormalized();
```

to...

```c++
const AZ::Vector3 forward = [&center, &cameraTransform]
{
    const AZ::Vector3 forward = (center - cameraTransform.GetTranslation()).GetNormalized();
    // if the camera is looking directly up or down, pitch the camera down or up respectively to avoid
    // a singularity when creating the lookat transformation below
    if (const float forwardDot = forward.Dot(AZ::Vector3::CreateAxisZ()); AZ::IsCloseMag(AZ::Abs(forwardDot), 1.0f, 0.001f))
    {
        return AZ::Transform::CreateFromQuaternion(
                    AZ::Quaternion::CreateFromAxisAngle(cameraTransform.GetBasisX(), AZ::DegToRad(5.0f) * -AZ::GetSign(forwardDot)))
            .TransformVector(AZ::Vector3::CreateAxisZ() * AZ::GetSign(forwardDot));
    }
    return forward;
}();
```

This ensures if the camera is looking directly up or down, we avoid the annoying singularity where we can't use the world up (Z) vector when computing our look-at transform. We pitch the camera gently up or down slightly (5 degrees) to avoid this case and things function a lot more smoothly.

The code has been factored out into a new function to make it easier to test in isolation.

## How was this PR tested?

Manual testing in the editor and new integration tests to verify functionality (in-progress).

### Before

https://user-images.githubusercontent.com/110163473/222423209-c063286a-a106-41d6-97c8-089b960724d8.mp4

### After

https://user-images.githubusercontent.com/82228511/227562509-734ef96b-d904-4930-a3cb-3bde52fb0d43.mp4

### Tests

#### Before

```bash
[==========] Running 3 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 3 tests from EditorViewportCamera
[ RUN      ] EditorViewportCamera.CalculateGoToEntityTransformHandlesNormalCaseLookingForward
[       OK ] EditorViewportCamera.CalculateGoToEntityTransformHandlesNormalCaseLookingForward (0 ms)
[ RUN      ] EditorViewportCamera.CalculateGoToEntityTransformHandlesDegenerateCaseLookingDown
C:/dev/o3de/Code/Editor/Lib/Tests/Camera/test_EditorCamera.cpp(986): error: Value of: *nextCameraTransform
Expected: is close translation: (X: 0, Y: -0.163416, Z: 2.36786) rotation: (X: -0.67559, Y: 0, Z: 0, W: 0.737277) scale: 1
  Actual: translation: (X: 0, Y: 0, Z: 2.37494) rotation: (X: -0.5, Y: 0.5, Z: -0.5, W: 0.5) scale: 1 (of type class AZ::Transform)
[  FAILED  ] EditorViewportCamera.CalculateGoToEntityTransformHandlesDegenerateCaseLookingDown (1 ms)
[ RUN      ] EditorViewportCamera.CalculateGoToEntityTransformHandlesDegenerateCaseLookingUp
C:/dev/o3de/Code/Editor/Lib/Tests/Camera/test_EditorCamera.cpp(1002): error: Value of: *nextCameraTransform
Expected: is close translation: (X: -0.163417, Y: 0, Z: 8.13214) rotation: (X: -0.477643, Y: 0.477786, Z: 0.521411, W: -0.521256) scale: 1
  Actual: translation: (X: 0, Y: 0, Z: 8.12506) rotation: (X: 0.5, Y: -0.5, Z: -0.5, W: 0.5) scale: 1 (of type class AZ::Transform)
[  FAILED  ] EditorViewportCamera.CalculateGoToEntityTransformHandlesDegenerateCaseLookingUp (0 ms)
[----------] 3 tests from EditorViewportCamera (4 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test case ran. (4 ms total)
[  PASSED  ] 1 test.
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] EditorViewportCamera.CalculateGoToEntityTransformHandlesDegenerateCaseLookingDown
[  FAILED  ] EditorViewportCamera.CalculateGoToEntityTransformHandlesDegenerateCaseLookingUp

 2 FAILED TESTS
```

#### After

```bash
[==========] Running 3 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 3 tests from EditorViewportCamera
[ RUN      ] EditorViewportCamera.CalculateGoToEntityTransformHandlesNormalCaseLookingForward
[       OK ] EditorViewportCamera.CalculateGoToEntityTransformHandlesNormalCaseLookingForward (1 ms)
[ RUN      ] EditorViewportCamera.CalculateGoToEntityTransformHandlesDegenerateCaseLookingDown
[       OK ] EditorViewportCamera.CalculateGoToEntityTransformHandlesDegenerateCaseLookingDown (0 ms)
[ RUN      ] EditorViewportCamera.CalculateGoToEntityTransformHandlesDegenerateCaseLookingUp
[       OK ] EditorViewportCamera.CalculateGoToEntityTransformHandlesDegenerateCaseLookingUp (0 ms)
[----------] 3 tests from EditorViewportCamera (1 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test case ran. (3 ms total)
[  PASSED  ] 3 tests.
```after