### PR TITLE
Select correct parent folder.

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -208,10 +208,8 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
                     return;
                 }
 
-                auto selectionModel = m_ui->m_assetBrowserTreeViewWidget->selectionModel();
                 auto targetIndex = m_filterModel.data()->mapFromSource(indexForEntry);
-
-                selectionModel->select(targetIndex, QItemSelectionModel::ClearAndSelect);
+                m_ui->m_assetBrowserTreeViewWidget->SetShowIndexAfterUpdate(targetIndex);
             });
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -366,6 +366,11 @@ namespace AzToolsFramework
                     curIndex = indexBelow(curIndex);
                 }
             }
+            else if (m_indexToSelectAfterUpdate.isValid())
+            {
+                selectionModel()->select(m_indexToSelectAfterUpdate, QItemSelectionModel::ClearAndSelect);
+                m_indexToSelectAfterUpdate = QModelIndex();
+            }
         }
 
         const AssetBrowserEntry* AssetBrowserTreeView::GetEntryByPath(QStringView path)
@@ -639,6 +644,11 @@ namespace AzToolsFramework
                     }
                   }
                 });
+        }
+
+        void AssetBrowserTreeView::SetShowIndexAfterUpdate(QModelIndex index)
+        {
+            m_indexToSelectAfterUpdate = index;
         }
     } // namespace AssetBrowser
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
@@ -101,6 +101,8 @@ namespace AzToolsFramework
 
             bool IsIndexExpandedByDefault(const QModelIndex& index) const override;
 
+            void SetShowIndexAfterUpdate(QModelIndex index);
+
         Q_SIGNALS:
             void selectionChangedSignal(const QItemSelection& selected, const QItemSelection& deselected);
             void ClearStringFilter();
@@ -128,6 +130,8 @@ namespace AzToolsFramework
             const int m_scUpdateInterval = 100;
 
             QString m_name;
+
+            QModelIndex m_indexToSelectAfterUpdate;
 
             bool SelectProduct(const QModelIndex& idxParent, AZ::Data::AssetId assetID);
             bool SelectEntry(const QModelIndex& idxParent, const AZStd::vector<AZStd::string>& entryPathTokens, const uint32_t entryPathIndex = 0, bool useDisplayName = false);


### PR DESCRIPTION
## What does this PR do?

This PR resolves #14427. Previously, the correct parent folder was selected, but would be overridden when the treeview was updated. This adds an additional selection to the update routine.

## How was this PR tested?

Manual testing.
