### PR TITLE
updated code for window title. Now selects display or internal version based on engine_info config

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectManagerWindow.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectManagerWindow.cpp
@@ -19,7 +19,9 @@ namespace O3DE::ProjectManager
         if (auto engineInfoOutcome = PythonBindingsInterface::Get()->GetEngineInfo(); engineInfoOutcome)
         {
             auto engineInfo = engineInfoOutcome.GetValue<EngineInfo>();
-            setWindowTitle(QString("%1 %2 %3").arg(engineInfo.m_name.toUpper(), engineInfo.m_version, tr("Project Manager")));
+            auto versionToDisplay = engineInfo.m_displayVersion == "00.00" ? 
+                                        engineInfo.m_version : engineInfo.m_displayVersion;
+            setWindowTitle(QString("%1 %2 %3").arg(engineInfo.m_name.toUpper(), versionToDisplay, tr("Project Manager")));
         }
         else
         {


### PR DESCRIPTION
## What does this PR do?
Updated the window title to select the correct version tag to display depending on if the display version is set or not.

## How was this PR tested?

Tested visually.

First with display version `00.00`
![image](https://user-images.githubusercontent.com/112996779/227674081-86b6dc36-bc92-4693-b031-29ce739131f1.png)

Then with display version `23.05`
![image](https://user-images.githubusercontent.com/112996779/227674470-f281e464-855b-45e6-ad5f-bce3dbaf8c2c.png)

