### PR TITLE
All decals no longer break if a decal material is missing

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -549,15 +549,18 @@ namespace AZ
         {
             const auto materialAsset = QueueMaterialAssetLoad(materialId);
 
-            m_materialLoadTracker.TrackAssetLoad(handle, materialAsset);
-
             if (materialAsset.IsLoading())
             {
+                m_materialLoadTracker.TrackAssetLoad(handle, materialAsset);
                 AZ::Data::AssetBus::MultiHandler::BusConnect(materialId);
             }
             else if (materialAsset.IsReady())
             {
                 OnAssetReady(materialAsset);
+            }
+            else if (materialAsset.IsError())
+            {
+                AZ_Warning("DecalTextureArrayFeatureProcessor", false, "Unable to load material for decal. Asset ID: %s", materialId.ToString<AZStd::string>().c_str());
             }
             else
             {


### PR DESCRIPTION
## What does this PR do?

Previously if a single decal material was missing, all decals would break. In addition to being a bug, it also made it difficult to track down which was the offending decal. With this change, it simply warns for the missing material's asset id, and all other decals continue to work.

Fixes #15193

## How was this PR tested?

Tested using repro steps from original bug.
