### PR TITLE
added fix for correctly displaying engine version in window title

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectManagerWindow.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectManagerWindow.cpp
@@ -19,7 +19,9 @@ namespace O3DE::ProjectManager
         if (auto engineInfoOutcome = PythonBindingsInterface::Get()->GetEngineInfo(); engineInfoOutcome)
         {
             auto engineInfo = engineInfoOutcome.GetValue<EngineInfo>();
-            setWindowTitle(QString("%1 %2 %3").arg(engineInfo.m_name.toUpper(), engineInfo.m_version, tr("Project Manager")));
+            auto versionToDisplay = engineInfo.m_displayVersion == "00.00" ?
+                                        engineInfo.m_version : engineInfo.m_displayVersion;
+            setWindowTitle(QString("%1 %2 %3").arg(engineInfo.m_name.toUpper(), versionToDisplay, tr("Project Manager")));
         }
         else
         {


### PR DESCRIPTION
## What does this PR do?
Updates the Project Manager to use the display version of `engine.json` if its value is not `00.00`.

## How was this PR tested?

Confirmed visually.

When the display version is `00.00`
![image](https://user-images.githubusercontent.com/112996779/227690206-e0c71649-f076-407a-8bd8-9b72da91ddf2.png)

When the display version is `23.05`
![image](https://user-images.githubusercontent.com/112996779/227690237-6bf8e497-e38a-450e-85d2-dc970a9de8b9.png)
