### PR TITLE
Fix asset reprocessing if "Skip Start Scan" AP option is enabled

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -3481,7 +3481,10 @@ namespace AssetProcessor
             m_fileModTimes.clear();
             m_fileHashes.clear();
 
-            QueueIdleCheck();
+            // place a message in the queue that will cause us to transition
+            // into a "no longer scanning" state and then continue with the next phase
+            QMetaObject::invokeMethod(this, "FinishAssetScan", Qt::QueuedConnection);
+
             m_initialScanSkippingFeature = false;
             return;
         }
@@ -3535,7 +3538,7 @@ namespace AssetProcessor
 
         // place a message in the queue that will cause us to transition
         // into a "no longer scanning" state and then continue with the next phase
-        // we place this at the end of the queue rather than calling it immediately, becuase
+        // we place this at the end of the queue rather than calling it immediately, because
         // other messages may still be in the queue such as the incoming file list.
         QMetaObject::invokeMethod(this, "FinishAssetScan", Qt::QueuedConnection);
     }


### PR DESCRIPTION
## What does this PR do?

**Bug** :
When the "Skip Start Scan" is enabled in Asset Processor settings, automatic or manual assets reprocess after AP launch are never processed.
If you modify an asset or manually ask to reprocess it through the AP "Assets" panel, this one will be counted in "analyzing jobs remaining" count, but the jobs never go as "processing jobs".

**Fix** :
This PR fixes this, the problem was due to a missing setting of `m_isCurrentlyScanning` to `false` before require the `Idel` phase. For this reason reporcess stay queued and the system enters in an infinite loop between `QueueIdleCheck `and `ScheduleNextUpdate` calls.

The boolean's value is supposed to be set in `FinishAssetScan`, which is never called if the option is enabled.

Note that a simple setting of  the boolean could have been enough to fix the bug, but by security, I had preferred to queu a `FinishAssetScan` event and come back to normal "End flow" for AP initialisation.
It avoid future problem if some other state variable or process are added.

## How was this PR tested?

- Launch Asset Processor with "Skip Start Scan" enabled
- Go in "Assets" pannel
- Right click on any asset or folder
- "Reprocess *"
