### PR TITLE
Fix SystemAllocator compilation in monolithic release (vs 2022)

### DIFF
--- a/Code/Framework/AzCore/AzCore/Memory/SystemAllocator.cpp
+++ b/Code/Framework/AzCore/AzCore/Memory/SystemAllocator.cpp
@@ -130,7 +130,7 @@ namespace AZ
         pointer newAddress = m_subAllocator->reallocate(ptr, newSize, newAlignment);
 
 #if defined(AZ_ENABLE_TRACING)
-        const size_type allocatedSize = get_allocated_size(newAddress, 1);
+        [[maybe_unused]] const size_type allocatedSize = get_allocated_size(newAddress, 1);
         AZ_PROFILE_MEMORY_ALLOC(MemoryReserved, newAddress, newSize, "SystemAllocator realloc");
         AZ_MEMORY_PROFILE(ProfileReallocation(ptr, newAddress, allocatedSize, newAlignment));
 #endif


### PR DESCRIPTION
## What does this PR do?

`SystemAllocator` compilation failed in monolithic release due to a "Warning as error" when AZ_ENABLE_TRACING is defined.

## How was this PR tested?

Compile a project in monolithic with release configuration.