### PR TITLE
Action Manager | Prevent Registration Hooks from being called if the system is disabled.

### DIFF
--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -64,6 +64,7 @@ AZ_POP_DISABLE_WARNING
 #include <AzToolsFramework/ActionManager/ActionManagerSystemComponent.h>
 #include <AzToolsFramework/Component/EditorComponentAPIBus.h>
 #include <AzToolsFramework/Component/EditorLevelComponentAPIBus.h>
+#include <AzToolsFramework/Editor/ActionManagerUtils.h>
 #include <AzToolsFramework/UI/UICore/ProgressShield.hxx>
 #include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
 #include <AzToolsFramework/Slice/SliceUtilities.h>
@@ -1816,7 +1817,10 @@ bool CCryEditApp::InitInstance()
     }
 
     // Trigger the Action Manager registration hooks once all systems and Gems are initialized and listening.
-    AzToolsFramework::ActionManagerSystemComponent::TriggerRegistrationNotifications();
+    if (AzToolsFramework::IsNewActionManagerEnabled())
+    {
+        AzToolsFramework::ActionManagerSystemComponent::TriggerRegistrationNotifications();
+    }
 
     CloseSplashScreen();
 


### PR DESCRIPTION
## What does this PR do?

Fix issue when running the Editor while the new Action Manager system is disabled. Change in https://github.com/o3de/o3de/pull/15266 would trigger the Action Manager Registration Hooks even when the system is disabled, causing crashes in systems that would connect to that bus and assume the functions would only be triggered when the system is available.

## How was this PR tested?

Manual testing.
