### PR TITLE
Check component validity before DoRefresh() in DPE component adapter

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
@@ -8,6 +8,7 @@
 
 #include <AzCore/DOM/Backends/JSON/JsonSerializationUtils.h>
 #include <AzFramework/DocumentPropertyEditor/AdapterBuilder.h>
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.h>
 #include <AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabAdapterInterface.h>
 #include <AzToolsFramework/Prefab/PrefabDomUtils.h>
@@ -89,9 +90,20 @@ namespace AZ::DocumentPropertyEditor
         SetValue(componentInstance, instanceTypeId);
     }
 
+    bool ComponentAdapter::IsComponentValid()
+    {
+        if (m_entityId.IsValid())
+        {
+            const Entity* entity = AzToolsFramework::GetEntity(m_entityId);
+            return entity->FindComponent(m_componentId) != nullptr;
+        }
+
+        return false;
+    }
+
     void ComponentAdapter::DoRefresh()
     {
-        if (!m_entityId.IsValid())
+        if (!IsComponentValid())
         {
             return;
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
@@ -90,12 +90,15 @@ namespace AZ::DocumentPropertyEditor
         SetValue(componentInstance, instanceTypeId);
     }
 
-    bool ComponentAdapter::IsComponentValid()
+    bool ComponentAdapter::IsComponentValid() const
     {
         if (m_entityId.IsValid())
         {
             const Entity* entity = AzToolsFramework::GetEntity(m_entityId);
-            return entity->FindComponent(m_componentId) != nullptr;
+            AZ_Assert(entity, "ComponentAdapter::IsComponentValid - Entity is nullptr.");
+
+            bool isEntityActive = entity->GetState() == AZ::Entity::State::Active;
+            return isEntityActive && entity->FindComponent(m_componentId) != nullptr;
         }
 
         return false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.h
@@ -61,7 +61,7 @@ namespace AZ::DocumentPropertyEditor
 
     private:
         //! Checks if the component is still valid in the entity.
-        bool IsComponentValid();
+        bool IsComponentValid() const;
 
     protected:
         AZ::EntityId m_entityId;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.h
@@ -59,8 +59,14 @@ namespace AZ::DocumentPropertyEditor
 
         void OnEntityDestroyed(const AZ::EntityId&) override;
 
+    private:
+        //! Checks if the component is still valid in the entity.
+        bool IsComponentValid();
+
     protected:
         AZ::EntityId m_entityId;
+
+        // Should call IsComponentValid() for validity check before using the component id and its component instance.
         AZ::ComponentId m_componentId = AZ::InvalidComponentId;
 
         AzToolsFramework::UndoSystem::URSequencePoint* m_currentUndoNode = nullptr;


### PR DESCRIPTION
## What does this PR do?

This PR adds a check on component validity. If the component is not valid, then skip 'DoRefresh()' and 'NotifyResetDocument()' in `DPEComponentAdapter`.

Looks like it can fix a couple of delete-component crashes:
- https://github.com/o3de/o3de/issues/15184
- https://github.com/o3de/o3de/issues/15097 (still verifying)
- Delete AudioAnimation component

## How was this PR tested?

Manually tested in editor to delete different components which could cause crashes earlier.