### PR TITLE
Asset Processor - Fix incorrect sorting comparison

### DIFF
--- a/Code/Tools/AssetProcessor/native/utilities/ProductOutputUtil.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ProductOutputUtil.cpp
@@ -84,7 +84,7 @@ namespace AssetProcessor
                     products.end(),
                     [](const AssetBuilderSDK::JobProduct& a, const AssetBuilderSDK::JobProduct& b)
                     {
-                        return a.m_productFileName.compare(b.m_productFileName);
+                        return a.m_productFileName.compare(b.m_productFileName) < 0;
                     });
 
                 for (auto& product : products)


### PR DESCRIPTION
## What does this PR do?

Fixed .compare result being treated as a boolean.  This was causing a crash when unit tests were run in debug mode.

This fixes a bug introduced by c2bc37b7d3fb304ebbdd2e59c8b53f4c16312465

## How was this PR tested?

Ran unit tests in debug mode.  Before the fix a debug assert was popping up, afterwards assert is gone.
